### PR TITLE
Fix Check Schema workflow

### DIFF
--- a/.github/workflows/check-lighthouse-schema.yml
+++ b/.github/workflows/check-lighthouse-schema.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Create admin .env file, which is referenced in docker-compose
         working-directory: frontend/admin
-        run: copy .env.example .env
+        run: cp .env.example .env
 
       - name: "Build docker image: api"
         working-directory: infrastructure

--- a/.github/workflows/check-lighthouse-schema.yml
+++ b/.github/workflows/check-lighthouse-schema.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
 
+      - name: Create admin .env file, which is referenced in docker-compose
+        working-directory: frontend/admin
+        run: copy .env.example .env
+
       - name: "Build docker image: api"
         working-directory: infrastructure
         run: docker compose up api --detach


### PR DESCRIPTION
The Check Schema workflow has been failing when it runs the command `docker compose up api --detach`, with the message `open /home/runner/work/gc-digital-talent/gc-digital-talent/frontend/admin/.env: no such file or directory`. 

I believe this is due to me adding a reference to admin/.env in the docker-compose file:
```
php:
    env_file:
          - ../frontend/admin/.env
```

This adds a step to the workflow to copy .example.env to .env, to ensure the docker-compose command can run correctly.