### PR TITLE
Bug - 2916 - Fix Toast css-loader Issue

### DIFF
--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -11,7 +11,7 @@ module.exports = {
   files: [
     {
       path: "frontend/talentsearch/dist/app.js",
-      maxSize: "255 kB",
+      maxSize: "260 kB",
     },
     {
       path: "frontend/admin/dist/app.js",

--- a/frontend/common/src/components/Toast/Toast.tsx
+++ b/frontend/common/src/components/Toast/Toast.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ToastContainer, Slide } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
+import { injectStyle } from "react-toastify/dist/inject-style";
 import { XCircleIcon } from "@heroicons/react/solid";
 
 const contextClass = {
@@ -19,6 +19,7 @@ const CloseButton = ({
 }) => <XCircleIcon style={{ width: "1rem" }} onClick={closeToast} />;
 
 const Toast: React.FunctionComponent = () => {
+  injectStyle();
   return (
     <ToastContainer
       position="top-center"


### PR DESCRIPTION
Resolves #2916 

## Summary

This switches out importing css directly for `injectStyles` from `react-toastify`. This prevents the use of `css-loader` and issues caused by it [as suggested in a related issue discussion](https://github.com/fkhadra/react-toastify/issues/195#issuecomment-860722903).

## Screenshot

<img width="1138" alt="Screen Shot 2022-06-10 at 9 16 19 AM" src="https://user-images.githubusercontent.com/4127998/173072533-cb8c4d16-4684-4d14-b376-a7ba8d89fc9e.png">

