### PR TITLE
Improve graphql devtools for VSCode

### DIFF
--- a/api/_lighthouse_ide_helper.php
+++ b/api/_lighthouse_ide_helper.php
@@ -84,6 +84,20 @@ namespace Illuminate\Testing {
         }
 
         /**
+         * Assert the response contains an error with the given debug message.
+         *
+         * Requires the config `lighthouse.debug` to include the option \GraphQL\Error\DebugFlag::INCLUDE_DEBUG_MESSAGE.
+         *
+         * @param  string  $message  the expected debug message
+         *
+         * @return $this
+         */
+        public function assertGraphQLDebugMessage(string $message): self
+        {
+            return $this;
+        }
+
+        /**
          * Assert the response contains no errors.
          *
          * @return $this

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -827,7 +827,7 @@ input UpdateUserAsUserInput {
     hasDiploma: Boolean @rename(attribute: "has_diploma")
     locationPreferences: [WorkRegion] @rename(attribute: "location_preferences")
     locationExemptions: String @rename(attribute: "location_exemptions")
-    acceptedOperationalRequirements: [OperationalRequirement] @rename(attribute: accepted_operational_requirements)
+    acceptedOperationalRequirements: [OperationalRequirement] @rename(attribute: "accepted_operational_requirements")
     expectedSalary: [SalaryRange] @rename(attribute: "expected_salary")
     expectedClassifications: ClassificationBelongsToMany
     expectedGenericJobTitles: GenericJobTitleBelongsToMany

--- a/api/programmatic-types.graphql
+++ b/api/programmatic-types.graphql
@@ -18,14 +18,50 @@ represent free-form human-readable text.
 """
 scalar String
 
+"""The `Boolean` scalar type represents `true` or `false`."""
+scalar Boolean
+
 """
 The `Int` scalar type represents non-fractional signed whole numeric
 values. Int can represent values between -(2^31) and 2^31 - 1. 
 """
 scalar Int
 
-"""The `Boolean` scalar type represents `true` or `false`."""
-scalar Boolean
+"""A paginated list of User items."""
+type UserPaginator {
+  """Pagination information about the list of items."""
+  paginatorInfo: PaginatorInfo!
+
+  """A list of User items."""
+  data: [User!]!
+}
+
+"""Information about pagination using a fully featured paginator."""
+type PaginatorInfo {
+  """Number of items in the current page."""
+  count: Int!
+
+  """Index of the current page."""
+  currentPage: Int!
+
+  """Index of the first item in the current page."""
+  firstItem: Int
+
+  """Are there more pages after this one?"""
+  hasMorePages: Boolean!
+
+  """Index of the last item in the current page."""
+  lastItem: Int
+
+  """Index of the last available page."""
+  lastPage: Int!
+
+  """Number of items per page."""
+  perPage: Int!
+
+  """Number of total available items."""
+  total: Int!
+}
 
 """
 The `Float` scalar type represents signed double-precision fractional
@@ -279,33 +315,6 @@ input OrderByClause {
 
   """The direction that is used for ordering."""
   order: SortOrder!
-}
-
-"""Information about pagination using a fully featured paginator."""
-type PaginatorInfo {
-  """Number of items in the current page."""
-  count: Int!
-
-  """Index of the current page."""
-  currentPage: Int!
-
-  """Index of the first item in the current page."""
-  firstItem: Int
-
-  """Are there more pages after this one?"""
-  hasMorePages: Boolean!
-
-  """Index of the last item in the current page."""
-  lastItem: Int
-
-  """Index of the last available page."""
-  lastPage: Int!
-
-  """Number of items per page."""
-  perPage: Int!
-
-  """Number of total available items."""
-  total: Int!
 }
 
 """Information about pagination using a simple paginator."""

--- a/api/schema-directives.graphql
+++ b/api/schema-directives.graphql
@@ -19,6 +19,17 @@ directive @canAsParent(
   ability: String!
 ) repeatable on FIELD_DEFINITION
 
+# Directive class: Nuwave\Lighthouse\Testing\MockDirective
+"""
+Allows you to easily hook up a resolver for an endpoint.
+"""
+directive @mock(
+    """
+    Specify a unique key for the mock resolver.
+    """
+    key: String = "default"
+) on FIELD_DEFINITION
+
 # Directive class: Nuwave\Lighthouse\Auth\AuthDirective
 """
 Return the currently authenticated user as the result of a query.
@@ -71,7 +82,7 @@ directive @can(
   """
   Statically defined arguments that are passed to `Gate::check`.
 
-  You may pass pass arbitrary GraphQL literals,
+  You may pass arbitrary GraphQL literals,
   e.g.: [1, 2, 3] or { foo: "bar" }
   """
   args: CanArgs
@@ -754,69 +765,6 @@ Any constant literal value: https://graphql.github.io/graphql-spec/draft/#sec-In
 """
 scalar BuilderValue
 
-# Directive class: Nuwave\Lighthouse\Schema\Directives\CacheDirective
-"""
-Cache the result of a resolver.
-"""
-directive @cache(
-  """
-  Set the duration it takes for the cache to expire in seconds.
-  If not given, the result will be stored forever.
-  """
-  maxAge: Int
-
-  """
-  Limit access to cached data to the currently authenticated user.
-  When the field is accessible by guest users, this will not have
-  any effect, they will access a shared cache.
-  """
-  private: Boolean = false
-) on FIELD_DEFINITION
-
-# Directive class: Nuwave\Lighthouse\Schema\Directives\CacheKeyDirective
-"""
-Specify the field to use as a key when creating a cache.
-"""
-directive @cacheKey on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
-
-# Directive class: Nuwave\Lighthouse\Schema\Directives\ClearCacheDirective
-"""
-Clear a resolver cache by tags.
-"""
-directive @clearCache(
-  """
-  Name of the parent type of the field to clear.
-  """
-  type: String!
-
-  """
-  Source of the parent ID to clear.
-  """
-  idSource: ClearCacheId
-
-  """
-  Name of the field to clear.
-  """
-  field: String
-) on FIELD_DEFINITION
-
-"""
-Options for the `id` argument on `@clearCache`.
-
-Exactly one of the fields must be given.
-"""
-input ClearCacheIdSource {
-  """
-  Path of an argument the client passes to the field `@clearCache` is applied to.
-  """
-  argument: String
-
-  """
-  Path of a field in the result returned from the field `@clearCache` is applied to.
-  """
-  field: String
-}
-
 # Directive class: Nuwave\Lighthouse\Schema\Directives\ComplexityDirective
 """
 Customize the calculation of a fields complexity score before execution.
@@ -829,6 +777,12 @@ directive @complexity(
   """
   resolver: String
 ) on FIELD_DEFINITION
+
+# Directive class: Nuwave\Lighthouse\Schema\Directives\ConvertEmptyStringsToNullDirective
+"""
+Replaces `""` with `null`.
+"""
+directive @convertEmptyStringsToNull on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 # Directive class: Nuwave\Lighthouse\Schema\Directives\CountDirective
 """
@@ -851,6 +805,17 @@ directive @count(
   Apply scopes to the underlying query.
   """
   scopes: [String!]
+
+  """
+  Count only rows where the given columns are non-null.
+  `*` counts every row.
+  """
+  columns: [String!]! = ["*"]
+
+  """
+  Should exclude duplicated rows?
+  """
+  distinct: Boolean! = false
 ) on FIELD_DEFINITION
 
 # Directive class: Nuwave\Lighthouse\Schema\Directives\CreateDirective
@@ -912,6 +877,18 @@ directive @deprecated(
   """
   reason: String = "No longer supported"
 ) on FIELD_DEFINITION | ENUM_VALUE
+
+# Directive class: Nuwave\Lighthouse\Schema\Directives\DropArgsDirective
+"""
+Apply the @drop directives on the incoming arguments.
+"""
+directive @dropArgs on FIELD_DEFINITION
+
+# Directive class: Nuwave\Lighthouse\Schema\Directives\DropDirective
+"""
+Ignore the user given value, don't pass it to the resolver.
+"""
+directive @drop on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
 # Directive class: Nuwave\Lighthouse\Schema\Directives\EnumDirective
 """
@@ -1339,7 +1316,51 @@ directive @morphToMany(
   Apply scopes to the underlying query.
   """
   scopes: [String!]
+
+  """
+  Allows to resolve the relation as a paginated list.
+  """
+  type: MorphToManyType
+
+  """
+  Allow clients to query paginated lists without specifying the amount of items.
+  Overrules the `pagination.default_count` setting from `lighthouse.php`.
+  """
+  defaultCount: Int
+
+  """
+  Limit the maximum amount of items that clients can request from paginated lists.
+  Overrules the `pagination.max_count` setting from `lighthouse.php`.
+  """
+  maxCount: Int
+
+  """
+  Specify a custom type that implements the Edge interface
+  to extend edge object.
+  Only applies when using Relay style "connection" pagination.
+  """
+  edgeType: String
 ) on FIELD_DEFINITION
+
+"""
+Options for the `type` argument of `@morphToMany`.
+"""
+enum MorphToManyType {
+    """
+    Offset-based pagination, similar to the Laravel default.
+    """
+    PAGINATOR
+
+    """
+    Offset-based pagination like the Laravel "Simple Pagination", which does not count the total number of records.
+    """
+    SIMPLE
+
+    """
+    Cursor-based pagination, compatible with the Relay specification.
+    """
+    CONNECTION
+}
 
 # Directive class: Nuwave\Lighthouse\Schema\Directives\NamespaceDirective
 """

--- a/graphql.config.yml
+++ b/graphql.config.yml
@@ -1,7 +1,8 @@
 # This config file allows the GraphQL.vscode-graphql extension to provide support for graphql files.
 projects:
-  api:
-    schema: "graphql/schema.graphql"
-  admin:
-    schema: "graphql/schema.graphql"
-    documents: "src/js/**/*.graphql"
+  gctalent:
+    schema:
+      - "api/graphql/schema.graphql"
+      - "api/schema-directives.graphql"
+      - "api/programmatic-types.graphql"
+    documents: "frontend/**/js/**/*.graphql"


### PR DESCRIPTION
By updating the graphql.config file, and re-running [php artisan lighthouse:ide-helper](https://lighthouse-php.com/4/api-reference/commands.html#ide-helper) I was finally able to get the [vscode-graphql](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) extension running without error!

It now provides Go to Definition, autocomplete, and much improved validation for the schema file and any operations.

The artisan lighthouse command I ran is supposed to run everytime we run composer install, so I'm not sure how those files ended up out of date...

Instructions for Testing
1. Checkout this branch
2. Open in VS Code
3. Install vscode-graphql extension (or restart VS Code if already installed)
4. Open the schema.graphql file
5. Try the "Go to Definition" functionality (alt+ click on a Type reference to go to the full definition)
6. Replace the type of a field with nonsense, and confirm that it highlights the error. Do the same with a directive.