### PR TITLE
Bug - 3250 -  no toasts appearing

### DIFF
--- a/frontend/admin/src/js/components/PoolDashboard.tsx
+++ b/frontend/admin/src/js/components/PoolDashboard.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Routes } from "universal-router";
 import { RouterResult } from "@common/helpers/router";
-import Toast from "@common/components/Toast";
 import { AuthenticationContext } from "@common/components/Auth";
 import { Helmet } from "react-helmet";
 import { getLocale } from "@common/helpers/localize";
@@ -276,7 +275,6 @@ export const PoolDashboard: React.FC = () => {
       <Helmet>
         <html lang={getLocale(intl)} />
       </Helmet>
-      <Toast />
     </>
   );
 };

--- a/frontend/admin/src/js/dashboard.tsx
+++ b/frontend/admin/src/js/dashboard.tsx
@@ -3,16 +3,20 @@ import ReactDOM from "react-dom";
 
 import ContextContainer from "@common/components/context";
 import { Messages } from "@common/components/LanguageRedirectContainer";
+import { Toast } from "@common/components";
 import { PoolDashboard } from "./components/PoolDashboard";
 import adminRoutes from "./adminRoutes";
 import * as adminFrench from "./lang/frCompiled.json";
 
 ReactDOM.render(
-  <ContextContainer
-    homePath={adminRoutes("").home()}
-    messages={adminFrench as Messages}
-  >
-    <PoolDashboard />
-  </ContextContainer>,
+  <>
+    <ContextContainer
+      homePath={adminRoutes("").home()}
+      messages={adminFrench as Messages}
+    >
+      <PoolDashboard />
+    </ContextContainer>
+    <Toast />
+  </>,
   document.getElementById("app"),
 );

--- a/frontend/common/src/components/Pending/Loading.tsx
+++ b/frontend/common/src/components/Pending/Loading.tsx
@@ -33,7 +33,7 @@ const Loading = ({ inline = false, live }: LoadingProps): JSX.Element => {
       data-h2-align-items="b(center)"
       data-h2-justify-content="b(center)"
       style={{
-        backgroundColor: `rgba(255,255,255,0.9)`,
+        backgroundColor: `rgba(255,255,255,0.99)`,
         bottom: 0,
         left: 0,
         right: 0,

--- a/frontend/common/src/components/Pending/Loading.tsx
+++ b/frontend/common/src/components/Pending/Loading.tsx
@@ -33,7 +33,7 @@ const Loading = ({ inline = false, live }: LoadingProps): JSX.Element => {
       data-h2-align-items="b(center)"
       data-h2-justify-content="b(center)"
       style={{
-        backgroundColor: `rgba(255,255,255,0.99)`,
+        backgroundColor: `rgba(255,255,255,0.95)`,
         bottom: 0,
         left: 0,
         right: 0,

--- a/frontend/common/src/components/Pending/Pending.tsx
+++ b/frontend/common/src/components/Pending/Pending.tsx
@@ -20,12 +20,7 @@ const Pending = ({
   children,
 }: PendingProps): JSX.Element => {
   if (fetching) {
-    return (
-      <>
-        <Loading inline={inline} live={live} />
-        {children}
-      </>
-    );
+    return <Loading inline={inline} live={live} />;
   }
 
   if (error) {

--- a/frontend/common/src/components/Pending/Pending.tsx
+++ b/frontend/common/src/components/Pending/Pending.tsx
@@ -20,7 +20,12 @@ const Pending = ({
   children,
 }: PendingProps): JSX.Element => {
   if (fetching) {
-    return <Loading inline={inline} live={live} />;
+    return (
+      <>
+        <Loading inline={inline} live={live} />
+        {children}
+      </>
+    );
   }
 
   if (error) {

--- a/frontend/talentsearch/src/js/components/Router.tsx
+++ b/frontend/talentsearch/src/js/components/Router.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useIntl } from "react-intl";
 import { Routes } from "universal-router";
 import { RouterResult } from "@common/helpers/router";
-import Toast from "@common/components/Toast";
 import { checkFeatureFlag } from "@common/helpers/runtimeVariable";
 import { AuthenticationContext } from "@common/components/Auth";
 import { Button } from "@common/components";
@@ -332,7 +331,6 @@ export const Router: React.FC = () => {
       <Helmet>
         <html lang={getLocale(intl)} />
       </Helmet>
-      <Toast />
       {loggedIn && (
         <Dialog
           confirmation

--- a/frontend/talentsearch/src/js/pageContainer.tsx
+++ b/frontend/talentsearch/src/js/pageContainer.tsx
@@ -3,16 +3,20 @@ import ReactDOM from "react-dom";
 
 import ContextContainer from "@common/components/context";
 import { Messages } from "@common/components/LanguageRedirectContainer";
+import { Toast } from "@common/components";
 import { Router } from "./components/Router";
 import talentSearchRoutes from "./talentSearchRoutes";
 import * as talentSearchFrench from "./lang/frCompiled.json";
 
 ReactDOM.render(
-  <ContextContainer
-    homePath={talentSearchRoutes("").home()}
-    messages={talentSearchFrench as Messages}
-  >
-    <Router />
-  </ContextContainer>,
+  <>
+    <ContextContainer
+      homePath={talentSearchRoutes("").home()}
+      messages={talentSearchFrench as Messages}
+    >
+      <Router />
+    </ContextContainer>
+    <Toast />
+  </>,
   document.getElementById("app"),
 );


### PR DESCRIPTION
Resolves #3250 

## Summary

This makes it so the `<Pending />` component renders the children in addition to the spinner so that the `<ToastContainer>` is always available.

## Testing

1. Edit a user (or other item in admin)
2. Submit
3. Confirm toast appears on top of the loading spinner.

## Screenshot

<img width="1503" alt="Screen Shot 2022-07-04 at 1 18 53 PM" src="https://user-images.githubusercontent.com/4127998/177197758-33ded08e-d169-4c4f-a652-4a96e333ba25.png">

