### PR TITLE
Set input type to email for email fields

### DIFF
--- a/admin/resources/js/components/poolCandidate/CreatePoolCandidate.tsx
+++ b/admin/resources/js/components/poolCandidate/CreatePoolCandidate.tsx
@@ -124,7 +124,7 @@ const UserFormSection: React.FunctionComponent<{
             defaultMessage: "Email:",
             description: "Label displayed on the user form email field.",
           })}
-          type="text"
+          type="email"
           name="email"
           rules={{
             required:

--- a/admin/resources/js/components/poolCandidate/UpdatePoolCandidate.tsx
+++ b/admin/resources/js/components/poolCandidate/UpdatePoolCandidate.tsx
@@ -205,7 +205,7 @@ export const UpdatePoolCandidateForm: React.FunctionComponent<
                 defaultMessage: "Email:",
                 description: "Label displayed on the user form email field.",
               })}
-              type="text"
+              type="email"
               name="email"
               disabled
               hideOptional

--- a/admin/resources/js/components/user/CreateUser.tsx
+++ b/admin/resources/js/components/user/CreateUser.tsx
@@ -70,7 +70,7 @@ export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
                 defaultMessage: "Email:",
                 description: "Label displayed on the user form email field.",
               })}
-              type="text"
+              type="email"
               name="email"
               rules={{
                 required: intl.formatMessage(errorMessages.required),

--- a/admin/resources/js/components/user/UpdateUser.tsx
+++ b/admin/resources/js/components/user/UpdateUser.tsx
@@ -72,7 +72,7 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
                 defaultMessage: "Email:",
                 description: "Label displayed on the user form email field.",
               })}
-              type="text"
+              type="email"
               name="email"
               value={initialUser.email}
               disabled


### PR DESCRIPTION
Closes #1272 

This branch sets the input type to email instead of text for a few email form fields that were missing it.  This allows the user's browser to ensure the email addresses appear well formed before submission.