### PR TITLE
Bug - 3335 - use custom render for dialog test

### DIFF
--- a/frontend/common/src/components/Dialog/Dialog.test.tsx
+++ b/frontend/common/src/components/Dialog/Dialog.test.tsx
@@ -2,8 +2,9 @@
  * @jest-environment jsdom
  */
 import "@testing-library/jest-dom";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 import React from "react";
+import { render } from "../../helpers/testUtils";
 import Dialog from "./Dialog";
 import type { DialogProps, Color } from "./Dialog";
 


### PR DESCRIPTION
Resolves #3335 

## Summary

Updates test to use the `customRender` in test utilities.