### PR TITLE
Add FR copy for Text displayed when skill block is open

### DIFF
--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1077,5 +1077,9 @@
   "CnB8IO": {
     "defaultMessage": "À propos de moi",
     "description": "Title of the about content section"
+  },
+  "BjRuMw": {
+    "defaultMessage": "Voir la définition",
+    "description": "Text displayed when skill block is open."
   }
 }


### PR DESCRIPTION
Resolves #3502.

Removed by accident in:

- https://github.com/GCTC-NTGC/gc-digital-talent/commit/48589886434d681cd6a9a1e52288f0605a3b014a#diff-9be88dc2973ab04fa23b50f6429fda5ef488c9ddd997982f35bdc12abda31e50L327-L330