### PR TITLE
Revert "Bump eslint-plugin-formatjs from 4.2.2 to 4.3.0 in /frontend"

### DIFF
--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -77,7 +77,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-alias": "^1.1.2",
-    "eslint-plugin-formatjs": "^4.3.0",
+    "eslint-plugin-formatjs": "^4.2.2",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-node": "^11.1.0",

--- a/frontend/common/package.json
+++ b/frontend/common/package.json
@@ -110,7 +110,7 @@
     "eslint": "^8.22.0",
     "eslint-config-airbnb": "^19.0.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-formatjs": "^4.3.0",
+    "eslint-plugin-formatjs": "^4.2.2",
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-node": "^11.1.0",

--- a/frontend/indigenousapprenticeship/package.json
+++ b/frontend/indigenousapprenticeship/package.json
@@ -84,7 +84,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-alias": "^1.1.2",
-    "eslint-plugin-formatjs": "^4.3.0",
+    "eslint-plugin-formatjs": "^4.2.2",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-node": "^11.1.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -86,7 +86,7 @@
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-alias": "^1.1.2",
-        "eslint-plugin-formatjs": "^4.3.0",
+        "eslint-plugin-formatjs": "^4.2.2",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsx-a11y": "^6.6.1",
         "eslint-plugin-node": "^11.1.0",
@@ -243,7 +243,7 @@
         "eslint": "^8.22.0",
         "eslint-config-airbnb": "^19.0.0",
         "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-formatjs": "^4.3.0",
+        "eslint-plugin-formatjs": "^4.2.2",
         "eslint-plugin-import": "^2.24.2",
         "eslint-plugin-jsx-a11y": "^6.6.1",
         "eslint-plugin-node": "^11.1.0",
@@ -414,7 +414,7 @@
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-alias": "^1.1.2",
-        "eslint-plugin-formatjs": "^4.3.0",
+        "eslint-plugin-formatjs": "^4.2.2",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsx-a11y": "^6.6.1",
         "eslint-plugin-node": "^11.1.0",
@@ -17541,86 +17541,23 @@
       }
     },
     "node_modules/eslint-plugin-formatjs": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-formatjs/-/eslint-plugin-formatjs-4.3.0.tgz",
-      "integrity": "sha512-cIGuQzjgWbQPVOafSuna9A4IWr9JCcjLHg1c568YAFhWRtXAhH6bROTfMfArJO+XFmlaZU32n8zNMffU/wuz4g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-formatjs/-/eslint-plugin-formatjs-4.2.2.tgz",
+      "integrity": "sha512-KAoGLoxz/I7+Cbeysjd21lhLB25nDxodvwDneIgVdZumiJZjg3Bo9D4iUXD1rFF0St4iiQJLR2Km51RiAcZNBw==",
       "dev": true,
       "dependencies": {
-        "@formatjs/icu-messageformat-parser": "2.1.7",
-        "@formatjs/ts-transformer": "3.10.0",
+        "@formatjs/icu-messageformat-parser": "2.1.6",
+        "@formatjs/ts-transformer": "3.9.11",
         "@types/eslint": "7 || 8",
         "@types/picomatch": "^2.3.0",
         "@typescript-eslint/typescript-estree": "^5.9.1",
         "emoji-regex": "^10.0.0",
         "picomatch": "^2.3.1",
         "tslib": "2.4.0",
-        "typescript": "^4.7"
+        "typescript": "^4.5"
       },
       "peerDependencies": {
         "eslint": "7 || 8"
-      }
-    },
-    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.12.0.tgz",
-      "integrity": "sha512-0/wm9b7brUD40kx7KSE0S532T8EfH06Zc41rGlinoNyYXnuusR6ull2x63iFJgVXgwahm42hAW7dcYdZ+llZzA==",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/intl-localematcher": "0.2.31",
-        "tslib": "2.4.0"
-      }
-    },
-    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.7.tgz",
-      "integrity": "sha512-KM4ikG5MloXMulqn39Js3ypuVzpPKq/DDplvl01PE2qD9rAzFO8YtaUCC9vr9j3sRXwdHPeTe8r3J/8IJgvYEQ==",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.12.0",
-        "@formatjs/icu-skeleton-parser": "1.3.13",
-        "tslib": "2.4.0"
-      }
-    },
-    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.13.tgz",
-      "integrity": "sha512-qb1kxnA4ep76rV+d9JICvZBThBpK5X+nh1dLmmIReX72QyglicsaOmKEcdcbp7/giCWfhVs6CXPVA2JJ5/ZvAw==",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.12.0",
-        "tslib": "2.4.0"
-      }
-    },
-    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.2.31",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.31.tgz",
-      "integrity": "sha512-9QTjdSBpQ7wHShZgsNzNig5qT3rCPvmZogS/wXZzKotns5skbXgs0I7J8cuN0PPqXyynvNVuN+iOKhNS2eb+ZA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "2.4.0"
-      }
-    },
-    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/ts-transformer": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.10.0.tgz",
-      "integrity": "sha512-5BOp9xjLaaSm+QlMoYSF3E0Juq3SI26j4satKffDYzl7diikkyGcyPHQh+mjcdmLT2Zu2kEMzU4/mF3SD3QPcw==",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/icu-messageformat-parser": "2.1.7",
-        "@types/json-stable-stringify": "^1.0.32",
-        "@types/node": "14 || 16 || 17",
-        "chalk": "^4.0.0",
-        "json-stable-stringify": "^1.0.1",
-        "tslib": "2.4.0",
-        "typescript": "^4.7"
-      },
-      "peerDependencies": {
-        "ts-jest": "27 || 28"
-      },
-      "peerDependenciesMeta": {
-        "ts-jest": {
-          "optional": true
-        }
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -31611,7 +31548,7 @@
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-alias": "^1.1.2",
-        "eslint-plugin-formatjs": "^4.3.0",
+        "eslint-plugin-formatjs": "^4.2.2",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsx-a11y": "^6.6.1",
         "eslint-plugin-node": "^11.1.0",
@@ -40016,7 +39953,7 @@
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-alias": "^1.1.2",
-        "eslint-plugin-formatjs": "^4.3.0",
+        "eslint-plugin-formatjs": "^4.2.2",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsx-a11y": "^6.6.1",
         "eslint-plugin-node": "^11.1.0",
@@ -43465,77 +43402,20 @@
       }
     },
     "eslint-plugin-formatjs": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-formatjs/-/eslint-plugin-formatjs-4.3.0.tgz",
-      "integrity": "sha512-cIGuQzjgWbQPVOafSuna9A4IWr9JCcjLHg1c568YAFhWRtXAhH6bROTfMfArJO+XFmlaZU32n8zNMffU/wuz4g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-formatjs/-/eslint-plugin-formatjs-4.2.2.tgz",
+      "integrity": "sha512-KAoGLoxz/I7+Cbeysjd21lhLB25nDxodvwDneIgVdZumiJZjg3Bo9D4iUXD1rFF0St4iiQJLR2Km51RiAcZNBw==",
       "dev": true,
       "requires": {
-        "@formatjs/icu-messageformat-parser": "2.1.7",
-        "@formatjs/ts-transformer": "3.10.0",
+        "@formatjs/icu-messageformat-parser": "2.1.6",
+        "@formatjs/ts-transformer": "3.9.11",
         "@types/eslint": "7 || 8",
         "@types/picomatch": "^2.3.0",
         "@typescript-eslint/typescript-estree": "^5.9.1",
         "emoji-regex": "^10.0.0",
         "picomatch": "^2.3.1",
         "tslib": "2.4.0",
-        "typescript": "^4.7"
-      },
-      "dependencies": {
-        "@formatjs/ecma402-abstract": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.12.0.tgz",
-          "integrity": "sha512-0/wm9b7brUD40kx7KSE0S532T8EfH06Zc41rGlinoNyYXnuusR6ull2x63iFJgVXgwahm42hAW7dcYdZ+llZzA==",
-          "dev": true,
-          "requires": {
-            "@formatjs/intl-localematcher": "0.2.31",
-            "tslib": "2.4.0"
-          }
-        },
-        "@formatjs/icu-messageformat-parser": {
-          "version": "2.1.7",
-          "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.7.tgz",
-          "integrity": "sha512-KM4ikG5MloXMulqn39Js3ypuVzpPKq/DDplvl01PE2qD9rAzFO8YtaUCC9vr9j3sRXwdHPeTe8r3J/8IJgvYEQ==",
-          "dev": true,
-          "requires": {
-            "@formatjs/ecma402-abstract": "1.12.0",
-            "@formatjs/icu-skeleton-parser": "1.3.13",
-            "tslib": "2.4.0"
-          }
-        },
-        "@formatjs/icu-skeleton-parser": {
-          "version": "1.3.13",
-          "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.13.tgz",
-          "integrity": "sha512-qb1kxnA4ep76rV+d9JICvZBThBpK5X+nh1dLmmIReX72QyglicsaOmKEcdcbp7/giCWfhVs6CXPVA2JJ5/ZvAw==",
-          "dev": true,
-          "requires": {
-            "@formatjs/ecma402-abstract": "1.12.0",
-            "tslib": "2.4.0"
-          }
-        },
-        "@formatjs/intl-localematcher": {
-          "version": "0.2.31",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.31.tgz",
-          "integrity": "sha512-9QTjdSBpQ7wHShZgsNzNig5qT3rCPvmZogS/wXZzKotns5skbXgs0I7J8cuN0PPqXyynvNVuN+iOKhNS2eb+ZA==",
-          "dev": true,
-          "requires": {
-            "tslib": "2.4.0"
-          }
-        },
-        "@formatjs/ts-transformer": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.10.0.tgz",
-          "integrity": "sha512-5BOp9xjLaaSm+QlMoYSF3E0Juq3SI26j4satKffDYzl7diikkyGcyPHQh+mjcdmLT2Zu2kEMzU4/mF3SD3QPcw==",
-          "dev": true,
-          "requires": {
-            "@formatjs/icu-messageformat-parser": "2.1.7",
-            "@types/json-stable-stringify": "^1.0.32",
-            "@types/node": "14 || 16 || 17",
-            "chalk": "^4.0.0",
-            "json-stable-stringify": "^1.0.1",
-            "tslib": "2.4.0",
-            "typescript": "^4.7"
-          }
-        }
+        "typescript": "^4.5"
       }
     },
     "eslint-plugin-import": {
@@ -44643,7 +44523,7 @@
         "eslint": "^8.22.0",
         "eslint-config-airbnb": "^19.0.0",
         "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-formatjs": "^4.3.0",
+        "eslint-plugin-formatjs": "^4.2.2",
         "eslint-plugin-import": "^2.24.2",
         "eslint-plugin-jsx-a11y": "^6.6.1",
         "eslint-plugin-node": "^11.1.0",
@@ -45483,7 +45363,7 @@
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-alias": "^1.1.2",
-        "eslint-plugin-formatjs": "^4.3.0",
+        "eslint-plugin-formatjs": "^4.2.2",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsx-a11y": "^6.6.1",
         "eslint-plugin-node": "^11.1.0",
@@ -51494,7 +51374,7 @@
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-alias": "^1.1.2",
-        "eslint-plugin-formatjs": "^4.3.0",
+        "eslint-plugin-formatjs": "^4.2.2",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsx-a11y": "^6.6.1",
         "eslint-plugin-node": "^11.1.0",

--- a/frontend/talentsearch/package.json
+++ b/frontend/talentsearch/package.json
@@ -82,7 +82,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-alias": "^1.1.2",
-    "eslint-plugin-formatjs": "^4.3.0",
+    "eslint-plugin-formatjs": "^4.2.2",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-node": "^11.1.0",


### PR DESCRIPTION
## Summary

Caused issues with jest tests.