### PR TITLE
Feature - 2796 - Admin pool placeholder page

### DIFF
--- a/frontend/admin/src/js/adminRoutes.ts
+++ b/frontend/admin/src/js/adminRoutes.ts
@@ -41,6 +41,7 @@ const adminRoutes = (lang: string) => {
     poolTable: (): string => path.join(home(), "pools"),
     poolCreate: (): string => path.join(home(), "pools", "create"),
     poolUpdate: (id: string): string => path.join(home(), "pools", id, "edit"),
+    poolView: (id: string): string => path.join(home(), "pools", id),
 
     poolCandidateTable: (poolId: string): string =>
       path.join(home(), "pools", poolId, "pool-candidates"),

--- a/frontend/admin/src/js/components/PoolDashboard.tsx
+++ b/frontend/admin/src/js/components/PoolDashboard.tsx
@@ -26,6 +26,7 @@ import UserPage from "./user/UserPage";
 import PoolPage from "./pool/PoolPage";
 import { CreatePool } from "./pool/CreatePool";
 import { UpdatePool } from "./pool/UpdatePool";
+import ViewPool from "./pool/ViewPool";
 import DepartmentPage from "./department/DepartmentPage";
 import { CreateDepartment } from "./department/CreateDepartment";
 import { UpdateDepartment } from "./department/UpdateDepartment";
@@ -236,6 +237,17 @@ const routes = (
       component:
         loggedIn && isAdmin ? (
           <UpdatePool poolId={params.id as string} />
+        ) : (
+          <AdminNotAuthorized />
+        ),
+    }),
+  },
+  {
+    path: paths.poolView(":id"),
+    action: ({ params }) => ({
+      component:
+        loggedIn && isAdmin ? (
+          <ViewPool poolId={params.id as string} />
         ) : (
           <AdminNotAuthorized />
         ),

--- a/frontend/admin/src/js/components/pool/ViewPool.tsx
+++ b/frontend/admin/src/js/components/pool/ViewPool.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { useIntl } from "react-intl";
+import { ViewGridIcon } from "@heroicons/react/outline";
+
+import PageHeader from "@common/components/PageHeader";
+import { commonMessages } from "@common/messages";
+
+import { usePoolQuery } from "../../api/generated";
+import type { Pool } from "../../api/generated";
+import DashboardContentContainer from "../DashboardContentContainer";
+
+interface ViewPoolPageProps {
+  pool: Pool;
+}
+
+export const ViewPoolPage: React.FC<ViewPoolPageProps> = ({ pool }) => {
+  const intl = useIntl();
+
+  return (
+    <div data-h2-padding="b(all, m)">
+      <PageHeader icon={ViewGridIcon}>
+        {intl.formatMessage({
+          defaultMessage: "Pool Details",
+          description: "Title for the page when viewing an individual pool.",
+        })}
+      </PageHeader>
+    </div>
+  );
+};
+
+interface ViewPoolProps {
+  poolId: string;
+}
+
+const ViewPool: React.FC<ViewPoolProps> = ({ poolId }) => {
+  const intl = useIntl();
+  const [{ data, fetching, error }] = usePoolQuery({
+    variables: { id: poolId },
+  });
+
+  if (fetching) {
+    return (
+      <DashboardContentContainer>
+        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
+      </DashboardContentContainer>
+    );
+  }
+
+  if (error) {
+    <DashboardContentContainer>
+      <p>
+        {intl.formatMessage(commonMessages.loadingError)} {error.message}
+      </p>
+    </DashboardContentContainer>;
+  }
+
+  return (
+    <DashboardContentContainer>
+      {data?.pool ? (
+        <ViewPoolPage pool={data.pool} />
+      ) : (
+        <p>
+          <p>
+            {intl.formatMessage(
+              {
+                defaultMessage: "Pool {poolId} not found.",
+                description: "Message displayed for pool not found.",
+              },
+              { poolId },
+            )}
+          </p>
+        </p>
+      )}
+    </DashboardContentContainer>
+  );
+};
+
+export default ViewPool;

--- a/frontend/admin/src/js/components/pool/ViewPool.tsx
+++ b/frontend/admin/src/js/components/pool/ViewPool.tsx
@@ -1,11 +1,17 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
-import { ViewGridIcon } from "@heroicons/react/outline";
+import { ViewGridIcon, HomeIcon } from "@heroicons/react/outline";
 
+import Breadcrumbs from "@common/components/Breadcrumbs";
+import type { BreadcrumbsProps } from "@common/components/Breadcrumbs";
 import PageHeader from "@common/components/PageHeader";
+import { Link } from "@common/components";
+import { Tab, TabSet } from "@common/components/tabs";
 import { commonMessages } from "@common/messages";
+import { getLocale } from "@common/helpers/localize";
 
-import { usePoolQuery } from "../../api/generated";
+import { useAdminRoutes } from "../../adminRoutes";
+import { useGetPoolQuery } from "../../api/generated";
 import type { Pool } from "../../api/generated";
 import DashboardContentContainer from "../DashboardContentContainer";
 
@@ -15,16 +21,82 @@ interface ViewPoolPageProps {
 
 export const ViewPoolPage: React.FC<ViewPoolPageProps> = ({ pool }) => {
   const intl = useIntl();
+  const locale = getLocale(intl);
+  const adminPaths = useAdminRoutes();
+
+  const pageTitle = intl.formatMessage({
+    defaultMessage: "Pool Details",
+    description: "Title for the page when viewing an individual pool.",
+  });
+
+  const poolName = pool.name ? pool.name[locale] : pageTitle;
+
+  const links = [
+    {
+      title: intl.formatMessage({
+        defaultMessage: "Home",
+        description: "Breadcrumb title for the home page link.",
+      }),
+      href: adminPaths.home(),
+      icon: <HomeIcon style={{ width: "1rem", marginRight: "5px" }} />,
+    },
+    {
+      title: intl.formatMessage({
+        defaultMessage: "Pools",
+        description: "Breadcrumb title for the pools page link.",
+      }),
+      href: adminPaths.poolTable(),
+      icon: <ViewGridIcon style={{ width: "1rem", marginRight: "5px" }} />,
+    },
+    {
+      title: poolName,
+    },
+  ] as BreadcrumbsProps["links"];
 
   return (
-    <div data-h2-padding="b(all, m)">
-      <PageHeader icon={ViewGridIcon}>
-        {intl.formatMessage({
-          defaultMessage: "Pool Details",
-          description: "Title for the page when viewing an individual pool.",
-        })}
-      </PageHeader>
-    </div>
+    <>
+      <PageHeader icon={ViewGridIcon}>{pageTitle}</PageHeader>
+      <Breadcrumbs links={links} />
+      <div
+        data-h2-align-items="b(flex-start"
+        data-h2-display="b(flex)"
+        data-h2-flex-direction="b(column) m(row)"
+        data-h2-margin="b(top-bottom, l)"
+      >
+        {pool.name && (
+          <h2 data-h2-margin="b(top-bottom, none)" data-h2-font-weight="b(800)">
+            {poolName}
+          </h2>
+        )}
+        <div data-h2-margin="m(left, auto)">
+          <Link
+            mode="outline"
+            color="primary"
+            type="button"
+            href={adminPaths.poolUpdate(pool.id)}
+          >
+            {intl.formatMessage({
+              defaultMessage: "Edit pool",
+              description: "Link text for button to edit a specific pool",
+            })}
+          </Link>
+        </div>
+      </div>
+      <TabSet>
+        <Tab
+          text={intl.formatMessage({
+            defaultMessage: "Pool details",
+            description: "Tabs title for the individual pool details.",
+          })}
+        />
+        <Tab
+          text={intl.formatMessage({
+            defaultMessage: "Pool candidates",
+            description: "Tabs title for the individual pool candidates.",
+          })}
+        />
+      </TabSet>
+    </>
   );
 };
 
@@ -34,7 +106,7 @@ interface ViewPoolProps {
 
 const ViewPool: React.FC<ViewPoolProps> = ({ poolId }) => {
   const intl = useIntl();
-  const [{ data, fetching, error }] = usePoolQuery({
+  const [{ data, fetching, error }] = useGetPoolQuery({
     variables: { id: poolId },
   });
 

--- a/frontend/admin/src/js/components/pool/ViewPool.tsx
+++ b/frontend/admin/src/js/components/pool/ViewPool.tsx
@@ -58,13 +58,16 @@ export const ViewPoolPage: React.FC<ViewPoolPageProps> = ({ pool }) => {
       <PageHeader icon={ViewGridIcon}>{pageTitle}</PageHeader>
       <Breadcrumbs links={links} />
       <div
-        data-h2-align-items="b(flex-start"
+        data-h2-align-items="b(center)"
         data-h2-display="b(flex)"
         data-h2-flex-direction="b(column) m(row)"
         data-h2-margin="b(top-bottom, l)"
       >
         {pool.name && (
-          <h2 data-h2-margin="b(top-bottom, none)" data-h2-font-weight="b(800)">
+          <h2
+            data-h2-margin="b(top-bottom, s) m(top-bottom, none)"
+            data-h2-font-weight="b(800)"
+          >
             {poolName}
           </h2>
         )}

--- a/frontend/admin/src/js/components/pool/pool.operations.graphql
+++ b/frontend/admin/src/js/components/pool/pool.operations.graphql
@@ -1,0 +1,9 @@
+query pool($id: ID!) {
+  pool(id: $id) {
+    id
+    name {
+      en
+      fr
+    }
+  }
+}

--- a/frontend/admin/src/js/components/pool/pool.operations.graphql
+++ b/frontend/admin/src/js/components/pool/pool.operations.graphql
@@ -1,9 +1,0 @@
-query pool($id: ID!) {
-  pool(id: $id) {
-    id
-    name {
-      en
-      fr
-    }
-  }
-}

--- a/frontend/common/src/components/PageHeader/PageHeader.tsx
+++ b/frontend/common/src/components/PageHeader/PageHeader.tsx
@@ -12,7 +12,7 @@ const PageHeader: React.FC<PageHeaderProps> = ({ icon, children, ...rest }) => {
   return (
     <h1
       data-h2-display="b(flex)"
-      data-h2-font-weight="b(800)"
+      data-h2-font-weight="b(300)"
       data-h2-align-items="b(center)"
       data-h2-margin="b(top, none) b(bottom, m)"
       data-h2-justify-content="b(start)"


### PR DESCRIPTION
Resolves #2796 

## Summary

This adds the placeholder page for an individual pool.

## Notes

### No Link

We currently have no link to this page and it will be introduced when we update to the new tables in #2639 I believe.

### Styles (Tabs)

The tabs do not look like they do in the [Prototype](https://www.figma.com/proto/XS4Ag6GWcgdq2dBlLzBkay/Admin-v3-(Profile-release)?node-id=752%3A6863&scaling=min-zoom&page-id=0%3A1&starting-point-node-id=410%3A1984&show-proto-sidebar=1) because they have yet to be updated. This will change when we update the tabs styling.

## Screenshot

<img width="1512" alt="Screen Shot 2022-05-20 at 1 07 18 PM" src="https://user-images.githubusercontent.com/4127998/169578206-e44f48b2-afed-4598-9608-a1790011703c.png">

