### PR TITLE
API - Update psr/cache to compatible version

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -14,7 +14,8 @@
         "lcobucci/jwt": "^4.1",
         "mll-lab/graphql-php-scalars": "^4.1",
         "mll-lab/laravel-graphql-playground": "^2.5",
-        "nuwave/lighthouse": "^5.8"
+        "nuwave/lighthouse": "^5.8",
+        "psr/cache": "^1.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff25094bcceab8a14c143f89b1405423",
+    "content-hash": "58d71930a92aa1b5f74f0099bb55600e",
     "packages": [
         {
             "name": "brick/math",
@@ -3752,20 +3752,20 @@
         },
         {
             "name": "psr/cache",
-            "version": "3.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/cache.git",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.0"
+                "php": ">=5.3.0"
             },
             "type": "library",
             "extra": {
@@ -3785,7 +3785,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
+                    "homepage": "http://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for caching libraries",
@@ -3795,9 +3795,9 @@
                 "psr-6"
             ],
             "support": {
-                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+                "source": "https://github.com/php-fig/cache/tree/master"
             },
-            "time": "2021-02-03T23:26:27+00:00"
+            "time": "2016-08-06T20:24:11+00:00"
         },
         {
             "name": "psr/container",
@@ -8937,5 +8937,5 @@
         "php": "^7.3|^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
Resolves #1249 by requiring a compatible version of psr/cache in `/api`.

This [Dependabot PR](https://github.com/GCTC-NTGC/gc-digital-talent/pull/1204/commits/a68e3aa28beca457fa8cfd676972594cb1f31b94#diff-1b2cd3a72459c07fc1894484568dad080f874329e95cd8e83538df0cacf69fcbR261) added psr/cache and resolved to using the [newest version (3.0.0)](https://github.com/GCTC-NTGC/gc-digital-talent/pull/1204/commits/a68e3aa28beca457fa8cfd676972594cb1f31b94#diff-1b2cd3a72459c07fc1894484568dad080f874329e95cd8e83538df0cacf69fcbR3755), which requires PHP 8.0+ (we are currently using [PHP 7.4](https://github.com/GCTC-NTGC/gc-digital-talent/blob/66a9dab4b858865efd7001d93567b236c8059bd5/infrastructure/maintenance-container/Dockerfile#L8)).