### PR TITLE
Finish migrating from email to sub for auth

### DIFF
--- a/api/app/Providers/AuthServiceProvider.php
+++ b/api/app/Providers/AuthServiceProvider.php
@@ -109,7 +109,7 @@ class AuthServiceProvider extends ServiceProvider
 
         // If a default user is set, and there is no bearer token, treat the request as if it were from the default user.
         if (config('oauth.default_user')) {
-            $user = User::where('email', config('oauth.default_user'))->first();
+            $user = User::where('sub', config('oauth.default_user'))->first();
             if ($user) {
                 return $user;
             }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -585,7 +585,7 @@ input PoolsHasMany {
     create: [CreatePoolInput]
 }
 """
-When creating a User, name and email are required.
+When creating a User, name is required.
 """
 input CreateUserInput {
     sub: String
@@ -594,7 +594,7 @@ input CreateUserInput {
     # Personal info
     firstName: String! @rename(attribute: "first_name")
     lastName: String! @rename(attribute: "last_name")
-    email: Email! @rules(apply: ["unique:users,email"])
+    email: Email
     telephone: PhoneNumber
     preferredLang: Language @rename(attribute: "preferred_lang")
     currentProvince: ProvinceOrTerritory @rename(attribute: "current_province")
@@ -642,9 +642,10 @@ input CreateUserInput {
     awardExperiences: AwardExperienceHasMany
 }
 """
-When updating a User, all fields are optional, and email cannot be changed.
+When updating a User, all fields are optional
 """
 input UpdateUserAsAdminInput {
+    email: Email
     sub: String
     roles: [Role]
 
@@ -701,6 +702,7 @@ input UpdateUserAsAdminInput {
 
 input UpdateUserAsUserInput {
     # Personal info
+    email: Email
     firstName: String @rename(attribute: "first_name")
     lastName: String @rename(attribute: "last_name")
     telephone: PhoneNumber

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -588,13 +588,13 @@ input PoolsHasMany {
 When creating a User, name is required.
 """
 input CreateUserInput {
-    sub: String
+    sub: String @rules(apply: ["unique:users,sub"])
     roles: [Role] = []
 
     # Personal info
     firstName: String! @rename(attribute: "first_name")
     lastName: String! @rename(attribute: "last_name")
-    email: Email
+    email: Email @rules(apply: ["unique:users,email"])
     telephone: PhoneNumber
     preferredLang: Language @rename(attribute: "preferred_lang")
     currentProvince: ProvinceOrTerritory @rename(attribute: "current_province")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -253,13 +253,13 @@ input CreateSkillInput {
   keywords: [String!]
 }
 
-"""When creating a User, name and email are required."""
+"""When creating a User, name is required."""
 input CreateUserInput {
   sub: String
   roles: [Role] = []
   firstName: String!
   lastName: String!
-  email: Email!
+  email: Email
   telephone: PhoneNumber
   preferredLang: Language
   currentProvince: ProvinceOrTerritory
@@ -995,10 +995,9 @@ input UpdateSkillInput {
   keywords: [String!]
 }
 
-"""
-When updating a User, all fields are optional, and email cannot be changed.
-"""
+"""When updating a User, all fields are optional"""
 input UpdateUserAsAdminInput {
+  email: Email
   sub: String
   roles: [Role]
   firstName: String
@@ -1041,6 +1040,7 @@ input UpdateUserAsAdminInput {
 }
 
 input UpdateUserAsUserInput {
+  email: Email
   firstName: String
   lastName: String
   telephone: PhoneNumber

--- a/frontend/admin/src/js/components/user/CreateUser.tsx
+++ b/frontend/admin/src/js/components/user/CreateUser.tsx
@@ -4,10 +4,11 @@ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 import { Input, MultiSelect, Select, Submit } from "@common/components/form";
 import { navigate } from "@common/helpers/router";
-import { emptyToNull, enumToOptions } from "@common/helpers/formUtils";
+import { enumToOptions } from "@common/helpers/formUtils";
 import { getLanguage, getRole } from "@common/constants/localizedConstants";
 import { errorMessages } from "@common/messages";
 import { phoneNumberRegex } from "@common/constants/regularExpressions";
+import { emptyToNull } from "@common/helpers/util";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Language,

--- a/frontend/admin/src/js/components/user/CreateUser.tsx
+++ b/frontend/admin/src/js/components/user/CreateUser.tsx
@@ -16,6 +16,7 @@ import {
   CreateUserMutation,
   useCreateUserMutation,
   Role,
+  InputMaybe,
 } from "../../api/generated";
 import DashboardContentContainer from "../DashboardContentContainer";
 
@@ -26,13 +27,16 @@ interface CreateUserFormProps {
   ) => Promise<CreateUserMutation["createUser"]>;
 }
 
+const emptyToNull = (s: InputMaybe<string>): string | null =>
+  empty(s) || s === "" ? null : s;
+
 const formValuesToData = (values: FormValues): CreateUserInput => ({
   ...values,
-  telephone:
-    // empty string isn't valid according to API validation regex pattern, but null is valid.
-    empty(values.telephone) || values.telephone === ""
-      ? null
-      : values.telephone,
+  // empty string isn't valid according to API validation regex pattern, but null is valid.
+  telephone: emptyToNull(values.telephone),
+  // empty string will violate uniqueness constraints
+  email: emptyToNull(values.email),
+  sub: emptyToNull(values.sub),
 });
 
 export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
@@ -85,9 +89,6 @@ export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
               })}
               type="email"
               name="email"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <Input
               id="firstName"

--- a/frontend/admin/src/js/components/user/CreateUser.tsx
+++ b/frontend/admin/src/js/components/user/CreateUser.tsx
@@ -4,11 +4,10 @@ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 import { Input, MultiSelect, Select, Submit } from "@common/components/form";
 import { navigate } from "@common/helpers/router";
-import { enumToOptions } from "@common/helpers/formUtils";
+import { emptyToNull, enumToOptions } from "@common/helpers/formUtils";
 import { getLanguage, getRole } from "@common/constants/localizedConstants";
 import { errorMessages } from "@common/messages";
 import { phoneNumberRegex } from "@common/constants/regularExpressions";
-import { empty } from "@common/helpers/util";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Language,
@@ -16,7 +15,6 @@ import {
   CreateUserMutation,
   useCreateUserMutation,
   Role,
-  InputMaybe,
 } from "../../api/generated";
 import DashboardContentContainer from "../DashboardContentContainer";
 
@@ -26,9 +24,6 @@ interface CreateUserFormProps {
     data: FormValues,
   ) => Promise<CreateUserMutation["createUser"]>;
 }
-
-const emptyToNull = (s: InputMaybe<string>): string | null =>
-  empty(s) || s === "" ? null : s;
 
 const formValuesToData = (values: FormValues): CreateUserInput => ({
   ...values,

--- a/frontend/admin/src/js/components/user/UpdateUser.tsx
+++ b/frontend/admin/src/js/components/user/UpdateUser.tsx
@@ -5,14 +5,11 @@ import pick from "lodash/pick";
 import { toast } from "react-toastify";
 import { Select, Submit, Input, MultiSelect } from "@common/components/form";
 import { navigate } from "@common/helpers/router";
-import {
-  emptyToNull,
-  enumToOptions,
-  unpackIds,
-} from "@common/helpers/formUtils";
+import { enumToOptions, unpackIds } from "@common/helpers/formUtils";
 import { errorMessages, commonMessages } from "@common/messages";
 import { getLanguage, getRole } from "@common/constants/localizedConstants";
 import { phoneNumberRegex } from "@common/constants/regularExpressions";
+import { emptyToNull } from "@common/helpers/util";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Language,

--- a/frontend/admin/src/js/components/user/UpdateUser.tsx
+++ b/frontend/admin/src/js/components/user/UpdateUser.tsx
@@ -5,14 +5,16 @@ import pick from "lodash/pick";
 import { toast } from "react-toastify";
 import { Select, Submit, Input, MultiSelect } from "@common/components/form";
 import { navigate } from "@common/helpers/router";
-import { enumToOptions, unpackIds } from "@common/helpers/formUtils";
+import {
+  emptyToNull,
+  enumToOptions,
+  unpackIds,
+} from "@common/helpers/formUtils";
 import { errorMessages, commonMessages } from "@common/messages";
 import { getLanguage, getRole } from "@common/constants/localizedConstants";
 import { phoneNumberRegex } from "@common/constants/regularExpressions";
-import { empty } from "@common/helpers/util";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
-  InputMaybe,
   Language,
   Role,
   UpdateUserAsAdminInput,
@@ -89,9 +91,6 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
     pools: unpackIds(data.pools),
     poolCandidates: unpackIds(data.poolCandidates),
   });
-
-  const emptyToNull = (s: InputMaybe<string>): string | null =>
-    empty(s) || s === "" ? null : s;
 
   const formValuesToSubmitData = (
     values: FormValues,

--- a/frontend/admin/src/js/components/user/UpdateUser.tsx
+++ b/frontend/admin/src/js/components/user/UpdateUser.tsx
@@ -12,6 +12,7 @@ import { phoneNumberRegex } from "@common/constants/regularExpressions";
 import { empty } from "@common/helpers/util";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
+  InputMaybe,
   Language,
   Role,
   UpdateUserAsAdminInput,
@@ -29,6 +30,7 @@ type FormValues = Pick<
   | "comprehensionLevel"
   | "currentCity"
   | "currentProvince"
+  | "email"
   | "estimatedLanguageAbility"
   | "expectedSalary"
   | "firstName"
@@ -88,15 +90,18 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
     poolCandidates: unpackIds(data.poolCandidates),
   });
 
+  const emptyToNull = (s: InputMaybe<string>): string | null =>
+    empty(s) || s === "" ? null : s;
+
   const formValuesToSubmitData = (
     values: FormValues,
   ): UpdateUserAsAdminInput => ({
     ...values,
-    telephone:
-      // empty string isn't valid according to API validation regex pattern, but null is valid.
-      empty(values.telephone) || values.telephone === ""
-        ? null
-        : values.telephone,
+    // empty string isn't valid according to API validation regex pattern, but null is valid.
+    telephone: emptyToNull(values.telephone),
+    // empty string will violate uniqueness constraints
+    email: emptyToNull(values.email),
+    sub: emptyToNull(values.sub),
     cmoAssets: {
       sync: values.cmoAssets,
     },
@@ -155,9 +160,6 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
               })}
               type="email"
               name="email"
-              value={initialUser.email ?? ""}
-              disabled
-              hideOptional
             />
             <Input
               id="firstName"
@@ -284,6 +286,7 @@ export const UpdateUser: React.FunctionComponent<{ userId: string }> = ({
     executeMutation({
       id,
       user: pick(data, [
+        "email",
         "firstName",
         "lastName",
         "telephone",

--- a/frontend/common/src/helpers/formUtils.ts
+++ b/frontend/common/src/helpers/formUtils.ts
@@ -1,5 +1,5 @@
-import { Maybe } from "../api/generated";
-import { getId, notEmpty } from "./util";
+import { InputMaybe, Maybe } from "../api/generated";
+import { empty, getId, notEmpty } from "./util";
 
 /**
  * Filters out empty data from data response.
@@ -119,3 +119,11 @@ export const countNumberOfWords = (text: string): number => {
   }
   return 0;
 };
+
+/**
+ * Accepts a input value and transforms empty strings to a null
+ * @param s String value from an input
+ * @returns The possibly-transformed-to-null input string
+ */
+export const emptyToNull = (s: InputMaybe<string>): string | null =>
+  empty(s) || s === "" ? null : s;

--- a/frontend/common/src/helpers/formUtils.ts
+++ b/frontend/common/src/helpers/formUtils.ts
@@ -1,5 +1,5 @@
-import { InputMaybe, Maybe } from "../api/generated";
-import { empty, getId, notEmpty } from "./util";
+import { Maybe } from "../api/generated";
+import { getId, notEmpty } from "./util";
 
 /**
  * Filters out empty data from data response.
@@ -119,11 +119,3 @@ export const countNumberOfWords = (text: string): number => {
   }
   return 0;
 };
-
-/**
- * Accepts a input value and transforms empty strings to a null
- * @param s String value from an input
- * @returns The possibly-transformed-to-null input string
- */
-export const emptyToNull = (s: InputMaybe<string>): string | null =>
-  empty(s) || s === "" ? null : s;

--- a/frontend/common/src/helpers/util.ts
+++ b/frontend/common/src/helpers/util.ts
@@ -1,3 +1,5 @@
+import { InputMaybe } from "../api/generated";
+
 export function identity<T>(value: T): T {
   return value;
 }
@@ -87,3 +89,11 @@ export function insertBetween<T>(separator: T, arr: T[]): T[] {
 export function isStringTrue(str: string | undefined): boolean {
   return str?.toLocaleUpperCase() === "TRUE";
 }
+
+/**
+ * Accepts a input value and transforms empty strings to a null
+ * @param s String value from an input
+ * @returns The possibly-transformed-to-null input string
+ */
+export const emptyToNull = (s: InputMaybe<string>): string | null =>
+  empty(s) || s === "" ? null : s;

--- a/frontend/talentsearch/src/js/components/aboutMeForm/AboutMeForm.tsx
+++ b/frontend/talentsearch/src/js/components/aboutMeForm/AboutMeForm.tsx
@@ -14,7 +14,6 @@ import {
   getLanguage,
 } from "@common/constants/localizedConstants";
 import { SubmitHandler } from "react-hook-form";
-import omit from "lodash/omit";
 import pick from "lodash/pick";
 import ProfileFormWrapper from "../applicantProfile/ProfileFormWrapper";
 import ProfileFormFooter from "../applicantProfile/ProfileFormFooter";
@@ -70,12 +69,6 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
   }
 
   const initialDataToFormValues = (data?: User | null): FormValues => {
-    if (!data) {
-      return {
-        email: "",
-      };
-    }
-
     return pick(data, [
       "preferredLang",
       "currentProvince",
@@ -88,9 +81,7 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
   };
 
   const formValuesToSubmitData = (data: FormValues): UpdateUserAsUserInput => {
-    // NOTE: Prototype included email field but API does not allow users to update email
-    const newData = omit(data, ["email"]);
-    return newData;
+    return data;
   };
 
   const handleSubmit: SubmitHandler<FormValues> = async (formValues) => {
@@ -274,7 +265,6 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
               id="email"
               name="email"
               type="email"
-              disabled
               label={intl.formatMessage({
                 defaultMessage: "Email",
                 description: "Label for email field in About Me form",

--- a/frontend/talentsearch/src/js/components/aboutMeForm/aboutMeFormOperations.graphql
+++ b/frontend/talentsearch/src/js/components/aboutMeForm/aboutMeFormOperations.graphql
@@ -20,6 +20,7 @@ mutation UpdateUserAsUser($id: ID!, $user: UpdateUserAsUserInput!) {
     telephone
     firstName
     lastName
+    email
     isProfileComplete
   }
 }


### PR DESCRIPTION
This branch finishes migrating from `email` to `sub` for authentication.
- Updates to schema
- Updates to admin site
- Updates to profile site

Use cases for testing
- [ ] A user can be created with no email or sub in the admin interface
- [ ] An admin should be able to fill these values
- [ ] An admin should be able to edit these values
- [ ] An admin should be able to clear these values
- [ ] An autocreated user should have the sub but no email
- [ ] An autocreated user should be able to log in but have no roles and not be able access protected pages
- [ ] An admin should be able to fill in the fields of an autocreated user to promote them to admin
- [ ] Login should work with SiC
- [ ] Login should work with Laravel Auth
- [ ] Regular (non-admin) user can update their email in *profiles*

Closes #2722 