### PR TITLE
a11y - 2902 - Remove title attributes

### DIFF
--- a/frontend/admin/src/js/components/classification/ClassificationPage.tsx
+++ b/frontend/admin/src/js/components/classification/ClassificationPage.tsx
@@ -34,7 +34,6 @@ export const ClassificationPage: React.FC = () => {
           >
             <Link
               href={paths.classificationCreate()}
-              title=""
               color="white"
               mode="outline"
               type="button"

--- a/frontend/common/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/common/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -24,7 +24,6 @@ const Breadcrumbs: React.FunctionComponent<BreadcrumbsProps> = ({ links }) => (
             data-h2-display="b(flex)"
             data-h2-align-items="b(center)"
             href={link.href}
-            title={link.title}
             key={link.title}
           >
             {link.icon || ""} {link.title}

--- a/frontend/common/src/components/Footer/Footer.tsx
+++ b/frontend/common/src/components/Footer/Footer.tsx
@@ -9,10 +9,6 @@ const Footer: React.FunctionComponent<{
   const links = [
     {
       route: "mailto:talent.cloud-nuage.de.talents@tbs-sct.gc.ca",
-      title: intl.formatMessage({
-        defaultMessage: "Submit feedback to GC Talent Cloud via email.",
-        description: "Title for the feedback link in the Footer.",
-      }),
       label: intl.formatMessage({
         defaultMessage: "Feedback",
         description: "Label for the feedback link in the Footer.",
@@ -20,10 +16,6 @@ const Footer: React.FunctionComponent<{
     },
     {
       route: `/${intl.locale}/terms-and-conditions`,
-      title: intl.formatMessage({
-        defaultMessage: "View our terms and conditions.",
-        description: "Title for the terms and conditions link in the Footer.",
-      }),
       label: intl.formatMessage({
         defaultMessage: "Terms & Conditions",
         description: "Label for the terms and conditions link in the Footer.",
@@ -31,10 +23,6 @@ const Footer: React.FunctionComponent<{
     },
     {
       route: `/${intl.locale}/privacy-notice`,
-      title: intl.formatMessage({
-        defaultMessage: "View our privacy policy.",
-        description: "Title for the privacy link in the Footer.",
-      }),
       label: intl.formatMessage({
         defaultMessage: "Privacy Policy",
         description: "Label for the privacy link in the Footer.",
@@ -42,10 +30,6 @@ const Footer: React.FunctionComponent<{
     },
     {
       route: `https://www.canada.ca/${intl.locale}.html`,
-      title: intl.formatMessage({
-        defaultMessage: "Visit Canada.ca",
-        description: "Title for the Canada link in the Footer.",
-      }),
       label: intl.formatMessage({
         defaultMessage: "Canada.ca",
         description: "Label for the Canada link in the Footer.",
@@ -74,16 +58,14 @@ const Footer: React.FunctionComponent<{
               data-h2-justify-content="b(center) m(flex-start)"
               data-h2-margin="b(bottom, xs)"
             >
-              {links.map(({ route, title, label }) => (
+              {links.map(({ route, label }) => (
                 <li
                   key={label}
                   data-h2-display="b(inline-block)"
                   data-h2-margin="b(top-bottom, none)"
                 >
                   {/* These links must use real anchor links, not the history api, as they may direct to outside of this app. */}
-                  <a href={route} title={title}>
-                    {label}
-                  </a>
+                  <a href={route}>{label}</a>
                 </li>
               ))}
             </ul>
@@ -114,10 +96,6 @@ const Footer: React.FunctionComponent<{
         >
           <a
             href={`https://www.canada.ca/${intl.locale}.html`}
-            title={intl.formatMessage({
-              defaultMessage: "Visit Canada.ca",
-              description: "Title for the Canada logo in the Footer.",
-            })}
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -125,8 +103,8 @@ const Footer: React.FunctionComponent<{
               style={{ width: "12rem" }}
               src={imageUrl(baseUrl, "logo_canada.png")}
               alt={intl.formatMessage({
-                defaultMessage: "Canada's Logo.",
-                description: "Alt text for the Canada logo in the Footer.",
+                defaultMessage: "Canada.ca",
+                description: "Alt text for the Canada logo link in the Footer.",
               })}
             />
           </a>

--- a/frontend/common/src/components/Header/Header.tsx
+++ b/frontend/common/src/components/Header/Header.tsx
@@ -26,10 +26,6 @@ const Header: React.FunctionComponent<HeaderProps> = ({ baseUrl }) => {
         >
           <a
             href={`https://www.canada.ca/${locale}.html`}
-            title={intl.formatMessage({
-              defaultMessage: "Visit Canada.ca",
-              description: "Title for the Canada logo in the Header.",
-            })}
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -37,8 +33,8 @@ const Header: React.FunctionComponent<HeaderProps> = ({ baseUrl }) => {
               style={{ width: "20rem" }}
               src={imageUrl(baseUrl, "logo_goc_colour.svg")}
               alt={intl.formatMessage({
-                defaultMessage: "Canada's Logo.",
-                description: "Alt text for the Canada logo in the Header.",
+                defaultMessage: "Canada.ca",
+                description: "Alt text for the Canada logo link in the Header.",
               })}
             />
           </a>

--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
@@ -80,11 +80,17 @@ const Fieldset: React.FC<FieldsetProps> = ({
               type="button"
               className="input-label-context-button"
               data-h2-margin="b(left, xxs)"
-              title="Toggle Context"
               onClick={() =>
                 setContextIsActive((currentState) => !currentState)
               }
             >
+              <span data-h2-visibility="b(invisible)">
+                {intl.formatMessage({
+                  defaultMessage: "Toggle context",
+                  description:
+                    "Label to toggle the context description of a field set.",
+                })}
+              </span>
               {contextIsActive ? (
                 <XCircleIcon
                   style={{ width: "calc(1rem/1.25)" }}

--- a/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
+++ b/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
@@ -60,9 +60,15 @@ const InputLabel: React.FC<InputLabelProps> = ({
             type="button"
             className="input-label-context-button"
             data-h2-margin="b(left, xxs)"
-            title="Toggle Context"
             onClick={clickHandler}
           >
+            <span data-h2-visibility="b(invisible)">
+              {intl.formatMessage({
+                defaultMessage: "Toggle context",
+                description:
+                  "Label to toggle the context description of an input.",
+              })}
+            </span>
             {contextIsActive ? (
               <XCircleIcon
                 style={{ width: "calc(1rem/1.25)" }}

--- a/frontend/talentsearch/src/js/components/applicantProfile/CancelButton.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/CancelButton.tsx
@@ -16,10 +16,6 @@ const CancelButton: React.FunctionComponent<{ link?: string }> = ({ link }) => {
       data-h2-width="b(auto)"
       data-h2-align-items="b(center)"
       type="button"
-      title={intl.formatMessage({
-        defaultMessage: "Cancel and go back",
-        description: "Title for cancel link in applicant profile forms.",
-      })}
     >
       <ArrowCircleLeftIcon style={{ width: "1rem" }} />
       <span data-h2-margin="b(left, xxs)">

--- a/frontend/talentsearch/src/js/components/applicantProfile/ExperienceAndSkills.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/ExperienceAndSkills.tsx
@@ -166,7 +166,6 @@ const ExperienceAndSkills: React.FunctionComponent<
             <a
               key={title}
               href={href}
-              title={title}
               data-h2-display="b(flex)"
               data-h2-align-items="b(center)"
               data-h2-margin="b(top-bottom, xs) m(top-bottom, none)"


### PR DESCRIPTION
Resolves #2902 

## Summary

This removes the `title` attribute from links in `admin`, `talentsearch` and `indigenousapprenticeship` to follow recommended a11y practices.

## Notes

### tc-report

I'm not sure how we feel about this but there are many instances on the `title` attribute in the `tc-report`. Do we plan on also removing those? 

### Language Selector

Right now our language selector has `title="Change language"` with text content of either "English" or "French". This would read, "link: Change language French". Do we want to replace this with a formatted string where we hide the first portion to screens?

#### Example

```tsx
const hiddenText = (...chunks: string[]) => (
  <span data-h2-visibility="b(invisible)">{chunks}</span>
);

<Link href={languageTogglePath}>
  {intl.formatMessage({
    defaultMessage: "<hidden>Change language to </hidden>{language}",
  }, {
    language: oppositeLocale(locale) === "en" ? "English" : "Français",
    hidden: hiddenText,
  })}
</Link>
```

