### PR TITLE
Copy - 3828 - IAP copy fixes

### DIFF
--- a/frontend/indigenousapprenticeship/src/js/components/Home/Home.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/Home/Home.tsx
@@ -386,7 +386,7 @@ const Home: React.FunctionComponent = () => {
                 <p data-h2-margin="base(x2, 0, x1, 0)">
                   {intl.formatMessage({
                     defaultMessage:
-                      "The Program is for First Nations, Inuit, and Métis peoples. If you are First Nations, an Inuk, or Metis, and if you have a passion for technology, then this Program is for you!",
+                      "The Program is for First Nations, Inuit, and Métis peoples. If you are First Nations, an Inuk, or Métis, and if you have a passion for technology, then this Program is for you!",
                     description: "First paragraph about who the program is for",
                   })}
                 </p>

--- a/frontend/indigenousapprenticeship/src/js/components/Home/Home.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/Home/Home.tsx
@@ -25,9 +25,6 @@ import CTAButtons from "../CallToAction/CTAButtons";
 
 import "./home.css";
 
-// TEMP: Disable rule until we get the proper URL
-// eslint-disable-next-line jsx-a11y/anchor-is-valid
-const honestyPledgeLink = (...chunks: string[]) => <a href="#">{chunks}</a>;
 const mailLink = (...chunks: string[]) => (
   <a href="mailto:edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca">{chunks}</a>
 );
@@ -629,7 +626,8 @@ const Home: React.FunctionComponent = () => {
               <Step
                 position="1"
                 title={intl.formatMessage({
-                  defaultMessage: "Complete the Community Honesty Pledge",
+                  defaultMessage:
+                    "Complete the Community Indigenous Peoples Self-Declaration Form",
                   description: "How it works, step 1 heading",
                 })}
               >
@@ -641,16 +639,11 @@ const Home: React.FunctionComponent = () => {
                   })}
                 </p>
                 <p data-h2-margin="base(x1, 0, 0, 0)">
-                  {intl.formatMessage(
-                    {
-                      defaultMessage:
-                        "There are  three distinct groups of Indigenous peoples recognized in the Canadian constitution. You will be asked to confirm which Indigenous group(s) you belong to via the <a>Honesty Pledge</a>.",
-                      description: "How it works, step 1 content paragraph 2",
-                    },
-                    {
-                      a: honestyPledgeLink,
-                    },
-                  )}
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "There are  three distinct groups of Indigenous peoples recognized in the Canadian constitution. You will be asked to confirm which Indigenous group(s) you belong to via the Indigenous Peoples Self-Declaration Form.",
+                    description: "How it works, step 1 content paragraph 2",
+                  })}
                 </p>
               </Step>
             </div>

--- a/frontend/indigenousapprenticeship/src/js/components/Home/Home.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/Home/Home.tsx
@@ -28,6 +28,9 @@ import "./home.css";
 // TEMP: Disable rule until we get the proper URL
 // eslint-disable-next-line jsx-a11y/anchor-is-valid
 const honestyPledgeLink = (...chunks: string[]) => <a href="#">{chunks}</a>;
+const mailLink = (...chunks: string[]) => (
+  <a href="mailto:edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca">{chunks}</a>
+);
 
 const Home: React.FunctionComponent = () => {
   const [isApplyDialogOpen, setApplyDialogOpen] =
@@ -391,12 +394,17 @@ const Home: React.FunctionComponent = () => {
                   })}
                 </p>
                 <p data-h2-margin="base(x1, 0)">
-                  {intl.formatMessage({
-                    defaultMessage:
-                      "If you are not sure if this Program is right for you, please contact us and a member of our team will be happy to meet with you to answer any questions you may have.",
-                    description:
-                      "Second paragraph about who the program is for",
-                  })}
+                  {intl.formatMessage(
+                    {
+                      defaultMessage:
+                        "If you are not sure if this Program is right for you, please <mailLink>contact us</mailLink> and a member of our team will be happy to meet with you to answer any questions you may have.",
+                      description:
+                        "Second paragraph about who the program is for",
+                    },
+                    {
+                      mailLink,
+                    },
+                  )}
                 </p>
                 <img
                   src={imageUrl(INDIGENOUSAPPRENTICESHIP_APP_DIR, "ulu.png")}

--- a/frontend/indigenousapprenticeship/src/js/lang/fr.json
+++ b/frontend/indigenousapprenticeship/src/js/lang/fr.json
@@ -183,10 +183,6 @@
     "defaultMessage": "Les apprentis feront l’expérience d’un apprentissage au travail et pendant la formation en ligne dans un ou plusieurs domaines de la technologie de l’information. On s’attend à ce que les apprentis démontrent leur intérêt et leur passion pour la technologie en étant prêts à observer, à apprendre et à pratiquer de nouvelles compétences qui sont développées au cours du programme. En moyenne, un apprenti passera quatre jours par semaine en apprentissage pratique, tandis que le cinquième jour de la semaine sera consacré au perfectionnement personnel et professionnel par la formation en ligne et par d’autres possibilités de formation et de perfectionnement.",
     "description": "Learn more dialog question eight paragraph one"
   },
-  "i6XB0+": {
-    "defaultMessage": "Si vous n’êtes pas certain(e) que ce programme vous convient, veuillez communiquer avec nous et un membre de notre équipe se fera un plaisir de vous rencontrer pour répondre à vos questions.",
-    "description": "Second paragraph about who the program is for"
-  },
   "WDRWcu": {
     "defaultMessage": "Dois-je déménager à Ottawa ou à un endroit précis pour participer à ce programme?",
     "description": "Learn more dialog question six heading"
@@ -362,5 +358,9 @@
   "khChKa": {
     "defaultMessage": "Le Programme s’adresse aux Premières Nations, aux Inuits et aux Métis. Si vous êtes un membre des Premières Nations, un Inuit ou un Métis et que vous avez une passion pour la technologie, ce programme est pour vous!",
     "description": "First paragraph about who the program is for"
+  },
+  "1FM1VL": {
+    "defaultMessage": "Si vous n’êtes pas certain(e) que ce programme vous convient, veuillez <mailLink>communiquer avec nous</mailLink> et un membre de notre équipe se fera un plaisir de vous rencontrer pour répondre à vos questions.communiquer avec nous",
+    "description": "Second paragraph about who the program is for"
   }
 }

--- a/frontend/indigenousapprenticeship/src/js/lang/fr.json
+++ b/frontend/indigenousapprenticeship/src/js/lang/fr.json
@@ -352,7 +352,7 @@
     "description": "First paragraph about who the program is for"
   },
   "1FM1VL": {
-    "defaultMessage": "Si vous n’êtes pas certain(e) que ce programme vous convient, veuillez <mailLink>communiquer avec nous</mailLink> et un membre de notre équipe se fera un plaisir de vous rencontrer pour répondre à vos questions.communiquer avec nous",
+    "defaultMessage": "Si vous n’êtes pas certain(e) que ce programme vous convient, veuillez <mailLink>communiquer avec nous</mailLink> et un membre de notre équipe se fera un plaisir de vous rencontrer pour répondre à vos questions.",
     "description": "Second paragraph about who the program is for"
   },
   "1pFMSH": {

--- a/frontend/indigenousapprenticeship/src/js/lang/fr.json
+++ b/frontend/indigenousapprenticeship/src/js/lang/fr.json
@@ -319,10 +319,6 @@
     "defaultMessage": "Le Programme a été conçu pour répondre aux efforts de réconciliation et pour bâtir une relation renouvelée qui est fondée sur les droits, le respect, la collaboration et le partenariat avec les peuples autochtones.",
     "description": "How it works, step 1 content paragraph 1"
   },
-  "X/BwwP": {
-    "defaultMessage": "Il existe trois groupes distincts de peuples autochtones qui sont reconnus par la Constitution canadienne. On vous demandera de confirmer au(x)quel(s) de vous appartenez par l’entremise de la <a>Promesse d’honnêteté</a>.",
-    "description": "How it works, step 1 content paragraph 2"
-  },
   "jyQi0m": {
     "defaultMessage": "Si vous êtes membre d’une Première Nation, Inuk ou Métis, et que vous vivez au Canada, vous pouvez demander à devenir un apprentis dans le cadre de ce programme.",
     "description": "Learn more dialog question on paragraph one"
@@ -334,10 +330,6 @@
   "pPOGwF": {
     "defaultMessage": "Ils sont membres des Premières Nations (avec ou sans statut), Inuit ou Métis ",
     "description": "IAP Requirement list item one"
-  },
-  "sqUD2Z": {
-    "defaultMessage": "Remplir la Promesse d’honnêteté de la collectivité",
-    "description": "How it works, step 1 heading"
   },
   "49UIne": {
     "defaultMessage": "Apprenti en TI du Gouvernement du Canada",
@@ -362,5 +354,13 @@
   "1FM1VL": {
     "defaultMessage": "Si vous n’êtes pas certain(e) que ce programme vous convient, veuillez <mailLink>communiquer avec nous</mailLink> et un membre de notre équipe se fera un plaisir de vous rencontrer pour répondre à vos questions.communiquer avec nous",
     "description": "Second paragraph about who the program is for"
+  },
+  "1pFMSH": {
+    "defaultMessage": "Remplir la Formulaire d’autodéclaration à l’intention des peuples autochtones",
+    "description": "How it works, step 1 heading"
+  },
+  "uJ1rk3": {
+    "defaultMessage": "Il existe trois groupes distincts de peuples autochtones qui sont reconnus par la Constitution canadienne. On vous demandera de confirmer au(x)quel(s) de vous appartenez par l’entremise de la Formulaire d’autodéclaration à l’intention des peuples autochtones.",
+    "description": "How it works, step 1 content paragraph 2"
   }
 }

--- a/frontend/indigenousapprenticeship/src/js/lang/fr.json
+++ b/frontend/indigenousapprenticeship/src/js/lang/fr.json
@@ -207,10 +207,6 @@
     "defaultMessage": "Vise à lancer le programme au début de 2022.",
     "description": "Talent portal strategy item 4 content"
   },
-  "ZHLkHX": {
-    "defaultMessage": "Le Programme s’adresse aux Premières Nations, aux Inuits et aux Métis. Si vous êtes un membre des Premières Nations, un Inuit ou un Métis et que vous avez une passion pour la technologie, ce programme est pour vous! ",
-    "description": "First paragraph about who the program is for"
-  },
   "b09U1u": {
     "defaultMessage": "À la fin de leurs 24 mois, les apprentis auront des attestations et des compétences en demande, ainsi que la confiance nécessaire pour contribuer à la main-d’œuvre numérique du Canada, tant à l’intérieur qu’à l’extérieur de la fonction publique fédérale.",
     "description": "First paragraph what will you learn at the program"
@@ -362,5 +358,9 @@
   "jPLaDk": {
     "defaultMessage": "Désolé, vous n'êtes pas autorisé(e) à consulter cette page.",
     "description": "Heading for the message saying the page to view is not authorized."
+  },
+  "khChKa": {
+    "defaultMessage": "Le Programme s’adresse aux Premières Nations, aux Inuits et aux Métis. Si vous êtes un membre des Premières Nations, un Inuit ou un Métis et que vous avez une passion pour la technologie, ce programme est pour vous!",
+    "description": "First paragraph about who the program is for"
   }
 }


### PR DESCRIPTION
Resolves #3828 

## Summary

This updates the IAP with some typo fixes and new copy.

## What This Does

- Fix typo for Métis (38e66cf9fb1f62d633004a443aeb0140e10cf8af)
- Adds a mail link to contact us (234b7fc2c960b163e64e10f49e2aee2734cf445e)
- Replaces honesty pledge references with new name (004dc3915eded125e8b67ac92ace5d75d5a7117d)

## Testing

1. Compile new translations `npm run intl-compile --workspace=indigenousapprenticeship`
2. Build the IAP project `npm run production --workspace=indigenousapprenticeship`
3. Navigate the IAP homepage
4. Confirm the following:
   - No ocurrence of "Metis" typo
   - "Contact us / communiquer avec nous" is linked to edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca
   - First step in "How it Will Work" references the "Indigenous Peoples Self-Declaration Form" rather than "Honesty Pledge"