### PR TITLE
Bug - 3512 - Fix empty unique user validation

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -736,13 +736,13 @@ input PoolsHasMany {
 When creating a User, name is required.
 """
 input CreateUserInput {
-    sub: String @rules(apply: ["unique:users,sub"])
+    sub: String @rules(apply: ["sometimes","unique:users,sub"])
     roles: [Role] = []
 
     # Personal info
     firstName: String! @rename(attribute: "first_name")
     lastName: String! @rename(attribute: "last_name")
-    email: Email @rules(apply: ["unique:users,email"])
+    email: Email @rules(apply: ["sometimes","unique:users,email"])
     telephone: PhoneNumber
     preferredLang: Language @rename(attribute: "preferred_lang")
     currentProvince: ProvinceOrTerritory @rename(attribute: "current_province")

--- a/frontend/admin/src/js/components/user/CreateUser.tsx
+++ b/frontend/admin/src/js/components/user/CreateUser.tsx
@@ -7,7 +7,7 @@ import { navigate } from "@common/helpers/router";
 import { enumToOptions } from "@common/helpers/formUtils";
 import { getLanguage, getRole } from "@common/constants/localizedConstants";
 import { errorMessages } from "@common/messages";
-import { emptyToNull } from "@common/helpers/util";
+import { emptyToNull, emptyToUndefined } from "@common/helpers/util";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Language,
@@ -30,8 +30,8 @@ const formValuesToData = (values: FormValues): CreateUserInput => ({
   // empty string isn't valid according to API validation regex pattern, but null is valid.
   telephone: emptyToNull(values.telephone),
   // empty string will violate uniqueness constraints
-  email: emptyToNull(values.email),
-  sub: emptyToNull(values.sub),
+  email: emptyToUndefined(values.email),
+  sub: emptyToUndefined(values.sub),
 });
 
 export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({

--- a/frontend/common/src/helpers/util.ts
+++ b/frontend/common/src/helpers/util.ts
@@ -97,3 +97,11 @@ export function isStringTrue(str: string | undefined): boolean {
  */
 export const emptyToNull = (s: InputMaybe<string>): string | null =>
   empty(s) || s === "" ? null : s;
+
+/**
+ * Accepts a input value and transforms empty strings to a undefined
+ * @param s String value from an input
+ * @returns The possibly-transformed-to-undefined input string
+ */
+export const emptyToUndefined = (s: InputMaybe<string>): string | undefined =>
+  empty(s) || s === "" ? undefined : s;


### PR DESCRIPTION
Resolves #3512 

## Summary

This adds the `sometimes` validation rule to `sub` and `email` when creating a user.

## Testing

### Before Each

1. Build admin `npm run production --workspace=admin`
2. Navigate to `/admin/users/create`

### Empty Email/Subject (Success)

1. Attempt to create a user with no Email or Subject
2. Confirm it submits

### Duplicate Email/Subject (Failure)

1. Create a user with known Email and Subject
2. Attempt to create second user with same Email and Subject
3. Confirm it fails