### PR TITLE
Some house-cleaning on the MultiSelect and story

### DIFF
--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.stories.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.stories.tsx
@@ -1,19 +1,17 @@
-import { Meta, Story } from "@storybook/react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { uniqueId } from "lodash";
 import React from "react";
 import Form from "../BasicForm";
 import Submit from "../Submit";
 import MultiSelect from "./MultiSelect";
-import type { MultiSelectProps } from ".";
 
 export default {
   component: MultiSelect,
   title: "Form/MultiSelect",
-  args: {},
-} as Meta;
+} as ComponentMeta<typeof MultiSelect>;
 
-const TemplateMultiSelect: Story<MultiSelectProps> = (args) => {
+const TemplateMultiSelect: ComponentStory<typeof MultiSelect> = (args) => {
   return (
     <Form
       onSubmit={action("Submit Form")}

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.stories.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.stories.tsx
@@ -28,7 +28,7 @@ const Template: ComponentStory<typeof MultiSelect> = (args) => {
 export const Default = Template.bind({});
 Default.args = {
   id: uniqueId(),
-  label: "Select a dept",
+  label: "Departments",
   name: "departments",
   options: [
     { value: 1, label: "CRA" },

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.stories.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.stories.tsx
@@ -27,8 +27,8 @@ const TemplateMultiSelect: Story<MultiSelectProps> = (args) => {
   );
 };
 
-export const MultiSelectDefault = TemplateMultiSelect.bind({});
-MultiSelectDefault.args = {
+export const Default = TemplateMultiSelect.bind({});
+Default.args = {
   id: uniqueId(),
   label: "Select a dept",
   name: "departments",
@@ -39,30 +39,28 @@ MultiSelectDefault.args = {
   ],
 };
 
-export const MultiSelectRequired = TemplateMultiSelect.bind({});
-MultiSelectRequired.args = {
-  ...MultiSelectDefault.args,
+export const Required = TemplateMultiSelect.bind({});
+Required.args = {
+  ...Default.args,
   rules: { required: "This must be accepted to continue." },
 };
 
-export const MultiSelectRequiredWithInfo = TemplateMultiSelect.bind({});
-MultiSelectRequiredWithInfo.args = {
-  ...MultiSelectDefault.args,
+export const RequiredWithInfo = TemplateMultiSelect.bind({});
+RequiredWithInfo.args = {
+  ...Default.args,
   context: "We collect the above data for account purposes.",
   rules: { required: "This must be accepted to continue." },
 };
 
-export const MultiSelectRequiredWithError = TemplateMultiSelect.bind({});
-MultiSelectRequiredWithError.args = {
-  ...MultiSelectDefault.args,
+export const RequiredWithError = TemplateMultiSelect.bind({});
+RequiredWithError.args = {
+  ...Default.args,
   rules: { required: "This must be accepted to continue." },
 };
 
-export const MultiSelectRequiredWithErrorAndContext = TemplateMultiSelect.bind(
-  {},
-);
-MultiSelectRequiredWithErrorAndContext.args = {
-  ...MultiSelectDefault.args,
+export const RequiredWithErrorAndContext = TemplateMultiSelect.bind({});
+RequiredWithErrorAndContext.args = {
+  ...Default.args,
   context: "We collect the above data for account purposes.",
   rules: { required: "This must be accepted to continue." },
 };

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.stories.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { uniqueId } from "lodash";
 import React from "react";
-import Form from "../BasicForm";
+import BasicForm from "../BasicForm";
 import Submit from "../Submit";
 import MultiSelect from "./MultiSelect";
 
@@ -13,7 +13,7 @@ export default {
 
 const Template: ComponentStory<typeof MultiSelect> = (args) => {
   return (
-    <Form
+    <BasicForm
       onSubmit={action("Submit Form")}
       options={{ defaultValues: { departments: "" } }}
     >
@@ -21,7 +21,7 @@ const Template: ComponentStory<typeof MultiSelect> = (args) => {
         <MultiSelect {...args} />
         <Submit />
       </div>
-    </Form>
+    </BasicForm>
   );
 };
 

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.stories.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.stories.tsx
@@ -11,7 +11,7 @@ export default {
   title: "Form/MultiSelect",
 } as ComponentMeta<typeof MultiSelect>;
 
-const TemplateMultiSelect: ComponentStory<typeof MultiSelect> = (args) => {
+const Template: ComponentStory<typeof MultiSelect> = (args) => {
   return (
     <Form
       onSubmit={action("Submit Form")}
@@ -25,7 +25,7 @@ const TemplateMultiSelect: ComponentStory<typeof MultiSelect> = (args) => {
   );
 };
 
-export const Default = TemplateMultiSelect.bind({});
+export const Default = Template.bind({});
 Default.args = {
   id: uniqueId(),
   label: "Select a dept",
@@ -37,26 +37,26 @@ Default.args = {
   ],
 };
 
-export const Required = TemplateMultiSelect.bind({});
+export const Required = Template.bind({});
 Required.args = {
   ...Default.args,
   rules: { required: "This must be accepted to continue." },
 };
 
-export const RequiredWithInfo = TemplateMultiSelect.bind({});
+export const RequiredWithInfo = Template.bind({});
 RequiredWithInfo.args = {
   ...Default.args,
   context: "We collect the above data for account purposes.",
   rules: { required: "This must be accepted to continue." },
 };
 
-export const RequiredWithError = TemplateMultiSelect.bind({});
+export const RequiredWithError = Template.bind({});
 RequiredWithError.args = {
   ...Default.args,
   rules: { required: "This must be accepted to continue." },
 };
 
-export const RequiredWithErrorAndContext = TemplateMultiSelect.bind({});
+export const RequiredWithErrorAndContext = Template.bind({});
 RequiredWithErrorAndContext.args = {
   ...Default.args,
   context: "We collect the above data for account purposes.",

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
@@ -22,7 +22,7 @@ export interface MultiSelectProps {
   placeholder?: string;
 }
 
-const MultiSelect: React.FunctionComponent<MultiSelectProps> = ({
+const MultiSelect = ({
   id,
   context,
   label,
@@ -30,7 +30,7 @@ const MultiSelect: React.FunctionComponent<MultiSelectProps> = ({
   options,
   rules,
   placeholder,
-}) => {
+}: MultiSelectProps): JSX.Element => {
   const {
     control,
     formState: { errors },

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
@@ -37,6 +37,7 @@ const MultiSelect: React.FunctionComponent<MultiSelectProps> = ({
     formState: { errors },
   } = useFormContext();
   const error = errors[name]?.message;
+  const isRequired = !!rules?.required;
   const optionMap = useMemo(() => {
     const map = new Map();
     options.forEach((option) => {
@@ -53,7 +54,7 @@ const MultiSelect: React.FunctionComponent<MultiSelectProps> = ({
       <InputWrapper
         inputId={id}
         label={label}
-        required={!!rules?.required}
+        required={isRequired}
         context={context}
         error={error}
       >
@@ -81,7 +82,7 @@ const MultiSelect: React.FunctionComponent<MultiSelectProps> = ({
             )}
             control={control}
             rules={rules}
-            aria-required={rules?.required ? "true" : undefined}
+            aria-required={isRequired}
           />
         </div>
       </InputWrapper>

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
@@ -52,25 +52,23 @@ const MultiSelect: React.FunctionComponent<MultiSelectProps> = ({
   return (
     <div data-h2-margin="b(bottom, xxs)">
       <InputWrapper
+        {...{ label, context, error }}
         inputId={id}
-        label={label}
         required={isRequired}
-        context={context}
-        error={error}
       >
         <div style={{ width: "100%" }}>
           <Controller
-            name={name}
+            {...{ name, control, rules }}
+            aria-required={isRequired}
             render={({ field }) => (
               <ReactSelect
                 isMulti
                 {...field}
+                {...{ placeholder, options }}
                 value={field.value ? field.value.map(valueToOption) : []}
                 onChange={
                   (x) => field.onChange(x ? x.map((option) => option.value) : x) // If x is null or undefined, return it to form
                 }
-                placeholder={placeholder}
-                options={options}
                 aria-label={label}
                 styles={{
                   placeholder: (provided) => ({
@@ -80,9 +78,6 @@ const MultiSelect: React.FunctionComponent<MultiSelectProps> = ({
                 }}
               />
             )}
-            control={control}
-            rules={rules}
-            aria-required={isRequired}
           />
         </div>
       </InputWrapper>

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
@@ -32,9 +32,9 @@ const MultiSelect = ({
   placeholder,
 }: MultiSelectProps): JSX.Element => {
   const {
-    control,
     formState: { errors },
   } = useFormContext();
+
   const error = errors[name]?.message;
   const isRequired = !!rules?.required;
   const optionMap = useMemo(() => {
@@ -57,7 +57,7 @@ const MultiSelect = ({
       >
         <div style={{ width: "100%" }}>
           <Controller
-            {...{ name, control, rules }}
+            {...{ name, rules }}
             aria-required={isRequired}
             render={({ field }) => (
               <ReactSelect

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
@@ -5,8 +5,7 @@ import { InputWrapper } from "../../inputPartials";
 
 export type Option = { value: string | number; label: string };
 
-export interface MultiSelectProps
-  extends React.SelectHTMLAttributes<HTMLSelectElement> {
+export interface MultiSelectProps {
   /** HTML id used to identify the element. */
   id: string;
   /** Optional context which user can view by toggling a button. */


### PR DESCRIPTION
Extracted from #2641 as things to make that PR more straightforward

- component
  - a7a2a18a5 stopped using React.FC (no longer recommended)
  - 539813e64 removed HTMLSelectElement props from type (not used, nor needed for react-select component that it wraps)
  - 042e46c6e used `{...{ foo, bar }}` spread to send unmodified (and so less important) props into component
  - c79e16d1e use same logic for `required` and `aria-required` props, which both accept bool
  - de9aa01d6 removed use of controller in `<Controller control={control} />`, which is optional when using FormProvider (which we use)
- storybook
  - 71cd4c6a1 less verbose boilerplate
  - 3f569fe42 migrated to the new storybook types Meta/Story => ComponentMeta/ComponentStory (prop types auto-detected)
  - 16740b382 made story titles less verbose (stopped mentioning component is each)