### PR TITLE
Add React Print Demo

### DIFF
--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -113,6 +113,7 @@
     "react-intl": "^5.25.1",
     "react-select": "^5.3.1",
     "react-table": "^7.7.0",
+    "react-to-print": "^2.14.7",
     "react-toastify": "^9.0.1",
     "regenerator-runtime": "^0.13.9",
     "universal-router": "^9.1.0",

--- a/frontend/admin/src/js/adminRoutes.ts
+++ b/frontend/admin/src/js/adminRoutes.ts
@@ -63,6 +63,9 @@ const adminRoutes = (lang: string) => {
     searchRequestTable: (): string => path.join(home(), "search-requests"),
     searchRequestUpdate: (id: string): string =>
       path.join(home(), "search-requests", id, "edit"),
+
+    userAggregateDocument: (): string =>
+      path.join(home(), "user-aggregate-document"),
   };
 };
 

--- a/frontend/admin/src/js/components/PoolDashboard.tsx
+++ b/frontend/admin/src/js/components/PoolDashboard.tsx
@@ -40,6 +40,7 @@ import { UpdateSkill } from "./skill/UpdateSkill";
 import HomePage from "./home/HomePage";
 import { Role, useGetPoolsQuery } from "../api/generated";
 import DashboardPage from "./dashboard/DashboardPage";
+import UserAggregateDocumentPage from "./pdfSpike/UserAggregatePage";
 
 const PoolListApi = (isAdmin: boolean) => {
   const intl = useIntl();
@@ -327,6 +328,17 @@ const routes = (
       component:
         loggedIn && isAdmin ? (
           <SingleSearchRequestPage searchRequestId={params.id as string} />
+        ) : (
+          <AdminNotAuthorized />
+        ),
+    }),
+  },
+  {
+    path: paths.userAggregateDocument(),
+    action: () => ({
+      component:
+        loggedIn && isAdmin ? (
+          <UserAggregateDocumentPage />
         ) : (
           <AdminNotAuthorized />
         ),

--- a/frontend/admin/src/js/components/dashboard/DashboardPage.tsx
+++ b/frontend/admin/src/js/components/dashboard/DashboardPage.tsx
@@ -11,6 +11,7 @@ import PageHeader from "@common/components/PageHeader";
 
 import { commonMessages } from "@common/messages";
 
+import { DocumentDownloadIcon } from "@heroicons/react/solid";
 import DashboardContentContainer from "../DashboardContentContainer";
 import { User, useMeQuery } from "../../api/generated";
 import { useAdminRoutes } from "../../adminRoutes";
@@ -99,6 +100,21 @@ const DashboardPage: React.FC<DashboardPageProps> = ({ currentUser }) => {
               defaultMessage: "Manage requests",
               description:
                 "Text label for link to requests page on admin dashboard",
+            })}
+          </IconLink>
+        </span>
+        <span data-h2-margin="b(bottom-right, s)">
+          <IconLink
+            mode="solid"
+            color="secondary"
+            type="button"
+            href={adminRoutes.userAggregateDocument()}
+            icon={DocumentDownloadIcon}
+          >
+            {intl.formatMessage({
+              defaultMessage: "Download Users",
+              description:
+                "Text label for link to download users page on admin dashboard",
             })}
           </IconLink>
         </span>

--- a/frontend/admin/src/js/components/pdfSpike/UserAggregateDocument.graphql
+++ b/frontend/admin/src/js/components/pdfSpike/UserAggregateDocument.graphql
@@ -1,0 +1,10 @@
+query getDataUserAggregateDocument {
+  users {
+    id,
+    firstName,
+    lastName,
+    experiences {
+      id
+    }
+  }
+}

--- a/frontend/admin/src/js/components/pdfSpike/UserAggregateDocument.tsx
+++ b/frontend/admin/src/js/components/pdfSpike/UserAggregateDocument.tsx
@@ -10,25 +10,45 @@ export const UserAggregateDocument = React.forwardRef<
   UserAggregateDocumentProps
 >(({ initialData }, ref) => (
   <div style={{ display: "none" }}>
-    <div ref={ref}>
-      <div className="print-container">
-        {initialData.users.map((user) => (
-          <React.Fragment key={user?.id}>
-            <strong>{`${user?.firstName} ${user?.lastName}`}</strong>
-            <p>Skills</p>
-            {user?.experiences ? (
-              <ul>
-                {user.experiences.map((experience) => (
-                  <li key={experience?.id}>{experience?.id}</li>
-                ))}
-              </ul>
-            ) : (
-              <p>(no experiences)</p>
-            )}
-            <div className="page-break" />
-          </React.Fragment>
-        ))}
-      </div>
+    <style type="text/css" media="print">
+      {`
+        @page
+        {
+          size: letter portrait;
+          margin: 1in;
+        }
+        @media print {
+          html, body {
+            height: initial !important;
+            overflow: initial !important;
+            -webkit-print-color-adjust: exact;
+          }
+          div.user-region {
+            margin-bottom: 2rem;
+            display: block;
+            page-break-after: auto;
+            page-break-inside: avoid;
+            -webkit-region-break-inside: avoid;
+          }
+        }
+      `}
+    </style>
+    <div ref={ref} className="print-container">
+      {initialData.users.map((user) => (
+        <div key={user?.id} className="user-region">
+          <strong>{`${user?.firstName} ${user?.lastName}`}</strong>
+          <p>Skills</p>
+          {user?.experiences ? (
+            <ul>
+              {user.experiences.map((experience) => (
+                <li key={experience?.id}>{experience?.id}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>(no experiences)</p>
+          )}
+        </div>
+      ))}
     </div>
   </div>
 ));

--- a/frontend/admin/src/js/components/pdfSpike/UserAggregateDocument.tsx
+++ b/frontend/admin/src/js/components/pdfSpike/UserAggregateDocument.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { GetDataUserAggregateDocumentQuery } from "../../api/generated";
+
+export interface UserAggregateDocumentProps {
+  initialData: GetDataUserAggregateDocumentQuery;
+}
+
+export const UserAggregateDocument = React.forwardRef<
+  HTMLDivElement,
+  UserAggregateDocumentProps
+>(({ initialData }, ref) => (
+  <div style={{ display: "none" }}>
+    <div ref={ref}>
+      <div className="print-container">
+        {initialData.users.map((user) => (
+          <React.Fragment key={user?.id}>
+            <strong>{`${user?.firstName} ${user?.lastName}`}</strong>
+            <p>Skills</p>
+            {user?.experiences ? (
+              <ul>
+                {user.experiences.map((experience) => (
+                  <li key={experience?.id}>{experience?.id}</li>
+                ))}
+              </ul>
+            ) : (
+              <p>(no experiences)</p>
+            )}
+            <div className="page-break" />
+          </React.Fragment>
+        ))}
+      </div>
+    </div>
+  </div>
+));
+
+export default UserAggregateDocument;

--- a/frontend/admin/src/js/components/pdfSpike/UserAggregatePage.tsx
+++ b/frontend/admin/src/js/components/pdfSpike/UserAggregatePage.tsx
@@ -8,30 +8,9 @@ const UserAggregateDocumentPage: React.FunctionComponent = () => {
   const [result] = useGetDataUserAggregateDocumentQuery();
   const { data, fetching, error } = result;
 
-  const pageStyle = `
-  @page {
-    size: letter portrait;
-  }
-
-  @media all {
-    .page-break {
-      display: none;
-    }
-  }
-
-  @media print {
-    .page-break {
-      margin-top: 1rem;
-      display: block;
-      page-break-after: always;
-    }
-  }
-`;
-
   const componentRef = useRef(null);
   const handlePrint = useReactToPrint({
     content: () => componentRef.current,
-    pageStyle,
     documentTitle: "User Aggregate",
   });
 

--- a/frontend/admin/src/js/components/pdfSpike/UserAggregatePage.tsx
+++ b/frontend/admin/src/js/components/pdfSpike/UserAggregatePage.tsx
@@ -1,0 +1,56 @@
+import { Button } from "@common/components";
+import React, { useRef } from "react";
+import { useReactToPrint } from "react-to-print";
+import { useGetDataUserAggregateDocumentQuery } from "../../api/generated";
+import UserAggregateDocument from "./UserAggregateDocument";
+
+const UserAggregateDocumentPage: React.FunctionComponent = () => {
+  const [result] = useGetDataUserAggregateDocumentQuery();
+  const { data, fetching, error } = result;
+
+  const pageStyle = `
+  @page {
+    size: letter portrait;
+  }
+
+  @media all {
+    .page-break {
+      display: none;
+    }
+  }
+
+  @media print {
+    .page-break {
+      margin-top: 1rem;
+      display: block;
+      page-break-after: always;
+    }
+  }
+`;
+
+  const componentRef = useRef(null);
+  const handlePrint = useReactToPrint({
+    content: () => componentRef.current,
+    pageStyle,
+    documentTitle: "User Aggregate",
+  });
+
+  if (fetching) {
+    return <p>Loading</p>;
+  }
+
+  if (error || !data) {
+    return <p>Error</p>;
+  }
+
+  return (
+    <div>
+      <Button color="primary" mode="solid" onClick={handlePrint}>
+        Print this out!
+      </Button>
+      <UserAggregateDocument initialData={data} ref={componentRef} />
+    </div>
+  );
+};
+
+export default UserAggregateDocumentPage;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,6 +39,7 @@
         "react-intl": "^5.25.1",
         "react-select": "^5.3.1",
         "react-table": "^7.7.0",
+        "react-to-print": "^2.14.7",
         "react-toastify": "^9.0.1",
         "regenerator-runtime": "^0.13.9",
         "universal-router": "^9.1.0",
@@ -32346,6 +32347,18 @@
         "react": "^16.8.0 || ^17.0.0"
       }
     },
+    "node_modules/react-to-print": {
+      "version": "2.14.7",
+      "resolved": "https://registry.npmjs.org/react-to-print/-/react-to-print-2.14.7.tgz",
+      "integrity": "sha512-lWVVAs9Co25uyE0toxcWeFsmaZObwUozXrJD9WMpDPclpBgk+WIzxlt3Q3omL/BCBG/cpf0XNvhayUWa+99YGw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-toastify": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.0.1.tgz",
@@ -48161,6 +48174,7 @@
         "react-refresh": "^0.13.0",
         "react-select": "^5.3.1",
         "react-table": "^7.7.0",
+        "react-to-print": "^2.14.7",
         "react-toastify": "^9.0.1",
         "regenerator-runtime": "^0.13.9",
         "storybook-addon-intl": "^2.4.1",
@@ -55100,7 +55114,7 @@
         "@types/react-select": "^5.0.1",
         "@typescript-eslint/eslint-plugin": "^5.21.0",
         "@typescript-eslint/parser": "^5.21.0",
-        "@urql/exchange-auth": "*",
+        "@urql/exchange-auth": "^0.1.7",
         "eslint": "^8.14.0",
         "eslint-config-airbnb": "^19.0.0",
         "eslint-config-prettier": "^8.5.0",
@@ -64184,6 +64198,14 @@
         "@babel/runtime": "^7.10.2",
         "use-composed-ref": "^1.0.0",
         "use-latest": "^1.0.0"
+      }
+    },
+    "react-to-print": {
+      "version": "2.14.7",
+      "resolved": "https://registry.npmjs.org/react-to-print/-/react-to-print-2.14.7.tgz",
+      "integrity": "sha512-lWVVAs9Co25uyE0toxcWeFsmaZObwUozXrJD9WMpDPclpBgk+WIzxlt3Q3omL/BCBG/cpf0XNvhayUWa+99YGw==",
+      "requires": {
+        "prop-types": "^15.8.1"
       }
     },
     "react-toastify": {


### PR DESCRIPTION
This branch demonstrates a possible solution to the "export to PDF" spike.

I didn't really like the "render on the backend" approach.  The library Eric suggested installed very easily and was nice to use but bypassing the graphql schema (and it's guards) made me uncomfortable.  Also, we don't have the ability to access the localized constants (or any localization) on the backend.

I didn't really like the "render to PDF" in react approach.  It worked nicely but blew out the bundle size (dev bundle size) from about 6 MB to 25 MB.  It might be possible to use bundle splittling to make the user download that extra only on print.  It also freezes the browser for about 8 seconds to render about 30 KB worth of JSON data.

I preferred the approach of using a React print library.  It only increased the dev bundle size from 6 MB to about 8 MB.  It was nice to use and performs much better.  And the user could actually use it to print if they want. :laughing: It's a little less user friendly since the concept of printing to get a PDF file is a little confusing.  On the plus side, they could use it to export to XPS or whatever other export printer driver they have installed.

To try it out, click the "Download Users" on the dashboard:
![image](https://user-images.githubusercontent.com/8978655/169326634-1a1fd47b-c680-4f61-a7ef-7830d35fdd87.png)


Related to #2648 but will probably not be merged.  Just use this branch as a reference.