### PR TITLE
Fix deprecated @faker-js/faker functions

### DIFF
--- a/frontend/common/package.json
+++ b/frontend/common/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",
-    "@faker-js/faker": "^6.3.0",
+    "@faker-js/faker": "^6.3.1",
     "@formatjs/cli": "^4.8.4",
     "@formatjs/ts-transformer": "^3.9.4",
     "@graphql-codegen/add": "^3.1.0",

--- a/frontend/common/src/fakeData/fakeExperiences.ts
+++ b/frontend/common/src/fakeData/fakeExperiences.ts
@@ -71,13 +71,13 @@ const generateAward = (): AwardExperience => {
     skills: [],
     details: faker.random.words(),
     title: faker.lorem.word(),
-    awardedTo: faker.random.arrayElement<AwardedTo>([
+    awardedTo: faker.helpers.arrayElement<AwardedTo>([
       AwardedTo.Me,
       AwardedTo.MyOrganization,
       AwardedTo.MyProject,
       AwardedTo.MyTeam,
     ]),
-    awardedScope: faker.random.arrayElement<AwardedScope>([
+    awardedScope: faker.helpers.arrayElement<AwardedScope>([
       AwardedScope.Community,
       AwardedScope.International,
       AwardedScope.Local,
@@ -122,7 +122,7 @@ const generateEducation = (): EducationExperience => {
     skills: [sampleSkill1, sampleSkill2],
     details: faker.random.words(),
     areaOfStudy: faker.music.genre(),
-    type: faker.random.arrayElement<EducationType>([
+    type: faker.helpers.arrayElement<EducationType>([
       EducationType.BachelorsDegree,
       EducationType.Certification,
       EducationType.Diploma,
@@ -133,7 +133,7 @@ const generateEducation = (): EducationExperience => {
       EducationType.PostDoctoralFellowship,
     ]),
     institution: faker.name.lastName(),
-    status: faker.random.arrayElement<EducationStatus>([
+    status: faker.helpers.arrayElement<EducationStatus>([
       EducationStatus.Audited,
       EducationStatus.DidNotComplete,
       EducationStatus.InProgress,
@@ -200,7 +200,7 @@ export default (numberOfExperiences: number) => {
 
   // fill an array with random experiences
   const experiences = [...Array(numberOfExperiences)].map(() => {
-    const generator = faker.random.arrayElement(generators);
+    const generator = faker.helpers.arrayElement(generators);
     return generator();
   });
 

--- a/frontend/common/src/fakeData/fakePoolCandidateFilters.ts
+++ b/frontend/common/src/fakeData/fakePoolCandidateFilters.ts
@@ -22,23 +22,23 @@ const generatePoolCandidateFilters = (
 
   return {
     id: faker.datatype.uuid(),
-    pools: faker.random.arrayElements(pools),
-    classifications: faker.random.arrayElements(classifications),
+    pools: faker.helpers.arrayElements(pools),
+    classifications: faker.helpers.arrayElements(classifications),
     isWoman: faker.datatype.boolean(),
     hasDisability: faker.datatype.boolean(),
     isIndigenous: faker.datatype.boolean(),
     isVisibleMinority: faker.datatype.boolean(),
     hasDiploma: faker.datatype.boolean(),
-    languageAbility: faker.random.arrayElement<LanguageAbility>(
+    languageAbility: faker.helpers.arrayElement<LanguageAbility>(
       Object.values(LanguageAbility),
     ),
-    workRegions: faker.random.arrayElements<WorkRegion>(
+    workRegions: faker.helpers.arrayElements<WorkRegion>(
       Object.values(WorkRegion),
     ),
-    operationalRequirements: faker.random.arrayElements<OperationalRequirement>(
+    operationalRequirements: faker.helpers.arrayElements<OperationalRequirement>(
       operationalRequirements,
     ),
-    cmoAssets: faker.random.arrayElements(cmoAssets),
+    cmoAssets: faker.helpers.arrayElements(cmoAssets),
   };
 };
 
@@ -46,7 +46,7 @@ export default (): PoolCandidateFilter[] => {
   const classifications = fakeClassifications();
   const cmoAssets = fakeCmoAssets();
   const operationalRequirements =
-    faker.random.arrayElements<OperationalRequirement>(
+    faker.helpers.arrayElements<OperationalRequirement>(
       Object.values(OperationalRequirement),
     );
   const pools = fakePools();

--- a/frontend/common/src/fakeData/fakePoolCandidates.ts
+++ b/frontend/common/src/fakeData/fakePoolCandidates.ts
@@ -23,10 +23,10 @@ const generatePoolCandidate = (
   faker.setLocale("en");
   return {
     id: faker.datatype.uuid(),
-    pool: faker.random.arrayElement(pools),
+    pool: faker.helpers.arrayElement(pools),
     expectedClassifications:
-      faker.random.arrayElements<Classification>(classifications),
-    user: faker.random.arrayElement<User>(users) as Applicant,
+      faker.helpers.arrayElements<Classification>(classifications),
+    user: faker.helpers.arrayElement<User>(users) as Applicant,
     cmoIdentifier: faker.helpers.slugify(
       faker.lorem.words(faker.datatype.number({ min: 1, max: 3 })),
     ),
@@ -39,20 +39,20 @@ const generatePoolCandidate = (
     isIndigenous: faker.datatype.boolean(),
     isVisibleMinority: faker.datatype.boolean(),
     hasDiploma: faker.datatype.boolean(),
-    languageAbility: faker.random.arrayElement<LanguageAbility>(
+    languageAbility: faker.helpers.arrayElement<LanguageAbility>(
       Object.values(LanguageAbility),
     ),
-    locationPreferences: faker.random.arrayElements<WorkRegion>(
+    locationPreferences: faker.helpers.arrayElements<WorkRegion>(
       Object.values(WorkRegion),
     ),
     acceptedOperationalRequirements:
-      faker.random.arrayElements<OperationalRequirement>(
+      faker.helpers.arrayElements<OperationalRequirement>(
         Object.values(OperationalRequirement),
       ),
-    expectedSalary: faker.random.arrayElements<SalaryRange>(
+    expectedSalary: faker.helpers.arrayElements<SalaryRange>(
       Object.values(SalaryRange),
     ),
-    status: faker.random.arrayElement<PoolCandidateStatus>(
+    status: faker.helpers.arrayElement<PoolCandidateStatus>(
       Object.values(PoolCandidateStatus),
     ),
   };

--- a/frontend/common/src/fakeData/fakePools.ts
+++ b/frontend/common/src/fakeData/fakePools.ts
@@ -17,7 +17,7 @@ const generatePool = (
 ): Pool => {
   faker.setLocale("en");
 
-  const ownerUser: User = faker.random.arrayElement<User>(users);
+  const ownerUser: User = faker.helpers.arrayElement<User>(users);
   return {
     id: faker.datatype.uuid(),
     owner: pick(ownerUser, [
@@ -35,7 +35,7 @@ const generatePool = (
       fr: `FR ${faker.lorem.sentence()}`,
     },
     classifications:
-      faker.random.arrayElements<Classification>(classifications),
+      faker.helpers.arrayElements<Classification>(classifications),
   };
 };
 

--- a/frontend/common/src/fakeData/fakeSearchRequests.ts
+++ b/frontend/common/src/fakeData/fakeSearchRequests.ts
@@ -18,13 +18,13 @@ const generateSearchRequest = (
     id: faker.datatype.uuid(),
     fullName: `${faker.name.firstName()} ${faker.name.lastName()}`,
     email: faker.internet.email(),
-    department: faker.random.arrayElement<Department>(departments),
+    department: faker.helpers.arrayElement<Department>(departments),
     jobTitle: faker.name.jobTitle(),
     additionalComments: faker.lorem.sentences(5),
     poolCandidateFilter:
-      faker.random.arrayElement<PoolCandidateFilter>(poolCandidateFilters),
+      faker.helpers.arrayElement<PoolCandidateFilter>(poolCandidateFilters),
     requestedDate: faker.date.between("2000-01-01", "2020-12-31").toISOString(),
-    status: faker.random.arrayElement<PoolCandidateSearchStatus>(
+    status: faker.helpers.arrayElement<PoolCandidateSearchStatus>(
       Object.values(PoolCandidateSearchStatus),
     ),
     adminNotes: faker.lorem.sentences(5),

--- a/frontend/common/src/fakeData/fakeSkillFamilies.ts
+++ b/frontend/common/src/fakeData/fakeSkillFamilies.ts
@@ -4,7 +4,7 @@ import { SkillCategory, SkillFamily, Skill } from "../api/generated";
 const generateSkillFamily = (skills: Skill[]) => {
   const name = faker.random.word();
   return {
-    category: faker.random.arrayElement<SkillCategory>([
+    category: faker.helpers.arrayElement<SkillCategory>([
       SkillCategory.Behavioural,
       SkillCategory.Technical,
     ]),
@@ -19,7 +19,7 @@ const generateSkillFamily = (skills: Skill[]) => {
       fr: `FR ${name}`,
     },
     skills: skills.length
-      ? faker.random.arrayElements<Skill>(skills)
+      ? faker.helpers.arrayElements<Skill>(skills)
       : ([] as Skill[]),
   };
 };

--- a/frontend/common/src/fakeData/fakeSkills.ts
+++ b/frontend/common/src/fakeData/fakeSkills.ts
@@ -16,7 +16,7 @@ const generateSkill = (skillFamilies: SkillFamily[]) => {
     },
     keywords: faker.lorem.words(3).split(" "),
     families: skillFamilies.length
-      ? faker.random.arrayElements<SkillFamily>(skillFamilies)
+      ? faker.helpers.arrayElements<SkillFamily>(skillFamilies)
       : ([] as SkillFamily[]),
     experienceSkills: [],
   };

--- a/frontend/common/src/fakeData/fakeUsers.ts
+++ b/frontend/common/src/fakeData/fakeUsers.ts
@@ -48,39 +48,41 @@ const generateUser = (
     firstName: faker.name.firstName(),
     lastName: faker.name.lastName(),
     telephone: faker.helpers.replaceSymbols("+###########"),
-    preferredLang: faker.random.arrayElement<Language>(Object.values(Language)),
-    currentProvince: faker.random.arrayElement<ProvinceOrTerritory>(
+    preferredLang: faker.helpers.arrayElement<Language>(
+      Object.values(Language),
+    ),
+    currentProvince: faker.helpers.arrayElement<ProvinceOrTerritory>(
       Object.values(ProvinceOrTerritory),
     ),
     currentCity: faker.address.city(),
 
     // Language
-    languageAbility: faker.random.arrayElement<LanguageAbility>(
+    languageAbility: faker.helpers.arrayElement<LanguageAbility>(
       Object.values(LanguageAbility),
     ),
     lookingForEnglish: faker.datatype.boolean(),
     lookingForFrench: faker.datatype.boolean(),
     lookingForBilingual: faker.datatype.boolean(),
-    bilingualEvaluation: faker.random.arrayElement<BilingualEvaluation>(
+    bilingualEvaluation: faker.helpers.arrayElement<BilingualEvaluation>(
       Object.values(BilingualEvaluation),
     ),
-    comprehensionLevel: faker.random.arrayElement<EvaluatedLanguageAbility>(
+    comprehensionLevel: faker.helpers.arrayElement<EvaluatedLanguageAbility>(
       Object.values(EvaluatedLanguageAbility),
     ),
-    writtenLevel: faker.random.arrayElement<EvaluatedLanguageAbility>(
+    writtenLevel: faker.helpers.arrayElement<EvaluatedLanguageAbility>(
       Object.values(EvaluatedLanguageAbility),
     ),
-    verbalLevel: faker.random.arrayElement<EvaluatedLanguageAbility>(
+    verbalLevel: faker.helpers.arrayElement<EvaluatedLanguageAbility>(
       Object.values(EvaluatedLanguageAbility),
     ),
     estimatedLanguageAbility:
-      faker.random.arrayElement<EstimatedLanguageAbility>(
+      faker.helpers.arrayElement<EstimatedLanguageAbility>(
         Object.values(EstimatedLanguageAbility),
       ),
 
     // Gov info
     isGovEmployee: faker.datatype.boolean(),
-    govEmployeeType: faker.random.arrayElement<GovEmployeeType>([
+    govEmployeeType: faker.helpers.arrayElement<GovEmployeeType>([
       GovEmployeeType.Student,
       GovEmployeeType.Casual,
       GovEmployeeType.Term,
@@ -88,7 +90,7 @@ const generateUser = (
     ]),
     interestedInLaterOrSecondment: faker.datatype.boolean(),
     currentClassification:
-      faker.random.arrayElement<Classification>(classifications),
+      faker.helpers.arrayElement<Classification>(classifications),
 
     // Employment Equity
     isWoman: faker.datatype.boolean(),
@@ -97,25 +99,25 @@ const generateUser = (
     isVisibleMinority: faker.datatype.boolean(),
 
     // Applicant info
-    jobLookingStatus: faker.random.arrayElement<JobLookingStatus>(
+    jobLookingStatus: faker.helpers.arrayElement<JobLookingStatus>(
       Object.values(JobLookingStatus),
     ),
     hasDiploma: faker.datatype.boolean(),
-    locationPreferences: faker.random.arrayElements<WorkRegion>(
+    locationPreferences: faker.helpers.arrayElements<WorkRegion>(
       Object.values(WorkRegion),
     ),
     locationExemptions: faker.address.city(),
     acceptedOperationalRequirements:
-      faker.random.arrayElements<OperationalRequirement>(
+      faker.helpers.arrayElements<OperationalRequirement>(
         Object.values(OperationalRequirement),
       ),
-    expectedSalary: faker.random.arrayElements<SalaryRange>(
+    expectedSalary: faker.helpers.arrayElements<SalaryRange>(
       Object.values(SalaryRange),
     ),
     expectedClassifications:
-      faker.random.arrayElements<Classification>(classifications),
+      faker.helpers.arrayElements<Classification>(classifications),
     wouldAcceptTemporary: faker.datatype.boolean(),
-    cmoAssets: faker.random.arrayElements<CmoAsset>(cmoAssets),
+    cmoAssets: faker.helpers.arrayElements<CmoAsset>(cmoAssets),
 
     poolCandidates,
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -336,7 +336,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.17.10",
-        "@faker-js/faker": "^6.3.0",
+        "@faker-js/faker": "^6.3.1",
         "@formatjs/cli": "^4.8.4",
         "@formatjs/ts-transformer": "^3.9.4",
         "@graphql-codegen/add": "^3.1.0",
@@ -3219,9 +3219,9 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.3.0.tgz",
-      "integrity": "sha512-MI4sLlXEFBujHYHZMUo7S4BkCcQRPr/7rB2DA1grhnFzg8yNnVbfeEPWSDO9TCmNMSowlE+0bFQdDwb1SypIxQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.3.1.tgz",
+      "integrity": "sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0",
@@ -42620,9 +42620,9 @@
       }
     },
     "@faker-js/faker": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.3.0.tgz",
-      "integrity": "sha512-MI4sLlXEFBujHYHZMUo7S4BkCcQRPr/7rB2DA1grhnFzg8yNnVbfeEPWSDO9TCmNMSowlE+0bFQdDwb1SypIxQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.3.1.tgz",
+      "integrity": "sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ==",
       "dev": true
     },
     "@formatjs/cli": {
@@ -58344,7 +58344,7 @@
       "version": "file:common",
       "requires": {
         "@babel/core": "^7.17.10",
-        "@faker-js/faker": "^6.3.0",
+        "@faker-js/faker": "6.3.1",
         "@formatjs/cli": "^4.8.4",
         "@formatjs/ts-transformer": "^3.9.4",
         "@graphql-codegen/add": "^3.1.0",


### PR DESCRIPTION
## Summary

This replaces the deprecated `faker.random.arrayElement()` with the new `faker.helpers.arrayElement()`.

Resolves #2624 
