### PR TITLE
Enable AUTH_DEFAULT_USER by default for local dev

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -56,6 +56,11 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 OAUTH_REDIRECT_URI="http://localhost:8000/auth-callback"
 OAUTH_POST_LOGIN_REDIRECT="http://localhost:8000/admin"
 
+# Unlike admin, talentsearch doesn't have a concept of user login.
+# Setting this value fakes a login for local development.
+# DEVELOPMENT ONLY. DO NOT ENABLE IN PRODUCTION.
+AUTH_DEFAULT_USER=admin@test.com
+
 # for local testing
 AUTH_SERVER_ISS="http://localhost:8000"
 AUTH_SERVER_PUBLIC_KEY=""


### PR DESCRIPTION
I am utterly ashamed to admit how long I misunderstood this setting, and thought it didn't apply to me. (I thought it was just for tests that didn't want to deal with login, and I didn't realize my logging in via laravel auth wasn't enough 🤦 )

I suspect I fell between the cracks, as it arrived just as I was onboarding, and it didn't get enabled during my initial setup. I've literally been unable to work on applicant profile issues (aside from storybook), and thought I was just an idiot for not being able to grok some pre-requisite step in the code. I was poring over READMEs trying to figure out what I was missing, but it was pretty miserable to feel lost like this on something so low-level. I didn't even know the question to ask for someone to point this out to me 😭  (@vd1992 finally helped me figure it out today 🙏:heart:)

This is a PR to make the developer environment defaults more forgiving for someone in my position, by referencing it in the .env files and enabling it by default in `api/.env.example`