### PR TITLE
Add SelectFieldV2 and MultiSelectV2 components

### DIFF
--- a/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.stories.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.stories.tsx
@@ -16,7 +16,8 @@ export default {
           onSubmit={action("Submit Form")}
           options={{ defaultValues: { departments: [] } }}
         >
-          <Story />
+          { /* See: https://github.com/storybookjs/storybook/issues/12596#issuecomment-723440097 */ }
+          {Story() /* Can't use <Story /> for inline decorator. */ }
           <Submit />
         </BasicForm>
       );

--- a/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.stories.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.stories.tsx
@@ -16,8 +16,8 @@ export default {
           onSubmit={action("Submit Form")}
           options={{ defaultValues: { departments: [] } }}
         >
-          { /* See: https://github.com/storybookjs/storybook/issues/12596#issuecomment-723440097 */ }
-          {Story() /* Can't use <Story /> for inline decorator. */ }
+          {/* See: https://github.com/storybookjs/storybook/issues/12596#issuecomment-723440097 */}
+          {Story() /* Can't use <Story /> for inline decorator. */}
           <Submit />
         </BasicForm>
       );

--- a/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.stories.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.stories.tsx
@@ -1,0 +1,67 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import { uniqueId } from "lodash";
+import React from "react";
+import BasicForm from "../BasicForm";
+import Submit from "../Submit";
+import MultiSelectFieldV2 from "./MultiSelectFieldV2";
+
+export default {
+  component: MultiSelectFieldV2,
+  title: "Form/MultiSelectFieldV2",
+  decorators: [
+    (Story) => {
+      return (
+        <BasicForm
+          onSubmit={action("Submit Form")}
+          options={{ defaultValues: { departments: "" } }}
+        >
+          <Story />
+          <Submit />
+        </BasicForm>
+      );
+    },
+  ],
+} as ComponentMeta<typeof MultiSelectFieldV2>;
+
+const Template: ComponentStory<typeof MultiSelectFieldV2> = (args) => {
+  return <MultiSelectFieldV2 {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  id: uniqueId(),
+  label: "Departments",
+  name: "departments",
+  options: [
+    { value: 1, label: "CRA" },
+    { value: 2, label: "TBS" },
+    { value: 3, label: "DND" },
+  ],
+};
+
+export const Required = Template.bind({});
+Required.args = {
+  ...Default.args,
+  rules: { required: "This must be accepted to continue." },
+};
+
+export const RequiredWithInfo = Template.bind({});
+RequiredWithInfo.args = {
+  ...Default.args,
+  context: "We collect the above data for account purposes.",
+  rules: { required: "This must be accepted to continue." },
+};
+
+export const RequiredWithError = Template.bind({});
+RequiredWithError.args = {
+  ...Default.args,
+  rules: { required: "This must be accepted to continue." },
+};
+
+export const RequiredWithErrorAndContext = Template.bind({});
+RequiredWithErrorAndContext.args = {
+  ...Default.args,
+  context: "We collect the above data for account purposes.",
+  rules: { required: "This must be accepted to continue." },
+};

--- a/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.stories.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import React from "react";
 import BasicForm from "../BasicForm";
 import Submit from "../Submit";

--- a/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.stories.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.stories.tsx
@@ -14,7 +14,7 @@ export default {
       return (
         <BasicForm
           onSubmit={action("Submit Form")}
-          options={{ defaultValues: { departments: "" } }}
+          options={{ defaultValues: { departments: [] } }}
         >
           <Story />
           <Submit />

--- a/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.test.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import "@testing-library/jest-dom";
+import {
+  screen,
+  render,
+  RenderOptions,
+  act,
+  fireEvent,
+} from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import type { FieldValues, SubmitHandler } from "react-hook-form";
+import IntlProvider from "react-intl/src/components/provider";
+import MultiSelectFieldV2 from "./MultiSelectFieldV2";
+
+const Providers = ({
+  children,
+  onSubmit,
+}: {
+  children: React.ReactNode;
+  onSubmit: SubmitHandler<FieldValues>;
+}) => {
+  const methods = useForm();
+
+  return (
+    <IntlProvider locale="en">
+      <FormProvider {...methods}>
+        <form onSubmit={methods.handleSubmit((data) => onSubmit(data))}>
+          {children}
+          <input type="submit" />
+        </form>
+      </FormProvider>
+    </IntlProvider>
+  );
+};
+
+// In SelectFieldV2, we hardcode the classNamePrefix prop into react-select's
+// Select component to making styling/testing simpler.
+const CLASS_PREFIX = "react-select";
+
+// Source: https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/__tests__/StateManaged.test.tsx
+function toggleMenuOpen(container: HTMLElement) {
+  const button = container.querySelector(
+    `.${CLASS_PREFIX}__dropdown-indicator`,
+  );
+  if (button) fireEvent.mouseDown(button, { button: 0 });
+}
+
+function selectFirstOption(container: HTMLElement) {
+  const menu = container.querySelector(`.${CLASS_PREFIX}__menu`);
+  if (menu) fireEvent.keyDown(menu, { keyCode: 13, key: "Enter" });
+}
+
+// Inspiration: https://github.com/testing-library/react-testing-library/issues/780#issuecomment-687525893
+const renderWithProviders = (
+  ui: React.ReactElement,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options?: Omit<RenderOptions, "wrapper"> & { wrapperProps: any },
+) =>
+  render(ui, {
+    // Pass extra props to provider, e.g. mocked onSubmit.
+    wrapper: (props) => <Providers {...props} {...options?.wrapperProps} />,
+    ...options,
+  });
+
+describe("MultiSelectFieldV2", () => {
+  it("should render properly with only label prop", () => {
+    renderWithProviders(<MultiSelectFieldV2 label="Foo Bar" />);
+    expect(
+      screen.getByRole("combobox", { name: /foo bar/i }),
+    ).toBeInTheDocument();
+    // Hidden input should exist.
+    expect(document.querySelectorAll('input[type="hidden"]')).toHaveLength(1);
+    expect(
+      document.querySelector('input[type="hidden"]')?.getAttribute("name"),
+    ).toBe("fooBar");
+    expect(
+      document.querySelector('input[type="hidden"]')?.getAttribute("value"),
+    ).toBeNull();
+  });
+
+  it("should submit empty when no validation rules", async () => {
+    const mockSubmit = jest.fn();
+    renderWithProviders(<MultiSelectFieldV2 label="Foo Bar" options={[]} />, {
+      wrapperProps: {
+        onSubmit: mockSubmit,
+      },
+    });
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button"));
+    });
+    expect(mockSubmit).toBeCalledTimes(1);
+    expect(mockSubmit).toBeCalledWith({ fooBar: undefined });
+  });
+
+  it("should submit correctly as array of values", async () => {
+    const mockSubmit = jest.fn();
+    renderWithProviders(
+      <MultiSelectFieldV2
+        label="Foo Bar"
+        options={[
+          { value: "BAZ", label: "Baz" },
+          { value: "BAM", label: "Bam" },
+        ]}
+      />,
+      {
+        wrapperProps: {
+          onSubmit: mockSubmit,
+        },
+      },
+    );
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button"));
+    });
+    expect(mockSubmit).toBeCalledTimes(1);
+    expect(mockSubmit).toHaveBeenLastCalledWith({ fooBar: undefined });
+
+    // Select first option.
+    toggleMenuOpen(document.body);
+    selectFirstOption(document.body);
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /submit/i }));
+    });
+    expect(mockSubmit).toBeCalledTimes(2);
+    expect(mockSubmit).toHaveBeenLastCalledWith({ fooBar: ["BAZ"] });
+
+    // Select second option.
+    toggleMenuOpen(document.body);
+    selectFirstOption(document.body);
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /submit/i }));
+    });
+    expect(mockSubmit).toBeCalledTimes(3);
+    expect(mockSubmit).toHaveBeenLastCalledWith({ fooBar: ["BAZ", "BAM"] });
+  });
+
+  it("should be clearable even when required", () => {
+    renderWithProviders(
+      <MultiSelectFieldV2
+        label="Foo Bar"
+        rules={{ required: "Required!" }}
+        options={[{ value: "BAZ", label: "Baz" }]}
+      />,
+    );
+    toggleMenuOpen(document.body);
+    selectFirstOption(document.body);
+    const clearIndicator = document.querySelector(
+      `.${CLASS_PREFIX}__clear-indicator`,
+    );
+    expect(clearIndicator).toBeInTheDocument();
+  });
+
+  it("should show loading indicator when isLoading", () => {
+    renderWithProviders(<MultiSelectFieldV2 label="Foo Bar" isLoading />);
+
+    const loadingIndicator = document.querySelector(
+      `.${CLASS_PREFIX}__loading-indicator`,
+    );
+    expect(loadingIndicator).toBeInTheDocument();
+  });
+});

--- a/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.test.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.test.tsx
@@ -18,11 +18,13 @@ import MultiSelectFieldV2 from "./MultiSelectFieldV2";
 const Providers = ({
   children,
   onSubmit,
+  defaultValues,
 }: {
   children: React.ReactNode;
   onSubmit: SubmitHandler<FieldValues>;
+  defaultValues: FieldValues;
 }) => {
-  const methods = useForm();
+  const methods = useForm({ defaultValues });
 
   return (
     <IntlProvider locale="en">
@@ -81,7 +83,7 @@ describe("MultiSelectFieldV2", () => {
     ).toBeNull();
   });
 
-  it("should submit empty when no validation rules", async () => {
+  it("should submit undefine when no default (no validation rules)", async () => {
     const mockSubmit = jest.fn();
     renderWithProviders(<MultiSelectFieldV2 label="Foo Bar" options={[]} />, {
       wrapperProps: {
@@ -109,6 +111,9 @@ describe("MultiSelectFieldV2", () => {
       {
         wrapperProps: {
           onSubmit: mockSubmit,
+          defaultValues: {
+            fooBar: [],
+          },
         },
       },
     );
@@ -117,7 +122,7 @@ describe("MultiSelectFieldV2", () => {
       fireEvent.submit(screen.getByRole("button"));
     });
     expect(mockSubmit).toBeCalledTimes(1);
-    expect(mockSubmit).toHaveBeenLastCalledWith({ fooBar: undefined });
+    expect(mockSubmit).toHaveBeenLastCalledWith({ fooBar: [] });
 
     // Select first option.
     toggleMenuOpen(document.body);

--- a/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.tsx
@@ -3,7 +3,10 @@ import SelectFieldV2, {
   type SelectFieldV2Props,
 } from "../Select/SelectFieldV2";
 
-export type MultiSelectFieldV2Props = Omit<SelectFieldV2Props, "isMulti">;
+export type MultiSelectFieldV2Props = Omit<
+  SelectFieldV2Props,
+  "isMulti" | "forceArrayFormValue"
+>;
 
 const MultiSelectFieldV2 = (props: MultiSelectFieldV2Props) => (
   <SelectFieldV2 isMulti {...props} />

--- a/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelectFieldV2.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import SelectFieldV2, {
+  type SelectFieldV2Props,
+} from "../Select/SelectFieldV2";
+
+export type MultiSelectFieldV2Props = Omit<SelectFieldV2Props, "isMulti">;
+
+const MultiSelectFieldV2 = (props: MultiSelectFieldV2Props) => (
+  <SelectFieldV2 isMulti {...props} />
+);
+
+export default MultiSelectFieldV2;

--- a/frontend/common/src/components/form/Select/SelectFieldV2.stories.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.stories.tsx
@@ -14,7 +14,7 @@ export default {
       return (
         <BasicForm
           onSubmit={action("Submit Form")}
-          options={{ defaultValues: { departments: "" } }}
+          options={{ defaultValues: { department: "" } }}
         >
           <Story />
           <Submit />

--- a/frontend/common/src/components/form/Select/SelectFieldV2.stories.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.stories.tsx
@@ -16,7 +16,8 @@ export default {
           onSubmit={action("Submit Form")}
           options={{ defaultValues: { department: "" } }}
         >
-          <Story />
+          { /* See: https://github.com/storybookjs/storybook/issues/12596#issuecomment-723440097 */ }
+          {Story() /* Can't use <Story /> for inline decorator. */ }
           <Submit />
         </BasicForm>
       );

--- a/frontend/common/src/components/form/Select/SelectFieldV2.stories.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.stories.tsx
@@ -16,8 +16,8 @@ export default {
           onSubmit={action("Submit Form")}
           options={{ defaultValues: { department: "" } }}
         >
-          { /* See: https://github.com/storybookjs/storybook/issues/12596#issuecomment-723440097 */ }
-          {Story() /* Can't use <Story /> for inline decorator. */ }
+          {/* See: https://github.com/storybookjs/storybook/issues/12596#issuecomment-723440097 */}
+          {Story() /* Can't use <Story /> for inline decorator. */}
           <Submit />
         </BasicForm>
       );

--- a/frontend/common/src/components/form/Select/SelectFieldV2.stories.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.stories.tsx
@@ -1,0 +1,67 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import { uniqueId } from "lodash";
+import React from "react";
+import BasicForm from "../BasicForm";
+import Submit from "../Submit";
+import SelectFieldV2 from "./SelectFieldV2";
+
+export default {
+  component: SelectFieldV2,
+  title: "Form/SelectFieldV2",
+  decorators: [
+    (Story) => {
+      return (
+        <BasicForm
+          onSubmit={action("Submit Form")}
+          options={{ defaultValues: { departments: "" } }}
+        >
+          <Story />
+          <Submit />
+        </BasicForm>
+      );
+    },
+  ],
+} as ComponentMeta<typeof SelectFieldV2>;
+
+const Template: ComponentStory<typeof SelectFieldV2> = (args) => {
+  return <SelectFieldV2 {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  id: uniqueId(),
+  label: "Department",
+  name: "department",
+  options: [
+    { value: 1, label: "CRA" },
+    { value: 2, label: "TBS" },
+    { value: 3, label: "DND" },
+  ],
+};
+
+export const Required = Template.bind({});
+Required.args = {
+  ...Default.args,
+  rules: { required: "This must be accepted to continue." },
+};
+
+export const RequiredWithInfo = Template.bind({});
+RequiredWithInfo.args = {
+  ...Default.args,
+  context: "We collect the above data for account purposes.",
+  rules: { required: "This must be accepted to continue." },
+};
+
+export const RequiredWithError = Template.bind({});
+RequiredWithError.args = {
+  ...Default.args,
+  rules: { required: "This must be accepted to continue." },
+};
+
+export const RequiredWithErrorAndContext = Template.bind({});
+RequiredWithErrorAndContext.args = {
+  ...Default.args,
+  context: "We collect the above data for account purposes.",
+  rules: { required: "This must be accepted to continue." },
+};

--- a/frontend/common/src/components/form/Select/SelectFieldV2.test.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.test.tsx
@@ -10,18 +10,27 @@ import {
   act,
   fireEvent,
   waitFor,
+  logRoles,
+  getByRole,
 } from "@testing-library/react";
 import { FormProvider, useForm } from "react-hook-form";
 import IntlProvider from "react-intl/src/components/provider";
 import SelectFieldV2 from "./SelectFieldV2";
 import type { SelectFieldV2Props } from "./SelectFieldV2";
 
+const mockSubmit = jest.fn((data) => Promise.resolve(data));
+
 const Providers = ({ children }: { children: React.ReactNode }) => {
   const methods = useForm();
+  const onSubmit = async (data: any) => {
+    await mockSubmit(data);
+    methods.reset();
+  };
+
   return (
     <IntlProvider locale="en">
       <FormProvider {...methods}>
-        <form>
+        <form onSubmit={methods.handleSubmit(onSubmit)}>
           {children}
           <input type="submit" />
         </form>
@@ -33,7 +42,27 @@ const Providers = ({ children }: { children: React.ReactNode }) => {
 // In SelectFieldV2, We hardcode the classNamePrefix prop into react-select's
 // Select component to making styling/testing simpler. The default random prefix
 // would make this harder.
-const CLASS_NAME_PREFIX = "react-select";
+const CLASS_PREFIX = "react-select";
+
+// Source: https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/__tests__/StateManaged.test.tsx
+function toggleMenuOpen(container: HTMLElement) {
+  const button = container.querySelector(
+    `.${CLASS_PREFIX}__dropdown-indicator`,
+  );
+  if (button) fireEvent.mouseDown(button, { button: 0 });
+}
+
+function selectFirstOption(container: HTMLElement) {
+  const menu = container.querySelector(`.${CLASS_PREFIX}__menu`);
+  if (menu) fireEvent.keyDown(menu, { keyCode: 13, key: "Enter" });
+}
+
+function clickClearIndicator(container: HTMLElement) {
+  const indicator = container.querySelector(
+    `.${CLASS_PREFIX}__clear-indicator`,
+  );
+  if (indicator) fireEvent.mouseDown(indicator, { button: 0 });
+}
 
 const renderWithProviders = (
   ui: React.ReactElement,
@@ -51,30 +80,102 @@ describe("SelectFieldV2", () => {
     expect(
       screen.getByRole("combobox", { name: /foo bar/i }),
     ).toBeInTheDocument();
-    // Hidden input
-    expect(container.querySelector('input[type="hidden"]')).toBeTruthy();
+    // Hidden input should exist.
+    expect(
+      container.querySelector('input[type="hidden"]')?.getAttribute("value"),
+    ).toBe("");
     expect(
       container.querySelector('input[type="hidden"]')?.getAttribute("name"),
     ).toBe("fooBar");
   });
 
-  it("should render a validation error when required", () => {});
+  it("should write proper text in options menu when none provided", () => {
+    const { container } = renderComponent({
+      label: "Foo Bar",
+      options: [],
+    });
+    toggleMenuOpen(container);
+    const noticeText = container.querySelector(
+      `.${CLASS_PREFIX}__menu-notice`,
+    )?.textContent;
+    expect(noticeText).toBe("No options");
+  });
 
-  it("should render a custom validation message", () => {});
+  it.skip("should submit empty when no rules", () => {
+    act(() => {
+      const { container } = renderComponent({
+        label: "Foo Bar",
+        options: [{ value: "BAZ", label: "Baz" }],
+      });
+      toggleMenuOpen(container);
+      selectFirstOption(container);
+    });
 
-  it("should show optional text when not required", () => {});
+    act(() => {
+      fireEvent.click(screen.getByRole("button"));
+    });
+    expect(mockSubmit).toBeCalled();
+  });
 
-  it("should be clearable when not required", () => {});
+  it.skip("should render a validation error when required", () => {
+    const { container } = renderComponent({
+      label: "Foo Bar",
+      rules: { required: true },
+    });
+    getByRole(container, "combobox", { name: /foo bar/i }).focus();
+    getByRole(container, "combobox", { name: /foo bar/i }).blur();
+    logRoles(container);
+    // #TODO Submit or focus/unfocus.
+    // #TODO
+  });
 
-  it("should not be clearable when required", () => {});
+  it.skip("should render a custom required validation message", async () => {
+    renderComponent({
+      label: "Foo Bar",
+      rules: { required: "Required!" },
+    });
+    fireEvent.submit(screen.getByRole("button"));
+    expect(await screen.getByRole("alert")).toBe("test");
+  });
+
+  it.skip("should show optional text when not required", () => {
+    const { container } = renderComponent({
+      label: "Foo Bar",
+    });
+  });
+
+  it("should be clearable when not required", () => {
+    const { container } = renderComponent({
+      label: "Foo Bar",
+      options: [{ value: "BAZ", label: "Baz" }],
+    });
+    toggleMenuOpen(container);
+    selectFirstOption(container);
+    expect(
+      container.querySelector('input[type="hidden"]')?.getAttribute("value"),
+    ).toBe("BAZ");
+    clickClearIndicator(container);
+    expect(
+      container.querySelector('input[type="hidden"]')?.getAttribute("value"),
+    ).toBe("");
+  });
+
+  it.skip("should not be clearable when required", () => {
+    const { container } = renderComponent({
+      label: "Foo Bar",
+      rules: { required: "Required!" },
+    });
+  });
 
   it("should have default placeholder when not specified", () => {
     const { container } = renderComponent({
       label: "Foo Bar",
     });
-    expect(
-      container.querySelector(`.${CLASS_NAME_PREFIX}__control`)?.textContent,
-    ).toBe("Select...");
+
+    const placeholderText = container.querySelector(
+      `.${CLASS_PREFIX}__control`,
+    )?.textContent;
+    expect(placeholderText).toBe("Select...");
   });
 
   it("should have custom placeholder when specified", () => {
@@ -82,9 +183,11 @@ describe("SelectFieldV2", () => {
       label: "Foo Bar",
       placeholder: "Select thing...",
     });
-    expect(
-      container.querySelector(`.${CLASS_NAME_PREFIX}__control`)?.textContent,
-    ).toBe("Select thing...");
+
+    const placeholderText = container.querySelector(
+      `.${CLASS_PREFIX}__control`,
+    )?.textContent;
+    expect(placeholderText).toBe("Select thing...");
   });
 
   it("should show loading indicator when isLoading", () => {
@@ -92,22 +195,23 @@ describe("SelectFieldV2", () => {
       label: "Foo Bar",
       isLoading: true,
     });
-    expect(
-      container.querySelector(`.${CLASS_NAME_PREFIX}__loading-indicator`),
-    ).toBeInTheDocument();
+
+    const loadingIndicator = container.querySelector(
+      `.${CLASS_PREFIX}__loading-indicator`,
+    );
+    expect(loadingIndicator).toBeInTheDocument();
   });
 
-  it("should show loading message in options when isLoading", async () => {
+  it("should write proper text in options menu when isLoading", () => {
     const { container } = renderComponent({
       label: "Foo Bar",
       isLoading: true,
     });
-    expect(console.log(container.innerHTML));
-    fireEvent.click(
-      container.querySelector(".react-select__dropdown-indicator"),
-    );
-    await waitFor(() => expect(screen.getByRole("option")).toBeInTheDocument());
-  });
+    toggleMenuOpen(container);
 
-  it("should have default loading message when not specified", () => {});
+    const loadingText = container.querySelector(
+      `.${CLASS_PREFIX}__menu-notice`,
+    )?.textContent;
+    expect(loadingText).toBe("Loading...");
+  });
 });

--- a/frontend/common/src/components/form/Select/SelectFieldV2.test.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.test.tsx
@@ -73,8 +73,8 @@ const renderComponent = (props: SelectFieldV2Props) =>
   renderWithProviders(<SelectFieldV2 {...props} />);
 
 describe("SelectFieldV2", () => {
-  it("should render with only label prop", () => {
-    const { container } = renderComponent({
+  it.only("should render with only label prop", () => {
+    renderComponent({
       label: "Foo Bar",
     });
     expect(
@@ -82,81 +82,83 @@ describe("SelectFieldV2", () => {
     ).toBeInTheDocument();
     // Hidden input should exist.
     expect(
-      container.querySelector('input[type="hidden"]')?.getAttribute("value"),
+      document.querySelector('input[type="hidden"]')?.getAttribute("value"),
     ).toBe("");
     expect(
-      container.querySelector('input[type="hidden"]')?.getAttribute("name"),
+      document.querySelector('input[type="hidden"]')?.getAttribute("name"),
     ).toBe("fooBar");
   });
 
-  it("should write proper text in options menu when none provided", () => {
-    const { container } = renderComponent({
+  it.only("should write proper text in options menu when none provided", () => {
+    renderComponent({
       label: "Foo Bar",
       options: [],
     });
-    toggleMenuOpen(container);
-    const noticeText = container.querySelector(
+    toggleMenuOpen(document.body);
+    const noticeText = document.querySelector(
       `.${CLASS_PREFIX}__menu-notice`,
     )?.textContent;
     expect(noticeText).toBe("No options");
   });
 
-  it.skip("should submit empty when no rules", () => {
-    act(() => {
-      const { container } = renderComponent({
-        label: "Foo Bar",
-        options: [{ value: "BAZ", label: "Baz" }],
-      });
-      toggleMenuOpen(container);
-      selectFirstOption(container);
-    });
-
-    act(() => {
-      fireEvent.click(screen.getByRole("button"));
-    });
-    expect(mockSubmit).toBeCalled();
-  });
-
-  it.skip("should render a validation error when required", () => {
-    const { container } = renderComponent({
+  it("should submit empty when no validation rules", async () => {
+    renderComponent({
       label: "Foo Bar",
-      rules: { required: true },
+      options: [],
     });
-    getByRole(container, "combobox", { name: /foo bar/i }).focus();
-    getByRole(container, "combobox", { name: /foo bar/i }).blur();
-    logRoles(container);
-    // #TODO Submit or focus/unfocus.
-    // #TODO
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button"));
+    });
+    expect(mockSubmit).toBeCalledTimes(1);
   });
 
-  it.skip("should render a custom required validation message", async () => {
+  it.only("should prevent submit and throw custom error message when required rule is provided", async () => {
     renderComponent({
       label: "Foo Bar",
       rules: { required: "Required!" },
     });
-    fireEvent.submit(screen.getByRole("button"));
-    expect(await screen.getByRole("alert")).toBe("test");
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button"));
+    });
+    expect(mockSubmit).not.toBeCalled();
+    expect(screen.queryByRole("alert")).toBeInTheDocument();
+    expect(screen.getByRole("alert").textContent).toBe("Required!");
   });
 
-  it.skip("should show optional text when not required", () => {
-    const { container } = renderComponent({
+  // TODO: Add a default required error message.
+  it.only("should prevent submit when required without message (but no default error message)", async () => {
+    renderComponent({
+      label: "Foo Bar",
+      rules: { required: true },
+    });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button"));
+    });
+    expect(mockSubmit).not.toBeCalled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it.only("should show optional text when not required", () => {
+    renderComponent({
       label: "Foo Bar",
     });
+    expect(screen.getByText("(Optional)")).toBeInTheDocument();
   });
 
-  it("should be clearable when not required", () => {
-    const { container } = renderComponent({
+  it.only("should be clearable when not required", () => {
+    renderComponent({
       label: "Foo Bar",
       options: [{ value: "BAZ", label: "Baz" }],
     });
-    toggleMenuOpen(container);
-    selectFirstOption(container);
+    toggleMenuOpen(document.body);
+    selectFirstOption(document.body);
     expect(
-      container.querySelector('input[type="hidden"]')?.getAttribute("value"),
+      document.querySelector('input[type="hidden"]')?.getAttribute("value"),
     ).toBe("BAZ");
-    clickClearIndicator(container);
+    clickClearIndicator(document.body);
     expect(
-      container.querySelector('input[type="hidden"]')?.getAttribute("value"),
+      document.querySelector('input[type="hidden"]')?.getAttribute("value"),
     ).toBe("");
   });
 
@@ -168,48 +170,48 @@ describe("SelectFieldV2", () => {
   });
 
   it("should have default placeholder when not specified", () => {
-    const { container } = renderComponent({
+    renderComponent({
       label: "Foo Bar",
     });
 
-    const placeholderText = container.querySelector(
+    const placeholderText = document.querySelector(
       `.${CLASS_PREFIX}__control`,
     )?.textContent;
     expect(placeholderText).toBe("Select...");
   });
 
   it("should have custom placeholder when specified", () => {
-    const { container } = renderComponent({
+    renderComponent({
       label: "Foo Bar",
       placeholder: "Select thing...",
     });
 
-    const placeholderText = container.querySelector(
+    const placeholderText = document.querySelector(
       `.${CLASS_PREFIX}__control`,
     )?.textContent;
     expect(placeholderText).toBe("Select thing...");
   });
 
   it("should show loading indicator when isLoading", () => {
-    const { container } = renderComponent({
+    renderComponent({
       label: "Foo Bar",
       isLoading: true,
     });
 
-    const loadingIndicator = container.querySelector(
+    const loadingIndicator = document.querySelector(
       `.${CLASS_PREFIX}__loading-indicator`,
     );
     expect(loadingIndicator).toBeInTheDocument();
   });
 
   it("should write proper text in options menu when isLoading", () => {
-    const { container } = renderComponent({
+    renderComponent({
       label: "Foo Bar",
       isLoading: true,
     });
-    toggleMenuOpen(container);
+    toggleMenuOpen(document.body);
 
-    const loadingText = container.querySelector(
+    const loadingText = document.querySelector(
       `.${CLASS_PREFIX}__menu-notice`,
     )?.textContent;
     expect(loadingText).toBe("Loading...");

--- a/frontend/common/src/components/form/Select/SelectFieldV2.test.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import "@testing-library/jest-dom";
+import { screen, render, RenderOptions, act } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import IntlProvider from "react-intl/src/components/provider";
+import SelectFieldV2 from "./SelectFieldV2";
+import type { SelectFieldV2Props } from "./SelectFieldV2";
+
+const Providers = ({ children }: { children: React.ReactNode }) => {
+  const methods = useForm();
+  return (
+    <IntlProvider locale="en">
+      <FormProvider {...methods}>{children}</FormProvider>
+    </IntlProvider>
+  );
+};
+
+const renderWithProviders = (
+  ui: React.ReactElement,
+  options?: Omit<RenderOptions, "wrapper">,
+) => render(ui, { wrapper: Providers, ...options });
+
+const renderComponent = (props: SelectFieldV2Props) =>
+  renderWithProviders(<SelectFieldV2 {...props} />);
+
+describe("SelectFieldV2", () => {
+  it("should render with only label prop", async () => {
+    await act(async () => {
+      renderComponent({
+        label: "Foo Bar",
+      });
+    });
+    expect(
+      await screen.getByRole("combobox", { name: /foo bar/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/common/src/components/form/Select/SelectFieldV2.test.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.test.tsx
@@ -73,18 +73,19 @@ const renderWithProviders = (
   });
 
 describe("SelectFieldV2", () => {
-  it("should render with only label prop", () => {
+  it("should render properly with only label prop", () => {
     renderWithProviders(<SelectFieldV2 label="Foo Bar" />);
     expect(
       screen.getByRole("combobox", { name: /foo bar/i }),
     ).toBeInTheDocument();
     // Hidden input should exist.
-    expect(
-      document.querySelector('input[type="hidden"]')?.getAttribute("value"),
-    ).toBe("");
+    expect(document.querySelectorAll('input[type="hidden"]')).toHaveLength(1);
     expect(
       document.querySelector('input[type="hidden"]')?.getAttribute("name"),
     ).toBe("fooBar");
+    expect(
+      document.querySelector('input[type="hidden"]')?.getAttribute("value"),
+    ).toBe("");
   });
 
   it("should write proper text in options menu when none provided", () => {
@@ -108,6 +109,7 @@ describe("SelectFieldV2", () => {
       fireEvent.submit(screen.getByRole("button"));
     });
     expect(mockSubmit).toBeCalledTimes(1);
+    expect(mockSubmit).toBeCalledWith({ fooBar: undefined });
   });
 
   it("should prevent submit and throw custom error message when required rule is provided", async () => {
@@ -150,9 +152,16 @@ describe("SelectFieldV2", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
-  it("should show optional text when not required", () => {
+  it("should show 'optional' text when not required", () => {
     renderWithProviders(<SelectFieldV2 label="Foo Bar" />);
     expect(screen.getByText("(Optional)")).toBeInTheDocument();
+  });
+
+  it("should show 'required' text when required", () => {
+    renderWithProviders(
+      <SelectFieldV2 label="Foo Bar" rules={{ required: true }} />,
+    );
+    expect(screen.getByText("(Required)")).toBeInTheDocument();
   });
 
   it("should be clearable when not required", () => {

--- a/frontend/common/src/components/form/Select/SelectFieldV2.test.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.test.tsx
@@ -18,11 +18,13 @@ import SelectFieldV2 from "./SelectFieldV2";
 const Providers = ({
   children,
   onSubmit,
+  defaultValues,
 }: {
   children: React.ReactNode;
   onSubmit: SubmitHandler<FieldValues>;
+  defaultValues: FieldValues;
 }) => {
-  const methods = useForm();
+  const methods = useForm({ defaultValues });
 
   return (
     <IntlProvider locale="en">
@@ -97,7 +99,7 @@ describe("SelectFieldV2", () => {
     expect(noticeText).toBe("No options");
   });
 
-  it("should submit empty when no validation rules", async () => {
+  it("should submit undefined when no selection (no validation rules)", async () => {
     const mockSubmit = jest.fn();
     renderWithProviders(<SelectFieldV2 label="Foo Bar" options={[]} />, {
       wrapperProps: {
@@ -110,6 +112,24 @@ describe("SelectFieldV2", () => {
     });
     expect(mockSubmit).toBeCalledTimes(1);
     expect(mockSubmit).toBeCalledWith({ fooBar: undefined });
+  });
+
+  it("should submit default when set and no selection (no validation rules)", async () => {
+    const mockSubmit = jest.fn();
+    renderWithProviders(<SelectFieldV2 label="Foo Bar" options={[]} />, {
+      wrapperProps: {
+        onSubmit: mockSubmit,
+        defaultValues: {
+          fooBar: "",
+        },
+      },
+    });
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button"));
+    });
+    expect(mockSubmit).toBeCalledTimes(1);
+    expect(mockSubmit).toBeCalledWith({ fooBar: "" });
   });
 
   it("should prevent submit and throw custom error message when required rule is provided", async () => {

--- a/frontend/common/src/components/form/Select/SelectFieldV2.test.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.test.tsx
@@ -3,7 +3,14 @@
  */
 import React from "react";
 import "@testing-library/jest-dom";
-import { screen, render, RenderOptions, act } from "@testing-library/react";
+import {
+  screen,
+  render,
+  RenderOptions,
+  act,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import { FormProvider, useForm } from "react-hook-form";
 import IntlProvider from "react-intl/src/components/provider";
 import SelectFieldV2 from "./SelectFieldV2";
@@ -13,10 +20,20 @@ const Providers = ({ children }: { children: React.ReactNode }) => {
   const methods = useForm();
   return (
     <IntlProvider locale="en">
-      <FormProvider {...methods}>{children}</FormProvider>
+      <FormProvider {...methods}>
+        <form>
+          {children}
+          <input type="submit" />
+        </form>
+      </FormProvider>
     </IntlProvider>
   );
 };
+
+// In SelectFieldV2, We hardcode the classNamePrefix prop into react-select's
+// Select component to making styling/testing simpler. The default random prefix
+// would make this harder.
+const CLASS_NAME_PREFIX = "react-select";
 
 const renderWithProviders = (
   ui: React.ReactElement,
@@ -27,14 +44,70 @@ const renderComponent = (props: SelectFieldV2Props) =>
   renderWithProviders(<SelectFieldV2 {...props} />);
 
 describe("SelectFieldV2", () => {
-  it("should render with only label prop", async () => {
-    await act(async () => {
-      renderComponent({
-        label: "Foo Bar",
-      });
+  it("should render with only label prop", () => {
+    const { container } = renderComponent({
+      label: "Foo Bar",
     });
     expect(
-      await screen.getByRole("combobox", { name: /foo bar/i }),
+      screen.getByRole("combobox", { name: /foo bar/i }),
+    ).toBeInTheDocument();
+    // Hidden input
+    expect(container.querySelector('input[type="hidden"]')).toBeTruthy();
+    expect(
+      container.querySelector('input[type="hidden"]')?.getAttribute("name"),
+    ).toBe("fooBar");
+  });
+
+  it("should render a validation error when required", () => {});
+
+  it("should render a custom validation message", () => {});
+
+  it("should show optional text when not required", () => {});
+
+  it("should be clearable when not required", () => {});
+
+  it("should not be clearable when required", () => {});
+
+  it("should have default placeholder when not specified", () => {
+    const { container } = renderComponent({
+      label: "Foo Bar",
+    });
+    expect(
+      container.querySelector(`.${CLASS_NAME_PREFIX}__control`)?.textContent,
+    ).toBe("Select...");
+  });
+
+  it("should have custom placeholder when specified", () => {
+    const { container } = renderComponent({
+      label: "Foo Bar",
+      placeholder: "Select thing...",
+    });
+    expect(
+      container.querySelector(`.${CLASS_NAME_PREFIX}__control`)?.textContent,
+    ).toBe("Select thing...");
+  });
+
+  it("should show loading indicator when isLoading", () => {
+    const { container } = renderComponent({
+      label: "Foo Bar",
+      isLoading: true,
+    });
+    expect(
+      container.querySelector(`.${CLASS_NAME_PREFIX}__loading-indicator`),
     ).toBeInTheDocument();
   });
+
+  it("should show loading message in options when isLoading", async () => {
+    const { container } = renderComponent({
+      label: "Foo Bar",
+      isLoading: true,
+    });
+    expect(console.log(container.innerHTML));
+    fireEvent.click(
+      container.querySelector(".react-select__dropdown-indicator"),
+    );
+    await waitFor(() => expect(screen.getByRole("option")).toBeInTheDocument());
+  });
+
+  it("should have default loading message when not specified", () => {});
 });

--- a/frontend/common/src/components/form/Select/SelectFieldV2.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.tsx
@@ -102,6 +102,7 @@ const SelectFieldV2 = ({
                 <ReactSelect
                   isClearable={isMulti || !isRequired}
                   {...field}
+                  // TODO: Make default placeholder text locale-aware.
                   {...{ placeholder, options, isMulti, isLoading }}
                   value={convertValueToOption(field.value)}
                   // This only affects react-hook-form state, not internal react-select state.

--- a/frontend/common/src/components/form/Select/SelectFieldV2.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.tsx
@@ -1,19 +1,20 @@
 import React from "react";
 import { Controller, RegisterOptions, useFormContext } from "react-hook-form";
 import ReactSelect, { Options, PropsValue } from "react-select";
+import camelCase from "lodash/camelCase";
 import { InputWrapper } from "../../inputPartials";
 
 export type Option = { value: string | number; label: string };
 
 export interface SelectFieldV2Props {
-  /** HTML id used to identify the element. */
-  id: string;
+  /** Optional HTML id used to identify the element. Default: camelCase of `label`. */
+  id?: string;
   /** Optional context which user can view by toggling a button. */
   context?: string;
   /** The text for the label associated with the select input. */
   label: string;
-  /** A string specifying a name for the input control. */
-  name: string;
+  /** Optional string specifying a name for the input control. Default: `id` value. */
+  name?: string;
   /** List of options for the select element. */
   options?: Options<Option>;
   /** Object set of validation rules to impose on input. */
@@ -40,6 +41,10 @@ const SelectFieldV2 = ({
   placeholder,
   isMulti = false,
 }: SelectFieldV2Props): JSX.Element => {
+  // Defaults from minimal attributes.
+  id ??= camelCase(label); // eslint-disable-line no-param-reassign
+  name ??= id; // eslint-disable-line no-param-reassign
+
   const {
     formState: { errors },
   } = useFormContext();

--- a/frontend/common/src/components/form/Select/SelectFieldV2.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.tsx
@@ -6,6 +6,7 @@ import { InputWrapper } from "../../inputPartials";
 
 export type Option = { value: string | number; label: string };
 
+// TODO: Eventually extend react-select's Select Props, so that anything extra is passed through.
 export interface SelectFieldV2Props {
   /** Optional HTML id used to identify the element. Default: camelCase of `label`. */
   id?: string;
@@ -25,6 +26,7 @@ export interface SelectFieldV2Props {
   isMulti?: boolean;
   /** Whether to force all form values into array, even single Select. */
   forceArrayFormValue?: boolean;
+  isLoading?: boolean;
 }
 
 // User-defined type guard for react-select's readonly Options.
@@ -43,6 +45,7 @@ const SelectFieldV2 = ({
   placeholder,
   isMulti = false,
   forceArrayFormValue = false,
+  isLoading = false,
 }: SelectFieldV2Props): JSX.Element => {
   // Defaults from minimal attributes.
   id ??= camelCase(label); // eslint-disable-line no-param-reassign
@@ -99,7 +102,7 @@ const SelectFieldV2 = ({
                 <ReactSelect
                   isClearable={isMulti || !isRequired}
                   {...field}
-                  {...{ placeholder, options, isMulti }}
+                  {...{ placeholder, options, isMulti, isLoading }}
                   value={convertValueToOption(field.value)}
                   // This only affects react-hook-form state, not internal react-select state.
                   onChange={convertSingleOrMultiOptionsToValues}

--- a/frontend/common/src/components/form/Select/SelectFieldV2.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.tsx
@@ -15,7 +15,7 @@ export interface SelectFieldV2Props {
   /** A string specifying a name for the input control. */
   name: string;
   /** List of options for the select element. */
-  options: Options<Option>;
+  options?: Options<Option>;
   /** Object set of validation rules to impose on input. */
   rules?: RegisterOptions;
   /** Default message shown on select input. */
@@ -35,7 +35,7 @@ const SelectFieldV2 = ({
   context,
   label,
   name,
-  options,
+  options = [],
   rules,
   placeholder,
   isMulti = false,

--- a/frontend/common/src/components/form/Select/SelectFieldV2.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { Controller, RegisterOptions, useFormContext } from "react-hook-form";
+import ReactSelect, { Options, PropsValue } from "react-select";
+import { InputWrapper } from "../../inputPartials";
+
+export type Option = { value: string | number; label: string };
+
+export interface SelectFieldV2Props {
+  /** HTML id used to identify the element. */
+  id: string;
+  /** Optional context which user can view by toggling a button. */
+  context?: string;
+  /** The text for the label associated with the select input. */
+  label: string;
+  /** A string specifying a name for the input control. */
+  name: string;
+  /** List of options for the select element. */
+  options: Options<Option>;
+  /** Object set of validation rules to impose on input. */
+  rules?: RegisterOptions;
+  /** Default message shown on select input. */
+  placeholder?: string;
+  /** Whether field allows multiple selections. */
+  isMulti?: boolean;
+}
+
+// User-defined type guard for react-select's readonly Options.
+// See: https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards
+function isArray<T>(arg: unknown): arg is readonly T[] {
+  return Array.isArray(arg);
+}
+
+const SelectFieldV2 = ({
+  id,
+  context,
+  label,
+  name,
+  options,
+  rules,
+  placeholder,
+  isMulti = false,
+}: SelectFieldV2Props): JSX.Element => {
+  const {
+    formState: { errors },
+  } = useFormContext();
+
+  const error = errors[name]?.message;
+  const isRequired = !!rules?.required;
+
+  return (
+    <div data-h2-margin="b(bottom, xxs)">
+      <InputWrapper
+        {...{ label, context, error }}
+        inputId={id}
+        required={isRequired}
+      >
+        <div style={{ width: "100%" }}>
+          <Controller
+            {...{ name, rules }}
+            aria-required={isRequired}
+            render={({ field }) => {
+              /** Converts our react-hook-form state to Option format that
+               * react-select understands. */
+              const convertValueToOption = (val: Option["value"]) =>
+                options.find((o) => val === o.value);
+              /** Converts react-select's more complex Option type into state we
+               * want in react-hook-form: an array of values. This works whether
+               * react-select is working with Option[] (MultiValue) or Option
+               * (SingleValue) */
+              const convertSingleOrMultiOptionsToValues = (
+                singleOrMulti: PropsValue<Option>,
+              ) =>
+                isArray<Option>(singleOrMulti)
+                  ? field.onChange(singleOrMulti.map((o) => o.value))
+                  : field.onChange(singleOrMulti?.value || null);
+
+              return (
+                <ReactSelect
+                  isClearable={isMulti || !isRequired}
+                  {...field}
+                  {...{ placeholder, options, isMulti }}
+                  value={convertValueToOption(field.value)}
+                  // This only affects react-hook-form state, not internal react-select state.
+                  onChange={convertSingleOrMultiOptionsToValues}
+                  aria-label={label}
+                  styles={{
+                    placeholder: (provided) => ({
+                      ...provided,
+                      color: `#646464`,
+                    }),
+                  }}
+                />
+              );
+            }}
+          />
+        </div>
+      </InputWrapper>
+    </div>
+  );
+};
+
+export default SelectFieldV2;

--- a/frontend/common/src/components/form/Select/SelectFieldV2.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.tsx
@@ -57,7 +57,6 @@ const SelectFieldV2 = ({
         <div style={{ width: "100%" }}>
           <Controller
             {...{ name, rules }}
-            aria-required={isRequired}
             render={({ field }) => {
               /** Converts our react-hook-form state to Option format that
                * react-select understands. */
@@ -83,6 +82,7 @@ const SelectFieldV2 = ({
                   // This only affects react-hook-form state, not internal react-select state.
                   onChange={convertSingleOrMultiOptionsToValues}
                   aria-label={label}
+                  aria-required={isRequired}
                   styles={{
                     placeholder: (provided) => ({
                       ...provided,

--- a/frontend/common/src/components/form/Select/SelectFieldV2.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.tsx
@@ -63,20 +63,23 @@ const SelectFieldV2 = ({
           <Controller
             {...{ name, rules }}
             render={({ field }) => {
-              /** Converts our react-hook-form state to Option format that
-               * react-select understands. */
-              const convertValueToOption = (val: Option["value"]) =>
-                options.find((o) => val === o.value);
-              /** Converts react-select's more complex Option type into state we
-               * want in react-hook-form: an array of values. This works whether
-               * react-select is working with Option[] (MultiValue) or Option
-               * (SingleValue) */
+              /** Converts our react-hook-form state to Option or Option[]
+               * format that react-select understands. */
+              const convertValueToOption = (
+                val: Option["value"] | Option["value"][],
+              ) =>
+                isArray<Option["value"]>(val)
+                  ? // Converts to Option[] for MultiSelect.
+                    options.filter((o) => val?.includes(o.value)) || []
+                  : // Converts to Option or null for single Select.
+                    options.find((o) => val === o.value) || null;
+
               const convertSingleOrMultiOptionsToValues = (
                 singleOrMulti: PropsValue<Option>,
               ) =>
                 isArray<Option>(singleOrMulti)
                   ? field.onChange(singleOrMulti.map((o) => o.value))
-                  : field.onChange(singleOrMulti?.value || null);
+                  : field.onChange(singleOrMulti ? [singleOrMulti?.value] : []);
 
               return (
                 <ReactSelect

--- a/frontend/common/src/components/form/Select/SelectFieldV2.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.tsx
@@ -164,6 +164,9 @@ const SelectFieldV2 = ({
                     LoadingMessage: LocalizedLoadingMessage,
                     NoOptionsMessage: LocalizedNoOptionsMessage,
                   }}
+                  // Adds predictable prefix, helpful for both theming and Jest testing.
+                  // E.g., `react-select__control` instead of `css-1s2u09g__control`.
+                  classNamePrefix="react-select"
                   {...field}
                   {...{ options, isMulti, isLoading }}
                   value={convertValueToOption(field.value)}


### PR DESCRIPTION
Extracted from https://github.com/GCTC-NTGC/gc-digital-talent/issues/2641

What this does:
- Adds components for using react-select (single select and multi-select), with MultiSelectFieldV2 as slim extension of SelectFieldV2
- adopts "XField" nomenclature to better communicate that component encloses more logic than just form/input element (label, context messages, input chrome, etc)
- rather than use react-select's more complex `Option: {value: string; label: string}` format, uses simpler `value` of `string` or `string[]`
- added prop `forceArrayFormValue` to optionally force `SelectFieldV2` to store values as array of single value (e.g., `["BAZ"]`). This should simplify submission logic that can now be more agnostic about field type (Select vs MultiSelect)
- makes text content inside react-select component localizable (e.g, default placeholder "Select...", "Loading...", etc.)
- adds tests for MultiSelectFieldV2 and SelectFieldV2
- allow `name`, `id`, `label` to be derived from one another. Specifically, `name` from `id`, and `id` from `label`. Setting `label` and `id` will result in working component.

## To Do
- [x] spawn issue to eventually migrate Select => SelectFieldV2 and MultiSelect => MultiSelectFieldV2 (remove V2 when full deprecated) https://github.com/GCTC-NTGC/gc-digital-talent/issues/3128

## Open Questions
1. ~~Will we ever need `id` and `name` to be different, or is this just a footgun for react-hook-form and validation? If not, should we just offer one prop and pass it to `InputWrapper` as `inputId`?~~ [EDIT: yes, helpful to allow diff between `id` and `name` for choosing formValue keys (`name`) and also ensuring uniqueness-on-page (`id`). keep both. inheritance of `name` from `id` is best]
2. upstream type definitions of react-hook-form say `rules: { required: true }` is valid, but it confuses our validation message logic -- it silently refuses to submit, but doesn't display a message [(example)](https://main--61e099a1bb1465003a73d3ce.chromatic.com/?path=/story/form-select--select-required&args=rules.required:true). Should we add a default message like "This field is required." when one isn't offered?