### PR TITLE
Bug - 3480 - Fix Setup Node Action

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
 
-      - uses: actions/setup-node@v2.5.1
+      - uses: actions/setup-node@v3
         with:
           node-version-file: 'frontend/.nvmrc'
           cache: npm

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -64,7 +64,7 @@ jobs:
       - name: "Run: setup.sh"
         run: docker-compose run --rm maintenance bash setup.sh
 
-      - uses: actions/setup-node@v2.5.1
+      - uses: actions/setup-node@v3
         with:
           node-version-file: 'frontend/.nvmrc'
           cache: npm

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
       - name: Use Node.js
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v3
         with:
           node-version-file: 'frontend/.nvmrc'
           cache: 'npm'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
       - name: Use Node.js
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v3
         with:
           node-version-file: 'frontend/.nvmrc'
           cache: 'npm'

--- a/.github/workflows/package-integrity-check.yml
+++ b/.github/workflows/package-integrity-check.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
       - name: Use Node.js
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v3
         with:
           node-version-file: 'frontend/.nvmrc'
           cache: 'npm'

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -24,7 +24,7 @@ jobs:
           # Chromatic requires full git history.
           fetch-depth: 0
 
-      - uses: actions/setup-node@v2.5.1
+      - uses: actions/setup-node@v3
         with:
           node-version-file: 'frontend/.nvmrc'
           cache: npm


### PR DESCRIPTION
Resolves #3480 

## Summary

We have bumped the version of `action/setup-node` to `v3` which fixes an issue with cache. Ran some of the most commonly failing tests 3-4 times and they were consistently passing.