### PR TITLE
Fix translation extract command

### DIFF
--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -36,7 +36,7 @@
     "build-storybook": "build-storybook",
     "chromatic": "npx chromatic --project-token=87148152bdff --auto-accept-changes",
     "codegen": "graphql-codegen",
-    "intl-extract": "formatjs extract ./resources/js/**/*.ts* --ignore ./**/*d.ts --out-file resources/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
+    "intl-extract": "formatjs extract ./resources/js/**/*.{ts,tsx} --ignore ./**/*.d.ts --out-file resources/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
     "intl-compile": "formatjs compile ./resources/js/lang/fr.json --out-file ./resources/js/lang/frCompiled.json"
   },
   "devDependencies": {

--- a/frontend/common/package.json
+++ b/frontend/common/package.json
@@ -15,7 +15,7 @@
     "h2-compile": "h2-compile",
     "h2-watch": "h2-watch",
     "h2-build": "h2-build",
-    "intl-extract": "formatjs extract ./src/**/*.ts* --ignore ./**/*d.ts --out-file src/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
+    "intl-extract": "formatjs extract ./src/**/*.{ts,tsx} --ignore ./**/*.d.ts --out-file src/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
     "intl-compile": "formatjs compile src/lang/fr.json --out-file src/lang/frCompiled.json",
     "check-intl-common": "node ./src/tooling/checkIntl.js --en src/lang/en.json --fr src/lang/fr.json --rm-orphaned --output-untranslated src/lang/untranslated.json --whitelist src/lang/whitelist.json",
     "check-intl-common-merge": "node src/tooling/checkIntl.js --en src/lang/en.json --fr src/lang/fr.json --rm-orphaned --output-untranslated src/lang/untranslated.json --whitelist src/lang/whitelist.json --merge-fr src/lang/newTranslations.json",

--- a/frontend/talentsearch/package.json
+++ b/frontend/talentsearch/package.json
@@ -35,7 +35,7 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "codegen": "graphql-codegen",
-    "intl-extract": "formatjs extract ./resources/js/**/*.ts* --ignore ./**/*d.ts --out-file resources/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
+    "intl-extract": "formatjs extract ./resources/js/**/*.{ts,tsx} --ignore ./**/*.d.ts --out-file resources/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
     "intl-compile": "formatjs compile ./resources/js/lang/fr.json --out-file ./resources/js/lang/frCompiled.json",
     "test": "jest",
     "test:watch": "jest --watch"


### PR DESCRIPTION
I found an apparent globbing issue in the translation extraction scripts while working on PR #1958 .  Maybe it only exists on Linux?  I put the updates here instead of inside that PR.