### PR TITLE
WIP: Feature - 2640 - Connect User Table to API

### DIFF
--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -15,7 +15,8 @@ import { FilterIcon, PlusIcon, TableIcon } from "@heroicons/react/outline";
 import Dialog from "@common/components/Dialog";
 import { Fieldset } from "@common/components/inputPartials";
 import SortIcon from "./SortIcon";
-import SearchForm, { type SearchFormProps } from "./SearchForm";
+import SearchForm, { type SearchFormProps, type SearchBy } from "./SearchForm";
+import { Maybe } from "../../api/generated";
 
 export type ColumnsOf<T extends Record<string, unknown>> = Array<Column<T>>;
 
@@ -33,7 +34,10 @@ export interface TableProps<
   pagination?: boolean;
   hiddenCols?: string[];
   labelledBy?: string;
-  onSearchSubmit?: () => void;
+  initialFilters?: {
+    searchTerm: Maybe<SearchBy>;
+  };
+  onSearch?: (input: Maybe<SearchBy>) => void;
 }
 
 const IndeterminateCheckbox: React.FC<
@@ -89,7 +93,8 @@ function Table<T extends Record<string, unknown>>({
   labelledBy,
   title,
   addBtn,
-  onSearchSubmit,
+  onSearch,
+  initialFilters,
   searchBy,
   filter = true,
   pagination = true,
@@ -123,9 +128,9 @@ function Table<T extends Record<string, unknown>>({
   const [showList, setShowList] = useState(false);
   const intl = useIntl();
 
-  const handleSubmit = () => {
-    if (onSearchSubmit) {
-      onSearchSubmit();
+  const handleSearch = (by: Maybe<SearchBy>) => {
+    if (onSearch) {
+      onSearch(by);
     }
   };
 
@@ -149,9 +154,9 @@ function Table<T extends Record<string, unknown>>({
             data-h2-justify-content="b(flex-end)"
           >
             <SearchForm
-              onChange={(term) => window.console.log(term)}
-              onSubmit={handleSubmit}
+              onSearch={handleSearch}
               searchBy={searchBy}
+              initial={initialFilters?.searchTerm}
             />
             <Spacer>
               <Button

--- a/frontend/admin/src/js/components/user/userOperations.graphql
+++ b/frontend/admin/src/js/components/user/userOperations.graphql
@@ -1,0 +1,17 @@
+query getUsersPaginated($where: UserFilterAndOrderInput) {
+  usersPaginated(where: $where) {
+    paginatorInfo {
+      currentPage
+      perPage
+      total
+    }
+    data {
+      id
+      email
+      firstName
+      lastName
+      telephone
+      preferredLang
+    }
+  }
+}

--- a/frontend/admin/src/js/stories/User.stories.tsx
+++ b/frontend/admin/src/js/stories/User.stories.tsx
@@ -18,10 +18,20 @@ const flawedUserData = [
 const stories = storiesOf("Users", module);
 
 stories.add("Users Table", () => (
-  <UserTable users={userData} editUrlRoot="#" />
+  <UserTable
+    users={userData || []}
+    editUrlRoot="#"
+    search={{}}
+    onSearch={(by) => action(JSON.stringify(by))}
+  />
 ));
 stories.add("Users Table with flawed data", () => (
-  <UserTable users={flawedUserData} editUrlRoot="#" />
+  <UserTable
+    search={{}}
+    users={flawedUserData || []}
+    editUrlRoot="#"
+    onSearch={(by) => action(JSON.stringify(by))}
+  />
 ));
 
 stories.add("Create User Form", () => {


### PR DESCRIPTION
Resolves #2640 

## Summary

This connects the `<Table />` search form on the `<UserTable />` component to the `graphql` API and performs a search.

## Testing

1. Run `npm run codegen --workspaces`
2. Run `npm run watch --workspace=admin`
3. Navigate to `/admin/users`
4. Perform a search and confirm table is updated with appropriate data