### PR TITLE
Fixed phpunit tests for DataSet

### DIFF
--- a/api/app/Services/Contracts/DatasetInterface.php
+++ b/api/app/Services/Contracts/DatasetInterface.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace App\Services\Contracts;
-
-use Lcobucci\JWT\Token\DataSet;
-
-// Need to abstract the Lcobucci\JWT\Token\DataSet class because it is a final class and cannot be mocked
-Interface DataSetInterface extends DataSet
-{ }

--- a/api/tests/Feature/AuthServiceProviderTest.php
+++ b/api/tests/Feature/AuthServiceProviderTest.php
@@ -3,7 +3,7 @@
 use App\Models\User;
 use App\Providers\AuthServiceProvider;
 use App\Services\Contracts\BearerTokenServiceInterface;
-use App\Services\Contracts\DataSetInterface;
+use Lcobucci\JWT\Token\DataSet;
 use Tests\TestCase;
 use Mockery\MockInterface;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -74,10 +74,9 @@ class AuthServiceProviderTest extends TestCase
     {
         $testSub = 'test-sub';
 
-        $mockClaims = Mockery::mock(DataSetInterface::class);
-        $mockClaims->shouldReceive('get')
-                    ->with('sub')
-                    ->andReturn($testSub);
+        // DataSet is a final class, and so we need to use it as a proxied partial mock.
+        // See: https://docs.mockery.io/en/latest/reference/final_methods_classes.html#dealing-with-final-classes-methods
+        $mockClaims = Mockery::mock(new DataSet(['sub' => $testSub], ''));
 
         $fakeToken = 'fake-token';
         $mockTokenService = Mockery::mock(BearerTokenServiceInterface::class);
@@ -104,10 +103,7 @@ class AuthServiceProviderTest extends TestCase
         $testSub = 'test-sub';
         $testRoles = ["ADMIN"];
 
-        $mockClaims = Mockery::mock(DataSetInterface::class);
-        $mockClaims->shouldReceive('get')
-                    ->with('sub')
-                    ->andReturn($testSub);
+        $mockClaims = Mockery::mock(new DataSet(['sub' => $testSub], ''));
 
         $fakeToken = 'fake-token';
         $mockTokenService = Mockery::mock(BearerTokenServiceInterface::class);


### PR DESCRIPTION
Resolves https://github.com/GCTC-NTGC/gc-digital-talent/issues/2873

Not sure why this was a quiet warning for everyone else and fatal errror for me. On investigating, it seems that the official mockery docks say that final classes can't be mocked, and they provide an alternative:
https://docs.mockery.io/en/latest/reference/final_methods_classes.html#dealing-with-final-classes-methods

I've swapped to using proxy mocks, and my phpunit tests are running now :)