### PR TITLE
Add option of treating un-authorized requests as a default user

### DIFF
--- a/api/app/Providers/AuthServiceProvider.php
+++ b/api/app/Providers/AuthServiceProvider.php
@@ -85,6 +85,13 @@ class AuthServiceProvider extends ServiceProvider
                 }
             }
 
+            // If a default user is set, and there is no bearer token, treat the request as if it were from the default user.
+            if (config('oauth.default_user')) {
+                $user = User::where('email', config('oauth.default_user'))->first();
+                if ($user) {
+                    return $user;
+                }
+            }
         });
     }
 }

--- a/api/config/oauth.php
+++ b/api/config/oauth.php
@@ -36,4 +36,15 @@ return [
     |
     */
     'server_public_key' => env('AUTH_SERVER_PUBLIC_KEY'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default User
+    |--------------------------------------------------------------------------
+    |
+    | If this is set to a valid user email, then any authenticated request will be treated as this user.
+    | THIS SHOULD BE NULL IN PRODUCTION!
+    |
+    */
+    'default_user' => env('AUTH_DEFAULT_USER', null),
 ];


### PR DESCRIPTION
Resolves #2033 

If AUTH_DEFAULT_USER env variable is set to a valid user email, then any requests to api _without a bearer token_ will be treated as authenticated as the the default user. This allows you to act as a different user if you _do_ provide a proper bearer token.

I originally tried to implement this as a third implementation of BearerTokenServiceInterface, but BearerTokenServiceInterface is only used if a bearer token _is_ present. Also, I like that in this implementation, the user can fall back on the normal BearerTokenServiceInterface if they do provide a token.

To test:
- Start logged out, and try to access the admin dashboard. You should get authentication errors.
- set `AUTH_DEFAULT_USER=admin@test.com` in api/.env . You should now have full access to admin dashboard.