### PR TITLE
Debt - 2360 - Extract browserslist Config

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -4,6 +4,7 @@ Authenticatable
 BEHAVIOURAL
 colour
 colours
+corejs
 darkgold
 darkgray
 darknavy
@@ -12,6 +13,7 @@ darkpurple
 datetime
 dedup
 DIRECTINTAKE
+Gatineau
 gctalent
 heroicons
 INDIGENOUSAPPRENTICESHIP
@@ -42,4 +44,3 @@ Unencrypted
 unlocalized
 urql
 WCAG
-Gatineau

--- a/frontend/admin/.babelrc
+++ b/frontend/admin/.babelrc
@@ -4,10 +4,12 @@
     "@babel/plugin-proposal-private-methods"
   ],
   "presets": [
-    ["@babel/preset-env", {
-      "useBuiltIns":"usage",
-      "corejs":3.21,
-      "targets":"> 0.5% in CA, last 2 versions, Firefox ESR, not dead, not IE 11"
-   }]
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "usage",
+        "corejs": "3.21"
+      }
+    ]
   ]
 }

--- a/frontend/admin/.browserslistrc
+++ b/frontend/admin/.browserslistrc
@@ -1,0 +1,5 @@
+> 0.5% in CA
+last 2 versions
+Firefox ESR
+not dead
+not ie 11

--- a/frontend/indigenousapprenticeship/.babelrc
+++ b/frontend/indigenousapprenticeship/.babelrc
@@ -4,11 +4,12 @@
     "@babel/plugin-proposal-private-methods"
   ],
   "presets": [
-    ["@babel/preset-env", {
-      "useBuiltIns":"usage",
-      "corejs":3.21,
-      "targets":"> 0.5% in CA, last 2 versions, Firefox ESR, not dead, not IE 11"
-   }]
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "usage",
+        "corejs": "3.21"
+      }
+    ]
   ]
 }
-

--- a/frontend/indigenousapprenticeship/.browserslistrc
+++ b/frontend/indigenousapprenticeship/.browserslistrc
@@ -1,0 +1,5 @@
+> 0.5% in CA
+last 2 versions
+Firefox ESR
+not dead
+not ie 11

--- a/frontend/talentsearch/.babelrc
+++ b/frontend/talentsearch/.babelrc
@@ -4,11 +4,12 @@
     "@babel/plugin-proposal-private-methods"
   ],
   "presets": [
-    ["@babel/preset-env", {
-      "useBuiltIns":"usage",
-      "corejs":3.21,
-      "targets":"> 0.5% in CA, last 2 versions, Firefox ESR, not dead, not IE 11"
-   }]
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "usage",
+        "corejs": "3.21"
+      }
+    ]
   ]
 }
-

--- a/frontend/talentsearch/.browserslistrc
+++ b/frontend/talentsearch/.browserslistrc
@@ -1,0 +1,5 @@
+> 0.5% in CA
+last 2 versions
+Firefox ESR
+not dead
+not ie 11


### PR DESCRIPTION
Resolves #2360 

## Summary

This takes the `browserslist` config from our `.babelrc` and puts them in their own file (`.browserslistrc`) for clarity.

### Current Config

```
> 0.5% in CA
last 2 versions
Firefox ESR
not dead
not ie 11
```