### PR TITLE
Monitor front-end bundlesize changes

### DIFF
--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  ci: {
+    trackBranches: [
+      process.env.CI_BRANCH_DEFAULT,
+    ],
+    // Allows bundlewatch GitHub Actions workflow to work on: pull_request, or push
+    commitSha: process.env.PR_COMMIT_SHA || process.env.PUSH_COMMIT_SHA,
+    repoBranchBase: process.env.PR_BRANCH_BASE || process.env.PUSH_BRANCH_BASE,
+    repoCurrentBranch: process.env.PR_BRANCH || process.env.PUSH_BRANCH,
+  },
+  files: [
+    {
+      path: "talentsearch/public/js/pageContainer.js",
+      maxSize: "240 kB",
+    },
+    {
+      path: "admin/public/js/dashboard.js",
+      maxSize: "260 kB",
+    },
+    {
+      path: "auth/public/js/app.js",
+      maxSize: "50 kB",
+    },
+  ]
+};

--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -11,11 +11,11 @@ module.exports = {
   files: [
     {
       path: "talentsearch/public/js/pageContainer.js",
-      maxSize: "240 kB",
+      maxSize: "185 kB",
     },
     {
       path: "admin/public/js/dashboard.js",
-      maxSize: "260 kB",
+      maxSize: "210 kB",
     },
     {
       path: "auth/public/js/app.js",

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -34,6 +34,19 @@ jobs:
     steps:
     - uses: actions/checkout@v2.4.0
 
+    - uses: actions/setup-node@v2.5.1
+      with:
+        node-version: 14.18.1
+        cache: npm
+        cache-dependency-path: |
+          auth/package-lock.json
+          common/package-lock.json
+          admin/package-lock.json
+          talentsearch/package-lock.json
+
+    - name: Upgrade to latest npm
+      run: npm install --global npm@latest
+
     - name: "Install & Build: auth"
       working-directory: auth
       run: |

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -1,0 +1,99 @@
+name: "bundlewatch"
+
+on:
+  push:
+    # Generating bundlesize for mainline allows comparison of PR runs against baseline via bundlewatch hosted service.
+    branches: ["main"]
+    paths:
+      - .github/workflows/bundlewatch.yml
+      - common/**
+      - talentsearch/**
+      - admin/**
+      - auth/**
+  pull_request:
+    types: ["opened", "reopened", "synchronize"]
+    paths:
+      - .github/workflows/bundlewatch.yml
+      - common/**
+      - talentsearch/**
+      - admin/**
+      - auth/**
+
+jobs:
+  runner:
+    runs-on: ubuntu-latest
+    env:
+      # Used to write status check on PRs within upstream repo.
+      # Note: Will not work for PRs from forks.
+      BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Use native docker command within docker-compose
+      COMPOSE_DOCKER_CLI_BUILD: 1
+      # Use buildkit to speed up docker command
+      DOCKER_BUILDKIT: 1
+
+    steps:
+    - uses: actions/checkout@v2.4.0
+
+    - name: "Install & Build: auth"
+      working-directory: auth
+      run: |
+        npm install
+        npm run production
+
+    - name: "Install & Build: common"
+      working-directory: common
+      run: |
+        npm install
+        npm run h2-build
+        npm run codegen
+
+    - name: "Install & Build: admin"
+      working-directory: admin
+      run: |
+        npm install
+        npm run h2-build
+        npm run codegen
+        npm run production
+
+    - name: "Install & Build: talentsearch"
+      working-directory: talentsearch
+      run: |
+        npm install
+        npm run h2-build
+        npm run codegen
+        npm run production
+
+    # Allows SSH access into CI environment for up to 1h.
+    # Use `touch ~/continue` with session to end each one.
+    # Only enable when trying to troubleshoot.
+    #
+    # Note: Be cautious, as secrets in environment can be compromised.
+    #   Consider using in PRs from forks, without secrets available.
+    #
+    # See: https://github.com/lhotari/action-upterm
+    - name: Create upterm session for debug
+      uses: lhotari/action-upterm@v1
+      if: ${{ false }}
+      # if: ${{ always() }}
+
+    - name: Install Bundlewatch
+      run: npm install -g bundlewatch@0.2.6
+
+    - name: "Run Bundlewatch"
+      env:
+        CI_BRANCH_DEFAULT: ${{ github.event.repository.default_branch }}
+
+        PR_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+        # Overrides `ci.repoBranchBase` (bundlewatch config)
+        PR_BRANCH_BASE: ${{ github.event.pull_request.base.ref }}
+
+        PUSH_COMMIT_SHA: ${{ github.event.after }}
+        # PUSH_BRANCH: see below (needs processing)
+        PUSH_BRANCH_BASE: ${{ github.event.repository.default_branch }}
+      # Empty `package.json` in root is a work-around to run bundlewatch in monorepo.
+      # See: https://github.com/bundlewatch/bundlewatch/pull/170#issuecomment-648881619
+      #
+      # GITHUB_REF is in format `refs/heads/branch-name`, so need to strip first part.
+      run: |
+        PUSH_BRANCH=${GITHUB_REF#refs/heads/} npx bundlewatch --config .bundlewatch.config.js

--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "note": "Workaround. Bundlewatch CLI needs package.json in root."
+}


### PR DESCRIPTION
A fresh redux of https://github.com/GCTC-NTGC/gc-digital-talent/pull/1449

This will add a workflow like so to the bottom of PRs (takes about 6 minutes to complete), using a CLI and service called bundlewatch:

<img width="927" alt="Screen Shot 2022-01-14 at 12 21 52 PM" src="https://user-images.githubusercontent.com/305339/149557916-978bc9b5-fb88-40fe-b392-2de1a5d984e9.png">

Unlike chromatic, this workflow **requires no special auth**: it simply pushes a minimal amount of data to an unauthenticated, hosted service, which generates a pretty summary page. Clicking the "Details" link in the status check takes you to this page:

<img width="1435" alt="Screen Shot 2022-01-14 at 12 29 21 PM" src="https://user-images.githubusercontent.com/305339/149559012-3e28dfcf-1569-4067-8bcb-75dab4d43d45.png">

Notable caveat: This tool and service are admittedly unmaintained for the past 2 years. But to be totally sincere, it has worked perfectly for me for since then, despite some complaining in the issue queue about lack of support. (The maintainer joined Dropbox and only works on private repos now.) The hosted service is really nice, and if on the odd chance it goes down, we still get the benefit of the CLI (without the helpful comparisons). And if we really love it by then, we can either (1) find an alternative, or (2) host our own server (it's also [open source](https://github.com/bundlewatch/service) and deploys via AWS serverless)