### PR TITLE
Bug - 3064 - Adjust Heading Styles

### DIFF
--- a/frontend/admin/src/js/components/dashboard/LatestRequestsTable.tsx
+++ b/frontend/admin/src/js/components/dashboard/LatestRequestsTable.tsx
@@ -9,6 +9,7 @@ import type { PoolCandidateSearchStatus } from "@common/api/generated";
 
 import { notEmpty } from "@common/helpers/util";
 import Pending from "@common/components/Pending";
+import Heading from "@common/components/Heading";
 import Table from "../Table";
 import type { ColumnsOf } from "../Table";
 
@@ -153,9 +154,9 @@ const LatestRequestsTable: React.FC<LatestRequestsTableProps> = ({ data }) => {
 
   return (
     <>
-      <h2
+      <Heading
         id="latest-requests-heading"
-        data-h2-font-weight="b(800)"
+        level="h2"
         data-h2-margin="b(top-bottom, m)"
       >
         {intl.formatMessage({
@@ -163,7 +164,7 @@ const LatestRequestsTable: React.FC<LatestRequestsTableProps> = ({ data }) => {
           description:
             "Title for the latests requests table in the admin dashboard",
         })}
-      </h2>
+      </Heading>
       <Table
         labelledBy="latest-requests-heading"
         data={tableData || []}

--- a/frontend/admin/src/js/components/user/GeneralInformationTab/GeneralInformationTab.tsx
+++ b/frontend/admin/src/js/components/user/GeneralInformationTab/GeneralInformationTab.tsx
@@ -22,6 +22,7 @@ import { commonMessages } from "@common/messages";
 import { BasicForm, TextArea } from "@common/components/form";
 import { unpackMaybes } from "@common/helpers/formUtils";
 import { toast } from "react-toastify";
+import Heading from "@common/components/Heading";
 import {
   AddToPoolDialog,
   ChangeDateDialog,
@@ -292,13 +293,13 @@ const CandidateStatusSection: React.FC<SectionWithPoolsProps> = ({
 
   return (
     <>
-      <h5>
+      <Heading level="h4">
         {intl.formatMessage({
           defaultMessage: "Personal status",
           description:
             "Title of the 'Personal status' section of the view-user page",
         })}
-      </h5>
+      </Heading>
       <div
         data-h2-bg-color="b(lightgray)"
         data-h2-padding="b(all, s)"
@@ -624,7 +625,7 @@ export const GeneralInformationTab: React.FC<SectionWithPoolsProps> = ({
       <TableOfContents.Content>
         {items.map((item) => (
           <TableOfContents.Section key={item.id} id={item.id}>
-            <TableOfContents.Heading icon={item.titleIcon} as="h4">
+            <TableOfContents.Heading icon={item.titleIcon} as="h3">
               {item.title}
             </TableOfContents.Heading>
             {item.content}

--- a/frontend/admin/src/js/components/user/ViewUser.tsx
+++ b/frontend/admin/src/js/components/user/ViewUser.tsx
@@ -12,6 +12,7 @@ import { Tab, TabSet } from "@common/components/tabs";
 import { commonMessages } from "@common/messages";
 import Pending from "@common/components/Pending";
 import NotFound from "@common/components/NotFound";
+import Heading from "@common/components/Heading";
 import { useAdminRoutes } from "../../adminRoutes";
 import { User, useUserQuery } from "../../api/generated";
 import DashboardContentContainer from "../DashboardContentContainer";
@@ -67,12 +68,12 @@ export const ViewUserPage: React.FC<ViewUserPageProps> = ({ user }) => {
         data-h2-margin="b(top-bottom, l)"
       >
         {userName !== " " && (
-          <h3
+          <Heading
+            level="h2"
             data-h2-margin="b(top-bottom, s) m(top-bottom, none)"
-            data-h2-font-weight="b(800)"
           >
             {userName}
-          </h3>
+          </Heading>
         )}
         <div data-h2-margin="m(left, auto)">
           <UserProfilePrintButton userId={user.id}>

--- a/frontend/common/src/components/Heading/Heading.tsx
+++ b/frontend/common/src/components/Heading/Heading.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+
+export type HeadingLevel = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  level?: HeadingLevel;
+}
+
+const styleMap: Record<HeadingLevel, Record<string, string>> = {
+  h1: {
+    "data-h2-font-weight": "b(300)",
+    "data-h2-font-size": "b(h1)",
+  },
+  h2: {
+    "data-h2-font-weight": "b(700)",
+    "data-h2-font-size": "b(h2)",
+  },
+  h3: {
+    "data-h2-font-weight": "b(400)",
+    "data-h2-font-size": "b(h3)",
+  },
+  h4: {
+    "data-h2-font-weight": "b(300)",
+    "data-h2-font-size": "b(h4)",
+  },
+  h5: {
+    "data-h2-font-weight": "b(700)",
+    "data-h2-font-size": "b(h5)",
+  },
+  h6: {
+    "data-h2-font-weight": "b(700)",
+    "data-h2-font-size": "b(h6)",
+  },
+};
+
+const Heading: React.FC<HeadingProps> = ({
+  level = "h2",
+  children,
+  ...rest
+}) => {
+  const El = level;
+
+  return (
+    <El {...styleMap[level]} {...rest}>
+      {children}
+    </El>
+  );
+};
+
+export default Heading;

--- a/frontend/common/src/components/Heading/index.ts
+++ b/frontend/common/src/components/Heading/index.ts
@@ -1,0 +1,4 @@
+import Heading, { type HeadingProps, type HeadingLevel } from "./Heading";
+
+export default Heading;
+export type { HeadingProps, HeadingLevel };

--- a/frontend/common/src/components/PageHeader/PageHeader.tsx
+++ b/frontend/common/src/components/PageHeader/PageHeader.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Heading from "../Heading";
 
 import "./pageHeader.css";
 
@@ -10,9 +11,9 @@ const PageHeader: React.FC<PageHeaderProps> = ({ icon, children, ...rest }) => {
   const Icon = icon || null;
 
   return (
-    <h1
+    <Heading
+      level="h1"
       data-h2-display="b(flex)"
-      data-h2-font-weight="b(300)"
       data-h2-align-items="b(center)"
       data-h2-margin="b(top, none) b(bottom, m)"
       data-h2-justify-content="b(start)"
@@ -20,7 +21,7 @@ const PageHeader: React.FC<PageHeaderProps> = ({ icon, children, ...rest }) => {
     >
       {Icon && <Icon className="page-header__icon" />}
       <span>{children}</span>
-    </h1>
+    </Heading>
   );
 };
 

--- a/frontend/common/src/components/TableOfContents/Heading.tsx
+++ b/frontend/common/src/components/TableOfContents/Heading.tsx
@@ -1,25 +1,23 @@
 import React, { HTMLAttributes } from "react";
 
+import Heading, { type HeadingLevel } from "../Heading";
+
 import "./heading.css";
 
 export interface HeadingProps {
-  as?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  as?: HeadingLevel;
   icon?: React.FC<{ className: string }>;
 }
 
-const Heading: React.FC<HeadingProps & HTMLAttributes<HTMLHeadingElement>> = ({
-  icon,
-  children,
-  as = "h2",
-  ...rest
-}) => {
-  const El = as;
+const TOCHeading: React.FC<
+  HeadingProps & HTMLAttributes<HTMLHeadingElement>
+> = ({ icon, children, as = "h2", ...rest }) => {
   const Icon = icon || null;
 
   return (
-    <El
+    <Heading
+      level={as}
       data-h2-display="b(flex)"
-      data-h2-font-weight="b(800)"
       data-h2-align-items="b(center)"
       data-h2-margin="b(top, none) b(bottom, m)"
       data-h2-justify-content="b(start)"
@@ -27,8 +25,8 @@ const Heading: React.FC<HeadingProps & HTMLAttributes<HTMLHeadingElement>> = ({
     >
       {Icon && <Icon className="toc-heading__icon" />}
       <span>{children}</span>
-    </El>
+    </Heading>
   );
 };
 
-export default Heading;
+export default TOCHeading;

--- a/frontend/common/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/common/src/components/UserProfile/UserProfile.tsx
@@ -162,6 +162,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ applicant, sections }) => {
           <TableOfContents.Section id="status-section">
             <HeadingWrapper show={!!sections.myStatus?.editUrl}>
               <TableOfContents.Heading
+                as="h3"
                 icon={LightBulbIcon}
                 style={{ flex: "1 1 0%" }}
               >
@@ -189,6 +190,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ applicant, sections }) => {
           <TableOfContents.Section id="pools-section">
             <HeadingWrapper show={!!sections.hiringPools?.editUrl}>
               <TableOfContents.Heading
+                as="h3"
                 icon={UserGroupIcon}
                 style={{ flex: "1 1 0%" }}
               >
@@ -220,6 +222,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ applicant, sections }) => {
           <TableOfContents.Section id="about-section">
             <HeadingWrapper show={!!sections.about?.editUrl}>
               <TableOfContents.Heading
+                as="h3"
                 icon={UserIcon}
                 style={{ flex: "1 1 0%" }}
               >
@@ -255,6 +258,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ applicant, sections }) => {
           <TableOfContents.Section id="language-section">
             <HeadingWrapper show={!!sections.language?.editUrl}>
               <TableOfContents.Heading
+                as="h3"
                 icon={ChatAlt2Icon}
                 style={{ flex: "1 1 0%" }}
               >
@@ -288,6 +292,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ applicant, sections }) => {
           <TableOfContents.Section id="government-section">
             <HeadingWrapper show={!!sections.government?.editUrl}>
               <TableOfContents.Heading
+                as="h3"
                 icon={LibraryIcon}
                 style={{ flex: "1 1 0%" }}
               >
@@ -321,6 +326,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ applicant, sections }) => {
           <TableOfContents.Section id="work-location-section">
             <HeadingWrapper show={!!sections.workLocation?.editUrl}>
               <TableOfContents.Heading
+                as="h3"
                 icon={LocationMarkerIcon}
                 style={{ flex: "1 1 0%" }}
               >
@@ -353,6 +359,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ applicant, sections }) => {
           <TableOfContents.Section id="work-preferences-section">
             <HeadingWrapper show={!!sections.workPreferences?.editUrl}>
               <TableOfContents.Heading
+                as="h3"
                 icon={ThumbUpIcon}
                 style={{ flex: "1 1 0%" }}
               >
@@ -385,6 +392,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ applicant, sections }) => {
           <TableOfContents.Section id="diversity-equity-inclusion-section">
             <HeadingWrapper show={!!sections.employmentEquity?.editUrl}>
               <TableOfContents.Heading
+                as="h3"
                 icon={UserCircleIcon}
                 style={{ flex: "1 1 0%" }}
               >
@@ -418,6 +426,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ applicant, sections }) => {
           <TableOfContents.Section id="role-and-salary-section">
             <HeadingWrapper show={!!sections.roleSalary?.editUrl}>
               <TableOfContents.Heading
+                as="h3"
                 icon={CurrencyDollarIcon}
                 style={{ flex: "1 1 0%" }}
               >
@@ -454,6 +463,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ applicant, sections }) => {
           <TableOfContents.Section id="skills-and-experience-section">
             <HeadingWrapper show={!!sections.skillsExperience?.editUrl}>
               <TableOfContents.Heading
+                as="h3"
                 icon={LightningBoltIcon}
                 style={{ flex: "1 1 0%" }}
               >


### PR DESCRIPTION
Resolves #3064 

## Summary

This introduces a new `<Heading />` component to normalize `font-size` and `font-weight` of different heading levels. It also replaces some of the new admin headings with the new component.

## Notes

The issue mentions `h2` to `h5`, on Candidate Profile tab. However, this bumps each of those up by one level each to meet WCAG 2.1.

## Screenshot
<img width="1511" alt="Screen Shot 2022-06-20 at 10 32 26 AM" src="https://user-images.githubusercontent.com/4127998/174624848-22682055-e080-4bf9-aacf-162878543e0f.png">

