### PR TITLE
Fix FR translations

### DIFF
--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -348,7 +348,7 @@
     "description": "Displayed next to required form inputs."
   },
   "WUC9pX": {
-    "defaultMessage": "facultatif",
+    "defaultMessage": "Champ facultatif",
     "description": "Displayed next to optional form inputs."
   },
   "5gS1sZ": {


### PR DESCRIPTION
Resolves #2985.

### Bonus
Updates text "Displayed next to optional form inputs" in French from _facultatif_ to _Champ facultatif_ (_Optional_ in English) to match text "Displayed next to required form inputs" in French _Champ obligatoire_ (_Required_ in English).