### PR TITLE
Debt - 2862 - Loading/Error Component

### DIFF
--- a/frontend/admin/src/js/components/classification/ClassificationTable.tsx
+++ b/frontend/admin/src/js/components/classification/ClassificationTable.tsx
@@ -2,14 +2,13 @@ import React, { useMemo } from "react";
 import { useIntl } from "react-intl";
 import { useLocation } from "@common/helpers/router";
 import { notEmpty } from "@common/helpers/util";
-import { commonMessages } from "@common/messages";
 import { FromArray } from "@common/types/utilityTypes";
 import { getLocale } from "@common/helpers/localize";
+import Pending from "@common/components/Pending";
 import {
   GetClassificationsQuery,
   useGetClassificationsQuery,
 } from "../../api/generated";
-import DashboardContentContainer from "../DashboardContentContainer";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
 
 type Data = NonNullable<FromArray<GetClassificationsQuery["classifications"]>>;
@@ -95,30 +94,16 @@ export const ClassificationTable: React.FC<
 };
 
 export const ClassificationTableApi: React.FunctionComponent = () => {
-  const intl = useIntl();
   const [result] = useGetClassificationsQuery();
   const { data, fetching, error } = result;
   const { pathname } = useLocation();
 
-  if (fetching)
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)} {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
   return (
-    <ClassificationTable
-      classifications={data?.classifications ?? []}
-      editUrlRoot={pathname}
-    />
+    <Pending fetching={fetching} error={error}>
+      <ClassificationTable
+        classifications={data?.classifications ?? []}
+        editUrlRoot={pathname}
+      />
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/classification/UpdateClassification.tsx
+++ b/frontend/admin/src/js/components/classification/UpdateClassification.tsx
@@ -7,6 +7,8 @@ import { toast } from "react-toastify";
 import { Input, Select, Submit } from "@common/components/form";
 import { navigate } from "@common/helpers/router";
 import { errorMessages, commonMessages } from "@common/messages";
+import Pending from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Classification,
@@ -219,39 +221,33 @@ export const UpdateClassification: React.FunctionComponent<{
       return Promise.reject(result.error);
     });
 
-  if (fetching)
-    return (
+  return (
+    <Pending fetching={fetching} error={error}>
       <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-  return classificationData?.classification ? (
-    <DashboardContentContainer>
-      <UpdateClassificationForm
-        initialClassification={classificationData?.classification}
-        handleUpdateClassification={handleUpdateClassification}
-      />
-    </DashboardContentContainer>
-  ) : (
-    <DashboardContentContainer>
-      <p>
-        {intl.formatMessage(
-          {
-            defaultMessage: "Classification {classificationId} not found.",
-            description: "Message displayed for classification not found.",
-          },
-          { classificationId },
+        {classificationData?.classification ? (
+          <UpdateClassificationForm
+            initialClassification={classificationData?.classification}
+            handleUpdateClassification={handleUpdateClassification}
+          />
+        ) : (
+          <NotFound
+            headingMessage={intl.formatMessage(commonMessages.notFound)}
+          >
+            {" "}
+            <p>
+              {intl.formatMessage(
+                {
+                  defaultMessage:
+                    "Classification {classificationId} not found.",
+                  description:
+                    "Message displayed for classification not found.",
+                },
+                { classificationId },
+              )}
+            </p>
+          </NotFound>
         )}
-      </p>
-    </DashboardContentContainer>
+      </DashboardContentContainer>
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/cmoAsset/CmoAssetTable.tsx
+++ b/frontend/admin/src/js/components/cmoAsset/CmoAssetTable.tsx
@@ -2,9 +2,9 @@ import React, { useMemo } from "react";
 import { useIntl } from "react-intl";
 import { useLocation } from "@common/helpers/router";
 import { notEmpty } from "@common/helpers/util";
-import { commonMessages } from "@common/messages";
 import { FromArray } from "@common/types/utilityTypes";
 import { getLocale } from "@common/helpers/localize";
+import Pending from "@common/components/Pending";
 import { GetCmoAssetsQuery, useGetCmoAssetsQuery } from "../../api/generated";
 import DashboardContentContainer from "../DashboardContentContainer";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
@@ -64,28 +64,18 @@ export const CmoAssetTable: React.FC<
 };
 
 export const CmoAssetTableApi: React.FC = () => {
-  const intl = useIntl();
   const [result] = useGetCmoAssetsQuery();
   const { data, fetching, error } = result;
   const { pathname } = useLocation();
 
-  if (fetching)
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
   return (
-    <CmoAssetTable cmoAssets={data?.cmoAssets ?? []} editUrlRoot={pathname} />
+    <Pending fetching={fetching} error={error}>
+      <DashboardContentContainer>
+        <CmoAssetTable
+          cmoAssets={data?.cmoAssets ?? []}
+          editUrlRoot={pathname}
+        />
+      </DashboardContentContainer>
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/cmoAsset/UpdateCmoAsset.tsx
+++ b/frontend/admin/src/js/components/cmoAsset/UpdateCmoAsset.tsx
@@ -6,6 +6,8 @@ import { toast } from "react-toastify";
 import { Input, Submit, TextArea } from "@common/components/form";
 import { navigate } from "@common/helpers/router";
 import { errorMessages, commonMessages } from "@common/messages";
+import Pending from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   CmoAsset,
@@ -144,39 +146,30 @@ export const UpdateCmoAsset: React.FunctionComponent<{
       return Promise.reject(result.error);
     });
 
-  if (fetching)
-    return (
+  return (
+    <Pending fetching={fetching} error={error}>
       <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-  return cmoAssetData?.cmoAsset ? (
-    <DashboardContentContainer>
-      <UpdateCmoAssetForm
-        initialCmoAsset={cmoAssetData.cmoAsset}
-        handleUpdateCmoAsset={handleUpdateCmoAsset}
-      />
-    </DashboardContentContainer>
-  ) : (
-    <DashboardContentContainer>
-      <p>
-        {intl.formatMessage(
-          {
-            defaultMessage: "CMO Asset {cmoAssetId} not found.",
-            description: "Message displayed for cmo asset not found.",
-          },
-          { cmoAssetId },
+        {cmoAssetData?.cmoAsset ? (
+          <UpdateCmoAssetForm
+            initialCmoAsset={cmoAssetData.cmoAsset}
+            handleUpdateCmoAsset={handleUpdateCmoAsset}
+          />
+        ) : (
+          <NotFound
+            headingMessage={intl.formatMessage(commonMessages.notFound)}
+          >
+            <p>
+              {intl.formatMessage(
+                {
+                  defaultMessage: "CMO Asset {cmoAssetId} not found.",
+                  description: "Message displayed for cmo asset not found.",
+                },
+                { cmoAssetId },
+              )}
+            </p>
+          </NotFound>
         )}
-      </p>
-    </DashboardContentContainer>
+      </DashboardContentContainer>
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/dashboard/DashboardPage.tsx
+++ b/frontend/admin/src/js/components/dashboard/DashboardPage.tsx
@@ -11,6 +11,7 @@ import PageHeader from "@common/components/PageHeader";
 
 import { commonMessages } from "@common/messages";
 
+import Pending from "@common/components/Pending";
 import DashboardContentContainer from "../DashboardContentContainer";
 import { User, useMeQuery } from "../../api/generated";
 import { useAdminRoutes } from "../../adminRoutes";
@@ -109,30 +110,13 @@ const DashboardPage: React.FC<DashboardPageProps> = ({ currentUser }) => {
 };
 
 const DashboardPageApi: React.FC = () => {
-  const intl = useIntl();
-  const [result] = useMeQuery();
-  const { data, fetching, error } = result;
+  const [{ data, fetching, error }] = useMeQuery();
 
-  if (fetching) {
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  }
-
-  if (error) {
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-  }
-
-  return <DashboardPage currentUser={data?.me} />;
+  return (
+    <Pending fetching={fetching} error={error}>
+      <DashboardPage currentUser={data?.me} />
+    </Pending>
+  );
 };
 
 export default DashboardPageApi;

--- a/frontend/admin/src/js/components/dashboard/DashboardPage.tsx
+++ b/frontend/admin/src/js/components/dashboard/DashboardPage.tsx
@@ -8,9 +8,6 @@ import {
 } from "@heroicons/react/outline";
 import { IconLink } from "@common/components/Link";
 import PageHeader from "@common/components/PageHeader";
-
-import { commonMessages } from "@common/messages";
-
 import Pending from "@common/components/Pending";
 import DashboardContentContainer from "../DashboardContentContainer";
 import { User, useMeQuery } from "../../api/generated";

--- a/frontend/admin/src/js/components/dashboard/LatestRequestsTable.tsx
+++ b/frontend/admin/src/js/components/dashboard/LatestRequestsTable.tsx
@@ -9,6 +9,7 @@ import { getLocale } from "@common/helpers/localize";
 import type { PoolCandidateSearchStatus } from "@common/api/generated";
 
 import { notEmpty } from "@common/helpers/util";
+import Pending from "@common/components/Pending";
 import Table from "../Table";
 import type { ColumnsOf } from "../Table";
 
@@ -176,24 +177,13 @@ const LatestRequestsTable: React.FC<LatestRequestsTableProps> = ({ data }) => {
 };
 
 const LatestRequestsTableApi: React.FC = () => {
-  const intl = useIntl();
-  const [results] = useLatestRequestsQuery();
-  const { data, fetching, error } = results;
+  const [{ data, fetching, error }] = useLatestRequestsQuery();
 
-  if (fetching) {
-    return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  }
-
-  if (error) {
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {error.message}
-      </p>
-    );
-  }
-
-  return <LatestRequestsTable data={data} />;
+  return (
+    <Pending fetching={fetching} error={error}>
+      <LatestRequestsTable data={data} />
+    </Pending>
+  );
 };
 
 export default LatestRequestsTableApi;

--- a/frontend/admin/src/js/components/dashboard/LatestRequestsTable.tsx
+++ b/frontend/admin/src/js/components/dashboard/LatestRequestsTable.tsx
@@ -3,7 +3,6 @@ import { useIntl } from "react-intl";
 import type { IntlShape } from "react-intl";
 
 import { FromArray } from "@common/types/utilityTypes";
-import { commonMessages } from "@common/messages";
 import { getPoolCandidateSearchStatus } from "@common/constants/localizedConstants";
 import { getLocale } from "@common/helpers/localize";
 import type { PoolCandidateSearchStatus } from "@common/api/generated";

--- a/frontend/admin/src/js/components/department/DepartmentTable.tsx
+++ b/frontend/admin/src/js/components/department/DepartmentTable.tsx
@@ -5,6 +5,7 @@ import { useLocation } from "@common/helpers/router";
 import { notEmpty } from "@common/helpers/util";
 import { FromArray } from "@common/types/utilityTypes";
 import { getLocale } from "@common/helpers/localize";
+import Pending from "@common/components/Pending";
 import { DepartmentsQuery, useDepartmentsQuery } from "../../api/generated";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
 import DashboardContentContainer from "../DashboardContentContainer";
@@ -50,31 +51,16 @@ export const DepartmentTable: React.FC<
 };
 
 export const DepartmentTableApi: React.FunctionComponent = () => {
-  const intl = useIntl();
   const [result] = useDepartmentsQuery();
   const { data, fetching, error } = result;
   const { pathname } = useLocation();
 
-  if (fetching)
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
   return (
-    <DepartmentTable
-      departments={data?.departments ?? []}
-      editUrlRoot={pathname}
-    />
+    <Pending fetching={fetching} error={error}>
+      <DepartmentTable
+        departments={data?.departments ?? []}
+        editUrlRoot={pathname}
+      />
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/department/DepartmentTable.tsx
+++ b/frontend/admin/src/js/components/department/DepartmentTable.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from "react";
 import { useIntl } from "react-intl";
-import commonMessages from "@common/messages/commonMessages";
 import { useLocation } from "@common/helpers/router";
 import { notEmpty } from "@common/helpers/util";
 import { FromArray } from "@common/types/utilityTypes";
@@ -8,7 +7,6 @@ import { getLocale } from "@common/helpers/localize";
 import Pending from "@common/components/Pending";
 import { DepartmentsQuery, useDepartmentsQuery } from "../../api/generated";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
-import DashboardContentContainer from "../DashboardContentContainer";
 
 type Data = NonNullable<FromArray<DepartmentsQuery["departments"]>>;
 

--- a/frontend/admin/src/js/components/department/UpdateDepartment.tsx
+++ b/frontend/admin/src/js/components/department/UpdateDepartment.tsx
@@ -6,6 +6,8 @@ import pick from "lodash/pick";
 import { navigate } from "@common/helpers/router";
 import { Input, Submit } from "@common/components/form";
 import { errorMessages, commonMessages } from "@common/messages";
+import Pending from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Department,
@@ -142,38 +144,30 @@ export const UpdateDepartment: React.FunctionComponent<{
       return Promise.reject(result.error);
     });
 
-  if (fetching)
-    return (
+  return (
+    <Pending fetching={fetching} error={error}>
       <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)} {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-  return departmentData?.department ? (
-    <DashboardContentContainer>
-      <UpdateDepartmentForm
-        initialDepartment={departmentData.department}
-        handleUpdateDepartment={handleUpdateDepartment}
-      />
-    </DashboardContentContainer>
-  ) : (
-    <DashboardContentContainer>
-      <p>
-        {intl.formatMessage(
-          {
-            defaultMessage: "Department {departmentId} not found.",
-            description: "Message displayed for department not found.",
-          },
-          { departmentId },
+        {departmentData?.department ? (
+          <UpdateDepartmentForm
+            initialDepartment={departmentData.department}
+            handleUpdateDepartment={handleUpdateDepartment}
+          />
+        ) : (
+          <NotFound
+            headingMessage={intl.formatMessage(commonMessages.notFound)}
+          >
+            <p>
+              {intl.formatMessage(
+                {
+                  defaultMessage: "Department {departmentId} not found.",
+                  description: "Message displayed for department not found.",
+                },
+                { departmentId },
+              )}
+            </p>
+          </NotFound>
         )}
-      </p>
-    </DashboardContentContainer>
+      </DashboardContentContainer>
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/pool/CreatePool.tsx
+++ b/frontend/admin/src/js/components/pool/CreatePool.tsx
@@ -12,13 +12,14 @@ import {
 import { getLocale } from "@common/helpers/localize";
 import { notEmpty } from "@common/helpers/util";
 import { navigate } from "@common/helpers/router";
-import { errorMessages, commonMessages } from "@common/messages";
+import { errorMessages } from "@common/messages";
 import { keyStringRegex } from "@common/constants/regularExpressions";
 import { enumToOptions } from "@common/helpers/formUtils";
 import {
   getOperationalRequirement,
   getPoolStatus,
 } from "@common/constants/localizedConstants";
+import Pending from "@common/components/Pending";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Classification,
@@ -356,7 +357,6 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
 };
 
 export const CreatePool: React.FunctionComponent = () => {
-  const intl = useIntl();
   const [lookupResult] = useGetCreatePoolDataQuery();
   const { data: lookupData, fetching, error } = lookupResult;
   const classifications: Classification[] | [] =
@@ -373,30 +373,16 @@ export const CreatePool: React.FunctionComponent = () => {
       return Promise.reject(result.error);
     });
 
-  if (fetching)
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
   return (
-    <DashboardContentContainer>
-      <CreatePoolForm
-        classifications={classifications}
-        cmoAssets={cmoAssets}
-        users={users}
-        handleCreatePool={handleCreatePool}
-      />
-    </DashboardContentContainer>
+    <Pending fetching={fetching} error={error}>
+      <DashboardContentContainer>
+        <CreatePoolForm
+          classifications={classifications}
+          cmoAssets={cmoAssets}
+          users={users}
+          handleCreatePool={handleCreatePool}
+        />
+      </DashboardContentContainer>
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/pool/PoolTable.tsx
+++ b/frontend/admin/src/js/components/pool/PoolTable.tsx
@@ -4,11 +4,10 @@ import { Link, Pill } from "@common/components";
 import { useLocation } from "@common/helpers/router";
 import { notEmpty } from "@common/helpers/util";
 import { getLocale } from "@common/helpers/localize";
-import { commonMessages } from "@common/messages";
 import { FromArray } from "@common/types/utilityTypes";
+import Pending from "@common/components/Pending";
 import { GetPoolsQuery, useGetPoolsQuery } from "../../api/generated";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
-import DashboardContentContainer from "../DashboardContentContainer";
 import { useAdminRoutes } from "../../adminRoutes";
 
 type Data = NonNullable<FromArray<GetPoolsQuery["pools"]>>;
@@ -117,26 +116,13 @@ export const PoolTable: React.FC<GetPoolsQuery & { editUrlRoot: string }> = ({
 };
 
 export const PoolTableApi: React.FunctionComponent = () => {
-  const intl = useIntl();
   const [result] = useGetPoolsQuery();
   const { data, fetching, error } = result;
   const { pathname } = useLocation();
 
-  if (fetching)
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
-  return <PoolTable pools={data?.pools ?? []} editUrlRoot={pathname} />;
+  return (
+    <Pending fetching={fetching} error={error}>
+      <PoolTable pools={data?.pools ?? []} editUrlRoot={pathname} />
+    </Pending>
+  );
 };

--- a/frontend/admin/src/js/components/pool/UpdatePool.tsx
+++ b/frontend/admin/src/js/components/pool/UpdatePool.tsx
@@ -19,6 +19,8 @@ import {
   getOperationalRequirement,
   getPoolStatus,
 } from "@common/constants/localizedConstants";
+import Pending from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Classification,
@@ -390,43 +392,33 @@ export const UpdatePool: React.FunctionComponent<{
       return Promise.reject(result.error);
     });
 
-  if (fetching)
-    return (
+  return (
+    <Pending fetching={fetching} error={error}>
       <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
-  return lookupData?.pool ? (
-    <DashboardContentContainer>
-      <UpdatePoolForm
-        classifications={classifications}
-        cmoAssets={cmoAssets}
-        initialPool={lookupData.pool}
-        users={users}
-        handleUpdatePool={handleUpdatePool}
-      />
-    </DashboardContentContainer>
-  ) : (
-    <DashboardContentContainer>
-      <p>
-        {intl.formatMessage(
-          {
-            defaultMessage: "Pool {poolId} not found.",
-            description: "Message displayed for pool not found.",
-          },
-          { poolId },
+        {lookupData?.pool ? (
+          <UpdatePoolForm
+            classifications={classifications}
+            cmoAssets={cmoAssets}
+            initialPool={lookupData.pool}
+            users={users}
+            handleUpdatePool={handleUpdatePool}
+          />
+        ) : (
+          <NotFound
+            headingMessage={intl.formatMessage(commonMessages.notFound)}
+          >
+            <p>
+              {intl.formatMessage(
+                {
+                  defaultMessage: "Pool {poolId} not found.",
+                  description: "Message displayed for pool not found.",
+                },
+                { poolId },
+              )}
+            </p>
+          </NotFound>
         )}
-      </p>
-    </DashboardContentContainer>
+      </DashboardContentContainer>
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/pool/ViewPool.tsx
+++ b/frontend/admin/src/js/components/pool/ViewPool.tsx
@@ -15,7 +15,6 @@ import NotFound from "@common/components/NotFound";
 import { useAdminRoutes } from "../../adminRoutes";
 import { useGetPoolQuery } from "../../api/generated";
 import type { Pool } from "../../api/generated";
-import DashboardContentContainer from "../DashboardContentContainer";
 
 interface ViewPoolPageProps {
   pool: Pool;

--- a/frontend/admin/src/js/components/pool/ViewPool.tsx
+++ b/frontend/admin/src/js/components/pool/ViewPool.tsx
@@ -10,6 +10,8 @@ import { Tab, TabSet } from "@common/components/tabs";
 import { commonMessages } from "@common/messages";
 import { getLocale } from "@common/helpers/localize";
 
+import Pending from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
 import { useAdminRoutes } from "../../adminRoutes";
 import { useGetPoolQuery } from "../../api/generated";
 import type { Pool } from "../../api/generated";
@@ -113,28 +115,12 @@ const ViewPool: React.FC<ViewPoolProps> = ({ poolId }) => {
     variables: { id: poolId },
   });
 
-  if (fetching) {
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  }
-
-  if (error) {
-    <DashboardContentContainer>
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)} {error.message}
-      </p>
-    </DashboardContentContainer>;
-  }
-
   return (
-    <DashboardContentContainer>
+    <Pending fetching={fetching} error={error}>
       {data?.pool ? (
         <ViewPoolPage pool={data.pool} />
       ) : (
-        <p>
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
           <p>
             {intl.formatMessage(
               {
@@ -144,9 +130,9 @@ const ViewPool: React.FC<ViewPoolProps> = ({ poolId }) => {
               { poolId },
             )}
           </p>
-        </p>
+        </NotFound>
       )}
-    </DashboardContentContainer>
+    </Pending>
   );
 };
 

--- a/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
@@ -28,8 +28,9 @@ import {
   getPoolCandidateStatus,
   getOperationalRequirement,
 } from "@common/constants/localizedConstants";
-import { errorMessages, commonMessages } from "@common/messages";
+import { errorMessages } from "@common/messages";
 import { phoneNumberRegex } from "@common/constants/regularExpressions";
+import Pending from "@common/components/Pending";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   CreatePoolCandidateAsAdminInput,
@@ -622,7 +623,6 @@ export const CreatePoolCandidateForm: React.FunctionComponent<
 export const CreatePoolCandidate: React.FunctionComponent<{
   poolId: string;
 }> = ({ poolId }) => {
-  const intl = useIntl();
   const [lookupResult] = useGetCreatePoolCandidateDataQuery();
   const { data: lookupData, fetching, error } = lookupResult;
   const classifications: Classification[] | [] =
@@ -640,32 +640,18 @@ export const CreatePoolCandidate: React.FunctionComponent<{
       return Promise.reject(result.error);
     });
 
-  if (fetching)
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
   return (
-    <DashboardContentContainer>
-      <CreatePoolCandidateForm
-        classifications={classifications}
-        cmoAssets={cmoAssets}
-        pools={pools}
-        poolId={poolId}
-        users={users}
-        handleCreatePoolCandidate={handleCreatePoolCandidate}
-      />
-    </DashboardContentContainer>
+    <Pending fetching={fetching} error={error}>
+      <DashboardContentContainer>
+        <CreatePoolCandidateForm
+          classifications={classifications}
+          cmoAssets={cmoAssets}
+          pools={pools}
+          poolId={poolId}
+          users={users}
+          handleCreatePoolCandidate={handleCreatePoolCandidate}
+        />
+      </DashboardContentContainer>
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
@@ -2,13 +2,13 @@ import React, { useMemo } from "react";
 import { IntlShape, useIntl } from "react-intl";
 import { notEmpty } from "@common/helpers/util";
 import { useLocation } from "@common/helpers/router";
-import { commonMessages } from "@common/messages";
 import { FromArray } from "@common/types/utilityTypes";
 import { getLocale } from "@common/helpers/localize";
 import {
   getLanguage,
   getLanguageAbility,
 } from "@common/constants/localizedConstants";
+import Pending from "@common/components/Pending";
 import {
   GetPoolCandidatesQuery,
   Language,
@@ -181,33 +181,18 @@ export default PoolCandidatesTable;
 export const PoolCandidatesTableApi: React.FC<{ poolId: string }> = ({
   poolId,
 }) => {
-  const intl = useIntl();
   const [result] = useGetPoolCandidatesByPoolQuery({
     variables: { id: poolId },
   });
   const { data, fetching, error } = result;
   const { pathname } = useLocation();
 
-  if (fetching)
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
   return (
-    <PoolCandidatesTable
-      poolCandidates={data?.pool?.poolCandidates ?? []}
-      editUrlRoot={pathname}
-    />
+    <Pending fetching={fetching} error={error}>
+      <PoolCandidatesTable
+        poolCandidates={data?.pool?.poolCandidates ?? []}
+        editUrlRoot={pathname}
+      />
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
@@ -20,7 +20,6 @@ import Table, {
   tableBooleanAccessor,
   tableEditButtonAccessor,
 } from "../Table";
-import DashboardContentContainer from "../DashboardContentContainer";
 
 type Data = NonNullable<FromArray<GetPoolCandidatesQuery["poolCandidates"]>>;
 

--- a/frontend/admin/src/js/components/searchRequest/SearchRequestTable.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SearchRequestTable.tsx
@@ -2,17 +2,16 @@ import React, { useMemo } from "react";
 import { IntlShape, useIntl } from "react-intl";
 import { notEmpty } from "@common/helpers/util";
 import { useLocation } from "@common/helpers/router";
-import { commonMessages } from "@common/messages";
 import { FromArray } from "@common/types/utilityTypes";
 import { getLocale } from "@common/helpers/localize";
 import { getPoolCandidateSearchStatus } from "@common/constants/localizedConstants";
 import { PoolCandidateSearchStatus } from "@common/api/generated";
+import Pending from "@common/components/Pending";
 import {
   GetPoolCandidateSearchRequestsQuery,
   useGetPoolCandidateSearchRequestsQuery,
 } from "../../api/generated";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
-import DashboardContentContainer from "../DashboardContentContainer";
 import { useAdminRoutes } from "../../adminRoutes";
 
 type Data = NonNullable<
@@ -132,31 +131,16 @@ export const SearchRequestTable: React.FunctionComponent<
 };
 
 export const SearchRequestTableApi: React.FunctionComponent = () => {
-  const intl = useIntl();
   const [result] = useGetPoolCandidateSearchRequestsQuery();
   const { data, fetching, error } = result;
   const { pathname } = useLocation();
 
-  if (fetching)
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
   return (
-    <SearchRequestTable
-      poolCandidateSearchRequests={data?.poolCandidateSearchRequests ?? []}
-      editUrlRoot={pathname}
-    />
+    <Pending fetching={fetching} error={error}>
+      <SearchRequestTable
+        poolCandidateSearchRequests={data?.poolCandidateSearchRequests ?? []}
+        editUrlRoot={pathname}
+      />
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/searchRequest/SingleSearchRequest.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SingleSearchRequest.tsx
@@ -8,6 +8,8 @@ import { useIntl } from "react-intl";
 import { commonMessages } from "@common/messages";
 import { notEmpty } from "@common/helpers/util";
 import { getPoolCandidateSearchStatus } from "@common/constants/localizedConstants";
+import Pending from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
 import {
   PoolCandidateFilterInput,
   PoolCandidateSearchRequest,
@@ -285,28 +287,26 @@ export const SingleSearchRequestApi: React.FunctionComponent<{
       variables: { id: searchRequestId },
     });
 
-  if (fetching) return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  if (error)
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {error.message}
-      </p>
-    );
-  return searchRequestData?.poolCandidateSearchRequest ? (
-    <SingleSearchRequest
-      searchRequest={searchRequestData?.poolCandidateSearchRequest}
-    />
-  ) : (
-    <p>
-      {intl.formatMessage(
-        {
-          defaultMessage: "Search Request {searchRequestId} not found.",
-          description:
-            "Message displayed for search request not found on single search request page.",
-        },
-        { searchRequestId },
+  return (
+    <Pending fetching={fetching} error={error}>
+      {searchRequestData?.poolCandidateSearchRequest ? (
+        <SingleSearchRequest
+          searchRequest={searchRequestData?.poolCandidateSearchRequest}
+        />
+      ) : (
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          <p>
+            {intl.formatMessage(
+              {
+                defaultMessage: "Search Request {searchRequestId} not found.",
+                description:
+                  "Message displayed for search request not found on single search request page.",
+              },
+              { searchRequestId },
+            )}
+          </p>
+        </NotFound>
       )}
-    </p>
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/searchRequest/SingleSearchRequestTable.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SingleSearchRequestTable.tsx
@@ -3,17 +3,16 @@ import { useIntl } from "react-intl";
 import { Button, Pill } from "@common/components";
 import { notEmpty } from "@common/helpers/util";
 import { navigate } from "@common/helpers/router";
-import { commonMessages } from "@common/messages";
 import { FromArray } from "@common/types/utilityTypes";
 import { getLocale } from "@common/helpers/localize";
 import { getOperationalRequirement } from "@common/constants/localizedConstants";
+import Pending from "@common/components/Pending";
 import {
   SearchPoolCandidatesQuery,
   useSearchPoolCandidatesQuery,
   PoolCandidateFilterInput,
 } from "../../api/generated";
 import Table, { ColumnsOf } from "../Table";
-import DashboardContentContainer from "../DashboardContentContainer";
 import { useAdminRoutes } from "../../adminRoutes";
 
 type Data = NonNullable<
@@ -222,31 +221,16 @@ export const SingleSearchRequestTable: React.FunctionComponent<
 export const SingleSearchRequestTableApi: React.FunctionComponent<{
   poolCandidateFilter: PoolCandidateFilterInput;
 }> = ({ poolCandidateFilter }) => {
-  const intl = useIntl();
   const [result] = useSearchPoolCandidatesQuery({
     variables: { poolCandidateFilter },
   });
   const { data, fetching, error } = result;
 
-  if (fetching)
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
   return (
-    <SingleSearchRequestTable
-      searchPoolCandidates={data?.searchPoolCandidates ?? []}
-    />
+    <Pending fetching={fetching} error={error}>
+      <SingleSearchRequestTable
+        searchPoolCandidates={data?.searchPoolCandidates ?? []}
+      />
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/skill/CreateSkill.tsx
+++ b/frontend/admin/src/js/components/skill/CreateSkill.tsx
@@ -8,7 +8,8 @@ import { getLocale } from "@common/helpers/localize";
 import { notEmpty } from "@common/helpers/util";
 import { navigate } from "@common/helpers/router";
 import { keyStringRegex } from "@common/constants/regularExpressions";
-import { errorMessages, commonMessages } from "@common/messages";
+import { errorMessages } from "@common/messages";
+import Pending from "@common/components/Pending";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Skill,
@@ -226,7 +227,6 @@ export const CreateSkillForm: React.FunctionComponent<CreateSkillFormProps> = ({
 };
 
 export const CreateSkill: React.FunctionComponent = () => {
-  const intl = useIntl();
   const [lookupResult] = useAllSkillFamiliesQuery();
   const { data: lookupData, fetching, error } = lookupResult;
   const families = lookupData?.skillFamilies.filter(notEmpty) ?? [];
@@ -240,28 +240,14 @@ export const CreateSkill: React.FunctionComponent = () => {
       return Promise.reject(result.error);
     });
 
-  if (fetching)
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
   return (
-    <DashboardContentContainer>
-      <CreateSkillForm
-        handleCreateSkill={handleCreateSkill}
-        families={families}
-      />
-    </DashboardContentContainer>
+    <Pending fetching={fetching} error={error}>
+      <DashboardContentContainer>
+        <CreateSkillForm
+          handleCreateSkill={handleCreateSkill}
+          families={families}
+        />
+      </DashboardContentContainer>
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/skill/SkillTable.tsx
+++ b/frontend/admin/src/js/components/skill/SkillTable.tsx
@@ -1,14 +1,13 @@
 import React, { useMemo } from "react";
 import { useIntl } from "react-intl";
 import { getLocale } from "@common/helpers/localize";
-import commonMessages from "@common/messages/commonMessages";
 import { useLocation } from "@common/helpers/router";
 import { notEmpty } from "@common/helpers/util";
 import { FromArray } from "@common/types/utilityTypes";
 import { Pill } from "@common/components";
+import Pending from "@common/components/Pending";
 import { AllSkillsQuery, useAllSkillsQuery } from "../../api/generated";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
-import DashboardContentContainer from "../DashboardContentContainer";
 
 type Data = NonNullable<FromArray<AllSkillsQuery["skills"]>>;
 
@@ -83,26 +82,13 @@ export const SkillTable: React.FC<AllSkillsQuery & { editUrlRoot: string }> = ({
 };
 
 export const SkillTableApi: React.FunctionComponent = () => {
-  const intl = useIntl();
   const [result] = useAllSkillsQuery();
   const { data, fetching, error } = result;
   const { pathname } = useLocation();
 
-  if (fetching)
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
-  return <SkillTable skills={data?.skills ?? []} editUrlRoot={pathname} />;
+  return (
+    <Pending fetching={fetching} error={error}>
+      <SkillTable skills={data?.skills ?? []} editUrlRoot={pathname} />
+    </Pending>
+  );
 };

--- a/frontend/admin/src/js/components/skill/UpdateSkill.tsx
+++ b/frontend/admin/src/js/components/skill/UpdateSkill.tsx
@@ -10,6 +10,8 @@ import { navigate } from "@common/helpers/router";
 import { getLocale } from "@common/helpers/localize";
 import { unpackIds } from "@common/helpers/formUtils";
 import { errorMessages, commonMessages } from "@common/messages";
+import Pending from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Skill,
@@ -237,42 +239,32 @@ export const UpdateSkill: React.FunctionComponent<{
       return Promise.reject(result.error);
     });
 
-  if (fetching)
-    return (
+  return (
+    <Pending fetching={fetching} error={error}>
       <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
-  return lookupData?.skill ? (
-    <DashboardContentContainer>
-      <UpdateSkillForm
-        initialSkill={lookupData?.skill}
-        families={families}
-        handleUpdateSkill={handleUpdateSkill}
-      />
-    </DashboardContentContainer>
-  ) : (
-    <DashboardContentContainer>
-      <p>
-        {intl.formatMessage(
-          {
-            defaultMessage: "Skill {skillId} not found.",
-            description: "Message displayed for skill not found.",
-          },
-          { skillId },
+        {lookupData?.skill ? (
+          <UpdateSkillForm
+            initialSkill={lookupData?.skill}
+            families={families}
+            handleUpdateSkill={handleUpdateSkill}
+          />
+        ) : (
+          <NotFound
+            headingMessage={intl.formatMessage(commonMessages.notFound)}
+          >
+            <p>
+              {intl.formatMessage(
+                {
+                  defaultMessage: "Skill {skillId} not found.",
+                  description: "Message displayed for skill not found.",
+                },
+                { skillId },
+              )}
+            </p>
+          </NotFound>
         )}
-      </p>
-    </DashboardContentContainer>
+      </DashboardContentContainer>
+    </Pending>
   );
 };
 

--- a/frontend/admin/src/js/components/skillFamily/CreateSkillFamily.tsx
+++ b/frontend/admin/src/js/components/skillFamily/CreateSkillFamily.tsx
@@ -14,8 +14,9 @@ import { getLocale } from "@common/helpers/localize";
 import { notEmpty } from "@common/helpers/util";
 import { navigate } from "@common/helpers/router";
 import { enumToOptions } from "@common/helpers/formUtils";
-import { errorMessages, commonMessages } from "@common/messages";
+import { errorMessages } from "@common/messages";
 import { getSkillCategory } from "@common/constants/localizedConstants";
+import Pending from "@common/components/Pending";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Skill,
@@ -231,7 +232,6 @@ export const CreateSkillFamilyForm: React.FunctionComponent<
 };
 
 export const CreateSkillFamily: React.FunctionComponent = () => {
-  const intl = useIntl();
   const [lookupResult] = useGetCreateSkillFamilyDataQuery();
   const { data: lookupData, fetching, error } = lookupResult;
   const skills = lookupData?.skills.filter(notEmpty) ?? [];
@@ -245,28 +245,14 @@ export const CreateSkillFamily: React.FunctionComponent = () => {
       return Promise.reject(result.error);
     });
 
-  if (fetching)
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
   return (
-    <DashboardContentContainer>
-      <CreateSkillFamilyForm
-        handleCreateSkillFamily={handleCreateSkillFamily}
-        skills={skills}
-      />
-    </DashboardContentContainer>
+    <Pending fetching={fetching} error={error}>
+      <DashboardContentContainer>
+        <CreateSkillFamilyForm
+          handleCreateSkillFamily={handleCreateSkillFamily}
+          skills={skills}
+        />
+      </DashboardContentContainer>
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/skillFamily/SkillFamilyTable.tsx
+++ b/frontend/admin/src/js/components/skillFamily/SkillFamilyTable.tsx
@@ -1,18 +1,17 @@
 import React, { useMemo } from "react";
 import { IntlShape, useIntl } from "react-intl";
 import { getLocale } from "@common/helpers/localize";
-import commonMessages from "@common/messages/commonMessages";
 import { useLocation } from "@common/helpers/router";
 import { notEmpty } from "@common/helpers/util";
 import { FromArray } from "@common/types/utilityTypes";
 import { getSkillCategory } from "@common/constants/localizedConstants";
 import { SkillCategory } from "@common/api/generated";
+import Pending from "@common/components/Pending";
 import {
   AllSkillFamiliesQuery,
   useAllSkillFamiliesQuery,
 } from "../../api/generated";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
-import DashboardContentContainer from "../DashboardContentContainer";
 
 type Data = NonNullable<FromArray<AllSkillFamiliesQuery["skillFamilies"]>>;
 
@@ -82,31 +81,16 @@ export const SkillFamilyTable: React.FC<
 };
 
 export const SkillFamilyTableApi: React.FunctionComponent = () => {
-  const intl = useIntl();
   const [result] = useAllSkillFamiliesQuery();
   const { data, fetching, error } = result;
   const { pathname } = useLocation();
 
-  if (fetching)
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
   return (
-    <SkillFamilyTable
-      skillFamilies={data?.skillFamilies ?? []}
-      editUrlRoot={pathname}
-    />
+    <Pending fetching={fetching} error={error}>
+      <SkillFamilyTable
+        skillFamilies={data?.skillFamilies ?? []}
+        editUrlRoot={pathname}
+      />
+    </Pending>
   );
 };

--- a/frontend/admin/src/js/components/skillFamily/UpdateSkillFamily.tsx
+++ b/frontend/admin/src/js/components/skillFamily/UpdateSkillFamily.tsx
@@ -18,6 +18,8 @@ import { unpackIds, enumToOptions } from "@common/helpers/formUtils";
 
 import { errorMessages, commonMessages } from "@common/messages";
 import { getSkillCategory } from "@common/constants/localizedConstants";
+import Pending from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Skill,
@@ -251,42 +253,32 @@ export const UpdateSkillFamily: React.FunctionComponent<{
       return Promise.reject(result.error);
     });
 
-  if (fetching)
-    return (
+  return (
+    <Pending fetching={fetching} error={error}>
       <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
-  return lookupData?.skillFamily ? (
-    <DashboardContentContainer>
-      <UpdateSkillFamilyForm
-        initialSkillFamily={lookupData?.skillFamily}
-        skills={skills}
-        handleUpdateSkillFamily={handleUpdateSkillFamily}
-      />
-    </DashboardContentContainer>
-  ) : (
-    <DashboardContentContainer>
-      <p>
-        {intl.formatMessage(
-          {
-            defaultMessage: "SkillFamily {skillFamilyId} not found.",
-            description: "Message displayed for skillFamily not found.",
-          },
-          { skillFamilyId },
+        {lookupData?.skillFamily ? (
+          <UpdateSkillFamilyForm
+            initialSkillFamily={lookupData?.skillFamily}
+            skills={skills}
+            handleUpdateSkillFamily={handleUpdateSkillFamily}
+          />
+        ) : (
+          <NotFound
+            headingMessage={intl.formatMessage(commonMessages.notFound)}
+          >
+            <p>
+              {intl.formatMessage(
+                {
+                  defaultMessage: "SkillFamily {skillFamilyId} not found.",
+                  description: "Message displayed for skillFamily not found.",
+                },
+                { skillFamilyId },
+              )}
+            </p>
+          </NotFound>
         )}
-      </p>
-    </DashboardContentContainer>
+      </DashboardContentContainer>
+    </Pending>
   );
 };
 

--- a/frontend/admin/src/js/components/user/UpdateUser.tsx
+++ b/frontend/admin/src/js/components/user/UpdateUser.tsx
@@ -10,6 +10,8 @@ import { errorMessages, commonMessages } from "@common/messages";
 import { getLanguage, getRole } from "@common/constants/localizedConstants";
 import { phoneNumberRegex } from "@common/constants/regularExpressions";
 import { emptyToNull } from "@common/helpers/util";
+import NotFound from "@common/components/NotFound";
+import Pending from "@common/components/Pending";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Language,
@@ -297,40 +299,32 @@ export const UpdateUser: React.FunctionComponent<{ userId: string }> = ({
       return Promise.reject(result.error);
     });
 
-  if (fetching)
-    return (
+  return (
+    <Pending fetching={fetching} error={error}>
+      {" "}
       <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-  return userData?.user ? (
-    <DashboardContentContainer>
-      <UpdateUserForm
-        initialUser={userData?.user}
-        handleUpdateUser={handleUpdateUser}
-      />
-    </DashboardContentContainer>
-  ) : (
-    <DashboardContentContainer>
-      <p>
-        {intl.formatMessage(
-          {
-            defaultMessage: "User {userId} not found.",
-            description: "Message displayed for user not found.",
-          },
-          { userId },
+        {userData?.user ? (
+          <UpdateUserForm
+            initialUser={userData?.user}
+            handleUpdateUser={handleUpdateUser}
+          />
+        ) : (
+          <NotFound
+            headingMessage={intl.formatMessage(commonMessages.notFound)}
+          >
+            <p>
+              {intl.formatMessage(
+                {
+                  defaultMessage: "User {userId} not found.",
+                  description: "Message displayed for user not found.",
+                },
+                { userId },
+              )}
+            </p>
+          </NotFound>
         )}
-      </p>
-    </DashboardContentContainer>
+      </DashboardContentContainer>
+    </Pending>
   );
 };
 

--- a/frontend/admin/src/js/components/user/UserProfile.tsx
+++ b/frontend/admin/src/js/components/user/UserProfile.tsx
@@ -3,6 +3,8 @@ import { useIntl } from "react-intl";
 import { commonMessages } from "@common/messages";
 
 import UserProfile from "@common/components/UserProfile";
+import Pending from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
 import { useGetUserProfileQuery } from "../../api/generated";
 import AdminAboutSection from "./AdminAboutSection";
 
@@ -16,38 +18,36 @@ const UserProfileApi: React.FunctionComponent<{
 
   const userData = initialData;
 
-  if (fetching) return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  if (error)
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {error.message}
-      </p>
-    );
-  return userData?.applicant ? (
-    <UserProfile
-      applicant={userData.applicant}
-      sections={{
-        about: {
-          isVisible: true,
-          override: <AdminAboutSection applicant={userData.applicant} />,
-        },
-        language: { isVisible: true },
-        government: { isVisible: true },
-        workLocation: { isVisible: true },
-        workPreferences: { isVisible: true },
-        employmentEquity: { isVisible: true },
-        roleSalary: { isVisible: true },
-        skillsExperience: { isVisible: true },
-      }}
-    />
-  ) : (
-    <p>
-      {intl.formatMessage({
-        defaultMessage: "No candidate data",
-        description: "No candidate data was found",
-      })}
-    </p>
+  return (
+    <Pending fetching={fetching} error={error}>
+      {userData?.applicant ? (
+        <UserProfile
+          applicant={userData.applicant}
+          sections={{
+            about: {
+              isVisible: true,
+              override: <AdminAboutSection applicant={userData.applicant} />,
+            },
+            language: { isVisible: true },
+            government: { isVisible: true },
+            workLocation: { isVisible: true },
+            workPreferences: { isVisible: true },
+            employmentEquity: { isVisible: true },
+            roleSalary: { isVisible: true },
+            skillsExperience: { isVisible: true },
+          }}
+        />
+      ) : (
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          <p>
+            {intl.formatMessage({
+              defaultMessage: "No candidate data",
+              description: "No candidate data was found",
+            })}
+          </p>
+        </NotFound>
+      )}
+    </Pending>
   );
 };
 

--- a/frontend/admin/src/js/components/user/UserTable.tsx
+++ b/frontend/admin/src/js/components/user/UserTable.tsx
@@ -2,13 +2,12 @@ import React, { useMemo } from "react";
 import { IntlShape, useIntl } from "react-intl";
 import { Link, useLocation } from "@common/helpers/router";
 import { notEmpty } from "@common/helpers/util";
-import { commonMessages } from "@common/messages";
 import { FromArray } from "@common/types/utilityTypes";
 import { getLanguage } from "@common/constants/localizedConstants";
+import Pending from "@common/components/Pending";
 import { useAdminRoutes } from "../../adminRoutes";
 import { AllUsersQuery, Language, useAllUsersQuery } from "../../api/generated";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
-import DashboardContentContainer from "../DashboardContentContainer";
 
 type Data = NonNullable<FromArray<AllUsersQuery["users"]>>;
 
@@ -106,26 +105,13 @@ export const UserTable: React.FC<AllUsersQuery & { editUrlRoot: string }> = ({
 };
 
 export const UserTableApi: React.FunctionComponent = () => {
-  const intl = useIntl();
   const [result] = useAllUsersQuery();
   const { data, fetching, error } = result;
   const { pathname } = useLocation();
 
-  if (fetching)
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  if (error)
-    return (
-      <DashboardContentContainer>
-        <p>
-          {intl.formatMessage(commonMessages.loadingError)}
-          {error.message}
-        </p>
-      </DashboardContentContainer>
-    );
-
-  return <UserTable users={data?.users ?? []} editUrlRoot={pathname} />;
+  return (
+    <Pending fetching={fetching} error={error}>
+      <UserTable users={data?.users ?? []} editUrlRoot={pathname} />
+    </Pending>
+  );
 };

--- a/frontend/admin/src/js/components/user/ViewUser.tsx
+++ b/frontend/admin/src/js/components/user/ViewUser.tsx
@@ -11,6 +11,8 @@ import PageHeader from "@common/components/PageHeader";
 import { Link } from "@common/components";
 import { Tab, TabSet } from "@common/components/tabs";
 import { commonMessages } from "@common/messages";
+import Pending from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
 import { useAdminRoutes } from "../../adminRoutes";
 import { User, useUserQuery } from "../../api/generated";
 import DashboardContentContainer from "../DashboardContentContainer";
@@ -119,40 +121,28 @@ const ViewUser: React.FC<ViewUserProps> = ({ userId }) => {
     variables: { id: userId },
   });
 
-  if (fetching) {
-    return (
-      <DashboardContentContainer>
-        <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>
-      </DashboardContentContainer>
-    );
-  }
-
-  if (error) {
-    <DashboardContentContainer>
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)} {error.message}
-      </p>
-    </DashboardContentContainer>;
-  }
-
   return (
-    <DashboardContentContainer>
-      {data?.user ? (
-        <ViewUserPage user={data.user} />
-      ) : (
-        <p>
-          <p>
-            {intl.formatMessage(
-              {
-                defaultMessage: "User {userId} not found.",
-                description: "Message displayed for user not found.",
-              },
-              { userId },
-            )}
-          </p>
-        </p>
-      )}
-    </DashboardContentContainer>
+    <Pending fetching={fetching} error={error}>
+      <DashboardContentContainer>
+        {data?.user ? (
+          <ViewUserPage user={data.user} />
+        ) : (
+          <NotFound
+            headingMessage={intl.formatMessage(commonMessages.notFound)}
+          >
+            <p>
+              {intl.formatMessage(
+                {
+                  defaultMessage: "User {userId} not found.",
+                  description: "Message displayed for user not found.",
+                },
+                { userId },
+              )}
+            </p>
+          </NotFound>
+        )}
+      </DashboardContentContainer>
+    </Pending>
   );
 };
 

--- a/frontend/common/src/components/NotFound/NotFound.tsx
+++ b/frontend/common/src/components/NotFound/NotFound.tsx
@@ -10,6 +10,7 @@ const NotFound: React.FC<NotFoundProps> = ({ headingMessage, children }) => {
     <div
       data-h2-flex-grid="b(top, contained, flush, xl)"
       data-h2-container="b(center, l)"
+      aria-live="polite"
     >
       <div data-h2-flex-item="b(1of1)" data-h2-text-align="b(center)">
         <h3

--- a/frontend/common/src/components/Pending/ErrorMessage.tsx
+++ b/frontend/common/src/components/Pending/ErrorMessage.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import type { CombinedError } from "urql";
+
+import { commonMessages } from "../../messages";
+
+interface ErrorMessageProps {
+  error: CombinedError;
+}
+
+const ErrorMessage: React.FC<ErrorMessageProps> = ({ error }) => {
+  const intl = useIntl();
+  return (
+    <p aria-live="polite">
+      {intl.formatMessage(commonMessages.loadingError)}
+      {error.message}
+    </p>
+  );
+};
+
+export default ErrorMessage;

--- a/frontend/common/src/components/Pending/Loading.tsx
+++ b/frontend/common/src/components/Pending/Loading.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+const Loading: React.FC = () => {
+  const intl = useIntl();
+
+  return (
+    <div
+      data-h2-position="b(fixed)"
+      data-h2-bg-color="b(white[0.2])"
+      data-h2-display="b(flex)"
+      data-h2-align-items="b(center)"
+      data-h2-justify-content="b(center)"
+      style={{
+        bottom: 0,
+        left: 0,
+        right: 0,
+        top: 0,
+        zIndex: 9999,
+      }}
+    >
+      <span className="lds-dual-ring">
+        <span data-h2-visibility="b(invisible)">
+          {intl.formatMessage({
+            defaultMessage: "Loading...",
+            description: "Message to display when a page is loading.",
+          })}
+        </span>
+      </span>
+    </div>
+  );
+};
+
+export default Loading;

--- a/frontend/common/src/components/Pending/NotFound.tsx
+++ b/frontend/common/src/components/Pending/NotFound.tsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-const NotFound: React.FC = ({ children }) => (
-  <p aria-live="polite">{children}</p>
-);
-
-export default NotFound;

--- a/frontend/common/src/components/Pending/NotFound.tsx
+++ b/frontend/common/src/components/Pending/NotFound.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const NotFound: React.FC = ({ children }) => (
+  <p aria-live="polite">{children}</p>
+);
+
+export default NotFound;

--- a/frontend/common/src/components/Pending/Pending.stories.tsx
+++ b/frontend/common/src/components/Pending/Pending.stories.tsx
@@ -67,7 +67,7 @@ PendingError.args = {
 
 PendingNotFound.args = {
   wait: 1000,
-  NotFound: "Nothing found.",
+  notFound: "Nothing found.",
 };
 
 PendingSuccess.args = {

--- a/frontend/common/src/components/Pending/Pending.stories.tsx
+++ b/frontend/common/src/components/Pending/Pending.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Story, Meta } from "@storybook/react";
 import type { CombinedError } from "urql";
 import Pending from "./Pending";
-import NotFound from "./NotFound";
+import NotFound from "../NotFound";
 
 export default {
   component: Pending,
@@ -47,7 +47,11 @@ const TemplatePending: Story = (args) => {
   return (
     <div style={{ width: "100%", height: "100vh" }}>
       <Pending fetching={isLoading} error={combinedError}>
-        {notFound ? <NotFound>{notFound}</NotFound> : <p>Finished Loading!</p>}
+        {notFound ? (
+          <NotFound headingMessage="Not Found">{notFound}</NotFound>
+        ) : (
+          <p>Finished Loading!</p>
+        )}
       </Pending>
     </div>
   );

--- a/frontend/common/src/components/Pending/Pending.stories.tsx
+++ b/frontend/common/src/components/Pending/Pending.stories.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import type { CombinedError } from "urql";
+import Pending from "./Pending";
+import NotFound from "./NotFound";
+
+export default {
+  component: Pending,
+  title: "Components/Pending",
+  argTypes: {
+    wait: {
+      name: "wait",
+      type: { name: "number", required: false },
+    },
+    error: {
+      name: "error",
+      type: { name: "boolean", required: false },
+    },
+    notFound: {
+      name: "notFound",
+      type: { name: "string", required: false },
+    },
+  },
+} as Meta;
+
+const TemplatePending: Story = (args) => {
+  const [isLoading, setLoading] = React.useState<boolean>(true);
+
+  const { wait, error, notFound } = args;
+
+  const combinedError = error
+    ? ({
+        name: "Error",
+        message: "There was an error fetching content.",
+      } as CombinedError)
+    : undefined;
+
+  // Fake a network request
+  React.useEffect(() => {
+    if (wait) {
+      setTimeout(() => {
+        setLoading(false);
+      }, wait);
+    }
+  }, [wait, setLoading]);
+
+  return (
+    <div style={{ width: "100%", height: "100vh" }}>
+      <Pending fetching={isLoading} error={combinedError}>
+        {notFound ? <NotFound>{notFound}</NotFound> : <p>Finished Loading!</p>}
+      </Pending>
+    </div>
+  );
+};
+
+export const PendingFetching = TemplatePending.bind({});
+export const PendingError = TemplatePending.bind({});
+export const PendingNotFound = TemplatePending.bind({});
+export const PendingSuccess = TemplatePending.bind({});
+
+PendingFetching.args = {};
+
+PendingError.args = {
+  wait: 1000,
+  error: true,
+};
+
+PendingNotFound.args = {
+  wait: 1000,
+  NotFound: "Nothing found.",
+};
+
+PendingSuccess.args = {
+  wait: 1000,
+};

--- a/frontend/common/src/components/Pending/Pending.tsx
+++ b/frontend/common/src/components/Pending/Pending.tsx
@@ -4,6 +4,8 @@ import ErrorMessage from "./ErrorMessage";
 
 import Loading from "./Loading";
 
+import "./pending.css";
+
 interface PendingProps {
   fetching: boolean;
   error?: CombinedError;

--- a/frontend/common/src/components/Pending/Pending.tsx
+++ b/frontend/common/src/components/Pending/Pending.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import type { CombinedError } from "urql";
+import ErrorMessage from "./ErrorMessage";
+
+import Loading from "./Loading";
+
+interface PendingProps {
+  fetching: boolean;
+  error?: CombinedError;
+}
+
+const Pending: React.FC<PendingProps> = ({ fetching, error, children }) => {
+  if (fetching) {
+    return <Loading />;
+  }
+
+  if (error) {
+    return <ErrorMessage error={error} />;
+  }
+
+  return children as React.ReactElement;
+};
+
+export default Pending;

--- a/frontend/common/src/components/Pending/index.ts
+++ b/frontend/common/src/components/Pending/index.ts
@@ -1,0 +1,3 @@
+import Pending from "./Pending";
+
+export default Pending;

--- a/frontend/common/src/components/Pending/index.ts
+++ b/frontend/common/src/components/Pending/index.ts
@@ -1,5 +1,3 @@
 import Pending from "./Pending";
-import NotFound from "./NotFound";
 
 export default Pending;
-export { NotFound };

--- a/frontend/common/src/components/Pending/index.ts
+++ b/frontend/common/src/components/Pending/index.ts
@@ -1,3 +1,5 @@
 import Pending from "./Pending";
+import NotFound from "./NotFound";
 
 export default Pending;
+export { NotFound };

--- a/frontend/common/src/components/Pending/pending.css
+++ b/frontend/common/src/components/Pending/pending.css
@@ -1,0 +1,28 @@
+.lds-dual-ring {
+  display: inline-block;
+  /* width: 2rem; */
+  height: 1.5rem;
+  /* padding: 0 1rem 0 0rem; */
+}
+
+.lds-dual-ring:after {
+  content: " ";
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  margin: 0px;
+  border-radius: 50%;
+  border: 6px solid #674c90;
+  border-color: #674c90 transparent #674c90 transparent;
+  -webkit-animation: lds-dual-ring 1.2s linear infinite;
+  animation: lds-dual-ring 1.2s linear infinite;
+}
+
+@keyframes lds-dual-ring {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/common/src/messages/commonMessages.ts
+++ b/frontend/common/src/messages/commonMessages.ts
@@ -17,6 +17,10 @@ const messages = defineMessages({
     defaultMessage: "Optional",
     description: "Displayed next to optional form inputs.",
   },
+  notFound: {
+    defaultMessage: "Not found",
+    description: "Title displayed when an item cannot be found.",
+  },
 });
 
 export default messages;

--- a/frontend/talentsearch/src/js/components/GovernmentInfoForm/GovernmentInfoForm.tsx
+++ b/frontend/talentsearch/src/js/components/GovernmentInfoForm/GovernmentInfoForm.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useForm, FormProvider } from "react-hook-form";
-import { errorMessages, commonMessages } from "@common/messages";
+import { errorMessages } from "@common/messages";
 import { Checkbox, RadioGroup, Select } from "@common/components/form";
 import { getLocale } from "@common/helpers/localize";
 import { toast } from "react-toastify";
 import { empty, notEmpty } from "@common/helpers/util";
 import { navigate } from "@common/helpers/router";
 
+import Pending from "@common/components/Pending";
 import {
   Classification,
   useGetAllClassificationsAndMeQuery,
@@ -401,19 +402,19 @@ export const GovInfoFormContainer: React.FunctionComponent = () => {
 
   // acquire classifications from graphQL to pass into component to render and pull "Me" at the same time
   const [lookUpResult] = useGetAllClassificationsAndMeQuery();
-  const { data: lookupData, fetching: fetchingLookupData } = lookUpResult;
-  const preProfileStatus = lookupData?.me?.isProfileComplete;
+  const { data, fetching, error } = lookUpResult;
+  const preProfileStatus = data?.me?.isProfileComplete;
   const classifications: Classification[] | [] =
-    lookupData?.classifications.filter(notEmpty) ?? [];
-  const meInfo = lookupData?.me;
+    data?.classifications.filter(notEmpty) ?? [];
+  const meInfo = data?.me;
   const meId = meInfo?.id;
 
   // submitting the form component values back out to graphQL, after smoothing form-values to appropriate type, then return to /profile
   const [, executeMutation] = useUpdateGovAsUserMutation();
-  const handleUpdateUser = (id: string, data: UpdateUserAsUserInput) =>
+  const handleUpdateUser = (id: string, updateData: UpdateUserAsUserInput) =>
     executeMutation({
       id,
-      user: data,
+      user: updateData,
     }).then((result) => {
       if (result.data?.updateUserAsUser) {
         return result.data.updateUserAsUser;
@@ -421,7 +422,7 @@ export const GovInfoFormContainer: React.FunctionComponent = () => {
       return Promise.reject(result.error);
     });
 
-  const onSubmit = async (data: UpdateUserAsUserInput) => {
+  const onSubmit = async (updateDate: UpdateUserAsUserInput) => {
     // tristan's suggestion to short-circuit this function if there is no id
     if (meId === undefined || meId === "") {
       toast.error(
@@ -432,7 +433,7 @@ export const GovInfoFormContainer: React.FunctionComponent = () => {
       );
       return;
     }
-    await handleUpdateUser(meId, data)
+    await handleUpdateUser(meId, updateDate)
       .then((res) => {
         if (res.isProfileComplete) {
           const currentProfileStatus = res.isProfileComplete;
@@ -449,16 +450,14 @@ export const GovInfoFormContainer: React.FunctionComponent = () => {
       });
   };
 
-  if (fetchingLookupData) {
-    return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  }
-
   return (
-    <GovernmentInfoForm
-      classifications={classifications}
-      initialData={meInfo}
-      submitHandler={onSubmit}
-    />
+    <Pending fetching={fetching} error={error}>
+      <GovernmentInfoForm
+        classifications={classifications}
+        initialData={meInfo}
+        submitHandler={onSubmit}
+      />
+    </Pending>
   );
 };
 

--- a/frontend/talentsearch/src/js/components/aboutMeForm/AboutMeForm.tsx
+++ b/frontend/talentsearch/src/js/components/aboutMeForm/AboutMeForm.tsx
@@ -15,6 +15,8 @@ import {
 } from "@common/constants/localizedConstants";
 import { SubmitHandler } from "react-hook-form";
 import pick from "lodash/pick";
+import Pending from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
 import ProfileFormWrapper from "../applicantProfile/ProfileFormWrapper";
 import ProfileFormFooter from "../applicantProfile/ProfileFormFooter";
 import {
@@ -44,7 +46,7 @@ export type AboutMeUpdateHandler = (
 ) => Promise<UpdateUserAsUserMutation["updateUserAsUser"]>;
 
 export interface AboutMeFormProps {
-  initialUser?: User | null;
+  initialUser: User | null;
   onUpdateAboutMe: AboutMeUpdateHandler;
 }
 
@@ -55,18 +57,6 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
   const intl = useIntl();
   const locale = getLocale(intl);
   const paths = applicantProfileRoutes(locale);
-
-  if (!initialUser) {
-    return (
-      <p>
-        {intl.formatMessage({
-          defaultMessage: "Could not load user.",
-          description:
-            "Error message that appears when current user could not be retrieved.",
-        })}
-      </p>
-    );
-  }
 
   const initialDataToFormValues = (data?: User | null): FormValues => {
     return pick(data, [
@@ -313,21 +303,16 @@ const AboutMeFormContainer: React.FunctionComponent = () => {
     );
   };
 
-  if (fetching) {
-    return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  }
-
-  if (error || !data) {
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {error?.message || ""}
-      </p>
-    );
-  }
-
   return (
-    <AboutMeForm initialUser={data.me} onUpdateAboutMe={handleUpdateUser} />
+    <Pending fetching={fetching} error={error}>
+      {data?.me ? (
+        <AboutMeForm initialUser={data.me} onUpdateAboutMe={handleUpdateUser} />
+      ) : (
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          <p>{intl.formatMessage(profileMessages.userNotFound)}</p>
+        </NotFound>
+      )}
+    </Pending>
   );
 };
 

--- a/frontend/talentsearch/src/js/components/applicantProfile/ExperienceAndSkills.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/ExperienceAndSkills.tsx
@@ -11,6 +11,8 @@ import { notEmpty } from "@common/helpers/util";
 import { EducationExperience } from "@common/api/generated";
 import { commonMessages } from "@common/messages";
 import ExperienceSection from "@common/components/UserProfile/ExperienceSection";
+import Pending from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
 import {
   AwardExperience,
   CommunityExperience,
@@ -23,6 +25,7 @@ import {
 import { useApplicantProfileRoutes } from "../../applicantProfileRoutes";
 import ProfileFormFooter from "./ProfileFormFooter";
 import ProfileFormWrapper from "./ProfileFormWrapper";
+import profileMessages from "../profile/profileMessages";
 
 export type ExperienceForDate =
   | (AwardExperience & { startDate: string; endDate: string })
@@ -241,22 +244,16 @@ export const ExperienceAndSkillsRouterApi: React.FunctionComponent = () => {
   const intl = useIntl();
   const [result] = useGetMeQuery();
   const { data, fetching, error } = result;
-  if (fetching) return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  if (error)
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {error.message}
-      </p>
-    );
-  return data?.me ? (
-    <ExperienceAndSkillsApi applicantId={data.me.id} />
-  ) : (
-    <p>
-      {intl.formatMessage({
-        defaultMessage: "User not found.",
-        description: "Message displayed for user not found.",
-      })}
-    </p>
+
+  return (
+    <Pending fetching={fetching} error={error}>
+      {data?.me ? (
+        <ExperienceAndSkillsApi applicantId={data.me.id} />
+      ) : (
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          <p>{intl.formatMessage(profileMessages.userNotFound)}</p>
+        </NotFound>
+      )}
+    </Pending>
   );
 };

--- a/frontend/talentsearch/src/js/components/applicantProfile/ExperienceAndSkills.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/ExperienceAndSkills.tsx
@@ -216,28 +216,26 @@ export const ExperienceAndSkillsApi: React.FunctionComponent<{
   const [{ data: applicantData, fetching, error }] =
     useGetAllApplicantExperiencesQuery({ variables: { id: applicantId } });
 
-  if (fetching) return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  if (error)
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {error.message}
-      </p>
-    );
-  return applicantData?.applicant ? (
-    <ExperienceAndSkills
-      experiences={applicantData.applicant.experiences?.filter(notEmpty)}
-    />
-  ) : (
-    <p>
-      {intl.formatMessage(
-        {
-          defaultMessage: "User {applicantId} not found.",
-          description: "Message displayed for user not found.",
-        },
-        { applicantId },
+  return (
+    <Pending fetching={fetching} error={error}>
+      {applicantData?.applicant ? (
+        <ExperienceAndSkills
+          experiences={applicantData.applicant.experiences?.filter(notEmpty)}
+        />
+      ) : (
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          <p>
+            {intl.formatMessage(
+              {
+                defaultMessage: "User {applicantId} not found.",
+                description: "Message displayed for user not found.",
+              },
+              { applicantId },
+            )}
+          </p>
+        </NotFound>
       )}
-    </p>
+    </Pending>
   );
 };
 export const ExperienceAndSkillsRouterApi: React.FunctionComponent = () => {

--- a/frontend/talentsearch/src/js/components/browse/BrowseIndividualPool.tsx
+++ b/frontend/talentsearch/src/js/components/browse/BrowseIndividualPool.tsx
@@ -1,16 +1,18 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { getLocale } from "@common/helpers/localize";
-import { commonMessages } from "@common/messages";
 import Breadcrumbs from "@common/components/Breadcrumbs";
 import type { BreadcrumbsProps } from "@common/components/Breadcrumbs";
 import Link from "@common/components/Link";
+import NotFound from "@common/components/NotFound";
+import Pending from "@common/components/Pending";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
 import { useBrowsePoolQuery } from "../../api/generated";
 import type { Pool } from "../../api/generated";
+import commonMessages from "../commonMessages";
 
 interface BrowseIndividualPoolProps {
-  pool: Pool | undefined | null;
+  pool: Pool;
 }
 
 const BrowseIndividualPool: React.FC<BrowseIndividualPoolProps> = ({
@@ -36,32 +38,19 @@ const BrowseIndividualPool: React.FC<BrowseIndividualPoolProps> = ({
 
   return (
     <div>
-      {pool ? (
-        <div>
-          <Breadcrumbs links={links} />
-          <h1>{pool.name?.[locale]}</h1>
-          <Link
-            type="button"
-            mode="outline"
-            color="primary"
-            href={paths.poolApply(pool ? pool.id : "/")}
-          >
-            {intl.formatMessage({
-              defaultMessage: "Apply",
-              description: "Apply label for button to apply to pool",
-            })}
-          </Link>
-        </div>
-      ) : (
-        <div>
-          <p>
-            {intl.formatMessage({
-              defaultMessage: "Error, pool unable to be loaded",
-              description: "Error message, placeholder",
-            })}
-          </p>
-        </div>
-      )}
+      <Breadcrumbs links={links} />
+      <h1>{pool.name?.[locale]}</h1>
+      <Link
+        type="button"
+        mode="outline"
+        color="primary"
+        href={paths.poolApply(pool ? pool.id : "/")}
+      >
+        {intl.formatMessage({
+          defaultMessage: "Apply",
+          description: "Apply label for button to apply to pool",
+        })}
+      </Link>
     </div>
   );
 };
@@ -72,20 +61,20 @@ const BrowseIndividualPoolApi: React.FC<{ poolId: string }> = ({ poolId }) => {
     variables: { id: poolId },
   });
 
-  if (fetching) {
-    return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  }
-
-  if (error) {
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {error.message}
-      </p>
-    );
-  }
-
-  return <BrowseIndividualPool pool={data?.pool} />;
+  return (
+    <Pending fetching={fetching} error={error}>
+      {data?.pool ? (
+        <BrowseIndividualPool pool={data?.pool} />
+      ) : (
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          {intl.formatMessage({
+            defaultMessage: "Error, pool unable to be loaded",
+            description: "Error message, placeholder",
+          })}
+        </NotFound>
+      )}
+    </Pending>
+  );
 };
 
 export default BrowseIndividualPoolApi;

--- a/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.tsx
+++ b/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { getLocale } from "@common/helpers/localize";
-import { commonMessages } from "@common/messages";
+import Pending from "@common/components/Pending";
 
+import NotFound from "@common/components/NotFound";
+import { commonMessages } from "@common/messages";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
 import { useBrowsePoolsQuery } from "../../api/generated";
 import type { Pool } from "../../api/generated";
@@ -34,41 +36,32 @@ const BrowsePools: React.FC<BrowsePoolsProps> = ({ pools }) => {
           ))}
         </ul>
       ) : (
-        <p>
-          {intl.formatMessage({
-            defaultMessage: "No pools found.",
-            description:
-              "Message displayed on the browse pools direct intake page when there are no pools.",
-          })}
-        </p>
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          <p>
+            {intl.formatMessage({
+              defaultMessage: "No pools found.",
+              description:
+                "Message displayed on the browse pools direct intake page when there are no pools.",
+            })}
+          </p>
+        </NotFound>
       )}
     </>
   );
 };
 
 const BrowsePoolsApi: React.FC = () => {
-  const intl = useIntl();
   const [{ data, fetching, error }] = useBrowsePoolsQuery();
 
-  if (fetching) {
-    return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  }
-
-  if (error) {
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {error.message}
-      </p>
-    );
-  }
-
-  // Filter out undefined | null pools
   const filteredPools = data?.pools.filter(
     (pool) => typeof pool !== undefined && !!pool,
   ) as Pool[];
 
-  return <BrowsePools pools={filteredPools} />;
+  return (
+    <Pending fetching={fetching} error={error}>
+      <BrowsePools pools={filteredPools} />
+    </Pending>
+  );
 };
 
 export default BrowsePoolsApi;

--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
@@ -3,7 +3,6 @@ import { useIntl } from "react-intl";
 import { toast } from "react-toastify";
 import { SubmitHandler } from "react-hook-form";
 import { BasicForm, TextArea } from "@common/components/form";
-import { commonMessages } from "@common/messages";
 import { getLocale } from "@common/helpers/localize";
 import { navigate } from "@common/helpers/router";
 import Dialog from "@common/components/Dialog";
@@ -12,6 +11,9 @@ import { Button } from "@common/components";
 import { TrashIcon } from "@heroicons/react/solid";
 
 import { removeFromSessionStorage } from "@common/helpers/storageUtils";
+import NotFound from "@common/components/NotFound";
+import Pending from "@common/components/Pending";
+import { commonMessages } from "@common/messages";
 import ProfileFormWrapper from "../applicantProfile/ProfileFormWrapper";
 import ProfileFormFooter from "../applicantProfile/ProfileFormFooter";
 
@@ -341,29 +343,33 @@ const ExperienceFormContainer: React.FunctionComponent<
     }
   };
 
-  if (fetchingSkills || fetchingMe || fetchingExperience) {
-    return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  }
-
-  if (skillError || !skillsData || meError || !meData) {
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {skillError?.message || ""}
-      </p>
-    );
-  }
-
   return (
-    <ExperienceForm
-      experience={experience as ExperienceQueryData}
-      experienceType={experienceType}
-      skills={skillsData.skills as Skill[]}
-      onUpdateExperience={handleUpdateExperience}
-      deleteExperience={handleDeleteExperience}
-      cacheKey={cacheKey}
-      edit={edit}
-    />
+    <Pending
+      fetching={fetchingSkills || fetchingMe || fetchingExperience}
+      error={skillError || meError}
+    >
+      {skillsData && meData ? (
+        <ExperienceForm
+          experience={experience as ExperienceQueryData}
+          experienceType={experienceType}
+          skills={skillsData.skills as Skill[]}
+          onUpdateExperience={handleUpdateExperience}
+          deleteExperience={handleDeleteExperience}
+          cacheKey={cacheKey}
+          edit={edit}
+        />
+      ) : (
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          <p>
+            {intl.formatMessage({
+              defaultMessage: "No user found.",
+              description:
+                "Message displayed when no user is found for experience form.",
+            })}
+          </p>
+        </NotFound>
+      )}
+    </Pending>
   );
 };
 

--- a/frontend/talentsearch/src/js/components/languageInformationForm/LanguageInformationForm.tsx
+++ b/frontend/talentsearch/src/js/components/languageInformationForm/LanguageInformationForm.tsx
@@ -3,6 +3,8 @@ import { useIntl } from "react-intl";
 import { commonMessages, errorMessages } from "@common/messages";
 import { Checklist, RadioGroup, Select } from "@common/components/form";
 import { FormProvider, useForm } from "react-hook-form";
+import NotFound from "@common/components/NotFound";
+import Pending from "@common/components/Pending";
 import { enumToOptions } from "@common/helpers/formUtils";
 import { compact, omit } from "lodash";
 import { getLocale } from "@common/helpers/localize";
@@ -504,28 +506,19 @@ export const LanguageInformationFormContainer: React.FunctionComponent = () => {
       });
   };
 
-  if (fetching) {
-    return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  }
-
-  if (error || !userData) {
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {error?.message || ""}
-      </p>
-    );
-  }
-
-  if (!userId) {
-    return <p>{intl.formatMessage(profileMessages.userNotFound)}</p>;
-  }
-
   return (
-    <LanguageInformationForm
-      initialData={userData.me}
-      submitHandler={onSubmit}
-    />
+    <Pending fetching={fetching} error={error}>
+      {userData && userId ? (
+        <LanguageInformationForm
+          initialData={userData.me}
+          submitHandler={onSubmit}
+        />
+      ) : (
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          <p>{intl.formatMessage(profileMessages.userNotFound)}</p>
+        </NotFound>
+      )}
+    </Pending>
   );
 };
 

--- a/frontend/talentsearch/src/js/components/myStatusForm/MyStatusForm.tsx
+++ b/frontend/talentsearch/src/js/components/myStatusForm/MyStatusForm.tsx
@@ -1,5 +1,5 @@
 import { navigate } from "@common/helpers/router";
-import { commonMessages, errorMessages } from "@common/messages";
+import { errorMessages } from "@common/messages";
 import React from "react";
 import { SubmitHandler } from "react-hook-form";
 import { useIntl } from "react-intl";
@@ -7,6 +7,7 @@ import { toast } from "react-toastify";
 import { enumToOptions } from "@common/helpers/formUtils";
 import { getJobLookingStatusDescription } from "@common/constants/localizedConstants";
 import { BasicForm, RadioGroup } from "@common/components/form";
+import Pending from "@common/components/Pending";
 import { useApplicantProfileRoutes } from "../../applicantProfileRoutes";
 import {
   UpdateUserAsUserInput,
@@ -16,6 +17,7 @@ import {
   UpdateMyStatusMutation,
   JobLookingStatus,
 } from "../../api/generated";
+import profileMessages from "../profile/profileMessages";
 
 export type FormValues = Pick<UpdateUserAsUserInput, "jobLookingStatus">;
 
@@ -171,7 +173,6 @@ const MyStatusApi: React.FunctionComponent = () => {
       return Promise.reject(result.error);
     });
 
-  if (fetching) return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
   if (error) {
     toast.error(
       intl.formatMessage({
@@ -180,22 +181,19 @@ const MyStatusApi: React.FunctionComponent = () => {
           "Message displayed to user after user fails to get updated.",
       }),
     );
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {error.message}
-      </p>
-    );
   }
-  return initialData?.me ? (
-    <MyStatusForm initialData={initialData} handleMyStatus={handleMyStatus} />
-  ) : (
-    <p>
-      {intl.formatMessage({
-        defaultMessage: "User not found.",
-        description: "Message displayed for user not found.",
-      })}
-    </p>
+
+  return (
+    <Pending fetching={fetching} error={error}>
+      {initialData?.me ? (
+        <MyStatusForm
+          initialData={initialData}
+          handleMyStatus={handleMyStatus}
+        />
+      ) : (
+        <p>{intl.formatMessage(profileMessages.userNotFound)}</p>
+      )}
+    </Pending>
   );
 };
 export default MyStatusApi;

--- a/frontend/talentsearch/src/js/components/pool/PoolApplicationThanksPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolApplicationThanksPage.tsx
@@ -5,6 +5,8 @@ import { commonMessages } from "@common/messages";
 import Breadcrumbs from "@common/components/Breadcrumbs";
 import type { BreadcrumbsProps } from "@common/components/Breadcrumbs";
 import Link from "@common/components/Link";
+import Pending from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
 import { useGetPoolQuery } from "../../api/generated";
 import type { Pool } from "../../api/generated";
@@ -92,31 +94,22 @@ const PoolApplicationThanksPage: React.FC<PoolApplicationThanksPageProps> = ({
     variables: { id },
   });
 
-  if (fetching) {
-    return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  }
-
-  if (error) {
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {error.message}
-      </p>
-    );
-  }
-
-  if (!data?.pool) {
-    return (
-      <p>
-        {intl.formatMessage({
-          defaultMessage: "Error, pool unable to be loaded",
-          description: "Error message, placeholder",
-        })}
-      </p>
-    );
-  }
-
-  return <PoolApplicationThanks pool={data?.pool} />;
+  return (
+    <Pending fetching={fetching} error={error}>
+      {data?.pool ? (
+        <PoolApplicationThanks pool={data?.pool} />
+      ) : (
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          <p>
+            {intl.formatMessage({
+              defaultMessage: "Error, pool unable to be loaded",
+              description: "Error message, placeholder",
+            })}
+          </p>
+        </NotFound>
+      )}
+    </Pending>
+  );
 };
 
 export default PoolApplicationThanksPage;

--- a/frontend/talentsearch/src/js/components/pool/PoolApplyPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolApplyPage.tsx
@@ -5,6 +5,8 @@ import { commonMessages } from "@common/messages";
 import Breadcrumbs from "@common/components/Breadcrumbs";
 import type { BreadcrumbsProps } from "@common/components/Breadcrumbs";
 import Link from "@common/components/Link";
+import NotFound from "@common/components/NotFound";
+import Pending from "@common/components/Pending";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
 import { useGetPoolQuery } from "../../api/generated";
 import type { Pool } from "../../api/generated";
@@ -62,31 +64,22 @@ const PoolApplyPage: React.FC<PoolApplyPageProps> = ({ id }) => {
     variables: { id },
   });
 
-  if (fetching) {
-    return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  }
-
-  if (error) {
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {error.message}
-      </p>
-    );
-  }
-
-  if (!data?.pool) {
-    return (
-      <p>
-        {intl.formatMessage({
-          defaultMessage: "Error, pool unable to be loaded",
-          description: "Error message, placeholder",
-        })}
-      </p>
-    );
-  }
-
-  return <PoolApply pool={data?.pool} />;
+  return (
+    <Pending fetching={fetching} error={error}>
+      {data?.pool ? (
+        <PoolApply pool={data?.pool} />
+      ) : (
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          <p>
+            {intl.formatMessage({
+              defaultMessage: "Error, pool unable to be loaded",
+              description: "Error message, placeholder",
+            })}
+          </p>
+        </NotFound>
+      )}
+    </Pending>
+  );
 };
 
 export default PoolApplyPage;

--- a/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
+++ b/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import commonMessages from "@common/messages/commonMessages";
+import Pending from "@common/components/Pending";
 import { imageUrl } from "@common/helpers/router";
 import { notEmpty } from "@common/helpers/util";
 import ExperienceSection from "@common/components/UserProfile/ExperienceSection";
@@ -107,22 +107,18 @@ export const ProfilePage: React.FunctionComponent = () => {
   };
   const userData = data ? dataToUser(data) : undefined;
 
-  if (fetching) return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  if (error)
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {error.message}
-      </p>
-    );
-
-  if (userData) return <ProfileForm profileDataInput={userData} />;
   return (
-    <p>
-      {intl.formatMessage({
-        defaultMessage: "No user data",
-        description: "No user data was found",
-      })}
-    </p>
+    <Pending fetching={fetching} error={error}>
+      {userData ? (
+        <ProfileForm profileDataInput={userData} />
+      ) : (
+        <p>
+          {intl.formatMessage({
+            defaultMessage: "No user data",
+            description: "No user data was found",
+          })}
+        </p>
+      )}
+    </Pending>
   );
 };

--- a/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
+++ b/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import Pending, { NotFound } from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
+import Pending from "@common/components/Pending";
 import { imageUrl } from "@common/helpers/router";
 import { notEmpty } from "@common/helpers/util";
 import ExperienceSection from "@common/components/UserProfile/ExperienceSection";
@@ -8,10 +9,12 @@ import ExperienceSection from "@common/components/UserProfile/ExperienceSection"
 import UserProfile from "@common/components/UserProfile";
 import type { Applicant } from "@common/api/generated";
 
+import { commonMessages } from "@common/messages";
 import MyStatusApi from "../../myStatusForm/MyStatusForm";
 import TALENTSEARCH_APP_DIR from "../../../talentSearchConstants";
 import { useApplicantProfileRoutes } from "../../../applicantProfileRoutes";
 import { useGetMeQuery, User, GetMeQuery } from "../../../api/generated";
+import profileMessages from "../profileMessages";
 
 export interface ProfilePageProps {
   profileDataInput: User;
@@ -112,11 +115,8 @@ export const ProfilePage: React.FunctionComponent = () => {
       {userData ? (
         <ProfileForm profileDataInput={userData} />
       ) : (
-        <NotFound>
-          {intl.formatMessage({
-            defaultMessage: "No user data",
-            description: "No user data was found",
-          })}
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          <p>{intl.formatMessage(profileMessages.userNotFound)}</p>
         </NotFound>
       )}
     </Pending>

--- a/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
+++ b/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import Pending from "@common/components/Pending";
+import Pending, { NotFound } from "@common/components/Pending";
 import { imageUrl } from "@common/helpers/router";
 import { notEmpty } from "@common/helpers/util";
 import ExperienceSection from "@common/components/UserProfile/ExperienceSection";
@@ -112,12 +112,12 @@ export const ProfilePage: React.FunctionComponent = () => {
       {userData ? (
         <ProfileForm profileDataInput={userData} />
       ) : (
-        <p>
+        <NotFound>
           {intl.formatMessage({
             defaultMessage: "No user data",
             description: "No user data was found",
           })}
-        </p>
+        </NotFound>
       )}
     </Pending>
   );

--- a/frontend/talentsearch/src/js/components/request/CreateRequest.tsx
+++ b/frontend/talentsearch/src/js/components/request/CreateRequest.tsx
@@ -2,7 +2,7 @@ import { Input, Select, Submit, TextArea } from "@common/components/form";
 import * as React from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
-import { commonMessages, errorMessages } from "@common/messages";
+import { errorMessages } from "@common/messages";
 import { getLocale } from "@common/helpers/localize";
 import { Button } from "@common/components";
 import { notEmpty } from "@common/helpers/util";
@@ -14,6 +14,7 @@ import {
   removeFromSessionStorage,
   setInSessionStorage,
 } from "@common/helpers/storageUtils";
+import Pending from "@common/components/Pending";
 import { useTalentSearchRoutes } from "../../talentSearchRoutes";
 import {
   Department,
@@ -373,7 +374,6 @@ export const CreateRequest: React.FunctionComponent<{
   candidateCount: Maybe<number>;
   searchFormInitialValues: Maybe<SearchFormValues>;
 }> = ({ poolCandidateFilter, candidateCount, searchFormInitialValues }) => {
-  const intl = useIntl();
   const [lookupResult] = useGetPoolCandidateSearchRequestDataQuery();
   const { data: lookupData, fetching, error } = lookupResult;
 
@@ -391,23 +391,17 @@ export const CreateRequest: React.FunctionComponent<{
       return Promise.reject(result.error);
     });
 
-  if (fetching) return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  if (error)
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)} {error.message}
-      </p>
-    );
-
   return (
-    <RequestForm
-      departments={departments}
-      poolCandidateFilter={poolCandidateFilter}
-      candidateCount={candidateCount}
-      searchFormInitialValues={searchFormInitialValues}
-      handleCreatePoolCandidateSearchRequest={
-        handleCreatePoolCandidateSearchRequest
-      }
-    />
+    <Pending fetching={fetching} error={error}>
+      <RequestForm
+        departments={departments}
+        poolCandidateFilter={poolCandidateFilter}
+        candidateCount={candidateCount}
+        searchFormInitialValues={searchFormInitialValues}
+        handleCreatePoolCandidateSearchRequest={
+          handleCreatePoolCandidateSearchRequest
+        }
+      />
+    </Pending>
   );
 };

--- a/frontend/talentsearch/src/js/components/workLocationPreferenceForm/WorkLocationPreferenceForm.tsx
+++ b/frontend/talentsearch/src/js/components/workLocationPreferenceForm/WorkLocationPreferenceForm.tsx
@@ -7,6 +7,8 @@ import React from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
 import { toast } from "react-toastify";
+import Pending from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
 import { useApplicantProfileRoutes } from "../../applicantProfileRoutes";
 import {
   CreateUserInput,
@@ -187,23 +189,19 @@ export const WorkLocationPreferenceApi: React.FunctionComponent = () => {
       return Promise.reject(result.error);
     });
 
-  if (fetching) return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
-  if (error) {
-    toast.error(intl.formatMessage(profileMessages.updatingFailed));
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {error.message}
-      </p>
-    );
-  }
-  return userData?.me ? (
-    <WorkLocationPreferenceForm
-      initialData={userData}
-      handleWorkLocationPreference={handleWorkLocationPreference}
-    />
-  ) : (
-    <p>{intl.formatMessage(profileMessages.userNotFound)}</p>
+  return (
+    <Pending fetching={fetching} error={error}>
+      {userData?.me ? (
+        <WorkLocationPreferenceForm
+          initialData={userData}
+          handleWorkLocationPreference={handleWorkLocationPreference}
+        />
+      ) : (
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          <p>{intl.formatMessage(profileMessages.userNotFound)}</p>
+        </NotFound>
+      )}
+    </Pending>
   );
 };
 

--- a/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
+++ b/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
@@ -7,6 +7,8 @@ import { enumToOptions } from "@common/helpers/formUtils";
 import { navigate } from "@common/helpers/router";
 import { toast } from "react-toastify";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+import Pending from "@common/components/Pending";
+import NotFound from "@common/components/NotFound";
 import { useApplicantProfileRoutes } from "../../applicantProfileRoutes";
 import ProfileFormFooter from "../applicantProfile/ProfileFormFooter";
 import ProfileFormWrapper from "../applicantProfile/ProfileFormWrapper";
@@ -221,23 +223,23 @@ export const WorkPreferencesApi: React.FunctionComponent = () => {
       return Promise.reject(result.error);
     });
 
-  if (fetching) return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
   if (error) {
-    toast.success(intl.formatMessage(profileMessages.updatingFailed));
-    return (
-      <p>
-        {intl.formatMessage(commonMessages.loadingError)}
-        {error.message}
-      </p>
-    );
+    toast.error(intl.formatMessage(profileMessages.updatingFailed));
   }
-  return initialData?.me ? (
-    <WorkPreferencesForm
-      initialData={initialData}
-      handleWorkPreferences={handleWorkPreferences}
-    />
-  ) : (
-    <p>{intl.formatMessage(profileMessages.userNotFound)}</p>
+
+  return (
+    <Pending fetching={fetching} error={error}>
+      {initialData?.me ? (
+        <WorkPreferencesForm
+          initialData={initialData}
+          handleWorkPreferences={handleWorkPreferences}
+        />
+      ) : (
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          <p>{intl.formatMessage(profileMessages.userNotFound)}</p>
+        </NotFound>
+      )}
+    </Pending>
   );
 };
 


### PR DESCRIPTION
Resolves #2862 

## Summary

This will introduce a new component that does two things:

1. Normalize our pending query UI
2. Make the loading state a little less ugly

## Pending - New Component!

This component takes two props, fetching and error. These can be passed in directly from the `urql` result. It will then display a loading spinner if `fetching` is `true` or a normalized error message if `fetching` is `false` and an error exists.

If `fetching` is `false` and no error exists, it will display the children.

Note: I could not think of  nice way of showing a "not found" message if the query is resolved, no error exists and no data exists. Mainly because we need to have the ability to inspect the data and decide what message to display if that is true. We could just export a `<NotFound>` component to normalize the look of this message however.

### Example

```tsx
import NotFound from "@common/components/NotFound";
import Pending  from "@common/components/Pending";

const Page: () => {
  const intl = useIntl();
  const [{fetching, error, data }] = useQuery();
  
  return (
    <Pending fetching={fetching} error={error}>
      {data ? (
        <InnerPage data={data} />
      ) : (
        <NotFound headingMessage="Not found">
          {intl.formatMessage({
            defaultMessage: "No data found.",
            description: "Message to display when no data was returned from query.",
          })}
        </NotFound>
      )}
    </Pending>
  );
}
```