### PR TITLE
Increased timeout on sporadically failing test

### DIFF
--- a/frontend/admin/src/js/components/pool/EditPool/EditPool.test.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/EditPool.test.tsx
@@ -26,6 +26,8 @@ const renderWithReactIntl = (
 };
 
 describe("Edit Pool tests", () => {
+  // This test is prone to going beyond the 5s default timeout.
+  const extendedTimeout = 10 * 1000;
   it("should have save buttons that emit a save event when the status is draft", async () => {
     const handleSave = jest.fn();
     const props = {
@@ -59,7 +61,7 @@ describe("Edit Pool tests", () => {
     });
 
     expect(handleSave).toHaveBeenCalledTimes(7);
-  });
+  }, extendedTimeout);
 
   it("should have a publish button that pops a modal and emits an event when the status is draft", async () => {
     const handleEvent = jest.fn();

--- a/frontend/admin/src/js/components/user/UserTableFilterDialog.test.tsx
+++ b/frontend/admin/src/js/components/user/UserTableFilterDialog.test.tsx
@@ -146,7 +146,7 @@ describe("UserTableFilterDialog", () => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
 
-    // This test is prone to going about the 5s default timeout.
+    // This test is prone to going beyond the 5s default timeout.
     const extendedTimeout = 10 * 1000;
     it(
       "submits non-empty filter data for all filters",


### PR DESCRIPTION
Re-ticketed from https://github.com/GCTC-NTGC/gc-digital-talent/pull/3781#issuecomment-1230731898

The above got merged before I pushed the fix, so just cherry-picked it into a new PR.

This is the error that's surfacing every so often. I think we've just been re-running and it goes away:
https://github.com/GCTC-NTGC/gc-digital-talent/runs/8078250319?check_suite_focus=true#step:7:24

We should probably avoid writing tests that do so many user actions at once, but this is the easiest fix.