### PR TITLE
Add login redirect from parameter

### DIFF
--- a/admin/app/Http/Controllers/AuthController.php
+++ b/admin/app/Http/Controllers/AuthController.php
@@ -13,6 +13,12 @@ class AuthController extends Controller
         $state = Str::random(40);
         $request->session()->put('state', $state = Str::random(40));
 
+        $request->session()->put('from',
+            isset($_GET['from'])
+            ? $_GET['from']
+            : null
+        );
+
         $query = http_build_query([
             'client_id' => config('oauth.client_id'),
             'redirect_uri' => config('oauth.redirect_uri'),
@@ -41,6 +47,15 @@ class AuthController extends Controller
             'code' => $request->code,
         ]);
         $query = http_build_query($response->json());
-        return redirect(config('app.url') . '?' . $query);
+
+        $from = $request->session()->pull('from');
+
+        if($from != filter_var($from, FILTER_SANITIZE_URL))
+            $from = null; // Contains unsanitary characters. Throw it away.
+        if(substr($from, 0, 1) != '/')
+            $from = null; // Does not start with / so it's not a relative url. Don't want an open redirect vulnerability. Throw it away.
+
+        $navigateToUri = strlen($from) > 0 ? $from : config('app.url');
+        return redirect($navigateToUri . '?' . $query);
     }
 }


### PR DESCRIPTION
The branch allows a user to add a `from` url parameter to the login so that they are automatically redirected to the desired location after logging in.  

For example, [http://localhost:8000/admin/login?from=%2Fadmin%2Fusers](http://localhost:8000/admin/login?from=%2Fadmin%2Fusers) should send the user to the users page after logging in.

If no url parameter is provided then they will be redirected to the default page as usual.  It should work with both local auth and SiC.

I'm concerned about this feature adding an [open redirect vulnerability](https://sec.okta.com/articles/2021/02/stealing-oauth-tokens-open-redirects) to the site.  For example, if there was a link to http://llocalhost:8000/admin/login?from=badsite.evil then the token could be stolen.  I have limited to redirect to accepting only relative urls starting with / but we could still be vulnerable to an open redirect chain.  I could open an issue where we discuss whitelisting valid redirect URLs or using named urls as suggested [here](https://www.netsparker.com/blog/web-security/open-redirect-vulnerabilities-netsparker-pauls-security-weekly/).

Closes #1462 