### PR TITLE
Design - 2656 - Admin Heading Update

### DIFF
--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -28,7 +28,7 @@ export interface TableProps<
   title?: string;
   addBtn?: {
     path: string;
-    label: string;
+    label: React.ReactNode;
   };
   filter?: boolean;
   pagination?: boolean;

--- a/frontend/admin/src/js/components/classification/ClassificationPage.tsx
+++ b/frontend/admin/src/js/components/classification/ClassificationPage.tsx
@@ -1,59 +1,26 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import Link from "@common/components/Link";
-import Pending from "@common/components/Pending";
-import { useAdminRoutes } from "../../adminRoutes";
+import { TagIcon } from "@heroicons/react/outline";
+
+import PageHeader from "@common/components/PageHeader";
+
 import { ClassificationTableApi } from "./ClassificationTable";
+import DashboardContentContainer from "../DashboardContentContainer";
 
 export const ClassificationPage: React.FC = () => {
   const intl = useIntl();
-  const paths = useAdminRoutes();
+
   return (
-    <Pending fetching={false}>
-      <div>
-        <header
-          data-h2-background-color="base(dt-linear)"
-          data-h2-padding="base(x2, 0)"
-        >
-          <div data-h2-container="base(center, large, x2)">
-            <div data-h2-flex-grid="base(center, 0, x2)">
-              <div data-h2-flex-item="base(1of1) l-tablet(fill)">
-                <h1
-                  data-h2-color="base(dt-white)"
-                  data-h2-font-weight="base(700)"
-                  data-h2-margin="base(0)"
-                  style={{ letterSpacing: "-2px" }}
-                >
-                  {intl.formatMessage({
-                    defaultMessage: "Classifications",
-                    description:
-                      "Heading displayed above the Classification Table component.",
-                  })}
-                </h1>
-              </div>
-              <div
-                data-h2-flex-item="base(1of1) l-tablet(content)"
-                data-h2-text-align="l-tablet(right)"
-              >
-                <Link
-                  href={paths.classificationCreate()}
-                  color="white"
-                  mode="outline"
-                  type="button"
-                >
-                  {intl.formatMessage({
-                    defaultMessage: "Create Classification",
-                    description:
-                      "Heading displayed above the Create Classification form.",
-                  })}
-                </Link>
-              </div>
-            </div>
-          </div>
-        </header>
-        <ClassificationTableApi />
-      </div>
-    </Pending>
+    <DashboardContentContainer>
+      <PageHeader icon={TagIcon}>
+        {intl.formatMessage({
+          defaultMessage: "Classifications",
+          description:
+            "Heading displayed above the Classification Table component.",
+        })}
+      </PageHeader>
+      <ClassificationTableApi />
+    </DashboardContentContainer>
   );
 };
 

--- a/frontend/admin/src/js/components/classification/ClassificationTable.tsx
+++ b/frontend/admin/src/js/components/classification/ClassificationTable.tsx
@@ -10,6 +10,7 @@ import {
   useGetClassificationsQuery,
 } from "../../api/generated";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
+import { useAdminRoutes } from "../../adminRoutes";
 
 type Data = NonNullable<FromArray<GetClassificationsQuery["classifications"]>>;
 
@@ -18,6 +19,7 @@ export const ClassificationTable: React.FC<
 > = ({ classifications, editUrlRoot }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
+  const paths = useAdminRoutes();
   const columns = useMemo<ColumnsOf<Data>>(
     () => [
       {
@@ -85,15 +87,19 @@ export const ClassificationTable: React.FC<
   );
 
   return (
-    <div data-h2-padding="base(0, 0, x3, 0)">
-      <div data-h2-container="base(center, large, x2)">
-        <Table
-          data={memoizedData}
-          columns={columns}
-          hiddenCols={["minSalary", "maxSalary"]}
-        />
-      </div>
-    </div>
+    <Table
+      data={memoizedData}
+      columns={columns}
+      hiddenCols={["minSalary", "maxSalary"]}
+      addBtn={{
+        path: paths.classificationCreate(),
+        label: intl.formatMessage({
+          defaultMessage: "Create Classification",
+          description:
+            "Heading displayed above the Create Classification form.",
+        }),
+      }}
+    />
   );
 };
 

--- a/frontend/admin/src/js/components/cmoAsset/CmoAssetPage.tsx
+++ b/frontend/admin/src/js/components/cmoAsset/CmoAssetPage.tsx
@@ -1,55 +1,25 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import Link from "@common/components/Link";
-import { useAdminRoutes } from "../../adminRoutes";
+import { PaperClipIcon } from "@heroicons/react/outline";
+
+import PageHeader from "@common/components/PageHeader";
+
 import { CmoAssetTableApi } from "./CmoAssetTable";
+import DashboardContentContainer from "../DashboardContentContainer";
 
 export const CmoAssetPage: React.FC = () => {
   const intl = useIntl();
-  const paths = useAdminRoutes();
+
   return (
-    <div>
-      <header
-        data-h2-background-color="base(dt-linear)"
-        data-h2-padding="base(x2, 0)"
-      >
-        <div data-h2-container="base(center, large, x2)">
-          <div data-h2-flex-grid="base(center, 0, x2)">
-            <div data-h2-flex-item="base(1of1) l-tablet(3of5)">
-              <h1
-                data-h2-color="base(dt-white)"
-                data-h2-font-weight="base(700)"
-                style={{ letterSpacing: "-2px" }}
-              >
-                {intl.formatMessage({
-                  defaultMessage: "CMO Assets",
-                  description:
-                    "Heading displayed above the CMO Asset Table component.",
-                })}
-              </h1>
-            </div>
-            <div
-              data-h2-flex-item="base(1of1) l-tablet(2of5)"
-              data-h2-text-align="l-tablet(right)"
-            >
-              <Link
-                href={paths.cmoAssetCreate()}
-                color="white"
-                mode="outline"
-                type="button"
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Create CMO Asset",
-                  description:
-                    "Heading displayed above the Create CMO Asset form.",
-                })}
-              </Link>
-            </div>
-          </div>
-        </div>
-      </header>
+    <DashboardContentContainer>
+      <PageHeader icon={PaperClipIcon}>
+        {intl.formatMessage({
+          defaultMessage: "CMO Assets",
+          description: "Heading displayed above the CMO Asset Table component.",
+        })}
+      </PageHeader>
       <CmoAssetTableApi />
-    </div>
+    </DashboardContentContainer>
   );
 };
 

--- a/frontend/admin/src/js/components/cmoAsset/CmoAssetTable.tsx
+++ b/frontend/admin/src/js/components/cmoAsset/CmoAssetTable.tsx
@@ -6,8 +6,8 @@ import { FromArray } from "@common/types/utilityTypes";
 import { getLocale } from "@common/helpers/localize";
 import Pending from "@common/components/Pending";
 import { GetCmoAssetsQuery, useGetCmoAssetsQuery } from "../../api/generated";
-import DashboardContentContainer from "../DashboardContentContainer";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
+import { useAdminRoutes } from "../../adminRoutes";
 
 type Data = NonNullable<FromArray<GetCmoAssetsQuery["cmoAssets"]>>;
 
@@ -16,6 +16,7 @@ export const CmoAssetTable: React.FC<
 > = ({ cmoAssets, editUrlRoot }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
+  const paths = useAdminRoutes();
   const columns = useMemo<ColumnsOf<Data>>(
     () => [
       {
@@ -60,7 +61,19 @@ export const CmoAssetTable: React.FC<
 
   const memoizedData = useMemo(() => cmoAssets.filter(notEmpty), [cmoAssets]);
 
-  return <Table data={memoizedData} columns={columns} />;
+  return (
+    <Table
+      data={memoizedData}
+      columns={columns}
+      addBtn={{
+        path: paths.cmoAssetCreate(),
+        label: intl.formatMessage({
+          defaultMessage: "Create CMO Asset",
+          description: "Heading displayed above the Create CMO Asset form.",
+        }),
+      }}
+    />
+  );
 };
 
 export const CmoAssetTableApi: React.FC = () => {
@@ -70,12 +83,7 @@ export const CmoAssetTableApi: React.FC = () => {
 
   return (
     <Pending fetching={fetching} error={error}>
-      <DashboardContentContainer>
-        <CmoAssetTable
-          cmoAssets={data?.cmoAssets ?? []}
-          editUrlRoot={pathname}
-        />
-      </DashboardContentContainer>
+      <CmoAssetTable cmoAssets={data?.cmoAssets ?? []} editUrlRoot={pathname} />
     </Pending>
   );
 };

--- a/frontend/admin/src/js/components/department/DepartmentPage.tsx
+++ b/frontend/admin/src/js/components/department/DepartmentPage.tsx
@@ -1,55 +1,25 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Link } from "@common/components";
-import { useAdminRoutes } from "../../adminRoutes";
+import { OfficeBuildingIcon } from "@heroicons/react/outline";
+
+import PageHeader from "@common/components/PageHeader";
+
 import { DepartmentTableApi } from "./DepartmentTable";
+import DashboardContentContainer from "../DashboardContentContainer";
 
 export const DepartmentPage: React.FC = () => {
   const intl = useIntl();
-  const paths = useAdminRoutes();
   return (
-    <div>
-      <header
-        data-h2-background-color="base(dt-linear)"
-        data-h2-padding="base(x2, 0)"
-      >
-        <div data-h2-container="base(center, large, x2)">
-          <div data-h2-flex-grid="base(center, 0, x2)">
-            <div data-h2-flex-item="base(1of1) l-tablet(3of5)">
-              <h1
-                data-h2-color="base(dt-white)"
-                data-h2-font-weight="base(700)"
-                style={{ letterSpacing: "-2px" }}
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Departments",
-                  description:
-                    "Heading displayed above the Department Table component.",
-                })}
-              </h1>
-            </div>
-            <div
-              data-h2-flex-item="base(1of1) l-tablet(2of5)"
-              data-h2-text-align="l-tablet(right)"
-            >
-              <Link
-                href={paths.departmentCreate()}
-                color="white"
-                mode="outline"
-                type="button"
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Create Department",
-                  description:
-                    "Heading displayed above the Create Department form.",
-                })}
-              </Link>
-            </div>
-          </div>
-        </div>
-      </header>
+    <DashboardContentContainer>
+      <PageHeader icon={OfficeBuildingIcon}>
+        {intl.formatMessage({
+          defaultMessage: "Departments",
+          description:
+            "Heading displayed above the Department Table component.",
+        })}
+      </PageHeader>
       <DepartmentTableApi />
-    </div>
+    </DashboardContentContainer>
   );
 };
 

--- a/frontend/admin/src/js/components/department/DepartmentTable.tsx
+++ b/frontend/admin/src/js/components/department/DepartmentTable.tsx
@@ -7,6 +7,7 @@ import { getLocale } from "@common/helpers/localize";
 import Pending from "@common/components/Pending";
 import { DepartmentsQuery, useDepartmentsQuery } from "../../api/generated";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
+import { useAdminRoutes } from "../../adminRoutes";
 
 type Data = NonNullable<FromArray<DepartmentsQuery["departments"]>>;
 
@@ -15,6 +16,7 @@ export const DepartmentTable: React.FC<
 > = ({ departments, editUrlRoot }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
+  const paths = useAdminRoutes();
   const columns = useMemo<ColumnsOf<Data>>(
     () => [
       {
@@ -46,11 +48,17 @@ export const DepartmentTable: React.FC<
   const data = useMemo(() => departments.filter(notEmpty), [departments]);
 
   return (
-    <div data-h2-padding="base(0, 0, x3, 0)">
-      <div data-h2-container="base(center, large, x2)">
-        <Table data={data} columns={columns} />
-      </div>
-    </div>
+    <Table
+      data={data}
+      columns={columns}
+      addBtn={{
+        path: paths.departmentCreate(),
+        label: intl.formatMessage({
+          defaultMessage: "Create Department",
+          description: "Heading displayed above the Create Department form.",
+        }),
+      }}
+    />
   );
 };
 

--- a/frontend/admin/src/js/components/pool/PoolPage.tsx
+++ b/frontend/admin/src/js/components/pool/PoolPage.tsx
@@ -1,55 +1,25 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Link } from "@common/components";
-import { useAdminRoutes } from "../../adminRoutes";
+import { ViewGridIcon } from "@heroicons/react/outline";
+
+import PageHeader from "@common/components/PageHeader";
+
+import DashboardContentContainer from "../DashboardContentContainer";
 import { PoolTableApi } from "./PoolTable";
 
 export const PoolPage: React.FC = () => {
   const intl = useIntl();
-  const paths = useAdminRoutes();
   return (
-    <div>
-      <header
-        data-h2-background-color="base(dt-linear)"
-        data-h2-padding="base(x2, 0)"
-      >
-        <div data-h2-container="base(center, full, x2)">
-          <div data-h2-flex-grid="base(center, 0, x2)">
-            <div data-h2-flex-item="base(1of1) l-tablet(3of5)">
-              <h1
-                data-h2-color="base(dt-white)"
-                data-h2-font-weight="base(700)"
-                style={{ letterSpacing: "-2px" }}
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Pools",
-                  description:
-                    "Heading displayed above the Pool Table component.",
-                })}
-              </h1>
-            </div>
-            <div
-              data-h2-flex-item="base(1of1) l-tablet(2of5)"
-              data-h2-text-align="l-tablet(right)"
-            >
-              <Link
-                href={paths.poolCreate()}
-                color="white"
-                mode="outline"
-                type="button"
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Create Pool",
-                  description: "Heading displayed above the Create Pool form.",
-                })}
-              </Link>
-            </div>
-          </div>
-        </div>
-      </header>
+    <DashboardContentContainer>
+      <PageHeader icon={ViewGridIcon}>
+        {intl.formatMessage({
+          defaultMessage: "Pools",
+          description: "Heading displayed above the Pool Table component.",
+        })}
+      </PageHeader>
 
       <PoolTableApi />
-    </div>
+    </DashboardContentContainer>
   );
 };
 

--- a/frontend/admin/src/js/components/pool/PoolTable.tsx
+++ b/frontend/admin/src/js/components/pool/PoolTable.tsx
@@ -131,15 +131,18 @@ export const PoolTable: React.FC<GetPoolsQuery & { editUrlRoot: string }> = ({
   const data = useMemo(() => pools.filter(notEmpty), [pools]);
 
   return (
-    <div data-h2-padding="base(0, 0, x3, 0)">
-      <div data-h2-container="base(center, full, x2)">
-        <Table
-          data={data}
-          columns={columns}
-          hiddenCols={["id", "description"]}
-        />
-      </div>
-    </div>
+    <Table
+      data={data}
+      columns={columns}
+      hiddenCols={["id", "description"]}
+      addBtn={{
+        path: paths.poolCreate(),
+        label: intl.formatMessage({
+          defaultMessage: "Create Pool",
+          description: "Heading displayed above the Create Pool form.",
+        }),
+      }}
+    />
   );
 };
 

--- a/frontend/admin/src/js/components/searchRequest/SearchRequestPage.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SearchRequestPage.tsx
@@ -1,43 +1,25 @@
 import React from "react";
+import { TicketIcon } from "@heroicons/react/outline";
 import { useIntl } from "react-intl";
+
+import PageHeader from "@common/components/PageHeader";
+
+import DashboardContentContainer from "../DashboardContentContainer";
 import { SearchRequestTableApi } from "./SearchRequestTable";
 
 export const SearchRequestPage: React.FunctionComponent = () => {
   const intl = useIntl();
   return (
-    <div>
-      <header
-        data-h2-background-color="base(dt-linear)"
-        data-h2-padding="base(x2, 0)"
-      >
-        <div data-h2-container="base(center, large, x2)">
-          <div data-h2-flex-grid="base(center, 0, x2)">
-            <div data-h2-flex-item="base(1of1) l-tablet(3of5)">
-              <h1
-                data-h2-color="base(dt-white)"
-                data-h2-font-weight="base(700)"
-                data-h2-margin="base(0)"
-                style={{ letterSpacing: "-2px" }}
-              >
-                {intl.formatMessage({
-                  defaultMessage: "All Requests",
-                  description:
-                    "Heading displayed above the search request component.",
-                })}
-              </h1>
-            </div>
-            {/* <div
-              data-h2-flex-item="base(1of1) l-tablet(2of5)"
-              data-h2-text-align="l-tablet(right)"
-            >
-
-            </div> */}
-          </div>
-        </div>
-      </header>
+    <DashboardContentContainer>
+      <PageHeader icon={TicketIcon}>
+        {intl.formatMessage({
+          defaultMessage: "All Requests",
+          description: "Heading displayed above the search request component.",
+        })}
+      </PageHeader>
 
       <SearchRequestTableApi />
-    </div>
+    </DashboardContentContainer>
   );
 };
 

--- a/frontend/admin/src/js/components/searchRequest/SearchRequestTable.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SearchRequestTable.tsx
@@ -140,13 +140,7 @@ export const SearchRequestTable: React.FunctionComponent<
     [poolCandidateSearchRequests],
   );
 
-  return (
-    <div data-h2-padding="base(0, 0, x3, 0)">
-      <div data-h2-container="base(center, large, x2)">
-        <Table data={memoizedData} columns={columns} hiddenCols={["id"]} />
-      </div>
-    </div>
-  );
+  return <Table data={memoizedData} columns={columns} hiddenCols={["id"]} />;
 };
 
 export const SearchRequestTableApi: React.FunctionComponent = () => {

--- a/frontend/admin/src/js/components/skill/SkillPage.tsx
+++ b/frontend/admin/src/js/components/skill/SkillPage.tsx
@@ -1,54 +1,25 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Link } from "@common/components";
-import { useAdminRoutes } from "../../adminRoutes";
+import { AcademicCapIcon } from "@heroicons/react/outline";
+
+import PageHeader from "@common/components/PageHeader";
+
 import { SkillTableApi } from "./SkillTable";
+import DashboardContentContainer from "../DashboardContentContainer";
 
 export const SkillPage: React.FC = () => {
   const intl = useIntl();
-  const paths = useAdminRoutes();
+
   return (
-    <div>
-      <header
-        data-h2-background-color="base(dt-linear)"
-        data-h2-padding="base(x2, 0)"
-      >
-        <div data-h2-container="base(center, large, x2)">
-          <div data-h2-flex-grid="base(center, 0, x2)">
-            <div data-h2-flex-item="base(1of1) l-tablet(3of5)">
-              <h1
-                data-h2-color="base(dt-white)"
-                data-h2-font-weight="base(700)"
-                style={{ letterSpacing: "-2px" }}
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Skills",
-                  description:
-                    "Heading displayed above the Skill Table component.",
-                })}
-              </h1>
-            </div>
-            <div
-              data-h2-flex-item="base(1of1) l-tablet(2of5)"
-              data-h2-text-align="l-tablet(right)"
-            >
-              <Link
-                href={paths.skillCreate()}
-                color="white"
-                mode="outline"
-                type="button"
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Create Skill",
-                  description: "Heading displayed above the Create Skill form.",
-                })}
-              </Link>
-            </div>
-          </div>
-        </div>
-      </header>
+    <DashboardContentContainer>
+      <PageHeader icon={AcademicCapIcon}>
+        {intl.formatMessage({
+          defaultMessage: "Skills",
+          description: "Heading displayed above the Skill Table component.",
+        })}
+      </PageHeader>
       <SkillTableApi />
-    </div>
+    </DashboardContentContainer>
   );
 };
 

--- a/frontend/admin/src/js/components/skill/SkillTable.tsx
+++ b/frontend/admin/src/js/components/skill/SkillTable.tsx
@@ -8,6 +8,7 @@ import { Pill } from "@common/components";
 import Pending from "@common/components/Pending";
 import { AllSkillsQuery, useAllSkillsQuery } from "../../api/generated";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
+import { useAdminRoutes } from "../../adminRoutes";
 
 type Data = NonNullable<FromArray<AllSkillsQuery["skills"]>>;
 
@@ -17,6 +18,7 @@ export const SkillTable: React.FC<AllSkillsQuery & { editUrlRoot: string }> = ({
 }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
+  const paths = useAdminRoutes();
   const columns = useMemo<ColumnsOf<Data>>(
     () => [
       {
@@ -86,11 +88,17 @@ export const SkillTable: React.FC<AllSkillsQuery & { editUrlRoot: string }> = ({
   const data = useMemo(() => skills.filter(notEmpty), [skills]);
 
   return (
-    <div data-h2-padding="base(0, 0, x3, 0)">
-      <div data-h2-container="base(center, large, x2)">
-        <Table data={data} columns={columns} />
-      </div>
-    </div>
+    <Table
+      data={data}
+      columns={columns}
+      addBtn={{
+        path: paths.skillCreate(),
+        label: intl.formatMessage({
+          defaultMessage: "Create Skill",
+          description: "Heading displayed above the Create Skill form.",
+        }),
+      }}
+    />
   );
 };
 

--- a/frontend/admin/src/js/components/skillFamily/SkillFamilyPage.tsx
+++ b/frontend/admin/src/js/components/skillFamily/SkillFamilyPage.tsx
@@ -1,55 +1,26 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Link } from "@common/components";
-import { useAdminRoutes } from "../../adminRoutes";
+import { UserGroupIcon } from "@heroicons/react/outline";
+
+import PageHeader from "@common/components/PageHeader";
+
 import { SkillFamilyTableApi } from "./SkillFamilyTable";
+import DashboardContentContainer from "../DashboardContentContainer";
 
 export const SkillFamilyPage: React.FC = () => {
   const intl = useIntl();
-  const paths = useAdminRoutes();
+
   return (
-    <div>
-      <header
-        data-h2-background-color="base(dt-linear)"
-        data-h2-padding="base(x2, 0)"
-      >
-        <div data-h2-container="base(center, large, x2)">
-          <div data-h2-flex-grid="base(center, 0, x2)">
-            <div data-h2-flex-item="base(1of1) l-tablet(3of5)">
-              <h1
-                data-h2-color="base(dt-white)"
-                data-h2-font-weight="base(700)"
-                style={{ letterSpacing: "-2px" }}
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Skill Families",
-                  description:
-                    "Heading displayed above the Skill Family Table component.",
-                })}
-              </h1>
-            </div>
-            <div
-              data-h2-flex-item="base(1of1) l-tablet(2of5)"
-              data-h2-text-align="l-tablet(right)"
-            >
-              <Link
-                href={paths.skillFamilyCreate()}
-                color="white"
-                mode="outline"
-                type="button"
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Create Skill Family",
-                  description:
-                    "Heading displayed above the Create Skill Family form.",
-                })}
-              </Link>
-            </div>
-          </div>
-        </div>
-      </header>
+    <DashboardContentContainer>
+      <PageHeader icon={UserGroupIcon}>
+        {intl.formatMessage({
+          defaultMessage: "Skill Families",
+          description:
+            "Heading displayed above the Skill Family Table component.",
+        })}
+      </PageHeader>
       <SkillFamilyTableApi />
-    </div>
+    </DashboardContentContainer>
   );
 };
 

--- a/frontend/admin/src/js/components/skillFamily/SkillFamilyTable.tsx
+++ b/frontend/admin/src/js/components/skillFamily/SkillFamilyTable.tsx
@@ -12,6 +12,7 @@ import {
   useAllSkillFamiliesQuery,
 } from "../../api/generated";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
+import { useAdminRoutes } from "../../adminRoutes";
 
 type Data = NonNullable<FromArray<AllSkillFamiliesQuery["skillFamilies"]>>;
 
@@ -30,6 +31,7 @@ export const SkillFamilyTable: React.FC<
 > = ({ skillFamilies, editUrlRoot }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
+  const paths = useAdminRoutes();
   const columns = useMemo<ColumnsOf<Data>>(
     () => [
       {
@@ -78,11 +80,17 @@ export const SkillFamilyTable: React.FC<
   const data = useMemo(() => skillFamilies.filter(notEmpty), [skillFamilies]);
 
   return (
-    <div data-h2-padding="base(0, 0, x3, 0)">
-      <div data-h2-container="base(center, large, x2)">
-        <Table data={data} columns={columns} />
-      </div>
-    </div>
+    <Table
+      data={data}
+      columns={columns}
+      addBtn={{
+        path: paths.skillFamilyCreate(),
+        label: intl.formatMessage({
+          defaultMessage: "Create Skill Family",
+          description: "Heading displayed above the Create Skill Family form.",
+        }),
+      }}
+    />
   );
 };
 


### PR DESCRIPTION
Resolves #2656 and #3014 

## Summary

This replaces the headings of all admin index pages with the new pattern as well as makes the use of `<DashboardContentContainer>` consistent across all of the index pages. 

## Testing

- [ ] Check chromatic diff
- [ ] navigate to all `/admin` index pages in side menu
  - [ ] Confirm it is using the new heading style

## New Style Screenshot

 > Note: Simple text with icon to left of heading, "Add" buttons moved to right side above table

<img width="1247" alt="Screen Shot 2022-08-30 at 1 15 42 PM" src="https://user-images.githubusercontent.com/4127998/187500743-65d2aec3-98e8-4090-9f8d-291d8988324a.png">
