### PR TITLE
Bug - 2668 - Fix Missing Request Button

### DIFF
--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -193,7 +193,7 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
           />
         </div>
         <div data-h2-flex-item="b(1of1)" style={{ paddingTop: "0" }}>
-          {!updatePending ? candidateResults : <Spinner />}
+          {!updatePending ? candidateResults() : <Spinner />}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

When changing the spinner to be more accessible and its own component, we moved the candidateResults to its own component to avoid nesting ternary operations. When this was done, we passed a reference of the function rather than calling it to have it render. 

This is a simple change to call the `candidateResults` function to actually render this component.

Resolves #2668

<img width="1414" alt="Screen Shot 2022-05-05 at 1 28 29 PM" src="https://user-images.githubusercontent.com/4127998/166979825-cf9f1fbe-a579-4d87-8476-63a06b94a893.png">

