### PR TITLE
Add label to "direct" deps in dependabot PRs, to determine easiest merge order

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,19 +66,55 @@ updates:
     open-pull-requests-limit: 15
 
   - package-ecosystem: "composer"
+    directory: "/api"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 15
+
+  # Flag the direct dependencies with additional label.
+  - package-ecosystem: "composer"
     directory: "/frontend/admin"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 15
-
+    allow:
+      - dependency-type: direct
+    labels:
+      - dependencies-priority
+      # Default labels
+      - dependencies
+      - php
   - package-ecosystem: "composer"
-    directory: "/auth"
+    directory: "/frontend/talentsearch"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 15
+    allow:
+      - dependency-type: direct
+    labels:
+      - dependencies-priority
+      # Default labels
+      - dependencies
+      - php
 
+  # The rest of dependencies.
+  - package-ecosystem: "composer"
+    directory: "/frontend/admin"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 15
+    ignore:
+      - dependency-type: direct
   - package-ecosystem: "composer"
     directory: "/frontend/talentsearch"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 15
+    ignore:
+      - dependency-type: direct
+
+  - package-ecosystem: "composer"
+    directory: "/auth"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 15

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,28 @@ version: 2
 updates:
   # JAVASCRIPT package.json updates
 
+  # Flag the direct dependencies with additional label.
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 15
+    allow:
+      - dependency-type: direct
+    labels:
+      - dependencies-priority
+      # Default labels
+      - dependencies
+      - javascript
+
+  # The rest of dependencies.
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 15
+    ignore:
+      - dependency-type: direct
 
   - package-ecosystem: "npm"
     directory: "/auth"


### PR DESCRIPTION
Resolves https://github.com/GCTC-NTGC/gc-digital-talent/issues/2175

## To Do
- [x] decide label to add to "top-level": `dependencies-priority`
- [x] split frontend npm packages into two types
- [x] split composer packages into two types
- docs??