### PR TITLE
Fix profile complete test

### DIFF
--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -37,7 +37,7 @@ class UserFactory extends Factory
         return [
             'first_name' => $this->faker->firstName(),
             'last_name' => $this->faker->lastName(),
-            'email' => $this->faker->boolean(75) ? $this->faker->unique()->safeEmail : null,
+            'email' => $this->faker->unique()->safeEmail(),
             'sub' => $this->faker->boolean(75) ? $this->faker->unique()->uuid() : null,
             'telephone' => $this->faker->e164PhoneNumber(),
             'preferred_lang' => $this->faker->randomElement(['en', 'fr']),

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\DB;
 use App\Models\AwardExperience;
 use App\Models\CommunityExperience;
 use App\Models\EducationExperience;
+use App\Models\GenericJobTitle;
 use App\Models\PersonalExperience;
 use App\Models\WorkExperience;
 use Faker;
@@ -61,6 +62,9 @@ class DatabaseSeeder extends Seeder
             ->afterCreating(function (User $user) use ($faker) {
                 $assets = CmoAsset::inRandomOrder()->limit(4)->pluck('id')->toArray();
                 $user->cmoAssets()->sync($assets);
+
+                $genericJobTitles = GenericJobTitle::inRandomOrder()->limit(2)->pluck('id')->toArray();
+                $user->expectedGenericJobTitles()->sync($genericJobTitles);
 
                 // pick a pool in which to place this user
                 $pool = Pool::inRandomOrder()->limit(1)->first();


### PR DESCRIPTION
This branch fixes a failing phpunit test - is profile complete.  The new Generic Job Title is part of the "profile complete" test so it must be added to the test users.  I also added it to the database seeder.

Suggested test method:
- run the phpunit test suites and confirm they are successful

Edit: I think the intermittent failure was due to email being null 75% of the time.  It was too much of a hassle to get unique emails in the test so I just changed the factory to never make null emails.

Closes #3072 