### PR TITLE
Update env variables to use the config helper

### DIFF
--- a/api/app/Providers/BearerTokenServiceProvider.php
+++ b/api/app/Providers/BearerTokenServiceProvider.php
@@ -16,19 +16,19 @@ class BearerTokenServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        if(env('AUTH_SERVER_ROOT'))
+        if(config('oauth.server_root'))
             $this->app->singleton(BearerTokenServiceInterface::class, function () {
                 return new OpenIdBearerTokenService(
-                    env('APP_TIMEZONE'),
-                    env('AUTH_SERVER_ROOT').'/.well-known/openid-configuration'
+                    config('app.timezone'),
+                    config('oauth.server_root').'/.well-known/openid-configuration'
                 );
             });
         else
             $this->app->singleton(BearerTokenServiceInterface::class, function () {
                 return new LocalAuthBearerTokenService(
-                    env('AUTH_SERVER_ISS'),
-                    env('AUTH_SERVER_PUBLIC_KEY'),
-                    env('APP_TIMEZONE')
+                    config('oauth.server_iss'),
+                    config('oauth.server_public_key'),
+                    config('app.timezone')
                 );
             });
     }

--- a/api/config/oauth.php
+++ b/api/config/oauth.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Server Root
+    |--------------------------------------------------------------------------
+    |
+    | This value is the root path of the authentication server.  If set
+    | then the bearer token service provider assumes it will be able to find
+    | the relative path ./.well-known/openid-configuration and use that for
+    | further configuration.  Should not end in a trailing slash.
+    |
+    */
+    'server_root' => env('AUTH_SERVER_ROOT'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Server Issuer
+    |--------------------------------------------------------------------------
+    |
+    | If the server root configuration is not provided then this will be used
+    | as the server issuer value to validate tokens.
+    | https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1
+    |
+    */
+    'server_iss' => env('AUTH_SERVER_ISS'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Server Public Key
+    |--------------------------------------------------------------------------
+    |
+    | If the server root configuration is not provided then this will be used
+    | as the server public key to validate tokens.
+    |
+    */
+    'server_public_key' => env('AUTH_SERVER_PUBLIC_KEY'),
+];


### PR DESCRIPTION
This branch reconfigures the bearer token service to use the config helper function rather than using the environment variables directly.

Closes #1524 