### PR TITLE
Improve workflow config

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -23,6 +23,7 @@ jobs:
   runner:
     runs-on: ubuntu-latest
     env:
+      NPM_VERSION: '8.3.0'
       # Used to write status check on PRs within upstream repo.
       # Note: Will not work for PRs from forks.
       BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -45,7 +46,7 @@ jobs:
           talentsearch/package-lock.json
 
     - name: Upgrade to latest npm
-      run: npm install --global npm@latest
+      run: npm install --global npm@${{ env.NPM_VERSION }}
 
     - name: "Install & Build: auth"
       working-directory: auth

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -11,7 +11,6 @@ on:
       - admin/**
       - auth/**
   pull_request:
-    types: ["opened", "reopened", "synchronize"]
     paths:
       - .github/workflows/bundlewatch.yml
       - common/**

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -36,7 +36,7 @@ jobs:
 
     - uses: actions/setup-node@v2.5.1
       with:
-        node-version: 14.18.1
+        node-version-file: 'admin/.nvmrc'
         cache: npm
         cache-dependency-path: |
           auth/package-lock.json

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -24,6 +24,21 @@ jobs:
           # Chromatic requires full git history.
           fetch-depth: 0
 
+      - uses: actions/setup-node@v2.5.1
+        with:
+          node-version-file: 'admin/.nvmrc'
+          cache: npm
+          # We include `auth/` even though we don't use it.
+          # This allows cache key to match across all workflows.
+          cache-dependency-path: |
+            auth/package-lock.json
+            common/package-lock.json
+            admin/package-lock.json
+            talentsearch/package-lock.json
+
+      - name: Upgrade to latest npm
+        run: npm install --global npm@latest
+
       - name: "Install & Compile: common"
         working-directory: common
         run: |

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   deployment:
     runs-on: ubuntu-latest
+    env:
+      NPM_VERSION: '8.3.0'
     steps:
       - uses: actions/checkout@v2.4.0
         with:
@@ -37,7 +39,7 @@ jobs:
             talentsearch/package-lock.json
 
       - name: Upgrade to latest npm
-        run: npm install --global npm@latest
+        run: npm install --global npm@${{ env.NPM_VERSION }}
 
       - name: "Install & Compile: common"
         working-directory: common

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,6 +1,19 @@
 name: Chromatic Storybook
 
-on: push
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - .github/workflows/storybook.yml
+      - 'common/**'
+      - 'admin/**'
+      - 'talentsearch/**'
+  pull_request:
+    paths:
+      - .github/workflows/storybook.yml
+      - 'common/**'
+      - 'admin/**'
+      - 'talentsearch/**'
 
 jobs:
   deployment:


### PR DESCRIPTION
This PR:
- Locked workflows' Node versions using `admin/.nvmrc` (arbitrarily chose the sub-project seemingly most active)
- Locked workflows' NPM versions to 8.3.0 (instead of floating with `latest`, so CI will only change when we change it)
- Only run storybook workflow when appropriate files change
- Only run storybook workflow on mainline pushes, and PRs