### PR TITLE
Bug - Fix @formatjs warning for default rich text elements

### DIFF
--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -34,7 +34,7 @@
     "build-storybook": "build-storybook",
     "chromatic": "npx chromatic --project-token=87148152bdff --auto-accept-changes",
     "codegen": "graphql-codegen",
-    "intl-extract": "formatjs extract './src/js/**/*.{ts,tsx}' --ignore './**/*.d.ts' --out-file src/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
+    "intl-extract": "formatjs extract './src/js/**/*.{ts,tsx}' --ignore './**/*.d.ts' --ast --out-file src/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
     "intl-compile": "formatjs compile ./src/js/lang/fr.json --out-file ./src/js/lang/frCompiled.json",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/frontend/common/package.json
+++ b/frontend/common/package.json
@@ -17,7 +17,7 @@
     "h2-watch": "h2-watch",
     "h2-build": "h2-build",
     "intl-extract": "formatjs extract './src/**/*.{ts,tsx}' --ignore './**/*.d.ts' --out-file src/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
-    "intl-compile": "formatjs compile src/lang/fr.json --out-file src/lang/frCompiled.json",
+    "intl-compile": "formatjs compile src/lang/fr.json --ast --out-file src/lang/frCompiled.json",
     "check-intl-common": "node ./src/tooling/checkIntl.js --en src/lang/en.json --fr src/lang/fr.json --rm-orphaned --output-untranslated src/lang/untranslated.json --whitelist src/lang/whitelist.yml",
     "check-intl-common-merge": "node src/tooling/checkIntl.js --en src/lang/en.json --fr src/lang/fr.json --rm-orphaned --output-untranslated src/lang/untranslated.json --whitelist src/lang/whitelist.yml --merge-fr src/lang/newTranslations.json",
     "check-intl-admin": "node ./src/tooling/checkIntl.js --en ../admin/src/js/lang/en.json --fr ../admin/src/js/lang/fr.json --rm-orphaned --output-untranslated ../admin/src/js/lang/untranslated.json --whitelist ../admin/src/js/lang/whitelist.yml",

--- a/frontend/indigenousapprenticeship/package.json
+++ b/frontend/indigenousapprenticeship/package.json
@@ -34,7 +34,7 @@
     "build-storybook": "build-storybook",
     "codegen": "graphql-codegen",
     "intl-extract": "formatjs extract './src/js/**/*.{ts,tsx}' --ignore './**/*.d.ts' --out-file src/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
-    "intl-compile": "formatjs compile ./src/js/lang/fr.json --out-file ./src/js/lang/frCompiled.json",
+    "intl-compile": "formatjs compile ./src/js/lang/fr.json --ast --out-file ./src/js/lang/frCompiled.json",
     "test": "jest",
     "test:watch": "jest --watch"
   },

--- a/frontend/talentsearch/package.json
+++ b/frontend/talentsearch/package.json
@@ -34,7 +34,7 @@
     "build-storybook": "build-storybook",
     "codegen": "graphql-codegen",
     "intl-extract": "formatjs extract './src/js/**/*.{ts,tsx}' --ignore './**/*.d.ts' --out-file src/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
-    "intl-compile": "formatjs compile ./src/js/lang/fr.json --out-file ./src/js/lang/frCompiled.json",
+    "intl-compile": "formatjs compile ./src/js/lang/fr.json --ast --out-file ./src/js/lang/frCompiled.json",
     "test": "jest",
     "test:watch": "jest --watch"
   },


### PR DESCRIPTION
## Summary

This changes our compile method from string to [AST](https://formatjs.io/docs/guides/advanced-usage).  I can't tell you why this is the solution but it should actually speed up the application as well as fix the `console.warn` we are getting during tests.

Ref: https://stackoverflow.com/a/71384834