### PR TITLE
WIP: Feature - 2925 - Logged out page

### DIFF
--- a/frontend/common/src/components/TileLink/TileLink.stories.tsx
+++ b/frontend/common/src/components/TileLink/TileLink.stories.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import TileLink from "./TileLink";
+import type { TileLinkProps } from "./TileLink";
+
+export default {
+  component: TileLink,
+  title: "Components/Tile Link",
+  args: {
+    label: "Tile Link Label",
+    color: "primary",
+  },
+  argTypes: {
+    label: {
+      name: "Label",
+      type: { name: "string", required: true },
+    },
+    color: {
+      name: "Colour",
+      options: [
+        "primary",
+        "secondary",
+        "cta",
+        "white",
+        "black",
+        "ia-primary",
+        "ia-secondary",
+      ],
+    },
+  },
+};
+
+const TemplateTileLink: Story = (args) => {
+  const { label, color } = args;
+
+  return (
+    <div style={{ width: 250 }}>
+      <TileLink color={color} href="#">
+        {label}
+      </TileLink>
+    </div>
+  );
+};
+
+export const BasicTileLink = TemplateTileLink.bind({});

--- a/frontend/common/src/components/TileLink/TileLink.tsx
+++ b/frontend/common/src/components/TileLink/TileLink.tsx
@@ -1,0 +1,83 @@
+import { ChevronDoubleRightIcon } from "@heroicons/react/solid";
+import React from "react";
+import { navigate } from "../../helpers/router";
+import type { Color } from "../Button";
+
+const colorMap: Record<Color, Record<string, string>> = {
+  primary: {
+    "data-h2-border": "b(lightpurple, left, solid, m)",
+  },
+  secondary: {
+    "data-h2-border": "b(lightnavy, left, solid, m)",
+  },
+  cta: {
+    "data-h2-border": "b(darkgold, left, solid, m)",
+  },
+  white: {
+    "data-h2-border": "b(white, left, solid, m)",
+  },
+  black: {
+    "data-h2-border": "b(black, left, solid, m)",
+  },
+  "ia-primary": {
+    "data-h2-border": "b(ia-pink, left, solid, m)",
+  },
+  "ia-secondary": {
+    "data-h2-border": "b(ia-purple, left, solid, m)",
+  },
+};
+
+export interface TileLinkProps extends React.HTMLProps<HTMLAnchorElement> {
+  /** The style colour of the link */
+  color: Color;
+  /** Use if link goes to a URL outside of the application */
+  external?: boolean;
+}
+
+const TileLink: React.FC<TileLinkProps> = ({
+  href,
+  title,
+  color,
+  children,
+  external = false,
+  ...rest
+}): React.ReactElement => (
+  <a
+    href={href}
+    title={title}
+    data-h2-bg-color="b(white) b:h(lightgray)"
+    data-h2-display="b(flex)"
+    data-h2-align-items="b(flex-end)"
+    data-h2-shadow="b(m)"
+    data-h2-padding="b(all, s)"
+    data-h2-justify-content="b(space-between)"
+    {...colorMap[color]}
+    {...rest}
+    onClick={
+      !external
+        ? (event): void => {
+            event.preventDefault();
+            if (href) navigate(href);
+          }
+        : undefined
+    }
+  >
+    <span
+      data-h2-display="b(block)"
+      data-h2-overflow="b(all, hidden)"
+      data-h2-padding="b(top, xl)"
+      data-h2-width="b(100)"
+      style={{
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+    <ChevronDoubleRightIcon
+      style={{ height: "1rem", width: "1rem", flexShrink: 0 }}
+    />
+  </a>
+);
+
+export default TileLink;

--- a/frontend/common/src/components/TileLink/index.ts
+++ b/frontend/common/src/components/TileLink/index.ts
@@ -1,0 +1,3 @@
+import TileLink from "./TileLink";
+
+export default TileLink;

--- a/frontend/talentsearch/src/js/components/loggedOut/LoggedOutPage.stories.tsx
+++ b/frontend/talentsearch/src/js/components/loggedOut/LoggedOutPage.stories.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Meta, Story } from "@storybook/react";
+
+import LoggedOutPage from "./LoggedOutPage";
+
+export default {
+  component: LoggedOutPage,
+  title: "Logged Out Page",
+} as Meta;
+
+const TemplateLoggedOutPage: Story = () => <LoggedOutPage />;
+
+export const IndividualLoggedOutPage = TemplateLoggedOutPage.bind({});

--- a/frontend/talentsearch/src/js/components/loggedOut/LoggedOutPage.tsx
+++ b/frontend/talentsearch/src/js/components/loggedOut/LoggedOutPage.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import TileLink from "@common/components/TileLink";
+import { imageUrl } from "@common/helpers/router";
+import { useApiRoutes } from "@common/hooks/useApiRoutes";
+import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
+import { useTalentSearchRoutes } from "../../talentSearchRoutes";
+
+import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
+
+const LoggedOutPage: React.FC = () => {
+  const intl = useIntl();
+  const apiPaths = useApiRoutes();
+  const directIntakePaths = useDirectIntakeRoutes();
+  const talentPaths = useTalentSearchRoutes();
+
+  /**
+   * TO DO:
+   *    - Check if user logged in and display logout modal if true
+   *    - Add alert component once created in /create-account
+   *    - Use auth routes created in register page
+   */
+
+  return (
+    <>
+      <div
+        data-h2-padding="b(top-bottom, m) b(right-left, s)"
+        data-h2-font-color="b(white)"
+        data-h2-text-align="b(center)"
+        style={{
+          background: `url(${imageUrl(
+            TALENTSEARCH_APP_DIR,
+            "applicant-profile-banner.png",
+          )})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          backgroundRepeat: "no-repeat",
+        }}
+      >
+        <h1 data-h2-margin="b(top-bottom, l)">
+          {intl.formatMessage({
+            defaultMessage: "See you next time!",
+            description:
+              "Title for the page users land on after successful logout.",
+          })}
+        </h1>
+      </div>
+      <div data-h2-container="b(center, s)" data-h2-margin="b(top-bottom, xl)">
+        {/** TO DO: Add alert here */}
+        <h2>
+          {intl.formatMessage({
+            defaultMessage: "Quick Links",
+            description:
+              "Title displayed for helpful links on logged out page.",
+          })}
+        </h2>
+        <p>
+          {intl.formatMessage({
+            defaultMessage:
+              "Not ready to leave just yet? Head back to the homepage, check out new opportunities, or learn more about some of the research behind this platform.",
+            description:
+              "Description of the links presented on the logged out page.",
+          })}
+        </p>
+        <div data-h2-flex-grid="b(normal, contained, flush, m)">
+          <div data-h2-flex-item="b(1of1) m(1of3)">
+            <TileLink href={talentPaths.home()} color="primary">
+              {intl.formatMessage({
+                defaultMessage: "Return home",
+                description: "Link text to return to the home page",
+              })}
+            </TileLink>
+          </div>
+          <div data-h2-flex-item="b(1of1) m(1of3)">
+            <TileLink href={directIntakePaths.allPools()} color="primary">
+              {intl.formatMessage({
+                defaultMessage: "View open pools",
+                description: "Link text to view all open pools",
+              })}
+            </TileLink>
+          </div>
+          <div data-h2-flex-item="b(1of1) m(1of3)">
+            <TileLink href="/talent-cloud/report" color="primary" external>
+              {intl.formatMessage({
+                defaultMessage: "Talent Cloud report",
+                description: "Link text to read the report on talent cloud",
+              })}
+            </TileLink>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default LoggedOutPage;

--- a/infrastructure/php-container/src/.htaccess
+++ b/infrastructure/php-container/src/.htaccess
@@ -36,6 +36,13 @@ DirectorySlash off
     # Send localized talent requests also to talentsearch dist folder;
     RewriteRule ^(en|fr)/talent(/(.*))?$ frontend/talentsearch/dist/$3 [L]
 
+    # Send logged-out requests to talentsearch dist folder (with or without public/ path prefix).
+    RewriteRule ^logged-out/public(/(.*))?$ frontend/talentsearch/dist/$2 [L]
+    RewriteRule ^logged-out(/(.*))?$ frontend/talentsearch/dist/$2 [L]
+
+    # Send localized talent requests also to talentsearch dist folder;
+    RewriteRule ^(en|fr)/logged-out(/(.*))?$ frontend/talentsearch/dist/$3 [L]
+
     # Send browse requests to talentsearch dist folder (with or without public/ path prefix).
     RewriteRule ^browse/public(/(.*))?$ frontend/talentsearch/dist/$2 [L]
     RewriteRule ^browse(/(.*))?$ frontend/talentsearch/dist/$2 [L]


### PR DESCRIPTION
Resolves #2925 

## WIP

This blocked by a few other issues so just waiting on those to finish it off.

- #2924 Waiting on the implementation of the alert here
- #2923 This has some routing needed to display the page
- #2896 Auth container needed to display log out confirmation dialog

## Summary

This created a page at `/logged-out` to display to a user **_after_** they have logged out. If they land on this page while logged in, a dialog will appear asking if they would like to logout.

## New Component - `<TileLink />`

This is a simplified version of the `<Link />`  component that accepts the following:

- **color**: Color - _required_
  - This controls the colour of the border to the left
- **href**: string - _required_
  - URL to point the link to
-  **external**: boolean
  - If the link goes to external location, avoid using `universal-router`