### PR TITLE
Bug - 3201 - Remove nested paragraph tags

### DIFF
--- a/frontend/common/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
@@ -212,13 +212,13 @@ const LanguageInformationSection: React.FunctionComponent<{
             </a>
           )}
           {!editPath && (
-            <p>
+            <>
               {intl.formatMessage({
                 defaultMessage: "No information has been provided.",
                 description:
                   "Message on Admin side when user not filled language section.",
               })}
-            </p>
+            </>
           )}
         </p>
       )}


### PR DESCRIPTION
Resolves #3201 

## Summary

This replaces the `<p>` with a `React.Fragment` to avoid nesting of `<p>` on the Candidate profile tab in admin.