### PR TITLE
Log admin requests

### DIFF
--- a/api/app/Http/Middleware/AuditQueryMiddleware.php
+++ b/api/app/Http/Middleware/AuditQueryMiddleware.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Middleware;
+
+
+
+use Closure;
+use Illuminate\Http\Request;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Logs every incoming GraphQL query.
+ * based on Nuwave\Lighthouse\Support\Http\Middleware\LogGraphQLQueries.php;
+ */
+class AuditQueryMiddleware
+{
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    protected $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * @return mixed Any kind of response
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $user = $request->user();
+        if (!is_null($user) && $user->isAdmin())
+        {
+            $message = 'GraphQL request from admin user ['.$user['email'].']';
+            $this->logger->info(
+                $message,
+                $request->json()->all()
+            );
+        }
+
+        return $next($request);
+    }
+}

--- a/api/config/lighthouse.php
+++ b/api/config/lighthouse.php
@@ -36,7 +36,7 @@ return [
             \Nuwave\Lighthouse\Support\Http\Middleware\AttemptAuthentication::class,
 
             // Logs every incoming GraphQL query.
-            // \Nuwave\Lighthouse\Support\Http\Middleware\LogGraphQLQueries::class,
+            App\Http\Middleware\AuditQueryMiddleware::class,
         ],
 
         /*


### PR DESCRIPTION
This branch adds logging of admin requests to the API subproject.  Works for queries from the site or the GraphQL playground.  If the user is unauthenticated or does not have the ADMIN role then no entry is logged.

By default the entries are logged to the daily file in api\storage\logs.  They look like this:
```
[2021-12-30 15:27:18] local.INFO: GraphQL request from admin user [admin@test.com] {"operationName":null,"variables":[],"query":"{
  me {
    email
  }
}
"} 
```


Closes #1538 