### PR TITLE
Feature - 2634 -  Admin Homepage Placeholder

### DIFF
--- a/frontend/admin/src/js/components/PoolDashboard.tsx
+++ b/frontend/admin/src/js/components/PoolDashboard.tsx
@@ -33,13 +33,13 @@ import { UpdateSkillFamily } from "./skillFamily/UpdateSkillFamily";
 import SkillPage from "./skill/SkillPage";
 import { CreateSkill } from "./skill/CreateSkill";
 import { UpdateSkill } from "./skill/UpdateSkill";
+import HomePage from "./home/HomePage";
 
 const routes = (paths: AdminRoutes): Routes<RouterResult> => [
   {
-    path: [paths.home()],
+    path: paths.home(),
     action: () => ({
-      component: <div />,
-      redirect: paths.poolTable(), // TODO: Which page should be treated as the dashboard Landing page?
+      component: <HomePage />,
     }),
   },
   {

--- a/frontend/admin/src/js/components/PoolDashboard.tsx
+++ b/frontend/admin/src/js/components/PoolDashboard.tsx
@@ -21,7 +21,7 @@ import UserPage from "./user/UserPage";
 import PoolPage from "./pool/PoolPage";
 import { CreatePool } from "./pool/CreatePool";
 import { UpdatePool } from "./pool/UpdatePool";
-import AuthContainer from "./AuthContainer";
+import { AuthContext } from "./AuthContainer";
 import DepartmentPage from "./department/DepartmentPage";
 import { CreateDepartment } from "./department/CreateDepartment";
 import { UpdateDepartment } from "./department/UpdateDepartment";
@@ -35,11 +35,15 @@ import { CreateSkill } from "./skill/CreateSkill";
 import { UpdateSkill } from "./skill/UpdateSkill";
 import HomePage from "./home/HomePage";
 
-const routes = (paths: AdminRoutes): Routes<RouterResult> => [
+const routes = (
+  paths: AdminRoutes,
+  loggedIn?: boolean,
+): Routes<RouterResult> => [
   {
     path: paths.home(),
     action: () => ({
       component: <HomePage />,
+      redirect: loggedIn ? paths.poolTable() : undefined,
     }),
   },
   {
@@ -207,6 +211,7 @@ const routes = (paths: AdminRoutes): Routes<RouterResult> => [
 ];
 
 export const PoolDashboard: React.FC = () => {
+  const { loggedIn } = React.useContext(AuthContext);
   const intl = useIntl();
   const paths = useAdminRoutes();
 
@@ -292,12 +297,13 @@ export const PoolDashboard: React.FC = () => {
   ];
 
   return (
-    <AuthContainer>
-      <ClientProvider>
-        <Dashboard menuItems={menuItems} contentRoutes={routes(paths)} />
-        <Toast />
-      </ClientProvider>
-    </AuthContainer>
+    <ClientProvider>
+      <Dashboard
+        menuItems={menuItems}
+        contentRoutes={routes(paths, loggedIn)}
+      />
+      <Toast />
+    </ClientProvider>
   );
 };
 

--- a/frontend/admin/src/js/components/home/HomePage.tsx
+++ b/frontend/admin/src/js/components/home/HomePage.tsx
@@ -3,7 +3,7 @@ import { useIntl } from "react-intl";
 import { HomeIcon, LoginIcon } from "@heroicons/react/outline";
 import CardLink from "@common/components/CardLink";
 import PageHeader from "@common/components/PageHeader";
-import { navigate } from "@common/helpers/router";
+// import { navigate } from "@common/helpers/router";
 
 import { AuthContext } from "../AuthContainer";
 import { useAdminRoutes } from "../../adminRoutes";
@@ -32,8 +32,11 @@ const HomePage: React.FC = () => {
         })}
       </PageHeader>
       <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean mollis
-        elit vitae lacinia sodales.
+        {intl.formatMessage({
+          defaultMessage: "Welcome to GC Talent, please log in to continue.",
+          description:
+            "Instructional text for the talent cloud pool manager portal home page.",
+        })}
       </p>
       <div data-h2-width="b(100) m(50) l(25)" data-h2-margin="b(top, l)">
         <CardLink

--- a/frontend/admin/src/js/components/home/HomePage.tsx
+++ b/frontend/admin/src/js/components/home/HomePage.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import { HomeIcon, LoginIcon } from "@heroicons/react/solid";
+import CardLink from "@common/components/CardLink";
+import PageHeader from "@common/components/PageHeader";
+import { navigate } from "@common/helpers/router";
+
+import { AuthContext } from "../AuthContainer";
+import { useAdminRoutes } from "../../adminRoutes";
+
+const HomePage: React.FC = () => {
+  const intl = useIntl();
+  const { loggedIn } = React.useContext(AuthContext);
+  const paths = useAdminRoutes();
+
+  /**
+   *   Note: I'm not sure if this is best practice
+   *        Should we be redirecting users here or else where?
+   */
+  React.useEffect(() => {
+    if (loggedIn) {
+      // navigate(paths.poolTable());
+    }
+  }, [loggedIn, paths]);
+
+  return (
+    <div data-h2-padding="b(all, m)">
+      <PageHeader icon={HomeIcon}>
+        {intl.formatMessage({
+          defaultMessage: "Home",
+          description: "Title for homepage on the talent cloud admin portal.",
+        })}
+      </PageHeader>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean mollis
+        elit vitae lacinia sodales.
+      </p>
+      <div data-h2-width="b(100) m(50) l(25)" data-h2-margin="b(top, l)">
+        <CardLink
+          href="#"
+          label={intl.formatMessage({
+            defaultMessage: "Login",
+            description:
+              "Text label for the login link to the talent cloud admin portal.",
+          })}
+          icon={LoginIcon}
+        >
+          {intl.formatMessage({
+            defaultMessage: "Portal manager portal",
+            description: "Title for the pool manager login link.",
+          })}
+        </CardLink>
+      </div>
+    </div>
+  );
+};
+
+export default HomePage;

--- a/frontend/admin/src/js/components/home/HomePage.tsx
+++ b/frontend/admin/src/js/components/home/HomePage.tsx
@@ -3,25 +3,9 @@ import { useIntl } from "react-intl";
 import { HomeIcon, LoginIcon } from "@heroicons/react/outline";
 import CardLink from "@common/components/CardLink";
 import PageHeader from "@common/components/PageHeader";
-// import { navigate } from "@common/helpers/router";
-
-import { AuthContext } from "../AuthContainer";
-import { useAdminRoutes } from "../../adminRoutes";
 
 const HomePage: React.FC = () => {
   const intl = useIntl();
-  const { loggedIn } = React.useContext(AuthContext);
-  const paths = useAdminRoutes();
-
-  /**
-   *   Note: I'm not sure if this is best practice
-   *        Should we be redirecting users here or else where?
-   */
-  React.useEffect(() => {
-    if (loggedIn) {
-      // navigate(paths.poolTable());
-    }
-  }, [loggedIn, paths]);
 
   return (
     <div data-h2-padding="b(all, m)">

--- a/frontend/admin/src/js/components/home/HomePage.tsx
+++ b/frontend/admin/src/js/components/home/HomePage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { HomeIcon, LoginIcon } from "@heroicons/react/solid";
+import { HomeIcon, LoginIcon } from "@heroicons/react/outline";
 import CardLink from "@common/components/CardLink";
 import PageHeader from "@common/components/PageHeader";
 import { navigate } from "@common/helpers/router";

--- a/frontend/admin/src/js/components/home/HomePage.tsx
+++ b/frontend/admin/src/js/components/home/HomePage.tsx
@@ -40,7 +40,8 @@ const HomePage: React.FC = () => {
       </p>
       <div data-h2-width="b(100) m(50) l(25)" data-h2-margin="b(top, l)">
         <CardLink
-          href="#"
+          href="/auth/login"
+          external
           label={intl.formatMessage({
             defaultMessage: "Login",
             description:

--- a/frontend/admin/src/js/components/home/HomePage.tsx
+++ b/frontend/admin/src/js/components/home/HomePage.tsx
@@ -3,9 +3,14 @@ import { useIntl } from "react-intl";
 import { HomeIcon, LoginIcon } from "@heroicons/react/outline";
 import CardLink from "@common/components/CardLink";
 import PageHeader from "@common/components/PageHeader";
+import { useLocation } from "@common/helpers/router";
+import { getLocale } from "@common/helpers/localize";
+import { useApiRoutes } from "../../apiRoutes";
 
 const HomePage: React.FC = () => {
   const intl = useIntl();
+  const apiRoutes = useApiRoutes();
+  const location = useLocation();
 
   return (
     <div data-h2-padding="b(all, m)">
@@ -24,8 +29,8 @@ const HomePage: React.FC = () => {
       </p>
       <div data-h2-width="b(100) m(50) l(25)" data-h2-margin="b(top, l)">
         <CardLink
-          href="/auth/login"
           external
+          href={apiRoutes.login(location.pathname, getLocale(intl))}
           label={intl.formatMessage({
             defaultMessage: "Login",
             description:

--- a/frontend/admin/src/js/dashboard.tsx
+++ b/frontend/admin/src/js/dashboard.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import LanguageRedirectContainer from "@common/components/LanguageRedirectContainer";
+import AuthContainer from "./components/AuthContainer";
 import { PoolDashboard } from "./components/PoolDashboard";
 import { getMessages } from "./components/IntlContainer";
 
 ReactDOM.render(
   <LanguageRedirectContainer getMessages={getMessages}>
-    <PoolDashboard />
+    <AuthContainer>
+      <PoolDashboard />
+    </AuthContainer>
   </LanguageRedirectContainer>,
   document.getElementById("app"),
 );

--- a/frontend/common/src/components/CardLink/CardLink.stories.tsx
+++ b/frontend/common/src/components/CardLink/CardLink.stories.tsx
@@ -22,7 +22,7 @@ const ExternalLink: React.FC = (props) => (
 
 export default {
   component: CardLink,
-  title: "Component/Card Link",
+  title: "Components/Card Link",
   args: {
     label: "Card Link",
   },

--- a/frontend/common/src/components/CardLink/CardLink.stories.tsx
+++ b/frontend/common/src/components/CardLink/CardLink.stories.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import CardLink from "./CardLink";
+
+const ExternalLink: React.FC = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className="h-6 w-6"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth={2}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+    />
+  </svg>
+);
+
+export default {
+  component: CardLink,
+  title: "Component/Card Link",
+  args: {
+    label: "Card Link",
+  },
+  argsTypes: {
+    label: {
+      name: "label",
+      type: { name: "string", required: true },
+      control: {
+        type: "text",
+      },
+    },
+    color: {
+      options: ["ts-primary", "ia-primary", "ia-secondary"],
+    },
+  },
+} as Meta;
+
+const TemplateCardLink: Story = (args) => {
+  const { label, color, icon } = args;
+  return (
+    <CardLink label={label} href="#" color={color} icon={icon}>
+      Card Link
+    </CardLink>
+  );
+};
+
+export const BasicCardLink = TemplateCardLink.bind({});
+export const IconCardLink = TemplateCardLink.bind({});
+export const IAPrimaryCardLink = TemplateCardLink.bind({});
+export const IASecondaryCardLink = TemplateCardLink.bind({});
+
+BasicCardLink.args = {
+  label: "Basic Card Link",
+};
+
+IconCardLink.args = {
+  label: "Icon Card Link",
+  icon: ExternalLink,
+};
+
+IAPrimaryCardLink.args = {
+  label: "IAP Primary Card Link",
+  color: "ia-primary",
+};
+
+IASecondaryCardLink.args = {
+  label: "IAP Secondary Card Link",
+  color: "ia-secondary",
+};

--- a/frontend/common/src/components/CardLink/CardLink.tsx
+++ b/frontend/common/src/components/CardLink/CardLink.tsx
@@ -11,6 +11,7 @@ export interface CardLinkProps {
   color?: Color;
   icon?: React.FC<{ className: string }>;
   className?: string;
+  external?: boolean;
 }
 
 export const colorMap: Record<Color, Record<string, string>> = {
@@ -33,6 +34,7 @@ const CardLink: React.FC<CardLinkProps> = ({
   color = "ts-primary",
   icon,
   label,
+  external = false,
   children,
   ...rest
 }) => {
@@ -40,10 +42,14 @@ const CardLink: React.FC<CardLinkProps> = ({
   return (
     <a
       href={href}
-      onClick={(event): void => {
-        event.preventDefault();
-        if (href) navigate(href);
-      }}
+      onClick={
+        !external
+          ? (event): void => {
+              event.preventDefault();
+              if (href) navigate(href);
+            }
+          : undefined
+      }
       className="card-link"
       data-h2-display="b(inline-block)"
       data-h2-radius="b(s)"

--- a/frontend/common/src/components/CardLink/CardLink.tsx
+++ b/frontend/common/src/components/CardLink/CardLink.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { navigate } from "../../helpers/router";
+
+import "./cardLink.css";
+
+export type Color = "ts-primary" | "ia-primary" | "ia-secondary";
+
+export interface CardLinkProps {
+  href: string;
+  label: string;
+  color?: Color;
+  icon?: React.FC<{ className: string }>;
+  className?: string;
+}
+
+export const colorMap: Record<Color, Record<string, string>> = {
+  "ts-primary": {
+    "data-h2-bg-color": "b(linear-70[lightpurple][lightnavy])",
+    "data-h2-font-color": "b(white)",
+  },
+  "ia-primary": {
+    "data-h2-bg-color": "b(linear-90[ia-lightpurple][ia-darkpurple])",
+    "data-h2-font-color": "b(white)",
+  },
+  "ia-secondary": {
+    "data-h2-bg-color": "b(linear-90[ia-pink][ia-darkpink])",
+    "data-h2-font-color": "b(white)",
+  },
+};
+
+const CardLink: React.FC<CardLinkProps> = ({
+  href,
+  color = "ts-primary",
+  icon,
+  label,
+  children,
+  ...rest
+}) => {
+  const Icon = icon || null;
+  return (
+    <a
+      href={href}
+      onClick={(event): void => {
+        event.preventDefault();
+        if (href) navigate(href);
+      }}
+      className="card-link"
+      data-h2-display="b(inline-block)"
+      data-h2-radius="b(s)"
+      data-h2-shadow="b(s) b:h(l)"
+      {...rest}
+    >
+      <span
+        className="card-link__header"
+        data-h2-display="b(block)"
+        data-h2-font-size="b(h4) l(h3)"
+        data-h2-font-weight="b(800)"
+        data-h2-padding="b(all, s)"
+        data-h2-radius="b(s, s, none, none)"
+        {...{ ...colorMap[color] }}
+      >
+        {children}
+      </span>
+      <span
+        className="card-link__label"
+        data-h2-bg-color="b(white)"
+        data-h2-display="b(flex)"
+        data-h2-align-items="b(center)"
+        data-h2-justify-content="b(flex-start)"
+        data-h2-radius="b(none, none, s, s)"
+        data-h2-padding="b(all, s)"
+      >
+        {Icon && <Icon className="card-link__icon" />}
+        <span>{label}</span>
+      </span>
+    </a>
+  );
+};
+
+export default CardLink;

--- a/frontend/common/src/components/CardLink/cardLink.css
+++ b/frontend/common/src/components/CardLink/cardLink.css
@@ -1,0 +1,17 @@
+.card-link {
+    text-decoration: none;
+}
+
+.card-link__header {
+    text-decoration: none;
+}
+
+.card-link__icon {
+    height: 1.25rem;
+    width: 1.25rem;
+    margin-right: 0.25rem;
+}
+
+.card-link__label > span {
+    text-decoration: underline;
+}

--- a/frontend/common/src/components/CardLink/index.ts
+++ b/frontend/common/src/components/CardLink/index.ts
@@ -1,0 +1,5 @@
+import CardLink from "./CardLink";
+import type { CardLinkProps } from "./CardLink";
+
+export default CardLink;
+export type { CardLinkProps };

--- a/frontend/common/src/components/PageHeader/PageHeader.stories.tsx
+++ b/frontend/common/src/components/PageHeader/PageHeader.stories.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import PageHeaderComponent from "./PageHeader";
+
+const HomeIcon: React.FC = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 20 20"
+    fill="currentColor"
+    {...props}
+  >
+    <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z" />
+  </svg>
+);
+
+export default {
+  component: PageHeaderComponent,
+  title: "Components/Page Header",
+  args: {
+    title: "Page Header",
+  },
+} as Meta;
+
+const TemplatePageHeader: Story = (args) => {
+  const { icon, title } = args;
+
+  return <PageHeaderComponent icon={icon}>{title}</PageHeaderComponent>;
+};
+
+export const PageHeader = TemplatePageHeader.bind({});
+export const IconPageHeader = TemplatePageHeader.bind({});
+
+PageHeader.args = {
+  label: "Basic Page Header",
+};
+
+IconPageHeader.args = {
+  label: "Icon Page Header",
+  icon: HomeIcon,
+};

--- a/frontend/common/src/components/PageHeader/PageHeader.tsx
+++ b/frontend/common/src/components/PageHeader/PageHeader.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import "./pageHeader.css";
+
+export interface PageHeaderProps {
+  icon?: React.FC<{ className: string }>;
+}
+
+const PageHeader: React.FC<PageHeaderProps> = ({ icon, children, ...rest }) => {
+  const Icon = icon || null;
+
+  return (
+    <h1
+      data-h2-display="b(flex)"
+      data-h2-font-weight="b(800)"
+      data-h2-align-items="b(center)"
+      data-h2-justify-content="b(start)"
+    >
+      {Icon && <Icon className="page-header__icon" />}
+      <span>{children}</span>
+    </h1>
+  );
+};
+
+export default PageHeader;

--- a/frontend/common/src/components/PageHeader/PageHeader.tsx
+++ b/frontend/common/src/components/PageHeader/PageHeader.tsx
@@ -14,6 +14,7 @@ const PageHeader: React.FC<PageHeaderProps> = ({ icon, children, ...rest }) => {
       data-h2-display="b(flex)"
       data-h2-font-weight="b(800)"
       data-h2-align-items="b(center)"
+      data-h2-margin="b(top, none) b(bottom, m)"
       data-h2-justify-content="b(start)"
     >
       {Icon && <Icon className="page-header__icon" />}

--- a/frontend/common/src/components/PageHeader/PageHeader.tsx
+++ b/frontend/common/src/components/PageHeader/PageHeader.tsx
@@ -16,6 +16,7 @@ const PageHeader: React.FC<PageHeaderProps> = ({ icon, children, ...rest }) => {
       data-h2-align-items="b(center)"
       data-h2-margin="b(top, none) b(bottom, m)"
       data-h2-justify-content="b(start)"
+      {...rest}
     >
       {Icon && <Icon className="page-header__icon" />}
       <span>{children}</span>

--- a/frontend/common/src/components/PageHeader/index.ts
+++ b/frontend/common/src/components/PageHeader/index.ts
@@ -1,0 +1,5 @@
+import PageHeader from "./PageHeader";
+import type { PageHeaderProps } from "./PageHeader";
+
+export default PageHeader;
+export type { PageHeaderProps };

--- a/frontend/common/src/components/PageHeader/pageHeader.css
+++ b/frontend/common/src/components/PageHeader/pageHeader.css
@@ -1,0 +1,5 @@
+.page-header__icon {
+    height: 3rem;
+    width: 3rem;
+    margin-right: 1rem;
+}


### PR DESCRIPTION
## Summary

This creates a placeholder for the admin homepage along with two new supporting components in the `common` project.

Resolves #2634 

## Questions

### Login Redirect

As I understand it, this page should only appear when an anonymous user navigate to the admin. As a result, it should redirect to the dashboard if a logged in user navigates to `/admin`. I wrote some preliminary logic for this but am unsure if what is there can be considered best practice. I essentially checked the `AuthContext` to see if the user was logged in, if they were not the page would navigate to a path (soon to be dashboard).

See: [HomePage.tsx:20-24](https://github.com/GCTC-NTGC/gc-digital-talent/blob/061e6cef9d7a2973dfac7bece424ae32be1b3fc8/frontend/admin/src/js/components/home/HomePage.tsx#L20)

```tsx
  const { loggedIn } = React.useContext(AuthContext);
  const paths = useAdminRoutes();

  React.useEffect(() => {
    if (loggedIn) {
      navigate(paths.dashboard());
    }
  }, [loggedIn, paths]);
```

## New Components

### Page Header

This seemed to be a recurring component on all of the new pages so I created it here for use when updating the next pages.

#### Props

##### icon - React.FC - optional

This will likely be passed directly in from an import from `@heroicons/react`. Example can be found at [`HomePage.tsx:28`](https://github.com/GCTC-NTGC/gc-digital-talent/blob/061e6cef9d7a2973dfac7bece424ae32be1b3fc8/frontend/admin/src/js/components/home/HomePage.tsx#L28)

### Card Link

This is the link that appears on the homepage to login. I'm not quite sure if this will be re-used, but it is there now so we have the option to.

#### Props

##### href - string - required

Simple path that the card should direct the user to when they click on it.

##### icon - React.FC - optional

Similar to the Page Header. See previous notes.

##### label - string - required

This will appear near the end of the link with a white background.

##### color - "ts-primary" | "ia-primary" | "ia-secondary"

This is the background colour for the top portion of the card and are gradients pulled directly from the hydrogen config.

