### PR TITLE
Component font consistency #2809

### DIFF
--- a/frontend/common/src/components/form/Input/Input.tsx
+++ b/frontend/common/src/components/form/Input/Input.tsx
@@ -59,6 +59,7 @@ const Input: React.FunctionComponent<InputProps> = ({
           data-h2-radius="b(s)"
           data-h2-border="b(darkgray, all, solid, s)"
           style={{ width: "100%" }}
+          data-h2-font-size="b(normal)"
           id={id}
           {...register(name, rules)}
           type={type}

--- a/frontend/common/src/components/form/Select/Select.tsx
+++ b/frontend/common/src/components/form/Select/Select.tsx
@@ -64,7 +64,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
           )}
           {options.map((option) => (
             <option
-              data-h2-font-size="b(caption)"
+              data-h2-font-size="b(normal)"
               key={option.value}
               value={option.value}
             >

--- a/frontend/common/src/components/form/TextArea/TextArea.tsx
+++ b/frontend/common/src/components/form/TextArea/TextArea.tsx
@@ -46,6 +46,7 @@ const TextArea: React.FunctionComponent<TextAreaProps> = ({
           data-h2-padding="b(all, xxs)"
           data-h2-radius="b(s)"
           data-h2-border="b(darkgray, all, solid, s)"
+          data-h2-font-size="b(normal)"
           style={{ width: "100%", resize: "vertical" }}
           id={id}
           {...register(name, rules)}


### PR DESCRIPTION
Resolves #2809 
There seems to be some font inconsistency between components. While "empty" and "filled" states might change in colour, it's best if they all have font type and size consistency.


![image](https://user-images.githubusercontent.com/16977254/169143231-473c8b53-aaa3-4d07-9bd9-342c68d71f9a.png)
