### PR TITLE
Auto create users

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -133,30 +133,6 @@ class User extends Model implements Authenticatable
     protected static function boot()
     {
         parent::boot();
-
-        static::creating(function ($model)
-        {
-            $model->generateSubject();
-        });
-    }
-
-     /**
-     * Generates the value for the User::sub field. Used to
-     * support authentication.
-     * @return bool
-     */
-    protected function generateSubject()
-    {
-        // TODO when moving to Sign In Canada we won't be using email any more
-
-        // fill sub with email if not already filled
-        if( !array_key_exists('sub', $this->attributes) )
-            $this->attributes['sub'] = $this->attributes['email'];
-
-        if( is_null($this->attributes['sub']) )
-            return false; // failed to create subject
-        else
-            return true;
     }
 
      // getIsProfileCompleteAttribute function is correspondent to isProfileComplete attribute in graphql schema

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -90,7 +90,7 @@ class User extends Model implements Authenticatable
 
     public function isAdmin(): bool
     {
-        return in_array('ADMIN', $this->roles);
+        return is_array($this->roles) && in_array('ADMIN', $this->roles);
     }
 
     // All the relationships for experiences

--- a/api/app/Providers/AuthServiceProvider.php
+++ b/api/app/Providers/AuthServiceProvider.php
@@ -100,7 +100,6 @@ class AuthServiceProvider extends ServiceProvider
                 // No user found for given subscriber - lets auto-register them
                 $newUser = new User;
                 $newUser->first_name = $sub;  // displayed on the landing page so should help us find the user
-                $newUser->email = $sub.'@new.user'; // junk, but email is currently non-nullable
                 $newUser->sub = $sub;
                 $newUser->roles = null;
                 $newUser->save();

--- a/api/app/Providers/AuthServiceProvider.php
+++ b/api/app/Providers/AuthServiceProvider.php
@@ -65,41 +65,57 @@ class AuthServiceProvider extends ServiceProvider
         Gate::policy(AwardExperience::class, ExperiencePolicy::class);
 
         $this->app['auth']->viaRequest('api', function ($request) use ($tokenService) {
-
-            $bearerToken = $request->bearerToken(); // 1. extract JWT access token from request.
-            if($bearerToken)
-            {
-                try {
-                    $claims = $tokenService->validateAndGetClaims($bearerToken);  // 2. validate access token.
-                    $sub = $claims->get('sub');
-                } catch (RequiredConstraintsViolated $e) {
-                    $violations = [];
-                    foreach ($e->violations() as $violationError) {
-                        array_push($violations, $violationError->getMessage());
-                    }
-                    Log::notice('Authorization token not valid: ', $violations);
-                    return abort(401, 'Authorization token not valid.');
-                } catch (Exception $e) {
-                    Log::notice('Error while validating authorization token: ' . $e->getMessage());
-                    return abort(401, 'Error while validating authorization token.');
-                }
-
-                $userMatch = User::where('sub', $sub)->first(); // 3. match "sub" claim to user 'sub' field.
-                if($userMatch) {
-                    return $userMatch;
-                } else {
-                    Log::notice('No user found for given subscriber: '.$sub);
-                    return null;
-                }
-            }
-
-            // If a default user is set, and there is no bearer token, treat the request as if it were from the default user.
-            if (config('oauth.default_user')) {
-                $user = User::where('email', config('oauth.default_user'))->first();
-                if ($user) {
-                    return $user;
-                }
-            }
+            return $this->resolveUserOrAbort($request->bearerToken(), $tokenService);
         });
+    }
+
+    /**
+     * Get the associated user model for a request or abort if something goes wrong with the lookup
+     *
+     */
+    public function resolveUserOrAbort($bearerToken, $tokenService): ?User {
+        if($bearerToken)
+        {
+            try {
+                $claims = $tokenService->validateAndGetClaims($bearerToken);  // 2. validate access token.
+                $sub = $claims->get('sub');
+            } catch (RequiredConstraintsViolated $e) {
+                $violations = [];
+                foreach ($e->violations() as $violationError) {
+                    array_push($violations, $violationError->getMessage());
+                }
+                Log::notice('Authorization token not valid: ', $violations);
+                return abort(401, 'Authorization token not valid.');
+            } catch (Exception $e) {
+                Log::notice('Error while validating authorization token: ' . $e->getMessage());
+                return abort(401, 'Error while validating authorization token.');
+            }
+
+            // By this point we have verified that the token is legitimate
+
+            $userMatch = User::where('sub', $sub)->first(); // 3. match "sub" claim to user 'sub' field.
+            if($userMatch) {
+                return $userMatch;
+            } else {
+                // No user found for given subscriber - lets auto-register them
+                $newUser = new User;
+                $newUser->first_name = $sub;  // displayed on the landing page so should help us find the user
+                $newUser->email = $sub.'@new.user'; // junk, but email is currently non-nullable
+                $newUser->sub = $sub;
+                $newUser->roles = null;
+                $newUser->save();
+                return $newUser;
+            }
+        }
+
+        // If a default user is set, and there is no bearer token, treat the request as if it were from the default user.
+        if (config('oauth.default_user')) {
+            $user = User::where('email', config('oauth.default_user'))->first();
+            if ($user) {
+                return $user;
+            }
+        }
+
+        return null;
     }
 }

--- a/api/app/Services/Contracts/BearerTokenServiceInterface.php
+++ b/api/app/Services/Contracts/BearerTokenServiceInterface.php
@@ -1,9 +1,7 @@
 <?php
 namespace App\Services\Contracts;
 
-use Lcobucci\JWT\Token\DataSet;
-
 Interface BearerTokenServiceInterface
 {
-    public function validateAndGetClaims(string $bearerToken) : DataSet;
+    public function validateAndGetClaims(string $bearerToken);
 }

--- a/api/app/Services/Contracts/DatasetInterface.php
+++ b/api/app/Services/Contracts/DatasetInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Services\Contracts;
+
+use Lcobucci\JWT\Token\DataSet;
+
+// Need to abstract the Lcobucci\JWT\Token\DataSet class because it is a final class and cannot be mocked
+Interface DataSetInterface extends DataSet
+{ }

--- a/api/app/Services/LocalAuthBearerTokenService.php
+++ b/api/app/Services/LocalAuthBearerTokenService.php
@@ -33,7 +33,7 @@ class LocalAuthBearerTokenService implements BearerTokenServiceInterface
     }
 
     /*
-    * @returns DataSet
+    * @returns Lcobucci\JWT\Token\DataSet
     */
     public function validateAndGetClaims(string $bearerToken)
     {

--- a/api/app/Services/LocalAuthBearerTokenService.php
+++ b/api/app/Services/LocalAuthBearerTokenService.php
@@ -12,7 +12,6 @@ use Lcobucci\JWT\Validation\Constraint\RelatedTo;
 use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
 use App\Services\Contracts\BearerTokenServiceInterface;
-use Lcobucci\JWT\Token\DataSet;
 
 class LocalAuthBearerTokenService implements BearerTokenServiceInterface
 {
@@ -33,7 +32,10 @@ class LocalAuthBearerTokenService implements BearerTokenServiceInterface
         $this->allowableClockSkew = $allowableClockSkew;
     }
 
-    public function validateAndGetClaims(string $bearerToken) : DataSet
+    /*
+    * @returns DataSet
+    */
+    public function validateAndGetClaims(string $bearerToken)
     {
         $token = $this->config->parser()->parse($bearerToken);
 

--- a/api/app/Services/OpenIdBearerTokenService.php
+++ b/api/app/Services/OpenIdBearerTokenService.php
@@ -12,7 +12,6 @@ use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer;
 use Lcobucci\JWT\UnencryptedToken;
 use Lcobucci\JWT\Signer\Key\InMemory;
-use Lcobucci\JWT\Token\DataSet;
 use Lcobucci\JWT\Validation\Constraint\IssuedBy;
 use Lcobucci\JWT\Validation\Constraint\RelatedTo;
 use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
@@ -141,7 +140,10 @@ class OpenIdBearerTokenService implements BearerTokenServiceInterface
         }
     }
 
-    public function validateAndGetClaims(string $bearerToken) : DataSet
+    /*
+    * @returns DataSet
+    */
+    public function validateAndGetClaims(string $bearerToken)
     {
         $unsecuredToken = $this->unsecuredConfig->parser()->parse($bearerToken);
 

--- a/api/app/Services/OpenIdBearerTokenService.php
+++ b/api/app/Services/OpenIdBearerTokenService.php
@@ -141,7 +141,7 @@ class OpenIdBearerTokenService implements BearerTokenServiceInterface
     }
 
     /*
-    * @returns DataSet
+    * @returns Lcobucci\JWT\Token\DataSet
     */
     public function validateAndGetClaims(string $bearerToken)
     {

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -38,8 +38,8 @@ class UserFactory extends Factory
         return [
             'first_name' => $this->faker->firstName(),
             'last_name' => $this->faker->lastName(),
-            'email' => $this->faker->unique()->safeEmail,
-            //'sub' => filled in User::creating event
+            'email' => $this->faker->boolean(75) ? $this->faker->unique()->safeEmail : null,
+            'sub' => $this->faker->boolean(75) ? $this->faker->unique()->uuid() : null,
             'telephone' => $this->faker->e164PhoneNumber(),
             'preferred_lang' => $this->faker->randomElement(['en', 'fr']),
             'roles' => [],

--- a/api/database/migrations/2022_05_12_125508_make_email_nullable.php
+++ b/api/database/migrations/2022_05_12_125508_make_email_nullable.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+class MakeEmailNullable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // make email nullable
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('email')->nullable()->change();
+        });
+
+        // set null for any emails that were stuffed with ID
+        DB::statement(" update users
+                        set email = null
+                        where email = id::text");
+
+        // make sub nullable
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('sub')->nullable()->change();
+        });
+
+        // set null for any subs that were stuffed with ID
+        DB::statement(" update users
+                        set sub = null
+                        where sub = id::text");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // stuff null emails with ID before making column non-nullable
+        DB::statement(" update users
+                        set email = id
+                        where email is null");
+
+        // make email non-nullable
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('email')->nullable(false)->change();
+        });
+
+        // stuff null subs with ID before making column non-nullable
+        DB::statement(" update users
+                        set sub = id
+                        where sub is null");
+
+        // make sub non-nullable
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('sub')->nullable(false)->change();
+        });
+    }
+}

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -35,7 +35,7 @@ type User {
     # Personal info
     firstName: String @rename(attribute: "first_name")
     lastName: String @rename(attribute: "last_name")
-    email: Email!
+    email: Email
     telephone: PhoneNumber
     preferredLang: Language @rename(attribute: "preferred_lang")
     currentProvince: ProvinceOrTerritory @rename(attribute: "current_province")
@@ -93,7 +93,7 @@ type User {
     pools: [Pool] @hasMany # Pools a user owns
 
     # Profile Status
-    isProfileComplete: Boolean 
+    isProfileComplete: Boolean
 }
 
 enum ProvinceOrTerritory {
@@ -152,7 +152,7 @@ type Applicant {
     # Personal info
     firstName: String @rename(attribute: "first_name")
     lastName: String @rename(attribute: "last_name")
-    email: Email!
+    email: Email
     telephone: PhoneNumber
     preferredLang: Language @rename(attribute: "preferred_lang")
     currentProvince: ProvinceOrTerritory @rename(attribute: "current_province")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -2,7 +2,7 @@ type Applicant {
   id: ID!
   firstName: String
   lastName: String
-  email: Email!
+  email: Email
   telephone: PhoneNumber
   preferredLang: Language
   currentProvince: ProvinceOrTerritory
@@ -1074,7 +1074,7 @@ type User {
   roles: [Role]
   firstName: String
   lastName: String
-  email: Email!
+  email: Email
   telephone: PhoneNumber
   preferredLang: Language
   currentProvince: ProvinceOrTerritory

--- a/api/tests/Feature/AuthServiceProviderTest.php
+++ b/api/tests/Feature/AuthServiceProviderTest.php
@@ -120,7 +120,6 @@ class AuthServiceProviderTest extends TestCase
 
         // manually add the user with the sub
         $existingUser = new User;
-        $existingUser->email = $testSub.'@existing.user'; // junk, but email is currently non-nullable
         $existingUser->sub = $testSub;
         $existingUser->roles = $testRoles;
         $existingUser->save();

--- a/api/tests/Feature/AuthServiceProviderTest.php
+++ b/api/tests/Feature/AuthServiceProviderTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use App\Models\User;
+use App\Providers\AuthServiceProvider;
+use App\Services\Contracts\BearerTokenServiceInterface;
+use App\Services\Contracts\DataSetInterface;
+use Tests\TestCase;
+use Mockery\MockInterface;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class AuthServiceProviderTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    /**
+     * @var MockInterface
+     */
+    private $mockApp;
+
+    /**
+     * @var MockInterface
+     */
+    private $mockAuthProvider;
+
+     /**
+     * @var AuthServiceProvider
+     */
+    private $provider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockAuthProvider = Mockery::mock();
+        $this->mockAuthProvider->shouldReceive('viaRequest');
+
+        $this->mockApp = Mockery::mock(ArrayAccess::class);
+        $this->mockApp
+                    ->shouldReceive('offsetGet')
+                    ->with('auth')
+                    ->andReturn($this->mockAuthProvider);
+
+         $this->provider = new AuthServiceProvider($this->mockApp);
+
+    }
+
+     /**
+     * @test
+     * The test checks a an HttpException with status 401 is thrown if an exception occurs during token validation
+     */
+    public function test401IfException()
+    {
+        $fakeToken = 'fake-token';
+        $mockTokenService = Mockery::mock(BearerTokenServiceInterface::class);
+        $mockTokenService->shouldReceive('validateAndGetClaims')
+                                        ->with($fakeToken)
+                                        ->andThrow(new Exception);
+
+        try {
+            $resolvedUser = $this->provider->resolveUserOrAbort($fakeToken, $mockTokenService);
+            $this->fail('HttpException was not thrown');
+        } catch (HttpException $e) {
+            $this->assertEquals(401, $e->getStatusCode(), 'Unexpected status code on HttpException');
+        }
+    }
+
+    /**
+     * @test
+     * The test checks that a user is automatically created if it doesn't yet exist (by sub)
+     * Also check that the new user has no roles
+     */
+    public function testUserIsAutoCreatedWhenMissing()
+    {
+        $testSub = 'test-sub';
+
+        $mockClaims = Mockery::mock(DataSetInterface::class);
+        $mockClaims->shouldReceive('get')
+                    ->with('sub')
+                    ->andReturn($testSub);
+
+        $fakeToken = 'fake-token';
+        $mockTokenService = Mockery::mock(BearerTokenServiceInterface::class);
+        $mockTokenService->shouldReceive('validateAndGetClaims')
+                            ->with($fakeToken)
+                            ->andReturn($mockClaims);
+
+        // starting off, they shouldn't exist
+        $this->assertDatabaseMissing('users', ['sub' => $testSub]);
+
+        // this resolve should auto-create them
+        $resolvedUser = $this->provider->resolveUserOrAbort($fakeToken, $mockTokenService);
+
+        // they should exist now, but should not be admin
+        $this->assertDatabaseHas('users', ['sub' => $testSub, 'roles' => null]);
+    }
+
+     /**
+     * @test
+     * The test checks that a user is not automatically created if it already exists(by sub)
+     */
+    public function testUserIsNotAutoCreatedWhenAlreadyExisting()
+    {
+        $testSub = 'test-sub';
+        $testRoles = ["ADMIN"];
+
+        $mockClaims = Mockery::mock(DataSetInterface::class);
+        $mockClaims->shouldReceive('get')
+                    ->with('sub')
+                    ->andReturn($testSub);
+
+        $fakeToken = 'fake-token';
+        $mockTokenService = Mockery::mock(BearerTokenServiceInterface::class);
+        $mockTokenService->shouldReceive('validateAndGetClaims')
+                            ->with($fakeToken)
+                            ->andReturn($mockClaims);
+
+        // starting off, they shouldn't exist
+        $this->assertDatabaseMissing('users', ['sub' => $testSub]);
+
+        // manually add the user with the sub
+        $existingUser = new User;
+        $existingUser->email = $testSub.'@existing.user'; // junk, but email is currently non-nullable
+        $existingUser->sub = $testSub;
+        $existingUser->roles = $testRoles;
+        $existingUser->save();
+
+        // they should exist now
+        $this->assertDatabaseHas('users', ['sub' => $testSub, 'roles' => json_encode($testRoles)]);
+        // this should not recreate them - that would wipe out the ADMIN role on our test user
+        $resolvedUser = $this->provider->resolveUserOrAbort($fakeToken, $mockTokenService);
+        // make sure our test user did not get roles wiped
+        $this->assertDatabaseHas('users', ['sub' => $testSub, 'roles' => json_encode($testRoles)]);
+    }
+}

--- a/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
@@ -67,10 +67,8 @@ type FormValues = Pick<
   | "acceptedOperationalRequirements"
   | "status"
 > &
-  Pick<
-    User,
-    "email" | "firstName" | "lastName" | "preferredLang" | "telephone"
-  > & {
+  Pick<User, "firstName" | "lastName" | "preferredLang" | "telephone"> & {
+    email: string; // email is Maybe<string> in User definition, but is required in the form.
     cmoAssets: string[] | undefined;
     expectedClassifications: string[] | undefined;
     pool: string;
@@ -256,7 +254,7 @@ export const CreatePoolCandidateForm: React.FunctionComponent<
       case "new":
         userObject = {
           create: {
-            email: values.email ?? "",
+            email: values.email,
             firstName: values.firstName ?? "",
             lastName: values.lastName ?? "",
             preferredLang: values.preferredLang,

--- a/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
@@ -255,7 +255,7 @@ export const CreatePoolCandidateForm: React.FunctionComponent<CreatePoolCandidat
         case "new":
           userObject = {
             create: {
-              email: values.email,
+              email: values.email ?? "",
               firstName: values.firstName ?? "",
               lastName: values.lastName ?? "",
               preferredLang: values.preferredLang,

--- a/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
@@ -223,404 +223,403 @@ interface CreatePoolCandidateFormProps {
   ) => Promise<CreatePoolCandidateMutation["createPoolCandidateAsAdmin"]>;
 }
 
-export const CreatePoolCandidateForm: React.FunctionComponent<CreatePoolCandidateFormProps> =
-  ({
-    classifications,
-    cmoAssets,
-    pools,
-    poolId,
-    users,
-    handleCreatePoolCandidate,
-  }) => {
-    const intl = useIntl();
-    const locale = getLocale(intl);
-    const paths = useAdminRoutes();
-    const methods = useForm<FormValues>({
-      defaultValues: {
-        pool: poolId,
-        status: PoolCandidateStatus.Available, // Status for new candidates should always default to Available.
+export const CreatePoolCandidateForm: React.FunctionComponent<
+  CreatePoolCandidateFormProps
+> = ({
+  classifications,
+  cmoAssets,
+  pools,
+  poolId,
+  users,
+  handleCreatePoolCandidate,
+}) => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
+  const paths = useAdminRoutes();
+  const methods = useForm<FormValues>({
+    defaultValues: {
+      pool: poolId,
+      status: PoolCandidateStatus.Available, // Status for new candidates should always default to Available.
+    },
+  });
+  const { control, handleSubmit } = methods;
+
+  const formValuesToSubmitData = (
+    values: FormValues,
+  ): CreatePoolCandidateAsAdminInput => {
+    // the user part of the submit data could be a mutation to connect an existing user or to create a new user
+    let userObject;
+    switch (values.userMode) {
+      case "existing":
+        userObject = { connect: values.user };
+        break;
+      case "new":
+        userObject = {
+          create: {
+            email: values.email ?? "",
+            firstName: values.firstName ?? "",
+            lastName: values.lastName ?? "",
+            preferredLang: values.preferredLang,
+            telephone:
+              // empty string isn't valid according to API validation regex pattern, but null is valid.
+              empty(values.telephone) || values.telephone === ""
+                ? null
+                : values.telephone,
+          },
+        };
+        break;
+      default:
+        userObject = {};
+    }
+
+    return {
+      acceptedOperationalRequirements: values.acceptedOperationalRequirements,
+      cmoAssets: {
+        sync: values.cmoAssets,
       },
-    });
-    const { control, handleSubmit } = methods;
-
-    const formValuesToSubmitData = (
-      values: FormValues,
-    ): CreatePoolCandidateAsAdminInput => {
-      // the user part of the submit data could be a mutation to connect an existing user or to create a new user
-      let userObject;
-      switch (values.userMode) {
-        case "existing":
-          userObject = { connect: values.user };
-          break;
-        case "new":
-          userObject = {
-            create: {
-              email: values.email ?? "",
-              firstName: values.firstName ?? "",
-              lastName: values.lastName ?? "",
-              preferredLang: values.preferredLang,
-              telephone:
-                // empty string isn't valid according to API validation regex pattern, but null is valid.
-                empty(values.telephone) || values.telephone === ""
-                  ? null
-                  : values.telephone,
-            },
-          };
-          break;
-        default:
-          userObject = {};
-      }
-
-      return {
-        acceptedOperationalRequirements: values.acceptedOperationalRequirements,
-        cmoAssets: {
-          sync: values.cmoAssets,
-        },
-        cmoIdentifier: values.cmoIdentifier,
-        expectedClassifications: {
-          sync: values.expectedClassifications,
-        },
-        expectedSalary: values.expectedSalary,
-        expiryDate: values.expiryDate,
-        hasDiploma: values.hasDiploma,
-        hasDisability: values.hasDisability,
-        isIndigenous: values.isIndigenous,
-        isVisibleMinority: values.isVisibleMinority,
-        isWoman: values.isWoman,
-        languageAbility: values.languageAbility,
-        locationPreferences: values.locationPreferences,
-        status: values.status,
-        pool: { connect: values.pool },
-        user: userObject, // connect or create mutation
-      };
+      cmoIdentifier: values.cmoIdentifier,
+      expectedClassifications: {
+        sync: values.expectedClassifications,
+      },
+      expectedSalary: values.expectedSalary,
+      expiryDate: values.expiryDate,
+      hasDiploma: values.hasDiploma,
+      hasDisability: values.hasDisability,
+      isIndigenous: values.isIndigenous,
+      isVisibleMinority: values.isVisibleMinority,
+      isWoman: values.isWoman,
+      languageAbility: values.languageAbility,
+      locationPreferences: values.locationPreferences,
+      status: values.status,
+      pool: { connect: values.pool },
+      user: userObject, // connect or create mutation
     };
-
-    const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
-      await handleCreatePoolCandidate(formValuesToSubmitData(data))
-        .then(() => {
-          navigate(paths.poolCandidateTable(poolId || data.pool));
-          toast.success(
-            intl.formatMessage({
-              defaultMessage: "Pool Candidate created successfully!",
-              description:
-                "Message displayed to user after pool candidate is created successfully.",
-            }),
-          );
-        })
-        .catch(() => {
-          toast.error(
-            intl.formatMessage({
-              defaultMessage: "Error: creating pool candidate failed",
-              description:
-                "Message displayed to pool candidate after pool candidate fails to get created.",
-            }),
-          );
-        });
-    };
-
-    const cmoAssetOptions: Option<string>[] = cmoAssets.map(({ id, name }) => ({
-      value: id,
-      label: name[locale] ?? "Error: name not loaded",
-    }));
-
-    const classificationOptions: Option<string>[] = classifications.map(
-      ({ id, group, level }) => ({
-        value: id,
-        label: `${group}-0${level}`,
-      }),
-    );
-
-    const poolOptions: Option<string>[] = pools?.map(({ id, name }) => ({
-      value: id,
-      label: name?.[locale] || "Error: pool name not found",
-    }));
-
-    const userOptions: Option<string>[] = users.map(
-      ({ id, firstName, lastName }) => ({
-        value: id,
-        label: `${firstName} ${lastName}`,
-      }),
-    );
-
-    return (
-      <section>
-        <h2 data-h2-text-align="b(center)" data-h2-margin="b(top, none)">
-          {intl.formatMessage({
-            defaultMessage: "Create Pool Candidate",
-            description: "Title displayed on the create a user form.",
-          })}
-        </h2>
-        <div data-h2-container="b(center, s)">
-          <FormProvider {...methods}>
-            <form onSubmit={handleSubmit(onSubmit)}>
-              <h4>
-                {intl.formatMessage({
-                  description: "Heading for the user information section",
-                  defaultMessage: "User Information",
-                })}
-              </h4>
-              <RadioGroup
-                idPrefix="userMode"
-                legend="User Assignment"
-                name="userMode"
-                items={[
-                  {
-                    value: "existing",
-                    label: intl.formatMessage({
-                      defaultMessage: "Assign Existing User",
-                      description:
-                        "Label for the existing user assignment option in the create pool candidate form.",
-                    }),
-                  },
-                  {
-                    value: "new",
-                    label: intl.formatMessage({
-                      defaultMessage: "Create New User",
-                      description:
-                        "Label for the new user assignment option in the create pool candidate form.",
-                    }),
-                  },
-                ]}
-                rules={{
-                  required: intl.formatMessage(errorMessages.required),
-                }}
-              />
-              <UserFormSection control={control} userOptions={userOptions} />
-              <h4>
-                {intl.formatMessage({
-                  description: "Heading for the candidate information section",
-                  defaultMessage: "Candidate Information",
-                })}
-              </h4>
-              <Select
-                id="pool"
-                label={intl.formatMessage({
-                  defaultMessage: "Pool",
-                  description:
-                    "Label displayed on the pool candidate form pool field.",
-                })}
-                nullSelection={intl.formatMessage({
-                  defaultMessage: "Select a pool...",
-                  description:
-                    "Placeholder displayed on the pool candidate form Pool field.",
-                })}
-                name="pool"
-                options={poolOptions}
-                disabled={!!poolId}
-                rules={{
-                  required: intl.formatMessage(errorMessages.required),
-                }}
-              />
-              <Input
-                id="cmoIdentifier"
-                label={intl.formatMessage({
-                  defaultMessage: "Process Number",
-                  description:
-                    "Label displayed on the pool candidate form process number field.",
-                })}
-                type="text"
-                name="cmoIdentifier"
-              />
-              <Input
-                id="expiryDate"
-                label={intl.formatMessage({
-                  defaultMessage: "Expiry Date",
-                  description:
-                    "Label displayed on the pool candidate form expiry date field.",
-                })}
-                type="date"
-                name="expiryDate"
-                rules={{
-                  required: intl.formatMessage(errorMessages.required),
-                  min: {
-                    value: currentDate(),
-                    message: intl.formatMessage(errorMessages.futureDate),
-                  },
-                }}
-              />
-              <Checkbox
-                id="isWoman"
-                label={intl.formatMessage({
-                  defaultMessage: "Woman",
-                  description:
-                    "Label displayed on the pool candidate form is woman field.",
-                })}
-                name="isWoman"
-              />
-              <Checkbox
-                id="hasDisability"
-                label={intl.formatMessage({
-                  defaultMessage: "Has Disability",
-                  description:
-                    "Label displayed on the pool candidate form has disability field.",
-                })}
-                name="hasDisability"
-              />
-              <Checkbox
-                id="isIndigenous"
-                label={intl.formatMessage({
-                  defaultMessage: "Indigenous",
-                  description:
-                    "Placeholder displayed on the pool candidate form is indigenous field.",
-                })}
-                name="isIndigenous"
-              />
-              <Checkbox
-                id="isVisibleMinority"
-                label={intl.formatMessage({
-                  defaultMessage: "Visible Minority",
-                  description:
-                    "Label displayed on the pool candidate form is visible minority field.",
-                })}
-                name="isVisibleMinority"
-              />
-              <Checkbox
-                id="hasDiploma"
-                label={intl.formatMessage({
-                  defaultMessage: "Has Diploma",
-                  description:
-                    "Label displayed on the pool candidate form has diploma field.",
-                })}
-                name="hasDiploma"
-              />
-              <Select
-                id="languageAbility"
-                label={intl.formatMessage({
-                  defaultMessage: "Language Ability",
-                  description:
-                    "Label displayed on the pool candidate form language ability field.",
-                })}
-                name="languageAbility"
-                nullSelection={intl.formatMessage({
-                  defaultMessage: "Select a language ability...",
-                  description:
-                    "Placeholder displayed on the pool candidate form language ability field.",
-                })}
-                options={enumToOptions(LanguageAbility).map(({ value }) => ({
-                  value,
-                  label: intl.formatMessage(getLanguageAbility(value)),
-                }))}
-                rules={{
-                  required: intl.formatMessage(errorMessages.required),
-                }}
-              />
-              <MultiSelect
-                id="locationPreferences"
-                name="locationPreferences"
-                label={intl.formatMessage({
-                  defaultMessage: "Location Preferences",
-                  description:
-                    "Label displayed on the pool candidate form location preferences field.",
-                })}
-                placeholder={intl.formatMessage({
-                  defaultMessage: "Select one or more location preferences...",
-                  description:
-                    "Placeholder displayed on the pool candidate form location preferences field.",
-                })}
-                options={enumToOptions(WorkRegion).map(({ value }) => ({
-                  value,
-                  label: intl.formatMessage(getWorkRegion(value)),
-                }))}
-              />
-              <MultiSelect
-                id="acceptedOperationalRequirements"
-                name="acceptedOperationalRequirements"
-                label={intl.formatMessage({
-                  defaultMessage: "Operational Requirements",
-                  description:
-                    "Label displayed on the pool candidate form operational requirements field.",
-                })}
-                placeholder={intl.formatMessage({
-                  defaultMessage:
-                    "Select one or more operational requirements...",
-                  description:
-                    "Placeholder displayed on the pool candidate form operational requirements field.",
-                })}
-                options={enumToOptions(OperationalRequirement).map(
-                  ({ value }) => ({
-                    value,
-                    label: intl.formatMessage(getOperationalRequirement(value)),
-                  }),
-                )}
-              />
-              <MultiSelect
-                id="expectedSalary"
-                label={intl.formatMessage({
-                  defaultMessage: "Expected Salary",
-                  description:
-                    "Label displayed on the pool candidate form expected salary field.",
-                })}
-                name="expectedSalary"
-                placeholder={intl.formatMessage({
-                  defaultMessage: "Select one or more expected salaries...",
-                  description:
-                    "Placeholder displayed on the pool candidate form expected salary field.",
-                })}
-                options={enumToOptions(SalaryRange).map(({ value }) => ({
-                  value,
-                  label: getSalaryRange(value),
-                }))}
-              />
-              <MultiSelect
-                id="expectedClassifications"
-                label={intl.formatMessage({
-                  defaultMessage: "Expected Classifications",
-                  description:
-                    "Label displayed on the pool candidate form expected classifications field.",
-                })}
-                placeholder={intl.formatMessage({
-                  defaultMessage: "Select one or more classifications...",
-                  description:
-                    "Placeholder displayed on the pool candidate form expected classifications field.",
-                })}
-                name="expectedClassifications"
-                options={classificationOptions}
-              />
-              <MultiSelect
-                id="cmoAssets"
-                label={intl.formatMessage({
-                  defaultMessage: "CMO Assets",
-                  description:
-                    "Label displayed on the pool candidate form cmo assets field.",
-                })}
-                placeholder={intl.formatMessage({
-                  defaultMessage: "Select one or more CMO Assets...",
-                  description:
-                    "Placeholder displayed on the pool candidate form cmo assets field.",
-                })}
-                name="cmoAssets"
-                options={cmoAssetOptions}
-              />
-              <Select
-                id="status"
-                label={intl.formatMessage({
-                  defaultMessage: "Status",
-                  description:
-                    "Label displayed on the pool candidate form status field.",
-                })}
-                nullSelection={intl.formatMessage({
-                  defaultMessage: "Select a status...",
-                  description:
-                    "Placeholder displayed on the pool candidate form status field.",
-                })}
-                name="status"
-                rules={{
-                  required: intl.formatMessage(errorMessages.required),
-                }}
-                options={enumToOptions(PoolCandidateStatus).map(
-                  ({ value }) => ({
-                    value,
-                    label: intl.formatMessage(getPoolCandidateStatus(value)),
-                  }),
-                )}
-              />
-              <Submit />
-            </form>
-          </FormProvider>
-        </div>
-      </section>
-    );
   };
+
+  const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
+    await handleCreatePoolCandidate(formValuesToSubmitData(data))
+      .then(() => {
+        navigate(paths.poolCandidateTable(poolId || data.pool));
+        toast.success(
+          intl.formatMessage({
+            defaultMessage: "Pool Candidate created successfully!",
+            description:
+              "Message displayed to user after pool candidate is created successfully.",
+          }),
+        );
+      })
+      .catch(() => {
+        toast.error(
+          intl.formatMessage({
+            defaultMessage: "Error: creating pool candidate failed",
+            description:
+              "Message displayed to pool candidate after pool candidate fails to get created.",
+          }),
+        );
+      });
+  };
+
+  const cmoAssetOptions: Option<string>[] = cmoAssets.map(({ id, name }) => ({
+    value: id,
+    label: name[locale] ?? "Error: name not loaded",
+  }));
+
+  const classificationOptions: Option<string>[] = classifications.map(
+    ({ id, group, level }) => ({
+      value: id,
+      label: `${group}-0${level}`,
+    }),
+  );
+
+  const poolOptions: Option<string>[] = pools?.map(({ id, name }) => ({
+    value: id,
+    label: name?.[locale] || "Error: pool name not found",
+  }));
+
+  const userOptions: Option<string>[] = users.map(
+    ({ id, firstName, lastName }) => ({
+      value: id,
+      label: `${firstName} ${lastName}`,
+    }),
+  );
+
+  return (
+    <section>
+      <h2 data-h2-text-align="b(center)" data-h2-margin="b(top, none)">
+        {intl.formatMessage({
+          defaultMessage: "Create Pool Candidate",
+          description: "Title displayed on the create a user form.",
+        })}
+      </h2>
+      <div data-h2-container="b(center, s)">
+        <FormProvider {...methods}>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <h4>
+              {intl.formatMessage({
+                description: "Heading for the user information section",
+                defaultMessage: "User Information",
+              })}
+            </h4>
+            <RadioGroup
+              idPrefix="userMode"
+              legend="User Assignment"
+              name="userMode"
+              items={[
+                {
+                  value: "existing",
+                  label: intl.formatMessage({
+                    defaultMessage: "Assign Existing User",
+                    description:
+                      "Label for the existing user assignment option in the create pool candidate form.",
+                  }),
+                },
+                {
+                  value: "new",
+                  label: intl.formatMessage({
+                    defaultMessage: "Create New User",
+                    description:
+                      "Label for the new user assignment option in the create pool candidate form.",
+                  }),
+                },
+              ]}
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <UserFormSection control={control} userOptions={userOptions} />
+            <h4>
+              {intl.formatMessage({
+                description: "Heading for the candidate information section",
+                defaultMessage: "Candidate Information",
+              })}
+            </h4>
+            <Select
+              id="pool"
+              label={intl.formatMessage({
+                defaultMessage: "Pool",
+                description:
+                  "Label displayed on the pool candidate form pool field.",
+              })}
+              nullSelection={intl.formatMessage({
+                defaultMessage: "Select a pool...",
+                description:
+                  "Placeholder displayed on the pool candidate form Pool field.",
+              })}
+              name="pool"
+              options={poolOptions}
+              disabled={!!poolId}
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <Input
+              id="cmoIdentifier"
+              label={intl.formatMessage({
+                defaultMessage: "Process Number",
+                description:
+                  "Label displayed on the pool candidate form process number field.",
+              })}
+              type="text"
+              name="cmoIdentifier"
+            />
+            <Input
+              id="expiryDate"
+              label={intl.formatMessage({
+                defaultMessage: "Expiry Date",
+                description:
+                  "Label displayed on the pool candidate form expiry date field.",
+              })}
+              type="date"
+              name="expiryDate"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+                min: {
+                  value: currentDate(),
+                  message: intl.formatMessage(errorMessages.futureDate),
+                },
+              }}
+            />
+            <Checkbox
+              id="isWoman"
+              label={intl.formatMessage({
+                defaultMessage: "Woman",
+                description:
+                  "Label displayed on the pool candidate form is woman field.",
+              })}
+              name="isWoman"
+            />
+            <Checkbox
+              id="hasDisability"
+              label={intl.formatMessage({
+                defaultMessage: "Has Disability",
+                description:
+                  "Label displayed on the pool candidate form has disability field.",
+              })}
+              name="hasDisability"
+            />
+            <Checkbox
+              id="isIndigenous"
+              label={intl.formatMessage({
+                defaultMessage: "Indigenous",
+                description:
+                  "Placeholder displayed on the pool candidate form is indigenous field.",
+              })}
+              name="isIndigenous"
+            />
+            <Checkbox
+              id="isVisibleMinority"
+              label={intl.formatMessage({
+                defaultMessage: "Visible Minority",
+                description:
+                  "Label displayed on the pool candidate form is visible minority field.",
+              })}
+              name="isVisibleMinority"
+            />
+            <Checkbox
+              id="hasDiploma"
+              label={intl.formatMessage({
+                defaultMessage: "Has Diploma",
+                description:
+                  "Label displayed on the pool candidate form has diploma field.",
+              })}
+              name="hasDiploma"
+            />
+            <Select
+              id="languageAbility"
+              label={intl.formatMessage({
+                defaultMessage: "Language Ability",
+                description:
+                  "Label displayed on the pool candidate form language ability field.",
+              })}
+              name="languageAbility"
+              nullSelection={intl.formatMessage({
+                defaultMessage: "Select a language ability...",
+                description:
+                  "Placeholder displayed on the pool candidate form language ability field.",
+              })}
+              options={enumToOptions(LanguageAbility).map(({ value }) => ({
+                value,
+                label: intl.formatMessage(getLanguageAbility(value)),
+              }))}
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <MultiSelect
+              id="locationPreferences"
+              name="locationPreferences"
+              label={intl.formatMessage({
+                defaultMessage: "Location Preferences",
+                description:
+                  "Label displayed on the pool candidate form location preferences field.",
+              })}
+              placeholder={intl.formatMessage({
+                defaultMessage: "Select one or more location preferences...",
+                description:
+                  "Placeholder displayed on the pool candidate form location preferences field.",
+              })}
+              options={enumToOptions(WorkRegion).map(({ value }) => ({
+                value,
+                label: intl.formatMessage(getWorkRegion(value)),
+              }))}
+            />
+            <MultiSelect
+              id="acceptedOperationalRequirements"
+              name="acceptedOperationalRequirements"
+              label={intl.formatMessage({
+                defaultMessage: "Operational Requirements",
+                description:
+                  "Label displayed on the pool candidate form operational requirements field.",
+              })}
+              placeholder={intl.formatMessage({
+                defaultMessage:
+                  "Select one or more operational requirements...",
+                description:
+                  "Placeholder displayed on the pool candidate form operational requirements field.",
+              })}
+              options={enumToOptions(OperationalRequirement).map(
+                ({ value }) => ({
+                  value,
+                  label: intl.formatMessage(getOperationalRequirement(value)),
+                }),
+              )}
+            />
+            <MultiSelect
+              id="expectedSalary"
+              label={intl.formatMessage({
+                defaultMessage: "Expected Salary",
+                description:
+                  "Label displayed on the pool candidate form expected salary field.",
+              })}
+              name="expectedSalary"
+              placeholder={intl.formatMessage({
+                defaultMessage: "Select one or more expected salaries...",
+                description:
+                  "Placeholder displayed on the pool candidate form expected salary field.",
+              })}
+              options={enumToOptions(SalaryRange).map(({ value }) => ({
+                value,
+                label: getSalaryRange(value),
+              }))}
+            />
+            <MultiSelect
+              id="expectedClassifications"
+              label={intl.formatMessage({
+                defaultMessage: "Expected Classifications",
+                description:
+                  "Label displayed on the pool candidate form expected classifications field.",
+              })}
+              placeholder={intl.formatMessage({
+                defaultMessage: "Select one or more classifications...",
+                description:
+                  "Placeholder displayed on the pool candidate form expected classifications field.",
+              })}
+              name="expectedClassifications"
+              options={classificationOptions}
+            />
+            <MultiSelect
+              id="cmoAssets"
+              label={intl.formatMessage({
+                defaultMessage: "CMO Assets",
+                description:
+                  "Label displayed on the pool candidate form cmo assets field.",
+              })}
+              placeholder={intl.formatMessage({
+                defaultMessage: "Select one or more CMO Assets...",
+                description:
+                  "Placeholder displayed on the pool candidate form cmo assets field.",
+              })}
+              name="cmoAssets"
+              options={cmoAssetOptions}
+            />
+            <Select
+              id="status"
+              label={intl.formatMessage({
+                defaultMessage: "Status",
+                description:
+                  "Label displayed on the pool candidate form status field.",
+              })}
+              nullSelection={intl.formatMessage({
+                defaultMessage: "Select a status...",
+                description:
+                  "Placeholder displayed on the pool candidate form status field.",
+              })}
+              name="status"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+              options={enumToOptions(PoolCandidateStatus).map(({ value }) => ({
+                value,
+                label: intl.formatMessage(getPoolCandidateStatus(value)),
+              }))}
+            />
+            <Submit />
+          </form>
+        </FormProvider>
+      </div>
+    </section>
+  );
+};
 
 export const CreatePoolCandidate: React.FunctionComponent<{
   poolId: string;

--- a/frontend/admin/src/js/components/user/UpdateUser.tsx
+++ b/frontend/admin/src/js/components/user/UpdateUser.tsx
@@ -155,7 +155,7 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
               })}
               type="email"
               name="email"
-              value={initialUser.email}
+              value={initialUser.email ?? ""}
               disabled
               hideOptional
             />


### PR DESCRIPTION
This branch adds the feature that users who visit the site with a valid token but don't yet exist in the database will have a new user created for them on-the-fly.

Suggested test methodology:
1) Switch your environment to Sign In Canada
2) Remove the seeded user row for your user (or disable it by clearing the sub value)
3) Log into the admin site
4) Verify that a new user was created with the correct sub value for your SiC ID
Note: New users are not admin so you still won't be able to use the admin site :smile: 
5) Run the test suite

I factored out most of the logic of `AuthServiceProvider` to the `resolveUserOrAbort` method to make it easier to test.  I was never able to figure out how to bootstrap the app with a mock `BearerTokenService` to be able to create a more end-to-end test, unfortunately.

I had to create a DataSetInterface to create test doubles for the JWT DataSet which is a final class.  Unfortunately since the real DataSet does not actually implement my DataSetInterface I had to remove the type hinting where that class was used.  If any PHP wizards have a way around that let me know.  PHP 8 (cough, cough) has type hinting with unions which would be nice.

Closes #2672 