### PR TITLE
Bug - 2760 - Null States Request Form

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,6 +39,10 @@ jobs:
         working-directory: frontend
         run: npm run codegen --workspaces --if-present
 
+      - name: "Compile Intl: all workspaces"
+        working-directory: frontend
+        run: npm run intl-compile --workspaces
+
       - name: "Run ESlint: all workspaces"
         working-directory: frontend
         # Temporarily ignore until we fix existing issues.

--- a/frontend/admin/.eslintrc
+++ b/frontend/admin/.eslintrc
@@ -47,7 +47,8 @@
         "import/no-extraneous-dependencies": "off",
         "import/extensions": [
             "warn",
-            "never"
+            "never",
+            {"json": "always"}
         ],
         "react/display-name": "off",
         "react/prop-types": "off",

--- a/frontend/admin/src/js/components/context/LanguageRedirectProvider.tsx
+++ b/frontend/admin/src/js/components/context/LanguageRedirectProvider.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import LanguageRedirectContainer from "@common/components/LanguageRedirectContainer";
 import type { Messages } from "@common/components/LanguageRedirectContainer";
 
-import AdminFrench from "../../lang/frCompiled.json";
+import * as AdminFrench from "../../lang/frCompiled.json";
 
 const LanguageRedirectProvider: React.FC = ({ children }) => (
   <LanguageRedirectContainer messages={AdminFrench as Messages}>

--- a/frontend/common/.eslintrc
+++ b/frontend/common/.eslintrc
@@ -61,7 +61,8 @@
         ],
         "import/extensions": [
             "warn",
-            "never"
+            "never",
+            {"json": "always"}
         ],
         "react/display-name": "off",
         "react/prop-types": "off",

--- a/frontend/common/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/frontend/common/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Story, Meta } from "@storybook/react";
 import { FilterIcon } from "@heroicons/react/solid";
 import Breadcrumbs from "./Breadcrumbs";
-import type { BreadcrumbProps } from "./Breadcrumbs";
+import type { BreadcrumbsProps } from "./Breadcrumbs";
 
 export default {
   component: Breadcrumbs,

--- a/frontend/common/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/frontend/common/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -20,6 +20,24 @@ const FilterBlock: React.FunctionComponent<FilterBlockProps> = ({
   content,
 }) => {
   const intl = useIntl();
+
+  const emptyArrayOutput = (input: string | string[] | null | undefined) => {
+    return input && !isEmpty(input) ? (
+      <p data-h2-display="b(inline)" data-h2-font-color="b(black)">
+        {input}
+      </p>
+    ) : (
+      <ul data-h2-font-color="b(black)">
+        <li>
+          {intl.formatMessage({
+            defaultMessage: "(None selected)",
+            description: "Text shown when the filter was not selected",
+          })}
+        </li>
+      </ul>
+    );
+  };
+
   return (
     <div data-h2-padding="b(bottom, s)">
       <div data-h2-visibility="b(visible) s(hidden)">
@@ -60,14 +78,7 @@ const FilterBlock: React.FunctionComponent<FilterBlockProps> = ({
             ))}
           </ul>
         ) : (
-          <p data-h2-display="b(inline)" data-h2-font-color="b(black)">
-            {content && !isEmpty(content)
-              ? content
-              : intl.formatMessage({
-                  defaultMessage: "N/A",
-                  description: "Text shown when the filter was not selected",
-                })}
-          </p>
+          emptyArrayOutput(content)
         )}
       </div>
     </div>

--- a/frontend/indigenousapprenticeship/.eslintrc
+++ b/frontend/indigenousapprenticeship/.eslintrc
@@ -55,7 +55,8 @@
         "import/no-extraneous-dependencies": "off",
         "import/extensions": [
             "warn",
-            "never"
+            "never",
+            {"json": "always"}
         ],
         "react/display-name": "off",
         "react/prop-types": "off",

--- a/frontend/indigenousapprenticeship/src/js/components/Svg/ThickCircle.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/Svg/ThickCircle.tsx
@@ -1,4 +1,4 @@
-import React, { ReactHTMLElement } from "react";
+import React from "react";
 
 const ThickCircle: React.FC<React.HTMLAttributes<HTMLOrSVGElement>> = (
   props,

--- a/frontend/indigenousapprenticeship/src/js/pageContainer.tsx
+++ b/frontend/indigenousapprenticeship/src/js/pageContainer.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom";
 import LanguageRedirectContainer from "@common/components/LanguageRedirectContainer";
 import { Router } from "./components/Router";
 
-import IndigenousApprenticeshipFrench from "./lang/frCompiled.json";
+import * as IndigenousApprenticeshipFrench from "./lang/frCompiled.json";
 
 ReactDOM.render(
   <LanguageRedirectContainer messages={IndigenousApprenticeshipFrench}>

--- a/frontend/talentsearch/.eslintrc
+++ b/frontend/talentsearch/.eslintrc
@@ -55,7 +55,8 @@
         "import/no-extraneous-dependencies": "off",
         "import/extensions": [
             "warn",
-            "never"
+            "never",
+            {"json": "always"}
         ],
         "react/display-name": "off",
         "react/prop-types": "off",

--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -231,8 +231,10 @@ const candidateFilterToQueryArgs = (
   return {
     where: {
       ...filter,
-      classifications: pickMap(filter.classifications, ["group", "level"]),
-      cmoAssets: pickMap(filter.cmoAssets, "key"),
+      classifications: filter.classifications
+        ? pickMap(filter.classifications, ["group", "level"])
+        : [],
+      cmoAssets: filter.cmoAssets ? pickMap(filter.cmoAssets, "key") : [],
       pools: poolId ? [{ id: poolId }] : pickMap(filter.pools, "id"),
     },
   };

--- a/frontend/talentsearch/src/js/pageContainer.tsx
+++ b/frontend/talentsearch/src/js/pageContainer.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom";
 import LanguageRedirectContainer from "@common/components/LanguageRedirectContainer";
 import { Router } from "./components/Router";
 
-import TalentSearchFrench from "./lang/frCompiled.json";
+import * as TalentSearchFrench from "./lang/frCompiled.json";
 
 ReactDOM.render(
   <LanguageRedirectContainer messages={TalentSearchFrench}>


### PR DESCRIPTION
Resolves #2760 

## Summary

This updates the output for the Request page filter summary to display "(None selected)" instead of "N/A". 

## Bug Fix (bonus!)

While working on this, a bug with the request button breaking when `classifications` and `cmoAssets` were null has been addressed as well.

## Mistakes Were Made

So, I thought I was on a different branch trying to shore up some of the remaining lint issues, especially in regards to the actions.

- Updates `import/extensions` to allow `.json`
- Adds a step to the lint action to compile intl to prevent `import/no-unresolved` erroring
- Changes import pattern for json files to avoid problems with typescript
  - Even though this was supposed to be fixed, I still ran into errors where typescript didn't like default imports of json files
  - `import * as json from "./file.json";` seems to prevent this from happening