### PR TITLE
Remove classification group constraint

### DIFF
--- a/api/tests/Feature/PoolCandidateTest.php
+++ b/api/tests/Feature/PoolCandidateTest.php
@@ -26,7 +26,9 @@ class PoolCandidateTest extends TestCase
 
     // Create initial data.
     Classification::factory()->count(3)->create();
-    PoolCandidate::factory()->count(5)->create();
+    PoolCandidate::factory()->count(5)->create([
+      'expected_salary' => [], // remove salaries to avoid accidental classification-to-salary matching
+    ]);
 
     // Create new classification and attach to two new pool candidates.
     $classification = Classification::factory()->create([
@@ -626,7 +628,9 @@ class PoolCandidateTest extends TestCase
   {
     // Create initial data.
     Classification::factory()->count(3)->create();
-    PoolCandidate::factory()->count(5)->create();
+    PoolCandidate::factory()->count(5)->create([
+      'expected_salary' => []
+    ]);
 
     // Create new classification.
     $classificationLvl1 = Classification::factory()->create([

--- a/api/tests/Feature/PoolCandidateTest.php
+++ b/api/tests/Feature/PoolCandidateTest.php
@@ -635,18 +635,6 @@ class PoolCandidateTest extends TestCase
       'min_salary' => 50000,
       'max_salary' => 69000,
     ]);
-    $classificationLvl2 = Classification::factory()->create([
-      'group' => 'ZZ',
-      'level' => 2,
-      'min_salary' => 70000,
-      'max_salary' => 89000,
-    ]);
-    $classificationLvl3 = Classification::factory()->create([
-      'group' => 'ZZ',
-      'level' => 3,
-      'min_salary' => 90000,
-      'max_salary' => 100000,
-    ]);
 
     // Attach new candidates that are in the expected salary range.
     $poolCandidate1 = PoolCandidate::factory()->create([
@@ -660,15 +648,12 @@ class PoolCandidateTest extends TestCase
       'expected_salary' => ['_60_69K', '_80_89K']
     ]);
     $poolCandidate2->expectedClassifications()->delete();
-    $poolCandidate2->expectedClassifications()->save($classificationLvl2);
 
     // Attach new candidates that are over the expected salary range.
     $poolCandidate3 = PoolCandidate::factory()->create([
       'expected_salary' => ['_90_99K', '_100K_PLUS']
     ]);
     $poolCandidate3->expectedClassifications()->delete();
-    $poolCandidate3->expectedClassifications()->save($classificationLvl3);
-
 
     // Assert query with no classifications filter will return all candidates
     $this->graphQL(/** @lang Graphql */ '
@@ -729,14 +714,6 @@ class PoolCandidateTest extends TestCase
       'max_salary' => 64999,
     ]);
 
-    // otherClassification is the higher one in the same group
-    $otherClassification = Classification::factory()->create([
-      'group' => 'ZZ',
-      'level' => 2,
-      'min_salary' => 65000,
-      'max_salary' => 74999,
-    ]);
-
     // *** first make three candidates in the right pool - 1 has an exact classification match, 1 has a salary to classification match, 1 has no match
 
     // Attach new candidate in the pool with the desired classification
@@ -753,7 +730,6 @@ class PoolCandidateTest extends TestCase
       'pool_id' => $myPool->id
     ]);
     $poolCandidate2->expectedClassifications()->delete();
-    $poolCandidate2->expectedClassifications()->save($otherClassification);
 
     // Attach new candidate in the pool that is over the expected salary range and has a matching class group (but not level).
     $poolCandidate3 = PoolCandidate::factory()->create([
@@ -761,7 +737,6 @@ class PoolCandidateTest extends TestCase
       'pool_id' => $myPool->id
     ]);
     $poolCandidate3->expectedClassifications()->delete();
-    $poolCandidate3->expectedClassifications()->save($otherClassification);
 
     // *** now make the same three candidates in the wrong pool
 
@@ -773,21 +748,19 @@ class PoolCandidateTest extends TestCase
     $poolCandidate1WrongPool->expectedClassifications()->delete();
     $poolCandidate1WrongPool->expectedClassifications()->save($myClassification);
 
-    // Attach new candidate in the pool that overlaps the expected salary range and has a matching class group (but not level). WRONG POOL
+    // Attach new candidate in the pool that overlaps the expected salary range. WRONG POOL
     $poolCandidate2WrongPool = PoolCandidate::factory()->create([
       'expected_salary' => ['_60_69K'],
       'pool_id' => $otherPool->id
     ]);
     $poolCandidate2WrongPool->expectedClassifications()->delete();
-    $poolCandidate2WrongPool->expectedClassifications()->save($otherClassification);
 
-    // Attach new candidate in the pool that is over the expected salary range and has a matching class group (but not level).  WRONG POOL
+    // Attach new candidate in the pool that is over the expected salary range.  WRONG POOL
     $poolCandidate3WrongPool = PoolCandidate::factory()->create([
       'expected_salary' => ['_90_99K', '_100K_PLUS'],
       'pool_id' => $otherPool->id
     ]);
     $poolCandidate3WrongPool->expectedClassifications()->delete();
-    $poolCandidate3WrongPool->expectedClassifications()->save($otherClassification);
 
     // Assert query with just pool filters will return all candidates in that pool
     $this->graphQL(/** @lang Graphql */ '

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -336,7 +336,9 @@ class UserTest extends TestCase
     public function testFilterByClassification(): void
     {
         // Create initial data.
-        User::factory()->count(5)->create();
+        User::factory()->count(5)->create([
+            'expected_salary' => [], // remove salaries to avoid accidental classification-to-salary matching
+        ]);
 
         // Create new classification and attach to two new users.
         $classification = Classification::factory()->create([
@@ -418,7 +420,9 @@ class UserTest extends TestCase
     public function testFilterByClassificationToSalary(): void
     {
         // Create initial data.
-        User::factory()->count(5)->create();
+        User::factory()->count(5)->create([
+            'expected_salary' => []
+        ]);
 
         // Create new classification.
         $classificationLvl1 = Classification::factory()->create([

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -427,18 +427,6 @@ class UserTest extends TestCase
             'min_salary' => 50000,
             'max_salary' => 69000,
         ]);
-        $classificationLvl2 = Classification::factory()->create([
-            'group' => 'ZZ',
-            'level' => 2,
-            'min_salary' => 70000,
-            'max_salary' => 89000,
-        ]);
-        $classificationLvl3 = Classification::factory()->create([
-            'group' => 'ZZ',
-            'level' => 3,
-            'min_salary' => 90000,
-            'max_salary' => 100000,
-        ]);
 
         // Attach new users that are in the expected salary range.
         $user1 = User::factory()->create([
@@ -452,15 +440,12 @@ class UserTest extends TestCase
             'expected_salary' => ['_60_69K', '_80_89K']
         ]);
         $user2->expectedClassifications()->delete();
-        $user2->expectedClassifications()->save($classificationLvl2);
 
         // Attach new users that are over the expected salary range.
         $user3 = User::factory()->create([
             'expected_salary' => ['_90_99K', '_100K_PLUS']
         ]);
         $user3->expectedClassifications()->delete();
-        $user3->expectedClassifications()->save($classificationLvl3);
-
 
         // Assert query with no classifications filter will return all users
         $this->graphQL(/** @lang Graphql */ '
@@ -1470,14 +1455,6 @@ class UserTest extends TestCase
             'max_salary' => 64999,
         ]);
 
-        // otherClassification is the higher one in the same group
-        $otherClassification = Classification::factory()->create([
-            'group' => 'ZZ',
-            'level' => 2,
-            'min_salary' => 65000,
-            'max_salary' => 74999,
-        ]);
-
         // *** first make three users in the right pool - 1 has an exact classification match, 1 has a salary to classification match, 1 has no match
 
         // Attach new user in the pool with the desired classification
@@ -1493,9 +1470,8 @@ class UserTest extends TestCase
 
         // Attach new user in the pool that overlaps the expected salary range and has a matching class group (but not level).
         PoolCandidate::factory()->create([
-            'user_id' => User::factory()->afterCreating(function($user) use ($otherClassification) {
+            'user_id' => User::factory()->afterCreating(function($user) {
                 $user->expectedClassifications()->delete();
-                $user->expectedClassifications()->save($otherClassification);
             })->create([
                 'expected_salary' => ['_60_69K']
             ]),
@@ -1504,9 +1480,8 @@ class UserTest extends TestCase
 
         // Attach new user in the pool that is over the expected salary range and has a matching class group (but not level).
         PoolCandidate::factory()->create([
-            'user_id' => User::factory()->afterCreating(function($user) use ($otherClassification) {
+            'user_id' => User::factory()->afterCreating(function($user) {
                 $user->expectedClassifications()->delete();
-                $user->expectedClassifications()->save($otherClassification);
             })->create([
                 'expected_salary' => ['_90_99K', '_100K_PLUS']
             ]),
@@ -1528,9 +1503,8 @@ class UserTest extends TestCase
 
         // Attach new user in the pool that overlaps the expected salary range and has a matching class group (but not level). WRONG POOL
         PoolCandidate::factory()->create([
-            'user_id' => User::factory()->afterCreating(function($user) use ($otherClassification) {
+            'user_id' => User::factory()->afterCreating(function($user) {
                 $user->expectedClassifications()->delete();
-                $user->expectedClassifications()->save($otherClassification);
             })->create([
                 'expected_salary' => ['_60_69K']
             ]),
@@ -1539,9 +1513,8 @@ class UserTest extends TestCase
 
         // Attach new user in the pool that is over the expected salary range and has a matching class group (but not level).  WRONG POOL
         PoolCandidate::factory()->create([
-            'user_id' => User::factory()->afterCreating(function($user) use ($otherClassification) {
+            'user_id' => User::factory()->afterCreating(function($user) {
                 $user->expectedClassifications()->delete();
-                $user->expectedClassifications()->save($otherClassification);
             })->create([
                 'expected_salary' => ['_90_99K', '_100K_PLUS']
             ]),


### PR DESCRIPTION
This branch removes the constraint that the candidate must have at least one attached classification of the group being search before they can be classification-to-salary matched.  Tests have been updated to exercise this behavior (or explicitly avoid it when not being tested).

Some queries I used for ad-hoc testing:
```
-- check salaries for IS 4 and 5
select * from classifications c 
where (c.group = 'IS' and c.level = 4) or (c.group = 'IS' and c.level = 5)

-- check candidates with expected salary ranges
select count(*) from pool_candidates pc 
where pc.expected_salary ?| array['_90_99K', '_100K_PLUS']
and "pool_id" in ('c2ed44d3-3bb9-4cf0-b99f-c961e0272779') 

-- check candidates without expected salary ranges but have classification matches
select count(*) from pool_candidates pc
join classification_pool_candidate cpc on pc.id = cpc.pool_candidate_id 
join classifications c on cpc.classification_id  = c.id
where not (pc.expected_salary ?| array[ '_90_99K', '_100K_PLUS'])
and "pool_id" in ('c2ed44d3-3bb9-4cf0-b99f-c961e0272779') 
and ( (c.group = 'IS' and c.level = 4) or (c.group = 'IS' and c.level = 5) )
```

Closes #2806 