### PR TITLE
Stabilize fakeSkillFamiliesWithSkills

### DIFF
--- a/frontend/common/src/fakeData/fakeSkillFamilies.ts
+++ b/frontend/common/src/fakeData/fakeSkillFamilies.ts
@@ -2,7 +2,7 @@ import faker from "faker";
 import { SkillCategory, SkillFamily } from "../api/generated";
 
 const generateSkillFamily = () => {
-  const name = faker.unique(faker.random.word);
+  const name = faker.random.word();
   return {
     category: faker.random.arrayElement([
       SkillCategory.Behavioural,

--- a/frontend/common/src/fakeData/fakeSkillFamiliesWithSkills.ts
+++ b/frontend/common/src/fakeData/fakeSkillFamiliesWithSkills.ts
@@ -8,6 +8,7 @@ import { Skill, SkillFamily } from "../api/generated";
 export default (): { skillFamilies: SkillFamily[]; skills: Skill[] } => {
   const skillFamilies = fakeSkillFamilies(4);
   const skills = fakeSkills(20);
+  faker.seed(0); // repeatable results
 
   skillFamilies.forEach((skillFamily) => {
     const skillsToAttach = faker.random.arrayElements(skills);

--- a/frontend/common/src/fakeData/fakeSkills.ts
+++ b/frontend/common/src/fakeData/fakeSkills.ts
@@ -2,7 +2,7 @@ import faker from "faker";
 import { Skill } from "../api/generated";
 
 const generateSkill = () => {
-  const name = faker.unique(faker.random.word);
+  const name = faker.random.word();
   return {
     id: faker.datatype.uuid(),
     key: faker.helpers.slugify(name),


### PR DESCRIPTION
This branch stabilizes the fakeSkillFamiliesWithSkills function to enable accurate Chromatic diffs.  It seems like the faker.js `unique` function does not work very well and prevents repeatable results.  Also, the seed reset was missing.
Closes #1954 