### PR TITLE
add new users to UserSeeder

### DIFF
--- a/api/database/seeders/UserSeederLocal.php
+++ b/api/database/seeders/UserSeederLocal.php
@@ -59,5 +59,10 @@ class UserSeederLocal extends Seeder
             'sub' => '2f3ee3fb-91ab-478e-a675-c56fdc043dc6',
             'roles' => ['ADMIN']
         ]);
+        User::factory()->create([
+            'email' => 'mnigh'.$fakeEmailDomain,
+            'sub' => 'c736bdff-c1f2-4538-b648-43a9743481a3',
+            'roles' => ['ADMIN']
+        ]);
     }
 }


### PR DESCRIPTION
resolves #2630 
I believe all you need to do for this to take effect is run `php artisan migrate:fresh --seed` in /infrastructure?

looking at the users listed, there are some missing, @RVany @esizer, do you want to be added in? if so, I think @petertgiles said he will help anyone who wanted in
afterwards, as Matt did in the issue above, share the `UserFactory.... etc` snippet here and I will add it in with a commit
