### PR TITLE
Ignore dependabot PRs from the Chromatic storybook workflow

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -7,6 +7,9 @@ on:
       - .github/workflows/storybook.yml
       - frontend/**
   pull_request:
+    branches-ignore:
+      # Avoids consuming limited Chromatic snapshots on dependabot PRs.
+      - dependabot/**
     paths:
       - .github/workflows/storybook.yml
       - frontend/**


### PR DESCRIPTION
Re-ticketed from https://github.com/GCTC-NTGC/gc-digital-talent/issues/2075#issuecomment-1092813935

This is just sitting pretty for whenever we want to merge it. Going to mark as draft for now, unless someone wants to retired it out of draft mode and just merge.

cc: @petertgiles