### PR TITLE
Early Snapshot Functionality

### DIFF
--- a/api/app/GraphQL/Mutations/TestPoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/TestPoolCandidateSnapshot.graphql
@@ -1,8 +1,7 @@
 # Comes from frontend/talentsearch/src/js/api/userOperations.graphql
-# Should match that file to take accurate snapshots
-
-        query getMe {
-            me {
+# Should match the getMe query from that file to take accurate snapshots
+query getProfile($userId:ID!) {
+            user(id:$userId) {
               id
               sub
               roles

--- a/api/app/GraphQL/Mutations/TestPoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/TestPoolCandidateSnapshot.graphql
@@ -51,7 +51,6 @@ query getProfile($userId:ID!) {
                   fr
                 }
               }
-
               isWoman
               hasDisability
               isIndigenous
@@ -148,21 +147,6 @@ query getProfile($userId:ID!) {
                   endDate
                 }
               }
-              # awardExperiences {
-              #   id
-              # }
-              # communityExperiences {
-              #   id
-              # }
-              # educationExperiences {
-              #   id
-              # }
-              # personalExperiences {
-              #   id
-              # }
-              # workExperiences {
-              #   id
-              # }
               poolCandidates {
                 status
                 expiryDate

--- a/api/app/GraphQL/Mutations/TestPoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/TestPoolCandidateSnapshot.graphql
@@ -1,0 +1,181 @@
+# Comes from frontend/talentsearch/src/js/api/userOperations.graphql
+# Should match that file to take accurate snapshots
+
+        query getMe {
+            me {
+              id
+              sub
+              roles
+              firstName
+              lastName
+              email
+              telephone
+              preferredLang
+              currentProvince
+              currentCity
+              citizenship
+              isVeteran
+              languageAbility
+              lookingForEnglish
+              lookingForFrench
+              lookingForBilingual
+              bilingualEvaluation
+              comprehensionLevel
+              writtenLevel
+              verbalLevel
+              estimatedLanguageAbility
+              isGovEmployee
+              govEmployeeType
+              interestedInLaterOrSecondment
+              department {
+                id
+                departmentNumber
+                name {
+                  en
+                  fr
+                }
+              }
+              currentClassification {
+                id
+                group
+                level
+                name {
+                  en
+                  fr
+                }
+              }
+              expectedGenericJobTitles {
+                id
+                key
+                name {
+                  en
+                  fr
+                }
+              }
+
+              isWoman
+              hasDisability
+              isIndigenous
+              isVisibleMinority
+              jobLookingStatus
+              hasDiploma
+              locationPreferences
+              locationExemptions
+              acceptedOperationalRequirements
+              expectedSalary
+              expectedClassifications {
+                id
+                name {
+                  en
+                  fr
+                }
+                group
+                level
+              }
+              wouldAcceptTemporary
+              cmoAssets {
+                id
+                name {
+                  en
+                  fr
+                }
+                description {
+                  en
+                  fr
+                }
+                key
+              }
+              experiences {
+                id
+                __typename
+                applicant {
+                  id
+                  email
+                }
+                details
+                skills {
+                  id
+                  key
+                  name {
+                    en
+                    fr
+                  }
+                  description {
+                    en
+                    fr
+                  }
+                  keywords {
+                    en
+                    fr
+                  }
+                  experienceSkillRecord {
+                    details
+                  }
+                }
+                ... on AwardExperience {
+                  title
+                  issuedBy
+                  awardedDate
+                  awardedTo
+                  awardedScope
+                }
+                ... on CommunityExperience {
+                  title
+                  organization
+                  project
+                  startDate
+                  endDate
+                }
+                ... on EducationExperience {
+                  institution
+                  areaOfStudy
+                  thesisTitle
+                  startDate
+                  endDate
+                  type
+                  status
+                }
+                ... on PersonalExperience {
+                  title
+                  description
+                  startDate
+                  endDate
+                }
+                ... on WorkExperience {
+                  role
+                  organization
+                  division
+                  startDate
+                  endDate
+                }
+              }
+              # awardExperiences {
+              #   id
+              # }
+              # communityExperiences {
+              #   id
+              # }
+              # educationExperiences {
+              #   id
+              # }
+              # personalExperiences {
+              #   id
+              # }
+              # workExperiences {
+              #   id
+              # }
+              poolCandidates {
+                status
+                expiryDate
+                pool {
+                  id
+                  name {
+                    en
+                    fr
+                  }
+                }
+                id
+              }
+              isProfileComplete
+            }
+          }

--- a/api/app/GraphQL/Mutations/TestPoolCandidateSnapshot.php
+++ b/api/app/GraphQL/Mutations/TestPoolCandidateSnapshot.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use App\Models\PoolCandidate;
+use App\GraphQL\Util\GraphQLClient;
+
+final class TestPoolCandidateSnapshot
+{
+    /**
+     * Publishes the pool advertisement.
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $id = $args['id'];
+        $poolCandidate = PoolCandidate::findOrFail($id);
+
+        // $result = GraphQLClient::graphQL($this->snapshotQuery(), ['id' => $id]);
+
+        $query = file_get_contents(base_path('app/GraphQL/Mutations/TestPoolCandidateSnapshot.graphql'), true);
+        $result = GraphQLClient::graphQL($query, ['id' => $id]);
+
+        $poolCandidate->profile_snapshot = $result;
+        $poolCandidate->save();
+        return $poolCandidate;
+    }
+}

--- a/api/app/GraphQL/Mutations/TestPoolCandidateSnapshot.php
+++ b/api/app/GraphQL/Mutations/TestPoolCandidateSnapshot.php
@@ -17,10 +17,8 @@ final class TestPoolCandidateSnapshot
         $id = $args['id'];
         $poolCandidate = PoolCandidate::findOrFail($id);
 
-        // $result = GraphQLClient::graphQL($this->snapshotQuery(), ['id' => $id]);
-
         $query = file_get_contents(base_path('app/GraphQL/Mutations/TestPoolCandidateSnapshot.graphql'), true);
-        $result = GraphQLClient::graphQL($query, ['id' => $id]);
+        $result = GraphQLClient::graphQL($query, ['userId' => $poolCandidate->user_id]);
 
         $poolCandidate->profile_snapshot = $result;
         $poolCandidate->save();

--- a/api/app/GraphQL/Mutations/TestPoolCandidateSnapshot.php
+++ b/api/app/GraphQL/Mutations/TestPoolCandidateSnapshot.php
@@ -8,7 +8,7 @@ use App\GraphQL\Util\GraphQLClient;
 final class TestPoolCandidateSnapshot
 {
     /**
-     * Publishes the pool advertisement.
+     * Tests snapshot capability by saving the user profile to the given pool candidate
      * @param  null  $_
      * @param  array{}  $args
      */

--- a/api/app/GraphQL/Util/GraphQLClient.php
+++ b/api/app/GraphQL/Util/GraphQLClient.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\GraphQL\Util;
+
+use Illuminate\Support\Facades\Http;
+
+/**
+ * A utility to issue GraphQL requests as if from a client.
+ * Adapted from api/vendor/nuwave/lighthouse/src/Testing/MakesGraphQLRequests.php
+ */
+class GraphQLClient
+{
+    /**
+     * Execute a query as if it was sent as a request to the server.
+     *
+     * @param  string  $query  The GraphQL query to send
+     * @param  array<string, mixed>  $variables  The variables to include in the query
+     * @param  array<string, mixed>  $extraParams  Extra parameters to add to the JSON payload
+     * @param  array<string, mixed>  $headers  HTTP headers to pass to the POST request
+     *
+     * @return \Illuminate\Testing\TestResponse
+     */
+    public static function graphQL(
+        string $query,
+        array $variables = [],
+        array $extraParams = [],
+        array $headers = []
+    ) {
+        $params = ['query' => $query];
+
+        if ([] !== $variables) {
+            $params += ['variables' => $variables];
+        }
+
+        $params += $extraParams;
+
+        return GraphQLClient::postGraphQL($params, $headers);
+    }
+
+    /**
+     * Execute a POST to the GraphQL endpoint.
+     *
+     * Use this over graphQL() when you need more control or want to
+     * test how your server behaves on incorrect inputs.
+     *
+     * @param  array<mixed, mixed>  $data  JSON-serializable payload
+     * @param  array<string, string>  $headers  HTTP headers to pass to the POST request
+     *
+     * @return \Illuminate\Testing\TestResponse
+     */
+    public static function postGraphQL(array $data, array $headers = [])
+    {
+        $response = Http::withHeaders($headers)->post(GraphQLClient::graphQLEndpointUrl(), $data);
+        return $response->json('data');
+    }
+
+    /**
+     * Return the full URL to the GraphQL endpoint.
+     */
+    private static function graphQLEndpointUrl(): string
+    {
+        return config('app.url').'/graphql';
+    }
+}

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -54,6 +54,7 @@ class PoolCandidate extends Model
         'location_preferences' => 'array',
         'expected_salary' => 'array',
         'accepted_operational_requirements' => 'array',
+        'profile_snapshot' => 'json'
     ];
 
     /**

--- a/api/database/migrations/2022_08_16_194515_add_application_snapshot_json.php
+++ b/api/database/migrations/2022_08_16_194515_add_application_snapshot_json.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddApplicationSnapshotJson extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pool_candidates', function (Blueprint $table) {
+            $table->jsonb('profile_snapshot')->nullable(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('pool_candidates', function (Blueprint $table) {
+            $table->dropColumn([
+                'profile_snapshot',
+            ]);
+        });
+    }
+}

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -16,6 +16,9 @@ scalar PhoneNumber
 "A human readable ID"
 scalar KeyString
 
+"Arbitrary data encoded in JavaScript Object Notation. See https://www.json.org."
+scalar JSON @scalar(class: "MLL\\GraphQLScalars\\JSON")
+
 type LocalizedString {
     en: String
     fr: String
@@ -330,6 +333,8 @@ type PoolCandidate {
     notes: String
     archivedAt: DateTime @rename(attribute: "archived_at")
     submittedAt: DateTime @rename(attribute: "submitted_at")
+
+    profileSnapshot: JSON @rename(attribute: "profile_snapshot")
 }
 
 enum LanguageAbility {
@@ -1293,4 +1298,6 @@ type Mutation {
 
     archiveApplication(id:ID!): PoolCandidate @guard @can(ability: "archiveApplication", find: "id")
     createApplication(userId:ID!, poolId:ID!): PoolCandidate
+
+    testPoolCandidateSnapshot(id:ID!): PoolCandidate @guard @can(ability: "update", find: "id")
 }

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -523,6 +523,11 @@ input IdInput {
   id: ID!
 }
 
+"""
+Arbitrary data encoded in JavaScript Object Notation. See https://www.json.org.
+"""
+scalar JSON
+
 enum JobLookingStatus {
   ACTIVELY_LOOKING
   OPEN_TO_OPPORTUNITIES
@@ -613,6 +618,7 @@ type Mutation {
   deletePoolAdvertisement(id: ID!): PoolAdvertisement
   archiveApplication(id: ID!): PoolCandidate
   createApplication(userId: ID!, poolId: ID!): PoolCandidate
+  testPoolCandidateSnapshot(id: ID!): PoolCandidate
 }
 
 """e.g. Overtime as Required, Shift Work, Travel as Required, etc."""
@@ -818,6 +824,7 @@ type PoolCandidate {
   notes: String
   archivedAt: DateTime
   submittedAt: DateTime
+  profileSnapshot: JSON
 }
 
 type PoolCandidateFilter {

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\PoolCandidate;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Illuminate\Foundation\Testing\WithFaker;
+
+use function PHPUnit\Framework\assertEquals;
+
+class SnapshotTest extends TestCase
+{
+    use RefreshDatabase;
+    use MakesGraphQLRequests;
+    use ClearsSchemaCache;
+    use WithFaker;
+
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function testCreateSnapshot()
+    {
+        $snapshotQuery = $query = file_get_contents(base_path('app/GraphQL/Mutations/TestPoolCandidateSnapshot.graphql'), true);
+
+        // set up a user with a pool candidate
+        $userId = $this->faker->Uuid();
+        $poolCandidateId = $this->faker->Uuid();
+        print_r($userId);
+        User::factory()->create([
+            "id" => $userId
+        ]);
+        PoolCandidate::factory()->create([
+            "id" => $poolCandidateId,
+            "user_id" => $userId
+        ]);
+
+        // get what the snapshot should look like
+        $expectedSnapshot = $this->graphQL($snapshotQuery, ["userId" => $userId])->json("data.user");
+
+        // make a snapshot
+        $this->graphQL(
+            /** @lang Graphql */
+            '
+            mutation snapshot($id: ID!) {
+                testPoolCandidateSnapshot(id: $id) { id }
+              }
+            ', ["id" => $poolCandidateId]
+            );
+
+        // get the just-created snapshot
+        $actualSnapshot = $this->graphQL(
+            /** @lang Graphql */
+            '
+            query getSnapshot($poolCandidateId:ID!) {
+                poolCandidate(id: $poolCandidateId) {
+                  profileSnapshot
+                }
+              }
+            ', ["poolCandidateId" => $poolCandidateId]
+            )->json("data.poolCandidate");
+
+        assertEquals($expectedSnapshot, $actualSnapshot);
+
+    }
+}

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -31,7 +31,6 @@ class SnapshotTest extends TestCase
         // set up a user with a pool candidate
         $userId = $this->faker->Uuid();
         $poolCandidateId = $this->faker->Uuid();
-        print_r($userId);
         User::factory()->create([
             "id" => $userId
         ]);

--- a/frontend/talentsearch/src/js/api/userOperations.graphql
+++ b/frontend/talentsearch/src/js/api/userOperations.graphql
@@ -49,7 +49,6 @@ query getMe {
         fr
       }
     }
-
     isWoman
     hasDisability
     isIndigenous
@@ -146,21 +145,6 @@ query getMe {
         endDate
       }
     }
-    # awardExperiences {
-    #   id
-    # }
-    # communityExperiences {
-    #   id
-    # }
-    # educationExperiences {
-    #   id
-    # }
-    # personalExperiences {
-    #   id
-    # }
-    # workExperiences {
-    #   id
-    # }
     poolCandidates {
       status
       expiryDate


### PR DESCRIPTION
## Intro
This branch demonstrates early snapshot functionality.  It adds a mutation to manually trigger snapshot creation.  Tying it in with application submission will be handled in #3661.

## Includes:
- A migration to add a JSONB column to pool_candidates to store the snapshot.
- A TestPoolCandidateSnapshot mutation to manually trigger a snapshot for a specific poolCandidate
- A phpunit test to verify that the stored snapshot matches the snapshotting query

## Testing
- [ ] Here's a query to run the mutation 
```
mutation snapshot($poolCandidateId: ID!) {
  testPoolCandidateSnapshot(id: $poolCandidateId) {
    profileSnapshot
  }
}
```
- [ ] Run the phpunit test
```
php artisan test tests/Feature/SnapshotTest.php 
```

Closes #3340 