### PR TITLE
replace countPool with countApplicants

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -575,7 +575,7 @@ input UserPoolFilterInput {
     statuses: [PoolCandidateStatus!] = []
 }
 input ApplicantPoolFilterInput {
-    pools: [ID!]!
+    pools: [ID]!
     expiryStatus: CANDIDATE_EXPIRY_FILTER = ACTIVE
     statuses: [PoolCandidateStatus!] = [AVAILABLE]
 }
@@ -612,7 +612,7 @@ input UserFilterAndOrderInput {
 }
 
 input ApplicantFilterInput {
-    poolCandidates: ApplicantPoolFilterInput! @builder(method: "App\\Models\\User@filterByPools")
+    poolCandidates: ApplicantPoolFilterInput @builder(method: "App\\Models\\User@filterByPools")
     jobLookingStatus: [JobLookingStatus] = [ACTIVELY_LOOKING, OPEN_TO_OPPORTUNITIES] @builder(method: "App\\Models\\User@filterByJobLookingStatus")
     languageAbility: LanguageAbility @builder(method: "App\\Models\\User@filterByLanguageAbility")
     expectedClassifications: [ClassificationFilterInput] @builder(method: "App\\Models\\User@filterByClassifications")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -45,7 +45,7 @@ type Applicant {
 }
 
 input ApplicantFilterInput {
-  poolCandidates: ApplicantPoolFilterInput!
+  poolCandidates: ApplicantPoolFilterInput
   jobLookingStatus: [JobLookingStatus] = [ACTIVELY_LOOKING, OPEN_TO_OPPORTUNITIES]
   languageAbility: LanguageAbility
   expectedClassifications: [ClassificationFilterInput]
@@ -58,7 +58,7 @@ input ApplicantFilterInput {
 }
 
 input ApplicantPoolFilterInput {
-  pools: [ID!]!
+  pools: [ID]!
   expiryStatus: CANDIDATE_EXPIRY_FILTER = ACTIVE
   statuses: [PoolCandidateStatus!] = [AVAILABLE]
 }

--- a/frontend/talentsearch/src/js/api/poolCandidateOperations.graphql
+++ b/frontend/talentsearch/src/js/api/poolCandidateOperations.graphql
@@ -2,6 +2,10 @@ query countPoolCandidates($where: PoolCandidateFilterInput) {
   countPoolCandidates(where: $where)
 }
 
+query countApplicants($where: ApplicantFilterInput) {
+  countApplicants(where: $where)
+}
+
 query getSearchFormData($poolKey: String!) {
   poolByKey(key: $poolKey) {
     id

--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -8,13 +8,13 @@ import {
   Classification,
   ClassificationFilterInput,
   CmoAsset,
-  CountPoolCandidatesQueryVariables,
+  CountApplicantsQueryVariables,
   KeyFilterInput,
   Maybe,
   Pool,
-  PoolCandidateFilterInput,
+  ApplicantFilterInput,
   PoolFilterInput,
-  useCountPoolCandidatesQuery,
+  useCountApplicantsQuery,
   useGetSearchFormDataQuery,
   UserPublicProfile,
 } from "../../api/generated";
@@ -27,9 +27,9 @@ import { useTalentSearchRoutes } from "../../talentSearchRoutes";
 import { DIGITAL_CAREERS_POOL_KEY } from "../../talentSearchConstants";
 
 const candidateFilterToQueryArgs = (
-  filter: PoolCandidateFilterInput | undefined,
+  filter: ApplicantFilterInput | undefined,
   poolId: string | undefined,
-): CountPoolCandidatesQueryVariables => {
+): CountApplicantsQueryVariables => {
   /* We must pick only the fields belonging to PoolCandidateFilterInput, because its possible
      the data object contains other props at runtime, and this will cause the
      graphql operation to fail.
@@ -47,6 +47,16 @@ const candidateFilterToQueryArgs = (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): any[] | undefined => list?.map((item) => pick(item, keys));
 
+  // coercing type from maybe undefined to definitely not undefined
+  const poolCandidatesTypeChange = (
+    poolObject: ApplicantFilterInput | undefined,
+  ) => {
+    if (poolObject?.poolCandidates?.pools) {
+      return poolObject.poolCandidates.pools;
+    }
+    return [];
+  };
+
   if (filter !== null || undefined)
     return {
       where: {
@@ -57,11 +67,14 @@ const candidateFilterToQueryArgs = (
           isVisibleMinority: filter?.equity?.isVisibleMinority,
           isWoman: filter?.equity?.isWoman,
         },
-        classifications: filter?.classifications
-          ? pickMap(filter.classifications, ["group", "level"])
+        expectedClassifications: filter?.expectedClassifications
+          ? pickMap(filter.expectedClassifications, ["group", "level"])
           : [],
-        cmoAssets: filter?.cmoAssets ? pickMap(filter.cmoAssets, "key") : [],
-        pools: poolId ? [{ id: poolId }] : pickMap(filter?.pools, "id"),
+        poolCandidates: {
+          expiryStatus: null,
+          statuses: null,
+          pools: poolId ? [poolId] : poolCandidatesTypeChange(filter),
+        },
       },
     };
   return {};
@@ -74,8 +87,8 @@ export interface SearchContainerProps {
   poolOwner?: Pick<UserPublicProfile, "firstName" | "lastName" | "email">;
   candidateCount: number;
   updatePending?: boolean;
-  candidateFilter?: PoolCandidateFilterInput | undefined;
-  onUpdateCandidateFilter: (candidateFilter: PoolCandidateFilterInput) => void;
+  candidateFilter?: ApplicantFilterInput | undefined;
+  onUpdateCandidateFilter: (candidateFilter: ApplicantFilterInput) => void;
   onSubmit: () => Promise<void>;
 }
 
@@ -99,8 +112,8 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
   const intl = useIntl();
 
   const classificationFilterCount =
-    candidateFilter?.classifications?.length ?? 0;
-  const cmoAssetFilterCount = candidateFilter?.cmoAssets?.length ?? 0;
+    candidateFilter?.expectedClassifications?.length ?? 0;
+  const cmoAssetFilterCount = 0; // TODO REMOVE WHEN REPLACING CMO ASSETS
   const operationalRequirementFilterCount =
     candidateFilter?.operationalRequirements?.length ?? 0;
 
@@ -203,20 +216,21 @@ const SearchContainerApi: React.FC = () => {
   const pool = data?.poolByKey;
 
   const [candidateFilter, setCandidateFilter] = React.useState<
-    PoolCandidateFilterInput | undefined
+    ApplicantFilterInput | undefined
   >(undefined);
 
   const [{ data: countData, fetching: countFetching }] =
-    useCountPoolCandidatesQuery({
+    useCountApplicantsQuery({
       variables: candidateFilterToQueryArgs(candidateFilter, pool?.id),
     });
 
-  const candidateCount = countData?.countPoolCandidates ?? 0;
+  const candidateCount = countData?.countApplicants ?? 0;
 
   const paths = useTalentSearchRoutes();
   const onSubmit = async () => {
     // pool ID is not in the form so it must be added manually
-    if (candidateFilter && pool) candidateFilter.pools = [{ id: pool.id }];
+    if (candidateFilter?.poolCandidates && pool)
+      candidateFilter.poolCandidates.pools = [pool.id];
 
     return pushToStateThenNavigate(paths.request(), {
       candidateFilter,

--- a/frontend/talentsearch/src/js/components/search/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchForm.tsx
@@ -18,8 +18,9 @@ import {
   LanguageAbility,
   OperationalRequirement,
   PoolCandidateFilter,
-  PoolCandidateFilterInput,
+  ApplicantFilterInput,
   WorkRegion,
+  ApplicantPoolFilterInput,
 } from "../../api/generated";
 import FilterBlock from "./FilterBlock";
 
@@ -39,10 +40,11 @@ export type FormValues = Pick<
 > & {
   languageAbility: LanguageAbility | typeof NullSelection;
   classifications: string[] | undefined;
-  cmoAssets: string[] | undefined;
+  cmoAssets: string[] | undefined; // TODO REMOVE WHEN REPLACING CMOASSETS
   employmentEquity: string[] | undefined;
   educationRequirement: "has_diploma" | "no_diploma";
   poolId: string;
+  poolCandidates: ApplicantPoolFilterInput;
 };
 
 type LocationState = {
@@ -54,7 +56,7 @@ type LocationState = {
 export interface SearchFormProps {
   classifications: Classification[];
   cmoAssets: CmoAsset[];
-  onUpdateCandidateFilter: (filter: PoolCandidateFilterInput) => void;
+  onUpdateCandidateFilter: (filter: ApplicantFilterInput) => void;
 }
 
 const SearchForm: React.FC<SearchFormProps> = ({
@@ -86,16 +88,18 @@ const SearchForm: React.FC<SearchFormProps> = ({
   }, [initialValues, onUpdateCandidateFilter]);
 
   React.useEffect(() => {
-    const formValuesToData = (values: FormValues): PoolCandidateFilterInput => {
+    const formValuesToData = (values: FormValues): ApplicantFilterInput => {
       return {
-        classifications: values.classifications
+        expectedClassifications: values.classifications
           ? values.classifications
               ?.filter((id) => !!id)
               .map((id) => (id ? classificationMap.get(id) : undefined))
           : [],
-        cmoAssets: values.cmoAssets
-          ? values.cmoAssets?.map((id) => (id ? assetMap.get(id) : undefined))
-          : [],
+        poolCandidates: {
+          expiryStatus: null,
+          pools: [values.poolId],
+          statuses: null,
+        },
         operationalRequirements: values.operationalRequirements
           ? unpackMaybes(values.operationalRequirements)
           : [],
@@ -117,11 +121,11 @@ const SearchForm: React.FC<SearchFormProps> = ({
         ...(values.languageAbility !== NullSelection
           ? { languageAbility: values.languageAbility as LanguageAbility }
           : {}), // Ensure null in FormValues is converted to undefined
-        workRegions: values.workRegions || [],
+        locationPreferences: values.workRegions || [],
       };
     };
 
-    const debounceUpdate = debounce((values: PoolCandidateFilterInput) => {
+    const debounceUpdate = debounce((values: ApplicantFilterInput) => {
       if (onUpdateCandidateFilter) {
         onUpdateCandidateFilter(values);
       }


### PR DESCRIPTION
resolves #3154 

The new 2.0 query was not added to the new talentsearch, this ought to be done too
Schema changes to make it possible for there to not be a pool ID, which I do believe is needed in certain cases such as when the page first loads and there is no filtering for any pools (initial query)
CMOassets is to be replaced by Skills, for the time being it is merely API disconnected 

Testing: ensure new /search querying works as intended