### PR TITLE
Remove text from request summary page #2484

### DIFF
--- a/frontend/talentsearch/src/js/components/request/CreateRequest.tsx
+++ b/frontend/talentsearch/src/js/components/request/CreateRequest.tsx
@@ -335,13 +335,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
               },
             )}
           </p>
-          <p>
-            {intl.formatMessage({
-              defaultMessage:
-                "After you click submit, you will receive a confirmation email of your request.",
-              description: "Message before submit button on the request form.",
-            })}
-          </p>
+
           <div data-h2-flex-item="b(1of1)">
             <Button
               color="primary"


### PR DESCRIPTION

Resolves #2484 

Please remove the text indicated in the image from the search-request (summary?) page. This text is incorrect and does not need to be replaced by anything. Just take it out.

![image.png](https://images.zenhubusercontent.com/5dc084854553760001149b53/2bab36ac-b3d0-4904-bd4c-3f5fdf0b05fe)
