### PR TITLE
adjust poolFactory to attach single classification

### DIFF
--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -49,7 +49,7 @@ class PoolFactory extends Factory
     {
         return $this->afterCreating(function (Pool $pool) {
             $assets = CmoAsset::inRandomOrder()->limit(4)->get();
-            $classifications = Classification::inRandomOrder()->limit(5)->get();
+            $classifications = Classification::inRandomOrder()->limit(1)->get();
             $skills = Skill::inRandomOrder()->limit(10)->get();
             $pool->essentialCriteria()->saveMany($assets->slice(0,2));
             $pool->assetCriteria()->saveMany($assets->slice(2,2));

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -67,7 +67,7 @@ class DatabaseSeeder extends Seeder
                     $user->save();
 
                     $user->expectedClassifications()->sync(
-                        $faker->randomElements($pool->classifications()->pluck('classifications.id')->toArray(), 3)
+                        $pool->classifications()->pluck('classifications.id')->toArray()
                     );
                 } else {
                     // non-government users have no current classification or expected classifications but have salary


### PR DESCRIPTION
currently the factory attaches 5 random classifications to a pool, going forward like with the pool advertisement the norm is one classification per pool
having multiple classifications attached to a pool causes a failure in validation

candidate classification seeding needed to be adjusted too as there is only a single classification involved with a pool, so each candidate has one expected classification now

see #3424 for context

**testing**
1) check out and migrate+seed
2) visit "Select: classification_pool" and "Select: classification_pool_candidate" in Adminer and ensure they look like what the above says the goal is
3) check anything you might think be suspicious??? not sure