### PR TITLE
Add Cell Key to Latest Requests Table

### DIFF
--- a/frontend/admin/src/js/components/dashboard/LatestRequestsTable.tsx
+++ b/frontend/admin/src/js/components/dashboard/LatestRequestsTable.tsx
@@ -113,12 +113,12 @@ const LatestRequestsTable: React.FC<LatestRequestsTableProps> = ({ data }) => {
         return pools?.map(
           (pool, index) =>
             pool && (
-              <>
-                <a key={pool.id} href={paths.poolCandidateTable(pool.id)}>
+              <React.Fragment key={pool.id}>
+                <a href={paths.poolCandidateTable(pool.id)}>
                   {pool.name?.[locale]}
                 </a>
                 {index > 0 && ", "}
-              </>
+              </React.Fragment>
             ),
         );
       },


### PR DESCRIPTION
## Summary

Moves the key for `Cell` accessor in the `LatestRequestsTable` up a level to the `React.Fragment`.