### PR TITLE
Fix null operational requriement handling for search

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -179,6 +179,11 @@ RAWSQL2;
     }
     public function filterByOperationalRequirements(Builder $query, ?array $operationalRequirements): Builder
     {
+        // if no filters provided then return query unchanged
+        if (empty($operationalRequirements)) {
+            return $query;
+        }
+
         // OperationalRequirements act as an AND filter. The query should only return candidates willing to accept ALL of the requirements.
             $query->whereJsonContains('accepted_operational_requirements', $operationalRequirements);
         return $query;

--- a/api/tests/Feature/PoolCandidateTest.php
+++ b/api/tests/Feature/PoolCandidateTest.php
@@ -144,7 +144,7 @@ class PoolCandidateTest extends TestCase
   {
     // Create initial data.
     PoolCandidate::factory()->count(5)->create([
-      'accepted_operational_requirements' => [],
+      'accepted_operational_requirements' => null,
     ]);
     $operationalRequirement1 = 'OVERTIME_SCHEDULED';
     $operationalRequirement2 = 'SHIFT_WORK';
@@ -172,6 +172,22 @@ class PoolCandidateTest extends TestCase
         'countPoolCandidates' => 9
       ]
     ]);
+
+     // Assert query with empty operationalRequirements filter will return all candidates
+     $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => [
+        'operationalRequirements' => []
+      ]
+    ])->assertJson([
+      'data' => [
+        'countPoolCandidates' => 9
+      ]
+    ]);
+
     // Assert query with one operationalRequirement filter will return correct candidate count
     $this->graphQL(/** @lang Graphql */ '
       query countPoolCandidates($where: PoolCandidateFilterInput) {


### PR DESCRIPTION
This branch adds a test to demonstrate, and a fix for, a search bug in the talent site.  If a pool candidate has a null field for operational requirement they are not returned when searching for candidates without an operational requirement filter.

The solution is simply to test for an empty filter clause and not populate the filter in the query.

I don't think any of the other fields have the same bug.  Only Work Locations uses the same JsonContains function and it works differently by building the query with a ForEach loop.

Closes #2516 