### PR TITLE
Print candidate profile

### DIFF
--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -15,7 +15,7 @@ module.exports = {
     },
     {
       path: "frontend/admin/dist/app.js",
-      maxSize: "235 kB",
+      maxSize: "245 kB",
     },
   ]
 };

--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -114,6 +114,7 @@
     "react-intl": "^6.0.3",
     "react-select": "^5.3.1",
     "react-table": "^7.8.0",
+    "react-to-print": "^2.14.7",
     "react-toastify": "^9.0.3",
     "regenerator-runtime": "^0.13.9",
     "universal-router": "^9.1.0",

--- a/frontend/admin/src/js/components/user/UserProfileDocument.tsx
+++ b/frontend/admin/src/js/components/user/UserProfileDocument.tsx
@@ -16,8 +16,8 @@ import WorkLocationSection from "@common/components/UserProfile/ProfileSections/
 import WorkPreferencesSection from "@common/components/UserProfile/ProfileSections/WorkPreferencesSection";
 import DiversityEquityInclusionSection from "@common/components/UserProfile/ProfileSections/DiversityEquityInclusionSection";
 import RoleSalarySection from "@common/components/UserProfile/ProfileSections/RoleSalarySection";
-import ExperienceSection from "@common/components/UserProfile/ExperienceSection";
 import { notEmpty } from "@common/helpers/util";
+import ExperienceByTypeListing from "@common/components/UserProfile/ExperienceByTypeListing";
 import { Applicant } from "../../api/generated";
 import AdminAboutSection from "./AdminAboutSection";
 
@@ -179,8 +179,9 @@ export const UserProfileDocument = React.forwardRef<
                 })}
               </Heading>
             </HeadingWrapper>
-            <ExperienceSection
+            <ExperienceByTypeListing
               experiences={applicant.experiences?.filter(notEmpty)}
+              defaultOpen
             />
           </div>
         </div>

--- a/frontend/admin/src/js/components/user/UserProfileDocument.tsx
+++ b/frontend/admin/src/js/components/user/UserProfileDocument.tsx
@@ -1,7 +1,32 @@
 import React from "react";
-import UserProfile from "@common/components/UserProfile";
+import TableOfContents from "@common/components/TableOfContents";
+import {
+  ChatAlt2Icon,
+  CurrencyDollarIcon,
+  InformationCircleIcon,
+  LibraryIcon,
+  LightBulbIcon,
+  LightningBoltIcon,
+  LocationMarkerIcon,
+  ThumbUpIcon,
+} from "@heroicons/react/outline";
+import { useIntl } from "react-intl";
+import LanguageInformationSection from "@common/components/UserProfile/ProfileSections/LanguageInformationSection";
+import GovernmentInformationSection from "@common/components/UserProfile/ProfileSections/GovernmentInformationSection";
+import WorkLocationSection from "@common/components/UserProfile/ProfileSections/WorkLocationSection";
+import WorkPreferencesSection from "@common/components/UserProfile/ProfileSections/WorkPreferencesSection";
+import DiversityEquityInclusionSection from "@common/components/UserProfile/ProfileSections/DiversityEquityInclusionSection";
+import RoleSalarySection from "@common/components/UserProfile/ProfileSections/RoleSalarySection";
+import ExperienceSection from "@common/components/UserProfile/ExperienceSection";
+import { notEmpty } from "@common/helpers/util";
 import { Applicant } from "../../api/generated";
 import AdminAboutSection from "./AdminAboutSection";
+
+const HeadingWrapper: React.FC = ({ children }) => {
+  return (
+    <div style={{ display: "flex", alignItems: "baseline" }}>{children}</div>
+  );
+};
 
 export interface UserProfileDocumentProps {
   applicant: Applicant;
@@ -11,6 +36,7 @@ export const UserProfileDocument = React.forwardRef<
   HTMLDivElement,
   UserProfileDocumentProps
 >(({ applicant }, ref) => {
+  const intl = useIntl();
   return (
     <div
       style={{
@@ -19,21 +45,125 @@ export const UserProfileDocument = React.forwardRef<
     >
       <div ref={ref}>
         <div className="print-container">
-          <UserProfile
-            applicant={applicant}
-            sections={{
-              about: {
-                isVisible: true,
-                override: <AdminAboutSection applicant={applicant} />,
-              },
-              language: { isVisible: true },
-              government: { isVisible: true },
-              workLocation: { isVisible: true },
-              workPreferences: { isVisible: true },
-              employmentEquity: { isVisible: true },
-              roleSalary: { isVisible: true },
-              skillsExperience: { isVisible: true },
-            }}
+          {/* My Status */}
+          <HeadingWrapper>
+            <TableOfContents.Heading
+              icon={LightBulbIcon}
+              style={{ flex: "1 1 0%" }}
+            >
+              {intl.formatMessage({
+                defaultMessage: "My Status",
+                description: "Title of the my status content section",
+              })}
+            </TableOfContents.Heading>
+          </HeadingWrapper>
+          <AdminAboutSection applicant={applicant} />
+
+          {/* Language Information */}
+          <HeadingWrapper>
+            <TableOfContents.Heading
+              icon={ChatAlt2Icon}
+              style={{ flex: "1 1 0%" }}
+            >
+              {intl.formatMessage({
+                defaultMessage: "Language Information",
+                description:
+                  "Title of the Language Information content section",
+              })}
+            </TableOfContents.Heading>
+          </HeadingWrapper>
+          <LanguageInformationSection applicant={applicant} />
+
+          {/* Government */}
+          <TableOfContents.Section id="government-section">
+            <HeadingWrapper>
+              <TableOfContents.Heading
+                icon={LibraryIcon}
+                style={{ flex: "1 1 0%" }}
+              >
+                {intl.formatMessage({
+                  defaultMessage: "Government Information",
+                  description:
+                    "Title of the Government Information content section",
+                })}
+              </TableOfContents.Heading>
+            </HeadingWrapper>
+            <GovernmentInformationSection applicant={applicant} />
+          </TableOfContents.Section>
+
+          {/* Work Location */}
+          <HeadingWrapper>
+            <TableOfContents.Heading
+              icon={LocationMarkerIcon}
+              style={{ flex: "1 1 0%" }}
+            >
+              {intl.formatMessage({
+                defaultMessage: "Work Location",
+                description: "Title of the Work Location content section",
+              })}
+            </TableOfContents.Heading>
+          </HeadingWrapper>
+          <WorkLocationSection applicant={applicant} />
+
+          {/* Work Preferences */}
+          <HeadingWrapper>
+            <TableOfContents.Heading
+              icon={ThumbUpIcon}
+              style={{ flex: "1 1 0%" }}
+            >
+              {intl.formatMessage({
+                defaultMessage: "Work Preferences",
+                description: "Title of the Work Preferences content section",
+              })}
+            </TableOfContents.Heading>
+          </HeadingWrapper>
+          <WorkPreferencesSection applicant={applicant} />
+
+          {/* Employment Equite */}
+          <HeadingWrapper>
+            <TableOfContents.Heading
+              icon={InformationCircleIcon}
+              style={{ flex: "1 1 0%" }}
+            >
+              {intl.formatMessage({
+                defaultMessage: "Employment Equity Information",
+                description:
+                  "Title of the Employment Equity Information content section",
+              })}
+            </TableOfContents.Heading>
+          </HeadingWrapper>
+          <DiversityEquityInclusionSection applicant={applicant} />
+
+          {/* Role Salary */}
+          <HeadingWrapper>
+            <TableOfContents.Heading
+              icon={CurrencyDollarIcon}
+              style={{ flex: "1 1 0%" }}
+            >
+              {intl.formatMessage({
+                defaultMessage: "Role and salary expectations",
+                description:
+                  "Title of the Role and salary expectations section",
+              })}
+            </TableOfContents.Heading>
+          </HeadingWrapper>
+          <RoleSalarySection applicant={applicant} />
+
+          {/* Skills Experience */}
+          <HeadingWrapper>
+            <TableOfContents.Heading
+              icon={LightningBoltIcon}
+              style={{ flex: "1 1 0%" }}
+            >
+              {intl.formatMessage({
+                defaultMessage: "My skills and experience",
+                description:
+                  "Title of the My skills and experience content section",
+              })}
+            </TableOfContents.Heading>
+          </HeadingWrapper>
+          <ExperienceSection
+            experiences={applicant.experiences?.filter(notEmpty)}
           />
         </div>
       </div>

--- a/frontend/admin/src/js/components/user/UserProfileDocument.tsx
+++ b/frontend/admin/src/js/components/user/UserProfileDocument.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import UserProfile from "@common/components/UserProfile";
+import { Applicant } from "../../api/generated";
+import AdminAboutSection from "./AdminAboutSection";
+
+export interface UserProfileDocumentProps {
+  applicant: Applicant;
+}
+
+export const UserProfileDocument = React.forwardRef<
+  HTMLDivElement,
+  UserProfileDocumentProps
+>(({ applicant }, ref) => {
+  return (
+    <div
+      style={{
+        display: "none",
+      }}
+    >
+      <div ref={ref}>
+        <div className="print-container">
+          <UserProfile
+            applicant={applicant}
+            sections={{
+              about: {
+                isVisible: true,
+                override: <AdminAboutSection applicant={applicant} />,
+              },
+              language: { isVisible: true },
+              government: { isVisible: true },
+              workLocation: { isVisible: true },
+              workPreferences: { isVisible: true },
+              employmentEquity: { isVisible: true },
+              roleSalary: { isVisible: true },
+              skillsExperience: { isVisible: true },
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+});
+
+export default UserProfileDocument;

--- a/frontend/admin/src/js/components/user/UserProfileDocument.tsx
+++ b/frontend/admin/src/js/components/user/UserProfileDocument.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import TableOfContents from "@common/components/TableOfContents";
+import React, { HTMLAttributes } from "react";
 import {
   ChatAlt2Icon,
   CurrencyDollarIcon,
@@ -28,6 +27,35 @@ const HeadingWrapper: React.FC = ({ children }) => {
   );
 };
 
+export interface HeadingProps {
+  as?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  icon?: React.FC<{ className: string }>;
+}
+
+const Heading: React.FC<HeadingProps & HTMLAttributes<HTMLHeadingElement>> = ({
+  icon,
+  children,
+  as = "h2",
+  ...rest
+}) => {
+  const El = as;
+  const Icon = icon || null;
+
+  return (
+    <El
+      data-h2-display="b(flex)"
+      data-h2-font-weight="b(800)"
+      data-h2-align-items="b(center)"
+      data-h2-margin="b(top, none) b(bottom, m)"
+      data-h2-justify-content="b(start)"
+      {...rest}
+    >
+      {Icon && <Icon className="heading-icon" />}
+      <span>{children}</span>
+    </El>
+  );
+};
+
 export interface UserProfileDocumentProps {
   applicant: Applicant;
 }
@@ -46,125 +74,115 @@ export const UserProfileDocument = React.forwardRef<
       <div ref={ref}>
         <div className="print-container">
           {/* My Status */}
-          <HeadingWrapper>
-            <TableOfContents.Heading
-              icon={LightBulbIcon}
-              style={{ flex: "1 1 0%" }}
-            >
-              {intl.formatMessage({
-                defaultMessage: "My Status",
-                description: "Title of the my status content section",
-              })}
-            </TableOfContents.Heading>
-          </HeadingWrapper>
-          <AdminAboutSection applicant={applicant} />
+          <div className="page-section">
+            <HeadingWrapper>
+              <Heading icon={LightBulbIcon} style={{ flex: "1 1 0%" }}>
+                {intl.formatMessage({
+                  defaultMessage: "My Status",
+                  description: "Title of the my status content section",
+                })}
+              </Heading>
+            </HeadingWrapper>
+            <AdminAboutSection applicant={applicant} />
+          </div>
 
-          {/* Language Information */}
-          <HeadingWrapper>
-            <TableOfContents.Heading
-              icon={ChatAlt2Icon}
-              style={{ flex: "1 1 0%" }}
-            >
-              {intl.formatMessage({
-                defaultMessage: "Language Information",
-                description:
-                  "Title of the Language Information content section",
-              })}
-            </TableOfContents.Heading>
-          </HeadingWrapper>
-          <LanguageInformationSection applicant={applicant} />
+          <div className="page-section">
+            {/* Language Information */}
+            <HeadingWrapper>
+              <Heading icon={ChatAlt2Icon} style={{ flex: "1 1 0%" }}>
+                {intl.formatMessage({
+                  defaultMessage: "Language Information",
+                  description:
+                    "Title of the Language Information content section",
+                })}
+              </Heading>
+            </HeadingWrapper>
+            <LanguageInformationSection applicant={applicant} />
+          </div>
 
           {/* Government */}
-          <TableOfContents.Section id="government-section">
+          <div className="page-section">
             <HeadingWrapper>
-              <TableOfContents.Heading
-                icon={LibraryIcon}
-                style={{ flex: "1 1 0%" }}
-              >
+              <Heading icon={LibraryIcon} style={{ flex: "1 1 0%" }}>
                 {intl.formatMessage({
                   defaultMessage: "Government Information",
                   description:
                     "Title of the Government Information content section",
                 })}
-              </TableOfContents.Heading>
+              </Heading>
             </HeadingWrapper>
             <GovernmentInformationSection applicant={applicant} />
-          </TableOfContents.Section>
+          </div>
 
           {/* Work Location */}
-          <HeadingWrapper>
-            <TableOfContents.Heading
-              icon={LocationMarkerIcon}
-              style={{ flex: "1 1 0%" }}
-            >
-              {intl.formatMessage({
-                defaultMessage: "Work Location",
-                description: "Title of the Work Location content section",
-              })}
-            </TableOfContents.Heading>
-          </HeadingWrapper>
-          <WorkLocationSection applicant={applicant} />
+          <div className="page-section">
+            <HeadingWrapper>
+              <Heading icon={LocationMarkerIcon} style={{ flex: "1 1 0%" }}>
+                {intl.formatMessage({
+                  defaultMessage: "Work Location",
+                  description: "Title of the Work Location content section",
+                })}
+              </Heading>
+            </HeadingWrapper>
+            <WorkLocationSection applicant={applicant} />
+          </div>
 
           {/* Work Preferences */}
-          <HeadingWrapper>
-            <TableOfContents.Heading
-              icon={ThumbUpIcon}
-              style={{ flex: "1 1 0%" }}
-            >
-              {intl.formatMessage({
-                defaultMessage: "Work Preferences",
-                description: "Title of the Work Preferences content section",
-              })}
-            </TableOfContents.Heading>
-          </HeadingWrapper>
-          <WorkPreferencesSection applicant={applicant} />
+          <div className="page-section">
+            <HeadingWrapper>
+              <Heading icon={ThumbUpIcon} style={{ flex: "1 1 0%" }}>
+                {intl.formatMessage({
+                  defaultMessage: "Work Preferences",
+                  description: "Title of the Work Preferences content section",
+                })}
+              </Heading>
+            </HeadingWrapper>
+            <WorkPreferencesSection applicant={applicant} />
+          </div>
 
-          {/* Employment Equite */}
-          <HeadingWrapper>
-            <TableOfContents.Heading
-              icon={InformationCircleIcon}
-              style={{ flex: "1 1 0%" }}
-            >
-              {intl.formatMessage({
-                defaultMessage: "Employment Equity Information",
-                description:
-                  "Title of the Employment Equity Information content section",
-              })}
-            </TableOfContents.Heading>
-          </HeadingWrapper>
-          <DiversityEquityInclusionSection applicant={applicant} />
+          {/* Employment Equity */}
+          <div className="page-section">
+            <HeadingWrapper>
+              <Heading icon={InformationCircleIcon} style={{ flex: "1 1 0%" }}>
+                {intl.formatMessage({
+                  defaultMessage: "Employment Equity Information",
+                  description:
+                    "Title of the Employment Equity Information content section",
+                })}
+              </Heading>
+            </HeadingWrapper>
+            <DiversityEquityInclusionSection applicant={applicant} />
+          </div>
 
           {/* Role Salary */}
-          <HeadingWrapper>
-            <TableOfContents.Heading
-              icon={CurrencyDollarIcon}
-              style={{ flex: "1 1 0%" }}
-            >
-              {intl.formatMessage({
-                defaultMessage: "Role and salary expectations",
-                description:
-                  "Title of the Role and salary expectations section",
-              })}
-            </TableOfContents.Heading>
-          </HeadingWrapper>
-          <RoleSalarySection applicant={applicant} />
+          <div className="page-section">
+            <HeadingWrapper>
+              <Heading icon={CurrencyDollarIcon} style={{ flex: "1 1 0%" }}>
+                {intl.formatMessage({
+                  defaultMessage: "Role and salary expectations",
+                  description:
+                    "Title of the Role and salary expectations section",
+                })}
+              </Heading>
+            </HeadingWrapper>
+            <RoleSalarySection applicant={applicant} />
+          </div>
 
           {/* Skills Experience */}
-          <HeadingWrapper>
-            <TableOfContents.Heading
-              icon={LightningBoltIcon}
-              style={{ flex: "1 1 0%" }}
-            >
-              {intl.formatMessage({
-                defaultMessage: "My skills and experience",
-                description:
-                  "Title of the My skills and experience content section",
-              })}
-            </TableOfContents.Heading>
-          </HeadingWrapper>
-          <ExperienceSection
-            experiences={applicant.experiences?.filter(notEmpty)}
-          />
+          <div className="page-section">
+            <HeadingWrapper>
+              <Heading icon={LightningBoltIcon} style={{ flex: "1 1 0%" }}>
+                {intl.formatMessage({
+                  defaultMessage: "My skills and experience",
+                  description:
+                    "Title of the My skills and experience content section",
+                })}
+              </Heading>
+            </HeadingWrapper>
+            <ExperienceSection
+              experiences={applicant.experiences?.filter(notEmpty)}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/admin/src/js/components/user/UserProfileDocument.tsx
+++ b/frontend/admin/src/js/components/user/UserProfileDocument.tsx
@@ -86,8 +86,8 @@ export const UserProfileDocument = React.forwardRef<
             <AdminAboutSection applicant={applicant} />
           </div>
 
+          {/* Language Information */}
           <div className="page-section">
-            {/* Language Information */}
             <HeadingWrapper>
               <Heading icon={ChatAlt2Icon} style={{ flex: "1 1 0%" }}>
                 {intl.formatMessage({

--- a/frontend/admin/src/js/components/user/UserProfilePrintButton.tsx
+++ b/frontend/admin/src/js/components/user/UserProfilePrintButton.tsx
@@ -5,7 +5,6 @@ import { useIntl } from "react-intl";
 import { useReactToPrint } from "react-to-print";
 import { Scalars, useGetUserProfileQuery } from "../../api/generated";
 import UserProfileDocument from "./UserProfileDocument";
-// import UserProfileDocument from "./UserProfileDocument";
 
 export interface UserProfilePrintButtonProps {
   userId: Scalars["ID"];
@@ -24,24 +23,29 @@ export const UserProfilePrintButton: React.FunctionComponent<{
   const componentRef = useRef(null);
   const handlePrint = useReactToPrint({
     content: () => componentRef.current,
+    copyStyles: false,
     pageStyle: `@page {
     size: letter portrait;
   }
 
-  @media all {
-    .page-break {
-      display: none;
-    }
-  }
-
   @media print {
-    .page-break {
-      margin-top: 1rem;
+
+    .page-section {
+      margin-bottom: 2rem;
       display: block;
-      page-break-after: always;
+      page-break-after: auto;
+      page-break-inside: avoid;
+      -webkit-region-break-inside: avoid;
+    }
+
+    .heading-icon {
+      flex-shrink: 0;
+      height: 1.5rem;
+      width: 1.5rem;
+      margin-right: 1rem;
     }
   }`,
-    documentTitle: "User Aggregate",
+    documentTitle: "Candidate Profile",
   });
 
   const userData = initialData;

--- a/frontend/admin/src/js/components/user/UserProfilePrintButton.tsx
+++ b/frontend/admin/src/js/components/user/UserProfilePrintButton.tsx
@@ -1,0 +1,79 @@
+import { Button } from "@common/components";
+import { commonMessages } from "@common/messages";
+import React, { useRef } from "react";
+import { useIntl } from "react-intl";
+import { useReactToPrint } from "react-to-print";
+import { Scalars, useGetUserProfileQuery } from "../../api/generated";
+import UserProfileDocument from "./UserProfileDocument";
+// import UserProfileDocument from "./UserProfileDocument";
+
+export interface UserProfilePrintButtonProps {
+  userId: Scalars["ID"];
+}
+
+export const UserProfilePrintButton: React.FunctionComponent<{
+  userId: Scalars["ID"];
+}> = ({ userId, children }) => {
+  const intl = useIntl();
+
+  const [{ data: initialData, fetching, error }] = useGetUserProfileQuery({
+    variables: { id: userId },
+  });
+
+  const componentRef = useRef(null);
+  const handlePrint = useReactToPrint({
+    content: () => componentRef.current,
+    pageStyle: `@page {
+    size: letter portrait;
+  }
+
+  @media all {
+    .page-break {
+      display: none;
+    }
+  }
+
+  @media print {
+    .page-break {
+      margin-top: 1rem;
+      display: block;
+      page-break-after: always;
+    }
+  }`,
+    documentTitle: "User Aggregate",
+  });
+
+  const userData = initialData;
+
+  if (fetching) return <p>{intl.formatMessage(commonMessages.loadingTitle)}</p>;
+  if (error)
+    return (
+      <p>
+        {intl.formatMessage(commonMessages.loadingError)}
+        {error.message}
+      </p>
+    );
+
+  return userData?.applicant ? (
+    <>
+      <Button
+        mode="outline"
+        color="primary"
+        type="button"
+        onClick={handlePrint}
+      >
+        {children}
+      </Button>
+      <UserProfileDocument applicant={userData.applicant} ref={componentRef} />
+    </>
+  ) : (
+    <p>
+      {intl.formatMessage({
+        defaultMessage: "No candidate data",
+        description: "No candidate data was found",
+      })}
+    </p>
+  );
+};
+
+export default UserProfilePrintButton;

--- a/frontend/admin/src/js/components/user/UserProfilePrintButton.tsx
+++ b/frontend/admin/src/js/components/user/UserProfilePrintButton.tsx
@@ -16,6 +16,7 @@ export const UserProfilePrintButton: React.FunctionComponent<{
 }> = ({ userId, children }) => {
   const intl = useIntl();
 
+  // would be nice to only fire this if the button was clicked but you would need an imperative version of the query that you could await on
   const [{ data: initialData, fetching, error }] = useGetUserProfileQuery({
     variables: { id: userId },
   });

--- a/frontend/admin/src/js/components/user/ViewUser.tsx
+++ b/frontend/admin/src/js/components/user/ViewUser.tsx
@@ -8,13 +8,13 @@ import {
 import Breadcrumbs from "@common/components/Breadcrumbs";
 import type { BreadcrumbsProps } from "@common/components/Breadcrumbs";
 import PageHeader from "@common/components/PageHeader";
-import { Link } from "@common/components";
 import { Tab, TabSet } from "@common/components/tabs";
 import { commonMessages } from "@common/messages";
 import { useAdminRoutes } from "../../adminRoutes";
 import { User, useUserQuery } from "../../api/generated";
 import DashboardContentContainer from "../DashboardContentContainer";
 import UserProfileApi from "./UserProfile";
+import UserProfilePrintButton from "./UserProfilePrintButton";
 
 interface ViewUserPageProps {
   user: User;
@@ -72,13 +72,7 @@ export const ViewUserPage: React.FC<ViewUserPageProps> = ({ user }) => {
           </h2>
         )}
         <div data-h2-margin="m(left, auto)">
-          <Link
-            mode="outline"
-            color="primary"
-            type="button"
-            href="/"
-            // download={ TODO }
-          >
+          <UserProfilePrintButton userId={user.id}>
             <span>
               <DownloadIcon style={{ width: "1rem" }} />{" "}
               {intl.formatMessage({
@@ -86,7 +80,7 @@ export const ViewUserPage: React.FC<ViewUserPageProps> = ({ user }) => {
                 description: "Text for button to download a user",
               })}
             </span>
-          </Link>
+          </UserProfilePrintButton>
         </div>
       </div>
       <TabSet>

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/ExperienceAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/ExperienceAccordion.tsx
@@ -28,11 +28,13 @@ export interface ExperiencePaths {
 export interface AccordionProps {
   experience: AnyExperience;
   editPaths?: ExperiencePaths;
+  defaultOpen?: boolean;
 }
 
 const ExperienceAccordion: React.FunctionComponent<AccordionProps> = ({
   experience,
   editPaths,
+  defaultOpen = false,
 }) => {
   const intl = useIntl();
 
@@ -43,6 +45,7 @@ const ExperienceAccordion: React.FunctionComponent<AccordionProps> = ({
     return AwardAccordion({
       ...experience,
       editUrl,
+      defaultOpen,
     });
   }
   if (isCommunityExperience(experience)) {
@@ -52,6 +55,7 @@ const ExperienceAccordion: React.FunctionComponent<AccordionProps> = ({
     return CommunityAccordion({
       ...experience,
       editUrl,
+      defaultOpen,
     });
   }
   if (isEducationExperience(experience)) {
@@ -61,6 +65,7 @@ const ExperienceAccordion: React.FunctionComponent<AccordionProps> = ({
     return EducationAccordion({
       ...experience,
       editUrl,
+      defaultOpen,
     });
   }
   if (isPersonalExperience(experience)) {
@@ -70,6 +75,7 @@ const ExperienceAccordion: React.FunctionComponent<AccordionProps> = ({
     return PersonalAccordion({
       ...experience,
       editUrl,
+      defaultOpen,
     });
   }
   if (isWorkExperience(experience)) {
@@ -77,6 +83,7 @@ const ExperienceAccordion: React.FunctionComponent<AccordionProps> = ({
     return WorkAccordion({
       ...experience,
       editUrl,
+      defaultOpen,
     });
   }
 

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/AwardAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/AwardAccordion.tsx
@@ -13,6 +13,7 @@ import { AwardExperience } from "../../../../api/generated";
 
 type AwardAccordionProps = AwardExperience & {
   editUrl?: string; // A link to edit the experience will only appear if editUrl is defined.
+  defaultOpen?: boolean;
 };
 
 const AwardAccordion: React.FunctionComponent<AwardAccordionProps> = ({
@@ -24,6 +25,7 @@ const AwardAccordion: React.FunctionComponent<AwardAccordionProps> = ({
   awardedScope,
   skills,
   editUrl,
+  defaultOpen = false,
 }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -68,6 +70,7 @@ const AwardAccordion: React.FunctionComponent<AwardAccordionProps> = ({
             )
       }
       Icon={BriefCaseIcon}
+      defaultOpen={defaultOpen}
     >
       <div data-h2-padding="b(left, l)">
         <p>

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/CommunityAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/CommunityAccordion.tsx
@@ -9,6 +9,7 @@ import { getDateRange } from "../../../../helpers/dateUtils";
 
 type CommunityAccordionProps = CommunityExperience & {
   editUrl?: string; // A link to edit the experience will only appear if editUrl is defined.
+  defaultOpen?: boolean;
 };
 
 const CommunityAccordion: React.FunctionComponent<CommunityAccordionProps> = ({
@@ -20,6 +21,7 @@ const CommunityAccordion: React.FunctionComponent<CommunityAccordionProps> = ({
   project,
   skills,
   editUrl,
+  defaultOpen = false,
 }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -62,6 +64,7 @@ const CommunityAccordion: React.FunctionComponent<CommunityAccordionProps> = ({
             )
       }
       Icon={BriefCaseIcon}
+      defaultOpen={defaultOpen}
     >
       {" "}
       <div data-h2-padding="b(left, l)">

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/EducationAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/EducationAccordion.tsx
@@ -13,6 +13,7 @@ import { getDateRange } from "../../../../helpers/dateUtils";
 
 type EducationAccordionProps = EducationExperience & {
   editUrl?: string; // A link to edit the experience will only appear if editUrl is defined.
+  defaultOpen?: boolean;
 };
 
 const EducationAccordion: React.FunctionComponent<EducationAccordionProps> = ({
@@ -26,6 +27,7 @@ const EducationAccordion: React.FunctionComponent<EducationAccordionProps> = ({
   thesisTitle,
   skills,
   editUrl,
+  defaultOpen = false,
 }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -67,6 +69,7 @@ const EducationAccordion: React.FunctionComponent<EducationAccordionProps> = ({
             )
       }
       Icon={BriefCaseIcon}
+      defaultOpen={defaultOpen}
     >
       <div data-h2-padding="b(left, l)">
         <p>

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/PersonalAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/PersonalAccordion.tsx
@@ -9,6 +9,7 @@ import { PersonalExperience } from "../../../../api/generated";
 
 type PersonalAccordionProps = PersonalExperience & {
   editUrl?: string; // A link to edit the experience will only appear if editUrl is defined.
+  defaultOpen?: boolean;
 };
 
 const PersonalAccordion: React.FunctionComponent<PersonalAccordionProps> = ({
@@ -19,6 +20,7 @@ const PersonalAccordion: React.FunctionComponent<PersonalAccordionProps> = ({
   description,
   skills,
   editUrl,
+  defaultOpen = false,
 }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -54,6 +56,7 @@ const PersonalAccordion: React.FunctionComponent<PersonalAccordionProps> = ({
             )
       }
       Icon={BriefCaseIcon}
+      defaultOpen={defaultOpen}
     >
       <div data-h2-padding="b(left, l)">
         <p>{description}</p>

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/WorkAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/WorkAccordion.tsx
@@ -9,6 +9,7 @@ import { WorkExperience } from "../../../../api/generated";
 
 type WorkAccordionProps = WorkExperience & {
   editUrl?: string; // A link to edit the experience will only appear if editUrl is defined.
+  defaultOpen?: boolean;
 };
 
 const WorkAccordion: React.FunctionComponent<WorkAccordionProps> = ({
@@ -20,6 +21,7 @@ const WorkAccordion: React.FunctionComponent<WorkAccordionProps> = ({
   division,
   skills,
   editUrl,
+  defaultOpen = false,
 }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -62,6 +64,7 @@ const WorkAccordion: React.FunctionComponent<WorkAccordionProps> = ({
             )
       }
       Icon={BriefCaseIcon}
+      defaultOpen={defaultOpen}
     >
       <div data-h2-padding="b(left, l)">
         <p>

--- a/frontend/common/src/components/UserProfile/ExperienceByTypeListing.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceByTypeListing.tsx
@@ -1,0 +1,132 @@
+import {
+  BookOpenIcon,
+  BriefcaseIcon,
+  LightBulbIcon,
+  StarIcon,
+  UserGroupIcon,
+} from "@heroicons/react/solid";
+import * as React from "react";
+import { useIntl } from "react-intl";
+import ExperienceAccordion, {
+  ExperiencePaths,
+} from "./ExperienceAccordion/ExperienceAccordion";
+import {
+  compareByDate,
+  isAwardExperience,
+  isCommunityExperience,
+  isEducationExperience,
+  isPersonalExperience,
+  isWorkExperience,
+} from "../../types/ExperienceUtils";
+import { AwardExperience, Experience } from "../../api/generated";
+
+const ExperienceByType: React.FunctionComponent<{
+  title: string;
+  icon: React.ReactNode;
+  experiences: Experience[];
+  experienceEditPaths?: ExperiencePaths; // If experienceEditPaths is not defined, links to edit experiences will not appear.
+  defaultOpen?: boolean;
+}> = ({
+  title,
+  icon,
+  experiences,
+  experienceEditPaths,
+  defaultOpen = false,
+}) => {
+  return (
+    <div>
+      <div data-h2-display="b(flex)" data-h2-margin="b(top-bottom, m)">
+        {icon}
+        <p
+          data-h2-font-size="b(h4)"
+          data-h2-margin="b(all, none)"
+          data-h2-padding="b(left, s)"
+        >
+          {title}
+        </p>
+      </div>
+      <div
+        data-h2-radius="b(s)"
+        data-h2-bg-color="b(lightgray)"
+        data-h2-padding="b(top-bottom, xxs) b(right-left, xs)"
+      >
+        {experiences.map((experience) => (
+          <ExperienceAccordion
+            key={experience.id}
+            experience={experience}
+            editPaths={experienceEditPaths}
+            defaultOpen={defaultOpen}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+export interface ExperienceSectionProps {
+  experiences?: Experience[];
+  defaultOpen?: boolean;
+}
+
+const ExperienceByTypeListing: React.FunctionComponent<
+  ExperienceSectionProps
+> = ({ experiences, defaultOpen = false }) => {
+  const intl = useIntl();
+
+  const awardExperiences =
+    experiences
+      ?.filter(isAwardExperience)
+      .map(
+        (award: AwardExperience) =>
+          ({
+            ...award,
+            startDate: award.awardedDate,
+            endDate: award.awardedDate,
+          } as AwardExperience & { startDate: string; endDate: string }),
+      )
+      .sort(compareByDate) || [];
+  const communityExperiences =
+    experiences?.filter(isCommunityExperience).sort(compareByDate) || [];
+  const educationExperiences =
+    experiences?.filter(isEducationExperience).sort(compareByDate) || [];
+  const personalExperiences =
+    experiences?.filter(isPersonalExperience).sort(compareByDate) || [];
+  const workExperiences =
+    experiences?.filter(isWorkExperience).sort(compareByDate) || [];
+
+  return (
+    <>
+      <ExperienceByType
+        title={intl.formatMessage({ defaultMessage: "Personal" })}
+        icon={<LightBulbIcon style={{ width: "1.5rem" }} />}
+        experiences={personalExperiences}
+        defaultOpen={defaultOpen}
+      />
+      <ExperienceByType
+        title={intl.formatMessage({ defaultMessage: "Community" })}
+        icon={<UserGroupIcon style={{ width: "1.5rem" }} />}
+        experiences={communityExperiences}
+        defaultOpen={defaultOpen}
+      />
+      <ExperienceByType
+        title={intl.formatMessage({ defaultMessage: "Work" })}
+        icon={<BriefcaseIcon style={{ width: "1.5rem" }} />}
+        experiences={workExperiences}
+        defaultOpen={defaultOpen}
+      />
+      <ExperienceByType
+        title={intl.formatMessage({ defaultMessage: "Education" })}
+        icon={<BookOpenIcon style={{ width: "1.5rem" }} />}
+        experiences={educationExperiences}
+        defaultOpen={defaultOpen}
+      />
+      <ExperienceByType
+        title={intl.formatMessage({ defaultMessage: "Award" })}
+        icon={<StarIcon style={{ width: "1.5rem" }} />}
+        experiences={awardExperiences}
+        defaultOpen={defaultOpen}
+      />
+    </>
+  );
+};
+
+export default ExperienceByTypeListing;

--- a/frontend/common/src/components/UserProfile/ExperienceSection.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceSection.tsx
@@ -1,10 +1,3 @@
-import {
-  BookOpenIcon,
-  BriefcaseIcon,
-  LightBulbIcon,
-  StarIcon,
-  UserGroupIcon,
-} from "@heroicons/react/solid";
 import * as React from "react";
 import { useIntl } from "react-intl";
 import ExperienceAccordion, {
@@ -14,85 +7,16 @@ import SkillAccordion from "./SkillAccordion/SkillAccordion";
 import { Tab, TabSet } from "../tabs";
 import { getLocale } from "../../helpers/localize";
 import {
+  compareByDate,
   isAwardExperience,
   isCommunityExperience,
   isEducationExperience,
   isPersonalExperience,
   isWorkExperience,
 } from "../../types/ExperienceUtils";
-import {
-  AwardExperience,
-  CommunityExperience,
-  Experience,
-  PersonalExperience,
-  Skill,
-  WorkExperience,
-  EducationExperience,
-} from "../../api/generated";
+import { AwardExperience, Experience, Skill } from "../../api/generated";
+import ExperienceByTypeListing from "./ExperienceByTypeListing";
 
-export type ExperienceForDate =
-  | (AwardExperience & { startDate: string; endDate: string })
-  | CommunityExperience
-  | EducationExperience
-  | PersonalExperience
-  | WorkExperience;
-
-export const compareByDate = (e1: ExperienceForDate, e2: ExperienceForDate) => {
-  const e1EndDate = e1.endDate ? new Date(e1.endDate).getTime() : null;
-  const e2EndDate = e2.endDate ? new Date(e2.endDate).getTime() : null;
-  const e1StartDate = e1.startDate ? new Date(e1.startDate).getTime() : -1;
-  const e2StartDate = e2.startDate ? new Date(e2.startDate).getTime() : -1;
-
-  // All items with no end date should be at the top and sorted by most recent start date.
-  if (!e1EndDate && !e2EndDate) {
-    return e2StartDate - e1StartDate;
-  }
-
-  if (!e1EndDate) {
-    return -1;
-  }
-
-  if (!e2EndDate) {
-    return 1;
-  }
-
-  // Items with end date should be sorted by most recent end date at top.
-  return e2EndDate - e1EndDate;
-};
-const ExperienceByType: React.FunctionComponent<{
-  title: string;
-  icon: React.ReactNode;
-  experiences: Experience[];
-  experienceEditPaths?: ExperiencePaths; // If experienceEditPaths is not defined, links to edit experiences will not appear.
-}> = ({ title, icon, experiences, experienceEditPaths }) => {
-  return (
-    <div>
-      <div data-h2-display="b(flex)" data-h2-margin="b(top-bottom, m)">
-        {icon}
-        <p
-          data-h2-font-size="b(h4)"
-          data-h2-margin="b(all, none)"
-          data-h2-padding="b(left, s)"
-        >
-          {title}
-        </p>
-      </div>
-      <div
-        data-h2-radius="b(s)"
-        data-h2-bg-color="b(lightgray)"
-        data-h2-padding="b(top-bottom, xxs) b(right-left, xs)"
-      >
-        {experiences.map((experience) => (
-          <ExperienceAccordion
-            key={experience.id}
-            experience={experience}
-            editPaths={experienceEditPaths}
-          />
-        ))}
-      </div>
-    </div>
-  );
-};
 export interface ExperienceSectionProps {
   experiences?: Experience[];
   experienceEditPaths?: ExperiencePaths; // If experienceEditPaths is not defined, links to edit experiences will not appear.
@@ -188,31 +112,7 @@ const ExperienceSection: React.FunctionComponent<ExperienceSectionProps> = ({
             "Tab title for experiences sorted by type in applicant profile.",
         })}
       >
-        <ExperienceByType
-          title={intl.formatMessage({ defaultMessage: "Personal" })}
-          icon={<LightBulbIcon style={{ width: "1.5rem" }} />}
-          experiences={personalExperiences}
-        />
-        <ExperienceByType
-          title={intl.formatMessage({ defaultMessage: "Community" })}
-          icon={<UserGroupIcon style={{ width: "1.5rem" }} />}
-          experiences={communityExperiences}
-        />
-        <ExperienceByType
-          title={intl.formatMessage({ defaultMessage: "Work" })}
-          icon={<BriefcaseIcon style={{ width: "1.5rem" }} />}
-          experiences={workExperiences}
-        />
-        <ExperienceByType
-          title={intl.formatMessage({ defaultMessage: "Education" })}
-          icon={<BookOpenIcon style={{ width: "1.5rem" }} />}
-          experiences={educationExperiences}
-        />
-        <ExperienceByType
-          title={intl.formatMessage({ defaultMessage: "Award" })}
-          icon={<StarIcon style={{ width: "1.5rem" }} />}
-          experiences={awardExperiences}
-        />
+        <ExperienceByTypeListing experiences={experiences} />
       </Tab>
       <Tab
         text={intl.formatMessage({

--- a/frontend/common/src/components/accordion/Accordion.tsx
+++ b/frontend/common/src/components/accordion/Accordion.tsx
@@ -38,10 +38,10 @@ const Accordion: React.FC<AccordionProps> = ({
     >
       <button
         type="button"
-        data-h2-text-align="b(left)"
+        // data-h2-text-align="b(left)"
         data-h2-bg-color="b(white)"
-        data-h2-padding="b(top-bottom, s) b(right, m) b(left, s)"
-        data-h2-width="b(100)"
+        // data-h2-padding="b(top-bottom, s) b(right, m) b(left, s)"
+        // data-h2-width="b(100)"
         onClick={() => handleOpen()}
         {...(isOpen && children
           ? { "data-h2-border": "b(lightpurple, left, solid, m)" }
@@ -52,12 +52,25 @@ const Accordion: React.FC<AccordionProps> = ({
           borderBottom: "none",
           borderLeft: simple ? "none" : "",
           cursor: "pointer",
+          transition: "all .2s ease",
+          width: "100%",
+          textAlign: "left",
+          paddingBottom: "1rem",
+          paddingTop: "1rem",
+          paddingRight: "1.5rem",
+          paddingLeft: "1rem",
         }}
         aria-expanded={isOpen}
       >
         <div
-          data-h2-flex-grid="b(middle, expanded, flush, s)"
-          data-h2-flex-wrap="b(nowrap)"
+          // data-h2-flex-grid="b(middle, expanded, flush, s)"
+          style={{
+            alignItems: "center",
+            display: "flex",
+            flexWrap: "wrap",
+            margin: "-.5rem",
+          }}
+          // data-h2-flex-wrap="b(nowrap)"
         >
           <span>
             {isOpen ? (
@@ -66,7 +79,11 @@ const Accordion: React.FC<AccordionProps> = ({
               <ChevronRightIcon style={{ width: "1.5rem" }} />
             )}
           </span>
-          <div data-h2-flex-item="b(auto)" data-h2-text-align="b(left)">
+          <div
+            // data-h2-flex-item="b(auto)"
+            style={{ flex: "auto", maxWidth: "100%", textAlign: "left" }}
+            // data-h2-text-align="b(left)"
+          >
             <p
               data-h2-margin="b(all, none)"
               data-h2-font-size="b(h5)"
@@ -78,11 +95,18 @@ const Accordion: React.FC<AccordionProps> = ({
             <p data-h2-margin="b(top, xxs) b(bottom, none)">{subtitle}</p>
           </div>
           <div
-            data-h2-flex-item="b(content)"
-            data-h2-display="b(flex)"
-            data-h2-align-items="b(center)"
-            data-h2-flex-direction="b(row)"
-            style={{ flexShrink: 0 }}
+            // data-h2-flex-item="b(content)"
+            // data-h2-display="b(flex)"
+            // data-h2-align-items="b(center)"
+            // data-h2-flex-direction="b(row)"
+            style={{
+              display: "flex",
+              flexShrink: 0,
+              flex: "initial",
+              maxWidth: "100%",
+              alignItems: "center",
+              flexDirection: "row",
+            }}
           >
             <p data-h2-font-size="b(normal)">{context}</p>
             {!simple && (

--- a/frontend/common/src/types/ExperienceUtils.ts
+++ b/frontend/common/src/types/ExperienceUtils.ts
@@ -26,3 +26,33 @@ export const isPersonalExperience = (
 ): e is PersonalExperience => e.__typename === "PersonalExperience";
 export const isWorkExperience = (e: AnyExperience): e is WorkExperience =>
   e.__typename === "WorkExperience";
+
+export type ExperienceForDate =
+  | (AwardExperience & { startDate: string; endDate: string })
+  | CommunityExperience
+  | EducationExperience
+  | PersonalExperience
+  | WorkExperience;
+
+export const compareByDate = (e1: ExperienceForDate, e2: ExperienceForDate) => {
+  const e1EndDate = e1.endDate ? new Date(e1.endDate).getTime() : null;
+  const e2EndDate = e2.endDate ? new Date(e2.endDate).getTime() : null;
+  const e1StartDate = e1.startDate ? new Date(e1.startDate).getTime() : -1;
+  const e2StartDate = e2.startDate ? new Date(e2.startDate).getTime() : -1;
+
+  // All items with no end date should be at the top and sorted by most recent start date.
+  if (!e1EndDate && !e2EndDate) {
+    return e2StartDate - e1StartDate;
+  }
+
+  if (!e1EndDate) {
+    return -1;
+  }
+
+  if (!e2EndDate) {
+    return 1;
+  }
+
+  // Items with end date should be sorted by most recent end date at top.
+  return e2EndDate - e1EndDate;
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,6 +40,7 @@
         "react-intl": "^6.0.3",
         "react-select": "^5.3.1",
         "react-table": "^7.8.0",
+        "react-to-print": "^2.14.7",
         "react-toastify": "^9.0.3",
         "regenerator-runtime": "^0.13.9",
         "universal-router": "^9.1.0",
@@ -32137,6 +32138,18 @@
         "react": "^16.8.3 || ^17.0.0-0 || ^18.0.0"
       }
     },
+    "node_modules/react-to-print": {
+      "version": "2.14.7",
+      "resolved": "https://registry.npmjs.org/react-to-print/-/react-to-print-2.14.7.tgz",
+      "integrity": "sha512-lWVVAs9Co25uyE0toxcWeFsmaZObwUozXrJD9WMpDPclpBgk+WIzxlt3Q3omL/BCBG/cpf0XNvhayUWa+99YGw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-toastify": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.0.3.tgz",
@@ -47531,6 +47544,7 @@
         "react-refresh": "^0.13.0",
         "react-select": "^5.3.1",
         "react-table": "^7.8.0",
+        "react-to-print": "^2.14.7",
         "react-toastify": "^9.0.3",
         "regenerator-runtime": "^0.13.9",
         "storybook-addon-intl": "^2.4.1",
@@ -63563,6 +63577,14 @@
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
       "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
       "requires": {}
+    },
+    "react-to-print": {
+      "version": "2.14.7",
+      "resolved": "https://registry.npmjs.org/react-to-print/-/react-to-print-2.14.7.tgz",
+      "integrity": "sha512-lWVVAs9Co25uyE0toxcWeFsmaZObwUozXrJD9WMpDPclpBgk+WIzxlt3Q3omL/BCBG/cpf0XNvhayUWa+99YGw==",
+      "requires": {
+        "prop-types": "^15.8.1"
+      }
     },
     "react-toastify": {
       "version": "9.0.3",


### PR DESCRIPTION
This branch adds the ability to print the candidate profile.  Using the browser built-in PDF printer will allow a PDF export.  It uses the same "react-to-print" library as the spike.

Suggested Tests:
- [ ] The accordion styling remains the same on screen
- [ ] Pressing the Download button on the user page triggers the browser print dialog
- [ ] The printed document resembles the Candidate Profile tab contents
- [ ] The printed accordions should be all open, on the "by type" tab

Closes #2663 