### PR TITLE
Bug - 3207 - Fix missing intl text

### DIFF
--- a/frontend/common/src/components/Dialog/Dialog.tsx
+++ b/frontend/common/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useIntl } from "react-intl";
 import { XIcon } from "@heroicons/react/outline";
 
 import Overlay from "./Overlay";
@@ -46,6 +47,7 @@ const Dialog: React.FC<DialogProps> = ({
   footer,
   children,
 }) => {
+  const intl = useIntl();
   return (
     <Overlay
       isOpen={isOpen}
@@ -84,7 +86,12 @@ const Dialog: React.FC<DialogProps> = ({
                   "data-h2-font-color": "b(white)",
                 })}
           >
-            <span data-h2-visibility="b(invisible)">Close dialog</span>
+            <span data-h2-visibility="b(invisible)">
+              {intl.formatMessage({
+                defaultMessage: "Close dialog",
+                description: "Text for the button to close a modal dialog.",
+              })}
+            </span>
             <XIcon className="dialog-close__icon" />
           </button>
           <div

--- a/frontend/common/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
@@ -27,6 +27,10 @@ import {
   isWorkExperience,
 } from "../../../types/ExperienceUtils";
 
+const purpleText = (chunks: string[]) => (
+  <span data-h2-font-color="b(lightpurple)">{...chunks}</span>
+);
+
 export interface SkillAccordionProps {
   skill: Skill;
 }
@@ -43,7 +47,7 @@ const SkillAccordion: React.FunctionComponent<SkillAccordionProps> = ({
     const { title, description, startDate, endDate, details } = experience;
     return (
       <>
-        <p data-h2-font-color="b(lightpurple)"> {title} </p>
+        <p data-h2-font-color="b(lightpurple)">{title}</p>
         <p>{getDateRange({ endDate, startDate, intl, locale })}</p>
         <p> {description} </p>
         <p> {details} </p>
@@ -110,16 +114,13 @@ const SkillAccordion: React.FunctionComponent<SkillAccordionProps> = ({
     return (
       <>
         <p>
-          <span data-h2-font-color="b(lightpurple)" title="award">
-            {" "}
-            {title}{" "}
-          </span>
           {intl.formatMessage(
             {
-              defaultMessage: " issued by {issuedBy}",
+              defaultMessage:
+                "<purpleText>{title}</purpleText> issued by {issuedBy}",
               description: "The award title is issued by some group",
             },
-            { issuedBy },
+            { issuedBy, title, purpleText },
           )}
         </p>
         <p>
@@ -158,13 +159,13 @@ const SkillAccordion: React.FunctionComponent<SkillAccordionProps> = ({
     return (
       <>
         <p>
-          <span data-h2-font-color="b(lightpurple)"> {title} </span>
           {intl.formatMessage(
             {
-              defaultMessage: " at {organization}",
+              defaultMessage:
+                "<purpleText>{title}</purpleText> at {organization}",
               description: "Title at organization",
             },
-            { organization },
+            { organization, title, purpleText },
           )}
         </p>
         <p>{getDateRange({ endDate, startDate, intl, locale })}</p>
@@ -198,15 +199,12 @@ const SkillAccordion: React.FunctionComponent<SkillAccordionProps> = ({
     return (
       <>
         <p>
-          <span data-h2-font-color="b(lightpurple)" title="work">
-            {role}{" "}
-          </span>
           {intl.formatMessage(
             {
-              defaultMessage: " at {division}",
+              defaultMessage: "<purpleText>{role}</purpleText> at {division}",
               description: "Role at Team, Group or Division",
             },
-            { division },
+            { division, role, purpleText },
           )}
         </p>
         <p>{organization}</p>


### PR DESCRIPTION
Resolves #3207 

## Summary

This fixes two components that had text not wrapped in `intl.formatMessage`.

- Dialog close button
- SkillAccordion title and role