### PR TITLE
Added smoke tests for setup scripts and docker environment

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -13,6 +13,9 @@ jobs:
       COMPOSE_DOCKER_CLI_BUILD: 1
       # Use buildkit to speed up docker command
       DOCKER_BUILDKIT: 1
+    defaults:
+      run:
+        working-directory: infrastructure
     steps:
       # This ensures only the most recently push commit will keep running.
       - name: Cancel other active runs of this workflow
@@ -24,13 +27,27 @@ jobs:
         uses: actions/checkout@v2.3.4
 
       - name: Serve app via docker-compose
-        working-directory: infrastructure
         run: docker-compose up --detach
 
-      - name: Run setup.sh
-        working-directory: infrastructure
+      - name: "Confirm fail response: 404 Not Found"
+        run: curl http://localhost:8000/talent --output /dev/null --silent --write-out "%{http_code}"  | grep 404 --quiet
+
+      - name: "Run: setup.sh"
         run: docker-compose run --rm maintenance bash setup.sh
 
-      - name: Run refresh_all.sh
-        working-directory: infrastructure
+      - name: "Confirm success response: setup.sh"
+        run: |
+          curl --silent http://localhost:8000/talent | grep /talent/app.js
+          curl --silent http://localhost:8000/admin | grep /admin/app.js
+          curl --silent http://localhost:8000/indigenous-it-apprentice | grep /indigenous-it-apprentice/app.js
+          curl --silent http://localhost:8000/en/talent-cloud | grep "GC Talent | Talent Cloud"
+
+      - name: "Run: refresh_all.sh"
         run: docker-compose run --rm maintenance bash refresh_all.sh
+
+      - name: "Confirm success response: refresh_all.sh"
+        run: |
+          curl --silent http://localhost:8000/talent | grep /talent/app.js
+          curl --silent http://localhost:8000/admin | grep /admin/app.js
+          curl --silent http://localhost:8000/indigenous-it-apprentice | grep /indigenous-it-apprentice/app.js
+          curl --silent http://localhost:8000/en/talent-cloud | grep "GC Talent | Talent Cloud"

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -13,9 +13,6 @@ jobs:
       COMPOSE_DOCKER_CLI_BUILD: 1
       # Use buildkit to speed up docker command
       DOCKER_BUILDKIT: 1
-    defaults:
-      run:
-        working-directory: infrastructure
     steps:
       # This ensures only the most recently push commit will keep running.
       - name: Cancel other active runs of this workflow
@@ -27,12 +24,16 @@ jobs:
         uses: actions/checkout@v2.3.4
 
       - name: Serve app via docker-compose
+        working-directory: infrastructure/
         run: docker-compose up --detach
 
-      - name: "Confirm non-200 response"
-        run: curl http://localhost:8000/talent --output /dev/null --silent --write-out "%{http_code}"  | grep --invert-match 200
+      - name: "Confirm failure response"
+        # Match any non-200 HTTP response code (301 or 404)
+        run: |
+          curl http://localhost:8000/talent --output /dev/null --silent --write-out "%{http_code}"  | grep --invert-match 200
 
       - name: "Run: setup.sh"
+        working-directory: infrastructure/
         run: docker-compose run --rm maintenance bash setup.sh
 
       - name: "Confirm success response: setup.sh"
@@ -42,7 +43,16 @@ jobs:
           curl --silent http://localhost:8000/indigenous-it-apprentice | grep /indigenous-it-apprentice/app.js
           curl --silent http://localhost:8000/en/talent-cloud | grep "GC Talent | Talent Cloud"
 
+      - name: Break web apps
+        run: rm frontend/*/dist/index.html
+
+      - name: "Confirm failure response"
+        # Match any non-200 HTTP response code (301 or 404)
+        run: |
+          curl http://localhost:8000/talent --output /dev/null --silent --write-out "%{http_code}"  | grep --invert-match 200
+
       - name: "Run: refresh_all.sh"
+        working-directory: infrastructure/
         run: docker-compose run --rm maintenance bash refresh_all.sh
 
       - name: "Confirm success response: refresh_all.sh"

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -69,6 +69,9 @@ jobs:
           curl --silent http://localhost:8000/admin | grep /admin/app.js
           curl --silent http://localhost:8000/indigenous-it-apprentice | grep /indigenous-it-apprentice/app.js
           curl --silent http://localhost:8000/en/talent-cloud | grep "GC Talent | Talent Cloud"
+          # Test that GraphQL API returns some data, and that the HTTP code is 200.
+          # See: https://www.apollographql.com/docs/apollo-server/monitoring/health-checks/#graphql-level-health-checks
+          curl "http://localhost:8000/graphql?query=\{__typename\}" --write-out "%{http_code}" --silent | grep '"data"' | grep 200
 
       - name: Break web apps
         run: rm frontend/*/dist/index.html
@@ -88,3 +91,6 @@ jobs:
           curl --silent http://localhost:8000/admin | grep /admin/app.js
           curl --silent http://localhost:8000/indigenous-it-apprentice | grep /indigenous-it-apprentice/app.js
           curl --silent http://localhost:8000/en/talent-cloud | grep "GC Talent | Talent Cloud"
+          # Test that GraphQL API returns some data, and that the HTTP code is 200.
+          # See: https://www.apollographql.com/docs/apollo-server/monitoring/health-checks/#graphql-level-health-checks
+          curl "http://localhost:8000/graphql?query=\{__typename\}" --write-out "%{http_code}" --silent | grep '"data"' | grep 200

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -9,6 +9,20 @@ on:
     paths-ignore:
       - '**.md'
 
+
+# Concurrency is used to cancel other currently-running jobs, to preserve
+# compute resources and cumulative build hours. (ie. If you push twice in a
+# row, this will cancel the previous run.)
+# See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
+concurrency:
+  # This scopes the group to:
+  # - the same workflow,
+  # - the same event type, and
+  # - the same branch name
+  # e.g., my-workflow-pull_request-feature/123-my-thing
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   run:
     # Platform recommended in cypress-io/github-action docs.
@@ -19,12 +33,6 @@ jobs:
       # Use buildkit to speed up docker command
       DOCKER_BUILDKIT: 1
     steps:
-      # This ensures only the most recently push commit will keep running.
-      - name: Cancel other active runs of this workflow
-        uses: rokroskar/workflow-run-cleanup-action@v0.3.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Checkout
         uses: actions/checkout@v2.3.4
 

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,11 +1,16 @@
-# Changes to workflow name require changes to badge URL in README.md
-name: Docker Smoke Test
+name: Docker Smoke Tests
 
 on:
   push:
+    branches: ["main"]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
 
 jobs:
-  cypress-run:
+  run:
     # Platform recommended in cypress-io/github-action docs.
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -23,6 +23,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
 
+      # This uses GitHub Action cache for docker container layers
+      # See: https://github.com/marketplace/actions/docker-layer-caching
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        # Ignore a failure of this step and avoid terminating the job.
+        continue-on-error: true
+        # By default, this cache is keyed to the workflow name. Consider
+        # setting a shared key if you'd like the docker cache to be shared
+        # across multiple workflows. (uncomment below)
+        #
+        #with:
+        #  key: some-shared-key-{hash}
+        #  restore-keys: |
+        #  some-shared-key-
+
       - name: Serve app via docker-compose
         working-directory: infrastructure/
         run: docker-compose up --detach

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Serve app via docker-compose
         run: docker-compose up --detach
 
-      - name: "Confirm fail response: 404 Not Found"
-        run: curl http://localhost:8000/talent --output /dev/null --silent --write-out "%{http_code}"  | grep 404 --quiet
+      - name: "Confirm non-200 response"
+        run: curl http://localhost:8000/talent --output /dev/null --silent --write-out "%{http_code}"  | grep --invert-match 200
 
       - name: "Run: setup.sh"
         run: docker-compose run --rm maintenance bash setup.sh

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,36 @@
+# Changes to workflow name require changes to badge URL in README.md
+name: Docker Smoke Test
+
+on:
+  push:
+
+jobs:
+  cypress-run:
+    # Platform recommended in cypress-io/github-action docs.
+    runs-on: ubuntu-20.04
+    env:
+      # Use native docker command within docker-compose
+      COMPOSE_DOCKER_CLI_BUILD: 1
+      # Use buildkit to speed up docker command
+      DOCKER_BUILDKIT: 1
+    steps:
+      # This ensures only the most recently push commit will keep running.
+      - name: Cancel other active runs of this workflow
+        uses: rokroskar/workflow-run-cleanup-action@v0.3.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Serve app via docker-compose
+        working-directory: infrastructure
+        run: docker-compose up --detach
+
+      - name: Run setup.sh
+        working-directory: infrastructure
+        run: docker-compose run --rm maintenance bash setup.sh
+
+      - name: Run refresh_all.sh
+        working-directory: infrastructure
+        run: docker-compose run --rm maintenance bash refresh_all.sh


### PR DESCRIPTION
Addresses https://github.com/GCTC-NTGC/gc-digital-talent/issues/2536

This does the following:
- creates a workflow that spins up the docker environment
- run it on pushes to "main" branch and any PRs, but skip if only markdown files have changed
- a series of tests are run that confirm:
  - there's no site served at first from /talent
  - the setup.sh completes successfully
  - a specific app successfully served for each of 4 paths after this
  - the app is broken intentionally and confirmed as such (deleting index.html)
  - the refresh_all.sh script completes successfully
  - a specific app successfully served for each of 4 paths after this
- this also adds docker layer caching between runs
- a little github action that cancels other running workflows, to keep two pushes from running at once (since this one's heavy)

### Open Questions
- is running setup.sh and refresh_all.sh good enough to give us confidence? Do we wish to add more or other scripts that might reasonably break on their own?