### PR TITLE
Add a template for creating new issues

### DIFF
--- a/.github/issue_template.yml
+++ b/.github/issue_template.yml
@@ -4,12 +4,13 @@ about: Use this template new features with links to prototypes.
 # These aren't used at the moment.
 # See: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repository
 title: null
-labels: null
+labels: feature
 assignees: null
 ---
 <sup>ℹ️ [Figma (root)][figma] | [Sitemap][sitemap]</sup>
 <sup>_This initial comment is collaborative and open to modification by all._</sup>
 
+## Description
 ## Screenshot: Prototype
 [![a screenshot of ...][image]][image-link]
 <sup>[Click screenshot to visit Figma.][image-link]</sup>

--- a/.github/issue_template.yml
+++ b/.github/issue_template.yml
@@ -1,0 +1,20 @@
+---
+name: New Feature (with prototype)
+about: Use this template new features with links to prototypes.
+# These aren't used at the moment.
+# See: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repository
+title: null
+labels: null
+assignees: null
+---
+## Screenshot: Prototype
+[![screenshot][screenshot]][figma]
+<sup>[Click screenshot to visit Figma.][figma]</sup>
+
+## Acceptance Criteria
+- [ ] ...
+
+<!-- Links -->
+   [screenshot]: https://user-images.githubusercontent.com/305339/166570935-6425a615-82c7-4b2f-9840-5c7d698fa2ab.png
+   [figma]: https://example.com
+<!-- Find your prototype via https://go.talent.c4nada.ca/figma and click "play button" ▷ in top-right. -->

--- a/.github/issue_template.yml
+++ b/.github/issue_template.yml
@@ -7,14 +7,19 @@ title: null
 labels: null
 assignees: null
 ---
+<sup>ℹ️ [Figma (root)][figma] | [Sitemap][sitemap]</sup>
+<sup>_This initial comment is collaborative and open to modification by all._</sup>
+
 ## Screenshot: Prototype
-[![screenshot][screenshot]][figma]
-<sup>[Click screenshot to visit Figma.][figma]</sup>
+[![a screenshot of ...][image]][image-link]
+<sup>[Click screenshot to visit Figma.][image-link]</sup>
 
 ## Acceptance Criteria
 - [ ] ...
 
 <!-- Links -->
-   [screenshot]: https://user-images.githubusercontent.com/305339/166570935-6425a615-82c7-4b2f-9840-5c7d698fa2ab.png
-   [figma]: https://example.com
+   [image]: https://user-images.githubusercontent.com/305339/166570935-6425a615-82c7-4b2f-9840-5c7d698fa2ab.png
+   [image-link]: https://example.com
+   [figma]: https://go.talent.c4nada.ca/figma
+   [sitemap]: https://go.talent.c4nada.ca/sitemap
 <!-- Find your prototype via https://go.talent.c4nada.ca/figma and click "play button" ▷ in top-right. -->


### PR DESCRIPTION
Just wanted to create a quick one. We can have a few, and this doesn't need to cover everything (a blank is always still an option).

Even if we create through ZenHub most of the time (and bypass GitHub's templates), this can be a file to copy-paste from for an idealized format.

<img width="867" alt="Screen Shot 2022-05-03 at 6 11 41 PM" src="https://user-images.githubusercontent.com/305339/166574674-a92a57a2-1ee8-4606-9a2a-a839351f453f.png">
