### PR TITLE
A11y - 3067 - Improve input required label proximity

### DIFF
--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
@@ -49,18 +49,19 @@ const Fieldset: React.FC<FieldsetProps> = ({
       <div
         data-h2-display="b(flex)"
         data-h2-flex-wrap="b(wrap)"
+        data-h2-align-items="b(center)"
+        data-h2-justify-content="b(flex-start)"
         data-h2-margin="b(bottom, xxs)"
       >
-        <div style={{ flex: "1" }}>
-          <span
-            aria-hidden="true"
-            role="presentation"
-            data-h2-font-size="b(caption)"
-          >
-            {legend}
-          </span>
-        </div>
-        <div>
+        <span
+          aria-hidden="true"
+          role="presentation"
+          data-h2-font-size="b(caption)"
+          data-h2-margin="b(right, xxs)"
+        >
+          {legend}
+        </span>
+        <div data-h2-display="b(flex)" data-h2-align-items="(center)">
           {
             /** If hideOptional is true, only show text if required is true. */
             (required || !hideOptional) && (
@@ -68,11 +69,13 @@ const Fieldset: React.FC<FieldsetProps> = ({
                 data-h2-font-size="b(caption)"
                 {...(required
                   ? { "data-h2-font-color": "b(red)" }
-                  : { "data-h2-font-color": "b(darkgray" })}
+                  : { "data-h2-font-color": "b(darkgray)" })}
               >
+                (
                 {required
                   ? intl.formatMessage(commonMessages.required)
                   : intl.formatMessage(commonMessages.optional)}
+                )
               </span>
             )
           }

--- a/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
+++ b/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
@@ -32,14 +32,18 @@ const InputLabel: React.FC<InputLabelProps> = ({
     <div
       data-h2-display="b(flex)"
       data-h2-flex-wrap="b(wrap)"
+      data-h2-align-items="b(center)"
+      data-h2-justify-content="b(flex-start)"
       data-h2-margin="b(bottom, xxs)"
     >
-      <div style={{ flex: "1" }}>
-        <label data-h2-font-size="b(caption)" htmlFor={inputId}>
-          {label}
-        </label>
-      </div>
-      <div>
+      <label
+        data-h2-font-size="b(caption)"
+        data-h2-margin="b(right, xxs)"
+        htmlFor={inputId}
+      >
+        {label}
+      </label>
+      <div data-h2-display="b(flex)" data-h2-align-items="b(center)">
         {
           /** If hideOptional is true, only show text if required is true. */
           (required || !hideOptional) && (
@@ -49,9 +53,11 @@ const InputLabel: React.FC<InputLabelProps> = ({
                 ? { "data-h2-font-color": "b(red)" }
                 : { "data-h2-font-color": "b(darkgray)" })}
             >
+              (
               {required
                 ? intl.formatMessage(commonMessages.required)
                 : intl.formatMessage(commonMessages.optional)}
+              )
             </span>
           )
         }

--- a/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
+++ b/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
@@ -33,7 +33,7 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
         data-h2-align-items="b(flex-start)"
         {...rest}
       >
-        <div style={{ width: "100%" }}>
+        <div>
           <InputLabel
             inputId={inputId}
             label={label}


### PR DESCRIPTION
Resolves #3067 

## Summary

This moves the "required" and "optional" key words next to the `label` of an input and `fieldset` to increase proximity.

## Testing

1.  Run the `common` workspace storybook
2. Check the `InputLabel` and `Fieldset` components for (required) or (optional) proximity to label

## Screenshot

<img width="1512" alt="Screen Shot 2022-06-28 at 10 13 21 AM" src="https://user-images.githubusercontent.com/4127998/176200907-763c3508-1359-419c-b03a-95af5ac75a14.png">

