### PR TITLE
Remove Required tag from some User & PoolCandidate fields

### DIFF
--- a/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
@@ -16,7 +16,7 @@ import {
   Checkbox,
   RadioGroup,
 } from "@common/components/form";
-import { notEmpty } from "@common/helpers/util";
+import { empty, notEmpty } from "@common/helpers/util";
 import { currentDate, enumToOptions } from "@common/helpers/formUtils";
 import { navigate } from "@common/helpers/router";
 import { getLocale } from "@common/helpers/localize";
@@ -223,399 +223,404 @@ interface CreatePoolCandidateFormProps {
   ) => Promise<CreatePoolCandidateMutation["createPoolCandidateAsAdmin"]>;
 }
 
-export const CreatePoolCandidateForm: React.FunctionComponent<
-  CreatePoolCandidateFormProps
-> = ({
-  classifications,
-  cmoAssets,
-  pools,
-  poolId,
-  users,
-  handleCreatePoolCandidate,
-}) => {
-  const intl = useIntl();
-  const locale = getLocale(intl);
-  const paths = useAdminRoutes();
-  const methods = useForm<FormValues>({
-    defaultValues: {
-      pool: poolId,
-      status: PoolCandidateStatus.Available, // Status for new candidates should always default to Available.
-    },
-  });
-  const { control, handleSubmit } = methods;
-
-  const formValuesToSubmitData = (
-    values: FormValues,
-  ): CreatePoolCandidateAsAdminInput => {
-    // the user part of the submit data could be a mutation to connect an existing user or to create a new user
-    let userObject;
-    switch (values.userMode) {
-      case "existing":
-        userObject = { connect: values.user };
-        break;
-      case "new":
-        userObject = {
-          create: {
-            email: values.email,
-            firstName: values.firstName ?? "",
-            lastName: values.lastName ?? "",
-            preferredLang: values.preferredLang,
-            telephone: values.telephone,
-          },
-        };
-        break;
-      default:
-        userObject = {};
-    }
-
-    return {
-      acceptedOperationalRequirements: values.acceptedOperationalRequirements,
-      cmoAssets: {
-        sync: values.cmoAssets,
+export const CreatePoolCandidateForm: React.FunctionComponent<CreatePoolCandidateFormProps> =
+  ({
+    classifications,
+    cmoAssets,
+    pools,
+    poolId,
+    users,
+    handleCreatePoolCandidate,
+  }) => {
+    const intl = useIntl();
+    const locale = getLocale(intl);
+    const paths = useAdminRoutes();
+    const methods = useForm<FormValues>({
+      defaultValues: {
+        pool: poolId,
+        status: PoolCandidateStatus.Available, // Status for new candidates should always default to Available.
       },
-      cmoIdentifier: values.cmoIdentifier,
-      expectedClassifications: {
-        sync: values.expectedClassifications,
-      },
-      expectedSalary: values.expectedSalary,
-      expiryDate: values.expiryDate,
-      hasDiploma: values.hasDiploma,
-      hasDisability: values.hasDisability,
-      isIndigenous: values.isIndigenous,
-      isVisibleMinority: values.isVisibleMinority,
-      isWoman: values.isWoman,
-      languageAbility: values.languageAbility,
-      locationPreferences: values.locationPreferences,
-      status: values.status,
-      pool: { connect: values.pool },
-      user: userObject, // connect or create mutation
+    });
+    const { control, handleSubmit } = methods;
+
+    const formValuesToSubmitData = (
+      values: FormValues,
+    ): CreatePoolCandidateAsAdminInput => {
+      // the user part of the submit data could be a mutation to connect an existing user or to create a new user
+      let userObject;
+      switch (values.userMode) {
+        case "existing":
+          userObject = { connect: values.user };
+          break;
+        case "new":
+          userObject = {
+            create: {
+              email: values.email,
+              firstName: values.firstName ?? "",
+              lastName: values.lastName ?? "",
+              preferredLang: values.preferredLang,
+              telephone:
+                // empty string isn't valid according to API validation regex pattern, but null is valid.
+                empty(values.telephone) || values.telephone === ""
+                  ? null
+                  : values.telephone,
+            },
+          };
+          break;
+        default:
+          userObject = {};
+      }
+
+      return {
+        acceptedOperationalRequirements: values.acceptedOperationalRequirements,
+        cmoAssets: {
+          sync: values.cmoAssets,
+        },
+        cmoIdentifier: values.cmoIdentifier,
+        expectedClassifications: {
+          sync: values.expectedClassifications,
+        },
+        expectedSalary: values.expectedSalary,
+        expiryDate: values.expiryDate,
+        hasDiploma: values.hasDiploma,
+        hasDisability: values.hasDisability,
+        isIndigenous: values.isIndigenous,
+        isVisibleMinority: values.isVisibleMinority,
+        isWoman: values.isWoman,
+        languageAbility: values.languageAbility,
+        locationPreferences: values.locationPreferences,
+        status: values.status,
+        pool: { connect: values.pool },
+        user: userObject, // connect or create mutation
+      };
     };
-  };
 
-  const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
-    await handleCreatePoolCandidate(formValuesToSubmitData(data))
-      .then(() => {
-        navigate(paths.poolCandidateTable(poolId || data.pool));
-        toast.success(
-          intl.formatMessage({
-            defaultMessage: "Pool Candidate created successfully!",
-            description:
-              "Message displayed to user after pool candidate is created successfully.",
-          }),
-        );
-      })
-      .catch(() => {
-        toast.error(
-          intl.formatMessage({
-            defaultMessage: "Error: creating pool candidate failed",
-            description:
-              "Message displayed to pool candidate after pool candidate fails to get created.",
-          }),
-        );
-      });
-  };
+    const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
+      await handleCreatePoolCandidate(formValuesToSubmitData(data))
+        .then(() => {
+          navigate(paths.poolCandidateTable(poolId || data.pool));
+          toast.success(
+            intl.formatMessage({
+              defaultMessage: "Pool Candidate created successfully!",
+              description:
+                "Message displayed to user after pool candidate is created successfully.",
+            }),
+          );
+        })
+        .catch(() => {
+          toast.error(
+            intl.formatMessage({
+              defaultMessage: "Error: creating pool candidate failed",
+              description:
+                "Message displayed to pool candidate after pool candidate fails to get created.",
+            }),
+          );
+        });
+    };
 
-  const cmoAssetOptions: Option<string>[] = cmoAssets.map(({ id, name }) => ({
-    value: id,
-    label: name[locale] ?? "Error: name not loaded",
-  }));
-
-  const classificationOptions: Option<string>[] = classifications.map(
-    ({ id, group, level }) => ({
+    const cmoAssetOptions: Option<string>[] = cmoAssets.map(({ id, name }) => ({
       value: id,
-      label: `${group}-0${level}`,
-    }),
-  );
+      label: name[locale] ?? "Error: name not loaded",
+    }));
 
-  const poolOptions: Option<string>[] = pools?.map(({ id, name }) => ({
-    value: id,
-    label: name?.[locale] || "Error: pool name not found",
-  }));
+    const classificationOptions: Option<string>[] = classifications.map(
+      ({ id, group, level }) => ({
+        value: id,
+        label: `${group}-0${level}`,
+      }),
+    );
 
-  const userOptions: Option<string>[] = users.map(
-    ({ id, firstName, lastName }) => ({
+    const poolOptions: Option<string>[] = pools?.map(({ id, name }) => ({
       value: id,
-      label: `${firstName} ${lastName}`,
-    }),
-  );
+      label: name?.[locale] || "Error: pool name not found",
+    }));
 
-  return (
-    <section>
-      <h2 data-h2-text-align="b(center)" data-h2-margin="b(top, none)">
-        {intl.formatMessage({
-          defaultMessage: "Create Pool Candidate",
-          description: "Title displayed on the create a user form.",
-        })}
-      </h2>
-      <div data-h2-container="b(center, s)">
-        <FormProvider {...methods}>
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <h4>
-              {intl.formatMessage({
-                description: "Heading for the user information section",
-                defaultMessage: "User Information",
-              })}
-            </h4>
-            <RadioGroup
-              idPrefix="userMode"
-              legend="User Assignment"
-              name="userMode"
-              items={[
-                {
-                  value: "existing",
-                  label: intl.formatMessage({
-                    defaultMessage: "Assign Existing User",
-                    description:
-                      "Label for the existing user assignment option in the create pool candidate form.",
-                  }),
-                },
-                {
-                  value: "new",
-                  label: intl.formatMessage({
-                    defaultMessage: "Create New User",
-                    description:
-                      "Label for the new user assignment option in the create pool candidate form.",
-                  }),
-                },
-              ]}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-            />
-            <UserFormSection control={control} userOptions={userOptions} />
-            <h4>
-              {intl.formatMessage({
-                description: "Heading for the candidate information section",
-                defaultMessage: "Candidate Information",
-              })}
-            </h4>
-            <Select
-              id="pool"
-              label={intl.formatMessage({
-                defaultMessage: "Pool",
-                description:
-                  "Label displayed on the pool candidate form pool field.",
-              })}
-              nullSelection={intl.formatMessage({
-                defaultMessage: "Select a pool...",
-                description:
-                  "Placeholder displayed on the pool candidate form Pool field.",
-              })}
-              name="pool"
-              options={poolOptions}
-              disabled={!!poolId}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-            />
-            <Input
-              id="cmoIdentifier"
-              label={intl.formatMessage({
-                defaultMessage: "CMO Identifier",
-                description:
-                  "Label displayed on the pool candidate form cmo identifier field.",
-              })}
-              type="text"
-              name="cmoIdentifier"
-            />
-            <Input
-              id="expiryDate"
-              label={intl.formatMessage({
-                defaultMessage: "Expiry Date",
-                description:
-                  "Label displayed on the pool candidate form expiry date field.",
-              })}
-              type="date"
-              name="expiryDate"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-                min: {
-                  value: currentDate(),
-                  message: intl.formatMessage(errorMessages.futureDate),
-                },
-              }}
-            />
-            <Checkbox
-              id="isWoman"
-              label={intl.formatMessage({
-                defaultMessage: "Woman",
-                description:
-                  "Label displayed on the pool candidate form is woman field.",
-              })}
-              name="isWoman"
-            />
-            <Checkbox
-              id="hasDisability"
-              label={intl.formatMessage({
-                defaultMessage: "Has Disability",
-                description:
-                  "Label displayed on the pool candidate form has disability field.",
-              })}
-              name="hasDisability"
-            />
-            <Checkbox
-              id="isIndigenous"
-              label={intl.formatMessage({
-                defaultMessage: "Indigenous",
-                description:
-                  "Placeholder displayed on the pool candidate form is indigenous field.",
-              })}
-              name="isIndigenous"
-            />
-            <Checkbox
-              id="isVisibleMinority"
-              label={intl.formatMessage({
-                defaultMessage: "Visible Minority",
-                description:
-                  "Label displayed on the pool candidate form is visible minority field.",
-              })}
-              name="isVisibleMinority"
-            />
-            <Checkbox
-              id="hasDiploma"
-              label={intl.formatMessage({
-                defaultMessage: "Has Diploma",
-                description:
-                  "Label displayed on the pool candidate form has diploma field.",
-              })}
-              name="hasDiploma"
-            />
-            <Select
-              id="languageAbility"
-              label={intl.formatMessage({
-                defaultMessage: "Language Ability",
-                description:
-                  "Label displayed on the pool candidate form language ability field.",
-              })}
-              name="languageAbility"
-              nullSelection={intl.formatMessage({
-                defaultMessage: "Select a language ability...",
-                description:
-                  "Placeholder displayed on the pool candidate form language ability field.",
-              })}
-              options={enumToOptions(LanguageAbility).map(({ value }) => ({
-                value,
-                label: intl.formatMessage(getLanguageAbility(value)),
-              }))}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-            />
-            <MultiSelect
-              id="locationPreferences"
-              name="locationPreferences"
-              label={intl.formatMessage({
-                defaultMessage: "Location Preferences",
-                description:
-                  "Label displayed on the pool candidate form location preferences field.",
-              })}
-              placeholder={intl.formatMessage({
-                defaultMessage: "Select one or more location preferences...",
-                description:
-                  "Placeholder displayed on the pool candidate form location preferences field.",
-              })}
-              options={enumToOptions(WorkRegion).map(({ value }) => ({
-                value,
-                label: intl.formatMessage(getWorkRegion(value)),
-              }))}
-            />
-            <MultiSelect
-              id="acceptedOperationalRequirements"
-              name="acceptedOperationalRequirements"
-              label={intl.formatMessage({
-                defaultMessage: "Operational Requirements",
-                description:
-                  "Label displayed on the pool candidate form operational requirements field.",
-              })}
-              placeholder={intl.formatMessage({
-                defaultMessage:
-                  "Select one or more operational requirements...",
-                description:
-                  "Placeholder displayed on the pool candidate form operational requirements field.",
-              })}
-              options={enumToOptions(OperationalRequirement).map(
-                ({ value }) => ({
+    const userOptions: Option<string>[] = users.map(
+      ({ id, firstName, lastName }) => ({
+        value: id,
+        label: `${firstName} ${lastName}`,
+      }),
+    );
+
+    return (
+      <section>
+        <h2 data-h2-text-align="b(center)" data-h2-margin="b(top, none)">
+          {intl.formatMessage({
+            defaultMessage: "Create Pool Candidate",
+            description: "Title displayed on the create a user form.",
+          })}
+        </h2>
+        <div data-h2-container="b(center, s)">
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(onSubmit)}>
+              <h4>
+                {intl.formatMessage({
+                  description: "Heading for the user information section",
+                  defaultMessage: "User Information",
+                })}
+              </h4>
+              <RadioGroup
+                idPrefix="userMode"
+                legend="User Assignment"
+                name="userMode"
+                items={[
+                  {
+                    value: "existing",
+                    label: intl.formatMessage({
+                      defaultMessage: "Assign Existing User",
+                      description:
+                        "Label for the existing user assignment option in the create pool candidate form.",
+                    }),
+                  },
+                  {
+                    value: "new",
+                    label: intl.formatMessage({
+                      defaultMessage: "Create New User",
+                      description:
+                        "Label for the new user assignment option in the create pool candidate form.",
+                    }),
+                  },
+                ]}
+                rules={{
+                  required: intl.formatMessage(errorMessages.required),
+                }}
+              />
+              <UserFormSection control={control} userOptions={userOptions} />
+              <h4>
+                {intl.formatMessage({
+                  description: "Heading for the candidate information section",
+                  defaultMessage: "Candidate Information",
+                })}
+              </h4>
+              <Select
+                id="pool"
+                label={intl.formatMessage({
+                  defaultMessage: "Pool",
+                  description:
+                    "Label displayed on the pool candidate form pool field.",
+                })}
+                nullSelection={intl.formatMessage({
+                  defaultMessage: "Select a pool...",
+                  description:
+                    "Placeholder displayed on the pool candidate form Pool field.",
+                })}
+                name="pool"
+                options={poolOptions}
+                disabled={!!poolId}
+                rules={{
+                  required: intl.formatMessage(errorMessages.required),
+                }}
+              />
+              <Input
+                id="cmoIdentifier"
+                label={intl.formatMessage({
+                  defaultMessage: "CMO Identifier",
+                  description:
+                    "Label displayed on the pool candidate form cmo identifier field.",
+                })}
+                type="text"
+                name="cmoIdentifier"
+              />
+              <Input
+                id="expiryDate"
+                label={intl.formatMessage({
+                  defaultMessage: "Expiry Date",
+                  description:
+                    "Label displayed on the pool candidate form expiry date field.",
+                })}
+                type="date"
+                name="expiryDate"
+                rules={{
+                  required: intl.formatMessage(errorMessages.required),
+                  min: {
+                    value: currentDate(),
+                    message: intl.formatMessage(errorMessages.futureDate),
+                  },
+                }}
+              />
+              <Checkbox
+                id="isWoman"
+                label={intl.formatMessage({
+                  defaultMessage: "Woman",
+                  description:
+                    "Label displayed on the pool candidate form is woman field.",
+                })}
+                name="isWoman"
+              />
+              <Checkbox
+                id="hasDisability"
+                label={intl.formatMessage({
+                  defaultMessage: "Has Disability",
+                  description:
+                    "Label displayed on the pool candidate form has disability field.",
+                })}
+                name="hasDisability"
+              />
+              <Checkbox
+                id="isIndigenous"
+                label={intl.formatMessage({
+                  defaultMessage: "Indigenous",
+                  description:
+                    "Placeholder displayed on the pool candidate form is indigenous field.",
+                })}
+                name="isIndigenous"
+              />
+              <Checkbox
+                id="isVisibleMinority"
+                label={intl.formatMessage({
+                  defaultMessage: "Visible Minority",
+                  description:
+                    "Label displayed on the pool candidate form is visible minority field.",
+                })}
+                name="isVisibleMinority"
+              />
+              <Checkbox
+                id="hasDiploma"
+                label={intl.formatMessage({
+                  defaultMessage: "Has Diploma",
+                  description:
+                    "Label displayed on the pool candidate form has diploma field.",
+                })}
+                name="hasDiploma"
+              />
+              <Select
+                id="languageAbility"
+                label={intl.formatMessage({
+                  defaultMessage: "Language Ability",
+                  description:
+                    "Label displayed on the pool candidate form language ability field.",
+                })}
+                name="languageAbility"
+                nullSelection={intl.formatMessage({
+                  defaultMessage: "Select a language ability...",
+                  description:
+                    "Placeholder displayed on the pool candidate form language ability field.",
+                })}
+                options={enumToOptions(LanguageAbility).map(({ value }) => ({
                   value,
-                  label: intl.formatMessage(getOperationalRequirement(value)),
-                }),
-              )}
-            />
-            <MultiSelect
-              id="expectedSalary"
-              label={intl.formatMessage({
-                defaultMessage: "Expected Salary",
-                description:
-                  "Label displayed on the pool candidate form expected salary field.",
-              })}
-              name="expectedSalary"
-              placeholder={intl.formatMessage({
-                defaultMessage: "Select one or more expected salaries...",
-                description:
-                  "Placeholder displayed on the pool candidate form expected salary field.",
-              })}
-              options={enumToOptions(SalaryRange).map(({ value }) => ({
-                value,
-                label: getSalaryRange(value),
-              }))}
-            />
-            <MultiSelect
-              id="expectedClassifications"
-              label={intl.formatMessage({
-                defaultMessage: "Expected Classifications",
-                description:
-                  "Label displayed on the pool candidate form expected classifications field.",
-              })}
-              placeholder={intl.formatMessage({
-                defaultMessage: "Select one or more classifications...",
-                description:
-                  "Placeholder displayed on the pool candidate form expected classifications field.",
-              })}
-              name="expectedClassifications"
-              options={classificationOptions}
-            />
-            <MultiSelect
-              id="cmoAssets"
-              label={intl.formatMessage({
-                defaultMessage: "CMO Assets",
-                description:
-                  "Label displayed on the pool candidate form cmo assets field.",
-              })}
-              placeholder={intl.formatMessage({
-                defaultMessage: "Select one or more CMO Assets...",
-                description:
-                  "Placeholder displayed on the pool candidate form cmo assets field.",
-              })}
-              name="cmoAssets"
-              options={cmoAssetOptions}
-            />
-            <Select
-              id="status"
-              label={intl.formatMessage({
-                defaultMessage: "Status",
-                description:
-                  "Label displayed on the pool candidate form status field.",
-              })}
-              nullSelection={intl.formatMessage({
-                defaultMessage: "Select a status...",
-                description:
-                  "Placeholder displayed on the pool candidate form status field.",
-              })}
-              name="status"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-              options={enumToOptions(PoolCandidateStatus).map(({ value }) => ({
-                value,
-                label: intl.formatMessage(getPoolCandidateStatus(value)),
-              }))}
-            />
-            <Submit />
-          </form>
-        </FormProvider>
-      </div>
-    </section>
-  );
-};
+                  label: intl.formatMessage(getLanguageAbility(value)),
+                }))}
+                rules={{
+                  required: intl.formatMessage(errorMessages.required),
+                }}
+              />
+              <MultiSelect
+                id="locationPreferences"
+                name="locationPreferences"
+                label={intl.formatMessage({
+                  defaultMessage: "Location Preferences",
+                  description:
+                    "Label displayed on the pool candidate form location preferences field.",
+                })}
+                placeholder={intl.formatMessage({
+                  defaultMessage: "Select one or more location preferences...",
+                  description:
+                    "Placeholder displayed on the pool candidate form location preferences field.",
+                })}
+                options={enumToOptions(WorkRegion).map(({ value }) => ({
+                  value,
+                  label: intl.formatMessage(getWorkRegion(value)),
+                }))}
+              />
+              <MultiSelect
+                id="acceptedOperationalRequirements"
+                name="acceptedOperationalRequirements"
+                label={intl.formatMessage({
+                  defaultMessage: "Operational Requirements",
+                  description:
+                    "Label displayed on the pool candidate form operational requirements field.",
+                })}
+                placeholder={intl.formatMessage({
+                  defaultMessage:
+                    "Select one or more operational requirements...",
+                  description:
+                    "Placeholder displayed on the pool candidate form operational requirements field.",
+                })}
+                options={enumToOptions(OperationalRequirement).map(
+                  ({ value }) => ({
+                    value,
+                    label: intl.formatMessage(getOperationalRequirement(value)),
+                  }),
+                )}
+              />
+              <MultiSelect
+                id="expectedSalary"
+                label={intl.formatMessage({
+                  defaultMessage: "Expected Salary",
+                  description:
+                    "Label displayed on the pool candidate form expected salary field.",
+                })}
+                name="expectedSalary"
+                placeholder={intl.formatMessage({
+                  defaultMessage: "Select one or more expected salaries...",
+                  description:
+                    "Placeholder displayed on the pool candidate form expected salary field.",
+                })}
+                options={enumToOptions(SalaryRange).map(({ value }) => ({
+                  value,
+                  label: getSalaryRange(value),
+                }))}
+              />
+              <MultiSelect
+                id="expectedClassifications"
+                label={intl.formatMessage({
+                  defaultMessage: "Expected Classifications",
+                  description:
+                    "Label displayed on the pool candidate form expected classifications field.",
+                })}
+                placeholder={intl.formatMessage({
+                  defaultMessage: "Select one or more classifications...",
+                  description:
+                    "Placeholder displayed on the pool candidate form expected classifications field.",
+                })}
+                name="expectedClassifications"
+                options={classificationOptions}
+              />
+              <MultiSelect
+                id="cmoAssets"
+                label={intl.formatMessage({
+                  defaultMessage: "CMO Assets",
+                  description:
+                    "Label displayed on the pool candidate form cmo assets field.",
+                })}
+                placeholder={intl.formatMessage({
+                  defaultMessage: "Select one or more CMO Assets...",
+                  description:
+                    "Placeholder displayed on the pool candidate form cmo assets field.",
+                })}
+                name="cmoAssets"
+                options={cmoAssetOptions}
+              />
+              <Select
+                id="status"
+                label={intl.formatMessage({
+                  defaultMessage: "Status",
+                  description:
+                    "Label displayed on the pool candidate form status field.",
+                })}
+                nullSelection={intl.formatMessage({
+                  defaultMessage: "Select a status...",
+                  description:
+                    "Placeholder displayed on the pool candidate form status field.",
+                })}
+                name="status"
+                rules={{
+                  required: intl.formatMessage(errorMessages.required),
+                }}
+                options={enumToOptions(PoolCandidateStatus).map(
+                  ({ value }) => ({
+                    value,
+                    label: intl.formatMessage(getPoolCandidateStatus(value)),
+                  }),
+                )}
+              />
+              <Submit />
+            </form>
+          </FormProvider>
+        </div>
+      </section>
+    );
+  };
 
 export const CreatePoolCandidate: React.FunctionComponent<{
   poolId: string;

--- a/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
@@ -236,7 +236,12 @@ export const CreatePoolCandidateForm: React.FunctionComponent<
   const intl = useIntl();
   const locale = getLocale(intl);
   const paths = useAdminRoutes();
-  const methods = useForm<FormValues>({ defaultValues: { pool: poolId } });
+  const methods = useForm<FormValues>({
+    defaultValues: {
+      pool: poolId,
+      status: PoolCandidateStatus.Available, // Status for new candidates should always default to Available.
+    },
+  });
   const { control, handleSubmit } = methods;
 
   const formValuesToSubmitData = (

--- a/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
@@ -177,10 +177,6 @@ const UserFormSection: React.FunctionComponent<{
           type="tel"
           name="telephone"
           rules={{
-            required:
-              userMode === "new"
-                ? intl.formatMessage(errorMessages.required)
-                : undefined,
             pattern: {
               value: phoneNumberRegex,
               message: intl.formatMessage(errorMessages.telephone),
@@ -416,9 +412,6 @@ export const CreatePoolCandidateForm: React.FunctionComponent<
               })}
               type="text"
               name="cmoIdentifier"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <Input
               id="expiryDate"
@@ -520,9 +513,6 @@ export const CreatePoolCandidateForm: React.FunctionComponent<
                 value,
                 label: intl.formatMessage(getWorkRegion(value)),
               }))}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <MultiSelect
               id="acceptedOperationalRequirements"
@@ -544,9 +534,6 @@ export const CreatePoolCandidateForm: React.FunctionComponent<
                   label: intl.formatMessage(getOperationalRequirement(value)),
                 }),
               )}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <MultiSelect
               id="expectedSalary"
@@ -565,9 +552,6 @@ export const CreatePoolCandidateForm: React.FunctionComponent<
                 value,
                 label: getSalaryRange(value),
               }))}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <MultiSelect
               id="expectedClassifications"
@@ -583,9 +567,6 @@ export const CreatePoolCandidateForm: React.FunctionComponent<
               })}
               name="expectedClassifications"
               options={classificationOptions}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <MultiSelect
               id="cmoAssets"
@@ -601,9 +582,6 @@ export const CreatePoolCandidateForm: React.FunctionComponent<
               })}
               name="cmoAssets"
               options={cmoAssetOptions}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <Select
               id="status"

--- a/frontend/admin/src/js/components/poolCandidate/UpdatePoolCandidate.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/UpdatePoolCandidate.tsx
@@ -262,9 +262,6 @@ export const UpdatePoolCandidateForm: React.FunctionComponent<
               })}
               type="text"
               name="cmoIdentifier"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <Input
               id="expiryDate"
@@ -361,9 +358,6 @@ export const UpdatePoolCandidateForm: React.FunctionComponent<
                 value,
                 label: intl.formatMessage(getWorkRegion(value)),
               }))}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <MultiSelect
               id="acceptedOperationalRequirements"
@@ -403,9 +397,6 @@ export const UpdatePoolCandidateForm: React.FunctionComponent<
                 value,
                 label: getSalaryRange(value),
               }))}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <MultiSelect
               id="expectedClassifications"
@@ -421,9 +412,6 @@ export const UpdatePoolCandidateForm: React.FunctionComponent<
               })}
               name="expectedClassifications"
               options={classificationOptions}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <MultiSelect
               id="cmoAssets"
@@ -439,9 +427,6 @@ export const UpdatePoolCandidateForm: React.FunctionComponent<
               })}
               name="cmoAssets"
               options={cmoAssetOptions}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <Select
               id="status"

--- a/frontend/admin/src/js/components/poolCandidate/UpdatePoolCandidate.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/UpdatePoolCandidate.tsx
@@ -10,7 +10,7 @@ import {
   MultiSelect,
   Checkbox,
 } from "@common/components/form";
-import { notEmpty } from "@common/helpers/util";
+import { empty, notEmpty } from "@common/helpers/util";
 import {
   currentDate,
   unpackIds,
@@ -84,378 +84,381 @@ interface UpdatePoolCandidateProps {
   ) => Promise<UpdatePoolCandidateMutation["updatePoolCandidateAsAdmin"]>;
 }
 
-export const UpdatePoolCandidateForm: React.FunctionComponent<
-  UpdatePoolCandidateProps
-> = ({
-  classifications,
-  cmoAssets,
-  initialPoolCandidate,
-  handleUpdatePoolCandidate,
-}) => {
-  const intl = useIntl();
-  const paths = useAdminRoutes();
-  const locale = getLocale(intl);
-  const dataToFormValues = (data: PoolCandidate): FormValues => ({
-    ...data,
-    acceptedOperationalRequirements: unpackMaybes(
-      data?.acceptedOperationalRequirements,
-    ),
-    cmoAssets: unpackIds(data?.cmoAssets),
-    expectedClassifications: unpackIds(data?.expectedClassifications),
-    expectedSalary: unpackMaybes(data?.expectedSalary),
-    locationPreferences: unpackMaybes(data?.locationPreferences),
-    userId: data?.user?.id ?? "",
-    email: data?.user?.email ?? "",
-    firstName: data?.user?.firstName,
-    lastName: data?.user?.lastName,
-    telephone: data?.user?.telephone,
-    preferredLang: data?.user?.preferredLang,
-  });
+export const UpdatePoolCandidateForm: React.FunctionComponent<UpdatePoolCandidateProps> =
+  ({
+    classifications,
+    cmoAssets,
+    initialPoolCandidate,
+    handleUpdatePoolCandidate,
+  }) => {
+    const intl = useIntl();
+    const paths = useAdminRoutes();
+    const locale = getLocale(intl);
+    const dataToFormValues = (data: PoolCandidate): FormValues => ({
+      ...data,
+      acceptedOperationalRequirements: unpackMaybes(
+        data?.acceptedOperationalRequirements,
+      ),
+      cmoAssets: unpackIds(data?.cmoAssets),
+      expectedClassifications: unpackIds(data?.expectedClassifications),
+      expectedSalary: unpackMaybes(data?.expectedSalary),
+      locationPreferences: unpackMaybes(data?.locationPreferences),
+      userId: data?.user?.id ?? "",
+      email: data?.user?.email ?? "",
+      firstName: data?.user?.firstName,
+      lastName: data?.user?.lastName,
+      telephone: data?.user?.telephone,
+      preferredLang: data?.user?.preferredLang,
+    });
 
-  const formValuesToSubmitData = (
-    values: FormValues,
-  ): UpdatePoolCandidateAsAdminInput => ({
-    ...values,
-    expectedClassifications: {
-      sync: values.expectedClassifications,
-    },
-    cmoAssets: {
-      sync: values.cmoAssets,
-    },
-  });
+    const formValuesToSubmitData = (
+      values: FormValues,
+    ): UpdatePoolCandidateAsAdminInput => ({
+      ...values,
+      expectedClassifications: {
+        sync: values.expectedClassifications,
+      },
+      cmoAssets: {
+        sync: values.cmoAssets,
+      },
+    });
 
-  const methods = useForm<FormValues>({
-    defaultValues: dataToFormValues(initialPoolCandidate),
-  });
-  const { handleSubmit } = methods;
+    const methods = useForm<FormValues>({
+      defaultValues: dataToFormValues(initialPoolCandidate),
+    });
+    const { handleSubmit } = methods;
 
-  const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
-    await handleUpdatePoolCandidate(
-      initialPoolCandidate.id,
-      formValuesToSubmitData(data),
-    )
-      .then(() => {
-        navigate(paths.poolCandidateTable(initialPoolCandidate.pool?.id || ""));
-        toast.success(
-          intl.formatMessage({
-            defaultMessage: "Pool Candidate updated successfully!",
-            description:
-              "Message displayed to user after pool candidate is updated successfully.",
-          }),
-        );
-      })
-      .catch(() => {
-        toast.error(
-          intl.formatMessage({
-            defaultMessage: "Error: updating pool candidate failed",
-            description:
-              "Message displayed to pool candidate after pool candidate fails to get updated.",
-          }),
-        );
-      });
-  };
+    const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
+      await handleUpdatePoolCandidate(
+        initialPoolCandidate.id,
+        formValuesToSubmitData(data),
+      )
+        .then(() => {
+          navigate(
+            paths.poolCandidateTable(initialPoolCandidate.pool?.id || ""),
+          );
+          toast.success(
+            intl.formatMessage({
+              defaultMessage: "Pool Candidate updated successfully!",
+              description:
+                "Message displayed to user after pool candidate is updated successfully.",
+            }),
+          );
+        })
+        .catch(() => {
+          toast.error(
+            intl.formatMessage({
+              defaultMessage: "Error: updating pool candidate failed",
+              description:
+                "Message displayed to pool candidate after pool candidate fails to get updated.",
+            }),
+          );
+        });
+    };
 
-  const cmoAssetOptions: Option<string>[] = cmoAssets.map(({ id, name }) => ({
-    value: id,
-    label: name[locale] ?? "Error: name not loaded",
-  }));
-
-  const classificationOptions: Option<string>[] = classifications.map(
-    ({ id, group, level }) => ({
+    const cmoAssetOptions: Option<string>[] = cmoAssets.map(({ id, name }) => ({
       value: id,
-      label: `${group}-0${level}`,
-    }),
-  );
+      label: name[locale] ?? "Error: name not loaded",
+    }));
 
-  return (
-    <section>
-      <h2 data-h2-text-align="b(center)" data-h2-margin="b(top, none)">
-        {intl.formatMessage({
-          defaultMessage: "Update Pool Candidate",
-          description: "Title displayed on the update a user form.",
-        })}
-      </h2>
-      <div data-h2-container="b(center, s)">
-        <FormProvider {...methods}>
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <h4>
-              {intl.formatMessage({
-                description: "Heading for the user information section",
-                defaultMessage: "User Information",
-              })}
-            </h4>
-            <Input
-              id="email"
-              label={intl.formatMessage({
-                defaultMessage: "Email",
-                description: "Label displayed on the user form email field.",
-              })}
-              type="email"
-              name="email"
-              disabled
-              hideOptional
-            />
-            <Input
-              id="firstName"
-              label={intl.formatMessage({
-                defaultMessage: "First Name",
-                description:
-                  "Label displayed on the user form first name field.",
-              })}
-              type="text"
-              name="firstName"
-              disabled
-            />
-            <Input
-              id="lastName"
-              label={intl.formatMessage({
-                defaultMessage: "Last Name",
-                description:
-                  "Label displayed on the user form last name field.",
-              })}
-              type="text"
-              name="lastName"
-              disabled
-            />
-            <Input
-              id="telephone"
-              label={intl.formatMessage({
-                defaultMessage: "Telephone",
-                description:
-                  "Label displayed on the user form telephone field.",
-              })}
-              type="tel"
-              name="telephone"
-              disabled
-            />
-            <Select
-              id="preferredLang"
-              label={intl.formatMessage({
-                defaultMessage: "Preferred Language",
-                description:
-                  "Label displayed on the user form preferred language field.",
-              })}
-              name="preferredLang"
-              nullSelection={intl.formatMessage({
-                defaultMessage: "Select a language...",
-                description:
-                  "Placeholder displayed on the user form preferred language field.",
-              })}
-              disabled
-              options={enumToOptions(Language).map(({ value }) => ({
-                value,
-                label: intl.formatMessage(getLanguage(value)),
-              }))}
-            />
-            <h4>
-              {intl.formatMessage({
-                description: "Heading for the candidate information section",
-                defaultMessage: "Candidate Information",
-              })}
-            </h4>
-            <Input
-              id="cmoIdentifier"
-              label={intl.formatMessage({
-                defaultMessage: "CMO Identifier",
-                description:
-                  "Label displayed on the pool candidate form cmo identifier field.",
-              })}
-              type="text"
-              name="cmoIdentifier"
-            />
-            <Input
-              id="expiryDate"
-              label={intl.formatMessage({
-                defaultMessage: "Expiry Date",
-                description:
-                  "Label displayed on the pool candidate form expiry date field.",
-              })}
-              type="date"
-              name="expiryDate"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-                min: {
-                  value: currentDate(),
-                  message: intl.formatMessage(errorMessages.futureDate),
-                },
-              }}
-            />
-            <Checkbox
-              id="isWoman"
-              label={intl.formatMessage({
-                defaultMessage: "Woman",
-                description:
-                  "Label displayed on the pool candidate form is woman field.",
-              })}
-              name="isWoman"
-            />
-            <Checkbox
-              id="hasDisability"
-              label={intl.formatMessage({
-                defaultMessage: "Has Disability",
-                description:
-                  "Label displayed on the pool candidate form has disability field.",
-              })}
-              name="hasDisability"
-            />
-            <Checkbox
-              id="isIndigenous"
-              label={intl.formatMessage({
-                defaultMessage: "Indigenous",
-                description:
-                  "Placeholder displayed on the pool candidate form is indigenous field.",
-              })}
-              name="isIndigenous"
-            />
-            <Checkbox
-              id="isVisibleMinority"
-              label={intl.formatMessage({
-                defaultMessage: "Visible Minority",
-                description:
-                  "Label displayed on the pool candidate form is visible minority field.",
-              })}
-              name="isVisibleMinority"
-            />
-            <Checkbox
-              id="hasDiploma"
-              label={intl.formatMessage({
-                defaultMessage: "Has Diploma",
-                description:
-                  "Label displayed on the pool candidate form has diploma field.",
-              })}
-              name="hasDiploma"
-            />
-            <Select
-              id="languageAbility"
-              label={intl.formatMessage({
-                defaultMessage: "Language Ability",
-                description:
-                  "Label displayed on the pool candidate form language ability field.",
-              })}
-              name="languageAbility"
-              options={enumToOptions(LanguageAbility).map(({ value }) => ({
-                value,
-                label: intl.formatMessage(getLanguageAbility(value)),
-              }))}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-            />
-            <MultiSelect
-              id="locationPreferences"
-              name="locationPreferences"
-              label={intl.formatMessage({
-                defaultMessage: "Location Preferences",
-                description:
-                  "Label displayed on the pool candidate form location preferences field.",
-              })}
-              placeholder={intl.formatMessage({
-                defaultMessage: "Select one or more location preferences...",
-                description:
-                  "Placeholder displayed on the pool candidate form location preferences field.",
-              })}
-              options={enumToOptions(WorkRegion).map(({ value }) => ({
-                value,
-                label: intl.formatMessage(getWorkRegion(value)),
-              }))}
-            />
-            <MultiSelect
-              id="acceptedOperationalRequirements"
-              name="acceptedOperationalRequirements"
-              label={intl.formatMessage({
-                defaultMessage: "Operational Requirements",
-                description:
-                  "Label displayed on the pool candidate form operational requirements field.",
-              })}
-              placeholder={intl.formatMessage({
-                defaultMessage:
-                  "Select one or more operational requirements...",
-                description:
-                  "Placeholder displayed on the pool candidate form operational requirements field.",
-              })}
-              options={enumToOptions(OperationalRequirement).map(
-                ({ value }) => ({
+    const classificationOptions: Option<string>[] = classifications.map(
+      ({ id, group, level }) => ({
+        value: id,
+        label: `${group}-0${level}`,
+      }),
+    );
+
+    return (
+      <section>
+        <h2 data-h2-text-align="b(center)" data-h2-margin="b(top, none)">
+          {intl.formatMessage({
+            defaultMessage: "Update Pool Candidate",
+            description: "Title displayed on the update a user form.",
+          })}
+        </h2>
+        <div data-h2-container="b(center, s)">
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(onSubmit)}>
+              <h4>
+                {intl.formatMessage({
+                  description: "Heading for the user information section",
+                  defaultMessage: "User Information",
+                })}
+              </h4>
+              <Input
+                id="email"
+                label={intl.formatMessage({
+                  defaultMessage: "Email",
+                  description: "Label displayed on the user form email field.",
+                })}
+                type="email"
+                name="email"
+                disabled
+                hideOptional
+              />
+              <Input
+                id="firstName"
+                label={intl.formatMessage({
+                  defaultMessage: "First Name",
+                  description:
+                    "Label displayed on the user form first name field.",
+                })}
+                type="text"
+                name="firstName"
+                disabled
+              />
+              <Input
+                id="lastName"
+                label={intl.formatMessage({
+                  defaultMessage: "Last Name",
+                  description:
+                    "Label displayed on the user form last name field.",
+                })}
+                type="text"
+                name="lastName"
+                disabled
+              />
+              <Input
+                id="telephone"
+                label={intl.formatMessage({
+                  defaultMessage: "Telephone",
+                  description:
+                    "Label displayed on the user form telephone field.",
+                })}
+                type="tel"
+                name="telephone"
+                disabled
+              />
+              <Select
+                id="preferredLang"
+                label={intl.formatMessage({
+                  defaultMessage: "Preferred Language",
+                  description:
+                    "Label displayed on the user form preferred language field.",
+                })}
+                name="preferredLang"
+                nullSelection={intl.formatMessage({
+                  defaultMessage: "Select a language...",
+                  description:
+                    "Placeholder displayed on the user form preferred language field.",
+                })}
+                disabled
+                options={enumToOptions(Language).map(({ value }) => ({
                   value,
-                  label: intl.formatMessage(getOperationalRequirement(value)),
-                }),
-              )}
-            />
-            <MultiSelect
-              id="expectedSalary"
-              label={intl.formatMessage({
-                defaultMessage: "Expected Salary",
-                description:
-                  "Label displayed on the pool candidate form expected salary field.",
-              })}
-              name="expectedSalary"
-              placeholder={intl.formatMessage({
-                defaultMessage: "Select one or more expected salaries...",
-                description:
-                  "Placeholder displayed on the pool candidate form expected salary field.",
-              })}
-              options={enumToOptions(SalaryRange).map(({ value }) => ({
-                value,
-                label: getSalaryRange(value),
-              }))}
-            />
-            <MultiSelect
-              id="expectedClassifications"
-              label={intl.formatMessage({
-                defaultMessage: "Expected Classifications",
-                description:
-                  "Label displayed on the pool candidate form expected classifications field.",
-              })}
-              placeholder={intl.formatMessage({
-                defaultMessage: "Select one or more classifications...",
-                description:
-                  "Placeholder displayed on the pool candidate form expected classifications field.",
-              })}
-              name="expectedClassifications"
-              options={classificationOptions}
-            />
-            <MultiSelect
-              id="cmoAssets"
-              label={intl.formatMessage({
-                defaultMessage: "CMO Assets",
-                description:
-                  "Label displayed on the pool candidate form cmo assets field.",
-              })}
-              placeholder={intl.formatMessage({
-                defaultMessage: "Select one or more CMO Assets...",
-                description:
-                  "Placeholder displayed on the pool candidate form cmo assets field.",
-              })}
-              name="cmoAssets"
-              options={cmoAssetOptions}
-            />
-            <Select
-              id="status"
-              label={intl.formatMessage({
-                defaultMessage: "Status",
-                description:
-                  "Label displayed on the pool candidate form status field.",
-              })}
-              nullSelection={intl.formatMessage({
-                defaultMessage: "Select a status...",
-                description:
-                  "Placeholder displayed on the pool candidate form status field.",
-              })}
-              name="status"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-              options={enumToOptions(PoolCandidateStatus).map(({ value }) => ({
-                value,
-                label: intl.formatMessage(getPoolCandidateStatus(value)),
-              }))}
-            />
-            <Submit />
-          </form>
-        </FormProvider>
-      </div>
-    </section>
-  );
-};
+                  label: intl.formatMessage(getLanguage(value)),
+                }))}
+              />
+              <h4>
+                {intl.formatMessage({
+                  description: "Heading for the candidate information section",
+                  defaultMessage: "Candidate Information",
+                })}
+              </h4>
+              <Input
+                id="cmoIdentifier"
+                label={intl.formatMessage({
+                  defaultMessage: "CMO Identifier",
+                  description:
+                    "Label displayed on the pool candidate form cmo identifier field.",
+                })}
+                type="text"
+                name="cmoIdentifier"
+              />
+              <Input
+                id="expiryDate"
+                label={intl.formatMessage({
+                  defaultMessage: "Expiry Date",
+                  description:
+                    "Label displayed on the pool candidate form expiry date field.",
+                })}
+                type="date"
+                name="expiryDate"
+                rules={{
+                  required: intl.formatMessage(errorMessages.required),
+                  min: {
+                    value: currentDate(),
+                    message: intl.formatMessage(errorMessages.futureDate),
+                  },
+                }}
+              />
+              <Checkbox
+                id="isWoman"
+                label={intl.formatMessage({
+                  defaultMessage: "Woman",
+                  description:
+                    "Label displayed on the pool candidate form is woman field.",
+                })}
+                name="isWoman"
+              />
+              <Checkbox
+                id="hasDisability"
+                label={intl.formatMessage({
+                  defaultMessage: "Has Disability",
+                  description:
+                    "Label displayed on the pool candidate form has disability field.",
+                })}
+                name="hasDisability"
+              />
+              <Checkbox
+                id="isIndigenous"
+                label={intl.formatMessage({
+                  defaultMessage: "Indigenous",
+                  description:
+                    "Placeholder displayed on the pool candidate form is indigenous field.",
+                })}
+                name="isIndigenous"
+              />
+              <Checkbox
+                id="isVisibleMinority"
+                label={intl.formatMessage({
+                  defaultMessage: "Visible Minority",
+                  description:
+                    "Label displayed on the pool candidate form is visible minority field.",
+                })}
+                name="isVisibleMinority"
+              />
+              <Checkbox
+                id="hasDiploma"
+                label={intl.formatMessage({
+                  defaultMessage: "Has Diploma",
+                  description:
+                    "Label displayed on the pool candidate form has diploma field.",
+                })}
+                name="hasDiploma"
+              />
+              <Select
+                id="languageAbility"
+                label={intl.formatMessage({
+                  defaultMessage: "Language Ability",
+                  description:
+                    "Label displayed on the pool candidate form language ability field.",
+                })}
+                name="languageAbility"
+                options={enumToOptions(LanguageAbility).map(({ value }) => ({
+                  value,
+                  label: intl.formatMessage(getLanguageAbility(value)),
+                }))}
+                rules={{
+                  required: intl.formatMessage(errorMessages.required),
+                }}
+              />
+              <MultiSelect
+                id="locationPreferences"
+                name="locationPreferences"
+                label={intl.formatMessage({
+                  defaultMessage: "Location Preferences",
+                  description:
+                    "Label displayed on the pool candidate form location preferences field.",
+                })}
+                placeholder={intl.formatMessage({
+                  defaultMessage: "Select one or more location preferences...",
+                  description:
+                    "Placeholder displayed on the pool candidate form location preferences field.",
+                })}
+                options={enumToOptions(WorkRegion).map(({ value }) => ({
+                  value,
+                  label: intl.formatMessage(getWorkRegion(value)),
+                }))}
+              />
+              <MultiSelect
+                id="acceptedOperationalRequirements"
+                name="acceptedOperationalRequirements"
+                label={intl.formatMessage({
+                  defaultMessage: "Operational Requirements",
+                  description:
+                    "Label displayed on the pool candidate form operational requirements field.",
+                })}
+                placeholder={intl.formatMessage({
+                  defaultMessage:
+                    "Select one or more operational requirements...",
+                  description:
+                    "Placeholder displayed on the pool candidate form operational requirements field.",
+                })}
+                options={enumToOptions(OperationalRequirement).map(
+                  ({ value }) => ({
+                    value,
+                    label: intl.formatMessage(getOperationalRequirement(value)),
+                  }),
+                )}
+              />
+              <MultiSelect
+                id="expectedSalary"
+                label={intl.formatMessage({
+                  defaultMessage: "Expected Salary",
+                  description:
+                    "Label displayed on the pool candidate form expected salary field.",
+                })}
+                name="expectedSalary"
+                placeholder={intl.formatMessage({
+                  defaultMessage: "Select one or more expected salaries...",
+                  description:
+                    "Placeholder displayed on the pool candidate form expected salary field.",
+                })}
+                options={enumToOptions(SalaryRange).map(({ value }) => ({
+                  value,
+                  label: getSalaryRange(value),
+                }))}
+              />
+              <MultiSelect
+                id="expectedClassifications"
+                label={intl.formatMessage({
+                  defaultMessage: "Expected Classifications",
+                  description:
+                    "Label displayed on the pool candidate form expected classifications field.",
+                })}
+                placeholder={intl.formatMessage({
+                  defaultMessage: "Select one or more classifications...",
+                  description:
+                    "Placeholder displayed on the pool candidate form expected classifications field.",
+                })}
+                name="expectedClassifications"
+                options={classificationOptions}
+              />
+              <MultiSelect
+                id="cmoAssets"
+                label={intl.formatMessage({
+                  defaultMessage: "CMO Assets",
+                  description:
+                    "Label displayed on the pool candidate form cmo assets field.",
+                })}
+                placeholder={intl.formatMessage({
+                  defaultMessage: "Select one or more CMO Assets...",
+                  description:
+                    "Placeholder displayed on the pool candidate form cmo assets field.",
+                })}
+                name="cmoAssets"
+                options={cmoAssetOptions}
+              />
+              <Select
+                id="status"
+                label={intl.formatMessage({
+                  defaultMessage: "Status",
+                  description:
+                    "Label displayed on the pool candidate form status field.",
+                })}
+                nullSelection={intl.formatMessage({
+                  defaultMessage: "Select a status...",
+                  description:
+                    "Placeholder displayed on the pool candidate form status field.",
+                })}
+                name="status"
+                rules={{
+                  required: intl.formatMessage(errorMessages.required),
+                }}
+                options={enumToOptions(PoolCandidateStatus).map(
+                  ({ value }) => ({
+                    value,
+                    label: intl.formatMessage(getPoolCandidateStatus(value)),
+                  }),
+                )}
+              />
+              <Submit />
+            </form>
+          </FormProvider>
+        </div>
+      </section>
+    );
+  };
 
 export const UpdatePoolCandidate: React.FunctionComponent<{
   poolCandidateId: string;

--- a/frontend/admin/src/js/components/user/CreateUser.tsx
+++ b/frontend/admin/src/js/components/user/CreateUser.tsx
@@ -115,7 +115,6 @@ export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
               type="tel"
               name="telephone"
               rules={{
-                required: intl.formatMessage(errorMessages.required),
                 pattern: {
                   value: phoneNumberRegex,
                   message: intl.formatMessage(errorMessages.telephone),

--- a/frontend/admin/src/js/components/user/CreateUser.tsx
+++ b/frontend/admin/src/js/components/user/CreateUser.tsx
@@ -8,6 +8,7 @@ import { enumToOptions } from "@common/helpers/formUtils";
 import { getLanguage, getRole } from "@common/constants/localizedConstants";
 import { errorMessages } from "@common/messages";
 import { phoneNumberRegex } from "@common/constants/regularExpressions";
+import { empty } from "@common/helpers/util";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Language,
@@ -25,6 +26,15 @@ interface CreateUserFormProps {
   ) => Promise<CreateUserMutation["createUser"]>;
 }
 
+const formValuesToData = (values: FormValues): CreateUserInput => ({
+  ...values,
+  telephone:
+    // empty string isn't valid according to API validation regex pattern, but null is valid.
+    empty(values.telephone) || values.telephone === ""
+      ? null
+      : values.telephone,
+});
+
 export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
   handleCreateUser,
 }) => {
@@ -34,7 +44,7 @@ export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
   const { handleSubmit } = methods;
 
   const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
-    return handleCreateUser(data)
+    return handleCreateUser(formValuesToData(data))
       .then(() => {
         navigate(paths.userTable());
         toast.success(

--- a/frontend/admin/src/js/components/user/UpdateUser.tsx
+++ b/frontend/admin/src/js/components/user/UpdateUser.tsx
@@ -9,6 +9,7 @@ import { enumToOptions, unpackIds } from "@common/helpers/formUtils";
 import { errorMessages, commonMessages } from "@common/messages";
 import { getLanguage, getRole } from "@common/constants/localizedConstants";
 import { phoneNumberRegex } from "@common/constants/regularExpressions";
+import { empty } from "@common/helpers/util";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Language,
@@ -91,6 +92,11 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
     values: FormValues,
   ): UpdateUserAsAdminInput => ({
     ...values,
+    telephone:
+      // empty string isn't valid according to API validation regex pattern, but null is valid.
+      empty(values.telephone) || values.telephone === ""
+        ? null
+        : values.telephone,
     cmoAssets: {
       sync: values.cmoAssets,
     },

--- a/frontend/admin/src/js/components/user/UpdateUser.tsx
+++ b/frontend/admin/src/js/components/user/UpdateUser.tsx
@@ -189,7 +189,6 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
               type="tel"
               name="telephone"
               rules={{
-                required: intl.formatMessage(errorMessages.required),
                 pattern: {
                   value: phoneNumberRegex,
                   message: intl.formatMessage(errorMessages.telephone),


### PR DESCRIPTION
Resolves #2455 

Removes required rule from multi-select inputs in PoolCandidate forms on Admin dashboard. An empty selection is reasonable for these fields.

Removes required rule from User telephone fields. 

Adds a default value for status field on new PoolCandidates, for convenience.