### PR TITLE
Update acr_values to enable gckey-passthrough

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -43,7 +43,7 @@ class AuthController extends Controller
             'scope' => $scope,
             'state' => $state,
             'nonce' => $nonce,
-            'acr_values' => 'mfa',
+            'acr_values' => 'gckey',
             'ui_locales' => $ui_locales,
         ]);
 


### PR DESCRIPTION
During final testing of our connection to the production SiC service, we realized that we no longer need to include acr_values=mfa in our request. MFA has been configured as mandatory for our SiC client account. Instead, we can set acr_values=gckey to enable gckey-passthrough, or sending users directly to the gckey login page, ignoring the option of signing in with a bank.

Related to #2252 