### PR TITLE
Explicitly enable dependabot to write status checks in PRs.

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -1,5 +1,11 @@
 name: "bundlewatch"
 
+# Ensure Dependabot can write bundlewatch summary to status check.
+# See: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#changing-github_token-permissions
+permissions:
+  statuses: write
+  checks: write
+
 on:
   push:
     # Generating bundlesize for mainline allows comparison of PR runs against baseline via bundlewatch hosted service.


### PR DESCRIPTION
Resolves #1848 

This was what was happening in a [main repo dependabot PR](https://github.com/GCTC-NTGC/gc-digital-talent/pull/1839) (note the lack of bundlesize summary check being written, since dependabot doesn't have permission):

<img width="892" alt="Screen Shot 2022-01-22 at 5 01 25 PM" src="https://user-images.githubusercontent.com/305339/150656867-d38104a1-6864-4076-b63f-98cea7097836.png">

This is the fix applied in a [test dependabot PR within my own  fork](https://github.com/patcon/gc-digital-talent/pull/44):

<img width="915" alt="Screen Shot 2022-01-22 at 5 02 00 PM" src="https://user-images.githubusercontent.com/305339/150656862-e89aebf6-4d6c-4a8f-b41c-de4d4d67de6e.png">
