### PR TITLE
2423 buttons wrapped by links

### DIFF
--- a/frontend/admin/src/js/components/classification/ClassificationPage.tsx
+++ b/frontend/admin/src/js/components/classification/ClassificationPage.tsx
@@ -33,15 +33,19 @@ export const ClassificationPage: React.FC = () => {
             data-h2-flex-item="b(1of1) m(2of5)"
             data-h2-text-align="m(right)"
           >
-            <Button color="white" mode="outline">
-              <Link href={paths.classificationCreate()} title="">
-                {intl.formatMessage({
-                  defaultMessage: "Create Classification",
-                  description:
-                    "Heading displayed above the Create Classification form.",
-                })}
-              </Link>
-            </Button>
+            <Link
+              href={paths.classificationCreate()}
+              title=""
+              color="white"
+              mode="outline"
+              type="button"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Create Classification",
+                description:
+                  "Heading displayed above the Create Classification form.",
+              })}
+            </Link>
           </div>
         </div>
       </header>

--- a/frontend/admin/src/js/components/classification/ClassificationPage.tsx
+++ b/frontend/admin/src/js/components/classification/ClassificationPage.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import Button from "@common/components/Button";
 import Link from "@common/components/Link";
 import { useAdminRoutes } from "../../adminRoutes";
 import { ClassificationTableApi } from "./ClassificationTable";

--- a/frontend/admin/src/js/components/cmoAsset/CmoAssetPage.tsx
+++ b/frontend/admin/src/js/components/cmoAsset/CmoAssetPage.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import Button from "@common/components/Button";
 import Link from "@common/components/Link";
 import { useAdminRoutes } from "../../adminRoutes";
 import { CmoAssetTableApi } from "./CmoAssetTable";

--- a/frontend/admin/src/js/components/cmoAsset/CmoAssetPage.tsx
+++ b/frontend/admin/src/js/components/cmoAsset/CmoAssetPage.tsx
@@ -33,15 +33,18 @@ export const CmoAssetPage: React.FC = () => {
             data-h2-flex-item="b(1of1) m(2of5)"
             data-h2-text-align="m(right)"
           >
-            <Button color="white" mode="outline">
-              <Link href={paths.cmoAssetCreate()} title="">
-                {intl.formatMessage({
-                  defaultMessage: "Create CMO Asset",
-                  description:
-                    "Heading displayed above the Create CMO Asset form.",
-                })}
-              </Link>
-            </Button>
+            <Link
+              href={paths.cmoAssetCreate()}
+              color="white"
+              mode="outline"
+              type="button"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Create CMO Asset",
+                description:
+                  "Heading displayed above the Create CMO Asset form.",
+              })}
+            </Link>
           </div>
         </div>
       </header>

--- a/frontend/admin/src/js/components/dashboard/Dashboard.tsx
+++ b/frontend/admin/src/js/components/dashboard/Dashboard.tsx
@@ -56,19 +56,22 @@ export const MenuLink: React.FC<MenuLinkProps> = ({
     <Link
       href={href}
       title={title ?? ""}
+      color="white"
+      mode="inline"
+      block
+      tabIndex={-1}
+      type="button"
       {...(isActive(href, location.pathname)
         ? { "data-h2-font-style": "b(reset)" }
         : { "data-h2-font-style": "b(underline)" })}
     >
-      <Button color="white" mode="inline" block tabIndex={-1}>
-        <span
-          {...(isActive(href, location.pathname)
-            ? { "data-h2-font-weight": "b(700)" }
-            : { "data-h2-font-weight": "b(100)" })}
-        >
-          {text}
-        </span>
-      </Button>
+      <span
+        {...(isActive(href, location.pathname)
+          ? { "data-h2-font-weight": "b(700)" }
+          : { "data-h2-font-weight": "b(100)" })}
+      >
+        {text}
+      </span>
     </Link>
   );
 };

--- a/frontend/admin/src/js/components/department/DepartmentPage.tsx
+++ b/frontend/admin/src/js/components/department/DepartmentPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Link, Button } from "@common/components";
+import { Link } from "@common/components";
 import { useAdminRoutes } from "../../adminRoutes";
 import { DepartmentTableApi } from "./DepartmentTable";
 

--- a/frontend/admin/src/js/components/department/DepartmentPage.tsx
+++ b/frontend/admin/src/js/components/department/DepartmentPage.tsx
@@ -32,15 +32,18 @@ export const DepartmentPage: React.FC = () => {
             data-h2-flex-item="b(1of1) m(2of5)"
             data-h2-text-align="m(right)"
           >
-            <Button color="white" mode="outline">
-              <Link href={paths.departmentCreate()} title="">
-                {intl.formatMessage({
-                  defaultMessage: "Create Department",
-                  description:
-                    "Heading displayed above the Create Department form.",
-                })}
-              </Link>
-            </Button>
+            <Link
+              href={paths.departmentCreate()}
+              color="white"
+              mode="outline"
+              type="button"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Create Department",
+                description:
+                  "Heading displayed above the Create Department form.",
+              })}
+            </Link>
           </div>
         </div>
       </header>

--- a/frontend/admin/src/js/components/pool/PoolPage.tsx
+++ b/frontend/admin/src/js/components/pool/PoolPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Link, Button } from "@common/components";
+import { Link } from "@common/components";
 import { useAdminRoutes } from "../../adminRoutes";
 import { PoolTableApi } from "./PoolTable";
 

--- a/frontend/admin/src/js/components/pool/PoolPage.tsx
+++ b/frontend/admin/src/js/components/pool/PoolPage.tsx
@@ -32,14 +32,17 @@ export const PoolPage: React.FC = () => {
             data-h2-flex-item="b(1of1) m(2of5)"
             data-h2-text-align="m(right)"
           >
-            <Button color="white" mode="outline">
-              <Link href={paths.poolCreate()} title="">
-                {intl.formatMessage({
-                  defaultMessage: "Create Pool",
-                  description: "Heading displayed above the Create Pool form.",
-                })}
-              </Link>
-            </Button>
+            <Link
+              href={paths.poolCreate()}
+              color="white"
+              mode="outline"
+              type="button"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Create Pool",
+                description: "Heading displayed above the Create Pool form.",
+              })}
+            </Link>
           </div>
         </div>
       </header>

--- a/frontend/admin/src/js/components/poolCandidate/PoolCandidatePage.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/PoolCandidatePage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Link, Button } from "@common/components";
+import { Link } from "@common/components";
 import { useAdminRoutes } from "../../adminRoutes";
 import { PoolCandidatesTableApi } from "./PoolCandidatesTable";
 

--- a/frontend/admin/src/js/components/poolCandidate/PoolCandidatePage.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/PoolCandidatePage.tsx
@@ -32,15 +32,18 @@ export const PoolCandidatePage: React.FC<{ poolId: string }> = ({ poolId }) => {
             data-h2-flex-item="b(1of1) m(2of5)"
             data-h2-text-align="m(right)"
           >
-            <Button color="white" mode="outline">
-              <Link href={paths.poolCandidateCreate(poolId)} title="">
-                {intl.formatMessage({
-                  defaultMessage: "Create Pool Candidate",
-                  description:
-                    "Heading displayed above the Create Pool Candidate form.",
-                })}
-              </Link>
-            </Button>
+            <Link
+              href={paths.poolCandidateCreate(poolId)}
+              color="white"
+              mode="outline"
+              type="button"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Create Pool Candidate",
+                description:
+                  "Heading displayed above the Create Pool Candidate form.",
+              })}
+            </Link>
           </div>
         </div>
       </header>

--- a/frontend/admin/src/js/components/skill/SkillPage.tsx
+++ b/frontend/admin/src/js/components/skill/SkillPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Link, Button } from "@common/components";
+import { Link } from "@common/components";
 import { useAdminRoutes } from "../../adminRoutes";
 import { SkillTableApi } from "./SkillTable";
 

--- a/frontend/admin/src/js/components/skill/SkillPage.tsx
+++ b/frontend/admin/src/js/components/skill/SkillPage.tsx
@@ -32,14 +32,17 @@ export const SkillPage: React.FC = () => {
             data-h2-flex-item="b(1of1) m(2of5)"
             data-h2-text-align="m(right)"
           >
-            <Button color="white" mode="outline">
-              <Link href={paths.skillCreate()} title="">
-                {intl.formatMessage({
-                  defaultMessage: "Create Skill",
-                  description: "Heading displayed above the Create Skill form.",
-                })}
-              </Link>
-            </Button>
+            <Link
+              href={paths.skillCreate()}
+              color="white"
+              mode="outline"
+              type="button"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Create Skill",
+                description: "Heading displayed above the Create Skill form.",
+              })}
+            </Link>
           </div>
         </div>
       </header>

--- a/frontend/admin/src/js/components/skillFamily/SkillFamilyPage.tsx
+++ b/frontend/admin/src/js/components/skillFamily/SkillFamilyPage.tsx
@@ -32,15 +32,18 @@ export const SkillFamilyPage: React.FC = () => {
             data-h2-flex-item="b(1of1) m(2of5)"
             data-h2-text-align="m(right)"
           >
-            <Button color="white" mode="outline">
-              <Link href={paths.skillFamilyCreate()} title="">
-                {intl.formatMessage({
-                  defaultMessage: "Create Skill Family",
-                  description:
-                    "Heading displayed above the Create Skill Family form.",
-                })}
-              </Link>
-            </Button>
+            <Link
+              href={paths.skillFamilyCreate()}
+              color="white"
+              mode="outline"
+              type="button"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Create Skill Family",
+                description:
+                  "Heading displayed above the Create Skill Family form.",
+              })}
+            </Link>
           </div>
         </div>
       </header>

--- a/frontend/admin/src/js/components/skillFamily/SkillFamilyPage.tsx
+++ b/frontend/admin/src/js/components/skillFamily/SkillFamilyPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Link, Button } from "@common/components";
+import { Link } from "@common/components";
 import { useAdminRoutes } from "../../adminRoutes";
 import { SkillFamilyTableApi } from "./SkillFamilyTable";
 

--- a/frontend/admin/src/js/components/user/UserPage.tsx
+++ b/frontend/admin/src/js/components/user/UserPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Link, Button } from "@common/components";
+import { Link } from "@common/components";
 import { useAdminRoutes } from "../../adminRoutes";
 import { UserTableApi } from "./UserTable";
 
@@ -32,14 +32,17 @@ export const UserPage: React.FC = () => {
             data-h2-flex-item="b(1of1) m(2of5)"
             data-h2-text-align="m(right)"
           >
-            <Button color="white" mode="outline">
-              <Link href={paths.userCreate()} title="">
-                {intl.formatMessage({
-                  defaultMessage: "Create User",
-                  description: "Heading displayed above the Create User form.",
-                })}
-              </Link>
-            </Button>
+            <Link
+              href={paths.userCreate()}
+              color="white"
+              mode="outline"
+              type="button"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Create User",
+                description: "Heading displayed above the Create User form.",
+              })}
+            </Link>
           </div>
         </div>
       </header>

--- a/frontend/common/src/components/Button/Button.tsx
+++ b/frontend/common/src/components/Button/Button.tsx
@@ -13,7 +13,7 @@ export interface ButtonProps extends React.HTMLProps<HTMLButtonElement> {
   classNames?: string;
 }
 
-const colorMap: Record<
+export const colorMap: Record<
   Color,
   Record<"solid" | "outline" | "inline", Record<string, string>>
 > = {

--- a/frontend/common/src/components/Link/Link.stories.tsx
+++ b/frontend/common/src/components/Link/Link.stories.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import { Link } from "./Link";
+import type { LinkProps } from "./Link";
+
+export default {
+  component: Link,
+  title: "Components/Link",
+  args: {
+    label: "Link Label",
+  },
+  argTypes: {
+    label: {
+      name: "label",
+      type: { name: "string", required: true },
+      control: {
+        type: "text",
+      },
+    },
+  },
+} as Meta;
+
+const TemplateLink: Story<LinkProps & { label: string }> = (args) => {
+  const { label, ...rest } = args;
+  return (
+    <Link {...rest}>
+      <span>{label}</span>
+    </Link>
+  );
+};
+
+export const LinkDefault = TemplateLink.bind({});
+export const LinkButtonPrimary = TemplateLink.bind({});
+export const LinkButtonPrimaryBlock = TemplateLink.bind({});
+export const LinkButtonPrimaryOutline = TemplateLink.bind({});
+export const LinkButtonPrimaryInline = TemplateLink.bind({});
+export const LinkButtonSecondary = TemplateLink.bind({});
+export const LinkButtonSecondaryBlock = TemplateLink.bind({});
+export const LinkButtonSecondaryOutline = TemplateLink.bind({});
+export const LinkButtonSecondaryInline = TemplateLink.bind({});
+export const LinkButtonCTA = TemplateLink.bind({});
+export const LinkButtonCTABlock = TemplateLink.bind({});
+export const LinkButtonCTAOutline = TemplateLink.bind({});
+export const LinkButtonCTAInline = TemplateLink.bind({});
+export const LinkButtonWhite = TemplateLink.bind({});
+export const LinkButtonWhiteBlock = TemplateLink.bind({});
+export const LinkButtonWhiteOutline = TemplateLink.bind({});
+export const LinkButtonWhiteInline = TemplateLink.bind({});
+
+LinkDefault.args = {
+  type: "link",
+};
+
+LinkButtonPrimary.args = {
+  color: "primary",
+  type: "button",
+  mode: "solid",
+};
+
+LinkButtonPrimaryBlock.args = {
+  color: "primary",
+  type: "button",
+  mode: "solid",
+  block: true,
+};
+
+LinkButtonPrimaryOutline.args = {
+  color: "primary",
+  type: "button",
+  mode: "outline",
+};
+
+LinkButtonPrimaryInline.args = {
+  color: "primary",
+  type: "button",
+  mode: "inline",
+};
+
+LinkButtonSecondary.args = {
+  color: "secondary",
+  type: "button",
+  mode: "solid",
+};
+
+LinkButtonSecondaryBlock.args = {
+  color: "secondary",
+  type: "button",
+  mode: "solid",
+  block: true,
+};
+
+LinkButtonSecondaryOutline.args = {
+  color: "secondary",
+  type: "button",
+  mode: "outline",
+};
+
+LinkButtonSecondaryInline.args = {
+  color: "secondary",
+  type: "button",
+  mode: "inline",
+};
+
+LinkButtonCTA.args = {
+  color: "cta",
+  type: "button",
+  mode: "solid",
+};
+
+LinkButtonCTABlock.args = {
+  color: "cta",
+  type: "button",
+  mode: "solid",
+  block: true,
+};
+
+LinkButtonCTAOutline.args = {
+  color: "cta",
+  type: "button",
+  mode: "outline",
+};
+
+LinkButtonWhiteInline.args = {
+  color: "white",
+  type: "button",
+  mode: "inline",
+};
+
+LinkButtonWhite.args = {
+  color: "white",
+  type: "button",
+  mode: "solid",
+};
+
+LinkButtonWhiteBlock.args = {
+  color: "white",
+  type: "button",
+  mode: "solid",
+  block: true,
+};
+
+LinkButtonWhiteOutline.args = {
+  color: "white",
+  type: "button",
+  mode: "outline",
+};
+
+LinkButtonWhiteInline.args = {
+  color: "white",
+  type: "button",
+  mode: "inline",
+};
+
+LinkButtonWhite.parameters = {
+  backgrounds: { default: "dark" },
+};
+
+LinkButtonWhiteOutline.parameters = {
+  backgrounds: { default: "dark" },
+};
+
+LinkButtonWhiteInline.parameters = {
+  backgrounds: { default: "dark" },
+};

--- a/frontend/common/src/components/Link/Link.tsx
+++ b/frontend/common/src/components/Link/Link.tsx
@@ -1,19 +1,50 @@
 import React from "react";
 import { navigate } from "../../helpers/router";
+import type { Color } from "../Button";
+import { colorMap } from "../Button/Button";
 
-export const Link: React.FC<{ href: string; title: string }> = ({
+export interface LinkProps extends React.HTMLProps<HTMLAnchorElement> {
+  /** The style colour of the link */
+  color?: Color;
+  /** The style mode of the element. */
+  mode?: "solid" | "outline" | "inline";
+  block?: boolean;
+  type?: "button" | "link";
+}
+
+export const Link: React.FC<LinkProps> = ({
   href,
   title,
+  color,
+  mode = "solid",
+  block = false,
+  type = "link",
   children,
+  className,
   ...rest
 }): React.ReactElement => (
   <a
     href={href}
     title={title}
+    className={`${type === "button" && `button `}${className}`}
+    {...(type === "button"
+      ? {
+          "data-h2-radius": "b(s)",
+          "data-h2-padding": "b(top-bottom, xs) b(right-left, s)",
+          "data-h2-font-size": "b(caption) m(normal)",
+          ...(color && mode ? { ...colorMap[color][mode] } : {}),
+          ...(block
+            ? {
+                "data-h2-display": "b(block)",
+                "data-h2-text-align": "b(center)",
+              }
+            : { "data-h2-display": "b(inline-block)" }),
+        }
+      : {})}
     {...rest}
     onClick={(event): void => {
       event.preventDefault();
-      navigate(href);
+      if (href) navigate(href);
     }}
   >
     {children}

--- a/frontend/talentsearch/src/js/components/applicantProfile/CancelButton.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/CancelButton.tsx
@@ -12,14 +12,10 @@ const CancelButton: React.FunctionComponent<{ link?: string }> = ({
       href={link} // TODO: Replace with profile link when ready.
       color="secondary"
       mode="outline"
-      // NOTE: This does not currently seem to work with hydrogen
-      // data-h2-display="s(inline-flex)"
+      data-h2-display="s(inline-flex)"
       data-h2-width="b(auto)"
       data-h2-align-items="b(center)"
       type="button"
-      style={{
-        display: "inline-flex",
-      }}
       title={intl.formatMessage({
         defaultMessage: "Cancel and go back",
         description: "Title for cancel link in applicant profile forms.",

--- a/frontend/talentsearch/src/js/components/applicantProfile/CancelButton.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/CancelButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Link } from "@common/components";
+import { Link } from "@common/components";
 import { ArrowCircleLeftIcon } from "@heroicons/react/outline";
 import * as React from "react";
 import { useIntl } from "react-intl";
@@ -10,25 +10,28 @@ const CancelButton: React.FunctionComponent<{ link?: string }> = ({
   return (
     <Link
       href={link} // TODO: Replace with profile link when ready.
+      color="secondary"
+      mode="outline"
+      // NOTE: This does not currently seem to work with hydrogen
+      // data-h2-display="s(inline-flex)"
+      data-h2-width="b(auto)"
+      data-h2-align-items="b(center)"
+      type="button"
+      style={{
+        display: "inline-flex",
+      }}
       title={intl.formatMessage({
         defaultMessage: "Cancel and go back",
         description: "Title for cancel link in applicant profile forms.",
       })}
     >
-      <Button
-        color="secondary"
-        mode="outline"
-        data-h2-display="b(flex)"
-        data-h2-align-items="b(center)"
-      >
-        <ArrowCircleLeftIcon style={{ width: "1rem" }} />
-        <span data-h2-margin="b(left, xxs)">
-          {intl.formatMessage({
-            defaultMessage: "Cancel and go back",
-            description: "Label for cancel button on profile form.",
-          })}
-        </span>
-      </Button>
+      <ArrowCircleLeftIcon style={{ width: "1rem" }} />
+      <span data-h2-margin="b(left, xxs)">
+        {intl.formatMessage({
+          defaultMessage: "Cancel and go back",
+          description: "Label for cancel button on profile form.",
+        })}
+      </span>
     </Link>
   );
 };


### PR DESCRIPTION
## Summary

Introduced a new API for the `<Link>` component to apply the same styles found with the `<Button>` component to avoid having to nest interactive elements and improve accessibility.

Resolves #2423 

## New API

I did my best to make this as identical to the API for the `<Button>` component but we could make some changes to simplify.

```typescript
export interface LinkProps extends React.HTMLProps<HTMLAnchorElement> {
  /** The style colour of the link */
  color?: Color;
  /** The style mode of the element. */
  mode?: "solid" | "outline" | "inline";
  block?: boolean;
  type?: "button" | "link";
}
```

### Example

```tsx
import { Link } from '@common/components/Link';
...
<Link type="button" mode="solid" color="primary" href="/">Home</Link>
... 
```

## Notes

### Simplify API

My only thought is that for the **type** prop, instead of accepting `"link" | "button"`, replace it with a `boolean` "button" prop that is false by default. The reason it is constructed that way is to mimc the `<Button>` which accepts `"button" | "submit" | "reset" | undefined`.  Though, with the `<Button>` component, it is mapping directly to an HTML property so it is not exactly apples to apples and could be changed to simplify.

#### Example

```tsx
export interface LinkProps extends React.HTMLProps<HTMLAnchorElement> {
...
button?: boolean;
...
}

const Link: React.FC<LinkProps> = ({ button = false, ... rest }) => {...}

<Link button mode="solid" color="primary" href="/">Home</Link>
```