### PR TITLE
Reduce logout logic complexity

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -31,10 +31,7 @@ class AuthController extends Controller
         else
             $ui_locales = $requestedLocale;
 
-        $scope = 'openid';
-        // Laravel auth server will error out if you request offline_access scope
-        if(config('oauth.authorize_uri') != 'http://localhost:8000/oauth/authorize')
-            $scope = $scope . ' offline_access';
+        $scope = 'openid offline_access';
 
         $query = http_build_query([
             'client_id' => config('oauth.client_id'),
@@ -69,24 +66,22 @@ class AuthController extends Controller
             'code' => $request->code,
         ]);
 
-        // to ensure this doesn't break with local test, nonce verification only runs in SiC .env settings
-        if(config('oauth.token_uri') !== 'http://localhost:80/oauth/token'){
-            // decode id_token stage
-            // pull token out of the response as json -> lcobucci parser, no key verification is being done here however
-            $idToken = $response->json("id_token");
+        // decode id_token stage
+        // pull token out of the response as json -> lcobucci parser, no key verification is being done here however
+        $idToken = $response->json("id_token");
 
-            $config = Configuration::forUnsecuredSigner();
-            assert($config instanceof Configuration);
-            $token = $config->parser()->parse($idToken);
-            assert($token instanceof UnencryptedToken);
+        $config = Configuration::forUnsecuredSigner();
+        assert($config instanceof Configuration);
+        $token = $config->parser()->parse($idToken);
+        assert($token instanceof UnencryptedToken);
 
-            //grab the tokenNonce out of the unencrypted thing and compare to original nonce, and throw_unless if mismatch
-            $tokenNonce = $token->claims()->get('nonce');
-            throw_unless(
-                strlen($tokenNonce) > 0 && $tokenNonce === $nonce,
-                new InvalidArgumentException("Invalid session nonce")
-            );
-        }
+        //grab the tokenNonce out of the unencrypted thing and compare to original nonce, and throw_unless if mismatch
+        $tokenNonce = $token->claims()->get('nonce');
+        throw_unless(
+            strlen($tokenNonce) > 0 && $tokenNonce === $nonce,
+            new InvalidArgumentException("Invalid session nonce")
+        );
+
         $query = http_build_query($response->json());
 
         $from = $request->session()->pull('from');

--- a/frontend/.apache_env
+++ b/frontend/.apache_env
@@ -1,4 +1,3 @@
-# TO DO: Update to /logged-out once ready
 OAUTH_POST_LOGOUT_REDIRECT="http://localhost:8000/logged-out"
 
 # Mock auth endpoint

--- a/frontend/admin/src/js/dashboard.tsx
+++ b/frontend/admin/src/js/dashboard.tsx
@@ -5,15 +5,11 @@ import ContextContainer from "@common/components/context";
 import { Messages } from "@common/components/LanguageRedirectContainer";
 import { Toast } from "@common/components";
 import { PoolDashboard } from "./components/PoolDashboard";
-import adminRoutes from "./adminRoutes";
 import * as adminFrench from "./lang/frCompiled.json";
 
 ReactDOM.render(
   <>
-    <ContextContainer
-      homePath={adminRoutes("").home()}
-      messages={adminFrench as Messages}
-    >
+    <ContextContainer messages={adminFrench as Messages}>
       <PoolDashboard />
     </ContextContainer>
     <Toast />

--- a/frontend/common/src/components/Auth/AuthenticationContainer.tsx
+++ b/frontend/common/src/components/Auth/AuthenticationContainer.tsx
@@ -40,9 +40,8 @@ export const AuthenticationContext =
   React.createContext<AuthenticationState>(defaultAuthState);
 
 const logoutAndRefreshPage = (
-  homePath: string,
-  logoutUri: string | undefined,
-  logoutRedirectUri: string | undefined,
+  logoutUri: string,
+  logoutRedirectUri: string,
 ): void => {
   // capture tokens before they are removed
   const accessToken = localStorage.getItem(ACCESS_TOKEN);
@@ -53,22 +52,21 @@ const logoutAndRefreshPage = (
   localStorage.removeItem(REFRESH_TOKEN);
   localStorage.removeItem(ID_TOKEN);
 
-  // check if we have everything we need to do an auth session end
-  let authLogOutUri = null;
-  if (accessToken && logoutUri && logoutRedirectUri) {
-    let tokenIsKnownToBeActive = false;
+  let authSessionIsCurrentlyActive = false; // assume false unless we can prove it below
+
+  if (accessToken) {
     const decodedAccessToken = jwtDecode<JwtPayload>(accessToken);
     if (decodedAccessToken.exp)
-      tokenIsKnownToBeActive = Date.now() < decodedAccessToken.exp * 1000; // JWT expiry date in seconds, not milliseconds
-    if (tokenIsKnownToBeActive) {
-      // we probably have an active session with the auth provider so we need to sign out of it
-      authLogOutUri = `${logoutUri}?post_logout_redirect_uri=${logoutRedirectUri}`;
-      if (idToken) authLogOutUri += `&id_token_hint=${idToken}`;
-    }
+      authSessionIsCurrentlyActive = Date.now() < decodedAccessToken.exp * 1000; // JWT expiry date in seconds, not milliseconds
   }
 
-  // Navigate to auth log out to end the session or at least a hard refresh to home (to restart react app)
-  window.location.href = authLogOutUri ?? homePath;
+  if (idToken && authSessionIsCurrentlyActive) {
+    // SiC logout will error out unless there is actually an active session
+    window.location.href = `${logoutUri}?post_logout_redirect_uri=${logoutRedirectUri}&id_token_hint=${idToken}`;
+  } else {
+    // at least a hard refresh to URI to restart react app
+    window.location.href = logoutRedirectUri;
+  }
 };
 
 const refreshTokenSet = async (
@@ -124,15 +122,13 @@ function getTokensFromLocation(
 }
 
 interface AuthenticationContainerProps {
-  homePath: string;
   tokenRefreshPath: string;
-  logoutUri: string | undefined;
-  logoutRedirectUri: string | undefined;
+  logoutUri: string;
+  logoutRedirectUri: string;
 }
 
 const AuthenticationContainer: React.FC<AuthenticationContainerProps> = ({
   tokenRefreshPath,
-  homePath,
   logoutUri,
   logoutRedirectUri,
   children,
@@ -174,7 +170,7 @@ const AuthenticationContainer: React.FC<AuthenticationContainerProps> = ({
       refreshToken: tokens.refreshToken,
       loggedIn: !!tokens.accessToken,
       logout: tokens.accessToken
-        ? () => logoutAndRefreshPage(homePath, logoutUri, logoutRedirectUri)
+        ? () => logoutAndRefreshPage(logoutUri, logoutRedirectUri)
         : () => {
             /* If not logged in, logout does nothing. */
           },
@@ -187,7 +183,6 @@ const AuthenticationContainer: React.FC<AuthenticationContainerProps> = ({
     tokens.accessToken,
     tokens.idToken,
     tokens.refreshToken,
-    homePath,
     logoutUri,
     logoutRedirectUri,
     tokenRefreshPath,

--- a/frontend/common/src/components/context/AuthenticationProvider.tsx
+++ b/frontend/common/src/components/context/AuthenticationProvider.tsx
@@ -2,25 +2,19 @@ import React from "react";
 
 import { AuthenticationContainer } from "../Auth";
 import { useApiRoutes } from "../../hooks/useApiRoutes";
-import { getRuntimeVariable } from "../../helpers/runtimeVariable";
+import { getRuntimeVariableNotNull } from "../../helpers/runtimeVariable";
 
-export interface AuthenticationProviderProps {
-  homePath: string;
-}
-
-const AuthenticationProvider: React.FC<AuthenticationProviderProps> = ({
-  homePath,
-  children,
-}) => {
+const AuthenticationProvider: React.FC = ({ children }) => {
   const apiPaths = useApiRoutes();
   const refreshTokenSetPath = apiPaths.refreshAccessToken();
 
-  const logoutUri = getRuntimeVariable("OAUTH_LOGOUT_URI");
-  const postLogoutRedirect = getRuntimeVariable("OAUTH_POST_LOGOUT_REDIRECT");
+  const logoutUri = getRuntimeVariableNotNull("OAUTH_LOGOUT_URI");
+  const postLogoutRedirect = getRuntimeVariableNotNull(
+    "OAUTH_POST_LOGOUT_REDIRECT",
+  );
 
   return (
     <AuthenticationContainer
-      homePath={homePath}
       tokenRefreshPath={refreshTokenSetPath}
       logoutUri={logoutUri}
       logoutRedirectUri={postLogoutRedirect}

--- a/frontend/common/src/components/context/ContextContainer.tsx
+++ b/frontend/common/src/components/context/ContextContainer.tsx
@@ -7,17 +7,15 @@ import AuthorizationProvider from "./AuthorizationProvider";
 import LanguageRedirectProvider from "./LanguageRedirectProvider";
 
 export interface ContextContainerProps {
-  homePath: string;
   messages: Messages;
 }
 
 const ContextContainer: React.FC<ContextContainerProps> = ({
-  homePath,
   messages,
   children,
 }) => (
   <LanguageRedirectProvider messages={messages}>
-    <AuthenticationProvider homePath={homePath}>
+    <AuthenticationProvider>
       <ClientProvider>
         <AuthorizationProvider>{children}</AuthorizationProvider>
       </ClientProvider>

--- a/frontend/common/src/helpers/runtimeVariable.ts
+++ b/frontend/common/src/helpers/runtimeVariable.ts
@@ -5,12 +5,26 @@ interface HasServerConfig {
 }
 
 /**
- * A function to retrieve a environment variable value from the window object
+ * Retrieve an environment variable value from the window object
  */
 export const getRuntimeVariable = (name: string): string | undefined => {
   const windowWithConfig = window as unknown as HasServerConfig;
   // eslint-disable-next-line no-underscore-dangle
   return windowWithConfig.__SERVER_CONFIG__?.get(name);
+};
+
+/**
+ * Retrieve an environment variable value from the window object with error if missing
+ */
+export const getRuntimeVariableNotNull = (name: string): string => {
+  const runtimeVariable = getRuntimeVariable(name);
+  if (runtimeVariable) {
+    return runtimeVariable;
+  }
+
+  // eslint-disable-next-line no-console
+  console.error(`Missing mandatory runtime variable: ${name}`);
+  return " ";
 };
 
 /**

--- a/frontend/indigenousapprenticeship/public/config.sjs
+++ b/frontend/indigenousapprenticeship/public/config.sjs
@@ -6,6 +6,10 @@
  * The sjs filetype lets apache know that this file should be parsed for SSI directives.
  */
 
+ // catch the placeholder string that Apache uses to indicate that the variable is missing
+const filterEmpty = (value) => value != "(none)" ? value : undefined;
+
+
 const data = new Map([
 
 ]);

--- a/frontend/talentsearch/public/config.sjs
+++ b/frontend/talentsearch/public/config.sjs
@@ -6,12 +6,15 @@
  * The sjs filetype lets apache know that this file should be parsed for SSI directives.
  */
 
+// catch the placeholder string that Apache uses to indicate that the variable is missing
+const filterEmpty = (value) => value != "(none)" ? value : undefined;
+
 const data = new Map([
-    ["OAUTH_POST_LOGOUT_REDIRECT", "<!--#echo var="OAUTH_POST_LOGOUT_REDIRECT" -->"],
-    ["OAUTH_LOGOUT_URI", "<!--#echo var="OAUTH_LOGOUT_URI" -->"],
-    ["FEATURE_APPLICANTPROFILE", "<!--#echo var="FEATURE_APPLICANTPROFILE" -->"],
-    ["FEATURE_DIRECTINTAKE", "<!--#echo var="FEATURE_DIRECTINTAKE" -->"],
-    ["FEATURE_APPLICANTSEARCH", "<!--#echo var="FEATURE_APPLICANTSEARCH" -->"],
+    ["OAUTH_POST_LOGOUT_REDIRECT", filterEmpty("<!--#echo var="OAUTH_POST_LOGOUT_REDIRECT" -->")],
+    ["OAUTH_LOGOUT_URI", filterEmpty("<!--#echo var="OAUTH_LOGOUT_URI" -->")],
+    ["FEATURE_APPLICANTPROFILE", filterEmpty("<!--#echo var="FEATURE_APPLICANTPROFILE" -->")],
+    ["FEATURE_DIRECTINTAKE", filterEmpty("<!--#echo var="FEATURE_DIRECTINTAKE" -->")],
+    ["FEATURE_APPLICANTSEARCH", filterEmpty("<!--#echo var="FEATURE_APPLICANTSEARCH" -->")],
 ]);
 
 window.__SERVER_CONFIG__ = data;

--- a/frontend/talentsearch/src/js/pageContainer.tsx
+++ b/frontend/talentsearch/src/js/pageContainer.tsx
@@ -5,15 +5,11 @@ import ContextContainer from "@common/components/context";
 import { Messages } from "@common/components/LanguageRedirectContainer";
 import { Toast } from "@common/components";
 import { Router } from "./components/Router";
-import talentSearchRoutes from "./talentSearchRoutes";
 import * as talentSearchFrench from "./lang/frCompiled.json";
 
 ReactDOM.render(
   <>
-    <ContextContainer
-      homePath={talentSearchRoutes("").home()}
-      messages={talentSearchFrench as Messages}
-    >
+    <ContextContainer messages={talentSearchFrench as Messages}>
       <Router />
     </ContextContainer>
     <Toast />


### PR DESCRIPTION
We can't make logout fully mandatory as in the AC of the issue.  If the browser is redirected to the Sign In Canada logout URI when there is no active session then a scary error page is displayed.  The logic to guess if a session is still active must remain.  This branch reduces the logic complexity around logout a bit.

## Highlights
- Removed some leftover Laravel Auth logic from api/app/Http/Controllers/AuthController.php.
- Removed the `homePath` prop from AuthenticationContainer.  Browswer will always be sent to `logoutRedirectUri`.
- Added a `getRuntimeVariableNotNull` function that will log an error if a mandatory variable is missing and has a not-null return type.
- Refactored the logic of `logoutAndRefreshPage` to (hopefully) make it a bit clearer

## Testing
- Test with both SiC and MockAuth
- Log in
- Check when your token expires (try jwt.io)
- If you logout before your token expires then you should see your browser navigating to the logout URI
- If you logout after your token expires then you should see your browser directly navigating to the /logged-out page
- If you have no OAUTH_LOGOUT_URI variable set in your PHP container you should see a console error logged when you try to logout

## Limitations
- Chose note to write Cypress test since behavior requires waiting several minutes and (as Patcon mentioned) mock-auth is stateless
- Chose to not use .well-known/openid-configuration endpoint to find end_session endpoint since that variable would be the only use on the frontend.  This probably will make more sense when we switch to frontend auth with PKCE

Closes #3012 