### PR TITLE
Bug - 2868 - Fix unauthorized component flashing

### DIFF
--- a/frontend/common/src/components/context/AuthorizationProvider.tsx
+++ b/frontend/common/src/components/context/AuthorizationProvider.tsx
@@ -2,18 +2,20 @@ import React from "react";
 
 import { AuthorizationContainer } from "../Auth";
 import { useGetMeQuery } from "../../api/generated";
+import Pending from "../Pending";
 
 const AuthorizationProvider: React.FC = ({ children }) => {
   const [result] = useGetMeQuery();
   const { data, fetching, stale } = result;
+  const isLoaded = !fetching && !stale;
 
   return (
     <AuthorizationContainer
       userRoles={data?.me?.roles}
       email={data?.me?.email}
-      isLoaded={!fetching && !stale}
+      isLoaded={isLoaded}
     >
-      {children}
+      <Pending fetching={!isLoaded}>{children}</Pending>
     </AuthorizationContainer>
   );
 };


### PR DESCRIPTION
Resolves #2868 

## Summary

This fixes an issue where the unauthorized message was flashing on the screen while the query was running. Now, the spinner is displayed while the necessary authorization query is ran.

## Testing

-  Login to `/admin`
- Refresh a page
- Confirm the spinner appears instead of "Not Authorized" while the `useGetMeQuery` is ran.