### PR TITLE
#1202-use env variable from webpack.mix 

### DIFF
--- a/admin/resources/js/components/Footer.tsx
+++ b/admin/resources/js/components/Footer.tsx
@@ -3,7 +3,6 @@ import { Link } from "@common/components";
 import { currentDate } from "@common/helpers/formUtils";
 import { imageUrl } from "@common/helpers/router";
 import { useIntl } from "react-intl";
-import { BASE_URL } from "../adminConstants";
 
 const Footer: React.FunctionComponent = () => {
   const intl = useIntl();
@@ -119,7 +118,7 @@ const Footer: React.FunctionComponent = () => {
           >
             <img
               style={{ width: "12rem" }}
-              src={imageUrl(BASE_URL, "logo_canada.png")}
+              src={imageUrl("logo_canada.png")}
               alt={intl.formatMessage({
                 defaultMessage: "Canada's Logo.",
                 description: "Alt text for the Canada logo in the Footer.",

--- a/admin/resources/js/components/Header.tsx
+++ b/admin/resources/js/components/Header.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { imageUrl } from "@common/helpers/router";
 import { useIntl } from "react-intl";
-import { BASE_URL } from "../adminConstants";
 
 const Header: React.FunctionComponent = () => {
   const intl = useIntl();
@@ -23,7 +22,7 @@ const Header: React.FunctionComponent = () => {
           >
             <img
               style={{ width: "20rem" }}
-              src={imageUrl(BASE_URL, "logo_goc_colour.svg")}
+              src={imageUrl("logo_goc_colour.svg")}
               alt={intl.formatMessage({
                 defaultMessage: "Canada's Logo.",
                 description: "Alt text for the Canada logo in the Header.",

--- a/common/src/helpers/router.tsx
+++ b/common/src/helpers/router.tsx
@@ -114,8 +114,9 @@ export const useRouter = (
  *
  * @param imgFile The name of the img file, not including the /images/ path.
  */
-export function imageUrl(baseUrl: string, imgFile: string): string {
-  return `${baseUrl}/public/images/${imgFile}`;
+export function imageUrl(imgFile: string): string {
+ const baseUrl =  process.env.TALENTSEARCH_APP_URL;
+  return  `${baseUrl}/public/images/${imgFile}`;
 }
 
 export function parseUrlQueryParameters(

--- a/talentsearch/resources/js/components/Footer.tsx
+++ b/talentsearch/resources/js/components/Footer.tsx
@@ -3,7 +3,6 @@ import { Link } from "@common/components";
 import { currentDate } from "@common/helpers/formUtils";
 import { imageUrl } from "@common/helpers/router";
 import { useIntl } from "react-intl";
-import { BASE_URL } from "../talentSearchConstants";
 
 const Footer: React.FunctionComponent = () => {
   const intl = useIntl();
@@ -116,7 +115,7 @@ const Footer: React.FunctionComponent = () => {
           >
             <img
               style={{ width: "12rem" }}
-              src={imageUrl(BASE_URL, "logo_canada.png")}
+              src={imageUrl("logo_canada.png")}
               alt={intl.formatMessage({
                 defaultMessage: "Canada's Logo.",
                 description: "Alt text for the Canada logo in the Footer.",

--- a/talentsearch/resources/js/components/Header.tsx
+++ b/talentsearch/resources/js/components/Header.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { imageUrl } from "@common/helpers/router";
 import { useIntl } from "react-intl";
-import { BASE_URL } from "../talentSearchConstants";
 
 const Header: React.FunctionComponent = () => {
   const intl = useIntl();
@@ -23,7 +22,7 @@ const Header: React.FunctionComponent = () => {
           >
             <img
               style={{ width: "20rem" }}
-              src={imageUrl(BASE_URL, "logo_goc_colour.svg")}
+              src={imageUrl("logo_goc_colour.svg")}
               alt={intl.formatMessage({
                 defaultMessage: "Canada's Logo.",
                 description: "Alt text for the Canada logo in the Header.",

--- a/talentsearch/resources/js/components/search/SearchPage.tsx
+++ b/talentsearch/resources/js/components/search/SearchPage.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { imageUrl } from "@common/helpers/router";
 import { useIntl } from "react-intl";
-import { BASE_URL } from "../../talentSearchConstants";
 import { SearchFormApi } from "./SearchForm";
 
 export const SearchPage: React.FC = () => {
@@ -15,7 +14,6 @@ export const SearchPage: React.FC = () => {
         data-h2-margin="b(bottom, xxl)"
         style={{
           background: `linear-gradient(70deg, rgba(103, 76, 144, 0.9), rgba(29, 44, 76, 1)), url(${imageUrl(
-            BASE_URL,
             "hero-background-search.png",
           )})`,
           backgroundSize: "cover",

--- a/talentsearch/resources/js/talentSearchConstants.ts
+++ b/talentsearch/resources/js/talentSearchConstants.ts
@@ -1,2 +1,0 @@
-export const BASE_URL = process.env.TALENTSEARCH_APP_URL as string;
-export const BASE_URL_DIR = process.env.TALENTSEARCH_APP_DIR as string;

--- a/talentsearch/resources/js/talentSearchRoutes.ts
+++ b/talentsearch/resources/js/talentSearchRoutes.ts
@@ -1,5 +1,3 @@
-import { BASE_URL_DIR } from "./talentSearchConstants";
-
-export const homePath = (): string => `${BASE_URL_DIR}`;
+export const homePath = (): string => `${process.env.TALENTSEARCH_APP_DIR}`;
 export const searchPath = (): string => `${homePath()}/search`;
 export const requestPath = (): string => `${homePath()}/request`;

--- a/talentsearch/webpack.mix.js
+++ b/talentsearch/webpack.mix.js
@@ -65,3 +65,4 @@ mix.webpackConfig({
 });
 
 mix.version();
+mix.sourceMaps();


### PR DESCRIPTION
This PR removes the below problem in the linked issue #1202 
`talentSearchConstants.ts and adminConstants.ts reference environment variables which must be available during the build process `

by  using env variables which would be available for each environment with env. specific keys/passwords . Also this PR deletes  talentSearchConstants.ts file as this is not being used any more. 

adminConstants.ts has been modified to use env variables. 

We basically used these hardcoded urls for imageUrl function. All references of those function is updated for the new signature. 

