### PR TITLE
Bug - 2994 - Add Edit Button Experience By Type Accordions

### DIFF
--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -11,7 +11,7 @@ module.exports = {
   files: [
     {
       path: "frontend/talentsearch/dist/app.js",
-      maxSize: "255 kB",
+      maxSize: "260 kB",
     },
     {
       path: "frontend/admin/dist/app.js",

--- a/frontend/common/src/components/UserProfile/ExperienceByTypeListing.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceByTypeListing.tsx
@@ -65,11 +65,12 @@ const ExperienceByType: React.FunctionComponent<{
 export interface ExperienceSectionProps {
   experiences?: Experience[];
   defaultOpen?: boolean;
+  editPaths?: ExperiencePaths;
 }
 
 const ExperienceByTypeListing: React.FunctionComponent<
   ExperienceSectionProps
-> = ({ experiences, defaultOpen = false }) => {
+> = ({ experiences, editPaths, defaultOpen = false }) => {
   const intl = useIntl();
 
   const awardExperiences =
@@ -100,30 +101,35 @@ const ExperienceByTypeListing: React.FunctionComponent<
         icon={<LightBulbIcon style={{ width: "1.5rem" }} />}
         experiences={personalExperiences}
         defaultOpen={defaultOpen}
+        experienceEditPaths={editPaths}
       />
       <ExperienceByType
         title={intl.formatMessage({ defaultMessage: "Community" })}
         icon={<UserGroupIcon style={{ width: "1.5rem" }} />}
         experiences={communityExperiences}
         defaultOpen={defaultOpen}
+        experienceEditPaths={editPaths}
       />
       <ExperienceByType
         title={intl.formatMessage({ defaultMessage: "Work" })}
         icon={<BriefcaseIcon style={{ width: "1.5rem" }} />}
         experiences={workExperiences}
         defaultOpen={defaultOpen}
+        experienceEditPaths={editPaths}
       />
       <ExperienceByType
         title={intl.formatMessage({ defaultMessage: "Education" })}
         icon={<BookOpenIcon style={{ width: "1.5rem" }} />}
         experiences={educationExperiences}
         defaultOpen={defaultOpen}
+        experienceEditPaths={editPaths}
       />
       <ExperienceByType
         title={intl.formatMessage({ defaultMessage: "Award" })}
         icon={<StarIcon style={{ width: "1.5rem" }} />}
         experiences={awardExperiences}
         defaultOpen={defaultOpen}
+        experienceEditPaths={editPaths}
       />
     </>
   );

--- a/frontend/common/src/components/UserProfile/ExperienceSection.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceSection.tsx
@@ -112,7 +112,10 @@ const ExperienceSection: React.FunctionComponent<ExperienceSectionProps> = ({
             "Tab title for experiences sorted by type in applicant profile.",
         })}
       >
-        <ExperienceByTypeListing experiences={experiences} />
+        <ExperienceByTypeListing
+          experiences={experiences}
+          editPaths={experienceEditPaths}
+        />
       </Tab>
       <Tab
         text={intl.formatMessage({


### PR DESCRIPTION
Resolves #2994 

## Summary

This adds the Edit Experience buttons to the accordions when filtering experiences by type on the profile page.

## Screenshot 

<img width="1000" alt="Screen Shot 2022-06-10 at 9 00 38 AM" src="https://user-images.githubusercontent.com/4127998/173069829-683d7146-a726-4a79-8cf7-29742496df37.png">

## Question

When filtering by skill, I don't see any experiences, is this a bug?

<img width="984" alt="Screen Shot 2022-06-10 at 9 01 35 AM" src="https://user-images.githubusercontent.com/4127998/173069972-92848d9a-3ed4-4f0d-8a74-85f1354da90e.png">

