### PR TITLE
Font weight 100 too light on Firefox Linux #2441

### DIFF
--- a/frontend/admin/src/js/components/dashboard/Dashboard.tsx
+++ b/frontend/admin/src/js/components/dashboard/Dashboard.tsx
@@ -68,7 +68,7 @@ export const MenuLink: React.FC<MenuLinkProps> = ({
       <span
         {...(isActive(href, location.pathname)
           ? { "data-h2-font-weight": "b(700)" }
-          : { "data-h2-font-weight": "b(100)" })}
+          : { "data-h2-font-weight": "b(200)" })}
       >
         {text}
       </span>

--- a/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormWrapper.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormWrapper.tsx
@@ -62,7 +62,7 @@ const ProfileFormWrapper: React.FunctionComponent<ProfileFormWrapperProps> = ({
         <h1
           data-h2-margin="b(all, none)"
           data-h2-font-size="b(h2)"
-          data-h2-font-weight="b(100)"
+          data-h2-font-weight="b(200)"
         >
           {title}
         </h1>

--- a/frontend/talentsearch/src/js/components/search/SearchPools.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchPools.tsx
@@ -38,7 +38,7 @@ const SearchPools: React.FunctionComponent<SearchPoolsProps> = ({
         </p>
         <p
           data-h2-margin="b(top, xxs) b(bottom, m)"
-          data-h2-font-weight="b(100)"
+          data-h2-font-weight="b(200)"
         >
           {intl.formatMessage(
             {


### PR DESCRIPTION
Resolves #2441 
So, I know this is extremely niche but font weight 100 on Firefox in Linux (Pop OS) is too light to easily see.
image.png
When I bump it up to 200 it looks much better.
image.png
On Chromium in Linux and on Windows (Firefox, Chrome, and Edge) it looks heavier and there is no difference between 100 and 200. This makes me think that the font in Firefox in Linux ([Fira Sans](https://fonts.google.com/specimen/Fira+Sans)) is the only one that actually has font weight light enough to show a realistic 100. Could we bump all the uses of 100 up to 200?

 Test in Lighthouse for contrast ratio