### PR TITLE
Bug - 3708 - Remove Skills Auto Focus

### DIFF
--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceSkills.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceSkills.tsx
@@ -36,11 +36,16 @@ const ExperienceSkills: React.FC<ExperienceSkillsProps> = ({ skills }) => {
 
   const handleAddSkill = (id: string) => {
     const foundSkill = skills.find((s) => s.id === id);
-    append({
-      skillId: id,
-      name: foundSkill?.name,
-      details: "",
-    });
+    append(
+      {
+        skillId: id,
+        name: foundSkill?.name,
+        details: "",
+      },
+      {
+        shouldFocus: false,
+      },
+    );
   };
 
   const handleRemoveSkill = (id: string) => {


### PR DESCRIPTION
Resolves #3708 

## Summary

Removes the default focus when appending a skill to `react-hook-form` `useFieldArray` method.

## Testing

1. Navigate to user profile
2. Create an experience
3. Add skills to the experience
4. Confirm the description `textarea` is not auto focused after adding a skill