### PR TITLE
WIP: Feature - 2654 - New User Table Style

### DIFF
--- a/frontend/admin/src/js/components/Table/SearchForm.tsx
+++ b/frontend/admin/src/js/components/Table/SearchForm.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import { SearchIcon } from "@heroicons/react/outline";
+import { debounce } from "lodash";
+
+import { Button } from "@common/components";
+
+interface SearchFormProps {
+  onChange: (term: string) => void;
+  onSubmit: () => void;
+}
+
+const SearchForm: React.FC<SearchFormProps> = ({ onChange, onSubmit }) => {
+  const intl = useIntl();
+  const [searchTerm, setSearchTerm] = React.useState<string>("");
+  const debouncedUpdate = debounce(onChange, 100);
+
+  React.useEffect(() => {
+    debouncedUpdate(searchTerm);
+  }, [searchTerm, debouncedUpdate]);
+
+  const handleChange = (e: React.FormEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    setSearchTerm(e.currentTarget.value);
+  };
+
+  return (
+    <div data-h2-display="b(flex)" data-h2-margin="b(left, s)">
+      <Button
+        type="button"
+        onClick={onSubmit}
+        color="black"
+        mode="outline"
+        data-h2-radius="b(s, none, none, s)"
+        style={{
+          flexShrink: 0,
+          borderRight: "none",
+        }}
+      >
+        <SearchIcon
+          style={{ width: "1em", height: "1em", verticalAlign: "top" }}
+        />
+        <span data-h2-visibility="b(invisible)">
+          {intl.formatMessage({
+            defaultMessage: "Search",
+            description: "Text label for admin table search button",
+          })}
+        </span>
+      </Button>
+      <input
+        name="search"
+        id="tableSearch"
+        type="text"
+        value={searchTerm}
+        aria-label={intl.formatMessage({
+          defaultMessage: "Search Table",
+          description: "Label for search field on admin tables.",
+        })}
+        placeholder={intl.formatMessage({
+          defaultMessage: "Start writing here...",
+          description:
+            "Placeholder displayed on the Global Filter form Search field.",
+        })}
+        onChange={handleChange}
+        data-h2-border="b(black, all, solid, s)"
+        data-h2-radius="b(none, s, s, none)"
+        data-h2-bg-color="b(white)"
+        data-h2-padding="b(top-bottom, xs) b(right-left, s)"
+        data-h2-font-size="b(caption) m(normal)"
+        data-h2-font-family="b(sans)"
+        data-h2-width="b(100)"
+      />
+    </div>
+  );
+};
+
+export default SearchForm;

--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -12,7 +12,6 @@ import {
 import { Button, Link } from "@common/components";
 import Pagination from "@common/components/Pagination";
 import { FilterIcon, PlusIcon, TableIcon } from "@heroicons/react/outline";
-import GlobalFilter from "../GlobalFilter";
 import SortIcon from "./SortIcon";
 import SearchForm from "./SearchForm";
 
@@ -121,115 +120,119 @@ function Table<T extends Record<string, unknown>>({
 
   return (
     <>
-      <div
-        data-h2-align-items="b(center)"
-        data-h2-display="b(flex)"
-        data-h2-bg-color="b(lightgray)"
-        data-h2-justify-content="b(space-between)"
-        data-h2-radius="b(s, s, none, none)"
-        data-h2-padding="b(all, s)"
-      >
-        <div>{title && <span data-h2-font-weight="b(700)">{title}</span>}</div>
-        <div style={{ flexShrink: 0 }} data-h2-display="b(flex)">
-          <SearchForm
-            onChange={(term) => window.console.log(term)}
-            onSubmit={() => window.console.log("submit")}
-          />
-          <Spacer>
-            <Button
-              mode="outline"
-              color="black"
-              type="button"
-              data-h2-display="b(inline-flex)"
-              data-h2-align-items="b(center)"
-            >
-              <ButtonIcon icon={FilterIcon} />
-              <span>
-                {intl.formatMessage({
-                  defaultMessage: "Filters",
-                  description:
-                    "Text label for button to open filter dialog on admin tables.",
-                })}
-              </span>
-            </Button>
-          </Spacer>
-          <Spacer>
-            <div data-h2-position="b(relative)">
+      {filter && (
+        <div
+          data-h2-align-items="b(center)"
+          data-h2-display="b(flex)"
+          data-h2-bg-color="b(lightgray)"
+          data-h2-justify-content="b(space-between)"
+          data-h2-radius="b(s, s, none, none)"
+          data-h2-padding="b(all, s)"
+        >
+          <div>
+            {title && <span data-h2-font-weight="b(700)">{title}</span>}
+          </div>
+          <div style={{ flexShrink: 0 }} data-h2-display="b(flex)">
+            <SearchForm
+              onChange={(term) => window.console.log(term)}
+              onSubmit={() => window.console.log("submit")}
+            />
+            <Spacer>
               <Button
                 mode="outline"
                 color="black"
                 type="button"
                 data-h2-display="b(inline-flex)"
                 data-h2-align-items="b(center)"
-                onClick={() => setShowList(!showList)}
               >
-                <ButtonIcon icon={TableIcon} />
+                <ButtonIcon icon={FilterIcon} />
                 <span>
                   {intl.formatMessage({
-                    defaultMessage: "Columns",
+                    defaultMessage: "Filters",
                     description:
-                      "Label displayed on the Table Columns toggle button.",
+                      "Text label for button to open filter dialog on admin tables.",
                   })}
                 </span>
               </Button>
-              {showList ? (
-                <div
-                  data-h2-position="b(absolute)"
-                  data-h2-padding="b(all, xs)"
-                  data-h2-display="b(flex)"
-                  data-h2-flex-direction="b(column)"
-                  data-h2-margin="b(top, xxs)"
-                  data-h2-border="b(gray, all, solid, s)"
-                  data-h2-radius="b(s)"
-                  data-h2-shadow="b(s)"
-                  data-h2-bg-color="b(white)"
-                  style={{
-                    textAlign: "left",
-                    width: "12rem",
-                    right: 0,
-                  }}
-                >
-                  <div data-h2-margin="b(top-bottom, xxs)">
-                    <IndeterminateCheckbox
-                      {...(getToggleHideAllColumnsProps() as React.ComponentProps<
-                        typeof IndeterminateCheckbox
-                      >)}
-                    />
-                  </div>
-                  {allColumns.map((column) => (
-                    <div key={column.id} data-h2-margin="b(top-bottom, xxs)">
-                      <label htmlFor={column.Header?.toString()}>
-                        <input
-                          id={column.Header?.toString()}
-                          type="checkbox"
-                          {...column.getToggleHiddenProps()}
-                        />{" "}
-                        {column.Header}
-                      </label>
-                    </div>
-                  ))}
-                </div>
-              ) : null}
-            </div>
-          </Spacer>
-          {addBtn && (
-            <Spacer>
-              <Link
-                mode="outline"
-                color="black"
-                type="button"
-                data-h2-display="b(inline-flex)"
-                data-h2-align-items="b(center)"
-                style={{ textDecoration: "none" }}
-                href={addBtn.path}
-              >
-                <ButtonIcon icon={PlusIcon} />
-                <span>{addBtn.label}</span>
-              </Link>
             </Spacer>
-          )}
+            <Spacer>
+              <div data-h2-position="b(relative)">
+                <Button
+                  mode="outline"
+                  color="black"
+                  type="button"
+                  data-h2-display="b(inline-flex)"
+                  data-h2-align-items="b(center)"
+                  onClick={() => setShowList(!showList)}
+                >
+                  <ButtonIcon icon={TableIcon} />
+                  <span>
+                    {intl.formatMessage({
+                      defaultMessage: "Columns",
+                      description:
+                        "Label displayed on the Table Columns toggle button.",
+                    })}
+                  </span>
+                </Button>
+                {showList ? (
+                  <div
+                    data-h2-position="b(absolute)"
+                    data-h2-padding="b(all, xs)"
+                    data-h2-display="b(flex)"
+                    data-h2-flex-direction="b(column)"
+                    data-h2-margin="b(top, xxs)"
+                    data-h2-border="b(gray, all, solid, s)"
+                    data-h2-radius="b(s)"
+                    data-h2-shadow="b(s)"
+                    data-h2-bg-color="b(white)"
+                    style={{
+                      textAlign: "left",
+                      width: "12rem",
+                      right: 0,
+                    }}
+                  >
+                    <div data-h2-margin="b(top-bottom, xxs)">
+                      <IndeterminateCheckbox
+                        {...(getToggleHideAllColumnsProps() as React.ComponentProps<
+                          typeof IndeterminateCheckbox
+                        >)}
+                      />
+                    </div>
+                    {allColumns.map((column) => (
+                      <div key={column.id} data-h2-margin="b(top-bottom, xxs)">
+                        <label htmlFor={column.Header?.toString()}>
+                          <input
+                            id={column.Header?.toString()}
+                            type="checkbox"
+                            {...column.getToggleHiddenProps()}
+                          />{" "}
+                          {column.Header}
+                        </label>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            </Spacer>
+            {addBtn && (
+              <Spacer>
+                <Link
+                  mode="outline"
+                  color="black"
+                  type="button"
+                  data-h2-display="b(inline-flex)"
+                  data-h2-align-items="b(center)"
+                  style={{ textDecoration: "none" }}
+                  href={addBtn.path}
+                >
+                  <ButtonIcon icon={PlusIcon} />
+                  <span>{addBtn.label}</span>
+                </Link>
+              </Spacer>
+            )}
+          </div>
         </div>
-      </div>
+      )}
       <div
         data-h2-overflow="b(all, auto)"
         style={{ maxWidth: "100%" }}

--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -11,8 +11,10 @@ import {
 } from "react-table";
 import { Button } from "@common/components";
 import Pagination from "@common/components/Pagination";
+import { FilterIcon } from "@heroicons/react/outline";
 import GlobalFilter from "../GlobalFilter";
 import SortIcon from "./SortIcon";
+import SearchForm from "./SearchForm";
 
 export type ColumnsOf<T extends Record<string, unknown>> = Array<Column<T>>;
 
@@ -21,6 +23,7 @@ export interface TableProps<
 > {
   columns: Array<Column<T>>;
   data: Array<T>;
+  title?: string;
   filter?: boolean;
   pagination?: boolean;
   hiddenCols?: string[];
@@ -59,6 +62,7 @@ function Table<T extends Record<string, unknown>>({
   columns,
   data,
   labelledBy,
+  title,
   filter = true,
   pagination = true,
   hiddenCols = [],
@@ -159,6 +163,44 @@ function Table<T extends Record<string, unknown>>({
           </div>
         </div>
       ) : null}
+
+      <div
+        data-h2-align-items="b(center)"
+        data-h2-display="b(flex)"
+        data-h2-bg-color="b(lightgray)"
+        data-h2-justify-content="b(space-between)"
+        data-h2-radius="b(s, s, none, none)"
+        data-h2-padding="b(all, s)"
+      >
+        <div>{title && <span data-h2-font-weight="b(700)">{title}</span>}</div>
+        <div style={{ flexShrink: 0 }} data-h2-display="b(flex)">
+          <SearchForm
+            onChange={(term) => window.console.log(term)}
+            onSubmit={() => window.console.log("submit")}
+          />
+          <div data-h2-margin="b(left, s)">
+            <Button
+              mode="outline"
+              color="black"
+              type="button"
+              data-h2-display="b(inline-flex)"
+              data-h2-align-items="b(center)"
+            >
+              <FilterIcon
+                style={{ height: "1em", width: "1rem" }}
+                data-h2-margin="b(right, xs)"
+              />
+              <span>
+                {intl.formatMessage({
+                  defaultMessage: "Filters",
+                  description:
+                    "Text label for button to open filter dialog on admin tables.",
+                })}
+              </span>
+            </Button>
+          </div>
+        </div>
+      </div>
       <div
         data-h2-overflow="b(all, auto)"
         style={{ maxWidth: "100%" }}

--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -31,6 +31,7 @@ export interface TableProps<
   pagination?: boolean;
   hiddenCols?: string[];
   labelledBy?: string;
+  onSearchSubmit?: () => void;
 }
 
 const IndeterminateCheckbox: React.FC<
@@ -84,6 +85,7 @@ function Table<T extends Record<string, unknown>>({
   labelledBy,
   title,
   addBtn,
+  onSearchSubmit,
   filter = true,
   pagination = true,
   hiddenCols = [],
@@ -93,8 +95,6 @@ function Table<T extends Record<string, unknown>>({
     getTableBodyProps,
     headerGroups,
     prepareRow,
-    setGlobalFilter,
-    state,
     allColumns,
     getToggleHideAllColumnsProps,
     rows,
@@ -118,8 +118,14 @@ function Table<T extends Record<string, unknown>>({
   const [showList, setShowList] = useState(false);
   const intl = useIntl();
 
+  const handleSubmit = () => {
+    if (onSearchSubmit) {
+      onSearchSubmit();
+    }
+  };
+
   return (
-    <>
+    <div data-h2-margin="b(top-bottom, m)">
       {filter && (
         <div
           data-h2-align-items="b(center)"
@@ -130,12 +136,12 @@ function Table<T extends Record<string, unknown>>({
           data-h2-padding="b(all, s)"
         >
           <div>
-            {title && <span data-h2-font-weight="b(700)">{title}</span>}
+            {title && <span data-h2-font-weight="b(800)">{title}</span>}
           </div>
           <div style={{ flexShrink: 0 }} data-h2-display="b(flex)">
             <SearchForm
               onChange={(term) => window.console.log(term)}
-              onSubmit={() => window.console.log("submit")}
+              onSubmit={handleSubmit}
             />
             <Spacer>
               <Button
@@ -294,21 +300,60 @@ function Table<T extends Record<string, unknown>>({
           </tbody>
         </table>
       </div>
-      {pagination && (
-        <Pagination
-          currentPage={pageIndex + 1}
-          handlePageChange={(pageNumber) => gotoPage(pageNumber - 1)}
-          handlePageSize={setPageSize}
-          pageSize={pageSize}
-          pageSizes={[10, 20, 30, 40, 50]}
-          totalCount={rows.length}
-          ariaLabel={intl.formatMessage({ defaultMessage: "Table results" })}
-          color="black"
-          mode="outline"
-          data-h2-margin="b(all, none)"
-        />
-      )}
-    </>
+      <div
+        data-h2-align-items="b(center)"
+        data-h2-display="b(flex)"
+        data-h2-bg-color="b(lightgray)"
+        data-h2-justify-content="b(space-between)"
+        data-h2-radius="b(none, none, s, s)"
+        data-h2-padding="b(all, s)"
+      >
+        <div
+          data-h2-display="b(flex)"
+          data-h2-align-items="b(center)"
+          data-h2-margin="b(right, s)"
+        >
+          <p>
+            {intl.formatMessage({
+              defaultMessage: "Selected actions:",
+              description: "Label for action buttons in footer of admin table.",
+            })}
+          </p>
+          <Spacer>
+            <Button type="button" mode="solid" color="primary">
+              {intl.formatMessage({
+                defaultMessage: "Download CSV",
+                description:
+                  "Text label for button to download a csv of items in a table.",
+              })}
+            </Button>
+          </Spacer>
+          <Spacer>
+            <Button type="button" mode="solid" color="primary">
+              {intl.formatMessage({
+                defaultMessage: "Download PDF",
+                description:
+                  "Text label for button to download a pdf of items in a table.",
+              })}
+            </Button>
+          </Spacer>
+        </div>
+        {pagination && (
+          <Pagination
+            currentPage={pageIndex + 1}
+            handlePageChange={(pageNumber) => gotoPage(pageNumber - 1)}
+            handlePageSize={setPageSize}
+            pageSize={pageSize}
+            pageSizes={[10, 20, 30, 40, 50]}
+            totalCount={rows.length}
+            ariaLabel={intl.formatMessage({ defaultMessage: "Table results" })}
+            color="black"
+            mode="outline"
+            data-h2-margin="b(all, none)"
+          />
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-key */
-import React, { ReactElement, useState } from "react";
+import React, { HTMLAttributes, ReactElement, useState } from "react";
 import { useIntl } from "react-intl";
 
 import {
@@ -9,9 +9,9 @@ import {
   Column,
   usePagination,
 } from "react-table";
-import { Button } from "@common/components";
+import { Button, Link } from "@common/components";
 import Pagination from "@common/components/Pagination";
-import { FilterIcon } from "@heroicons/react/outline";
+import { FilterIcon, PlusIcon, TableIcon } from "@heroicons/react/outline";
 import GlobalFilter from "../GlobalFilter";
 import SortIcon from "./SortIcon";
 import SearchForm from "./SearchForm";
@@ -24,6 +24,10 @@ export interface TableProps<
   columns: Array<Column<T>>;
   data: Array<T>;
   title?: string;
+  addBtn?: {
+    path: string;
+    label: string;
+  };
   filter?: boolean;
   pagination?: boolean;
   hiddenCols?: string[];
@@ -58,11 +62,29 @@ const IndeterminateCheckbox: React.FC<
   );
 };
 
+const Spacer: React.FC = ({ children }) => (
+  <div data-h2-margin="b(left, s)">{children}</div>
+);
+
+const ButtonIcon: React.FC<{
+  icon: React.FC<HTMLAttributes<HTMLOrSVGElement>>;
+}> = ({ icon }) => {
+  const Icon = icon;
+
+  return (
+    <Icon
+      style={{ height: "1em", width: "1rem" }}
+      data-h2-margin="b(right, xs)"
+    />
+  );
+};
+
 function Table<T extends Record<string, unknown>>({
   columns,
   data,
   labelledBy,
   title,
+  addBtn,
   filter = true,
   pagination = true,
   hiddenCols = [],
@@ -98,72 +120,7 @@ function Table<T extends Record<string, unknown>>({
   const intl = useIntl();
 
   return (
-    <div>
-      {filter ? (
-        <div data-h2-padding="b(top-bottom, m) b(right-left, xl)">
-          <div data-h2-flex-grid="b(middle, expanded, flush, m)">
-            <div data-h2-flex-item="b(1of1) m(1of3)">
-              <GlobalFilter
-                globalFilter={state.globalFilter}
-                setGlobalFilter={setGlobalFilter}
-              />
-            </div>
-            <div
-              data-h2-flex-item="b(1of1) m(2of3)"
-              data-h2-text-align="b(center) m(right)"
-            >
-              <div data-h2-position="b(relative)" style={{ float: "right" }}>
-                <Button
-                  color="secondary"
-                  mode="inline"
-                  onClick={() => {
-                    setShowList((currentState) => !currentState);
-                  }}
-                >
-                  {intl.formatMessage({
-                    defaultMessage: "Hide/Show Table Columns",
-                    description: "Label displayed on the Table Columns toggle.",
-                  })}
-                </Button>
-                {showList ? (
-                  <div
-                    data-h2-position="b(absolute)"
-                    data-h2-margin="b(right-left, s)"
-                    data-h2-padding="b(all, s)"
-                    data-h2-border="b(gray, all, solid, s)"
-                    data-h2-radius="b(s)"
-                    data-h2-bg-color="b(white)"
-                    style={{
-                      textAlign: "left",
-                    }}
-                  >
-                    <div>
-                      <IndeterminateCheckbox
-                        {...(getToggleHideAllColumnsProps() as React.ComponentProps<
-                          typeof IndeterminateCheckbox
-                        >)}
-                      />
-                    </div>
-                    {allColumns.map((column) => (
-                      <div key={column.id}>
-                        <label htmlFor={column.Header?.toString()}>
-                          <input
-                            id={column.Header?.toString()}
-                            type="checkbox"
-                            {...column.getToggleHiddenProps()}
-                          />{" "}
-                          {column.Header}
-                        </label>
-                      </div>
-                    ))}
-                  </div>
-                ) : null}
-              </div>
-            </div>
-          </div>
-        </div>
-      ) : null}
-
+    <>
       <div
         data-h2-align-items="b(center)"
         data-h2-display="b(flex)"
@@ -178,7 +135,7 @@ function Table<T extends Record<string, unknown>>({
             onChange={(term) => window.console.log(term)}
             onSubmit={() => window.console.log("submit")}
           />
-          <div data-h2-margin="b(left, s)">
+          <Spacer>
             <Button
               mode="outline"
               color="black"
@@ -186,10 +143,7 @@ function Table<T extends Record<string, unknown>>({
               data-h2-display="b(inline-flex)"
               data-h2-align-items="b(center)"
             >
-              <FilterIcon
-                style={{ height: "1em", width: "1rem" }}
-                data-h2-margin="b(right, xs)"
-              />
+              <ButtonIcon icon={FilterIcon} />
               <span>
                 {intl.formatMessage({
                   defaultMessage: "Filters",
@@ -198,7 +152,82 @@ function Table<T extends Record<string, unknown>>({
                 })}
               </span>
             </Button>
-          </div>
+          </Spacer>
+          <Spacer>
+            <div data-h2-position="b(relative)">
+              <Button
+                mode="outline"
+                color="black"
+                type="button"
+                data-h2-display="b(inline-flex)"
+                data-h2-align-items="b(center)"
+                onClick={() => setShowList(!showList)}
+              >
+                <ButtonIcon icon={TableIcon} />
+                <span>
+                  {intl.formatMessage({
+                    defaultMessage: "Columns",
+                    description:
+                      "Label displayed on the Table Columns toggle button.",
+                  })}
+                </span>
+              </Button>
+              {showList ? (
+                <div
+                  data-h2-position="b(absolute)"
+                  data-h2-padding="b(all, xs)"
+                  data-h2-display="b(flex)"
+                  data-h2-flex-direction="b(column)"
+                  data-h2-margin="b(top, xxs)"
+                  data-h2-border="b(gray, all, solid, s)"
+                  data-h2-radius="b(s)"
+                  data-h2-shadow="b(s)"
+                  data-h2-bg-color="b(white)"
+                  style={{
+                    textAlign: "left",
+                    width: "12rem",
+                    right: 0,
+                  }}
+                >
+                  <div data-h2-margin="b(top-bottom, xxs)">
+                    <IndeterminateCheckbox
+                      {...(getToggleHideAllColumnsProps() as React.ComponentProps<
+                        typeof IndeterminateCheckbox
+                      >)}
+                    />
+                  </div>
+                  {allColumns.map((column) => (
+                    <div key={column.id} data-h2-margin="b(top-bottom, xxs)">
+                      <label htmlFor={column.Header?.toString()}>
+                        <input
+                          id={column.Header?.toString()}
+                          type="checkbox"
+                          {...column.getToggleHiddenProps()}
+                        />{" "}
+                        {column.Header}
+                      </label>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          </Spacer>
+          {addBtn && (
+            <Spacer>
+              <Link
+                mode="outline"
+                color="black"
+                type="button"
+                data-h2-display="b(inline-flex)"
+                data-h2-align-items="b(center)"
+                style={{ textDecoration: "none" }}
+                href={addBtn.path}
+              >
+                <ButtonIcon icon={PlusIcon} />
+                <span>{addBtn.label}</span>
+              </Link>
+            </Spacer>
+          )}
         </div>
       </div>
       <div
@@ -276,7 +305,7 @@ function Table<T extends Record<string, unknown>>({
           data-h2-margin="b(all, none)"
         />
       )}
-    </div>
+    </>
   );
 }
 

--- a/frontend/admin/src/js/components/Table/TableEditButton.tsx
+++ b/frontend/admin/src/js/components/Table/TableEditButton.tsx
@@ -1,32 +1,44 @@
-import React, { ReactElement } from "react";
-import { Link } from "@common/components";
+import React from "react";
 import { useIntl } from "react-intl";
+
+import { Link } from "@common/components";
+import { hidden } from "@common/helpers/format";
 
 export interface TableEditButtonProps {
   /** Id of the object in the table. */
   id: string;
   /** The current url root. */
   editUrlRoot: string;
+  /** Label for link text  */
+  label?: string;
 }
 
 function TableEditButton({
   id,
   editUrlRoot,
-}: TableEditButtonProps): ReactElement {
+  label,
+}: TableEditButtonProps): React.ReactElement {
   const intl = useIntl();
   const href = `${editUrlRoot}/${id}/edit`;
   return (
     <Link href={href} type="button" mode="inline" color="primary">
-      {intl.formatMessage({
-        defaultMessage: "Edit",
-        description: "Title displayed for the Edit column.",
-      })}
+      {intl.formatMessage(
+        {
+          defaultMessage: "Edit <hidden>{label}</hidden>",
+          description: "Title displayed for the Edit column.",
+        },
+        { label, hidden },
+      )}
     </Link>
   );
 }
 
 export default TableEditButton;
 
-export function tableEditButtonAccessor(id: string, editUrlRoot: string) {
-  return <TableEditButton id={id} editUrlRoot={editUrlRoot} />;
+export function tableEditButtonAccessor(
+  id: string,
+  editUrlRoot: string,
+  label?: string,
+) {
+  return <TableEditButton id={id} editUrlRoot={editUrlRoot} label={label} />;
 }

--- a/frontend/admin/src/js/components/user/UserPage.tsx
+++ b/frontend/admin/src/js/components/user/UserPage.tsx
@@ -1,53 +1,31 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Link } from "@common/components";
-import { useAdminRoutes } from "../../adminRoutes";
+import { UserGroupIcon } from "@heroicons/react/outline";
+import PageHeader from "@common/components/PageHeader";
+
 import { UserTableApi } from "./UserTable";
+import DashboardContentContainer from "../DashboardContentContainer";
 
 export const UserPage: React.FC = () => {
   const intl = useIntl();
-  const paths = useAdminRoutes();
   return (
-    <div>
-      <header
-        data-h2-bg-color="b(linear-70[lightpurple][lightnavy])"
-        data-h2-padding="b(top-bottom, l) b(right-left, xl)"
-      >
-        <div data-h2-flex-grid="b(middle, expanded, flush, l)">
-          <div data-h2-flex-item="b(1of1) m(3of5)">
-            <h1
-              data-h2-font-color="b(white)"
-              data-h2-font-weight="b(800)"
-              data-h2-margin="b(all, none)"
-              style={{ letterSpacing: "-2px" }}
-            >
-              {intl.formatMessage({
-                defaultMessage: "Users",
-                description:
-                  "Heading displayed above the User Table component.",
-              })}
-            </h1>
-          </div>
-          <div
-            data-h2-flex-item="b(1of1) m(2of5)"
-            data-h2-text-align="m(right)"
-          >
-            <Link
-              href={paths.userCreate()}
-              color="white"
-              mode="outline"
-              type="button"
-            >
-              {intl.formatMessage({
-                defaultMessage: "Create User",
-                description: "Heading displayed above the Create User form.",
-              })}
-            </Link>
-          </div>
-        </div>
-      </header>
+    <DashboardContentContainer>
+      <PageHeader icon={UserGroupIcon}>
+        {intl.formatMessage({
+          defaultMessage: "Users",
+          description: "Title for users page on the admin portal.",
+        })}
+      </PageHeader>
+      <p>
+        {intl.formatMessage({
+          defaultMessage:
+            "The following is a list of active users along with some of their details.",
+          description:
+            "Descriptive text about the list of users in the admin portal.",
+        })}
+      </p>
       <UserTableApi />
-    </div>
+    </DashboardContentContainer>
   );
 };
 

--- a/frontend/admin/src/js/components/user/UserTable.tsx
+++ b/frontend/admin/src/js/components/user/UserTable.tsx
@@ -103,7 +103,16 @@ export const UserTable: React.FC<AllUsersQuery & { editUrlRoot: string }> = ({
 
   const data = useMemo(() => users.filter(notEmpty), [users]);
 
-  return <Table data={data} columns={columns} />;
+  return (
+    <Table
+      data={data}
+      columns={columns}
+      title={intl.formatMessage({
+        defaultMessage: "All Users",
+        description: "Title for the admin users table",
+      })}
+    />
+  );
 };
 
 export const UserTableApi: React.FunctionComponent = () => {

--- a/frontend/admin/src/js/components/user/UserTable.tsx
+++ b/frontend/admin/src/js/components/user/UserTable.tsx
@@ -108,7 +108,7 @@ export const UserTable: React.FC<AllUsersQuery & { editUrlRoot: string }> = ({
       data={data}
       columns={columns}
       title={intl.formatMessage({
-        defaultMessage: "All Users",
+        defaultMessage: "All users",
         description: "Title for the admin users table",
       })}
       addBtn={{

--- a/frontend/admin/src/js/components/user/UserTable.tsx
+++ b/frontend/admin/src/js/components/user/UserTable.tsx
@@ -6,10 +6,17 @@ import { FromArray } from "@common/types/utilityTypes";
 import { getLanguage } from "@common/constants/localizedConstants";
 import Pending from "@common/components/Pending";
 import { useAdminRoutes } from "../../adminRoutes";
-import { AllUsersQuery, Language, useAllUsersQuery } from "../../api/generated";
+import {
+  AllUsersQuery,
+  Language,
+  useAllUsersQuery,
+  User,
+} from "../../api/generated";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
 
 type Data = NonNullable<FromArray<AllUsersQuery["users"]>>;
+
+const fullName = (u: User): string => `${u.firstName} ${u.lastName}`;
 
 // callbacks extracted to separate function to stabilize memoized component
 const languageAccessor = (
@@ -49,17 +56,11 @@ export const UserTable: React.FC<AllUsersQuery & { editUrlRoot: string }> = ({
     () => [
       {
         Header: intl.formatMessage({
-          defaultMessage: "First Name",
-          description: "Title displayed on the User table First Name column.",
+          defaultMessage: "Candidate Name",
+          description:
+            "Title displayed on the User table Candidate Name column.",
         }),
-        accessor: "firstName",
-      },
-      {
-        Header: intl.formatMessage({
-          defaultMessage: "Last Name",
-          description: "Title displayed for the User table Last Name column.",
-        }),
-        accessor: "lastName",
+        accessor: (user) => fullName(user),
       },
       {
         Header: intl.formatMessage({
@@ -93,7 +94,8 @@ export const UserTable: React.FC<AllUsersQuery & { editUrlRoot: string }> = ({
           defaultMessage: "Edit",
           description: "Title displayed for the User table Edit column.",
         }),
-        accessor: (d) => tableEditButtonAccessor(d.id, editUrlRoot), // callback extracted to separate function to stabilize memoized component
+        accessor: (d) =>
+          tableEditButtonAccessor(d.id, editUrlRoot, fullName(d)), // callback extracted to separate function to stabilize memoized component
       },
     ],
     [editUrlRoot, intl, paths],

--- a/frontend/admin/src/js/components/user/UserTable.tsx
+++ b/frontend/admin/src/js/components/user/UserTable.tsx
@@ -111,6 +111,13 @@ export const UserTable: React.FC<AllUsersQuery & { editUrlRoot: string }> = ({
         defaultMessage: "All Users",
         description: "Title for the admin users table",
       })}
+      addBtn={{
+        label: intl.formatMessage({
+          defaultMessage: "New user",
+          description: "Text label for link to create new user on admin table",
+        }),
+        path: paths.userCreate(),
+      }}
     />
   );
 };

--- a/frontend/common/src/components/Button/Button.tsx
+++ b/frontend/common/src/components/Button/Button.tsx
@@ -94,12 +94,12 @@ export const colorMap: Record<
   },
   black: {
     solid: {
-      "data-h2-border": "b(white, all, solid, s)",
+      "data-h2-border": "b(black, all, solid, s)",
       "data-h2-bg-color": "b(black)",
       "data-h2-font-color": "b(white)",
     },
     outline: {
-      "data-h2-border": "b(white, all, solid, s)",
+      "data-h2-border": "b(black, all, solid, s)",
       "data-h2-bg-color": "b([light]white[0])",
       "data-h2-font-color": "b(black)",
     },

--- a/frontend/common/src/helpers/format.tsx
+++ b/frontend/common/src/helpers/format.tsx
@@ -1,9 +1,17 @@
 import React from "react";
+
 /**
  * Wraps text in strong tags.
  * @param text text to wrap.
  */
-// eslint-disable-next-line import/prefer-default-export
 export const strong = (text: string): React.ReactNode => (
   <strong>{text}</strong>
+);
+
+/**
+ * Wraps text in span to make invisible to sighted users
+ * @param text text to wrap.
+ */
+export const hidden = (text: string): React.ReactNode => (
+  <span data-h2-visibility="b(invisible)">{text}</span>
 );


### PR DESCRIPTION
Resolves #2654 

## Summary

This updates the `<Table />` component to match the new style provided in the [prototype](https://www.figma.com/proto/XS4Ag6GWcgdq2dBlLzBkay/Admin-v3?node-id=465%3A8698&scaling=min-zoom&page-id=0%3A1&starting-point-node-id=410%3A1984&show-proto-sidebar=1).

## Notes

This is notably missing the dropdown in the search form for the column to search on. This was intentional since I believe we should source a headless component to handle these types of components. Something like [headlessui](https://headlessui.dev/react/popover#accessibility-notes) or [reachui](https://reach.tech/menu-button) is something that provides:

- Relevant `aria-*` attributes
- Focus management
- Void click to close

We used `@reach/ui` for the `<Dialog />` component, and it could be useful here as well. However, if we expect content other than `<button>` or `<a>` to exist, we may need to look into others.

## Testing

- Navigate to `/admin`
- Login with admin@test.com
- Navigate to `/admin/users`

Right now, search and filters do not function. This will be added with a few other issues this sprint.

## Screenshot

<img width="1318" alt="Screen Shot 2022-06-17 at 3 08 06 PM" src="https://user-images.githubusercontent.com/4127998/174387478-143f80b9-5ba7-468b-9398-df40a0d17c23.png">

