### PR TITLE
Increased cypress timeout

### DIFF
--- a/frontend/cypress.json
+++ b/frontend/cypress.json
@@ -1,4 +1,8 @@
 {
+  "defaultCommandTimeout": 4000,
+  "pageLoadTimeout": 60000,
+  "requestTimeout": 5000,
+  "responseTimeout": 30000,
   "reporter": "cypress-multi-reporters",
   "reporterOptions": {
     "configFile": "cypress/reporters-config.json"

--- a/frontend/cypress.json
+++ b/frontend/cypress.json
@@ -1,5 +1,5 @@
 {
-  "defaultCommandTimeout": 4000,
+  "defaultCommandTimeout": 8000,
   "pageLoadTimeout": 60000,
   "requestTimeout": 5000,
   "responseTimeout": 30000,

--- a/frontend/cypress/integration/admin/auth.spec.js
+++ b/frontend/cypress/integration/admin/auth.spec.js
@@ -1,4 +1,4 @@
-import { aliasQuery } from '../../support/graphql-test-utils'
+import { setUpGraphqlIntercepts } from '../../support/graphql-test-utils'
 
 describe('Auth flows (development)', () => {
   // Helpers
@@ -16,12 +16,7 @@ describe('Auth flows (development)', () => {
 
   // Prepare to intercept/detect relevant GraphQL requests.
   beforeEach(() => {
-    cy.intercept('POST', '/graphql', (req) => {
-      // Creates aliases for use later.
-      // E.g., cy.wait('@gqlgetMeQuery')
-      aliasQuery(req, 'getMe')
-      aliasQuery(req, 'me')
-    })
+    setUpGraphqlIntercepts()
   })
 
   context('Anonymous visitor', () => {

--- a/frontend/cypress/integration/talentsearch/searchpage.spec.js
+++ b/frontend/cypress/integration/talentsearch/searchpage.spec.js
@@ -1,16 +1,26 @@
+import { setUpGraphqlIntercepts } from '../../support/graphql-test-utils'
+
 describe("Talentsearch Search Page", () => {
-  beforeEach(() => cy.visit("/en/talent/search"));
+  beforeEach(() => {
+    setUpGraphqlIntercepts()
+    cy.visit("/en/talent/search")
+  });
 
   it("loads page successfully", () => {
     cy.findByRole("button", { name: /Request Candidates/i }).should("exist");
   });
 
   it("checks, submits, and navigates to /request", () => {
+    const doneLoading = () => {
+      cy.wait('@gqlcountPoolCandidatesQuery')
+    }
+
     cy.get("form")
       .findByRole("radio", {
         name: /Required diploma from post-secondary institution/i,
       })
       .check();
+    doneLoading()
     cy.findByRole("button", { name: /Request Candidates/i }).click();
     cy.findByRole("button", { name: /Submit Request/i }).should("exist");
   });

--- a/frontend/cypress/support/graphql-test-utils.js
+++ b/frontend/cypress/support/graphql-test-utils.js
@@ -21,3 +21,13 @@ export const aliasMutation = (req, operationName) => {
     req.alias = `gql${operationName}Mutation`
   }
 }
+
+export const setUpGraphqlIntercepts = () => {
+  cy.intercept('POST', '/graphql', (req) => {
+    // Creates aliases for use later.
+    // E.g., cy.wait('@gqlgetMeQuery')
+    aliasQuery(req, 'getMe')
+    aliasQuery(req, 'me')
+    aliasQuery(req, 'countPoolCandidates')
+  })
+}


### PR DESCRIPTION
Re-ticketed [from Slack message](https://talent-cloud.slack.com/archives/C0259G6KXJ6/p1654691932999009?thread_ts=1654635948.795159&cid=C0259G6KXJ6) :lock:

We have some actions that take longer than the 4-second timeout of cypress commands.

The ways to handle this, from best to worst:
1. wait for a related http request to finish via `cy.wait('@someAlias')`
2. look for progressive changes on the way, helpful for progressively loading UIs like ours (each `cy.get()` or equivalent has its own timeout)
3. Bump timeout either on the command or globally in `cypress.json`:
    ```js
    cy.get('.my-selector', {timeout: 10000}).should('not.exist')
    ```

I bumped the timeout globally (3), but also added an example of the intended way (1).