### PR TITLE
Bug - 2763 - Fix Accordion Icon Wrapping

### DIFF
--- a/frontend/common/src/components/accordion/Accordion.tsx
+++ b/frontend/common/src/components/accordion/Accordion.tsx
@@ -55,7 +55,10 @@ const Accordion: React.FC<AccordionProps> = ({
         }}
         aria-expanded={isOpen}
       >
-        <div data-h2-flex-grid="b(middle, expanded, flush, s)">
+        <div
+          data-h2-flex-grid="b(middle, expanded, flush, s)"
+          data-h2-flex-wrap="b(nowrap)"
+        >
           <span>
             {isOpen ? (
               <ChevronDownIcon height="1.5rem" />
@@ -74,14 +77,16 @@ const Accordion: React.FC<AccordionProps> = ({
 
             <p data-h2-margin="b(top, xxs) b(bottom, none)">{subtitle}</p>
           </div>
-          <div data-h2-flex-item="b(content)" data-h2-text-align="b(right)">
-            <p data-h2-text-align="b(right)" data-h2-font-size="b(normal)">
-              {context}
-            </p>
-          </div>
-          <div data-h2-flex-item="b(content)">
+          <div
+            data-h2-flex-item="b(content)"
+            data-h2-display="b(flex)"
+            data-h2-align-items="b(center)"
+            data-h2-flex-direction="b(row)"
+            style={{ flexShrink: 0 }}
+          >
+            <p data-h2-font-size="b(normal)">{context}</p>
             {!simple && (
-              <span className="icon" data-h2-text-align="b(left)">
+              <span className="icon" data-h2-margin="b(left, xs)">
                 {Icon && <Icon height="1.5rem" width="1.5rem" />}
               </span>
             )}


### PR DESCRIPTION
Resolves #2763 

## Summary

This applies a few changes to styling for the accordions to avoid the icon wrapping.

- Add `flex-wrap: nowrap` to container to prevent wrapping
- Add wrapper div to suffix + icon
- Prevent suffix wrapper div from shrinking to stay uniform

## Notes

Would love @Jerryescandon to review the screenshots to provide some feedback/approval since this has some design concerns.

## Results

### Desktop 

<img width="818" alt="Screen Shot 2022-05-17 at 9 06 15 AM" src="https://user-images.githubusercontent.com/4127998/168818279-6cc7eb10-8194-455c-8131-7ce225947c86.png">

### Tablet

<img width="412" alt="Screen Shot 2022-05-17 at 9 06 03 AM" src="https://user-images.githubusercontent.com/4127998/168818318-773e2ab0-1d01-4d17-a6f7-118f87fcc1bd.png">

### Mobile

<img width="366" alt="Screen Shot 2022-05-17 at 9 04 06 AM" src="https://user-images.githubusercontent.com/4127998/168818385-2a0f5ba3-9ff4-4554-988c-7a363bea44d9.png">

