### PR TITLE
Linting - 2495 - no-resticted-exports

### DIFF
--- a/frontend/admin/src/js/components/searchRequest/SingleSearchRequest.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SingleSearchRequest.tsx
@@ -1,5 +1,6 @@
 import { getLocale } from "@common/helpers/localize";
-import SearchRequestFilters, {
+import {
+  SearchRequestFilters,
   FilterBlock,
 } from "@common/components/SearchRequestFilters";
 import * as React from "react";

--- a/frontend/common/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/frontend/common/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
 import { FilterIcon } from "@heroicons/react/solid";
-import Breadcrumbs, { BreadcrumbsProps } from "./Breadcrumbs";
+import Breadcrumbs from "./Breadcrumbs";
 
 export default {
   component: Breadcrumbs,

--- a/frontend/common/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/common/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -6,7 +6,7 @@ export interface BreadcrumbsProps {
   links: { title: string; href?: string; icon?: JSX.Element }[];
 }
 
-export const Breadcrumbs: React.FunctionComponent<BreadcrumbsProps> = ({
+const Breadcrumbs: React.FunctionComponent<BreadcrumbsProps> = ({
   links,
 }) => (
   <div data-h2-display="b(flex)">

--- a/frontend/common/src/components/Breadcrumbs/index.ts
+++ b/frontend/common/src/components/Breadcrumbs/index.ts
@@ -1,2 +1,5 @@
-export { default, Breadcrumbs } from "./Breadcrumbs";
-export type { BreadcrumbsProps } from "./Breadcrumbs";
+import Breadcrumbs from "./Breadcrumbs";
+import type { BreadcrumbsProps } from "./Breadcrumbs";
+
+export default Breadcrumbs;
+export type { BreadcrumbsProps };

--- a/frontend/common/src/components/Button/Button.stories.tsx
+++ b/frontend/common/src/components/Button/Button.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import { Button, ButtonProps } from "./Button";
+import Button from "./Button";
+import type { ButtonProps } from "./Button";
 
 export default {
   component: Button,

--- a/frontend/common/src/components/Button/Button.tsx
+++ b/frontend/common/src/components/Button/Button.tsx
@@ -104,7 +104,7 @@ export const colorMap: Record<
   },
 };
 
-export const Button: React.FC<ButtonProps> = ({
+const Button: React.FC<ButtonProps> = ({
   children,
   type,
   color,

--- a/frontend/common/src/components/Button/index.ts
+++ b/frontend/common/src/components/Button/index.ts
@@ -1,2 +1,5 @@
-export { default, Button } from "./Button";
-export type { ButtonProps, Color } from "./Button";
+import Button from "./Button";
+import type { ButtonProps, Color } from "./Button";
+
+export default Button;
+export type { ButtonProps, Color };

--- a/frontend/common/src/components/Chip/Chip.stories.tsx
+++ b/frontend/common/src/components/Chip/Chip.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
-import { Chip, ChipProps } from "./Chip";
+import Chip from "./Chip";
+import type { ChipProps } from "./Chip";
 
 export default {
   component: Chip,

--- a/frontend/common/src/components/Chip/Chip.tsx
+++ b/frontend/common/src/components/Chip/Chip.tsx
@@ -43,7 +43,7 @@ const colorMap: Record<
   },
 };
 
-export const Chip: React.FC<ChipProps> = ({
+const Chip: React.FC<ChipProps> = ({
   color,
   mode,
   onDismiss,

--- a/frontend/common/src/components/Chip/index.ts
+++ b/frontend/common/src/components/Chip/index.ts
@@ -1,1 +1,5 @@
-export { default, Chip } from "./Chip";
+import Chip from "./Chip";
+import type { ChipProps } from "./Chip";
+
+export default Chip;
+export type { ChipProps };

--- a/frontend/common/src/components/Dialog/index.ts
+++ b/frontend/common/src/components/Dialog/index.ts
@@ -1,2 +1,5 @@
-// eslint-disable-next-line no-restricted-exports
-export { default } from "./Dialog";
+import Dialog from "./Dialog";
+import type { DialogProps } from "./Dialog";
+
+export default Dialog;
+export type { DialogProps };

--- a/frontend/common/src/components/Footer/Footer.stories.tsx
+++ b/frontend/common/src/components/Footer/Footer.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
-import { Footer as FooterComponent } from "./Footer";
+import FooterComponent from "./Footer";
 
 export default {
   component: FooterComponent,

--- a/frontend/common/src/components/Footer/Footer.tsx
+++ b/frontend/common/src/components/Footer/Footer.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useIntl } from "react-intl";
 import { imageUrl } from "../../helpers/router";
 
-export const Footer: React.FunctionComponent<{
+const Footer: React.FunctionComponent<{
   baseUrl: string;
 }> = ({ baseUrl }) => {
   const intl = useIntl();

--- a/frontend/common/src/components/Footer/index.ts
+++ b/frontend/common/src/components/Footer/index.ts
@@ -1,1 +1,3 @@
-export { default, Footer } from "./Footer";
+import Footer from "./Footer";
+
+export default Footer;

--- a/frontend/common/src/components/Header/Header.stories.tsx
+++ b/frontend/common/src/components/Header/Header.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
-import { Header as HeaderComponent } from "./Header";
+import HeaderComponent from "./Header";
 
 export default {
   component: HeaderComponent,

--- a/frontend/common/src/components/Header/Header.tsx
+++ b/frontend/common/src/components/Header/Header.tsx
@@ -7,9 +7,11 @@ import {
 } from "../../helpers/localize";
 import { imageUrl, Link, useLocation } from "../../helpers/router";
 
-export const Header: React.FunctionComponent<{
+export interface HeaderProps {
   baseUrl: string;
-}> = ({ baseUrl }) => {
+}
+
+const Header: React.FunctionComponent<HeaderProps> = ({ baseUrl }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
 

--- a/frontend/common/src/components/Header/index.ts
+++ b/frontend/common/src/components/Header/index.ts
@@ -1,1 +1,5 @@
-export { default, Header } from "./Header";
+import Header from "./Header";
+import type { HeaderProps } from "./Header";
+
+export default Header;
+export type { HeaderProps };

--- a/frontend/common/src/components/LanguageRedirectContainer/LanguageRedirectContainer.tsx
+++ b/frontend/common/src/components/LanguageRedirectContainer/LanguageRedirectContainer.tsx
@@ -24,11 +24,15 @@ function guessLocale(): Locales {
   return "en";
 }
 
-type Messages = React.ComponentProps<typeof IntlProvider>["messages"];
+export type Messages = React.ComponentProps<typeof IntlProvider>["messages"];
 
-export const LanguageRedirectContainer: React.FC<{
+export interface LanguageRedirectContainerProps {
   getMessages: (locale: string) => Messages;
-}> = ({ getMessages, children }) => {
+}
+
+export const LanguageRedirectContainer: React.FC<
+  LanguageRedirectContainerProps
+> = ({ getMessages, children }) => {
   const location = useLocation();
 
   const pathLocale = getPathLocale(location.pathname);

--- a/frontend/common/src/components/LanguageRedirectContainer/index.ts
+++ b/frontend/common/src/components/LanguageRedirectContainer/index.ts
@@ -1,4 +1,8 @@
-export {
-  default,
-  LanguageRedirectContainer,
+import LanguageRedirectContainer from "./LanguageRedirectContainer";
+import type {
+  LanguageRedirectContainerProps,
+  Messages,
 } from "./LanguageRedirectContainer";
+
+export default LanguageRedirectContainer;
+export type { LanguageRedirectContainerProps, Messages };

--- a/frontend/common/src/components/Link/Link.stories.tsx
+++ b/frontend/common/src/components/Link/Link.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
-import { Link } from "./Link";
+import Link from "./Link";
 import type { LinkProps } from "./Link";
 
 export default {

--- a/frontend/common/src/components/Link/Link.tsx
+++ b/frontend/common/src/components/Link/Link.tsx
@@ -12,7 +12,7 @@ export interface LinkProps extends React.HTMLProps<HTMLAnchorElement> {
   type?: "button" | "link";
 }
 
-export const Link: React.FC<LinkProps> = ({
+const Link: React.FC<LinkProps> = ({
   href,
   title,
   color,

--- a/frontend/common/src/components/Link/index.ts
+++ b/frontend/common/src/components/Link/index.ts
@@ -1,1 +1,5 @@
-export { default, Link } from "./Link";
+import Link from "./Link";
+import type { LinkProps } from "./Link";
+
+export default Link;
+export type { LinkProps };

--- a/frontend/common/src/components/NavMenu/NavMenu.tsx
+++ b/frontend/common/src/components/NavMenu/NavMenu.tsx
@@ -1,8 +1,10 @@
 import React, { ReactElement } from "react";
 
-export const NavMenu: React.FunctionComponent<{
+export interface NavMenuProps {
   items: ReactElement[];
-}> = ({ items }) => {
+}
+
+const NavMenu: React.FunctionComponent<NavMenuProps> = ({ items }) => {
   return (
     <div data-h2-flex-grid="b(middle, contained, flush, xl)">
       <div

--- a/frontend/common/src/components/NavMenu/index.ts
+++ b/frontend/common/src/components/NavMenu/index.ts
@@ -1,1 +1,5 @@
-export { default, NavMenu } from "./NavMenu";
+import NavMenu from "./NavMenu";
+import type { NavMenuProps } from "./NavMenu";
+
+export default NavMenu;
+export type { NavMenuProps };

--- a/frontend/common/src/components/NotFound/index.ts
+++ b/frontend/common/src/components/NotFound/index.ts
@@ -1,2 +1,5 @@
-export { default } from "./NotFound";
-export type { NotFoundProps } from "./NotFound";
+import NotFound from "./NotFound";
+import type { NotFoundProps } from "./NotFound";
+
+export default NotFound;
+export type { NotFoundProps };

--- a/frontend/common/src/components/Pagination/Pagination.stories.tsx
+++ b/frontend/common/src/components/Pagination/Pagination.stories.tsx
@@ -4,7 +4,8 @@ import React from "react";
 import { usePaginationVars } from ".";
 import { Skill } from "../../api/generated";
 import { fakeSkills } from "../../fakeData";
-import Pagination, { PaginationProps } from "./Pagination";
+import Pagination from "./Pagination";
+import type { PaginationProps } from "./Pagination";
 
 export default {
   component: Pagination,

--- a/frontend/common/src/components/Pagination/index.ts
+++ b/frontend/common/src/components/Pagination/index.ts
@@ -1,3 +1,6 @@
-export { default } from "./Pagination";
-export type { PaginationProps } from "./Pagination";
+import Pagination from "./Pagination";
+import type { PaginationProps } from "./Pagination";
+
+export default Pagination;
+export type { PaginationProps };
 export { usePagination, usePaginationVars } from "./usePagination";

--- a/frontend/common/src/components/Pill/Pill.stories.tsx
+++ b/frontend/common/src/components/Pill/Pill.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
-import { Pill } from "./Pill";
+import Pill from "./Pill";
 import type { PillProps } from "./Pill";
 
 export default {

--- a/frontend/common/src/components/Pill/Pill.stories.tsx
+++ b/frontend/common/src/components/Pill/Pill.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
-import { Pill, PillProps } from "./Pill";
+import { Pill } from "./Pill";
+import type { PillProps } from "./Pill";
 
 export default {
   component: Pill,

--- a/frontend/common/src/components/Pill/Pill.tsx
+++ b/frontend/common/src/components/Pill/Pill.tsx
@@ -52,7 +52,7 @@ const colorMap: Record<
   },
 };
 
-export const Pill: React.FC<PillProps> = ({
+const Pill: React.FC<PillProps> = ({
   children,
   color,
   mode,

--- a/frontend/common/src/components/Pill/index.ts
+++ b/frontend/common/src/components/Pill/index.ts
@@ -1,1 +1,5 @@
-export { default, Pill } from "./Pill";
+import Pill from "./Pill";
+import type { PillProps } from "./Pill";
+
+export default Pill;
+export type { PillProps };

--- a/frontend/common/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/frontend/common/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -10,10 +10,12 @@ import {
 } from "../../constants/localizedConstants";
 import { getLocale } from "../../helpers/localize";
 
-export const FilterBlock: React.FunctionComponent<{
+export interface FilterBlockProps {
   title: string;
   content: Maybe<string> | Maybe<string[]>;
-}> = ({ title, content }) => {
+}
+
+const FilterBlock: React.FunctionComponent<FilterBlockProps> = ({ title, content }) => {
   const intl = useIntl();
   return (
     <div data-h2-padding="b(bottom, s)">
@@ -69,186 +71,188 @@ export const FilterBlock: React.FunctionComponent<{
   );
 };
 
-interface SearchRequestFiltersProps {
+export interface SearchRequestFiltersProps {
   poolCandidateFilter: Maybe<PoolCandidateFilter>;
 }
 
-export const SearchRequestFilters: React.FunctionComponent<SearchRequestFiltersProps> =
-  ({ poolCandidateFilter }) => {
-    const intl = useIntl();
-    const locale = getLocale(intl);
+const SearchRequestFilters: React.FunctionComponent<
+  SearchRequestFiltersProps
+> = ({ poolCandidateFilter }) => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
 
-    const classifications: string[] | undefined =
-      poolCandidateFilter?.classifications?.map(
-        (classification) =>
-          `${classification?.group.toLocaleUpperCase()}-0${
-            classification?.level
-          }`,
-      );
-    const educationLevel: string | undefined = poolCandidateFilter?.hasDiploma
-      ? intl.formatMessage({
-          defaultMessage: "Required diploma from post-secondary institution",
-          description:
-            "Education level message when candidate has a diploma found on the request page.",
-        })
-      : intl.formatMessage({
-          defaultMessage:
-            "Can accept a combination of work experience and education",
-          description:
-            "Education level message when candidate does not have a diploma found on the request page.",
-        });
-    const employmentEquity: string[] | undefined = [
-      ...(poolCandidateFilter?.isWoman
-        ? [
-            intl.formatMessage({
-              defaultMessage: "Woman",
-              description:
-                "Message for woman option in the employment equity section of the request page.",
-            }),
-          ]
-        : []),
-      ...(poolCandidateFilter?.isVisibleMinority
-        ? [
-            intl.formatMessage({
-              defaultMessage: "Visible Minority",
-              description:
-                "Message for visible minority option in the employment equity section of the request page.",
-            }),
-          ]
-        : []),
-      ...(poolCandidateFilter?.isIndigenous
-        ? [
-            intl.formatMessage({
-              defaultMessage: "Indigenous",
-              description:
-                "Message for indigenous option in the employment equity section of the request page.",
-            }),
-          ]
-        : []),
-      ...(poolCandidateFilter?.hasDisability
-        ? [
-            intl.formatMessage({
-              defaultMessage: "Disability",
-              description:
-                "Message for disability option in the employment equity section of the request page.",
-            }),
-          ]
-        : []),
-    ];
-    const operationalRequirementIds: string[] =
-      (poolCandidateFilter?.operationalRequirements as string[]) ?? [];
-    const operationalRequirements: string[] | undefined =
-      operationalRequirementIds.map((id) =>
-        intl.formatMessage(getOperationalRequirement(id)),
-      );
-    const workLocationIds: string[] =
-      (poolCandidateFilter?.workRegions as string[]) ?? [];
-    const workLocations: string[] | undefined = workLocationIds.map((id) =>
-      intl.formatMessage(getWorkRegion(id)),
+  const classifications: string[] | undefined =
+    poolCandidateFilter?.classifications?.map(
+      (classification) =>
+        `${classification?.group.toLocaleUpperCase()}-0${
+          classification?.level
+        }`,
     );
-    const languageAbility: string = poolCandidateFilter?.languageAbility
-      ? intl.formatMessage(
-          getLanguageAbility(poolCandidateFilter?.languageAbility),
-        )
-      : intl.formatMessage({
-          defaultMessage: "Any language",
-        });
-    const skills: string[] | undefined = poolCandidateFilter?.cmoAssets?.map(
-      (cmoAsset) =>
-        cmoAsset?.name[locale] ||
-        intl.formatMessage({
-          defaultMessage: "Error: skill name not found",
-          description:
-            "Error message when cmo asset name is not found on request page.",
-        }),
+  const educationLevel: string | undefined = poolCandidateFilter?.hasDiploma
+    ? intl.formatMessage({
+        defaultMessage: "Required diploma from post-secondary institution",
+        description:
+          "Education level message when candidate has a diploma found on the request page.",
+      })
+    : intl.formatMessage({
+        defaultMessage:
+          "Can accept a combination of work experience and education",
+        description:
+          "Education level message when candidate does not have a diploma found on the request page.",
+      });
+  const employmentEquity: string[] | undefined = [
+    ...(poolCandidateFilter?.isWoman
+      ? [
+          intl.formatMessage({
+            defaultMessage: "Woman",
+            description:
+              "Message for woman option in the employment equity section of the request page.",
+          }),
+        ]
+      : []),
+    ...(poolCandidateFilter?.isVisibleMinority
+      ? [
+          intl.formatMessage({
+            defaultMessage: "Visible Minority",
+            description:
+              "Message for visible minority option in the employment equity section of the request page.",
+          }),
+        ]
+      : []),
+    ...(poolCandidateFilter?.isIndigenous
+      ? [
+          intl.formatMessage({
+            defaultMessage: "Indigenous",
+            description:
+              "Message for indigenous option in the employment equity section of the request page.",
+          }),
+        ]
+      : []),
+    ...(poolCandidateFilter?.hasDisability
+      ? [
+          intl.formatMessage({
+            defaultMessage: "Disability",
+            description:
+              "Message for disability option in the employment equity section of the request page.",
+          }),
+        ]
+      : []),
+  ];
+  const operationalRequirementIds: string[] =
+    (poolCandidateFilter?.operationalRequirements as string[]) ?? [];
+  const operationalRequirements: string[] | undefined =
+    operationalRequirementIds.map((id) =>
+      intl.formatMessage(getOperationalRequirement(id)),
     );
-    const typeOfOpportunity = ""; // TODO: Replace with data fetched from api
+  const workLocationIds: string[] =
+    (poolCandidateFilter?.workRegions as string[]) ?? [];
+  const workLocations: string[] | undefined = workLocationIds.map((id) =>
+    intl.formatMessage(getWorkRegion(id)),
+  );
+  const languageAbility: string = poolCandidateFilter?.languageAbility
+    ? intl.formatMessage(
+        getLanguageAbility(poolCandidateFilter?.languageAbility),
+      )
+    : intl.formatMessage({
+        defaultMessage: "Any language",
+      });
+  const skills: string[] | undefined = poolCandidateFilter?.cmoAssets?.map(
+    (cmoAsset) =>
+      cmoAsset?.name[locale] ||
+      intl.formatMessage({
+        defaultMessage: "Error: skill name not found",
+        description:
+          "Error message when cmo asset name is not found on request page.",
+      }),
+  );
+  const typeOfOpportunity = ""; // TODO: Replace with data fetched from api
 
-    return (
-      <section data-h2-flex-grid="b(top, contained, flush, xs)">
-        <div
-          data-h2-flex-item="b(1of1) s(1of2)"
-          data-h2-border="s(lightgray, right, solid, s)"
-          style={{ paddingBottom: "0" }}
-        >
-          <div data-h2-padding="s(right, s)">
-            <FilterBlock
-              title={intl.formatMessage({
-                defaultMessage: "Group and level",
-                description:
-                  "Title for group and level on summary of filters section",
-              })}
-              content={classifications}
-            />
-            <FilterBlock
-              title={intl.formatMessage({
-                defaultMessage: "Education Level",
-                description:
-                  "Title for education level on summary of filters section",
-              })}
-              content={educationLevel}
-            />
-            <FilterBlock
-              title={intl.formatMessage({
-                defaultMessage: "Type of opportunity",
-                description:
-                  "Title for type of opportunity section on summary of filters section",
-              })}
-              content={typeOfOpportunity}
-            />
-            <FilterBlock
-              title={intl.formatMessage({
-                defaultMessage:
-                  "Conditions of employment / Operational requirements",
-                description:
-                  "Title for operational requirements section on summary of filters section",
-              })}
-              content={operationalRequirements}
-            />
-          </div>
+  return (
+    <section data-h2-flex-grid="b(top, contained, flush, xs)">
+      <div
+        data-h2-flex-item="b(1of1) s(1of2)"
+        data-h2-border="s(lightgray, right, solid, s)"
+        style={{ paddingBottom: "0" }}
+      >
+        <div data-h2-padding="s(right, s)">
+          <FilterBlock
+            title={intl.formatMessage({
+              defaultMessage: "Group and level",
+              description:
+                "Title for group and level on summary of filters section",
+            })}
+            content={classifications}
+          />
+          <FilterBlock
+            title={intl.formatMessage({
+              defaultMessage: "Education Level",
+              description:
+                "Title for education level on summary of filters section",
+            })}
+            content={educationLevel}
+          />
+          <FilterBlock
+            title={intl.formatMessage({
+              defaultMessage: "Type of opportunity",
+              description:
+                "Title for type of opportunity section on summary of filters section",
+            })}
+            content={typeOfOpportunity}
+          />
+          <FilterBlock
+            title={intl.formatMessage({
+              defaultMessage:
+                "Conditions of employment / Operational requirements",
+              description:
+                "Title for operational requirements section on summary of filters section",
+            })}
+            content={operationalRequirements}
+          />
         </div>
-        <div
-          data-h2-flex-item="b(1of1) s(1of2)"
-          data-h2-padding="s(left, xxl)"
-          style={{ paddingTop: "0" }}
-        >
-          <div data-h2-padding="s(left, xxl)">
-            <FilterBlock
-              title={intl.formatMessage({
-                defaultMessage: "Work Location",
-                description:
-                  "Title for work location section on summary of filters section",
-              })}
-              content={workLocations}
-            />
-            <FilterBlock
-              title={intl.formatMessage({
-                defaultMessage: "Work language ability",
-                description:
-                  "Title for work language on summary of filters section",
-              })}
-              content={languageAbility}
-            />
-            <FilterBlock
-              title={intl.formatMessage({
-                defaultMessage: "Employment equity",
-                description:
-                  "Title for employment equity section on summary of filters section",
-              })}
-              content={employmentEquity}
-            />
-            <FilterBlock
-              title={intl.formatMessage({
-                defaultMessage: "Skills",
-                description:
-                  "Title for skills section on summary of filters section",
-              })}
-              content={skills}
-            />
-          </div>
+      </div>
+      <div
+        data-h2-flex-item="b(1of1) s(1of2)"
+        data-h2-padding="s(left, xxl)"
+        style={{ paddingTop: "0" }}
+      >
+        <div data-h2-padding="s(left, xxl)">
+          <FilterBlock
+            title={intl.formatMessage({
+              defaultMessage: "Work Location",
+              description:
+                "Title for work location section on summary of filters section",
+            })}
+            content={workLocations}
+          />
+          <FilterBlock
+            title={intl.formatMessage({
+              defaultMessage: "Work language ability",
+              description:
+                "Title for work language on summary of filters section",
+            })}
+            content={languageAbility}
+          />
+          <FilterBlock
+            title={intl.formatMessage({
+              defaultMessage: "Employment equity",
+              description:
+                "Title for employment equity section on summary of filters section",
+            })}
+            content={employmentEquity}
+          />
+          <FilterBlock
+            title={intl.formatMessage({
+              defaultMessage: "Skills",
+              description:
+                "Title for skills section on summary of filters section",
+            })}
+            content={skills}
+          />
         </div>
-      </section>
-    );
-  };
+      </div>
+    </section>
+  );
+};
 
 export default SearchRequestFilters;
+export { FilterBlock };

--- a/frontend/common/src/components/SearchRequestFilters/index.ts
+++ b/frontend/common/src/components/SearchRequestFilters/index.ts
@@ -1,5 +1,3 @@
-export {
-  default,
-  SearchRequestFilters,
-  FilterBlock,
-} from "./SearchRequestFilters";
+import SearchRequestFilters, { FilterBlock } from "./SearchRequestFilters";
+
+export { SearchRequestFilters, FilterBlock };

--- a/frontend/common/src/components/Toast/Toast.tsx
+++ b/frontend/common/src/components/Toast/Toast.tsx
@@ -18,7 +18,7 @@ const CloseButton = ({
   closeToast: React.MouseEventHandler;
 }) => <XCircleIcon style={{ width: "1rem" }} onClick={closeToast} />;
 
-export const Toast: React.FunctionComponent = () => {
+const Toast: React.FunctionComponent = () => {
   return (
     <ToastContainer
       position="top-center"

--- a/frontend/common/src/components/Toast/index.ts
+++ b/frontend/common/src/components/Toast/index.ts
@@ -1,1 +1,3 @@
-export { default, Toast } from "./Toast";
+import Toast from "./Toast";
+
+export default Toast;

--- a/frontend/common/src/components/WordCounter/WordCounter.tsx
+++ b/frontend/common/src/components/WordCounter/WordCounter.tsx
@@ -9,7 +9,7 @@ export interface WordCounterProps {
   wordLimit: number;
 }
 
-export const WordCounter: React.FunctionComponent<WordCounterProps> = ({
+const WordCounter: React.FunctionComponent<WordCounterProps> = ({
   text,
   wordLimit,
   ...rest

--- a/frontend/common/src/components/WordCounter/index.ts
+++ b/frontend/common/src/components/WordCounter/index.ts
@@ -1,2 +1,5 @@
-export { default, WordCounter } from "./WordCounter";
-export type { WordCounterProps } from "./WordCounter";
+import WordCounter from "./WordCounter";
+import type { WordCounterProps } from "./WordCounter";
+
+export default WordCounter;
+export type { WordCounterProps };

--- a/frontend/common/src/components/accordion/Accordion.stories.tsx
+++ b/frontend/common/src/components/accordion/Accordion.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
 import { AcademicCapIcon } from "@heroicons/react/solid";
-import { Accordion as AccordionComponent, AccordionProps } from "./Accordion";
+import AccordionComponent from "./Accordion";
+import type { AccordionProps } from "./Accordion";
 import Button from "../Button";
 
 export default {

--- a/frontend/common/src/components/accordion/Accordion.stories.tsx
+++ b/frontend/common/src/components/accordion/Accordion.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Story, Meta } from "@storybook/react";
 import { AcademicCapIcon } from "@heroicons/react/solid";
 import { Accordion as AccordionComponent, AccordionProps } from "./Accordion";
-import { Button } from "../Button";
+import Button from "../Button";
 
 export default {
   component: AccordionComponent,

--- a/frontend/common/src/components/accordion/Accordion.tsx
+++ b/frontend/common/src/components/accordion/Accordion.tsx
@@ -11,7 +11,7 @@ export interface AccordionProps {
   children?: React.ReactNode;
 }
 
-export const Accordion: React.FC<AccordionProps> = ({
+const Accordion: React.FC<AccordionProps> = ({
   title,
   subtitle,
   context,

--- a/frontend/common/src/components/accordion/index.ts
+++ b/frontend/common/src/components/accordion/index.ts
@@ -1,2 +1,5 @@
-export { default, Accordion } from "./Accordion";
-export type { AccordionProps } from "./Accordion";
+import Accordion from "./Accordion";
+import type { AccordionProps } from "./Accordion";
+
+export default Accordion;
+export type { AccordionProps };

--- a/frontend/common/src/components/form/Checkbox/Checkbox.stories.tsx
+++ b/frontend/common/src/components/form/Checkbox/Checkbox.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import Checkbox, { CheckboxProps } from ".";
+import Checkbox from ".";
+import type { CheckboxProps } from ".";
+
 import Form from "../BasicForm";
 import Submit from "../Submit";
 

--- a/frontend/common/src/components/form/Checkbox/index.ts
+++ b/frontend/common/src/components/form/Checkbox/index.ts
@@ -1,2 +1,5 @@
-export { default, Checkbox } from "./Checkbox";
-export type { CheckboxProps } from "./Checkbox";
+import Checkbox from "./Checkbox";
+import type { CheckboxProps } from "./Checkbox";
+
+export default Checkbox;
+export type { CheckboxProps };

--- a/frontend/common/src/components/form/Checklist/Checklist.stories.tsx
+++ b/frontend/common/src/components/form/Checklist/Checklist.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import Checklist, { ChecklistProps } from ".";
+import Checklist from ".";
+import type { ChecklistProps } from ".";
 import Form from "../BasicForm";
 import Submit from "../Submit";
 

--- a/frontend/common/src/components/form/Checklist/Checklist.tsx
+++ b/frontend/common/src/components/form/Checklist/Checklist.tsx
@@ -34,7 +34,7 @@ export interface ChecklistProps {
  * Must be part of a form controlled by react-hook-form.
  * The form will represent the data at `name` as an array, containing the values of the checked boxes.
  */
-export const Checklist: React.FunctionComponent<ChecklistProps> = ({
+const Checklist: React.FunctionComponent<ChecklistProps> = ({
   idPrefix,
   legend,
   name,

--- a/frontend/common/src/components/form/Checklist/index.ts
+++ b/frontend/common/src/components/form/Checklist/index.ts
@@ -1,2 +1,5 @@
-export { default, Checklist } from "./Checklist";
-export type { ChecklistProps, Checkbox } from "./Checklist";
+import Checklist from "./Checklist";
+import type { ChecklistProps, Checkbox } from "./Checklist";
+
+export default Checklist;
+export type { ChecklistProps, Checkbox };

--- a/frontend/common/src/components/form/Input/Input.stories.tsx
+++ b/frontend/common/src/components/form/Input/Input.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import Input, { InputProps } from ".";
+import Input from ".";
+import type { InputProps } from ".";
 import Form from "../BasicForm";
 import Submit from "../Submit";
 import { phoneNumberRegex } from "../../../constants/regularExpressions";

--- a/frontend/common/src/components/form/Input/Input.tsx
+++ b/frontend/common/src/components/form/Input/Input.tsx
@@ -25,7 +25,7 @@ export interface InputProps
   errorPosition?: "top" | "bottom";
 }
 
-export const Input: React.FunctionComponent<InputProps> = ({
+const Input: React.FunctionComponent<InputProps> = ({
   id,
   context,
   label,

--- a/frontend/common/src/components/form/Input/index.ts
+++ b/frontend/common/src/components/form/Input/index.ts
@@ -1,2 +1,5 @@
-export { default, Input } from "./Input";
-export type { InputProps } from "./Input";
+import Input from "./Input";
+import type { InputProps } from "./Input";
+
+export default Input;
+export type { InputProps };

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.stories.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.stories.tsx
@@ -4,7 +4,8 @@ import { uniqueId } from "lodash";
 import React from "react";
 import Form from "../BasicForm";
 import Submit from "../Submit";
-import MultiSelect, { MultiSelectProps } from "./MultiSelect";
+import MultiSelect from "./MultiSelect";
+import type { MultiSelectProps } from ".";
 
 export default {
   component: MultiSelect,

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
@@ -4,6 +4,7 @@ import ReactSelect from "react-select";
 import { InputWrapper } from "../../inputPartials";
 
 export type Option = { value: string | number; label: string };
+
 export interface MultiSelectProps
   extends React.SelectHTMLAttributes<HTMLSelectElement> {
   /** HTML id used to identify the element. */
@@ -22,7 +23,7 @@ export interface MultiSelectProps
   placeholder?: string;
 }
 
-export const MultiSelect: React.FunctionComponent<MultiSelectProps> = ({
+const MultiSelect: React.FunctionComponent<MultiSelectProps> = ({
   id,
   context,
   label,

--- a/frontend/common/src/components/form/MultiSelect/index.ts
+++ b/frontend/common/src/components/form/MultiSelect/index.ts
@@ -1,2 +1,5 @@
-export { default, MultiSelect } from "./MultiSelect";
-export type { Option } from "./MultiSelect";
+import MultiSelect from "./MultiSelect";
+import type { MultiSelectProps, Option } from "./MultiSelect";
+
+export default MultiSelect;
+export type { MultiSelectProps, Option };

--- a/frontend/common/src/components/form/Radio/Radio.stories.tsx
+++ b/frontend/common/src/components/form/Radio/Radio.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import Radio, { RadioProps } from ".";
+import Radio from ".";
+import type { RadioProps } from ".";
 import Form from "../BasicForm";
 import Submit from "../Submit";
 

--- a/frontend/common/src/components/form/Radio/Radio.tsx
+++ b/frontend/common/src/components/form/Radio/Radio.tsx
@@ -20,7 +20,7 @@ export interface RadioProps
   context?: string;
 }
 
-export const Radio: React.FunctionComponent<RadioProps> = ({
+const Radio: React.FunctionComponent<RadioProps> = ({
   id,
   label,
   name,

--- a/frontend/common/src/components/form/Radio/index.ts
+++ b/frontend/common/src/components/form/Radio/index.ts
@@ -1,2 +1,5 @@
-export { default, Radio } from "./Radio";
-export type { RadioProps } from "./Radio";
+import Radio from "./Radio";
+import type { RadioProps } from "./Radio";
+
+export default Radio;
+export type { RadioProps };

--- a/frontend/common/src/components/form/RadioGroup/RadioGroup.stories.tsx
+++ b/frontend/common/src/components/form/RadioGroup/RadioGroup.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import RadioGroup, { RadioGroupProps } from ".";
+import RadioGroup from ".";
+import type { RadioGroupProps } from ".";
 import Form from "../BasicForm";
 import Submit from "../Submit";
 

--- a/frontend/common/src/components/form/RadioGroup/RadioGroup.tsx
+++ b/frontend/common/src/components/form/RadioGroup/RadioGroup.tsx
@@ -33,7 +33,7 @@ export interface RadioGroupProps {
  * Must be part of a form controlled by react-hook-form.
  * The form will represent the data at `name` as an array, containing the values of the checked boxes.
  */
-export const RadioGroup: React.FunctionComponent<RadioGroupProps> = ({
+const RadioGroup: React.FunctionComponent<RadioGroupProps> = ({
   idPrefix,
   legend,
   name,

--- a/frontend/common/src/components/form/RadioGroup/index.ts
+++ b/frontend/common/src/components/form/RadioGroup/index.ts
@@ -1,2 +1,5 @@
-export { default, RadioGroup } from "./RadioGroup";
-export type { RadioGroupProps, Radio } from "./RadioGroup";
+import RadioGroup from "./RadioGroup";
+import type { RadioGroupProps, Radio } from "./RadioGroup";
+
+export default RadioGroup;
+export type { RadioGroupProps, Radio };

--- a/frontend/common/src/components/form/Select/Select.stories.tsx
+++ b/frontend/common/src/components/form/Select/Select.stories.tsx
@@ -3,7 +3,8 @@ import { Story, Meta } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import uniqueId from "lodash/uniqueId";
 import Form from "../BasicForm";
-import Select, { SelectProps } from ".";
+import Select from ".";
+import type { SelectProps } from ".";
 import Submit from "../Submit";
 
 export default {

--- a/frontend/common/src/components/form/Select/Select.tsx
+++ b/frontend/common/src/components/form/Select/Select.tsx
@@ -21,7 +21,7 @@ export interface SelectProps
   nullSelection?: string;
 }
 
-export const Select: React.FunctionComponent<SelectProps> = ({
+const Select: React.FunctionComponent<SelectProps> = ({
   id,
   label,
   name,

--- a/frontend/common/src/components/form/Select/index.ts
+++ b/frontend/common/src/components/form/Select/index.ts
@@ -1,2 +1,5 @@
-export { default, Select } from "./Select";
-export type { SelectProps } from "./Select";
+import Select from "./Select";
+import type { SelectProps } from "./Select";
+
+export default Select;
+export type { SelectProps };

--- a/frontend/common/src/components/form/Submit/Submit.tsx
+++ b/frontend/common/src/components/form/Submit/Submit.tsx
@@ -3,13 +3,22 @@ import { useFormState } from "react-hook-form";
 import { useIntl } from "react-intl";
 import { Button } from "../..";
 
-export const Submit: React.FunctionComponent<{
+export interface SubmitProps {
   text?: string | React.ReactNode;
   submittedText?: string | React.ReactNode;
   isSubmittingText?: string | React.ReactNode;
   color?: "primary" | "secondary" | "cta" | "white";
   mode?: "solid" | "outline" | "inline";
-}> = ({ text, submittedText, isSubmittingText, color, mode, ...rest }) => {
+}
+
+const Submit: React.FunctionComponent<SubmitProps> = ({
+  text,
+  submittedText,
+  isSubmittingText,
+  color,
+  mode,
+  ...rest
+}) => {
   const intl = useIntl();
   const defaultText = intl.formatMessage({
     defaultMessage: "Submit",

--- a/frontend/common/src/components/form/Submit/index.ts
+++ b/frontend/common/src/components/form/Submit/index.ts
@@ -1,1 +1,5 @@
-export { default, Submit } from "./Submit";
+import Submit from "./Submit";
+import type { SubmitProps } from "./Submit";
+
+export default Submit;
+export type { SubmitProps };

--- a/frontend/common/src/components/form/TextArea/TextArea.stories.tsx
+++ b/frontend/common/src/components/form/TextArea/TextArea.stories.tsx
@@ -3,7 +3,8 @@ import { action } from "@storybook/addon-actions";
 import { Meta, Story } from "@storybook/react";
 import Form from "../BasicForm";
 import Submit from "../Submit";
-import TextArea, { TextAreaProps } from ".";
+import TextArea from ".";
+import type { TextAreaProps } from ".";
 
 export default {
   component: TextArea,

--- a/frontend/common/src/components/form/TextArea/TextArea.tsx
+++ b/frontend/common/src/components/form/TextArea/TextArea.tsx
@@ -17,7 +17,7 @@ export interface TextAreaProps
   rules?: RegisterOptions;
 }
 
-export const TextArea: React.FunctionComponent<TextAreaProps> = ({
+const TextArea: React.FunctionComponent<TextAreaProps> = ({
   id,
   context,
   label,

--- a/frontend/common/src/components/form/TextArea/index.ts
+++ b/frontend/common/src/components/form/TextArea/index.ts
@@ -1,2 +1,5 @@
-export { default, TextArea } from "./TextArea";
-export type { TextAreaProps } from "./TextArea";
+import TextArea from "./TextArea";
+import type { TextAreaProps } from "./TextArea";
+
+export default TextArea;
+export type { TextAreaProps };

--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.stories.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
-import { Fieldset } from "./Fieldset";
+import Fieldset from "./Fieldset";
 import type { FieldsetProps } from "./Fieldset";
 
 export default {

--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.stories.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
-import { Fieldset, FieldsetProps } from "./Fieldset";
+import { Fieldset } from "./Fieldset";
+import type { FieldsetProps } from "./Fieldset";
 
 export default {
   component: Fieldset,

--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
@@ -22,7 +22,7 @@ export interface FieldsetProps {
   hideOptional?: boolean;
 }
 
-export const Fieldset: React.FC<FieldsetProps> = ({
+const Fieldset: React.FC<FieldsetProps> = ({
   legend,
   name,
   required,

--- a/frontend/common/src/components/inputPartials/Fieldset/index.ts
+++ b/frontend/common/src/components/inputPartials/Fieldset/index.ts
@@ -1,2 +1,5 @@
-export { default, Fieldset } from "./Fieldset";
-export type { FieldsetProps } from "./Fieldset";
+import Fieldset from "./Fieldset";
+import type { FieldsetProps } from "./Fieldset";
+
+export default Fieldset;
+export type { FieldsetProps };

--- a/frontend/common/src/components/inputPartials/InputContext/InputContext.tsx
+++ b/frontend/common/src/components/inputPartials/InputContext/InputContext.tsx
@@ -1,20 +1,27 @@
 import React from "react";
 
-export const InputContext: React.FC<{ isVisible: boolean; context: string }> =
-  ({ context, isVisible }) => {
-    return isVisible ? (
-      <span
-        data-h2-display="b(block)"
-        data-h2-radius="b(s)"
-        data-h2-bg-color="b(lightpurple[.1])"
-        data-h2-padding="b(all, xs)"
-        data-h2-font-color="b(lightpurple)"
-        data-h2-font-size="b(caption)"
-        role="alert"
-      >
-        {context}
-      </span>
-    ) : null;
-  };
+export interface InputContextProps {
+  isVisible: boolean;
+  context: string;
+}
+
+export const InputContext: React.FC<InputContextProps> = ({
+  context,
+  isVisible,
+}) => {
+  return isVisible ? (
+    <span
+      data-h2-display="b(block)"
+      data-h2-radius="b(s)"
+      data-h2-bg-color="b(lightpurple[.1])"
+      data-h2-padding="b(all, xs)"
+      data-h2-font-color="b(lightpurple)"
+      data-h2-font-size="b(caption)"
+      role="alert"
+    >
+      {context}
+    </span>
+  ) : null;
+};
 
 export default InputContext;

--- a/frontend/common/src/components/inputPartials/InputContext/index.ts
+++ b/frontend/common/src/components/inputPartials/InputContext/index.ts
@@ -1,1 +1,5 @@
-export { default, InputContext } from "./InputContext";
+import InputContext from "./InputContext";
+import type { InputContextProps } from "./InputContext";
+
+export default InputContext;
+export type { InputContextProps };

--- a/frontend/common/src/components/inputPartials/InputError/InputError.tsx
+++ b/frontend/common/src/components/inputPartials/InputError/InputError.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 
-export const InputError: React.FC<{ isVisible: boolean; error: string }> = ({
-  error,
-  isVisible,
-}) => {
+export interface InputErrorProps {
+  isVisible: boolean;
+  error: string;
+}
+
+const InputError: React.FC<InputErrorProps> = ({ error, isVisible }) => {
   return isVisible ? (
     <span
       data-h2-display="b(block)"

--- a/frontend/common/src/components/inputPartials/InputError/index.ts
+++ b/frontend/common/src/components/inputPartials/InputError/index.ts
@@ -1,1 +1,5 @@
-export { default, InputError } from "./InputError";
+import InputError from "./InputError";
+import type { InputErrorProps } from "./InputError";
+
+export default InputError;
+export type { InputErrorProps };

--- a/frontend/common/src/components/inputPartials/InputLabel/InputLabel.stories.tsx
+++ b/frontend/common/src/components/inputPartials/InputLabel/InputLabel.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import InputLabel, { InputLabelProps } from "./InputLabel";
+import InputLabel from "./InputLabel";
+import type { InputLabelProps } from "./InputLabel";
 
 export default {
   component: InputLabel,

--- a/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
+++ b/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
@@ -12,7 +12,7 @@ export interface InputLabelProps {
   hideOptional?: boolean;
 }
 
-export const InputLabel: React.FC<InputLabelProps> = ({
+const InputLabel: React.FC<InputLabelProps> = ({
   inputId,
   label,
   required,

--- a/frontend/common/src/components/inputPartials/InputLabel/index.ts
+++ b/frontend/common/src/components/inputPartials/InputLabel/index.ts
@@ -1,2 +1,5 @@
-export { default, InputLabel } from "./InputLabel";
-export type { InputLabelProps } from "./InputLabel";
+import InputLabel from "./InputLabel";
+import type { InputLabelProps } from "./InputLabel";
+
+export default InputLabel;
+export type { InputLabelProps };

--- a/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.stories.tsx
+++ b/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
-import { InputWrapper } from "./InputWrapper";
+import InputWrapper from "./InputWrapper";
 import type { InputWrapperProps } from "./InputWrapper";
 
 export default {

--- a/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.stories.tsx
+++ b/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
-import { InputWrapper, InputWrapperProps } from "./InputWrapper";
+import { InputWrapper } from "./InputWrapper";
+import type { InputWrapperProps } from "./InputWrapper";
 
 export default {
   component: InputWrapper,

--- a/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
+++ b/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
@@ -13,7 +13,7 @@ export interface InputWrapperProps {
   hideOptional?: boolean;
 }
 
-export const InputWrapper: React.FC<InputWrapperProps> = ({
+const InputWrapper: React.FC<InputWrapperProps> = ({
   inputId,
   label,
   required,

--- a/frontend/common/src/components/inputPartials/InputWrapper/index.ts
+++ b/frontend/common/src/components/inputPartials/InputWrapper/index.ts
@@ -1,2 +1,5 @@
-export { default, InputWrapper } from "./InputWrapper";
-export type { InputWrapperProps } from "./InputWrapper";
+import InputWrapper from "./InputWrapper";
+import type { InputWrapperProps } from "./InputWrapper";
+
+export default InputWrapper;
+export type { InputWrapperProps };

--- a/frontend/common/src/components/tabs/Tab.tsx
+++ b/frontend/common/src/components/tabs/Tab.tsx
@@ -32,7 +32,7 @@ export interface TabProps extends React.HTMLProps<HTMLElement> {
   onToggleOpen?: VoidFunction;
 }
 
-export const Tab: React.FC<TabProps> = ({
+const Tab: React.FC<TabProps> = ({
   icon,
   iconOpen,
   iconClosed,
@@ -149,4 +149,5 @@ export const Tab: React.FC<TabProps> = ({
 
   return assembledTab;
 };
+
 export default Tab;

--- a/frontend/common/src/components/tabs/TabSet.tsx
+++ b/frontend/common/src/components/tabs/TabSet.tsx
@@ -18,7 +18,7 @@ const firstSelectableTab = (tabs: React.ReactElement<TabProps>[]): number => {
   return firstIndex >= 0 ? firstIndex : 0;
 };
 
-export const TabSet: React.FC<TabSetProps> = ({
+const TabSet: React.FC<TabSetProps> = ({
   children,
 }): React.ReactElement => {
   const [tabSetState, setTabSetState] = useState<TabSetState>({

--- a/frontend/common/src/components/tabs/index.ts
+++ b/frontend/common/src/components/tabs/index.ts
@@ -1,3 +1,7 @@
-export { TabSet } from "./TabSet";
-export { Tab } from "./Tab";
-export type { TabSetProps } from "./TabSet";
+import TabSet from "./TabSet";
+import Tab from "./Tab";
+import type { TabProps } from "./Tab";
+import type { TabSetProps } from "./TabSet";
+
+export { Tab, TabSet };
+export type { TabSetProps, TabProps };

--- a/frontend/common/src/components/tabs/tabs.stories.tsx
+++ b/frontend/common/src/components/tabs/tabs.stories.tsx
@@ -6,7 +6,8 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
 } from "@heroicons/react/solid";
-import { TabSet, Tab, TabSetProps } from ".";
+import { TabSet, Tab } from ".";
+import type { TabSetProps } from ".";
 
 export default {
   component: TabSet,

--- a/frontend/common/src/lang/index.ts
+++ b/frontend/common/src/lang/index.ts
@@ -1,1 +1,3 @@
-export { default } from "./frCompiled.json";
+import frCompiled from "./frCompiled.json";
+
+export default frCompiled;

--- a/frontend/talentsearch/src/js/components/ExperienceAccordion/ExperienceAccordion.tsx
+++ b/frontend/talentsearch/src/js/components/ExperienceAccordion/ExperienceAccordion.tsx
@@ -1,7 +1,7 @@
 // Using graphql __TypeName property for type guard discriminator
 /* eslint-disable no-underscore-dangle */
 import React from "react";
-import { Accordion } from "@common/components/accordion/Accordion";
+import Accordion from "@common/components/accordion/Accordion";
 import { useIntl } from "react-intl";
 import AwardAccordion from "./individualExperienceAccordions/AwardAccordion";
 import CommunityAccordion from "./individualExperienceAccordions/CommunityAccordion";

--- a/frontend/talentsearch/src/js/components/ExperienceAccordion/individualExperienceAccordions/AwardAccordion.tsx
+++ b/frontend/talentsearch/src/js/components/ExperienceAccordion/individualExperienceAccordions/AwardAccordion.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Accordion } from "@common/components/accordion/Accordion";
+import Accordion from "@common/components/accordion/Accordion";
 import BriefCaseIcon from "@heroicons/react/solid/BriefcaseIcon";
 import { Button } from "@common/components";
 import {

--- a/frontend/talentsearch/src/js/components/ExperienceAccordion/individualExperienceAccordions/CommunityAccordion.tsx
+++ b/frontend/talentsearch/src/js/components/ExperienceAccordion/individualExperienceAccordions/CommunityAccordion.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Accordion } from "@common/components/accordion/Accordion";
+import Accordion from "@common/components/accordion/Accordion";
 import BriefCaseIcon from "@heroicons/react/solid/BriefcaseIcon";
 import { Button } from "@common/components";
 import { CommunityExperience } from "@common/api/generated";

--- a/frontend/talentsearch/src/js/components/ExperienceAccordion/individualExperienceAccordions/EducationAccordion.tsx
+++ b/frontend/talentsearch/src/js/components/ExperienceAccordion/individualExperienceAccordions/EducationAccordion.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Accordion } from "@common/components/accordion/Accordion";
+import Accordion from "@common/components/accordion/Accordion";
 import BriefCaseIcon from "@heroicons/react/solid/BriefcaseIcon";
 import { Button } from "@common/components";
 import { EducationExperience } from "@common/api/generated";

--- a/frontend/talentsearch/src/js/components/ExperienceAccordion/individualExperienceAccordions/PersonalAccordion.tsx
+++ b/frontend/talentsearch/src/js/components/ExperienceAccordion/individualExperienceAccordions/PersonalAccordion.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Accordion } from "@common/components/accordion/Accordion";
+import Accordion from "@common/components/accordion/Accordion";
 import BriefCaseIcon from "@heroicons/react/solid/BriefcaseIcon";
 import { Button } from "@common/components";
 import { useIntl } from "react-intl";

--- a/frontend/talentsearch/src/js/components/ExperienceAccordion/individualExperienceAccordions/WorkAccordion.tsx
+++ b/frontend/talentsearch/src/js/components/ExperienceAccordion/individualExperienceAccordions/WorkAccordion.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Accordion } from "@common/components/accordion/Accordion";
+import Accordion from "@common/components/accordion/Accordion";
 import BriefCaseIcon from "@heroicons/react/solid/BriefcaseIcon";
 import { Button } from "@common/components";
 import { useIntl } from "react-intl";

--- a/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormWrapper.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormWrapper.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Breadcrumbs, BreadcrumbsProps } from "@common/components/Breadcrumbs";
+import Breadcrumbs, { BreadcrumbsProps } from "@common/components/Breadcrumbs";
 import { UserIcon } from "@heroicons/react/solid";
 import { useIntl } from "react-intl";
 import { imageUrl } from "@common/helpers/router";

--- a/frontend/talentsearch/src/js/components/awardDetailsForm/AwardDetailsForm.tsx
+++ b/frontend/talentsearch/src/js/components/awardDetailsForm/AwardDetailsForm.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Input } from "@common/components/form/Input";
-import { Select } from "@common/components/form/Select";
+import Input from "@common/components/form/Input";
+import Select from "@common/components/form/Select";
 import { errorMessages } from "@common/messages";
 import { enumToOptions } from "@common/helpers/formUtils";
 import {

--- a/frontend/talentsearch/src/js/components/communityExperienceForm/CommunityExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/communityExperienceForm/CommunityExperienceForm.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useWatch } from "react-hook-form";
-import { Input } from "@common/components/form/Input";
-import { Checkbox } from "@common/components/form/Checkbox";
+import Input from "@common/components/form/Input";
+import Checkbox from "@common/components/form/Checkbox";
 import { errorMessages } from "@common/messages";
 
 export const CommunityExperienceForm: React.FunctionComponent = () => {

--- a/frontend/talentsearch/src/js/components/educationExperienceForm/EducationExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/educationExperienceForm/EducationExperienceForm.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { useWatch } from "react-hook-form";
 import { useIntl } from "react-intl";
-import { Input } from "@common/components/form/Input";
-import { Select } from "@common/components/form/Select";
-import { Checkbox } from "@common/components/form/Checkbox";
+import Input from "@common/components/form/Input";
+import Select from "@common/components/form/Select";
+import Checkbox from "@common/components/form/Checkbox";
 import { errorMessages } from "@common/messages";
 import { enumToOptions } from "@common/helpers/formUtils";
 import {

--- a/frontend/talentsearch/src/js/components/personalExperienceForm/PersonalExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/personalExperienceForm/PersonalExperienceForm.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { useWatch } from "react-hook-form";
 import { useIntl } from "react-intl";
-import { Input } from "@common/components/form/Input";
-import { Checkbox } from "@common/components/form/Checkbox";
-import { TextArea } from "@common/components/form/TextArea";
+import Input from "@common/components/form/Input";
+import Checkbox from "@common/components/form/Checkbox";
+import TextArea from "@common/components/form/TextArea";
 import { errorMessages } from "@common/messages";
 
 export const PersonalExperienceForm: React.FunctionComponent = () => {

--- a/frontend/talentsearch/src/js/components/skills/AddedSkills/AddedSkills.tsx
+++ b/frontend/talentsearch/src/js/components/skills/AddedSkills/AddedSkills.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Chip } from "@common/components/Chip";
+import Chip from "@common/components/Chip";
 import { Scalars, Skill } from "@common/api/generated";
 import { getLocale } from "@common/helpers/localize";
 

--- a/frontend/talentsearch/src/js/components/skills/SearchBar/index.ts
+++ b/frontend/talentsearch/src/js/components/skills/SearchBar/index.ts
@@ -1,1 +1,5 @@
-export { default, SearchBarProps } from "./SearchBar";
+import SearchBar from "./SearchBar";
+import type { SearchBarProps } from "./SearchBar";
+
+export default SearchBar;
+export type { SearchBarProps };

--- a/frontend/talentsearch/src/js/components/skills/SkillChecklist/index.ts
+++ b/frontend/talentsearch/src/js/components/skills/SkillChecklist/index.ts
@@ -1,1 +1,5 @@
-export { default, SkillChecklistProps } from "./SkillChecklist";
+import SkillChecklist from "./SkillChecklist";
+import type { SkillChecklistProps } from "./SkillChecklist";
+
+export default SkillChecklist;
+export type { SkillChecklistProps };

--- a/frontend/talentsearch/src/js/components/skills/SkillResults/index.ts
+++ b/frontend/talentsearch/src/js/components/skills/SkillResults/index.ts
@@ -1,1 +1,5 @@
-export { default, SkillResultsProps } from "./SkillResults";
+import SkillResults from "./SkillResults";
+import type { SkillResultsProps } from "./SkillResults";
+
+export default SkillResults;
+export type { SkillResultsProps };

--- a/frontend/talentsearch/src/js/components/workExperienceForm/WorkExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/workExperienceForm/WorkExperienceForm.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useWatch } from "react-hook-form";
-import { Input } from "@common/components/form/Input";
-import { Checkbox } from "@common/components/form/Checkbox";
+import Input from "@common/components/form/Input";
+import Checkbox from "@common/components/form/Checkbox";
 import { errorMessages } from "@common/messages";
 
 export const WorkExperienceForm: React.FunctionComponent = () => {


### PR DESCRIPTION
## Summary

So, this one is a little strange because of a suspected bug related to the rule that @patcon noticed. To work around this while keeping the rule intact all exports have been updated to avoid the pattern causing the bug.

Resolves #2495 

## Example

```tsx
// Current Pattern
export { default, ComponentProps } from "./Component"

// New Pattern
import Component from "./Component"
import type { ComponentProps } from "./Component" 

export default Component;
export type { ComponentProps }; 
```

## Additional Comments

### Default/Named Exports

While completing this, I noticed we had some slight inconsistencies between default and named exports so there have also been modifications to normalize and ultimately prefer default exports where possible.

### `type` Keyword

Where I could, I also updated the exports to use the `type` keyword to export `interfaces` for component props.

Ref: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html