### PR TITLE
Feature - 2922 - Login Page

### DIFF
--- a/frontend/talentsearch/src/js/authRoutes.ts
+++ b/frontend/talentsearch/src/js/authRoutes.ts
@@ -8,6 +8,7 @@ const authRoutes = (lang: string) => {
   const home = (): string => path.join("/", lang);
 
   return {
+    login: (): string => path.join(home(), "login-info"),
     register: (): string => path.join(home(), "register"),
   };
 };

--- a/frontend/talentsearch/src/js/components/Router.tsx
+++ b/frontend/talentsearch/src/js/components/Router.tsx
@@ -37,6 +37,7 @@ import BrowseIndividualPoolApi from "./browse/BrowseIndividualPool";
 import PoolApplyPage from "./pool/PoolApplyPage";
 import PoolApplicationThanksPage from "./pool/PoolApplicationThanksPage";
 import RegisterPage from "./register/RegisterPage";
+import LoginPage from "./login/LoginPage";
 
 const talentRoutes = (
   talentPaths: TalentSearchRoutes,
@@ -67,6 +68,12 @@ const authRoutes = (authPaths: AuthRoutes): Routes<RouterResult> => [
     path: authPaths.register(),
     action: () => ({
       component: <RegisterPage />,
+    }),
+  },
+  {
+    path: authPaths.login(),
+    action: () => ({
+      component: <LoginPage />,
     }),
   },
 ];

--- a/frontend/talentsearch/src/js/components/login/LoginPage.tsx
+++ b/frontend/talentsearch/src/js/components/login/LoginPage.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { Link } from "@common/components";
+import { imageUrl } from "@common/helpers/router";
+import { useApiRoutes } from "@common/hooks/useApiRoutes";
+
+import { useTalentSearchRoutes } from "../../talentSearchRoutes";
+import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
+
+const keyRegistrationLink = (path: string, ...chunks: React.ReactNode[]) => (
+  <a href={path}>{chunks}</a>
+);
+
+const boldText = (...chunks: React.ReactNode[]) => (
+  <span data-h2-font-weight="b(800)">{chunks}</span>
+);
+
+const LoginPage: React.FC = () => {
+  const intl = useIntl();
+  const paths = useApiRoutes();
+  const talentPaths = useTalentSearchRoutes();
+
+  return (
+    <>
+      <div
+        data-h2-padding="b(top-bottom, m) b(right-left, s)"
+        data-h2-font-color="b(white)"
+        data-h2-text-align="b(center)"
+        style={{
+          background: `url(${imageUrl(
+            TALENTSEARCH_APP_DIR,
+            "applicant-profile-banner.png",
+          )})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          backgroundRepeat: "no-repeat",
+        }}
+      >
+        <h1 data-h2-margin="b(top-bottom, l)">
+          {intl.formatMessage({
+            defaultMessage: "Login using GC Key",
+            description: "Title for the login page for applicant profiles.",
+          })}
+        </h1>
+      </div>
+      <div data-h2-container="b(center, s)" data-h2-margin="b(top-bottom, xl)">
+        <p>
+          {intl.formatMessage({
+            defaultMessage:
+              "You can log into your Digital Talent profile using your existing GC Key, even if you’ve never used this platform before.",
+            description: "Instructions on how to login with GC Key.",
+          })}
+        </p>
+        <p>
+          {intl.formatMessage({
+            defaultMessage:
+              "If you’re unsure whether you have an existing GC Key account, continue to the website and try logging in. If you can’t remember your password, you can also reset it there.",
+            description:
+              "Instructions on what to do if user doesn't know if they have a GC Key",
+          })}
+        </p>
+        <p>
+          {intl.formatMessage(
+            {
+              defaultMessage:
+                "<b>Don't have a GC Key account?</b> <a>Register for one.</a>",
+              description:
+                "Instruction on what to do if user does not have a GC Key.",
+            },
+            {
+              a: (...chunks) => keyRegistrationLink(paths.login(), chunks),
+              b: boldText,
+            },
+          )}
+        </p>
+        <hr data-h2-margin="b(top-bottom, l)" />
+        <div
+          data-h2-display="b(flex)"
+          data-h2-flex-direction="b(column) m(row)"
+          data-h2-align-items="b(center)"
+          data-h2-justify-content="b(space-between)"
+        >
+          <p>
+            <Link
+              href={talentPaths.home()}
+              mode="outline"
+              color="primary"
+              type="button"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Cancel",
+                description:
+                  "Link text to cancel logging in and return to talent search home.",
+              })}
+            </Link>
+          </p>
+          <p>
+            <Link
+              href={paths.login()}
+              mode="solid"
+              type="button"
+              color="primary"
+              external
+            >
+              {intl.formatMessage({
+                defaultMessage: "Continue to GC Key and Login",
+                description: "GC Key login link text on the login page.",
+              })}
+            </Link>
+          </p>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default LoginPage;

--- a/frontend/talentsearch/src/js/components/login/LoginPage.tsx
+++ b/frontend/talentsearch/src/js/components/login/LoginPage.tsx
@@ -97,7 +97,7 @@ const LoginPage: React.FC = () => {
           </p>
           <p>
             <Link
-              href={paths.login()}
+              href={paths.login(talentPaths.profile())}
               mode="solid"
               type="button"
               color="primary"

--- a/infrastructure/php-container/src/.htaccess
+++ b/infrastructure/php-container/src/.htaccess
@@ -50,6 +50,13 @@ DirectorySlash off
     # Send localized talent requests also to talentsearch dist folder;
     RewriteRule ^(en|fr)/register(/(.*))?$ frontend/talentsearch/dist/$3 [L]
 
+    # Send login-info requests to talentsearch dist folder (with or without public/ path prefix).
+    RewriteRule ^login-info/public(/(.*))?$ frontend/talentsearch/dist/$2 [L]
+    RewriteRule ^login-info(/(.*))?$ frontend/talentsearch/dist/$2 [L]
+
+    # Send localized talent requests also to talentsearch dist folder;
+    RewriteRule ^(en|fr)/login-info(/(.*))?$ frontend/talentsearch/dist/$3 [L]
+
     # Indigenous Apprenticeship routes
     RewriteRule ^indigenous-it-apprentice(/(.*))?$ frontend/indigenousapprenticeship/dist/$2 [L]
     RewriteRule ^(en|fr)/indigenous-it-apprentice(/(.*))?$ frontend/indigenousapprenticeship/dist/$3 [L]


### PR DESCRIPTION
Resolves #2922 

## Summary

This creates the `/login-info` route and page for users to get information before logging into `talentsearch` profiles.

## Screenshot
<img width="1512" alt="Screen Shot 2022-06-07 at 3 02 28 PM" src="https://user-images.githubusercontent.com/4127998/172461728-f3802093-48e7-4341-9e11-416ca1f1f8dc.png">

