### PR TITLE
Fix Dependabot auto-label GitHub workflow

### DIFF
--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -26,4 +26,4 @@ jobs:
         run: gh pr edit "$PR_URL" --add-label "dependencies-priority"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    #if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
         id: metadata
@@ -22,7 +22,7 @@ jobs:
       - name: Add priority label for all direct dependencies
         # Indirect dependencies deeper in dependency graph are implicitly lower priority.
         # See: https://github.com/dependabot/fetch-metadata#usage-instructions
-        #if: ${{ startsWith(steps.metadata.outputs.dependency-type, 'direct:') }}
+        if: ${{ startsWith(steps.metadata.outputs.dependency-type, 'direct:') }}
         run: gh pr edit "$PR_URL" --add-label "dependencies-priority"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    #if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
         id: metadata
@@ -22,7 +22,7 @@ jobs:
       - name: Add priority label for all direct dependencies
         # Indirect dependencies deeper in dependency graph are implicitly lower priority.
         # See: https://github.com/dependabot/fetch-metadata#usage-instructions
-        if: ${{ startsWith(steps.metadata.outputs.dependency-type, 'direct:') }}
+        #if: ${{ startsWith(steps.metadata.outputs.dependency-type, 'direct:') }}
         run: gh pr edit "$PR_URL" --add-label "dependencies-priority"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Removes orphan quote wrapping `GH_TOKEN` value in Dependabot auto-label workflow from https://github.com/GCTC-NTGC/gc-digital-talent/pull/3562.