### PR TITLE
add mock auth logout uri

### DIFF
--- a/frontend/.apache_env
+++ b/frontend/.apache_env
@@ -3,7 +3,7 @@ OAUTH_POST_LOGOUT_REDIRECT="http://localhost:8000/logged-out"
 
 # Mock auth endpoint
 OAUTH_LOGOUT_URI="http://localhost:8000/oxauth/endsession"
-#SiC endpoint
+# SiC endpoint (will break e2e tests)
 # OAUTH_LOGOUT_URI="https://te-auth.id.tbs-sct.gc.ca/oxauth/restv1/end_session"
 
 # Feature flags


### PR DESCRIPTION
## Summary

We needed to add the new mock auth endpoint as the env var `OAUTH_LOGOUT_URI` to have the logout test pass.