### PR TITLE
Add GraphQL logging error handler

### DIFF
--- a/api/app/GraphQL/Handlers/LoggingErrorHandler.php
+++ b/api/app/GraphQL/Handlers/LoggingErrorHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\GraphQL\Handlers;
+
+use Closure;
+use GraphQL\Error\Error;
+use Nuwave\Lighthouse\Execution\ErrorHandler;
+use Illuminate\Support\Facades\Log;
+
+class LoggingErrorHandler implements ErrorHandler
+{
+    public function __invoke(?Error $error, Closure $next): ?array
+    {
+        // pass nulls through
+        if (null === $error) {
+            return $next(null);
+        }
+
+        // Log the error
+        Log::info('GraphQL Error: '.$error->getMessage());
+
+        // Keep the pipeline going, last step formats the error into an array
+        return $next($error);
+    }
+}

--- a/api/config/lighthouse.php
+++ b/api/config/lighthouse.php
@@ -213,6 +213,7 @@ return [
     'error_handlers' => [
         \Nuwave\Lighthouse\Execution\ExtensionErrorHandler::class,
         \Nuwave\Lighthouse\Execution\ReportingErrorHandler::class,
+        \App\GraphQL\Handlers\LoggingErrorHandler::class,
     ],
 
     /*


### PR DESCRIPTION
This branch adds an error handler to Lighthouse which logs any errors passed to it using the Log facade.  Unfortunately, the error handler is not passed the original request so I think it is not possible to log anything other than what is displayed in the Playground results pane.

## Testing
Here are some test queries to trigger errors:
```
# "Field \"me\" of type \"User\" must have a sub selection."
query whoAmI {
  me
}
```
```
# "Unauthenticated."
query users {
  users {
    firstName
  }
}
```
```
# "Cannot query field \"foo\" on type \"Query\". Did you mean \"pool\"?"
query whoAmI {
  foo
}
```
You should see the errors appear in your `laravel.log` file.
![image](https://user-images.githubusercontent.com/8978655/180867267-c4b1f040-a50c-4b6e-a3c5-4240f7e71d58.png)

You can test on the dev server, too:
![image](https://user-images.githubusercontent.com/8978655/180871703-c3fa819e-9d5d-423c-a015-3e7f31c26a84.png)


Closes #2526 