### PR TITLE
Localize form validation error messages

### DIFF
--- a/admin/resources/js/components/classification/CreateClassification.tsx
+++ b/admin/resources/js/components/classification/CreateClassification.tsx
@@ -19,112 +19,115 @@ interface CreateClassificationFormProps {
   handleCreateClassification: (data: FormValues) => Promise<FormValues>;
 }
 
-export const CreateClassificationForm: React.FunctionComponent<CreateClassificationFormProps> =
-  ({ handleCreateClassification }) => {
-    const intl = useIntl();
-    const methods = useForm<FormValues>();
-    const { handleSubmit, watch } = methods;
-    const watchMinSalary = watch("minSalary");
+export const CreateClassificationForm: React.FunctionComponent<
+  CreateClassificationFormProps
+> = ({ handleCreateClassification }) => {
+  const intl = useIntl();
+  const methods = useForm<FormValues>();
+  const { handleSubmit, watch } = methods;
+  const watchMinSalary = watch("minSalary");
 
-    const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
-      const classification: FormValues = {
-        ...data,
-        group: upperCase(data.group),
-        level: Number(data.level),
-        minSalary: Number(data.minSalary),
-        maxSalary: Number(data.maxSalary),
-      };
-      return handleCreateClassification(classification)
-        .then(() => {
-          navigate(classificationTablePath());
-          toast.success(intl.formatMessage(messages.createSuccess));
-        })
-        .catch(() => {
-          toast.error(intl.formatMessage(messages.createError));
-        });
+  const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
+    const classification: FormValues = {
+      ...data,
+      group: upperCase(data.group),
+      level: Number(data.level),
+      minSalary: Number(data.minSalary),
+      maxSalary: Number(data.maxSalary),
     };
-    return (
-      <section>
-        <h2 data-h2-text-align="b(center)" data-h2-margin="b(top, none)">
-          {intl.formatMessage(messages.createHeading)}
-        </h2>
-        <div data-h2-container="b(center, s)">
-          <FormProvider {...methods}>
-            <form onSubmit={handleSubmit(onSubmit)}>
-              <Input
-                id="name_en"
-                name="name.en"
-                label={intl.formatMessage(messages.nameEnLabel)}
-                type="text"
-                rules={{ required: intl.formatMessage(errorMessages.required) }}
-              />
-              <Input
-                id="name_fr"
-                name="name.fr"
-                label={intl.formatMessage(messages.nameFrLabel)}
-                type="text"
-                rules={{ required: intl.formatMessage(errorMessages.required) }}
-              />
-              <Input
-                id="group"
-                name="group"
-                label={intl.formatMessage(messages.groupLabel)}
-                type="text"
-                rules={{ required: intl.formatMessage(errorMessages.required) }}
-              />
-              <Select
-                id="level"
-                name="level"
-                label={intl.formatMessage(messages.levelLabel)}
-                nullSelection={intl.formatMessage(messages.levelPlaceholder)}
-                rules={{ required: intl.formatMessage(errorMessages.required) }}
-                options={[
-                  { value: 1, label: "1" },
-                  { value: 2, label: "2" },
-                  { value: 3, label: "3" },
-                  { value: 4, label: "4" },
-                  { value: 5, label: "5" },
-                  { value: 6, label: "6" },
-                  { value: 7, label: "7" },
-                  { value: 8, label: "8" },
-                  { value: 9, label: "9" },
-                ]}
-              />
-              <Input
-                id="minSalary"
-                name="minSalary"
-                label={intl.formatMessage(messages.minSalaryLabel)}
-                type="number"
-                rules={{
-                  required: intl.formatMessage(errorMessages.required),
-                  min: {
-                    value: 0,
-                    message: `${errorMessages.mustBeGreater} 0`,
-                  },
-                }}
-              />
-              <Input
-                id="maxSalary"
-                name="maxSalary"
-                label={intl.formatMessage(messages.maxSalaryLabel)}
-                type="number"
-                rules={{
-                  required: intl.formatMessage(errorMessages.required),
-                  min: {
-                    value: watchMinSalary || 0,
-                    message: `${errorMessages.mustBeGreater} ${
-                      watchMinSalary || 0
-                    }`,
-                  },
-                }}
-              />
-              <Submit />
-            </form>
-          </FormProvider>
-        </div>
-      </section>
-    );
+    return handleCreateClassification(classification)
+      .then(() => {
+        navigate(classificationTablePath());
+        toast.success(intl.formatMessage(messages.createSuccess));
+      })
+      .catch(() => {
+        toast.error(intl.formatMessage(messages.createError));
+      });
   };
+  return (
+    <section>
+      <h2 data-h2-text-align="b(center)" data-h2-margin="b(top, none)">
+        {intl.formatMessage(messages.createHeading)}
+      </h2>
+      <div data-h2-container="b(center, s)">
+        <FormProvider {...methods}>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <Input
+              id="name_en"
+              name="name.en"
+              label={intl.formatMessage(messages.nameEnLabel)}
+              type="text"
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
+            />
+            <Input
+              id="name_fr"
+              name="name.fr"
+              label={intl.formatMessage(messages.nameFrLabel)}
+              type="text"
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
+            />
+            <Input
+              id="group"
+              name="group"
+              label={intl.formatMessage(messages.groupLabel)}
+              type="text"
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
+            />
+            <Select
+              id="level"
+              name="level"
+              label={intl.formatMessage(messages.levelLabel)}
+              nullSelection={intl.formatMessage(messages.levelPlaceholder)}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
+              options={[
+                { value: 1, label: "1" },
+                { value: 2, label: "2" },
+                { value: 3, label: "3" },
+                { value: 4, label: "4" },
+                { value: 5, label: "5" },
+                { value: 6, label: "6" },
+                { value: 7, label: "7" },
+                { value: 8, label: "8" },
+                { value: 9, label: "9" },
+              ]}
+            />
+            <Input
+              id="minSalary"
+              name="minSalary"
+              label={intl.formatMessage(messages.minSalaryLabel)}
+              type="number"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+                min: {
+                  value: 0,
+                  message: intl.formatMessage(errorMessages.mustBeGreater, {
+                    value: 0,
+                  }),
+                },
+              }}
+            />
+            <Input
+              id="maxSalary"
+              name="maxSalary"
+              label={intl.formatMessage(messages.maxSalaryLabel)}
+              type="number"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+                min: {
+                  value: watchMinSalary || 0,
+                  message: intl.formatMessage(errorMessages.mustBeGreater, {
+                    value: watchMinSalary || 0,
+                  }),
+                },
+              }}
+            />
+            <Submit />
+          </form>
+        </FormProvider>
+      </div>
+    </section>
+  );
+};
 
 export const CreateClassification: React.FunctionComponent = () => {
   const [_result, executeMutation] = useCreateClassificationMutation();

--- a/admin/resources/js/components/classification/CreateClassification.tsx
+++ b/admin/resources/js/components/classification/CreateClassification.tsx
@@ -56,28 +56,28 @@ export const CreateClassificationForm: React.FunctionComponent<CreateClassificat
                 name="name.en"
                 label={intl.formatMessage(messages.nameEnLabel)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Input
                 id="name_fr"
                 name="name.fr"
                 label={intl.formatMessage(messages.nameFrLabel)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Input
                 id="group"
                 name="group"
                 label={intl.formatMessage(messages.groupLabel)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Select
                 id="level"
                 name="level"
                 label={intl.formatMessage(messages.levelLabel)}
                 nullSelection={intl.formatMessage(messages.levelPlaceholder)}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
                 options={[
                   { value: 1, label: "1" },
                   { value: 2, label: "2" },
@@ -96,7 +96,7 @@ export const CreateClassificationForm: React.FunctionComponent<CreateClassificat
                 label={intl.formatMessage(messages.minSalaryLabel)}
                 type="number"
                 rules={{
-                  required: errorMessages.required,
+                  required: intl.formatMessage(errorMessages.required),
                   min: {
                     value: 0,
                     message: `${errorMessages.mustBeGreater} 0`,
@@ -109,7 +109,7 @@ export const CreateClassificationForm: React.FunctionComponent<CreateClassificat
                 label={intl.formatMessage(messages.maxSalaryLabel)}
                 type="number"
                 rules={{
-                  required: errorMessages.required,
+                  required: intl.formatMessage(errorMessages.required),
                   min: {
                     value: watchMinSalary || 0,
                     message: `${errorMessages.mustBeGreater} ${

--- a/admin/resources/js/components/classification/UpdateClassification.tsx
+++ b/admin/resources/js/components/classification/UpdateClassification.tsx
@@ -69,21 +69,21 @@ export const UpdateClassificationForm: React.FunctionComponent<UpdateClassificat
                 name="name.en"
                 label={intl.formatMessage(messages.nameEnLabel)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Input
                 id="name_fr"
                 name="name.fr"
                 label={intl.formatMessage(messages.nameFrLabel)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Input
                 id="group"
                 name="group"
                 label={intl.formatMessage(messages.groupLabel)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Select
                 id="level"
@@ -109,7 +109,7 @@ export const UpdateClassificationForm: React.FunctionComponent<UpdateClassificat
                 label={intl.formatMessage(messages.minSalaryLabel)}
                 type="number"
                 rules={{
-                  required: errorMessages.required,
+                  required: intl.formatMessage(errorMessages.required),
                   min: {
                     value: 0,
                     message: `${errorMessages.mustBeGreater} 0`,
@@ -122,7 +122,7 @@ export const UpdateClassificationForm: React.FunctionComponent<UpdateClassificat
                 label={intl.formatMessage(messages.maxSalaryLabel)}
                 type="number"
                 rules={{
-                  required: errorMessages.required,
+                  required: intl.formatMessage(errorMessages.required),
                   min: {
                     value: watchMinSalary || 0,
                     message: `${errorMessages.mustBeGreater} ${

--- a/admin/resources/js/components/classification/UpdateClassification.tsx
+++ b/admin/resources/js/components/classification/UpdateClassification.tsx
@@ -25,119 +25,119 @@ interface UpdateClassificationFormProps {
   ) => Promise<FormValues>;
 }
 
-export const UpdateClassificationForm: React.FunctionComponent<UpdateClassificationFormProps> =
-  ({ initialClassification, handleUpdateClassification }) => {
-    const intl = useIntl();
-    const methods = useForm<FormValues>({
-      defaultValues: initialClassification,
-    });
-    const { handleSubmit, watch } = methods;
-    const watchMinSalary = watch("minSalary");
+export const UpdateClassificationForm: React.FunctionComponent<
+  UpdateClassificationFormProps
+> = ({ initialClassification, handleUpdateClassification }) => {
+  const intl = useIntl();
+  const methods = useForm<FormValues>({
+    defaultValues: initialClassification,
+  });
+  const { handleSubmit, watch } = methods;
+  const watchMinSalary = watch("minSalary");
 
-    const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
-      const classification: FormValues = {
-        name: {
-          en: data.name?.en,
-          fr: data.name?.fr,
-        },
-        group: upperCase(data.group || ""),
-        minSalary: Number(data.minSalary),
-        maxSalary: Number(data.maxSalary),
-      };
-      return handleUpdateClassification(
-        initialClassification.id,
-        classification,
-      )
-        .then(() => {
-          navigate(classificationTablePath());
-          toast.success(intl.formatMessage(messages.updateSuccess));
-        })
-        .catch(() => {
-          toast.error(intl.formatMessage(messages.updateError));
-        });
+  const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
+    const classification: FormValues = {
+      name: {
+        en: data.name?.en,
+        fr: data.name?.fr,
+      },
+      group: upperCase(data.group || ""),
+      minSalary: Number(data.minSalary),
+      maxSalary: Number(data.maxSalary),
     };
-    return (
-      <section>
-        <h2 data-h2-text-align="b(center)" data-h2-margin="b(top, none)">
-          {intl.formatMessage(messages.updateHeading)}
-        </h2>
-        <div data-h2-container="b(center, s)">
-          <FormProvider {...methods}>
-            <form onSubmit={handleSubmit(onSubmit)}>
-              <Input
-                id="name_en"
-                name="name.en"
-                label={intl.formatMessage(messages.nameEnLabel)}
-                type="text"
-                rules={{ required: intl.formatMessage(errorMessages.required) }}
-              />
-              <Input
-                id="name_fr"
-                name="name.fr"
-                label={intl.formatMessage(messages.nameFrLabel)}
-                type="text"
-                rules={{ required: intl.formatMessage(errorMessages.required) }}
-              />
-              <Input
-                id="group"
-                name="group"
-                label={intl.formatMessage(messages.groupLabel)}
-                type="text"
-                rules={{ required: intl.formatMessage(errorMessages.required) }}
-              />
-              <Select
-                id="level"
-                name="level"
-                label={intl.formatMessage(messages.levelLabel)}
-                nullSelection={intl.formatMessage(messages.levelPlaceholder)}
-                options={[
-                  { value: 1, label: "1" },
-                  { value: 2, label: "2" },
-                  { value: 3, label: "3" },
-                  { value: 4, label: "4" },
-                  { value: 5, label: "5" },
-                  { value: 6, label: "6" },
-                  { value: 7, label: "7" },
-                  { value: 8, label: "8" },
-                  { value: 9, label: "9" },
-                ]}
-                disabled
-              />
-              <Input
-                id="minSalary"
-                name="minSalary"
-                label={intl.formatMessage(messages.minSalaryLabel)}
-                type="number"
-                rules={{
-                  required: intl.formatMessage(errorMessages.required),
-                  min: {
-                    value: 0,
-                    message: `${errorMessages.mustBeGreater} 0`,
-                  },
-                }}
-              />
-              <Input
-                id="maxSalary"
-                name="maxSalary"
-                label={intl.formatMessage(messages.maxSalaryLabel)}
-                type="number"
-                rules={{
-                  required: intl.formatMessage(errorMessages.required),
-                  min: {
-                    value: watchMinSalary || 0,
-                    message: `${errorMessages.mustBeGreater} ${
-                      watchMinSalary || 0
-                    }`,
-                  },
-                }}
-              />
-              <Submit />
-            </form>
-          </FormProvider>
-        </div>
-      </section>
-    );
+    return handleUpdateClassification(initialClassification.id, classification)
+      .then(() => {
+        navigate(classificationTablePath());
+        toast.success(intl.formatMessage(messages.updateSuccess));
+      })
+      .catch(() => {
+        toast.error(intl.formatMessage(messages.updateError));
+      });
   };
+  return (
+    <section>
+      <h2 data-h2-text-align="b(center)" data-h2-margin="b(top, none)">
+        {intl.formatMessage(messages.updateHeading)}
+      </h2>
+      <div data-h2-container="b(center, s)">
+        <FormProvider {...methods}>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <Input
+              id="name_en"
+              name="name.en"
+              label={intl.formatMessage(messages.nameEnLabel)}
+              type="text"
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
+            />
+            <Input
+              id="name_fr"
+              name="name.fr"
+              label={intl.formatMessage(messages.nameFrLabel)}
+              type="text"
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
+            />
+            <Input
+              id="group"
+              name="group"
+              label={intl.formatMessage(messages.groupLabel)}
+              type="text"
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
+            />
+            <Select
+              id="level"
+              name="level"
+              label={intl.formatMessage(messages.levelLabel)}
+              nullSelection={intl.formatMessage(messages.levelPlaceholder)}
+              options={[
+                { value: 1, label: "1" },
+                { value: 2, label: "2" },
+                { value: 3, label: "3" },
+                { value: 4, label: "4" },
+                { value: 5, label: "5" },
+                { value: 6, label: "6" },
+                { value: 7, label: "7" },
+                { value: 8, label: "8" },
+                { value: 9, label: "9" },
+              ]}
+              disabled
+            />
+            <Input
+              id="minSalary"
+              name="minSalary"
+              label={intl.formatMessage(messages.minSalaryLabel)}
+              type="number"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+                min: {
+                  value: 0,
+                  message: intl.formatMessage(errorMessages.mustBeGreater, {
+                    value: 0,
+                  }),
+                },
+              }}
+            />
+            <Input
+              id="maxSalary"
+              name="maxSalary"
+              label={intl.formatMessage(messages.maxSalaryLabel)}
+              type="number"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+                min: {
+                  value: watchMinSalary || 0,
+                  message: intl.formatMessage(errorMessages.mustBeGreater, {
+                    value: watchMinSalary || 0,
+                  }),
+                },
+              }}
+            />
+            <Submit />
+          </form>
+        </FormProvider>
+      </div>
+    </section>
+  );
+};
 
 export const UpdateClassification: React.FunctionComponent<{
   classificationId: string;

--- a/admin/resources/js/components/cmoAsset/CreateCmoAsset.tsx
+++ b/admin/resources/js/components/cmoAsset/CreateCmoAsset.tsx
@@ -54,7 +54,7 @@ export const CreateCmoAssetForm: React.FunctionComponent<CreateCmoAssetFormProps
                 })}
                 type="text"
                 rules={{
-                  required: errorMessages.required,
+                  required: intl.formatMessage(errorMessages.required),
                   pattern: {
                     value: /^[a-z]+(_[a-z]+)*$/,
                     message: intl.formatMessage({
@@ -69,26 +69,26 @@ export const CreateCmoAssetForm: React.FunctionComponent<CreateCmoAssetFormProps
                 name="name.en"
                 label={intl.formatMessage(messages.nameEnLabel)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Input
                 id="name_fr"
                 name="name.fr"
                 label={intl.formatMessage(messages.nameFrLabel)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <TextArea
                 id="description_en"
                 name="description.en"
                 label={intl.formatMessage(messages.descriptionEnLabel)}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <TextArea
                 id="description_fr"
                 name="description.fr"
                 label={intl.formatMessage(messages.descriptionFrLabel)}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Submit />
             </form>

--- a/admin/resources/js/components/cmoAsset/UpdateCmoAsset.tsx
+++ b/admin/resources/js/components/cmoAsset/UpdateCmoAsset.tsx
@@ -51,26 +51,26 @@ export const UpdateCmoAssetForm: React.FunctionComponent<UpdateCmoAssetFormProps
                 name="name.en"
                 label={intl.formatMessage(messages.nameEnLabel)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Input
                 id="name_fr"
                 name="name.fr"
                 label={intl.formatMessage(messages.nameFrLabel)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <TextArea
                 id="description_en"
                 name="description.en"
                 label={intl.formatMessage(messages.descriptionEnLabel)}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <TextArea
                 id="description_fr"
                 name="description.fr"
                 label={intl.formatMessage(messages.descriptionFrLabel)}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Submit />
             </form>

--- a/admin/resources/js/components/department/CreateDepartment.tsx
+++ b/admin/resources/js/components/department/CreateDepartment.tsx
@@ -55,21 +55,21 @@ export const CreateDepartmentForm: React.FunctionComponent<CreateDepartmentProps
                 name="departmentNumber"
                 label={intl.formatMessage(messages.departmentNumberLabel)}
                 type="number"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Input
                 id="name_en"
                 name="name.en"
                 label={intl.formatMessage(messages.nameEnLabel)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Input
                 id="name_fr"
                 name="name.fr"
                 label={intl.formatMessage(messages.nameFrLabel)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Submit />
             </form>

--- a/admin/resources/js/components/department/UpdateDepartment.tsx
+++ b/admin/resources/js/components/department/UpdateDepartment.tsx
@@ -65,21 +65,21 @@ export const UpdateDepartmentForm: React.FunctionComponent<UpdateDepartmentProps
                 name="departmentNumber"
                 label={intl.formatMessage(messages.departmentNumberLabel)}
                 type="number"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Input
                 id="name_en"
                 name="name.en"
                 label={intl.formatMessage(messages.nameEnLabel)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Input
                 id="name_fr"
                 name="name.fr"
                 label={intl.formatMessage(messages.nameFrLabel)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Submit />
             </form>

--- a/admin/resources/js/components/operationalRequirement/CreateOperationalRequirement.tsx
+++ b/admin/resources/js/components/operationalRequirement/CreateOperationalRequirement.tsx
@@ -54,7 +54,7 @@ export const CreateOperationalRequirementForm: React.FunctionComponent<CreateOpe
                 })}
                 type="text"
                 rules={{
-                  required: errorMessages.required,
+                  required: intl.formatMessage(errorMessages.required),
                   pattern: {
                     value: /^[a-z]+(_[a-z]+)*$/,
                     message: intl.formatMessage({
@@ -69,26 +69,26 @@ export const CreateOperationalRequirementForm: React.FunctionComponent<CreateOpe
                 name="name.en"
                 label={intl.formatMessage(messages.nameLabelEn)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Input
                 id="name_fr"
                 name="name.fr"
                 label={intl.formatMessage(messages.nameLabelFr)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <TextArea
                 id="description_en"
                 name="description.en"
                 label={intl.formatMessage(messages.descriptionLabelEn)}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <TextArea
                 id="description_fr"
                 name="description.fr"
                 label={intl.formatMessage(messages.descriptionLabelFr)}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Submit />
             </form>

--- a/admin/resources/js/components/operationalRequirement/UpdateOperationalRequirement.tsx
+++ b/admin/resources/js/components/operationalRequirement/UpdateOperationalRequirement.tsx
@@ -59,26 +59,26 @@ export const UpdateOperationalRequirementForm: React.FunctionComponent<UpdateOpe
                 name="name.en"
                 label={intl.formatMessage(messages.nameLabelEn)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Input
                 id="name_fr"
                 name="name.fr"
                 label={intl.formatMessage(messages.nameLabelFr)}
                 type="text"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <TextArea
                 id="description_en"
                 name="description.en"
                 label={intl.formatMessage(messages.descriptionLabelEn)}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <TextArea
                 id="description_fr"
                 name="description.fr"
                 label={intl.formatMessage(messages.descriptionLabelFr)}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Submit />
             </form>

--- a/admin/resources/js/components/pool/CreatePool.tsx
+++ b/admin/resources/js/components/pool/CreatePool.tsx
@@ -132,21 +132,21 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
               name="owner"
               nullSelection={intl.formatMessage(messages.ownerPlaceholder)}
               options={userOptions}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <Input
               id="name_en"
               name="name.en"
               label={intl.formatMessage(messages.nameLabelEn)}
               type="text"
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <Input
               id="name_fr"
               name="name.fr"
               label={intl.formatMessage(messages.nameLabelFr)}
               type="text"
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <Input
               id="key"
@@ -155,7 +155,7 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
               context={intl.formatMessage(messages.keyContext)}
               type="text"
               rules={{
-                required: errorMessages.required,
+                required: intl.formatMessage(errorMessages.required),
                 pattern: {
                   value: /^[a-z]+(_[a-z]+)*$/,
                   message: intl.formatMessage(messages.keyPattern),
@@ -166,13 +166,13 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
               id="description_en"
               name="description.en"
               label={intl.formatMessage(messages.descriptionLabelEn)}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <TextArea
               id="description_fr"
               name="description.fr"
               label={intl.formatMessage(messages.descriptionLabelFr)}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <MultiSelect
               id="classifications"
@@ -182,7 +182,7 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
               )}
               name="classifications"
               options={classificationOptions}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <MultiSelect
               id="assetCriteria"
@@ -192,7 +192,7 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
               )}
               name="assetCriteria"
               options={cmoAssetOptions}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <MultiSelect
               id="essentialCriteria"
@@ -202,7 +202,7 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
               )}
               name="essentialCriteria"
               options={cmoAssetOptions}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <MultiSelect
               id="operationalRequirements"
@@ -212,7 +212,7 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
                 messages.operationalRequirementsPlaceholder,
               )}
               options={operationalRequirementOptions}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <Submit />
           </form>

--- a/admin/resources/js/components/pool/UpdatePool.tsx
+++ b/admin/resources/js/components/pool/UpdatePool.tsx
@@ -153,33 +153,33 @@ export const UpdatePoolForm: React.FunctionComponent<UpdatePoolFormProps> = ({
               name="owner"
               nullSelection={intl.formatMessage(messages.ownerPlaceholder)}
               options={userOptions}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <Input
               id="name_en"
               name="name.en"
               label={intl.formatMessage(messages.nameLabelEn)}
               type="text"
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <Input
               id="name_fr"
               name="name.fr"
               label={intl.formatMessage(messages.nameLabelFr)}
               type="text"
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <TextArea
               id="description_en"
               name="description.en"
               label={intl.formatMessage(messages.descriptionLabelEn)}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <TextArea
               id="description_fr"
               name="description.fr"
               label={intl.formatMessage(messages.descriptionLabelFr)}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <MultiSelect
               id="classifications"
@@ -189,7 +189,7 @@ export const UpdatePoolForm: React.FunctionComponent<UpdatePoolFormProps> = ({
               )}
               name="classifications"
               options={classificationOptions}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <MultiSelect
               id="assetCriteria"
@@ -199,7 +199,7 @@ export const UpdatePoolForm: React.FunctionComponent<UpdatePoolFormProps> = ({
               )}
               name="assetCriteria"
               options={cmoAssetOptions}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <MultiSelect
               id="essentialCriteria"
@@ -209,7 +209,7 @@ export const UpdatePoolForm: React.FunctionComponent<UpdatePoolFormProps> = ({
               )}
               name="essentialCriteria"
               options={cmoAssetOptions}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <MultiSelect
               id="operationalRequirements"
@@ -219,7 +219,7 @@ export const UpdatePoolForm: React.FunctionComponent<UpdatePoolFormProps> = ({
                 messages.operationalRequirementsPlaceholder,
               )}
               options={operationalRequirementOptions}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <Submit />
           </form>

--- a/admin/resources/js/components/poolCandidate/CreatePoolCandidate.tsx
+++ b/admin/resources/js/components/poolCandidate/CreatePoolCandidate.tsx
@@ -157,7 +157,7 @@ export const CreatePoolCandidateForm: React.FunctionComponent<CreatePoolCandidat
                 name="pool"
                 options={poolOptions}
                 disabled={!!poolId}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Select
                 id="user"
@@ -165,14 +165,14 @@ export const CreatePoolCandidateForm: React.FunctionComponent<CreatePoolCandidat
                 nullSelection={intl.formatMessage(messages.userPlaceholder)}
                 name="user"
                 options={userOptions}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Input
                 id="cmoIdentifier"
                 label={intl.formatMessage(messages.cmoIdentifierLabel)}
                 type="text"
                 name="cmoIdentifier"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Input
                 id="expiryDate"
@@ -180,10 +180,10 @@ export const CreatePoolCandidateForm: React.FunctionComponent<CreatePoolCandidat
                 type="date"
                 name="expiryDate"
                 rules={{
-                  required: errorMessages.required,
+                  required: intl.formatMessage(errorMessages.required),
                   min: {
                     value: currentDate(),
-                    message: errorMessages.futureDate,
+                    message: intl.formatMessage(errorMessages.futureDate),
                   },
                 }}
               />
@@ -220,7 +220,7 @@ export const CreatePoolCandidateForm: React.FunctionComponent<CreatePoolCandidat
                   messages.languageAbilityPlaceholder,
                 )}
                 options={enumToOptions(LanguageAbility)}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <MultiSelect
                 id="locationPreferences"
@@ -230,7 +230,7 @@ export const CreatePoolCandidateForm: React.FunctionComponent<CreatePoolCandidat
                   messages.locationPreferencesPlaceholder,
                 )}
                 options={enumToOptions(WorkRegion)}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <MultiSelect
                 id="acceptedOperationalRequirements"
@@ -242,7 +242,7 @@ export const CreatePoolCandidateForm: React.FunctionComponent<CreatePoolCandidat
                   messages.acceptedOperationalRequirementsPlaceholder,
                 )}
                 options={operationalRequirementOptions}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <MultiSelect
                 id="expectedSalary"
@@ -257,7 +257,7 @@ export const CreatePoolCandidateForm: React.FunctionComponent<CreatePoolCandidat
                   value,
                   label: getSalaryRange(value),
                 }))}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <MultiSelect
                 id="expectedClassifications"
@@ -269,7 +269,7 @@ export const CreatePoolCandidateForm: React.FunctionComponent<CreatePoolCandidat
                 )}
                 name="expectedClassifications"
                 options={classificationOptions}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <MultiSelect
                 id="cmoAssets"
@@ -277,14 +277,14 @@ export const CreatePoolCandidateForm: React.FunctionComponent<CreatePoolCandidat
                 placeholder={intl.formatMessage(messages.cmoAssetsPlaceholder)}
                 name="cmoAssets"
                 options={cmoAssetOptions}
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
               />
               <Select
                 id="status"
                 label={intl.formatMessage(messages.statusLabel)}
                 nullSelection={intl.formatMessage(messages.statusPlaceholder)}
                 name="status"
-                rules={{ required: errorMessages.required }}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
                 options={enumToOptions(PoolCandidateStatus)}
               />
               <Submit />

--- a/admin/resources/js/components/poolCandidate/UpdatePoolCandidate.tsx
+++ b/admin/resources/js/components/poolCandidate/UpdatePoolCandidate.tsx
@@ -174,215 +174,208 @@ export const UpdatePoolCandidateForm: React.FunctionComponent<UpdatePoolCandidat
       }));
 
     return (
-      <>
-        <section>
-          <h2 data-h2-text-align="b(center)" data-h2-margin="b(top, none)">
-            {intl.formatMessage(poolCandidateMessages.updateHeading)}
-          </h2>
-          <div data-h2-container="b(center, s)">
-            <FormProvider {...methods}>
-              <form onSubmit={handleSubmit(onSubmit)}>
-                <h4>
-                  {intl.formatMessage({
-                    description: "Heading for the user information section",
-                    defaultMessage: "User Information",
-                  })}
-                </h4>
-                <Input
-                  id="email"
-                  label={intl.formatMessage(userMessages.emailLabel)}
-                  type="text"
-                  name="email"
-                  disabled
-                  hideOptional
-                />
-                <Input
-                  id="firstName"
-                  label={intl.formatMessage(userMessages.firstNameLabel)}
-                  type="text"
-                  name="firstName"
-                  rules={{ required: errorMessages.required }}
-                />
-                <Input
-                  id="lastName"
-                  label={intl.formatMessage(userMessages.lastNameLabel)}
-                  type="text"
-                  name="lastName"
-                  rules={{ required: errorMessages.required }}
-                />
-                <Input
-                  id="telephone"
-                  label={intl.formatMessage(userMessages.telephoneLabel)}
-                  type="tel"
-                  name="telephone"
-                  rules={{
-                    required: errorMessages.required,
-                    pattern: {
-                      value: /^\+[1-9]\d{1,14}$/,
-                      message: errorMessages.telephone,
-                    },
-                  }}
-                />
-                <Select
-                  id="preferredLang"
-                  label={intl.formatMessage(
-                    userMessages.preferredLanguageLabel,
-                  )}
-                  name="preferredLang"
-                  nullSelection={intl.formatMessage(
-                    userMessages.preferredLanguagePlaceholder,
-                  )}
-                  rules={{ required: errorMessages.required }}
-                  options={enumToOptions(Language).map(({ value }) => ({
-                    value,
-                    label: intl.formatMessage(getLanguage(value)),
-                  }))}
-                />
-                <h4>
-                  {intl.formatMessage({
-                    description:
-                      "Heading for the candidate information section",
-                    defaultMessage: "Candidate Information",
-                  })}
-                </h4>
-                <Input
-                  id="cmoIdentifier"
-                  label={intl.formatMessage(
-                    poolCandidateMessages.cmoIdentifierLabel,
-                  )}
-                  type="text"
-                  name="cmoIdentifier"
-                  rules={{ required: errorMessages.required }}
-                />
-                <Input
-                  id="expiryDate"
-                  label={intl.formatMessage(
-                    poolCandidateMessages.expiryDateLabel,
-                  )}
-                  type="date"
-                  name="expiryDate"
-                  rules={{
-                    required: errorMessages.required,
-                    min: {
-                      value: currentDate(),
-                      message: errorMessages.futureDate,
-                    },
-                  }}
-                />
-                <Checkbox
-                  id="isWoman"
-                  label={intl.formatMessage(poolCandidateMessages.isWomanLabel)}
-                  name="isWoman"
-                />
-                <Checkbox
-                  id="hasDisability"
-                  label={intl.formatMessage(
-                    poolCandidateMessages.hasDiplomaLabel,
-                  )}
-                  name="hasDisability"
-                />
-                <Checkbox
-                  id="isIndigenous"
-                  label={intl.formatMessage(
-                    poolCandidateMessages.isIndigenousLabel,
-                  )}
-                  name="isIndigenous"
-                />
-                <Checkbox
-                  id="isVisibleMinority"
-                  label={intl.formatMessage(
-                    poolCandidateMessages.isVisibleMinorityLabel,
-                  )}
-                  name="isVisibleMinority"
-                />
-                <Select
-                  id="languageAbility"
-                  label={intl.formatMessage(
-                    poolCandidateMessages.languageAbilityLabel,
-                  )}
-                  name="languageAbility"
-                  options={enumToOptions(LanguageAbility)}
-                  rules={{ required: errorMessages.required }}
-                />
-                <MultiSelect
-                  id="locationPreferences"
-                  name="locationPreferences"
-                  label={intl.formatMessage(
-                    poolCandidateMessages.locationPreferencesLabel,
-                  )}
-                  placeholder={intl.formatMessage(
-                    poolCandidateMessages.locationPreferencesPlaceholder,
-                  )}
-                  options={enumToOptions(WorkRegion)}
-                  rules={{ required: errorMessages.required }}
-                />
-                <MultiSelect
-                  id="acceptedOperationalRequirements.sync"
-                  name="acceptedOperationalRequirements"
-                  label={intl.formatMessage(
-                    poolCandidateMessages.acceptedOperationalRequirementsLabel,
-                  )}
-                  placeholder={intl.formatMessage(
-                    poolCandidateMessages.acceptedOperationalRequirementsPlaceholder,
-                  )}
-                  options={operationalRequirementOptions}
-                  rules={{ required: errorMessages.required }}
-                />
-                <MultiSelect
-                  id="expectedSalary"
-                  label={intl.formatMessage(
-                    poolCandidateMessages.expectedSalaryLabel,
-                  )}
-                  name="expectedSalary"
-                  placeholder={intl.formatMessage(
-                    poolCandidateMessages.expectedSalaryPlaceholder,
-                  )}
-                  options={enumToOptions(SalaryRange).map(({ value }) => ({
-                    value,
-                    label: getSalaryRange(value),
-                  }))}
-                  rules={{ required: errorMessages.required }}
-                />
-                <MultiSelect
-                  id="expectedClassifications"
-                  label={intl.formatMessage(
-                    poolCandidateMessages.expectedClassificationsLabel,
-                  )}
-                  placeholder={intl.formatMessage(
-                    poolCandidateMessages.expectedClassificationsPlaceholder,
-                  )}
-                  name="expectedClassifications"
-                  options={classificationOptions}
-                  rules={{ required: errorMessages.required }}
-                />
-                <MultiSelect
-                  id="cmoAssets"
-                  label={intl.formatMessage(
-                    poolCandidateMessages.cmoAssetsLabel,
-                  )}
-                  placeholder={intl.formatMessage(
-                    poolCandidateMessages.cmoAssetsPlaceholder,
-                  )}
-                  name="cmoAssets"
-                  options={cmoAssetOptions}
-                  rules={{ required: errorMessages.required }}
-                />
-                <Select
-                  id="status"
-                  label={intl.formatMessage(poolCandidateMessages.statusLabel)}
-                  nullSelection={intl.formatMessage(
-                    poolCandidateMessages.statusPlaceholder,
-                  )}
-                  name="status"
-                  rules={{ required: errorMessages.required }}
-                  options={enumToOptions(PoolCandidateStatus)}
-                />
-                <Submit />
-              </form>
-            </FormProvider>
-          </div>
-        </section>
-      </>
+      <section>
+        <h2 data-h2-text-align="b(center)" data-h2-margin="b(top, none)">
+          {intl.formatMessage(poolCandidateMessages.updateHeading)}
+        </h2>
+        <div data-h2-container="b(center, s)">
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(onSubmit)}>
+              <h4>
+                {intl.formatMessage({
+                  description: "Heading for the user information section",
+                  defaultMessage: "User Information",
+                })}
+              </h4>
+              <Input
+                id="email"
+                label={intl.formatMessage(userMessages.emailLabel)}
+                type="text"
+                name="email"
+                disabled
+                hideOptional
+              />
+              <Input
+                id="firstName"
+                label={intl.formatMessage(userMessages.firstNameLabel)}
+                type="text"
+                name="firstName"
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
+              />
+              <Input
+                id="lastName"
+                label={intl.formatMessage(userMessages.lastNameLabel)}
+                type="text"
+                name="lastName"
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
+              />
+              <Input
+                id="telephone"
+                label={intl.formatMessage(userMessages.telephoneLabel)}
+                type="tel"
+                name="telephone"
+                rules={{
+                  required: intl.formatMessage(errorMessages.required),
+                  pattern: {
+                    value: /^\+[1-9]\d{1,14}$/,
+                    message: intl.formatMessage(errorMessages.telephone),
+                  },
+                }}
+              />
+              <Select
+                id="preferredLang"
+                label={intl.formatMessage(userMessages.preferredLanguageLabel)}
+                name="preferredLang"
+                nullSelection={intl.formatMessage(
+                  userMessages.preferredLanguagePlaceholder,
+                )}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
+                options={enumToOptions(Language).map(({ value }) => ({
+                  value,
+                  label: intl.formatMessage(getLanguage(value)),
+                }))}
+              />
+              <h4>
+                {intl.formatMessage({
+                  description: "Heading for the candidate information section",
+                  defaultMessage: "Candidate Information",
+                })}
+              </h4>
+              <Input
+                id="cmoIdentifier"
+                label={intl.formatMessage(
+                  poolCandidateMessages.cmoIdentifierLabel,
+                )}
+                type="text"
+                name="cmoIdentifier"
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
+              />
+              <Input
+                id="expiryDate"
+                label={intl.formatMessage(
+                  poolCandidateMessages.expiryDateLabel,
+                )}
+                type="date"
+                name="expiryDate"
+                rules={{
+                  required: intl.formatMessage(errorMessages.required),
+                  min: {
+                    value: currentDate(),
+                    message: intl.formatMessage(errorMessages.futureDate),
+                  },
+                }}
+              />
+              <Checkbox
+                id="isWoman"
+                label={intl.formatMessage(poolCandidateMessages.isWomanLabel)}
+                name="isWoman"
+              />
+              <Checkbox
+                id="hasDisability"
+                label={intl.formatMessage(
+                  poolCandidateMessages.hasDiplomaLabel,
+                )}
+                name="hasDisability"
+              />
+              <Checkbox
+                id="isIndigenous"
+                label={intl.formatMessage(
+                  poolCandidateMessages.isIndigenousLabel,
+                )}
+                name="isIndigenous"
+              />
+              <Checkbox
+                id="isVisibleMinority"
+                label={intl.formatMessage(
+                  poolCandidateMessages.isVisibleMinorityLabel,
+                )}
+                name="isVisibleMinority"
+              />
+              <Select
+                id="languageAbility"
+                label={intl.formatMessage(
+                  poolCandidateMessages.languageAbilityLabel,
+                )}
+                name="languageAbility"
+                options={enumToOptions(LanguageAbility)}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
+              />
+              <MultiSelect
+                id="locationPreferences"
+                name="locationPreferences"
+                label={intl.formatMessage(
+                  poolCandidateMessages.locationPreferencesLabel,
+                )}
+                placeholder={intl.formatMessage(
+                  poolCandidateMessages.locationPreferencesPlaceholder,
+                )}
+                options={enumToOptions(WorkRegion)}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
+              />
+              <MultiSelect
+                id="acceptedOperationalRequirements.sync"
+                name="acceptedOperationalRequirements"
+                label={intl.formatMessage(
+                  poolCandidateMessages.acceptedOperationalRequirementsLabel,
+                )}
+                placeholder={intl.formatMessage(
+                  poolCandidateMessages.acceptedOperationalRequirementsPlaceholder,
+                )}
+                options={operationalRequirementOptions}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
+              />
+              <MultiSelect
+                id="expectedSalary"
+                label={intl.formatMessage(
+                  poolCandidateMessages.expectedSalaryLabel,
+                )}
+                name="expectedSalary"
+                placeholder={intl.formatMessage(
+                  poolCandidateMessages.expectedSalaryPlaceholder,
+                )}
+                options={enumToOptions(SalaryRange).map(({ value }) => ({
+                  value,
+                  label: getSalaryRange(value),
+                }))}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
+              />
+              <MultiSelect
+                id="expectedClassifications"
+                label={intl.formatMessage(
+                  poolCandidateMessages.expectedClassificationsLabel,
+                )}
+                placeholder={intl.formatMessage(
+                  poolCandidateMessages.expectedClassificationsPlaceholder,
+                )}
+                name="expectedClassifications"
+                options={classificationOptions}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
+              />
+              <MultiSelect
+                id="cmoAssets"
+                label={intl.formatMessage(poolCandidateMessages.cmoAssetsLabel)}
+                placeholder={intl.formatMessage(
+                  poolCandidateMessages.cmoAssetsPlaceholder,
+                )}
+                name="cmoAssets"
+                options={cmoAssetOptions}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
+              />
+              <Select
+                id="status"
+                label={intl.formatMessage(poolCandidateMessages.statusLabel)}
+                nullSelection={intl.formatMessage(
+                  poolCandidateMessages.statusPlaceholder,
+                )}
+                name="status"
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
+                options={enumToOptions(PoolCandidateStatus)}
+              />
+              <Submit />
+            </form>
+          </FormProvider>
+        </div>
+      </section>
     );
   };
 

--- a/admin/resources/js/components/user/CreateUser.tsx
+++ b/admin/resources/js/components/user/CreateUser.tsx
@@ -55,21 +55,21 @@ export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
               label={intl.formatMessage(messages.emailLabel)}
               type="text"
               name="email"
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <Input
               id="firstName"
               label={intl.formatMessage(messages.firstNameLabel)}
               type="text"
               name="firstName"
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <Input
               id="lastName"
               label={intl.formatMessage(messages.lastNameLabel)}
               type="text"
               name="lastName"
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <Input
               id="telephone"
@@ -77,10 +77,10 @@ export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
               type="tel"
               name="telephone"
               rules={{
-                required: errorMessages.required,
+                required: intl.formatMessage(errorMessages.required),
                 pattern: {
                   value: /^\+[1-9]\d{1,14}$/,
-                  message: errorMessages.telephone,
+                  message: intl.formatMessage(errorMessages.telephone),
                 },
               }}
             />
@@ -91,7 +91,7 @@ export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
               nullSelection={intl.formatMessage(
                 messages.preferredLanguagePlaceholder,
               )}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
               options={enumToOptions(Language).map(({ value }) => ({
                 value,
                 label: intl.formatMessage(getLanguage(value)),

--- a/admin/resources/js/components/user/UpdateUser.tsx
+++ b/admin/resources/js/components/user/UpdateUser.tsx
@@ -66,14 +66,14 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
               label={intl.formatMessage(messages.firstNameLabel)}
               type="text"
               name="firstName"
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <Input
               id="lastName"
               label={intl.formatMessage(messages.lastNameLabel)}
               type="text"
               name="lastName"
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <Input
               id="telephone"
@@ -81,10 +81,10 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
               type="tel"
               name="telephone"
               rules={{
-                required: errorMessages.required,
+                required: intl.formatMessage(errorMessages.required),
                 pattern: {
                   value: /^\+[1-9]\d{1,14}$/,
-                  message: errorMessages.telephone,
+                  message: intl.formatMessage(errorMessages.telephone),
                 },
               }}
             />
@@ -95,7 +95,7 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
               nullSelection={intl.formatMessage(
                 messages.preferredLanguagePlaceholder,
               )}
-              rules={{ required: errorMessages.required }}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
               options={enumToOptions(Language).map(({ value }) => ({
                 value,
                 label: intl.formatMessage(getLanguage(value)),

--- a/common/src/messages/errorMessages.ts
+++ b/common/src/messages/errorMessages.ts
@@ -16,8 +16,9 @@ const messages = defineMessages({
     description: "Error message that the provided date must be in the future.",
   },
   mustBeGreater: {
-    defaultMessage: "Value must be greater than",
-    description: "Error message that the provided value must be greater.",
+    defaultMessage: "Value must be greater than {value}",
+    description:
+      "Error message that the provided value must be greater than some referenced minimum value.",
   },
 });
 

--- a/common/src/messages/errorMessages.ts
+++ b/common/src/messages/errorMessages.ts
@@ -1,8 +1,24 @@
-const messages = {
-  required: "This field is required.",
-  telephone: "This field must follow the pattern +123243234.",
-  futureDate: "This field must use future dates only.",
-  mustBeGreater: "Value must be greater than",
-};
+import { defineMessages } from "react-intl";
+
+const messages = defineMessages({
+  required: {
+    defaultMessage: "This field is required.",
+    description:
+      "Error message that this field must filled for the form to be valid.",
+  },
+  telephone: {
+    defaultMessage: "This field must follow the pattern +123243234.",
+    description:
+      "Error message that the field must contain a phone number validated by the specified pattern.",
+  },
+  futureDate: {
+    defaultMessage: "This field must use future dates only.",
+    description: "Error message that the provided date must be in the future.",
+  },
+  mustBeGreater: {
+    defaultMessage: "Value must be greater than",
+    description: "Error message that the provided value must be greater.",
+  },
+});
 
 export default messages;

--- a/talentsearch/resources/js/components/request/CreateRequest.tsx
+++ b/talentsearch/resources/js/components/request/CreateRequest.tsx
@@ -130,7 +130,9 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
                     description:
                       "Placeholder for full name input in the request form.",
                   })}
-                  rules={{ required: errorMessages.required }}
+                  rules={{
+                    required: intl.formatMessage(errorMessages.required),
+                  }}
                 />
               </div>
             </div>
@@ -150,7 +152,9 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
                       "Null selection for department select input in the request form.",
                   })}
                   options={departmentOptions}
-                  rules={{ required: errorMessages.required }}
+                  rules={{
+                    required: intl.formatMessage(errorMessages.required),
+                  }}
                 />
               </div>
             </div>
@@ -170,7 +174,9 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
                     description:
                       "Placeholder for government email input in the request form",
                   })}
-                  rules={{ required: errorMessages.required }}
+                  rules={{
+                    required: intl.formatMessage(errorMessages.required),
+                  }}
                 />
               </div>
             </div>
@@ -190,7 +196,9 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
                     description:
                       "Placeholder for job title input in the request form.",
                   })}
-                  rules={{ required: errorMessages.required }}
+                  rules={{
+                    required: intl.formatMessage(errorMessages.required),
+                  }}
                 />
               </div>
             </div>


### PR DESCRIPTION
Convert form validation error messages in common/src/messages/errorMessages.ts from plain strings to strings that can be localized.

Prettier removed the unneeded wrapper element in UpdatePoolCandidate.tsx as well.

Closes #1039 