### PR TITLE
Tooling - 2866 - Fix Lint Errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,4 @@ jobs:
 
       - name: "Run ESlint: all workspaces"
         working-directory: frontend
-        # Temporarily ignore until we fix existing issues.
-        # See: https://github.com/GCTC-NTGC/gc-digital-talent/issues/2043
-        continue-on-error: true
         run: npm run lint --workspaces --if-present


### PR DESCRIPTION
Resolves #2866 

## Summary

This removes that `continue-on-error` in the lint action after ensuring there are no remaining linting errors.

```sh
[frontend] npm run lint --workspaces                                                                                                       main 

> admin@1.3.2 lint
> eslint ./src/js --ext .js,.ts,.jsx,.tsx

> gc-digital-talent-common@1.0.11 lint
> eslint ./src --ext .js,.ts,.jsx,.tsx

> talentsearch@1.0.0 lint
> eslint ./src/js --ext .js,.ts,.jsx,.tsx

> indigenousapprenticeship@1.0.0 lint
> eslint ./src/js --ext .js,.ts,.jsx,.tsx

```