### PR TITLE
Bug - 3139 -  Fix Lang Info Edit Path

### DIFF
--- a/frontend/common/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/common/src/components/UserProfile/UserProfile.tsx
@@ -286,7 +286,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ applicant, sections }) => {
             ) : (
               <LanguageInformationSection
                 applicant={applicant}
-                editPath={sections.workLocation?.editUrl}
+                editPath={sections.language?.editUrl}
               />
             )}
           </TableOfContents.Section>

--- a/frontend/common/src/components/context/AuthorizationProvider.tsx
+++ b/frontend/common/src/components/context/AuthorizationProvider.tsx
@@ -5,13 +5,13 @@ import { useGetMeQuery } from "../../api/generated";
 
 const AuthorizationProvider: React.FC = ({ children }) => {
   const [result] = useGetMeQuery();
-  const { data, fetching } = result;
+  const { data, fetching, stale } = result;
 
   return (
     <AuthorizationContainer
       userRoles={data?.me?.roles}
       email={data?.me?.email}
-      isLoaded={!fetching}
+      isLoaded={!fetching && !stale}
     >
       {children}
     </AuthorizationContainer>


### PR DESCRIPTION
Resolves #3139 

## Summary

Fixes a bug where the **Get Started** link in the **Language Information** section of the **User Profile** was linking to the **Work Location** edit page.

## Testing

1. Login with a new user (or one with no language info)
2. Scroll to the Language Information section
3. Click on the link "Click here to get started"
4. Ensure you are directed to the Language Information form