### PR TITLE
WIP - Server paginated table

### DIFF
--- a/frontend/admin/src/js/components/TableServerSide/SortIcon.tsx
+++ b/frontend/admin/src/js/components/TableServerSide/SortIcon.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { SortAscendingIcon, SortDescendingIcon } from "@heroicons/react/solid";
+
+interface SortIconProps {
+  isSortedDesc?: boolean;
+  size?: string | number;
+}
+
+const SortIcon: React.FC<SortIconProps> = ({
+  isSortedDesc,
+  size = "0.75rem",
+}) => {
+  const iconStyles = {
+    width: size,
+    height: size,
+    marginLeft: "0.5rem",
+    flexShrink: 0,
+  };
+  return isSortedDesc ? (
+    <SortDescendingIcon style={iconStyles} />
+  ) : (
+    <SortAscendingIcon style={iconStyles} />
+  );
+};
+
+export default SortIcon;

--- a/frontend/admin/src/js/components/TableServerSide/Table.tsx
+++ b/frontend/admin/src/js/components/TableServerSide/Table.tsx
@@ -1,0 +1,233 @@
+/* eslint-disable react/jsx-key */
+import React, { ReactElement, useState } from "react";
+import { useIntl } from "react-intl";
+
+import { useTable, useGlobalFilter, useSortBy, Column } from "react-table";
+import { Button } from "@common/components";
+import Pagination from "@common/components/Pagination";
+import GlobalFilter from "../GlobalFilter";
+import SortIcon from "./SortIcon";
+import { PaginatorInfo } from "../../api/generated";
+
+export type ColumnsOf<T extends Record<string, unknown>> = Array<Column<T>>;
+
+export interface TableProps<
+  T extends Record<string, unknown> = Record<string, unknown>,
+> {
+  columns: Array<Column<T>>;
+  data: Array<T>;
+  filter?: boolean;
+  hiddenCols?: string[];
+  labelledBy?: string;
+  onChangePageNumber: (pageNumber: number) => void;
+  onChangePageSize: (pageSize: number) => void;
+  paginatorInfo: PaginatorInfo;
+}
+
+const IndeterminateCheckbox: React.FC<
+  React.HTMLProps<HTMLInputElement> & { indeterminate: boolean }
+> = ({ indeterminate, ...rest }) => {
+  const intl = useIntl();
+  const ref = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (ref.current) {
+      ref.current.indeterminate = indeterminate;
+    }
+  }, [ref, indeterminate]);
+
+  return (
+    <label htmlFor="column-fieldset-toggle-all">
+      <input
+        id="column-fieldset-toggle-all"
+        type="checkbox"
+        ref={ref}
+        {...rest}
+      />{" "}
+      {intl.formatMessage({
+        defaultMessage: "Toggle All",
+        description: "Label displayed on the Table Columns toggle fieldset.",
+      })}
+    </label>
+  );
+};
+
+function Table<T extends Record<string, unknown>>({
+  columns,
+  data,
+  labelledBy,
+  filter = true,
+  hiddenCols = [],
+  onChangePageNumber,
+  onChangePageSize,
+  paginatorInfo,
+}: TableProps<T>): ReactElement {
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    prepareRow,
+    setGlobalFilter,
+    state,
+    allColumns,
+    getToggleHideAllColumnsProps,
+    rows,
+  } = useTable<T>(
+    {
+      columns,
+      data,
+      initialState: {
+        hiddenColumns: hiddenCols,
+      },
+    },
+    useGlobalFilter,
+    useSortBy,
+  );
+
+  const [showList, setShowList] = useState(false);
+  const intl = useIntl();
+
+  return (
+    <div>
+      {filter ? (
+        <div data-h2-padding="b(top-bottom, m) b(right-left, xl)">
+          <div data-h2-flex-grid="b(middle, expanded, flush, m)">
+            <div data-h2-flex-item="b(1of1) m(1of3)">
+              <GlobalFilter
+                globalFilter={state.globalFilter}
+                setGlobalFilter={setGlobalFilter}
+              />
+            </div>
+            <div
+              data-h2-flex-item="b(1of1) m(2of3)"
+              data-h2-text-align="b(center) m(right)"
+            >
+              <div data-h2-position="b(relative)" style={{ float: "right" }}>
+                <Button
+                  color="secondary"
+                  mode="inline"
+                  onClick={() => {
+                    setShowList((currentState) => !currentState);
+                  }}
+                >
+                  {intl.formatMessage({
+                    defaultMessage: "Hide/Show Table Columns",
+                    description: "Label displayed on the Table Columns toggle.",
+                  })}
+                </Button>
+                {showList ? (
+                  <div
+                    data-h2-position="b(absolute)"
+                    data-h2-margin="b(right-left, s)"
+                    data-h2-padding="b(all, s)"
+                    data-h2-border="b(gray, all, solid, s)"
+                    data-h2-radius="b(s)"
+                    data-h2-bg-color="b(white)"
+                    style={{
+                      textAlign: "left",
+                    }}
+                  >
+                    <div>
+                      <IndeterminateCheckbox
+                        {...(getToggleHideAllColumnsProps() as React.ComponentProps<
+                          typeof IndeterminateCheckbox
+                        >)}
+                      />
+                    </div>
+                    {allColumns.map((column) => (
+                      <div key={column.id}>
+                        <label htmlFor={column.Header?.toString()}>
+                          <input
+                            id={column.Header?.toString()}
+                            type="checkbox"
+                            {...column.getToggleHiddenProps()}
+                          />{" "}
+                          {column.Header}
+                        </label>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+      <div
+        data-h2-overflow="b(all, auto)"
+        style={{ maxWidth: "100%" }}
+        data-h2-shadow="b(s)"
+      >
+        <table
+          aria-labelledby={labelledBy}
+          data-h2-width="b(100)"
+          {...getTableProps()}
+        >
+          <thead>
+            {headerGroups.map((headerGroup) => (
+              <tr {...headerGroup.getHeaderGroupProps()}>
+                {headerGroup.headers.map((column) => (
+                  <th
+                    {...column.getHeaderProps(column.getSortByToggleProps())}
+                    key={column.id}
+                    data-h2-bg-color="b(lightnavy)"
+                    data-h2-font-color="b(white)"
+                    data-h2-font-weight="b(800)"
+                    data-h2-padding="b(right-left, m) b(top-bottom, s)"
+                    data-h2-text-align="b(left)"
+                    data-h2-font-size="b(caption)"
+                  >
+                    <span
+                      data-h2-display="b(flex)"
+                      data-h2-align-items="b(center)"
+                    >
+                      <span>{column.render("Header")}</span>
+                      {column.isSorted && (
+                        <SortIcon isSortedDesc={column.isSortedDesc} />
+                      )}
+                    </span>
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody {...getTableBodyProps()}>
+            {rows.map((row) => {
+              prepareRow(row);
+              return (
+                <tr {...row.getRowProps()}>
+                  {row.cells.map((cell) => {
+                    return (
+                      <td
+                        {...cell.getCellProps()}
+                        data-h2-padding="b(all, s)"
+                        data-h2-text-align="b(left)"
+                        data-h2-font-size="b(caption)"
+                      >
+                        {cell.render("Cell")}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <Pagination
+        currentPage={paginatorInfo.currentPage}
+        handlePageChange={onChangePageNumber}
+        handlePageSize={onChangePageSize}
+        pageSize={paginatorInfo.perPage}
+        pageSizes={[10, 20, 30, 40, 50]}
+        totalCount={paginatorInfo.total}
+        ariaLabel={intl.formatMessage({ defaultMessage: "Table results" })}
+        color="black"
+        mode="outline"
+        data-h2-margin="b(all, none)"
+      />
+    </div>
+  );
+}
+
+export default Table;

--- a/frontend/admin/src/js/components/TableServerSide/TableBoolean.stories.tsx
+++ b/frontend/admin/src/js/components/TableServerSide/TableBoolean.stories.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import TableBoolean from "./TableBoolean";
+import type { TableBooleanProps } from "./TableBoolean";
+
+export default {
+  component: TableBoolean,
+  title: "Components/Table Boolean",
+} as Meta;
+
+const TemplateTableBoolean: Story<TableBooleanProps> = ({ checked }) => {
+  return <TableBoolean checked={checked} />;
+};
+
+export const TableBooleanTrue = TemplateTableBoolean.bind({});
+
+TableBooleanTrue.args = {
+  checked: true,
+};
+
+export const TableBooleanFalse = TemplateTableBoolean.bind({});
+
+TableBooleanFalse.args = {
+  checked: false,
+};

--- a/frontend/admin/src/js/components/TableServerSide/TableBoolean.tsx
+++ b/frontend/admin/src/js/components/TableServerSide/TableBoolean.tsx
@@ -1,0 +1,20 @@
+import { CheckIcon, XIcon } from "@heroicons/react/solid";
+import React, { ReactElement } from "react";
+
+export interface TableBooleanProps {
+  checked?: boolean | undefined | null;
+}
+
+function TableBoolean({ checked }: TableBooleanProps): ReactElement {
+  return checked ? (
+    <CheckIcon style={{ width: "1rem" }} />
+  ) : (
+    <XIcon style={{ width: "1rem" }} />
+  );
+}
+
+export default TableBoolean;
+
+export function tableBooleanAccessor(checked: boolean | null | undefined) {
+  return <TableBoolean checked={checked} />;
+}

--- a/frontend/admin/src/js/components/TableServerSide/TableEditButton.tsx
+++ b/frontend/admin/src/js/components/TableServerSide/TableEditButton.tsx
@@ -1,0 +1,32 @@
+import React, { ReactElement } from "react";
+import { Link } from "@common/components";
+import { useIntl } from "react-intl";
+
+export interface TableEditButtonProps {
+  /** Id of the object in the table. */
+  id: string;
+  /** The current url root. */
+  editUrlRoot: string;
+}
+
+function TableEditButton({
+  id,
+  editUrlRoot,
+}: TableEditButtonProps): ReactElement {
+  const intl = useIntl();
+  const href = `${editUrlRoot}/${id}/edit`;
+  return (
+    <Link href={href} type="button" mode="inline" color="primary">
+      {intl.formatMessage({
+        defaultMessage: "Edit",
+        description: "Title displayed for the Edit column.",
+      })}
+    </Link>
+  );
+}
+
+export default TableEditButton;
+
+export function tableEditButtonAccessor(id: string, editUrlRoot: string) {
+  return <TableEditButton id={id} editUrlRoot={editUrlRoot} />;
+}

--- a/frontend/admin/src/js/components/TableServerSide/index.ts
+++ b/frontend/admin/src/js/components/TableServerSide/index.ts
@@ -1,0 +1,16 @@
+import Table from "./Table";
+import TableBoolean, { tableBooleanAccessor } from "./TableBoolean";
+import TableEditButton, { tableEditButtonAccessor } from "./TableEditButton";
+
+import type { TableProps, ColumnsOf } from "./Table";
+import type { TableBooleanProps } from "./TableBoolean";
+import type { TableEditButtonProps } from "./TableEditButton";
+
+export default Table;
+export {
+  TableBoolean,
+  tableBooleanAccessor,
+  TableEditButton,
+  tableEditButtonAccessor,
+};
+export type { ColumnsOf, TableProps, TableBooleanProps, TableEditButtonProps };

--- a/frontend/admin/src/js/components/user/userOperations.graphql
+++ b/frontend/admin/src/js/components/user/userOperations.graphql
@@ -1,0 +1,22 @@
+query AllUsersPaginated($where: UserFilterAndOrderInput, $first: Int, $page: Int) {
+  usersPaginated(where: $where, first: $first, page: $page) {
+    data {
+      id
+      email
+      firstName
+      lastName
+      telephone
+      preferredLang
+    }
+    paginatorInfo {
+      count
+      currentPage
+      firstItem
+      hasMorePages
+      lastItem
+      lastPage
+      perPage
+      total
+    }
+  }
+}

--- a/frontend/admin/src/js/stories/User.stories.tsx
+++ b/frontend/admin/src/js/stories/User.stories.tsx
@@ -18,10 +18,24 @@ const flawedUserData = [
 const stories = storiesOf("Users", module);
 
 stories.add("Users Table", () => (
-  <UserTable users={userData} editUrlRoot="#" />
+  <UserTable
+    users={userData}
+    editUrlRoot="#"
+    onChangePageNumber={(pageNumber) =>
+      action(`onChangePageNumber: ${pageNumber}`)
+    }
+    onChangePageSize={(pageSize) => action(`onChangePageSize: ${pageSize}`)}
+  />
 ));
 stories.add("Users Table with flawed data", () => (
-  <UserTable users={flawedUserData} editUrlRoot="#" />
+  <UserTable
+    users={flawedUserData}
+    editUrlRoot="#"
+    onChangePageNumber={(pageNumber) =>
+      action(`onChangePageNumber: ${pageNumber}`)
+    }
+    onChangePageSize={(pageSize) => action(`onChangePageSize: ${pageSize}`)}
+  />
 ));
 
 stories.add("Create User Form", () => {


### PR DESCRIPTION
This WIP branch copies the `Table` directory to a `TableServerSide` directory to make a new component.  The main change is that ReactTable pagination is disabled and instead the changePage and changePageSize events are passed up to the API handler to be included in the server requests.

Note: This Table copy happened before the new styling that Eric just merged.