### PR TITLE
Debt - 2771 - Ignore console.error for integrity tests

### DIFF
--- a/frontend/common/jest.config.js
+++ b/frontend/common/jest.config.js
@@ -36,4 +36,7 @@ module.exports = {
 
   // Module file extensions for importing
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+
+  verbose: true,
+  setupFilesAfterEnv: ["<rootDir>/tests/setup.js"],
 };

--- a/frontend/common/tests/setup.js
+++ b/frontend/common/tests/setup.js
@@ -1,0 +1,9 @@
+global.console = {
+  ...console,
+  // uncomment to ignore a specific log level
+  //log: jest.fn(),
+  //debug: jest.fn(),
+  //info: jest.fn(),
+  // warn: jest.fn(),
+  error: jest.fn(),
+};


### PR DESCRIPTION
Resolves #2771 

## Summary

This updates the jest config to mock the `console.error` function globally to prevent the `checkIntegrity.test.js` from being too noisy muddying up the tests. It also makes tests verbose so we have better knowledge of the tests we are running.

h/t @petertgiles 

Ref: https://stackoverflow.com/questions/44467657/jest-better-way-to-disable-console-inside-unit-tests 

_**Note**: Sprint backlog is blocked and this seemed simple enough to update so I picked it up._