### PR TITLE
Talent Search - Pluralize Candidate Result Count #2370

### DIFF
--- a/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
+++ b/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
@@ -27,12 +27,6 @@ const EstimatedCandidates: React.FunctionComponent<
     }
   }, [updatePending, candidateCount]);
 
-  // React.useEffect(() => {
-  //   if (candidateCount === 1) {
-  //     setPluralizedWord("candidate");
-  //   }
-  // }, [candidateCount]);
-
   return (
     <div
       data-h2-bg-color="b(white)"

--- a/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
+++ b/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
@@ -47,7 +47,7 @@ const EstimatedCandidates: React.FunctionComponent<
           {intl.formatMessage(
             {
               defaultMessage:
-                "There are approximately <weight>{candidateCount}</weight> {candidateCount,plural, =0 {candidate} =1 {candidate} other {candidates}} right now who meet your criteria.",
+                "There are approximately <weight>{candidateCount}</weight> {candidateCount, plural, =1 {candidate} other {candidates}} right now who {candidateCount, plural, =1 {meets} other {meet}} your criteria.",
               description:
                 "Message for total estimated candidates box next to search form.",
             },

--- a/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
+++ b/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
@@ -10,7 +10,6 @@ const EstimatedCandidates: React.FunctionComponent<
   EstimatedCandidatesProps
 > = ({ candidateCount, updatePending }) => {
   const intl = useIntl();
-  const [pluralizedWord, setPluralizedWord] = React.useState("candidates");
 
   function weight(msg: string) {
     return updatePending ? (
@@ -19,13 +18,6 @@ const EstimatedCandidates: React.FunctionComponent<
       <span data-h2-font-weight="b(800)">{msg}</span>
     );
   }
-  React.useEffect(() => {
-    if (candidateCount < 2) {
-      setPluralizedWord("candidate");
-    } else {
-      setPluralizedWord("candidates");
-    }
-  }, [updatePending, candidateCount]);
 
   return (
     <div

--- a/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
+++ b/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
@@ -55,14 +55,13 @@ const EstimatedCandidates: React.FunctionComponent<
           {intl.formatMessage(
             {
               defaultMessage:
-                "There are approximately <weight>{candidateCount}</weight> {pluralizedWord} right now who meet your criteria.",
+                "There are approximately <weight>{candidateCount}</weight> {candidateCount,plural, =0 {candidate} =1 {candidate} other {candidates}} right now who meet your criteria.",
               description:
                 "Message for total estimated candidates box next to search form.",
             },
             {
               weight,
               candidateCount,
-              pluralizedWord,
             },
           )}
         </p>

--- a/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
+++ b/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
@@ -10,6 +10,7 @@ const EstimatedCandidates: React.FunctionComponent<
   EstimatedCandidatesProps
 > = ({ candidateCount, updatePending }) => {
   const intl = useIntl();
+  const [pluralizedWord, setPluralizedWord] = React.useState("candidates");
 
   function weight(msg: string) {
     return updatePending ? (
@@ -18,6 +19,19 @@ const EstimatedCandidates: React.FunctionComponent<
       <span data-h2-font-weight="b(800)">{msg}</span>
     );
   }
+  React.useEffect(() => {
+    if (candidateCount < 2) {
+      setPluralizedWord("candidate");
+    } else {
+      setPluralizedWord("candidates");
+    }
+  }, [updatePending, candidateCount]);
+
+  // React.useEffect(() => {
+  //   if (candidateCount === 1) {
+  //     setPluralizedWord("candidate");
+  //   }
+  // }, [candidateCount]);
 
   return (
     <div
@@ -47,13 +61,14 @@ const EstimatedCandidates: React.FunctionComponent<
           {intl.formatMessage(
             {
               defaultMessage:
-                "There are approximately <weight>{candidateCount}</weight> candidates right now who meet your criteria.",
+                "There are approximately <weight>{candidateCount}</weight> {pluralizedWord} right now who meet your criteria.",
               description:
                 "Message for total estimated candidates box next to search form.",
             },
             {
               weight,
               candidateCount,
+              pluralizedWord,
             },
           )}
         </p>

--- a/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
+++ b/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
@@ -46,8 +46,7 @@ const EstimatedCandidates: React.FunctionComponent<
         <p data-h2-text-align="b(center)">
           {intl.formatMessage(
             {
-              defaultMessage:
-                "There are approximately <weight>{candidateCount}</weight> {candidateCount, plural, =1 {candidate} other {candidates}} right now who {candidateCount, plural, =1 {meets} other {meet}} your criteria.",
+              defaultMessage: `{candidateCount, plural, =1 {There is approximately <weight>{candidateCount}</weight> candidate right now who meets your criteria.} other {There are approximately <weight>{candidateCount}</weight> candidates right now who meet your criteria.}}`,
               description:
                 "Message for total estimated candidates box next to search form.",
             },


### PR DESCRIPTION
The candidate search should properly pluralize the word _candidates_ for a result count of 1 in the search results:
![image.png](https://images.zenhubusercontent.com/6172cf6e898e11fd20507433/b3e49eb1-2638-49a4-a483-f3146e45a796)

Resolves #2370 