### PR TITLE
CoE Translations

### DIFF
--- a/api/database/seeders/CmoAssetSeeder.php
+++ b/api/database/seeders/CmoAssetSeeder.php
@@ -67,8 +67,8 @@ class CmoAssetSeeder extends Seeder
             [
                 'key' => 'infrastructure_ops',
                 'name' => [
-                    'en' => 'Infrastructure/Operations',
-                    'fr' => 'Infrastructure/Opérations'
+                    'en' => 'Infrastructure / Operations',
+                    'fr' => 'Infrastructure / Opérations'
                 ],
             ],
             [

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -343,37 +343,9 @@
     "defaultMessage": "Soumis",
     "description": "Default text for submitted button."
   },
-  "3HAFul": {
-    "defaultMessage": "Déplacements selon les besoins",
-    "description": "The operational requirement described as travel as required."
-  },
-  "8QkGEF": {
-    "defaultMessage": "Transport de matériel jusqu'à 20 kg",
-    "description": "The operational requirement described as transport equipment up to 20kg."
-  },
-  "Dk5E2+": {
-    "defaultMessage": "Garde 24/7",
-    "description": "The operational requirement described as 24/7 on-call."
-  },
-  "hCy99h": {
-    "defaultMessage": "Travailler des quarts de travail",
-    "description": "The operational requirement described as shift work."
-  },
-  "vhFe42": {
-    "defaultMessage": "Permis de conduire",
-    "description": "The operational requirement described as driver's license."
-  },
   "6I3OCB": {
     "defaultMessage": "Travailler les fins de semaine",
     "description": "The operational requirement described as work weekends."
-  },
-  "Bw9k0J": {
-    "defaultMessage": "Travailler des heures supplémentaires prévues",
-    "description": "The operational requirement described as scheduled overtime."
-  },
-  "eJCfxF": {
-    "defaultMessage": "Travailler des heures supplémentaires à court préavis",
-    "description": "The operational requirement described as short notice overtime."
   },
   "ACppq6": {
     "defaultMessage": "Placé Occasionnels",
@@ -844,7 +816,7 @@
     "description": "The operational requirement described as 24/7 on-call."
   },
   "janplU": {
-    "defaultMessage": "Bilingues (français et anglais)",
+    "defaultMessage": "Bilingue (français et anglais)",
     "description": "The language ability is bilingual - both English and French."
   },
   "jhImZp": {
@@ -937,10 +909,6 @@
   "p8Gi1k": {
     "defaultMessage": "Modifier les préférences de travail",
     "description": "Text on link to update a users work preferences."
-  },
-  "pXDHYb": {
-    "defaultMessage": "Voir l'expérience :",
-    "description": "Tabs title for the users experience list in applicant profile."
   },
   "pbXAOp": {
     "defaultMessage": "Afficher {numOfRows}",
@@ -1041,5 +1009,33 @@
   "zKjtAa": {
     "defaultMessage": "Territoires du Nord-Ouest",
     "description": "Northwest Territories selection for province or territory input"
+  },
+  "4pZrst": {
+    "defaultMessage": "Être disponible, disposé(e) et apte à voyager au besoin.",
+    "description": "The operational requirement described as travel as required."
+  },
+  "Gc9PeN": {
+    "defaultMessage": "Être disponible, disposé(e) et apte à travailler par quarts.",
+    "description": "The operational requirement described as shift work."
+  },
+  "KzhnAz": {
+    "defaultMessage": "Être disponible, disposé(e) et apte à travailler des heures supplémentaires (occasionnellement).",
+    "description": "The operational requirement described as occasional overtime."
+  },
+  "QhRU19": {
+    "defaultMessage": "Doit posséder un permis de conduire valide ou une mobilité personnelle du degré normalement associé à la possession d'un permis de conduire valide.",
+    "description": "The operational requirement described as driver's license."
+  },
+  "XpK4rL": {
+    "defaultMessage": "Être disponible, disposé(e) et apte à transporter, soulever et déposer de l'équipement pouvant peser jusqu'à 20 kg.",
+    "description": "The operational requirement described as transport equipment up to 20kg."
+  },
+  "vDrJp6": {
+    "defaultMessage": "Être disponible, disposé(e) et apte à travailler sur appel 24/7.",
+    "description": "The operational requirement described as 24/7 on-call."
+  },
+  "vvtqRv": {
+    "defaultMessage": "Être disponible, disposé(e) et apte à travailler des heures supplémentaires (régulièrement).",
+    "description": "The operational requirement described as regular overtime."
   }
 }

--- a/frontend/talentsearch/src/js/components/search/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchForm.tsx
@@ -414,8 +414,8 @@ const SearchForm: React.FC<SearchFormProps> = ({
           <Checklist
             idPrefix="employmentEquity"
             legend={intl.formatMessage({
-              defaultMessage: "Conditions of employment",
-              description: "Legend for the Conditions of employment checklist",
+              defaultMessage: "Employment equity groups",
+              description: "Legend for the employment equity checklist",
             })}
             name="employmentEquity"
             context={intl.formatMessage(

--- a/frontend/talentsearch/src/js/components/search/deprecated/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/deprecated/SearchForm.tsx
@@ -385,8 +385,8 @@ export const SearchForm: React.FunctionComponent<SearchFormProps> = ({
           <Checklist
             idPrefix="employmentEquity"
             legend={intl.formatMessage({
-              defaultMessage: "Conditions of employment",
-              description: "Legend for the Conditions of employment checklist",
+              defaultMessage: "Employment equity groups",
+              description: "Legend for the employment equity checklist",
             })}
             name="employmentEquity"
             context={intl.formatMessage(

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -1657,10 +1657,6 @@
     "defaultMessage": "<bold>Remarque :</bold> Si vous sélectionnez plus d'un groupe visé par l'équité en matière d'emploi, TOUS les candidats qui se sont déclarés membres de N'IMPORTE LEQUEL des groupes visés par l'équité en matière d'emploi sélectionnés seront recommandés. Si vous avez des exigences plus détaillées concernant l'équité en matière d'emploi, veuillez nous en faire part dans la section des commentaires du formulaire de soumission.",
     "description": "Context for employment equity filter in search form."
   },
-  "ps2IK6": {
-    "defaultMessage": "Conditions d'emploi",
-    "description": "Legend for the Conditions of employment checklist"
-  },
   "sdUnnh": {
     "defaultMessage": "Je m'identifie comme faisant partie d'un ou de plusieurs groupes de minorités visibles.",
     "description": "Label for the checkbox to identify as a visible minority under employment equity"
@@ -1668,5 +1664,13 @@
   "z44LTK": {
     "defaultMessage": "Tel que défini par <link>Statistique Canada</link>.",
     "description": "Link to Statistics Canada's employment equity definitions"
+  },
+  "sk9CeW": {
+    "defaultMessage": "Langue",
+    "description": "Legend for the Working Language Ability radio buttons"
+  },
+  "m3qn9l": {
+    "defaultMessage": "Groupes visés par l’équité en matière d’emploi",
+    "description": "Legend for the employment equity checklist"
   }
 }


### PR DESCRIPTION
This branch updates some translations on the search page.

Note 1:
The scope is a little bigger since Corinne send a few extra translation requests

Note 2:
@tristan-orourke : Many of Corinne's requests are actually for data in the database.  The CmoAssetSeeder.php and PoolSeeder will need to be rerun in production after this merge.

Note 3:
Corinne translated `Availability, willingness and ability to work overtime as required.` as `Être disponible, disposé(e) et apte à travailler des heures supplémentaires au besoin.`.  However, we have two different strings:
- Availability, willingness and ability to work overtime (Occasionally).
- Availability, willingness and ability to work overtime (Regularly).

Which I've translated as:
- Être disponible, disposé(e) et apte à travailler des heures supplémentaires (occasionnellement).
- Être disponible, disposé(e) et apte à travailler des heures supplémentaires (régulièrement).
Could a French speaker confirm this is OK?


Testing instructions:
Rebuild the site (including seeders) and check Corinne's list: https://talent-cloud.slack.com/files/USLACKBOT/F03N53ZEM6J/fwd__talent_platform_-_french_text

Closes #3226 