### PR TITLE
Bugfix: Added talentsearch path to admin project's hydrogen config

### DIFF
--- a/admin/hydrogen.config.json
+++ b/admin/hydrogen.config.json
@@ -3,7 +3,7 @@
   "mediaWarnings": false,
   "folders": {
     "markup": "resources/views",
-    "scripts": ["resources/js", "../common/src"],
+    "scripts": ["resources/js", "../common/src", "../talentsearch/resources/js"],
     "styles": "resources/css"
   },
   "colors": [


### PR DESCRIPTION
Reticketed from https://github.com/GCTC-NTGC/gc-digital-talent/issues/1779#issuecomment-1014982666 (Fixes issue in https://github.com/GCTC-NTGC/gc-digital-talent/pull/1767)

Offering this fix for quick merge to get mainline components looking correctly again.

cc @JoshBeveridge for h2 feedback

cc @yonikid15 for merge

<img width="1413" alt="Screen Shot 2022-01-17 at 8 30 58 PM" src="https://user-images.githubusercontent.com/305339/149855379-4ee771f2-efe7-4e5f-8c92-b9dca611988e.png">