### PR TITLE
Added workflow (and container) to generate and confirm up-to-date graphql schema

### DIFF
--- a/.github/workflows/check-lighthouse-schema.yml
+++ b/.github/workflows/check-lighthouse-schema.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "Re-generate lighthouse schema"
         working-directory: infrastructure
         run: |
-          docker compose exec api php artisan lighthouse:print-schema --write
+          docker compose exec --no-TTY api php artisan lighthouse:print-schema --write
           docker compose cp api:/var/www/html/api/storage/app/lighthouse-schema.graphql ../api/storage/app/
 
       - name: Check for uncommitted changes

--- a/.github/workflows/check-lighthouse-schema.yml
+++ b/.github/workflows/check-lighthouse-schema.yml
@@ -1,0 +1,54 @@
+name: Check schema
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - .github/workflows/*lighthouse*.yml
+      - api/**
+  pull_request:
+    paths:
+      - .github/workflows/*lighthouse*.yml
+      - api/**
+
+jobs:
+  runner:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.4.0
+
+      - name: "Build docker image: api"
+        working-directory: infrastructure
+        run: docker compose up api --detach
+
+      - name: "Re-generate lighthouse schema"
+        working-directory: infrastructure
+        run: |
+          docker compose exec api php artisan lighthouse:print-schema --write
+          docker compose cp api:/var/www/html/api/storage/app/lighthouse-schema.graphql ../api/storage/app/
+
+      - name: Check for uncommitted changes
+        id: changes
+        # See: https://github.com/UnicornGlobal/has-changes-action
+        uses: UnicornGlobal/has-changes-action@v1.0.12
+
+      - name: Error if changes
+        if: steps.changes.outputs.changed == 1
+        # See: https://github.com/actions/github-script
+        uses: actions/github-script@v5.1.0
+        with:
+          script: |
+            core.setFailed('Please update api/storage/app/lighthouse-schema.graphql')
+
+      # Allows SSH access into CI environment for up to 1h.
+      # Use `touch ~/continue` with session to end each one.
+      # Only enable when trying to troubleshoot.
+      #
+      # Note: Be cautious, as secrets in environment can be compromised.
+      #   Consider using in PRs from forks, without secrets available.
+      #
+      # See: https://github.com/lhotari/action-upterm
+      - name: Create upterm session for debug
+        uses: lhotari/action-upterm@v1
+        if: ${{ false }}
+        # if: ${{ always() }}

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
     && apt-get install -y libzip-dev \
     && docker-php-ext-install zip
 # Copy composer binary from official image.
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 RUN composer install --prefer-dist
 
 # Re-use base layer without composer.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,20 @@
+FROM php:7.4.27-apache-bullseye
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+# Install pdo_pgsql extension
+RUN apt-get update \
+    && apt-get install -y \
+        libpq-dev \
+        # Required for composer install from dist.
+        libzip-dev \
+    && docker-php-ext-install pdo_pgsql zip
+
+WORKDIR /var/www/html/api
+
+COPY .env.example .env
+COPY composer.json composer.lock ./
+COPY tests/ tests/
+RUN composer install --prefer-dist
+
+COPY . .
+RUN chmod -R 777 ./storage

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,20 +1,27 @@
-FROM php:7.4.27-apache-bullseye
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+FROM php:7.4.27-apache-bullseye as base
 
-# Install pdo_pgsql extension
+# Install pdo_pgsql extension.
 RUN apt-get update \
-    && apt-get install -y \
-        libpq-dev \
-        # Required for composer install from dist.
-        libzip-dev \
-    && docker-php-ext-install pdo_pgsql zip
+    && apt-get install -y libpq-dev \
+    && docker-php-ext-install pdo_pgsql
 
 WORKDIR /var/www/html/api
 
 COPY .env.example .env
 COPY composer.json composer.lock ./
 COPY tests/ tests/
+
+FROM base as builder
+# Install zip ext required for composer install from dist.
+RUN apt-get update \
+    && apt-get install -y libzip-dev \
+    && docker-php-ext-install zip
+# Copy composer binary from official image.
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 RUN composer install --prefer-dist
 
+# Re-use base layer without composer.
+FROM base
+COPY --from=builder /var/www/html/api/vendor vendor
 COPY . .
 RUN chmod -R 777 ./storage

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
 
 WORKDIR /var/www/html/api
 
-COPY .env.example .env
 COPY composer.json composer.lock ./
 COPY tests/ tests/
 
@@ -23,5 +22,8 @@ RUN composer install --prefer-dist
 # Re-use base layer without composer.
 FROM base
 COPY --from=builder /var/www/html/api/vendor vendor
+# Default configuration in case needed.
+COPY .env.example .env
+# Overrides default with custom .env if file exists.
 COPY . .
 RUN chmod -R 777 ./storage

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -47,6 +47,18 @@ services:
       - ../auth:/var/www/html/auth
       - ../frontend:/var/www/html/frontend
 
+  # This container is an alternative approach to builds, more closely following
+  # docker conventions. For now, it will only be used for performing CI tasks.
+  #
+  # With a profile designated, it will not build/run unless explicitly executed.
+  # See: https://docs.docker.com/compose/profiles/
+  api:
+    build: ../api
+    depends_on:
+      - postgres
+    profiles:
+      - new
+
 volumes:
   pgdata:
   maintenancedata:


### PR DESCRIPTION
Addresses #1775 

This PR:
- adds a dockerfile for multi-stage build of php-based api container image
  - in the docker-compose.yml file, this new service is under its own "profile". This ensures that `docker compose up` won't build/run this new container, unless explicitly requested with `docker compose --profile=new up` or `docker compose up api`
- added a workflow to run the new api container. After starting container, the workflow will:
  - generate the lighthouse-schema.graphql in the container,
  - copy the file from container to the CI workspace,
  - check whether the git workspace has new, uncommitted changes (from that file)
  - if so, it fails the build

Note, this new `api` container:
1. reflects a proof-of-concept for a more conventional way to run docker containers (minimal build containers, and one process per running container)
2. doesn't run database migrations automatically
3. can't be logged in via shell to run composer commands (since we discard the docker layer with composer on it)

Either (2) and (3) can be mitigated or reversed later. I'm hoping we can expand more into (1), but this shouldn't be considered a commitment to that path, just a way to try the approach while running a CI workflow.