### PR TITLE
Fix admin docker env

### DIFF
--- a/frontend/admin/.apache_env
+++ b/frontend/admin/.apache_env
@@ -1,0 +1,5 @@
+# TODO: some sort of logout landing page
+OAUTH_POST_LOGOUT_REDIRECT="http://localhost:8000/admin"
+
+# Don't use with local Laravel auth
+# OAUTH_LOGOUT_URI="https://te-auth.id.tbs-sct.gc.ca/oxauth/restv1/end_session"

--- a/frontend/admin/.env.example
+++ b/frontend/admin/.env.example
@@ -25,12 +25,6 @@ QUEUE_CONNECTION=sync
 
 API_URI="/graphql"
 
-# TODO: some sort of logout landing page
-OAUTH_POST_LOGOUT_REDIRECT="http://localhost:8000/admin"
-
-# Don't use with local Laravel auth
-# OAUTH_LOGOUT_URI="https://te-auth.id.tbs-sct.gc.ca/oxauth/restv1/end_session"
-
 # continuous integration only
 MERGE_STORYBOOKS=false
 

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - 8000:80
       - 8001:443
     env_file:
-      - ../frontend/admin/.env
+      - ../frontend/admin/.apache_env
 
   maintenance:
     build: ./maintenance-container


### PR DESCRIPTION
This branch factors out the environment variables used by Apache to a separate env file.  

This resolves #2327 by ensuring that an incomplete .env file is not used for php container construction resulting in some environment variables being unset in the container environment.

This resolves #2328 by ensuring that the env file needed for the php container creation is present in a fresh install environment instead of relying on a previous setup script run.