### PR TITLE
Add auth fields to create/update users in admin

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -271,6 +271,7 @@ type Query {
 When creating a User, name and email are required.
 """
 input CreateUserInput {
+    sub: String
     firstName: String! @rename(attribute: "first_name")
     lastName: String! @rename(attribute: "last_name")
     email: Email! @rules(apply: ["unique:users,email"])
@@ -283,6 +284,7 @@ When updating a User, all fields are optional, and email cannot be changed.
 """
 input UpdateUserInput {
     id: ID
+    sub: String
     firstName: String @rename(attribute: "first_name")
     lastName: String @rename(attribute: "last_name")
     telephone: PhoneNumber

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -110,6 +110,7 @@ input CreatePoolInput {
 
 """When creating a User, name and email are required."""
 input CreateUserInput {
+  sub: String
   firstName: String!
   lastName: String!
   email: Email!
@@ -635,6 +636,7 @@ When updating a User, all fields are optional, and email cannot be changed.
 """
 input UpdateUserInput {
   id: ID
+  sub: String
   firstName: String
   lastName: String
   telephone: PhoneNumber

--- a/frontend/admin/resources/js/api/userOperations.graphql
+++ b/frontend/admin/resources/js/api/userOperations.graphql
@@ -13,30 +13,36 @@ query User($id: ID!) {
   user(id: $id) {
     id
     email
+    sub
     firstName
     lastName
     telephone
     preferredLang
+    roles
   }
 }
 
 mutation UpdateUser($id: ID!, $user: UpdateUserInput!) {
   updateUser(id: $id, user: $user) {
     id
+    sub
     firstName
     lastName
     email
     telephone
     preferredLang
+    roles
   }
 }
 
 mutation CreateUser($user: CreateUserInput!) {
   createUser(user: $user) {
+    sub
     firstName
     lastName
     email
     telephone
     preferredLang
+    roles
   }
 }

--- a/frontend/admin/resources/js/components/classification/UpdateClassification.tsx
+++ b/frontend/admin/resources/js/components/classification/UpdateClassification.tsx
@@ -130,6 +130,9 @@ export const UpdateClassificationForm: React.FunctionComponent<
                 description:
                   "Placeholder displayed on the classification form level field.",
               })}
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
               options={[
                 { value: 1, label: "1" },
                 { value: 2, label: "2" },

--- a/frontend/admin/resources/js/components/user/CreateUser.tsx
+++ b/frontend/admin/resources/js/components/user/CreateUser.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { useIntl } from "react-intl";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { toast } from "react-toastify";
-import { Input, Select, Submit } from "@common/components/form";
+import { Input, MultiSelect, Select, Submit } from "@common/components/form";
 import { navigate } from "@common/helpers/router";
 import { enumToOptions } from "@common/helpers/formUtils";
-import { getLanguage } from "@common/constants/localizedConstants";
+import { getLanguage, getRole } from "@common/constants/localizedConstants";
 import { errorMessages } from "@common/messages";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
@@ -13,6 +13,7 @@ import {
   CreateUserInput,
   CreateUserMutation,
   useCreateUserMutation,
+  Role,
 } from "../../api/generated";
 import DashboardContentContainer from "../DashboardContentContainer";
 
@@ -141,6 +142,50 @@ export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
                 label: intl.formatMessage(getLanguage(value)),
               }))}
             />
+            <Input
+              id="subject"
+              label={intl.formatMessage({
+                defaultMessage: "Subject",
+                description: "Label displayed on the user form subject field.",
+              })}
+              type="text"
+              name="subject"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+              context={intl.formatMessage({
+                defaultMessage:
+                  "The 'subject' is a string that uniquely identifies a user's login identity.",
+                description:
+                  "Additional context describing the purpose of the users's 'subject' field.",
+              })}
+            />
+            <MultiSelect
+              id="roles"
+              name="roles"
+              label={intl.formatMessage({
+                defaultMessage: "Roles",
+                description: "Label displayed on the user form roles field.",
+              })}
+              placeholder={intl.formatMessage({
+                defaultMessage: "Select zero or more roles...",
+                description:
+                  "Placeholder displayed on the user form roles field.",
+              })}
+              options={enumToOptions(Role).map(({ value }) => ({
+                value,
+                label: intl.formatMessage(getRole(value)),
+              }))}
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+              context={intl.formatMessage({
+                defaultMessage:
+                  "The roles grant additional functionality to a user's login.",
+                description:
+                  "Additional context describing the purpose of the users's 'role' field.",
+              })}
+            />
             <Submit />
           </form>
         </FormProvider>
@@ -150,7 +195,7 @@ export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
 };
 
 export const CreateUser: React.FunctionComponent = () => {
-  const [_result, executeMutation] = useCreateUserMutation();
+  const [, executeMutation] = useCreateUserMutation();
   const handleCreateUser = (data: CreateUserInput) =>
     executeMutation({ user: data }).then((result) => {
       if (result.data?.createUser) {

--- a/frontend/admin/resources/js/components/user/CreateUser.tsx
+++ b/frontend/admin/resources/js/components/user/CreateUser.tsx
@@ -150,9 +150,6 @@ export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
               })}
               type="text"
               name="sub"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
               context={intl.formatMessage({
                 defaultMessage:
                   "The 'subject' is a string that uniquely identifies a user's login identity.",

--- a/frontend/admin/resources/js/components/user/CreateUser.tsx
+++ b/frontend/admin/resources/js/components/user/CreateUser.tsx
@@ -143,13 +143,13 @@ export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
               }))}
             />
             <Input
-              id="subject"
+              id="sub"
               label={intl.formatMessage({
                 defaultMessage: "Subject",
                 description: "Label displayed on the user form subject field.",
               })}
               type="text"
-              name="subject"
+              name="sub"
               rules={{
                 required: intl.formatMessage(errorMessages.required),
               }}
@@ -176,9 +176,6 @@ export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
                 value,
                 label: intl.formatMessage(getRole(value)),
               }))}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
               context={intl.formatMessage({
                 defaultMessage:
                   "The roles grant additional functionality to a user's login.",

--- a/frontend/admin/resources/js/components/user/UpdateUser.tsx
+++ b/frontend/admin/resources/js/components/user/UpdateUser.tsx
@@ -152,9 +152,6 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
               })}
               type="text"
               name="sub"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
               context={intl.formatMessage({
                 defaultMessage:
                   "The 'subject' is a string that uniquely identifies a user's login identity.",
@@ -208,7 +205,14 @@ export const UpdateUser: React.FunctionComponent<{ userId: string }> = ({
        graphql operation to fail. */
     executeMutation({
       id,
-      user: pick(data, ["firstName", "lastName", "telephone", "preferredLang"]),
+      user: pick(data, [
+        "firstName",
+        "lastName",
+        "telephone",
+        "preferredLang",
+        "sub",
+        "roles",
+      ]),
     }).then((result) => {
       if (result.data?.updateUser) {
         return result.data?.updateUser;

--- a/frontend/admin/resources/js/components/user/UpdateUser.tsx
+++ b/frontend/admin/resources/js/components/user/UpdateUser.tsx
@@ -145,13 +145,13 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
               }))}
             />
             <Input
-              id="subject"
+              id="sub"
               label={intl.formatMessage({
                 defaultMessage: "Subject",
                 description: "Label displayed on the user form subject field.",
               })}
               type="text"
-              name="subject"
+              name="sub"
               rules={{
                 required: intl.formatMessage(errorMessages.required),
               }}
@@ -178,9 +178,6 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
                 value,
                 label: intl.formatMessage(getRole(value)),
               }))}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
               context={intl.formatMessage({
                 defaultMessage:
                   "The roles grant additional functionality to a user's login.",

--- a/frontend/admin/resources/js/components/user/UpdateUser.tsx
+++ b/frontend/admin/resources/js/components/user/UpdateUser.tsx
@@ -3,14 +3,15 @@ import { useIntl } from "react-intl";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import pick from "lodash/pick";
 import { toast } from "react-toastify";
-import { Select, Submit, Input } from "@common/components/form";
+import { Select, Submit, Input, MultiSelect } from "@common/components/form";
 import { navigate } from "@common/helpers/router";
 import { enumToOptions } from "@common/helpers/formUtils";
 import { errorMessages, commonMessages } from "@common/messages";
-import { getLanguage } from "@common/constants/localizedConstants";
+import { getLanguage, getRole } from "@common/constants/localizedConstants";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Language,
+  Role,
   UpdateUserInput,
   User,
   useUpdateUserMutation,
@@ -142,6 +143,50 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
                 value,
                 label: intl.formatMessage(getLanguage(value)),
               }))}
+            />
+            <Input
+              id="subject"
+              label={intl.formatMessage({
+                defaultMessage: "Subject",
+                description: "Label displayed on the user form subject field.",
+              })}
+              type="text"
+              name="subject"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+              context={intl.formatMessage({
+                defaultMessage:
+                  "The 'subject' is a string that uniquely identifies a user's login identity.",
+                description:
+                  "Additional context describing the purpose of the users's 'subject' field.",
+              })}
+            />
+            <MultiSelect
+              id="roles"
+              name="roles"
+              label={intl.formatMessage({
+                defaultMessage: "Roles",
+                description: "Label displayed on the user form roles field.",
+              })}
+              placeholder={intl.formatMessage({
+                defaultMessage: "Select zero or more roles...",
+                description:
+                  "Placeholder displayed on the user form roles field.",
+              })}
+              options={enumToOptions(Role).map(({ value }) => ({
+                value,
+                label: intl.formatMessage(getRole(value)),
+              }))}
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+              context={intl.formatMessage({
+                defaultMessage:
+                  "The roles grant additional functionality to a user's login.",
+                description:
+                  "Additional context describing the purpose of the users's 'role' field.",
+              })}
             />
             <Submit />
           </form>

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
@@ -55,7 +55,6 @@ export const MultiSelect: React.FunctionComponent<MultiSelectProps> = ({
         required={!!rules?.required}
         context={context}
         error={error}
-        hideOptional
       >
         <div data-h2-margin="b(bottom, xxs)" style={{ flexBasis: "100%" }}>
           <Controller

--- a/frontend/common/src/components/form/Select/Select.tsx
+++ b/frontend/common/src/components/form/Select/Select.tsx
@@ -45,7 +45,6 @@ export const Select: React.FunctionComponent<SelectProps> = ({
         required={!!rules?.required}
         context={context}
         error={error}
-        hideOptional
       >
         <select
           data-h2-radius="b(s)"

--- a/frontend/common/src/constants/localizedConstants.tsx
+++ b/frontend/common/src/constants/localizedConstants.tsx
@@ -7,6 +7,7 @@ import {
   WorkRegion,
   PoolCandidateSearchStatus,
   SkillCategory,
+  Role,
 } from "../api/generated";
 import { getOrThrowError } from "../helpers/util";
 
@@ -191,3 +192,13 @@ export const getSkillCategory = (
     skillCategoryId,
     `Invalid Skill Category '${skillCategoryId}'`,
   );
+
+export const Roles = defineMessages({
+  [Role.Admin]: {
+    defaultMessage: "Administrator",
+    description: "The name of the Administrator user role.",
+  },
+});
+
+export const getRole = (roleId: string | number): MessageDescriptor =>
+  getOrThrowError(Roles, roleId, `Invalid role '${roleId}'`);


### PR DESCRIPTION
This branch adds to the admin site the ability to edit the user's auth fields. The sub and roles fields can be set when creating or updating users.

Closes #1898 