### PR TITLE
Add leading zero to classification label

### DIFF
--- a/frontend/admin/src/js/components/user/useFilterOptions.tsx
+++ b/frontend/admin/src/js/components/user/useFilterOptions.tsx
@@ -56,7 +56,7 @@ export default function useFilterOptions(enableEducationType = false) {
       .filter(notEmpty)
       .map(({ id, group, level }) => ({
         value: id,
-        label: `${group}-${level}`,
+        label: `${group}-0${level}`,
       })),
     operationalRequirement: OperationalRequirementV2.map((value) => ({
       value,


### PR DESCRIPTION
Resolves missing leading zero in classification label used in `useFilterOptions` hook.

### Previously
![Screen Shot 2022-08-24 at 14 17 09](https://user-images.githubusercontent.com/3046459/186495371-9186b9b1-b8c8-4ab8-bddf-1283fb458d83.png)
