### PR TITLE
Add auth-callback route to web root

### DIFF
--- a/admin/.env.example
+++ b/admin/.env.example
@@ -28,6 +28,7 @@ API_URI="http://localhost:8000/graphql"
 # for local testing
 OAUTH_URI="http://localhost:8000/oauth/authorize"
 OAUTH_TOKEN_URI="http://localhost:80/oauth/token"
+OAUTH_REDIRECT_URI="http://localhost:8000/admin/auth-callback"
 OAUTH_ADMIN_CLIENT_ID=
 OAUTH_ADMIN_CLIENT_SECRET=
 

--- a/admin/app/Http/Controllers/AuthController.php
+++ b/admin/app/Http/Controllers/AuthController.php
@@ -15,7 +15,7 @@ class AuthController extends Controller
 
         $query = http_build_query([
             'client_id' => config('oauth.client_id'),
-            'redirect_uri' => config('oauth.redirct_uri'),
+            'redirect_uri' => config('oauth.redirect_uri'),
             'response_type' => 'code',
             'scope' => 'openid',
             'state' => $state,
@@ -37,7 +37,7 @@ class AuthController extends Controller
             'grant_type' => 'authorization_code',
             'client_id' => config('oauth.client_id'),
             'client_secret' => config('oauth.client_secret'),
-            'redirect_uri' => config('oauth.redirct_uri'),
+            'redirect_uri' => config('oauth.redirect_uri'),
             'code' => $request->code,
         ]);
         $query = http_build_query($response->json());

--- a/admin/app/Http/Controllers/AuthController.php
+++ b/admin/app/Http/Controllers/AuthController.php
@@ -15,7 +15,7 @@ class AuthController extends Controller
 
         $query = http_build_query([
             'client_id' => config('oauth.client_id'),
-            'redirect_uri' => config('app.url') . '/auth-callback',
+            'redirect_uri' => config('oauth.redirct_uri'),
             'response_type' => 'code',
             'scope' => 'openid',
             'state' => $state,
@@ -37,7 +37,7 @@ class AuthController extends Controller
             'grant_type' => 'authorization_code',
             'client_id' => config('oauth.client_id'),
             'client_secret' => config('oauth.client_secret'),
-            'redirect_uri' => config('app.url') . '/auth-callback',
+            'redirect_uri' => config('oauth.redirct_uri'),
             'code' => $request->code,
         ]);
         $query = http_build_query($response->json());

--- a/admin/config/oauth.php
+++ b/admin/config/oauth.php
@@ -6,6 +6,7 @@ return [
      */
     'authorize_uri' => env('OAUTH_URI', null),
     'token_uri' => env('OAUTH_TOKEN_URI', null),
+    'redirct_uri' => env('OAUTH_REDIRECT_URI', config('app.url') . '/auth-callback'),
 
     /**
      * This server's client id and secret, known to the OAuth server.

--- a/admin/config/oauth.php
+++ b/admin/config/oauth.php
@@ -6,7 +6,7 @@ return [
      */
     'authorize_uri' => env('OAUTH_URI', null),
     'token_uri' => env('OAUTH_TOKEN_URI', null),
-    'redirct_uri' => env('OAUTH_REDIRECT_URI', config('app.url') . '/auth-callback'),
+    'redirect_uri' => env('OAUTH_REDIRECT_URI', config('app.url') . '/auth-callback'),
 
     /**
      * This server's client id and secret, known to the OAuth server.

--- a/admin/routes/web.php
+++ b/admin/routes/web.php
@@ -22,3 +22,8 @@ Route::prefix(config('app.app_dir'))->group(function () {
     Route::get('/', [DashboardController::class, 'index']);
     Route::get('/{any}', [DashboardController::class, 'index'])->where('any', '.*');
 });
+
+// We may be redirecting the auth-callback route from the server root back here using Appache rewrite
+Route::prefix('')->group(function () {
+    Route::get('/auth-callback', [AuthController::class, 'authCallback']);
+});

--- a/admin/routes/web.php
+++ b/admin/routes/web.php
@@ -23,7 +23,7 @@ Route::prefix(config('app.app_dir'))->group(function () {
     Route::get('/{any}', [DashboardController::class, 'index'])->where('any', '.*');
 });
 
-// We may be redirecting the auth-callback route from the server root back here using Appache rewrite
+// We may be redirecting the auth-callback route from the server root back here using Apache rewrite.
 Route::prefix('')->group(function () {
     Route::get('/auth-callback', [AuthController::class, 'authCallback']);
 });

--- a/infrastructure/php-container/src/.htaccess
+++ b/infrastructure/php-container/src/.htaccess
@@ -8,6 +8,7 @@ DirectorySlash off
     RewriteRule ^graphql api/public/graphql [L]
     RewriteRule ^auth(/.*)?$ auth/public/ [L]
     RewriteRule ^oauth(/.*)?$ auth/public/ [L]
+    RewriteRule ^auth-callback admin/public/ [L]
     RewriteRule ^admin(/.*)?$ admin/public/ [L]
     RewriteRule ^public/(.*)$ talentsearch/public/$1 [L]
     RewriteRule ^(.*)$ talentsearch/public/$1 [L]


### PR DESCRIPTION
This branch adds an auth-callback route to the web root.  This allows the auth redirect URI to be either {{host}}/admin/auth-callback (as before) or {{host}}/auth-callback (as requested in the issue).  This is accomplished by adding a new rewrite rule to the .htaccess file and adding a new route in the admin application's web.php file.

To test this you can add a new client to the auth app with a redirct uri of `http://localhost:8000/auth-callback` and ~update the redirect uri strings in the admin app's AuthController.php file~ set the OAUTH_REDIRECT_URI value in the admin project's .env file.

Closes #1266 