### PR TITLE
Select subset of rows v2

### DIFF
--- a/frontend/admin/src/js/components/apiManagedTable/BasicTable.tsx
+++ b/frontend/admin/src/js/components/apiManagedTable/BasicTable.tsx
@@ -24,6 +24,7 @@ function BasicTable<T extends Record<string, unknown>>({
   hiddenColumnIds,
 }: BasicTableProps<T>): ReactElement {
   const intl = useIntl();
+
   // calculate a new sortingRule and emit it to parent
   const handleColumnSelect = (column: Column<T>): void => {
     // some columns are not sortable
@@ -97,7 +98,7 @@ function BasicTable<T extends Record<string, unknown>>({
                     })}
                     onClick={() => handleColumnSelect(column)}
                   >
-                    {column.label}
+                    {column.header ? column.header : column.label}
                     {sortingRule?.column.id === column.id && (
                       <SortIcon isSortedDesc={sortingRule.desc} />
                     )}

--- a/frontend/admin/src/js/components/apiManagedTable/TableHeader.tsx
+++ b/frontend/admin/src/js/components/apiManagedTable/TableHeader.tsx
@@ -131,7 +131,7 @@ function TableHeader<T extends Record<string, unknown>>({
                     </div>
                     {columns.map((column) => (
                       <div key={column.id} data-h2-margin="b(top-bottom, xxs)">
-                        <label htmlFor={column.label}>
+                        <label htmlFor={column.id}>
                           <input
                             id={column.id}
                             type="checkbox"

--- a/frontend/admin/src/js/components/user/UserTable.tsx
+++ b/frontend/admin/src/js/components/user/UserTable.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { IntlShape, useIntl } from "react-intl";
 import { Link, useLocation } from "@common/helpers/router";
 import { notEmpty } from "@common/helpers/util";
@@ -81,6 +81,10 @@ export const UserTable: React.FC = () => {
   const [hiddenColumnIds, setHiddenColumnIds] = useState<IdType<Data>[]>([]);
   const [selectedRows, setSelectedRows] = useState<User[]>([]);
   const [searchState, setSearchState] = useState<string | undefined>();
+
+  useEffect(() => {
+    setSelectedRows([]);
+  }, [currentPage, pageSize, searchState, sortingRule]);
 
   const [result] = useAllUsersPaginatedQuery({
     variables: {


### PR DESCRIPTION
Resolves #2643.

Defines a column for selecting rows for the new table component and setup the user table to use it.

Notes:
- Currently the selection is setup to be cleared anytime filtering/ordering/pagination takes place.

Test by selecting rows on the user table and ensuring the `selectedRows` state changes as expected.