### PR TITLE
Bugfix - Storybook stories deprecated warning

### DIFF
--- a/admin/resources/js/stories/H2Components/Button.stories.tsx
+++ b/admin/resources/js/stories/H2Components/Button.stories.tsx
@@ -6,15 +6,13 @@ import Button, { ButtonProps } from "../../components/H2Components/Button";
 export default {
   component: Button,
   title: "Components/Button",
+  args: {
+    label: "Button Label",
+  },
   argTypes: {
     label: {
       name: "label",
       type: { name: "string", required: true },
-      defaultValue: "Button Label",
-      table: {
-        type: { summary: "string" },
-        defaultValue: { summary: "Button Label" },
-      },
       control: {
         type: "text",
       },

--- a/admin/resources/js/stories/form/Input.stories.tsx
+++ b/admin/resources/js/stories/form/Input.stories.tsx
@@ -8,15 +8,13 @@ import Submit from "../../components/form/Submit";
 export default {
   component: Input,
   title: "Form/Input",
+  args: {
+    maxWidth: "20rem",
+  },
   argTypes: {
     maxWidth: {
       name: "Max Width",
       type: { name: "string", required: true },
-      defaultValue: "20rem",
-      table: {
-        type: { summary: "string" },
-        defaultValue: { summary: "Button Label" },
-      },
       control: {
         type: "text",
       },

--- a/admin/resources/js/stories/form/TextArea.stories.tsx
+++ b/admin/resources/js/stories/form/TextArea.stories.tsx
@@ -8,15 +8,13 @@ import TextArea, { TextAreaProps } from "../../components/form/TextArea";
 export default {
   component: TextArea,
   title: "Form/TextArea",
+  args: {
+    maxWidth: "20rem",
+  },
   argTypes: {
     maxWidth: {
       name: "Max Width",
       type: { name: "string", required: true },
-      defaultValue: "20rem",
-      table: {
-        type: { summary: "string" },
-        defaultValue: { summary: "Button Label" },
-      },
       control: {
         type: "text",
       },


### PR DESCRIPTION
Replaces [deprecated](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#no-longer-inferring-default-values-of-args) argType.defaultValue.

`argType.defaultValue` is deprecated and will be removed in Storybook 7.0.