### PR TITLE
create application mutation

### DIFF
--- a/api/app/GraphQL/Mutations/CreateApplication.php
+++ b/api/app/GraphQL/Mutations/CreateApplication.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+use App\Models\PoolCandidate;
+
+final class CreateApplication
+{
+    /**
+     * Create an application
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        // attempt to find existing application, if found return that otherwise create new application
+        $application = PoolCandidate::where('user_id', $args['userId'])->where('pool_id', $args['poolId'])->first();
+        if($application) {
+            return $application;
+        }
+        $newApplication = new PoolCandidate;
+        $newApplication->user_id = $args['userId'];
+        $newApplication->pool_id = $args['poolId'];
+        $newApplication->save();
+        return $newApplication;
+    }
+}

--- a/api/app/GraphQL/Mutations/CreateApplication.php
+++ b/api/app/GraphQL/Mutations/CreateApplication.php
@@ -13,14 +13,10 @@ final class CreateApplication
     public function __invoke($_, array $args)
     {
         // attempt to find existing application, if found return that otherwise create new application
-        $application = PoolCandidate::where('user_id', $args['userId'])->where('pool_id', $args['poolId'])->first();
-        if($application) {
-            return $application;
-        }
-        $newApplication = new PoolCandidate;
-        $newApplication->user_id = $args['userId'];
-        $newApplication->pool_id = $args['poolId'];
-        $newApplication->save();
-        return $newApplication;
+        $application = PoolCandidate::firstOrCreate([
+            'user_id' => $args['userId'],
+            'pool_id' => $args['poolId']
+          ]);
+        return $application;
     }
 }

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Eloquent\Builder;
  * @property boolean $is_visible_minority
  * @property boolean $has_diploma
  * @property Illuminate\Support\Carbon $archived_at
+ * @property Illuminate\Support\Carbon $submitted_at
  * @property string $language_ability
  * @property array $location_preferences
  * @property array $expected_salary
@@ -49,6 +50,7 @@ class PoolCandidate extends Model
     protected $casts = [
         'expiry_date' => 'date',
         'archived_at' => 'datetime',
+        'submitted_at' => 'datetime',
         'location_preferences' => 'array',
         'expected_salary' => 'array',
         'accepted_operational_requirements' => 'array',
@@ -61,6 +63,7 @@ class PoolCandidate extends Model
     */
     protected $fillable = [
         'archived_at',
+        'submitted_at',
     ];
 
     public function user(): BelongsTo

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -64,6 +64,8 @@ class PoolCandidate extends Model
     protected $fillable = [
         'archived_at',
         'submitted_at',
+        'user_id',
+        'pool_id',
     ];
 
     public function user(): BelongsTo

--- a/api/database/migrations/2022_08_11_161706_submitted_at_field_added_application.php
+++ b/api/database/migrations/2022_08_11_161706_submitted_at_field_added_application.php
@@ -14,7 +14,7 @@ class SubmittedAtFieldAddedApplication extends Migration
     public function up()
     {
         Schema::table('pool_candidates', function (Blueprint $table) {
-            $table->timestamp('submitted_at')->nullable();
+            $table->timestamp('submitted_at')->nullable()->default(null);
         });
     }
 

--- a/api/database/migrations/2022_08_11_161706_submitted_at_field_added_application.php
+++ b/api/database/migrations/2022_08_11_161706_submitted_at_field_added_application.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class SubmittedAtFieldAddedApplication extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pool_candidates', function (Blueprint $table) {
+            $table->timestamp('submitted_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('pool_candidates', function (Blueprint $table) {
+            $table->dropColumn([
+                'submitted_at',
+            ]);
+        });
+    }
+}

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -329,6 +329,7 @@ type PoolCandidate {
     status: PoolCandidateStatus @rename(attribute: "pool_candidate_status")
     notes: String
     archivedAt: DateTime @rename(attribute: "archived_at")
+    submittedAt: DateTime @rename(attribute: "submitted_at")
 }
 
 enum LanguageAbility {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1292,4 +1292,5 @@ type Mutation {
     deletePoolAdvertisement(id: ID!): PoolAdvertisement @delete(model: "Pool", globalId: false) @guard @can(ability: "delete", find: "id", model: "Pool")
 
     archiveApplication(id:ID!): PoolCandidate @guard @can(ability: "archiveApplication", find: "id")
+    createApplication(userId:ID!, poolId:ID!): PoolCandidate
 }

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -816,6 +816,7 @@ type PoolCandidate {
   status: PoolCandidateStatus
   notes: String
   archivedAt: DateTime
+  submittedAt: DateTime
 }
 
 type PoolCandidateFilter {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -612,6 +612,7 @@ type Mutation {
   closePoolAdvertisement(id: ID!): PoolAdvertisement
   deletePoolAdvertisement(id: ID!): PoolAdvertisement
   archiveApplication(id: ID!): PoolCandidate
+  createApplication(userId: ID!, poolId: ID!): PoolCandidate
 }
 
 """e.g. Overtime as Required, Shift Work, Travel as Required, etc."""


### PR DESCRIPTION
resolves #3332 

testing: 
use this mutation
you will need to fill in values from adminer, if you attempt to create a duplicate application the row count should remain unchanged, and should increment by one when you attempt to make a new one
```
mutation createApplication {
  createApplication(userId: "USER_ID", poolId: "POOL_ID") {
    user {
      id
    }
    pool {
      id
    }
  }
}
```

status work I did not complete as #3660 deals with that, adding DRAFT as well as doing the status logic
so what I did was just implement the submitted_at field for that issue