### PR TITLE
Add 'key' field to Pools

### DIFF
--- a/admin/resources/js/api/generated.ts
+++ b/admin/resources/js/api/generated.ts
@@ -139,9 +139,10 @@ export type CreatePoolInput = {
   classifications?: Maybe<ClassificationBelongsToMany>;
   description?: Maybe<LocalizedStringInput>;
   essentialCriteria?: Maybe<CmoAssetBelongsToMany>;
-  name?: Maybe<LocalizedStringInput>;
+  key: Scalars["String"];
+  name: LocalizedStringInput;
   operationalRequirements?: Maybe<OperationalRequirementBelongsToMany>;
-  owner?: Maybe<UserBelongsTo>;
+  owner: UserBelongsTo;
 };
 
 /** When creating a User, name and email are required. */
@@ -388,6 +389,7 @@ export type Pool = {
   description?: Maybe<LocalizedString>;
   essentialCriteria?: Maybe<Array<Maybe<CmoAsset>>>;
   id: Scalars["ID"];
+  key?: Maybe<Scalars["String"]>;
   name?: Maybe<LocalizedString>;
   operationalRequirements?: Maybe<Array<Maybe<OperationalRequirement>>>;
   owner?: Maybe<User>;
@@ -2168,6 +2170,7 @@ export type UpdatePoolCandidateMutation = {
 export type PoolFragment = {
   __typename?: "Pool";
   id: string;
+  key?: string | null | undefined;
   owner?:
     | {
         __typename?: "User";
@@ -2280,6 +2283,7 @@ export type GetPoolQuery = {
     | {
         __typename?: "Pool";
         id: string;
+        key?: string | null | undefined;
         owner?:
           | {
               __typename?: "User";
@@ -2499,6 +2503,7 @@ export type GetUpdatePoolDataQuery = {
     | {
         __typename?: "Pool";
         id: string;
+        key?: string | null | undefined;
         owner?:
           | {
               __typename?: "User";
@@ -2612,6 +2617,7 @@ export type GetPoolsQuery = {
     | {
         __typename?: "Pool";
         id: string;
+        key?: string | null | undefined;
         owner?:
           | { __typename?: "User"; id: string; email: string }
           | null
@@ -2655,6 +2661,7 @@ export type CreatePoolMutation = {
   createPool?:
     | {
         __typename?: "Pool";
+        key?: string | null | undefined;
         owner?: { __typename?: "User"; id: string } | null | undefined;
         name?:
           | {
@@ -2728,6 +2735,7 @@ export type UpdatePoolMutation = {
   updatePool?:
     | {
         __typename?: "Pool";
+        key?: string | null | undefined;
         owner?: { __typename?: "User"; id: string } | null | undefined;
         name?:
           | {
@@ -3009,6 +3017,7 @@ export const PoolFragmentDoc = gql`
       en
       fr
     }
+    key
     description {
       en
       fr
@@ -3779,6 +3788,7 @@ export const GetPoolsDocument = gql`
         en
         fr
       }
+      key
       description {
         en
         fr
@@ -3806,6 +3816,7 @@ export const CreatePoolDocument = gql`
         en
         fr
       }
+      key
       description {
         en
         fr
@@ -3846,6 +3857,7 @@ export const UpdatePoolDocument = gql`
         en
         fr
       }
+      key
       description {
         en
         fr

--- a/admin/resources/js/api/poolOperations.graphql
+++ b/admin/resources/js/api/poolOperations.graphql
@@ -12,6 +12,7 @@ fragment pool on Pool {
     en
     fr
   }
+  key
   description {
     en
     fr
@@ -129,6 +130,7 @@ query getPools {
       en
       fr
     }
+    key
     description {
       en
       fr
@@ -149,6 +151,7 @@ mutation createPool($pool: CreatePoolInput!) {
       en
       fr
     }
+    key
     description {
       en
       fr
@@ -182,6 +185,7 @@ mutation updatePool($id: ID!, $pool: UpdatePoolInput!) {
       en
       fr
     }
+    key
     description {
       en
       fr

--- a/admin/resources/js/components/pool/CreatePool.tsx
+++ b/admin/resources/js/components/pool/CreatePool.tsx
@@ -30,7 +30,12 @@ import DashboardContentContainer from "../DashboardContentContainer";
 
 type Option<V> = { value: V; label: string };
 
-type FormValues = Pick<Pool, "name" | "description"> & {
+type FormValues = Pick<Pool, "description"> & {
+  key: string;
+  name: {
+    en: string;
+    fr: string;
+  };
   assetCriteria: string[] | undefined;
   classifications: string[] | undefined;
   essentialCriteria: string[] | undefined;

--- a/admin/resources/js/components/pool/CreatePool.tsx
+++ b/admin/resources/js/components/pool/CreatePool.tsx
@@ -143,6 +143,20 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
               type="text"
               rules={{ required: errorMessages.required }}
             />
+            <Input
+              id="key"
+              name="key"
+              label={intl.formatMessage(messages.keyLabel)}
+              context={intl.formatMessage(messages.keyContext)}
+              type="text"
+              rules={{
+                required: errorMessages.required,
+                pattern: {
+                  value: /^[a-z]+(_[a-z]+)*$/,
+                  message: intl.formatMessage(messages.keyPattern),
+                },
+              }}
+            />
             <TextArea
               id="description_en"
               name="description.en"

--- a/admin/resources/js/components/pool/PoolTable.tsx
+++ b/admin/resources/js/components/pool/PoolTable.tsx
@@ -19,6 +19,10 @@ const messages = defineMessages({
     defaultMessage: "Pool Name",
     description: "Title displayed for the Pool table pool name column.",
   },
+  columnPoolKey: {
+    defaultMessage: "Key",
+    description: "Title displayed for the Pool table key column.",
+  },
   columnPoolDescription: {
     defaultMessage: "Pool Description",
     description: "Title displayed for the Pool table pool description column.",
@@ -49,6 +53,10 @@ export const PoolTable: React.FC<GetPoolsQuery & { editUrlRoot: string }> = ({
       {
         Header: intl.formatMessage(messages.columnUniqueIdentifier),
         accessor: "id",
+      },
+      {
+        Header: intl.formatMessage(messages.columnPoolKey),
+        accessor: "key",
       },
       {
         Header: intl.formatMessage(messages.columnPoolName),

--- a/admin/resources/js/components/pool/messages.ts
+++ b/admin/resources/js/components/pool/messages.ts
@@ -25,6 +25,19 @@ export default defineMessages({
     defaultMessage: "Name (French):",
     description: "Label displayed on the pool form name (French) field.",
   },
+  keyLabel: {
+    defaultMessage: "Key:",
+    description: "Label displayed on the 'key' input field.",
+  },
+  keyContext: {
+    defaultMessage:
+      "The 'key' is a string that uniquely identifies a Pool. It should be based on the Pool's english name, and be descriptive but concise. A good example would be \"digial_careers\". It may be used in the code to specify this particular Pool, so it cannot be changed later.",
+    description:
+      "Additional context describing the purpose of the Pool's 'key' field.",
+  },
+  keyPattern: {
+    defaultMessage: "Please use only lowercase letters and underscores",
+  },
   descriptionLabelEn: {
     defaultMessage: "Description (English):",
     description:

--- a/admin/resources/js/components/pool/messages.ts
+++ b/admin/resources/js/components/pool/messages.ts
@@ -31,7 +31,7 @@ export default defineMessages({
   },
   keyContext: {
     defaultMessage:
-      "The 'key' is a string that uniquely identifies a Pool. It should be based on the Pool's english name, and be descriptive but concise. A good example would be \"digial_careers\". It may be used in the code to specify this particular Pool, so it cannot be changed later.",
+      "The 'key' is a string that uniquely identifies a Pool. It should be based on the Pool's english name, and it should be concise. A good example would be \"digial_careers\". It may be used in the code to refer to this particular Pool, so it cannot be changed later.",
     description:
       "Additional context describing the purpose of the Pool's 'key' field.",
   },

--- a/admin/resources/js/components/user/UpdateUser.tsx
+++ b/admin/resources/js/components/user/UpdateUser.tsx
@@ -59,6 +59,7 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
               name="email"
               value={initialUser.email}
               disabled
+              hideOptional
             />
             <Input
               id="firstName"

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  *
  * @property int $id
  * @property array $name
+ * @property string $key
  * @property array $description
  * @property int $user_id
  * @property Illuminate\Support\Carbon $created_at

--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -28,6 +28,7 @@ class PoolFactory extends Factory
         $name = $this->faker->company();
         return [
             'name' => ['en' => $name, 'fr' => $name],
+            'key' => strtolower(preg_replace('/\s+/', '_', $name)),
             'description' => ['en' => $this->faker->paragraph(), 'fr' => $this->faker->paragraph()],
             'user_id' => User::factory(),
         ];

--- a/api/database/migrations/2021_11_02_142947_update_pools_table_with_key_column.php
+++ b/api/database/migrations/2021_11_02_142947_update_pools_table_with_key_column.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class UpdatePoolsTableWithKeyColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Initially allow key to be nullable, so it can be initialized to match the en name.
+        Schema::table('pools', function (Blueprint $table) {
+            $table->string('key')->nullable(true)->unique();
+        });
+        DB::statement("UPDATE pools SET key = name->>'en'");
+        // After initializing keys, make them not nullable.
+        Schema::table('pools', function (Blueprint $table) {
+            $table->string('key')->nullable(false)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('pools', function (Blueprint $table) {
+            $table->dropColumn('key');
+        });
+    }
+}

--- a/api/database/seeders/PoolSeeder.php
+++ b/api/database/seeders/PoolSeeder.php
@@ -19,9 +19,10 @@ class PoolSeeder extends Seeder
         $pools = [
             [
                 'name' => [
-                    'en' => 'CMO',
-                    'fr' => 'CMO'
+                    'en' => 'CMO Digital Careers',
+                    'fr' => 'CMO Carrières Numériques'
                 ],
+                'key' => 'digital_careers',
                 'user_id' => User::where('email', 'admin@test.com')->first()->id,
             ],
             [
@@ -29,6 +30,7 @@ class PoolSeeder extends Seeder
                     'en' => 'Indigenous Apprenticeship Program',
                     'fr' => 'Indigenous Apprenticeship Program FR'
                 ],
+                'key' => 'indigenous_apprenticeship',
                 'user_id' => User::where('email', 'admin@test.com')->first()->id,
             ],
         ];

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -41,6 +41,7 @@ type Pool {
     id: ID!
     owner: User @belongsTo(relation: "user")
     name: LocalizedString
+    key: String
     description: LocalizedString
     classifications: [Classification] @belongsToMany
     assetCriteria: [CmoAsset] @belongsToMany
@@ -328,8 +329,9 @@ input PoolCandidateHasMany {
 }
 
 input CreatePoolInput {
-    owner: UserBelongsTo @rename(attribute: "user")
-    name: LocalizedStringInput
+    owner: UserBelongsTo! @rename(attribute: "user")
+    name: LocalizedStringInput!
+    key: String!
     description: LocalizedStringInput
     classifications: ClassificationBelongsToMany
     assetCriteria: CmoAssetBelongsToMany

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -98,8 +98,9 @@ input CreatePoolCandidateSearchRequestInput {
 }
 
 input CreatePoolInput {
-  owner: UserBelongsTo
-  name: LocalizedStringInput
+  owner: UserBelongsTo!
+  name: LocalizedStringInput!
+  key: String!
   description: LocalizedStringInput
   classifications: ClassificationBelongsToMany
   assetCriteria: CmoAssetBelongsToMany
@@ -280,6 +281,7 @@ type Pool {
   id: ID!
   owner: User
   name: LocalizedString
+  key: String
   description: LocalizedString
   classifications: [Classification]
   assetCriteria: [CmoAsset]

--- a/common/src/api/generated.ts
+++ b/common/src/api/generated.ts
@@ -139,9 +139,10 @@ export type CreatePoolInput = {
   classifications?: Maybe<ClassificationBelongsToMany>;
   description?: Maybe<LocalizedStringInput>;
   essentialCriteria?: Maybe<CmoAssetBelongsToMany>;
-  name?: Maybe<LocalizedStringInput>;
+  key: Scalars["String"];
+  name: LocalizedStringInput;
   operationalRequirements?: Maybe<OperationalRequirementBelongsToMany>;
-  owner?: Maybe<UserBelongsTo>;
+  owner: UserBelongsTo;
 };
 
 /** When creating a User, name and email are required. */
@@ -388,6 +389,7 @@ export type Pool = {
   description?: Maybe<LocalizedString>;
   essentialCriteria?: Maybe<Array<Maybe<CmoAsset>>>;
   id: Scalars["ID"];
+  key?: Maybe<Scalars["String"]>;
   name?: Maybe<LocalizedString>;
   operationalRequirements?: Maybe<Array<Maybe<OperationalRequirement>>>;
   owner?: Maybe<User>;
@@ -2168,6 +2170,7 @@ export type UpdatePoolCandidateMutation = {
 export type PoolFragment = {
   __typename?: "Pool";
   id: string;
+  key?: string | null | undefined;
   owner?:
     | {
         __typename?: "User";
@@ -2280,6 +2283,7 @@ export type GetPoolQuery = {
     | {
         __typename?: "Pool";
         id: string;
+        key?: string | null | undefined;
         owner?:
           | {
               __typename?: "User";
@@ -2499,6 +2503,7 @@ export type GetUpdatePoolDataQuery = {
     | {
         __typename?: "Pool";
         id: string;
+        key?: string | null | undefined;
         owner?:
           | {
               __typename?: "User";
@@ -2612,6 +2617,7 @@ export type GetPoolsQuery = {
     | {
         __typename?: "Pool";
         id: string;
+        key?: string | null | undefined;
         owner?:
           | { __typename?: "User"; id: string; email: string }
           | null
@@ -2655,6 +2661,7 @@ export type CreatePoolMutation = {
   createPool?:
     | {
         __typename?: "Pool";
+        key?: string | null | undefined;
         owner?: { __typename?: "User"; id: string } | null | undefined;
         name?:
           | {
@@ -2728,6 +2735,7 @@ export type UpdatePoolMutation = {
   updatePool?:
     | {
         __typename?: "Pool";
+        key?: string | null | undefined;
         owner?: { __typename?: "User"; id: string } | null | undefined;
         name?:
           | {
@@ -3454,6 +3462,7 @@ export const PoolFragmentDoc = gql`
       en
       fr
     }
+    key
     description {
       en
       fr
@@ -4272,6 +4281,7 @@ export const GetPoolsDocument = gql`
         en
         fr
       }
+      key
       description {
         en
         fr
@@ -4299,6 +4309,7 @@ export const CreatePoolDocument = gql`
         en
         fr
       }
+      key
       description {
         en
         fr
@@ -4339,6 +4350,7 @@ export const UpdatePoolDocument = gql`
         en
         fr
       }
+      key
       description {
         en
         fr

--- a/common/src/components/form/Input/Input.tsx
+++ b/common/src/components/form/Input/Input.tsx
@@ -20,6 +20,8 @@ export interface InputProps
   rules?: RegisterOptions;
   /** Set the type of the input. */
   type: "text" | "number" | "email" | "tel" | "password" | "date";
+  /** If input is not required, hide the 'Optional' label */
+  hideOptional?: boolean;
 }
 
 export const Input: React.FunctionComponent<InputProps> = ({
@@ -29,6 +31,7 @@ export const Input: React.FunctionComponent<InputProps> = ({
   name,
   rules = {},
   type,
+  hideOptional,
   ...rest
 }) => {
   const {
@@ -46,6 +49,7 @@ export const Input: React.FunctionComponent<InputProps> = ({
         required={!!rules.required}
         context={context}
         error={error}
+        hideOptional={hideOptional}
       >
         <input
           data-h2-padding="b(all, xxs)"

--- a/talentsearch/resources/js/api/generated.ts
+++ b/talentsearch/resources/js/api/generated.ts
@@ -139,9 +139,10 @@ export type CreatePoolInput = {
   classifications?: Maybe<ClassificationBelongsToMany>;
   description?: Maybe<LocalizedStringInput>;
   essentialCriteria?: Maybe<CmoAssetBelongsToMany>;
-  name?: Maybe<LocalizedStringInput>;
+  key: Scalars["String"];
+  name: LocalizedStringInput;
   operationalRequirements?: Maybe<OperationalRequirementBelongsToMany>;
-  owner?: Maybe<UserBelongsTo>;
+  owner: UserBelongsTo;
 };
 
 /** When creating a User, name and email are required. */
@@ -388,6 +389,7 @@ export type Pool = {
   description?: Maybe<LocalizedString>;
   essentialCriteria?: Maybe<Array<Maybe<CmoAsset>>>;
   id: Scalars["ID"];
+  key?: Maybe<Scalars["String"]>;
   name?: Maybe<LocalizedString>;
   operationalRequirements?: Maybe<Array<Maybe<OperationalRequirement>>>;
   owner?: Maybe<User>;


### PR DESCRIPTION
Resolves #1008 

This ~can~must now be set when a Pool is created. It's more descriptive than a UUID, making it easier to refer to in code to specify a particular pool (eg on the talentsearch page).