### PR TITLE
Add direct intake flag

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -8,6 +8,7 @@ darkpink
 darkpurple
 datetime
 dedup
+DIRECTINTAKE
 gctalent
 heroicons
 INDIGENOUSAPPRENTICESHIP

--- a/frontend/.apache_env
+++ b/frontend/.apache_env
@@ -6,3 +6,4 @@ OAUTH_POST_LOGOUT_REDIRECT="http://localhost:8000/admin"
 
 # Feature flags
 FEATURE_APPLICANTPROFILE=true
+FEATURE_DIRECTINTAKE=true

--- a/frontend/talentsearch/src/.htaccess
+++ b/frontend/talentsearch/src/.htaccess
@@ -33,3 +33,4 @@ AddOutputFilter INCLUDES .shtml .sjs
 
 # Make certain environment variables available for SSI
 PassEnv FEATURE_APPLICANTPROFILE
+PassEnv FEATURE_DIRECTINTAKE

--- a/frontend/talentsearch/src/config.sjs
+++ b/frontend/talentsearch/src/config.sjs
@@ -8,6 +8,7 @@
 
 const data = new Map([
     ["FEATURE_APPLICANTPROFILE", "<!--#echo var="FEATURE_APPLICANTPROFILE" -->"],
+    ["FEATURE_DIRECTINTAKE", "<!--#echo var="FEATURE_DIRECTINTAKE" -->"],
 ]);
 
 window.__SERVER_CONFIG__ = data;

--- a/frontend/talentsearch/src/js/components/Router.tsx
+++ b/frontend/talentsearch/src/js/components/Router.tsx
@@ -129,6 +129,18 @@ const profileRoutes = (
   },
 ];
 
+const directIntakeRoutes = (
+  talentPaths: TalentSearchRoutes,
+): Routes<RouterResult> => [
+  // placeholder, switch with real routes
+  {
+    path: "/en/talent/direct-intake",
+    action: () => ({
+      component: <SearchPage />,
+    }),
+  },
+];
+
 export const Router: React.FC = () => {
   const intl = useIntl();
   const talentPaths = useTalentSearchRoutes();
@@ -160,6 +172,9 @@ export const Router: React.FC = () => {
           ...talentRoutes(talentPaths),
           ...(checkFeatureFlag("FEATURE_APPLICANTPROFILE")
             ? profileRoutes(profilePaths)
+            : []),
+          ...(checkFeatureFlag("FEATURE_DIRECTINTAKE")
+            ? directIntakeRoutes(talentPaths)
             : []),
         ]}
       />


### PR DESCRIPTION
This branch adds a feature flag for DIRECTINTAKE.

Remember, to use it you must rebuild the PHP container.
To test, a placeholder route `/en/talent/direct-intake` was created that will render the talent search page when the flag is enabled.

Also, printing `window.__SERVER_CONFIG__` in the dev console will show the flags.

Closes #2782 