### PR TITLE
Bug - 2964 - Add lang Attribute to i18n Toggle

### DIFF
--- a/frontend/common/src/components/Header/Header.tsx
+++ b/frontend/common/src/components/Header/Header.tsx
@@ -16,7 +16,8 @@ const Header: React.FunctionComponent<HeaderProps> = ({ baseUrl }) => {
   const locale = getLocale(intl);
 
   const location = useLocation();
-  const languageTogglePath = localizePath(location, oppositeLocale(locale));
+  const changeToLang = oppositeLocale(locale);
+  const languageTogglePath = localizePath(location, changeToLang);
   return (
     <header data-h2-border="b(gray, bottom, solid, s)">
       <div data-h2-flex-grid="b(middle, contained, flush, xl)">
@@ -45,12 +46,13 @@ const Header: React.FunctionComponent<HeaderProps> = ({ baseUrl }) => {
         >
           <Link
             href={languageTogglePath}
+            lang={changeToLang === "en" ? "en" : "fr"}
             title={intl.formatMessage({
               defaultMessage: "Change language",
               description: "Title for the language toggle link.",
             })}
           >
-            {oppositeLocale(locale) === "en" ? "English" : "Français"}
+            {changeToLang === "en" ? "English" : "Français"}
           </Link>
         </div>
       </div>

--- a/frontend/common/src/helpers/router.tsx
+++ b/frontend/common/src/helpers/router.tsx
@@ -1,12 +1,6 @@
 import { createBrowserHistory, Location, Path, State } from "history";
 import UniversalRouter, { Routes } from "universal-router";
-import React, {
-  useState,
-  useEffect,
-  useMemo,
-  ReactElement,
-  HTMLAttributes,
-} from "react";
+import React, { useState, useEffect, useMemo, ReactElement } from "react";
 import fromPairs from "lodash/fromPairs";
 import toPairs from "lodash/toPairs";
 import path from "path-browserify";

--- a/frontend/common/src/helpers/router.tsx
+++ b/frontend/common/src/helpers/router.tsx
@@ -1,6 +1,12 @@
 import { createBrowserHistory, Location, Path, State } from "history";
 import UniversalRouter, { Routes } from "universal-router";
-import React, { useState, useEffect, useMemo, ReactElement } from "react";
+import React, {
+  useState,
+  useEffect,
+  useMemo,
+  ReactElement,
+  HTMLAttributes,
+} from "react";
 import fromPairs from "lodash/fromPairs";
 import toPairs from "lodash/toPairs";
 import path from "path-browserify";
@@ -206,7 +212,9 @@ export function queryParametersToSearchString(
   return queryString ? `?${queryString}` : "";
 }
 
-export const Link: React.FC<{ href: string; title: string }> = ({
+type LinkProps = React.HTMLProps<HTMLAnchorElement>;
+
+export const Link: React.FC<LinkProps> = ({
   href,
   title,
   children,
@@ -218,7 +226,9 @@ export const Link: React.FC<{ href: string; title: string }> = ({
     {...props}
     onClick={(event): void => {
       event.preventDefault();
-      navigate(href);
+      if (href) {
+        navigate(href);
+      }
     }}
   >
     {children}


### PR DESCRIPTION
Resolves #2964 

## Summary

This adds the `lang` attribute to the i18n toggle to improve accessibility by allowing assistive technology to know that the language in this link does not match that of the page improving pronunciation. 

## Note

Inorder to do this, we have updated the prop types for the `<Link />` component to use ` React.HTMLProps<HTMLAnchorElement>`