### PR TITLE
New Component - Chip

### DIFF
--- a/common/src/components/Chip/Chip.stories.tsx
+++ b/common/src/components/Chip/Chip.stories.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import { Chip, ChipProps } from "./Chip";
+
+export default {
+  component: Chip,
+  title: "Components/Chip",
+  args: {
+    label: "IT Business Analyst / IT Project Management",
+  },
+  argTypes: {
+    label: {
+      name: "label",
+      type: { name: "string", required: true },
+      control: {
+        type: "text",
+      },
+    },
+    onDismiss: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} as Meta;
+
+const TemplateDismissChip: Story<ChipProps> = (args) => {
+  return <Chip {...args} />;
+};
+const TemplateNoDismissChip: Story<ChipProps> = (args) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { onDismiss, ...argsWithNoDismiss } = args;
+  return <Chip {...argsWithNoDismiss} />;
+};
+
+const TemplateMultiChip: Story<ChipProps> = (args) => {
+  return (
+    <>
+      <Chip {...args} />
+      <Chip {...args} />
+      <Chip {...args} />
+      <Chip {...args} />
+      <Chip {...args} />
+    </>
+  );
+};
+
+export const ChipDismiss = TemplateDismissChip.bind({});
+export const ChipNoDismiss = TemplateNoDismissChip.bind({});
+export const ChipMulti = TemplateMultiChip.bind({});
+
+const defaultLook: Partial<ChipProps> = {
+  color: "neutral",
+  mode: "outline",
+};
+
+ChipDismiss.args = defaultLook;
+ChipNoDismiss.args = defaultLook;
+ChipMulti.args = defaultLook;

--- a/common/src/components/Chip/Chip.tsx
+++ b/common/src/components/Chip/Chip.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { XCircleIcon } from "@heroicons/react/outline";
+import Pill from "../Pill";
+
+export interface ChipProps extends React.HTMLProps<HTMLElement> {
+  /** The style type of the element. */
+  color: "primary" | "secondary" | "neutral";
+  /** The style mode of the element. */
+  mode: "solid" | "outline";
+  /** Handler for clicking the dismiss button in the chip */
+  onDismiss?: React.MouseEventHandler<Element>;
+  /** Text for inside the chip */
+  label: string;
+}
+
+const colorMap: Record<
+  "primary" | "secondary" | "neutral",
+  Record<"solid" | "outline", Record<string, string>>
+> = {
+  primary: {
+    solid: {
+      "data-h2-font-color": "b(white)",
+    },
+    outline: {
+      "data-h2-font-color": "b(darkpurple)",
+    },
+  },
+  secondary: {
+    solid: {
+      "data-h2-font-color": "b(white)",
+    },
+    outline: {
+      "data-h2-font-color": "b(darknavy)",
+    },
+  },
+  neutral: {
+    solid: {
+      "data-h2-font-color": "b(white)",
+    },
+    outline: {
+      "data-h2-font-color": "b(darkgray)",
+    },
+  },
+};
+
+export const Chip: React.FC<ChipProps> = ({
+  color,
+  mode,
+  onDismiss,
+  label,
+}): React.ReactElement => {
+  return (
+    <Pill color={color} mode={mode}>
+      {label}
+      {onDismiss && (
+        <XCircleIcon
+          style={{ width: "1.25rem", cursor: "pointer" }}
+          data-h2-margin="b(left, xxs)"
+          {...colorMap[color][mode]}
+          onClick={onDismiss}
+        />
+      )}
+    </Pill>
+  );
+};
+
+export default Chip;

--- a/common/src/components/Chip/index.ts
+++ b/common/src/components/Chip/index.ts
@@ -1,0 +1,1 @@
+export { default, Chip } from "./Chip";

--- a/common/src/components/Pill/Pill.stories.tsx
+++ b/common/src/components/Pill/Pill.stories.tsx
@@ -47,6 +47,8 @@ export const PillPrimaryBlock = TemplatePill.bind({});
 export const PillPrimaryOutline = TemplatePill.bind({});
 export const PillSecondary = TemplatePill.bind({});
 export const PillSecondaryOutline = TemplatePill.bind({});
+export const PillNeutral = TemplatePill.bind({});
+export const PillNeutralOutline = TemplatePill.bind({});
 export const PillMulti = TemplateMultiPill.bind({});
 
 PillPrimary.args = {
@@ -72,6 +74,16 @@ PillSecondary.args = {
 
 PillSecondaryOutline.args = {
   color: "secondary",
+  mode: "outline",
+};
+
+PillNeutral.args = {
+  color: "neutral",
+  mode: "solid",
+};
+
+PillNeutralOutline.args = {
+  color: "neutral",
   mode: "outline",
 };
 

--- a/common/src/components/Pill/Pill.tsx
+++ b/common/src/components/Pill/Pill.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export interface PillProps extends React.HTMLProps<HTMLSpanElement> {
   /** The style type of the element. */
-  color: "primary" | "secondary";
+  color: "primary" | "secondary" | "neutral";
   /** The style mode of the element. */
   mode: "solid" | "outline";
   /** Determines whether the element should be block level and 100% width. */
@@ -10,7 +10,7 @@ export interface PillProps extends React.HTMLProps<HTMLSpanElement> {
 }
 
 const colorMap: Record<
-  "primary" | "secondary",
+  "primary" | "secondary" | "neutral",
   Record<"solid" | "outline", Record<string, string>>
 > = {
   primary: {
@@ -37,6 +37,19 @@ const colorMap: Record<
       "data-h2-font-color": "b(darknavy)",
     },
   },
+  neutral: {
+    solid: {
+      /* not very visible - should probably be fixed before using */
+      "data-h2-border": "b(darkgray, all, solid, s)",
+      "data-h2-bg-color": "b(gray)",
+      "data-h2-font-color": "b(white)",
+    },
+    outline: {
+      "data-h2-border": "b(darkgray, all, solid, s)",
+      "data-h2-bg-color": "b(lightgray[.1])",
+      "data-h2-font-color": "b(darkgray)",
+    },
+  },
 };
 
 export const Pill: React.FC<PillProps> = ({
@@ -60,7 +73,10 @@ export const Pill: React.FC<PillProps> = ({
       data-h2-text-align="b(center)"
       {...rest}
     >
-      {children}
+      {/* parent span already has a display style */}
+      <span data-h2-display="b(flex)" data-h2-align-items="b(center)">
+        {children}
+      </span>
     </span>
   );
 };

--- a/common/src/components/Pill/Pill.tsx
+++ b/common/src/components/Pill/Pill.tsx
@@ -74,7 +74,11 @@ export const Pill: React.FC<PillProps> = ({
       {...rest}
     >
       {/* parent span already has a display style */}
-      <span data-h2-display="b(flex)" data-h2-align-items="b(center)">
+      <span
+        data-h2-display="b(flex)"
+        data-h2-align-items="b(center)"
+        data-h2-justify-content="b(center)"
+      >
         {children}
       </span>
     </span>


### PR DESCRIPTION
This branch adds a new chip component
- Sends event up when dismissed
- Adds storybook stories
- Based on the pill component
- Only dismissed when the X is clicked, not the entire pill
- Similar to provided wireframe
![image](https://user-images.githubusercontent.com/8978655/149995570-9b71b15c-f627-46a1-a834-daacce56e022.png)

The wireframe has chips with no colour in them so I created a new "neutral" set of colours in the `colorMap` objects.  They're OK but it seems like the gray colours in our hydrogen config file are not matching the Design Foundations document so it's not exactly the same.

Closes #1685 