### PR TITLE
Updating README to include required command before step 1

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -1,11 +1,13 @@
 # Laravel Passport
 
+0. Run `composer install` and `npm install` to install dependencies.
+
 1. As with any Laravel application, you should run start by running `php artisan key:generate`.
 
 2. The Passport migrations will create the tables your application needs to store OAuth2 clients and access tokens:
 `php artisan migrate`
 
-3. This command will create the encryption keys needed to generate secure access tokens: `php artisan passport:keys`. They will be created in the storage folder. This command will also create a file called `.rnd`, which can be ignored. (Alternatively, you can define these keys as [environment variables](https://laravel.com/docs/8.x/passport#loading-keys-from-the-environment).) 
+3. This command will create the encryption keys needed to generate secure access tokens: `php artisan passport:keys`. They will be created in the storage folder. This command will also create a file called `.rnd`, which can be ignored. (Alternatively, you can define these keys as [environment variables](https://laravel.com/docs/8.x/passport#loading-keys-from-the-environment).)
 
 4. In order to hash client secrets, the [Personal Access Client](https://laravel.com/docs/8.x/passport#creating-a-personal-access-client) Id and secret must be saved as environment variables. You can generate the id and secret with the following command (it needs a database connection) but you must save them as env variables manually: `php artisan passport:client --personal`
 


### PR DESCRIPTION
One should run  `composer install` (and should also run `npm install`) to install dependencies before php artisan key:generate