### PR TITLE
Update Conditions of Employment

### DIFF
--- a/api/database/helpers/EnumsForFactories.php
+++ b/api/database/helpers/EnumsForFactories.php
@@ -13,12 +13,14 @@ class EnumsForFactories
     public static function operationalRequirements() : array
     {
         return [
-            'OVERTIME',
             'SHIFT_WORK',
             'ON_CALL',
             'TRAVEL',
             'TRANSPORT_EQUIPMENT',
             'DRIVERS_LICENSE',
+            'WORK_WEEKENDS',
+            'OVERTIME_SCHEDULED',
+            'OVERTIME_SHORT_NOTICE'
         ];
     }
 }

--- a/api/database/migrations/2022_04_13_190734_convert_overtime_enum.php
+++ b/api/database/migrations/2022_04_13_190734_convert_overtime_enum.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Models\Pool;
+use App\Models\PoolCandidate;
+use App\Models\PoolCandidateFilter;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ConvertOvertimeEnum extends Migration
+{
+
+    protected function convertOperationalEnumValue($oldValue, $newValue)
+    {
+        $converEnumValue = function($item) use ($oldValue, $newValue) {
+            if($item === $oldValue) {
+                return $newValue;
+            }
+            return $item;
+        };
+
+        $users = User::whereJsonContains('accepted_operational_requirements', $oldValue)->get();
+        foreach($users as $user) {
+            $user->accepted_operational_requirements = collect($user->accepted_operational_requirements)
+                ->map($converEnumValue)->toArray();
+            $user->save();
+        }
+        $poolCandidates = PoolCandidate::whereJsonContains('accepted_operational_requirements', $oldValue)->get();
+        foreach ($poolCandidates as $poolCandidate) {
+            $poolCandidate->accepted_operational_requirements = collect($poolCandidate->accepted_operational_requirements)
+                ->map($converEnumValue)->toArray();
+            $poolCandidate->save();
+        }
+        $pools = Pool::whereJsonContains('operational_requirements', $oldValue)->get();
+        foreach ($pools as $pool) {
+            $pool->operational_requirements = collect($pool->operational_requirements)
+                ->map($converEnumValue)->toArray();
+            $pool->save();
+        }
+        $poolCandidateFilters = PoolCandidateFilter::whereJsonContains('operational_requirements', $oldValue)->get();
+        foreach($poolCandidateFilters as $poolCandidateFilter) {
+            $poolCandidateFilter->operational_requirements = collect($poolCandidateFilter->operational_requirements)
+                ->map($converEnumValue)->toArray();
+            $poolCandidateFilter->save();
+        }
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->convertOperationalEnumValue("OVERTIME", "OVERTIME_SCHEDULED");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->convertOperationalEnumValue("OVERTIME_SCHEDULED", "OVERTIME");
+    }
+}

--- a/api/database/migrations/2022_04_13_190734_convert_overtime_enum.php
+++ b/api/database/migrations/2022_04_13_190734_convert_overtime_enum.php
@@ -5,15 +5,13 @@ use App\Models\PoolCandidate;
 use App\Models\PoolCandidateFilter;
 use App\Models\User;
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 
 class ConvertOvertimeEnum extends Migration
 {
 
     protected function convertOperationalEnumValue($oldValue, $newValue)
     {
-        $converEnumValue = function($item) use ($oldValue, $newValue) {
+        $convertEnumValue = function($item) use ($oldValue, $newValue) {
             if($item === $oldValue) {
                 return $newValue;
             }
@@ -23,25 +21,25 @@ class ConvertOvertimeEnum extends Migration
         $users = User::whereJsonContains('accepted_operational_requirements', $oldValue)->get();
         foreach($users as $user) {
             $user->accepted_operational_requirements = collect($user->accepted_operational_requirements)
-                ->map($converEnumValue)->toArray();
+                ->map($convertEnumValue)->toArray();
             $user->save();
         }
         $poolCandidates = PoolCandidate::whereJsonContains('accepted_operational_requirements', $oldValue)->get();
         foreach ($poolCandidates as $poolCandidate) {
             $poolCandidate->accepted_operational_requirements = collect($poolCandidate->accepted_operational_requirements)
-                ->map($converEnumValue)->toArray();
+                ->map($convertEnumValue)->toArray();
             $poolCandidate->save();
         }
         $pools = Pool::whereJsonContains('operational_requirements', $oldValue)->get();
         foreach ($pools as $pool) {
             $pool->operational_requirements = collect($pool->operational_requirements)
-                ->map($converEnumValue)->toArray();
+                ->map($convertEnumValue)->toArray();
             $pool->save();
         }
         $poolCandidateFilters = PoolCandidateFilter::whereJsonContains('operational_requirements', $oldValue)->get();
         foreach($poolCandidateFilters as $poolCandidateFilter) {
             $poolCandidateFilter->operational_requirements = collect($poolCandidateFilter->operational_requirements)
-                ->map($converEnumValue)->toArray();
+                ->map($convertEnumValue)->toArray();
             $poolCandidateFilter->save();
         }
     }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -264,12 +264,14 @@ enum WorkRegion {
 e.g. Overtime as Required, Shift Work, Travel as Required, etc.
 """
 enum OperationalRequirement {
-    OVERTIME
     SHIFT_WORK
     ON_CALL
     TRAVEL
     TRANSPORT_EQUIPMENT
     DRIVERS_LICENSE
+    WORK_WEEKENDS
+    OVERTIME_SCHEDULED
+    OVERTIME_SHORT_NOTICE
 }
 
 enum SalaryRange {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -478,12 +478,14 @@ type Mutation {
 
 """e.g. Overtime as Required, Shift Work, Travel as Required, etc."""
 enum OperationalRequirement {
-  OVERTIME
   SHIFT_WORK
   ON_CALL
   TRAVEL
   TRANSPORT_EQUIPMENT
   DRIVERS_LICENSE
+  WORK_WEEKENDS
+  OVERTIME_SCHEDULED
+  OVERTIME_SHORT_NOTICE
 }
 
 """Allows ordering a list of records."""

--- a/api/tests/Feature/PoolCandidateTest.php
+++ b/api/tests/Feature/PoolCandidateTest.php
@@ -146,7 +146,7 @@ class PoolCandidateTest extends TestCase
     PoolCandidate::factory()->count(5)->create([
       'accepted_operational_requirements' => [],
     ]);
-    $operationalRequirement1 = 'OVERTIME';
+    $operationalRequirement1 = 'OVERTIME_SCHEDULED';
     $operationalRequirement2 = 'SHIFT_WORK';
     $operationalRequirement3 = 'ON_CALL';
 

--- a/frontend/admin/src/js/stories/PoolCandidate.stories.tsx
+++ b/frontend/admin/src/js/stories/PoolCandidate.stories.tsx
@@ -55,7 +55,7 @@ stories.add("Update Pool Candidate Form", () => {
   const poolCandidate: PoolCandidate = {
     id: "1",
     acceptedOperationalRequirements: [
-      OperationalRequirement.Overtime,
+      OperationalRequirement.OvertimeScheduled,
       OperationalRequirement.ShiftWork,
     ],
     cmoAssets: [fakeCmoAssets()[0], fakeCmoAssets()[1]],

--- a/frontend/common/src/constants/localizedConstants.tsx
+++ b/frontend/common/src/constants/localizedConstants.tsx
@@ -167,8 +167,7 @@ export const workRegions = defineMessages({
 
 export const workRegionsDetailed = defineMessages({
   [WorkRegion.Telework]: {
-    defaultMessage:
-      "<bold>Virtual:</bold> Work from home, anywhere in Canada.",
+    defaultMessage: "<bold>Virtual:</bold> Work from home, anywhere in Canada.",
     description: "The work region of Canada described as Telework.",
   },
   [WorkRegion.NationalCapital]: {
@@ -446,10 +445,6 @@ export const getEducationType = (
   );
 
 export const operationalRequirements = defineMessages({
-  [OperationalRequirement.Overtime]: {
-    defaultMessage: "Overtime as required",
-    description: "The operational requirement described as overtime.",
-  },
   [OperationalRequirement.ShiftWork]: {
     defaultMessage: "Shift work",
     description: "The operational requirement described as shift work.",
@@ -470,6 +465,19 @@ export const operationalRequirements = defineMessages({
   [OperationalRequirement.DriversLicense]: {
     defaultMessage: "Driver's license",
     description: "The operational requirement described as driver's license.",
+  },
+  [OperationalRequirement.WorkWeekends]: {
+    defaultMessage: "Work weekends",
+    description: "The operational requirement described as work weekends.",
+  },
+  [OperationalRequirement.OvertimeScheduled]: {
+    defaultMessage: "Work scheduled overtime",
+    description: "The operational requirement described as scheduled overtime.",
+  },
+  [OperationalRequirement.OvertimeShortNotice]: {
+    defaultMessage: "Work overtime on short notice",
+    description:
+      "The operational requirement described as short notice overtime.",
   },
 });
 

--- a/frontend/common/src/constants/localizedConstants.tsx
+++ b/frontend/common/src/constants/localizedConstants.tsx
@@ -445,32 +445,41 @@ export const getEducationType = (
   );
 
 export const OperationalRequirementCandidateDescription = defineMessages({
-  [OperationalRequirement.Overtime]: {
-    defaultMessage: "...requires me to <boldText>work overtime.</boldText>",
-    description: "The operational requirement described as overtime.",
-  },
   [OperationalRequirement.ShiftWork]: {
-    defaultMessage: "...has <boldText>shift-work</boldText>",
+    defaultMessage: "...has <bold>shift-work</bold>.",
     description: "The operational requirement described as shift work.",
   },
   [OperationalRequirement.OnCall]: {
-    defaultMessage: "...has <boldText>24/7 on call-shifts</boldText>",
+    defaultMessage: "...has <bold>24/7 on call-shifts</bold>.",
     description: "The operational requirement described as 24/7 on-call.",
   },
   [OperationalRequirement.Travel]: {
-    defaultMessage: "...requires me to <boldText>travel</boldText>",
+    defaultMessage: "...requires me to <bold>travel</bold>.",
     description: "The operational requirement described as travel as required.",
   },
   [OperationalRequirement.TransportEquipment]: {
     defaultMessage:
-      "...requires me to <boldText>transport, lift and set down equipment weighing up to 20kg</boldText>",
+      "...requires me to <bold>transport, lift and set down equipment weighing up to 20kg</bold>.",
     description:
       "The operational requirement described as transport equipment up to 20kg.",
   },
   [OperationalRequirement.DriversLicense]: {
     defaultMessage:
-      "...requires me to <boldText>have a valid driver's license</boldText> or personal mobility to the degree normally associated with the possession of a valid driver's license",
+      "...requires me to <bold>have a valid driver's license</bold> or personal mobility to the degree normally associated with the possession of a valid driver's license.",
     description: "The operational requirement described as driver's license.",
+  },
+  [OperationalRequirement.WorkWeekends]: {
+    defaultMessage: "...requires me to <bold>work weekends</bold>.",
+    description: "The operational requirement described as work weekends.",
+  },
+  [OperationalRequirement.OvertimeScheduled]: {
+    defaultMessage: "...requires me to <bold>work scheduled overtime</bold>.",
+    description: "The operational requirement described as scheduled overtime.",
+  },
+  [OperationalRequirement.OvertimeShortNotice]: {
+    defaultMessage:
+      "...requires me to <bold>work overtime on short notice</bold>.",
+    description: "The operational requirement described as overtime.",
   },
 });
 

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -311,10 +311,6 @@
     "defaultMessage": "Diplôme",
     "description": "Diploma selection for education type input"
   },
-  "jm4url": {
-    "defaultMessage": "Navigation par pagination",
-    "description": "Aria label for pagination nav"
-  },
   "nv2kXl": {
     "defaultMessage": "Maîtrise",
     "description": "Masters Degree selection for education type input"
@@ -392,15 +388,23 @@
     "description": "The operational requirement described as 24/7 on-call."
   },
   "hCy99h": {
-    "defaultMessage": "Travail posté",
+    "defaultMessage": "Travailler des quarts de travail",
     "description": "The operational requirement described as shift work."
-  },
-  "uD2AqA": {
-    "defaultMessage": "Heures supplémentaires selon les besoins",
-    "description": "The operational requirement described as overtime."
   },
   "vhFe42": {
     "defaultMessage": "Permis de conduire",
     "description": "The operational requirement described as driver's license."
+  },
+  "6I3OCB": {
+    "defaultMessage": "Travailler les fins de semaine",
+    "description": "The operational requirement described as work weekends."
+  },
+  "Bw9k0J": {
+    "defaultMessage": "Travailler des heures supplémentaires prévues",
+    "description": "The operational requirement described as scheduled overtime."
+  },
+  "eJCfxF": {
+    "defaultMessage": "Travailler des heures supplémentaires à court préavis",
+    "description": "The operational requirement described as short notice overtime."
   }
 }

--- a/frontend/talentsearch/src/js/components/search/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchForm.tsx
@@ -182,6 +182,13 @@ export const SearchForm: React.FunctionComponent<SearchFormProps> = ({
     [cmoAssets, locale, intl],
   );
 
+  const operationalRequirementsSubset = [
+    OperationalRequirement.ShiftWork,
+    OperationalRequirement.WorkWeekends,
+    OperationalRequirement.OvertimeScheduled,
+    OperationalRequirement.OvertimeShortNotice,
+  ];
+
   return (
     <FormProvider {...methods}>
       <form>
@@ -274,7 +281,7 @@ export const SearchForm: React.FunctionComponent<SearchFormProps> = ({
             idPrefix="operationalRequirements"
             legend="Conditions of employment"
             name="operationalRequirements"
-            items={enumToOptions(OperationalRequirement).map(({ value }) => ({
+            items={operationalRequirementsSubset.map((value) => ({
               value,
               label: intl.formatMessage(getOperationalRequirement(value)),
             }))}

--- a/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
+++ b/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
@@ -18,7 +18,7 @@ export const WorkPreferencesForm: React.FunctionComponent<{
 }> = ({ handleSubmit }) => {
   const intl = useIntl();
 
-  function boldText(msg: string) {
+  function bold(msg: string) {
     return <span data-h2-font-weight="b(700)">{msg}</span>;
   }
 
@@ -77,11 +77,11 @@ export const WorkPreferencesForm: React.FunctionComponent<{
                     label: intl.formatMessage(
                       {
                         defaultMessage:
-                          "...only those of an <boldText>indeterminate</boldText> duration. (permanent)",
+                          "...only those of an <bold>indeterminate</bold> duration. (permanent)",
                         description:
                           "Label displayed on Work Preferences form for indeterminate duration option.",
                       },
-                      { boldText },
+                      { bold },
                     ),
                   },
                 ]}
@@ -105,7 +105,7 @@ export const WorkPreferencesForm: React.FunctionComponent<{
                     label: intl.formatMessage(
                       getOperationalRequirementCandidateDescription(value),
                       {
-                        boldText,
+                        bold,
                       },
                     ),
                   }),


### PR DESCRIPTION
Resolves #2477

This PR removes a value from the OperationalRequirements enums. If that value remains in the database anywhere, it can cause errors in GraphQL queries. To test:
1. Edit the database to enter a value of `["OVERTIME", "SHIFT_WORK"]` in the following tables & columns:
    - users.accepted_operational_requirements
    - pool_candidates.accepted_operational_requirements
    - pools.operational_requirements
    - pool_candidate_filters.operational_requirements
2. Go to http://localhost:8000/graphql-playground, run the following query. (Ensure you either have an admin bearer token, or have set AUTH_DEFAULT_USER=admin@test.com in api/.env) 
   You should get an error, something like `Expected a value of type \"OperationalRequirement\" but received: OVERTIME`
```
query {
  poolCandidates {
    acceptedOperationalRequirements
  }
  users {
    acceptedOperationalRequirements
  }
  pools {
    operationalRequirements
  }
  poolCandidateFilters {
    operationalRequirements
  }
}
```  
4. Run migrations (run `docker-compose exec -w /var/www/html/api php sh -c "php artisan migrate"` from /infrastructure folder). 
5. Running the same query from graphql-playground should now work! Viewing the database directly, you should see previous instances of "OVERTIME" replaced with "OVERTIME_SCHEDULED".