### PR TITLE
Add workflow to label direct dependencies as priority

### DIFF
--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -23,4 +23,5 @@ jobs:
         if: ${{ startsWith(steps.metadata.outputs.dependency-type, 'direct:') }}
         run: gh pr edit "$PR_URL" --add-label "dependencies-priority"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -1,6 +1,8 @@
 # Source: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#label-a-pull-request
 name: Dependabot auto-label
-on: pull_request
+# Can't use `pull_request` due to GITHUB_TOKEN and security
+# See: https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544
+on: pull_request_target
 
 permissions:
   pull-requests: write

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -1,3 +1,4 @@
+# Source: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#label-a-pull-request
 name: Dependabot auto-label
 on: pull_request
 

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-label
+on: pull_request
+
+permissions:
+  pull-requests: write
+  issues: write
+  repository-projects: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Add priority label for all direct dependencies
+        # Indirect dependencies deeper in dependency graph are implicitly lower priority.
+        # See: https://github.com/dependabot/fetch-metadata#usage-instructions
+        if: ${{ startsWith(steps.metadata.outputs.dependency-type, 'direct:') }}
+        run: gh pr edit "$PR_URL" --add-label "dependencies-priority"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
Resolves: #2175

To close the other lingering draft PR https://github.com/GCTC-NTGC/gc-digital-talent/pull/2176

Source: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#label-a-pull-request

## To Do
- [x] add workflow
- [x] test/debug workflow on fork
- [x] create label in upstream https://github.com/GCTC-NTGC/gc-digital-talent/labels
  - name: `dependencies-priority`
  - color: `#d66103`
  - description: `Pull requests that update a dependency file (top-level package)`