### PR TITLE
Bug - Missing French versions of URLs

### DIFF
--- a/frontend/talentsearch/src/js/components/diversityEquityInclusion/dialogs/DisabilityDialog.tsx
+++ b/frontend/talentsearch/src/js/components/diversityEquityInclusion/dialogs/DisabilityDialog.tsx
@@ -85,7 +85,13 @@ const DisabilityDialog: React.FC<EquityDialogProps> = ({
             "Definition of accepted ways to identify as person with a disability.",
         })}
       </p>
-      <Definition url="https://www23.statcan.gc.ca/imdb/p3VD.pl?Function=getVD&TVD=247841&CVD=247841&CLV=0&MLV=1&D=1" />
+      <Definition
+        url={
+          intl.locale === "en"
+            ? "https://www23.statcan.gc.ca/imdb/p3VD.pl?Function=getVD&TVD=247841&CVD=247841&CLV=0&MLV=1&D=1"
+            : "https://www23.statcan.gc.ca/imdb/p3VD_f.pl?Function=getVD&TVD=247841&CVD=247841&CLV=0&MLV=1&D=1"
+        }
+      />
     </Dialog>
   );
 };

--- a/frontend/talentsearch/src/js/components/diversityEquityInclusion/dialogs/IndigenousDialog.tsx
+++ b/frontend/talentsearch/src/js/components/diversityEquityInclusion/dialogs/IndigenousDialog.tsx
@@ -84,7 +84,13 @@ const IndigenousDialog: React.FC<EquityDialogProps> = ({
           description: "Definition of accepted ways to identify as indigenous.",
         })}
       </p>
-      <Definition url="https://www23.statcan.gc.ca/imdb/p3Var.pl?Function=DEC&Id=42927" />
+      <Definition
+        url={
+          intl.locale === "en"
+            ? "https://www23.statcan.gc.ca/imdb/p3Var.pl?Function=DEC&Id=42927"
+            : "https://www23.statcan.gc.ca/imdb/p3Var_f.pl?Function=DEC&Id=42927"
+        }
+      />
     </Dialog>
   );
 };

--- a/frontend/talentsearch/src/js/components/diversityEquityInclusion/dialogs/VisibleMinorityDialog.tsx
+++ b/frontend/talentsearch/src/js/components/diversityEquityInclusion/dialogs/VisibleMinorityDialog.tsx
@@ -86,7 +86,13 @@ const VisibleMinorityDialog: React.FC<EquityDialogProps> = ({
             "Definition of accepted ways to identify as a visible minority",
         })}
       </p>
-      <Definition url="https://www23.statcan.gc.ca/imdb/p3Var.pl?Function=DEC&Id=45152" />
+      <Definition
+        url={
+          intl.locale === "en"
+            ? "https://www23.statcan.gc.ca/imdb/p3Var.pl?Function=DEC&Id=45152"
+            : "https://www23.statcan.gc.ca/imdb/p3Var_f.pl?Function=DEC&Id=45152"
+        }
+      />
     </Dialog>
   );
 };

--- a/frontend/talentsearch/src/js/components/diversityEquityInclusion/dialogs/WomanDialog.tsx
+++ b/frontend/talentsearch/src/js/components/diversityEquityInclusion/dialogs/WomanDialog.tsx
@@ -84,7 +84,13 @@ const WomanDialog: React.FC<EquityDialogProps> = ({
           description: "Definition of accepted ways to identify as a women",
         })}
       </p>
-      <Definition url="https://www23.statcan.gc.ca/imdb/p3VD.pl?Function=getVD&TVD=1326727&CVD=1326727&CLV=0&MLV=1&D=1" />
+      <Definition
+        url={
+          intl.locale === "en"
+            ? "https://www23.statcan.gc.ca/imdb/p3VD.pl?Function=getVD&TVD=1326727&CVD=1326727&CLV=0&MLV=1&D=1"
+            : "https://www23.statcan.gc.ca/imdb/p3VD_f.pl?Function=getVD&TVD=1326727&CVD=1326727&CLV=0&MLV=1&D=1"
+        }
+      />
     </Dialog>
   );
 };

--- a/frontend/talentsearch/src/js/components/roleSalaryForm/RoleSalaryForm.tsx
+++ b/frontend/talentsearch/src/js/components/roleSalaryForm/RoleSalaryForm.tsx
@@ -263,7 +263,9 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
                   link: (msg: string) =>
                     link(
                       msg,
-                      "https://www.canada.ca/en/government/system/digital-government/gcdigital-community/careers-digital.html",
+                      intl.locale === "en"
+                        ? "https://www.canada.ca/en/government/system/digital-government/gcdigital-community/careers-digital.html"
+                        : "https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/collectivite-gcnumerique/carriere-domaine-numerique.html",
                     ),
                 },
               )}

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -565,7 +565,7 @@
     "description": "Message in My Status Form."
   },
   "/AJCvK": {
-    "defaultMessage": "Ajouter<hidden>{title} </hidden>au profil",
+    "defaultMessage": "Ajouter <hidden>{title} </hidden>au profil",
     "description": "Text label for button to add employment equity category to profile."
   },
   "/DCykA": {
@@ -980,7 +980,7 @@
     "description": "Label displayed on Personal Experience form for current experience bounded box"
   },
   "OQ+K+X": {
-    "defaultMessage": "Retirer<hidden>{title} </hidden>du profil",
+    "defaultMessage": "Retirer <hidden>{title} </hidden>du profil",
     "description": "Text label for button to remove employment equity category from profile."
   },
   "OT0QP3": {


### PR DESCRIPTION
Resolves #3208.

### Steps to Test (classifications link)
1. Navigate to `en/talent/profile/role-salary`
2. Click language toggle link to switch to French
3. Click "Cliquez ici pour en savoir plus sur les classifications dans la collectivité numérique du gouvernement du Canada." that should take you to: https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/collectivite-gcnumerique/carriere-domaine-numerique.html

### Steps to Test (dialogs)
1. Navigate to `en/talent/profile/diversity-and-inclusion`
2. Click language toggle link to switch to French
3. Click "Ajouter au profil" or "Retirer du profil"
4. In dialog that opens, click "Statistique Canada" link that should take you to: (see [issue](https://github.com/GCTC-NTGC/gc-digital-talent/issues/3208) for list)