### PR TITLE
Update departments table id column type to uuid

### DIFF
--- a/api/database/migrations/2021_09_13_180950_create_departments_table.php
+++ b/api/database/migrations/2021_09_13_180950_create_departments_table.php
@@ -14,12 +14,13 @@ class CreateDepartmentsTable extends Migration
     public function up()
     {
         Schema::create('departments', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id')->primary('id');
             $table->timestamps();
             $table->integer('department_number')->unique();
             $table->jsonb('name')->nullable(false)->default(json_encode(['en' => '', 'fr' => '']));
             $table->softDeletes();
         });
+        DB::statement('ALTER TABLE departments ALTER COLUMN id SET DEFAULT gen_random_uuid();');
     }
 
     /**


### PR DESCRIPTION
Resolves #503.

In the `infrastructure` folder, run the following so that the departments table gets the new column type change and uuid values:
```
docker-compose exec -w /var/www/html/api php sh -c "php artisan migrate:fresh"
docker-compose exec -w /var/www/html/api php sh -c "php artisan db:seed"
```