### PR TITLE
Bug - 2777 - Check refreshed AuthState before returning 

### DIFF
--- a/frontend/common/src/components/ClientProvider/ClientProvider.tsx
+++ b/frontend/common/src/components/ClientProvider/ClientProvider.tsx
@@ -109,15 +109,28 @@ const ClientProvider: React.FC<{ client?: Client }> = ({
         return null;
       }
 
+      /**
+       * Logout the user and return null AuthState
+       *
+       * @returns null
+       */
+      const logoutNullState = () => {
+        logout();
+        return null;
+      };
+
       // If authState is not null, and getAuth is called again, then it means authentication failed for some reason.
       // let's try to use a refresh token to get new tokens
       if (refreshToken) {
-        const refreshedAuthState = refreshTokenSet();
-        return refreshedAuthState;
+        const refreshedAuthState = await refreshTokenSet();
+        if (refreshedAuthState) {
+          return refreshedAuthState;
+        }
+
+        return logoutNullState();
       }
 
-      logout();
-      return null;
+      return logoutNullState();
     },
     // This function is inside of `useCallback` to prevent breaking the memoization of internalClient.
     // If internalClient is re-instantiated it will lose its error count and can cause refresh loops.


### PR DESCRIPTION
Resolves #2777 

## Summary

This adds an `await` to the `refreshTokenSet` function so we can check the state before returning it. Additionally, if that state is no valid, we call `logout`.

Since we reuse `logout` and `return null;` now, this can been moved to a function.

```tsx
/**
 * Logout the user and return null AuthState
 *
  * @returns null
*/
const logoutNullState = () => {
  logout();
  return null;
};
```

## Testing

We should write some automated tests here to confirm we can refresh tokens and properly logout when needed. However, I am not sure where to start and opted to get this PR through and do the following manual testing.

### Invalid Access Token + Valid Refresh Token

This tests that the refresh token is able to successfully refresh the access token.

1. Login to the application
2. Open the DevTools and delete or modify the access token to dirty the AuthState and force a refresh attempt
3. Refresh the page
4. Make sure the token is refreshed and you are still logged in

### Invalid Access Token + Invalid Refresh Token

Test to make sure we are logged out when both tokens are invalid causing an error on refresh.

1. Login to the application
2. Open the DevTools and delete or modify the access and refresh token to dirty the AuthState and force a refresh attempt
3. Refresh the page
4. Make sure you are logged out and redirected to the homepage