### PR TITLE
linting - type any

### DIFF
--- a/frontend/admin/src/js/adminConstants.ts
+++ b/frontend/admin/src/js/adminConstants.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// I believe this is essential as is
 export const ADMIN_APP_DIR = process.env.ADMIN_APP_DIR ?? "/admin";
 
 // eslint-disable-next-line no-underscore-dangle

--- a/frontend/admin/src/js/components/GlobalFilter.tsx
+++ b/frontend/admin/src/js/components/GlobalFilter.tsx
@@ -5,8 +5,8 @@ import "regenerator-runtime/runtime.js"; // This is required for useAsyncDebounc
 import { InputWrapper } from "@common/components/inputPartials";
 
 interface GlobalFilterProps {
-  globalFilter: any;
-  setGlobalFilter: any;
+  globalFilter: string | undefined;
+  setGlobalFilter: (val: string | undefined) => void;
 }
 
 const GlobalFilter: React.FC<GlobalFilterProps> = ({

--- a/frontend/admin/src/js/types/react-table-config.d.ts
+++ b/frontend/admin/src/js/types/react-table-config.d.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// disable due to not owned by us
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /*
 This file is seemingly required since (TypeScript) Type definitions are incomplete for sortable tables. #2970

--- a/frontend/common/src/components/form/BasicForm.tsx
+++ b/frontend/common/src/components/form/BasicForm.tsx
@@ -13,7 +13,8 @@ import {
 
 type BasicFormProps<TFieldValues extends FieldValues> = PropsWithChildren<{
   onSubmit: SubmitHandler<TFieldValues>;
-  options?: UseFormProps<TFieldValues, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options?: UseFormProps<TFieldValues, any>; // FieldValues deals in "any"
   cacheKey?: string; // If included, will cache form values in local storage and retrieve from there if possible.
 }>;
 

--- a/frontend/common/src/types/utilityTypes.ts
+++ b/frontend/common/src/types/utilityTypes.ts
@@ -27,6 +27,7 @@ type Join<T extends Primitive[], D extends string = "."> = T extends []
  * Turns an object type into the list of keys to primitive values,
  * with keys to nested objects represented by dot-notation.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type NestedPaths<T extends Record<string, any>> = Join<
   PathsToPrimitiveProps<T>,
   "."

--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -12,6 +12,10 @@ import {
   PoolCandidateFilterInput,
   Pool,
   UserPublicProfile,
+  KeyFilterInput,
+  PoolFilterInput,
+  ClassificationFilterInput,
+  Maybe,
 } from "../../api/generated";
 import { DIGITAL_CAREERS_POOL_KEY } from "../../talentSearchConstants";
 import EstimatedCandidates from "./EstimatedCandidates";
@@ -210,8 +214,14 @@ const candidateFilterToQueryArgs = (
 
   // Apply pick to each element of an array.
   const pickMap = (
-    list: any[] | null | undefined,
+    list:
+      | Maybe<Maybe<PoolFilterInput>[]>
+      | Maybe<Maybe<KeyFilterInput>[]>
+      | Maybe<Maybe<ClassificationFilterInput>[]>
+      | null
+      | undefined,
     keys: string | string[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): any[] | undefined => list?.map((item) => pick(item, keys));
 
   return {

--- a/frontend/talentsearch/src/js/types/react-table-config.d.ts
+++ b/frontend/talentsearch/src/js/types/react-table-config.d.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// not our file
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /*
 This file is seemingly required since (TypeScript) Type definitions are incomplete for sortable tables. #2970

--- a/frontend/talentsearch/src/js/types/utilityTypes.ts
+++ b/frontend/talentsearch/src/js/types/utilityTypes.ts
@@ -27,6 +27,7 @@ type Join<T extends Primitive[], D extends string = "."> = T extends []
  * Turns an object type into the list of keys to primitive values,
  * with keys to nested objects represented by dot-notation.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type NestedPaths<T extends Record<string, any>> = Join<
   PathsToPrimitiveProps<T>,
   "."


### PR DESCRIPTION
resolves #2487 

Some "ignores", some fixes. 
I would like to figure out a way to get rid of the remaining `any` in /searchContainer
