### PR TITLE
Feature - Candidate count unit tests

### DIFF
--- a/api/app/Models/Classification.php
+++ b/api/app/Models/Classification.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
@@ -21,6 +22,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Classification extends Model
 {
 
+    use HasFactory;
     use SoftDeletes;
 
     protected $keyType = 'string';

--- a/api/app/Models/CmoAsset.php
+++ b/api/app/Models/CmoAsset.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
@@ -19,6 +20,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class CmoAsset extends Model
 {
 
+    use HasFactory;
     use SoftDeletes;
 
     protected $keyType = 'string';

--- a/api/app/Models/OperationalRequirement.php
+++ b/api/app/Models/OperationalRequirement.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
@@ -18,6 +19,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class OperationalRequirement extends Model
 {
+    use HasFactory;
     use SoftDeletes;
 
     protected $keyType = 'string';

--- a/api/database/factories/ClassificationFactory.php
+++ b/api/database/factories/ClassificationFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Classification;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ClassificationFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Classification::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        $faker = $this->faker;
+        return [
+            'group' => $faker->name,
+            'name' => ['en' => $faker->name, 'fr' => $faker->name],
+            'level' => $faker->numberBetween(0,5),
+            'min_salary' => $faker->numberBetween(0,1000),
+            'max_salary' => $faker->numberBetween(1000,10000),
+        ];
+    }
+}

--- a/api/database/factories/ClassificationFactory.php
+++ b/api/database/factories/ClassificationFactory.php
@@ -26,8 +26,8 @@ class ClassificationFactory extends Factory
             'group' => $faker->name,
             'name' => ['en' => $faker->name, 'fr' => $faker->name],
             'level' => $faker->numberBetween(0,5),
-            'min_salary' => $faker->numberBetween(0,1000),
-            'max_salary' => $faker->numberBetween(1000,10000),
+            'min_salary' => $faker->randomElement([50000, 60000, 70000]),
+            'max_salary' => $faker->randomElement([80000, 90000, 100000]),
         ];
     }
 }

--- a/api/database/factories/CmoAssetFactory.php
+++ b/api/database/factories/CmoAssetFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CmoAsset;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CmoAssetFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = CmoAsset::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        $faker = $this->faker;
+        return [
+            'key' => $faker->word,
+            'name' => ['en' => $faker->name, 'fr' => $faker->name],
+        ];
+    }
+}

--- a/api/database/factories/OperationalRequirementFactory.php
+++ b/api/database/factories/OperationalRequirementFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\OperationalRequirement;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class OperationalRequirementFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = OperationalRequirement::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        $faker = $this->faker;
+        return [
+            'key' => $faker->word,
+            'name' => ['en' => $faker->name, 'fr' => $faker->name],
+        ];
+    }
+}

--- a/api/tests/PoolCandidateTest.php
+++ b/api/tests/PoolCandidateTest.php
@@ -28,9 +28,9 @@ class PoolCandidateTest extends TestCase
     Classification::factory()->count(3)->create();
     PoolCandidate::factory()->count(5)->create();
 
-    // Create new classification and attach to 2 new pool candidates.
+    // Create new classification and attach to two new pool candidates.
     $classification = Classification::factory()->create([
-      'group' => 'CS',
+      'group' => 'ZZ',
       'level' => 1,
     ]);
     PoolCandidate::factory()->count(2)->create()->each(function($candidate) use ($classification) {
@@ -57,7 +57,7 @@ class PoolCandidateTest extends TestCase
       }
     ', [
       'where' => [
-        'classifications' => [['group' => 'CS', 'level' => 1 ]],
+        'classifications' => [['group' => 'ZZ', 'level' => 1 ]],
       ]
     ])->seeJson([
       'data' => [

--- a/api/tests/PoolCandidateTest.php
+++ b/api/tests/PoolCandidateTest.php
@@ -131,7 +131,7 @@ class PoolCandidateTest extends TestCase
       }
     ', [
       'where' => [
-        'cmoAssets' => [[ 'id' => 'unknown_id' ]],
+        'cmoAssets' => [[ 'key' => 'unknown_id' ]],
       ]
     ])->seeJson([
       'data' => [
@@ -233,7 +233,7 @@ class PoolCandidateTest extends TestCase
       }
     ', [
       'where' => [
-        'pools' => [[ 'id' => $id ]],
+        'pools' => [[ 'id' => $pool['id'] ]],
       ]
     ])->seeJson([
       'data' => [
@@ -555,7 +555,7 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
 
-    // Assert query with operationalRequirement filter will return correct candidate count
+    // Assert query with WorkRegion filter will return correct candidate count
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)

--- a/api/tests/PoolCandidateTest.php
+++ b/api/tests/PoolCandidateTest.php
@@ -1,0 +1,606 @@
+<?php
+
+use App\Models\Classification;
+use App\Models\CmoAsset;
+use App\Models\OperationalRequirement;
+use App\Models\Pool;
+use App\Models\PoolCandidate;
+use GraphQL\Type\Definition\EnumType;
+use Laravel\Lumen\Testing\DatabaseMigrations;
+use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequestsLumen;
+// use PHPUnit\Framework\TestCase;
+
+class PoolCandidateTest extends TestCase
+{
+  use DatabaseMigrations;
+  use MakesGraphQLRequestsLumen;
+  use ClearsSchemaCache;
+
+  protected function setUp(): void
+  {
+    parent::setUp();
+    $this->bootClearsSchemaCache();
+  }
+
+  public function testFilterByClassification(): void
+  {
+
+    // Create 5 pool candidates.
+    Classification::factory()->count(3)->create();
+    PoolCandidate::factory()->count(5)->create();
+
+    // Create new classification and attach to 2 new pool candidates.
+    $classification = Classification::factory()->create([
+      'group' => 'CS',
+      'level' => 1,
+    ]);
+    PoolCandidate::factory()->count(2)->create()->each(function($candidate) use ($classification) {
+      $candidate->expectedClassifications()->save($classification);
+    });
+
+    // Assert query will with no classifications filter will return all candidates
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => []
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 7
+      ]
+    ]);
+
+    // Assert query with classification filter will return correct candidate count
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'classifications' => [['group' => 'CS', 'level' => 1 ]],
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 2
+      ]
+    ]);
+
+    // Assert query with unknown classification filter will return 0
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'classifications' => [['group' => 'UNKNOWN', 'level' => 1324234 ]],
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 0
+      ]
+    ]);
+  }
+
+  public function testFilterByCmoAsset(): void
+  {
+
+    // Create 5 pool candidates.
+    CmoAsset::factory()->count(3)->create();
+    PoolCandidate::factory()->count(5)->create();
+
+    // Create new cmoAsset and attach to 2 new pool candidates.
+    $cmoAsset = CmoAsset::factory()->create([
+      'id' => 'new_cmo_asset'
+    ]);
+    PoolCandidate::factory()->count(2)->create()->each(function($candidate) use ($cmoAsset) {
+      $candidate->cmoAssets()->save($cmoAsset);
+    });
+
+    // Assert query will with no cmoAssets filter will return all candidates
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => []
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 7
+      ]
+    ]);
+
+    // Assert query with cmoAsset filter will return correct candidate count
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'cmoAssets' => [[ 'id' => 'new_cmo_asset' ]],
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 2
+      ]
+    ]);
+
+    // Assert query with unknown cmoAsset filter will return 0
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'cmoAssets' => [[ 'id' => 'unknown_id' ]],
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 0
+      ]
+    ]);
+  }
+
+  public function testFilterByOperationalRequirements(): void
+  {
+
+    // Create 5 pool candidates.
+    OperationalRequirement::factory()->count(3)->create();
+    PoolCandidate::factory()->count(5)->create();
+
+    // Create new operationalRequirement and attach to 2 new pool candidates.
+    $operationalRequirement = OperationalRequirement::factory()->create([
+      'key' => 'new_operational_requirement'
+    ]);
+    PoolCandidate::factory()->count(2)->create()->each(function($candidate) use ($operationalRequirement) {
+      $candidate->acceptedOperationalRequirements()->save($operationalRequirement);
+    });
+
+    // Assert query will with no operationalRequirements filter will return all candidates
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => []
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 7
+      ]
+    ]);
+
+    // Assert query with operationalRequirement filter will return correct candidate count
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'operationalRequirements' => [[ 'key' => 'new_operational_requirement' ]],
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 2
+      ]
+    ]);
+
+    // Assert query with unknown operationalRequirement filter will return 0
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'operationalRequirements' => [[ 'key' => 'unknown_operational_requirement' ]],
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 0
+      ]
+    ]);
+  }
+
+  public function testFilterByPool(): void
+  {
+
+    // Create 5 pool candidates.
+    Pool::factory()->count(3)->create();
+    PoolCandidate::factory()->count(5)->create();
+
+    // Create new cmoAsset and attach to 2 new pool candidates.
+    $id = strtolower(preg_replace('/\s+/', '_', 'test'));
+    $pool = Pool::factory()->create();
+    PoolCandidate::factory()->count(2)->create()->each(function($candidate) use ($pool) {
+      $candidate->pool()->associate($pool);
+      $candidate->save();
+    });
+
+    // Assert query will with no cmoAssets filter will return all candidates
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => []
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 7
+      ]
+    ]);
+
+    // Assert query with cmoAsset filter will return correct candidate count
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'pools' => [[ 'id' => $id ]],
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 2
+      ]
+    ]);
+
+    // Assert query with unknown cmoAsset filter will return 0
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'pools' => [[ 'id' => 'unknown_id' ]],
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 0
+      ]
+    ]);
+  }
+
+  public function testFilterByDiploma(): void
+  {
+
+    // Create 5 pool candidates.
+    PoolCandidate::factory()->count(5)->create([
+      'has_diploma' => false,
+    ]);
+
+    // Create new operationalRequirement and attach to 2 new pool candidates.
+    PoolCandidate::factory()->count(2)->create([
+      'has_diploma' => true,
+    ]);
+
+    // Assert query will with no operationalRequirements filter will return all candidates
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => []
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 7
+      ]
+    ]);
+
+    // Assert query with operationalRequirement filter will return correct candidate count
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'hasDiploma' => true,
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 2
+      ]
+    ]);
+
+    // Assert query with unknown operationalRequirement filter will return 0
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'hasDiploma' => false,
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 7
+      ]
+    ]);
+  }
+
+  public function testFilterByEmploymentEquity(): void
+  {
+
+    // Create 5 pool candidates.
+    PoolCandidate::factory()->count(5)->create([
+      'has_disability' => false,
+      'is_indigenous' => false,
+      'is_visible_minority' => false,
+      'is_woman' => false,
+    ]);
+
+    // Create new operationalRequirement and attach to 2 new pool candidates.
+    PoolCandidate::factory()->create([
+      'has_disability' => true,
+      'is_indigenous' => false,
+      'is_visible_minority' => false,
+      'is_woman' => false,
+    ]);
+    PoolCandidate::factory()->create([
+      'has_disability' => false,
+      'is_indigenous' => true,
+      'is_visible_minority' => false,
+      'is_woman' => false,
+    ]);
+    PoolCandidate::factory()->create([
+      'has_disability' => false,
+      'is_indigenous' => false,
+      'is_visible_minority' => true,
+      'is_woman' => false,
+    ]);
+    PoolCandidate::factory()->create([
+      'has_disability' => false,
+      'is_indigenous' => false,
+      'is_visible_minority' => false,
+      'is_woman' => true,
+    ]);
+
+    // Assert query will with no operationalRequirements filter will return all candidates
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => []
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 9
+      ]
+    ]);
+
+    // Assert query with operationalRequirement filter will return correct candidate count
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'isIndigenous' => true,
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 1
+      ]
+    ]);
+    // Assert query with operationalRequirement filter will return correct candidate count
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'isVisibleMinority' => true,
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 1
+      ]
+    ]);
+    // Assert query with operationalRequirement filter will return correct candidate count
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'hasDisability' => true,
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 1
+      ]
+    ]);
+    // Assert query with operationalRequirement filter will return correct candidate count
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'isWoman' => true,
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 1
+      ]
+    ]);
+
+    // Assert query with unknown operationalRequirement filter will return 0
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'hasDisability' => false,
+        'isIndigenous' => false,
+        'isVisibleMinority' => false,
+        'isWoman' => false,
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 9
+      ]
+    ]);
+  }
+
+  public function testFilterByLanguageAbility(): void
+  {
+
+    // Create 5 pool candidates.
+    PoolCandidate::factory()->count(5)->create([
+      'language_ability' => 'TEST'
+    ]);
+
+    // Create new operationalRequirement and attach to 2 new pool candidates.
+    PoolCandidate::factory()->create([
+      'language_ability' => 'FRENCH'
+    ]);
+    PoolCandidate::factory()->create([
+      'language_ability' => 'ENGLISH'
+    ]);
+    PoolCandidate::factory()->create([
+      'language_ability' => 'BILINGUAL'
+    ]);
+
+    // Assert query will with no operationalRequirements filter will return all candidates
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => []
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 8
+      ]
+    ]);
+
+    // Assert query with operationalRequirement filter will return correct candidate count
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'languageAbility' => "ENGLISH",
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 1
+      ]
+    ]);
+    // Assert query with operationalRequirement filter will return correct candidate count
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'languageAbility' => "ENGLISH",
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 1
+      ]
+    ]);
+    // Assert query with operationalRequirement filter will return correct candidate count
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'languageAbility' => "FRENCH",
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 1
+      ]
+    ]);
+    // Assert query with operationalRequirement filter will return correct candidate count
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'languageAbility' => "BILINGUAL",
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 1
+      ]
+    ]);
+    // Assert query with operationalRequirement filter will return correct candidate count
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'languageAbility' => null,
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 0
+      ]
+    ]);
+  }
+
+  public function testFilterByWorkRegions(): void
+  {
+
+    PoolCandidate::factory()->count(5)->create([
+      'location_preferences' => ["ONTARIO"],
+    ]);
+
+    // Create new operationalRequirement and attach to 2 new pool candidates.
+    PoolCandidate::factory()->count(2)->create([
+      'location_preferences' => ["TELEWORK"],
+    ]);
+
+    // Assert query will with no operationalRequirements filter will return all candidates
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => []
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 7
+      ]
+    ]);
+
+    // Assert query with operationalRequirement filter will return correct candidate count
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'workRegions' => ["TELEWORK"],
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 2
+      ]
+    ]);
+
+    // Assert query with unknown operationalRequirement filter will return 0
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'workRegions' => [],
+      ]
+    ])->seeJson([
+      'data' => [
+        'countPoolCandidates' => 7
+      ]
+    ]);
+  }
+}
+

--- a/api/tests/PoolCandidateTest.php
+++ b/api/tests/PoolCandidateTest.php
@@ -90,7 +90,7 @@ class PoolCandidateTest extends TestCase
 
     // Create new cmoAsset and attach to 2 new pool candidates.
     $cmoAsset = CmoAsset::factory()->create([
-      'id' => 'new_cmo_asset'
+      'key' => 'new_cmo_asset'
     ]);
     PoolCandidate::factory()->count(2)->create()->each(function($candidate) use ($cmoAsset) {
       $candidate->cmoAssets()->save($cmoAsset);
@@ -116,7 +116,7 @@ class PoolCandidateTest extends TestCase
       }
     ', [
       'where' => [
-        'cmoAssets' => [[ 'id' => 'new_cmo_asset' ]],
+        'cmoAssets' => [[ 'key' => 'new_cmo_asset' ]],
       ]
     ])->seeJson([
       'data' => [
@@ -207,7 +207,6 @@ class PoolCandidateTest extends TestCase
     PoolCandidate::factory()->count(5)->create();
 
     // Create new cmoAsset and attach to 2 new pool candidates.
-    $id = strtolower(preg_replace('/\s+/', '_', 'test'));
     $pool = Pool::factory()->create();
     PoolCandidate::factory()->count(2)->create()->each(function($candidate) use ($pool) {
       $candidate->pool()->associate($pool);
@@ -249,7 +248,7 @@ class PoolCandidateTest extends TestCase
       }
     ', [
       'where' => [
-        'pools' => [[ 'id' => 'unknown_id' ]],
+        'pools' => [[ 'id' => '00000000-0000-0000-0000-000000000000' ]],
       ]
     ])->seeJson([
       'data' => [
@@ -299,7 +298,7 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
 
-    // Assert query with unknown operationalRequirement filter will return 0
+    // Assert query with filter set to false will return all candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -326,7 +325,7 @@ class PoolCandidateTest extends TestCase
       'is_woman' => false,
     ]);
 
-    // Create new operationalRequirement and attach to 2 new pool candidates.
+    // Create one new candidate for each EmploymentEquity filter
     PoolCandidate::factory()->create([
       'has_disability' => true,
       'is_indigenous' => false,
@@ -352,7 +351,7 @@ class PoolCandidateTest extends TestCase
       'is_woman' => true,
     ]);
 
-    // Assert query will with no operationalRequirements filter will return all candidates
+    // Assert query will with no EmploymentEquity filter will return all candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -365,7 +364,7 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
 
-    // Assert query with operationalRequirement filter will return correct candidate count
+    // Assert query with EmploymentEquity filter will return correct candidate count
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -379,7 +378,7 @@ class PoolCandidateTest extends TestCase
         'countPoolCandidates' => 1
       ]
     ]);
-    // Assert query with operationalRequirement filter will return correct candidate count
+    // Assert query with EmploymentEquity filter will return correct candidate count
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -393,7 +392,7 @@ class PoolCandidateTest extends TestCase
         'countPoolCandidates' => 1
       ]
     ]);
-    // Assert query with operationalRequirement filter will return correct candidate count
+    // Assert query with EmploymentEquity filter will return correct candidate count
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -407,7 +406,7 @@ class PoolCandidateTest extends TestCase
         'countPoolCandidates' => 1
       ]
     ]);
-    // Assert query with operationalRequirement filter will return correct candidate count
+    // Assert query with EmploymentEquity filter will return correct candidate count
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -422,7 +421,7 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
 
-    // Assert query with unknown operationalRequirement filter will return 0
+    // Assert query with all EmploymentEquity filters set to false will return all candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -449,7 +448,7 @@ class PoolCandidateTest extends TestCase
       'language_ability' => 'TEST'
     ]);
 
-    // Create new operationalRequirement and attach to 2 new pool candidates.
+    // Create new LanguageAbility and attach to 3 new pool candidates.
     PoolCandidate::factory()->create([
       'language_ability' => 'FRENCH'
     ]);
@@ -460,7 +459,7 @@ class PoolCandidateTest extends TestCase
       'language_ability' => 'BILINGUAL'
     ]);
 
-    // Assert query will with no operationalRequirements filter will return all candidates
+    // Assert query will with no LanguageAbility filter will return all candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -473,7 +472,7 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
 
-    // Assert query with operationalRequirement filter will return correct candidate count
+    // Assert query with LanguageAbility filter will return correct candidate count
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -487,21 +486,7 @@ class PoolCandidateTest extends TestCase
         'countPoolCandidates' => 1
       ]
     ]);
-    // Assert query with operationalRequirement filter will return correct candidate count
-    $this->graphQL(/** @lang Graphql */ '
-      query countPoolCandidates($where: PoolCandidateFilterInput) {
-        countPoolCandidates(where: $where)
-      }
-    ', [
-      'where' => [
-        'languageAbility' => "ENGLISH",
-      ]
-    ])->seeJson([
-      'data' => [
-        'countPoolCandidates' => 1
-      ]
-    ]);
-    // Assert query with operationalRequirement filter will return correct candidate count
+    // Assert query with LanguageAbility filter will return correct candidate count
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -515,7 +500,7 @@ class PoolCandidateTest extends TestCase
         'countPoolCandidates' => 1
       ]
     ]);
-    // Assert query with operationalRequirement filter will return correct candidate count
+    // Assert query with LanguageAbility filter will return correct candidate count
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -529,7 +514,7 @@ class PoolCandidateTest extends TestCase
         'countPoolCandidates' => 1
       ]
     ]);
-    // Assert query with operationalRequirement filter will return correct candidate count
+    // Assert query with a null LanguageAbility filter will return no candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -547,17 +532,17 @@ class PoolCandidateTest extends TestCase
 
   public function testFilterByWorkRegions(): void
   {
-
+    // Create 5 new pool candidates for ONTARIO.
     PoolCandidate::factory()->count(5)->create([
       'location_preferences' => ["ONTARIO"],
     ]);
 
-    // Create new operationalRequirement and attach to 2 new pool candidates.
+    // Create 2 new pool candidates for TELEWORK.
     PoolCandidate::factory()->count(2)->create([
       'location_preferences' => ["TELEWORK"],
     ]);
 
-    // Assert query will with no operationalRequirements filter will return all candidates
+    // Assert query will with no WorkRegion filter will return all candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -585,7 +570,7 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
 
-    // Assert query with unknown operationalRequirement filter will return 0
+    // Assert query with empty WorkRegion filter will return 0
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)

--- a/api/tests/PoolCandidateTest.php
+++ b/api/tests/PoolCandidateTest.php
@@ -5,7 +5,6 @@ use App\Models\CmoAsset;
 use App\Models\OperationalRequirement;
 use App\Models\Pool;
 use App\Models\PoolCandidate;
-use GraphQL\Type\Definition\EnumType;
 use Laravel\Lumen\Testing\DatabaseMigrations;
 use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequestsLumen;

--- a/api/tests/PoolCandidateTest.php
+++ b/api/tests/PoolCandidateTest.php
@@ -8,7 +8,6 @@ use App\Models\PoolCandidate;
 use Laravel\Lumen\Testing\DatabaseMigrations;
 use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequestsLumen;
-// use PHPUnit\Framework\TestCase;
 
 class PoolCandidateTest extends TestCase
 {

--- a/api/tests/PoolCandidateTest.php
+++ b/api/tests/PoolCandidateTest.php
@@ -24,7 +24,7 @@ class PoolCandidateTest extends TestCase
   public function testFilterByClassification(): void
   {
 
-    // Create 5 pool candidates.
+    // Create initial data.
     Classification::factory()->count(3)->create();
     PoolCandidate::factory()->count(5)->create();
 
@@ -37,7 +37,7 @@ class PoolCandidateTest extends TestCase
       $candidate->expectedClassifications()->save($classification);
     });
 
-    // Assert query will with no classifications filter will return all candidates
+    // Assert query with no classifications filter will return all candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -65,7 +65,7 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
 
-    // Assert query with unknown classification filter will return 0
+    // Assert query with unknown classification filter will return zero
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -84,11 +84,11 @@ class PoolCandidateTest extends TestCase
   public function testFilterByCmoAsset(): void
   {
 
-    // Create 5 pool candidates.
+    // Create initial data.
     CmoAsset::factory()->count(3)->create();
     PoolCandidate::factory()->count(5)->create();
 
-    // Create new cmoAsset and attach to 2 new pool candidates.
+    // Create new cmoAsset and attach to two new pool candidates.
     $cmoAsset = CmoAsset::factory()->create([
       'key' => 'new_cmo_asset'
     ]);
@@ -96,7 +96,7 @@ class PoolCandidateTest extends TestCase
       $candidate->cmoAssets()->save($cmoAsset);
     });
 
-    // Assert query will with no cmoAssets filter will return all candidates
+    // Assert query with no cmoAssets filter will return all candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -124,14 +124,14 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
 
-    // Assert query with unknown cmoAsset filter will return 0
+    // Assert query with unknown cmoAsset filter will return zero
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
       }
     ', [
       'where' => [
-        'cmoAssets' => [[ 'key' => 'unknown_id' ]],
+        'cmoAssets' => [[ 'key' => 'unknown_cmo_asset' ]],
       ]
     ])->seeJson([
       'data' => [
@@ -143,11 +143,11 @@ class PoolCandidateTest extends TestCase
   public function testFilterByOperationalRequirements(): void
   {
 
-    // Create 5 pool candidates.
+    // Create initial data.
     OperationalRequirement::factory()->count(3)->create();
     PoolCandidate::factory()->count(5)->create();
 
-    // Create new operationalRequirement and attach to 2 new pool candidates.
+    // Create new operationalRequirement and attach to two new pool candidates.
     $operationalRequirement = OperationalRequirement::factory()->create([
       'key' => 'new_operational_requirement'
     ]);
@@ -155,7 +155,7 @@ class PoolCandidateTest extends TestCase
       $candidate->acceptedOperationalRequirements()->save($operationalRequirement);
     });
 
-    // Assert query will with no operationalRequirements filter will return all candidates
+    // Assert query with no operationalRequirements filter will return all candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -183,7 +183,7 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
 
-    // Assert query with unknown operationalRequirement filter will return 0
+    // Assert query with unknown operationalRequirement filter will return zero
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -202,18 +202,18 @@ class PoolCandidateTest extends TestCase
   public function testFilterByPool(): void
   {
 
-    // Create 5 pool candidates.
+    // Create initial data.
     Pool::factory()->count(3)->create();
     PoolCandidate::factory()->count(5)->create();
 
-    // Create new cmoAsset and attach to 2 new pool candidates.
+    // Create new pool and attach to two new pool candidates.
     $pool = Pool::factory()->create();
     PoolCandidate::factory()->count(2)->create()->each(function($candidate) use ($pool) {
       $candidate->pool()->associate($pool);
       $candidate->save();
     });
 
-    // Assert query will with no cmoAssets filter will return all candidates
+    // Assert query with no pool filter will return all candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -226,7 +226,7 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
 
-    // Assert query with cmoAsset filter will return correct candidate count
+    // Assert query with pool filter will return correct candidate count
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -241,7 +241,7 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
 
-    // Assert query with unknown cmoAsset filter will return 0
+    // Assert query with unknown pool filter will return zero
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -260,17 +260,17 @@ class PoolCandidateTest extends TestCase
   public function testFilterByDiploma(): void
   {
 
-    // Create 5 pool candidates.
+    // Create initial set of 5 candidates with no diploma.
     PoolCandidate::factory()->count(5)->create([
       'has_diploma' => false,
     ]);
 
-    // Create new operationalRequirement and attach to 2 new pool candidates.
+    // Create two new pool candidates with a diploma.
     PoolCandidate::factory()->count(2)->create([
       'has_diploma' => true,
     ]);
 
-    // Assert query will with no operationalRequirements filter will return all candidates
+    // Assert query no hasDiploma filter will return all candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -283,7 +283,7 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
 
-    // Assert query with operationalRequirement filter will return correct candidate count
+    // Assert query with hasDiploma filter set to true will return correct candidate count
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -298,7 +298,7 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
 
-    // Assert query with filter set to false will return all candidates
+    // Assert query with hasDiploma filter set to false will return all candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -317,7 +317,7 @@ class PoolCandidateTest extends TestCase
   public function testFilterByEmploymentEquity(): void
   {
 
-    // Create 5 pool candidates.
+    // Create initial data.
     PoolCandidate::factory()->count(5)->create([
       'has_disability' => false,
       'is_indigenous' => false,
@@ -351,7 +351,7 @@ class PoolCandidateTest extends TestCase
       'is_woman' => true,
     ]);
 
-    // Assert query will with no EmploymentEquity filter will return all candidates
+    // Assert query with no EmploymentEquity filter will return all candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -364,7 +364,7 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
 
-    // Assert query with EmploymentEquity filter will return correct candidate count
+    // Assert query with isIndigenous filter will return correct candidate count
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -378,7 +378,7 @@ class PoolCandidateTest extends TestCase
         'countPoolCandidates' => 1
       ]
     ]);
-    // Assert query with EmploymentEquity filter will return correct candidate count
+    // Assert query with isVisibleMinority filter will return correct candidate count
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -392,7 +392,7 @@ class PoolCandidateTest extends TestCase
         'countPoolCandidates' => 1
       ]
     ]);
-    // Assert query with EmploymentEquity filter will return correct candidate count
+    // Assert query with hasDisability filter will return correct candidate count
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -406,7 +406,7 @@ class PoolCandidateTest extends TestCase
         'countPoolCandidates' => 1
       ]
     ]);
-    // Assert query with EmploymentEquity filter will return correct candidate count
+    // Assert query with isWoman filter will return correct candidate count
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -443,7 +443,7 @@ class PoolCandidateTest extends TestCase
   public function testFilterByLanguageAbility(): void
   {
 
-    // Create 5 pool candidates.
+    // Create initial data.
     PoolCandidate::factory()->count(5)->create([
       'language_ability' => 'TEST'
     ]);
@@ -459,7 +459,7 @@ class PoolCandidateTest extends TestCase
       'language_ability' => 'BILINGUAL'
     ]);
 
-    // Assert query will with no LanguageAbility filter will return all candidates
+    // Assert query with no LanguageAbility filter will return all candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -514,7 +514,7 @@ class PoolCandidateTest extends TestCase
         'countPoolCandidates' => 1
       ]
     ]);
-    // Assert query with a null LanguageAbility filter will return no candidates
+    // Assert query with a unknown LanguageAbility filter will return no candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -532,17 +532,17 @@ class PoolCandidateTest extends TestCase
 
   public function testFilterByWorkRegions(): void
   {
-    // Create 5 new pool candidates for ONTARIO.
+    // Create 5 new pool candidates with a ONTARIO location preference.
     PoolCandidate::factory()->count(5)->create([
       'location_preferences' => ["ONTARIO"],
     ]);
 
-    // Create 2 new pool candidates for TELEWORK.
+    // Create 2 new pool candidates with a TELEWORK location preference.
     PoolCandidate::factory()->count(2)->create([
       'location_preferences' => ["TELEWORK"],
     ]);
 
-    // Assert query will with no WorkRegion filter will return all candidates
+    // Assert query with no WorkRegion filter will return all candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)
@@ -570,7 +570,7 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
 
-    // Assert query with empty WorkRegion filter will return 0
+    // Assert query with empty WorkRegion filter will return all candidates
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {
         countPoolCandidates(where: $where)

--- a/api/tests/PoolCandidateTest.php
+++ b/api/tests/PoolCandidateTest.php
@@ -588,6 +588,10 @@ class PoolCandidateTest extends TestCase
 
   public function testFilterByClassificationToSalary(): void
   {
+    // Create initial data.
+    Classification::factory()->count(3)->create();
+    PoolCandidate::factory()->count(5)->create();
+
     // Create new classification.
     $classificationLvl1 = Classification::factory()->create([
       'group' => 'ZZ',
@@ -607,24 +611,28 @@ class PoolCandidateTest extends TestCase
       'min_salary' => 90000,
       'max_salary' => 100000,
     ]);
-    // Attach two new candidates that are in the expected salary range.
-    PoolCandidate::factory()->count(2)->create([
+
+    // Attach new candidates that are in the expected salary range.
+    $poolCandidate1 = PoolCandidate::factory()->create([
       'expected_salary' => ['_50_59K', '_70_79K']
-    ])->each(function($candidate) use ($classificationLvl1) {
-      $candidate->expectedClassifications()->save($classificationLvl1);
-    });
-    // Attach two new candidates that overlap the expected salary range.
-    PoolCandidate::factory()->count(2)->create([
+    ]);
+    $poolCandidate1->expectedClassifications()->delete();
+    $poolCandidate1->expectedClassifications()->save($classificationLvl1);
+
+    // Attach new candidates that overlap the expected salary range.
+    $poolCandidate2 = PoolCandidate::factory()->create([
       'expected_salary' => ['_60_69K', '_80_89K']
-    ])->each(function($candidate) use ($classificationLvl2) {
-      $candidate->expectedClassifications()->save($classificationLvl2);
-    });
-    // Attach two new candidates that are over the expected salary range.
-    PoolCandidate::factory()->count(2)->create([
+    ]);
+    $poolCandidate2->expectedClassifications()->delete();
+    $poolCandidate2->expectedClassifications()->save($classificationLvl2);
+
+    // Attach new candidates that are over the expected salary range.
+    $poolCandidate3 = PoolCandidate::factory()->create([
       'expected_salary' => ['_90_99K', '_100K_PLUS']
-    ])->each(function($candidate) use ($classificationLvl3) {
-      $candidate->expectedClassifications()->save($classificationLvl3);
-    });
+    ]);
+    $poolCandidate3->expectedClassifications()->delete();
+    $poolCandidate3->expectedClassifications()->save($classificationLvl3);
+
 
     // Assert query with no classifications filter will return all candidates
     $this->graphQL(/** @lang Graphql */ '
@@ -635,7 +643,7 @@ class PoolCandidateTest extends TestCase
       'where' => []
     ])->seeJson([
       'data' => [
-        'countPoolCandidates' => 6
+        'countPoolCandidates' => 8
       ]
     ]);
 
@@ -650,7 +658,7 @@ class PoolCandidateTest extends TestCase
       ]
     ])->seeJson([
       'data' => [
-        'countPoolCandidates' => 4
+        'countPoolCandidates' => 2
       ]
     ]);
 


### PR DESCRIPTION
Closes #500 

Creates tests for the `countPoolCandidates($where: PoolCandidateFilterInput)` query. I wrote tests for each filter type:
- testFilterByClassifications
- testFilterByCmoAssets
- testFilterByDiploma
- testFilterByEmploymentEquity
- testFilterByLanguageAbility
- testFilterByOperationalRequirements
- testFilterByWorkRegions
- testFilterByPools
- testFilterByClassificationToSalaryRange (one of the assertions occasionally fails. still looking into it)