### PR TITLE
Add KeyString scalar to backend-validate keys

### DIFF
--- a/api/app/GraphQL/Scalars/KeyString.php
+++ b/api/app/GraphQL/Scalars/KeyString.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\GraphQL\Scalars;
+
+use MLL\GraphQLScalars\Regex;
+
+/**
+ * Read more about scalars here https://webonyx.github.io/graphql-php/type-definitions/scalars
+ */
+class KeyString extends Regex
+{
+    /**
+     * The description that is used for schema introspection.
+     *
+     * @var string
+     */
+    public $description = <<<'DESCRIPTION'
+    Certain models, like our lookup tables, have a "key" field.
+    This is meant to act similar to an ID, but be human readable, and allow for code to reference particular items in special circumstance.
+DESCRIPTION;
+
+    public static function regex(): string
+    {
+        return '/^[a-z]+(_[a-z]+)*$/';
+    }
+}

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -10,6 +10,9 @@ scalar Email @scalar(class: "MLL\\GraphQLScalars\\Email")
 "A phone number string which must comply with E.164 international notation, including country code and preceding '+'."
 scalar PhoneNumber
 
+"A human readable ID"
+scalar KeyString
+
 type LocalizedString {
     en: String
     fr: String
@@ -41,7 +44,7 @@ type Pool {
     id: ID!
     owner: User @belongsTo(relation: "user")
     name: LocalizedString
-    key: String
+    key: KeyString
     description: LocalizedString
     classifications: [Classification] @belongsToMany
     assetCriteria: [CmoAsset] @belongsToMany
@@ -105,7 +108,7 @@ e.g. Overtime as Required, Shift Work, Travel as Required, etc.
 """
 type OperationalRequirement {
     id: ID!
-    key: String!
+    key: KeyString!
     name: LocalizedString!
     description: LocalizedString
 }
@@ -133,7 +136,7 @@ e.g. Application Development, Quality Assurance, Enterprise Architecture, IT Pro
 """
 type CmoAsset {
     id: ID!
-    key: String!
+    key: KeyString!
     name: LocalizedString!
     description: LocalizedString
 }
@@ -183,7 +186,7 @@ input ClassificationFilterInput {
 }
 
 input KeyFilterInput {
-    key: String!
+    key: KeyString!
 }
 
 input PoolFilterInput {
@@ -287,7 +290,7 @@ input ClassificationBelongsToMany {
 }
 
 input CreateCmoAssetInput {
-    key: String!
+    key: KeyString!
     name: LocalizedStringInput!
     description: LocalizedStringInput
 }
@@ -297,7 +300,7 @@ input CmoAssetBelongsToMany {
 }
 
 input CreateOperationalRequirementInput {
-    key: String!
+    key: KeyString!
     name: LocalizedStringInput!
     description: LocalizedStringInput
 }
@@ -332,7 +335,7 @@ input PoolCandidateHasMany {
 input CreatePoolInput {
     owner: UserBelongsTo! @rename(attribute: "user")
     name: LocalizedStringInput!
-    key: String!
+    key: KeyString!
     description: LocalizedStringInput
     classifications: ClassificationBelongsToMany
     assetCriteria: CmoAssetBelongsToMany

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -21,7 +21,7 @@ e.g. Application Development, Quality Assurance, Enterprise Architecture, IT Pro
 """
 type CmoAsset {
   id: ID!
-  key: String!
+  key: KeyString!
   name: LocalizedString!
   description: LocalizedString
 }
@@ -39,7 +39,7 @@ input CreateClassificationInput {
 }
 
 input CreateCmoAssetInput {
-  key: String!
+  key: KeyString!
   name: LocalizedStringInput!
   description: LocalizedStringInput
 }
@@ -50,7 +50,7 @@ input CreateDepartmentInput {
 }
 
 input CreateOperationalRequirementInput {
-  key: String!
+  key: KeyString!
   name: LocalizedStringInput!
   description: LocalizedStringInput
 }
@@ -100,7 +100,7 @@ input CreatePoolCandidateSearchRequestInput {
 input CreatePoolInput {
   owner: UserBelongsTo!
   name: LocalizedStringInput!
-  key: String!
+  key: KeyString!
   description: LocalizedStringInput
   classifications: ClassificationBelongsToMany
   assetCriteria: CmoAssetBelongsToMany
@@ -140,8 +140,11 @@ input DepartmentBelongsTo {
 scalar Email
 
 input KeyFilterInput {
-  key: String!
+  key: KeyString!
 }
+
+"""A human readable ID"""
+scalar KeyString
 
 enum Language {
   EN
@@ -200,7 +203,7 @@ type Mutation {
 """e.g. Overtime as Required, Shift Work, Travel as Required, etc."""
 type OperationalRequirement {
   id: ID!
-  key: String!
+  key: KeyString!
   name: LocalizedString!
   description: LocalizedString
 }
@@ -281,7 +284,7 @@ type Pool {
   id: ID!
   owner: User
   name: LocalizedString
-  key: String
+  key: KeyString
   description: LocalizedString
   classifications: [Classification]
   assetCriteria: [CmoAsset]


### PR DESCRIPTION
This PR adds a KeyString scalar type to the GraphQL schema and updates the types of the key fields from String to KeyString.  The API service will now validate the keys with the same regex used in the frontend to ensure that valid strings are used for the keys.

Solves #1084  