### PR TITLE
Small copy change for dates on Digital Community page #2485

### DIFF
--- a/tc-report/en/communities/digital-talent/index.html
+++ b/tc-report/en/communities/digital-talent/index.html
@@ -40,9 +40,9 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&display=swap" rel="stylesheet">
   <!-- Hydrogen CSS -->
-  
+
     <link rel="stylesheet" href="/assets/css/hydrogen.css">
-  
+
   <!-- App CSS -->
   <link rel="stylesheet" href="/assets/css/app.css">
 </head>
@@ -65,68 +65,68 @@
         /></a>
       </div>
       <div data-h2-flex-item="m(1of2)" data-h2-text-align="b(center) m(right)">
-         
+
         <a href="/fr/communities/digital-talent/" title="Voir ce contenu en français.">Français</a>
-        
+
       </div>
     </div>
   </div>
 </div>
- 
+
 <div data-h2-container="b(center, full)" >
   <nav data-h2-padding="b(top-bottom, m)">
     <ul class="reset-ul" data-h2-padding="b(all, none)" data-h2-margin="b(all, none)" data-h2-text-align="b(center) m(left)" style="margin-left: -.7rem;">
-      
+
         <li data-h2-margin="b(all, none)" data-h2-padding="b(all, none)" data-h2-display="b(inline-block)">
           <a href="/en/" title="Visit the GC Talent homepage."
-            
+
             data-h2-display="b(block)"
             data-h2-padding="b(all, xs) m(right-left, s)">Home</a>
         </li>
-      
+
         <li data-h2-margin="b(all, none)" data-h2-padding="b(all, none)" data-h2-display="b(inline-block)">
           <a href="/en/talent-cloud/" title="Learn more about the Talent Cloud project."
-            
+
             data-h2-display="b(block)"
             data-h2-padding="b(all, xs) m(right-left, s)">Talent Cloud</a>
         </li>
-      
+
         <li data-h2-margin="b(all, none)" data-h2-padding="b(all, none)" data-h2-display="b(inline-block)">
           <a href="/en/communities/digital-talent/" title="Learn more about the Digital Talent community."
-            
+
             data-h2-display="b(block)"
             data-h2-padding="b(all, xs) m(right-left, s)">Digital Talent</a>
         </li>
-      
+
     </ul>
   </nav>
-</div> 
+</div>
 
   <section id="mainContent">
   <div
     data-h2-text-align="b(center)"
     data-h2-padding="b(top, xxl) b(bottom, xl)"
     data-h2-container="b(center, m)">
-     
+
     <h1
   data-h2-font-weight="b(800)"
   data-h2-font-size="b(h1)"
-  
+
   style="letter-spacing: -3px"
-  
+
 >
   The Government of Canada’s Digital Community
 </h1>
 
   </div>
   <div data-h2-position="b(relative)" data-h2-padding="b(top, xxl)">
-    
+
       <div data-h2-position="b(absolute)" data-h2-location="b(top-left, none)" data-h2-width="b(100)">
-  
+
     <img src="/assets/img/ui-hex.svg" data-h2-width="b(100)">
-  
+
 </div>
-    
+
     <div
       data-h2-container="b(center, l)"
       data-h2-padding="b(bottom, xl)"
@@ -145,7 +145,7 @@
               data-h2-align-items="b(center)"
               data-h2-text-align="b(center) m(left)"
               data-h2-padding="b(bottom, s) m(bottom, m)">
-              
+
                 <div style="width: 4rem" data-h2-margin="m(right, m)">
   <img
     src="/assets/img/ui-icon-dt.svg"
@@ -154,34 +154,34 @@
   />
 </div>
 
-                
-                
-                
-                
-                
-                
-                
-               
+
+
+
+
+
+
+
+
               <h2
-  
+
   data-h2-font-weight="b(200)"
   data-h2-font-size="b(h2)"
-  
-  
-  
-  
+
+
+
+
   style="letter-spacing: -2px;">
   What is the Digital Community?
 </h2>
             </div>
             <div>
-              
+
                 <p>The GC Digital Community is a diverse and vibrant community of talent making a real difference in the lives of Canadians.</p>
-              
+
                 <p>The public servants in the GC Digital Community are passionate about delivering more effective and efficient services that Canadians and residents need.</p>
-              
+
                 <p>The community exemplifies the <a href='https://www.canada.ca/en/government/system/digital-government/government-canada-digital-standards.html' title='Learn more about the Digital Standards.'>Digital Standards</a>, which includes working in the open, designing for the user, and making services more accessible for Canadians. Encompassing areas such as artificial intelligence and cybersecurity, the community is contributing to the use of <a href='https://www.canada.ca/en/government/system/digital-government/digital-government-innovations.html' title='Learn more about how the Government of Canada is innovating in technology.'>modern and emerging technologies</a> to deliver better digital services.</p>
-              
+
             </div>
           </div>
         </div>
@@ -200,23 +200,23 @@
             style="height: 100%; min-height: 50vh;">
             <span>
               <h2
-  
+
   data-h2-font-weight="b(200)"
   data-h2-font-size="b(h2)"
-  
-  
-  
-  
+
+
+
+
   style="letter-spacing: -2px;">
   I am interested in #GCDigital job opportunities
 </h2>
             </span>
             <span>
-              <p>New features for creating a reusable profile are scheduled to launch in Spring 2021. Sign-up for our mailing list to be in the know.</p>
+              <p>New features for creating a reusable profile are scheduled to launch in Summer 2022. Sign-up for our mailing list to be in the know.</p>
             </span>
             <span>
-               
-               
+
+
 <a
   data-h2-display="b(inline-block)"
   data-h2-border="b(primary, all, solid, s) b:h(hover, all, solid, s) b:f(hover, all, solid, s)"
@@ -226,11 +226,11 @@
   data-h2-padding="b(top-bottom, xs) b(right-left, m)"
   href="mailto:Talent.Cloud-nuage.de.talents@tbs-sct.gc.ca"
   style="transition: all .2s ease;"
-  
+
   title="Send us an email to learn more."
   >Sign up</a
 >
- 
+
 
             </span>
           </div>
@@ -250,13 +250,13 @@
             style="height: 100%; min-height: 50vh;">
             <span>
               <h2
-  
+
   data-h2-font-weight="b(200)"
   data-h2-font-size="b(h2)"
-  
-  
-  
-  
+
+
+
+
   style="letter-spacing: -2px;">
   I’m a Manager: I want to hire digital talent
 </h2>
@@ -265,8 +265,8 @@
               <p>You can get started by contacting the Digital Community Management Office.</p>
             </span>
             <span>
-               
-               
+
+
 <a
   data-h2-display="b(inline-block)"
   data-h2-border="b(primary, all, solid, s) b:h(hover, all, solid, s) b:f(hover, all, solid, s)"
@@ -276,11 +276,11 @@
   data-h2-padding="b(top-bottom, xs) b(right-left, m)"
   href="mailto:recruitmentIMIT-recrutementGITI@tbs-sct.gc.ca"
   style="transition: all .2s ease;"
-  
+
   title="Send us an email to begin the talent search process."
   >Contact Us</a
 >
- 
+
 
             </span>
           </div>
@@ -302,23 +302,23 @@
       style="align-items: normal">
       <div data-h2-flex-grid="b(stretch, expanded, flush, m) m(stretch, expanded, flush, xl)">
         <div data-h2-flex-item="b(1of1)">
-           
-          
+
+
   <div data-h2-shadow="b(s)"
 
-  
+
     data-h2-bg-color="b(white)"
-  
+
   data-h2-padding="b(all, m) m(all, xl)"
   data-h2-radius="b(s)"
   >
-  
+
             <div
               data-h2-display="b(flex)"
               data-h2-align-items="b(center)"
               data-h2-text-align="b(center) m(left)"
               data-h2-padding="b(bottom, s) m(bottom, m)">
-              
+
                 <div style="width: 4rem" data-h2-margin="m(right, m)">
   <img
     src="/assets/img/ui-icon-dt.svg"
@@ -327,29 +327,29 @@
   />
 </div>
 
-                
+
               <h2
-  
+
   data-h2-font-weight="b(200)"
   data-h2-font-size="b(h2)"
-  
-  
-  
-  
+
+
+
+
   style="letter-spacing: -2px;">
   About the Digital Talent Portal
 </h2>
             </div>
             <div>
-              
+
                 <p>The Digital Talent Portal connects Government of Canada managers with digital talent across the country.</p>
-              
+
                 <p>When the portal goes live, digital talent will be able to create reusable profiles that showcase their skills and experiences. These profiles can then be found by Government of Canada managers searching the platform for new talent.</p>
-              
+
                 <p>The portal will provide managers with a comprehensive view of all the recruitment campaigns managed by the Digital Community Management Office, making it faster and easier to search and find the digital talent their teams need.</p>
-              
+
             </div>
-          
+
 
   </div>
 
@@ -358,25 +358,25 @@
     </div>
   </div>
 </section>
- 
+
   <section data-h2-bg-color='b(black)' data-h2-padding="b(top, xl)">
   <div data-h2-container="b(center, m)" data-h2-font-color="b(white)">
     <span data-h2-text-align="b(center)">
       <h2
-  
+
   data-h2-font-weight="b(200)"
   data-h2-font-size="b(h2)"
-  
-  
-  
-  
+
+
+
+
   style="letter-spacing: -2px;">
   Digital Community Management Office<br>+ The Digital Talent Portal
 </h2>
       <p data-h2-margin="b(top-bottom, l)">In collaboration with the Digital Community Management Office, the Digital Talent Portal will:</p>
     </span>
     <div data-h2-flex-grid="b(top, expanded, flush, l)">
-      
+
         <div
           data-h2-flex-item="b(1of1) m(1of2)"
           data-h2-display="b(flex)"
@@ -390,7 +390,7 @@
           </span>
           <p data-h2-margin="b(all, none)" style="flex: 1">Iterate based on user feedback</p>
         </div>
-      
+
         <div
           data-h2-flex-item="b(1of1) m(1of2)"
           data-h2-display="b(flex)"
@@ -404,7 +404,7 @@
           </span>
           <p data-h2-margin="b(all, none)" style="flex: 1">Help address the great demand for digital talent in the Government of Canada</p>
         </div>
-      
+
         <div
           data-h2-flex-item="b(1of1) m(1of2)"
           data-h2-display="b(flex)"
@@ -418,7 +418,7 @@
           </span>
           <p data-h2-margin="b(all, none)" style="flex: 1">Provide a comprehensive view on available talent looking to be part of #GCDigital</p>
         </div>
-      
+
         <div
           data-h2-flex-item="b(1of1) m(1of2)"
           data-h2-display="b(flex)"
@@ -432,13 +432,13 @@
           </span>
           <p data-h2-margin="b(all, none)" style="flex: 1">Support talent from diverse background in getting recognized by GC managers</p>
         </div>
-      
+
     </div>
   </div>
 </section>
- 
+
   <section data-h2-position="b(relative)" data-h2-padding="b(top-bottom, xxl)">
-  
+
   <div
       data-h2-bg-color='b(black)'
       data-h2-position="b(absolute)"
@@ -451,25 +451,25 @@
     data-h2-padding="b(top, m)">
     <div data-h2-flex-grid="b(stretch, expanded, flush, xl) m(stretch, expanded, flush, xl)">
       <div data-h2-flex-item="b(1of1)">
-         
-        
+
+
   <div data-h2-shadow="b(s)"
 
-  
+
     data-h2-bg-color="b(white)"
-  
+
   data-h2-padding="b(all, m) m(all, xl)"
   data-h2-radius="b(s)"
-  
+
     style="height: 100%;"
   >
-  
+
           <div
             data-h2-display="b(flex)"
             data-h2-align-items="b(center)"
             data-h2-text-align="b(center) m(left)"
             data-h2-padding="b(bottom, s) m(bottom, m)">
-            
+
               <div style="width: 4rem" data-h2-margin="m(right, m)">
   <img
     src="/assets/img/ui-icon-dt.svg"
@@ -478,23 +478,23 @@
   />
 </div>
 
-            
+
             <h2
-  
+
   data-h2-font-weight="b(200)"
   data-h2-font-size="b(h2)"
-  
-  
-  
-  
+
+
+
+
   style="letter-spacing: -2px;">
   Want to learn more about #GCDigital?
 </h2>
           </div>
-          
+
             <p>Are you curious about what the Government of Canada is doing to deliver better digital services to Canadians? Learn about the <a href='https://www.canada.ca/en/government/system/digital-government/digital-government-innovations.html' title='Learn about how the public service uses technology.'>various modern and emerging technologies</a> the public service uses. Find out the different <a href='https://www.canada.ca/en/government/system/digital-government/digital-government-response-to-covid-19.html' title='Learn more about digital tooling.'>digital tools</a> available to help Canadians access services and get information on COVID-19. <a href='https://www.canada.ca/en/government/system/digital-government/living-digital.html' title='Read stories about innovation in the public service.'>Read stories</a> of forward-thinking ideas and endeavours by public servants in the GC Digital Community.</p>
-          
-        
+
+
 
   </div>
 
@@ -502,7 +502,7 @@
     </div>
   </div>
 </section>
- 
+
 
 <section data-h2-border="b([light]gray, top, solid, s)" data-h2-position="b(relative)" style="background: rgba(240, 240, 240, 1)" data-h2-overflow="b(x, hidden)">
   <footer data-h2-container="b(center, full)" data-h2-padding="b(top-bottom, l)">
@@ -511,7 +511,7 @@
         data-h2-flex-item="b(1of1) m(1of2)"
         data-h2-padding="b(left, xl)"
         data-h2-text-align="b(center) m(left)">
-        
+
           <nav>
             <ul
               style="gap: 1rem;"
@@ -520,40 +520,40 @@
               data-h2-flex-wrap="b(wrap)"
               data-h2-justify-content="b(center) m(flex-start)"
               data-h2-margin="b(bottom, xs)">
-              
+
               <li data-h2-display="b(inline-block)" data-h2-margin="b(top-bottom, none)">
-                
+
                   <a href="mailto:talent.cloud-nuage.de.talents@tbs-sct.gc.ca" title="Submit feedback to GC Talent Cloud via email.">Feedback</a>
-                
+
               </li>
-              
+
               <li data-h2-display="b(inline-block)" data-h2-margin="b(top-bottom, none)">
-                
+
                   <a href="/en/terms-and-conditions" title="View our terms and conditions.">Terms & Conditions</a>
-                
+
               </li>
-              
+
               <li data-h2-display="b(inline-block)" data-h2-margin="b(top-bottom, none)">
-                
+
                   <a href="/en/privacy-notice" title="View our privacy policy.">Privacy Policy</a>
-                
+
               </li>
-              
+
               <li data-h2-display="b(inline-block)" data-h2-margin="b(top-bottom, none)">
-                
+
                   <a href="/en/https://www.canada.ca/en.html" title="Visit Canada.ca.">Canada.ca</a>
-                
+
               </li>
-              
+
             </ul>
           </nav>
-          <p 
+          <p
             data-h2-font-size="b(caption)"
-            data-h2-font-color="b(black)" 
+            data-h2-font-color="b(black)"
             data-h2-margin="b(bottom, none) b(top, m)">
             Date Modified: July 07, 2021
           </p>
-        
+
       </div>
       <div
         data-h2-flex-item="b(1of1) m(1of2)"

--- a/tc-report/fr/communities/digital-talent/index.html
+++ b/tc-report/fr/communities/digital-talent/index.html
@@ -40,9 +40,9 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&display=swap" rel="stylesheet">
   <!-- Hydrogen CSS -->
-  
+
     <link rel="stylesheet" href="/assets/css/hydrogen.css">
-  
+
   <!-- App CSS -->
   <link rel="stylesheet" href="/assets/css/app.css">
 </head>
@@ -65,68 +65,68 @@
         /></a>
       </div>
       <div data-h2-flex-item="m(1of2)" data-h2-text-align="b(center) m(right)">
-         
+
         <a href="/en/communities/digital-talent/" title="View this content in English.">English</a>
-        
+
       </div>
     </div>
   </div>
 </div>
- 
+
 <div data-h2-container="b(center, full)" >
   <nav data-h2-padding="b(top-bottom, m)">
     <ul class="reset-ul" data-h2-padding="b(all, none)" data-h2-margin="b(all, none)" data-h2-text-align="b(center) m(left)" style="margin-left: -.7rem;">
-      
+
         <li data-h2-margin="b(all, none)" data-h2-padding="b(all, none)" data-h2-display="b(inline-block)">
           <a href="/fr/" title="Visitez la page d'accueil de GC Talent."
-            
+
             data-h2-display="b(block)"
             data-h2-padding="b(all, xs) m(right-left, s)">Accueil</a>
         </li>
-      
+
         <li data-h2-margin="b(all, none)" data-h2-padding="b(all, none)" data-h2-display="b(inline-block)">
           <a href="/fr/talent-cloud/" title="En savoir plus sur le projet Nuage de talents."
-            
+
             data-h2-display="b(block)"
             data-h2-padding="b(all, xs) m(right-left, s)">Nuage de talents</a>
         </li>
-      
+
         <li data-h2-margin="b(all, none)" data-h2-padding="b(all, none)" data-h2-display="b(inline-block)">
           <a href="/fr/communities/digital-talent/" title="En savoir plus sur la communauté des talents numériques."
-            
+
             data-h2-display="b(block)"
             data-h2-padding="b(all, xs) m(right-left, s)">Talent numérique</a>
         </li>
-      
+
     </ul>
   </nav>
-</div> 
+</div>
 
   <section id="mainContent">
   <div
     data-h2-text-align="b(center)"
     data-h2-padding="b(top, xxl) b(bottom, xl)"
     data-h2-container="b(center, m)">
-     
+
     <h1
   data-h2-font-weight="b(800)"
   data-h2-font-size="b(h1)"
-  
+
   style="letter-spacing: -3px"
-  
+
 >
   La collectivité du numérique du gouvernement du Canada
 </h1>
 
   </div>
   <div data-h2-position="b(relative)" data-h2-padding="b(top, xxl)">
-    
+
       <div data-h2-position="b(absolute)" data-h2-location="b(top-left, none)" data-h2-width="b(100)">
-  
+
     <img src="/assets/img/ui-hex.svg" data-h2-width="b(100)">
-  
+
 </div>
-    
+
     <div
       data-h2-container="b(center, l)"
       data-h2-padding="b(bottom, xl)"
@@ -145,7 +145,7 @@
               data-h2-align-items="b(center)"
               data-h2-text-align="b(center) m(left)"
               data-h2-padding="b(bottom, s) m(bottom, m)">
-              
+
                 <div style="width: 4rem" data-h2-margin="m(right, m)">
   <img
     src="/assets/img/ui-icon-dt.svg"
@@ -154,34 +154,34 @@
   />
 </div>
 
-                
-                
-                
-                
-                
-                
-                
-               
+
+
+
+
+
+
+
+
               <h2
-  
+
   data-h2-font-weight="b(200)"
   data-h2-font-size="b(h2)"
-  
-  
-  
-  
+
+
+
+
   style="letter-spacing: -2px;">
   Qu'est-ce que la communauté numérique ?
 </h2>
             </div>
             <div>
-              
+
                 <p>La collectivité du numérique du GC est un regroupement de talents diversifié et dynamique qui change vraiment la vie des Canadiens et des Canadiennes.</p>
-              
+
                 <p>Les fonctionnaires de la collectivité du numérique du GC sont passionnés par la prestation de services plus efficaces dont la population du Canada a besoin.</p>
-              
+
                 <p>La collectivité incarne les <a href='https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/normes-numeriques-gouvernement-canada.html' title='En savoir plus sur les normes numériques.'>normes relatives au numérique</a>, notamment travailler ouvertement, concevoir pour l’utilisateur et améliorer l’accessibilité des services pour la population canadienne. Englobant des domaines comme l’analyse de données et la cybersécurité, la gestion des produits et les opérations, la collectivité contribue à l’utilisation de <a href='https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/innovations-gouvernementales-numeriques.html' title='Apprenez-en davantage sur la façon dont le gouvernement du Canada innove en matière de technologie.'>technologies modernes et émergentes</a> pour offrir de meilleurs services numériques.</p>
-              
+
             </div>
           </div>
         </div>
@@ -200,23 +200,23 @@
             style="height: 100%; min-height: 50vh;">
             <span>
               <h2
-  
+
   data-h2-font-weight="b(200)"
   data-h2-font-size="b(h2)"
-  
-  
-  
-  
+
+
+
+
   style="letter-spacing: -2px;">
   Je m’intéresse aux possibilités d’emploi #GCNumérique
 </h2>
             </span>
             <span>
-              <p>La nouvelle fonction de création d’un profil réutilisable devrait être lancée au printemps 2021. Inscrivez-vous à notre liste d’envoi pour rester informé.</p>
+              <p>La nouvelle fonction de création d’un profil réutilisable devrait être lancé à l'été 2022. Inscrivez-vous à notre liste d’envoi pour rester informé.</p>
             </span>
             <span>
-               
-               
+
+
 <a
   data-h2-display="b(inline-block)"
   data-h2-border="b(primary, all, solid, s) b:h(hover, all, solid, s) b:f(hover, all, solid, s)"
@@ -226,11 +226,11 @@
   data-h2-padding="b(top-bottom, xs) b(right-left, m)"
   href="mailto:Talent.Cloud-nuage.de.talents@tbs-sct.gc.ca"
   style="transition: all .2s ease;"
-  
+
   title="Envoyez-nous un courriel pour en savoir plus."
   >S'inscrire</a
 >
- 
+
 
             </span>
           </div>
@@ -250,13 +250,13 @@
             style="height: 100%; min-height: 50vh;">
             <span>
               <h2
-  
+
   data-h2-font-weight="b(200)"
   data-h2-font-size="b(h2)"
-  
-  
-  
-  
+
+
+
+
   style="letter-spacing: -2px;">
   Je suis gestionnaire et je souhaite embaucher des talents numériques
 </h2>
@@ -265,8 +265,8 @@
               <p>Vous pouvez commencer en communiquant avec le Bureau de gestion de la collectivité du numérique.</p>
             </span>
             <span>
-               
-               
+
+
 <a
   data-h2-display="b(inline-block)"
   data-h2-border="b(primary, all, solid, s) b:h(hover, all, solid, s) b:f(hover, all, solid, s)"
@@ -276,11 +276,11 @@
   data-h2-padding="b(top-bottom, xs) b(right-left, m)"
   href="mailto:recruitmentIMIT-recrutementGITI@tbs-sct.gc.ca"
   style="transition: all .2s ease;"
-  
+
   title="Envoyez-nous un courriel pour commencer le processus de recherche de talents."
   >Nous contacter</a
 >
- 
+
 
             </span>
           </div>
@@ -302,23 +302,23 @@
       style="align-items: normal">
       <div data-h2-flex-grid="b(stretch, expanded, flush, m) m(stretch, expanded, flush, xl)">
         <div data-h2-flex-item="b(1of1)">
-           
-          
+
+
   <div data-h2-shadow="b(s)"
 
-  
+
     data-h2-bg-color="b(white)"
-  
+
   data-h2-padding="b(all, m) m(all, xl)"
   data-h2-radius="b(s)"
   >
-  
+
             <div
               data-h2-display="b(flex)"
               data-h2-align-items="b(center)"
               data-h2-text-align="b(center) m(left)"
               data-h2-padding="b(bottom, s) m(bottom, m)">
-              
+
                 <div style="width: 4rem" data-h2-margin="m(right, m)">
   <img
     src="/assets/img/ui-icon-dt.svg"
@@ -327,29 +327,29 @@
   />
 </div>
 
-                
+
               <h2
-  
+
   data-h2-font-weight="b(200)"
   data-h2-font-size="b(h2)"
-  
-  
-  
-  
+
+
+
+
   style="letter-spacing: -2px;">
   À propos du Portail des talents numériques
 </h2>
             </div>
             <div>
-              
+
                 <p>Le Portail des talents numériques met en relation les gestionnaires du gouvernement du Canada avec des talents numériques de tout le pays.</p>
-              
+
                 <p>Lorsque le Portail sera lancé, les talents numériques pourront créer des profils réutilisables qui mettront en valeur leurs compétences et leur expérience. Les gestionnaires du gouvernement du Canada pourront ensuite trouver ces profils sur la plateforme pour repérer de nouveaux talents.</p>
-              
+
                 <p>Le Portail fournira aux gestionnaires un aperçu complet de toutes les campagnes de recrutement gérées par le Bureau de gestion de la collectivité du numérique, ce qui permettra de trouver plus rapidement et plus facilement les talents numériques dont leurs équipes ont besoin.</p>
-              
+
             </div>
-          
+
 
   </div>
 
@@ -358,25 +358,25 @@
     </div>
   </div>
 </section>
- 
+
   <section data-h2-bg-color='b(black)' data-h2-padding="b(top, xl)">
   <div data-h2-container="b(center, m)" data-h2-font-color="b(white)">
     <span data-h2-text-align="b(center)">
       <h2
-  
+
   data-h2-font-weight="b(200)"
   data-h2-font-size="b(h2)"
-  
-  
-  
-  
+
+
+
+
   style="letter-spacing: -2px;">
   Bureau de gestion de la collectivité du numérique<br>+ Portail des talents numériques
 </h2>
       <p data-h2-margin="b(top-bottom, l)">En collaboration avec le Bureau de gestion de la collectivité du numérique, le Portail des talents numériques assumera les fonctions suivantes :</p>
     </span>
     <div data-h2-flex-grid="b(top, expanded, flush, l)">
-      
+
         <div
           data-h2-flex-item="b(1of1) m(1of2)"
           data-h2-display="b(flex)"
@@ -390,7 +390,7 @@
           </span>
           <p data-h2-margin="b(all, none)" style="flex: 1">Apporter des améliorations fondées sur les commentaires des utilisateurs.</p>
         </div>
-      
+
         <div
           data-h2-flex-item="b(1of1) m(1of2)"
           data-h2-display="b(flex)"
@@ -404,7 +404,7 @@
           </span>
           <p data-h2-margin="b(all, none)" style="flex: 1">Aider à répondre à la grande demande de talents numériques au sein du gouvernement du Canada.</p>
         </div>
-      
+
         <div
           data-h2-flex-item="b(1of1) m(1of2)"
           data-h2-display="b(flex)"
@@ -418,7 +418,7 @@
           </span>
           <p data-h2-margin="b(all, none)" style="flex: 1">Fournir une vue d’ensemble des talents disponibles qui cherchent à faire partie de #GCNumérique.</p>
         </div>
-      
+
         <div
           data-h2-flex-item="b(1of1) m(1of2)"
           data-h2-display="b(flex)"
@@ -432,13 +432,13 @@
           </span>
           <p data-h2-margin="b(all, none)" style="flex: 1">Appuyer les talents provenant de divers milieux pour qu’ils soient reconnus par les gestionnaires du GC.</p>
         </div>
-      
+
     </div>
   </div>
 </section>
- 
+
   <section data-h2-position="b(relative)" data-h2-padding="b(top-bottom, xxl)">
-  
+
   <div
       data-h2-bg-color='b(black)'
       data-h2-position="b(absolute)"
@@ -451,25 +451,25 @@
     data-h2-padding="b(top, m)">
     <div data-h2-flex-grid="b(stretch, expanded, flush, xl) m(stretch, expanded, flush, xl)">
       <div data-h2-flex-item="b(1of1)">
-         
-        
+
+
   <div data-h2-shadow="b(s)"
 
-  
+
     data-h2-bg-color="b(white)"
-  
+
   data-h2-padding="b(all, m) m(all, xl)"
   data-h2-radius="b(s)"
-  
+
     style="height: 100%;"
   >
-  
+
           <div
             data-h2-display="b(flex)"
             data-h2-align-items="b(center)"
             data-h2-text-align="b(center) m(left)"
             data-h2-padding="b(bottom, s) m(bottom, m)">
-            
+
               <div style="width: 4rem" data-h2-margin="m(right, m)">
   <img
     src="/assets/img/ui-icon-dt.svg"
@@ -478,23 +478,23 @@
   />
 </div>
 
-            
+
             <h2
-  
+
   data-h2-font-weight="b(200)"
   data-h2-font-size="b(h2)"
-  
-  
-  
-  
+
+
+
+
   style="letter-spacing: -2px;">
   Vous voulez en savoir plus sur #GCNumérique?
 </h2>
           </div>
-          
+
             <p>Êtes-vous curieux de savoir ce que fait le gouvernement du Canada pour offrir de meilleurs services numériques aux Canadiennes et aux Canadiens? Découvrez les <a href='https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/innovations-gouvernementales-numeriques.html' title='Découvrez comment le service public utilise la technologie.'>diverses technologies modernes et émergentes</a> que la fonction publique utilise. Découvrez les différents <a href='https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/reponse-numerique-du-gouvernement-du-canada-covid-19.html' title='En savoir plus sur l'outillage numérique.'>outils numériques</a> disponibles pour aider les Canadiennes et les Canadiens à accéder aux services et à obtenir de l’information sur la COVID‑19. Lisez des <a href='https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/la-vie-en-numerique.html' title='Lisez des histoires sur l'innovation dans le service public.'>articles</a> portant sur des idées et des initiatives avant-gardistes prises par des fonctionnaires de la collectivité du numérique du GC.</p>
-          
-        
+
+
 
   </div>
 
@@ -502,7 +502,7 @@
     </div>
   </div>
 </section>
- 
+
 
 <section data-h2-border="b([light]gray, top, solid, s)" data-h2-position="b(relative)" style="background: rgba(240, 240, 240, 1)" data-h2-overflow="b(x, hidden)">
   <footer data-h2-container="b(center, full)" data-h2-padding="b(top-bottom, l)">
@@ -511,7 +511,7 @@
         data-h2-flex-item="b(1of1) m(1of2)"
         data-h2-padding="b(left, xl)"
         data-h2-text-align="b(center) m(left)">
-        
+
           <nav>
             <ul
               style="gap: 1rem;"
@@ -520,40 +520,40 @@
               data-h2-flex-wrap="b(wrap)"
               data-h2-justify-content="b(center) m(flex-start)"
               data-h2-margin="b(bottom, xs)">
-              
+
               <li data-h2-display="b(inline-block)" data-h2-margin="b(top-bottom, none)">
-                
+
                   <a href="mailto:talent.cloud-nuage.de.talents@tbs-sct.gc.ca" title="Soumettre des commentaires au Nuage de talents du GC par courriel.">Retour d'information</a>
-                
+
               </li>
-              
+
               <li data-h2-display="b(inline-block)" data-h2-margin="b(top-bottom, none)">
-                
+
                   <a href="/fr/terms-and-conditions" title="Voir nos avis.">Avis</a>
-                
+
               </li>
-              
+
               <li data-h2-display="b(inline-block)" data-h2-margin="b(top-bottom, none)">
-                
+
                   <a href="/fr/privacy-notice" title="Voir notre politique de confidentialité.">Confidentialité</a>
-                
+
               </li>
-              
+
               <li data-h2-display="b(inline-block)" data-h2-margin="b(top-bottom, none)">
-                
+
                   <a href="/fr/https://www.canada.ca/fr.html" title="Visiter Canada.ca.">Canada.ca</a>
-                
+
               </li>
-              
+
             </ul>
           </nav>
-          <p 
+          <p
             data-h2-font-size="b(caption)"
-            data-h2-font-color="b(black)" 
+            data-h2-font-color="b(black)"
             data-h2-margin="b(bottom, none) b(top, m)">
             Date de modification: July 07, 2021
           </p>
-        
+
       </div>
       <div
         data-h2-flex-item="b(1of1) m(1of2)"


### PR DESCRIPTION
Resolves #2485 
On the Digital Community page (https://talent.canada.ca/en/communities/digital-talent), update the date from "Spring 2021" to "Summer 2022".

French:
"lancée au printemps 2021" -> "lancé à l'été 2022"

![image.png](https://images.zenhubusercontent.com/5dc084854553760001149b53/6d48f2f1-bc10-446e-aaa3-27e7f1338912)