### PR TITLE
Design - 3455 - Remove Tab Gray Backgrounds

### DIFF
--- a/frontend/common/src/components/UserProfile/ExperienceByTypeListing.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceByTypeListing.tsx
@@ -45,20 +45,14 @@ const ExperienceByType: React.FunctionComponent<{
           {title}
         </p>
       </div>
-      <div
-        data-h2-radius="b(s)"
-        data-h2-bg-color="b(lightgray)"
-        data-h2-padding="b(top-bottom, xxs) b(right-left, xs)"
-      >
-        {experiences.map((experience) => (
-          <ExperienceAccordion
-            key={experience.id}
-            experience={experience}
-            editPaths={experienceEditPaths}
-            defaultOpen={defaultOpen}
-          />
-        ))}
-      </div>
+      {experiences.map((experience) => (
+        <ExperienceAccordion
+          key={experience.id}
+          experience={experience}
+          editPaths={experienceEditPaths}
+          defaultOpen={defaultOpen}
+        />
+      ))}
     </div>
   );
 };

--- a/frontend/common/src/components/UserProfile/ExperienceSection.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceSection.tsx
@@ -124,11 +124,7 @@ const ExperienceSection: React.FunctionComponent<ExperienceSectionProps> = ({
   ];
 
   return (
-    <div
-      data-h2-bg-color="b(lightgray)"
-      data-h2-padding="b(all, m)"
-      data-h2-radius="b(s)"
-    >
+    <>
       {isExperience && (
         <Tabs>
           <TabList>
@@ -140,19 +136,13 @@ const ExperienceSection: React.FunctionComponent<ExperienceSectionProps> = ({
           </TabList>
           <TabPanels>
             <TabPanel>
-              <div
-                data-h2-radius="b(s)"
-                data-h2-bg-color="b(lightgray)"
-                data-h2-padding="b(top-bottom, xxs) b(right-left, xs)"
-              >
-                {sortedByDate.map((experience) => (
-                  <ExperienceAccordion
-                    key={experience.id}
-                    experience={experience}
-                    editPaths={experienceEditPaths}
-                  />
-                ))}
-              </div>
+              {sortedByDate.map((experience) => (
+                <ExperienceAccordion
+                  key={experience.id}
+                  experience={experience}
+                  editPaths={experienceEditPaths}
+                />
+              ))}
             </TabPanel>
             <TabPanel>
               <ExperienceByTypeListing
@@ -161,15 +151,9 @@ const ExperienceSection: React.FunctionComponent<ExperienceSectionProps> = ({
               />
             </TabPanel>
             <TabPanel>
-              <div
-                data-h2-radius="b(s)"
-                data-h2-bg-color="b(lightgray)"
-                data-h2-padding="b(top-bottom, xxs) b(right-left, xs)"
-              >
-                {sortedBySkills.map((skill) => (
-                  <SkillAccordion key={skill.id} skill={skill} />
-                ))}
-              </div>
+              {sortedBySkills.map((skill) => (
+                <SkillAccordion key={skill.id} skill={skill} />
+              ))}
             </TabPanel>
           </TabPanels>
         </Tabs>
@@ -201,7 +185,7 @@ const ExperienceSection: React.FunctionComponent<ExperienceSectionProps> = ({
           </p>
         </>
       )}
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
Resolves #3455 

## Summary

Removes the gray backgrounds on tabs for Experience & Skills.

## Screenshot

<img width="1000" alt="Screen Shot 2022-07-22 at 10 07 51 AM" src="https://user-images.githubusercontent.com/4127998/180457792-aa83d0e1-bea3-41cc-ad38-56ef9141c4c0.png">

