### PR TITLE
API_APP_URL to APP_URL

### DIFF
--- a/.github/workflows/check-lighthouse-schema.yml
+++ b/.github/workflows/check-lighthouse-schema.yml
@@ -17,10 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
 
-      - name: Create admin .env file, which is referenced in docker-compose
-        working-directory: frontend/admin
-        run: copy .env.example .env
-
       - name: "Build docker image: api"
         working-directory: infrastructure
         run: docker compose up api --detach

--- a/.github/workflows/check-lighthouse-schema.yml
+++ b/.github/workflows/check-lighthouse-schema.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
 
+      - name: Create admin .env file, which is referenced in docker-compose
+        working-directory: frontend/admin
+        run: copy .env.example .env
+
       - name: "Build docker image: api"
         working-directory: infrastructure
         run: docker compose up api --detach

--- a/api/.env.example
+++ b/api/.env.example
@@ -2,7 +2,7 @@ APP_NAME=api
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-API_APP_URL="http://localhost:8000"
+APP_URL="http://localhost:8000"
 APP_TIMEZONE=UTC
 
 LOG_CHANNEL=stack

--- a/api/config/app.php
+++ b/api/config/app.php
@@ -52,7 +52,7 @@ return [
     */
 
 
-    'url' => env('API_APP_URL', 'http://localhost:8000'),
+    'url' => env('APP_URL', 'http://localhost:8000'),
     'app_dir' => env('API_APP_DIR', null),
     'asset_url' => env('API_ASSET_URL', null),
     'mix_url' => env('API_MIX_ASSET_URL', null),

--- a/api/config/sanctum.php
+++ b/api/config/sanctum.php
@@ -16,7 +16,7 @@ return [
     'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
         '%s%s',
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
-        env('API_APP_URL') ? ','.parse_url(env('API_APP_URL'), PHP_URL_HOST) : ''
+        env('APP_URL') ? ','.parse_url(env('APP_URL'), PHP_URL_HOST) : ''
     ))),
 
     /*


### PR DESCRIPTION
Changes the environment variable used in the _API_ project from `API_APP_URL` to `APP_URL`.  The _API_ project uses this variable for post login redirect with the _from_ parameter.  So if _from_ is /admin/pools they will be redirected to API_APP_URL/admin/pools.  The value of API_APP_URL on the server is tbs-dev.whatever/api so you end up with tbs-dev.whatever/api/admin/pools which fails.  I've switched it to using the APP_URL variable which is just tbs-dev.whatever and can properly accept a relative url.  There's no routing for /api anyway so that variable may not even need to exist.