### PR TITLE
Bug - 3519 - Add Alert Dialog Styles

### DIFF
--- a/frontend/common/src/components/AlertDialog/AlertDialog.tsx
+++ b/frontend/common/src/components/AlertDialog/AlertDialog.tsx
@@ -4,6 +4,9 @@ import {
   AlertDialogOverlay,
 } from "@reach/alert-dialog";
 import type { AlertDialogProps as ReachAlertDialogProps } from "@reach/alert-dialog";
+
+import "@reach/dialog/styles.css";
+
 import AlertDialogActions from "./AlertDialogActions";
 import AlertDialogContent from "./AlertDialogContent";
 import AlertDialogHeading from "./AlertDialogHeading";


### PR DESCRIPTION
Resolves #3519 

## Summary

Adds the required alert dialog styles from @reach. Turns out, they need to be imported from dialog, not alert-dialog 😓 