### PR TITLE
Copy/Bug - 2764 - update get on touch email link

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -25,6 +25,8 @@ nuage
 Nuwave
 pgsql
 Queueable
+recruitmentimit
+recrutementgiti
 resumé
 subquery
 TALENTSEARCH

--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -68,7 +68,10 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
 
   function a(msg: string) {
     return (
-      <a href={`mailto:${poolOwner?.email}`} data-h2-font-weight="b(700)">
+      <a
+        href="mailto:recruitmentimit-recrutementgiti@tbs-sct.gc.c"
+        data-h2-font-weight="b(700)"
+      >
         {msg}
       </a>
     );

--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -69,7 +69,7 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
   function a(msg: string) {
     return (
       <a
-        href="mailto:recruitmentimit-recrutementgiti@tbs-sct.gc.c"
+        href="mailto:recruitmentimit-recrutementgiti@tbs-sct.gc.ca"
         data-h2-font-weight="b(700)"
       >
         {msg}


### PR DESCRIPTION
Resolves #2764 

## Summary

This just updates the `mailto` link for the "Get in Touch" link when no candidates appear in search results. We were using the pool owner's email but have changed it to the hardcoded recruitmentimit-recrutementgiti@tbs-sct.gc.ca