### PR TITLE
A11y - 3195 - Improve get started link context

### DIFF
--- a/frontend/admin/src/js/components/searchRequest/SingleSearchRequest.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SingleSearchRequest.tsx
@@ -10,7 +10,6 @@ import { getPoolCandidateSearchStatus } from "@common/constants/localizedConstan
 import Pending from "@common/components/Pending";
 import NotFound from "@common/components/NotFound";
 import {
-  ApplicantFilterInput,
   PoolCandidateFilterInput,
   PoolCandidateSearchRequest,
   useGetPoolCandidateSearchRequestQuery,
@@ -31,7 +30,6 @@ const ManagerInfo: React.FunctionComponent<{
     status,
     requestedDate,
     poolCandidateFilter,
-    applicantFilter,
   } = searchRequest;
 
   return (

--- a/frontend/admin/src/js/stories/Pool.stories.tsx
+++ b/frontend/admin/src/js/stories/Pool.stories.tsx
@@ -7,7 +7,6 @@ import {
   fakeUsers,
   fakePools,
 } from "@common/fakeData";
-import { OperationalRequirementV2 } from "@common/constants/localizedConstants";
 import {
   Classification,
   CmoAsset,

--- a/frontend/common/src/components/SearchRequestFilters/deprecated/SearchRequestFilters.tsx
+++ b/frontend/common/src/components/SearchRequestFilters/deprecated/SearchRequestFilters.tsx
@@ -96,6 +96,8 @@ export interface SearchRequestFiltersProps {
 
 const SearchRequestFilters: React.FunctionComponent<
   SearchRequestFiltersProps
+  // Deprecated but needed
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
 > = ({ poolCandidateFilter, poolApplicantFilter }) => {
   const intl = useIntl();
   const locale = getLocale(intl);

--- a/frontend/common/src/components/UserProfile/ExperienceSection.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceSection.tsx
@@ -178,8 +178,9 @@ const ExperienceSection: React.FunctionComponent<ExperienceSectionProps> = ({
           <p>
             <a href={editPath}>
               {intl.formatMessage({
-                defaultMessage: "Click here to get started.",
-                description: "Message to click on the words to begin something",
+                defaultMessage: "Edit your experience options.",
+                description:
+                  "Link text to edit experience information on profile.",
               })}
             </a>
           </p>

--- a/frontend/common/src/components/UserProfile/ProfileSections/AboutSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/AboutSection.tsx
@@ -134,7 +134,7 @@ const AboutSection: React.FC<AboutSectionProps> = ({
           <a href={editPath}>
             {intl.formatMessage({
               defaultMessage: "Edit your about me options.",
-              description: "Link text to edit about me section of profile.",
+              description: "Link text to edit about me section on profile.",
             })}
           </a>
         </p>

--- a/frontend/common/src/components/UserProfile/ProfileSections/AboutSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/AboutSection.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { getProvinceOrTerritory } from "../../../constants/localizedConstants";
+import {
+  getProvinceOrTerritory,
+  requiredFieldsMissing,
+} from "../../../constants/localizedConstants";
 import { getLanguage } from "../../../constants";
 import type { Applicant } from "../../../api/generated";
 
@@ -127,15 +130,11 @@ const AboutSection: React.FC<AboutSectionProps> = ({
         !currentCity ||
         !currentProvince) && (
         <p>
-          {intl.formatMessage({
-            defaultMessage: "There are <red>required</red> fields missing.",
-            description:
-              "Message that there are required fields missing. Please ignore things in <> tags.",
-          })}{" "}
+          {intl.formatMessage(requiredFieldsMissing)}{" "}
           <a href={editPath}>
             {intl.formatMessage({
-              defaultMessage: "Click here to get started.",
-              description: "Message to click on the words to begin something",
+              defaultMessage: "Edit your about me options.",
+              description: "Link text to edit about me section of profile.",
             })}
           </a>
         </p>

--- a/frontend/common/src/components/UserProfile/ProfileSections/AboutSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/AboutSection.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-import {
-  getProvinceOrTerritory,
-  requiredFieldsMissing,
-} from "../../../constants/localizedConstants";
+import messages from "../../../messages/commonMessages";
+import { getProvinceOrTerritory } from "../../../constants/localizedConstants";
 import { getLanguage } from "../../../constants";
 import type { Applicant } from "../../../api/generated";
 
@@ -130,7 +128,7 @@ const AboutSection: React.FC<AboutSectionProps> = ({
         !currentCity ||
         !currentProvince) && (
         <p>
-          {intl.formatMessage(requiredFieldsMissing)}{" "}
+          {intl.formatMessage(messages.requiredFieldsMissing)}{" "}
           <a href={editPath}>
             {intl.formatMessage({
               defaultMessage: "Edit your about me options.",

--- a/frontend/common/src/components/UserProfile/ProfileSections/DiversityEquityInclusionSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/DiversityEquityInclusionSection.tsx
@@ -40,8 +40,10 @@ const DiversityEquityInclusionSection: React.FunctionComponent<{
           <p>
             <a href={editPath}>
               {intl.formatMessage({
-                defaultMessage: "Click here to get started.",
-                description: "Message to click on the words to begin something",
+                defaultMessage:
+                  "Edit your diversity, equity and inclusion options.",
+                description:
+                  "Link text to edit diversity, equity and inclusion information on profile.",
               })}
             </a>
           </p>

--- a/frontend/common/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { enumToOptions } from "../../../helpers/formUtils";
-import {
-  getGovEmployeeType,
-  requiredFieldsMissing,
-} from "../../../constants/localizedConstants";
+import messages from "../../../messages/commonMessages";
+import { getGovEmployeeType } from "../../../constants/localizedConstants";
 import { getLocale } from "../../../helpers/localize";
 import { Applicant, GovEmployeeType } from "../../../api/generated";
 
@@ -93,7 +91,7 @@ const GovernmentInformationSection: React.FunctionComponent<{
               })}
             </p>
             <p>
-              {intl.formatMessage(requiredFieldsMissing)}{" "}
+              {intl.formatMessage(messages.requiredFieldsMissing)}{" "}
               <a href={editPath}>
                 {intl.formatMessage({
                   defaultMessage: "Edit your government information options.",

--- a/frontend/common/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { enumToOptions } from "../../../helpers/formUtils";
-import { getGovEmployeeType } from "../../../constants/localizedConstants";
+import {
+  getGovEmployeeType,
+  requiredFieldsMissing,
+} from "../../../constants/localizedConstants";
 import { getLocale } from "../../../helpers/localize";
 import { Applicant, GovEmployeeType } from "../../../api/generated";
 
@@ -90,16 +93,12 @@ const GovernmentInformationSection: React.FunctionComponent<{
               })}
             </p>
             <p>
-              {intl.formatMessage({
-                defaultMessage: "There are <red>required</red> fields missing.",
-                description:
-                  "Message that there are required fields missing. Please ignore things in <> tags.",
-              })}
+              {intl.formatMessage(requiredFieldsMissing)}
               <a href={editPath}>
                 {intl.formatMessage({
-                  defaultMessage: "Click here to get started.",
+                  defaultMessage: "Edit your government information options.",
                   description:
-                    "Message to click on the words to begin something",
+                    "Link text to edit government information on profile.",
                 })}
               </a>
             </p>

--- a/frontend/common/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
@@ -93,7 +93,7 @@ const GovernmentInformationSection: React.FunctionComponent<{
               })}
             </p>
             <p>
-              {intl.formatMessage(requiredFieldsMissing)}
+              {intl.formatMessage(requiredFieldsMissing)}{" "}
               <a href={editPath}>
                 {intl.formatMessage({
                   defaultMessage: "Edit your government information options.",

--- a/frontend/common/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { Applicant, BilingualEvaluation } from "../../../api/generated";
-import { getLanguageProficiency } from "../../../constants/localizedConstants";
+import {
+  getLanguageProficiency,
+  requiredFieldsMissing,
+} from "../../../constants/localizedConstants";
 
 const LanguageInformationSection: React.FunctionComponent<{
   applicant: Pick<
@@ -187,19 +190,16 @@ const LanguageInformationSection: React.FunctionComponent<{
               bilingualEvaluation === BilingualEvaluation.CompletedFrench) &&
               (!comprehensionLevel || !writtenLevel || !verbalLevel))))) && (
         <p>
-          {editPath &&
-            intl.formatMessage({
-              defaultMessage: "There are <red>required</red> fields missing.",
-              description:
-                "Message that there are required fields missing. Please ignore things in <> tags.",
-            })}{" "}
           {editPath && (
-            <a href={editPath}>
-              {intl.formatMessage({
-                defaultMessage: "Click here to get started.",
-                description: "Message to click on the words to begin something",
-              })}
-            </a>
+            <>
+              {intl.formatMessage(requiredFieldsMissing)}{" "}
+              <a href={editPath}>
+                {intl.formatMessage({
+                  defaultMessage: "Edit your language information options.",
+                  description: "Link text to edit language information.",
+                })}
+              </a>
+            </>
           )}
           {!editPath && (
             <>

--- a/frontend/common/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
@@ -196,7 +196,7 @@ const LanguageInformationSection: React.FunctionComponent<{
               <a href={editPath}>
                 {intl.formatMessage({
                   defaultMessage: "Edit your language information options.",
-                  description: "Link text to edit language information.",
+                  description: "Link text to edit language information on profile.",
                 })}
               </a>
             </>

--- a/frontend/common/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
@@ -196,7 +196,8 @@ const LanguageInformationSection: React.FunctionComponent<{
               <a href={editPath}>
                 {intl.formatMessage({
                   defaultMessage: "Edit your language information options.",
-                  description: "Link text to edit language information on profile.",
+                  description:
+                    "Link text to edit language information on profile.",
                 })}
               </a>
             </>

--- a/frontend/common/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { Applicant, BilingualEvaluation } from "../../../api/generated";
-import {
-  getLanguageProficiency,
-  requiredFieldsMissing,
-} from "../../../constants/localizedConstants";
+import messages from "../../../messages/commonMessages";
+import { getLanguageProficiency } from "../../../constants/localizedConstants";
 
 const LanguageInformationSection: React.FunctionComponent<{
   applicant: Pick<
@@ -192,7 +190,7 @@ const LanguageInformationSection: React.FunctionComponent<{
         <p>
           {editPath && (
             <>
-              {intl.formatMessage(requiredFieldsMissing)}{" "}
+              {intl.formatMessage(messages.requiredFieldsMissing)}{" "}
               <a href={editPath}>
                 {intl.formatMessage({
                   defaultMessage: "Edit your language information options.",

--- a/frontend/common/src/components/UserProfile/ProfileSections/RoleSalarySection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/RoleSalarySection.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { isEmpty } from "lodash";
-import { getGenericJobTitles } from "../../../constants/localizedConstants";
+import {
+  getGenericJobTitles,
+  requiredFieldsMissing,
+} from "../../../constants/localizedConstants";
 import { Applicant } from "../../../api/generated";
 
 const RoleSalarySection: React.FunctionComponent<{
@@ -47,18 +50,14 @@ const RoleSalarySection: React.FunctionComponent<{
                 description: "Message for when no data exists for the section",
               })}
             </p>
-
             <p>
-              {intl.formatMessage({
-                defaultMessage: "There are <red>required</red> fields missing.",
-                description:
-                  "Message that there are required fields missing. Please ignore things in <> tags.",
-              })}{" "}
+              {intl.formatMessage(requiredFieldsMissing)}{" "}
               <a href={editPath}>
                 {intl.formatMessage({
-                  defaultMessage: "Click here to get started.",
+                  defaultMessage:
+                    "Edit your role and salary expectation options.",
                   description:
-                    "Message to click on the words to begin something",
+                    "Link text to edit role and salary expectations on profile.",
                 })}
               </a>
             </p>

--- a/frontend/common/src/components/UserProfile/ProfileSections/RoleSalarySection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/RoleSalarySection.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { isEmpty } from "lodash";
-import {
-  getGenericJobTitles,
-  requiredFieldsMissing,
-} from "../../../constants/localizedConstants";
+import messages from "../../../messages/commonMessages";
+import { getGenericJobTitles } from "../../../constants/localizedConstants";
 import { Applicant } from "../../../api/generated";
 
 const RoleSalarySection: React.FunctionComponent<{
@@ -51,7 +49,7 @@ const RoleSalarySection: React.FunctionComponent<{
               })}
             </p>
             <p>
-              {intl.formatMessage(requiredFieldsMissing)}{" "}
+              {intl.formatMessage(messages.requiredFieldsMissing)}{" "}
               <a href={editPath}>
                 {intl.formatMessage({
                   defaultMessage:

--- a/frontend/common/src/components/UserProfile/ProfileSections/SkillExperienceSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/SkillExperienceSection.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
+import { requiredFieldsMissing } from "../../../constants/localizedConstants";
 import { notEmpty } from "../../../helpers/util";
 import { Applicant } from "../../../api/generated";
 import ExperienceSection from "../ExperienceSection";
@@ -46,15 +47,12 @@ const SkillExperienceSection: React.FunctionComponent<{
             })}
           </p>
           <p>
-            {intl.formatMessage({
-              defaultMessage: "There are <red>required</red> fields missing.",
-              description:
-                "Message that there are required fields missing. Please ignore things in <> tags.",
-            })}{" "}
+            {intl.formatMessage(requiredFieldsMissing)}{" "}
             <a href={editPath}>
               {intl.formatMessage({
-                defaultMessage: "Click here to get started.",
-                description: "Message to click on the words to begin something",
+                defaultMessage: "Edit your skill and experience options.",
+                description:
+                  "Link text for editing skills and experiences on profile.",
               })}
             </a>
           </p>

--- a/frontend/common/src/components/UserProfile/ProfileSections/SkillExperienceSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/SkillExperienceSection.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { requiredFieldsMissing } from "../../../constants/localizedConstants";
+import messages from "../../../messages/commonMessages";
 import { notEmpty } from "../../../helpers/util";
 import { Applicant } from "../../../api/generated";
 import ExperienceSection from "../ExperienceSection";
@@ -47,7 +47,7 @@ const SkillExperienceSection: React.FunctionComponent<{
             })}
           </p>
           <p>
-            {intl.formatMessage(requiredFieldsMissing)}{" "}
+            {intl.formatMessage(messages.requiredFieldsMissing)}{" "}
             <a href={editPath}>
               {intl.formatMessage({
                 defaultMessage: "Edit your skill and experience options.",

--- a/frontend/common/src/components/UserProfile/ProfileSections/WorkLocationSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/WorkLocationSection.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { isEmpty } from "lodash";
-import { getWorkRegion } from "../../../constants/localizedConstants";
+import {
+  getWorkRegion,
+  requiredFieldsMissing,
+} from "../../../constants/localizedConstants";
 import { insertBetween } from "../../../helpers/util";
 
 import { Applicant } from "../../../api/generated";
@@ -55,15 +58,11 @@ const WorkLocationSection: React.FunctionComponent<{
             })}
           </p>
           <p>
-            {intl.formatMessage({
-              defaultMessage: "There are <red>required</red> fields missing.",
-              description:
-                "Message that there are required fields missing. Please ignore things in <> tags.",
-            })}{" "}
+            {intl.formatMessage(requiredFieldsMissing)}{" "}
             <a href={editPath}>
               {intl.formatMessage({
-                defaultMessage: "Click here to get started.",
-                description: "Message to click on the words to begin something",
+                defaultMessage: "Edit your work location options.",
+                description: "Link text to edit work location on profile",
               })}
             </a>
           </p>

--- a/frontend/common/src/components/UserProfile/ProfileSections/WorkLocationSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/WorkLocationSection.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { isEmpty } from "lodash";
-import {
-  getWorkRegion,
-  requiredFieldsMissing,
-} from "../../../constants/localizedConstants";
+import messages from "../../../messages/commonMessages";
+import { getWorkRegion } from "../../../constants/localizedConstants";
 import { insertBetween } from "../../../helpers/util";
 
 import { Applicant } from "../../../api/generated";
@@ -58,7 +56,7 @@ const WorkLocationSection: React.FunctionComponent<{
             })}
           </p>
           <p>
-            {intl.formatMessage(requiredFieldsMissing)}{" "}
+            {intl.formatMessage(messages.requiredFieldsMissing)}{" "}
             <a href={editPath}>
               {intl.formatMessage({
                 defaultMessage: "Edit your work location options.",

--- a/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { isEmpty } from "lodash";
-import {
-  getOperationalRequirement,
-  requiredFieldsMissing,
-} from "../../../constants/localizedConstants";
+import messages from "../../../messages/commonMessages";
+import { getOperationalRequirement } from "../../../constants/localizedConstants";
 import { Applicant, OperationalRequirement } from "../../../api/generated";
 
 const WorkPreferencesSection: React.FunctionComponent<{
@@ -72,7 +70,7 @@ const WorkPreferencesSection: React.FunctionComponent<{
             })}
           </p>
           <p>
-            {intl.formatMessage(requiredFieldsMissing)}{" "}
+            {intl.formatMessage(messages.requiredFieldsMissing)}{" "}
             <a href={editPath}>
               {intl.formatMessage({
                 defaultMessage: "Edit your work preference options.",

--- a/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { isEmpty } from "lodash";
-import { getOperationalRequirement } from "../../../constants/localizedConstants";
+import {
+  getOperationalRequirement,
+  requiredFieldsMissing,
+} from "../../../constants/localizedConstants";
 import { Applicant, OperationalRequirement } from "../../../api/generated";
 
 const WorkPreferencesSection: React.FunctionComponent<{
@@ -69,15 +72,11 @@ const WorkPreferencesSection: React.FunctionComponent<{
             })}
           </p>
           <p>
-            {intl.formatMessage({
-              defaultMessage: "There are <red>required</red> fields missing.",
-              description:
-                "Message that there are required fields missing. Please ignore things in <> tags.",
-            })}{" "}
+            {intl.formatMessage(requiredFieldsMissing)}{" "}
             <a href={editPath}>
               {intl.formatMessage({
-                defaultMessage: "Click here to get started.",
-                description: "Message to click on the words to begin something",
+                defaultMessage: "Edit your work preference options.",
+                description: "Link text to edit work preferences on profile",
               })}
             </a>
           </p>

--- a/frontend/common/src/constants/localizedConstants.tsx
+++ b/frontend/common/src/constants/localizedConstants.tsx
@@ -1,4 +1,4 @@
-import { defineMessage, defineMessages, MessageDescriptor } from "react-intl";
+import { defineMessages, MessageDescriptor } from "react-intl";
 import {
   Language,
   LanguageAbility,
@@ -44,12 +44,6 @@ export const disabilityLocalized = {
   defaultMessage: "I identify as a person with a disability",
   description: "Message for person with a disability",
 };
-
-export const requiredFieldsMissing = defineMessage({
-  defaultMessage: "There are <red>required</red> fields missing.",
-  description:
-    "Message that there are required fields missing. Please ignore things in <> tags.",
-});
 
 export const languageProficiency = defineMessages({
   [EstimatedLanguageAbility.Beginner]: {

--- a/frontend/common/src/constants/localizedConstants.tsx
+++ b/frontend/common/src/constants/localizedConstants.tsx
@@ -1,4 +1,4 @@
-import { defineMessages, MessageDescriptor } from "react-intl";
+import { defineMessage, defineMessages, MessageDescriptor } from "react-intl";
 import {
   Language,
   LanguageAbility,
@@ -44,6 +44,12 @@ export const disabilityLocalized = {
   defaultMessage: "I identify as a person with a disability",
   description: "Message for person with a disability",
 };
+
+export const requiredFieldsMissing = defineMessage({
+  defaultMessage: "There are <red>required</red> fields missing.",
+  description:
+    "Message that there are required fields missing. Please ignore things in <> tags.",
+});
 
 export const languageProficiency = defineMessages({
   [EstimatedLanguageAbility.Beginner]: {

--- a/frontend/common/src/messages/commonMessages.ts
+++ b/frontend/common/src/messages/commonMessages.ts
@@ -21,6 +21,11 @@ const messages = defineMessages({
     defaultMessage: "Not found",
     description: "Title displayed when an item cannot be found.",
   },
+  requiredFieldsMissing: {
+    defaultMessage: "There are <red>required</red> fields missing.",
+    description:
+      "Message that there are required fields missing. Please ignore things in <> tags.",
+  },
 });
 
 export default messages;


### PR DESCRIPTION
Resolves #3195 

## Summary

This adds more context to the get started links for assistive technology.

## Screenshot

<img width="983" alt="Screen Shot 2022-07-22 at 2 23 11 PM" src="https://user-images.githubusercontent.com/4127998/180500715-da633edf-e9fc-45ce-9b3b-77276ce23667.png">

