### PR TITLE
Bug - 2091 - Improve long label checkbox

### DIFF
--- a/frontend/common/src/components/form/Checkbox/Checkbox.stories.tsx
+++ b/frontend/common/src/components/form/Checkbox/Checkbox.stories.tsx
@@ -24,6 +24,7 @@ const TemplateCheckbox: Story<CheckboxProps> = (args) => {
 export const IndividualCheckbox = TemplateCheckbox.bind({});
 export const CheckboxWithBoundingBox = TemplateCheckbox.bind({});
 export const CheckboxElementLabel = TemplateCheckbox.bind({});
+export const LongTextCheckbox = TemplateCheckbox.bind({});
 
 IndividualCheckbox.args = {
   id: "hasDiploma",
@@ -43,4 +44,19 @@ CheckboxElementLabel.args = {
   id: "Red Selection",
   name: "Red Selection",
   label: <span data-h2-bg-color="b(red)">Red Selection</span>,
+};
+
+LongTextCheckbox.args = {
+  id: "iAgree",
+  name: "iAgree",
+  label:
+    "I agree to share this information with verified Government of Canada hiring managers and HR advisors who have access to this platform.",
+  context: "This is a really long string.",
+  rules: { required: "This must be accepted to continue." },
+};
+
+LongTextCheckbox.parameters = {
+  viewport: {
+    defaultViewport: "mobile1",
+  },
 };

--- a/frontend/common/src/components/form/Checkbox/Checkbox.tsx
+++ b/frontend/common/src/components/form/Checkbox/Checkbox.tsx
@@ -51,7 +51,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
           context={context}
           error={error}
           data-h2-flex-direction="b(row)"
-          data-h2-align-items="b(center)"
+          data-h2-align-items="b(flex-start)"
         >
           <input
             style={{ order: -1 }}


### PR DESCRIPTION
Resolves #2091 

## Summary

This changes checkbox component to align items using `flex-start` instead of `center` to provide a better layout when providing long labels.

## Note

There was a mockup provided that had `required` text at the top but this is a limitation of the `InputWrapper` component making this come *after* the label. Putting this first may also be considered an a11y problem since one of two scenarios would occur:

- Change reading order so that required is read before label
- Rendering order is changed with CSS which would make it not match expected reading order

## Screenshot
<img width="316" alt="Screen Shot 2022-07-19 at 3 52 22 PM" src="https://user-images.githubusercontent.com/4127998/179836779-96c047b8-3299-4c9d-9747-2c25e7b1b94c.png">

