### PR TITLE
Limit when Azure pipeline builds a new release artifact

### DIFF
--- a/infrastructure/azure-pipelines.yml
+++ b/infrastructure/azure-pipelines.yml
@@ -3,6 +3,11 @@ trigger:
   branches:
     include:
     - main
+  paths:
+    exclude:
+    - documentation
+    - maintenance
+pr: none
 resources:
   repositories:
   - repository: self


### PR DESCRIPTION
Only trigger azure build on changes to main, not every PR. Exclude changes to only documentation or maintenance scripts.

Main motivation:
Since we automatically deploy to the Dev server every time an artifact is built, and we're currently building an artifact every time a PR is created or updated (and not necessarily ready for merging into main), the Dev server is likely to be broken at any given time.