### PR TITLE
Ensure field height is consistent both with/without context info

### DIFF
--- a/frontend/common/src/css/common.css
+++ b/frontend/common/src/css/common.css
@@ -16,6 +16,7 @@ textarea {
   border: none;
   padding: 0;
   vertical-align: middle;
+  line-height: 0;
   text-decoration: none;
   background: transparent;
   cursor: pointer;


### PR DESCRIPTION
The non-zero line-heigh of the icon was causing the field layout to jitter and be slightly different depending on whether context info was set. The jitter wouldn't likely be noticed in live site conditions, but the slight difference in field height when two fields are alongside might be perceptible.

## Before
[![](https://recordit.co/uxjMICz0hK.gif)](https://recordit.co/uxjMICz0hK)

## After

[![](https://recordit.co/vJGd3O92rb.gif)](https://recordit.co/vJGd3O92rb)