### PR TITLE
Allow composer plugin

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -39,6 +39,9 @@
         "optimize-autoloader": true,
         "platform": {
             "php": "7.4.26"
+        },
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Allows composer to run without asking for permission to run the `composer/package-versions-deprecated` plugin.

Closes #1643 