### PR TITLE
Copy - 3393 - Update profile back button text

### DIFF
--- a/frontend/common/src/messages/commonMessages.ts
+++ b/frontend/common/src/messages/commonMessages.ts
@@ -26,6 +26,10 @@ const messages = defineMessages({
     description:
       "Message that there are required fields missing. Please ignore things in <> tags.",
   },
+  backToProfile: {
+    defaultMessage: "Go back to my profile",
+    description: "Link text for button to return to user profile",
+  },
 });
 
 export default messages;

--- a/frontend/talentsearch/src/js/components/applicantProfile/CancelButton.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/CancelButton.tsx
@@ -4,12 +4,17 @@ import * as React from "react";
 import { useIntl } from "react-intl";
 import { useApplicantProfileRoutes } from "../../applicantProfileRoutes";
 
-const CancelButton: React.FunctionComponent<{ link?: string }> = ({ link }) => {
+export interface CancelButtonProps {
+  href?: string;
+  children?: React.ReactNode;
+}
+
+const CancelButton = ({ href, children }: CancelButtonProps) => {
   const intl = useIntl();
   const profilePaths = useApplicantProfileRoutes();
   return (
     <Link
-      href={link || profilePaths.home()}
+      href={href || profilePaths.home()}
       color="secondary"
       mode="outline"
       data-h2-display="s(inline-flex)"
@@ -19,10 +24,11 @@ const CancelButton: React.FunctionComponent<{ link?: string }> = ({ link }) => {
     >
       <ArrowCircleLeftIcon style={{ width: "1rem" }} />
       <span data-h2-margin="b(left, xxs)">
-        {intl.formatMessage({
-          defaultMessage: "Cancel and go back",
-          description: "Label for cancel button on profile form.",
-        })}
+        {children ||
+          intl.formatMessage({
+            defaultMessage: "Cancel and go back",
+            description: "Label for cancel button on profile form.",
+          })}
       </span>
     </Link>
   );

--- a/frontend/talentsearch/src/js/components/applicantProfile/ExperienceAndSkills.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/ExperienceAndSkills.tsx
@@ -139,6 +139,12 @@ export const ExperienceAndSkills: React.FunctionComponent<
         description:
           "Heading for experience and skills page in applicant profile.",
       })}
+      cancelLink={{
+        children: intl.formatMessage({
+          defaultMessage: "Go back to my profile",
+          description: "Link text for button to return to user profile",
+        }),
+      }}
     >
       <p
         data-h2-font-style="b(reset)"

--- a/frontend/talentsearch/src/js/components/applicantProfile/ExperienceAndSkills.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/ExperienceAndSkills.tsx
@@ -140,10 +140,7 @@ export const ExperienceAndSkills: React.FunctionComponent<
           "Heading for experience and skills page in applicant profile.",
       })}
       cancelLink={{
-        children: intl.formatMessage({
-          defaultMessage: "Go back to my profile",
-          description: "Link text for button to return to user profile",
-        }),
+        children: intl.formatMessage(commonMessages.backToProfile),
       }}
     >
       <p
@@ -206,8 +203,12 @@ export const ExperienceAndSkills: React.FunctionComponent<
           experienceEditPaths={experienceEditPaths}
         />
       )}
-
-      <ProfileFormFooter mode="cancelButton" />
+      <ProfileFormFooter
+        mode="cancelButton"
+        cancelLink={{
+          children: intl.formatMessage(commonMessages.backToProfile),
+        }}
+      />
     </ProfileFormWrapper>
   );
 };

--- a/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormFooter.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormFooter.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
-import CancelButton from "./CancelButton";
+import CancelButton, { type CancelButtonProps } from "./CancelButton";
 import SaveButton from "./SaveButton";
 
 export interface ProfileFormFooterProps {
   mode: "cancelButton" | "saveButton" | "bothButtons";
-  link?: string;
+  link?: CancelButtonProps;
 }
 
 const ProfileFormFooter: React.FunctionComponent<ProfileFormFooterProps> = ({
@@ -18,7 +18,7 @@ const ProfileFormFooter: React.FunctionComponent<ProfileFormFooterProps> = ({
         return (
           <>
             <span data-h2-padding="b(right, xs)">
-              <CancelButton link={link} />
+              <CancelButton {...link} />
             </span>
             <span>
               <SaveButton />

--- a/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormFooter.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormFooter.tsx
@@ -4,13 +4,13 @@ import SaveButton from "./SaveButton";
 
 export interface ProfileFormFooterProps {
   mode: "cancelButton" | "saveButton" | "bothButtons";
-  link?: CancelButtonProps;
+  cancelLink?: CancelButtonProps;
 }
 
 const ProfileFormFooter: React.FunctionComponent<ProfileFormFooterProps> = ({
   mode,
   children,
-  link,
+  cancelLink,
 }) => {
   const bottomButtons = () => {
     switch (mode) {
@@ -18,7 +18,7 @@ const ProfileFormFooter: React.FunctionComponent<ProfileFormFooterProps> = ({
         return (
           <>
             <span data-h2-padding="b(right, xs)">
-              <CancelButton {...link} />
+              <CancelButton {...cancelLink} />
             </span>
             <span>
               <SaveButton />
@@ -26,7 +26,7 @@ const ProfileFormFooter: React.FunctionComponent<ProfileFormFooterProps> = ({
           </>
         );
       case "cancelButton":
-        return <CancelButton />;
+        return <CancelButton {...cancelLink} />;
       case "saveButton":
         return <SaveButton />;
       default:

--- a/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormWrapper.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormWrapper.tsx
@@ -4,14 +4,14 @@ import { UserIcon } from "@heroicons/react/solid";
 import { useIntl } from "react-intl";
 import { imageUrl } from "@common/helpers/router";
 import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
-import CancelButton from "./CancelButton";
+import CancelButton, { type CancelButtonProps } from "./CancelButton";
 import { useApplicantProfileRoutes } from "../../applicantProfileRoutes";
 
 export interface ProfileFormWrapperProps {
   crumbs: BreadcrumbsProps["links"];
   description: string;
   title: string;
-  cancelLink?: string;
+  cancelLink?: CancelButtonProps;
 }
 
 const ProfileFormWrapper: React.FunctionComponent<ProfileFormWrapperProps> = ({
@@ -59,7 +59,7 @@ const ProfileFormWrapper: React.FunctionComponent<ProfileFormWrapperProps> = ({
         data-h2-width="b(100) s(75)"
       >
         <div data-h2-margin="b(top-bottom, l)">
-          <CancelButton link={cancelLink} />
+          <CancelButton {...cancelLink} />
         </div>
         <h1
           data-h2-margin="b(all, none)"

--- a/frontend/talentsearch/src/js/components/diversityEquityInclusion/DiversityEquityInclusionForm.tsx
+++ b/frontend/talentsearch/src/js/components/diversityEquityInclusion/DiversityEquityInclusionForm.tsx
@@ -57,10 +57,7 @@ export const DiversityEquityInclusionForm: React.FC<
         },
       ]}
       cancelLink={{
-        children: intl.formatMessage({
-          defaultMessage: "Go back to my profile",
-          description: "Link text for button to return to user profile",
-        }),
+        children: intl.formatMessage(commonMessages.backToProfile),
       }}
     >
       <p>

--- a/frontend/talentsearch/src/js/components/diversityEquityInclusion/DiversityEquityInclusionForm.tsx
+++ b/frontend/talentsearch/src/js/components/diversityEquityInclusion/DiversityEquityInclusionForm.tsx
@@ -56,6 +56,12 @@ export const DiversityEquityInclusionForm: React.FC<
           }),
         },
       ]}
+      cancelLink={{
+        children: intl.formatMessage({
+          defaultMessage: "Go back to my profile",
+          description: "Link text for button to return to user profile",
+        }),
+      }}
     >
       <p>
         {intl.formatMessage({

--- a/frontend/talentsearch/src/js/components/diversityEquityInclusion/DiversityEquityInclusionForm.tsx
+++ b/frontend/talentsearch/src/js/components/diversityEquityInclusion/DiversityEquityInclusionForm.tsx
@@ -16,6 +16,7 @@ import {
 import EquityOptions from "./EquityOptions";
 import type { DiversityInclusionUpdateHandler, EquityKeys } from "./types";
 import profileMessages from "../profile/profileMessages";
+import ProfileFormFooter from "../applicantProfile/ProfileFormFooter";
 
 export interface DiversityEquityInclusionFormProps {
   user: User;
@@ -148,6 +149,12 @@ export const DiversityEquityInclusionForm: React.FC<
         hasDisability={user.hasDisability}
         onAdd={(key: EquityKeys) => handleUpdate(key, true)}
         onRemove={(key: EquityKeys) => handleUpdate(key, false)}
+      />
+      <ProfileFormFooter
+        mode="cancelButton"
+        cancelLink={{
+          children: intl.formatMessage(commonMessages.backToProfile),
+        }}
       />
     </ProfileFormWrapper>
   );

--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
@@ -118,7 +118,9 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
               }),
         },
       ]}
-      cancelLink={paths.skillsAndExperiences()}
+      cancelLink={{
+        href: paths.skillsAndExperiences(),
+      }}
     >
       <BasicForm
         onSubmit={handleSubmit}
@@ -175,7 +177,9 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
         )}
         <ProfileFormFooter
           mode="bothButtons"
-          link={paths.skillsAndExperiences()}
+          link={{
+            href: paths.skillsAndExperiences(),
+          }}
         />
       </BasicForm>
       <AlertDialog

--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
@@ -177,7 +177,7 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
         )}
         <ProfileFormFooter
           mode="bothButtons"
-          link={{
+          cancelLink={{
             href: paths.skillsAndExperiences(),
           }}
         />


### PR DESCRIPTION
Resolves #3393 

## Summary

This updates the props for the `ProfileFormWrapper` and `CancelButton` to components to allow more customisation. As well, it changes the cancel link text on `/talent/profile/skills-and-experiences` and `/talent/profile/diversity-and-inclusion` for improved context.

## Screenshot
<img width="673" alt="Screen Shot 2022-08-11 at 9 49 09 AM" src="https://user-images.githubusercontent.com/4127998/184148718-557e27f2-5b6a-41b9-bce1-125113781e8a.png">

## Testing

1. Build talentsearch `cd frontend && npm run production --workspace=talentsearch`
2. Navigate to `/talent/profile/skills-and-experiences` and `/talent/profile/diversity-and-inclusion`
3. Confirm the cancel links contain the text "Go back to my profile"
