### PR TITLE
Debt - 3317 - Improve candidate request validation

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -2,6 +2,7 @@ alertdialog
 Analyser
 APPLICANTPROFILE
 APPLICANTSEARCH
+Assertable
 Authenticatable
 BEHAVIOURAL
 colour

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1066,8 +1066,8 @@ input CreatePoolCandidateSearchRequestInput {
     department: DepartmentBelongsTo!
     jobTitle: String! @rename(attribute: "job_title")
     additionalComments: String @rename(attribute: "additional_comments")
-    poolCandidateFilter: PoolCandidateFilterBelongsTo # TODO: remove this field when we've completed the transition from using poolCandidateCount to applicantCount
-    applicantFilter: ApplicantFilterBelongsTo # TODO: make this required when we've completed the transition from using poolCandidateCount to applicantCount
+    poolCandidateFilter: PoolCandidateFilterBelongsTo @rules(apply: ["required_without:applicantFilter"]) # TODO: remove this field when we've completed the transition from using poolCandidateCount to applicantCount
+    applicantFilter: ApplicantFilterBelongsTo  @rules(apply: ["required_without:poolCandidateFilter"]) # TODO: make this required when we've completed the transition from using poolCandidateCount to applicantCount
     # requestedDate will be set to current date in Eloquent model.
     # status will be set to PENDING in Eloquent model.
 }

--- a/api/tests/Feature/PoolCandidateSearchRequestTest.php
+++ b/api/tests/Feature/PoolCandidateSearchRequestTest.php
@@ -10,18 +10,10 @@ use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 use Illuminate\Testing\Fluent\AssertableJson;
 
-class PoolCandidateSearchRequestTest extends TestCase
-{
+class PoolCandidateSearchRequestTest extends TestCase {
     use RefreshDatabase;
     use MakesGraphQLRequests;
     use ClearsSchemaCache;
-
-    /**
-     * Run a specific seeder before each test.
-     *
-     * @var string
-     */
-    protected $seeder = DepartmentSeeder::class;
 
     /**
      * Default required fields
@@ -70,7 +62,7 @@ class PoolCandidateSearchRequestTest extends TestCase
             [
                 'input' => $this->getInput($input)
             ]
-        );
+            );
     }
 
     /**
@@ -80,6 +72,7 @@ class PoolCandidateSearchRequestTest extends TestCase
      */
     public function testMutationCreateFailsWithNoFilter()
     {
+        $this->seed(DepartmentSeeder::class);
 
         $this->runCreateMutation([
             'department' => [
@@ -89,6 +82,7 @@ class PoolCandidateSearchRequestTest extends TestCase
             'poolCandidateSearchRequest.poolCandidateFilter',
             'poolCandidateSearchRequest.applicantFilter'
         ]);
+
     }
 
     /**
@@ -99,6 +93,7 @@ class PoolCandidateSearchRequestTest extends TestCase
      */
     public function testMutationCreatePassesWithApplicantFilter()
     {
+        $this->seed(DepartmentSeeder::class);
 
         $this->runCreateMutation([
             'department' => [
@@ -112,6 +107,7 @@ class PoolCandidateSearchRequestTest extends TestCase
         ])->assertJson(function (AssertableJson $json) {
             $json->has('data.createPoolCandidateSearchRequest.id');
         });
+
     }
 
     /**
@@ -122,6 +118,7 @@ class PoolCandidateSearchRequestTest extends TestCase
      */
     public function testMutationCreatePassesWithPoolCandidateFilter()
     {
+        $this->seed(DepartmentSeeder::class);
 
         $this->runCreateMutation([
             'department' => [

--- a/api/tests/Feature/PoolCandidateSearchRequestTest.php
+++ b/api/tests/Feature/PoolCandidateSearchRequestTest.php
@@ -10,10 +10,18 @@ use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 use Illuminate\Testing\Fluent\AssertableJson;
 
-class PoolCandidateSearchRequestTest extends TestCase {
+class PoolCandidateSearchRequestTest extends TestCase
+{
     use RefreshDatabase;
     use MakesGraphQLRequests;
     use ClearsSchemaCache;
+
+    /**
+     * Run a specific seeder before each test.
+     *
+     * @var string
+     */
+    protected $seeder = DepartmentSeeder::class;
 
     /**
      * Default required fields
@@ -62,7 +70,7 @@ class PoolCandidateSearchRequestTest extends TestCase {
             [
                 'input' => $this->getInput($input)
             ]
-            );
+        );
     }
 
     /**
@@ -72,7 +80,6 @@ class PoolCandidateSearchRequestTest extends TestCase {
      */
     public function testMutationCreateFailsWithNoFilter()
     {
-        $this->seed(DepartmentSeeder::class);
 
         $this->runCreateMutation([
             'department' => [
@@ -82,7 +89,6 @@ class PoolCandidateSearchRequestTest extends TestCase {
             'poolCandidateSearchRequest.poolCandidateFilter',
             'poolCandidateSearchRequest.applicantFilter'
         ]);
-
     }
 
     /**
@@ -93,7 +99,6 @@ class PoolCandidateSearchRequestTest extends TestCase {
      */
     public function testMutationCreatePassesWithApplicantFilter()
     {
-        $this->seed(DepartmentSeeder::class);
 
         $this->runCreateMutation([
             'department' => [
@@ -107,7 +112,6 @@ class PoolCandidateSearchRequestTest extends TestCase {
         ])->assertJson(function (AssertableJson $json) {
             $json->has('data.createPoolCandidateSearchRequest.id');
         });
-
     }
 
     /**
@@ -118,7 +122,6 @@ class PoolCandidateSearchRequestTest extends TestCase {
      */
     public function testMutationCreatePassesWithPoolCandidateFilter()
     {
-        $this->seed(DepartmentSeeder::class);
 
         $this->runCreateMutation([
             'department' => [

--- a/api/tests/Feature/PoolCandidateSearchRequestTest.php
+++ b/api/tests/Feature/PoolCandidateSearchRequestTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use Database\Seeders\DepartmentSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+use Illuminate\Testing\Fluent\AssertableJson;
+
+class PoolCandidateSearchRequestTest extends TestCase {
+    use RefreshDatabase;
+    use MakesGraphQLRequests;
+    use ClearsSchemaCache;
+
+    /**
+     * Default required fields
+     */
+    private $defaultInput = [
+        'fullName' => 'Test',
+        'email' => 'test@domain.com',
+        'jobTitle' => 'Job Title',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->bootClearsSchemaCache();
+    }
+
+    /**
+     * Get Input for mutation
+     *
+     * @param   array<mixed>    input to merge with default
+     * @param   array<mixed>    Final input values
+     */
+    private function getInput($additionalInput)
+    {
+        return array_merge($this->defaultInput, $additionalInput);
+    }
+
+    /**
+     * Run generic mutation with input
+     *
+     * @param   array<mixed>    CreatePoolCandidateSearchRequestInput
+     * @return \Illuminate\Testing\TestResponse
+     */
+    private function runCreateMutation($input)
+    {
+        return $this->graphQL(
+            /** @lang GraphQL */
+            '
+            mutation createPoolCandidateSearchRequest($input: CreatePoolCandidateSearchRequestInput!) {
+                createPoolCandidateSearchRequest(poolCandidateSearchRequest: $input) {
+                    id
+                }
+            }
+            ',
+            [
+                'input' => $this->getInput($input)
+            ]
+            );
+    }
+
+    /**
+     * Test create mutation fail when neither filter present
+     *
+     * @return void
+     */
+    public function testMutationCreateFailsWithNoFilter()
+    {
+        $this->seed(DepartmentSeeder::class);
+
+        $this->runCreateMutation([
+            'department' => [
+                'connect' => Department::inRandomOrder()->first()->id
+            ],
+        ])->assertGraphQLValidationKeys([
+            'poolCandidateSearchRequest.poolCandidateFilter',
+            'poolCandidateSearchRequest.applicantFilter'
+        ]);
+
+    }
+
+    /**
+     * Test create mutation passes when
+     * applicant filter is present
+     *
+     * @return void
+     */
+    public function testMutationCreatePassesWithApplicantFilter()
+    {
+        $this->seed(DepartmentSeeder::class);
+
+        $this->runCreateMutation([
+            'department' => [
+                'connect' => Department::inRandomOrder()->first()->id
+            ],
+            'applicantFilter' => [
+                'create' => [
+                    'hasDiploma' => true
+                ]
+            ]
+        ])->assertJson(function (AssertableJson $json) {
+            $json->has('data.createPoolCandidateSearchRequest.id');
+        });
+
+    }
+
+    /**
+     * Test create mutation passes when
+     * pool candidate filter is present
+     *
+     * @return void
+     */
+    public function testMutationCreatePassesWithPoolCandidateFilter()
+    {
+        $this->seed(DepartmentSeeder::class);
+
+        $this->runCreateMutation([
+            'department' => [
+                'connect' => Department::inRandomOrder()->first()->id
+            ],
+            'poolCandidateFilter' => [
+                'create' => [
+                    'hasDiploma' => false
+                ]
+            ]
+        ])->assertJson(function (AssertableJson $json) {
+            $json->has('data.createPoolCandidateSearchRequest.id');
+        });
+    }
+}


### PR DESCRIPTION
Resolves #3317 

## Summary

This adds `required_without` validation to the `createPoolCandidateSearchRequest` mutation for `poolCandidateFilter` and `applicantFilter`.