### PR TITLE
Feature - 2781 - browse pools placeholder page

### DIFF
--- a/frontend/talentsearch/src/js/components/Router.tsx
+++ b/frontend/talentsearch/src/js/components/Router.tsx
@@ -15,6 +15,10 @@ import {
   ApplicantProfileRoutes,
   useApplicantProfileRoutes,
 } from "../applicantProfileRoutes";
+import {
+  DirectIntakeRoutes,
+  useDirectIntakeRoutes,
+} from "../directIntakeRoutes";
 import RequestPage from "./request/RequestPage";
 import WorkLocationPreferenceApi from "./workLocationPreferenceForm/WorkLocationPreferenceForm";
 import { ProfilePage } from "./profile/ProfilePage/ProfilePage";
@@ -27,6 +31,7 @@ import AboutMeFormContainer from "./aboutMeForm/AboutMeForm";
 import DiversityEquityInclusionFormApi from "./diversityEquityInclusion/DiversityEquityInclusionForm";
 import { ExperienceAndSkillsRouterApi } from "./applicantProfile/ExperienceAndSkills";
 import RoleSalaryFormContainer from "./roleSalaryForm/RoleSalaryForm";
+import BrowsePoolsPage from "./browse/BrowsePoolsPage";
 
 const talentRoutes = (
   talentPaths: TalentSearchRoutes,
@@ -137,13 +142,13 @@ const profileRoutes = (
 ];
 
 const directIntakeRoutes = (
-  talentPaths: TalentSearchRoutes,
+  directIntakePaths: DirectIntakeRoutes,
 ): Routes<RouterResult> => [
   // placeholder, switch with real routes
   {
-    path: "/en/talent/direct-intake",
+    path: directIntakePaths.home(),
     action: () => ({
-      component: <SearchPage />,
+      component: <BrowsePoolsPage />,
     }),
   },
 ];
@@ -152,6 +157,7 @@ export const Router: React.FC = () => {
   const intl = useIntl();
   const talentPaths = useTalentSearchRoutes();
   const profilePaths = useApplicantProfileRoutes();
+  const directIntakePaths = useDirectIntakeRoutes();
 
   const menuItems = [
     <MenuLink
@@ -181,7 +187,7 @@ export const Router: React.FC = () => {
             ? profileRoutes(profilePaths)
             : []),
           ...(checkFeatureFlag("FEATURE_DIRECTINTAKE")
-            ? directIntakeRoutes(talentPaths)
+            ? directIntakeRoutes(directIntakePaths)
             : []),
         ]}
       />

--- a/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.tsx
+++ b/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import { getLocale } from "@common/helpers/localize";
+import { commonMessages } from "@common/messages";
+
+import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
+import { useBrowsePoolsQuery } from "../../api/generated";
+import type { Pool } from "../../api/generated";
+
+interface BrowsePoolsProps {
+  pools?: Array<Pick<Pool, "__typename" | "id" | "name">>;
+}
+
+const BrowsePools: React.FC<BrowsePoolsProps> = ({ pools }) => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
+  const paths = useDirectIntakeRoutes();
+  return (
+    <>
+      <h1>
+        {intl.formatMessage({
+          defaultMessage: "Browse Pools",
+          description: "Page title for the direct intake browse pools page.",
+        })}
+      </h1>
+      {pools && pools.length ? (
+        <ul>
+          {pools.map((pool) => (
+            <li key={pool.id}>
+              <a href={paths.pool(pool.id)}>
+                {pool.name ? pool.name[locale] : pool.id}
+              </a>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>
+          {intl.formatMessage({
+            defaultMessage: "No pools found.",
+            description:
+              "Message displayed on the browse pools direct intake page when there are no pools.",
+          })}
+        </p>
+      )}
+    </>
+  );
+};
+
+const BrowsePoolsApi: React.FC = () => {
+  const intl = useIntl();
+  const [{ data, fetching, error }] = useBrowsePoolsQuery();
+
+  if (fetching) {
+    return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
+  }
+
+  if (error) {
+    return (
+      <p>
+        {intl.formatMessage(commonMessages.loadingError)}
+        {error.message}
+      </p>
+    );
+  }
+
+  // Filter out undefined | null pools
+  const filteredPools = data?.pools.filter(
+    (pool) => typeof pool !== undefined && !!pool,
+  ) as Pool[];
+
+  return <BrowsePools pools={filteredPools} />;
+};
+
+export default BrowsePoolsApi;

--- a/frontend/talentsearch/src/js/components/browse/browseOperations.graphql
+++ b/frontend/talentsearch/src/js/components/browse/browseOperations.graphql
@@ -1,0 +1,9 @@
+query browsePools {
+  pools {
+    id
+    name {
+      en
+      fr
+    }
+  }
+}

--- a/frontend/talentsearch/src/js/directIntakeRoutes.ts
+++ b/frontend/talentsearch/src/js/directIntakeRoutes.ts
@@ -1,0 +1,23 @@
+import { getLocale } from "@common/helpers/localize";
+import path from "path-browserify";
+import { useIntl } from "react-intl";
+import { DIRECTINTAKE_APP_DIR } from "./talentSearchConstants";
+
+export type DirectIntakeRoutes = ReturnType<typeof directIntakeRoutes>;
+
+const directIntakeRoutes = (lang: string) => {
+  const home = (): string => path.join("/", lang, DIRECTINTAKE_APP_DIR);
+
+  return {
+    home,
+    pool: (id: string) => path.join(home(), "pools", id),
+  };
+};
+
+export const useDirectIntakeRoutes = (): DirectIntakeRoutes => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
+  return directIntakeRoutes(locale);
+};
+
+export default directIntakeRoutes;

--- a/frontend/talentsearch/src/js/talentSearchConstants.ts
+++ b/frontend/talentsearch/src/js/talentSearchConstants.ts
@@ -5,6 +5,8 @@ export const DIGITAL_CAREERS_POOL_KEY =
   (process.env.DIGITAL_CAREERS_POOL_KEY as string) ?? "digital_careers";
 export const APPLICANTPROFILE_APP_DIR =
   (process.env.APPLICANTPROFILE_APP_DIR as string) ?? "/talent/profile";
+export const DIRECTINTAKE_APP_DIR =
+  (process.env.DIRECTINTAKE_APP_DIR as string) ?? "/browse";
 export const TALENTSEARCH_RECRUITMENT_EMAIL =
   (process.env.TALENTSEARCH_RECRUITMENT_EMAIL as string) ??
   "recruitmentimit-recrutementgiti@tbs-sct.gc.ca";

--- a/infrastructure/php-container/src/.htaccess
+++ b/infrastructure/php-container/src/.htaccess
@@ -39,6 +39,13 @@ DirectorySlash off
     # Send localized talent requests also to talentsearch dist folder;
     RewriteRule ^(en|fr)/talent(/(.*))?$ frontend/talentsearch/dist/$3 [L]
 
+    # Send browse requests to talentsearch dist folder (with or without public/ path prefix).
+    RewriteRule ^browse/public(/(.*))?$ frontend/talentsearch/dist/$2 [L]
+    RewriteRule ^browse(/(.*))?$ frontend/talentsearch/dist/$2 [L]
+
+    # Send localized talent requests also to talentsearch dist folder;
+    RewriteRule ^(en|fr)/browse(/(.*))?$ frontend/talentsearch/dist/$3 [L]
+
     # Indigenous Apprenticeship routes
     RewriteRule ^indigenous-it-apprentice(/(.*))?$ frontend/indigenousapprenticeship/dist/$2 [L]
     RewriteRule ^(en|fr)/indigenous-it-apprentice(/(.*))?$ frontend/indigenousapprenticeship/dist/$3 [L]


### PR DESCRIPTION
Resolves #2781 

## Summary

This adds the new `/browse` route and page for direct intake.

## Testing

1. You _may_ need to rebuild your php container 
`docker-compose down php && docker-compose rm php && docker-compose up -d`
2. Build talent search app `cd frontend && npm run production --workspace=talentsearch`
3. Open browser and navigate to `http://localhost:8000/browse`