### PR TITLE
Create DataSeeder intended (and able) to run on UAT

### DIFF
--- a/api/database/seeders/ClassificationSeeder.php
+++ b/api/database/seeders/ClassificationSeeder.php
@@ -44,7 +44,7 @@ class ClassificationSeeder extends Seeder
             array_merge(
                 $itGroup,
                 [
-                    'level' => 3
+                    'level' => 3,
                     'min_salary' => 88683,
                     'max_salary' => 110182,
                 ]
@@ -85,7 +85,7 @@ class ClassificationSeeder extends Seeder
             array_merge(
                 $asGroup,
                 [
-                    'level' => 3
+                    'level' => 3,
                     'min_salary' => 53139,
                     'max_salary' => 56390,
                 ]

--- a/api/database/seeders/ClassificationSeeder.php
+++ b/api/database/seeders/ClassificationSeeder.php
@@ -14,64 +14,105 @@ class ClassificationSeeder extends Seeder
      */
     public function run()
     {
-        $groups = [
-            [
-                'group' => 'CS',
-                'name' => ['en' => 'Computer Systems', 'fr' => 'Systèmes d\'ordinateurs'],
-            ],
-            [
-                'group' => 'AS',
-                'name' => ['en' => 'Administrative Services', 'fr' => 'Services des programmes et de l\'administration'],
-            ],
-            [
-                'group' => 'EC',
-                'name' => ['en' => 'Economics and Social Science Services', 'fr' => 'Économique et services de sciences sociales'],
-            ],
-            [
-                'group' => 'PM',
-                'name' => ['en' => 'Programme Administration', 'fr' => 'Administration des programmes'],
-            ],
-            [
-                'group' => 'IS',
-                'name' => ['en' => 'Information Services', 'fr' => 'Services d\'information'],
-            ]
+        $itGroup = [
+            'group' => 'IT',
+            'name' => ['en' => 'Information Technology', 'fr' => 'Technologie de l\'information']
         ];
-        $levels = [
-            [
-                'level' => 1,
-                'min_salary' => 50000,
-                'max_salary' => 80000
-            ],
-            [
-                'level' => 2,
-                'min_salary' => 65000,
-                'max_salary' => 94000
-            ],
-            [
-                'level' => 3,
-                'min_salary' => 83000,
-                'max_salary' => 113000
-            ],
-            [
-                'level' => 4,
-                'min_salary' => 94000,
-                'max_salary' => 130000
-            ],
-            [
-                'level' => 5,
-                'min_salary' => 105000,
-                'max_salary' => 157000
-            ],
+        $asGroup = [
+            'group' => 'AS',
+            'name' => ['en' => 'Administrative Services', 'fr' => 'Services administratifs']
         ];
-        foreach ($groups as $group) {
-            foreach ($levels as $level) {
-                $identifier = [
-                    'level' => $level['level'],
-                    'group' => $group['group'],
-                ];
-                $content = array_merge($group, $level);
-                Classification::updateOrCreate($identifier, $content);
-            }
+
+        $classifications = [
+            // IT classifications 01-05.
+            array_merge(
+                $itGroup,
+                [
+                    'level' => 1,
+                    'min_salary' => 60696,
+                    'max_salary' => 78216,
+                ]
+            ),
+            array_merge(
+                $itGroup,
+                [
+                    'level' => 2,
+                    'min_salary' => 75129,
+                    'max_salary' => 91953,
+                ]
+            ),
+            array_merge(
+                $itGroup,
+                [
+                    'level' => 3
+                    'min_salary' => 88683,
+                    'max_salary' => 110182,
+                ]
+            ),
+            array_merge(
+                $itGroup,
+                [
+                    'level' => 4,
+                    'min_salary' => 101541,
+                    'max_salary' => 126390,
+                ]
+            ),
+            array_merge(
+                $itGroup,
+                [
+                    'level' => 5,
+                    'min_salary' => 115754,
+                    'max_salary' => 150842,
+                ]
+            ),
+            // AS classifications 01-05.
+            array_merge(
+                $asGroup,
+                [
+                    'level' => 1,
+                    'min_salary' => 43514,
+                    'max_salary' => 49351,
+                ]
+            ),
+            array_merge(
+                $asGroup,
+                [
+                    'level' => 2,
+                    'min_salary' => 48323,
+                    'max_salary' => 53416,
+                ]
+            ),
+            array_merge(
+                $asGroup,
+                [
+                    'level' => 3
+                    'min_salary' => 53139,
+                    'max_salary' => 56390,
+                ]
+            ),
+            array_merge(
+                $asGroup,
+                [
+                    'level' => 4,
+                    'min_salary' => 56951,
+                    'max_salary' => 61594,
+                ]
+            ),
+            array_merge(
+                $asGroup,
+                [
+                    'level' => 5,
+                    'min_salary' => 67981,
+                    'max_salary' => 73495,
+                ]
+            ),
+        ];
+        foreach ($classifications as $classification) {
+            $identifier = [
+                'level' => $classification['level'],
+                'group' => $classification['group'],
+            ];
+            Classification::updateOrCreate($identifier, $classification);
         }
     }
 }

--- a/api/database/seeders/CmoAssetSeeder.php
+++ b/api/database/seeders/CmoAssetSeeder.php
@@ -78,6 +78,34 @@ class CmoAssetSeeder extends Seeder
                     'fr' => 'Analyste d\'affaires TI / Gestion de projets TI'
                 ],
             ],
+            [
+                'key' => 'teamwork',
+                'name' => [
+                    'en' => 'Teamwork',
+                    'fr' => 'Travail d\'équipe'
+                ],
+            ],
+            [
+                'key' => 'at',
+                'name' => [
+                    'en' => 'Analytical Thinking',
+                    'fr' => 'Pensée Stratégique'
+                ],
+            ],
+            [
+                'key' => 'cs',
+                'name' => [
+                    'en' => 'Client Service',
+                    'fr' => 'Orientation client'
+                ],
+            ],
+            [
+                'key' => 'comms',
+                'name' => [
+                    'en' => 'Communication',
+                    'fr' => 'Communication'
+                ],
+            ],
         ];
         foreach ($assets as $asset) {
             $identifier = [

--- a/api/database/seeders/PoolSeederUat.php
+++ b/api/database/seeders/PoolSeederUat.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Classification;
+use App\Models\CmoAsset;
+use App\Models\Pool;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Database\Helpers\ApiEnums;
+
+class PoolSeederUat extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $defaultOwner = User::where('email', 'tristan-orourke@talent.test')->first();
+
+        $digitalCareers = Pool::updateOrCreate(
+            ['key' => 'digital_careers'],
+            [
+                'name' => [
+                    'en' => 'Digital Careers',
+                    'fr' => 'Carrières Numériques'
+                ],
+                'user_id' => $defaultOwner->id,
+                'operational_requirements' => [
+                    'SHIFT_WORK',
+                    'WORK_WEEKENDS',
+                    'OVERTIME_SCHEDULED',
+                    'OVERTIME_SHORT_NOTICE'
+                ],
+            ]
+        );
+
+        $softAssets = CmoAsset::whereIn('key', ['teamwork', 'at', 'cs', 'comms'])->get();
+        $hardAssets = CmoAsset::whereIn('key', [
+            'app_dev',
+            'app_testing',
+            'cybersecurity',
+            'data_science',
+            'db_admin',
+            'enterprise_architecture',
+            'information_management',
+            'infrastructure_ops',
+            'project_management'
+        ])->get();
+        $digitalCareers->essentialCriteria()->sync($softAssets);
+        $digitalCareers->assetCriteria()->sync($hardAssets);
+
+        $itClassifications = Classification::where('group', 'IT')->get();
+        $digitalCareers->classifications()->sync($itClassifications);
+    }
+}

--- a/api/database/seeders/PoolSeederUat.php
+++ b/api/database/seeders/PoolSeederUat.php
@@ -7,7 +7,6 @@ use App\Models\CmoAsset;
 use App\Models\Pool;
 use App\Models\User;
 use Illuminate\Database\Seeder;
-use Database\Helpers\ApiEnums;
 
 class PoolSeederUat extends Seeder
 {

--- a/api/database/seeders/ProdSeeder.php
+++ b/api/database/seeders/ProdSeeder.php
@@ -13,6 +13,7 @@ class ProdSeeder extends Seeder
      */
     public function run()
     {
+        $this->call(ClassificationSeeder::class);
         $this->call(CmoAssetSeeder::class);
         $this->call(DepartmentSeeder::class);
     }

--- a/api/database/seeders/UatSeeder.php
+++ b/api/database/seeders/UatSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class UatSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $this->call(ClassificationSeeder::class);
+        $this->call(CmoAssetSeeder::class);
+        $this->call(DepartmentSeeder::class);
+        $this->call(UserSeederUat::class);
+        $this->call(PoolSeederUat::class);
+    }
+}

--- a/api/database/seeders/UserSeederUat.php
+++ b/api/database/seeders/UserSeederUat.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class UserSeederUat extends Seeder
+{
+    /**
+     * Seeds initial user records into that database.
+     * These users are only useful for testing on UAT server.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $fakeEmailDomain = '@talent.test';
+
+        // users with sub values from Sign In Canada, redirecting to uat-talentcloud.tbs-sct.gc.ca
+
+        // Ensure we don't create duplicates if users already exist, since we don't truncate tables by default (unlike on local).
+        User::updateOrCreate(
+            ['email' => 'tristan-orourke'.$fakeEmailDomain],
+            [
+                'first_name' => 'tristan-orourke',
+                'last_name' => 'Talent',
+                'sub' => 'b4c734a1-dcf3-4fb8-a860-c642700cb0b8',
+                'roles' => ['ADMIN']
+            ]
+        );
+
+        // TODO: Add Gray and DCMO users.
+
+        // TODO: Add devs back in once subs are known.
+    }
+}


### PR DESCRIPTION
Closes #1763 

- Adds a new UserSeederUat class for where we can add users with subs specific to the UAT server.
- Adds PoolSeederUat which creates a digital_careers pool which should be identical to the one created on Prod. (This required adding a few more CmoAssets, for soft skills.)
- Modified ClassificationSeeder so it creates only realistic Classifications - ie the ones we created manually on Prod.
- Since none of the seeders called by UatSeeder use Model Factories or Faker, it can be run even when composer dev dependencies are not installed.

UatSeeder can be run with `php artisan db:seed --class=UatSeeder`.

This has been tested on the UAT server, and works!