### PR TITLE
Bug - 3080 - Fix Create Account Redirect

### DIFF
--- a/frontend/common/src/helpers/router.tsx
+++ b/frontend/common/src/helpers/router.tsx
@@ -138,8 +138,7 @@ export const useRouter = (
           authorizationLoaded &&
           empty(loggedInEmail)
         ) {
-          redirect(welcomeRoute);
-          return null;
+          navigate(welcomeRoute);
         }
 
         // handling a redirect
@@ -161,7 +160,7 @@ export const useRouter = (
         let isAuthorized: boolean;
 
         // if there is a list of authorized roles required then let's see if the user is authorized
-        if (authorizationRequired) {
+        if (authorizationLoaded && authorizationRequired) {
           // the user is considered authorized if there are no roles needed or they have at least one of the required roles
           isAuthorized =
             authorizedRoles.length === 0 ||

--- a/frontend/cypress/integration/talentsearch/direct-intake.spec.js
+++ b/frontend/cypress/integration/talentsearch/direct-intake.spec.js
@@ -56,6 +56,7 @@ describe("Talentsearch Direct Intake Page", () => {
       cy.visit('/en/browse/pools');
 
       cy.location('pathname').should('eq', '/en/talent/profile/create-account');
+      cy.contains("successfully logged in");
     });
   })
 


### PR DESCRIPTION
Resolves #3080 

## Summary

Following the login redirect, there was a `return null;` added after the navigation to the new path. This should only be used when navigating away from the site. Returning null caused the application to navigate but never mount the new component and instead showed the last component that was mounted.

Also, added more safety around the authorisation, waiting until the roles have loaded before checking them.