### PR TITLE
Admin - Limit page and route authorization

### DIFF
--- a/frontend/admin/src/js/api/meOperations.graphql
+++ b/frontend/admin/src/js/api/meOperations.graphql
@@ -1,0 +1,5 @@
+query getMe {
+  me {
+    roles
+  }
+}

--- a/frontend/admin/src/js/components/AuthorizationContainer.tsx
+++ b/frontend/admin/src/js/components/AuthorizationContainer.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Role, useGetMeQuery } from "../api/generated";
+
+interface AuthorizationState {
+  loggedInUserRoles: (Role | null | undefined)[] | null | undefined;
+}
+
+export const AuthorizationContext = React.createContext<AuthorizationState>({
+  loggedInUserRoles: null,
+});
+
+export const AuthorizationContainer: React.FC = ({ children }) => {
+  const [result] = useGetMeQuery();
+  const { data } = result;
+  const state = React.useMemo<AuthorizationState>(() => {
+    return {
+      loggedInUserRoles: data?.me?.roles,
+    };
+  }, [data?.me?.roles]);
+
+  return (
+    <AuthorizationContext.Provider value={state}>
+      {children}
+    </AuthorizationContext.Provider>
+  );
+};
+
+export default AuthorizationContainer;

--- a/frontend/admin/src/js/components/PoolDashboard.tsx
+++ b/frontend/admin/src/js/components/PoolDashboard.tsx
@@ -3,10 +3,11 @@ import { useIntl } from "react-intl";
 import { Routes } from "universal-router";
 import { RouterResult } from "@common/helpers/router";
 import Toast from "@common/components/Toast";
+import NotAuthorized from "@common/components/NotAuthorized";
+import { getLocale } from "@common/helpers/localize";
 import { AdminRoutes, useAdminRoutes } from "../adminRoutes";
 import { CreateClassification } from "./classification/CreateClassification";
 import { UpdateClassification } from "./classification/UpdateClassification";
-import ClientProvider from "./ClientProvider";
 import CmoAssetPage from "./cmoAsset/CmoAssetPage";
 import { CreateCmoAsset } from "./cmoAsset/CreateCmoAsset";
 import { UpdateCmoAsset } from "./cmoAsset/UpdateCmoAsset";
@@ -34,178 +35,292 @@ import SkillPage from "./skill/SkillPage";
 import { CreateSkill } from "./skill/CreateSkill";
 import { UpdateSkill } from "./skill/UpdateSkill";
 import HomePage from "./home/HomePage";
+import { Role, useGetPoolsQuery } from "../api/generated";
+import { AuthorizationContext } from "./AuthorizationContainer";
+
+const PoolListApi = (isAdmin: boolean) => {
+  const intl = useIntl();
+  const paths = useAdminRoutes();
+  const [result] = useGetPoolsQuery();
+  const { data, fetching, error } = result;
+  const items = [];
+
+  if (!fetching && !error && isAdmin) {
+    items.push(
+      <MenuHeading
+        key="pool-candidates"
+        text={intl.formatMessage({
+          defaultMessage: "Pool Candidates",
+          description: "Label displayed on the Pool Candidates menu item.",
+        })}
+      />,
+    );
+    data?.pools.map((pool) =>
+      items.push(
+        <MenuLink
+          key={`pools/${pool?.id}/pool-candidates`}
+          href={paths.poolCandidateTable(pool?.id ?? "")}
+          text={(pool?.name && pool?.name[getLocale(intl)]) ?? ""}
+        />,
+      ),
+    );
+  }
+
+  return items;
+};
+
+const AdminNotAuthorized: React.FC = () => {
+  const intl = useIntl();
+  return (
+    <NotAuthorized
+      headingMessage={intl.formatMessage({
+        description:
+          "Heading for the message saying the page to view is not authorized.",
+        defaultMessage: "Sorry, you are not authorized to view this page.",
+      })}
+    >
+      <p>
+        {intl.formatMessage({
+          description:
+            "Detailed message saying the page to view is not authorized.",
+          defaultMessage:
+            "Oops, it looks like you've landed on a page that you are not authorized to view.",
+        })}
+      </p>
+    </NotAuthorized>
+  );
+};
 
 const routes = (
   paths: AdminRoutes,
   loggedIn?: boolean,
+  isAdmin?: boolean,
 ): Routes<RouterResult> => [
   {
     path: paths.home(),
     action: () => ({
       component: <HomePage />,
-      redirect: loggedIn ? paths.poolTable() : undefined,
+      redirect: loggedIn && isAdmin ? paths.poolTable() : undefined,
     }),
   },
   {
     path: paths.userTable(),
     action: () => ({
-      component: <UserPage />,
+      component: loggedIn && isAdmin ? <UserPage /> : <AdminNotAuthorized />,
     }),
   },
   {
     path: paths.userCreate(),
     action: () => ({
-      component: <CreateUser />,
+      component: loggedIn && isAdmin ? <CreateUser /> : <AdminNotAuthorized />,
     }),
   },
   {
     path: paths.userUpdate(":id"),
     action: ({ params }) => ({
-      component: <UpdateUser userId={params.id as string} />,
+      component:
+        loggedIn && isAdmin ? (
+          <UpdateUser userId={params.id as string} />
+        ) : (
+          <AdminNotAuthorized />
+        ),
     }),
   },
   {
     path: paths.classificationTable(),
     action: () => ({
-      component: <ClassificationPage />,
+      component:
+        loggedIn && isAdmin ? <ClassificationPage /> : <AdminNotAuthorized />,
     }),
   },
   {
     path: paths.classificationCreate(),
     action: () => ({
-      component: <CreateClassification />,
+      component:
+        loggedIn && isAdmin ? <CreateClassification /> : <AdminNotAuthorized />,
     }),
   },
   {
     path: paths.classificationUpdate(":id"),
     action: ({ params }) => ({
-      component: (
-        <UpdateClassification classificationId={params.id as string} />
-      ),
+      component:
+        loggedIn && isAdmin ? (
+          <UpdateClassification classificationId={params.id as string} />
+        ) : (
+          <AdminNotAuthorized />
+        ),
     }),
   },
   {
     path: paths.cmoAssetTable(),
     action: () => ({
-      component: <CmoAssetPage />,
+      component:
+        loggedIn && isAdmin ? <CmoAssetPage /> : <AdminNotAuthorized />,
     }),
   },
   {
     path: paths.cmoAssetCreate(),
     action: () => ({
-      component: <CreateCmoAsset />,
+      component:
+        loggedIn && isAdmin ? <CreateCmoAsset /> : <AdminNotAuthorized />,
     }),
   },
   {
     path: paths.cmoAssetUpdate(":id"),
     action: ({ params }) => ({
-      component: <UpdateCmoAsset cmoAssetId={params.id as string} />,
+      component:
+        loggedIn && isAdmin ? (
+          <UpdateCmoAsset cmoAssetId={params.id as string} />
+        ) : (
+          <AdminNotAuthorized />
+        ),
     }),
   },
   {
     path: paths.poolCandidateTable(":id"),
     action: ({ params }) => ({
-      component: <PoolCandidatePage poolId={params.id as string} />,
+      component:
+        loggedIn && isAdmin ? (
+          <PoolCandidatePage poolId={params.id as string} />
+        ) : (
+          <AdminNotAuthorized />
+        ),
     }),
   },
   {
     path: paths.poolCandidateCreate(":id"),
     action: ({ params }) => ({
-      component: <CreatePoolCandidate poolId={params.id as string} />,
+      component:
+        loggedIn && isAdmin ? (
+          <CreatePoolCandidate poolId={params.id as string} />
+        ) : (
+          <AdminNotAuthorized />
+        ),
     }),
   },
   {
     path: paths.poolCandidateUpdate(":poolId", ":candidateId"),
     action: ({ params }) => ({
-      component: (
-        <UpdatePoolCandidate poolCandidateId={params.candidateId as string} />
-      ),
+      component:
+        loggedIn && isAdmin ? (
+          <UpdatePoolCandidate poolCandidateId={params.candidateId as string} />
+        ) : (
+          <AdminNotAuthorized />
+        ),
     }),
   },
   {
     path: paths.poolTable(),
     action: () => ({
-      component: <PoolPage />,
+      component: loggedIn && isAdmin ? <PoolPage /> : <AdminNotAuthorized />,
     }),
   },
   {
     path: paths.poolCreate(),
     action: () => ({
-      component: <CreatePool />,
+      component: loggedIn && isAdmin ? <CreatePool /> : <AdminNotAuthorized />,
     }),
   },
   {
     path: paths.poolUpdate(":id"),
     action: ({ params }) => ({
-      component: <UpdatePool poolId={params.id as string} />,
+      component:
+        loggedIn && isAdmin ? (
+          <UpdatePool poolId={params.id as string} />
+        ) : (
+          <AdminNotAuthorized />
+        ),
     }),
   },
   {
     path: paths.departmentTable(),
     action: () => ({
-      component: <DepartmentPage />,
+      component:
+        loggedIn && isAdmin ? <DepartmentPage /> : <AdminNotAuthorized />,
     }),
   },
   {
     path: paths.departmentCreate(),
     action: () => ({
-      component: <CreateDepartment />,
+      component:
+        loggedIn && isAdmin ? <CreateDepartment /> : <AdminNotAuthorized />,
     }),
   },
   {
     path: paths.departmentUpdate(":id"),
     action: ({ params }) => ({
-      component: <UpdateDepartment departmentId={params.id as string} />,
+      component:
+        loggedIn && isAdmin ? (
+          <UpdateDepartment departmentId={params.id as string} />
+        ) : (
+          <AdminNotAuthorized />
+        ),
     }),
   },
   {
     path: paths.skillFamilyTable(),
     action: () => ({
-      component: <SkillFamilyPage />,
+      component:
+        loggedIn && isAdmin ? <SkillFamilyPage /> : <AdminNotAuthorized />,
     }),
   },
   {
     path: paths.skillFamilyCreate(),
     action: () => ({
-      component: <CreateSkillFamily />,
+      component:
+        loggedIn && isAdmin ? <CreateSkillFamily /> : <AdminNotAuthorized />,
     }),
   },
   {
     path: paths.skillFamilyUpdate(":id"),
     action: ({ params }) => ({
-      component: <UpdateSkillFamily skillFamilyId={params.id as string} />,
+      component:
+        loggedIn && isAdmin ? (
+          <UpdateSkillFamily skillFamilyId={params.id as string} />
+        ) : (
+          <AdminNotAuthorized />
+        ),
     }),
   },
   {
     path: paths.skillTable(),
     action: () => ({
-      component: <SkillPage />,
+      component: loggedIn && isAdmin ? <SkillPage /> : <AdminNotAuthorized />,
     }),
   },
   {
     path: paths.skillCreate(),
     action: () => ({
-      component: <CreateSkill />,
+      component: loggedIn && isAdmin ? <CreateSkill /> : <AdminNotAuthorized />,
     }),
   },
   {
     path: paths.skillUpdate(":id"),
     action: ({ params }) => ({
-      component: <UpdateSkill skillId={params.id as string} />,
+      component:
+        loggedIn && isAdmin ? (
+          <UpdateSkill skillId={params.id as string} />
+        ) : (
+          <AdminNotAuthorized />
+        ),
     }),
   },
   {
     path: paths.searchRequestTable(),
     action: () => ({
-      component: <SearchRequestPage />,
+      component:
+        loggedIn && isAdmin ? <SearchRequestPage /> : <AdminNotAuthorized />,
     }),
   },
   {
     path: paths.searchRequestUpdate(":id"),
     action: ({ params }) => ({
-      component: (
-        <SingleSearchRequestPage searchRequestId={params.id as string} />
-      ),
+      component:
+        loggedIn && isAdmin ? (
+          <SingleSearchRequestPage searchRequestId={params.id as string} />
+        ) : (
+          <AdminNotAuthorized />
+        ),
     }),
   },
 ];
@@ -214,8 +329,10 @@ export const PoolDashboard: React.FC = () => {
   const { loggedIn } = React.useContext(AuthContext);
   const intl = useIntl();
   const paths = useAdminRoutes();
+  const { loggedInUserRoles } = React.useContext(AuthorizationContext);
+  const isAdmin = !!loggedInUserRoles?.includes(Role.Admin);
 
-  const menuItems = [
+  const menuItemsAdmin = [
     <MenuHeading
       key="search-requests"
       text={intl.formatMessage({
@@ -296,14 +413,31 @@ export const PoolDashboard: React.FC = () => {
     />,
   ];
 
+  const menuItemsPool = PoolListApi(isAdmin);
+
+  const menuItems = [
+    <MenuLink
+      key="home"
+      href={paths.home()}
+      text={intl.formatMessage({
+        defaultMessage: "Home",
+        description: "Label displayed on the home menu item.",
+      })}
+    />,
+  ];
+
   return (
-    <ClientProvider>
+    <>
       <Dashboard
-        menuItems={menuItems}
-        contentRoutes={routes(paths, loggedIn)}
+        menuItems={[
+          ...menuItems,
+          ...(isAdmin ? menuItemsAdmin : []),
+          ...(isAdmin ? menuItemsPool : []),
+        ]}
+        contentRoutes={routes(paths, loggedIn, isAdmin)}
       />
       <Toast />
-    </ClientProvider>
+    </>
   );
 };
 

--- a/frontend/admin/src/js/components/dashboard/Dashboard.tsx
+++ b/frontend/admin/src/js/components/dashboard/Dashboard.tsx
@@ -116,6 +116,7 @@ const LoginOrLogout = () => {
   if (loggedIn) {
     return (
       <Button
+        key="loginlogout"
         color="white"
         mode="inline"
         block

--- a/frontend/admin/src/js/components/dashboard/Dashboard.tsx
+++ b/frontend/admin/src/js/components/dashboard/Dashboard.tsx
@@ -8,9 +8,7 @@ import NotFound from "@common/components/NotFound";
 import Header from "@common/components/Header";
 import Footer from "@common/components/Footer";
 import { ADMIN_APP_DIR } from "../../adminConstants";
-import { useAdminRoutes } from "../../adminRoutes";
 import { useApiRoutes } from "../../apiRoutes";
-import { useGetPoolsQuery } from "../../api/generated";
 import SideMenu from "../menu/SideMenu";
 import { AuthContext } from "../AuthContainer";
 
@@ -74,37 +72,6 @@ export const MenuLink: React.FC<MenuLinkProps> = ({
       </span>
     </Link>
   );
-};
-
-const PoolListApi = () => {
-  const intl = useIntl();
-  const paths = useAdminRoutes();
-  const [result] = useGetPoolsQuery();
-  const { data, fetching, error } = result;
-  const items = [];
-
-  if (!fetching && !error) {
-    items.push(
-      <MenuHeading
-        key="pool-candidates"
-        text={intl.formatMessage({
-          defaultMessage: "Pool Candidates",
-          description: "Label displayed on the Pool Candidates menu item.",
-        })}
-      />,
-    );
-    data?.pools.map((pool) =>
-      items.push(
-        <MenuLink
-          key={`pools/${pool?.id}/pool-candidates`}
-          href={paths.poolCandidateTable(pool?.id ?? "")}
-          text={(pool?.name && pool?.name[getLocale(intl)]) ?? ""}
-        />,
-      ),
-    );
-  }
-
-  return items;
 };
 
 const LoginOrLogout = () => {
@@ -192,6 +159,7 @@ export const Dashboard: React.FC<{
   // stabilize component that will not change during life of app, avoid render loops in router
   const notFoundComponent = useRef(<AdminNotFound />);
   const content = useRouter(contentRoutes, notFoundComponent.current);
+
   return (
     <>
       <a href="#main" data-h2-visibility="b(hidden)">
@@ -215,9 +183,7 @@ export const Dashboard: React.FC<{
               data-h2-position="b(static) m(sticky)"
               style={{ top: "0", maxHeight: "100vh", overflow: "auto" }}
             >
-              <SideMenu
-                items={[...menuItems, ...PoolListApi(), LoginOrLogout()]}
-              />
+              <SideMenu items={[...menuItems, LoginOrLogout()]} />
             </div>
           </div>
           <div

--- a/frontend/admin/src/js/dashboard.tsx
+++ b/frontend/admin/src/js/dashboard.tsx
@@ -4,11 +4,17 @@ import LanguageRedirectContainer from "@common/components/LanguageRedirectContai
 import AuthContainer from "./components/AuthContainer";
 import { PoolDashboard } from "./components/PoolDashboard";
 import { getMessages } from "./components/IntlContainer";
+import ClientProvider from "./components/ClientProvider";
+import AuthorizationContainer from "./components/AuthorizationContainer";
 
 ReactDOM.render(
   <LanguageRedirectContainer getMessages={getMessages}>
     <AuthContainer>
-      <PoolDashboard />
+      <ClientProvider>
+        <AuthorizationContainer>
+          <PoolDashboard />
+        </AuthorizationContainer>
+      </ClientProvider>
     </AuthContainer>
   </LanguageRedirectContainer>,
   document.getElementById("app"),

--- a/frontend/common/src/components/NotAuthorized/NotAuthorized.stories.tsx
+++ b/frontend/common/src/components/NotAuthorized/NotAuthorized.stories.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import NotAuthorized from "./NotAuthorized";
+
+export default {
+  component: NotAuthorized,
+  title: "Components/Not Authorized",
+} as Meta;
+
+const Template: Story = (args) => {
+  const { headingMessage, children } = args;
+  return (
+    <NotAuthorized headingMessage={headingMessage}>{children}</NotAuthorized>
+  );
+};
+
+export const Example1 = Template.bind({});
+Example1.args = {
+  headingMessage: "Sorry, you are not authorized to view this page.",
+  children: (
+    <p>
+      Oops, it looks like you&apos;ve landed on a page that you are not
+      authorized to view.
+    </p>
+  ),
+};

--- a/frontend/common/src/components/NotAuthorized/NotAuthorized.tsx
+++ b/frontend/common/src/components/NotAuthorized/NotAuthorized.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+export interface NotAuthorizedProps {
+  headingMessage: string;
+  children: React.ReactNode;
+}
+
+const NotAuthorized: React.FC<NotAuthorizedProps> = ({
+  headingMessage,
+  children,
+}) => {
+  return (
+    <div
+      data-h2-flex-grid="b(top, contained, flush, xl)"
+      data-h2-container="b(center, l)"
+    >
+      <div data-h2-flex-item="b(1of1)" data-h2-text-align="b(center)">
+        <h3
+          data-h2-font-size="b(h4)"
+          data-h2-font-weight="b(700)"
+          data-h2-margin="b(bottom, m)"
+        >
+          {headingMessage}
+        </h3>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default NotAuthorized;

--- a/frontend/common/src/components/NotAuthorized/index.ts
+++ b/frontend/common/src/components/NotAuthorized/index.ts
@@ -1,0 +1,5 @@
+import NotAuthorized from "./NotAuthorized";
+import type { NotAuthorizedProps } from "./NotAuthorized";
+
+export default NotAuthorized;
+export type { NotAuthorizedProps };


### PR DESCRIPTION
Resolves #2635.

- Adds NotAuthorized component
- Adds getMe graphQL query
- Adds AuthorizationContainer component
- Adds missing key prop to LoginOrLogout button
- Updates PoolDashboard, Dashboard component to limit access based on logged in status and presence of ADMIN role for a logged in user
- Wraps ClientProvider, AuthorizationContainer components around PoolDashboard
- Moves PoolListApi query from Dashboard to PoolDashboard component