### PR TITLE
Use root app url in login redirect

### DIFF
--- a/api/database/seeders/UserSeederLocal.php
+++ b/api/database/seeders/UserSeederLocal.php
@@ -51,7 +51,7 @@ class UserSeederLocal extends Seeder
         ]);
         User::factory()->create([
             'email' => 'tristan-orourke'.$fakeEmailDomain,
-            'sub' => 'b4c734a1-dcf3-4fb8-a860-c642700cb0b8',
+            'sub' => 'd9f27aca-b2ea-4c4a-9459-25bb7a7b77f6',
             'roles' => ['ADMIN']
         ]);
     }

--- a/frontend/admin/.env.example
+++ b/frontend/admin/.env.example
@@ -2,7 +2,7 @@ APP_NAME=Admin
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-ADMIN_APP_URL="http://localhost:8000/admin"
+APP_URL="http://localhost:8000"
 APP_TIMEZONE=UTC
 ADMIN_APP_DIR="/admin"
 
@@ -38,6 +38,7 @@ MERGE_STORYBOOKS=false
 # for SiC testing
 # OAUTH_URI="https://te-auth.id.tbs-sct.gc.ca/oxauth/restv1/authorize"
 # OAUTH_TOKEN_URI="https://te-auth.id.tbs-sct.gc.ca/oxauth/restv1/token"
+# OAUTH_REDIRECT_URI="http://localhost:8000/admin/auth-callback"
 # OAUTH_ADMIN_CLIENT_ID=
 # OAUTH_ADMIN_CLIENT_SECRET=
 

--- a/frontend/admin/app/Http/Controllers/AuthController.php
+++ b/frontend/admin/app/Http/Controllers/AuthController.php
@@ -70,7 +70,7 @@ class AuthController extends Controller
         if(substr($from, 0, 1) != '/')
             $from = null; // Does not start with / so it's not a relative url. Don't want an open redirect vulnerability. Throw it away.
 
-        $navigateToUri = strlen($from) > 0 ? $from : config('app.url');
+        $navigateToUri = strlen($from) > 0 ? config('app.url').$from : config('app.url');
         return redirect($navigateToUri . '?' . $query);
     }
 

--- a/frontend/admin/app/Http/Controllers/AuthController.php
+++ b/frontend/admin/app/Http/Controllers/AuthController.php
@@ -70,7 +70,7 @@ class AuthController extends Controller
         if(substr($from, 0, 1) != '/')
             $from = null; // Does not start with / so it's not a relative url. Don't want an open redirect vulnerability. Throw it away.
 
-        $navigateToUri = strlen($from) > 0 ? config('app.url').$from : config('app.url');
+        $navigateToUri = strlen($from) > 0 ? config('app.url').$from : config('app.url').config('app.app_dir');
         return redirect($navigateToUri . '?' . $query);
     }
 

--- a/frontend/admin/config/app.php
+++ b/frontend/admin/config/app.php
@@ -52,7 +52,7 @@ return [
     |
     */
 
-    'url' => env('ADMIN_APP_URL', 'http://localhost'),
+    'url' => env('APP_URL', 'http://localhost'),
     'app_dir' => env('ADMIN_APP_DIR', 'admin'),
     'asset_url' => env('ADMIN_ASSET_URL', null),
     'mix_url' => env('ADMIN_MIX_ASSET_URL', null),


### PR DESCRIPTION
Resolves #2044

Our app is hosted behind a proxy in production, so redirecting from the server to a url path won't work, we need to be able to add the domain of the frontend url.

I set the AuthController to use the root APP_URL instead of ADMIN_APP_URL, because the `from` parameter includes the entire domain, including the `/admin`. And since ADMIN_APP_URL wasn't being used anywhere else, I removed it from .env.example. I added an explicit APP_URL in .env.example, but it defaults to localhost in the config file, so the app should work even without changing your .env file.

One unfortunate consequence of this strategy is that if you navigate straight to `/admin/login` like we were doing before, without entering a from parameter, you will be redirected back to the main landing page, which can't actually process the access_token url parameter. This is less of a problem now that we have a login button which includes the from parameter for you, but I'm open to discussing alternatives with reviewers.

