### PR TITLE
Feature - 2951 - Redirect new users

### DIFF
--- a/frontend/admin/src/js/components/menu/SideMenu.stories.tsx
+++ b/frontend/admin/src/js/components/menu/SideMenu.stories.tsx
@@ -31,6 +31,7 @@ const Template: Story<TemplateProps> = (args) => {
     () => ({
       ...AuthorizationContext,
       loggedInUserRoles: isLoggedIn ? [Role.Admin] : null,
+      isLoaded: true,
     }),
     [isLoggedIn],
   );

--- a/frontend/common/src/components/Auth/AuthorizationContainer.tsx
+++ b/frontend/common/src/components/Auth/AuthorizationContainer.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { Role } from "../../api/generated";
+import { Maybe, Role } from "../../api/generated";
 
 export type PossibleUserRoles = (Role | null | undefined)[] | null | undefined;
-export type PossibleEmail = string | null;
+export type MaybeEmail = Maybe<string>;
 
 interface AuthorizationState {
   loggedInUserRoles: PossibleUserRoles;

--- a/frontend/common/src/components/Auth/AuthorizationContainer.tsx
+++ b/frontend/common/src/components/Auth/AuthorizationContainer.tsx
@@ -2,28 +2,34 @@ import React from "react";
 import { Role } from "../../api/generated";
 
 export type PossibleUserRoles = (Role | null | undefined)[] | null | undefined;
+export type PossibleEmail = string | null;
 
 interface AuthorizationState {
   loggedInUserRoles: PossibleUserRoles;
+  loggedInEmail?: PossibleEmail;
 }
 
 export const AuthorizationContext = React.createContext<AuthorizationState>({
   loggedInUserRoles: null,
+  loggedInEmail: null,
 });
 
 interface AuthorizationContainerProps {
   userRoles?: PossibleUserRoles;
+  email?: PossibleEmail;
 }
 
 export const AuthorizationContainer: React.FC<AuthorizationContainerProps> = ({
   userRoles,
+  email,
   children,
 }) => {
   const state = React.useMemo<AuthorizationState>(() => {
     return {
       loggedInUserRoles: userRoles,
+      loggedInEmail: email,
     };
-  }, [userRoles]);
+  }, [userRoles, email]);
 
   return (
     <AuthorizationContext.Provider value={state}>

--- a/frontend/common/src/components/Auth/AuthorizationContainer.tsx
+++ b/frontend/common/src/components/Auth/AuthorizationContainer.tsx
@@ -7,29 +7,34 @@ export type MaybeEmail = Maybe<string>;
 interface AuthorizationState {
   loggedInUserRoles: PossibleUserRoles;
   loggedInEmail?: MaybeEmail;
+  isLoaded: boolean;
 }
 
 export const AuthorizationContext = React.createContext<AuthorizationState>({
   loggedInUserRoles: null,
   loggedInEmail: null,
+  isLoaded: false,
 });
 
 interface AuthorizationContainerProps {
   userRoles?: PossibleUserRoles;
   email?: MaybeEmail;
+  isLoaded: boolean;
 }
 
 export const AuthorizationContainer: React.FC<AuthorizationContainerProps> = ({
   userRoles,
   email,
+  isLoaded,
   children,
 }) => {
   const state = React.useMemo<AuthorizationState>(() => {
     return {
       loggedInUserRoles: userRoles,
       loggedInEmail: email,
+      isLoaded,
     };
-  }, [userRoles, email]);
+  }, [userRoles, email, isLoaded]);
 
   return (
     <AuthorizationContext.Provider value={state}>

--- a/frontend/common/src/components/Auth/AuthorizationContainer.tsx
+++ b/frontend/common/src/components/Auth/AuthorizationContainer.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { Maybe, Role } from "../../api/generated";
 
-export type PossibleUserRoles = (Role | null | undefined)[] | null | undefined;
+export type PossibleUserRoles = Maybe<Array<Maybe<Role>>>;
 export type MaybeEmail = Maybe<string>;
 
 interface AuthorizationState {
   loggedInUserRoles: PossibleUserRoles;
-  loggedInEmail?: PossibleEmail;
+  loggedInEmail?: MaybeEmail;
 }
 
 export const AuthorizationContext = React.createContext<AuthorizationState>({
@@ -16,7 +16,7 @@ export const AuthorizationContext = React.createContext<AuthorizationState>({
 
 interface AuthorizationContainerProps {
   userRoles?: PossibleUserRoles;
-  email?: PossibleEmail;
+  email?: MaybeEmail;
 }
 
 export const AuthorizationContainer: React.FC<AuthorizationContainerProps> = ({

--- a/frontend/common/src/components/context/AuthorizationProvider.tsx
+++ b/frontend/common/src/components/context/AuthorizationProvider.tsx
@@ -8,7 +8,7 @@ const AuthorizationProvider: React.FC = ({ children }) => {
   const { data } = result;
 
   return (
-    <AuthorizationContainer userRoles={data?.me?.roles}>
+    <AuthorizationContainer userRoles={data?.me?.roles} email={data?.me?.email}>
       {children}
     </AuthorizationContainer>
   );

--- a/frontend/common/src/components/context/AuthorizationProvider.tsx
+++ b/frontend/common/src/components/context/AuthorizationProvider.tsx
@@ -5,10 +5,14 @@ import { useGetMeQuery } from "../../api/generated";
 
 const AuthorizationProvider: React.FC = ({ children }) => {
   const [result] = useGetMeQuery();
-  const { data } = result;
+  const { data, fetching } = result;
 
   return (
-    <AuthorizationContainer userRoles={data?.me?.roles} email={data?.me?.email}>
+    <AuthorizationContainer
+      userRoles={data?.me?.roles}
+      email={data?.me?.email}
+      isLoaded={!fetching}
+    >
       {children}
     </AuthorizationContainer>
   );

--- a/frontend/common/src/components/context/contextOperations.graphql
+++ b/frontend/common/src/components/context/contextOperations.graphql
@@ -1,5 +1,6 @@
 query getMe {
   me {
     roles
+    email
   }
 }

--- a/frontend/common/src/helpers/router.tsx
+++ b/frontend/common/src/helpers/router.tsx
@@ -10,6 +10,7 @@ import { Role } from "../api/generated";
 import { AuthorizationContext } from "../components/Auth/AuthorizationContainer";
 import { useApiRoutes } from "../hooks/useApiRoutes";
 import { getLocale } from "./localize";
+import { empty } from "./util";
 
 export const HISTORY = createBrowserHistory();
 
@@ -111,8 +112,11 @@ export const useRouter = (
   const apiRoutes = useApiRoutes();
   const locale = getLocale(useIntl());
   const { loggedIn } = React.useContext(AuthenticationContext);
-  const { loggedInUserRoles, loggedInEmail } =
-    React.useContext(AuthorizationContext);
+  const {
+    loggedInUserRoles,
+    loggedInEmail,
+    isLoaded: authorizationLoaded,
+  } = React.useContext(AuthorizationContext);
   // Render the result of routing
   useEffect((): void => {
     router
@@ -121,11 +125,18 @@ export const useRouter = (
         // may or may not be a promise, so attempt to resolve it. A non-promise value will simply resolve to itself.
         const route = await Promise.resolve(routeMaybePromise);
 
-        // Redirect authenticated user if no email exists yet
+        /**
+         * Check the following then redirect to welcome page
+         *  - Application has a welcome page
+         *  - User Logged in
+         *  - Authorization query is not loading
+         *  - User has no email associated with account
+         */
         if (
           welcomeRoute &&
           loggedIn &&
-          (typeof loggedInEmail === undefined || loggedInEmail === null)
+          authorizationLoaded &&
+          empty(loggedInEmail)
         ) {
           redirect(welcomeRoute);
           return null;

--- a/frontend/common/src/helpers/router.tsx
+++ b/frontend/common/src/helpers/router.tsx
@@ -110,7 +110,8 @@ export const useRouter = (
   const apiRoutes = useApiRoutes();
   const locale = getLocale(useIntl());
   const { loggedIn } = React.useContext(AuthenticationContext);
-  const { loggedInUserRoles } = React.useContext(AuthorizationContext);
+  const { loggedInUserRoles, loggedInEmail } =
+    React.useContext(AuthorizationContext);
   // Render the result of routing
   useEffect((): void => {
     router
@@ -118,6 +119,16 @@ export const useRouter = (
       .then(async (routeMaybePromise) => {
         // may or may not be a promise, so attempt to resolve it. A non-promise value will simply resolve to itself.
         const route = await Promise.resolve(routeMaybePromise);
+
+        // Redirect authenticated user if no email exists yet
+        if (
+          loggedIn &&
+          (typeof loggedInEmail === undefined || loggedInEmail === null)
+        ) {
+          // Hardcoded path due to no easy way to share code
+          redirect(`/talent/profile/create-account`);
+          return null;
+        }
 
         // handling a redirect
         if (route?.redirect) {
@@ -168,6 +179,7 @@ export const useRouter = (
     loggedIn,
     locale,
     loggedInUserRoles,
+    loggedInEmail,
     missingRouteComponent,
     notAuthorizedComponent,
     pathName,

--- a/frontend/common/src/helpers/router.tsx
+++ b/frontend/common/src/helpers/router.tsx
@@ -197,6 +197,7 @@ export const useRouter = (
     pathName,
     router,
     welcomeRoute,
+    authorizationLoaded,
   ]);
 
   return component;

--- a/frontend/common/src/helpers/router.tsx
+++ b/frontend/common/src/helpers/router.tsx
@@ -185,6 +185,7 @@ export const useRouter = (
     notAuthorizedComponent,
     pathName,
     router,
+    welcomeRoute,
   ]);
 
   return component;

--- a/frontend/common/src/helpers/router.tsx
+++ b/frontend/common/src/helpers/router.tsx
@@ -102,6 +102,7 @@ export const useRouter = (
   routes: Routes<RouterResult>,
   missingRouteComponent: ReactElement,
   notAuthorizedComponent: ReactElement,
+  welcomeRoute?: string,
 ): React.ReactElement | null => {
   const location = useLocation();
   const router = useMemo(() => new UniversalRouter(routes), [routes]);
@@ -122,11 +123,11 @@ export const useRouter = (
 
         // Redirect authenticated user if no email exists yet
         if (
+          welcomeRoute &&
           loggedIn &&
           (typeof loggedInEmail === undefined || loggedInEmail === null)
         ) {
-          // Hardcoded path due to no easy way to share code
-          redirect(`/talent/profile/create-account`);
+          redirect(welcomeRoute);
           return null;
         }
 

--- a/frontend/cypress/fixtures/users.json
+++ b/frontend/cypress/fixtures/users.json
@@ -16,5 +16,11 @@
     "last": "Test NoRoles",
     "email": "noroles@test.com",
     "password": "testpassword"
+  },
+  "noemail": {
+    "first": "Test NoEmail",
+    "last": "Test NoEmail",
+    "email": null,
+    "password": "testpassword"
   }
 }

--- a/frontend/cypress/integration/talentsearch/direct-intake.spec.js
+++ b/frontend/cypress/integration/talentsearch/direct-intake.spec.js
@@ -49,4 +49,14 @@ describe("Talentsearch Direct Intake Page", () => {
     });
   })
 
+  context('logged in with no email', () => {
+    beforeEach(() => cy.login('noemail'));
+
+    it("redirects to create account", () => {
+      cy.visit('/en/browse/pools');
+
+      cy.location('pathname').should('eq', '/en/talent/profile/create-account');
+    });
+  })
+
 });

--- a/frontend/talentsearch/src/js/components/PageContainer.tsx
+++ b/frontend/talentsearch/src/js/components/PageContainer.tsx
@@ -14,6 +14,7 @@ import Header from "@common/components/Header";
 import Footer from "@common/components/Footer";
 import NotAuthorized from "@common/components/NotAuthorized";
 import TALENTSEARCH_APP_DIR from "../talentSearchConstants";
+import { useApplicantProfileRoutes } from "../applicantProfileRoutes";
 
 export const exactMatch = (ref: string | null, test: string): boolean =>
   ref === test;
@@ -109,6 +110,7 @@ export const PageContainer: React.FC<{
   contentRoutes: Routes<RouterResult>;
 }> = ({ menuItems, contentRoutes, authLinks }) => {
   const intl = useIntl();
+  const paths = useApplicantProfileRoutes();
   // stabilize components that will not change during life of app, avoid render loops in router
   const notFoundComponent = useRef(<TalentSearchNotFound />);
   const notAuthorizedComponent = useRef(<TalentSearchNotAuthorized />);
@@ -116,6 +118,7 @@ export const PageContainer: React.FC<{
     contentRoutes,
     notFoundComponent.current,
     notAuthorizedComponent.current,
+    paths.createAccount(),
   );
   return (
     <ScrollToTop>

--- a/frontend/talentsearch/src/js/components/PageContainer.tsx
+++ b/frontend/talentsearch/src/js/components/PageContainer.tsx
@@ -14,7 +14,6 @@ import Header from "@common/components/Header";
 import Footer from "@common/components/Footer";
 import NotAuthorized from "@common/components/NotAuthorized";
 import TALENTSEARCH_APP_DIR from "../talentSearchConstants";
-import { useApplicantProfileRoutes } from "../applicantProfileRoutes";
 
 export const exactMatch = (ref: string, test: string): boolean => ref === test;
 

--- a/frontend/talentsearch/src/js/components/PageContainer.tsx
+++ b/frontend/talentsearch/src/js/components/PageContainer.tsx
@@ -14,6 +14,7 @@ import Header from "@common/components/Header";
 import Footer from "@common/components/Footer";
 import NotAuthorized from "@common/components/NotAuthorized";
 import TALENTSEARCH_APP_DIR from "../talentSearchConstants";
+import { useApplicantProfileRoutes } from "../applicantProfileRoutes";
 
 export const exactMatch = (ref: string, test: string): boolean => ref === test;
 


### PR DESCRIPTION
Resolves #2951 

## Summary

This checks to see if a user is logged in and has an email associated with their account. If the user has no email, it will redirect to `/talent/profile/create-account`.

## Note

### Hardcoded Path

~~I'm not happy about it but I had to hardcode the path since the functionality exists in `common` but the path is exclusive to `talentsearch`. Any suggestions to avoid hardcoding this?~~

Answered by @tristan-orourke :D We are now passing this through the `useRouter` hook.