### PR TITLE
Bug/2410 fix lh a11y issues

### DIFF
--- a/frontend/common/hydrogen.config.json
+++ b/frontend/common/hydrogen.config.json
@@ -37,7 +37,7 @@
     },
     {
       "key": "red",
-      "color": "#FF0000",
+      "color": "#e90101",
       "opacities": [
         ".1"
       ]

--- a/frontend/common/src/components/Footer/Footer.tsx
+++ b/frontend/common/src/components/Footer/Footer.tsx
@@ -91,7 +91,7 @@ export const Footer: React.FunctionComponent<{
           </nav>
           <p
             data-h2-font-size="b(caption)"
-            data-h2-font-color="b([dark]gray)"
+            data-h2-font-color="b(darkgray)"
             data-h2-margin="b(bottom, none) b(top, m)"
           >
             {intl.formatMessage(

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
@@ -69,7 +69,13 @@ export const MultiSelect: React.FunctionComponent<MultiSelectProps> = ({
                 }
                 placeholder={placeholder}
                 options={options}
-                styles={{}}
+                aria-label={label}
+                styles={{
+                  placeholder: (provided) => ({
+                    ...provided,
+                    color: `#646464`,
+                  }),
+                }}
               />
             )}
             control={control}


### PR DESCRIPTION
## Summary

This fixes the issues found by lighthouse on the `/talent/search` and `/talent/request` pages.

Resolves #2410 

## Missing Input Labels

### Multi-Select Fields

The multi-select fields, using `react-select`, were missing a label. We have added an `aria-label` attribute using the label passed in as a prop to remedy this.

## Colour Contrast

There were a few spots where the colour contrast ratio was not being met. These include the placeholders for the multi-select fields, required indicator on inputs, date modified in the footer.

### Multi-Select Fields

The placeholders were made slightly darker (hydrogran darkgray `#646464`)  which resulted in a colour contrast ratio of 5.91:1.

<img width="229" alt="multi-select-contrast" src="https://user-images.githubusercontent.com/4127998/162754944-d53ca669-fc93-494e-8e4c-51a722560442.png">

### Required Input Indicator

Previously, this used pure red (`#ff0000`) and was modified slightly to `#e90101` to get to a contrast ratio of 4.69:1.

<img width="231" alt="required-input-label-colour-contrast" src="https://user-images.githubusercontent.com/4127998/162755203-f37a1352-da83-4548-b829-cccd4aaceb2c.png">

### Date Modified

This was using the default gray set in hydrogen (`#B9B9B9`) but was darkened to the darkgray (`#646464`) to get a ratio of 5.47:1.

<img width="243" alt="footer-colour-contrast" src="https://user-images.githubusercontent.com/4127998/162755530-a64aea32-d955-4e33-b135-1fdd5882e62a.png">

## Results

Both pages now score 100/100 on lighthouse accessibility audits.

### Search Page 

<img width="889" alt="search-page-audit" src="https://user-images.githubusercontent.com/4127998/162755643-b5e0be95-108f-481c-85d5-2d38f1a84666.png">

### Request Page

<img width="887" alt="request-page-audit" src="https://user-images.githubusercontent.com/4127998/162756114-bbb07d51-c14c-4e05-8043-c429261f5637.png">
