### PR TITLE
Allow heroicons to undergo treeshaking (bundlesize)

### DIFF
--- a/frontend/admin/resources/js/components/TableBoolean.tsx
+++ b/frontend/admin/resources/js/components/TableBoolean.tsx
@@ -1,4 +1,5 @@
-import { CheckIcon, XIcon } from "@heroicons/react/solid";
+import XIcon from "@heroicons/react/solid/esm/XIcon";
+import CheckIcon from "@heroicons/react/solid/esm/CheckIcon";
 import React, { ReactElement } from "react";
 
 export interface TableBooleanProps {

--- a/frontend/common/src/components/Chip/Chip.tsx
+++ b/frontend/common/src/components/Chip/Chip.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { XCircleIcon } from "@heroicons/react/outline";
+import XCircleIcon from "@heroicons/react/outline/esm/XCircleIcon";
 import Pill from "../Pill";
 
 export interface ChipProps extends React.HTMLProps<HTMLElement> {

--- a/frontend/common/src/components/Toast/Toast.tsx
+++ b/frontend/common/src/components/Toast/Toast.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ToastContainer, Slide } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
-import { XCircleIcon } from "@heroicons/react/solid";
+import XCircleIcon from "@heroicons/react/outline/esm/XCircleIcon";
 
 const contextClass = {
   success: "toast-success",

--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
@@ -1,4 +1,5 @@
-import { QuestionMarkCircleIcon, XCircleIcon } from "@heroicons/react/solid";
+import QuestionMarkCircleIcon from "@heroicons/react/solid/esm/QuestionMarkCircleIcon";
+import XCircleIcon from "@heroicons/react/solid/esm/XCircleIcon";
 import React, { useState } from "react";
 import InputContext from "../InputContext/InputContext";
 import InputError from "../InputError/InputError";

--- a/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
+++ b/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import { QuestionMarkCircleIcon, XCircleIcon } from "@heroicons/react/solid";
+import QuestionMarkCircleIcon from "@heroicons/react/solid/esm/QuestionMarkCircleIcon";
+import XCircleIcon from "@heroicons/react/solid/esm/XCircleIcon";
 
 export interface InputLabelProps {
   inputId: string;


### PR DESCRIPTION
Explored adding bundle analyzer support in another branch, and discovered some bloat with our use of heroicons.

Reference: https://github.com/tailwindlabs/heroicons/issues/309