### PR TITLE
Enable Typescript Debugging in VS Code

### DIFF
--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,0 +1,1 @@
+launch.json

--- a/.vscode/launch.json.example
+++ b/.vscode/launch.json.example
@@ -2,14 +2,55 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Admin Localhost Chrome",
+      "request": "launch",
+      "type": "pwa-chrome",
+      "url": "http://localhost:8000/admin",
+      "webRoot": "${workspaceFolder}/admin",
+      "pathMappings": [
+        {
+          "url": "webpack://admin/resources",
+          "path": "${workspaceFolder}/admin/resources"
+        },
+        {
+          "url": "webpack://admin/common",
+          "path": "${workspaceFolder}/common"
+        }
+      ],
+      "userDataDir": false,
+      "runtimeArgs": [
+        "--profile-directory=debug-profile"
+      ]
+    },
+    {
+      "name": "Talent Search Localhost Chrome",
+      "request": "launch",
+      "type": "pwa-chrome",
+      "url": "http://localhost:8000",
+      "webRoot": "${workspaceFolder}/talentsearch",
+      "pathMappings": [
+        {
+          "url": "webpack://talentsearch/resources",
+          "path": "${workspaceFolder}/talentsearch/resources"
+        },
+        {
+          "url": "webpack://talentsearch/common",
+          "path": "${workspaceFolder}/common"
+        }
+      ],
+      "userDataDir": false,
+      "runtimeArgs": [
+        "--profile-directory=debug-profile"
+      ]
+    },
+    {
       "name": "Admin Localhost Firefox",
       "type": "firefox",
       "request": "launch",
       "reAttach": true,
       "url": "http://localhost:8000/admin",
-      "webRoot": "${workspaceFolder}",
       "keepProfileChanges": true,
-      "profile": "Dev",
+      "profile": "debug-profile",
       "pathMappings": [
         {
           "url": "webpack://admin/resources",
@@ -27,14 +68,14 @@
       }
     },
     {
-      "name": "Admin Localhost Talent Search",
+      "name": "Talent Search Localhost Firefox",
       "type": "firefox",
       "request": "launch",
       "reAttach": true,
       "url": "http://localhost:8000",
       "webRoot": "${workspaceFolder}",
       "keepProfileChanges": true,
-      "profile": "Dev",
+      "profile": "debug-profile",
       "pathMappings": [
         {
           "url": "webpack://talentsearch/resources",

--- a/.vscode/launch.json.example
+++ b/.vscode/launch.json.example
@@ -1,0 +1,55 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Admin Localhost Firefox",
+      "type": "firefox",
+      "request": "launch",
+      "reAttach": true,
+      "url": "http://localhost:8000/admin",
+      "webRoot": "${workspaceFolder}",
+      "keepProfileChanges": true,
+      "profile": "Dev",
+      "pathMappings": [
+        {
+          "url": "webpack://admin/resources",
+          "path": "${workspaceFolder}/admin/resources"
+        },
+        {
+          "url": "webpack://admin/common",
+          "path": "${workspaceFolder}/common"
+        }
+      ],
+      "reloadOnChange": {
+        "watch": [
+          "${workspaceFolder}/admin/public/js/**"
+        ]
+      }
+    },
+    {
+      "name": "Admin Localhost Talent Search",
+      "type": "firefox",
+      "request": "launch",
+      "reAttach": true,
+      "url": "http://localhost:8000",
+      "webRoot": "${workspaceFolder}",
+      "keepProfileChanges": true,
+      "profile": "Dev",
+      "pathMappings": [
+        {
+          "url": "webpack://talentsearch/resources",
+          "path": "${workspaceFolder}/talentsearch/resources"
+        },
+        {
+          "url": "webpack://talentsearch/common",
+          "path": "${workspaceFolder}/common"
+        }
+      ],
+      "reloadOnChange": {
+        "watch": [
+          "${workspaceFolder}/talentsearch/public/js/**"
+        ]
+      }
+    }
+  ]
+}

--- a/admin/tsconfig.json
+++ b/admin/tsconfig.json
@@ -18,7 +18,7 @@
     "jsx": "react",                                 /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
     // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                           /* Generates corresponding '.map' file. */
+    "sourceMap": true,                              /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */
     // "outDir": "./",                              /* Redirect output structure to the directory. */
     // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */

--- a/admin/webpack.mix.js
+++ b/admin/webpack.mix.js
@@ -67,3 +67,4 @@ mix.webpackConfig({
 });
 
 mix.version();
+mix.sourceMaps();

--- a/talentsearch/tsconfig.json
+++ b/talentsearch/tsconfig.json
@@ -18,7 +18,7 @@
     "jsx": "react",                                 /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
     // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                           /* Generates corresponding '.map' file. */
+    "sourceMap": true,                              /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */
     // "outDir": "./",                              /* Redirect output structure to the directory. */
     // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */

--- a/talentsearch/webpack.mix.js
+++ b/talentsearch/webpack.mix.js
@@ -65,3 +65,4 @@ mix.webpackConfig({
 });
 
 mix.version();
+mix.sourceMaps();


### PR DESCRIPTION
This branch enables Typescript debugging in VS Code.  It enables sourcemap generation and provides example debugging profiles for Chrome and Firefox.  To test it:
1) `npm run dev`
2) Copy desired profiles from launch.json.example to launch.json
3) In the _Run and Debug_ pane choose the profile and click _Start Debugging_

Possible Bugs:
- When I first visited http://localhost:8000/admin in both Firefox and Chrome I got a cached 302 redirect to /admin/public/admin.  I'm not sure why it happened and it might just be my machine.  I clicked the _Disable Cache_ option in my browser's tools and it never happened again. 🤷‍♂️

Chrome Notes:
- It seems like the built-in debugging extension does not support auto-reload on changes.
- The example debugging profile should automatically create a new Chrome profile to use.  You can disable the profile picker to auto-start your regular profile when you start Chrome manually.

Firefox Notes:
- Firefox debugging requires installing the extension firefox-devtools.vscode-firefox-debug
- The example debugging profile expects a separate `debug-profile` Firefox profile to exist but will not automatically create it.  You can create it manually by navigating to about:profiles.

Closes #1358 