### PR TITLE
Bug - 2577 - fix classification not being removed when student

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -555,7 +555,8 @@ type Query {
     skills: [Skill]! @all
 }
 input ClassificationBelongsTo {
-    connect: ID!
+    connect: ID
+    disconnect: Boolean
 }
 input PoolsHasMany {
     create: [CreatePoolInput]

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -101,7 +101,8 @@ type Classification {
 }
 
 input ClassificationBelongsTo {
-  connect: ID!
+  connect: ID
+  disconnect: Boolean
 }
 
 input ClassificationBelongsToMany {

--- a/frontend/talentsearch/src/js/components/GovernmentInfoForm/GovernmentInfoForm.tsx
+++ b/frontend/talentsearch/src/js/components/GovernmentInfoForm/GovernmentInfoForm.tsx
@@ -57,7 +57,9 @@ const formValuesToSubmitData = (
       isGovEmployee: false,
       govEmployeeType: null,
       interestedInLaterOrSecondment: null,
-      currentClassification: null,
+      currentClassification: {
+        connect: null,
+      },
     };
   }
   if (values.govEmployeeType === GovEmployeeType.Student) {
@@ -65,7 +67,9 @@ const formValuesToSubmitData = (
       isGovEmployee: values.govEmployeeYesNo === "yes",
       govEmployeeType: values.govEmployeeType,
       interestedInLaterOrSecondment: null,
-      currentClassification: null,
+      currentClassification: {
+        disconnect: true,
+      },
     };
   }
   if (values.govEmployeeType === GovEmployeeType.Casual) {


### PR DESCRIPTION
## Summary

This fixes an issue when a user had previously set a classification under the Government Information and reset to student (who should not have a classification), the classification would not be disconnected from the user.

Resolves #2577 

### Changes

- Made the ClassificationBelongsTo connect argument optional
- Added a disconnect option to remove the relationship
- Updated form logic to disconnect when student was selected as type