### PR TITLE
Bug/3409 download buttons on wrong pages

### DIFF
--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -289,36 +289,6 @@ function Table<T extends Record<string, unknown>>({
         data-h2-radius="b(none, none, s, s)"
         data-h2-padding="b(all, s)"
       >
-        <div
-          data-h2-display="b(flex)"
-          data-h2-align-items="b(center)"
-          data-h2-margin="b(right, s)"
-        >
-          <p>
-            {intl.formatMessage({
-              defaultMessage: "Selected actions:",
-              description: "Label for action buttons in footer of admin table.",
-            })}
-          </p>
-          <Spacer>
-            <Button type="button" mode="solid" color="primary">
-              {intl.formatMessage({
-                defaultMessage: "Download XML",
-                description:
-                  "Text label for button to download an xml file of items in a table.",
-              })}
-            </Button>
-          </Spacer>
-          <Spacer>
-            <Button type="button" mode="solid" color="primary">
-              {intl.formatMessage({
-                defaultMessage: "Download PDF",
-                description:
-                  "Text label for button to download a pdf of items in a table.",
-              })}
-            </Button>
-          </Spacer>
-        </div>
         {pagination && (
           <Pagination
             currentPage={pageIndex + 1}

--- a/frontend/admin/src/js/components/apiManagedTable/TableFooter.tsx
+++ b/frontend/admin/src/js/components/apiManagedTable/TableFooter.tsx
@@ -62,12 +62,7 @@ function TableFooter({
           </p>
           <Pending fetching={fetchingSelected} error={selectionError} inline>
             <Spacer>
-              <Button
-                type="button"
-                mode="solid"
-                color="primary"
-                disabled={disableActions}
-              >
+              <Button type="button" mode="solid" color="primary" disabled>
                 {intl.formatMessage({
                   defaultMessage: "Download XML",
                   description:

--- a/frontend/admin/src/js/components/apiManagedTable/TableFooter.tsx
+++ b/frontend/admin/src/js/components/apiManagedTable/TableFooter.tsx
@@ -12,6 +12,7 @@ export interface TableFooterProps {
   onCurrentPageChange: (n: number) => void;
   onPageSizeChange: (n: number) => void;
   onPrint?: () => void;
+  hasSelection?: boolean;
   disableActions?: boolean;
   fetchingSelected?: boolean;
   selectionError?: CombinedError;
@@ -32,6 +33,7 @@ function TableFooter({
   onPageSizeChange,
   onPrint,
   disableActions,
+  hasSelection = false,
   fetchingSelected = false,
   selectionError,
 }: TableFooterProps): ReactElement {
@@ -46,48 +48,51 @@ function TableFooter({
       data-h2-radius="b(none, none, s, s)"
       data-h2-padding="b(all, s)"
     >
-      <div
-        data-h2-display="b(flex)"
-        data-h2-align-items="b(center)"
-        data-h2-margin="b(right, s)"
-      >
-        <p>
-          {intl.formatMessage({
-            defaultMessage: "Selected actions:",
-            description: "Label for action buttons in footer of admin table.",
-          })}
-        </p>
-        <Pending fetching={fetchingSelected} error={selectionError} inline>
-          <Spacer>
-            <Button
-              type="button"
-              mode="solid"
-              color="primary"
-              disabled={disableActions}
-            >
-              {intl.formatMessage({
-                defaultMessage: "Download XML",
-                description:
-                  "Text label for button to download an xml file of items in a table.",
-              })}
-            </Button>
-          </Spacer>
-          <Spacer>
-            <Button
-              type="button"
-              mode="solid"
-              color="primary"
-              disabled={disableActions}
-              onClick={onPrint}
-            >
-              {intl.formatMessage({
-                defaultMessage: "Print",
-                description: "Text label for button to print items in a table.",
-              })}
-            </Button>
-          </Spacer>
-        </Pending>
-      </div>
+      {hasSelection && (
+        <div
+          data-h2-display="b(flex)"
+          data-h2-align-items="b(center)"
+          data-h2-margin="b(right, s)"
+        >
+          <p>
+            {intl.formatMessage({
+              defaultMessage: "Selected actions:",
+              description: "Label for action buttons in footer of admin table.",
+            })}
+          </p>
+          <Pending fetching={fetchingSelected} error={selectionError} inline>
+            <Spacer>
+              <Button
+                type="button"
+                mode="solid"
+                color="primary"
+                disabled={disableActions}
+              >
+                {intl.formatMessage({
+                  defaultMessage: "Download XML",
+                  description:
+                    "Text label for button to download an xml file of items in a table.",
+                })}
+              </Button>
+            </Spacer>
+            <Spacer>
+              <Button
+                type="button"
+                mode="solid"
+                color="primary"
+                disabled={disableActions}
+                onClick={onPrint}
+              >
+                {intl.formatMessage({
+                  defaultMessage: "Print",
+                  description:
+                    "Text label for button to print items in a table.",
+                })}
+              </Button>
+            </Spacer>
+          </Pending>
+        </div>
+      )}
       <Pagination
         currentPage={paginatorInfo.currentPage}
         onCurrentPageChange={onCurrentPageChange}

--- a/frontend/admin/src/js/components/user/UserTable.tsx
+++ b/frontend/admin/src/js/components/user/UserTable.tsx
@@ -278,6 +278,7 @@ export const UserTable: React.FC = () => {
         onCurrentPageChange={setCurrentPage}
         onPageSizeChange={setPageSize}
         onPrint={handlePrint}
+        hasSelection
         fetchingSelected={selectedUsersFetching}
         selectionError={selectedUsersError}
         disableActions={


### PR DESCRIPTION
Resolves #3409.

Removes the download buttons from all the tables but Users because none of them have row selection at this point.

Notes:
- Removes the download buttons from the old frontend-paginated table component since it can't currently handle row selection.
- Hides the download buttons in the backend paginated table unless specified.
- Set the "Download XML" button to always be disabled since we don't have functionality for it yet anyway.