### PR TITLE
Quote glob patterns for Format.JS to avoid auto shell expansion

### DIFF
--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -34,7 +34,7 @@
     "build-storybook": "build-storybook",
     "chromatic": "npx chromatic --project-token=87148152bdff --auto-accept-changes",
     "codegen": "graphql-codegen",
-    "intl-extract": "formatjs extract ./src/js/**/*.{ts,tsx} --ignore ./**/*.d.ts --out-file src/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
+    "intl-extract": "formatjs extract './src/js/**/*.{ts,tsx}' --ignore './**/*.d.ts' --out-file src/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
     "intl-compile": "formatjs compile ./src/js/lang/fr.json --out-file ./src/js/lang/frCompiled.json",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch --passWithNoTests"

--- a/frontend/common/README.md
+++ b/frontend/common/README.md
@@ -65,7 +65,7 @@ Step 3 will resolve the "no-unresolved" eslint error when importing using the "@
 
 Unfortunately, I do not know a good way around the "no-extraneous-dependencies" eslint error, hence turning that rule off entirely in step 4.
 
-# Translation Utility script
+## Translation Utility script
 
 This project contains a script (`src/tooling/checkIntl.js`) to help manage your react-intl translations files. It has been written to run without any dependencies or compilation. It is expected to be used along with the [formatjs cli](https://formatjs.io/docs/tooling/cli).
 

--- a/frontend/common/package.json
+++ b/frontend/common/package.json
@@ -16,7 +16,7 @@
     "h2-compile": "h2-compile",
     "h2-watch": "h2-watch",
     "h2-build": "h2-build",
-    "intl-extract": "formatjs extract ./src/**/*.{ts,tsx} --ignore ./**/*.d.ts --out-file src/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
+    "intl-extract": "formatjs extract './src/**/*.{ts,tsx}' --ignore './**/*.d.ts' --out-file src/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
     "intl-compile": "formatjs compile src/lang/fr.json --out-file src/lang/frCompiled.json",
     "check-intl-common": "node ./src/tooling/checkIntl.js --en src/lang/en.json --fr src/lang/fr.json --rm-orphaned --output-untranslated src/lang/untranslated.json --whitelist src/lang/whitelist.json",
     "check-intl-common-merge": "node src/tooling/checkIntl.js --en src/lang/en.json --fr src/lang/fr.json --rm-orphaned --output-untranslated src/lang/untranslated.json --whitelist src/lang/whitelist.json --merge-fr src/lang/newTranslations.json",

--- a/frontend/indigenousapprenticeship/package.json
+++ b/frontend/indigenousapprenticeship/package.json
@@ -33,7 +33,7 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "codegen": "graphql-codegen",
-    "intl-extract": "formatjs extract ./src/js/**/*.{ts,tsx} --ignore ./**/*.d.ts --out-file src/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
+    "intl-extract": "formatjs extract './src/js/**/*.{ts,tsx}' --ignore './**/*.d.ts' --out-file src/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
     "intl-compile": "formatjs compile ./src/js/lang/fr.json --out-file ./src/js/lang/frCompiled.json",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/frontend/talentsearch/package.json
+++ b/frontend/talentsearch/package.json
@@ -33,7 +33,7 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "codegen": "graphql-codegen",
-    "intl-extract": "formatjs extract ./src/js/**/*.{ts,tsx} --ignore ./**/*.d.ts --out-file src/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
+    "intl-extract": "formatjs extract './src/js/**/*.{ts,tsx}' --ignore './**/*.d.ts' --out-file src/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
     "intl-compile": "formatjs compile ./src/js/lang/fr.json --out-file ./src/js/lang/frCompiled.json",
     "test": "jest",
     "test:watch": "jest --watch"


### PR DESCRIPTION
Resolves #2932.

### Bonus

- [Fix order of headings to be semantically correct in README.md](https://github.com/GCTC-NTGC/gc-digital-talent/commit/9f2fcba2d196b23d46da3940f70aa657cd43e152)