### PR TITLE
Debt - 3516 - Remove Duplicate Link Component

### DIFF
--- a/frontend/admin/src/js/components/classification/CreateClassification.tsx
+++ b/frontend/admin/src/js/components/classification/CreateClassification.tsx
@@ -181,7 +181,7 @@ export const CreateClassificationForm: React.FunctionComponent<
 };
 
 const CreateClassification: React.FunctionComponent = () => {
-  const [_, executeMutation] = useCreateClassificationMutation();
+  const [, executeMutation] = useCreateClassificationMutation();
   const handleCreateClassification = (data: CreateClassificationInput) =>
     executeMutation({ classification: data }).then((result) => {
       if (result.data?.createClassification) {

--- a/frontend/admin/src/js/components/user/UserTable.tsx
+++ b/frontend/admin/src/js/components/user/UserTable.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { IntlShape, useIntl } from "react-intl";
-import { Link, useLocation } from "@common/helpers/router";
+import { useLocation } from "@common/helpers/router";
 import { notEmpty } from "@common/helpers/util";
 import { FromArray } from "@common/types/utilityTypes";
 import { getLanguage } from "@common/constants/localizedConstants";
 import Pending from "@common/components/Pending";
 import printStyles from "@common/constants/printStyles";
 import { useReactToPrint } from "react-to-print";
+import { Link } from "@common/components";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   InputMaybe,

--- a/frontend/common/README.md
+++ b/frontend/common/README.md
@@ -51,7 +51,7 @@ To import code from this folder in another Javascript package in a sibling folde
 ### Done!
 Now you can import common code into your TypeScript files by prefixing the import statement with "@common", and everything (linting, introspection, and building) should work correctly. Some examples:
 
-`import { Link } from "@common/helpers/router";`
+`import { useLocation } from "@common/helpers/router";`
 
 `import Table from "@common/components/Table";`
 

--- a/frontend/common/src/components/Header/Header.tsx
+++ b/frontend/common/src/components/Header/Header.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { useIntl } from "react-intl";
+import Link from "../Link";
 import {
   getLocale,
   localizePath,
   oppositeLocale,
 } from "../../helpers/localize";
-import { imageUrl, Link, useLocation } from "../../helpers/router";
+import { imageUrl, useLocation } from "../../helpers/router";
 
 export interface HeaderProps {
   baseUrl: string;

--- a/frontend/common/src/helpers/router.tsx
+++ b/frontend/common/src/helpers/router.tsx
@@ -231,29 +231,6 @@ export function queryParametersToSearchString(
   return queryString ? `?${queryString}` : "";
 }
 
-type LinkProps = React.HTMLProps<HTMLAnchorElement>;
-
-export const Link: React.FC<LinkProps> = ({
-  href,
-  title,
-  children,
-  ...props
-}): React.ReactElement => (
-  <a
-    href={href}
-    title={title}
-    {...props}
-    onClick={(event): void => {
-      event.preventDefault();
-      if (href) {
-        navigate(href);
-      }
-    }}
-  >
-    {children}
-  </a>
-);
-
 export const ScrollToTop: React.FC<{ children: React.ReactElement }> = ({
   children,
 }): React.ReactElement => {

--- a/frontend/common/src/helpers/router.tsx
+++ b/frontend/common/src/helpers/router.tsx
@@ -5,14 +5,12 @@ import fromPairs from "lodash/fromPairs";
 import toPairs from "lodash/toPairs";
 import path from "path-browserify";
 import { useIntl } from "react-intl";
-import useLinkClickHandler from "../components/Link/useLinkClickHandler";
 import { AuthenticationContext } from "../components/Auth";
 import { Role } from "../api/generated";
 import { AuthorizationContext } from "../components/Auth/AuthorizationContainer";
 import { useApiRoutes } from "../hooks/useApiRoutes";
 import { getLocale } from "./localize";
 import { empty } from "./util";
-import sanitizeUrl from "./sanitizeUrl";
 
 export const HISTORY = createBrowserHistory();
 


### PR DESCRIPTION
Resolves #3516 

## Summary

Removes the `<Link />` component found in the common `router.tsx` file and replaces its usage with the other `<Link />` component.