### PR TITLE
a11y - 3736 - Darken Required Labels

### DIFF
--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
@@ -75,7 +75,7 @@ const Fieldset: React.FC<FieldsetProps> = ({
               <span
                 data-h2-font-size="base(caption)"
                 {...(required
-                  ? { "data-h2-color": "base(dt-error)" }
+                  ? { "data-h2-color": "base(dark.dt-error)" }
                   : { "data-h2-color": "base(dark.dt-gray)" })}
               >
                 (

--- a/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
+++ b/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
@@ -59,7 +59,7 @@ const InputLabel: React.FC<InputLabelProps> = ({
               data-h2-display="base(inline-block)"
               data-h2-margin="base(0, 0, 0, x.125)"
               {...(required
-                ? { "data-h2-color": "base(dt-error)" }
+                ? { "data-h2-color": "base(dark.dt-error)" }
                 : { "data-h2-color": "base(dark.dt-gray)" })}
             >
               (


### PR DESCRIPTION
Resolves #3736 

## Summary

This darkens the red colour of the required label to meet the current minimum colour contrast rations for WCAG 2.0 AA.

## Ratios

- [Profile](https://colourcontrast.cc/ffffff/bf0000) - 6.53:1
- [Admin](https://colourcontrast.cc/f5f5f5/bf0000) - 5.9:1

## Testing

- [x] Build admin/talentsearch `npm run production --workspaces`
- [x] Navigate to a form with required field
- [x] Run axe and confirm no colour contrast errors related to required label

