### PR TITLE
Add secure and samesite=none flags to GA instances

### DIFF
--- a/tc-report/404.html
+++ b/tc-report/404.html
@@ -22,7 +22,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/001-executive-summary.html
+++ b/tc-report/en/2000/01/01/001-executive-summary.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/401-overview.html
+++ b/tc-report/en/2000/01/01/401-overview.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/403-overall-impact.html
+++ b/tc-report/en/2000/01/01/403-overall-impact.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/404-110-days.html
+++ b/tc-report/en/2000/01/01/404-110-days.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/406-top-talent.html
+++ b/tc-report/en/2000/01/01/406-top-talent.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/407-volume.html
+++ b/tc-report/en/2000/01/01/407-volume.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/409-priority.html
+++ b/tc-report/en/2000/01/01/409-priority.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/410-security.html
+++ b/tc-report/en/2000/01/01/410-security.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/411-online-screening.html
+++ b/tc-report/en/2000/01/01/411-online-screening.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/412-languages.html
+++ b/tc-report/en/2000/01/01/412-languages.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/413-platform-tools.html
+++ b/tc-report/en/2000/01/01/413-platform-tools.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/414-job-ads.html
+++ b/tc-report/en/2000/01/01/414-job-ads.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/415-assessment-planning.html
+++ b/tc-report/en/2000/01/01/415-assessment-planning.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/416-tracking.html
+++ b/tc-report/en/2000/01/01/416-tracking.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/417-record-of-decision.html
+++ b/tc-report/en/2000/01/01/417-record-of-decision.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/502-5-things.html
+++ b/tc-report/en/2000/01/01/502-5-things.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/503-talent-reserve.html
+++ b/tc-report/en/2000/01/01/503-talent-reserve.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/504-blockchain.html
+++ b/tc-report/en/2000/01/01/504-blockchain.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/2000/01/01/601-in-news.html
+++ b/tc-report/en/2000/01/01/601-in-news.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/communities/digital-talent/index.html
+++ b/tc-report/en/communities/digital-talent/index.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/diversity/2000/01/01/301-overview.html
+++ b/tc-report/en/diversity/2000/01/01/301-overview.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/diversity/2000/01/01/303-accessible.html
+++ b/tc-report/en/diversity/2000/01/01/303-accessible.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/diversity/2000/01/01/304-skills-instead-of-experience.html
+++ b/tc-report/en/diversity/2000/01/01/304-skills-instead-of-experience.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/diversity/2000/01/01/305-indigenous-talent.html
+++ b/tc-report/en/diversity/2000/01/01/305-indigenous-talent.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/diversity/2000/01/01/306-essential-education.html
+++ b/tc-report/en/diversity/2000/01/01/306-essential-education.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/diversity/2000/01/01/307-applicant-story.html
+++ b/tc-report/en/diversity/2000/01/01/307-applicant-story.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/diversity/2000/01/01/308-freetobeme.html
+++ b/tc-report/en/diversity/2000/01/01/308-freetobeme.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/diversity/2000/01/01/309-anon-recruitment.html
+++ b/tc-report/en/diversity/2000/01/01/309-anon-recruitment.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/diversity/hiring/2000/01/01/302-takeaways.html
+++ b/tc-report/en/diversity/hiring/2000/01/01/302-takeaways.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/hiring/2000/01/01/201-overview.html
+++ b/tc-report/en/hiring/2000/01/01/201-overview.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/hiring/2000/01/01/202-takeaways.html
+++ b/tc-report/en/hiring/2000/01/01/202-takeaways.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/hiring/2000/01/01/203-impact-staffing.html
+++ b/tc-report/en/hiring/2000/01/01/203-impact-staffing.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/hiring/2000/01/01/204-five-factor.html
+++ b/tc-report/en/hiring/2000/01/01/204-five-factor.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/hiring/2000/01/01/205-manager-employee-responses.html
+++ b/tc-report/en/hiring/2000/01/01/205-manager-employee-responses.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/hiring/2000/01/01/206-manager-story.html
+++ b/tc-report/en/hiring/2000/01/01/206-manager-story.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/hiring/2000/01/01/207-remote-work.html
+++ b/tc-report/en/hiring/2000/01/01/207-remote-work.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/hiring/2000/01/01/208-flexibility.html
+++ b/tc-report/en/hiring/2000/01/01/208-flexibility.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/hiring/2000/01/01/209-skill-assessment.html
+++ b/tc-report/en/hiring/2000/01/01/209-skill-assessment.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/hiring/2000/01/01/402-takeaways.html
+++ b/tc-report/en/hiring/2000/01/01/402-takeaways.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/hiring/2000/01/01/405-intervention.html
+++ b/tc-report/en/hiring/2000/01/01/405-intervention.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/hiring/2000/01/01/408-criteria.html
+++ b/tc-report/en/hiring/2000/01/01/408-criteria.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/index.html
+++ b/tc-report/en/index.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/privacy-notice/index.html
+++ b/tc-report/en/privacy-notice/index.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/projects/2000/01/01/101-caveat-to-begin.html
+++ b/tc-report/en/projects/2000/01/01/101-caveat-to-begin.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/projects/2000/01/01/102-problem-statement.html
+++ b/tc-report/en/projects/2000/01/01/102-problem-statement.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/projects/2000/01/01/104-deliverables.html
+++ b/tc-report/en/projects/2000/01/01/104-deliverables.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/projects/2000/01/01/105-partnerships.html
+++ b/tc-report/en/projects/2000/01/01/105-partnerships.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/projects/2000/01/01/106-standards.html
+++ b/tc-report/en/projects/2000/01/01/106-standards.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/projects/2000/01/01/107-approach.html
+++ b/tc-report/en/projects/2000/01/01/107-approach.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/projects/2000/01/01/108-team.html
+++ b/tc-report/en/projects/2000/01/01/108-team.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/projects/2000/01/01/109-research-engine.html
+++ b/tc-report/en/projects/2000/01/01/109-research-engine.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/projects/2000/01/01/110-portals.html
+++ b/tc-report/en/projects/2000/01/01/110-portals.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/projects/2000/01/01/111-policy-compliance.html
+++ b/tc-report/en/projects/2000/01/01/111-policy-compliance.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/projects/2000/01/01/112-process.html
+++ b/tc-report/en/projects/2000/01/01/112-process.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/projects/2000/01/01/113-road-to-talent-cloud.html
+++ b/tc-report/en/projects/2000/01/01/113-road-to-talent-cloud.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/projects/2000/01/01/114-pro-b.html
+++ b/tc-report/en/projects/2000/01/01/114-pro-b.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/projects/2000/01/01/510-where-to.html
+++ b/tc-report/en/projects/2000/01/01/510-where-to.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/talent-cloud/index.html
+++ b/tc-report/en/talent-cloud/index.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/talent-cloud/report/index.html
+++ b/tc-report/en/talent-cloud/report/index.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/terms-and-conditions/index.html
+++ b/tc-report/en/terms-and-conditions/index.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/vision/2000/01/01/501-overview.html
+++ b/tc-report/en/vision/2000/01/01/501-overview.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/vision/2000/01/01/505-credentials.html
+++ b/tc-report/en/vision/2000/01/01/505-credentials.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/vision/2000/01/01/506-talent-repository.html
+++ b/tc-report/en/vision/2000/01/01/506-talent-repository.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/vision/2000/01/01/509-gov-wide.html
+++ b/tc-report/en/vision/2000/01/01/509-gov-wide.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/vision/diversity/2000/01/01/507-diversity-at-scale.html
+++ b/tc-report/en/vision/diversity/2000/01/01/507-diversity-at-scale.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/vision/diversity/2000/01/01/508-equity.html
+++ b/tc-report/en/vision/diversity/2000/01/01/508-equity.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/en/vision/projects/2000/01/01/103-vision.html
+++ b/tc-report/en/vision/projects/2000/01/01/103-vision.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/001-executive-summary.html
+++ b/tc-report/fr/2000/01/01/001-executive-summary.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/401-overview.html
+++ b/tc-report/fr/2000/01/01/401-overview.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/403-overall-impact.html
+++ b/tc-report/fr/2000/01/01/403-overall-impact.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/404-110-days.html
+++ b/tc-report/fr/2000/01/01/404-110-days.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/406-top-talent.html
+++ b/tc-report/fr/2000/01/01/406-top-talent.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/407-volume.html
+++ b/tc-report/fr/2000/01/01/407-volume.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/409-priority.html
+++ b/tc-report/fr/2000/01/01/409-priority.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/410-security.html
+++ b/tc-report/fr/2000/01/01/410-security.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/411-online-screening.html
+++ b/tc-report/fr/2000/01/01/411-online-screening.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/412-languages.html
+++ b/tc-report/fr/2000/01/01/412-languages.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/413-platform-tools.html
+++ b/tc-report/fr/2000/01/01/413-platform-tools.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/414-job-ads.html
+++ b/tc-report/fr/2000/01/01/414-job-ads.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/415-assessment-planning.html
+++ b/tc-report/fr/2000/01/01/415-assessment-planning.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/416-tracking.html
+++ b/tc-report/fr/2000/01/01/416-tracking.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/417-record-of-decision.html
+++ b/tc-report/fr/2000/01/01/417-record-of-decision.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/502-5-things.html
+++ b/tc-report/fr/2000/01/01/502-5-things.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/503-talent-reserve.html
+++ b/tc-report/fr/2000/01/01/503-talent-reserve.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/504-blockchain.html
+++ b/tc-report/fr/2000/01/01/504-blockchain.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/2000/01/01/601-in-news.html
+++ b/tc-report/fr/2000/01/01/601-in-news.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/communities/digital-talent/index.html
+++ b/tc-report/fr/communities/digital-talent/index.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/diversity/2000/01/01/301-overview.html
+++ b/tc-report/fr/diversity/2000/01/01/301-overview.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/diversity/2000/01/01/303-accessible.html
+++ b/tc-report/fr/diversity/2000/01/01/303-accessible.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/diversity/2000/01/01/304-skills-instead-of-experience.html
+++ b/tc-report/fr/diversity/2000/01/01/304-skills-instead-of-experience.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/diversity/2000/01/01/305-indigenous-talent.html
+++ b/tc-report/fr/diversity/2000/01/01/305-indigenous-talent.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/diversity/2000/01/01/306-essential-education.html
+++ b/tc-report/fr/diversity/2000/01/01/306-essential-education.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/diversity/2000/01/01/307-applicant-story.html
+++ b/tc-report/fr/diversity/2000/01/01/307-applicant-story.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/diversity/2000/01/01/308-freetobeme.html
+++ b/tc-report/fr/diversity/2000/01/01/308-freetobeme.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/diversity/2000/01/01/309-anon-recruitment.html
+++ b/tc-report/fr/diversity/2000/01/01/309-anon-recruitment.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/diversity/hiring/2000/01/01/302-takeaways.html
+++ b/tc-report/fr/diversity/hiring/2000/01/01/302-takeaways.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/hiring/2000/01/01/201-overview.html
+++ b/tc-report/fr/hiring/2000/01/01/201-overview.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/hiring/2000/01/01/202-takeaways.html
+++ b/tc-report/fr/hiring/2000/01/01/202-takeaways.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/hiring/2000/01/01/203-impact-staffing.html
+++ b/tc-report/fr/hiring/2000/01/01/203-impact-staffing.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/hiring/2000/01/01/204-five-factor.html
+++ b/tc-report/fr/hiring/2000/01/01/204-five-factor.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/hiring/2000/01/01/205-manager-employee-responses.html
+++ b/tc-report/fr/hiring/2000/01/01/205-manager-employee-responses.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/hiring/2000/01/01/206-manager-story.html
+++ b/tc-report/fr/hiring/2000/01/01/206-manager-story.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/hiring/2000/01/01/207-remote-work.html
+++ b/tc-report/fr/hiring/2000/01/01/207-remote-work.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/hiring/2000/01/01/208-flexibility.html
+++ b/tc-report/fr/hiring/2000/01/01/208-flexibility.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/hiring/2000/01/01/209-skill-assessment.html
+++ b/tc-report/fr/hiring/2000/01/01/209-skill-assessment.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/hiring/2000/01/01/402-takeaways.html
+++ b/tc-report/fr/hiring/2000/01/01/402-takeaways.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/hiring/2000/01/01/405-intervention.html
+++ b/tc-report/fr/hiring/2000/01/01/405-intervention.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/hiring/2000/01/01/408-criteria.html
+++ b/tc-report/fr/hiring/2000/01/01/408-criteria.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/index.html
+++ b/tc-report/fr/index.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/privacy-notice/index.html
+++ b/tc-report/fr/privacy-notice/index.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/projects/2000/01/01/101-caveat-to-begin.html
+++ b/tc-report/fr/projects/2000/01/01/101-caveat-to-begin.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/projects/2000/01/01/102-problem-statement.html
+++ b/tc-report/fr/projects/2000/01/01/102-problem-statement.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/projects/2000/01/01/104-deliverables.html
+++ b/tc-report/fr/projects/2000/01/01/104-deliverables.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/projects/2000/01/01/105-partnerships.html
+++ b/tc-report/fr/projects/2000/01/01/105-partnerships.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/projects/2000/01/01/106-standards.html
+++ b/tc-report/fr/projects/2000/01/01/106-standards.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/projects/2000/01/01/107-approach.html
+++ b/tc-report/fr/projects/2000/01/01/107-approach.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/projects/2000/01/01/108-team.html
+++ b/tc-report/fr/projects/2000/01/01/108-team.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/projects/2000/01/01/109-research-engine.html
+++ b/tc-report/fr/projects/2000/01/01/109-research-engine.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/projects/2000/01/01/110-portals.html
+++ b/tc-report/fr/projects/2000/01/01/110-portals.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/projects/2000/01/01/111-policy-compliance.html
+++ b/tc-report/fr/projects/2000/01/01/111-policy-compliance.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/projects/2000/01/01/112-process.html
+++ b/tc-report/fr/projects/2000/01/01/112-process.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/projects/2000/01/01/113-road-to-talent-cloud.html
+++ b/tc-report/fr/projects/2000/01/01/113-road-to-talent-cloud.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/projects/2000/01/01/114-pro-b.html
+++ b/tc-report/fr/projects/2000/01/01/114-pro-b.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/projects/2000/01/01/510-where-to.html
+++ b/tc-report/fr/projects/2000/01/01/510-where-to.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/talent-cloud/index.html
+++ b/tc-report/fr/talent-cloud/index.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/talent-cloud/report/index.html
+++ b/tc-report/fr/talent-cloud/report/index.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/terms-and-conditions/index.html
+++ b/tc-report/fr/terms-and-conditions/index.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/vision/2000/01/01/501-overview.html
+++ b/tc-report/fr/vision/2000/01/01/501-overview.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/vision/2000/01/01/505-credentials.html
+++ b/tc-report/fr/vision/2000/01/01/505-credentials.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/vision/2000/01/01/506-talent-repository.html
+++ b/tc-report/fr/vision/2000/01/01/506-talent-repository.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/vision/2000/01/01/509-gov-wide.html
+++ b/tc-report/fr/vision/2000/01/01/509-gov-wide.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/vision/diversity/2000/01/01/507-diversity-at-scale.html
+++ b/tc-report/fr/vision/diversity/2000/01/01/507-diversity-at-scale.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/vision/diversity/2000/01/01/508-equity.html
+++ b/tc-report/fr/vision/diversity/2000/01/01/508-equity.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/fr/vision/projects/2000/01/01/103-vision.html
+++ b/tc-report/fr/vision/projects/2000/01/01/103-vision.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/tc-report/index.html
+++ b/tc-report/index.html
@@ -23,7 +23,9 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'UA-115747902-1');
+        gtag('config', 'UA-115747902-1', {
+          cookie_flags: 'samesite=none;secure'
+        });
     </script>
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">


### PR DESCRIPTION
Resolves #2147.

I wasn't sure how to properly test this without running another VA scan, since our local environments serve over HTTP.

Rationale for `samesite=none`:

https://www.simoahava.com/analytics/cookieflags-field-google-analytics/

"Without setting the `samesite=none;secure` flags in Google Analytics’ settings, the cookies created by GA would not be available in third-party context, thus messing with your ability to track the same user on the parent site and in the embedded resource."