### PR TITLE
Fix routing fallback location

### DIFF
--- a/frontend/admin/src/.htaccess
+++ b/frontend/admin/src/.htaccess
@@ -1,8 +1,8 @@
 # Map all SPA-looking routes to our single page app index file
-FallbackResource index.html
+FallbackResource /frontend/admin/dist/index.html
 
 # Requests for files should return a real 404 and not fallback to the index.html page, though
-<Files ~ "\.(js|css|gif|jpe?g|png)$">
+<Files ~ "\.(js|css|gif|jpe?g|png|svg)$">
   FallbackResource disabled
   ErrorDocument 404 "File not found"
 </Files>
@@ -26,10 +26,6 @@ FallbackResource index.html
     # Send Requests To Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
-    #RewriteRule ^ index.php [L]
-
-
-
 </IfModule>
 
 # Set SSI to run on .shtml and .sjs files in this directory

--- a/frontend/admin/src/.htaccess
+++ b/frontend/admin/src/.htaccess
@@ -22,10 +22,6 @@ FallbackResource /frontend/admin/dist/index.html
     # RewriteCond %{REQUEST_FILENAME} !-d
     # RewriteCond %{REQUEST_URI} (.+)/$
     # RewriteRule ^ %1 [L,R=301]
-
-    # Send Requests To Front Controller...
-    RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteCond %{REQUEST_FILENAME} !-f
 </IfModule>
 
 # Set SSI to run on .shtml and .sjs files in this directory

--- a/frontend/talentsearch/src/.htaccess
+++ b/frontend/talentsearch/src/.htaccess
@@ -1,8 +1,8 @@
 # Map all SPA-looking routes to our single page app index file
-FallbackResource index.html
+FallbackResource /frontend/talentsearch/dist/index.html
 
 # Requests for files should return a real 404 and not fallback to the index.html page, though
-<Files ~ "\.(js|css|gif|jpe?g|png)$">
+<Files ~ "\.(js|css|gif|jpe?g|png|svg)$">
   FallbackResource disabled
   ErrorDocument 404 "File not found"
 </Files>
@@ -26,5 +26,4 @@ FallbackResource index.html
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
-    # RewriteRule ^ index.php [L]
 </IfModule>

--- a/frontend/talentsearch/src/.htaccess
+++ b/frontend/talentsearch/src/.htaccess
@@ -1,6 +1,7 @@
 # Map all SPA-looking routes to our single page app index file
 FallbackResource /frontend/talentsearch/dist/index.html
 
+
 # Requests for files should return a real 404 and not fallback to the index.html page, though
 <Files ~ "\.(js|css|gif|jpe?g|png|svg)$">
   FallbackResource disabled

--- a/frontend/talentsearch/src/.htaccess
+++ b/frontend/talentsearch/src/.htaccess
@@ -23,8 +23,4 @@ FallbackResource /frontend/talentsearch/dist/index.html
     # RewriteCond %{REQUEST_FILENAME} !-d
     # RewriteCond %{REQUEST_URI} (.+)/$
     # RewriteRule ^ %1 [L,R=301]
-
-    # Handle Front Controller...
-    RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteCond %{REQUEST_FILENAME} !-f
 </IfModule>


### PR DESCRIPTION
This branch changes the routing fallback file to an absolute path to avoid hitting the 10 rewrite limit in Apache on URLs with many segments.

~Note: leaving as draft until I can test on the dev server.~

Closes #2375 