### PR TITLE
Bug/sql injection vul scan 3

### DIFF
--- a/api/app/Models/Classification.php
+++ b/api/app/Models/Classification.php
@@ -23,6 +23,8 @@ class Classification extends Model
 
     use SoftDeletes;
 
+    protected $keyType = 'string';
+
     /**
      * The attributes that should be cast.
      *

--- a/api/app/Models/CmoAsset.php
+++ b/api/app/Models/CmoAsset.php
@@ -21,6 +21,8 @@ class CmoAsset extends Model
 
     use SoftDeletes;
 
+    protected $keyType = 'string';
+
     /**
      * The attributes that should be cast.
      *

--- a/api/app/Models/OperationalRequirement.php
+++ b/api/app/Models/OperationalRequirement.php
@@ -20,6 +20,8 @@ class OperationalRequirement extends Model
 {
     use SoftDeletes;
 
+    protected $keyType = 'string';
+
     /**
      * The attributes that should be cast.
      *

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -25,6 +25,8 @@ class Pool extends Model
     use HasFactory;
     use SoftDeletes;
 
+    protected $keyType = 'string';
+
     /**
      * The attributes that should be cast.
      *

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -34,11 +34,14 @@ class PoolCandidate extends Model
     use HasFactory;
     use SoftDeletes;
 
+    protected $keyType = 'string';
+
     /**
      * The attributes that should be cast.
      *
      * @var array
      */
+
     protected $casts = [
         'expiry_date' => 'date',
         'location_preferences' => 'array',

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -29,6 +29,8 @@ class User extends Model implements Authenticatable
     use SoftDeletes;
     use AuthenticableTrait;
 
+    protected $keyType = 'string';
+
     protected $casts = [
         'roles' => 'array',
     ];

--- a/api/database/migrations/2021_05_05_163948_create_users_table.php
+++ b/api/database/migrations/2021_05_05_163948_create_users_table.php
@@ -14,7 +14,8 @@ class CreateUsersTable extends Migration
     public function up()
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
+            $table->primary('id');
             $table->timestamps();
             $table->string('email')->nullable(false);
             $table->string('first_name')->nullable();
@@ -22,6 +23,7 @@ class CreateUsersTable extends Migration
             $table->string('telephone')->nullable();
             $table->string('preferred_lang')->nullable();
         });
+        DB::statement('ALTER TABLE users ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
     }
 
     /**

--- a/api/database/migrations/2021_05_05_163948_create_users_table.php
+++ b/api/database/migrations/2021_05_05_163948_create_users_table.php
@@ -14,8 +14,7 @@ class CreateUsersTable extends Migration
     public function up()
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->uuid('id');
-            $table->primary('id');
+            $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->string('email')->nullable(false);
             $table->string('first_name')->nullable();

--- a/api/database/migrations/2021_05_05_163948_create_users_table.php
+++ b/api/database/migrations/2021_05_05_163948_create_users_table.php
@@ -22,7 +22,7 @@ class CreateUsersTable extends Migration
             $table->string('telephone')->nullable();
             $table->string('preferred_lang')->nullable();
         });
-        DB::statement('ALTER TABLE users ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
+        DB::statement('ALTER TABLE users ALTER COLUMN id SET DEFAULT gen_random_uuid();');
     }
 
     /**

--- a/api/database/migrations/2021_05_26_195131_create_pools_table.php
+++ b/api/database/migrations/2021_05_26_195131_create_pools_table.php
@@ -14,12 +14,14 @@ class CreatePoolsTable extends Migration
     public function up()
     {
         Schema::create('pools', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
+            $table->primary('id');
             $table->timestamps();
             $table->jsonb('name')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
             $table->jsonb('description')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
             $table->foreignId('user_id');
         });
+        DB::statement('ALTER TABLE pools ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
     }
 
     /**

--- a/api/database/migrations/2021_05_26_195131_create_pools_table.php
+++ b/api/database/migrations/2021_05_26_195131_create_pools_table.php
@@ -20,7 +20,7 @@ class CreatePoolsTable extends Migration
             $table->jsonb('description')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
             $table->foreignId('user_id');
         });
-        DB::statement('ALTER TABLE pools ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
+        DB::statement('ALTER TABLE pools ALTER COLUMN id SET DEFAULT gen_random_uuid();');
     }
 
     /**

--- a/api/database/migrations/2021_05_26_195131_create_pools_table.php
+++ b/api/database/migrations/2021_05_26_195131_create_pools_table.php
@@ -18,7 +18,7 @@ class CreatePoolsTable extends Migration
             $table->timestamps();
             $table->jsonb('name')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
             $table->jsonb('description')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
-            $table->foreignId('user_id');
+            $table->string('user_id', 36)->references('id')->on('users');
         });
         DB::statement('ALTER TABLE pools ALTER COLUMN id SET DEFAULT gen_random_uuid();');
     }

--- a/api/database/migrations/2021_05_26_195131_create_pools_table.php
+++ b/api/database/migrations/2021_05_26_195131_create_pools_table.php
@@ -14,8 +14,7 @@ class CreatePoolsTable extends Migration
     public function up()
     {
         Schema::create('pools', function (Blueprint $table) {
-            $table->uuid('id');
-            $table->primary('id');
+            $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->jsonb('name')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
             $table->jsonb('description')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));

--- a/api/database/migrations/2021_05_27_182801_create_classifications_table.php
+++ b/api/database/migrations/2021_05_27_182801_create_classifications_table.php
@@ -22,7 +22,7 @@ class CreateClassificationsTable extends Migration
             $table->integer('min_salary')->nullable();
             $table->integer('max_salary')->nullable();
         });
-        DB::statement('ALTER TABLE classifications ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
+        DB::statement('ALTER TABLE classifications ALTER COLUMN id SET DEFAULT gen_random_uuid();');
     }
 
     /**

--- a/api/database/migrations/2021_05_27_182801_create_classifications_table.php
+++ b/api/database/migrations/2021_05_27_182801_create_classifications_table.php
@@ -14,7 +14,8 @@ class CreateClassificationsTable extends Migration
     public function up()
     {
         Schema::create('classifications', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
+            $table->primary('id');
             $table->timestamps();
             $table->jsonb('name')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
             $table->string('group')->nullable(false);
@@ -22,6 +23,7 @@ class CreateClassificationsTable extends Migration
             $table->integer('min_salary')->nullable();
             $table->integer('max_salary')->nullable();
         });
+        DB::statement('ALTER TABLE classifications ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
     }
 
     /**

--- a/api/database/migrations/2021_05_27_182801_create_classifications_table.php
+++ b/api/database/migrations/2021_05_27_182801_create_classifications_table.php
@@ -14,8 +14,7 @@ class CreateClassificationsTable extends Migration
     public function up()
     {
         Schema::create('classifications', function (Blueprint $table) {
-            $table->uuid('id');
-            $table->primary('id');
+            $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->jsonb('name')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
             $table->string('group')->nullable(false);

--- a/api/database/migrations/2021_05_27_182826_create_cmo_assets_table.php
+++ b/api/database/migrations/2021_05_27_182826_create_cmo_assets_table.php
@@ -20,7 +20,7 @@ class CreateCmoAssetsTable extends Migration
             $table->jsonb('name')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
             $table->jsonb('description')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
         });
-        DB::statement('ALTER TABLE cmo_assets ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
+        DB::statement('ALTER TABLE cmo_assets ALTER COLUMN id SET DEFAULT gen_random_uuid();');
     }
 
     /**

--- a/api/database/migrations/2021_05_27_182826_create_cmo_assets_table.php
+++ b/api/database/migrations/2021_05_27_182826_create_cmo_assets_table.php
@@ -14,12 +14,14 @@ class CreateCmoAssetsTable extends Migration
     public function up()
     {
         Schema::create('cmo_assets', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
+            $table->primary('id');
             $table->timestamps();
             $table->string('key')->nullable(false);
             $table->jsonb('name')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
             $table->jsonb('description')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
         });
+        DB::statement('ALTER TABLE cmo_assets ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
     }
 
     /**

--- a/api/database/migrations/2021_05_27_182826_create_cmo_assets_table.php
+++ b/api/database/migrations/2021_05_27_182826_create_cmo_assets_table.php
@@ -14,8 +14,7 @@ class CreateCmoAssetsTable extends Migration
     public function up()
     {
         Schema::create('cmo_assets', function (Blueprint $table) {
-            $table->uuid('id');
-            $table->primary('id');
+            $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->string('key')->nullable(false);
             $table->jsonb('name')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));

--- a/api/database/migrations/2021_05_27_182844_create_operational_requirements_table.php
+++ b/api/database/migrations/2021_05_27_182844_create_operational_requirements_table.php
@@ -14,12 +14,14 @@ class CreateOperationalRequirementsTable extends Migration
     public function up()
     {
         Schema::create('operational_requirements', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
+            $table->primary('id');
             $table->timestamps();
             $table->string('key')->nullable(false);
             $table->jsonb('name')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
             $table->jsonb('description')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
         });
+        DB::statement('ALTER TABLE operational_requirements ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
     }
 
     /**

--- a/api/database/migrations/2021_05_27_182844_create_operational_requirements_table.php
+++ b/api/database/migrations/2021_05_27_182844_create_operational_requirements_table.php
@@ -14,8 +14,7 @@ class CreateOperationalRequirementsTable extends Migration
     public function up()
     {
         Schema::create('operational_requirements', function (Blueprint $table) {
-            $table->uuid('id');
-            $table->primary('id');
+            $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->string('key')->nullable(false);
             $table->jsonb('name')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));

--- a/api/database/migrations/2021_05_27_182844_create_operational_requirements_table.php
+++ b/api/database/migrations/2021_05_27_182844_create_operational_requirements_table.php
@@ -20,7 +20,7 @@ class CreateOperationalRequirementsTable extends Migration
             $table->jsonb('name')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
             $table->jsonb('description')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
         });
-        DB::statement('ALTER TABLE operational_requirements ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
+        DB::statement('ALTER TABLE operational_requirements ALTER COLUMN id SET DEFAULT gen_random_uuid();');
     }
 
     /**

--- a/api/database/migrations/2021_05_28_200606_create_pool_lookup_pivot_tables.php
+++ b/api/database/migrations/2021_05_28_200606_create_pool_lookup_pivot_tables.php
@@ -14,32 +14,28 @@ class CreatePoolLookupPivotTables extends Migration
     public function up()
     {
         Schema::create('classification_pool', function (Blueprint $table) {
-            $table->uuid('id');
-            $table->primary('id');
+            $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->foreignId('classification_id');
             $table->foreignId('pool_id');
         });
         DB::statement('ALTER TABLE classification_pool ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
         Schema::create('essential_cmo_asset_pool', function (Blueprint $table) {
-            $table->uuid('id');
-            $table->primary('id');
+            $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->foreignId('cmo_asset_id');
             $table->foreignId('pool_id');
         });
         DB::statement('ALTER TABLE essential_cmo_asset_pool ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
         Schema::create('asset_cmo_asset_pool', function (Blueprint $table) {
-            $table->uuid('id');
-            $table->primary('id');
+            $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->foreignId('cmo_asset_id');
             $table->foreignId('pool_id');
         });
         DB::statement('ALTER TABLE asset_cmo_asset_pool ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
         Schema::create('operational_requirement_pool', function (Blueprint $table) {
-            $table->uuid('id');
-            $table->primary('id');
+            $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->foreignId('operational_requirement_id');
             $table->foreignId('pool_id');

--- a/api/database/migrations/2021_05_28_200606_create_pool_lookup_pivot_tables.php
+++ b/api/database/migrations/2021_05_28_200606_create_pool_lookup_pivot_tables.php
@@ -19,28 +19,28 @@ class CreatePoolLookupPivotTables extends Migration
             $table->foreignId('classification_id');
             $table->foreignId('pool_id');
         });
-        DB::statement('ALTER TABLE classification_pool ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
+        DB::statement('ALTER TABLE classification_pool ALTER COLUMN id SET DEFAULT gen_random_uuid();');
         Schema::create('essential_cmo_asset_pool', function (Blueprint $table) {
             $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->foreignId('cmo_asset_id');
             $table->foreignId('pool_id');
         });
-        DB::statement('ALTER TABLE essential_cmo_asset_pool ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
+        DB::statement('ALTER TABLE essential_cmo_asset_pool ALTER COLUMN id SET DEFAULT gen_random_uuid();');
         Schema::create('asset_cmo_asset_pool', function (Blueprint $table) {
             $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->foreignId('cmo_asset_id');
             $table->foreignId('pool_id');
         });
-        DB::statement('ALTER TABLE asset_cmo_asset_pool ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
+        DB::statement('ALTER TABLE asset_cmo_asset_pool ALTER COLUMN id SET DEFAULT gen_random_uuid();');
         Schema::create('operational_requirement_pool', function (Blueprint $table) {
             $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->foreignId('operational_requirement_id');
             $table->foreignId('pool_id');
         });
-        DB::statement('ALTER TABLE operational_requirement_pool ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
+        DB::statement('ALTER TABLE operational_requirement_pool ALTER COLUMN id SET DEFAULT gen_random_uuid();');
     }
 
     /**

--- a/api/database/migrations/2021_05_28_200606_create_pool_lookup_pivot_tables.php
+++ b/api/database/migrations/2021_05_28_200606_create_pool_lookup_pivot_tables.php
@@ -14,29 +14,37 @@ class CreatePoolLookupPivotTables extends Migration
     public function up()
     {
         Schema::create('classification_pool', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
+            $table->primary('id');
             $table->timestamps();
             $table->foreignId('classification_id');
             $table->foreignId('pool_id');
         });
+        DB::statement('ALTER TABLE classification_pool ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
         Schema::create('essential_cmo_asset_pool', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
+            $table->primary('id');
             $table->timestamps();
             $table->foreignId('cmo_asset_id');
             $table->foreignId('pool_id');
         });
+        DB::statement('ALTER TABLE essential_cmo_asset_pool ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
         Schema::create('asset_cmo_asset_pool', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
+            $table->primary('id');
             $table->timestamps();
             $table->foreignId('cmo_asset_id');
             $table->foreignId('pool_id');
         });
+        DB::statement('ALTER TABLE asset_cmo_asset_pool ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
         Schema::create('operational_requirement_pool', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
+            $table->primary('id');
             $table->timestamps();
             $table->foreignId('operational_requirement_id');
             $table->foreignId('pool_id');
         });
+        DB::statement('ALTER TABLE operational_requirement_pool ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
     }
 
     /**

--- a/api/database/migrations/2021_05_28_200606_create_pool_lookup_pivot_tables.php
+++ b/api/database/migrations/2021_05_28_200606_create_pool_lookup_pivot_tables.php
@@ -16,29 +16,38 @@ class CreatePoolLookupPivotTables extends Migration
         Schema::create('classification_pool', function (Blueprint $table) {
             $table->uuid('id')->primary('id');
             $table->timestamps();
-            $table->foreignId('classification_id');
-            $table->foreignId('pool_id');
+            $table->string('classification_id', 36)->references('id')->on('classifications');
+            $table->string('pool_id', 36)->references('id')->on('pools');
+            // $table->foreignId('classification_id');
+            // $table->foreignId('pool_id');
+
         });
         DB::statement('ALTER TABLE classification_pool ALTER COLUMN id SET DEFAULT gen_random_uuid();');
         Schema::create('essential_cmo_asset_pool', function (Blueprint $table) {
             $table->uuid('id')->primary('id');
             $table->timestamps();
-            $table->foreignId('cmo_asset_id');
-            $table->foreignId('pool_id');
+            // $table->foreignId('cmo_asset_id');
+            // $table->foreignId('pool_id');
+            $table->string('cmo_asset_id', 36)->references('id')->on('cmo_assets');
+            $table->string('pool_id', 36)->references('id')->on('pools');
         });
         DB::statement('ALTER TABLE essential_cmo_asset_pool ALTER COLUMN id SET DEFAULT gen_random_uuid();');
         Schema::create('asset_cmo_asset_pool', function (Blueprint $table) {
             $table->uuid('id')->primary('id');
             $table->timestamps();
-            $table->foreignId('cmo_asset_id');
-            $table->foreignId('pool_id');
+            // $table->foreignId('cmo_asset_id');
+            // $table->foreignId('pool_id');
+            $table->string('cmo_asset_id', 36)->references('id')->on('cmo_assets');
+            $table->string('pool_id', 36)->references('id')->on('pools');
         });
         DB::statement('ALTER TABLE asset_cmo_asset_pool ALTER COLUMN id SET DEFAULT gen_random_uuid();');
         Schema::create('operational_requirement_pool', function (Blueprint $table) {
             $table->uuid('id')->primary('id');
             $table->timestamps();
-            $table->foreignId('operational_requirement_id');
-            $table->foreignId('pool_id');
+            // $table->foreignId('operational_requirement_id');
+            // $table->foreignId('pool_id');
+            $table->string('operational_requirement_id', 36)->references('id')->on('operational_requirements');
+            $table->string('pool_id', 36)->references('id')->on('pools');
         });
         DB::statement('ALTER TABLE operational_requirement_pool ALTER COLUMN id SET DEFAULT gen_random_uuid();');
     }

--- a/api/database/migrations/2021_06_01_140524_create_pool_candidates_table.php
+++ b/api/database/migrations/2021_06_01_140524_create_pool_candidates_table.php
@@ -14,9 +14,9 @@ class CreatePoolCandidatesTable extends Migration
     public function up()
     {
         Schema::create('pool_candidates', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
+            $table->primary('id');
             $table->timestamps();
-
             $table->string('cmo_identifier')->nullable(true);
             $table->date('expiry_date')->nullable(true);
 
@@ -34,24 +34,31 @@ class CreatePoolCandidatesTable extends Migration
             $table->foreignId('pool_id')->nullable(false);
             $table->foreignId('user_id')->nullable(false);
         });
+        DB::statement('ALTER TABLE pool_candidates ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
         Schema::create('operational_requirement_pool_candidate', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
+            $table->primary('id');
             $table->timestamps();
             $table->foreignId('pool_candidate_id')->nullable(false);;
             $table->foreignId('operational_requirement_id')->nullable(false);;
         });
+        DB::statement('ALTER TABLE operational_requirement_pool_candidate ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
         Schema::create('classification_pool_candidate', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
+            $table->primary('id');
             $table->timestamps();
             $table->foreignId('pool_candidate_id')->nullable(false);;
             $table->foreignId('classification_id')->nullable(false);;
         });
+        DB::statement('ALTER TABLE classification_pool_candidate ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
         Schema::create('cmo_asset_pool_candidate', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
+            $table->primary('id');
             $table->timestamps();
             $table->foreignId('pool_candidate_id')->nullable(false);;
             $table->foreignId('cmo_asset_id')->nullable(false);;
         });
+        DB::statement('ALTER TABLE cmo_asset_pool_candidate ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
     }
 
     /**

--- a/api/database/migrations/2021_06_01_140524_create_pool_candidates_table.php
+++ b/api/database/migrations/2021_06_01_140524_create_pool_candidates_table.php
@@ -29,30 +29,29 @@ class CreatePoolCandidatesTable extends Migration
             $table->jsonb('location_preferences')->nullable(true);
             $table->jsonb('expected_salary')->nullable(true);
             $table->string('pool_candidate_status')->nullable(true);
-
-            $table->foreignId('pool_id')->nullable(false);
-            $table->foreignId('user_id')->nullable(false);
+            $table->string('pool_id', 36)->references('id')->on('pools')->nullable(false);
+            $table->string('user_id', 36)->references('id')->on('users')->nullable(false);
         });
         DB::statement('ALTER TABLE pool_candidates ALTER COLUMN id SET DEFAULT gen_random_uuid();');
         Schema::create('operational_requirement_pool_candidate', function (Blueprint $table) {
             $table->uuid('id')->primary('id');
             $table->timestamps();
-            $table->foreignId('pool_candidate_id')->nullable(false);;
-            $table->foreignId('operational_requirement_id')->nullable(false);;
+            $table->string('pool_candidate_id', 36)->references('id')->on('pool_candidates')->nullable(false);
+            $table->string('operational_requirement_id', 36)->references('id')->on('operational_requirements')->nullable(false);
         });
         DB::statement('ALTER TABLE operational_requirement_pool_candidate ALTER COLUMN id SET DEFAULT gen_random_uuid();');
         Schema::create('classification_pool_candidate', function (Blueprint $table) {
             $table->uuid('id')->primary('id');
             $table->timestamps();
-            $table->foreignId('pool_candidate_id')->nullable(false);;
-            $table->foreignId('classification_id')->nullable(false);;
+            $table->string('pool_candidate_id', 36)->references('id')->on('pool_candidates')->nullable(false);
+            $table->string('classification_id', 36)->references('id')->on('classifications')->nullable(false);
         });
         DB::statement('ALTER TABLE classification_pool_candidate ALTER COLUMN id SET DEFAULT gen_random_uuid();');
         Schema::create('cmo_asset_pool_candidate', function (Blueprint $table) {
             $table->uuid('id')->primary('id');
             $table->timestamps();
-            $table->foreignId('pool_candidate_id')->nullable(false);;
-            $table->foreignId('cmo_asset_id')->nullable(false);;
+            $table->string('pool_candidate_id', 36)->references('id')->on('pool_candidates')->nullable(false);
+            $table->string('cmo_asset_id', 36)->references('id')->on('cmo_assets')->nullable(false);
         });
         DB::statement('ALTER TABLE cmo_asset_pool_candidate ALTER COLUMN id SET DEFAULT gen_random_uuid();');
     }

--- a/api/database/migrations/2021_06_01_140524_create_pool_candidates_table.php
+++ b/api/database/migrations/2021_06_01_140524_create_pool_candidates_table.php
@@ -14,8 +14,7 @@ class CreatePoolCandidatesTable extends Migration
     public function up()
     {
         Schema::create('pool_candidates', function (Blueprint $table) {
-            $table->uuid('id');
-            $table->primary('id');
+            $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->string('cmo_identifier')->nullable(true);
             $table->date('expiry_date')->nullable(true);
@@ -36,24 +35,21 @@ class CreatePoolCandidatesTable extends Migration
         });
         DB::statement('ALTER TABLE pool_candidates ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
         Schema::create('operational_requirement_pool_candidate', function (Blueprint $table) {
-            $table->uuid('id');
-            $table->primary('id');
+            $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->foreignId('pool_candidate_id')->nullable(false);;
             $table->foreignId('operational_requirement_id')->nullable(false);;
         });
         DB::statement('ALTER TABLE operational_requirement_pool_candidate ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
         Schema::create('classification_pool_candidate', function (Blueprint $table) {
-            $table->uuid('id');
-            $table->primary('id');
+            $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->foreignId('pool_candidate_id')->nullable(false);;
             $table->foreignId('classification_id')->nullable(false);;
         });
         DB::statement('ALTER TABLE classification_pool_candidate ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
         Schema::create('cmo_asset_pool_candidate', function (Blueprint $table) {
-            $table->uuid('id');
-            $table->primary('id');
+            $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->foreignId('pool_candidate_id')->nullable(false);;
             $table->foreignId('cmo_asset_id')->nullable(false);;

--- a/api/database/migrations/2021_06_01_140524_create_pool_candidates_table.php
+++ b/api/database/migrations/2021_06_01_140524_create_pool_candidates_table.php
@@ -33,28 +33,28 @@ class CreatePoolCandidatesTable extends Migration
             $table->foreignId('pool_id')->nullable(false);
             $table->foreignId('user_id')->nullable(false);
         });
-        DB::statement('ALTER TABLE pool_candidates ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
+        DB::statement('ALTER TABLE pool_candidates ALTER COLUMN id SET DEFAULT gen_random_uuid();');
         Schema::create('operational_requirement_pool_candidate', function (Blueprint $table) {
             $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->foreignId('pool_candidate_id')->nullable(false);;
             $table->foreignId('operational_requirement_id')->nullable(false);;
         });
-        DB::statement('ALTER TABLE operational_requirement_pool_candidate ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
+        DB::statement('ALTER TABLE operational_requirement_pool_candidate ALTER COLUMN id SET DEFAULT gen_random_uuid();');
         Schema::create('classification_pool_candidate', function (Blueprint $table) {
             $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->foreignId('pool_candidate_id')->nullable(false);;
             $table->foreignId('classification_id')->nullable(false);;
         });
-        DB::statement('ALTER TABLE classification_pool_candidate ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
+        DB::statement('ALTER TABLE classification_pool_candidate ALTER COLUMN id SET DEFAULT gen_random_uuid();');
         Schema::create('cmo_asset_pool_candidate', function (Blueprint $table) {
             $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->foreignId('pool_candidate_id')->nullable(false);;
             $table->foreignId('cmo_asset_id')->nullable(false);;
         });
-        DB::statement('ALTER TABLE cmo_asset_pool_candidate ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
+        DB::statement('ALTER TABLE cmo_asset_pool_candidate ALTER COLUMN id SET DEFAULT gen_random_uuid();');
     }
 
     /**

--- a/infrastructure/db/init.sh
+++ b/infrastructure/db/init.sh
@@ -1,0 +1,1 @@
+psql gctalent --username postgres -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'

--- a/infrastructure/db/init.sh
+++ b/infrastructure/db/init.sh
@@ -1,1 +1,0 @@
-psql gctalent --username postgres -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'


### PR DESCRIPTION
Resolves #389

Adding migration to change column type to string in the DB (which GraphQL was already assuming was the case).

Everyone will be required to
1. Rebuild postgres container (to have the init.sh script run to add in uuid support)
2. Re-run migrations from scratch after this change. Previous migrations were modified.