### PR TITLE
Fix linting warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,6 +57,7 @@
     "composer.json",
     "composer.lock",
     "generated.ts",
-    "tsconfig.json"
+    "tsconfig.json",
+    ".eslintrc"
   ]
 }

--- a/admin/.eslintrc
+++ b/admin/.eslintrc
@@ -28,7 +28,8 @@
     },
     "ignorePatterns": [
         ".eslintrc",
-        "generated.ts"
+        "generated.ts",
+        "webpack.mix.js"
     ],
     "plugins": [
         "prettier",

--- a/talentsearch/.eslintrc
+++ b/talentsearch/.eslintrc
@@ -27,7 +27,9 @@
         ]
     },
     "ignorePatterns": [
-        ".eslintrc"
+        ".eslintrc",
+        "generated.ts",
+        "webpack.mix.js"
     ],
     "plugins": [
         "prettier",

--- a/talentsearch/package-lock.json
+++ b/talentsearch/package-lock.json
@@ -57,6 +57,7 @@
         "eslint": "^8.5.0",
         "eslint-config-airbnb": "^19.0.2",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-import-resolver-alias": "^1.1.2",
         "eslint-plugin-import": "^2.25.3",
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-node": "^11.1.0",
@@ -17103,6 +17104,18 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-alias": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
+      "integrity": "sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      },
+      "peerDependencies": {
+        "eslint-plugin-import": ">=1.4.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -46530,6 +46543,13 @@
     "eslint-config-prettier": {
       "version": "8.3.0",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-import-resolver-alias": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
+      "integrity": "sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==",
       "dev": true,
       "requires": {}
     },

--- a/talentsearch/package.json
+++ b/talentsearch/package.json
@@ -66,6 +66,7 @@
     "eslint": "^8.5.0",
     "eslint-config-airbnb": "^19.0.2",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-node": "^11.1.0",


### PR DESCRIPTION
Branch fixes a few linting warnings:
- add missing dev dependency on eslint-import-resolver-alias
- exclude generated.ts and webpack.mix.js from linting
- exclude .eslintrc from cspell

Closes #1527 