### PR TITLE
Change wildcard url to use Laravel format

### DIFF
--- a/admin/routes/web.php
+++ b/admin/routes/web.php
@@ -20,5 +20,5 @@ Route::prefix(config('app.app_dir'))->group(function () {
     Route::get('/auth-callback', [AuthController::class, 'authCallback']);
 
     Route::get('/', [DashboardController::class, 'index']);
-    Route::get('/{any:.*}', [DashboardController::class, 'index']);
+    Route::get('/{any}', [DashboardController::class, 'index'])->where('any', '.*');
 });


### PR DESCRIPTION
Resolves #726

Lumen used a different format for wildcard routes, it was no longer working after upgrading the project to Laravel.