### PR TITLE
Speed up phpunit test runs

### DIFF
--- a/api/tests/Feature/AuthServiceProviderTest.php
+++ b/api/tests/Feature/AuthServiceProviderTest.php
@@ -8,11 +8,11 @@ use Lcobucci\JWT\Token\DataSet;
 use Tests\TestCase;
 use Mockery\MockInterface;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class AuthServiceProviderTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     /**
      * @var MockInterface

--- a/api/tests/Feature/PoolCandidateTest.php
+++ b/api/tests/Feature/PoolCandidateTest.php
@@ -5,7 +5,7 @@ use App\Models\CmoAsset;
 use App\Models\Pool;
 use App\Models\PoolCandidate;
 use App\Models\User;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
@@ -16,7 +16,7 @@ const FAR_FUTURE_DATE = '2050-01-01';
 
 class PoolCandidateTest extends TestCase
 {
-  use DatabaseMigrations;
+  use \Illuminate\Foundation\Testing\RefreshDatabase;
   use MakesGraphQLRequests;
   use ClearsSchemaCache;
 

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -10,7 +10,7 @@ use App\Models\CommunityExperience;
 use App\Models\EducationExperience;
 use App\Models\PersonalExperience;
 use App\Models\WorkExperience;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
@@ -21,7 +21,7 @@ const FAR_FUTURE_DATE = '2050-01-01';
 
 class UserTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
     use MakesGraphQLRequests;
     use ClearsSchemaCache;
 


### PR DESCRIPTION
While trying to sort out a potential bug, I noticed that there was a faster way to do setUp in our phpunit tests. Full test run came **down to 12 sec from 45 sec**.

### Screenshot
<img width="643" alt="Screen Shot 2022-06-14 at 2 49 58 PM" src="https://user-images.githubusercontent.com/305339/173666742-8fd2e0a7-e942-432c-932f-433915a35b40.png">

### To Validate
Just run this (might be faster for you, as my docker is slow):
```
docker-compose exec --workdir /var/www/html/api php php vendor/bin/phpunit --verbose
```

---

For anyone curious, this is **how it works**: It runs migration only once at start of each test run (rather than before each test), and keeps every test in a DB transaction that's rolled back after each test completes.

Video explaining it before it was brought into laravel: https://adamwathan.me/2016/11/14/a-better-database-testing-workflow-in-laravel/