### PR TITLE
linting - jsx a11y errors

### DIFF
--- a/frontend/admin/.eslintrc
+++ b/frontend/admin/.eslintrc
@@ -64,15 +64,13 @@
         "react/require-default-props": "off",
         "react-hooks/rules-of-hooks": "error",
         "react-hooks/exhaustive-deps": "warn",
-        "jsx-a11y/label-has-associated-control": [
-            2,
-            {
-                "assert": "either",
-                "depth": 3
-            }
-        ],
+        "jsx-a11y/label-has-associated-control": [ 2, {
+            "labelComponents": ["CustomInputLabel"],
+            "labelAttributes": ["label"],
+            "controlComponents": ["CustomInput"],
+            "depth": 3
+          }],
         "no-param-reassign": "warn",
-        "jsx-a11y/label-has-for": "error",
         "jsx-a11y/no-noninteractive-element-to-interactive-role": [
             "error",
             {

--- a/frontend/admin/src/js/components/Table.tsx
+++ b/frontend/admin/src/js/components/Table.tsx
@@ -26,6 +26,7 @@ interface TableProps<
 const IndeterminateCheckbox: React.FC<
   React.HTMLProps<HTMLInputElement> & { indeterminate: boolean }
 > = ({ indeterminate, ...rest }) => {
+  const intl = useIntl();
   const ref = React.useRef<HTMLInputElement>(null);
 
   React.useEffect(() => {
@@ -34,7 +35,21 @@ const IndeterminateCheckbox: React.FC<
     }
   }, [ref, indeterminate]);
 
-  return <input type="checkbox" ref={ref} {...rest} />;
+  return (
+    <label htmlFor="column-fieldset-toggle-all">
+      <input
+        id="column-fieldset-toggle-all"
+        type="checkbox"
+        ref={ref}
+        {...rest}
+      />
+      {" "}
+      {intl.formatMessage({
+        defaultMessage: "Toggle All",
+        description: "Label displayed on the Table Columns toggle fieldset.",
+      })}
+    </label>
+  );
 };
 
 function Table<T extends Record<string, unknown>>({
@@ -114,23 +129,17 @@ function Table<T extends Record<string, unknown>>({
                     }}
                   >
                     <div>
-                      <label>
-                        <IndeterminateCheckbox
-                          {...(getToggleHideAllColumnsProps() as React.ComponentProps<
-                            typeof IndeterminateCheckbox
-                          >)}
-                        />{" "}
-                        {intl.formatMessage({
-                          defaultMessage: "Toggle All",
-                          description:
-                            "Label displayed on the Table Columns toggle fieldset.",
-                        })}
-                      </label>
+                      <IndeterminateCheckbox
+                        {...(getToggleHideAllColumnsProps() as React.ComponentProps<
+                          typeof IndeterminateCheckbox
+                        >)}
+                      />
                     </div>
                     {allColumns.map((column) => (
                       <div key={column.id}>
-                        <label>
+                        <label htmlFor={column.Header?.toString()}>
                           <input
+                            id={column.Header?.toString()}
                             type="checkbox"
                             {...column.getToggleHiddenProps()}
                           />{" "}

--- a/frontend/admin/src/js/components/Table.tsx
+++ b/frontend/admin/src/js/components/Table.tsx
@@ -42,8 +42,7 @@ const IndeterminateCheckbox: React.FC<
         type="checkbox"
         ref={ref}
         {...rest}
-      />
-      {" "}
+      />{" "}
       {intl.formatMessage({
         defaultMessage: "Toggle All",
         description: "Label displayed on the Table Columns toggle fieldset.",

--- a/frontend/common/.eslintrc
+++ b/frontend/common/.eslintrc
@@ -76,16 +76,14 @@
         ],
         "react/jsx-props-no-spreading": "off",
         "react/require-default-props": "off",
-        "jsx-a11y/label-has-for": "error",
         "react-hooks/rules-of-hooks": "error",
         "react-hooks/exhaustive-deps": "warn",
-        "jsx-a11y/label-has-associated-control": [
-            2,
-            {
-                "assert": "either",
-                "depth": 3
-            }
-        ],
+        "jsx-a11y/label-has-associated-control": [ 2, {
+            "labelComponents": ["CustomInputLabel"],
+            "labelAttributes": ["label"],
+            "controlComponents": ["CustomInput"],
+            "depth": 3
+          }],
         "no-param-reassign": "warn",
         "jsx-a11y/no-noninteractive-element-to-interactive-role": [
             "error",

--- a/frontend/common/src/components/form/Checkbox/Checkbox.tsx
+++ b/frontend/common/src/components/form/Checkbox/Checkbox.tsx
@@ -79,7 +79,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
             data-h2-align-items="b(center)"
             style={{ width: "100%" }}
           >
-            <label htmlFor={id}>
+            <label htmlFor={name}>
               <input
                 id={id}
                 {...register(name, rules)}

--- a/frontend/common/src/components/form/Checkbox/Checkbox.tsx
+++ b/frontend/common/src/components/form/Checkbox/Checkbox.tsx
@@ -79,7 +79,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
             data-h2-align-items="b(center)"
             style={{ width: "100%" }}
           >
-            <label htmlFor={name}>
+            <label htmlFor={id}>
               <input
                 id={id}
                 {...register(name, rules)}

--- a/frontend/common/src/components/form/Checkbox/Checkbox.tsx
+++ b/frontend/common/src/components/form/Checkbox/Checkbox.tsx
@@ -79,7 +79,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
             data-h2-align-items="b(center)"
             style={{ width: "100%" }}
           >
-            <label>
+            <label htmlFor={id}>
               <input
                 id={id}
                 {...register(name, rules)}

--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.stories.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.stories.tsx
@@ -11,17 +11,17 @@ const TemplateFieldset: Story<FieldsetProps> = (args) => {
   const { name } = args;
   return (
     <Fieldset {...args}>
-      <label data-h2-display="b(block)" htmlFor={name}>
+      <label data-h2-display="b(block)" htmlFor="one">
         One
-        <input type="checkbox" name={name} value="One" id={name} />
+        <input type="checkbox" name={name} value="One" id="one" />
       </label>
-      <label data-h2-display="b(block)" htmlFor={name}>
+      <label data-h2-display="b(block)" htmlFor="two">
         Two
-        <input type="checkbox" name={name} value="Two" id={name} />
+        <input type="checkbox" name={name} value="Two" id="two" />
       </label>
-      <label data-h2-display="b(block)" htmlFor={name}>
+      <label data-h2-display="b(block)" htmlFor="three">
         Three
-        <input type="checkbox" name={name} value="Three" id={name} />
+        <input type="checkbox" name={name} value="Three" id="three" />
       </label>
     </Fieldset>
   );

--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.stories.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.stories.tsx
@@ -11,17 +11,17 @@ const TemplateFieldset: Story<FieldsetProps> = (args) => {
   const { name } = args;
   return (
     <Fieldset {...args}>
-      <label data-h2-display="b(block)">
+      <label data-h2-display="b(block)" htmlFor={name}>
         One
-        <input type="checkbox" name={name} value="One" />
+        <input type="checkbox" name={name} value="One" id={name} />
       </label>
-      <label data-h2-display="b(block)">
+      <label data-h2-display="b(block)" htmlFor={name}>
         Two
-        <input type="checkbox" name={name} value="Two" />
+        <input type="checkbox" name={name} value="Two" id={name} />
       </label>
-      <label data-h2-display="b(block)">
+      <label data-h2-display="b(block)" htmlFor={name}>
         Three
-        <input type="checkbox" name={name} value="Three" />
+        <input type="checkbox" name={name} value="Three" id={name} />
       </label>
     </Fieldset>
   );

--- a/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
+++ b/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/label-has-for */
+// can't nest label around the input directly since separate files
 import React, { useState } from "react";
 import { QuestionMarkCircleIcon, XCircleIcon } from "@heroicons/react/solid";
 import { useIntl } from "react-intl";

--- a/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
+++ b/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/label-has-for */
-// can't nest label around the input directly since separate files
 import React, { useState } from "react";
 import { QuestionMarkCircleIcon, XCircleIcon } from "@heroicons/react/solid";
 import { useIntl } from "react-intl";

--- a/frontend/indigenousapprenticeship/.eslintrc
+++ b/frontend/indigenousapprenticeship/.eslintrc
@@ -70,16 +70,14 @@
         ],
         "react/jsx-props-no-spreading": "off",
         "react/require-default-props": "off",
-        "jsx-a11y/label-has-for": "error",
         "react-hooks/rules-of-hooks": "error",
         "react-hooks/exhaustive-deps": "warn",
-        "jsx-a11y/label-has-associated-control": [
-            2,
-            {
-                "assert": "either",
-                "depth": 3
-            }
-        ],
+        "jsx-a11y/label-has-associated-control": [ 2, {
+            "labelComponents": ["CustomInputLabel"],
+            "labelAttributes": ["label"],
+            "controlComponents": ["CustomInput"],
+            "depth": 3
+          }],
         "no-param-reassign": "warn",
         "jsx-a11y/no-noninteractive-element-to-interactive-role": [
             "error",

--- a/frontend/talentsearch/.eslintrc
+++ b/frontend/talentsearch/.eslintrc
@@ -72,7 +72,6 @@
         "react/require-default-props": "off",
         "react-hooks/rules-of-hooks": "error",
         "react-hooks/exhaustive-deps": "warn",
-        "jsx-a11y/label-has-for":"error",
         "jsx-a11y/label-has-associated-control": [
             2,
             {

--- a/frontend/talentsearch/.eslintrc
+++ b/frontend/talentsearch/.eslintrc
@@ -72,13 +72,12 @@
         "react/require-default-props": "off",
         "react-hooks/rules-of-hooks": "error",
         "react-hooks/exhaustive-deps": "warn",
-        "jsx-a11y/label-has-associated-control": [
-            2,
-            {
-                "assert": "either",
-                "depth": 3
-            }
-        ],
+        "jsx-a11y/label-has-associated-control": [ 2, {
+            "labelComponents": ["CustomInputLabel"],
+            "labelAttributes": ["label"],
+            "controlComponents": ["CustomInput"],
+            "depth": 3
+          }],
         "no-param-reassign": "warn",
         "jsx-a11y/no-noninteractive-element-to-interactive-role": [
             "error",

--- a/frontend/talentsearch/src/js/components/skills/SkillChecklist/SkillChecklist.tsx
+++ b/frontend/talentsearch/src/js/components/skills/SkillChecklist/SkillChecklist.tsx
@@ -38,7 +38,7 @@ const Family: React.FunctionComponent<FamilyProps> = ({
       data-h2-padding="b(all, xxs)"
       key={family.key}
     >
-      <label htmlFor={htmlForAssigner}>
+      <label>
         <input
           type="checkbox"
           id={htmlForAssigner}

--- a/frontend/talentsearch/src/js/components/skills/SkillChecklist/SkillChecklist.tsx
+++ b/frontend/talentsearch/src/js/components/skills/SkillChecklist/SkillChecklist.tsx
@@ -23,10 +23,9 @@ const Family: React.FunctionComponent<FamilyProps> = ({
 
   // generate the linguistically appropriate htmlFor, type checking requires a bit of a roundabout approach as [locale] evaluates to a type maybe
   let htmlForAssigner = "";
-  if (locale === "en"){
+  if (locale === "en") {
     htmlForAssigner = family.name.en ? family.name.en : "";
-  }
-  else {
+  } else {
     htmlForAssigner = family.name.fr ? family.name.fr : "";
   }
 
@@ -42,7 +41,7 @@ const Family: React.FunctionComponent<FamilyProps> = ({
       <label htmlFor={htmlForAssigner}>
         <input
           type="checkbox"
-          id={family.id}
+          id={htmlForAssigner}
           onChange={(e) => {
             callback(family, e.target.checked);
           }}

--- a/frontend/talentsearch/src/js/components/skills/SkillChecklist/SkillChecklist.tsx
+++ b/frontend/talentsearch/src/js/components/skills/SkillChecklist/SkillChecklist.tsx
@@ -21,6 +21,15 @@ const Family: React.FunctionComponent<FamilyProps> = ({
   const intl = useIntl();
   const locale = getLocale(intl);
 
+  // generate the linguistically appropriate htmlFor, type checking requires a bit of a roundabout approach as [locale] evaluates to a type maybe
+  let htmlForAssigner = "";
+  if (locale === "en"){
+    htmlForAssigner = family.name.en ? family.name.en : "";
+  }
+  else {
+    htmlForAssigner = family.name.fr ? family.name.fr : "";
+  }
+
   const uncheckedStyle = { "data-h2-font-weight": "b(400)" };
   const checkedStyle = { "data-h2-font-weight": "b(700)" };
 
@@ -30,7 +39,7 @@ const Family: React.FunctionComponent<FamilyProps> = ({
       data-h2-padding="b(all, xxs)"
       key={family.key}
     >
-      <label htmlFor={family.id}>
+      <label htmlFor={htmlForAssigner}>
         <input
           type="checkbox"
           id={family.id}

--- a/frontend/talentsearch/src/js/components/skills/SkillChecklist/SkillChecklist.tsx
+++ b/frontend/talentsearch/src/js/components/skills/SkillChecklist/SkillChecklist.tsx
@@ -30,15 +30,15 @@ const Family: React.FunctionComponent<FamilyProps> = ({
       data-h2-padding="b(all, xxs)"
       key={family.key}
     >
-      <input
-        type="checkbox"
-        id={family.id}
-        onChange={(e) => {
-          callback(family, e.target.checked);
-        }}
-      />
-      &nbsp;
       <label htmlFor={family.id}>
+        <input
+          type="checkbox"
+          id={family.id}
+          onChange={(e) => {
+            callback(family, e.target.checked);
+          }}
+        />
+        &nbsp;
         {family.name?.[locale]} ({family.skills ? family.skills.length : 0})
       </label>
     </div>

--- a/frontend/talentsearch/src/js/components/skills/SkillChecklist/SkillChecklist.tsx
+++ b/frontend/talentsearch/src/js/components/skills/SkillChecklist/SkillChecklist.tsx
@@ -21,14 +21,6 @@ const Family: React.FunctionComponent<FamilyProps> = ({
   const intl = useIntl();
   const locale = getLocale(intl);
 
-  // generate the linguistically appropriate htmlFor, type checking requires a bit of a roundabout approach as [locale] evaluates to a type maybe
-  let htmlForAssigner = "";
-  if (locale === "en") {
-    htmlForAssigner = family.name.en ? family.name.en : "";
-  } else {
-    htmlForAssigner = family.name.fr ? family.name.fr : "";
-  }
-
   const uncheckedStyle = { "data-h2-font-weight": "b(400)" };
   const checkedStyle = { "data-h2-font-weight": "b(700)" };
 
@@ -41,7 +33,6 @@ const Family: React.FunctionComponent<FamilyProps> = ({
       <label>
         <input
           type="checkbox"
-          id={htmlForAssigner}
           onChange={(e) => {
             callback(family, e.target.checked);
           }}


### PR DESCRIPTION
resolves #2563 

Think I got all them and fixed without things getting funky. One I'm not sure is properly fixable, it wants the label to nest around `<inputs>` and I think the input label being structured as it is makes it throw errors. To fix it might require refactoring the inputs group of components?