### PR TITLE
Bug - 3227 - Restore Client Side Table Search

### DIFF
--- a/frontend/admin/src/js/components/Table/SearchForm.tsx
+++ b/frontend/admin/src/js/components/Table/SearchForm.tsx
@@ -4,10 +4,9 @@ import { useAsyncDebounce } from "react-table";
 
 export interface SearchFormProps {
   onChange: (val: string | undefined) => void;
-  value: string | undefined;
 }
 
-const SearchForm: React.FC<SearchFormProps> = ({ onChange, value }) => {
+const SearchForm: React.FC<SearchFormProps> = ({ onChange }) => {
   const intl = useIntl();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/admin/src/js/components/Table/SearchForm.tsx
+++ b/frontend/admin/src/js/components/Table/SearchForm.tsx
@@ -1,97 +1,29 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { SearchIcon } from "@heroicons/react/outline";
-import { debounce } from "lodash";
-
-import DropdownMenu, {
-  MenuButton,
-  MenuItem,
-  MenuList,
-} from "@common/components/DropdownMenu";
-import { Button } from "@common/components";
-
-export interface SearchColumn {
-  value: string;
-  label: string;
-}
+import { useAsyncDebounce } from "react-table";
 
 export interface SearchFormProps {
-  onChange: (term: string) => void;
-  onSubmit: () => void;
-  searchBy?: SearchColumn[];
+  onChange: (val: string | undefined) => void;
+  value: string | undefined;
 }
 
-const SearchForm: React.FC<SearchFormProps> = ({
-  onChange,
-  onSubmit,
-  searchBy,
-}) => {
+const SearchForm: React.FC<SearchFormProps> = ({ onChange, value }) => {
   const intl = useIntl();
-  const [searchTerm, setSearchTerm] = React.useState<string>("");
-  const [column, setColumn] = React.useState<SearchColumn | null>(null);
-  const debouncedUpdate = debounce(onChange, 100);
 
-  React.useEffect(() => {
-    debouncedUpdate(searchTerm);
-  }, [searchTerm, debouncedUpdate]);
-
-  const handleChange = (e: React.FormEvent<HTMLInputElement>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.preventDefault();
-    setSearchTerm(e.currentTarget.value);
+    onChange(e.target.value);
   };
+
+  const debouncedHandleChange = useAsyncDebounce(handleChange, 200);
 
   return (
     <div data-h2-display="b(flex)" data-h2-margin="b(left, s)">
-      <Button
-        type="button"
-        onClick={onSubmit}
-        color="black"
-        mode="outline"
-        data-h2-radius="b(s, none, none, s)"
-        style={{
-          flexShrink: 0,
-          borderRight: "none",
-        }}
-      >
-        <SearchIcon
-          style={{ width: "1em", height: "1em", verticalAlign: "top" }}
-        />
-        <span data-h2-visibility="b(invisible)">
-          {intl.formatMessage({
-            defaultMessage: "Search",
-            description: "Text label for admin table search button",
-          })}
-        </span>
-      </Button>
-      {searchBy && searchBy.length ? (
-        <DropdownMenu>
-          <MenuButton
-            color="black"
-            data-h2-radius="b(none)"
-            style={{ flexShrink: 0 }}
-          >
-            {column
-              ? column.label
-              : intl.formatMessage({
-                  defaultMessage: "All table",
-                  description:
-                    "Text in table search form column dropdown when no column is selected.",
-                })}
-          </MenuButton>
-          <MenuList>
-            {searchBy.map((col) => (
-              <MenuItem key={col.value} onSelect={() => setColumn(col)}>
-                {col.label}
-              </MenuItem>
-            ))}
-          </MenuList>
-        </DropdownMenu>
-      ) : null}
       <input
         name="search"
         id="tableSearch"
         type="text"
-        value={searchTerm}
+        onChange={debouncedHandleChange}
         aria-label={intl.formatMessage({
           defaultMessage: "Search Table",
           description: "Label for search field on admin tables.",
@@ -101,9 +33,8 @@ const SearchForm: React.FC<SearchFormProps> = ({
           description:
             "Placeholder displayed on the Global Filter form Search field.",
         })}
-        onChange={handleChange}
         data-h2-border="b(black, all, solid, s)"
-        data-h2-radius="b(none, s, s, none)"
+        data-h2-radius="b(s)"
         data-h2-bg-color="b(white)"
         data-h2-padding="b(top-bottom, xs) b(right-left, s)"
         data-h2-font-size="b(caption) m(normal)"

--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -102,7 +102,7 @@ function Table<T extends Record<string, unknown>>({
     getToggleHideAllColumnsProps,
     rows,
     setGlobalFilter,
-    state: { globalFilter, pageIndex, pageSize },
+    state: { pageIndex, pageSize },
     gotoPage,
     setPageSize,
     page,
@@ -141,10 +141,7 @@ function Table<T extends Record<string, unknown>>({
             data-h2-display="b(flex)"
             data-h2-justify-content="b(flex-end)"
           >
-            <SearchForm
-              onChange={setGlobalFilter}
-              value={globalFilter?.target?.value}
-            />
+            <SearchForm onChange={setGlobalFilter} />
             <Spacer>
               <div data-h2-position="b(relative)">
                 <Button

--- a/frontend/admin/src/js/components/user/UserTable.tsx
+++ b/frontend/admin/src/js/components/user/UserTable.tsx
@@ -111,32 +111,6 @@ export const UserTable: React.FC<AllUsersQuery & { editUrlRoot: string }> = ({
         defaultMessage: "All users",
         description: "Title for the admin users table",
       })}
-      searchBy={[
-        {
-          value: "name",
-          label: intl.formatMessage({
-            defaultMessage: "Name",
-            description:
-              "Text displayed in user table search form dropdown for name column",
-          }),
-        },
-        {
-          value: "email",
-          label: intl.formatMessage({
-            defaultMessage: "Email",
-            description:
-              "Text displayed in user table search form dropdown for email column",
-          }),
-        },
-        {
-          value: "phone",
-          label: intl.formatMessage({
-            defaultMessage: "Phone number",
-            description:
-              "Text displayed in user table search form dropdown for phone number column",
-          }),
-        },
-      ]}
       addBtn={{
         label: intl.formatMessage({
           defaultMessage: "New user",


### PR DESCRIPTION
Resolves #3227 

## Summary

This modifies the styled client side table to use `react-table` search, restoring the ability for users to search tables not using the new api driven table.

## Testing

1. Navigate to any of the `/admin` pages that include a table
2. Type in the search field
3. Ensure the table updates with appropriate rows