### PR TITLE
Add applicant role

### DIFF
--- a/api/app/Providers/AuthServiceProvider.php
+++ b/api/app/Providers/AuthServiceProvider.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Log;
 use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
+use Database\Helpers\ApiEnums;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -101,7 +102,7 @@ class AuthServiceProvider extends ServiceProvider
                 $newUser = new User;
                 $newUser->first_name = $sub;  // displayed on the landing page so should help us find the user
                 $newUser->sub = $sub;
-                $newUser->roles = null;
+                $newUser->roles = [ApiEnums::ROLE_APPLICANT]; // every new user is automatically an APPLICANT
                 $newUser->save();
                 return $newUser;
             }

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -4,7 +4,6 @@ namespace Database\Factories;
 
 use App\Models\User;
 use App\Models\Classification;
-use App\Models\CmoAsset;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Database\Helpers\ApiEnums;
 

--- a/api/database/helpers/ApiEnums.php
+++ b/api/database/helpers/ApiEnums.php
@@ -64,4 +64,19 @@ class ApiEnums
     const CANDIDATE_EXPIRY_FILTER_ACTIVE = 'ACTIVE';
     const CANDIDATE_EXPIRY_FILTER_EXPIRED = 'EXPIRED';
     const CANDIDATE_EXPIRY_FILTER_ALL = 'ALL';
+
+    const ROLE_ADMIN = 'ADMIN';
+    const ROLE_APPLICANT = 'APPLICANT';
+    /**
+     * A collection of enums for Role in factories and seeders
+     *
+     * @return string[]
+     */
+    public static function roles() : array
+    {
+        return [
+            self::ROLE_ADMIN,
+            self::ROLE_APPLICANT,
+        ];
+    }
 }

--- a/api/database/migrations/2022_06_07_131233_add_applicant_role.php
+++ b/api/database/migrations/2022_06_07_131233_add_applicant_role.php
@@ -1,0 +1,54 @@
+<?php
+
+use Database\Helpers\ApiEnums;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+class AddApplicantRole extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // turn any nulls to empty array
+        DB::statement(<<<SQL
+            update users
+            set roles = '[]'::jsonb
+            where roles is null
+        SQL);
+
+        // add APPLICANT role to any rows that are missing it
+        DB::statement(<<<SQL
+            UPDATE users
+            SET roles = roles || :new_role::jsonb
+            WHERE not roles ?? :new_role
+        SQL, ['new_role' => json_encode([ApiEnums::ROLE_APPLICANT])]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // remove APPLICANT role from any rows that contain it
+        DB::statement(<<<SQL
+            UPDATE users
+            SET roles = roles - :new_role
+            WHERE roles ?? :new_role
+        SQL, ['new_role' => ApiEnums::ROLE_APPLICANT]);
+
+        // turn empty array to null
+        DB::statement(<<<SQL
+            update users
+            set roles = null
+            where roles = '[]'::jsonb
+        SQL);
+    }
+}

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -19,7 +19,7 @@ use App\Models\EducationExperience;
 use App\Models\PersonalExperience;
 use App\Models\WorkExperience;
 use Faker;
-
+use Database\Helpers\ApiEnums;
 class DatabaseSeeder extends Seeder
 {
     /**
@@ -52,7 +52,9 @@ class DatabaseSeeder extends Seeder
         $this->call(UserSeederLocal::class);
         $this->call(PoolSeeder::class);
 
-        User::factory()
+        User::factory([
+             'roles' => [ApiEnums::ROLE_APPLICANT]
+        ])
             ->count(60)
             ->afterCreating(function (User $user) {
                 $assets = CmoAsset::inRandomOrder()->limit(4)->pluck('id')->toArray();

--- a/api/database/seeders/UserSeederLocal.php
+++ b/api/database/seeders/UserSeederLocal.php
@@ -16,11 +16,16 @@ class UserSeederLocal extends Seeder
      */
     public function run()
     {
-        // shared Laravel auth user
+        // shared auth users for testing
         User::factory()->create([
             'email' => 'admin@test.com',
             'sub' => 'admin@test.com',
             'roles' => [ApiEnums::ROLE_ADMIN, ApiEnums::ROLE_APPLICANT]
+        ]);
+        User::factory()->create([
+            'email' => 'applicant@test.com',
+            'sub' => 'applicant@test.com',
+            'roles' => [ApiEnums::ROLE_APPLICANT]
         ]);
 
         $fakeEmailDomain = '@talent.test';

--- a/api/database/seeders/UserSeederLocal.php
+++ b/api/database/seeders/UserSeederLocal.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Database\Helpers\ApiEnums;
 
 class UserSeederLocal extends Seeder
 {
@@ -19,7 +20,7 @@ class UserSeederLocal extends Seeder
         User::factory()->create([
             'email' => 'admin@test.com',
             'sub' => 'admin@test.com',
-            'roles' => ['ADMIN']
+            'roles' => [ApiEnums::ROLE_ADMIN, ApiEnums::ROLE_APPLICANT]
         ]);
 
         $fakeEmailDomain = '@talent.test';
@@ -27,52 +28,52 @@ class UserSeederLocal extends Seeder
         User::factory()->create([
             'email' => 'petertgiles'.$fakeEmailDomain,
             'sub' => '4810df0d-fcb6-4353-af93-b25c0a5a9c3e',
-            'roles' => ['ADMIN']
+            'roles' => [ApiEnums::ROLE_ADMIN, ApiEnums::ROLE_APPLICANT]
         ]);
         User::factory()->create([
             'email' => 'gggrant'.$fakeEmailDomain,
             'sub' => 'cd537460-1fee-40bd-ada6-8ee40b6f63c9',
-            'roles' => ['ADMIN']
+            'roles' => [ApiEnums::ROLE_ADMIN, ApiEnums::ROLE_APPLICANT]
         ]);
         User::factory()->create([
             'email' => 'yonikid15'.$fakeEmailDomain,
             'sub' => 'c65dd054-db44-4bf6-af39-37eedb39305d',
-            'roles' => ['ADMIN']
+            'roles' => [ApiEnums::ROLE_ADMIN, ApiEnums::ROLE_APPLICANT]
         ]);
         User::factory()->create([
             'email' => 'JamesHuf'.$fakeEmailDomain,
             'sub' => 'e64b8057-0eaf-4a19-a14a-4a93fa2e8a04',
-            'roles' => ['ADMIN']
+            'roles' => [ApiEnums::ROLE_ADMIN, ApiEnums::ROLE_APPLICANT]
         ]);
         User::factory()->create([
             'email' => 'brindasasi'.$fakeEmailDomain,
             'sub' => '2e72b97b-017a-4ed3-a803-a8773c2e1b14',
-            'roles' => ['ADMIN']
+            'roles' => [ApiEnums::ROLE_ADMIN, ApiEnums::ROLE_APPLICANT]
         ]);
         User::factory()->create([
             'email' => 'tristan-orourke'.$fakeEmailDomain,
             'sub' => 'd9f27aca-b2ea-4c4a-9459-25bb7a7b77f6',
-            'roles' => ['ADMIN']
+            'roles' => [ApiEnums::ROLE_ADMIN, ApiEnums::ROLE_APPLICANT]
         ]);
         User::factory()->create([
             'email' => 'vd1992'.$fakeEmailDomain,
             'sub' => '2f3ee3fb-91ab-478e-a675-c56fdc043dc6',
-            'roles' => ['ADMIN']
+            'roles' => [ApiEnums::ROLE_ADMIN, ApiEnums::ROLE_APPLICANT]
         ]);
         User::factory()->create([
             'email' => 'mnigh'.$fakeEmailDomain,
             'sub' => 'c736bdff-c1f2-4538-b648-43a9743481a3',
-            'roles' => ['ADMIN']
+            'roles' => [ApiEnums::ROLE_ADMIN, ApiEnums::ROLE_APPLICANT]
         ]);
         User::factory()->create([
             'email' => 'rvany'.$fakeEmailDomain,
             'sub' => 'a46a681f-31c0-42c8-8be3-97466d77f96a',
-            'roles' => ['ADMIN']
+            'roles' => [ApiEnums::ROLE_ADMIN, ApiEnums::ROLE_APPLICANT]
         ]);
         User::factory()->create([
             'email' => 'patcon'.$fakeEmailDomain,
             'sub' => '88f7d707-01df-4f56-8eed-a823d16c232c',
-            'roles' => ['ADMIN']
+            'roles' => [ApiEnums::ROLE_ADMIN, ApiEnums::ROLE_APPLICANT]
         ]);
     }
 }

--- a/api/database/seeders/UserSeederUat.php
+++ b/api/database/seeders/UserSeederUat.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Database\Helpers\ApiEnums;
 
 class UserSeederUat extends Seeder
 {
@@ -26,7 +27,16 @@ class UserSeederUat extends Seeder
                 'first_name' => 'tristan-orourke',
                 'last_name' => 'Talent',
                 'sub' => 'b4c734a1-dcf3-4fb8-a860-c642700cb0b8',
-                'roles' => ['ADMIN']
+                'roles' => [ApiEnums::ROLE_ADMIN, ApiEnums::ROLE_APPLICANT]
+            ]
+        );
+        User::updateOrCreate(
+            ['email' => 'petertgiles'.$fakeEmailDomain],
+            [
+                'first_name' => 'petertgiles',
+                'last_name' => 'Talent',
+                'sub' => '5d0ce9a8-8164-46a5-9fe1-b7a2b42d61fc',
+                'roles' => [ApiEnums::ROLE_ADMIN, ApiEnums::ROLE_APPLICANT]
             ]
         );
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -24,7 +24,10 @@ enum Language {
 }
 
 enum Role {
-    ADMIN
+    "A user who has administrator privileges"
+    ADMIN,
+    "A user who has a profile to apply to hiring pools"
+    APPLICANT
 }
 
 type User {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -806,7 +806,11 @@ type Query {
 }
 
 enum Role {
+  """A user who has administrator privileges"""
   ADMIN
+
+  """A user who has a profile to apply to hiring pools"""
+  APPLICANT
 }
 
 """The available SQL operators that are used to filter query results."""

--- a/api/tests/Feature/AuthServiceProviderTest.php
+++ b/api/tests/Feature/AuthServiceProviderTest.php
@@ -3,6 +3,7 @@
 use App\Models\User;
 use App\Providers\AuthServiceProvider;
 use App\Services\OpenIdBearerTokenService;
+use Database\Helpers\ApiEnums;
 use Lcobucci\JWT\Token\DataSet;
 use Tests\TestCase;
 use Mockery\MockInterface;
@@ -91,7 +92,7 @@ class AuthServiceProviderTest extends TestCase
         $resolvedUser = $this->provider->resolveUserOrAbort($fakeToken, $mockTokenService);
 
         // they should exist now, but should not be admin
-        $this->assertDatabaseHas('users', ['sub' => $testSub, 'roles' => null]);
+        $this->assertDatabaseHas('users', ['sub' => $testSub, 'roles' => json_encode([ApiEnums::ROLE_APPLICANT])]);
     }
 
      /**
@@ -101,7 +102,7 @@ class AuthServiceProviderTest extends TestCase
     public function testUserIsNotAutoCreatedWhenAlreadyExisting()
     {
         $testSub = 'test-sub';
-        $testRoles = ["ADMIN"];
+        $testRoles = ['TEST'];
 
         $mockClaims = Mockery::mock(new DataSet(['sub' => $testSub], ''));
 
@@ -122,7 +123,7 @@ class AuthServiceProviderTest extends TestCase
 
         // they should exist now
         $this->assertDatabaseHas('users', ['sub' => $testSub, 'roles' => json_encode($testRoles)]);
-        // this should not recreate them - that would wipe out the ADMIN role on our test user
+        // this should not recreate them - that would wipe out the test role on our test user
         $resolvedUser = $this->provider->resolveUserOrAbort($fakeToken, $mockTokenService);
         // make sure our test user did not get roles wiped
         $this->assertDatabaseHas('users', ['sub' => $testSub, 'roles' => json_encode($testRoles)]);

--- a/api/tests/Feature/AuthServiceProviderTest.php
+++ b/api/tests/Feature/AuthServiceProviderTest.php
@@ -102,7 +102,7 @@ class AuthServiceProviderTest extends TestCase
     public function testUserIsNotAutoCreatedWhenAlreadyExisting()
     {
         $testSub = 'test-sub';
-        $testRoles = ['TEST'];
+        $testRoles = ["TEST"];
 
         $mockClaims = Mockery::mock(new DataSet(['sub' => $testSub], ''));
 

--- a/frontend/common/src/constants/localizedConstants.tsx
+++ b/frontend/common/src/constants/localizedConstants.tsx
@@ -309,6 +309,10 @@ export const Roles = defineMessages({
     defaultMessage: "Administrator",
     description: "The name of the Administrator user role.",
   },
+  [Role.Applicant]: {
+    defaultMessage: "Applicant",
+    description: "The name of the Applicant user role.",
+  },
 });
 
 export const getRole = (roleId: string | number): MessageDescriptor =>

--- a/frontend/cypress/fixtures/users.json
+++ b/frontend/cypress/fixtures/users.json
@@ -5,10 +5,10 @@
     "email": "admin@test.com",
     "password": "Test123!"
   },
-  "user": {
-    "first": "Test User",
-    "last": "Test User",
-    "email": "test.user@talent.test",
+  "applicant": {
+    "first": "Test Applicant",
+    "last": "Test Applicant",
+    "email": "applicant@test.com",
     "password": "testpassword"
   }
 }

--- a/frontend/cypress/integration/admin/auth.spec.js
+++ b/frontend/cypress/integration/admin/auth.spec.js
@@ -8,7 +8,7 @@ describe('Auth flows (development)', () => {
 
   const loginViaUI = (role) => {
     cy.fixture('users.json').then(users => {
-      const user = users['admin']
+      const user = users[role]
       cy.get('input[name=username]').type(user.email)
     })
     cy.findByText('Sign-in').click()
@@ -95,7 +95,7 @@ describe('Auth flows (development)', () => {
       })
 
       onAuthLoginPage()
-      loginViaUI()
+      loginViaUI('admin')
 
       cy.url().should('equal', Cypress.config().baseUrl + '/en/admin/dashboard')
       // Confirm login status via button state.
@@ -112,14 +112,14 @@ describe('Auth flows (development)', () => {
       cy.visit(initialPath)
 
       onAuthLoginPage()
-      loginViaUI()
+      loginViaUI('admin')
 
       cy.url().should('equal', Cypress.config().baseUrl + initialPath)
     })
 
   })
 
-  context('Authenticated', () => {
+  context('Authenticated as admin', () => {
     beforeEach(() => cy.login('admin'))
 
     it('redirects by default to dashboard', () => {
@@ -154,6 +154,29 @@ describe('Auth flows (development)', () => {
         .should('not.exist')
       cy.findByRole('link', { name: 'Login' })
         .should('exist').and('be.visible')
+    })
+
+  })
+
+  context('Authenticated as applicant', () => {
+    beforeEach(() => cy.login('applicant'))
+
+    it('displays a not authorized message if logged in without the admin role', () => {
+      [
+        '/en/admin/dashboard',
+        '/en/admin/skills',
+        '/en/admin/search-requests',
+        '/en/admin/users',
+        '/en/admin/classifications',
+        '/en/admin/cmo-assets',
+        '/en/admin/pools',
+        '/en/admin/departments',
+        '/en/admin/skill-families',
+        '/en/admin/skills',
+      ].forEach(restrictedPath => {
+        cy.visit(restrictedPath)
+        cy.contains('not authorized');
+      });
     })
 
   })


### PR DESCRIPTION
This branch adds the applicant role to the API.

Tips:
- A test user was added to the seeder for testing as applicant `applicant@test.com`.

Suggested test steps:
- [ ] Run DB migration
- [ ] Ensure all seeded users in the DB have applicant role
- [ ] Sign into application with a new sub and ensure autocreated user has APPLICANT role
- [ ] Admin site pages should give "not authorized" error when signed in as user with just APPLICANT role

Closes #2911 