### PR TITLE
Add url prefix to admin routes

### DIFF
--- a/admin/routes/web.php
+++ b/admin/routes/web.php
@@ -12,6 +12,7 @@
 | and give it the Closure to call when that URI is requested.
 |
 */
-
-$router->get('/', 'DashboardController@index');
-$router->get('/{any:.*}', 'DashboardController@index');
+$router->group(['prefix' => env('APP_DIR')], function () use ($router) {
+    $router->get('/', 'DashboardController@index');
+    $router->get('/{any:.*}', 'DashboardController@index');
+});


### PR DESCRIPTION
Resolves #421.

It was mostly working, already, because the ASSET_URL env variable was already being used, and because the admin app's only real route right now is a wildcard. But for any non-wildcard routes to work, they should really have the APP_DIR (ie "admin") prefix.