### PR TITLE
Workaround to prevent storybook crash

### DIFF
--- a/frontend/talentsearch/resources/js/components/applicantProfile/ProfileFormWrapper.tsx
+++ b/frontend/talentsearch/resources/js/components/applicantProfile/ProfileFormWrapper.tsx
@@ -37,7 +37,7 @@ const ProfileFormWrapper: React.FunctionComponent<ProfileFormWrapperProps> = ({
       data-h2-font-color="b(white)"
       style={{
         background: `url(${imageUrl(
-          TALENTSEARCH_APP_DIR,
+          TALENTSEARCH_APP_DIR ?? "/",
           "applicant-profile-banner.jpg",
         )})`,
         backgroundSize: "100vw 5rem",


### PR DESCRIPTION
I think the missing image from #2219 is causing the GitHub actions to crash.
![image](https://user-images.githubusercontent.com/8978655/158224899-d8f38ef1-96b8-4a50-8bd2-4856909f642a.png)
This workaround should fix it until we get a proper fix in with #1455 .