### PR TITLE
Fix candidate statuses

### DIFF
--- a/api/database/migrations/2022_09_06_155536_update_candidate_statuses.php
+++ b/api/database/migrations/2022_09_06_155536_update_candidate_statuses.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+// status updates associated with PR 3744
+class UpdateCandidateStatuses extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement("
+            update pool_candidates
+                set pool_candidate_status =
+                    case pool_candidate_status
+                        when 'AVAILABLE' then 'QUALIFIED_AVAILABLE'
+                        when 'NO_LONGER_INTERESTED' then 'QUALIFIED_WITHDREW'
+                        when 'UNAVAILABLE' then 'QUALIFIED_UNAVAILABLE'
+                        else pool_candidate_status
+                    end
+        ");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement("
+            update pool_candidates
+                set pool_candidate_status =
+                    case pool_candidate_status
+                        when 'QUALIFIED_AVAILABLE' then 'AVAILABLE'
+                        when 'QUALIFIED_WITHDREW' then 'NO_LONGER_INTERESTED'
+                        when 'QUALIFIED_UNAVAILABLE' then 'UNAVAILABLE'
+                        else pool_candidate_status
+                    end
+        ");
+    }
+}


### PR DESCRIPTION
This branch adds a migration so that existing candidate rows in a database will have the updated statuses needed for PR 3744.  See the status changes [here](https://github.com/GCTC-NTGC/gc-digital-talent/pull/3744/files#diff-bda6dd953620b9cc44f8ffc3bc4acb3f4a4d6089be006de5dcafdf8f0dadf728).

## Testing
- [ ] Check out the code before PR 3744: `git checkout 6bb41efc0fef0f394f26e2110c9689332e1d10ba`
- [ ] Setup the database: `php artisan migrate:fresh --seed`
- [ ] Observe the statuses:
```
select
  pool_candidate_status,
    count(*)
  from pool_candidates pc
group by pool_candidate_status
```
- [ ] Checkout this branch
- [ ] Run this migrations: `php artisan migrate`
- [ ] Observe the statuses again
- [ ] Try rolling back and observe statuses again: `php artisan migrate:rollback --step=1`

Closes #3810 