### PR TITLE
Fix eslint rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,7 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "eslint.workingDirectories": ["admin", "common", "talentsearch"],
+  "eslint.workingDirectories": ["frontend/admin", "frontend/common", "frontend/talentsearch"],
   "[typescriptreact]": {
     "editor.tabSize": 2
   },

--- a/frontend/admin/.eslintrc
+++ b/frontend/admin/.eslintrc
@@ -39,12 +39,7 @@
         "formatjs"
     ],
     "rules": {
-        "formatjs/enforce-id": [
-            "error",
-            {
-              "idInterpolationPattern": "no-id"
-            }
-          ],
+        "formatjs/no-id": "error",
         "camelcase": "warn",
         "consistent-return": "warn",
         "import/no-extraneous-dependencies": "off",

--- a/frontend/admin/.eslintrc
+++ b/frontend/admin/.eslintrc
@@ -35,9 +35,16 @@
         "prettier",
         "react",
         "react-hooks",
-        "@typescript-eslint"
+        "@typescript-eslint",
+        "formatjs"
     ],
     "rules": {
+        "formatjs/enforce-id": [
+            "error",
+            {
+              "idInterpolationPattern": "no-id"
+            }
+          ],
         "camelcase": "warn",
         "consistent-return": "warn",
         "import/no-extraneous-dependencies": "off",

--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -67,6 +67,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-alias": "^1.1.2",
+    "eslint-plugin-formatjs": "^2.20.5",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-node": "^11.1.0",

--- a/frontend/common/.eslintrc
+++ b/frontend/common/.eslintrc
@@ -46,12 +46,7 @@
         "formatjs"
     ],
     "rules": {
-        "formatjs/enforce-id": [
-            "error",
-            {
-              "idInterpolationPattern": "no-id"
-            }
-          ],
+        "formatjs/no-id": "error",
         "camelcase": "warn",
         "consistent-return": "warn",
         "import/no-extraneous-dependencies": [

--- a/frontend/common/.eslintrc
+++ b/frontend/common/.eslintrc
@@ -42,7 +42,8 @@
         "prettier",
         "react",
         "react-hooks",
-        "@typescript-eslint"
+        "@typescript-eslint",
+        "formatjs"
     ],
     "rules": {
         "formatjs/enforce-id": [

--- a/frontend/common/package.json
+++ b/frontend/common/package.json
@@ -86,6 +86,7 @@
     "eslint": "^8.7.0",
     "eslint-config-airbnb": "^19.0.0",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-formatjs": "^2.20.5",
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-node": "^11.1.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -64,6 +64,7 @@
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.3.0",
         "eslint-import-resolver-alias": "^1.1.2",
+        "eslint-plugin-formatjs": "^2.20.5",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-node": "^11.1.0",
@@ -4733,6 +4734,7 @@
         "eslint": "^8.7.0",
         "eslint-config-airbnb": "^19.0.0",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-formatjs": "^2.20.5",
         "eslint-plugin-import": "^2.24.2",
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-node": "^11.1.0",
@@ -28796,6 +28798,143 @@
         "node": ">=4"
       }
     },
+    "node_modules/eslint-plugin-formatjs": {
+      "version": "2.20.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-formatjs/-/eslint-plugin-formatjs-2.20.5.tgz",
+      "integrity": "sha512-VxqoeThPaMMFpAjeGkoGNNFbmUFkLnY1J5m1I2b2yZzjpNF0+FeBykDUxbtGb569TwZRI3qxt5Zn1yXjCU9RjQ==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "2.0.17",
+        "@formatjs/ts-transformer": "3.9.1",
+        "@types/eslint": "8",
+        "@typescript-eslint/typescript-estree": "^5.9.1",
+        "emoji-regex": "^10.0.0",
+        "tslib": "^2.1.0",
+        "typescript": "^4.5"
+      },
+      "peerDependencies": {
+        "eslint": "8"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/ecma402-abstract": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.2.tgz",
+      "integrity": "sha512-qDgOL0vtfJ51cc0pRbFB/oXc4qDbamG22Z6h/QWy6FBxaQgppiy8JF0iYbmNO35cC8r88bQGsgfd/eM6/eTEQQ==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/intl-localematcher": "0.2.23",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.17.tgz",
+      "integrity": "sha512-GO4DzmyiDUyT4p9UxSlOcdnRL1CCt43oHBBGe21s5043UjP6dwMbOotugKs1bRiN+FrNrRUSW+TLdT3+4CBI5A==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.2",
+        "@formatjs/icu-skeleton-parser": "1.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.4.tgz",
+      "integrity": "sha512-BbKjX3rF3hq2bRjI9NjnSPUrNqI1TwwbMomOBamWfAkpOEf4LYEezPL9tHEds/+sN2/82Z+qEmK7s/l9G2J+qA==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.2",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.23.tgz",
+      "integrity": "sha512-oCe2TOciTtB1bEbJ85EvYrXQxD0epusmVJfJ7AduO0tlbXP42CmDIYIH2CZ+kP2GE+PTLQD1Hbt9kpOpl939MQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/ts-transformer": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.9.1.tgz",
+      "integrity": "sha512-FY31pBrqIO8AeL6+vFFCSqBXe4NZyxCfIb1jRColBXiQHbUlmfaoTFu19BXibqbU5CxFd+wG2LhDLZuitGhDBA==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "2.0.17",
+        "@types/node": "14 || 16 || 17",
+        "chalk": "^4.0.0",
+        "tslib": "^2.1.0",
+        "typescript": "^4.5"
+      },
+      "peerDependencies": {
+        "ts-jest": "27"
+      },
+      "peerDependenciesMeta": {
+        "ts-jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/emoji-regex": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.0.0.tgz",
+      "integrity": "sha512-KmJa8l6uHi1HrBI34udwlzZY1jOEuID/ft4d8BSSEdRyap7PwBEt910453PJa5MuGvxkLqlt4Uvhu7tttFHViw==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/eslint-plugin-import": {
       "version": "2.25.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
@@ -51224,6 +51363,7 @@
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.3.0",
         "eslint-import-resolver-alias": "^1.1.2",
+        "eslint-plugin-formatjs": "^2.20.5",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-node": "^11.1.0",
@@ -66329,6 +66469,7 @@
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.3.0",
         "eslint-import-resolver-alias": "^1.1.2",
+        "eslint-plugin-formatjs": "^2.20.5",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-node": "^11.1.0",
@@ -74949,6 +75090,116 @@
         }
       }
     },
+    "eslint-plugin-formatjs": {
+      "version": "2.20.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-formatjs/-/eslint-plugin-formatjs-2.20.5.tgz",
+      "integrity": "sha512-VxqoeThPaMMFpAjeGkoGNNFbmUFkLnY1J5m1I2b2yZzjpNF0+FeBykDUxbtGb569TwZRI3qxt5Zn1yXjCU9RjQ==",
+      "dev": true,
+      "requires": {
+        "@formatjs/icu-messageformat-parser": "2.0.17",
+        "@formatjs/ts-transformer": "3.9.1",
+        "@types/eslint": "8",
+        "@typescript-eslint/typescript-estree": "^5.9.1",
+        "emoji-regex": "^10.0.0",
+        "tslib": "^2.1.0",
+        "typescript": "^4.5"
+      },
+      "dependencies": {
+        "@formatjs/ecma402-abstract": {
+          "version": "1.11.2",
+          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.2.tgz",
+          "integrity": "sha512-qDgOL0vtfJ51cc0pRbFB/oXc4qDbamG22Z6h/QWy6FBxaQgppiy8JF0iYbmNO35cC8r88bQGsgfd/eM6/eTEQQ==",
+          "dev": true,
+          "requires": {
+            "@formatjs/intl-localematcher": "0.2.23",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@formatjs/icu-messageformat-parser": {
+          "version": "2.0.17",
+          "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.17.tgz",
+          "integrity": "sha512-GO4DzmyiDUyT4p9UxSlOcdnRL1CCt43oHBBGe21s5043UjP6dwMbOotugKs1bRiN+FrNrRUSW+TLdT3+4CBI5A==",
+          "dev": true,
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.11.2",
+            "@formatjs/icu-skeleton-parser": "1.3.4",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@formatjs/icu-skeleton-parser": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.4.tgz",
+          "integrity": "sha512-BbKjX3rF3hq2bRjI9NjnSPUrNqI1TwwbMomOBamWfAkpOEf4LYEezPL9tHEds/+sN2/82Z+qEmK7s/l9G2J+qA==",
+          "dev": true,
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.11.2",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@formatjs/intl-localematcher": {
+          "version": "0.2.23",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.23.tgz",
+          "integrity": "sha512-oCe2TOciTtB1bEbJ85EvYrXQxD0epusmVJfJ7AduO0tlbXP42CmDIYIH2CZ+kP2GE+PTLQD1Hbt9kpOpl939MQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@formatjs/ts-transformer": {
+          "version": "3.9.1",
+          "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.9.1.tgz",
+          "integrity": "sha512-FY31pBrqIO8AeL6+vFFCSqBXe4NZyxCfIb1jRColBXiQHbUlmfaoTFu19BXibqbU5CxFd+wG2LhDLZuitGhDBA==",
+          "dev": true,
+          "requires": {
+            "@formatjs/icu-messageformat-parser": "2.0.17",
+            "@types/node": "14 || 16 || 17",
+            "chalk": "^4.0.0",
+            "tslib": "^2.1.0",
+            "typescript": "^4.5"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.0.0.tgz",
+          "integrity": "sha512-KmJa8l6uHi1HrBI34udwlzZY1jOEuID/ft4d8BSSEdRyap7PwBEt910453PJa5MuGvxkLqlt4Uvhu7tttFHViw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.25.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
@@ -76741,6 +76992,7 @@
         "eslint": "^8.7.0",
         "eslint-config-airbnb": "^19.0.0",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-formatjs": "*",
         "eslint-plugin-import": "^2.24.2",
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-node": "^11.1.0",
@@ -92882,6 +93134,7 @@
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.3.0",
         "eslint-import-resolver-alias": "^1.1.2",
+        "eslint-plugin-formatjs": "^2.20.5",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-node": "^11.1.0",

--- a/frontend/talentsearch/.eslintrc
+++ b/frontend/talentsearch/.eslintrc
@@ -43,7 +43,8 @@
         "prettier",
         "react",
         "react-hooks",
-        "@typescript-eslint"
+        "@typescript-eslint",
+        "formatjs"
     ],
     "rules": {
         "formatjs/enforce-id": [

--- a/frontend/talentsearch/.eslintrc
+++ b/frontend/talentsearch/.eslintrc
@@ -47,12 +47,7 @@
         "formatjs"
     ],
     "rules": {
-        "formatjs/enforce-id": [
-            "error",
-            {
-              "idInterpolationPattern": "no-id"
-            }
-          ],
+        "formatjs/no-id": "error",
         "camelcase": "warn",
         "consistent-return": "warn",
         "import/no-extraneous-dependencies": "off",

--- a/frontend/talentsearch/package.json
+++ b/frontend/talentsearch/package.json
@@ -21,8 +21,8 @@
     "npm": ">=8.0.0"
   },
   "scripts": {
-    "lint": "eslint ./resources/js --ext .js,.ts",
-    "lint:fix": "eslint ./resources/js --fix --ext .js,.ts",
+    "lint": "eslint ./resources/js --ext .js,.ts,.jsx,.tsx",
+    "lint:fix": "eslint ./resources/js --fix --ext .js,.ts,.jsx,.tsx",
     "prettier": "prettier --write ./resources/js",
     "dev": "mix",
     "watch": "mix watch",
@@ -75,6 +75,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-alias": "^1.1.2",
+    "eslint-plugin-formatjs": "^2.20.5",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-node": "^11.1.0",


### PR DESCRIPTION
This branches fixes the eslint rules:
- Update VS code settings to locate working directories one level deeper
- Update eslintrc files to properly use formatjs plugin

Fixes #1807 