### PR TITLE
Bug - 3442 - Remove duplicate volumes key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,8 +95,6 @@ services:
       # - we set interactiveLogin:true, for easy selection of any test user
       #   (for which subject/sub will be something like `admin@test.com`).
       JSON_CONFIG_PATH: /app/conf/mock-oauth2-server.json
-    volumes:
-      - ./infrastructure/conf:/app/conf
       # Uncomment for direct access without proxy.
       # We override default port 8080 sincer already used by adminer container.
       #SERVER_PORT: 8081


### PR DESCRIPTION
Resolves #3442 

## Summary

This removes the duplicate `volumes` key in the `docker-compose.yml` file.