### PR TITLE
Feature - 3164 - Public Pool Advertisement Page

### DIFF
--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -11,7 +11,7 @@ module.exports = {
   files: [
     {
       path: "frontend/talentsearch/dist/app.js",
-      maxSize: "280 kB",
+      maxSize: "295 kB",
     },
     {
       path: "frontend/admin/dist/app.js",

--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -34,6 +34,7 @@ Nuwave
 pgsql
 Queueable
 recruitmentimit
+recruitments
 recrutementgiti
 resumé
 subquery

--- a/frontend/common/package.json
+++ b/frontend/common/package.json
@@ -53,6 +53,7 @@
     "@reach/tabs": "^0.16.0",
     "@testing-library/react-hooks": "^8.0.1",
     "@urql/exchange-auth": "^0.1.7",
+    "date-fns": "^2.28.0",
     "graphql": "^16.4.0",
     "history": "^5.3.0",
     "jwt-decode": "^3.1.2",

--- a/frontend/common/src/components/Card/Card.stories.tsx
+++ b/frontend/common/src/components/Card/Card.stories.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import Card from "./Card";
+
+export default {
+  component: Card,
+  title: "Components/Card",
+  args: {
+    title: "Card Title",
+    content:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam sed purus tristique, finibus nisi sit amet, lacinia elit. Nam vitae tellus condimentum, iaculis mauris pellentesque, venenatis ipsum.",
+  },
+} as Meta;
+
+const Spacer: React.FC = ({ children }) => (
+  <div
+    data-h2-display="b(flex)"
+    data-h2-flex-direction="b(column)"
+    data-h2-align-items="b(center)"
+    style={{ padding: "1rem" }}
+  >
+    {children}
+  </div>
+);
+
+const Template: Story = (args) => {
+  const { title, content } = args;
+
+  return (
+    <div
+      data-h2-display="b(flex)"
+      data-h2-justify-content="b(space-around)"
+      style={{ margin: "-1rem" }}
+    >
+      <Spacer>
+        <Card title="TS Primary">
+          <p>
+            Etiam auctor bibendum lectus, ornare dapibus est placerat vitae.
+          </p>
+        </Card>
+      </Spacer>
+      <Spacer>
+        <Card title="TS Secondary" color="ts-secondary">
+          <p>
+            Etiam auctor bibendum lectus, ornare dapibus est placerat vitae.
+          </p>
+        </Card>
+      </Spacer>
+      <Spacer>
+        <Card title="IA Primary" color="ia-primary">
+          <p>
+            Etiam auctor bibendum lectus, ornare dapibus est placerat vitae.
+          </p>
+        </Card>
+      </Spacer>
+      <Spacer>
+        <Card title="IA Secondary" color="ia-secondary">
+          <p>
+            Etiam auctor bibendum lectus, ornare dapibus est placerat vitae.
+          </p>
+        </Card>
+      </Spacer>
+    </div>
+  );
+};
+
+export const CardStory = Template.bind({});

--- a/frontend/common/src/components/Card/Card.stories.tsx
+++ b/frontend/common/src/components/Card/Card.stories.tsx
@@ -5,11 +5,6 @@ import Card from "./Card";
 export default {
   component: Card,
   title: "Components/Card",
-  args: {
-    title: "Card Title",
-    content:
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam sed purus tristique, finibus nisi sit amet, lacinia elit. Nam vitae tellus condimentum, iaculis mauris pellentesque, venenatis ipsum.",
-  },
 } as Meta;
 
 const Spacer: React.FC = ({ children }) => (
@@ -23,45 +18,33 @@ const Spacer: React.FC = ({ children }) => (
   </div>
 );
 
-const Template: Story = (args) => {
-  const { title, content } = args;
-
-  return (
-    <div
-      data-h2-display="b(flex)"
-      data-h2-justify-content="b(space-around)"
-      style={{ margin: "-1rem" }}
-    >
-      <Spacer>
-        <Card title="TS Primary">
-          <p>
-            Etiam auctor bibendum lectus, ornare dapibus est placerat vitae.
-          </p>
-        </Card>
-      </Spacer>
-      <Spacer>
-        <Card title="TS Secondary" color="ts-secondary">
-          <p>
-            Etiam auctor bibendum lectus, ornare dapibus est placerat vitae.
-          </p>
-        </Card>
-      </Spacer>
-      <Spacer>
-        <Card title="IA Primary" color="ia-primary">
-          <p>
-            Etiam auctor bibendum lectus, ornare dapibus est placerat vitae.
-          </p>
-        </Card>
-      </Spacer>
-      <Spacer>
-        <Card title="IA Secondary" color="ia-secondary">
-          <p>
-            Etiam auctor bibendum lectus, ornare dapibus est placerat vitae.
-          </p>
-        </Card>
-      </Spacer>
-    </div>
-  );
-};
+const Template: Story = () => (
+  <div
+    data-h2-display="b(flex)"
+    data-h2-justify-content="b(space-around)"
+    style={{ margin: "-1rem" }}
+  >
+    <Spacer>
+      <Card title="TS Primary">
+        <p>Etiam auctor bibendum lectus, ornare dapibus est placerat vitae.</p>
+      </Card>
+    </Spacer>
+    <Spacer>
+      <Card title="TS Secondary" color="ts-secondary">
+        <p>Etiam auctor bibendum lectus, ornare dapibus est placerat vitae.</p>
+      </Card>
+    </Spacer>
+    <Spacer>
+      <Card title="IA Primary" color="ia-primary">
+        <p>Etiam auctor bibendum lectus, ornare dapibus est placerat vitae.</p>
+      </Card>
+    </Spacer>
+    <Spacer>
+      <Card title="IA Secondary" color="ia-secondary">
+        <p>Etiam auctor bibendum lectus, ornare dapibus est placerat vitae.</p>
+      </Card>
+    </Spacer>
+  </div>
+);
 
 export const CardStory = Template.bind({});

--- a/frontend/common/src/components/Card/Card.tsx
+++ b/frontend/common/src/components/Card/Card.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+
+export type Color =
+  | "ts-primary"
+  | "ia-primary"
+  | "ts-secondary"
+  | "ia-secondary";
+
+export interface CardProps {
+  title: string;
+  color?: Color;
+  children: React.ReactNode;
+}
+
+const colorMap = {
+  "ts-primary": {
+    "data-h2-bg-color": "b(lightpurple)",
+    "data-h2-font-color": "b(white)",
+  },
+  "ts-secondary": {
+    "data-h2-bg-color": "b(lightnavy)",
+    "data-h2-font-color": "b(white)",
+  },
+  "ia-primary": {
+    "data-h2-bg-color": "b(ia-pink)",
+    "data-h2-font-color": "b(white)",
+  },
+  "ia-secondary": {
+    "data-h2-bg-color": "b(ia-purple)",
+    "data-h2-font-color": "b(white)",
+  },
+};
+
+const Card = ({
+  title,
+  color = "ts-primary",
+  children,
+  ...rest
+}: CardProps & React.HTMLProps<HTMLDivElement>) => {
+  return (
+    <div
+      className="card"
+      data-h2-display="b(block)"
+      data-h2-radius="b(s)"
+      data-h2-shadow="b(s)"
+      {...rest}
+    >
+      <span
+        className="card__header"
+        data-h2-display="b(block)"
+        data-h2-font-size="b(h5) l(h4)"
+        data-h2-padding="b(all, s)"
+        data-h2-margin="b(all, none)"
+        data-h2-radius="b(s, s, none, none)"
+        {...colorMap[color]}
+      >
+        {title}
+      </span>
+      <div
+        className="card__body"
+        data-h2-bg-color="b(white)"
+        data-h2-radius="b(none, none, s, s)"
+        data-h2-padding="b(all, s)"
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Card;

--- a/frontend/common/src/components/Card/index.ts
+++ b/frontend/common/src/components/Card/index.ts
@@ -1,0 +1,3 @@
+import Card from "./Card";
+
+export default Card;

--- a/frontend/common/src/helpers/dateUtils.ts
+++ b/frontend/common/src/helpers/dateUtils.ts
@@ -63,14 +63,14 @@ export const relativeExpiryDate = (
   const strLocale = getLocale(intl);
   const locale = strLocale === "fr" ? fr : undefined;
   const now = new Date();
-  const diff = now.getTime() - date.getTime();
+  const diff = date.getTime() - now.getTime();
   const time = format(date, `h:mm aaaa xxxxx`);
   const days = formatDistance(date, now, {
     locale,
     addSuffix: true,
   });
 
-  if (diff > 0) {
+  if (diff < 0) {
     return intl.formatMessage({
       defaultMessage: "The deadline for submission has passed.",
       description: "Message displayed when a date has expired.",

--- a/frontend/common/src/helpers/dateUtils.ts
+++ b/frontend/common/src/helpers/dateUtils.ts
@@ -1,6 +1,8 @@
-import { IntlShape } from "react-intl";
+import type { IntlShape } from "react-intl";
+import { format, formatDistance } from "date-fns";
+import { fr } from "date-fns/locale";
 import { Maybe, Scalars } from "../api/generated";
-import { Locales } from "./localize";
+import { getLocale, Locales } from "./localize";
 
 export function formattedDate(date: Scalars["Date"], locale: Locales) {
   const formatter = new Intl.DateTimeFormat(locale, {
@@ -45,3 +47,41 @@ export function getDateRange({
         { d1 },
       );
 }
+
+const DAY_IN_MILLISECONDS = 86400000;
+
+export const relativeDate = (date: Date, intl: IntlShape) => {
+  const strLocale = getLocale(intl);
+  const locale = strLocale === "fr" ? fr : undefined;
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  let relative = formatDistance(date, now, {
+    locale,
+    addSuffix: true,
+  });
+
+  if (diff < DAY_IN_MILLISECONDS && diff > -(DAY_IN_MILLISECONDS - 1)) {
+    relative = intl.formatMessage({
+      defaultMessage: "Today",
+      description: "Text displayed when relative date is today.",
+    });
+  }
+
+  if (diff < DAY_IN_MILLISECONDS * 2 && diff > 0) {
+    relative = intl.formatMessage({
+      defaultMessage: "Tomorrow",
+      description: "Text displayed when relative date is tomorrow.",
+    });
+  }
+
+  if (diff > -(DAY_IN_MILLISECONDS * 2) && diff < 0) {
+    relative = intl.formatMessage({
+      defaultMessage: "Yesterday",
+      description: "Text displayed when relative date is yesterday.",
+    });
+  }
+
+  const formatted = format(date, "PP", { locale });
+
+  return `${formatted} (${relative})`;
+};

--- a/frontend/common/src/helpers/dateUtils.ts
+++ b/frontend/common/src/helpers/dateUtils.ts
@@ -50,38 +50,62 @@ export function getDateRange({
 
 const DAY_IN_MILLISECONDS = 86400000;
 
-export const relativeDate = (date: Date, intl: IntlShape) => {
+/**
+ *
+ * @param date The date you would like to format
+ * @param intl react-intl object
+ * @returns Boolean if in past otherwise, string of formatted date
+ */
+export const relativeExpiryDate = (
+  date: Date,
+  intl: IntlShape,
+): string | boolean => {
   const strLocale = getLocale(intl);
   const locale = strLocale === "fr" ? fr : undefined;
   const now = new Date();
   const diff = now.getTime() - date.getTime();
-  let relative = formatDistance(date, now, {
+  const time = format(date, `h:mm aaaa xxxxx`);
+  const days = formatDistance(date, now, {
     locale,
     addSuffix: true,
   });
 
-  if (diff < DAY_IN_MILLISECONDS && diff > -(DAY_IN_MILLISECONDS - 1)) {
-    relative = intl.formatMessage({
-      defaultMessage: "Today",
-      description: "Text displayed when relative date is today.",
+  if (diff > 0) {
+    return intl.formatMessage({
+      defaultMessage: "The deadline for submission has passed.",
+      description: "Message displayed when a date has expired.",
     });
+  }
+
+  if (diff < DAY_IN_MILLISECONDS) {
+    return intl.formatMessage(
+      {
+        defaultMessage: "Closes today at {time}",
+        description: "Text displayed when relative date is today.",
+      },
+      {
+        time,
+      },
+    );
   }
 
   if (diff < DAY_IN_MILLISECONDS * 2 && diff > 0) {
-    relative = intl.formatMessage({
-      defaultMessage: "Tomorrow",
-      description: "Text displayed when relative date is tomorrow.",
-    });
+    return intl.formatMessage(
+      {
+        defaultMessage: "Closes tomorrow at {time}",
+        description: "Text displayed when relative date is tomorrow.",
+      },
+      { time },
+    );
   }
 
-  if (diff > -(DAY_IN_MILLISECONDS * 2) && diff < 0) {
-    relative = intl.formatMessage({
-      defaultMessage: "Yesterday",
-      description: "Text displayed when relative date is yesterday.",
-    });
-  }
-
-  const formatted = format(date, "PP", { locale });
-
-  return `${formatted} (${relative})`;
+  return intl.formatMessage(
+    {
+      defaultMessage: "Closes {days}",
+      description: "Text displayed when expiry date is in X amount of days",
+    },
+    {
+      days,
+    },
+  );
 };

--- a/frontend/common/src/helpers/localize.ts
+++ b/frontend/common/src/helpers/localize.ts
@@ -76,6 +76,7 @@ export const localizeCurrency = (
     currency,
     currencyDisplay: "narrowSymbol",
     maximumFractionDigits: 0,
+    minimumFractionDigits: 0,
   }).format(value);
 };
 

--- a/frontend/common/src/helpers/localize.ts
+++ b/frontend/common/src/helpers/localize.ts
@@ -1,5 +1,5 @@
 import { createPath, parsePath, Path } from "history";
-import { IntlShape } from "react-intl";
+import type { IntlShape } from "react-intl";
 import type { LocalizedString, Maybe } from "../api/generated";
 
 export type Locales = "en" | "fr";
@@ -64,4 +64,41 @@ export const getLocalizedName = (
   }
 
   return name[locale] ?? notAvailable;
+};
+
+export const localizeCurrency = (
+  value: number,
+  locale: string,
+  currency = "CAD",
+) => {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+    currencyDisplay: "narrowSymbol",
+    maximumFractionDigits: 0,
+  }).format(value);
+};
+
+export const localizeSalaryRange = (
+  min: Maybe<number>,
+  max: Maybe<number>,
+  locale: string,
+  currency = "USD",
+) => {
+  let salaryRange;
+  if (min || max) {
+    if (min && max) {
+      salaryRange = `${localizeCurrency(
+        min,
+        locale,
+        currency,
+      )} - ${localizeCurrency(max, locale, currency)}`;
+    } else if (min) {
+      salaryRange = localizeCurrency(min, locale, currency);
+    } else if (max) {
+      salaryRange = localizeCurrency(max, locale, currency);
+    }
+  }
+
+  return salaryRange;
 };

--- a/frontend/common/src/helpers/skillUtils.ts
+++ b/frontend/common/src/helpers/skillUtils.ts
@@ -1,5 +1,11 @@
 import { flatMap, uniqBy } from "lodash";
-import { Experience, Skill, SkillFamily } from "../api/generated";
+import {
+  Experience,
+  Maybe,
+  Skill,
+  SkillCategory,
+  SkillFamily,
+} from "../api/generated";
 import { notEmpty } from "./util";
 
 /**
@@ -70,6 +76,29 @@ export function invertSkillExperienceTree(experiences: Experience[]): Skill[] {
     };
   });
   return skillsWithExperiences;
+}
+
+export function filterSkillsBy(
+  skills: Maybe<Array<Skill>>,
+  category: SkillCategory,
+) {
+  return skills
+    ?.filter((skill) => {
+      return skill.families?.some((family) => family.category === category);
+    })
+    .filter(notEmpty);
+}
+
+export function categorizeSkill(
+  skills: Maybe<Array<Skill>>,
+): Record<SkillCategory, Maybe<Array<Skill>>> {
+  return {
+    [SkillCategory.Technical]: filterSkillsBy(skills, SkillCategory.Technical),
+    [SkillCategory.Behavioural]: filterSkillsBy(
+      skills,
+      SkillCategory.Behavioural,
+    ),
+  };
 }
 
 export default { invertSkillSkillFamilyTree, invertSkillExperienceTree };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -246,6 +246,7 @@
         "@reach/tabs": "^0.16.0",
         "@testing-library/react-hooks": "^8.0.1",
         "@urql/exchange-auth": "^0.1.7",
+        "date-fns": "^2.28.0",
         "graphql": "^16.4.0",
         "history": "^5.3.0",
         "jwt-decode": "^3.1.2",
@@ -522,6 +523,18 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.8.0"
+      }
+    },
+    "common/node_modules/date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "common/node_modules/jest": {
@@ -54879,6 +54892,7 @@
         "@typescript-eslint/eslint-plugin": "^5.30.4",
         "@typescript-eslint/parser": "^5.30.4",
         "@urql/exchange-auth": "^0.1.7",
+        "date-fns": "*",
         "eslint": "^8.19.0",
         "eslint-config-airbnb": "^19.0.0",
         "eslint-config-prettier": "^8.5.0",
@@ -55065,6 +55079,11 @@
             "graceful-fs": "^4.2.9",
             "slash": "^3.0.0"
           }
+        },
+        "date-fns": {
+          "version": "2.28.0",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+          "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
         },
         "jest": {
           "version": "28.1.2",

--- a/frontend/talentsearch/src/js/components/ClassificationDefinition/ClassificationDefinition.tsx
+++ b/frontend/talentsearch/src/js/components/ClassificationDefinition/ClassificationDefinition.tsx
@@ -4,47 +4,25 @@ import { GenericJobTitleKey } from "../../api/generated";
 import ITDefinitions from "./ITDefinitions";
 
 interface ClassificationDefinitionProps {
-  group: string;
-  level: number;
-  name?: string;
+  name: string;
 }
 
-const definitionMap: Record<
-  string,
-  Record<number, Record<string, React.FC>>
-> = {
-  IT: {
-    1: {
-      [GenericJobTitleKey.TechnicianIt01]: ITDefinitions.LevelOne,
-    },
-    2: { [GenericJobTitleKey.AnalystIt02]: ITDefinitions.LevelTwo },
-    3: {
-      [GenericJobTitleKey.TeamLeaderIt03]: ITDefinitions.LevelThreeLead,
-      [GenericJobTitleKey.TechnicalAdvisorIt03]: ITDefinitions.LevelThreeLead,
-    },
-    4: {
-      [GenericJobTitleKey.SeniorAdvisorIt04]: ITDefinitions.LevelFourAdvisor,
-      [GenericJobTitleKey.ManagerIt04]: ITDefinitions.LevelFourManager,
-    },
-  },
+const definitionMap: Record<string, React.FC> = {
+  [GenericJobTitleKey.TechnicianIt01]: ITDefinitions.LevelOne,
+  [GenericJobTitleKey.AnalystIt02]: ITDefinitions.LevelTwo,
+  [GenericJobTitleKey.TeamLeaderIt03]: ITDefinitions.LevelThreeLead,
+  [GenericJobTitleKey.TechnicalAdvisorIt03]: ITDefinitions.LevelThreeLead,
+  [GenericJobTitleKey.SeniorAdvisorIt04]: ITDefinitions.LevelFourAdvisor,
+  [GenericJobTitleKey.ManagerIt04]: ITDefinitions.LevelFourManager,
 };
 
-const ClassificationDefinition = ({
-  group,
-  level,
-  name,
-}: ClassificationDefinitionProps) => {
+const ClassificationDefinition = ({ name }: ClassificationDefinitionProps) => {
   if (!name) {
     return null;
   }
 
-  const El = definitionMap[group] ? definitionMap[group][level][name] : null;
-
-  if (El) {
-    return <El />;
-  }
-
-  return null;
+  const El = definitionMap[name];
+  return <El />;
 };
 
 export default ClassificationDefinition;

--- a/frontend/talentsearch/src/js/components/ClassificationDefinition/ClassificationDefinition.tsx
+++ b/frontend/talentsearch/src/js/components/ClassificationDefinition/ClassificationDefinition.tsx
@@ -11,7 +11,7 @@ const definitionMap: Record<string, React.FC> = {
   [GenericJobTitleKey.TechnicianIt01]: ITDefinitions.LevelOne,
   [GenericJobTitleKey.AnalystIt02]: ITDefinitions.LevelTwo,
   [GenericJobTitleKey.TeamLeaderIt03]: ITDefinitions.LevelThreeLead,
-  [GenericJobTitleKey.TechnicalAdvisorIt03]: ITDefinitions.LevelThreeLead,
+  [GenericJobTitleKey.TechnicalAdvisorIt03]: ITDefinitions.LevelThreeAdvisor,
   [GenericJobTitleKey.SeniorAdvisorIt04]: ITDefinitions.LevelFourAdvisor,
   [GenericJobTitleKey.ManagerIt04]: ITDefinitions.LevelFourManager,
 };

--- a/frontend/talentsearch/src/js/components/ClassificationDefinition/ClassificationDefinition.tsx
+++ b/frontend/talentsearch/src/js/components/ClassificationDefinition/ClassificationDefinition.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { GenericJobTitleKey } from "../../api/generated";
+
+import ITDefinitions from "./ITDefinitions";
+
+interface ClassificationDefinitionProps {
+  group: string;
+  level: number;
+  name?: string;
+}
+
+const definitionMap: Record<
+  string,
+  Record<number, Record<string, React.FC>>
+> = {
+  IT: {
+    1: {
+      [GenericJobTitleKey.TechnicianIt01]: ITDefinitions.LevelOne,
+    },
+    2: { [GenericJobTitleKey.AnalystIt02]: ITDefinitions.LevelTwo },
+    3: {
+      [GenericJobTitleKey.TeamLeaderIt03]: ITDefinitions.LevelThreeLead,
+      [GenericJobTitleKey.TechnicalAdvisorIt03]: ITDefinitions.LevelThreeLead,
+    },
+    4: {
+      [GenericJobTitleKey.SeniorAdvisorIt04]: ITDefinitions.LevelFourAdvisor,
+      [GenericJobTitleKey.ManagerIt04]: ITDefinitions.LevelFourManager,
+    },
+  },
+};
+
+const ClassificationDefinition = ({
+  group,
+  level,
+  name,
+}: ClassificationDefinitionProps) => {
+  if (!name) {
+    return null;
+  }
+
+  const El = definitionMap[group] ? definitionMap[group][level][name] : null;
+
+  if (El) {
+    return <El />;
+  }
+
+  return null;
+};
+
+export default ClassificationDefinition;

--- a/frontend/talentsearch/src/js/components/ClassificationDefinition/ITDefinitions.tsx
+++ b/frontend/talentsearch/src/js/components/ClassificationDefinition/ITDefinitions.tsx
@@ -1,0 +1,216 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { strong } from "@common/helpers/format";
+
+const LevelOne = () => {
+  const intl = useIntl();
+
+  return (
+    <>
+      <p>
+        {intl.formatMessage({
+          defaultMessage:
+            "Technicians (IT-01) provide technical support in the development, implementation, integration, and maintenance of service delivery to clients and stakeholders",
+          description: "blurb describing IT-01",
+        })}
+      </p>
+      <p>
+        {intl.formatMessage({
+          defaultMessage:
+            "IT Technicians are primarily found in three work streams: ",
+          description: "Preceding list description",
+        })}
+      </p>
+      <ul>
+        <li>
+          {intl.formatMessage({
+            defaultMessage: "IT Infrastructure Operations",
+            description: "work stream example",
+          })}
+        </li>
+        <li>
+          {intl.formatMessage({
+            defaultMessage: "IT Security",
+            description: "work stream example",
+          })}
+        </li>
+        <li>
+          {intl.formatMessage({
+            defaultMessage: "IT Software Solutions",
+            description: "work stream example",
+          })}
+        </li>
+      </ul>
+    </>
+  );
+};
+
+const LevelTwo = () => {
+  const intl = useIntl();
+
+  return (
+    <p>
+      {intl.formatMessage({
+        defaultMessage:
+          "Analysts (IT-02) provide technical services, advice, analysis, and research in their field of expertise to support service delivery to clients and stakeholders. IT analysts are found in all work streams.",
+        description: "blurb describing IT-02",
+      })}
+    </p>
+  );
+};
+
+const LevelThreeLead = () => {
+  const intl = useIntl();
+
+  return (
+    <>
+      <p>
+        {intl.formatMessage({
+          defaultMessage:
+            "There are two types of IT-03 employees: those following a management path, and individual contributors.",
+          description: "IT-03 description precursor",
+        })}
+      </p>
+      <p>
+        {intl.formatMessage(
+          {
+            defaultMessage:
+              "<strong>Management Path</strong>: IT Team Leads (IT-03) are responsible for supervising work and project teams for IT services and operations in their field of expertise to support service delivery to clients and stakeholders. IT Team Leads are found in all work streams.",
+            description:
+              "IT-03 team lead path description, ignore things in <> tags please",
+          },
+          { strong },
+        )}
+      </p>
+    </>
+  );
+};
+
+const LevelThreeAdvisor = () => {
+  const intl = useIntl();
+
+  return (
+    <>
+      <p>
+        {intl.formatMessage({
+          defaultMessage:
+            "There are two types of IT-03 employees: those following a management path, and individual contributors.",
+          description: "IT-03 description precursor",
+        })}
+      </p>
+      <p>
+        {intl.formatMessage(
+          {
+            defaultMessage:
+              "<strong>Individual Contributor</strong>: IT Technical Advisors (IT-03) provide specialized technical advice, recommendations and support on solutions and services in their field of expertise in support of service delivery to clients and stakeholders. IT Technical Advisors are found in all work streams.",
+            description:
+              "IT-03 advisor description, ignore things in <> tags please",
+          },
+          { strong },
+        )}
+      </p>
+    </>
+  );
+};
+
+const LevelFourManager = () => {
+  const intl = useIntl();
+
+  return (
+    <>
+      <p>
+        {intl.formatMessage({
+          defaultMessage:
+            "There are two types of IT-04 employees: those following a management path, and individual contributors.",
+          description: "IT-04 description precursor",
+        })}
+      </p>
+      <p>
+        {intl.formatMessage(
+          {
+            defaultMessage:
+              "<strong>Management Path</strong>: IT Managers (IT-04) are responsible for managing the development and delivery of IT services and/or operations through subordinate team leaders, technical advisors, and project teams, for service delivery to clients and stakeholders. IT Managers are found in all work streams.",
+            description:
+              "IT-04 manager path description, ignore things in <> tags please",
+          },
+          { strong },
+        )}
+      </p>
+    </>
+  );
+};
+
+const LevelFourAdvisor = (): JSX.Element => {
+  const intl = useIntl();
+
+  return (
+    <>
+      <p>
+        {intl.formatMessage({
+          defaultMessage:
+            "There are two types of IT-04 employees: those following a management path, and individual contributors.",
+          description: "IT-04 description precursor",
+        })}
+      </p>
+      <p>
+        {intl.formatMessage(
+          {
+            defaultMessage:
+              "<strong>Individual Contributor</strong>: IT Senior Advisors (IT-04) provide expert technical advice and strategic direction in their field of expertise in the provision of solutions and services to internal or external clients, and stakeholders. IT Senior Advisors are primarily found in six work streams:",
+            description:
+              "IT-04 senior advisor description precursor to work stream list, ignore things in <> tags please",
+          },
+          { strong },
+        )}
+      </p>
+      <ul>
+        <li>
+          {intl.formatMessage({
+            defaultMessage: "IT Infrastructure Operations",
+            description: "work stream example",
+          })}
+        </li>
+        <li>
+          {intl.formatMessage({
+            defaultMessage: "IT Security",
+            description: "work stream example",
+          })}
+        </li>
+        <li>
+          {intl.formatMessage({
+            defaultMessage: "IT Software Solutions",
+            description: "work stream example",
+          })}
+        </li>
+        <li>
+          {intl.formatMessage({
+            defaultMessage: "IT Database Management",
+            description: "work stream example",
+          })}
+        </li>
+        <li>
+          {intl.formatMessage({
+            defaultMessage: "IT Enterprise Architecture",
+            description: "work stream example",
+          })}
+        </li>
+        <li>
+          {intl.formatMessage({
+            defaultMessage: "IT Project Portfolio Management",
+            description: "work stream example",
+          })}
+        </li>
+      </ul>
+    </>
+  );
+};
+
+export default {
+  LevelOne,
+  LevelTwo,
+  LevelThreeLead,
+  LevelThreeAdvisor,
+  LevelFourManager,
+  LevelFourAdvisor,
+};

--- a/frontend/talentsearch/src/js/components/ClassificationDefinition/index.ts
+++ b/frontend/talentsearch/src/js/components/ClassificationDefinition/index.ts
@@ -1,0 +1,3 @@
+import ClassificationDefinition from "./ClassificationDefinition";
+
+export default ClassificationDefinition;

--- a/frontend/talentsearch/src/js/components/Router.tsx
+++ b/frontend/talentsearch/src/js/components/Router.tsx
@@ -44,6 +44,7 @@ import LoggedOutPage from "./loggedOut/LoggedOutPage";
 import LoginPage from "./login/LoginPage";
 import { CreateAccount } from "./createAccount/CreateAccountPage";
 import { Role } from "../api/generated";
+import PoolAdvertisementPage from "./pool/PoolAdvertisementPage";
 
 const talentRoutes = (
   talentPaths: TalentSearchRoutes,
@@ -242,6 +243,15 @@ const directIntakeRoutes = (
       return {
         component: <PoolApplicationThanksPage id={poolId} />,
         authorizedRoles: [Role.Applicant],
+      };
+    },
+  },
+  {
+    path: directIntakePaths.poolAdvertisement(":id"),
+    action: (context) => {
+      const poolId = context.params.id as string;
+      return {
+        component: <PoolAdvertisementPage id={poolId} />,
       };
     },
   },

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import { BriefcaseIcon } from "@heroicons/react/solid";
+
+import Breadcrumbs from "@common/components/Breadcrumbs";
+import type { BreadcrumbsProps } from "@common/components/Breadcrumbs";
+import NotFound from "@common/components/NotFound";
+import Pending from "@common/components/Pending";
+import { getLocale, getLocalizedName } from "@common/helpers/localize";
+import { imageUrl } from "@common/helpers/router";
+
+import { useGetPoolAdvertisementQuery } from "../../api/generated";
+import type { PoolAdvertisement } from "../../api/generated";
+import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
+import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
+import commonMessages from "../commonMessages";
+
+interface PoolAdvertisementProps {
+  poolAdvertisement: PoolAdvertisement;
+}
+
+const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
+  const paths = useDirectIntakeRoutes();
+
+  const classification = poolAdvertisement.classifications
+    ? poolAdvertisement.classifications[0]
+    : null;
+  const genericTitle = classification?.genericJobTitles?.length
+    ? classification.genericJobTitles[0]
+    : null;
+  const localizedClassificationName = getLocalizedName(
+    classification?.name,
+    intl,
+  );
+  const localizedTitle = getLocalizedName(genericTitle?.name, intl);
+  const fullTitle = `${localizedClassificationName} ${localizedTitle} (${classification?.group}-0${classification?.level})`;
+
+  const links = [
+    {
+      title: intl.formatMessage({
+        defaultMessage: "Browse opportunities",
+        description: "Breadcrumb title for the browse pools page.",
+      }),
+      href: paths.home(),
+      icon: <BriefcaseIcon style={{ width: "1rem", marginRight: "5px" }} />,
+    },
+    {
+      title: fullTitle,
+    },
+  ] as BreadcrumbsProps["links"];
+
+  return (
+    <>
+      <div
+        data-h2-padding="b(top-bottom, m) b(right-left, s)"
+        data-h2-font-color="b(white)"
+        style={{
+          background: `url(${imageUrl(
+            TALENTSEARCH_APP_DIR,
+            "applicant-profile-banner.png",
+          )})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          backgroundRepeat: "no-repeat",
+        }}
+      >
+        <div data-h2-container="b(center, m)">
+          <h1 data-h2-margin="b(top-bottom, l)">{fullTitle}</h1>
+        </div>
+      </div>
+      <div
+        data-h2-bg-color="b(white)"
+        data-h2-shadow="b(m)"
+        data-h2-padding="b(top-bottom, m)"
+      >
+        <div data-h2-container="b(center, m)">
+          <Breadcrumbs links={links} />
+        </div>
+      </div>
+    </>
+  );
+};
+
+interface PoolAdvertisementPageProps {
+  id: string;
+}
+
+const PoolAdvertisementPage = ({ id }: PoolAdvertisementPageProps) => {
+  const intl = useIntl();
+
+  const [{ data, fetching, error }] = useGetPoolAdvertisementQuery({
+    variables: { id },
+  });
+
+  return (
+    <Pending fetching={fetching} error={error}>
+      {data?.poolAdvertisement ? (
+        <PoolAdvertisement poolAdvertisement={data?.poolAdvertisement} />
+      ) : (
+        <NotFound
+          headingMessage={intl.formatMessage(commonMessages.notFound, {
+            type: "Pool",
+            id,
+          })}
+        >
+          {intl.formatMessage({
+            defaultMessage: "Error, pool unable to be loaded",
+            description: "Error message, placeholder",
+          })}
+        </NotFound>
+      )}
+    </Pending>
+  );
+};
+
+export default PoolAdvertisementPage;

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -15,8 +15,10 @@ import TableOfContents from "@common/components/TableOfContents";
 import {
   LightningBoltIcon,
   BriefcaseIcon as BriefcaseIconOutline,
+  PhoneIcon,
 } from "@heroicons/react/outline";
 import Accordion from "@common/components/accordion";
+import { strong } from "@common/helpers/format";
 import { useGetPoolAdvertisementQuery } from "../../api/generated";
 import type { PoolAdvertisement } from "../../api/generated";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
@@ -24,6 +26,50 @@ import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
 import commonMessages from "../commonMessages";
 import PoolInfoCard from "./PoolInfoCard";
 import ClassificationDefinition from "../ClassificationDefinition/ClassificationDefinition";
+
+interface ApplyButtonProps {
+  disabled: boolean;
+  href: string;
+}
+
+const ApplyButton = ({ disabled, href }: ApplyButtonProps) => {
+  const intl = useIntl();
+  return (
+    <Link
+      type="button"
+      color="primary"
+      mode="solid"
+      disabled={disabled}
+      href={href}
+    >
+      {intl.formatMessage({
+        defaultMessage: "Apply for this process",
+        description: "Link text to apply for a pool advertisement",
+      })}
+    </Link>
+  );
+};
+interface IconTitleProps {
+  children: React.ReactNode;
+  icon: React.FC<React.SVGProps<SVGSVGElement>>;
+}
+
+const IconTitle = ({ children, icon }: IconTitleProps) => {
+  const Icon = icon;
+
+  return (
+    <h3 data-h2-display="b(flex)" data-h2-align-items="b(center)">
+      <Icon style={{ width: "1em", marginRight: "0.5rem" }} />
+      <span>{children}</span>
+    </h3>
+  );
+};
+
+// NOTE: Not entirely sure why this is failing?
+const accommodationEmail = (chunks: string[]) => (
+  // eslint-disable-next-line jsx-a11y/anchor-has-content
+  <a href="mailto:fames@acanteipsum.ca">{...chunks}</a>
+);
 
 interface PoolAdvertisementProps {
   poolAdvertisement: PoolAdvertisement;
@@ -47,6 +93,16 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
   const localizedTitle = getLocalizedName(genericTitle?.name, intl);
   const classificationSuffix = `${classification?.group}-0${classification?.level}`;
   const fullTitle = `${localizedClassificationName} ${localizedTitle} (${classificationSuffix})`;
+  const canApply =
+    poolAdvertisement.advertisementStatus &&
+    poolAdvertisement.advertisementStatus === AdvertisementStatus.Published;
+
+  const applyBtn = (
+    <ApplyButton
+      disabled={!canApply}
+      href={paths.poolApply(poolAdvertisement.id)}
+    />
+  );
 
   const links = [
     {
@@ -154,24 +210,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 }}
               />
             </div>
-            {poolAdvertisement.advertisementStatus &&
-              poolAdvertisement.advertisementStatus ===
-                AdvertisementStatus.Published && (
-                <div>
-                  <Link
-                    type="button"
-                    color="primary"
-                    mode="solid"
-                    href={paths.poolApply(poolAdvertisement.id)}
-                  >
-                    {intl.formatMessage({
-                      defaultMessage: "Apply for this process",
-                      description:
-                        "Link text to apply for a pool advertisement",
-                    })}
-                  </Link>
-                </div>
-              )}
+            <div>{applyBtn}</div>
           </div>
         </div>
       </div>
@@ -246,35 +285,25 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
 
             {poolAdvertisement.yourImpact ? (
               <>
-                <h3 data-h2-display="b(flex)" data-h2-align-items="b(center)">
-                  <LightningBoltIcon
-                    style={{ width: "1em", marginRight: "0.5rem" }}
-                  />
-                  <span>
-                    {intl.formatMessage({
-                      defaultMessage: "Your impact",
-                      description:
-                        "Title for a pool advertisements impact section.",
-                    })}
-                  </span>
-                </h3>
+                <IconTitle icon={LightningBoltIcon}>
+                  {intl.formatMessage({
+                    defaultMessage: "Your impact",
+                    description:
+                      "Title for a pool advertisements impact section.",
+                  })}
+                </IconTitle>
                 {poolAdvertisement.yourImpact[locale]}
               </>
             ) : null}
             {poolAdvertisement.keyTasks ? (
               <>
-                <h3 data-h2-display="b(flex)" data-h2-align-items="b(center)">
-                  <BriefcaseIconOutline
-                    style={{ width: "1em", marginRight: "0.5rem" }}
-                  />
-                  <span>
-                    {intl.formatMessage({
-                      defaultMessage: "Your work",
-                      description:
-                        "Title for a pool advertisements key tasks section.",
-                    })}
-                  </span>
-                </h3>
+                <IconTitle icon={BriefcaseIconOutline}>
+                  {intl.formatMessage({
+                    defaultMessage: "Your work",
+                    description:
+                      "Title for a pool advertisements key tasks section.",
+                  })}
+                </IconTitle>
                 {poolAdvertisement.keyTasks[locale]}
               </>
             ) : null}
@@ -298,11 +327,73 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
             <TableOfContents.Heading>
               {sections.details.title}
             </TableOfContents.Heading>
+            <IconTitle icon={PhoneIcon}>
+              {intl.formatMessage({
+                defaultMessage: "Contact and Accommodations",
+                description:
+                  "Title for contact information on pool advertisement",
+              })}
+            </IconTitle>
+            <p>
+              {intl.formatMessage({
+                defaultMessage:
+                  "Do you require accommodations? or do you have any questions about this process?",
+                description:
+                  "Opening sentence asking if accommodations are needed",
+              })}
+            </p>
+            <p>
+              {intl.formatMessage({
+                defaultMessage:
+                  "Please contact the Digital Community Management Office if you require any accommodations during this application process.",
+                description:
+                  "Description of what to do when accommodations are needed",
+              })}
+            </p>
+            <p>
+              {intl.formatMessage(
+                {
+                  defaultMessage:
+                    "<strong>Email</strong>: <accommodationEmail>fames@acanteipsum.ca</accommodationEmail>",
+                },
+                {
+                  strong,
+                  accommodationEmail,
+                },
+              )}
+            </p>
+            <IconTitle icon={PhoneIcon}>
+              {intl.formatMessage({
+                defaultMessage: "Hiring Policies",
+                description:
+                  "Title for hiring information on pool advertisement",
+              })}
+            </IconTitle>
+            <p>
+              {intl.formatMessage({
+                defaultMessage:
+                  "Preference will be given to veterans, Canadian citizens and to permanent residents.",
+                description: "First hiring policy for pool advertisement",
+              })}
+            </p>
           </TableOfContents.Section>
           <TableOfContents.Section id={sections.apply.id}>
             <TableOfContents.Heading>
               {sections.apply.title}
             </TableOfContents.Heading>
+            <p>
+              {canApply
+                ? intl.formatMessage({
+                    defaultMessage:
+                      "If this process looks like the right fit for you apply now!",
+                  })
+                : intl.formatMessage({
+                    defaultMessage: "The deadline for submission has passed.",
+                    description:
+                      "Message displayed when the pool advertisement has expired.",
+                  })}
+            </p>
+            {applyBtn}
           </TableOfContents.Section>
         </TableOfContents.Content>
       </TableOfContents.Wrapper>

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -29,7 +29,7 @@ import {
   getSecurityClearance,
 } from "@common/constants/localizedConstants";
 import { categorizeSkill } from "@common/helpers/skillUtils";
-import { useGetPoolAdvertisementQuery } from "../../api/generated";
+import { Role, useGetPoolAdvertisementQuery } from "../../api/generated";
 import type { PoolAdvertisement } from "../../api/generated";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
 import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
@@ -668,9 +668,16 @@ const PoolAdvertisementPage = ({ id }: PoolAdvertisementPageProps) => {
     variables: { id },
   });
 
+  let visible = data?.me?.roles?.includes(Role.Admin) ?? false;
+  if (
+    data?.poolAdvertisement?.advertisementStatus !== AdvertisementStatus.Draft
+  ) {
+    visible = true;
+  }
+
   return (
     <Pending fetching={fetching} error={error}>
-      {data?.poolAdvertisement ? (
+      {data?.poolAdvertisement && visible ? (
         <PoolAdvertisement poolAdvertisement={data?.poolAdvertisement} />
       ) : (
         <NotFound

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -6,6 +6,7 @@ import Breadcrumbs from "@common/components/Breadcrumbs";
 import type { BreadcrumbsProps } from "@common/components/Breadcrumbs";
 import NotFound from "@common/components/NotFound";
 import Pending from "@common/components/Pending";
+import { Link } from "@common/components";
 import { getLocale, getLocalizedName } from "@common/helpers/localize";
 import { imageUrl } from "@common/helpers/router";
 
@@ -14,6 +15,7 @@ import type { PoolAdvertisement } from "../../api/generated";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
 import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
 import commonMessages from "../commonMessages";
+import PoolInfoCard from "./PoolInfoCard";
 
 interface PoolAdvertisementProps {
   poolAdvertisement: PoolAdvertisement;
@@ -77,6 +79,36 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
       >
         <div data-h2-container="b(center, m)">
           <Breadcrumbs links={links} />
+          <div
+            data-h2-display="b(flex)"
+            data-h2-flex-direction="b(column) m(row)"
+            data-h2-justify-content="b(space-between)"
+            data-h2-align-items="b(center) m(flex-end)"
+            data-h2-margin="b(top, m)"
+          >
+            <div>
+              <PoolInfoCard
+                closingDate={poolAdvertisement.expiryDate}
+                salary={{
+                  min: classification?.minSalary,
+                  max: classification?.maxSalary,
+                }}
+              />
+            </div>
+            <div>
+              <Link
+                type="button"
+                color="primary"
+                mode="solid"
+                href={paths.poolApply(poolAdvertisement.id)}
+              >
+                {intl.formatMessage({
+                  defaultMessage: "Apply for this process",
+                  description: "Link text to apply for a pool advertisement",
+                })}
+              </Link>
+            </div>
+          </div>
         </div>
       </div>
     </>

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -10,7 +10,7 @@ import { Link } from "@common/components";
 import { getLocale, getLocalizedName } from "@common/helpers/localize";
 import { imageUrl } from "@common/helpers/router";
 
-import { AdvertisementStatus } from "@common/api/generated";
+import { AdvertisementStatus, SkillCategory } from "@common/api/generated";
 import TableOfContents from "@common/components/TableOfContents";
 import {
   LightningBoltIcon,
@@ -18,6 +18,8 @@ import {
   PhoneIcon,
   LightBulbIcon,
   CheckCircleIcon,
+  ChipIcon,
+  CloudIcon,
 } from "@heroicons/react/outline";
 import Accordion from "@common/components/accordion";
 import { strong } from "@common/helpers/format";
@@ -25,6 +27,7 @@ import {
   getLanguageRequirement,
   getSecurityClearance,
 } from "@common/constants/localizedConstants";
+import { categorizeSkill } from "@common/helpers/skillUtils";
 import { useGetPoolAdvertisementQuery } from "../../api/generated";
 import type { PoolAdvertisement } from "../../api/generated";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
@@ -64,7 +67,11 @@ const IconTitle = ({ children, icon }: IconTitleProps) => {
   const Icon = icon;
 
   return (
-    <h3 data-h2-display="b(flex)" data-h2-align-items="b(center)">
+    <h3
+      data-h2-display="b(flex)"
+      data-h2-align-items="b(center)"
+      data-h2-font-size="b(h4)"
+    >
       <Icon style={{ width: "1em", marginRight: "0.5rem" }} />
       <span>{children}</span>
     </h3>
@@ -109,6 +116,11 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
 
   const securityClearance = intl.formatMessage(
     getSecurityClearance(poolAdvertisement.securityClearance ?? ""),
+  );
+
+  const essentialSkills = categorizeSkill(poolAdvertisement.essentialSkills);
+  const nonEssentialSkills = categorizeSkill(
+    poolAdvertisement.nonessentialSkills,
   );
 
   const applyBtn = (
@@ -296,7 +308,6 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 <ClassificationDefinition name={genericTitle.key} />
               </Accordion>
             )}
-
             {poolAdvertisement.yourImpact ? (
               <>
                 <IconTitle icon={LightningBoltIcon}>
@@ -326,11 +337,104 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
             <TableOfContents.Heading>
               {sections.requiredSkills.title}
             </TableOfContents.Heading>
+            {essentialSkills[SkillCategory.Technical]?.length ? (
+              <>
+                <IconTitle icon={ChipIcon}>
+                  {intl.formatMessage({
+                    defaultMessage: "Occupational skills",
+                    description:
+                      "Title for occupational skills on a pool advertisement",
+                  })}
+                </IconTitle>
+                <p>
+                  {intl.formatMessage(
+                    {
+                      defaultMessage:
+                        "To be admitted into this process, you will need to submit sufficient information to verify your experience in <strong>all of these  skills (Need to have - Occupational)</strong> with your application.",
+                      description:
+                        "Explanation of a pools required occupational skills",
+                    },
+                    {
+                      strong,
+                    },
+                  )}
+                </p>
+                {essentialSkills[SkillCategory.Technical]?.map((skill) => (
+                  <Accordion title={skill.name[locale] || ""} key={skill.id}>
+                    <p>{skill.description ? skill.description[locale] : ""}</p>
+                  </Accordion>
+                ))}
+              </>
+            ) : null}
+            {essentialSkills[SkillCategory.Behavioural]?.length ? (
+              <>
+                <IconTitle icon={CloudIcon}>
+                  {intl.formatMessage({
+                    defaultMessage: "Transferrable skills",
+                    description:
+                      "Title for transferrable skills on a pool advertisement",
+                  })}
+                </IconTitle>
+                <p>
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "To be admitted into this process, you will need to display  capability in these skills during the assessment process.",
+                    description:
+                      "Explanation of a pools required transferrable skills",
+                  })}
+                </p>
+                {essentialSkills[SkillCategory.Behavioural]?.map((skill) => (
+                  <Accordion title={skill.name[locale] || ""} key={skill.id}>
+                    <p>{skill.description ? skill.description[locale] : ""}</p>
+                  </Accordion>
+                ))}
+              </>
+            ) : null}
           </TableOfContents.Section>
           <TableOfContents.Section id={sections.optionalSkills.id}>
             <TableOfContents.Heading>
               {sections.optionalSkills.title}
             </TableOfContents.Heading>
+            {nonEssentialSkills[SkillCategory.Technical]?.length ? (
+              <>
+                <IconTitle icon={ChipIcon}>
+                  {intl.formatMessage({
+                    defaultMessage: "Occupational skills",
+                    description:
+                      "Title for occupational skills on a pool advertisement",
+                  })}
+                </IconTitle>
+                <p>
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "To strengthen your application, take into consideration these skills that many hiring managers are looking for.",
+                    description:
+                      "Explanation of a pools optional transferrable skills",
+                  })}
+                </p>
+                {nonEssentialSkills[SkillCategory.Technical]?.map((skill) => (
+                  <Accordion title={skill.name[locale] || ""} key={skill.id}>
+                    <p>{skill.description ? skill.description[locale] : ""}</p>
+                  </Accordion>
+                ))}
+              </>
+            ) : null}
+            {nonEssentialSkills[SkillCategory.Behavioural]?.length ? (
+              <>
+                <IconTitle icon={CloudIcon}>
+                  {intl.formatMessage({
+                    defaultMessage: "Transferrable skills",
+                    description:
+                      "Title for transferrable skills on a pool advertisement",
+                  })}
+                </IconTitle>
+                {nonEssentialSkills[SkillCategory.Behavioural]?.map((skill) => (
+                  <Accordion title={skill.name[locale] || ""} key={skill.id}>
+                    <p>{skill.description ? skill.description[locale] : ""}</p>
+                  </Accordion>
+                ))}
+              </>
+            ) : null}
           </TableOfContents.Section>
           <TableOfContents.Section id={sections.requirements.id}>
             <TableOfContents.Heading>

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -10,6 +10,7 @@ import { Link } from "@common/components";
 import { getLocale, getLocalizedName } from "@common/helpers/localize";
 import { imageUrl } from "@common/helpers/router";
 
+import { AdvertisementStatus } from "@common/api/generated";
 import { useGetPoolAdvertisementQuery } from "../../api/generated";
 import type { PoolAdvertisement } from "../../api/generated";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
@@ -95,19 +96,24 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 }}
               />
             </div>
-            <div>
-              <Link
-                type="button"
-                color="primary"
-                mode="solid"
-                href={paths.poolApply(poolAdvertisement.id)}
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Apply for this process",
-                  description: "Link text to apply for a pool advertisement",
-                })}
-              </Link>
-            </div>
+            {poolAdvertisement.advertisementStatus &&
+              poolAdvertisement.advertisementStatus ===
+                AdvertisementStatus.Published && (
+                <div>
+                  <Link
+                    type="button"
+                    color="primary"
+                    mode="solid"
+                    href={paths.poolApply(poolAdvertisement.id)}
+                  >
+                    {intl.formatMessage({
+                      defaultMessage: "Apply for this process",
+                      description:
+                        "Link text to apply for a pool advertisement",
+                    })}
+                  </Link>
+                </div>
+              )}
           </div>
         </div>
       </div>

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -6,6 +6,7 @@ import Breadcrumbs from "@common/components/Breadcrumbs";
 import type { BreadcrumbsProps } from "@common/components/Breadcrumbs";
 import NotFound from "@common/components/NotFound";
 import Pending from "@common/components/Pending";
+import Card from "@common/components/Card";
 import { Link } from "@common/components";
 import { getLocale, getLocalizedName } from "@common/helpers/localize";
 import { imageUrl } from "@common/helpers/router";
@@ -447,6 +448,90 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                   "Title for experience and education pool requirements",
               })}
             </IconTitle>
+            <div
+              data-h2-display="b(flex)"
+              data-h2-flex-direction="b(column) m(row)"
+              data-h2-align-items="b(center) m(stretch)"
+            >
+              <Card
+                color="ts-secondary"
+                style={{ width: "100%" }}
+                title={intl.formatMessage({
+                  defaultMessage: "Combination Experience",
+                  description:
+                    "Title for pool applicant experience requirements",
+                })}
+              >
+                <p data-h2-margin="b(top, none)">
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "2 or more years of combined experience in a related field including any of the following:",
+                    description:
+                      "lead in to list of experience required for a pool applicant",
+                  })}
+                </p>
+                <ul>
+                  <li>
+                    {intl.formatMessage({
+                      defaultMessage: "On-the-job learning",
+                      description:
+                        "pool experience requirement, on job learning",
+                    })}
+                  </li>
+                  <li>
+                    {intl.formatMessage({
+                      defaultMessage: "Non-conventional training",
+                      description:
+                        "pool experience requirement, non-conventional training",
+                    })}
+                  </li>
+                  <li>
+                    {intl.formatMessage({
+                      defaultMessage: "Formal education",
+                      description:
+                        "pool experience requirement, formal education",
+                    })}
+                  </li>
+                  <li>
+                    {intl.formatMessage({
+                      defaultMessage: "Other field related experience",
+                      description: "pool experience requirement, other",
+                    })}
+                  </li>
+                </ul>
+              </Card>
+              <div
+                data-h2-font-size="b(h4)"
+                data-h2-padding="b(all, s)"
+                data-h2-font-weight="b(800)"
+                data-h2-align-self="b(center)"
+                style={{ textTransform: "uppercase" }}
+              >
+                {intl.formatMessage({
+                  defaultMessage: "or",
+                  description:
+                    "that appears between different experience requirements for a pool applicant",
+                })}
+              </div>
+              <Card
+                style={{ width: "100%" }}
+                color="ts-secondary"
+                title={intl.formatMessage({
+                  defaultMessage: "2-Year Post-secondary Experience",
+                  description:
+                    "Title for pool applicant education requirements",
+                })}
+              >
+                <p data-h2-margin="b(top-bottom, none)">
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "Successful completion of two years of post secondary education in computer science, information technology, information management or another specialty relevant to this position.",
+                    description:
+                      "post secondary education experience for pool advertisement",
+                  })}
+                </p>
+              </Card>
+            </div>
             <IconTitle icon={CheckCircleIcon}>
               {intl.formatMessage({
                 defaultMessage: "Other requirements",

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -11,6 +11,11 @@ import { getLocale, getLocalizedName } from "@common/helpers/localize";
 import { imageUrl } from "@common/helpers/router";
 
 import { AdvertisementStatus } from "@common/api/generated";
+import TableOfContents from "@common/components/TableOfContents";
+import {
+  LightningBoltIcon,
+  BriefcaseIcon as BriefcaseIconOutline,
+} from "@heroicons/react/outline";
 import { useGetPoolAdvertisementQuery } from "../../api/generated";
 import type { PoolAdvertisement } from "../../api/generated";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
@@ -38,7 +43,8 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
     intl,
   );
   const localizedTitle = getLocalizedName(genericTitle?.name, intl);
-  const fullTitle = `${localizedClassificationName} ${localizedTitle} (${classification?.group}-0${classification?.level})`;
+  const classificationSuffix = `(${classification?.group}-0${classification?.level})`;
+  const fullTitle = `${localizedClassificationName} ${localizedTitle} ${classificationSuffix}`;
 
   const links = [
     {
@@ -53,6 +59,55 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
       title: fullTitle,
     },
   ] as BreadcrumbsProps["links"];
+
+  const sections: Record<string, { id: string; title: string }> = {
+    about: {
+      id: "about-section",
+      title: intl.formatMessage({
+        defaultMessage: "About this process",
+        description: "Title for the about section of a pool advertisement",
+      }),
+    },
+    requiredSkills: {
+      id: "required-skills-section",
+      title: intl.formatMessage({
+        defaultMessage: "Need to have",
+        description:
+          "Title for the required skills section of a pool advertisement",
+      }),
+    },
+    optionalSkills: {
+      id: "optional-skills-section",
+      title: intl.formatMessage({
+        defaultMessage: "Nice to have",
+        description:
+          "Title for the optional skills section of a pool advertisement",
+      }),
+    },
+    requirements: {
+      id: "requirements-section",
+      title: intl.formatMessage({
+        defaultMessage: "Requirements",
+        description:
+          "Title for the requirements section of a pool advertisement",
+      }),
+    },
+    details: {
+      id: "details-section",
+      title: intl.formatMessage({
+        defaultMessage: "Additional details",
+        description: "Title for the details section of a pool advertisement",
+      }),
+    },
+    apply: {
+      id: "apply-section",
+      title: intl.formatMessage({
+        defaultMessage: "Apply now",
+        description:
+          "Title for the apply button section of a pool advertisement",
+      }),
+    },
+  };
 
   return (
     <>
@@ -90,6 +145,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
             <div>
               <PoolInfoCard
                 closingDate={poolAdvertisement.expiryDate}
+                classification={classificationSuffix}
                 salary={{
                   min: classification?.minSalary,
                   max: classification?.maxSalary,
@@ -117,6 +173,95 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
           </div>
         </div>
       </div>
+      <TableOfContents.Wrapper>
+        <TableOfContents.Navigation>
+          <TableOfContents.AnchorLink id={sections.about.id}>
+            {sections.about.title}
+          </TableOfContents.AnchorLink>
+          <TableOfContents.AnchorLink id={sections.requiredSkills.id}>
+            {sections.requiredSkills.title}
+          </TableOfContents.AnchorLink>
+          <TableOfContents.AnchorLink id={sections.optionalSkills.id}>
+            {sections.optionalSkills.title}
+          </TableOfContents.AnchorLink>
+          <TableOfContents.AnchorLink id={sections.requirements.id}>
+            {sections.requirements.title}
+          </TableOfContents.AnchorLink>
+          <TableOfContents.AnchorLink id={sections.details.id}>
+            {sections.details.title}
+          </TableOfContents.AnchorLink>
+          <TableOfContents.AnchorLink id={sections.apply.id}>
+            {sections.apply.title}
+          </TableOfContents.AnchorLink>
+        </TableOfContents.Navigation>
+        <TableOfContents.Content>
+          <TableOfContents.Section id={sections.about.id}>
+            <TableOfContents.Heading>
+              {sections.about.title}
+            </TableOfContents.Heading>
+            {/** TO DO: Accordions here */}
+            {poolAdvertisement.yourImpact ? (
+              <>
+                <h3 data-h2-display="b(flex)" data-h2-align-items="b(center)">
+                  <LightningBoltIcon
+                    style={{ width: "1em", marginRight: "0.5rem" }}
+                  />
+                  <span>
+                    {intl.formatMessage({
+                      defaultMessage: "Your impact",
+                      description:
+                        "Title for a pool advertisements impact section.",
+                    })}
+                  </span>
+                </h3>
+                {poolAdvertisement.yourImpact[locale]}
+              </>
+            ) : null}
+            {poolAdvertisement.keyTasks ? (
+              <>
+                <h3 data-h2-display="b(flex)" data-h2-align-items="b(center)">
+                  <BriefcaseIconOutline
+                    style={{ width: "1em", marginRight: "0.5rem" }}
+                  />
+                  <span>
+                    {intl.formatMessage({
+                      defaultMessage: "Your work",
+                      description:
+                        "Title for a pool advertisements key tasks section.",
+                    })}
+                  </span>
+                </h3>
+                {poolAdvertisement.keyTasks[locale]}
+              </>
+            ) : null}
+          </TableOfContents.Section>
+          <TableOfContents.Section id={sections.requiredSkills.id}>
+            <TableOfContents.Heading>
+              {sections.requiredSkills.title}
+            </TableOfContents.Heading>
+          </TableOfContents.Section>
+          <TableOfContents.Section id={sections.optionalSkills.id}>
+            <TableOfContents.Heading>
+              {sections.optionalSkills.title}
+            </TableOfContents.Heading>
+          </TableOfContents.Section>
+          <TableOfContents.Section id={sections.requirements.id}>
+            <TableOfContents.Heading>
+              {sections.requirements.title}
+            </TableOfContents.Heading>
+          </TableOfContents.Section>
+          <TableOfContents.Section id={sections.details.id}>
+            <TableOfContents.Heading>
+              {sections.details.title}
+            </TableOfContents.Heading>
+          </TableOfContents.Section>
+          <TableOfContents.Section id={sections.apply.id}>
+            <TableOfContents.Heading>
+              {sections.apply.title}
+            </TableOfContents.Heading>
+          </TableOfContents.Section>
+        </TableOfContents.Content>
+      </TableOfContents.Wrapper>
     </>
   );
 };

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -223,7 +223,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 })}
               </p>
             </Accordion>
-            {classification?.group && classification.level && (
+            {genericTitle?.key && (
               <Accordion
                 title={intl.formatMessage(
                   {
@@ -240,11 +240,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                   },
                 )}
               >
-                <ClassificationDefinition
-                  group={classification.group}
-                  level={classification.level}
-                  name={genericTitle?.key}
-                />
+                <ClassificationDefinition name={genericTitle.key} />
               </Accordion>
             )}
 

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -16,12 +16,14 @@ import {
   LightningBoltIcon,
   BriefcaseIcon as BriefcaseIconOutline,
 } from "@heroicons/react/outline";
+import Accordion from "@common/components/accordion";
 import { useGetPoolAdvertisementQuery } from "../../api/generated";
 import type { PoolAdvertisement } from "../../api/generated";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
 import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
 import commonMessages from "../commonMessages";
 import PoolInfoCard from "./PoolInfoCard";
+import ClassificationDefinition from "../ClassificationDefinition/ClassificationDefinition";
 
 interface PoolAdvertisementProps {
   poolAdvertisement: PoolAdvertisement;
@@ -43,8 +45,8 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
     intl,
   );
   const localizedTitle = getLocalizedName(genericTitle?.name, intl);
-  const classificationSuffix = `(${classification?.group}-0${classification?.level})`;
-  const fullTitle = `${localizedClassificationName} ${localizedTitle} ${classificationSuffix}`;
+  const classificationSuffix = `${classification?.group}-0${classification?.level}`;
+  const fullTitle = `${localizedClassificationName} ${localizedTitle} (${classificationSuffix})`;
 
   const links = [
     {
@@ -199,7 +201,53 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
             <TableOfContents.Heading>
               {sections.about.title}
             </TableOfContents.Heading>
-            {/** TO DO: Accordions here */}
+            <Accordion
+              title={intl.formatMessage({
+                defaultMessage: "What are pool recruitment's?",
+                description:
+                  "Title for according describing pool recruitment's",
+              })}
+            >
+              <p>
+                {intl.formatMessage({
+                  defaultMessage:
+                    "When you apply to this process, you are not applying for a specific position. This process is intended to create and maintain an inventory to staff various positions at the same level in different departments and agencies across the Government of Canada.",
+                  description: "Description of pool recruitment, paragraph one",
+                })}
+              </p>
+              <p>
+                {intl.formatMessage({
+                  defaultMessage:
+                    "When hiring managers have IT staffing needs and positions become available, applicants who meet the qualifications for this process may be contacted for further assessment. This means various managers may reach out to you about specific opportunities in the area of application development.",
+                  description: "Description of pool recruitment, paragraph two",
+                })}
+              </p>
+            </Accordion>
+            {classification?.group && classification.level && (
+              <Accordion
+                title={intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "What does {classification}{genericTitle} mean?",
+                    description:
+                      "Title for description of a pool advertisements classification group/level",
+                  },
+                  {
+                    classification: classificationSuffix,
+                    genericTitle: genericTitle?.name
+                      ? ` ${genericTitle.name[locale]}`
+                      : ``,
+                  },
+                )}
+              >
+                <ClassificationDefinition
+                  group={classification.group}
+                  level={classification.level}
+                  name={genericTitle?.key}
+                />
+              </Accordion>
+            )}
+
             {poolAdvertisement.yourImpact ? (
               <>
                 <h3 data-h2-display="b(flex)" data-h2-align-items="b(center)">

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -16,9 +16,15 @@ import {
   LightningBoltIcon,
   BriefcaseIcon as BriefcaseIconOutline,
   PhoneIcon,
+  LightBulbIcon,
+  CheckCircleIcon,
 } from "@heroicons/react/outline";
 import Accordion from "@common/components/accordion";
 import { strong } from "@common/helpers/format";
+import {
+  getLanguageRequirement,
+  getSecurityClearance,
+} from "@common/constants/localizedConstants";
 import { useGetPoolAdvertisementQuery } from "../../api/generated";
 import type { PoolAdvertisement } from "../../api/generated";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
@@ -96,6 +102,14 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
   const canApply =
     poolAdvertisement.advertisementStatus &&
     poolAdvertisement.advertisementStatus === AdvertisementStatus.Published;
+
+  const languageRequirement = intl.formatMessage(
+    getLanguageRequirement(poolAdvertisement.advertisementLanguage ?? ""),
+  );
+
+  const securityClearance = intl.formatMessage(
+    getSecurityClearance(poolAdvertisement.securityClearance ?? ""),
+  );
 
   const applyBtn = (
     <ApplyButton
@@ -322,6 +336,59 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
             <TableOfContents.Heading>
               {sections.requirements.title}
             </TableOfContents.Heading>
+            <IconTitle icon={LightBulbIcon}>
+              {intl.formatMessage({
+                defaultMessage: "Experience and education",
+                description:
+                  "Title for experience and education pool requirements",
+              })}
+            </IconTitle>
+            <IconTitle icon={CheckCircleIcon}>
+              {intl.formatMessage({
+                defaultMessage: "Other requirements",
+                description: "Title for other pool requirements",
+              })}
+            </IconTitle>
+            <ul>
+              <li>
+                {intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "Language requirement: {languageRequirement}",
+                    description: "Pool advertisement language requirement",
+                  },
+                  {
+                    languageRequirement,
+                  },
+                )}
+              </li>
+              <li>
+                {intl.formatMessage(
+                  {
+                    defaultMessage: "Security clearance: {securityClearance}",
+                    description:
+                      "Pool advertisement security clearance requirement",
+                  },
+                  {
+                    securityClearance,
+                  },
+                )}
+              </li>
+              {poolAdvertisement.advertisementLocation && (
+                <li>
+                  {intl.formatMessage(
+                    {
+                      defaultMessage: "Location: {location}",
+                      description:
+                        "Pool advertisement location requirement, English",
+                    },
+                    {
+                      location: poolAdvertisement.advertisementLocation[locale],
+                    },
+                  )}
+                </li>
+              )}
+            </ul>
           </TableOfContents.Section>
           <TableOfContents.Section id={sections.details.id}>
             <TableOfContents.Heading>

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -269,7 +269,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
             </TableOfContents.Heading>
             <Accordion
               title={intl.formatMessage({
-                defaultMessage: "What are pool recruitment's?",
+                defaultMessage: "What are pool recruitments?",
                 description:
                   "Title for according describing pool recruitment's",
               })}
@@ -593,7 +593,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
             <p>
               {intl.formatMessage({
                 defaultMessage:
-                  "Do you require accommodations? or do you have any questions about this process?",
+                  "Do you require accommodations, or do you have any questions about this process?",
                 description:
                   "Opening sentence asking if accommodations are needed",
               })}

--- a/frontend/talentsearch/src/js/components/pool/PoolInfoCard.test.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolInfoCard.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import "@testing-library/jest-dom";
+import { render } from "../../tests/testUtils";
+import PoolInfoCard from "./PoolInfoCard";
+import type { PoolInfoCardProps } from "./PoolInfoCard";
+
+const renderPoolInfoCard = (props: PoolInfoCardProps) =>
+  render(<PoolInfoCard {...props} />);
+
+const now = new Date();
+
+describe("PoolInfoCard", () => {
+  it("should render today", () => {
+    const today = new Date(now);
+    today.setHours(23);
+    today.setMinutes(59);
+    const card = renderPoolInfoCard({
+      closingDate: today,
+      classification: "",
+      salary: {
+        min: 1,
+        max: 100,
+      },
+    });
+
+    expect(card.getByText(/today/i)).toBeInTheDocument();
+  });
+
+  it("should render tomorrow", () => {
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setHours(23);
+    tomorrow.setMinutes(59);
+    const card = renderPoolInfoCard({
+      closingDate: tomorrow,
+      classification: "",
+      salary: {
+        min: 1,
+        max: 100,
+      },
+    });
+
+    expect(card.getByText(/tomorrow/i)).toBeInTheDocument();
+  });
+
+  it("should render 'in x days'", () => {
+    const date = new Date(now);
+    date.setDate(date.getDate() + 5);
+    date.setHours(23);
+    date.setMinutes(59);
+    const card = renderPoolInfoCard({
+      closingDate: date,
+      classification: "",
+      salary: {
+        min: 1,
+        max: 100,
+      },
+    });
+
+    expect(card.getByText(/in 5 days/i)).toBeInTheDocument();
+  });
+
+  it("should render expired", () => {
+    const date = new Date(now);
+    date.setDate(date.getDate() - 1);
+    date.setHours(23);
+    date.setMinutes(59);
+    const card = renderPoolInfoCard({
+      closingDate: date,
+      classification: "",
+      salary: {
+        min: 1,
+        max: 100,
+      },
+    });
+
+    expect(
+      card.getByText(/the deadline for submission has passed/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
@@ -7,7 +7,7 @@ import { relativeExpiryDate } from "@common/helpers/dateUtils";
 
 import type { Maybe } from "../../api/generated";
 
-interface PoolInfoCardProps {
+export interface PoolInfoCardProps {
   closingDate: Date;
   classification: string;
   salary: {

--- a/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
@@ -64,7 +64,8 @@ const PoolInfoCard = ({
             defaultMessage: "Salary range:",
             description: "Label for pool advertisement salary range",
           })}{" "}
-          {localizeSalaryRange(salary.min, salary.max, locale)} {classification}
+          {localizeSalaryRange(salary.min, salary.max, locale)} (
+          {classification})
         </span>
       </P>
     </div>

--- a/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
@@ -9,6 +9,7 @@ import type { Maybe } from "../../api/generated";
 
 interface PoolInfoCardProps {
   closingDate: Date;
+  classification: string;
   salary: {
     min: Maybe<number>;
     max: Maybe<number>;
@@ -25,7 +26,11 @@ const P: React.FC = ({ children }) => (
   </p>
 );
 
-const PoolInfoCard = ({ closingDate, salary }: PoolInfoCardProps) => {
+const PoolInfoCard = ({
+  closingDate,
+  salary,
+  classification,
+}: PoolInfoCardProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
 
@@ -59,7 +64,7 @@ const PoolInfoCard = ({ closingDate, salary }: PoolInfoCardProps) => {
             defaultMessage: "Salary range:",
             description: "Label for pool advertisement salary range",
           })}{" "}
-          {localizeSalaryRange(salary.min, salary.max, locale)}
+          {localizeSalaryRange(salary.min, salary.max, locale)} {classification}
         </span>
       </P>
     </div>

--- a/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
@@ -3,7 +3,7 @@ import { useIntl } from "react-intl";
 import { CalendarIcon, CurrencyDollarIcon } from "@heroicons/react/solid";
 
 import { getLocale, localizeSalaryRange } from "@common/helpers/localize";
-import { relativeDate } from "@common/helpers/dateUtils";
+import { relativeExpiryDate } from "@common/helpers/dateUtils";
 
 import type { Maybe } from "../../api/generated";
 
@@ -52,7 +52,7 @@ const PoolInfoCard = ({
             defaultMessage: "Closing date:",
             description: "Label for pool advertisement closing date",
           })}{" "}
-          {relativeDate(new Date(closingDate), intl)}
+          {relativeExpiryDate(new Date(closingDate), intl)}
         </span>
       </P>
       <P>

--- a/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import { CalendarIcon, CurrencyDollarIcon } from "@heroicons/react/solid";
+
+import { getLocale, localizeSalaryRange } from "@common/helpers/localize";
+import { relativeDate } from "@common/helpers/dateUtils";
+
+import type { Maybe } from "../../api/generated";
+
+interface PoolInfoCardProps {
+  closingDate: Date;
+  salary: {
+    min: Maybe<number>;
+    max: Maybe<number>;
+  };
+}
+
+const P: React.FC = ({ children }) => (
+  <p
+    data-h2-display="b(flex)"
+    data-h2-align-items="b(center)"
+    data-h2-margin="b(top-bottom, xxs)"
+  >
+    {children}
+  </p>
+);
+
+const PoolInfoCard = ({ closingDate, salary }: PoolInfoCardProps) => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
+
+  return (
+    <div
+      data-h2-bg-color="b(lightgray)"
+      data-h2-radius="b(s)"
+      data-h2-padding="b(all, s)"
+      data-h2-display="b(flex)"
+      data-h2-flex-direction="b(column)"
+      data-h2-align-items="b(flex-start)"
+    >
+      <P>
+        <CalendarIcon
+          style={{ height: "1em", width: "1em", marginRight: "0.25rem" }}
+        />
+        <span>
+          {intl.formatMessage({
+            defaultMessage: "Closing date:",
+            description: "Label for pool advertisement closing date",
+          })}{" "}
+          {relativeDate(new Date(closingDate), intl)}
+        </span>
+      </P>
+      <P>
+        <CurrencyDollarIcon
+          style={{ height: "1em", width: "1em", marginRight: "0.25rem" }}
+        />
+        <span>
+          {intl.formatMessage({
+            defaultMessage: "Salary range:",
+            description: "Label for pool advertisement salary range",
+          })}{" "}
+          {localizeSalaryRange(salary.min, salary.max, locale)}
+        </span>
+      </P>
+    </div>
+  );
+};
+
+export default PoolInfoCard;

--- a/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
+++ b/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
@@ -36,6 +36,12 @@ query getPoolAdvertisement($id: ID!) {
     }
     expiryDate
     advertisementStatus
+    advertisementLanguage
+    securityClearance
+    advertisementLocation {
+      en
+      fr
+    }
     yourImpact {
       en
       fr

--- a/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
+++ b/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
@@ -50,5 +50,47 @@ query getPoolAdvertisement($id: ID!) {
        en
        fr
     }
+        essentialSkills {
+      id
+      key
+      name {
+        en
+        fr
+      }
+      families {
+        id
+        key
+        description {
+          en
+          fr
+        }
+        name {
+          en
+          fr
+        }
+        category
+      }
+    }
+    nonessentialSkills {
+      id
+      key
+      name {
+        en
+        fr
+      }
+      families {
+        id
+        key
+        description {
+          en
+          fr
+        }
+        name {
+          en
+          fr
+        }
+        category
+      }
+    }
   }
 }

--- a/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
+++ b/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
@@ -9,6 +9,9 @@ query getPool($id: ID!) {
 }
 
 query getPoolAdvertisement($id: ID!) {
+  me {
+    roles
+  }
   poolAdvertisement(id: $id) {
     id
     name {

--- a/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
+++ b/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
@@ -7,3 +7,30 @@ query getPool($id: ID!) {
     }
   }
 }
+
+query getPoolAdvertisement($id: ID!) {
+  poolAdvertisement(id: $id) {
+    id
+    name {
+      en
+      fr
+    }
+    classifications {
+      id
+      group
+      level
+      name {
+        en
+        fr
+      }
+      genericJobTitles {
+        id
+        key
+        name {
+          en
+          fr
+        }
+      }
+    }
+  }
+}

--- a/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
+++ b/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
@@ -36,5 +36,13 @@ query getPoolAdvertisement($id: ID!) {
     }
     expiryDate
     advertisementStatus
+    yourImpact {
+      en
+      fr
+    }
+    keyTasks {
+       en
+       fr
+    }
   }
 }

--- a/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
+++ b/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
@@ -31,6 +31,9 @@ query getPoolAdvertisement($id: ID!) {
           fr
         }
       }
+      minSalary
+      maxSalary
     }
+    expiryDate
   }
 }

--- a/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
+++ b/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
@@ -35,5 +35,6 @@ query getPoolAdvertisement($id: ID!) {
       maxSalary
     }
     expiryDate
+    advertisementStatus
   }
 }

--- a/frontend/talentsearch/src/js/components/request/CreateRequest.tsx
+++ b/frontend/talentsearch/src/js/components/request/CreateRequest.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
 import { errorMessages } from "@common/messages";
-import { getLocale } from "@common/helpers/localize";
 import { Button } from "@common/components";
 import { notEmpty } from "@common/helpers/util";
 import { toast } from "react-toastify";

--- a/frontend/talentsearch/src/js/directIntakeRoutes.ts
+++ b/frontend/talentsearch/src/js/directIntakeRoutes.ts
@@ -13,6 +13,7 @@ const directIntakeRoutes = (lang: string) => {
     allPools: (): string => path.join(home(), "pools"),
     pool: (id: string) => path.join(home(), "pools", id),
     poolApply: (id: string) => path.join(home(), "pools", id, "apply"),
+    poolAdvertisement: (id: string) => path.join(home(), "pools", id, "view"),
     poolApplyThanks: (id: string) =>
       path.join(home(), "pools", id, "apply", "thanks"),
   };


### PR DESCRIPTION
Resolves #3164 

## Summary

This creates the public facing page for pool advertisements.

## Testing

1. Navigate to `/browse/pools`
2. Click on one of the pools
3. Add `/view` to the end of the path
4. Confirm you can see the page and it matches the prototype

### Testing Notes

#### Missing Cypress Tests

We are still waiting on mutations to be able to test this with cypress.

#### Status

We have the following statuses and you should expect the following when you encounter them:

- DRAFT
  - 404 if logged in as applicant
  - View normally as admin
- PUBLISHED
  - See as admin or applicant
  - Can apply as applicant
  - Tile with info in header should indicate number of days until it expires
    - Tomorrow and Today are replaced by number of days when appropriate
- EXPIRED
  - See as admin or applicant
  - Tile indicates the post is expired
  - Apply buttons should be disabled

> We will have ARCHIVED and CLOSED eventually but those have not been added yet so are not reflected. 