### PR TITLE
Add link to "holding tank" for proposed/deferred/discarded DoD/DoR items

### DIFF
--- a/documentation/definition-of-done.md
+++ b/documentation/definition-of-done.md
@@ -13,3 +13,8 @@
   - Security scans (eventually)
   - Visual regression testing (eventually)
 - Pull request labeled for Change Management Board (trivial / minor / major / emergency)
+
+_(For a shared list of all candidate/discarded/deferred suggestions, see [here][long-list].)_
+
+<!-- Links -->
+   [long-list]: https://github.com/GCTC-NTGC/gc-digital-talent/issues/2209#issuecomment-1083046965

--- a/documentation/definition-of-ready.md
+++ b/documentation/definition-of-ready.md
@@ -4,3 +4,8 @@
 - Accessibility considerations
 - URLs for new pages defined
 - Mobile views
+
+_(For a shared list of all candidate/discarded/deferred suggestions, see [here][long-list].)_
+
+<!-- Links -->
+   [long-list]: https://github.com/GCTC-NTGC/gc-digital-talent/issues/2209#issuecomment-1083046965


### PR DESCRIPTION
Small doc change to have a single shared place (current location just temporary; i'm sure there's a better place) to store candidates outside the "authoritative" files that have a bit of a barrier (as they should have).

cc: @tristan-orourke @gggrant 

Not urgent, just wanted to capture it in complete PR without talking about it, since it only took 5 min to do. Happy to see it merged, changed, or discarded after retro.

Can anyone suggest the clearest way to queue this up for consideration during backlog refinement?

tags: definition of done / ready