### PR TITLE
navigate redirect to /profile

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -54,7 +54,7 @@ MIX_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
 MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 
 OAUTH_REDIRECT_URI="http://localhost:8000/auth-callback"
-OAUTH_POST_LOGIN_REDIRECT="http://localhost:8000/admin"
+OAUTH_POST_LOGIN_REDIRECT="http://localhost:8000/talent/profile"
 
 # Setting this value fakes a login for local development.
 # DEVELOPMENT ONLY. DO NOT ENABLE IN PRODUCTION.


### PR DESCRIPTION
resolves #3488 
upon login from `/` path, direct to `/talent/profile` rather than `/admin`

to test
1) copy from .env.example over to your .env
2) navigate to http://localhost:8000/login
3) login and you should be directed to /talent/profile

### DEPLOYMENT
This change will require additional care
On the servers, the environment variable `OAUTH_POST_LOGIN_REDIRECT` will have to be changed from "http://{hostname}/admin" to "http://{hostname}/talent/profile" to resolve this fully. 

Thank you, Peter