### PR TITLE
Allow chromatic to run on every commit on main branch

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -13,8 +13,9 @@ on:
 
 jobs:
   deployment:
-    # Never run automatically on first trigger event, only on manual re-run.
-    if: ${{ github.run_attempt > 1 }}
+    # 1. Always run for commits on main branch, and for any other commits...
+    # 2. Never run automatically on first trigger event, only on manual re-run.
+    if: ${{ github.ref_name == 'main' || github.run_attempt > 1 }}
     runs-on: ubuntu-latest
     env:
       NPM_VERSION: '8.3.0'


### PR DESCRIPTION
Resolves #3527

Didn't really understand how urgent this was. E.g. Accumulating noise in Chromatic visual diffs to the point of it being useless: (guess it's helpful to have a mainline to diff against 🙃 )
https://www.chromatic.com/pullrequest?appId=61e099a1bb1465003a73d3ce&number=3538&view=changes

<img width="1204" alt="Screen Shot 2022-07-29 at 1 44 04 AM" src="https://user-images.githubusercontent.com/305339/181690828-c2c58a24-fe8b-4e99-adb0-9a610f5eaee3.png">
