### PR TITLE
Added restart policy on mock-auth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,10 @@ services:
     image: ghcr.io/navikt/mock-oauth2-server:0.4.8
     volumes:
       - ./infrastructure/conf:/app/conf
+    # Container shuts down with exit code 143 instead of the standard "0", so
+    # we ensure it comes back up after a Docker Desktop console restart.
+    # See: https://docs.docker.com/config/containers/start-containers-automatically/#use-a-restart-policy
+    restart: unless-stopped
     environment:
       # Things to note in config:
       # - we mock a response but leave out "sub", so that value entered in fake


### PR DESCRIPTION
Pls drop an approval if it works to mitigate the issue you're experiencing :)

## Steps to confirm (my best guess)

**Before** checking out this branch

1. `docker-compose down`
2. `docker-compose up --detach` (presumably needs to be up)
3. shut down docker desktop and restart
4. `docker-compose ps` should show mock-auth container is down with exit code 143

Checkout this branch and repeat. If mock-auth container is up, it should me this is working