### PR TITLE
a11y - 2915 - Add aria-required

### DIFF
--- a/frontend/common/src/components/form/Checkbox/Checkbox.tsx
+++ b/frontend/common/src/components/form/Checkbox/Checkbox.tsx
@@ -60,6 +60,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
             {...register(name, rules)}
             type="checkbox"
             aria-invalid={error ? "true" : "false"}
+            aria-required={rules.required ? "true" : undefined}
             {...rest}
           />
         </InputWrapper>

--- a/frontend/common/src/components/form/Checklist/Checklist.tsx
+++ b/frontend/common/src/components/form/Checklist/Checklist.tsx
@@ -82,6 +82,7 @@ const Checklist: React.FunctionComponent<ChecklistProps> = ({
               {...register(name, rules)}
               value={value}
               type="checkbox"
+              aria-required={rules.required ? "true" : undefined}
               aria-invalid={error ? "true" : "false"}
             />
           </InputWrapper>

--- a/frontend/common/src/components/form/Input/Input.tsx
+++ b/frontend/common/src/components/form/Input/Input.tsx
@@ -64,6 +64,7 @@ const Input: React.FunctionComponent<InputProps> = ({
           id={id}
           {...register(name, rules)}
           type={type}
+          aria-required={rules.required ? "true" : undefined}
           aria-invalid={error ? "true" : "false"}
           {...rest}
         />

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
@@ -81,6 +81,7 @@ const MultiSelect: React.FunctionComponent<MultiSelectProps> = ({
             )}
             control={control}
             rules={rules}
+            aria-required={rules?.required ? "true" : undefined}
           />
         </div>
       </InputWrapper>

--- a/frontend/common/src/components/form/Select/Select.tsx
+++ b/frontend/common/src/components/form/Select/Select.tsx
@@ -54,6 +54,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
           style={{ width: "100%", paddingTop: "4.5px", paddingBottom: "4.5px" }}
           {...register(name, rules)}
           aria-invalid={error ? "true" : "false"}
+          aria-required={rules?.required ? "true" : undefined}
           {...rest}
           defaultValue=""
         >

--- a/frontend/common/src/components/form/TextArea/TextArea.tsx
+++ b/frontend/common/src/components/form/TextArea/TextArea.tsx
@@ -51,6 +51,7 @@ const TextArea: React.FunctionComponent<TextAreaProps> = ({
           style={{ width: "100%", resize: "vertical" }}
           id={id}
           {...register(name, rules)}
+          aria-required={rules.required ? "true" : undefined}
           aria-invalid={error ? "true" : "false"}
           {...rest}
         />

--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
@@ -38,6 +38,7 @@ const Fieldset: React.FC<FieldsetProps> = ({
     <fieldset
       name={name}
       disabled={disabled}
+      aria-required={required ? "true" : undefined}
       style={{
         border: "0 none",
         padding: "0",


### PR DESCRIPTION
Resolves #2915 

## Summary

This adds the `aria-required="true"` attribute to inputs when `rules.required` is defined so they are properly announced to screen readers.