### PR TITLE
adjust language seeding

### DIFF
--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -36,6 +36,7 @@ class UserFactory extends Factory
         $randomDepartment = Department::inRandomOrder()->first();
         $randomClassification = Classification::inRandomOrder()->first();
         $isGovEmployee = $this->faker->boolean();
+        $hasBeenEvaluated = $this->faker->boolean();
 
         return [
             'first_name' => $this->faker->firstName(),
@@ -69,21 +70,21 @@ class UserFactory extends Factory
             'looking_for_english' => $this->faker->boolean(),
             'looking_for_french' => $this->faker->boolean(),
             'looking_for_bilingual' => $this->faker->boolean(),
-            'bilingual_evaluation' => $this->faker->optional->randomElement([
-                'COMPLETED_ENGLISH',
-                'COMPLETED_FRENCH',
-                'NOT_COMPLETED',
-            ]),
-            'comprehension_level' => $this->faker->randomElement(
+            'bilingual_evaluation' => $hasBeenEvaluated ? $this->faker->randomElement([
+                    'COMPLETED_ENGLISH',
+                    'COMPLETED_FRENCH',
+                    ]) : 'NOT_COMPLETED',
+
+            'comprehension_level' => $hasBeenEvaluated ? $this->faker->randomElement(
                 $evaluatedLanguageAbility
-            ),
-            'written_level' => $this->faker->randomElement(
+            ) : null,
+            'written_level' => $hasBeenEvaluated ? $this->faker->randomElement(
                 $evaluatedLanguageAbility
-            ),
-            'verbal_level' => $this->faker->randomElement(
+            ) : null,
+            'verbal_level' => $hasBeenEvaluated ? $this->faker->randomElement(
                 $evaluatedLanguageAbility
-            ),
-            'estimated_language_ability' => $this->faker->optional->randomElement([
+            ) : null,
+            'estimated_language_ability' => $hasBeenEvaluated ? null : $this->faker->randomElement([
                 'BEGINNER',
                 'INTERMEDIATE',
                 'ADVANCED'


### PR DESCRIPTION
resolves #2736 

Specifically the second bit about the acceptance criteria. 
Two cases: 
-> evaluation true in which case random levels are assigned to assessments and estimated ability is nulled
-> evaluation false in which case null assigned to assessments and estimated ability is randomly picked

Now a state of not_complete with assessment levels should not occur, as well as estimated ability with assessed levels
The latter added as per language profile form, you either did an assessment or you add estimated proficiency 

Testing: Migrate and view data in adminer
