### PR TITLE
Fixed profile language information always required

### DIFF
--- a/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
+++ b/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
@@ -625,7 +625,15 @@ export const ProfileForm: React.FC<ProfilePageProps> = ({
                 {((!lookingForEnglish &&
                   !lookingForFrench &&
                   !lookingForBilingual) ||
-                  !bilingualEvaluation) && (
+                  (lookingForBilingual &&
+                    (!bilingualEvaluation ||
+                      ((bilingualEvaluation ===
+                        BilingualEvaluation.CompletedEnglish ||
+                        bilingualEvaluation ===
+                          BilingualEvaluation.CompletedFrench) &&
+                        (!comprehensionLevel ||
+                          !writtenLevel ||
+                          !verbalLevel))))) && (
                   <p>
                     {intl.formatMessage(
                       {


### PR DESCRIPTION
Fixes #2705 

Fixed the logic for the language information section of the profile form showing incomplete when it's not. You should now be unable to get the section incomplete message after successfully submitting the form.