### PR TITLE
Update VS Code Jest debug definition

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,13 +2,13 @@
     "configurations": [
         {
             "type": "node",
-            "name": "vscode-jest-tests",
+            "name": "jest-common",
             "request": "launch",
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "disableOptimisticBPs": true,
-            "program": "${workspaceFolder}/test",
-            "cwd": "${workspaceFolder}",
+            "program":"${workspaceRoot}/frontend/node_modules/jest/bin/jest.js",
+            "cwd": "${workspaceFolder}/frontend/common",
             "args": [
                 "--runInBand",
                 "--watchAll=false"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,34 @@
                 "--runInBand",
                 "--watchAll=false"
             ]
+        },
+        {
+            "type": "node",
+            "name": "jest-admin",
+            "request": "launch",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "program":"${workspaceRoot}/frontend/node_modules/jest/bin/jest.js",
+            "cwd": "${workspaceFolder}/frontend/admin",
+            "args": [
+                "--runInBand",
+                "--watchAll=false"
+            ]
+        },
+        {
+            "type": "node",
+            "name": "jest-talentsearch",
+            "request": "launch",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "program":"${workspaceRoot}/frontend/node_modules/jest/bin/jest.js",
+            "cwd": "${workspaceFolder}/frontend/talentsearch",
+            "args": [
+                "--runInBand",
+                "--watchAll=false"
+            ]
         }
     ]
 }


### PR DESCRIPTION
I noticed the Jest debug definitions didn't quite work.  I updated it for common (which I was working on).  Is this useful to anyone else?  Do you want me to create the profiles for talentsearch and admin?