### PR TITLE
Bugfix: Added formatjs --ast flag to appropriate command.

### DIFF
--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -34,8 +34,8 @@
     "build-storybook": "build-storybook",
     "chromatic": "npx chromatic --project-token=87148152bdff --auto-accept-changes",
     "codegen": "graphql-codegen",
-    "intl-extract": "formatjs extract './src/js/**/*.{ts,tsx}' --ignore './**/*.d.ts' --ast --out-file src/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
-    "intl-compile": "formatjs compile ./src/js/lang/fr.json --out-file ./src/js/lang/frCompiled.json",
+    "intl-extract": "formatjs extract './src/js/**/*.{ts,tsx}' --ignore './**/*.d.ts' --out-file src/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
+    "intl-compile": "formatjs compile ./src/js/lang/fr.json --ast --out-file ./src/js/lang/frCompiled.json",
     "test": "jest",
     "test:watch": "jest --watch"
   },


### PR DESCRIPTION
Fixes bug in #3385 


@tristan-orourke [in Slack](https://app.slack.com/client/T5ZFRSQ3V/threads/thread/C0259G6KXJ6-1658167365.124319):
> Were you both able to run intl-extract like this? Now npm run intl-extract throws an error when I run it locally: error: unknown option '--ast'.