### PR TITLE
Make pill more reusable

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -15,3 +15,11 @@ TELEWORK
 toastify
 Unencrypted
 urql
+darkpurple
+lightpurple
+darknavy
+lightnavy
+darkgold
+lightgold
+darkgray
+lightgray

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,6 +58,7 @@
     "composer.lock",
     "generated.ts",
     "tsconfig.json",
-    ".eslintrc"
+    ".eslintrc",
+    "hydrogen.config.json"
   ]
 }

--- a/admin/resources/js/components/pool/PoolTable.tsx
+++ b/admin/resources/js/components/pool/PoolTable.tsx
@@ -68,8 +68,11 @@ export const PoolTable: React.FC<GetPoolsQuery & { editUrlRoot: string }> = ({
             return (
               <Pill
                 key={`${classification?.group}-${classification?.level}`}
-                content={`${classification?.group}-${classification?.level}`}
-              />
+                color="primary"
+                mode="outline"
+              >
+                {`${classification?.group}-${classification?.level}`}
+              </Pill>
             );
           }),
       },

--- a/admin/resources/js/components/searchRequest/SingleSearchRequestTable.tsx
+++ b/admin/resources/js/components/searchRequest/SingleSearchRequestTable.tsx
@@ -76,8 +76,11 @@ export const SingleSearchRequestTable: React.FunctionComponent<
             return (
               <Pill
                 key={`${classification?.group}-${classification?.level}`}
-                content={`${classification?.group}-${classification?.level}`}
-              />
+                color="secondary"
+                mode="outline"
+              >
+                {`${classification?.group}-${classification?.level}`}
+              </Pill>
             );
           }),
       },
@@ -92,15 +95,16 @@ export const SingleSearchRequestTable: React.FunctionComponent<
             return (
               <Pill
                 key={operationalRequirement?.key}
-                content={
-                  operationalRequirement?.name?.[locale] ||
+                color="primary"
+                mode="outline"
+              >
+                {operationalRequirement?.name?.[locale] ||
                   intl.formatMessage({
                     defaultMessage: "Error: Name not found.",
                     description:
                       "Error message displayed on the single search request table operational requirements column.",
-                  })
-                }
-              />
+                  })}
+              </Pill>
             );
           }),
       },
@@ -156,17 +160,14 @@ export const SingleSearchRequestTable: React.FunctionComponent<
           ];
           return employmentEquity?.map((option) => {
             return (
-              <Pill
-                key={option}
-                content={
-                  option ||
+              <Pill key={option} color="secondary" mode="outline">
+                {option ||
                   intl.formatMessage({
                     defaultMessage: "Error: Name not found.",
                     description:
                       "Error message displayed on the single search request table employment equity column.",
-                  })
-                }
-              />
+                  })}
+              </Pill>
             );
           });
         },
@@ -180,17 +181,14 @@ export const SingleSearchRequestTable: React.FunctionComponent<
         accessor: ({ cmoAssets }) =>
           cmoAssets?.map((cmoAsset) => {
             return (
-              <Pill
-                key={cmoAsset?.key}
-                content={
-                  cmoAsset?.name?.[locale] ||
+              <Pill key={cmoAsset?.key} color="primary" mode="outline">
+                {cmoAsset?.name?.[locale] ||
                   intl.formatMessage({
                     defaultMessage: "Error: Name not found.",
                     description:
                       "Error message displayed on the single search request table operational requirements column.",
-                  })
-                }
-              />
+                  })}
+              </Pill>
             );
           }),
       },

--- a/common/src/components/Pill/Pill.stories.tsx
+++ b/common/src/components/Pill/Pill.stories.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import { Pill, PillProps } from "./Pill";
+
+export default {
+  component: Pill,
+  title: "Components/Pill",
+  args: {
+    content: "IT Business Analyst / IT Project Management",
+  },
+  argTypes: {
+    content: {
+      name: "content",
+      type: { name: "string", required: true },
+      control: {
+        type: "text",
+      },
+    },
+    onClick: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} as Meta;
+
+const TemplatePill: Story<PillProps & { content: string }> = (args) => {
+  const { content, ...rest } = args;
+  return <Pill {...rest}>{content}</Pill>;
+};
+
+const TemplateMultiPill: Story<PillProps & { content: string }> = (args) => {
+  const { content, ...rest } = args;
+  return (
+    <>
+      <Pill {...rest}>{content}</Pill>
+      <Pill {...rest}>{content}</Pill>
+      <Pill {...rest}>{content}</Pill>
+      <Pill {...rest}>{content}</Pill>
+      <Pill {...rest}>{content}</Pill>
+    </>
+  );
+};
+
+export const PillPrimary = TemplatePill.bind({});
+export const PillPrimaryBlock = TemplatePill.bind({});
+export const PillPrimaryOutline = TemplatePill.bind({});
+export const PillSecondary = TemplatePill.bind({});
+export const PillSecondaryOutline = TemplatePill.bind({});
+export const PillRoleTest = TemplatePill.bind({});
+export const PillMulti = TemplateMultiPill.bind({});
+
+PillPrimary.args = {
+  color: "primary",
+  mode: "solid",
+};
+
+PillPrimaryBlock.args = {
+  color: "primary",
+  mode: "solid",
+  block: true,
+};
+
+PillPrimaryOutline.args = {
+  color: "primary",
+  mode: "outline",
+};
+
+PillSecondary.args = {
+  color: "secondary",
+  mode: "solid",
+};
+
+PillSecondaryOutline.args = {
+  color: "secondary",
+  mode: "outline",
+};
+
+PillRoleTest.args = {
+  color: "primary",
+  mode: "solid",
+  role: "cell",
+};
+
+PillMulti.args = {
+  color: "primary",
+  mode: "solid",
+};

--- a/common/src/components/Pill/Pill.tsx
+++ b/common/src/components/Pill/Pill.tsx
@@ -1,19 +1,69 @@
 import React from "react";
 
-export const Pill: React.FC<{ content: string }> = ({ content }) => {
+export interface PillProps extends React.HTMLProps<HTMLSpanElement> {
+  /** The style type of the element. */
+  color: "primary" | "secondary";
+  /** The style mode of the element. */
+  mode: "solid" | "outline";
+  /** Determines whether the element should be block level and 100% width. */
+  block?: boolean;
+  role?: "cell" | undefined;
+}
+
+const colorMap: Record<
+  "primary" | "secondary",
+  Record<"solid" | "outline", Record<string, string>>
+> = {
+  primary: {
+    solid: {
+      "data-h2-border": "b(darkpurple, all, solid, s)",
+      "data-h2-bg-color": "b(lightpurple)",
+      "data-h2-font-color": "b(white)",
+    },
+    outline: {
+      "data-h2-border": "b(darkpurple, all, solid, s)",
+      "data-h2-bg-color": "b(lightpurple[.1])",
+      "data-h2-font-color": "b(darkpurple)",
+    },
+  },
+  secondary: {
+    solid: {
+      "data-h2-border": "b(darknavy, all, solid, s)",
+      "data-h2-bg-color": "b(lightnavy)",
+      "data-h2-font-color": "b(white)",
+    },
+    outline: {
+      "data-h2-border": "b(darknavy, all, solid, s)",
+      "data-h2-bg-color": "b(lightnavy[.1])",
+      "data-h2-font-color": "b(darknavy)",
+    },
+  },
+};
+
+export const Pill: React.FC<PillProps> = ({
+  children,
+  color,
+  mode,
+  role,
+  block = false,
+  ...rest
+}): React.ReactElement => {
   return (
     <span
-      data-h2-border="b(darkpurple, all, solid, s)"
-      data-h2-display="b(block)"
+      data-h2-padding="b(all, xs)"
+      {...(block
+        ? { "data-h2-display": "b(block)" }
+        : { "data-h2-display": "b(inline-block)" })}
       data-h2-radius="b(m)"
-      data-h2-bg-color="b(lightpurple[.1])"
-      data-h2-padding="b(all, s)"
-      data-h2-font-color="b(darkpurple)"
       data-h2-font-size="b(caption)"
-      data-h2-margin="b(top-bottom, s)"
-      role="cell"
+      data-h2-font-family="b(sans)"
+      {...colorMap[color][mode]}
+      data-h2-margin="b(all, xxs)"
+      role={role || "cell"}
+      data-h2-text-align="b(center)"
+      {...rest}
     >
-      {content}
+      {children}
     </span>
   );
 };


### PR DESCRIPTION
This branch makes the pill component more reusable.

- Switches the pill content from a prop to the regular child property
- Add color, mode, block, and role props to align with button component and allow easy appearance switching
- Add storybook stories
- Update some pill appearances in the admin site to get closer to the wireframe
- Tweak margin and padding to mimic the chips from the wireframe.  It's not perfect yet but I think it's an improvement.  To do better I think we would need to add a new component like a pill container to manage the flow, wrap, alignment, etc.
- Bonus!  Add some spellcheck words.

Closes #359 