### PR TITLE
Bugfix - Omit capture attribute from input props (Radio, Input, Checkbox)

### DIFF
--- a/common/src/components/form/Checkbox/Checkbox.tsx
+++ b/common/src/components/form/Checkbox/Checkbox.tsx
@@ -4,7 +4,7 @@ import { RegisterOptions, useFormContext } from "react-hook-form";
 import { InputWrapper } from "../../inputPartials";
 
 export interface CheckboxProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> {
+  extends Omit<React.HTMLProps<HTMLInputElement>, "capture" | "type"> {
   /** HTML id used to identify the element. */
   id: string;
   /** Holds text for the label associated with the input element */

--- a/common/src/components/form/Input/Input.tsx
+++ b/common/src/components/form/Input/Input.tsx
@@ -4,7 +4,10 @@ import { RegisterOptions, useFormContext } from "react-hook-form";
 import { InputWrapper } from "../../inputPartials";
 
 export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "capture" | "type"
+  > {
   /** HTML id used to identify the element. */
   id: string;
   /** Optional context which user can view by toggling a button. */

--- a/common/src/components/form/Radio/Radio.tsx
+++ b/common/src/components/form/Radio/Radio.tsx
@@ -4,7 +4,10 @@ import { RegisterOptions, useFormContext } from "react-hook-form";
 import { InputWrapper } from "../../inputPartials";
 
 export interface RadioProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> {
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "capture" | "type"
+  > {
   /** HTML id used to identify the element. */
   id: string;
   /** Holds text for the label associated with the input element */


### PR DESCRIPTION
Ran into this error right now with typescript complaining that the `capture` attribute does not exist on the input element. I omitted it for now since the attribute isn't something we need/will need.

![image](https://user-images.githubusercontent.com/22059495/134584866-77194c78-478b-4959-9c2a-8b47c8568f49.png)
