### PR TITLE
Bug - 3525 - Fix Tab Styles

### DIFF
--- a/frontend/common/src/components/Tabs/Tab.tsx
+++ b/frontend/common/src/components/Tabs/Tab.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { Tab as ReachTab, useTabsContext, type TabProps } from "@reach/tabs";
 
+import "@reach/tabs/styles.css";
+import "./tabs.css";
+
 const Tab = (props: TabProps) => {
   const { index, children } = props;
   const { selectedIndex } = useTabsContext();

--- a/frontend/common/src/components/Tabs/index.ts
+++ b/frontend/common/src/components/Tabs/index.ts
@@ -3,7 +3,4 @@ import Tab from "./Tab";
 import TabPanel from "./TabPanel";
 import TabPanels from "./TabPanels";
 
-import "@reach/tabs/styles.css";
-import "./tabs.css";
-
 export { Tabs, TabList, Tab, TabPanels, TabPanel };

--- a/frontend/common/src/components/UserProfile/ExperienceSection.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceSection.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from "../Tabs";
-import "../Tabs/tabs.css"; // Work around tree shaking
 import { invertSkillExperienceTree } from "../../helpers/skillUtils";
 import ExperienceAccordion, {
   ExperiencePaths,


### PR DESCRIPTION
Resolves #3525 

## Summary

Moves the tab css imports to prevent being improperly tree shaken.