### PR TITLE
resolve broken chromatic build

### DIFF
--- a/frontend/common/src/constants/localizedConstants.tsx
+++ b/frontend/common/src/constants/localizedConstants.tsx
@@ -378,6 +378,14 @@ export const poolCandidateStatuses = defineMessages({
     defaultMessage: "Placed Casual",
     description: "The pool candidate's status is Placed Casual.",
   },
+  [PoolCandidateStatus.Draft]: {
+    defaultMessage: "Draft",
+    description: "The pool candidate's status is Draft.",
+  },
+  [PoolCandidateStatus.DraftExpired]: {
+    defaultMessage: "Draft Expired",
+    description: "The pool candidate's status is Expired Draft.",
+  },
 });
 
 export const getPoolCandidateStatus = (


### PR DESCRIPTION
my last merge updated the enum Pool Candidate Statuses, I didn't realize that was something another piece was tightly coupled to and so errors resulted as the piece in LocalizedConstants wasn't updated but components that fetched the enum tried to run the enum through LocalizedConstants

testing
- check out
- run codegen and dev in /admin
- run storybook in /admin and confirms it doesn't error


