### PR TITLE
Fix missing pool ID

### DIFF
--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -271,6 +271,9 @@ export const SearchContainerApi: React.FC = () => {
 
   const paths = useTalentSearchRoutes();
   const onSubmit = async () => {
+    // pool ID is not in the form so it must be added manually
+    if (candidateFilter && pool) candidateFilter.pools = [{ id: pool.id }];
+
     return pushToStateThenNavigate(paths.request(), {
       candidateFilter,
       candidateCount,


### PR DESCRIPTION
This branch fixes the bug where the pool ID is not properly attached to the pool candidate filter when making search requests.

## Suggested Test Steps
- [ ] Navigate to the talent search page
- [ ] Submit a search request with no added filters
- [ ] Submit a search request with many added filters
- [ ] Navigate to the admin site
- [ ] Review the new search requests to ensure that both have pool ID filters and whatever other filters were added

Closes #3058 