### PR TITLE
Admin - add skill page and table

### DIFF
--- a/frontend/admin/resources/js/adminRoutes.ts
+++ b/frontend/admin/resources/js/adminRoutes.ts
@@ -25,8 +25,8 @@ const adminRoutes = (lang: string) => {
     departmentUpdate: (id: string): string =>
       path.join(home(), "departments", id, "edit"),
 
-    skillFamilyTable: (): string =>
-      path.join(home(), "skill-families"),
+    skillFamilyTable: (): string => path.join(home(), "skill-families"),
+    skillTable: (): string => path.join(home(), "skills"),
 
     operationalRequirementTable: (): string =>
       path.join(home(), "operational-requirements"),

--- a/frontend/admin/resources/js/api/skillOperations.graphql
+++ b/frontend/admin/resources/js/api/skillOperations.graphql
@@ -18,14 +18,6 @@ query AllSkills {
         en
         fr
       }
-      description {
-        en
-        fr
-      }
-      skills {
-        id
-      }
-      category
     }
   }
 }

--- a/frontend/admin/resources/js/api/skillOperations.graphql
+++ b/frontend/admin/resources/js/api/skillOperations.graphql
@@ -1,0 +1,31 @@
+query AllSkills {
+  skills {
+    id
+    key
+    name {
+      en
+      fr
+    }
+    description {
+      en
+      fr
+    }
+    keywords
+    families {
+      id
+      key
+      name {
+        en
+        fr
+      }
+      description {
+        en
+        fr
+      }
+      skills {
+        id
+      }
+      category
+    }
+  }
+}

--- a/frontend/admin/resources/js/components/PoolDashboard.tsx
+++ b/frontend/admin/resources/js/components/PoolDashboard.tsx
@@ -31,6 +31,7 @@ import { UpdateDepartment } from "./department/UpdateDepartment";
 import SearchRequestPage from "./searchRequest/SearchRequestPage";
 import SingleSearchRequestPage from "./searchRequest/SingleSearchRequestPage";
 import SkillFamilyPage from "./skillFamily/SkillFamilyPage";
+import SkillPage from "./skill/SkillPage";
 
 const routes = (paths: AdminRoutes): Routes<RouterResult> => [
   {
@@ -181,6 +182,12 @@ const routes = (paths: AdminRoutes): Routes<RouterResult> => [
     }),
   },
   {
+    path: paths.skillTable(),
+    action: () => ({
+      component: <SkillPage />,
+    }),
+  },
+  {
     path: paths.searchRequestTable(),
     action: () => ({
       component: <SearchRequestPage />,
@@ -278,6 +285,14 @@ export const PoolDashboard: React.FC = () => {
       text={intl.formatMessage({
         defaultMessage: "Skill Families",
         description: "Label displayed on the Skill Families menu item.",
+      })}
+    />,
+    <MenuLink
+      key="skills"
+      href={paths.skillTable()}
+      text={intl.formatMessage({
+        defaultMessage: "Skills",
+        description: "Label displayed on the Skills menu item.",
       })}
     />,
   ];

--- a/frontend/admin/resources/js/components/skill/SkillPage.tsx
+++ b/frontend/admin/resources/js/components/skill/SkillPage.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import { Link, Button } from "@common/components";
+import { SkillTableApi } from "./SkillTable";
+
+export const SkillPage: React.FC = () => {
+  const intl = useIntl();
+  return (
+    <div>
+      <header
+        data-h2-bg-color="b(linear-70[lightpurple][lightnavy])"
+        data-h2-padding="b(top-bottom, l) b(right-left, xl)"
+      >
+        <div data-h2-flex-grid="b(middle, expanded, flush, l)">
+          <div data-h2-flex-item="b(1of1) m(3of5)">
+            <h1
+              data-h2-font-color="b(white)"
+              data-h2-font-weight="b(800)"
+              data-h2-margin="b(all, none)"
+              style={{ letterSpacing: "-2px" }}
+            >
+              {intl.formatMessage({
+                defaultMessage: "Skills",
+                description:
+                  "Heading displayed above the Skill Table component.",
+              })}
+            </h1>
+          </div>
+          <div
+            data-h2-flex-item="b(1of1) m(2of5)"
+            data-h2-text-align="m(right)"
+          >
+            <Button color="white" mode="outline">
+              <Link href="" title="">
+                {intl.formatMessage({
+                  defaultMessage: "Create Skill",
+                  description: "Heading displayed above the Create Skill form.",
+                })}
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </header>
+      <SkillTableApi />
+    </div>
+  );
+};
+
+export default SkillPage;

--- a/frontend/admin/resources/js/components/skill/SkillTable.tsx
+++ b/frontend/admin/resources/js/components/skill/SkillTable.tsx
@@ -1,0 +1,95 @@
+import React, { useMemo } from "react";
+import { useIntl } from "react-intl";
+import { getLocale } from "@common/helpers/localize";
+import commonMessages from "@common/messages/commonMessages";
+import { useLocation } from "@common/helpers/router";
+import { notEmpty } from "@common/helpers/util";
+import { FromArray } from "@common/types/utilityTypes";
+import { AllSkillsQuery, useAllSkillsQuery } from "../../api/generated";
+import Table, { ColumnsOf } from "../Table";
+import DashboardContentContainer from "../DashboardContentContainer";
+import { tableEditButtonAccessor } from "../TableEditButton";
+
+type Data = NonNullable<FromArray<AllSkillsQuery["skills"]>>;
+
+export const SkillTable: React.FC<AllSkillsQuery & { editUrlRoot: string }> = ({
+  skills,
+  editUrlRoot,
+}) => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
+  const columns = useMemo<ColumnsOf<Data>>(
+    () => [
+      {
+        Header: intl.formatMessage({
+          defaultMessage: "ID",
+          description: "Title displayed on the Skill table ID column.",
+        }),
+        accessor: "id",
+      },
+      {
+        Header: intl.formatMessage({
+          defaultMessage: "Name",
+          description: "Title displayed for the skill table Name column.",
+        }),
+        accessor: (skill) => skill.name?.[locale],
+      },
+      {
+        Header: intl.formatMessage({
+          defaultMessage: "Description",
+          description:
+            "Title displayed for the skill table Description column.",
+        }),
+        accessor: (skill) => skill.description?.[locale],
+      },
+      {
+        Header: intl.formatMessage({
+          defaultMessage: "Keywords",
+          description: "Title displayed for the skill table Keywords column.",
+        }),
+        accessor: (skill) => {
+          if (skill.keywords && skill.keywords.length > 0)
+            return skill.keywords.join(", ");
+          return "";
+        },
+      },
+      {
+        Header: intl.formatMessage({
+          defaultMessage: "Edit",
+          description: "Title displayed for the skill table Edit column.",
+        }),
+        accessor: (skill) => tableEditButtonAccessor(skill.id, editUrlRoot), // callback extracted to separate function to stabilize memoized component
+      },
+    ],
+    [editUrlRoot, intl, locale],
+  );
+
+  const data = useMemo(() => skills.filter(notEmpty), [skills]);
+
+  return <Table data={data} columns={columns} />;
+};
+
+export const SkillTableApi: React.FunctionComponent = () => {
+  const intl = useIntl();
+  const [result] = useAllSkillsQuery();
+  const { data, fetching, error } = result;
+  const { pathname } = useLocation();
+
+  if (fetching)
+    return (
+      <DashboardContentContainer>
+        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
+      </DashboardContentContainer>
+    );
+  if (error)
+    return (
+      <DashboardContentContainer>
+        <p>
+          {intl.formatMessage(commonMessages.loadingError)}
+          {error.message}
+        </p>
+      </DashboardContentContainer>
+    );
+
+  return <SkillTable skills={data?.skills ?? []} editUrlRoot={pathname} />;
+};

--- a/frontend/admin/resources/js/components/skill/SkillTable.tsx
+++ b/frontend/admin/resources/js/components/skill/SkillTable.tsx
@@ -5,6 +5,7 @@ import commonMessages from "@common/messages/commonMessages";
 import { useLocation } from "@common/helpers/router";
 import { notEmpty } from "@common/helpers/util";
 import { FromArray } from "@common/types/utilityTypes";
+import { Pill } from "@common/components";
 import { AllSkillsQuery, useAllSkillsQuery } from "../../api/generated";
 import Table, { ColumnsOf } from "../Table";
 import DashboardContentContainer from "../DashboardContentContainer";
@@ -52,6 +53,19 @@ export const SkillTable: React.FC<AllSkillsQuery & { editUrlRoot: string }> = ({
             return skill.keywords.join(", ");
           return "";
         },
+      },
+      {
+        Header: intl.formatMessage({
+          defaultMessage: "Skill Families",
+          description:
+            "Title displayed for the skill table Skill Families column.",
+        }),
+        accessor: (skill) =>
+          skill.families?.map((family) => (
+            <Pill color="primary" mode="outline" key={family?.key}>
+              {family?.name?.[locale]}
+            </Pill>
+          )),
       },
       {
         Header: intl.formatMessage({

--- a/frontend/admin/resources/js/stories/Skill.stories.tsx
+++ b/frontend/admin/resources/js/stories/Skill.stories.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { fakeSkillFamiliesWithSkills } from "@common/fakeData";
+import { SkillTable } from "../components/skill/SkillTable";
+
+const { skills } = fakeSkillFamiliesWithSkills();
+
+const stories = storiesOf("Skills", module);
+
+stories.add("Skills Table", () => (
+  <SkillTable skills={skills} editUrlRoot="#" />
+));

--- a/frontend/admin/resources/js/stories/SkillFamily.stories.tsx
+++ b/frontend/admin/resources/js/stories/SkillFamily.stories.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { fakeSkillFamilies } from "@common/fakeData";
+import { fakeSkillFamiliesWithSkills } from "@common/fakeData";
 import { SkillFamilyTable } from "../components/skillFamily/SkillFamilyTable";
 
-const skillFamilyData = fakeSkillFamilies();
+const { skillFamilies } = fakeSkillFamiliesWithSkills();
 
 const stories = storiesOf("Skill Families", module);
 
 stories.add("Skill Families Table", () => (
-  <SkillFamilyTable skillFamilies={skillFamilyData} editUrlRoot="#" />
+  <SkillFamilyTable skillFamilies={skillFamilies} editUrlRoot="#" />
 ));

--- a/frontend/common/src/fakeData/fakeSkillFamilies.ts
+++ b/frontend/common/src/fakeData/fakeSkillFamilies.ts
@@ -1,8 +1,8 @@
 import faker from "faker";
-import fakeSkills from "./fakeSkills";
 import { SkillCategory, SkillFamily } from "../api/generated";
 
-const generateSkillFamily = (name: string) => {
+const generateSkillFamily = () => {
+  const name = faker.unique(faker.random.word);
   return {
     category: faker.random.arrayElement([
       SkillCategory.Behavioural,
@@ -13,12 +13,12 @@ const generateSkillFamily = (name: string) => {
       fr: `FR ${faker.lorem.sentences()}`,
     },
     id: faker.datatype.uuid(),
-    key: name,
+    key: faker.helpers.slugify(name),
     name: {
       en: `EN ${name}`,
       fr: `FR ${name}`,
     },
-    skills: fakeSkills(faker.datatype.number(20)),
+    skills: [], // generating skills here causes recursion
   };
 };
 
@@ -26,7 +26,5 @@ export default (): SkillFamily[] => {
   faker.seed(0); // repeatable results
   faker.setLocale("en");
 
-  return [...Array(15)].map(() =>
-    generateSkillFamily(faker.unique(faker.random.word)),
-  );
+  return [...Array(15)].map(generateSkillFamily);
 };

--- a/frontend/common/src/fakeData/fakeSkillFamilies.ts
+++ b/frontend/common/src/fakeData/fakeSkillFamilies.ts
@@ -22,9 +22,9 @@ const generateSkillFamily = () => {
   };
 };
 
-export default (): SkillFamily[] => {
+export default (numToGenerate = 15): SkillFamily[] => {
   faker.seed(0); // repeatable results
   faker.setLocale("en");
 
-  return [...Array(15)].map(generateSkillFamily);
+  return [...Array(numToGenerate)].map(generateSkillFamily);
 };

--- a/frontend/common/src/fakeData/fakeSkillFamiliesWithSkills.ts
+++ b/frontend/common/src/fakeData/fakeSkillFamiliesWithSkills.ts
@@ -6,8 +6,8 @@ import { Skill, SkillFamily } from "../api/generated";
 // This avoids the issue of each fake dataset simultaneously needing the other to fully generate.
 
 export default (): { skillFamilies: SkillFamily[]; skills: Skill[] } => {
-  const skillFamilies = fakeSkillFamilies();
-  const skills = fakeSkills();
+  const skillFamilies = fakeSkillFamilies(4);
+  const skills = fakeSkills(20);
 
   skillFamilies.forEach((skillFamily) => {
     const skillsToAttach = faker.random.arrayElements(skills);

--- a/frontend/common/src/fakeData/fakeSkillFamiliesWithSkills.ts
+++ b/frontend/common/src/fakeData/fakeSkillFamiliesWithSkills.ts
@@ -1,0 +1,20 @@
+import faker from "faker";
+import { fakeSkillFamilies, fakeSkills } from ".";
+import { Skill, SkillFamily } from "../api/generated";
+
+// This helper function generates the Skill Families and Skills separately then combines them together.
+// This avoids the issue of each fake dataset simultaneously needing the other to fully generate.
+
+export default (): { skillFamilies: SkillFamily[]; skills: Skill[] } => {
+  const skillFamilies = fakeSkillFamilies();
+  const skills = fakeSkills();
+
+  skillFamilies.forEach((skillFamily) => {
+    const skillsToAttach = faker.random.arrayElements(skills);
+    // eslint-disable-next-line no-param-reassign
+    skillFamily.skills = skillsToAttach;
+    skillsToAttach.forEach((skill) => skill.families?.push(skillFamily));
+  });
+
+  return { skillFamilies, skills };
+};

--- a/frontend/common/src/fakeData/fakeSkills.ts
+++ b/frontend/common/src/fakeData/fakeSkills.ts
@@ -1,18 +1,21 @@
 import faker from "faker";
 import { Skill } from "../api/generated";
 
-const generateSkill = (name: string) => {
+const generateSkill = () => {
+  const name = faker.unique(faker.random.word);
   return {
-    description: {
-      en: `EN ${faker.lorem.sentences()}`,
-      fr: `FR ${faker.lorem.sentences()}`,
-    },
     id: faker.datatype.uuid(),
-    key: name,
+    key: faker.helpers.slugify(name),
     name: {
       en: `EN ${name}`,
       fr: `FR ${name}`,
     },
+    description: {
+      en: `EN ${faker.lorem.sentences()}`,
+      fr: `FR ${faker.lorem.sentences()}`,
+    },
+    keywords: faker.lorem.words(3).split(" "),
+    families: [], // generating families here causes recursion
   };
 };
 
@@ -20,7 +23,5 @@ export default (numToGenerate = 10): Skill[] => {
   faker.seed(0); // repeatable results
   faker.setLocale("en");
 
-  return [...Array(numToGenerate)].map(() =>
-    generateSkill(faker.random.word()),
-  );
+  return [...Array(numToGenerate)].map(generateSkill);
 };

--- a/frontend/common/src/fakeData/index.ts
+++ b/frontend/common/src/fakeData/index.ts
@@ -9,6 +9,7 @@ import fakeSearchRequests from "./fakeSearchRequests";
 import fakePoolCandidateFilters from "./fakePoolCandidateFilters";
 import fakeSkillFamilies from "./fakeSkillFamilies";
 import fakeSkills from "./fakeSkills";
+import fakeSkillFamiliesWithSkills from "./fakeSkillFamiliesWithSkills";
 
 export {
   fakeClassifications,
@@ -22,4 +23,5 @@ export {
   fakePoolCandidateFilters,
   fakeSkillFamilies,
   fakeSkills,
+  fakeSkillFamiliesWithSkills,
 };


### PR DESCRIPTION
This branch adds:
- A page and table for listing skills
- The sidebar link and route to navigate to the page
- The GraphQL operation for retrieving all the skills from storage
- A Storybook story for the table

There's a bit of refactoring around fake skill and skill families as well.  Since the two data sets are interdependent they cause recursion when being generated.  My solution was to add the function `fakeSkillFamiliesWithSkills` to generate the two independently and then combine them.

Closes #1679 