### PR TITLE
Bug - 3711 - Improve active link detection

### DIFF
--- a/frontend/admin/src/js/components/menu/AdminSideMenu.tsx
+++ b/frontend/admin/src/js/components/menu/AdminSideMenu.tsx
@@ -52,8 +52,6 @@ const checkRole = (
   return visible;
 };
 
-const startsWith = (ref: string, test: string): boolean => test.startsWith(ref);
-
 const AdminSideMenu: React.FC<AdminSideMenuProps> = ({
   isOpen,
   onToggle,
@@ -176,7 +174,7 @@ const AdminSideMenu: React.FC<AdminSideMenuProps> = ({
             <SideMenuItem
               href={item.href}
               icon={item.icon}
-              isActive={startsWith(item.href, location.pathname)}
+              isActive={item.href === location.pathname}
             >
               {item.text}
             </SideMenuItem>


### PR DESCRIPTION
Resolves #3711 

## Summary

This replaces the existing `startsWith` for active link detection with a strict equals operator.

## Screenshot

<img width="268" alt="Screen Shot 2022-09-06 at 3 16 28 PM" src="https://user-images.githubusercontent.com/4127998/188720171-614485b5-b168-442b-8e8e-bcced838ec25.png">

## Testing

1. Build the admin project `npm run production --workspace=admin`
2. Navigate and login to admin project
3. Use the side menu and confirm the proper item is highlighted when active

> Note: Pay close attentions to "Skills" and "Skill Families" since this is where the issue was originally ocurring.