### PR TITLE
Bug - 2625 - Disable Chromatic for dependabot

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   deployment:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     env:
       NPM_VERSION: '8.3.0'

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -7,9 +7,6 @@ on:
       - .github/workflows/storybook.yml
       - frontend/**
   pull_request:
-    branches-ignore:
-      # Avoids consuming limited Chromatic snapshots on dependabot PRs.
-      - dependabot/**
     paths:
       - .github/workflows/storybook.yml
       - frontend/**


### PR DESCRIPTION
## Summary

It seems as though github actions and dependabot have made some changes and the way we were disabling it is no longer the accepted method. Instead of ignoring branches as we were, we have added a conditinola in the job to not run if the actor is dependabot.

Refs: 
 - https://github.community/t/how-to-stop-github-actions-workflow-to-trigger-when-the-pull-request-is-from-dependabot-preview/116486/3
 - https://stackoverflow.com/questions/71679568/github-actions-ignore-or-exclude-dependabot-pull-requests

Resolves #2625

## Testing

You can test locally with [nektos/act](https://github.com/nektos/act).  To run just the storybook workflow with and without dependabot actor:

```sh
# Without Actor
act -W ./.github/workflows/storybook.yml pull_request

# With Actor
act -a "dependabot[bot]" -W ./.github/workflows/storybook.yml pull_request
```

### Non-Dependabot Actor - Workflow runs (cancelled early to save time)

```sh
[gc-digital-talent] act -W ./.github/workflows/storybook.yml --container-architecture linux/amd64 pull_request
[Chromatic Storybook/deployment] 🚀  Start image=ghcr.io/catthehacker/ubuntu:act-latest
[Chromatic Storybook/deployment]   🐳  docker pull image=ghcr.io/catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=false
[Chromatic Storybook/deployment]   🐳  docker create image=ghcr.io/catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Chromatic Storybook/deployment]   🐳  docker run image=ghcr.io/catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Chromatic Storybook/deployment]   🐳  docker exec cmd=[mkdir -m 0777 -p /var/run/act] user=root workdir=
[Chromatic Storybook/deployment]   🐳  docker cp src=/Users/daedalus/Projects/gc-digital-talent/. dst=/Users/daedalus/Projects/gc-digital-talent
[Chromatic Storybook/deployment]   🐳  docker exec cmd=[mkdir -p /Users/daedalus/Projects/gc-digital-talent] user= workdir=
^CError: context canceled
```

### Run with the Dependabot Actor

No action is taken (expected because of conditional)

```sh
[gc-digital-talent] act -a "dependabot[bot]" -W ./.github/workflows/storybook.yml --container-architecture linux/amd64 pull_request
[gc-digital-talent]                                                                                      bug/2625-disable-chromatic-dependabot 
```