### PR TITLE
Feature - 3323 - Application Page Wrapper

### DIFF
--- a/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationNavigation.tsx
+++ b/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationNavigation.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import Step, { type StepProps } from "./Step";
+
+export interface ApplicationNavigationProps {
+  currentStep: number;
+  steps: Omit<StepProps, "disabled">[];
+}
+
+const ApplicationNavigation = ({
+  currentStep,
+  steps,
+}: ApplicationNavigationProps) => (
+  <div
+    data-h2-padding="b(top-bottom, m)"
+    data-h2-display="b(flex)"
+    data-h2-flex-direction="b(column) s(row)"
+  >
+    {steps.map((step, index) => (
+      <Step
+        key={step.path}
+        {...step}
+        disabled={index + 1 === currentStep}
+        {...(index !== steps.length - 1 && {
+          "data-h2-margin": "s(right, s)",
+        })}
+      />
+    ))}
+  </div>
+);
+
+export default ApplicationNavigation;

--- a/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationNavigation.tsx
+++ b/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationNavigation.tsx
@@ -2,6 +2,19 @@ import React from "react";
 
 import Step, { type StepProps } from "./Step";
 
+interface SpacerProps {
+  children: React.ReactNode;
+  isLast: boolean;
+}
+
+const Spacer = ({ children, isLast }: SpacerProps) => {
+  if (isLast) {
+    return children as JSX.Element;
+  }
+
+  return <div data-h2-margin="b(left, xxs)">{children}</div>;
+};
+
 export interface ApplicationNavigationProps {
   currentStep: number;
   steps: Omit<StepProps, "disabled">[];
@@ -11,20 +24,17 @@ const ApplicationNavigation = ({
   currentStep,
   steps,
 }: ApplicationNavigationProps) => (
-  <div
-    data-h2-padding="b(top-bottom, m)"
-    data-h2-display="b(flex)"
-    data-h2-flex-direction="b(column) s(row)"
-  >
+  <div data-h2-display="b(flex)" data-h2-flex-direction="b(column) s(row)">
     {steps.map((step, index) => (
-      <Step
-        key={step.path}
-        {...step}
-        disabled={index + 1 === currentStep}
-        {...(index !== steps.length - 1 && {
-          "data-h2-margin": "s(right, s)",
-        })}
-      />
+      <Spacer key={step.path} isLast={index + 1 !== steps.length}>
+        <Step
+          {...step}
+          disabled={index + 1 === currentStep}
+          {...(index !== steps.length - 1 && {
+            "data-h2-margin": "s(right, s)",
+          })}
+        />
+      </Spacer>
     ))}
   </div>
 );

--- a/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.stories.tsx
+++ b/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.stories.tsx
@@ -97,3 +97,19 @@ BasicApplicationPageWrapper.args = {
     ],
   },
 };
+
+export const NoNavigationApplicationPageWrapper = Template.bind({});
+NoNavigationApplicationPageWrapper.args = {
+  title: "Basic Application Page Wrapper",
+  subtitle: "Subtitle for Page Wrapper",
+  closingDate: new Date(new Date(TODAY).setMonth(TODAY.getMonth() + 1)),
+  crumbs: [{ title: "Pool Name" }, { title: "About Me" }],
+};
+
+export const ExpiredApplicationPageWrapper = Template.bind({});
+ExpiredApplicationPageWrapper.args = {
+  title: "Basic Application Page Wrapper",
+  subtitle: "Subtitle for Page Wrapper",
+  closingDate: new Date(new Date(TODAY).setMonth(TODAY.getMonth() - 1)),
+  crumbs: [{ title: "Pool Name" }, { title: "About Me" }],
+};

--- a/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.stories.tsx
+++ b/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.stories.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
-import ApplicationPageWrapper, {
-  type ApplicationPageWrapperProps,
-} from "./ApplicationPageWrapper";
+import ApplicationPageWrapper from "./ApplicationPageWrapper";
 
 type ApplicationPageWrapperComponent = typeof ApplicationPageWrapper;
 

--- a/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.stories.tsx
+++ b/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.stories.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import ApplicationPageWrapper, {
+  type ApplicationPageWrapperProps,
+} from "./ApplicationPageWrapper";
+
+type ApplicationPageWrapperComponent = typeof ApplicationPageWrapper;
+
+export default {
+  component: ApplicationPageWrapper,
+  title: "Direct Intake/Application Page Wrapper",
+} as ComponentMeta<ApplicationPageWrapperComponent>;
+
+const Template: ComponentStory<ApplicationPageWrapperComponent> = (args) => {
+  return (
+    <ApplicationPageWrapper {...args}>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus
+        imperdiet ullamcorper pharetra. Suspendisse ullamcorper diam leo, sit
+        amet finibus metus varius in. Donec congue orci at neque mattis viverra.
+        Nunc ultrices imperdiet nulla ut ultrices. Nullam tempus odio magna, vel
+        euismod nulla semper quis. Nulla rutrum quam metus. Suspendisse ac ex
+        nec mi malesuada convallis. Vivamus cursus orci vitae velit ullamcorper
+        eleifend. Sed est elit, dapibus sed tortor nec, fringilla venenatis
+        libero. In ornare fermentum elit, sed mattis urna semper non. Cras quis
+        odio sit amet leo hendrerit consectetur id a magna.
+      </p>
+      <p>
+        Vivamus vel est ex. Vivamus ut aliquam mi. Morbi faucibus malesuada
+        urna, a posuere sapien dapibus eget. Aenean vulputate metus feugiat urna
+        sagittis hendrerit. Vivamus convallis, lorem ut facilisis egestas, quam
+        sapien lobortis dui, eu convallis nunc sem eget leo. Interdum et
+        malesuada fames ac ante ipsum primis in faucibus. Nam porta facilisis
+        cursus. Nulla euismod lectus malesuada diam molestie elementum. Sed
+        egestas interdum ex nec venenatis. Praesent tincidunt dapibus enim, sed
+        volutpat lorem molestie id.
+      </p>
+      <p>
+        Maecenas elementum, erat id pharetra accumsan, mauris tellus volutpat
+        lorem, at pulvinar nunc sem convallis lacus. Integer sapien orci,
+        tristique vel vulputate sit amet, efficitur ut lorem. Etiam lectus arcu,
+        accumsan sit amet lacus a, semper malesuada nulla. Nam posuere euismod
+        tortor non dapibus. Mauris dapibus vel arcu quis placerat. Pellentesque
+        varius vestibulum mauris, vel malesuada eros aliquet vel. Mauris
+        vulputate sagittis dapibus.
+      </p>
+      <p>
+        Mauris ullamcorper at metus ac tristique. Nunc maximus venenatis nisi
+        vel ultrices. Vivamus posuere dolor nec vestibulum vulputate. Sed
+        blandit condimentum lacus. Etiam rhoncus nibh et sapien efficitur
+        sodales. Curabitur sit amet odio nec neque pellentesque ultrices.
+        Aliquam rutrum non ipsum sit amet rhoncus. Pellentesque tortor tortor,
+        egestas eget fermentum non, egestas quis urna. Aliquam tempor, tellus
+        aliquam convallis vestibulum, urna erat faucibus nunc, et consectetur
+        lacus tortor et dolor. Proin sagittis ex et quam hendrerit lacinia.
+        Etiam non nisi efficitur nibh vulputate fringilla. Interdum et malesuada
+        fames ac ante ipsum primis in faucibus. Phasellus malesuada euismod nisi
+        eu lobortis. Integer sodales nunc eu varius ornare.
+      </p>
+      <p>
+        Sed nec ullamcorper metus. Nulla sit amet arcu ornare, condimentum
+        ligula porttitor, bibendum massa. Duis sagittis suscipit purus, ac
+        ultrices est condimentum sit amet. Fusce vulputate facilisis nunc ac
+        pellentesque. Nunc a arcu nisi. Morbi scelerisque velit ut sem lacinia
+        commodo. Duis viverra turpis neque, at cursus mauris ullamcorper a.
+        Nulla a cursus mauris. Nulla ut justo vulputate sapien ornare vulputate.
+        Praesent fermentum metus sed ipsum blandit, ac faucibus dui vestibulum.
+        Vestibulum sed ex eget mi iaculis convallis ut eget mauris. Nullam
+        lectus neque, ultricies vitae est ut, consectetur semper felis.
+        Curabitur eu semper lorem. Proin tristique augue quis sapien volutpat,
+        in vehicula lectus accumsan. Phasellus hendrerit eleifend eleifend.
+      </p>
+    </ApplicationPageWrapper>
+  );
+};
+
+const TODAY = new Date();
+
+export const BasicApplicationPageWrapper = Template.bind({});
+BasicApplicationPageWrapper.args = {
+  title: "Basic Application Page Wrapper",
+  subtitle: "Subtitle for Page Wrapper",
+  closingDate: new Date(new Date(TODAY).setMonth(TODAY.getMonth() + 1)),
+  crumbs: [{ title: "Pool Name" }, { title: "About Me" }],
+  navigation: {
+    currentStep: 1,
+    steps: [
+      {
+        path: "#step-one",
+        label: "Step One",
+      },
+      {
+        path: "#step-two",
+        label: "Step Two",
+      },
+    ],
+  },
+};

--- a/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.tsx
+++ b/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.tsx
@@ -117,7 +117,7 @@ const ApplicationPageWrapper = ({
                     "Label for a pool advertisements closing date on the application",
                 })}
                 <br />
-                {relativeExpiryDate(closingDate, intl)}
+                {relativeExpiryDate(new Date(closingDate), intl)}
               </p>
             </div>
           </div>

--- a/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.tsx
+++ b/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+import Breadcrumbs, { BreadcrumbsProps } from "@common/components/Breadcrumbs";
+import { imageUrl } from "@common/helpers/router";
+
+import ApplicationNavigation, {
+  type ApplicationNavigationProps,
+} from "./ApplicationNavigation";
+import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
+
+export interface ApplicationPageWrapperProps {
+  title: string;
+  subtitle?: string;
+  crumbs?: BreadcrumbsProps["links"];
+  navigation?: ApplicationNavigationProps;
+}
+
+const ApplicationPageWrapper = ({
+  title,
+  subtitle,
+  crumbs,
+  navigation,
+}: ApplicationPageWrapperProps) => {
+  return (
+    <div
+      data-h2-padding="b(top-bottom, m) b(right-left, s)"
+      data-h2-font-color="b(white)"
+      data-h2-text-align="b(center)"
+      style={{
+        background: `url(${imageUrl(
+          TALENTSEARCH_APP_DIR,
+          "applicant-profile-banner.png",
+        )})`,
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+        backgroundRepeat: "no-repeat",
+      }}
+    >
+      <h1 data-h2-margin="b(top-bottom, l)">{title}</h1>
+    </div>
+  );
+};

--- a/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.tsx
+++ b/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.tsx
@@ -1,42 +1,144 @@
 import React from "react";
+import { useIntl } from "react-intl";
+import { BriefcaseIcon } from "@heroicons/react/solid";
 
 import Breadcrumbs, { BreadcrumbsProps } from "@common/components/Breadcrumbs";
 import { imageUrl } from "@common/helpers/router";
+import { relativeExpiryDate } from "@common/helpers/dateUtils";
 
+import { CalendarIcon } from "@heroicons/react/outline";
 import ApplicationNavigation, {
   type ApplicationNavigationProps,
 } from "./ApplicationNavigation";
 import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
+import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
 
 export interface ApplicationPageWrapperProps {
   title: string;
   subtitle?: string;
   crumbs?: BreadcrumbsProps["links"];
   navigation?: ApplicationNavigationProps;
+  closingDate: Date;
+  children: React.ReactNode;
 }
 
 const ApplicationPageWrapper = ({
   title,
   subtitle,
   crumbs,
+  closingDate,
   navigation,
+  children,
 }: ApplicationPageWrapperProps) => {
+  const intl = useIntl();
+  const paths = useDirectIntakeRoutes();
+
+  const banner = imageUrl(TALENTSEARCH_APP_DIR, "applicant-profile-banner.png");
+
+  const breadcrumbs = crumbs ? (
+    <Breadcrumbs
+      links={[
+        {
+          title: intl.formatMessage({
+            defaultMessage: "Browse opportunities",
+            description: "Breadcrumb from applicant profile wrapper.",
+          }),
+          href: paths.allPools(),
+          icon: <BriefcaseIcon style={{ width: "1rem", marginRight: "5px" }} />,
+        },
+        ...crumbs,
+      ]}
+    />
+  ) : null;
+
+  const showNav = !!(navigation && navigation.steps.length > 0);
+
   return (
-    <div
-      data-h2-padding="b(top-bottom, m) b(right-left, s)"
-      data-h2-font-color="b(white)"
-      data-h2-text-align="b(center)"
-      style={{
-        background: `url(${imageUrl(
-          TALENTSEARCH_APP_DIR,
-          "applicant-profile-banner.png",
-        )})`,
-        backgroundSize: "cover",
-        backgroundPosition: "center",
-        backgroundRepeat: "no-repeat",
-      }}
-    >
-      <h1 data-h2-margin="b(top-bottom, l)">{title}</h1>
-    </div>
+    <>
+      <div
+        data-h2-padding="b(top-bottom, m) b(right-left, s)"
+        data-h2-font-color="b(white)"
+        style={{
+          background: `url(${banner})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          backgroundRepeat: "no-repeat",
+        }}
+      >
+        <div data-h2-container="b(center, m)">
+          <h1 data-h2-margin="b(top-bottom, l)">{title}</h1>
+          {breadcrumbs}
+        </div>
+      </div>
+      <div
+        data-h2-bg-color="b(white)"
+        data-h2-padding="b(top-bottom, s)"
+        data-h2-shadow="b(m)"
+      >
+        <div data-h2-container="b(center, m)">
+          <div
+            data-h2-display="b(flex)"
+            data-h2-flex-direction="b(column) s(row)"
+            data-h2-align-items="b(center)"
+            data-h2-justify-content="b(space-between)"
+            data-h2-margin="b(bottom, s) s(top-bottom, s)"
+            {...(showNav && {
+              "data-h2-border": "b(darkgray, bottom, solid, s)",
+              "data-h2-padding": "b(bottom, s)",
+            })}
+          >
+            <div>
+              {subtitle && (
+                <h2
+                  data-h2-font-color="b(darkgray)"
+                  data-h2-font-size="b(h5)"
+                  data-h2-margin="s(top-bottom, none)"
+                >
+                  {subtitle}
+                </h2>
+              )}
+            </div>
+            <div
+              data-h2-font-size="b(h5)"
+              data-h2-display="b(flex)"
+              data-h2-align-items="b(center)"
+            >
+              <CalendarIcon
+                style={{
+                  width: "1em",
+                  height: "1em",
+                  marginRight: "0.5rem",
+                }}
+              />
+              <p data-h2-font-size="b(h6)" data-h2-margin="b(top-bottom, none)">
+                {intl.formatMessage({
+                  defaultMessage: "Closing date:",
+                  description:
+                    "Label for a pool advertisements closing date on the application",
+                })}
+                <br />
+                {relativeExpiryDate(closingDate, intl)}
+              </p>
+            </div>
+          </div>
+          {showNav && <ApplicationNavigation {...navigation} />}
+        </div>
+      </div>
+      {children}
+      {crumbs ? (
+        <div
+          data-h2-padding="b(top-bottom, m) b(right-left, s) s(right-left, xxl)"
+          data-h2-font-color="b(white)"
+          style={{
+            background: `url(${banner})`,
+            backgroundSize: "100vw 5rem",
+          }}
+        >
+          {breadcrumbs}
+        </div>
+      ) : null}
+    </>
   );
 };
+
+export default ApplicationPageWrapper;

--- a/frontend/talentsearch/src/js/components/ApplicationPageWrapper/Step.tsx
+++ b/frontend/talentsearch/src/js/components/ApplicationPageWrapper/Step.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import Link from "@common/components/Link";
+
+export interface StepProps {
+  path: string;
+  label: string;
+  disabled?: boolean;
+}
+
+const Step = ({ path, label, disabled }: StepProps) => (
+  <Link
+    href={path}
+    mode="solid"
+    type="button"
+    color="primary"
+    disabled={disabled}
+  >
+    {label}
+  </Link>
+);
+
+export default Step;

--- a/frontend/talentsearch/src/js/components/ApplicationPageWrapper/Step.tsx
+++ b/frontend/talentsearch/src/js/components/ApplicationPageWrapper/Step.tsx
@@ -10,9 +10,9 @@ export interface StepProps {
 const Step = ({ path, label, disabled }: StepProps) => (
   <Link
     href={path}
-    mode="solid"
+    mode={disabled ? "solid" : "outline"}
     type="button"
-    color="primary"
+    color="black"
     disabled={disabled}
   >
     {label}

--- a/frontend/talentsearch/src/js/components/ApplicationPageWrapper/Step.tsx
+++ b/frontend/talentsearch/src/js/components/ApplicationPageWrapper/Step.tsx
@@ -3,7 +3,7 @@ import Link from "@common/components/Link";
 
 export interface StepProps {
   path: string;
-  label: string;
+  label: React.ReactNode;
   disabled?: boolean;
 }
 


### PR DESCRIPTION
Resolves #3323 

## Summary

This adds a new component meant to wrap the application pages.

### Props

```tsx
export interface StepProps {
  path: string; // Path to the page of the step
  label: string; // Text to be displayed in the link
  disabled?: boolean; // Derived from currentStep in ApplicationNavigationProps
}

interface ApplicationNavigationProps {
  currentStep: number; // The current step the user is on (disables that button)
  steps: Omit<StepProps, "disabled">[];  // Array of the allowed steps
}

interface ApplicationPageWrapperProps {
  title: string; // Main page title
  subtitle?: string; // Jpb advertisement title
  crumbs?: BreadcrumbsProps["links"]; // Array of breadcrumb links to show
  navigation?: ApplicationNavigationProps; // If set, displays the steps as buttons
  closingDate: Date; // The closing date of the advertisement
  children: React.ReactNode; // The page contents
}
```

## Screenshot 

### Header

<img width="1244" alt="Screen Shot 2022-08-02 at 4 02 59 PM" src="https://user-images.githubusercontent.com/4127998/182463167-c832a175-90c7-4dce-aa3d-bee0ee997d09.png">

### Footer
<img width="1241" alt="Screen Shot 2022-08-02 at 4 03 09 PM" src="https://user-images.githubusercontent.com/4127998/182463202-46d3e8e2-e084-4c3f-922f-f1a8f1938347.png">


