### PR TITLE
Move docker compose

### DIFF
--- a/.github/workflows/check-lighthouse-schema.yml
+++ b/.github/workflows/check-lighthouse-schema.yml
@@ -22,14 +22,12 @@ jobs:
         run: cp .env.example .env
 
       - name: "Build docker image: api"
-        working-directory: infrastructure
         run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up api --detach
 
       - name: "Re-generate lighthouse schema"
-        working-directory: infrastructure
         run: |
           docker compose exec --no-TTY api php artisan lighthouse:print-schema --write
-          docker compose cp api:/var/www/html/api/storage/app/lighthouse-schema.graphql ../api/storage/app/
+          docker compose cp api:/var/www/html/api/storage/app/lighthouse-schema.graphql ./api/storage/app/
 
       - name: Check for uncommitted changes
         id: changes

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -50,7 +50,6 @@ jobs:
             docker-
 
       - name: Serve app via docker-compose
-        working-directory: infrastructure/
         run: docker-compose up --detach
 
       - name: "Confirm failure response"
@@ -59,7 +58,6 @@ jobs:
           curl http://localhost:8000/talent --output /dev/null --silent --write-out "%{http_code}"  | grep --invert-match 200
 
       - name: "Run: setup.sh"
-        working-directory: infrastructure/
         run: docker-compose run --rm maintenance bash setup.sh
 
       - name: "Confirm success response: setup.sh"
@@ -81,7 +79,6 @@ jobs:
           curl http://localhost:8000/talent --output /dev/null --silent --write-out "%{http_code}"  | grep --invert-match 200
 
       - name: "Run: refresh_all.sh"
-        working-directory: infrastructure/
         run: docker-compose run --rm maintenance bash refresh_all.sh
 
       - name: "Confirm success response: refresh_all.sh"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -52,11 +52,9 @@ jobs:
             docker-
 
       - name: Serve app via docker-compose
-        working-directory: infrastructure/
         run: docker-compose up --detach
 
       - name: "Run: setup.sh"
-        working-directory: infrastructure/
         run: docker-compose run --rm maintenance bash setup.sh
 
       - name: "Run Cypress tests: all"
@@ -85,10 +83,8 @@ jobs:
 
       - name: Check status of containers
         if: failure()
-        working-directory: infrastructure/
         run: docker-compose ps
 
       - name: 'Check logs: PHP container'
         if: failure()
-        working-directory: infrastructure/
         run: docker-compose logs php

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -5,7 +5,7 @@ services:
   # With a profile designated, it will not build/run unless explicitly executed.
   # See: https://docs.docker.com/compose/profiles/
   api:
-    build: ../api
+    build: ./api
     depends_on:
       - postgres
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       POSTGRES_PASSWORD: password1234
     volumes:
-      - ./db:/docker-entrypoint-initdb.d/
+      - ./infrastructure/db:/docker-entrypoint-initdb.d/
       - pgdata:/var/lib/postgresql/data
     ports:
       - "5432:5432"
@@ -20,23 +20,23 @@ services:
       - 8080:8080
 
   php:
-    build: ./php-container
+    build: ./infrastructure/php-container
     working_dir: /var/www/html
     restart: always
     volumes:
-      - ./php-container/src:/var/www/html/
-      - ../api:/var/www/html/api
-      - ../auth:/var/www/html/auth
-      - ../frontend:/var/www/html/frontend
-      - ../tc-report:/var/www/html/tc-report
+      - ./infrastructure/php-container/src:/var/www/html/
+      - ./api:/var/www/html/api
+      - ./auth:/var/www/html/auth
+      - ./frontend:/var/www/html/frontend
+      - ./tc-report:/var/www/html/tc-report
     ports:
       - 8000:80
       - 8001:443
     env_file:
-      - ../frontend/.apache_env
+      - ./frontend/.apache_env
 
   maintenance:
-    build: ./maintenance-container
+    build: ./infrastructure/maintenance-container
     working_dir: /root/scripts
     deploy:
       mode: replicated
@@ -48,11 +48,11 @@ services:
       - CYPRESS_INSTALL_BINARY=0
     volumes:
       - maintenancedata:/root
-      - ../maintenance/scripts:/root/scripts
-      - ../api:/var/www/html/api
-      - ../auth:/var/www/html/auth
-      - ../frontend:/var/www/html/frontend
-      - ../tc-report:/var/www/html/tc-report
+      - ./maintenance/scripts:/root/scripts
+      - ./api:/var/www/html/api
+      - ./auth:/var/www/html/auth
+      - ./frontend:/var/www/html/frontend
+      - ./tc-report:/var/www/html/tc-report
 
 volumes:
   pgdata:


### PR DESCRIPTION
Just pulling this out of #2217, as it's something I've wished was available already.

It should change anything, except we can now run docker-compose commands from anywhere in the project, instead of having to back out into `infrastructure/` to run them :)

Ready for review! If docker workflows pass, it should be all good.