### PR TITLE
API - Remove explicit dependency on psr/cache

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -14,8 +14,7 @@
         "lcobucci/jwt": "^4.1",
         "mll-lab/graphql-php-scalars": "^4.1",
         "mll-lab/laravel-graphql-playground": "^2.5",
-        "nuwave/lighthouse": "^5.8",
-        "psr/cache": "^1.0"
+        "nuwave/lighthouse": "^5.8"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "928cea892a91c3012a65416a4e434e71",
+    "content-hash": "ad501f89332fe3c2cf809f61cbb1c98b",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
With the addition of the PHP platform dependency in the composer.json file the explicit dependency on psr/cache is no longer necessary.  Removing the explicit dependency will allow composer to resolve the best version automatically going forward.  After removing the dependency, composer resolved the same version of psr/cache as was previously hard-coded and the lock file remains mostly unchanged.

Closes #1255 