### PR TITLE
Security - 2993 - Sanitize URLs

### DIFF
--- a/frontend/common/src/components/Link/Link.tsx
+++ b/frontend/common/src/components/Link/Link.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { navigate } from "../../helpers/router";
+import sanitizeUrl from "../../helpers/sanitizeUrl";
 import type { Color } from "../Button";
 import { colorMap } from "../Button/Button";
 
@@ -27,7 +28,7 @@ const Link: React.FC<LinkProps> = ({
   ...rest
 }): React.ReactElement => (
   <a
-    href={href}
+    href={sanitizeUrl(href)}
     title={title}
     className={`${type === "button" && `button `}${className}`}
     {...(type === "button"

--- a/frontend/common/src/components/Link/Link.tsx
+++ b/frontend/common/src/components/Link/Link.tsx
@@ -26,37 +26,40 @@ const Link: React.FC<LinkProps> = ({
   children,
   className,
   ...rest
-}): React.ReactElement => (
-  <a
-    href={sanitizeUrl(href)}
-    title={title}
-    className={`${type === "button" && `button `}${className}`}
-    {...(type === "button"
-      ? {
-          "data-h2-radius": "b(s)",
-          "data-h2-padding": "b(top-bottom, xs) b(right-left, s)",
-          "data-h2-font-size": "b(caption) m(normal)",
-          ...(color && mode ? { ...colorMap[color][mode] } : {}),
-          ...(block
-            ? {
-                "data-h2-display": "b(block)",
-                "data-h2-text-align": "b(center)",
-              }
-            : { "data-h2-display": "b(inline-block)" }),
-        }
-      : {})}
-    {...rest}
-    onClick={
-      !external
-        ? (event): void => {
-            event.preventDefault();
-            if (href) navigate(href);
+}): React.ReactElement => {
+  const url = sanitizeUrl(href);
+  return (
+    <a
+      href={url}
+      title={title}
+      className={`${type === "button" && `button `}${className}`}
+      {...(type === "button"
+        ? {
+            "data-h2-radius": "b(s)",
+            "data-h2-padding": "b(top-bottom, xs) b(right-left, s)",
+            "data-h2-font-size": "b(caption) m(normal)",
+            ...(color && mode ? { ...colorMap[color][mode] } : {}),
+            ...(block
+              ? {
+                  "data-h2-display": "b(block)",
+                  "data-h2-text-align": "b(center)",
+                }
+              : { "data-h2-display": "b(inline-block)" }),
           }
-        : undefined
-    }
-  >
-    {children}
-  </a>
-);
+        : {})}
+      {...rest}
+      onClick={
+        !external
+          ? (event): void => {
+              event.preventDefault();
+              if (href) navigate(href);
+            }
+          : undefined
+      }
+    >
+      {children}
+    </a>
+  );
+};
 
 export default Link;

--- a/frontend/common/src/helpers/sanitizeUrl.ts
+++ b/frontend/common/src/helpers/sanitizeUrl.ts
@@ -8,7 +8,7 @@ const SAFE_URL_PATTERN =
 
 /** A pattern that matches safe data URLs. It only matches image, video, and audio types. */
 const DATA_URL_PATTERN =
-  /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|oga|ogg|opus));base64,[a-z0-9+\/]+=*$/i;
+  /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video(?:mpeg|mp4|ogg|webm)|audio(?:mp3|oga|ogg|opus));base64,[a-z0-9+]+=*$/i;
 
 const sanitizeUrl = (url: string | undefined) => {
   if (typeof url === undefined) {

--- a/frontend/common/src/helpers/sanitizeUrl.ts
+++ b/frontend/common/src/helpers/sanitizeUrl.ts
@@ -1,0 +1,37 @@
+/**
+ * Sanitize a URL to use in href
+ *
+ * Ref: https://pragmaticwebsecurity.com/articles/spasecurity/react-xss-part1.html
+ */
+const SAFE_URL_PATTERN =
+  /^(?:(?:https?|mailto|ftp|tel|file|sms):|[^&:/?#]*(?:[/?#]|$))/gi;
+
+/** A pattern that matches safe data URLs. It only matches image, video, and audio types. */
+const DATA_URL_PATTERN =
+  /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|oga|ogg|opus));base64,[a-z0-9+\/]+=*$/i;
+
+const sanitizeUrl = (url: string | undefined) => {
+  if (typeof url === undefined) {
+    return undefined;
+  }
+
+  const trimmedUrl = String(url).trim();
+  if (
+    trimmedUrl === "null" ||
+    trimmedUrl.length === 0 ||
+    trimmedUrl === "about:blank"
+  ) {
+    return "about:blank";
+  }
+
+  if (
+    trimmedUrl.match(SAFE_URL_PATTERN) ||
+    trimmedUrl.match(DATA_URL_PATTERN)
+  ) {
+    return trimmedUrl;
+  }
+
+  return `unsafe:${trimmedUrl}`;
+};
+
+export default sanitizeUrl;

--- a/frontend/common/src/helpers/sanitizeUrl.ts
+++ b/frontend/common/src/helpers/sanitizeUrl.ts
@@ -8,7 +8,7 @@ const SAFE_URL_PATTERN =
 
 /** A pattern that matches safe data URLs. It only matches image, video, and audio types. */
 const DATA_URL_PATTERN =
-  /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video(?:mpeg|mp4|ogg|webm)|audio(?:mp3|oga|ogg|opus));base64,[a-z0-9+]+=*$/i;
+  /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|oga|ogg|opus));base64,[a-z0-9+/]+=*$/i;
 
 const sanitizeUrl = (url: string | undefined) => {
   if (typeof url === undefined) {


### PR DESCRIPTION
Resolves #2993 

## Summary

This fixes a [medium severity xss vulnerability](https://github.com/GCTC-NTGC/gc-digital-talent/security/code-scanning/10) by sanitizing the `href` input for our `Link` component.

Ref: https://pragmaticwebsecurity.com/articles/spasecurity/react-xss-part1.html

## Note

It still flags this even after the addition of sanitization. I think the problem is that all it can do is detect when we are outputting user provided input to the screen and doesn't know if or how well we are sanitizing it.

If someone can confirm the sanitize works, we should be able to safely ignore this as a false positive.