### PR TITLE
resolve backend advertiseStatus bug

### DIFF
--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -87,7 +87,8 @@ class Pool extends Model
     /* accessor to obtain Advertisement Status, depends on two variables regarding published and expiry */
     public function getAdvertisementStatusAttribute()
     {
-        date_default_timezone_set('America/Vancouver');
+        // given database is functioning in UTC, all backend should consistently enforce the same timezone
+        date_default_timezone_set('UTC');
         $isPublished = $this->is_published;
         $expiryDate = $this->expiry_date;
         $currentTime = date("Y-m-d H:i:s");

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -88,7 +88,6 @@ class Pool extends Model
     public function getAdvertisementStatusAttribute()
     {
         // given database is functioning in UTC, all backend should consistently enforce the same timezone
-        date_default_timezone_set('UTC');
         $isPublished = $this->is_published;
         $expiryDate = $this->expiry_date;
         $currentTime = date("Y-m-d H:i:s");

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -107,7 +107,6 @@ class PoolTest extends TestCase
   public function testPoolAdvertisementAccessorTime(): void
   {
     // test that expiry on day of functions as expected, that soon to expire can be applied to and just expired is longer open for application
-    date_default_timezone_set('UTC');
     $expireInHour = date("Y-m-d H:i:s", strtotime('+1 hour'));
     $expiredLastHour = date("Y-m-d H:i:s", strtotime('-1 hour'));
 


### PR DESCRIPTION
resolves #3354 

having the timezone set as Pacific in the accessor attribute was messing with things when current time and expiry time were within a few hours of one another
given the database deals in UTC, I elected to go with UTC time being enforced for the backend, I think it'll be easier that way, plus it seems that sticking with Laravel/database conventions would be preferred in that other issue

as well, added an additional test to ensure the bug was (ideally) resolved
testing: see if you can break the accessor in Adminer + viewing pool poster

sidenote: I think this convention should be kept in mind for mutations creating posters too, to convert time to UTC before executeMutation