### PR TITLE
Add allowable clock skew to token validation

### DIFF
--- a/api/app/Providers/BearerTokenServiceProvider.php
+++ b/api/app/Providers/BearerTokenServiceProvider.php
@@ -2,10 +2,12 @@
 
 namespace App\Providers;
 
+use DateTimeZone;
 use Illuminate\Support\ServiceProvider;
 use App\Services\Contracts\BearerTokenServiceInterface;
 use App\Services\LocalAuthBearerTokenService;
 use App\Services\OpenIdBearerTokenService;
+use Lcobucci\Clock\SystemClock;
 
 class BearerTokenServiceProvider extends ServiceProvider
 {
@@ -16,19 +18,23 @@ class BearerTokenServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
+        $systemClock = new SystemClock(new DateTimeZone(config('app.timezone')));
+
         if(config('oauth.server_root'))
-            $this->app->singleton(BearerTokenServiceInterface::class, function () {
+            $this->app->singleton(BearerTokenServiceInterface::class, function () use ($systemClock) {
                 return new OpenIdBearerTokenService(
-                    config('app.timezone'),
-                    config('oauth.server_root').'/.well-known/openid-configuration'
+                    $systemClock,
+                    config('oauth.server_root').'/.well-known/openid-configuration',
+                    config('oauth.allowable_clock_skew')
                 );
             });
         else
-            $this->app->singleton(BearerTokenServiceInterface::class, function () {
+            $this->app->singleton(BearerTokenServiceInterface::class, function () use ($systemClock) {
                 return new LocalAuthBearerTokenService(
                     config('oauth.server_iss'),
                     config('oauth.server_public_key'),
-                    config('app.timezone')
+                    $systemClock,
+                    config('oauth.allowable_clock_skew')
                 );
             });
     }

--- a/api/app/Services/OpenIdBearerTokenService.php
+++ b/api/app/Services/OpenIdBearerTokenService.php
@@ -1,11 +1,11 @@
 <?php
 namespace App\Services;
 
-use DateTimeZone;
 use Exception;
 use App\Services\Contracts\BearerTokenServiceInterface;
+use DateInterval;
 use Illuminate\Support\Facades\Cache;
-use Lcobucci\Clock\SystemClock;
+use Lcobucci\Clock\Clock;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer;
 use Lcobucci\JWT\UnencryptedToken;
@@ -19,14 +19,16 @@ use Lcobucci\JWT\Validation\Constraint\SignedWith;
 class OpenIdBearerTokenService implements BearerTokenServiceInterface
 {
     private Configuration $unsecuredConfig;
-    private SystemClock $clock;
+    private Clock $clock;
     private string $configUri;
+    private DateInterval $allowableClockSkew;
 
-    public function __construct(string $timeZone, string $configUri)
+    public function __construct(Clock $clock, string $configUri, DateInterval $allowableClockSkew)
     {
         $this->unsecuredConfig = Configuration::forUnsecuredSigner(); // need a config to parse the token and get the key id
-        $this->clock = new SystemClock(new DateTimeZone($timeZone));
+        $this->clock = $clock;
         $this->configUri = $configUri;
+        $this->allowableClockSkew = $allowableClockSkew;
     }
 
     // parse the jwks json document and build a dictionary of key id to configuration object
@@ -123,7 +125,7 @@ class OpenIdBearerTokenService implements BearerTokenServiceInterface
         $config->setValidationConstraints(
             new IssuedBy($this->getConfigProperty('issuer')),
             new RelatedTo($token->claims()->get('sub')),
-            new LooseValidAt($this->clock),
+            new LooseValidAt($this->clock, $this->allowableClockSkew),
             new SignedWith($config->signer(), $config->verificationKey()),
         );
         $constraints = $config->validationConstraints();

--- a/api/config/oauth.php
+++ b/api/config/oauth.php
@@ -36,4 +36,17 @@ return [
     |
     */
     'server_public_key' => env('AUTH_SERVER_PUBLIC_KEY'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Allowable Clock Skew
+    |--------------------------------------------------------------------------
+    |
+    | According to CATSv3, section 4.1, Deployments MUST allow between three (3)
+    | and five (5) minutes of clock skew — in either direction — when interpreting
+    | the exp and nbf claims in ID tokens and when enforcing security policies
+    | based thereupon.
+    |
+    */
+    'allowable_clock_skew' =>  DateInterval::createFromDateString('4 minutes'),
 ];

--- a/api/tests/OpenIdBearerTokenTest.php
+++ b/api/tests/OpenIdBearerTokenTest.php
@@ -2,7 +2,7 @@
 
 use App\Services\OpenIdBearerTokenService;
 use App\Services\Contracts\BearerTokenServiceInterface;
-use Illuminate\Support\Facades\Route;
+use Lcobucci\Clock\FrozenClock;
 
 class OpenIdBearerTokenTest extends TestCase
 {
@@ -13,6 +13,9 @@ class OpenIdBearerTokenTest extends TestCase
 
     protected $tempConfigFile;
     protected $tempJwksFile;
+
+    protected DateTimeImmutable $now;
+    protected DateInterval $allowableClockSkew;
 
     protected function setUp(): void
     {
@@ -55,8 +58,13 @@ RAWJSON);
         // generate keys and tokens for testing at https://jwt.io/#debugger-io
         // make sure you set algorithm to RS256
 
-        $timeZone = 'UTC';
-        $this->service_provider = new OpenIdBearerTokenService($timeZone, stream_get_meta_data($this->tempConfigFile)['uri']);
+        $this->now = new DateTimeImmutable('2020-01-01 00:02:00', new DateTimeZone('UTC'));
+        $this->allowableClockSkew = DateInterval::createFromDateString('4 minutes');
+        $this->service_provider = new OpenIdBearerTokenService(
+            new FrozenClock($this->now),
+             stream_get_meta_data($this->tempConfigFile)['uri'],
+             $this->allowableClockSkew
+        );
 
         parent::setUp();
     }
@@ -201,5 +209,31 @@ RAWJSON);
         }
          */
         $this->service_provider->validateAndGetClaims($token);
+    }
+    /**
+     * @test
+     * A token is provided but has expired within allowable clock skew and should be accepted.
+     */
+    public function testAcceptsExpiredTokenWithinAllowableSkew()
+    {
+        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoxNTc3ODM2ODYwLCJpYXQiOjB9.zI4EHjfWyZP3G8DFRAMJXF9mZrA65RizQMrnQGVuKFYm0cwMusBToaH5k4feB0b2WPfBkl3-gHOJ5qKoNcR50RI_t5LEZbBVZrGhCDfpCDVlO5ZnwABhQo48NUi2ZbMb1ZoDTa_802hifvpjhOtEE0V9_zCsDZ1pcA9G4rsqEv5T3N35JV_xwgD_PqToZrxCMNuJOG5k8suoIKazzN5eJm3adKi7UsOqh-DJTni7-z88A95UycS0ONw5APFYU-IE3kL5UL1K6OwvXEgpD0md06qB3GUmkkjXeGumDefokT8RouAIbX8p37cfvxeuctJ1WtKZJ3IrJx0E4y-15JCLaPQ3tmv4XQ7lfHf9Yblith7Sw4T4upO7wtynogg2Y_Oget7zLksvaza77SRkXLf8Si3lGJ9ydqSlkLKqo8aX5nQJAkUnRY72eIz5jEEdBBrkpTQdQRG4g2-R9xXd9rGCscdAt2S3COJEFhO2FrgwUiD0piHah-PlMVN5fw3wr2ISN9OYfd5_e15UxLgo0Qw99_mKaakXBf20umTkk2TGi8YmMZLvbOS6yI7eS1wo3rFPzdTOPT7WoW6iPl_kW0FdGZYQQb1GxI2RrjFl6Ud4axKqJbtv1dV9ml1Z9PPawBcIP2B702uLwc9RZrX8b3S3Cnq72-7iCWJVvET9IQr1ess';
+        /** analyze token at https://jwt.io/
+        {
+        "kid": "key1",
+        "typ": "JWT",
+        "alg": "RS256"
+        }
+        {
+        "sub": "1234567890",
+        "iss": "http://test.com",
+        "exp": 1577836860, //2020-01-01 00:01:00
+        "iat": 0
+        }
+         */
+        $claims = $this->service_provider->validateAndGetClaims($token);  // will throw an exception for rejected tokens
+
+        // checks that the test was properly set up
+        $this->assertTrue($this->now > $claims->get('exp'), 'test value for now was not after strict expiry date');
+        $this->assertTrue($this->now < $claims->get('exp')->add($this->allowableClockSkew), 'test value for now was not within the expiry date plus allowed skew');
     }
 }


### PR DESCRIPTION
This branch adds 4 minutes of allowable clock skew to the token validation.  This functionality is required as part of the CATSv3 specifications.

A pair of phpunit tests is included to verify that a token can be accepted after the expiry date but within allowable skew time.

To allow reliable testing the providers were refactored to allow the clock to be injected as a dependency.  This allows a test clock with a specific time to be used for testing.

Closes #1976 