### PR TITLE
Assemble add skills to experience component

### DIFF
--- a/frontend/common/src/components/tabs/Tab.tsx
+++ b/frontend/common/src/components/tabs/Tab.tsx
@@ -16,6 +16,8 @@ export interface TabProps extends React.HTMLProps<HTMLElement> {
   iconClosed?: JSX.Element;
   iconPosition?: "left" | "right";
   text?: string;
+  textOpen?: string;
+  textClosed?: string;
   /** The type of tab to add to the set:
    * *normal* - a tab that can be clicked to show content
    * *closer* - a tab that opens and closes the entire tab set but doesn't have its own content
@@ -36,6 +38,8 @@ export const Tab: React.FC<TabProps> = ({
   iconClosed,
   iconPosition = "left",
   text,
+  textOpen,
+  textClosed,
   tabType = "normal",
   placement = "default",
   isTabSetOpen,
@@ -53,22 +57,32 @@ export const Tab: React.FC<TabProps> = ({
     effectiveIcon = icon;
   }
 
+  // calculate the text to show
+  let effectiveText;
+  if (isTabSetOpen && textOpen) {
+    effectiveText = textOpen;
+  } else if (!isTabSetOpen && textClosed) {
+    effectiveText = textClosed;
+  } else {
+    effectiveText = text;
+  }
+
   // arrange the contents of the label
   let label;
   if (!effectiveIcon) {
-    label = text;
+    label = effectiveText;
   } else if (iconPosition === "left") {
     label = (
       <div data-h2-display="b(flex)">
         {effectiveIcon}
         &nbsp;
-        {text}
+        {effectiveText}
       </div>
     );
   } else if (iconPosition === "right") {
     label = (
       <div data-h2-display="b(flex)">
-        {text}
+        {effectiveText}
         &nbsp;
         {effectiveIcon}
       </div>

--- a/frontend/common/src/components/tabs/tabs.stories.tsx
+++ b/frontend/common/src/components/tabs/tabs.stories.tsx
@@ -46,10 +46,11 @@ const TemplateSkillsToExperience: Story<TabSetProps> = (args) => {
       </Tab>
       <Tab
         tabType="closer"
-        iconOpen={<ChevronUpIcon style={{ width: "1.25rem" }} />}
-        iconClosed={<ChevronDownIcon style={{ width: "1.25rem" }} />}
         iconPosition="right"
-        text="Close"
+        iconOpen={<ChevronUpIcon style={{ width: "1.25rem" }} />}
+        textOpen="Close"
+        iconClosed={<ChevronDownIcon style={{ width: "1.25rem" }} />}
+        textClosed="Open"
         placement="end"
       />
     </TabSet>

--- a/frontend/talentsearch/resources/js/components/skills/AddSkillsToExperience/AddSkillsToExperience.stories.tsx
+++ b/frontend/talentsearch/resources/js/components/skills/AddSkillsToExperience/AddSkillsToExperience.stories.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Meta, Story } from "@storybook/react";
+import { fakeSkills, fakeSkillFamilies } from "@common/fakeData";
+import AddSkillsToExperience, { AddSkillsToExperienceProps } from ".";
+
+const skills = fakeSkills(15, fakeSkillFamilies(4));
+
+export default {
+  component: AddSkillsToExperience,
+  title: "Skills/Add Skills To Experience",
+  args: {
+    allSkills: skills,
+    frequentSkills: skills.slice(0, 10),
+    addedSkills: skills.slice(7, 12),
+  },
+  argTypes: {
+    onRemoveSkill: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} as Meta;
+
+const TemplateAddedSkillsFew: Story<AddSkillsToExperienceProps> = (args) => {
+  return <AddSkillsToExperience {...args} />;
+};
+
+export const FewSkills = TemplateAddedSkillsFew.bind({});

--- a/frontend/talentsearch/resources/js/components/skills/AddSkillsToExperience/AddSkillsToExperience.tsx
+++ b/frontend/talentsearch/resources/js/components/skills/AddSkillsToExperience/AddSkillsToExperience.tsx
@@ -206,10 +206,11 @@ const AddSkillsToExperience: React.FunctionComponent<
         </Tab>
         <Tab
           tabType="closer"
-          iconOpen={<ChevronUpIcon style={{ width: "1.25rem" }} />}
-          iconClosed={<ChevronDownIcon style={{ width: "1.25rem" }} />}
           iconPosition="right"
-          text="Close"
+          iconOpen={<ChevronUpIcon style={{ width: "1.25rem" }} />}
+          textOpen="Close"
+          iconClosed={<ChevronDownIcon style={{ width: "1.25rem" }} />}
+          textClosed="Open"
           placement="end"
         />
       </TabSet>

--- a/frontend/talentsearch/resources/js/components/skills/AddSkillsToExperience/AddSkillsToExperience.tsx
+++ b/frontend/talentsearch/resources/js/components/skills/AddSkillsToExperience/AddSkillsToExperience.tsx
@@ -1,0 +1,211 @@
+import React, { useMemo, useState } from "react";
+import { useIntl } from "react-intl";
+import { getLocale } from "@common/helpers/localize";
+import { Scalars, Skill, SkillFamily } from "@common/api/generated";
+import { Tab, TabSet } from "@common/components/tabs";
+import {
+  FilterIcon,
+  SearchCircleIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from "@heroicons/react/solid";
+import { matchStringCaseDiacriticInsensitive } from "@common/helpers/formUtils";
+import Pagination, { usePaginationVars } from "@common/components/Pagination";
+import { invertSkillTree } from "@common/helpers/skillUtils";
+import AddedSkills from "../AddedSkills";
+import SkillResults from "../SkillResults";
+import SkillChecklist from "../SkillChecklist";
+import SearchBar from "../SearchBar";
+
+export interface AddSkillsToExperienceProps {
+  allSkills: Skill[];
+  frequentSkills: Skill[];
+  addedSkills: Skill[];
+  onRemoveSkill: (id: Scalars["ID"]) => Promise<void>;
+  onAddSkill: (id: Scalars["ID"]) => Promise<void>;
+}
+
+const AddSkillsToExperience: React.FunctionComponent<
+  AddSkillsToExperienceProps
+> = ({ allSkills, frequentSkills, addedSkills, onRemoveSkill, onAddSkill }) => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
+
+  const [familyFilteredSkills, setFamilyFilteredSkills] = useState<Skill[]>([]);
+  const [searchFilteredSkills, setSearchFilteredSkills] = useState<Skill[]>([]);
+
+  const resultsPaginationPageSize = 5;
+  const frequentSkillsPagination = usePaginationVars<Skill>(
+    1,
+    resultsPaginationPageSize,
+    frequentSkills,
+  );
+  const mainstreamSkillsPagination = usePaginationVars<Skill>(
+    1,
+    resultsPaginationPageSize,
+    familyFilteredSkills,
+  );
+  const keywordSearchPagination = usePaginationVars<Skill>(
+    1,
+    resultsPaginationPageSize,
+    searchFilteredSkills,
+  );
+
+  /**
+   * A handler which takes a list of skill families and filters the allSkills list to
+   * any skills that are a part of those families.  Applies the filter
+   * internally using the useState hook.
+   * @param {SkillFamily[]} checkedFamilies - The selected skill families to filter against.
+   */
+  const handleSkillFamilyChange = (checkedFamilies: SkillFamily[]): void => {
+    const checkedFamilyIds = checkedFamilies.map((family) => family.id);
+    const matchingSkills = allSkills.filter((skill) =>
+      // https://stackoverflow.com/a/39893636
+      skill.families?.some((skillFamily) =>
+        checkedFamilyIds.includes(skillFamily.id),
+      ),
+    );
+    setFamilyFilteredSkills(matchingSkills);
+    mainstreamSkillsPagination.setCurrentPage(1);
+  };
+
+  /**
+   * A handler which takes a search query and uses a matching function to filter
+   * a list of skills.  Applies the filter internally using the useState hook.
+   * @param {string} searchQuery - The search text to filter against.
+   */
+  const handleSearch = (searchQuery: string): Promise<void> => {
+    return new Promise<void>((resolve) => {
+      const matchedSkills = allSkills.filter((skill) =>
+        matchStringCaseDiacriticInsensitive(
+          searchQuery,
+          skill.name[locale] ?? "",
+        ),
+      );
+      setSearchFilteredSkills(matchedSkills);
+      keywordSearchPagination.setCurrentPage(1); // just in case the new list of matched skills requires fewer pages
+      resolve();
+    });
+  };
+
+  // this function can be a bit heavy
+  const allSkillFamilies = useMemo(
+    () => invertSkillTree(allSkills),
+    [allSkills],
+  );
+
+  return (
+    <>
+      <AddedSkills skills={addedSkills} onRemoveSkill={onRemoveSkill} />
+      <hr />
+      <h5>
+        {intl.formatMessage({
+          defaultMessage: "Add Skills",
+          description: "Section header for adding skills to this experience",
+        })}
+      </h5>
+      <TabSet>
+        <Tab
+          icon={<SearchCircleIcon style={{ width: "1rem" }} />}
+          text="My frequent skills"
+        >
+          <SkillResults
+            title={intl.formatMessage(
+              {
+                defaultMessage: "Frequently used skills ({skillCount})",
+                description:
+                  "Section header for a list of frequently used skills",
+              },
+              {
+                skillCount: frequentSkills.length,
+              },
+            )}
+            skills={frequentSkillsPagination.currentTableData}
+            addedSkills={addedSkills}
+            handleAddSkill={onAddSkill}
+            handleRemoveSkill={onRemoveSkill}
+          />
+          <Pagination
+            currentPage={frequentSkillsPagination.currentPage}
+            pageSize={resultsPaginationPageSize}
+            totalCount={frequentSkills.length}
+            handlePageChange={(page) =>
+              frequentSkillsPagination.setCurrentPage(page)
+            }
+          />
+        </Tab>
+        <Tab
+          icon={<FilterIcon style={{ width: "1rem" }} />}
+          text="Mainstream skills"
+        >
+          <SkillChecklist
+            skillFamilies={allSkillFamilies}
+            callback={handleSkillFamilyChange}
+          />
+          <SkillResults
+            title={intl.formatMessage(
+              {
+                defaultMessage: "Results ({skillCount})",
+                description: "A title for a skill list of results",
+              },
+              {
+                skillCount: familyFilteredSkills.length,
+              },
+            )}
+            skills={mainstreamSkillsPagination.currentTableData}
+            addedSkills={addedSkills}
+            handleAddSkill={onAddSkill}
+            handleRemoveSkill={onRemoveSkill}
+          />
+          <Pagination
+            currentPage={mainstreamSkillsPagination.currentPage}
+            pageSize={resultsPaginationPageSize}
+            totalCount={familyFilteredSkills.length}
+            handlePageChange={(page) =>
+              mainstreamSkillsPagination.setCurrentPage(page)
+            }
+          />
+        </Tab>
+        <Tab
+          icon={<SearchCircleIcon style={{ width: "1rem" }} />}
+          text="Search by keyword"
+        >
+          <SearchBar handleSearch={handleSearch} />
+          <SkillResults
+            title={intl.formatMessage(
+              {
+                defaultMessage: "Results ({skillCount})",
+                description: "A title for a list of results",
+              },
+              {
+                skillCount: searchFilteredSkills.length,
+              },
+            )}
+            skills={keywordSearchPagination.currentTableData}
+            addedSkills={addedSkills}
+            handleAddSkill={onAddSkill}
+            handleRemoveSkill={onRemoveSkill}
+          />
+          <Pagination
+            currentPage={keywordSearchPagination.currentPage}
+            pageSize={resultsPaginationPageSize}
+            totalCount={searchFilteredSkills.length}
+            handlePageChange={(page) =>
+              keywordSearchPagination.setCurrentPage(page)
+            }
+          />
+        </Tab>
+        <Tab
+          tabType="closer"
+          iconOpen={<ChevronUpIcon style={{ width: "1.25rem" }} />}
+          iconClosed={<ChevronDownIcon style={{ width: "1.25rem" }} />}
+          iconPosition="right"
+          text="Close"
+          placement="end"
+        />
+      </TabSet>
+    </>
+  );
+};
+
+export default AddSkillsToExperience;

--- a/frontend/talentsearch/resources/js/components/skills/AddSkillsToExperience/AddSkillsToExperience.tsx
+++ b/frontend/talentsearch/resources/js/components/skills/AddSkillsToExperience/AddSkillsToExperience.tsx
@@ -66,7 +66,7 @@ const AddSkillsToExperience: React.FunctionComponent<
       ),
     );
     setFamilyFilteredSkills(matchingSkills);
-    mainstreamSkillsPagination.setCurrentPage(1);
+    mainstreamSkillsPagination.setCurrentPage(1); // just in case the new list of matched skills requires fewer pages
   };
 
   /**
@@ -107,7 +107,10 @@ const AddSkillsToExperience: React.FunctionComponent<
       <TabSet>
         <Tab
           icon={<SearchCircleIcon style={{ width: "1rem" }} />}
-          text="My frequent skills"
+          text={intl.formatMessage({
+            defaultMessage: "My frequent skills",
+            description: "Tab name for a list of frequently used skills",
+          })}
         >
           <SkillResults
             title={intl.formatMessage(
@@ -136,7 +139,10 @@ const AddSkillsToExperience: React.FunctionComponent<
         </Tab>
         <Tab
           icon={<FilterIcon style={{ width: "1rem" }} />}
-          text="Mainstream skills"
+          text={intl.formatMessage({
+            defaultMessage: "Mainstream skills",
+            description: "Tab name for a list of mainstream skills",
+          })}
         >
           <SkillChecklist
             skillFamilies={allSkillFamilies}
@@ -168,7 +174,10 @@ const AddSkillsToExperience: React.FunctionComponent<
         </Tab>
         <Tab
           icon={<SearchCircleIcon style={{ width: "1rem" }} />}
-          text="Search by keyword"
+          text={intl.formatMessage({
+            defaultMessage: "Search by keyword",
+            description: "Tab name for a box to search for skills",
+          })}
         >
           <SearchBar handleSearch={handleSearch} />
           <SkillResults

--- a/frontend/talentsearch/resources/js/components/skills/AddSkillsToExperience/index.ts
+++ b/frontend/talentsearch/resources/js/components/skills/AddSkillsToExperience/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-exports
+export { default, AddSkillsToExperienceProps } from "./AddSkillsToExperience";


### PR DESCRIPTION
This branch composes the various skills components to an AddSkillsToExperience component.  It includes a Storybook story to view it.  The component emits add and remove skill events to a parent component.

Note that Jerbo requested that *Skills in demand* be changed to *Mainstream skills* so that will be different from the wireframe.
Note that there are a few weird button things going on like stray dots on the pagination and the cursor not changing to pointer in the skill lists.  I believe these are due to #1977.

Closes #1683 