### PR TITLE
Move legend to be direct descendant of fieldset

### DIFF
--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
@@ -44,9 +44,7 @@ export const Fieldset: React.FC<FieldsetProps> = ({
       }}
       data-h2-margin="b(bottom, xxs)"
     >
-      <legend data-h2-visibility="b(invisible)" data-h2-font-size="b(caption)">
-        {legend}
-      </legend>
+      <legend data-h2-visibility="b(invisible)">{legend}</legend>
       <div
         data-h2-display="b(flex)"
         data-h2-flex-wrap="b(wrap)"

--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
@@ -44,13 +44,22 @@ export const Fieldset: React.FC<FieldsetProps> = ({
       }}
       data-h2-margin="b(bottom, xxs)"
     >
+      <legend data-h2-visibility="b(invisible)" data-h2-font-size="b(caption)">
+        {legend}
+      </legend>
       <div
         data-h2-display="b(flex)"
         data-h2-flex-wrap="b(wrap)"
         data-h2-margin="b(bottom, xxs)"
       >
         <div style={{ flex: "1" }}>
-          <legend data-h2-font-size="b(caption)">{legend}</legend>
+          <span
+            aria-hidden="true"
+            role="presentation"
+            data-h2-font-size="b(caption)"
+          >
+            {legend}
+          </span>
         </div>
         <div>
           {


### PR DESCRIPTION
## Summary

This is a simple change to move the `<legend>` of our `<fieldset>` to be a direct child so they are properly associated for assistive technologies. There _should_ be **no visual changes**, just moving the markup around.

Resolves: #2425 