### PR TITLE
Fix exhaustive deps linting errors

### DIFF
--- a/frontend/admin/.eslintrc
+++ b/frontend/admin/.eslintrc
@@ -63,7 +63,13 @@
         "react/jsx-props-no-spreading": "off",
         "react/require-default-props": "off",
         "react-hooks/rules-of-hooks": "error",
-        "react-hooks/exhaustive-deps": "warn",
+        "react-hooks/exhaustive-deps": [
+            "warn",
+            {
+                "additionalHooks":
+                    "(useDeepCompareEffect)"
+            }
+        ],
         "jsx-a11y/label-has-associated-control": [
             2,
             {

--- a/frontend/admin/src/js/components/dashboard/Dashboard.tsx
+++ b/frontend/admin/src/js/components/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext } from "react";
+import React, { ReactElement, useContext, useRef } from "react";
 import { useIntl } from "react-intl";
 import { useLocation, useRouter, RouterResult } from "@common/helpers/router";
 import { getLocale } from "@common/helpers/localize";
@@ -188,7 +188,9 @@ export const Dashboard: React.FC<{
   contentRoutes: Routes<RouterResult>;
 }> = ({ menuItems, contentRoutes }) => {
   const intl = useIntl();
-  const content = useRouter(contentRoutes, <AdminNotFound />);
+  // stabilize component that will not change during life of app, avoid render loops in router
+  const notFoundComponent = useRef(<AdminNotFound />);
+  const content = useRouter(contentRoutes, notFoundComponent.current);
   return (
     <>
       <a href="#main" data-h2-visibility="b(hidden)">

--- a/frontend/admin/src/js/components/searchRequest/SearchRequestTable.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SearchRequestTable.tsx
@@ -121,7 +121,7 @@ export const SearchRequestTable: React.FunctionComponent<
         accessor: ({ id }) => tableEditButtonAccessor(id, editUrlRoot),
       },
     ],
-    [intl, locale, editUrlRoot],
+    [intl, locale, paths, editUrlRoot],
   );
 
   const memoizedData = useMemo(

--- a/frontend/common/src/helpers/router.tsx
+++ b/frontend/common/src/helpers/router.tsx
@@ -115,7 +115,7 @@ export const useRouter = (
       .catch(async () => {
         setComponent(missingRouteComponent);
       });
-  }, [pathName, router]);
+  }, [missingRouteComponent, pathName, router]);
 
   return component;
 };

--- a/frontend/common/src/hooks/useDeepCompareEffect.ts
+++ b/frontend/common/src/hooks/useDeepCompareEffect.ts
@@ -18,6 +18,8 @@ export function useDeepCompareEffect(
   callback: EffectCallback,
   dependencies: DependencyList,
 ): void {
+  // this function was added to eslint so deps will be checked at the calling location
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(callback, dependencies.map(useDeepCompareMemoize));
 }
 

--- a/frontend/indigenousapprenticeship/.eslintrc
+++ b/frontend/indigenousapprenticeship/.eslintrc
@@ -72,7 +72,13 @@
         "react/require-default-props": "off",
         "jsx-a11y/label-has-for": "error",
         "react-hooks/rules-of-hooks": "error",
-        "react-hooks/exhaustive-deps": "warn",
+        "react-hooks/exhaustive-deps": [
+            "warn",
+            {
+                "additionalHooks":
+                    "(useDeepCompareEffect)"
+            }
+        ],
         "jsx-a11y/label-has-associated-control": [
             2,
             {

--- a/frontend/indigenousapprenticeship/src/js/components/PageContainer.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/PageContainer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useRef } from "react";
 import { Routes } from "universal-router";
 import { useIntl } from "react-intl";
 import NavMenu from "@common/components/NavMenu";
@@ -73,7 +73,9 @@ export const PageContainer: React.FC<{
   menuItems: ReactElement[];
   contentRoutes: Routes<RouterResult>;
 }> = ({ menuItems, contentRoutes }) => {
-  const content = useRouter(contentRoutes, <IndigenousApprenticeshipNotFound />);
+  // stabilize component that will not change during life of app, avoid render loops in router
+  const notFoundComponent = useRef(<IndigenousApprenticeshipNotFound />);
+  const content = useRouter(contentRoutes, notFoundComponent.current);
   return (
     <ScrollToTop>
       <div

--- a/frontend/talentsearch/.eslintrc
+++ b/frontend/talentsearch/.eslintrc
@@ -71,7 +71,13 @@
         "react/jsx-props-no-spreading": "off",
         "react/require-default-props": "off",
         "react-hooks/rules-of-hooks": "error",
-        "react-hooks/exhaustive-deps": "warn",
+        "react-hooks/exhaustive-deps": [
+            "warn",
+            {
+                "additionalHooks":
+                    "(useDeepCompareEffect)"
+            }
+        ],
         "jsx-a11y/label-has-for":"error",
         "jsx-a11y/label-has-associated-control": [
             2,

--- a/frontend/talentsearch/src/js/components/PageContainer.tsx
+++ b/frontend/talentsearch/src/js/components/PageContainer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useRef } from "react";
 import { Routes } from "universal-router";
 import { useIntl } from "react-intl";
 import NavMenu from "@common/components/NavMenu";
@@ -74,7 +74,9 @@ export const PageContainer: React.FC<{
   contentRoutes: Routes<RouterResult>;
 }> = ({ menuItems, contentRoutes }) => {
   const intl = useIntl();
-  const content = useRouter(contentRoutes, <TalentSearchNotFound />);
+  // stabilize component that will not change during life of app, avoid render loops in router
+  const notFoundComponent = useRef(<TalentSearchNotFound />);
+  const content = useRouter(contentRoutes, notFoundComponent.current);
   return (
     <ScrollToTop>
       <>

--- a/frontend/talentsearch/src/js/components/search/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchForm.tsx
@@ -152,13 +152,14 @@ export const SearchForm: React.FunctionComponent<SearchFormProps> = ({
 
   // Use deep comparison to prevent infinite re-rendering
   useDeepCompareEffect(() => {
-    submitDebounced.current(formValues);
+    const debouncingFunc = submitDebounced.current;
+    debouncingFunc(formValues);
     updateInitialValues(formValues);
     return () => {
       // Clear debounce timer when component unmounts
-      submitDebounced.current.clear();
+      debouncingFunc.clear();
     };
-  }, [formValues]);
+  }, [formValues, updateInitialValues]);
 
   const classificationOptions: Option<string>[] = useMemo(
     () =>

--- a/frontend/talentsearch/src/js/components/search/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchForm.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback } from "react";
+import React, { useMemo, useCallback, useRef } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
 import { Checklist, MultiSelect, RadioGroup } from "@common/components/form";
@@ -141,22 +141,22 @@ export const SearchForm: React.FunctionComponent<SearchFormProps> = ({
 
   // Whenever form values change (with some debounce allowance), call updateCandidateFilter
   const formValues = watch();
-  const submitDebounced = useCallback(
+  // Need just a single instance of the debounce function without dependencies.  It has internal state that shouldn't be lost between renders.
+  const submitDebounced = useRef(
     debounce((values: FormValues) => {
       if (updateCandidateFilter) {
         updateCandidateFilter(formValuesToData(values));
       }
     }, 200),
-    [formValuesToData, updateCandidateFilter],
   );
 
   // Use deep comparison to prevent infinite re-rendering
   useDeepCompareEffect(() => {
-    submitDebounced(formValues);
+    submitDebounced.current(formValues);
     updateInitialValues(formValues);
     return () => {
       // Clear debounce timer when component unmounts
-      submitDebounced.clear();
+      submitDebounced.current.clear();
     };
   }, [formValues]);
 


### PR DESCRIPTION
This branch addresses the [exhaustive deps](https://github.com/facebook/react/issues/14920) linting warnings we have in our code base.  I found four instances.

c6872c2a8d6d2b7e8e590d466b5f3c42e7179a98 solves the warning in router.tsx.  The solution provided is to stabilize the "not found" component in the parent by storing it in a ref.  This way it can be safely added to the dependency list without triggering continuous rendering.

8330f66cb16a336719b374b15446c230313e9c31 solves the warning in SearchRequestTable.tsx.  The missing dependency can be added without any issues.

aa27bdd4382b2e0c8ae0bc4115153895ee747cce solves the warning in SearchForm.tsx.  The solution provided stabilizes the debounce function in a ref.  The debounce function needs to be a single instance for the life of the component since it has its own internal state.  Once the instance is in a ref it does not need to be tracked as a dependency.

4496b6d5124beec141e64070b5c100681bf6aff7 solves the warning in useDeepCompareEffect.  I ended up disabling the warning here though it makes me a bit uneasy.  This function is essentially a wrapper around useEffect so I figured it wasn't too important to track the callback itself as a dependency since it was unlikely to change.  I did add useDeepCompareEffect to the eslint rules, though, so that proper checking can happen at the calling location.


Closes #2497