### PR TITLE
Add and update FR copy for logout strings

### DIFF
--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -1423,7 +1423,7 @@
     "description": "Third section of text on the change candidate status dialog"
   },
   "Zx3BVC": {
-    "defaultMessage": "Êtes-vous sûr(e) que vous voulez vous déconnecter?",
+    "defaultMessage": "Êtes-vous sûr(e) de vouloir vous déconnecter?",
     "description": "Question displayed when authenticated user lands on /logged-out."
   },
   "aJVlIF": {

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1081,5 +1081,13 @@
   "s3FrzP": {
     "defaultMessage": "Êtes-vous sûr(e) de vouloir vous déconnecter?",
     "description": "Question displayed when authenticated user attempts to logout"
+  },
+  "ivKwx0": {
+    "defaultMessage": "Déconnexion",
+    "description": "Title for the modal that appears when an authenticated user attempts to logout"
+  },
+  "6rhyxk": {
+    "defaultMessage": "Déconnexion",
+    "description": "Link text to logout."
   }
 }

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1077,5 +1077,9 @@
   "CnB8IO": {
     "defaultMessage": "À propos de moi",
     "description": "Title of the about content section"
+  },
+  "s3FrzP": {
+    "defaultMessage": "Êtes-vous sûr(e) de vouloir vous déconnecter?",
+    "description": "Question displayed when authenticated user attempts to logout"
   }
 }


### PR DESCRIPTION
Resolves #3507.

- Removed by accident in: https://github.com/GCTC-NTGC/gc-digital-talent/commit/efc33e01a9037d654f2d8e6e7228167b946f4d94#diff-395e2af46ce720b6af1549a80254c2acc90e207dc270993d490498b4e6c06e55L973-L976
- Translates _Are you sure you would like to logout?_ the [same way](https://github.com/GCTC-NTGC/gc-digital-talent/commit/825a9b65fb9b17b4ee9a9118cea503bb73e5db1d) across projects.