### PR TITLE
fix: search pools render condition

### DIFF
--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -146,48 +146,50 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
           />
         </div>
         <div data-h2-flex-item="b(1of1)" style={{ paddingTop: "0" }}>
-          {!updatePending && candidateCount === 0 && (
-            <div
-              data-h2-shadow="b(m)"
-              data-h2-padding="b(top-bottom, xs) b(left, s)"
-              data-h2-border="b(darkgray, left, solid, l)"
-            >
-              <p data-h2-margin="b(bottom, none)">
-                {intl.formatMessage({
-                  defaultMessage: "We can still help!",
-                  description:
-                    "Heading for helping user if no candidates matched the filters chosen.",
-                })}
-              </p>
-
-              <p data-h2-margin="b(top, xxs)" data-h2-font-size="b(caption)">
-                {intl.formatMessage(
-                  {
-                    defaultMessage:
-                      "If there are no matching candidates <a>Get in touch!</a>",
+          {!updatePending &&
+            (candidateCount > 0 ? (
+              <div
+                data-h2-shadow="b(m)"
+                data-h2-border="b(lightnavy, left, solid, l)"
+                data-h2-margin="b(top, s) b(bottom, m)"
+                data-h2-flex-grid="b(middle, contained, flush, xl)"
+              >
+                <SearchPools
+                  candidateCount={candidateCount}
+                  pool={pool}
+                  poolOwner={poolOwner}
+                  handleSubmit={handleSubmit}
+                />
+              </div>
+            ) : (
+              <div
+                data-h2-shadow="b(m)"
+                data-h2-margin="b(top, s) b(bottom, m)"
+                data-h2-padding="b(top-bottom, xs) b(left, s)"
+                data-h2-border="b(darkgray, left, solid, l)"
+              >
+                <p data-h2-margin="b(bottom, none)">
+                  {intl.formatMessage({
+                    defaultMessage: "We can still help!",
                     description:
-                      "Message for helping user if no candidates matched the filters chosen.",
-                  },
-                  {
-                    a,
-                  },
-                )}
-              </p>
-            </div>
-          )}
-          <div
-            data-h2-shadow="b(m)"
-            data-h2-border="b(lightnavy, left, solid, l)"
-            data-h2-margin="b(top, s) b(bottom, m)"
-            data-h2-flex-grid="b(middle, contained, flush, xl)"
-          >
-            <SearchPools
-              candidateCount={candidateCount}
-              pool={pool}
-              poolOwner={poolOwner}
-              handleSubmit={handleSubmit}
-            />
-          </div>
+                      "Heading for helping user if no candidates matched the filters chosen.",
+                  })}
+                </p>
+                <p data-h2-margin="b(top, xxs)" data-h2-font-size="b(caption)">
+                  {intl.formatMessage(
+                    {
+                      defaultMessage:
+                        "If there are no matching candidates <a>Get in touch!</a>",
+                      description:
+                        "Message for helping user if no candidates matched the filters chosen.",
+                    },
+                    {
+                      a,
+                    },
+                  )}
+                </p>
+              </div>
+            ))}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Modifies the condition to display either the no candidates or the search pool message. First check if the candidate pool is greater than 0 and displays the search pool. Otherwise, if the candidate pool is 0 or less than 0, it will display the no candidate message along with the filter advice.

Resolves #2213 

### Candidates Found

<img width="1400" alt="Screen Shot 2022-04-06 at 2 18 04 PM" src="https://user-images.githubusercontent.com/4127998/162042007-be75220b-e20c-4537-b0db-e385f41e7b40.png">

### No Candidates

<img width="1415" alt="Screen Shot 2022-04-06 at 2 18 19 PM" src="https://user-images.githubusercontent.com/4127998/162042028-3fb88f7f-1ffc-4aa3-8751-e865a9a69498.png">


## Note

I made a bit of an assumption that the entire box should be removed from the DOM rather than just the button referred to in the issue.