### PR TITLE
Remove urql Errors from Toasts

### DIFF
--- a/frontend/admin/src/js/components/ClientProvider.tsx
+++ b/frontend/admin/src/js/components/ClientProvider.tsx
@@ -129,11 +129,14 @@ export const ClientProvider: React.FC<{ client?: Client }> = ({
       createClient({
         url: apiUri,
         exchanges: [
-          errorExchange({
-            onError: (error: CombinedError) => {
-              toast.error(error.message);
-            },
-          }),
+          /**
+           * Commented out to stop urlq errors being displayed in toasts
+           */
+          //   errorExchange({
+          //     onError: (error: CombinedError) => {
+          //       toast.error(error.message);
+          //     },
+          //   }),
           dedupExchange,
           cacheExchange,
           authExchange({

--- a/frontend/admin/src/js/components/ClientProvider.tsx
+++ b/frontend/admin/src/js/components/ClientProvider.tsx
@@ -131,12 +131,17 @@ export const ClientProvider: React.FC<{ client?: Client }> = ({
         exchanges: [
           /**
            * Commented out to stop urlq errors being displayed in toasts
+           *
+           * TODO: Confirm errors are being logged on the server
+           * before removing console.error
            */
-          //   errorExchange({
-          //     onError: (error: CombinedError) => {
-          //       toast.error(error.message);
-          //     },
-          //   }),
+          errorExchange({
+            onError: (error: CombinedError) => {
+              // toast.error(error.message);
+              // eslint-disable-next-line no-console
+              console.error(error);
+            },
+          }),
           dedupExchange,
           cacheExchange,
           authExchange({


### PR DESCRIPTION
## Summary

We were piping all urql errors to the toasts, displaying them to users which caused two issues.

1. Unfriendly error messages were being displayed to users
2. Came in the form of a long JSON string with no spaces which caused overflow issues

## Solution

Stopped displaying the urql errors from the toasts since it is not friendly to users.

Resolves #2354 

## Recommendations 

### Logging of urql Errors

If we are not currently, we should be logging these errors.

### Toast Character Count Limit

While it is still a good idea we come up with a character limit for toasts, I believe it should be a fairly soft one since a test was done with > 800 characters and, while not ideal, the toast handled the large amount of text decently. I believe that the main issue here was the lack of spaces which causes the odd overflow issues. As long as we ensure that friendly errors messages are being displayed, a character limit becomes a lower priority.

<img width="1510" alt="toast-large" src="https://user-images.githubusercontent.com/4127998/164244199-8034e299-1b2e-4f54-a718-c1d93227e317.png">

