### PR TITLE
Prep for API managed table

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -522,10 +522,4 @@ RAWSQL2;
         }
         return $query;
     }
-    public function scopeOrder(Builder $query, ?array $args): Builder
-    {
-        $orderBy = isset($args['where']['orderBy']) ? $args['where']['orderBy'] : 'id';
-        $query->orderBy($orderBy);
-        return $query;
-    }
 }

--- a/api/database/migrations/2022_06_29_172400_index_user_created_at.php
+++ b/api/database/migrations/2022_06_29_172400_index_user_created_at.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class IndexUserCreatedAt extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->index('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex('users_created_at_index');
+        });
+    }
+}

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -591,7 +591,7 @@ input PoolCandidateFilterInput {
     pools: [PoolFilterInput] @builder(method: "App\\Models\\PoolCandidate@filterByPools")
 }
 
-input UserFilterAndOrderInput {
+input UserFilterInput {
     poolCandidates: UserPoolFilterInput @builder(method: "App\\Models\\User@filterByPools")
     languageAbility: LanguageAbility @builder(method: "App\\Models\\User@filterByLanguageAbility")
     expectedClassifications: [ClassificationFilterInput] @builder(method: "App\\Models\\User@filterByClassifications")
@@ -608,7 +608,6 @@ input UserFilterAndOrderInput {
     email: String @scope
     name: String @builder(method: "App\\Models\\User@filterByName")
     generalSearch: String @builder(method: "App\\Models\\User@filterByGeneralSearch")
-    orderBy: String   # This needs to be the name of the field in the database eg. first_name
 }
 
 input ApplicantFilterInput {
@@ -628,7 +627,7 @@ type Query {
     me: User @auth
     user(id: ID! @eq): User @find @guard @can(ability: "view", query: true)
     users: [User]! @all @guard @can(ability: "viewAny")
-    usersPaginated(where: UserFilterAndOrderInput): [User]! @paginate(defaultCount: 10, maxCount: 1000 scopes: ["order"]) @guard @can(ability: "viewAny")
+    usersPaginated(where: UserFilterInput orderBy: [OrderByClause!] @orderBy): [User]! @paginate(defaultCount: 10, maxCount: 1000 ) @guard @can(ability: "viewAny")
     applicant(id: ID! @eq): Applicant @find(model: "User") @guard @can(ability: "viewApplicant", query: true, model: "User")
     applicants: [Applicant]! @all(model: "User") @guard @can(ability: "viewAnyApplicants", model: "User")
     # countApplicants returns the number of candidates matching its filters, and requires no special permissions.

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -627,7 +627,7 @@ type Query {
     me: User @auth
     user(id: ID! @eq): User @find @guard @can(ability: "view", query: true)
     users: [User]! @all @guard @can(ability: "viewAny")
-    usersPaginated(where: UserFilterInput orderBy: [OrderByClause!] @orderBy): [User]! @paginate(defaultCount: 10, maxCount: 1000 ) @guard @can(ability: "viewAny")
+    usersPaginated(where: UserFilterInput orderBy: [OrderByClause!] @orderBy): [User]! @orderBy(column: "id", direction: ASC) @paginate(defaultCount: 10, maxCount: 1000 ) @guard @can(ability: "viewAny")
     applicant(id: ID! @eq): Applicant @find(model: "User") @guard @can(ability: "viewApplicant", query: true, model: "User")
     applicants: [Applicant]! @all(model: "User") @guard @can(ability: "viewAnyApplicants", model: "User")
     # countApplicants returns the number of candidates matching its filters, and requires no special permissions.

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -627,7 +627,7 @@ type Query {
     me: User @auth
     user(id: ID! @eq): User @find @guard @can(ability: "view", query: true)
     users: [User]! @all @guard @can(ability: "viewAny")
-    usersPaginated(where: UserFilterInput orderBy: [OrderByClause!] @orderBy): [User]! @orderBy(column: "id", direction: ASC) @paginate(defaultCount: 10, maxCount: 1000 ) @guard @can(ability: "viewAny")
+    usersPaginated(where: UserFilterInput orderBy: [OrderByClause!] @orderBy): [User]! @orderBy(column: "created_at", direction: DESC) @paginate(defaultCount: 10, maxCount: 1000 ) @guard @can(ability: "viewAny")
     applicant(id: ID! @eq): Applicant @find(model: "User") @guard @can(ability: "viewApplicant", query: true, model: "User")
     applicants: [Applicant]! @all(model: "User") @guard @can(ability: "viewAnyApplicants", model: "User")
     # countApplicants returns the number of candidates matching its filters, and requires no special permissions.

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -842,7 +842,8 @@ type Query {
   genericJobTitle(id: ID!): GenericJobTitle
   genericJobTitles: [GenericJobTitle]!
   usersPaginated(
-    where: UserFilterAndOrderInput
+    where: UserFilterInput
+    orderBy: [OrderByClause!]
 
     """Limits number of fetched items. Maximum allowed value: 1000."""
     first: Int = 10
@@ -1213,7 +1214,7 @@ input UserBelongsTo {
   connect: ID
 }
 
-input UserFilterAndOrderInput {
+input UserFilterInput {
   poolCandidates: UserPoolFilterInput
   languageAbility: LanguageAbility
   expectedClassifications: [ClassificationFilterInput]
@@ -1230,7 +1231,6 @@ input UserFilterAndOrderInput {
   email: String
   name: String
   generalSearch: String
-  orderBy: String
 }
 
 """A paginated list of User items."""

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -841,7 +841,7 @@ class UserTest extends TestCase
 
         // Assert query with no classifications filter will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -862,7 +862,7 @@ class UserTest extends TestCase
 
         // Assert query with one classification filter will return correct number of users.
         $results = $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -886,7 +886,7 @@ class UserTest extends TestCase
 
         // Assert query with two classification filters will return correct number of users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -912,7 +912,7 @@ class UserTest extends TestCase
 
         // Assert that adding an unknown classification to query to classification won't reduce number of users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -1940,6 +1940,25 @@ class UserTest extends TestCase
         $usersByName = User::select('id')->orderBy('first_name')->get()->toArray();
         $usersById = User::select('id')->orderBy('id')->get()->toArray();
 
+        // Assert query no orderBy given defaults to id
+        $this->graphQL(/** @lang Graphql */ '
+            query getUsersPaginated($where: UserFilterInput) {
+                usersPaginated(where: $where) {
+                    data {
+                        id
+                    }
+                }
+            }
+        ', [
+            'where' => []
+        ])->assertJson([
+            'data' => [
+                'usersPaginated' => [
+                    'data' => $usersById
+                ]
+            ]
+        ]);
+
         // Assert query orders by given attribute
         $this->graphQL(/** @lang Graphql */ '
             query getUsersPaginated($orderBy: [OrderByClause!]) {

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -177,7 +177,7 @@ class UserTest extends TestCase
 
         // Assert query with no pool filter will return all users, including unavailable
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -198,7 +198,7 @@ class UserTest extends TestCase
 
         // Assert query with pool filter but no statuses filter
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -223,7 +223,7 @@ class UserTest extends TestCase
 
         // Assert query with pool filter, only expired status
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -249,7 +249,7 @@ class UserTest extends TestCase
 
         // Assert query with pool filter, expired + available statuses
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -275,7 +275,7 @@ class UserTest extends TestCase
 
         // Assert query with pool filter, empty array of statuses will return all candidates in pool.
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -301,7 +301,7 @@ class UserTest extends TestCase
 
         // Assert query with unknown pool filter will return zero
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -381,7 +381,7 @@ class UserTest extends TestCase
 
         // Assert query with no parameters returns all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -400,7 +400,7 @@ class UserTest extends TestCase
 
         // Assert query for pool with default expiryStatus returns correct users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -426,7 +426,7 @@ class UserTest extends TestCase
 
         // Assert query with pool and expiryStatus ACTIVE returns correct users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -453,7 +453,7 @@ class UserTest extends TestCase
 
         // Assert query with pool and expiryStatus EXPIRED returns correct users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -480,7 +480,7 @@ class UserTest extends TestCase
 
         // Assert query with pool and expiryStatus ALL returns all users in pool
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -525,7 +525,7 @@ class UserTest extends TestCase
 
         // Assert query with no LanguageAbility filter will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -546,7 +546,7 @@ class UserTest extends TestCase
 
         // Assert query with ENGLISH filter will return correct user count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -569,7 +569,7 @@ class UserTest extends TestCase
 
         // Assert query with FRENCH filter will return correct user count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -592,7 +592,7 @@ class UserTest extends TestCase
 
         // Assert query with BILINGUAL filter will return correct user count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -632,7 +632,7 @@ class UserTest extends TestCase
 
         // Assert query with no classifications filter will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -653,7 +653,7 @@ class UserTest extends TestCase
 
         // Assert query with classification filter will return correct number of users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -676,7 +676,7 @@ class UserTest extends TestCase
 
         // Assert query with unknown classification filter will return zero
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -734,7 +734,7 @@ class UserTest extends TestCase
 
         // Assert query with no classifications filter will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -755,7 +755,7 @@ class UserTest extends TestCase
 
         // Assert query with classification filter will return users in range and overlapping.
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -778,7 +778,7 @@ class UserTest extends TestCase
 
         // Assert query with unknown classification filter will return zero
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -822,7 +822,7 @@ class UserTest extends TestCase
 
         // Assert query with no operationalRequirements filter will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -843,7 +843,7 @@ class UserTest extends TestCase
 
         // Assert query with empty operationalRequirements filter will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -866,7 +866,7 @@ class UserTest extends TestCase
 
         // Assert query with one operationalRequirement filter will return correct user count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -889,7 +889,7 @@ class UserTest extends TestCase
 
         // Assert query with two operationalRequirement filters will return correct user count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -912,7 +912,7 @@ class UserTest extends TestCase
 
         // Assert query with an unused operationalRequirement filter will return zero
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -948,7 +948,7 @@ class UserTest extends TestCase
 
         // Assert query with no locationPreferences filter will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -969,7 +969,7 @@ class UserTest extends TestCase
 
         // Assert query with locationPreferences filter will return correct user count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -992,7 +992,7 @@ class UserTest extends TestCase
 
         // Assert query with empty locationPreferences filter will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1028,7 +1028,7 @@ class UserTest extends TestCase
 
         // Assert query no hasDiploma filter will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1049,7 +1049,7 @@ class UserTest extends TestCase
 
         // Assert query with hasDiploma filter set to true will return correct user count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1072,7 +1072,7 @@ class UserTest extends TestCase
 
         // Assert query with hasDiploma filter set to false will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1108,7 +1108,7 @@ class UserTest extends TestCase
 
         // Assert query no wouldAcceptTemporary filter will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1129,7 +1129,7 @@ class UserTest extends TestCase
 
         // Assert query with wouldAcceptTemporary filter set to true will return correct user count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1152,7 +1152,7 @@ class UserTest extends TestCase
 
         // Assert query with wouldAcceptTemporary filter set to false will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1196,7 +1196,7 @@ class UserTest extends TestCase
 
         // Assert query with no jobLookingStatus filter will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1217,7 +1217,7 @@ class UserTest extends TestCase
 
         // Assert query with empty jobLookingStatus filter will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1240,7 +1240,7 @@ class UserTest extends TestCase
 
         // Assert query with one jobLookingStatus filter will return correct user count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1263,7 +1263,7 @@ class UserTest extends TestCase
 
         // Assert query with two jobLookingStatus filters will return correct user count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1286,7 +1286,7 @@ class UserTest extends TestCase
 
         // Assert query with an unused jobLookingStatus filter will return zero
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1359,7 +1359,7 @@ class UserTest extends TestCase
 
         // Assert query no isProfileComplete filter will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1380,7 +1380,7 @@ class UserTest extends TestCase
 
         // Assert query with isProfileComplete filter set to true will return correct user count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1403,7 +1403,7 @@ class UserTest extends TestCase
 
         // Assert query with isProfileComplete filter set to false will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1741,7 +1741,7 @@ class UserTest extends TestCase
 
         // Assert query no skills filter will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1762,7 +1762,7 @@ class UserTest extends TestCase
 
         // Assert query empty skills filter array will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1785,7 +1785,7 @@ class UserTest extends TestCase
 
         // Assert query with one skills filter will return correct user count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1808,7 +1808,7 @@ class UserTest extends TestCase
 
         // Assert query with two skills will return correct user count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1831,7 +1831,7 @@ class UserTest extends TestCase
 
         // Assert query with unused skill will return correct user count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1867,7 +1867,7 @@ class UserTest extends TestCase
 
         // Assert query no isGovEmployee filter will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1888,7 +1888,7 @@ class UserTest extends TestCase
 
         // Assert query with isGovEmployee filter set to true will return correct user count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1911,7 +1911,7 @@ class UserTest extends TestCase
 
         // Assert query with isGovEmployee filter set to false will return all users
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -1940,37 +1940,21 @@ class UserTest extends TestCase
         $usersByName = User::select('id')->orderBy('first_name')->get()->toArray();
         $usersById = User::select('id')->orderBy('id')->get()->toArray();
 
-        // Assert query no orderBy given defaults to id
-        $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
-                usersPaginated(where: $where) {
-                    data {
-                        id
-                    }
-                }
-            }
-        ', [
-            'where' => []
-        ])->assertJson([
-            'data' => [
-                'usersPaginated' => [
-                    'data' => $usersById
-                ]
-            ]
-        ]);
-
         // Assert query orders by given attribute
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
-                usersPaginated(where: $where) {
+            query getUsersPaginated($orderBy: [OrderByClause!]) {
+                usersPaginated(orderBy: $orderBy) {
                     data {
                         id
                     }
                 }
             }
         ', [
-            'where' => [
-                'orderBy' => 'first_name',
+            'orderBy' => [
+                [
+                'column' => 'first_name',
+                'order' => 'ASC'
+                ]
             ]
         ])->assertJson([
             'data' => [
@@ -2076,7 +2060,7 @@ class UserTest extends TestCase
 
         // Assert query with just pool filters will return all users in that pool
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -2102,7 +2086,7 @@ class UserTest extends TestCase
 
         // Assert query with classification filter will return users in range and overlapping in that pool
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -2129,7 +2113,7 @@ class UserTest extends TestCase
 
         // Assert query with unknown classification filter will return zero
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -2295,7 +2279,7 @@ class UserTest extends TestCase
 
         // Assert no filters returns all five users plus admin@test.com
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -2317,7 +2301,7 @@ class UserTest extends TestCase
         // Name filtering  //
         // casing should not matter
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -2339,7 +2323,7 @@ class UserTest extends TestCase
         ]);
         // ensure single letter returns all relevant results
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -2361,7 +2345,7 @@ class UserTest extends TestCase
         ]);
         // test a full name
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -2383,7 +2367,7 @@ class UserTest extends TestCase
         ]);
         // test name segments
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -2405,7 +2389,7 @@ class UserTest extends TestCase
         ]);
         // test name segments but in reverse
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -2428,7 +2412,7 @@ class UserTest extends TestCase
 
         // ensure queries with multiple filter variables apply separately as AND operations (builds off assertion above)
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -2452,7 +2436,7 @@ class UserTest extends TestCase
 
         // Assert email filter with partial email returns correct count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -2475,7 +2459,7 @@ class UserTest extends TestCase
 
         // Assert filtering for phone digit in general search returns correct count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -2498,7 +2482,7 @@ class UserTest extends TestCase
 
         // Assert filtering for last name in general search returns correct count
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total
@@ -2521,7 +2505,7 @@ class UserTest extends TestCase
 
         // Assert filtering general search and name search (both subqueries) filter as AND
         $this->graphQL(/** @lang Graphql */ '
-            query getUsersPaginated($where: UserFilterAndOrderInput) {
+            query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
                     paginatorInfo {
                         total

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -1938,9 +1938,9 @@ class UserTest extends TestCase
         // Create users for testing
         User::factory()->count(8)->create();
         $usersByName = User::select('id')->orderBy('first_name')->get()->toArray();
-        $usersById = User::select('id')->orderBy('id')->get()->toArray();
+        $usersByCreated = User::select('id')->orderByDesc('created_at')->get()->toArray();
 
-        // Assert query no orderBy given defaults to id
+        // Assert query no orderBy given defaults to created_at desc
         $this->graphQL(/** @lang Graphql */ '
             query getUsersPaginated($where: UserFilterInput) {
                 usersPaginated(where: $where) {
@@ -1954,7 +1954,7 @@ class UserTest extends TestCase
         ])->assertJson([
             'data' => [
                 'usersPaginated' => [
-                    'data' => $usersById
+                    'data' => $usersByCreated
                 ]
             ]
         ]);

--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-key */
-import React, { HTMLAttributes, ReactElement, useState } from "react";
+import React, { ReactElement, useState } from "react";
 import { useIntl } from "react-intl";
 
 import {
@@ -16,6 +16,7 @@ import Dialog from "@common/components/Dialog";
 import { Fieldset } from "@common/components/inputPartials";
 import SortIcon from "./SortIcon";
 import SearchForm, { type SearchFormProps } from "./SearchForm";
+import { IndeterminateCheckbox, Spacer, ButtonIcon } from "./tableComponents";
 
 export type ColumnsOf<T extends Record<string, unknown>> = Array<Column<T>>;
 
@@ -35,53 +36,6 @@ export interface TableProps<
   labelledBy?: string;
   onSearchSubmit?: () => void;
 }
-
-const IndeterminateCheckbox: React.FC<
-  React.HTMLProps<HTMLInputElement> & { indeterminate: boolean }
-> = ({ indeterminate, ...rest }) => {
-  const intl = useIntl();
-  const ref = React.useRef<HTMLInputElement>(null);
-
-  React.useEffect(() => {
-    if (ref.current) {
-      ref.current.indeterminate = indeterminate;
-    }
-  }, [ref, indeterminate]);
-
-  return (
-    <label htmlFor="column-fieldset-toggle-all">
-      <input
-        id="column-fieldset-toggle-all"
-        type="checkbox"
-        ref={ref}
-        {...rest}
-      />{" "}
-      {intl.formatMessage({
-        defaultMessage: "Toggle All",
-        description: "Label displayed on the Table Columns toggle fieldset.",
-      })}
-    </label>
-  );
-};
-
-const Spacer: React.FC = ({ children }) => (
-  <div data-h2-margin="b(left, s)" style={{ flexShrink: 0 }}>
-    {children}
-  </div>
-);
-
-const ButtonIcon: React.FC<{
-  icon: React.FC<HTMLAttributes<HTMLOrSVGElement>>;
-}> = ({ icon }) => {
-  const Icon = icon;
-
-  return (
-    <Icon
-      style={{ height: "1em", width: "1rem" }}
-      data-h2-margin="b(right, xs)"
-    />
-  );
-};
 
 function Table<T extends Record<string, unknown>>({
   columns,
@@ -351,8 +305,8 @@ function Table<T extends Record<string, unknown>>({
         {pagination && (
           <Pagination
             currentPage={pageIndex + 1}
-            handlePageChange={(pageNumber) => gotoPage(pageNumber - 1)}
-            handlePageSize={setPageSize}
+            onCurrentPageChange={(pageNumber) => gotoPage(pageNumber - 1)}
+            onPageSizeChange={setPageSize}
             pageSize={pageSize}
             pageSizes={[10, 20, 30, 40, 50]}
             totalCount={rows.length}

--- a/frontend/admin/src/js/components/Table/tableComponents.tsx
+++ b/frontend/admin/src/js/components/Table/tableComponents.tsx
@@ -1,0 +1,49 @@
+import React, { HTMLAttributes } from "react";
+import { useIntl } from "react-intl";
+
+export const IndeterminateCheckbox: React.FC<
+  React.HTMLProps<HTMLInputElement> & { indeterminate: boolean }
+> = ({ indeterminate, ...rest }) => {
+  const intl = useIntl();
+  const ref = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (ref.current) {
+      ref.current.indeterminate = indeterminate;
+    }
+  }, [ref, indeterminate]);
+
+  return (
+    <label htmlFor="column-fieldset-toggle-all">
+      <input
+        id="column-fieldset-toggle-all"
+        type="checkbox"
+        ref={ref}
+        {...rest}
+      />{" "}
+      {intl.formatMessage({
+        defaultMessage: "Toggle All",
+        description: "Label displayed on the Table Columns toggle fieldset.",
+      })}
+    </label>
+  );
+};
+
+export const Spacer: React.FC = ({ children }) => (
+  <div data-h2-margin="b(left, s)" style={{ flexShrink: 0 }}>
+    {children}
+  </div>
+);
+
+export const ButtonIcon: React.FC<{
+  icon: React.FC<HTMLAttributes<HTMLOrSVGElement>>;
+}> = ({ icon }) => {
+  const Icon = icon;
+
+  return (
+    <Icon
+      style={{ height: "1em", width: "1rem" }}
+      data-h2-margin="b(right, xs)"
+    />
+  );
+};

--- a/frontend/common/src/components/Pagination/Pagination.stories.tsx
+++ b/frontend/common/src/components/Pagination/Pagination.stories.tsx
@@ -72,12 +72,12 @@ const TemplatePaginationWithData: Story<PaginationProps> = () => {
         ariaLabel="Pagination table"
         color="black"
         mode="outline"
-        handlePageSize={setPageSize}
+        onPageSizeChange={setPageSize}
         currentPage={currentPage}
         pageSize={pageSize}
         siblingCount={1}
         totalCount={skills.length}
-        handlePageChange={(page) => setCurrentPage(page)}
+        onCurrentPageChange={(page) => setCurrentPage(page)}
       />
     </div>
   );

--- a/frontend/common/src/components/Pagination/Pagination.tsx
+++ b/frontend/common/src/components/Pagination/Pagination.tsx
@@ -27,9 +27,9 @@ export interface PaginationProps {
   /** Button mode type  */
   mode: "solid" | "outline" | "inline";
   /** Callback that changes to the page number value. */
-  handlePageChange: (pageNumber: number) => void;
+  onCurrentPageChange: (pageNumber: number) => void;
   /** Callback that changes max number of visible items on a single page */
-  handlePageSize: (pageSize: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
 }
 
 const Pagination: React.FunctionComponent<PaginationProps> = ({
@@ -41,8 +41,8 @@ const Pagination: React.FunctionComponent<PaginationProps> = ({
   ariaLabel,
   color,
   mode,
-  handlePageChange,
-  handlePageSize,
+  onCurrentPageChange,
+  onPageSizeChange,
   ...rest
 }) => {
   const intl = useIntl();
@@ -58,11 +58,11 @@ const Pagination: React.FunctionComponent<PaginationProps> = ({
   const lessThanTwoItems = currentPage === 0 || paginationRange.length < 2;
 
   const nextPage = () => {
-    handlePageChange(currentPage + 1);
+    onCurrentPageChange(currentPage + 1);
   };
 
   const previousPage = () => {
-    handlePageChange(currentPage - 1);
+    onCurrentPageChange(currentPage - 1);
   };
 
   const lastPage = paginationRange[paginationRange.length - 1];
@@ -147,7 +147,7 @@ const Pagination: React.FunctionComponent<PaginationProps> = ({
                     { pageNumber },
                   )}
                   aria-current={current}
-                  onClick={() => handlePageChange(Number(pageNumber))}
+                  onClick={() => onCurrentPageChange(Number(pageNumber))}
                   data-h2-margin="b(right-left, xxs)"
                   data-h2-padding="b(top-bottom, xxs) b(right-left, xs)"
                 >
@@ -193,7 +193,7 @@ const Pagination: React.FunctionComponent<PaginationProps> = ({
             value={currentPage}
             onChange={(e) => {
               const p = e.target.value ? Number(e.target.value) : 0;
-              handlePageChange(p);
+              onCurrentPageChange(p);
             }}
             disabled={lessThanTwoItems}
             min={1}
@@ -207,7 +207,7 @@ const Pagination: React.FunctionComponent<PaginationProps> = ({
           style={{ cursor: "pointer" }}
           value={pageSize}
           onChange={(e) => {
-            handlePageSize(Number(e.target.value));
+            onPageSizeChange(Number(e.target.value));
           }}
         >
           {pageSizes.map((numOfRows) => (

--- a/frontend/talentsearch/src/js/components/skills/AddSkillsToExperience/AddSkillsToExperience.tsx
+++ b/frontend/talentsearch/src/js/components/skills/AddSkillsToExperience/AddSkillsToExperience.tsx
@@ -134,10 +134,10 @@ const AddSkillsToExperience: React.FunctionComponent<
             currentPage={frequentSkillsPagination.currentPage}
             pageSize={resultsPaginationPageSize}
             totalCount={frequentSkills.length}
-            handlePageChange={(page) =>
+            onCurrentPageChange={(page) =>
               frequentSkillsPagination.setCurrentPage(page)
             }
-            handlePageSize={frequentSkillsPagination.setPageSize}
+            onPageSizeChange={frequentSkillsPagination.setPageSize}
           />
         </Tab>
         <Tab
@@ -175,10 +175,10 @@ const AddSkillsToExperience: React.FunctionComponent<
             currentPage={mainstreamSkillsPagination.currentPage}
             pageSize={resultsPaginationPageSize}
             totalCount={familyFilteredSkills.length}
-            handlePageChange={(page) =>
+            onCurrentPageChange={(page) =>
               mainstreamSkillsPagination.setCurrentPage(page)
             }
-            handlePageSize={mainstreamSkillsPagination.setPageSize}
+            onPageSizeChange={mainstreamSkillsPagination.setPageSize}
           />
         </Tab>
         <Tab
@@ -213,10 +213,10 @@ const AddSkillsToExperience: React.FunctionComponent<
             currentPage={keywordSearchPagination.currentPage}
             pageSize={resultsPaginationPageSize}
             totalCount={searchFilteredSkills.length}
-            handlePageChange={(page) =>
+            onCurrentPageChange={(page) =>
               keywordSearchPagination.setCurrentPage(page)
             }
-            handlePageSize={keywordSearchPagination.setPageSize}
+            onPageSizeChange={keywordSearchPagination.setPageSize}
           />
         </Tab>
         <Tab


### PR DESCRIPTION
Related to (but will not close) #3173 
The main changes will happen in a followup PR.
This PR sets some groundwork to make the changes in the followup PR clearer.

## This branch
- Updates the paginated query in the API to use the built-in lighthouse ordering functionality instead of the recreated scope 
  - We lose the "order by id by default" behavior
  - But we gain the ability to order by multiple columns and order by ASC and DESC
- Factors out some lower-order table components to a separate file.  This will be shared with the API driven table
- Renames the Pagination component props from `handle*` to `on*`

## Remarks
- I hate that we have to specify the column name for ordering instead of the field name.  It's leaking the implementation into our interface.  I haven't figured out a way around this though.

## Testing
- [ ] phpunit tests complete
- [ ] Users table in Admin behaves normally
- [ ] AddSkillsToExpierience in Profiles behaves normally