### PR TITLE
Copy - 3390 - Update About Section Title

### DIFF
--- a/frontend/common/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/common/src/components/UserProfile/UserProfile.tsx
@@ -93,7 +93,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ applicant, sections }) => {
         {showSection("about") && (
           <TableOfContents.AnchorLink id="about-section">
             {intl.formatMessage({
-              defaultMessage: "About",
+              defaultMessage: "About Me",
               description: "Title of the About link section",
             })}
           </TableOfContents.AnchorLink>
@@ -227,7 +227,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ applicant, sections }) => {
                 style={{ flex: "1 1 0%" }}
               >
                 {intl.formatMessage({
-                  defaultMessage: "About",
+                  defaultMessage: "About Me",
                   description: "Title of the about content section",
                 })}
               </TableOfContents.Heading>

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -434,10 +434,6 @@
     "defaultMessage": "<strong>Oui</strong>, je suis un employé du gouvernement du Canada.",
     "description": "Message to state user is employed by government"
   },
-  "5sX4lz": {
-    "defaultMessage": "À propos",
-    "description": "Title of the about content section"
-  },
   "6RiVQA": {
     "defaultMessage": "{role} au sein de la {division}",
     "description": "Role at division"
@@ -528,10 +524,6 @@
   },
   "GcPFLS": {
     "defaultMessage": "Travail"
-  },
-  "H4sbll": {
-    "defaultMessage": "À propos",
-    "description": "Title of the About link section"
   },
   "HalXgi": {
     "defaultMessage": "Nouvelle-Écosse",
@@ -761,10 +753,6 @@
   },
   "jtygmI": {
     "defaultMessage": "Éducation"
-  },
-  "kP04tf": {
-    "defaultMessage": "Cliquez ici pour commencer.",
-    "description": "Message to click on the words to begin something"
   },
   "kjX7mF": {
     "defaultMessage": "Aucune information n'a été fournie.",
@@ -1081,5 +1069,13 @@
   "OperationalRequirement.WorkWeekends.short": {
     "defaultMessage": "Travailler les fins de semaine",
     "description": "The operational requirement described as work weekends. (short-form for limited space)"
+  },
+  "4sJvia": {
+    "defaultMessage": "À propos de moi",
+    "description": "Title of the About link section"
+  },
+  "CnB8IO": {
+    "defaultMessage": "À propos de moi",
+    "description": "Title of the about content section"
   }
 }

--- a/frontend/cypress/integration/talentsearch/profile-page.spec.js
+++ b/frontend/cypress/integration/talentsearch/profile-page.spec.js
@@ -51,7 +51,7 @@ describe("Talentsearch Profile Page", () => {
       cy.visit('/en/talent/profile')
       cy.contains("My Status");
       cy.contains("My hiring pools");
-      cy.contains("About");
+      cy.contains("About Me");
       cy.contains("Language Information");
       cy.contains("Government Information");
       cy.contains("Work Location");


### PR DESCRIPTION
Resolves #3390 

## Summary

This updates the About section title to About Me (en) and À propos de moi (fr).

## Screenshot

### English

<img width="856" alt="Screen Shot 2022-07-26 at 10 33 46 AM" src="https://user-images.githubusercontent.com/4127998/181034481-4c2e3f45-833a-485c-b713-07240b4e398c.png">

### French

<img width="899" alt="Screen Shot 2022-07-26 at 10 33 28 AM" src="https://user-images.githubusercontent.com/4127998/181034554-e830a4f8-09d7-4f88-b971-56e6b3df5154.png">



