### PR TITLE
Feature - 3451 - Missing Skills Component

### DIFF
--- a/frontend/common/src/components/skills/MissingSkills/MissingSkills.stories.tsx
+++ b/frontend/common/src/components/skills/MissingSkills/MissingSkills.stories.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import MissingSkills from "./MissingSkills";
+
+import { fakeSkills } from "../../../fakeData";
+
+type MissingSkillsComponent = typeof MissingSkills;
+
+const skills = fakeSkills();
+
+const fakeRequiredSkills = skills.splice(0, skills.length / 2);
+const fakeOptionalSkills = skills.splice(skills.length / 2, skills.length);
+
+export default {
+  title: "Skills/Missing Skills",
+  component: MissingSkills,
+} as ComponentMeta<MissingSkillsComponent>;
+
+const Template: ComponentStory<MissingSkillsComponent> = (args) => {
+  const { optionalSkills, requiredSkills, addedSkills } = args;
+  return (
+    <MissingSkills
+      optionalSkills={optionalSkills}
+      requiredSkills={requiredSkills}
+      addedSkills={addedSkills}
+    />
+  );
+};
+
+export const MissingBothSkills = Template.bind({});
+MissingBothSkills.args = {
+  requiredSkills: fakeRequiredSkills,
+  optionalSkills: fakeOptionalSkills,
+  addedSkills: [],
+};
+
+export const MissingRequiredSkills = Template.bind({});
+MissingRequiredSkills.args = {
+  requiredSkills: fakeRequiredSkills,
+  optionalSkills: fakeOptionalSkills,
+  addedSkills: fakeOptionalSkills,
+};
+
+export const MissingOptionalSkills = Template.bind({});
+MissingOptionalSkills.args = {
+  requiredSkills: fakeRequiredSkills,
+  optionalSkills: fakeOptionalSkills,
+  addedSkills: fakeRequiredSkills,
+};
+
+export const MissingSomeSkills = Template.bind({});
+MissingSomeSkills.args = {
+  requiredSkills: fakeRequiredSkills,
+  optionalSkills: fakeOptionalSkills,
+  addedSkills: [
+    ...fakeRequiredSkills.sort(() => 0.5 - Math.random()).slice(0, 2),
+    ...fakeOptionalSkills.sort(() => 0.5 - Math.random()).slice(0, 1),
+  ],
+};

--- a/frontend/common/src/components/skills/MissingSkills/MissingSkills.test.tsx
+++ b/frontend/common/src/components/skills/MissingSkills/MissingSkills.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { axeTest, render, within } from "../../../helpers/testUtils";
+import { fakeSkills } from "../../../fakeData";
+
+import MissingSkills, { type MissingSkillsProps } from "./MissingSkills";
+
+const skills = fakeSkills();
+
+const fakeRequiredSkills = skills.splice(0, skills.length / 2);
+const fakeOptionalSkills = skills.splice(skills.length / 2, skills.length);
+
+const defaultProps = {
+  requiredSkills: fakeRequiredSkills,
+  optionalSkills: fakeOptionalSkills,
+  addedSkills: [],
+};
+
+const renderMissingSkills = (overrideProps?: MissingSkillsProps) => {
+  const props = {
+    ...defaultProps,
+    ...overrideProps,
+  };
+  return render(<MissingSkills {...props} />);
+};
+
+describe("MissingSkills", () => {
+  it("should have no accessibility errors", async () => {
+    const { container } = renderMissingSkills();
+
+    await axeTest(container);
+  });
+
+  it("should render all skills when none added", () => {
+    const element = renderMissingSkills();
+
+    const lists = element.getAllByRole("list");
+    expect(lists.length).toEqual(2);
+
+    const requiredListItems = within(lists[0]).queryAllByRole("listitem");
+    expect(requiredListItems.length).toEqual(
+      defaultProps.requiredSkills?.length,
+    );
+
+    const optionalListItems = within(lists[1]).queryAllByRole("listitem");
+    expect(optionalListItems.length).toEqual(
+      defaultProps.optionalSkills?.length,
+    );
+  });
+
+  it("should only render required skills if not missing optional", () => {
+    const element = renderMissingSkills({
+      addedSkills: defaultProps.optionalSkills,
+    });
+
+    const lists = element.getAllByRole("list");
+    expect(lists.length).toEqual(1);
+
+    const requiredListItems = within(lists[0]).queryAllByRole("listitem");
+    expect(requiredListItems.length).toEqual(
+      defaultProps.requiredSkills?.length,
+    );
+  });
+
+  it("should only render optional skills if not missing required", () => {
+    const element = renderMissingSkills({
+      addedSkills: defaultProps.requiredSkills,
+    });
+
+    const lists = element.getAllByRole("list");
+    expect(lists.length).toEqual(1);
+
+    const optionalListItems = within(lists[0]).queryAllByRole("listitem");
+    expect(optionalListItems.length).toEqual(
+      defaultProps.optionalSkills?.length,
+    );
+  });
+
+  it("should not render added skills", () => {
+    const element = renderMissingSkills({
+      // Adding one from each array to added skills
+      addedSkills: [
+        ...defaultProps.requiredSkills.slice(0, 1),
+        ...defaultProps.optionalSkills.slice(0, 1),
+      ],
+    });
+
+    const lists = element.getAllByRole("list");
+    expect(lists.length).toEqual(2);
+
+    const requiredListItems = within(lists[0]).queryAllByRole("listitem");
+    expect(requiredListItems.length).toEqual(
+      defaultProps.requiredSkills.length - 1, // Check that we are missing an item
+    );
+
+    const optionalListItems = within(lists[1]).queryAllByRole("listitem");
+    expect(optionalListItems.length).toEqual(
+      defaultProps.optionalSkills.length - 1, // Check that we are missing an item
+    );
+  });
+});

--- a/frontend/common/src/components/skills/MissingSkills/MissingSkills.tsx
+++ b/frontend/common/src/components/skills/MissingSkills/MissingSkills.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { getLocale } from "../../../helpers/localize";
+import type { Skill } from "../../../api/generated";
+import Chip, { Chips } from "../../Chip";
+
+export interface MissingSkillsProps {
+  requiredSkills?: Skill[];
+  optionalSkills?: Skill[];
+  addedSkills?: Skill[];
+}
+
+const getMissingSkills = (required: Skill[], added?: Skill[]) => {
+  return !added?.length
+    ? required
+    : required.filter((skill) => {
+        return !added.find((addedSkill) => addedSkill.id === skill.id);
+      });
+};
+
+const MissingSkills = ({
+  requiredSkills,
+  optionalSkills,
+  addedSkills,
+}: MissingSkillsProps) => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
+
+  const missingRequiredSkills = getMissingSkills(
+    requiredSkills || [],
+    addedSkills,
+  );
+  const missingOptionalSkills = getMissingSkills(
+    optionalSkills || [],
+    addedSkills,
+  );
+
+  return (
+    <>
+      {missingRequiredSkills.length ? (
+        <>
+          <p>
+            {intl.formatMessage({
+              defaultMessage:
+                'The following "Need to have" <red>required</red> skills are missing from your profile:',
+              description: "Text",
+            })}
+          </p>
+          <Chips>
+            {missingRequiredSkills.map((skill) => (
+              <Chip
+                key={skill.id}
+                color="primary"
+                mode="outline"
+                label={skill.name[locale] ?? ""}
+              />
+            ))}
+          </Chips>
+        </>
+      ) : null}
+      {missingOptionalSkills.length ? (
+        <>
+          <p>
+            {intl.formatMessage({
+              defaultMessage:
+                'Other "Nice to have" skills you may want to consider adding to your profile:',
+              description: "Text",
+            })}
+          </p>
+          <Chips>
+            {missingOptionalSkills.map((skill) => (
+              <Chip
+                key={skill.id}
+                color="primary"
+                mode="outline"
+                label={skill.name[locale] ?? ""}
+              />
+            ))}
+          </Chips>
+        </>
+      ) : null}
+    </>
+  );
+};
+
+export default MissingSkills;

--- a/frontend/common/src/components/skills/MissingSkills/MissingSkills.tsx
+++ b/frontend/common/src/components/skills/MissingSkills/MissingSkills.tsx
@@ -44,7 +44,8 @@ const MissingSkills = ({
             {intl.formatMessage({
               defaultMessage:
                 'The following "Need to have" <red>required</red> skills are missing from your profile:',
-              description: "Text",
+              description:
+                "Text that appears when a user is missing required skills on their profile",
             })}
           </p>
           <Chips>
@@ -65,7 +66,8 @@ const MissingSkills = ({
             {intl.formatMessage({
               defaultMessage:
                 'Other "Nice to have" skills you may want to consider adding to your profile:',
-              description: "Text",
+              description:
+                "Text that appears when a user is missing optional skills on their profile",
             })}
           </p>
           <Chips>

--- a/frontend/common/src/components/skills/MissingSkills/index.ts
+++ b/frontend/common/src/components/skills/MissingSkills/index.ts
@@ -1,0 +1,4 @@
+import MissingSkills, { type MissingSkillsProps } from "./MissingSkills";
+
+export type { MissingSkillsProps };
+export default MissingSkills;


### PR DESCRIPTION
Resolves #3451 

## Summary

This adds a new `MissingSkills` component to `common`. 

## Props

```tsx
export interface MissingSkillsProps {
  requiredSkills?: Skill[];
  optionalSkills?: Skill[];
  addedSkills?: Skill[];
}
```

### Required Skills

This is an array of the "Need to Have" skills.

### Optional Skills

This is an array of the "Nice to Have" skills.

### Added Skills

This is an array of the skills that have been added to the users profile.

## Screenshot

<img width="646" alt="Screen Shot 2022-08-02 at 12 46 15 PM" src="https://user-images.githubusercontent.com/4127998/182429213-55636a1a-cc58-460a-8899-fc7442aadc56.png">

