### PR TITLE
Create InputWrapper component to combine Input error, label and context.

### DIFF
--- a/admin/.storybook/preview.js
+++ b/admin/.storybook/preview.js
@@ -9,3 +9,11 @@ export const parameters = {
     },
   },
 }
+
+export const decorators = [
+    (Story) => (
+      <div data-h2-font-family="b(sans)">
+        <Story />
+      </div>
+    ),
+  ];

--- a/admin/resources/js/components/H2Components/InputLabel.tsx
+++ b/admin/resources/js/components/H2Components/InputLabel.tsx
@@ -24,18 +24,20 @@ const InputLabel: React.FC<InputLabelProps> = ({
     setContextIsActive((currentState) => !currentState);
   };
   return (
-    <div
-      data-h2-flex-grid="b(middle, contained, flush, none)"
-      data-h2-font-family="b(sans)"
-    >
+    <div data-h2-flex-grid="b(middle, contained, flush, none)">
       <div data-h2-flex-item="b(1of1) s(1of2)" data-h2-text-align="b(left)">
-        <label htmlFor={inputId}>{label}</label>
+        <label data-h2-font-size="b(caption)" htmlFor={inputId}>
+          {label}
+        </label>
       </div>
       <div
         data-h2-flex-item="b(1of1) s(1of2)"
         data-h2-text-align="b(left) s(right)"
       >
-        <span data-h2-font-color={required ? "b(red)" : "b(darkgray)"}>
+        <span
+          data-h2-font-size="b(caption)"
+          data-h2-font-color={required ? "b(red)" : "b(darkgray)"}
+        >
           {required ? "Required" : "Optional"}
         </span>
         {contextIsVisible && (
@@ -49,12 +51,12 @@ const InputLabel: React.FC<InputLabelProps> = ({
             <>
               {contextIsActive ? (
                 <XCircleIcon
-                  style={{ width: "1rem" }}
+                  style={{ width: "calc(1rem/1.25)" }}
                   data-h2-font-color="b(lightpurple)"
                 />
               ) : (
                 <QuestionMarkCircleIcon
-                  style={{ width: "1rem" }}
+                  style={{ width: "calc(1rem/1.25)" }}
                   data-h2-font-color="b(lightpurple)"
                 />
               )}

--- a/admin/resources/js/components/H2Components/InputWrapper.tsx
+++ b/admin/resources/js/components/H2Components/InputWrapper.tsx
@@ -28,9 +28,15 @@ export const InputWrapper: React.FC<InputWrapperProps> = ({
         contextToggleHandler={setContextVisible}
       />
       {children}
-      {error && <span role="alert">{error}</span>}
+      {error && (
+        <p data-h2-font-size="b(caption)" role="alert">
+          {error}
+        </p>
+      )}
       {contextVisible && context && (
-        <p data-h2-bg-color="b(lightpurple)">{context}</p>
+        <p data-h2-font-size="b(caption)" data-h2-bg-color="b(lightpurple)">
+          {context}
+        </p>
       )}
     </div>
   );

--- a/admin/resources/js/components/H2Components/InputWrapper.tsx
+++ b/admin/resources/js/components/H2Components/InputWrapper.tsx
@@ -6,7 +6,6 @@ export interface InputWrapperProps {
   label: string;
   required: boolean;
   error?: string;
-  contextToggleIsVisible?: boolean;
   context?: string;
 }
 
@@ -15,7 +14,6 @@ export const InputWrapper: React.FC<InputWrapperProps> = ({
   label,
   required,
   error,
-  contextToggleIsVisible,
   context,
   children,
 }) => {
@@ -26,12 +24,12 @@ export const InputWrapper: React.FC<InputWrapperProps> = ({
         inputId={inputId}
         label={label}
         required={required}
-        contextIsVisible={contextToggleIsVisible}
+        contextIsVisible={context !== undefined && context !== ""}
         contextToggleHandler={setContextVisible}
       />
       {children}
       {error && <span role="alert">{error}</span>}
-      {contextVisible && context && contextToggleIsVisible && (
+      {contextVisible && context && (
         <p data-h2-bg-color="b(lightpurple)">{context}</p>
       )}
     </div>

--- a/admin/resources/js/components/H2Components/InputWrapper.tsx
+++ b/admin/resources/js/components/H2Components/InputWrapper.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import InputLabel from "./InputLabel";
+
+export interface InputWrapperProps {
+  inputId: string;
+  label: string;
+  required: boolean;
+  error?: string;
+  contextToggleIsVisible?: boolean;
+  context?: string;
+}
+
+export const InputWrapper: React.FC<InputWrapperProps> = ({
+  inputId,
+  label,
+  required,
+  error,
+  contextToggleIsVisible,
+  context,
+  children,
+}) => {
+  const [contextVisible, setContextVisible] = useState(false);
+  return (
+    <div>
+      <InputLabel
+        inputId={inputId}
+        label={label}
+        required={required}
+        contextIsVisible={contextToggleIsVisible}
+        contextToggleHandler={setContextVisible}
+      />
+      {children}
+      {error && <span role="alert">{error}</span>}
+      {contextVisible && context && contextToggleIsVisible && (
+        <p data-h2-bg-color="b(lightpurple)">{context}</p>
+      )}
+    </div>
+  );
+};
+
+export default InputWrapper;

--- a/admin/resources/js/stories/InputWrapper.stories.tsx
+++ b/admin/resources/js/stories/InputWrapper.stories.tsx
@@ -26,7 +26,6 @@ InputWrapperWithTextInput.args = {
   label: "First Name",
   required: true,
   error: "This input is required",
-  contextToggleIsVisible: true,
   context:
     "We collect the above data for account purposes. It may be shared with Hiring Managers.",
 };

--- a/admin/resources/js/stories/InputWrapper.stories.tsx
+++ b/admin/resources/js/stories/InputWrapper.stories.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import {
+  InputWrapper,
+  InputWrapperProps,
+} from "../components/H2Components/InputWrapper";
+
+export default {
+  component: InputWrapper,
+  title: "Components/Input Wrapper",
+} as Meta;
+
+const TemplateInputWrapper: Story<InputWrapperProps> = (args) => {
+  const { inputId } = args;
+  return (
+    <InputWrapper {...args}>
+      <input id={inputId} type="text" style={{ minWidth: "100%" }} />
+    </InputWrapper>
+  );
+};
+
+export const InputWrapperWithTextInput = TemplateInputWrapper.bind({});
+
+InputWrapperWithTextInput.args = {
+  inputId: "firstName",
+  label: "First Name",
+  required: true,
+  error: "This input is required",
+  contextToggleIsVisible: true,
+  context:
+    "We collect the above data for account purposes. It may be shared with Hiring Managers.",
+};

--- a/admin/resources/views/dashboard.blade.php
+++ b/admin/resources/views/dashboard.blade.php
@@ -13,7 +13,7 @@
   <title>GC Talent</title>
 </head>
 <body>
-  <div id="app"></div>
+  <div id="app" data-h2-font-family="b(sans)"></div>
   <script src="{{ mix("js/dashboard.js") }}"></script>
 </body>
 </html>


### PR DESCRIPTION
This component combines the Input error, label, and context. By passing the actual <input> element in as children, it can be used for various kinds of inputs.

When InputError (#130) and InputContext (#131) tasks are complete, they should be added to InputWrapper.