### PR TITLE
Group two halves of classification filter

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -74,22 +74,26 @@ class PoolCandidate extends Model
     {
         // Classifications act as an OR filter. The query should return candidates with any of the classifications.
         // A single whereHas clause for the relationship, containing multiple orWhere clauses accomplishes this.
-        $query->whereHas('expectedClassifications', function ($query) use ($classifications) {
-            foreach ($classifications as $index => $classification) {
-                if ($index === 0) {
-                    // First iteration must use where instead of orWhere
-                    $query->where(function($query) use ($classification) {
-                        $query->where('group', $classification['group'])->where('level', $classification['level']);
-                    });
-                } else {
-                    $query->orWhere(function($query) use ($classification) {
-                        $query->where('group', $classification['group'])->where('level', $classification['level']);
-                    });
-                }
-            }
-        });
 
-        $this->orFilterByClassificationToSalary($query, $classifications);
+        // group these in a subquery to properly handle "OR" condition
+        $query->where(function($query) use ($classifications) {
+            $query->whereHas('expectedClassifications', function ($query) use ($classifications) {
+                foreach ($classifications as $index => $classification) {
+                    if ($index === 0) {
+                        // First iteration must use where instead of orWhere
+                        $query->where(function($query) use ($classification) {
+                            $query->where('group', $classification['group'])->where('level', $classification['level']);
+                        });
+                    } else {
+                        $query->orWhere(function($query) use ($classification) {
+                            $query->where('group', $classification['group'])->where('level', $classification['level']);
+                        });
+                    }
+                }
+            });
+
+            $this->orFilterByClassificationToSalary($query, $classifications);
+        });
 
         return $query;
     }


### PR DESCRIPTION
This branch solves the bug where candidates can get pulled in from other pools in the salary-to-classification query.  h/t to Eagle-Eye @vd1992 .  I started by adding some tests for validation.

The query was being built like this:
```
select count(*) from pool_candidates where exists (
  select from joined tables where
  (exact classification match)
  or
  (salary to classification match)
  and
  (candidate_id predicate for exists clause)
)
```
Since AND has precedence the OR operator was not working as intended. I updated the builder to group the OR like this:
```
select count(*) from pool_candidates where exists (
  select from joined tables where
  (
    (exact classification match)
    or
    (salary to classification match)
  )
  and
  (candidate_id predicate for exists clause)
)
```

Closes #2801 