### PR TITLE
Stabilize storybook fake data

### DIFF
--- a/admin/webpack.mix.js
+++ b/admin/webpack.mix.js
@@ -10,6 +10,7 @@ const dotenvplugin = new webpack.DefinePlugin({
     API_URI: JSON.stringify(process.env.API_URI),
     ADMIN_APP_URL: JSON.stringify(process.env.ADMIN_APP_URL),
     ADMIN_APP_DIR: JSON.stringify(process.env.ADMIN_APP_DIR),
+    BUILD_DATE: JSON.stringify(new Date()),
   },
 });
 

--- a/common/src/components/Footer/Footer.tsx
+++ b/common/src/components/Footer/Footer.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
 import { Link } from "../Link";
-import { currentDate } from "../../helpers/formUtils";
 import { imageUrl } from "../../helpers/router";
 
 export const Footer: React.FunctionComponent<{
@@ -96,11 +95,15 @@ export const Footer: React.FunctionComponent<{
           >
             {intl.formatMessage(
               {
-                defaultMessage: "Date Modified: {currentDate}",
+                defaultMessage: "Date Modified: {modifiedDate}",
                 description:
                   "Header for the sites last date modification found in the footer.",
               },
-              { currentDate: currentDate() },
+              {
+                modifiedDate: new Date(process.env.BUILD_DATE ?? "1970-01-01")
+                  .toISOString()
+                  .slice(0, 10),
+              },
             )}
           </p>
         </div>

--- a/common/src/fakeData/fakePoolCandidates.ts
+++ b/common/src/fakeData/fakePoolCandidates.ts
@@ -30,7 +30,10 @@ const generatePoolCandidate = (
     cmoIdentifier: faker.helpers.slugify(
       faker.lorem.words(faker.datatype.number({ min: 1, max: 3 })),
     ),
-    expiryDate: faker.date.future().toISOString().substring(0, 10),
+    expiryDate: faker.date
+      .between("2100-01-01", "2100-12-31")
+      .toISOString()
+      .substring(0, 10),
     isWoman: faker.datatype.boolean(),
     hasDisability: faker.datatype.boolean(),
     isIndigenous: faker.datatype.boolean(),

--- a/common/src/fakeData/fakeSearchRequests.ts
+++ b/common/src/fakeData/fakeSearchRequests.ts
@@ -22,7 +22,7 @@ const generateSearchRequest = (
     jobTitle: faker.name.jobTitle(),
     additionalComments: faker.lorem.sentences(5),
     poolCandidateFilter: faker.random.arrayElement(poolCandidateFilters),
-    requestedDate: faker.date.past().toISOString(),
+    requestedDate: faker.date.between("2000-01-01", "2020-12-31").toISOString(),
     status: faker.random.arrayElement(Object.values(PoolCandidateSearchStatus)),
     adminNotes: faker.lorem.sentences(5),
   };

--- a/talentsearch/webpack.mix.js
+++ b/talentsearch/webpack.mix.js
@@ -10,6 +10,7 @@ let dotenvplugin = new webpack.DefinePlugin({
     API_URI: JSON.stringify(process.env.API_URI),
     TALENTSEARCH_APP_URL: JSON.stringify(process.env.TALENTSEARCH_APP_URL),
     TALENTSEARCH_APP_DIR: JSON.stringify(process.env.TALENTSEARCH_APP_DIR),
+    BUILD_DATE: JSON.stringify(new Date()),
   },
 });
 


### PR DESCRIPTION
This branch stabilizes the fake data that appears in the storybook stories.  This should allow Chormatic to accurately highlight the changes in a PR instead of finding false positives on each one.

- switch fake data generators from `faker.date.future()` and `faker.date.past()` to `faker.date.between()`
- switch footer from `currentDate()` to a build date calculated by webpack on compilation and a fallback for storybook

Closes #1761