### PR TITLE
semi-refactor WorkPreferencesSection

### DIFF
--- a/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useIntl } from "react-intl";
 import { isEmpty } from "lodash";
 import { getOperationalRequirement } from "../../../constants/localizedConstants";
-import { Applicant } from "../../../api/generated";
+import { Applicant, OperationalRequirement } from "../../../api/generated";
 
 const WorkPreferencesSection: React.FunctionComponent<{
   applicant: Pick<
@@ -26,45 +26,130 @@ const WorkPreferencesSection: React.FunctionComponent<{
     : null;
 
   const anyCriteriaSelected = !isEmpty(acceptedOperationalArray);
+
+  // all V2 operational requirements
+  const operationalRequirementsSubsetV2 = [
+    OperationalRequirement.OvertimeOccasional,
+    OperationalRequirement.OvertimeRegular,
+    OperationalRequirement.ShiftWork,
+    OperationalRequirement.OnCall,
+    OperationalRequirement.Travel,
+    OperationalRequirement.TransportEquipment,
+    OperationalRequirement.DriversLicense,
+  ];
+
+  // requirements that have not been selected made into an array
+  const unselectedOperationalArray = operationalRequirementsSubsetV2.filter(
+    (requirement) => !acceptedOperationalRequirements?.includes(requirement),
+  );
+
+  // generate list of unaccepted operational requirements
+  const unacceptedOperationalArray = unselectedOperationalArray
+    ? unselectedOperationalArray.map((opRequirement) => (
+        <li data-h2-font-weight="b(700)" key={opRequirement}>
+          {opRequirement
+            ? getOperationalRequirement(opRequirement).defaultMessage
+            : ""}
+        </li>
+      ))
+    : null;
+
   return (
     <div
       data-h2-bg-color="b(lightgray)"
       data-h2-padding="b(all, m)"
       data-h2-radius="b(s)"
     >
-      {anyCriteriaSelected && (
+      {wouldAcceptTemporary === null && (
         <p>
+          <p>
+            {intl.formatMessage({
+              defaultMessage: "You haven't added any information here yet.",
+              description: "Message for when no data exists for the section",
+            })}
+          </p>
           {intl.formatMessage({
-            defaultMessage: "I would consider accepting a job that lasts for:",
+            defaultMessage: "There are <red>required</red> fields missing.",
             description:
-              "Label for what length of position user prefers, followed by colon",
+              "Message that there are required fields missing. Please ignore things in <> tags.",
           })}{" "}
+          <a href={editPath}>
+            {intl.formatMessage({
+              defaultMessage: "Click here to get started.",
+              description: "Message to click on the words to begin something",
+            })}
+          </a>
         </p>
       )}
+
       {wouldAcceptTemporary && (
-        <ul data-h2-padding="b(left, l)">
-          <li data-h2-font-weight="b(700)">
+        <>
+          <p>
             {intl.formatMessage({
               defaultMessage:
-                "Any duration (short, long term, or indeterminate duration)",
+                "I would consider accepting a job that lasts for:",
               description:
-                "Duration of any length is good, specified three example lengths",
-            })}
-          </li>
-        </ul>
-      )}
-      {wouldAcceptTemporary === false && (
-        <ul data-h2-padding="b(left, l)">
-          <li data-h2-font-weight="b(700)">
-            {intl.formatMessage({
-              defaultMessage: "Permanent duration",
-              description: "Permanent duration only",
+                "Label for what length of position user prefers, followed by colon",
             })}{" "}
-          </li>
-        </ul>
+          </p>
+          <ul data-h2-padding="b(left, l)">
+            <li data-h2-font-weight="b(700)">
+              {intl.formatMessage({
+                defaultMessage:
+                  "Any duration (short, long term, or indeterminate duration)",
+                description:
+                  "Duration of any length is good, specified three example lengths",
+              })}
+            </li>
+          </ul>
+        </>
       )}
 
-      {anyCriteriaSelected && (
+      {wouldAcceptTemporary === false && (
+        <>
+          <p>
+            {intl.formatMessage({
+              defaultMessage:
+                "I would consider accepting a job that lasts for:",
+              description:
+                "Label for what length of position user prefers, followed by colon",
+            })}{" "}
+          </p>
+          <ul data-h2-padding="b(left, l)">
+            <li data-h2-font-weight="b(700)">
+              {intl.formatMessage({
+                defaultMessage: "Permanent duration",
+                description: "Permanent duration only",
+              })}{" "}
+            </li>
+          </ul>
+        </>
+      )}
+
+      {anyCriteriaSelected && !isEmpty(unacceptedOperationalArray) && (
+        <>
+          <p>
+            {intl.formatMessage({
+              defaultMessage: "I would consider accepting a job that:",
+              description:
+                "Label for what conditions a user will accept, followed by a colon",
+            })}
+          </p>
+          <ul data-h2-padding="b(left, l)">{acceptedOperationalArray}</ul>
+
+          <p>
+            {intl.formatMessage({
+              defaultMessage:
+                "I would <strong>not</strong> consider accepting a job that:",
+              description:
+                "would not accept job line before a list, ignore things in <> please",
+            })}
+          </p>
+          <ul data-h2-padding="b(left, l)">{unacceptedOperationalArray}</ul>
+        </>
+      )}
+
+      {anyCriteriaSelected && isEmpty(unacceptedOperationalArray) && (
         <>
           <p>
             {intl.formatMessage({
@@ -81,25 +166,16 @@ const WorkPreferencesSection: React.FunctionComponent<{
         <>
           <p>
             {intl.formatMessage({
-              defaultMessage: "You haven't added any information here yet.",
-              description: "Message for when no data exists for the section",
+              defaultMessage:
+                "I would <strong>not</strong> consider accepting a job that:",
+              description:
+                "would not accept job line before a list, ignore things in <> please",
             })}
           </p>
-          <p>
-            {intl.formatMessage({
-              defaultMessage: "There are <red>required</red> fields missing.",
-              description:
-                "Message that there are required fields missing. Please ignore things in <> tags.",
-            })}{" "}
-            <a href={editPath}>
-              {intl.formatMessage({
-                defaultMessage: "Click here to get started.",
-                description: "Message to click on the words to begin something",
-              })}
-            </a>
-          </p>
+          <ul data-h2-padding="b(left, l)">{unacceptedOperationalArray}</ul>
         </>
       )}
+
       {!anyCriteriaSelected && !editPath && (
         <p>
           {intl.formatMessage({

--- a/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
@@ -61,7 +61,7 @@ const WorkPreferencesSection: React.FunctionComponent<{
       data-h2-radius="b(s)"
     >
       {wouldAcceptTemporary === null && (
-        <p>
+        <>
           <p>
             {intl.formatMessage({
               defaultMessage: "You haven't added any information here yet.",
@@ -79,7 +79,7 @@ const WorkPreferencesSection: React.FunctionComponent<{
               description: "Message to click on the words to begin something",
             })}
           </a>
-        </p>
+        </>
       )}
 
       {wouldAcceptTemporary && (

--- a/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
@@ -68,17 +68,19 @@ const WorkPreferencesSection: React.FunctionComponent<{
               description: "Message for when no data exists for the section",
             })}
           </p>
-          {intl.formatMessage({
-            defaultMessage: "There are <red>required</red> fields missing.",
-            description:
-              "Message that there are required fields missing. Please ignore things in <> tags.",
-          })}{" "}
-          <a href={editPath}>
+          <p>
             {intl.formatMessage({
-              defaultMessage: "Click here to get started.",
-              description: "Message to click on the words to begin something",
-            })}
-          </a>
+              defaultMessage: "There are <red>required</red> fields missing.",
+              description:
+                "Message that there are required fields missing. Please ignore things in <> tags.",
+            })}{" "}
+            <a href={editPath}>
+              {intl.formatMessage({
+                defaultMessage: "Click here to get started.",
+                description: "Message to click on the words to begin something",
+              })}
+            </a>
+          </p>
         </>
       )}
 


### PR DESCRIPTION
resolves #3403 

The look of the WorkPreferences section needs some changing. Now what is _and_ what isn't selected needs to be represented.
As well as what appears required and how things look nulled. 

To test, go to /profile and view the Work Preferences section and...
- test null for wouldAcceptTemporary
- zero selected requirements
- some selected requirements
- all selected requirements 

