### PR TITLE
Fix handling for filtering by zero classifications

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -102,6 +102,11 @@ class PoolCandidate extends Model
         // Since salary ranges are text enums a custom SQL subquery is used to convert them to
         // numeric values and compare them to specified classifications
 
+        // This subquery only works for a non-zero number of filter classifications.
+        // If passed zero classifications then return same query builder unchanged.
+        if(count($classifications) == 0)
+            return $query;
+
         $parameters = [];
         $sql = <<<RAWSQL1
 


### PR DESCRIPTION
Fixes orFilterByClassificationToSalary function handling of filtering by zero classifications.  Instead of crashing the function simply returns the same query builder unchanged.

Closes #1379