### PR TITLE
Preserve search in language redirect

### DIFF
--- a/frontend/common/src/components/Header/Header.tsx
+++ b/frontend/common/src/components/Header/Header.tsx
@@ -1,4 +1,3 @@
-import { createPath } from "history";
 import React from "react";
 import { useIntl } from "react-intl";
 import {
@@ -15,9 +14,7 @@ export const Header: React.FunctionComponent<{
   const locale = getLocale(intl);
 
   const location = useLocation();
-  const languageTogglePath = createPath(
-    localizePath(location, oppositeLocale(locale)),
-  );
+  const languageTogglePath = localizePath(location, oppositeLocale(locale));
   return (
     <header data-h2-border="b(gray, bottom, solid, s)">
       <div data-h2-flex-grid="b(middle, contained, flush, xl)">

--- a/frontend/common/src/components/Header/Header.tsx
+++ b/frontend/common/src/components/Header/Header.tsx
@@ -1,3 +1,4 @@
+import { createPath, parsePath } from "history";
 import React from "react";
 import { useIntl } from "react-intl";
 import {
@@ -14,10 +15,10 @@ export const Header: React.FunctionComponent<{
   const locale = getLocale(intl);
 
   const location = useLocation();
-  const languageTogglePath = localizePath(
-    location.pathname,
+  const languageTogglePath = createPath(localizePath(
+    parsePath(location.pathname),
     oppositeLocale(locale),
-  );
+  ));
   return (
     <header data-h2-border="b(gray, bottom, solid, s)">
       <div data-h2-flex-grid="b(middle, contained, flush, xl)">

--- a/frontend/common/src/components/Header/Header.tsx
+++ b/frontend/common/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { createPath, parsePath } from "history";
+import { createPath } from "history";
 import React from "react";
 import { useIntl } from "react-intl";
 import {
@@ -15,10 +15,9 @@ export const Header: React.FunctionComponent<{
   const locale = getLocale(intl);
 
   const location = useLocation();
-  const languageTogglePath = createPath(localizePath(
-    parsePath(location.pathname),
-    oppositeLocale(locale),
-  ));
+  const languageTogglePath = createPath(
+    localizePath(location, oppositeLocale(locale)),
+  );
   return (
     <header data-h2-border="b(gray, bottom, solid, s)">
       <div data-h2-flex-grid="b(middle, contained, flush, xl)">

--- a/frontend/common/src/components/LanguageRedirectContainer/LanguageRedirectContainer.test.tsx
+++ b/frontend/common/src/components/LanguageRedirectContainer/LanguageRedirectContainer.test.tsx
@@ -5,9 +5,9 @@
 import React from "react";
 import { screen, render } from "@testing-library/react";
 import { FormattedMessage } from "react-intl";
+import { createPath } from "history";
 import { HISTORY } from "../../helpers/router";
 import LanguageRedirectContainer from ".";
-import { createPath } from "history";
 
 function getMessages(locale: string) {
   return locale === "fr" ? { hello: "Bonjour" } : undefined;
@@ -17,6 +17,7 @@ function renderContainer() {
   return render(
     <LanguageRedirectContainer getMessages={getMessages}>
       <div>
+        {/* eslint-disable-next-line formatjs/no-id */}
         <FormattedMessage id="hello" defaultMessage="Hello" />
       </div>
     </LanguageRedirectContainer>,

--- a/frontend/common/src/components/LanguageRedirectContainer/LanguageRedirectContainer.test.tsx
+++ b/frontend/common/src/components/LanguageRedirectContainer/LanguageRedirectContainer.test.tsx
@@ -7,6 +7,7 @@ import { screen, render } from "@testing-library/react";
 import { FormattedMessage } from "react-intl";
 import { HISTORY } from "../../helpers/router";
 import LanguageRedirectContainer from ".";
+import { createPath } from "history";
 
 function getMessages(locale: string) {
   return locale === "fr" ? { hello: "Bonjour" } : undefined;
@@ -52,27 +53,27 @@ describe("LanguageRedirectContainer tests", () => {
   test("If url doesn't start with a lang, it should be redirected to '/en/...' by default", async () => {
     HISTORY.push("/home");
     renderContainer();
-    expect(HISTORY.location.pathname).toBe("/en/home");
+    expect(createPath(HISTORY.location)).toBe("/en/home");
   });
   test("If url doesn't start with a lang but localStorage.stored_locale == fr, then redirect to '/fr/...'", () => {
     localStorage.setItem("stored_locale", "fr");
     HISTORY.push("/home");
     renderContainer();
-    expect(HISTORY.location.pathname).toBe("/fr/home");
+    expect(createPath(HISTORY.location)).toBe("/fr/home");
   });
   test("If localeStorage is empty and navigator.language returns fr, redirect to '/fr/...'", async () => {
     const languageGetter = jest.spyOn(navigator, "language", "get");
     languageGetter.mockReturnValue("fr");
     HISTORY.push("/home");
     renderContainer();
-    expect(HISTORY.location.pathname).toBe("/fr/home");
+    expect(createPath(HISTORY.location)).toBe("/fr/home");
   });
   test("If localeStorage is empty and navigator.language returns anything besides fr, redirect to '/en/...'", async () => {
     const languageGetter = jest.spyOn(navigator, "language", "get");
     languageGetter.mockReturnValue("de");
     HISTORY.push("/home");
     renderContainer();
-    expect(HISTORY.location.pathname).toBe("/en/home");
+    expect(createPath(HISTORY.location)).toBe("/en/home");
   });
   test("After being redirected to /fr/... french messages should be rendered and localeStorage.stored_locale should be set", () => {
     localStorage.setItem("stored_locale", "fr");
@@ -81,5 +82,10 @@ describe("LanguageRedirectContainer tests", () => {
     const element = screen.getByText("Bonjour");
     expect(element).toBeTruthy();
     expect(localStorage.getItem("stored_locale")).toBe("fr");
+  });
+  test("If url has a search query it should be preserved", async () => {
+    HISTORY.push("/home?token=xyz");
+    renderContainer();
+    expect(createPath(HISTORY.location)).toBe("/en/home?token=xyz");
   });
 });

--- a/frontend/common/src/components/LanguageRedirectContainer/LanguageRedirectContainer.tsx
+++ b/frontend/common/src/components/LanguageRedirectContainer/LanguageRedirectContainer.tsx
@@ -41,7 +41,7 @@ export const LanguageRedirectContainer: React.FC<{
       localStorage.setItem(STORED_LOCALE, pathLocale);
     } else {
       // The redirect call must be in a useEffect hook to ensure the component process the change in location correctly.
-      redirect(localizePath(createPath(location), guessedLocale));
+      redirect(localizePath(location, guessedLocale));
     }
   }, [location, pathLocale, guessedLocale]);
 

--- a/frontend/common/src/components/LanguageRedirectContainer/LanguageRedirectContainer.tsx
+++ b/frontend/common/src/components/LanguageRedirectContainer/LanguageRedirectContainer.tsx
@@ -1,4 +1,3 @@
-import { createPath } from "history";
 import React, { useEffect } from "react";
 import { IntlProvider } from "react-intl";
 import { isLocale, Locales, localizePath } from "../../helpers/localize";

--- a/frontend/common/src/components/LanguageRedirectContainer/LanguageRedirectContainer.tsx
+++ b/frontend/common/src/components/LanguageRedirectContainer/LanguageRedirectContainer.tsx
@@ -1,3 +1,4 @@
+import { createPath } from "history";
 import React, { useEffect } from "react";
 import { IntlProvider } from "react-intl";
 import { isLocale, Locales, localizePath } from "../../helpers/localize";
@@ -40,9 +41,9 @@ export const LanguageRedirectContainer: React.FC<{
       localStorage.setItem(STORED_LOCALE, pathLocale);
     } else {
       // The redirect call must be in a useEffect hook to ensure the component process the change in location correctly.
-      redirect(localizePath(location.pathname, guessedLocale));
+      redirect(localizePath(createPath(location), guessedLocale));
     }
-  }, [location.pathname, pathLocale, guessedLocale]);
+  }, [location, pathLocale, guessedLocale]);
 
   // If the url already begins with locale, pass it to IntlContainer. Otherwise, return null while we redirect.
   return pathLocale ? (

--- a/frontend/common/src/helpers/localize.test.ts
+++ b/frontend/common/src/helpers/localize.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { createPath, parsePath } from "history";
 import { IntlShape } from "react-intl";
 import { getLocale, Locales, localizePath, oppositeLocale } from "./localize";
 
@@ -33,16 +34,27 @@ describe("localize helper tests", () => {
   });
   describe("localizePath", () => {
     test("sets non-localized paths to correct locale", () => {
-      expect(localizePath("/admin/users", "en")).toBe("/en/admin/users");
-      expect(localizePath("/admin/users", "fr")).toBe("/fr/admin/users");
+      expect(createPath(localizePath(parsePath("/admin/users"), "en"))).toBe("/en/admin/users");
+      expect(createPath(localizePath(parsePath("/admin/users"), "fr"))).toBe("/fr/admin/users");
     });
     test("sets already localized paths to correct locale", () => {
-      expect(localizePath("/en/admin/users", "en")).toBe("/en/admin/users");
-      expect(localizePath("/en/admin/users", "fr")).toBe("/fr/admin/users");
+      expect(createPath(localizePath(parsePath("/en/admin/users"), "en"))).toBe("/en/admin/users");
+      expect(createPath(localizePath(parsePath("/en/admin/users"), "fr"))).toBe("/fr/admin/users");
     });
     test("leaves relative paths relative", () => {
-      expect(localizePath("admin/users", "en")).toBe("en/admin/users");
-      expect(localizePath("fr/admin/users", "en")).toBe("en/admin/users");
+      expect(createPath(localizePath(parsePath("admin/users"), "en"))).toBe("en/admin/users");
+      expect(createPath(localizePath(parsePath("fr/admin/users"), "en"))).toBe("en/admin/users");
+    });
+    test("works on single slash", () => {
+      expect(createPath(localizePath(parsePath("/"), "en"))).toBe("/en/");
+    });
+    // test("works on empty string", () => {
+    //   expect(createPath(localizePath(parsePath(""), "en"))).toBe("en/");
+    // });
+    test("leaves hash and query parameters alone", () => {
+      expect(createPath(localizePath(parsePath("/admin/users?foo=bar#baz"), "en"))).toBe(
+        "/en/admin/users?foo=bar#baz",
+      );
     });
   });
 });

--- a/frontend/common/src/helpers/localize.test.ts
+++ b/frontend/common/src/helpers/localize.test.ts
@@ -3,12 +3,7 @@
  */
 
 import { IntlShape } from "react-intl";
-import {
-  getLocale,
-  Locales,
-  localizePathString as localizePath,
-  oppositeLocale,
-} from "./localize";
+import { getLocale, Locales, localizePath, oppositeLocale } from "./localize";
 
 describe("localize helper tests", () => {
   describe("getLocale", () => {
@@ -52,9 +47,9 @@ describe("localize helper tests", () => {
     test("works on single slash", () => {
       expect(localizePath("/", "en")).toBe("/en/");
     });
-    // test("works on empty string", () => {
-    //   expect(localizePath("", "en"))).toBe("en/");
-    // });
+    test("works on empty string", () => {
+      expect(localizePath("", "en")).toBe("en");
+    });
     test("leaves hash and query parameters alone", () => {
       expect(localizePath("/admin/users?foo=bar#baz", "en")).toBe(
         "/en/admin/users?foo=bar#baz",

--- a/frontend/common/src/helpers/localize.test.ts
+++ b/frontend/common/src/helpers/localize.test.ts
@@ -2,9 +2,13 @@
  * @jest-environment jsdom
  */
 
-import { createPath, parsePath } from "history";
 import { IntlShape } from "react-intl";
-import { getLocale, Locales, localizePath, oppositeLocale } from "./localize";
+import {
+  getLocale,
+  Locales,
+  localizePathString as localizePath,
+  oppositeLocale,
+} from "./localize";
 
 describe("localize helper tests", () => {
   describe("getLocale", () => {
@@ -34,25 +38,25 @@ describe("localize helper tests", () => {
   });
   describe("localizePath", () => {
     test("sets non-localized paths to correct locale", () => {
-      expect(createPath(localizePath(parsePath("/admin/users"), "en"))).toBe("/en/admin/users");
-      expect(createPath(localizePath(parsePath("/admin/users"), "fr"))).toBe("/fr/admin/users");
+      expect(localizePath("/admin/users", "en")).toBe("/en/admin/users");
+      expect(localizePath("/admin/users", "fr")).toBe("/fr/admin/users");
     });
     test("sets already localized paths to correct locale", () => {
-      expect(createPath(localizePath(parsePath("/en/admin/users"), "en"))).toBe("/en/admin/users");
-      expect(createPath(localizePath(parsePath("/en/admin/users"), "fr"))).toBe("/fr/admin/users");
+      expect(localizePath("/en/admin/users", "en")).toBe("/en/admin/users");
+      expect(localizePath("/en/admin/users", "fr")).toBe("/fr/admin/users");
     });
     test("leaves relative paths relative", () => {
-      expect(createPath(localizePath(parsePath("admin/users"), "en"))).toBe("en/admin/users");
-      expect(createPath(localizePath(parsePath("fr/admin/users"), "en"))).toBe("en/admin/users");
+      expect(localizePath("admin/users", "en")).toBe("en/admin/users");
+      expect(localizePath("fr/admin/users", "en")).toBe("en/admin/users");
     });
     test("works on single slash", () => {
-      expect(createPath(localizePath(parsePath("/"), "en"))).toBe("/en/");
+      expect(localizePath("/", "en")).toBe("/en/");
     });
     // test("works on empty string", () => {
-    //   expect(createPath(localizePath(parsePath(""), "en"))).toBe("en/");
+    //   expect(localizePath("", "en"))).toBe("en/");
     // });
     test("leaves hash and query parameters alone", () => {
-      expect(createPath(localizePath(parsePath("/admin/users?foo=bar#baz"), "en"))).toBe(
+      expect(localizePath("/admin/users?foo=bar#baz", "en")).toBe(
         "/en/admin/users?foo=bar#baz",
       );
     });

--- a/frontend/common/src/helpers/localize.ts
+++ b/frontend/common/src/helpers/localize.ts
@@ -1,3 +1,4 @@
+import { createPath, parsePath } from "history";
 import { IntlShape } from "react-intl";
 
 export type Locales = "en" | "fr";
@@ -19,8 +20,13 @@ export function oppositeLocale(locale: Locales): Locales {
 }
 
 export function localizePath(path: string, locale: string): string {
-  const pathIsAbsolute = path.startsWith("/");
-  const pathSegments = path.split("/");
+
+  const {pathname, search, hash} = parsePath(path);
+  if(!pathname)
+    throw Error('Missing path');
+
+  const pathIsAbsolute = pathname.startsWith("/");
+  const pathSegments = pathname.split("/");
 
   // Check if path is already localized, ie starts with a valid locale.
   const currentLocale = pathSegments[pathIsAbsolute ? 1 : 0];
@@ -34,5 +40,9 @@ export function localizePath(path: string, locale: string): string {
     // Otherwise, add the locale segment to the beginning of the path.
     outputSegments.splice(pathIsAbsolute ? 1 : 0, 0, locale);
   }
-  return outputSegments.join("/");
+  return createPath({
+    pathname: outputSegments.join("/"),
+    search,
+    hash
+  });
 }

--- a/frontend/common/src/helpers/localize.ts
+++ b/frontend/common/src/helpers/localize.ts
@@ -20,11 +20,13 @@ export function oppositeLocale(locale: Locales): Locales {
 }
 
 export function localizePath(
-  path: Partial<Path>,
+  path: string | Partial<Path>,
   locale: string,
-): Partial<Path> {
-  const pathIsAbsolute = path.pathname?.startsWith("/");
-  const pathSegments = path.pathname?.split("/") ?? [];
+): string {
+  const inputPath = typeof path === "string" ? parsePath(path) : path;
+
+  const pathIsAbsolute = inputPath.pathname?.startsWith("/");
+  const pathSegments = inputPath.pathname?.split("/") ?? [];
 
   // Check if path is already localized, ie starts with a valid locale.
   const currentLocale = pathSegments[pathIsAbsolute ? 1 : 0];
@@ -38,13 +40,9 @@ export function localizePath(
     // Otherwise, add the locale segment to the beginning of the path.
     outputSegments.splice(pathIsAbsolute ? 1 : 0, 0, locale);
   }
-  return {
+  return createPath({
     pathname: outputSegments.join("/"),
-    search: path.search,
-    hash: path.hash,
-  };
-}
-
-export function localizePathString(path: string, locale: string): string {
-  return createPath(localizePath(parsePath(path), locale));
+    search: inputPath.search,
+    hash: inputPath.hash,
+  });
 }

--- a/frontend/common/src/helpers/localize.ts
+++ b/frontend/common/src/helpers/localize.ts
@@ -1,4 +1,4 @@
-import { createPath, parsePath } from "history";
+import { createPath, parsePath, Path } from "history";
 import { IntlShape } from "react-intl";
 
 export type Locales = "en" | "fr";
@@ -19,14 +19,9 @@ export function oppositeLocale(locale: Locales): Locales {
   return locale === "fr" ? "en" : "fr";
 }
 
-export function localizePath(path: string, locale: string): string {
-
-  const {pathname, search, hash} = parsePath(path);
-  if(!pathname)
-    throw Error('Missing path');
-
-  const pathIsAbsolute = pathname.startsWith("/");
-  const pathSegments = pathname.split("/");
+export function localizePath(path: Partial<Path>, locale: string): Partial<Path> {
+  const pathIsAbsolute = path.pathname?.startsWith("/");
+  const pathSegments = path.pathname?.split("/") ?? [];
 
   // Check if path is already localized, ie starts with a valid locale.
   const currentLocale = pathSegments[pathIsAbsolute ? 1 : 0];
@@ -40,9 +35,9 @@ export function localizePath(path: string, locale: string): string {
     // Otherwise, add the locale segment to the beginning of the path.
     outputSegments.splice(pathIsAbsolute ? 1 : 0, 0, locale);
   }
-  return createPath({
+  return {
     pathname: outputSegments.join("/"),
-    search,
-    hash
-  });
+    search: path.search,
+    hash: path.hash,
+  };
 }

--- a/frontend/common/src/helpers/localize.ts
+++ b/frontend/common/src/helpers/localize.ts
@@ -19,7 +19,10 @@ export function oppositeLocale(locale: Locales): Locales {
   return locale === "fr" ? "en" : "fr";
 }
 
-export function localizePath(path: Partial<Path>, locale: string): Partial<Path> {
+export function localizePath(
+  path: Partial<Path>,
+  locale: string,
+): Partial<Path> {
   const pathIsAbsolute = path.pathname?.startsWith("/");
   const pathSegments = path.pathname?.split("/") ?? [];
 
@@ -40,4 +43,8 @@ export function localizePath(path: Partial<Path>, locale: string): Partial<Path>
     search: path.search,
     hash: path.hash,
   };
+}
+
+export function localizePathString(path: string, locale: string): string {
+  return createPath(localizePath(parsePath(path), locale));
 }


### PR DESCRIPTION
This branch solves an issue where the URL search parameters are lost by the language redirect container.  It also adds a Jest test to verify.

Closes #1866 