### PR TITLE
Inject some constant into admin html at runtime

### DIFF
--- a/frontend/admin/public/.htaccess
+++ b/frontend/admin/public/.htaccess
@@ -18,4 +18,16 @@
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
+
+
+
 </IfModule>
+
+# Set SSI to run on .shtml and .sjs files in this directory
+Options +Includes
+AddType text/html .shtml
+AddType text/javascript .sjs
+AddOutputFilter INCLUDES .shtml .sjs
+
+# Make certain environment variables available for SSI
+PassEnv OAUTH_POST_LOGOUT_REDIRECT OAUTH_LOGOUT_URI

--- a/frontend/admin/public/config.sjs
+++ b/frontend/admin/public/config.sjs
@@ -1,0 +1,14 @@
+/**
+ * This javascript file uses Apache Server Side Includes (SSI) to inject server-side environment
+ * variables into the frontend.
+ * https://httpd.apache.org/docs/current/howto/ssi.html
+ *
+ * The sjs filetype lets apache know that this file should be parsed for SSI directives.
+ */
+
+const data = {
+    "OAUTH_LOGOUT_URI": "<!--#echo var="OAUTH_LOGOUT_URI" -->",
+    "OAUTH_POST_LOGOUT_REDIRECT": "<!--#echo var="OAUTH_POST_LOGOUT_REDIRECT" -->",
+}
+
+window.__SERVER_CONFIG__ = data;

--- a/frontend/admin/resources/js/adminConstants.ts
+++ b/frontend/admin/resources/js/adminConstants.ts
@@ -1,3 +1,7 @@
 export const ADMIN_APP_DIR = process.env.ADMIN_APP_DIR ?? "admin";
-export const LOGOUT_URI = process.env.OAUTH_LOGOUT_URI;
-export const POST_LOGOUT_REDIRECT = process.env.OAUTH_POST_LOGOUT_REDIRECT;
+
+// eslint-disable-next-line no-underscore-dangle
+const serverConfig = (window as any).__SERVER_CONFIG__;
+export const LOGOUT_URI = serverConfig?.OAUTH_LOGOUT_URI ?? "/logout";
+export const POST_LOGOUT_REDIRECT =
+  serverConfig?.OAUTH_POST_LOGOUT_REDIRECT ?? "/admin";

--- a/frontend/admin/resources/views/dashboard.blade.php
+++ b/frontend/admin/resources/views/dashboard.blade.php
@@ -16,6 +16,17 @@
 </head>
 <body>
   <div id="app" data-h2-font-family="b(sans)"></div>
+  <script type='text/javascript'>
+@php
+$data = [
+    "OAUTH_LOGOUT_URI" => $_ENV["OAUTH_LOGOUT_URI"],
+    "OAUTH_POST_LOGOUT_REDIRECT" => $_ENV["OAUTH_POST_LOGOUT_REDIRECT"],
+];
+$json = json_encode($data);
+echo "window.__SERVER_CONFIG__ = $json;";
+@endphp
+  </script>
+  <script>window.__TEST = "hello"</script>
   <script src="{{ asset(mix('/js/dashboard.js')) }}"></script>
 </body>
 </html>

--- a/frontend/admin/resources/views/dashboard.blade.php
+++ b/frontend/admin/resources/views/dashboard.blade.php
@@ -16,17 +16,7 @@
 </head>
 <body>
   <div id="app" data-h2-font-family="b(sans)"></div>
-  <script type='text/javascript'>
-@php
-$data = [
-    "OAUTH_LOGOUT_URI" => $_ENV["OAUTH_LOGOUT_URI"],
-    "OAUTH_POST_LOGOUT_REDIRECT" => $_ENV["OAUTH_POST_LOGOUT_REDIRECT"],
-];
-$json = json_encode($data);
-echo "window.__SERVER_CONFIG__ = $json;";
-@endphp
-  </script>
-  <script>window.__TEST = "hello"</script>
+  <script src="{{ asset('config.sjs') }}"></script>
   <script src="{{ asset(mix('/js/dashboard.js')) }}"></script>
 </body>
 </html>

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -34,6 +34,8 @@ services:
     ports:
       - 8000:80
       - 8001:443
+    env_file:
+      - ../frontend/admin/.env
 
   maintenance:
     build: ./maintenance-container

--- a/infrastructure/php-container/Dockerfile
+++ b/infrastructure/php-container/Dockerfile
@@ -3,6 +3,7 @@ FROM php:7.4-apache
 
 # Enable mod_rewrite
 RUN a2enmod rewrite
+RUN a2enmod include
 
 # Install pdo_pgsql extension
 RUN apt-get update \


### PR DESCRIPTION
Closes #2261

Based on [this trick](https://create-react-app.dev/docs/title-and-meta-tags/#injecting-data-from-the-server-into-the-page), this allows some environment variables to be injected directly into the html when served. ~I tried to do with this with pure PHP (instead of passing variables from the Laravel controller) so as to conflict as little as possible with #1387.~ Environment variables are injected using [Apache SSI](https://httpd.apache.org/docs/current/howto/ssi.html). Any environment variables that we want available at run-time like this must be defined in three places: the htaccess file, the config.sjs file, and the adminConstants file (or other _____Constants file).

To test, simply run `npm run dev` in frontend/admin, and try to login, then logout. The logout will fail if this isn't working.

Contrary to the warning [referenced](https://medium.com/node-security/the-most-common-xss-vulnerability-in-react-js-applications-2bdffbcc1fa0) in the [create-react-app docs](https://create-react-app.dev/docs/title-and-meta-tags/#injecting-data-from-the-server-into-the-page), this solution doesn't seem to cause an XSS vulnerability. Try setting `OAUTH_POST_LOGOUT_REDIRECT='"};alert("You have an XSS vulnerability!");const x={"test":"''` in your admin/.env file to test it.

:warning: This PR updates the Docker infrastructure ⚠️ 
This PR updates the php dockerfile, and updates the docker-compose file to pass env variables to the apache environment. To ensure your environment is up to date, rebuild your docker image with the following commands:
```
docker-compose build
docker-compose up -d
```
