### PR TITLE
Added dependabot config for docker images and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,45 +5,72 @@
 
 version: 2
 updates:
+  # JAVASCRIPT package.json updates
 
   - package-ecosystem: "npm"
-    # Files stored in `frontend` workspace
     directory: "/frontend"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 15
 
   - package-ecosystem: "npm"
-    # Files stored in `auth` directory
     directory: "/auth"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 15
 
+  # PHP composer.json package updates
+
   - package-ecosystem: "composer"
-    # Files stored in `api` directory
     directory: "/api"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 15
 
   - package-ecosystem: "composer"
-    # Files stored in `admin` directory
     directory: "/frontend/admin"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 15
 
   - package-ecosystem: "composer"
-    # Files stored in `auth` directory
     directory: "/auth"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 15
 
   - package-ecosystem: "composer"
-    # Files stored in `talentsearch` directory
     directory: "/frontend/talentsearch"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 15
+
+  # DOCKER image updates
+
+  - directory: "/api"
+    package-ecosystem: "docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+
+  - directory: "/infrastructure/php-container"
+    package-ecosystem: "docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+
+  - directory: "/infrastructure/maintenance-container"
+    package-ecosystem: "docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+
+  # GITHUB ACTIONS external action updates
+
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+  - directory: "/"
+    package-ecosystem: "github-actions"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Re-ticketed from https://github.com/GCTC-NTGC/gc-digital-talent/pull/1855#issuecomment-1020629661

This will use dependabot PRs to update external github actions, like here:

https://github.com/GCTC-NTGC/gc-digital-talent/blob/e24472cb3fbabc03ce6c470e8a7efe40a1b3aa63/.github/workflows/bundlewatch.yml#L39

and docker images like here:

https://github.com/patcon/gc-digital-talent/blob/39c1ad507912c40e86a9817259bbe5b35ca79cea/api/Dockerfile#L1


