### PR TITLE
Default storybook viewer background to off-white

### DIFF
--- a/frontend/admin/.storybook/preview.js
+++ b/frontend/admin/.storybook/preview.js
@@ -6,6 +6,11 @@ import frCompiled from "../resources/js/lang/frCompiled.json";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
+  backgrounds: {
+    // Set default to "light gray" rather that default "white", to better catch
+    // components with transparent backgrounds.
+    default: 'light',
+  },
   controls: {
     matchers: {
       color: /(background|color)$/i,

--- a/frontend/common/.storybook/preview.js
+++ b/frontend/common/.storybook/preview.js
@@ -5,6 +5,11 @@ import frCompiled from "../src/lang/frCompiled.json";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
+  backgrounds: {
+    // Set default to "light gray" rather that default "white", to better catch
+    // components with transparent backgrounds.
+    default: 'light',
+  },
   controls: {
     matchers: {
       color: /(background|color)$/i,

--- a/frontend/talentsearch/.storybook/preview.js
+++ b/frontend/talentsearch/.storybook/preview.js
@@ -6,6 +6,11 @@ import frCompiled from "../resources/js/lang/frCompiled.json";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
+  backgrounds: {
+    // Set default to "light gray" rather that default "white", to better catch
+    // components with transparent backgrounds.
+    default: 'light',
+  },
   controls: {
     matchers: {
       color: /(background|color)$/i,


### PR DESCRIPTION
Re-ticketed from: https://github.com/GCTC-NTGC/gc-digital-talent/issues/1974#issuecomment-1030216310

Small fix to prevent these missing background issues from catching us again (esp for components that we expect to have a background). White is still an option by selecting "reset" under "background color" of storybook chrome.

cc: @petertgiles 