### PR TITLE
Tooling - 2776 - Add IAP Mobile Snapshots

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -43,4 +43,5 @@ toastify
 Unencrypted
 unlocalized
 urql
+viewports
 WCAG

--- a/frontend/indigenousapprenticeship/src/js/components/Home/Home.stories.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/Home/Home.stories.tsx
@@ -24,6 +24,19 @@ const TemplateFrenchHome: Story = () => {
   );
 };
 
+const VIEWPORTS = [
+  375, // Modern iPhone
+  1366, // Most common viewport size that falls within chromatic range
+];
+
 export const EnglishHomeStory = TemplateEnglishHome.bind({});
 
+EnglishHomeStory.parameters = {
+  chromatic: { viewports: VIEWPORTS },
+};
+
 export const FrenchHomeStory = TemplateFrenchHome.bind({});
+
+FrenchHomeStory.parameters = {
+  chromatic: { viewports: VIEWPORTS },
+};


### PR DESCRIPTION
Resolves #2776 

## Summary

This adds mobile snapshots to the IAP homepage stories.

## Testing

1. Navigate to the [Chromatic build](https://www.chromatic.com/build?appId=61e099a1bb1465003a73d3ce&number=2719)
2. Confirm the English and French Homepage stories for IAP have desktop and mobile snapshots