### PR TITLE
Add formatjs/enforce-id rule to make autogen ID easier to work with

### DIFF
--- a/frontend/talentsearch/.eslintrc
+++ b/frontend/talentsearch/.eslintrc
@@ -50,6 +50,13 @@
     ],
     "rules": {
         "formatjs/no-id": "off",
+        "formatjs/enforce-id": [
+            "error",
+            {
+                "idInterpolationPattern": "[sha512:contenthash:base64:6]",
+                "idWhitelist": ["\\."]
+            }
+        ],
         "camelcase": "warn",
         "consistent-return": "warn",
         "import/no-extraneous-dependencies": "off",

--- a/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.tsx
+++ b/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.tsx
@@ -94,6 +94,7 @@ const ApplicationPageWrapper = ({
               <p data-h2-font-size="base(h6, 1)">
                 {intl.formatMessage({
                   defaultMessage: "Closing date:",
+                  id: "GIN69n",
                   description:
                     "Label for a pool advertisements closing date on the application",
                 })}

--- a/frontend/talentsearch/src/js/components/ClassificationDefinition/ITDefinitions.tsx
+++ b/frontend/talentsearch/src/js/components/ClassificationDefinition/ITDefinitions.tsx
@@ -10,6 +10,7 @@ const LevelOne = () => {
         {intl.formatMessage({
           defaultMessage:
             "Technicians (IT-01) provide technical support in the development, implementation, integration, and maintenance of service delivery to clients and stakeholders",
+          id: "Z9Uex5",
           description: "blurb describing IT-01",
         })}
       </p>
@@ -17,6 +18,7 @@ const LevelOne = () => {
         {intl.formatMessage({
           defaultMessage:
             "IT Technicians are primarily found in three work streams: ",
+          id: "vQzmUH",
           description: "Preceding list description",
         })}
       </p>
@@ -24,18 +26,21 @@ const LevelOne = () => {
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Infrastructure Operations",
+            id: "QZ9FZB",
             description: "work stream example",
           })}
         </li>
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Security",
+            id: "nrBkon",
             description: "work stream example",
           })}
         </li>
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Software Solutions",
+            id: "SDDp1t",
             description: "work stream example",
           })}
         </li>
@@ -52,6 +57,7 @@ const LevelTwo = () => {
       {intl.formatMessage({
         defaultMessage:
           "Analysts (IT-02) provide technical services, advice, analysis, and research in their field of expertise to support service delivery to clients and stakeholders. IT analysts are found in all work streams.",
+        id: "raFdbB",
         description: "blurb describing IT-02",
       })}
     </p>
@@ -67,6 +73,7 @@ const LevelThreeLead = () => {
         {intl.formatMessage({
           defaultMessage:
             "There are two types of IT-03 employees: those following a management path, and individual contributors.",
+          id: "hCgrxA",
           description: "IT-03 description precursor",
         })}
       </p>
@@ -74,6 +81,7 @@ const LevelThreeLead = () => {
         {intl.formatMessage({
           defaultMessage:
             "<strong>Management Path</strong>: IT Team Leads (IT-03) are responsible for supervising work and project teams for IT services and operations in their field of expertise to support service delivery to clients and stakeholders. IT Team Leads are found in all work streams.",
+          id: "+bC9lc",
           description:
             "IT-03 team lead path description, ignore things in <> tags please",
         })}
@@ -91,6 +99,7 @@ const LevelThreeAdvisor = () => {
         {intl.formatMessage({
           defaultMessage:
             "There are two types of IT-03 employees: those following a management path, and individual contributors.",
+          id: "hCgrxA",
           description: "IT-03 description precursor",
         })}
       </p>
@@ -98,6 +107,7 @@ const LevelThreeAdvisor = () => {
         {intl.formatMessage({
           defaultMessage:
             "<strong>Individual Contributor</strong>: IT Technical Advisors (IT-03) provide specialized technical advice, recommendations and support on solutions and services in their field of expertise in support of service delivery to clients and stakeholders. IT Technical Advisors are found in all work streams.",
+          id: "u+9mg1",
           description:
             "IT-03 advisor description, ignore things in <> tags please",
         })}
@@ -115,6 +125,7 @@ const LevelFourManager = () => {
         {intl.formatMessage({
           defaultMessage:
             "There are two types of IT-04 employees: those following a management path, and individual contributors.",
+          id: "87nFC8",
           description: "IT-04 description precursor",
         })}
       </p>
@@ -122,6 +133,7 @@ const LevelFourManager = () => {
         {intl.formatMessage({
           defaultMessage:
             "<strong>Management Path</strong>: IT Managers (IT-04) are responsible for managing the development and delivery of IT services and/or operations through subordinate team leaders, technical advisors, and project teams, for service delivery to clients and stakeholders. IT Managers are found in all work streams.",
+          id: "m21EOJ",
           description:
             "IT-04 manager path description, ignore things in <> tags please",
         })}
@@ -139,6 +151,7 @@ const LevelFourAdvisor = (): JSX.Element => {
         {intl.formatMessage({
           defaultMessage:
             "There are two types of IT-04 employees: those following a management path, and individual contributors.",
+          id: "87nFC8",
           description: "IT-04 description precursor",
         })}
       </p>
@@ -146,6 +159,7 @@ const LevelFourAdvisor = (): JSX.Element => {
         {intl.formatMessage({
           defaultMessage:
             "<strong>Individual Contributor</strong>: IT Senior Advisors (IT-04) provide expert technical advice and strategic direction in their field of expertise in the provision of solutions and services to internal or external clients, and stakeholders. IT Senior Advisors are primarily found in six work streams:",
+          id: "58BEeZ",
           description:
             "IT-04 senior advisor description precursor to work stream list, ignore things in <> tags please",
         })}
@@ -154,36 +168,42 @@ const LevelFourAdvisor = (): JSX.Element => {
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Infrastructure Operations",
+            id: "QZ9FZB",
             description: "work stream example",
           })}
         </li>
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Security",
+            id: "nrBkon",
             description: "work stream example",
           })}
         </li>
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Software Solutions",
+            id: "SDDp1t",
             description: "work stream example",
           })}
         </li>
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Database Management",
+            id: "6LTC0y",
             description: "work stream example",
           })}
         </li>
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Enterprise Architecture",
+            id: "oOcegG",
             description: "work stream example",
           })}
         </li>
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Project Portfolio Management",
+            id: "tm3zLD",
             description: "work stream example",
           })}
         </li>

--- a/frontend/talentsearch/src/js/components/GovernmentInfoForm/GovernmentInfoForm.tsx
+++ b/frontend/talentsearch/src/js/components/GovernmentInfoForm/GovernmentInfoForm.tsx
@@ -191,6 +191,7 @@ export const GovernmentInfoForm: React.FunctionComponent<
           classification.group ||
           intl.formatMessage({
             defaultMessage: "Error: classification group not found.",
+            id: "YA/7nb",
             description:
               "Error message if classification group is not defined.",
           }),
@@ -221,6 +222,7 @@ export const GovernmentInfoForm: React.FunctionComponent<
           legend={intl.formatMessage({
             defaultMessage:
               "Do you currently work for the government of Canada?",
+            id: "MtONBT",
             description: "Employee Status in Government Info Form",
           })}
           name="govEmployeeYesNo"
@@ -233,6 +235,7 @@ export const GovernmentInfoForm: React.FunctionComponent<
               label: intl.formatMessage({
                 defaultMessage:
                   "<strong>No</strong>, I am not a Government of Canada employee",
+                id: "rJMWiV",
                 description:
                   "Label displayed for is not a government employee option",
               }),
@@ -242,6 +245,7 @@ export const GovernmentInfoForm: React.FunctionComponent<
               label: intl.formatMessage({
                 defaultMessage:
                   "<strong>Yes</strong>, I am a Government of Canada employee",
+                id: "jbftvG",
                 description:
                   "Label displayed for is a government employee option",
               }),
@@ -257,11 +261,13 @@ export const GovernmentInfoForm: React.FunctionComponent<
               name="department"
               label={intl.formatMessage({
                 defaultMessage: "Which department do you work for?",
+                id: "NP/fsS",
                 description:
                   "Label for department select input in the request form",
               })}
               nullSelection={intl.formatMessage({
                 defaultMessage: "Select a department...",
+                id: "WE/Nu+",
                 description:
                   "Null selection for department select input in the request form.",
               })}
@@ -280,6 +286,7 @@ export const GovernmentInfoForm: React.FunctionComponent<
               legend={intl.formatMessage({
                 defaultMessage:
                   "As an employee, what is your employment status?",
+                id: "3f9P13",
                 description: "Employee Status in Government Info Form",
               })}
               name="govEmployeeType"
@@ -302,6 +309,7 @@ export const GovernmentInfoForm: React.FunctionComponent<
             {intl.formatMessage({
               defaultMessage:
                 "Please indicate your current substantive group classification and level.",
+              id: "TS63OC",
               description:
                 "Text blurb, asking about classification and level in the government info form",
             })}
@@ -323,11 +331,13 @@ export const GovernmentInfoForm: React.FunctionComponent<
                 id="currentClassificationGroup"
                 label={intl.formatMessage({
                   defaultMessage: "Current Classification Group",
+                  id: "/K1/1n",
                   description: "Label displayed on classification group input",
                 })}
                 name="currentClassificationGroup"
                 nullSelection={intl.formatMessage({
                   defaultMessage: "Choose Group",
+                  id: "u4v1RB",
                   description: "Null selection for form.",
                 })}
                 rules={{
@@ -347,6 +357,7 @@ export const GovernmentInfoForm: React.FunctionComponent<
                 id="currentClassificationLevel"
                 label={intl.formatMessage({
                   defaultMessage: "Current Classification Level",
+                  id: "gnGAe8",
                   description: "Label displayed on classification level input",
                 })}
                 name="currentClassificationLevel"
@@ -355,6 +366,7 @@ export const GovernmentInfoForm: React.FunctionComponent<
                 }}
                 nullSelection={intl.formatMessage({
                   defaultMessage: "Choose Level",
+                  id: "e/ez/m",
                   description: "Null selection for form.",
                 })}
                 options={levelOptions}
@@ -367,6 +379,7 @@ export const GovernmentInfoForm: React.FunctionComponent<
           {intl.formatMessage({
             defaultMessage:
               "Do you have a priority entitlement for Government of Canada job applications?",
+            id: "v0JyBd",
             description:
               "Sentence asking whether the user possesses priority entitlement",
           })}
@@ -375,6 +388,7 @@ export const GovernmentInfoForm: React.FunctionComponent<
           idPrefix="priorityEntitlementYesNo"
           legend={intl.formatMessage({
             defaultMessage: "Priority Entitlement",
+            id: "FqXo5j",
             description: "Priority Entitlement Status in Government Info Form",
           })}
           name="priorityEntitlementYesNo"
@@ -386,6 +400,7 @@ export const GovernmentInfoForm: React.FunctionComponent<
               value: "no",
               label: intl.formatMessage({
                 defaultMessage: "I do not have a priority entitlement",
+                id: "brQu7D",
                 description:
                   "Label displayed for does not have priority entitlement option",
               }),
@@ -394,6 +409,7 @@ export const GovernmentInfoForm: React.FunctionComponent<
               value: "yes",
               label: intl.formatMessage({
                 defaultMessage: "I have a priority entitlement",
+                id: "uQ8Tss",
                 description:
                   "Label displayed does have priority entitlement option",
               }),
@@ -407,6 +423,7 @@ export const GovernmentInfoForm: React.FunctionComponent<
               type="text"
               label={intl.formatMessage({
                 defaultMessage: "Priority number",
+                id: "P+UY4i",
                 description: "label for priority number input",
               })}
               name="priorityEntitlementNumber"
@@ -475,6 +492,7 @@ export const GovInfoFormWithProfileWrapper: React.FunctionComponent<
         {
           title: intl.formatMessage({
             defaultMessage: "My Applications",
+            id: "mq4G8h",
             description:
               "'My Applications' breadcrumb from applicant profile wrapper.",
           }),
@@ -486,6 +504,7 @@ export const GovInfoFormWithProfileWrapper: React.FunctionComponent<
             application.poolAdvertisement?.name?.[locale] ||
             intl.formatMessage({
               defaultMessage: "Pool name not found",
+              id: "FmD1sL",
               description:
                 "Pools name breadcrumb from applicant profile wrapper if no name set.",
             }),
@@ -499,11 +518,13 @@ export const GovInfoFormWithProfileWrapper: React.FunctionComponent<
       description={intl.formatMessage({
         defaultMessage:
           "Please indicate if you are currently an employee in the Government of Canada.",
+        id: "6vsgLY",
         description:
           "Description blurb for Profile Form Wrapper in the Government Information Form",
       })}
       title={intl.formatMessage({
         defaultMessage: "Government Information",
+        id: "xDgNfZ",
         description:
           "Title for Profile Form Wrapper in Government Information Form",
       })}
@@ -515,6 +536,7 @@ export const GovInfoFormWithProfileWrapper: React.FunctionComponent<
         {
           title: intl.formatMessage({
             defaultMessage: "Government Information",
+            id: "Uh9Yj4",
             description:
               "Display Text for Government Information Form Page Link",
           }),

--- a/frontend/talentsearch/src/js/components/GovernmentInfoForm/GovernmentInfoFormPage.tsx
+++ b/frontend/talentsearch/src/js/components/GovernmentInfoForm/GovernmentInfoFormPage.tsx
@@ -137,6 +137,7 @@ const GovernmentInfoFormPage: React.FunctionComponent<{ meId: string }> = ({
       toast.error(
         intl.formatMessage({
           defaultMessage: "Error: user not found",
+          id: "4bjh8X",
           description: "Message displayed to user if user is not found",
         }),
       );

--- a/frontend/talentsearch/src/js/components/PageContainer.tsx
+++ b/frontend/talentsearch/src/js/components/PageContainer.tsx
@@ -69,6 +69,7 @@ const TalentSearchNotFound: React.FC = () => {
       headingMessage={intl.formatMessage({
         description: "Heading for the message saying the page was not found.",
         defaultMessage: "Sorry, we can't find the page you were looking for.",
+        id: "pBJzgi",
       })}
     >
       <p>
@@ -76,6 +77,7 @@ const TalentSearchNotFound: React.FC = () => {
           description: "Detailed message saying the page was not found.",
           defaultMessage:
             "Oops, it looks like you've landed on a page that either doesn't exist or has moved.",
+          id: "pgHTkX",
         })}
       </p>
     </NotFound>
@@ -90,6 +92,7 @@ const TalentSearchNotAuthorized: React.FC = () => {
         description:
           "Heading for the message saying the page to view is not authorized.",
         defaultMessage: "Sorry, you are not authorized to view this page.",
+        id: "jPLaDk",
       })}
     >
       <p>
@@ -98,6 +101,7 @@ const TalentSearchNotAuthorized: React.FC = () => {
             "Detailed message saying the page to view is not authorized.",
           defaultMessage:
             "Oops, it looks like you've landed on a page that you are not authorized to view.",
+          id: "gKyog2",
         })}
       </p>
     </NotAuthorized>
@@ -129,6 +133,7 @@ export const PageContainer: React.FC<{
         >
           {intl.formatMessage({
             defaultMessage: "Skip to main content",
+            id: "Srs7a4",
             description: "Assistive technology skip link",
           })}
         </a>

--- a/frontend/talentsearch/src/js/components/Router.tsx
+++ b/frontend/talentsearch/src/js/components/Router.tsx
@@ -485,6 +485,7 @@ export const Router: React.FC = () => {
       href={talentPaths.search()}
       text={intl.formatMessage({
         defaultMessage: "Search",
+        id: "OezjH3",
         description: "Label displayed on the Search menu item.",
       })}
     />,
@@ -493,6 +494,7 @@ export const Router: React.FC = () => {
       href={talentPaths.request()}
       text={intl.formatMessage({
         defaultMessage: "Request",
+        id: "i7hOcw",
         description: "Label displayed on the Request menu item.",
       })}
     />,
@@ -505,6 +507,7 @@ export const Router: React.FC = () => {
         href={directIntakePaths.allPools()}
         text={intl.formatMessage({
           defaultMessage: "Browse opportunities",
+          id: "SXvOXV",
           description: "Label displayed on the browse pools menu item.",
         })}
       />,
@@ -517,6 +520,7 @@ export const Router: React.FC = () => {
           href={directIntakePaths.applications(data.me.id)}
           text={intl.formatMessage({
             defaultMessage: "My applications",
+            id: "ioghLh",
             description:
               "Label displayed on the users pool applications menu item.",
           })}
@@ -532,6 +536,7 @@ export const Router: React.FC = () => {
         href={profilePaths.home(data.me.id)}
         text={intl.formatMessage({
           defaultMessage: "My profile",
+          id: "5lBIzg",
           description: "Label displayed on the applicant profile menu item.",
         })}
       />,
@@ -544,6 +549,7 @@ export const Router: React.FC = () => {
       href={authPaths.login()}
       text={intl.formatMessage({
         defaultMessage: "Login",
+        id: "md7Klw",
         description: "Label displayed on the login link menu item.",
       })}
     />,
@@ -552,6 +558,7 @@ export const Router: React.FC = () => {
       href={authPaths.register()}
       text={intl.formatMessage({
         defaultMessage: "Register",
+        id: "LMGaDQ",
         description: "Label displayed on the register link menu item.",
       })}
     />,
@@ -568,6 +575,7 @@ export const Router: React.FC = () => {
         }}
         text={intl.formatMessage({
           defaultMessage: "Logout",
+          id: "3vDhoc",
           description: "Label displayed on the logout link menu item.",
         })}
       />,

--- a/frontend/talentsearch/src/js/components/Spinner/Spinner.tsx
+++ b/frontend/talentsearch/src/js/components/Spinner/Spinner.tsx
@@ -8,6 +8,7 @@ const Spinner: React.FC = () => {
       <span data-h2-visibility="base(invisible)">
         {intl.formatMessage({
           defaultMessage: "Searching...",
+          id: "w6vHXf",
           description: "Message to display when a search is in progress.",
         })}
       </span>

--- a/frontend/talentsearch/src/js/components/aboutMeForm/AboutMeForm.tsx
+++ b/frontend/talentsearch/src/js/components/aboutMeForm/AboutMeForm.tsx
@@ -100,6 +100,7 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
         {
           title: intl.formatMessage({
             defaultMessage: "My Applications",
+            id: "mq4G8h",
             description:
               "'My Applications' breadcrumb from applicant profile wrapper.",
           }),
@@ -111,6 +112,7 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
             application.poolAdvertisement?.name?.[locale] ||
             intl.formatMessage({
               defaultMessage: "Pool name not found",
+              id: "FmD1sL",
               description:
                 "Pools name breadcrumb from applicant profile wrapper if no name set.",
             }),
@@ -137,11 +139,13 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
       description={intl.formatMessage({
         defaultMessage:
           "This information is used for account management and communications purposes, it has no impact on the job matching or job recommendations.",
+        id: "B/LE8S",
         description:
           "Description text for the Profile Form wrapper in the About Me form",
       })}
       title={intl.formatMessage({
         defaultMessage: "About me",
+        id: "XY19Sh",
         description: "Title for Profile Form wrapper in About me form",
       })}
       cancelLink={{
@@ -153,6 +157,7 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
         {
           title: intl.formatMessage({
             defaultMessage: "About Me",
+            id: "uG2MuI",
             description: "Display text for About Me Form Page Link",
           }),
         },
@@ -171,6 +176,7 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
         >
           {intl.formatMessage({
             defaultMessage: "Personal Information",
+            id: "7qR4UK",
             description:
               "Title for Personal Information section of the About Me form",
           })}
@@ -179,6 +185,7 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
           {intl.formatMessage({
             defaultMessage:
               "This additional personal information will be used only for communication purposes.",
+            id: "JjPpGt",
             description:
               "Description for Personal Information section of the About Me form",
           })}
@@ -189,6 +196,7 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
               idPrefix="required-lang-preferences"
               legend={intl.formatMessage({
                 defaultMessage: "Language preference for communication",
+                id: "D8IMp7",
                 description:
                   "Legend text for required language preference in About Me form",
               })}
@@ -204,11 +212,13 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
               name="currentProvince"
               label={intl.formatMessage({
                 defaultMessage: "Current province or territory",
+                id: "r4PFx0",
                 description:
                   "Label for current province or territory field in About Me form",
               })}
               nullSelection={intl.formatMessage({
                 defaultMessage: "Select a province or territory...",
+                id: "M6PbPI",
                 description:
                   "Placeholder displayed on the About Me form province or territory field.",
               })}
@@ -226,10 +236,12 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
               type="text"
               label={intl.formatMessage({
                 defaultMessage: "Current city",
+                id: "de/Vcy",
                 description: "Label for current city field in About Me form",
               })}
               placeholder={intl.formatMessage({
                 defaultMessage: "Start writing here...",
+                id: "xq6TbG",
                 description:
                   "Placeholder displayed on the About Me form current city field.",
               })}
@@ -243,10 +255,12 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
               type="tel"
               label={intl.formatMessage({
                 defaultMessage: "Telephone",
+                id: "gBWsuB",
                 description: "Label for telephone field in About Me form",
               })}
               placeholder={intl.formatMessage({
                 defaultMessage: "+123243234",
+                id: "FmN1eN",
                 description:
                   "Placeholder displayed on the About Me form telephone field.",
               })}
@@ -258,6 +272,7 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
               idPrefix="armedForcesStatus"
               legend={intl.formatMessage({
                 defaultMessage: "Member of the Canadian Armed Forces (CAF)",
+                id: "DZwVvi",
                 description:
                   "Legend text for required Canadian Armed Forces selection in About Me form",
               })}
@@ -275,6 +290,7 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
                 idPrefix="citizenship"
                 legend={intl.formatMessage({
                   defaultMessage: "Citizenship Status",
+                  id: "o5pks7",
                   description:
                     "Legend text for required citizenship status in About Me form",
                 })}
@@ -289,6 +305,7 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
                 context={intl.formatMessage({
                   defaultMessage:
                     "Preference will be given to Canadian citizens and permanent residents of Canada",
+                  id: "fI6Hjf",
                   description:
                     "Context text for required citizenship status section in About Me form, explaining preference",
                 })}
@@ -303,6 +320,7 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
         >
           {intl.formatMessage({
             defaultMessage: "Account Details",
+            id: "GqVBqi",
             description:
               "Title for Account Details section of the About Me form",
           })}
@@ -311,6 +329,7 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
           {intl.formatMessage({
             defaultMessage:
               "This information is used to manage your account and to communicate.",
+            id: "ghmTOo",
             description:
               "Description for Account Details section of the About Me form",
           })}
@@ -323,6 +342,7 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
               type="text"
               label={intl.formatMessage({
                 defaultMessage: "First Name and Middle Name",
+                id: "g097KT",
                 description:
                   "Label for first and middle name field in About Me form",
               })}
@@ -336,6 +356,7 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
               type="text"
               label={intl.formatMessage({
                 defaultMessage: "Last Name(s)",
+                id: "rGNWy6",
                 description: "Label for last name field in About Me form",
               })}
               rules={{
@@ -348,6 +369,7 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
               type="email"
               label={intl.formatMessage({
                 defaultMessage: "Email",
+                id: "i5xxbe",
                 description: "Label for email field in About Me form",
               })}
               rules={{

--- a/frontend/talentsearch/src/js/components/applicantProfile/CancelButton.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/CancelButton.tsx
@@ -28,6 +28,7 @@ const CancelButton = ({ href, children }: CancelButtonProps) => {
         {children ||
           intl.formatMessage({
             defaultMessage: "Cancel and go back",
+            id: "rMYmPd",
             description: "Label for cancel button on profile form.",
           })}
       </span>

--- a/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormWrapper.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormWrapper.tsx
@@ -30,6 +30,7 @@ const ProfileFormWrapper: React.FunctionComponent<ProfileFormWrapperProps> = ({
       {
         title: intl.formatMessage({
           defaultMessage: "My Profile",
+          id: "tlsomU",
           description: "Breadcrumb from applicant profile wrapper.",
         }),
         href: profilePath.myProfile(),

--- a/frontend/talentsearch/src/js/components/applicantProfile/SaveButton.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/SaveButton.tsx
@@ -17,6 +17,7 @@ const SaveButton: React.FunctionComponent = () => {
           <span data-h2-margin="base(auto, auto, auto, x.125)">
             {intl.formatMessage({
               defaultMessage: "Save and go back",
+              id: "CuHYqt",
               description: "Text for save button on profile form.",
             })}
           </span>
@@ -28,6 +29,7 @@ const SaveButton: React.FunctionComponent = () => {
           <span data-h2-margin="base(auto, auto, auto, x.125)">
             {intl.formatMessage({
               defaultMessage: "Saving...",
+              id: "lai6E5",
               description: "Submitting text for save button on profile form.",
             })}
           </span>
@@ -39,6 +41,7 @@ const SaveButton: React.FunctionComponent = () => {
           <span data-h2-margin="base(auto, auto, auto, x.125)">
             {intl.formatMessage({
               defaultMessage: "Saved",
+              id: "TV4UWm",
               description: "Submitted text for save button on profile form.",
             })}
           </span>

--- a/frontend/talentsearch/src/js/components/applications/ApplicationActions.tsx
+++ b/frontend/talentsearch/src/js/components/applications/ApplicationActions.tsx
@@ -40,6 +40,7 @@ const ContinueAction = ({ show, application }: ContinueActionProps) => {
       {intl.formatMessage(
         {
           defaultMessage: "Continue my application<hidden> {name}</hidden>",
+          id: "60Ee78",
           description: "Link text to continue a specific application",
         },
         {
@@ -73,6 +74,7 @@ const SeeAdvertisementAction = ({
       {intl.formatMessage(
         {
           defaultMessage: "See advertisement<hidden> {name}</hidden>",
+          id: "HXNJ6Z",
           description: "Link text to see an applications advertisement",
         },
         {
@@ -106,6 +108,7 @@ const DeleteAction = ({ show, application }: DeleteActionProps) => {
         toast.success(
           intl.formatMessage({
             defaultMessage: "Application deleted successfully!",
+            id: "xdGPxT",
             description:
               "Message displayed to user after application is deleted successfully.",
           }),
@@ -114,6 +117,7 @@ const DeleteAction = ({ show, application }: DeleteActionProps) => {
         toast.error(
           intl.formatMessage({
             defaultMessage: "Error: deleting application failed",
+            id: "M3c9Yo",
             description:
               "Message displayed to user after application fails to get deleted.",
           }),
@@ -136,6 +140,7 @@ const DeleteAction = ({ show, application }: DeleteActionProps) => {
         {intl.formatMessage(
           {
             defaultMessage: "Delete<hidden> application {name}</hidden>",
+            id: "1lmME7",
             description: "Link text to continue a specific application",
           },
           {
@@ -150,6 +155,7 @@ const DeleteAction = ({ show, application }: DeleteActionProps) => {
         title={intl.formatMessage(
           {
             defaultMessage: "Delete Application",
+            id: "FFD16/",
             description:
               "Title for the modal that appears when a user attempts to delete an application",
           },
@@ -161,6 +167,7 @@ const DeleteAction = ({ show, application }: DeleteActionProps) => {
             {
               defaultMessage:
                 "Are you sure you would like to delete application {name}?",
+              id: "5pZFQ3",
               description:
                 "Question displayed when user attempts to delete an application",
             },
@@ -177,6 +184,7 @@ const DeleteAction = ({ show, application }: DeleteActionProps) => {
           >
             {intl.formatMessage({
               defaultMessage: "Cancel",
+              id: "/JLaO5",
               description: "Link text to cancel deleting application.",
             })}
           </Button>
@@ -184,6 +192,7 @@ const DeleteAction = ({ show, application }: DeleteActionProps) => {
             <Button mode="solid" color="cta" type="button" onClick={onDelete}>
               {intl.formatMessage({
                 defaultMessage: "Delete",
+                id: "IUQGA0",
                 description: "Link text to delete.",
               })}
             </Button>
@@ -215,6 +224,7 @@ const ArchiveAction = ({ show, application }: ArchiveActionProps) => {
         toast.success(
           intl.formatMessage({
             defaultMessage: "Application archived successfully!",
+            id: "KEhCJX",
             description:
               "Message displayed to user after application is archived successfully.",
           }),
@@ -223,6 +233,7 @@ const ArchiveAction = ({ show, application }: ArchiveActionProps) => {
         toast.error(
           intl.formatMessage({
             defaultMessage: "Error: archiving application failed",
+            id: "i3IjQt",
             description:
               "Message displayed to user after application fails to get archived.",
           }),
@@ -245,6 +256,7 @@ const ArchiveAction = ({ show, application }: ArchiveActionProps) => {
         {intl.formatMessage(
           {
             defaultMessage: "Archive<hidden> application {name}</hidden>",
+            id: "6B7e8/",
             description: "Link text to continue a specific application",
           },
           {
@@ -258,6 +270,7 @@ const ArchiveAction = ({ show, application }: ArchiveActionProps) => {
         onDismiss={onDismiss}
         title={intl.formatMessage({
           defaultMessage: "Archive Application",
+          id: "yiJYdP",
           description:
             "Title for the modal that appears when a user attempts to archive an application",
         })}
@@ -267,6 +280,7 @@ const ArchiveAction = ({ show, application }: ArchiveActionProps) => {
             {
               defaultMessage:
                 "Are you sure you would like to archive application {name}?",
+              id: "Z0PCOW",
               description:
                 "Question displayed when user attempts to archive an application",
             },
@@ -283,6 +297,7 @@ const ArchiveAction = ({ show, application }: ArchiveActionProps) => {
           >
             {intl.formatMessage({
               defaultMessage: "Cancel",
+              id: "r6DZ71",
               description: "Link text to cancel archiving application.",
             })}
           </Button>
@@ -290,6 +305,7 @@ const ArchiveAction = ({ show, application }: ArchiveActionProps) => {
             <Button mode="solid" color="cta" type="button" onClick={onArchive}>
               {intl.formatMessage({
                 defaultMessage: "Archive",
+                id: "PXfQOZ",
                 description: "Link text to archive application.",
               })}
             </Button>

--- a/frontend/talentsearch/src/js/components/applications/ApplicationCard.tsx
+++ b/frontend/talentsearch/src/js/components/applications/ApplicationCard.tsx
@@ -94,6 +94,7 @@ const ApplicationCard = ({ application }: ApplicationCardProps) => {
             {intl.formatMessage(
               {
                 defaultMessage: "ID: {id}",
+                id: "hEXXG0",
                 description: "Label for application ID",
               },
               {

--- a/frontend/talentsearch/src/js/components/applications/ArchivedApplications.tsx
+++ b/frontend/talentsearch/src/js/components/applications/ArchivedApplications.tsx
@@ -25,6 +25,7 @@ const ArchivedApplications = ({ applications }: ArchivedApplicationsProps) => {
         <h2>
           {intl.formatMessage({
             defaultMessage: "Archived Applications",
+            id: "D0bpvq",
             description: "Title for a users archived applications",
           })}
         </h2>
@@ -38,11 +39,13 @@ const ArchivedApplications = ({ applications }: ArchivedApplicationsProps) => {
           {isOpen
             ? intl.formatMessage({
                 defaultMessage: "Hide archived applications",
+                id: "sOmB9g",
                 description:
                   "Button text to hide a users archived applications.",
               })
             : intl.formatMessage({
                 defaultMessage: "Show archived applications",
+                id: "da8nDk",
                 description:
                   "Button text to show a users archived applications.",
               })}
@@ -63,6 +66,7 @@ const ArchivedApplications = ({ applications }: ArchivedApplicationsProps) => {
           <p>
             {intl.formatMessage({
               defaultMessage: "You currently have no archived applications.",
+              id: "Vfxtz/",
               description:
                 "Messaged displayed when a user has no archived applications.",
             })}

--- a/frontend/talentsearch/src/js/components/applications/MyApplicationsPage.tsx
+++ b/frontend/talentsearch/src/js/components/applications/MyApplicationsPage.tsx
@@ -61,6 +61,7 @@ export const MyApplications = ({ applications }: MyApplicationsProps) => {
         >
           {intl.formatMessage({
             defaultMessage: "My Applications",
+            id: "Boze7x",
             description:
               "Title for page that displays current users applications.",
           })}
@@ -85,6 +86,7 @@ export const MyApplications = ({ applications }: MyApplicationsProps) => {
             <p>
               {intl.formatMessage({
                 defaultMessage: "You currently have no applications.",
+                id: "rw05Jq",
                 description:
                   "Messaged displayed when a user has no applications.",
               })}
@@ -112,6 +114,7 @@ const MyApplicationsPage = () => {
         <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
           {intl.formatMessage({
             defaultMessage: "Error, applications unable to be loaded",
+            id: "Q7yh4j",
             description: "My applications error message, placeholder",
           })}
         </NotFound>

--- a/frontend/talentsearch/src/js/components/awardDetailsForm/AwardDetailsForm.tsx
+++ b/frontend/talentsearch/src/js/components/awardDetailsForm/AwardDetailsForm.tsx
@@ -18,6 +18,7 @@ export const AwardDetailsForm: React.FunctionComponent = () => {
       <h2 data-h2-font-size="base(h3, 1)" data-h2-margin="base(x2, 0, x1, 0)">
         {intl.formatMessage({
           defaultMessage: "1. Award Details",
+          id: "i55f5L",
           description: "Title for Award Details Form",
         })}
       </h2>
@@ -25,6 +26,7 @@ export const AwardDetailsForm: React.FunctionComponent = () => {
         {intl.formatMessage({
           defaultMessage:
             "Did you get recognized for going above and beyond? There are many ways to get recognized, awards are just one of them.",
+          id: "a6c/ce",
           description: "Description blurb for Award Details Form",
         })}
       </p>
@@ -35,11 +37,13 @@ export const AwardDetailsForm: React.FunctionComponent = () => {
               id="awardTitle"
               label={intl.formatMessage({
                 defaultMessage: "Award Title",
+                id: "qeD2p/",
                 description:
                   "Label displayed on award form for award title input",
               })}
               placeholder={intl.formatMessage({
                 defaultMessage: "Write award title here...",
+                id: "9ttiBB",
                 description: "Placeholder for award title input",
               })}
               name="awardTitle"
@@ -52,6 +56,7 @@ export const AwardDetailsForm: React.FunctionComponent = () => {
               id="awardedDate"
               label={intl.formatMessage({
                 defaultMessage: "Date Awarded",
+                id: "5CONbw",
                 description:
                   "Label displayed on award form for date awarded input",
               })}
@@ -65,12 +70,14 @@ export const AwardDetailsForm: React.FunctionComponent = () => {
               id="awardedTo"
               label={intl.formatMessage({
                 defaultMessage: "Awarded to",
+                id: "0H0CLx",
                 description:
                   "Label displayed on Award form for awarded to input",
               })}
               name="awardedTo"
               nullSelection={intl.formatMessage({
                 defaultMessage: "Choose one...",
+                id: "WjssQc",
                 description:
                   "Null selection for select input in the awarded to form.",
               })}
@@ -93,11 +100,13 @@ export const AwardDetailsForm: React.FunctionComponent = () => {
               id="issuedBy"
               label={intl.formatMessage({
                 defaultMessage: "Issuing Organization or Institution",
+                id: "YJdsMY",
                 description:
                   "Label displayed on award form for issuing organization input",
               })}
               placeholder={intl.formatMessage({
                 defaultMessage: "Write name here...",
+                id: "TSqr8X",
                 description: "Placeholder for issuing organization input",
               })}
               name="issuedBy"
@@ -110,12 +119,14 @@ export const AwardDetailsForm: React.FunctionComponent = () => {
               id="awardedScope"
               label={intl.formatMessage({
                 defaultMessage: "Award Scope",
+                id: "DyaaHi",
                 description:
                   "Label displayed on Award form for award scope input",
               })}
               name="awardedScope"
               nullSelection={intl.formatMessage({
                 defaultMessage: "Choose one...",
+                id: "sIM1t+",
                 description:
                   "Null selection for select input in the award scope form.",
               })}

--- a/frontend/talentsearch/src/js/components/browse/BrowseIndividualPool.tsx
+++ b/frontend/talentsearch/src/js/components/browse/BrowseIndividualPool.tsx
@@ -26,6 +26,7 @@ const BrowseIndividualPool: React.FC<BrowseIndividualPoolProps> = ({
     {
       title: intl.formatMessage({
         defaultMessage: "Pools Index",
+        id: "tf/wEc",
         description: "Breadcrumb title for the pools index link.",
       }),
       href: paths.home(),
@@ -48,6 +49,7 @@ const BrowseIndividualPool: React.FC<BrowseIndividualPoolProps> = ({
       >
         {intl.formatMessage({
           defaultMessage: "Apply",
+          id: "mMGycA",
           description: "Apply label for button to apply to pool",
         })}
       </Link>
@@ -69,6 +71,7 @@ const BrowseIndividualPoolApi: React.FC<{ poolId: string }> = ({ poolId }) => {
         <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
           {intl.formatMessage({
             defaultMessage: "Error, pool unable to be loaded",
+            id: "DcEinN",
             description: "Error message, placeholder",
           })}
         </NotFound>

--- a/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.tsx
+++ b/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.tsx
@@ -22,6 +22,7 @@ const BrowsePools: React.FC<BrowsePoolsProps> = ({ pools }) => {
       <h1>
         {intl.formatMessage({
           defaultMessage: "Browse Pools",
+          id: "oG9dAi",
           description: "Page title for the direct intake browse pools page.",
         })}
       </h1>
@@ -40,6 +41,7 @@ const BrowsePools: React.FC<BrowsePoolsProps> = ({ pools }) => {
           <p>
             {intl.formatMessage({
               defaultMessage: "No pools found.",
+              id: "mW0/n1",
               description:
                 "Message displayed on the browse pools direct intake page when there are no pools.",
             })}

--- a/frontend/talentsearch/src/js/components/communityExperienceForm/CommunityExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/communityExperienceForm/CommunityExperienceForm.tsx
@@ -18,6 +18,7 @@ export const CommunityExperienceForm: React.FunctionComponent = () => {
       <h2 data-h2-font-size="base(h3, 1)" data-h2-margin="base(x2, 0, x1, 0)">
         {intl.formatMessage({
           defaultMessage: "1. Community Experience Details",
+          id: "OUKOBH",
           description: "Title for Community Experience form",
         })}
       </h2>
@@ -25,6 +26,7 @@ export const CommunityExperienceForm: React.FunctionComponent = () => {
         {intl.formatMessage({
           defaultMessage:
             "Gained experience by being part of or giving back to a community? People learn skills from a wide range of experiences like volunteering or being part of non-profit organizations, indigenous communities, or virtual collaborations.",
+          id: "gDQZIQ",
           description: "Description blurb for Community Experience form",
         })}
       </p>
@@ -35,11 +37,13 @@ export const CommunityExperienceForm: React.FunctionComponent = () => {
               id="role"
               label={intl.formatMessage({
                 defaultMessage: "My Role / Job Title",
+                id: "tyPFpt",
                 description:
                   "Label displayed on Community Experience form for role input",
               })}
               placeholder={intl.formatMessage({
                 defaultMessage: "Write title here...",
+                id: "5ikciS",
                 description:
                   "Placeholder displayed on the Community Experience form for role input",
               })}
@@ -54,12 +58,14 @@ export const CommunityExperienceForm: React.FunctionComponent = () => {
                 boundingBox
                 boundingBoxLabel={intl.formatMessage({
                   defaultMessage: "Current Role",
+                  id: "yfVLxM",
                   description:
                     "Label displayed on Community Experience form for current role bounded box",
                 })}
                 id="currentRole"
                 label={intl.formatMessage({
                   defaultMessage: "I am currently active in this role",
+                  id: "wASF5V",
                   description:
                     "Label displayed on Community Experience form for current role input",
                 })}
@@ -72,11 +78,13 @@ export const CommunityExperienceForm: React.FunctionComponent = () => {
               id="organization"
               label={intl.formatMessage({
                 defaultMessage: "Group / Organization / Community",
+                id: "Badvbb",
                 description:
                   "Label displayed on Community Experience form for organization input",
               })}
               placeholder={intl.formatMessage({
                 defaultMessage: "Write group name here...",
+                id: "EfR7Rv",
                 description:
                   "Placeholder displayed on the Community Experience form for organization input",
               })}
@@ -92,6 +100,7 @@ export const CommunityExperienceForm: React.FunctionComponent = () => {
                   id="startDate"
                   label={intl.formatMessage({
                     defaultMessage: "Start Date",
+                    id: "lRuuJ3",
                     description:
                       "Label displayed on Community Experience form for start date input",
                   })}
@@ -109,6 +118,7 @@ export const CommunityExperienceForm: React.FunctionComponent = () => {
                     id="endDate"
                     label={intl.formatMessage({
                       defaultMessage: "End Date",
+                      id: "p39ofW",
                       description:
                         "Label displayed on Community Experience form for end date input",
                     })}
@@ -142,11 +152,13 @@ export const CommunityExperienceForm: React.FunctionComponent = () => {
               id="project"
               label={intl.formatMessage({
                 defaultMessage: "Project / Product",
+                id: "0RlNw7",
                 description:
                   "Label displayed on Community Experience form for project input",
               })}
               placeholder={intl.formatMessage({
                 defaultMessage: "Write project name here...",
+                id: "81ITk+",
                 description:
                   "Placeholder displayed on the Community Experience form for project input",
               })}

--- a/frontend/talentsearch/src/js/components/createAccount/CreateAccountPage.tsx
+++ b/frontend/talentsearch/src/js/components/createAccount/CreateAccountPage.tsx
@@ -98,6 +98,7 @@ export const CreateAccountForm: React.FunctionComponent<
         >
           {intl.formatMessage({
             defaultMessage: "Welcome to Digital Talent",
+            id: "0m7BIV",
             description:
               "Title for the create account page for applicant profiles.",
           })}
@@ -111,12 +112,14 @@ export const CreateAccountForm: React.FunctionComponent<
         <Alert
           title={intl.formatMessage({
             defaultMessage: "You’ve successfully logged in",
+            id: "4FEV7d",
             description:
               "Title for successful login alert in create account page.",
           })}
           message={intl.formatMessage({
             defaultMessage:
               "Welcome to the Digital Talent platform. Moving forward, you can log into your profile using the same GC Key username and password.",
+            id: "0O/eV0",
             description:
               "Message for successful login alert in create account page.",
           })}
@@ -129,6 +132,7 @@ export const CreateAccountForm: React.FunctionComponent<
             <h2 data-h2-margin="base(x2, 0, x1, 0)">
               {intl.formatMessage({
                 defaultMessage: "Getting started",
+                id: "o/YTo0",
                 description: "Main heading in create account page.",
               })}
             </h2>
@@ -136,6 +140,7 @@ export const CreateAccountForm: React.FunctionComponent<
               {intl.formatMessage({
                 defaultMessage:
                   "Before we take you to your profile, we need to collect some required information to complete your account set up. ",
+                id: "bYg+MM",
                 description:
                   "Message after main heading in create account page.",
               })}
@@ -152,11 +157,13 @@ export const CreateAccountForm: React.FunctionComponent<
                     type="text"
                     label={intl.formatMessage({
                       defaultMessage: "Given name(s)",
+                      id: "WpRB7Z",
                       description:
                         "Label displayed for the first name field in create account form.",
                     })}
                     placeholder={intl.formatMessage({
                       defaultMessage: "e.g. Thomas",
+                      id: "H1J8wl",
                       description:
                         "Placeholder displayed for the first name field in create account form.",
                     })}
@@ -172,11 +179,13 @@ export const CreateAccountForm: React.FunctionComponent<
                     type="text"
                     label={intl.formatMessage({
                       defaultMessage: "Surname(s)",
+                      id: "h9q52R",
                       description:
                         "Label displayed for the last name field in create account form.",
                     })}
                     placeholder={intl.formatMessage({
                       defaultMessage: "e.g. Edison",
+                      id: "X9IdZQ",
                       description:
                         "Placeholder displayed for the first name field in create account form.",
                     })}
@@ -194,11 +203,13 @@ export const CreateAccountForm: React.FunctionComponent<
                   label={intl.formatMessage({
                     defaultMessage:
                       "Which email do you like to be contacted at?",
+                    id: "MTwQ3S",
                     description:
                       "Label displayed for the email field in create account form.",
                   })}
                   placeholder={intl.formatMessage({
                     defaultMessage: "e.g. thomas.edison@example.com",
+                    id: "UIkTbl",
                     description:
                       "Placeholder displayed for the first name field in create account form.",
                   })}
@@ -211,6 +222,7 @@ export const CreateAccountForm: React.FunctionComponent<
                 idPrefix="required-lang-preferences"
                 legend={intl.formatMessage({
                   defaultMessage: "What is your preferred contact language?",
+                  id: "0ScnOT",
                   description:
                     "Legend text for required language preference in create account form",
                 })}
@@ -226,6 +238,7 @@ export const CreateAccountForm: React.FunctionComponent<
                 {intl.formatMessage({
                   defaultMessage:
                     "Below we’d like to know if you’re already an employee with the Government of Canada. We collect this information because it helps us understand, at an aggregate level, how digital skills are distributed amongst departments.",
+                  id: "XijxiY",
                   description:
                     "First message before is a government of canada radio group in create account form.",
                 })}
@@ -234,6 +247,7 @@ export const CreateAccountForm: React.FunctionComponent<
                 {intl.formatMessage({
                   defaultMessage:
                     "We also use this information to provide you with more contextualized opportunities and suggestions based on your employment status.",
+                  id: "5U4C61",
                   description:
                     "Second message before is a government of canada radio group in create account form.",
                 })}
@@ -258,6 +272,7 @@ export const CreateAccountForm: React.FunctionComponent<
                   color="primary"
                   text={intl.formatMessage({
                     defaultMessage: "Save and go to my profile",
+                    id: "H3Za3e",
                     description:
                       "Button label for submit button on create account form.",
                   })}
@@ -302,6 +317,7 @@ const CreateAccount: React.FunctionComponent = () => {
       toast.error(
         intl.formatMessage({
           defaultMessage: "Error: user not found",
+          id: "4bjh8X",
           description: "Message displayed to user if user is not found",
         }),
       );
@@ -313,6 +329,7 @@ const CreateAccount: React.FunctionComponent = () => {
         toast.success(
           intl.formatMessage({
             defaultMessage: "Account successfully created.",
+            id: "DK870a",
             description:
               "Message displayed to user if account is created successfully.",
           }),
@@ -322,6 +339,7 @@ const CreateAccount: React.FunctionComponent = () => {
         toast.error(
           intl.formatMessage({
             defaultMessage: "Error: creating account failed.",
+            id: "BruLeg",
             description:
               "Message displayed to user if account fails to get updated.",
           }),

--- a/frontend/talentsearch/src/js/components/educationExperienceForm/EducationExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/educationExperienceForm/EducationExperienceForm.tsx
@@ -24,6 +24,7 @@ export const EducationExperienceForm: React.FunctionComponent = () => {
       <h2 data-h2-font-size="base(h3, 1)" data-h2-margin="base(x2, 0, x1, 0)">
         {intl.formatMessage({
           defaultMessage: "1. Education Details",
+          id: "W7LpsW",
           description: "Title for Education Details Form",
         })}
       </h2>
@@ -31,6 +32,7 @@ export const EducationExperienceForm: React.FunctionComponent = () => {
         {intl.formatMessage({
           defaultMessage:
             "Got credentials? Share your degree, certificates, online courses, trade apprenticeship, licences or alternative credentials. If you've learned something from a recognized educational provider, include your experiences here.",
+          id: "7inIW/",
           description: "Description blurb for Education Details Form",
         })}
       </p>
@@ -41,12 +43,14 @@ export const EducationExperienceForm: React.FunctionComponent = () => {
               id="educationType"
               label={intl.formatMessage({
                 defaultMessage: "Type of Education",
+                id: "elFbzT",
                 description:
                   "Label displayed on Education form for education type input",
               })}
               name="educationType"
               nullSelection={intl.formatMessage({
                 defaultMessage: "Choose one...",
+                id: "3YyYDt",
                 description:
                   "Null selection for select education type in the education form.",
               })}
@@ -75,11 +79,13 @@ export const EducationExperienceForm: React.FunctionComponent = () => {
                 boundingBox
                 boundingBoxLabel={intl.formatMessage({
                   defaultMessage: "Current Education",
+                  id: "aDRIDD",
                   description:
                     "Label displayed on Education Experience form for current education bounded box",
                 })}
                 label={intl.formatMessage({
                   defaultMessage: "I am currently active in this education",
+                  id: "491LrZ",
                   description:
                     "Label displayed on Education Experience form for current education input",
                 })}
@@ -92,11 +98,13 @@ export const EducationExperienceForm: React.FunctionComponent = () => {
               id="areaOfStudy"
               label={intl.formatMessage({
                 defaultMessage: "Area of study",
+                id: "nzw1ry",
                 description:
                   "Label displayed on education form for area of study input",
               })}
               placeholder={intl.formatMessage({
                 defaultMessage: "Write area of study here...",
+                id: "Uv9q53",
                 description: "Placeholder for area of study input",
               })}
               name="areaOfStudy"
@@ -111,6 +119,7 @@ export const EducationExperienceForm: React.FunctionComponent = () => {
                   id="startDate"
                   label={intl.formatMessage({
                     defaultMessage: "Start Date",
+                    id: "/sQHOb",
                     description:
                       "Label displayed on Education Experience form for start date input",
                   })}
@@ -127,6 +136,7 @@ export const EducationExperienceForm: React.FunctionComponent = () => {
                     id="endDate"
                     label={intl.formatMessage({
                       defaultMessage: "End Date",
+                      id: "Nqwbu3",
                       description:
                         "Label displayed on Education Experience form for end date input",
                     })}
@@ -158,11 +168,13 @@ export const EducationExperienceForm: React.FunctionComponent = () => {
               id="institution"
               label={intl.formatMessage({
                 defaultMessage: "Institution",
+                id: "o0Yt8Q",
                 description:
                   "Label displayed on education form for institution input",
               })}
               placeholder={intl.formatMessage({
                 defaultMessage: "Write name here...",
+                id: "EHOcOR",
                 description: "Placeholder for institution input",
               })}
               name="institution"
@@ -175,12 +187,14 @@ export const EducationExperienceForm: React.FunctionComponent = () => {
               id="educationStatus"
               label={intl.formatMessage({
                 defaultMessage: "Status",
+                id: "OQhL7A",
                 description:
                   "Label displayed on Education form for status input",
               })}
               name="educationStatus"
               nullSelection={intl.formatMessage({
                 defaultMessage: "Choose one...",
+                id: "wwiDm1",
                 description:
                   "Null selection for select status in the education form.",
               })}
@@ -204,11 +218,13 @@ export const EducationExperienceForm: React.FunctionComponent = () => {
               id="thesisTitle"
               label={intl.formatMessage({
                 defaultMessage: "Thesis Title",
+                id: "N87bC7",
                 description:
                   "Label displayed on education form for thesis title input",
               })}
               placeholder={intl.formatMessage({
                 defaultMessage: "Write title here...",
+                id: "8THvSC",
                 description: "Placeholder for thesis title input",
               })}
               name="thesisTitle"

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/EmploymentEquityForm.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/EmploymentEquityForm.tsx
@@ -45,6 +45,7 @@ export const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
         {
           title: intl.formatMessage({
             defaultMessage: "My Applications",
+            id: "mq4G8h",
             description:
               "'My Applications' breadcrumb from applicant profile wrapper.",
           }),
@@ -56,6 +57,7 @@ export const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
             application.poolAdvertisement?.name?.[locale] ||
             intl.formatMessage({
               defaultMessage: "Pool name not found",
+              id: "FmD1sL",
               description:
                 "Pools name breadcrumb from applicant profile wrapper if no name set.",
             }),
@@ -69,11 +71,13 @@ export const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
       description={intl.formatMessage({
         defaultMessage:
           "The Employment Equity Act of Canada (1995) identifies four groups who have experienced systemic employment barriers, and a number of obligations for the Government of Canada in addressing these barriers.",
+        id: "Or11km",
         description:
           "Description text for Profile Form wrapper in DiversityEquityInclusionForm",
       })}
       title={intl.formatMessage({
         defaultMessage: "Diversity, equity and inclusion",
+        id: "TfoHYi",
         description:
           "Title for Profile Form wrapper  in DiversityEquityInclusionForm",
       })}
@@ -82,6 +86,7 @@ export const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
         {
           title: intl.formatMessage({
             defaultMessage: "Diversity, equity and inclusion",
+            id: "pGTTrp",
             description:
               "Display Text for Diversity, equity and inclusion Page",
           }),
@@ -101,6 +106,7 @@ export const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "While the language around these categories is in need of updating, the Government of Canada will sometimes use these categories in hiring to make sure that it is meeting the aims of employment equity.",
+          id: "usb0gM",
           description:
             "Description of how the Government of Canada uses employment equity categories in hiring.",
         })}
@@ -109,6 +115,7 @@ export const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
         {intl.formatMessage({
           defaultMessage:
             'These four groups are "women, Aboriginal peoples, persons with disabilities, and members of visible minorities."',
+          id: "uQYCfd",
           description: "List of the employment equity categories",
         })}
       </p>
@@ -122,6 +129,7 @@ export const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
           {intl.formatMessage({
             defaultMessage:
               "<strong>This section is optional</strong>. If you are a member of one or more of these employment equity groups, and you do not wish to self identify on this platform, there is no obligation to do so. <strong>Complete the form below if you meet both of these conditions</strong>:",
+            id: "zHaQlT",
             description:
               "Explanation that employment equity information is optional.",
           })}
@@ -131,6 +139,7 @@ export const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
             {intl.formatMessage({
               defaultMessage:
                 "You are a member of one or more of these employment equity groups.",
+              id: "6cYs7i",
               description:
                 "Instruction on when to fill out equity information, item one",
             })}
@@ -139,6 +148,7 @@ export const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
             {intl.formatMessage({
               defaultMessage:
                 "You would like to be considered for opportunities addressed to  underrepresented groups.",
+              id: "WZwXDb",
               description:
                 "Instruction on when to fill out equity information, item two",
             })}
@@ -148,6 +158,7 @@ export const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
       <h2 data-h2-font-size="base(h5, 1)" data-h2-margin="base(x2, 0, x1, 0)">
         {intl.formatMessage({
           defaultMessage: "How will this data be used?",
+          id: "ttRVSp",
           description:
             "Heading for how employment equity information will be used.",
         })}
@@ -157,6 +168,7 @@ export const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
           {intl.formatMessage({
             defaultMessage:
               "This information will be shared with hiring managers.",
+            id: "dh2xc5",
             description:
               "Explanation on how employment equity information will be used, item one",
           })}
@@ -165,6 +177,7 @@ export const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
           {intl.formatMessage({
             defaultMessage:
               "This information will be used to match you to prioritized jobs.",
+            id: "zqBqj1",
             description:
               "Explanation on how employment equity information will be used, item two",
           })}
@@ -173,6 +186,7 @@ export const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
           {intl.formatMessage({
             defaultMessage:
               "This information will be used in an anonymous form for statistical purposes.",
+            id: "QpfFEG",
             description:
               "Explanation on how employment equity information will be used, item three",
           })}

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/EquityOption.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/EquityOption.tsx
@@ -20,6 +20,7 @@ const EquityOption: React.FC<EquityOptionProps> = ({
   const removeText = intl.formatMessage(
     {
       defaultMessage: "Remove <hidden>{title} </hidden>from profile",
+      id: "OQ+K+X",
       description:
         "Text label for button to remove employment equity category from profile.",
     },
@@ -31,6 +32,7 @@ const EquityOption: React.FC<EquityOptionProps> = ({
   const addText = intl.formatMessage(
     {
       defaultMessage: "Add <hidden>{title} </hidden>to profile",
+      id: "/AJCvK",
       description:
         "Text label for button to add employment equity category to profile.",
     },

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/EquityOptions.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/EquityOptions.tsx
@@ -89,6 +89,7 @@ const EquityOptions: React.FC<EquityOptionsProps> = ({
             >
               {intl.formatMessage({
                 defaultMessage: "My employment equity information:",
+                id: "Q96xMb",
                 description:
                   "Heading for employment equity categories added to user profile.",
               })}
@@ -145,6 +146,7 @@ const EquityOptions: React.FC<EquityOptionsProps> = ({
                   {intl.formatMessage({
                     defaultMessage:
                       "You have not added any employment equity options to your profile.",
+                    id: "fK7jxe",
                     description:
                       "Message displayed when a user has no employment equity information.",
                   })}
@@ -159,6 +161,7 @@ const EquityOptions: React.FC<EquityOptionsProps> = ({
             >
               {intl.formatMessage({
                 defaultMessage: "Employment equity options:",
+                id: "TuhgU0",
                 description:
                   "Heading for employment equity categories available to be added to user profile.",
               })}
@@ -215,6 +218,7 @@ const EquityOptions: React.FC<EquityOptionsProps> = ({
                   {intl.formatMessage({
                     defaultMessage:
                       "There are no available employment equity options.",
+                    id: "px7yu1",
                     description:
                       "Message displayed when there are no employment equity categories available to be added.",
                   })}

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/AddToProfile.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/AddToProfile.tsx
@@ -9,6 +9,7 @@ const AddToProfile: React.FC = () => {
       {intl.formatMessage({
         defaultMessage:
           "Based on this definition, I want to add the following to my profile:",
+        id: "DDwQg5",
         description: "Text that appears before employment equity form options.",
       })}
     </p>

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/Definition.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/Definition.tsx
@@ -22,6 +22,7 @@ const Definition: React.FC<DefinitionProps> = ({ url }) => {
         {
           defaultMessage:
             "According to <link>Statistics Canada's definition.</link>",
+          id: "z44LTK",
           description:
             "Link to Statistics Canada's employment equity definitions",
         },

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/DialogFooter.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/DialogFooter.tsx
@@ -24,6 +24,7 @@ const DialogFooter: React.FC<DialogFooterProps> = ({ onDismiss }) => {
           <span>
             {intl.formatMessage({
               defaultMessage: "Save and go back",
+              id: "t12bCU",
               description: "Button text to submit employment equity form.",
             })}
           </span>
@@ -38,6 +39,7 @@ const DialogFooter: React.FC<DialogFooterProps> = ({ onDismiss }) => {
         >
           {intl.formatMessage({
             defaultMessage: "Cancel",
+            id: "LjE48l",
             description: "Button text to close employment equity form.",
           })}
         </Button>

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/DisabilityDialog.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/DisabilityDialog.tsx
@@ -83,6 +83,7 @@ const DisabilityDialog: React.FC<EquityDialogProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "Refers to a person whose daily activities are limited as a result of an impairment or difficulty with particular tasks. The only exception to this is for developmental disabilities where a person is considered to be disabled if the respondent has been diagnosed with this condition.",
+          id: "hz8OYx",
           description:
             "Definition of accepted ways to identify as person with a disability.",
         })}

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/IndigenousDialog.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/IndigenousDialog.tsx
@@ -83,6 +83,7 @@ const IndigenousDialog: React.FC<EquityDialogProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "Indigenous identity refers to whether the person identified with the Indigenous peoples of Canada. This includes those who identify as First Nations (North American Indian), Métis and/or Inuk (Inuit), and/or those who report being Registered or Treaty Indians (that is, registered under the Indian Act of Canada), and/or those who have membership in a First Nation or Indian band. Aboriginal peoples of Canada (referred to here as Indigenous peoples) are defined in the Constitution Act, 1982, Section 35 (2) as including the Indian, Inuit and Métis peoples of Canada.",
+          id: "AjEdUz",
           description: "Definition of accepted ways to identify as indigenous.",
         })}
       </p>

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/UnderReview.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/UnderReview.tsx
@@ -36,6 +36,7 @@ const UnderReview: React.FC = () => {
         {
           defaultMessage:
             "The <actLink>Employment Equity Act</actLink> is currently <reviewLink>under review</reviewLink>.",
+          id: "dcV5qH",
           description:
             "Text that appears in Employment equity dialogs explaining the act is under review.",
         },

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/VisibleMinorityDialog.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/VisibleMinorityDialog.tsx
@@ -81,6 +81,7 @@ const VisibleMinorityDialog: React.FC<EquityDialogProps> = ({
         {intl.formatMessage({
           defaultMessage:
             'Visible minority refers to whether a person is a visible minority or not, as defined by the Employment Equity Act. The Employment Equity Act defines visible minorities as "persons, other than Aboriginal peoples, who are non-Caucasian in race or non-white in colour". The visible minority population consists mainly of the following groups: South Asian, Chinese, Black, Filipino, Arab, Latin American, Southeast Asian, West Asian, Korean and Japanese.',
+          id: "NFL+q8",
           description:
             "Definition of accepted ways to identify as a visible minority",
         })}

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/WomanDialog.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/WomanDialog.tsx
@@ -83,6 +83,7 @@ const WomanDialog: React.FC<EquityDialogProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "This category includes persons whose reported gender is female. It includes cisgender (cis) and transgender (trans) women.",
+          id: "E1WElo",
           description: "Definition of accepted ways to identify as a women",
         })}
       </p>

--- a/frontend/talentsearch/src/js/components/experienceAndSkills/ExperienceAndSkills.tsx
+++ b/frontend/talentsearch/src/js/components/experienceAndSkills/ExperienceAndSkills.tsx
@@ -114,6 +114,7 @@ export const ExperienceAndSkills: React.FunctionComponent<
       href: `${paths.createPersonal(applicantId)}${applicationParam}`,
       title: intl.formatMessage({
         defaultMessage: "Personal",
+        id: "nuP1BG",
         description: "Title for personal experience form button.",
       }),
       icon: LightBulbIcon,
@@ -122,6 +123,7 @@ export const ExperienceAndSkills: React.FunctionComponent<
       href: `${paths.createCommunity(applicantId)}${applicationParam}`,
       title: intl.formatMessage({
         defaultMessage: "Community",
+        id: "mrhpJS",
         description: "Title for community experience form button.",
       }),
       icon: UserGroupIcon,
@@ -130,6 +132,7 @@ export const ExperienceAndSkills: React.FunctionComponent<
       href: `${paths.createWork(applicantId)}${applicationParam}`,
       title: intl.formatMessage({
         defaultMessage: "Work",
+        id: "RF51Bp",
         description: "Title for work experience form button.",
       }),
       icon: BriefcaseIcon,
@@ -138,6 +141,7 @@ export const ExperienceAndSkills: React.FunctionComponent<
       href: `${paths.createEducation(applicantId)}${applicationParam}`,
       title: intl.formatMessage({
         defaultMessage: "Education",
+        id: "JUk80l",
         description: "Title for education experience form button.",
       }),
       icon: BookOpenIcon,
@@ -146,6 +150,7 @@ export const ExperienceAndSkills: React.FunctionComponent<
       href: `${paths.createAward(applicantId)}${applicationParam}`,
       title: intl.formatMessage({
         defaultMessage: "Award",
+        id: "XF4Ok2",
         description: "Title for award experience form button.",
       }),
       icon: StarIcon,
@@ -158,6 +163,7 @@ export const ExperienceAndSkills: React.FunctionComponent<
     {
       title: intl.formatMessage({
         defaultMessage: "Experience and Skills",
+        id: "PF2m1d",
         description:
           "Breadcrumb for experience and skills page in applicant profile.",
       }),
@@ -174,6 +180,7 @@ export const ExperienceAndSkills: React.FunctionComponent<
       {
         title: intl.formatMessage({
           defaultMessage: "My Applications",
+          id: "q04FCp",
           description: "Link text for breadcrumb to user applications page.",
         }),
         href: directIntakePaths.applications(applicantId),
@@ -193,11 +200,13 @@ export const ExperienceAndSkills: React.FunctionComponent<
       description={intl.formatMessage({
         defaultMessage:
           "Here is where you can add experiences and skills to your profile. This could be anything from helping community members troubleshoot their computers to full-time employment at an IT organization.",
+        id: "GAjpqU",
         description:
           "Description for the experience and skills page in applicant profile.",
       })}
       title={intl.formatMessage({
         defaultMessage: "My experience and skills",
+        id: "KE49r9",
         description:
           "Heading for experience and skills page in applicant profile.",
       })}
@@ -215,6 +224,7 @@ export const ExperienceAndSkills: React.FunctionComponent<
             >
               {intl.formatMessage({
                 defaultMessage: "Add new experience:",
+                id: "Tr5Pga",
                 description:
                   "Message to user when no experiences have been attached to profile",
               })}
@@ -235,6 +245,7 @@ export const ExperienceAndSkills: React.FunctionComponent<
                       {
                         defaultMessage:
                           "<hidden>Add new </hidden>{title}<hidden> experience</hidden>",
+                        id: "XiUgMy",
                         description:
                           "Link text for adding a new experience of a specific type.",
                       },
@@ -268,6 +279,7 @@ export const ExperienceAndSkills: React.FunctionComponent<
             {intl.formatMessage({
               defaultMessage:
                 "There are no experiences on your profile yet. You can add some using the preceding buttons.",
+              id: "XzUzZz",
               description:
                 "Message to user when no experiences have been attached to profile.",
             })}

--- a/frontend/talentsearch/src/js/components/experienceAndSkills/ExperienceAndSkillsPage.tsx
+++ b/frontend/talentsearch/src/js/components/experienceAndSkills/ExperienceAndSkillsPage.tsx
@@ -49,6 +49,7 @@ const ExperienceAndSkillsApi = ({
           <p>
             {intl.formatMessage({
               defaultMessage: "Application not found.",
+              id: "78ITuW",
               description:
                 "Text displayed when a users application does not exist.",
             })}

--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
@@ -100,6 +100,7 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
     {
       title: intl.formatMessage({
         defaultMessage: "Experience and Skills",
+        id: "P/Mm5G",
         description: "Display text for My experience and skills Form Page Link",
       }),
       href: returnPath,
@@ -108,10 +109,12 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
       title: experience
         ? intl.formatMessage({
             defaultMessage: "Edit Experience",
+            id: "NrivlZ",
             description: "Display text for edit experience form in breadcrumbs",
           })
         : intl.formatMessage({
             defaultMessage: "Add Experience",
+            id: "mJ1HE4",
             description: "Display text for add experience form in breadcrumbs",
           }),
     },
@@ -127,6 +130,7 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
       {
         title: intl.formatMessage({
           defaultMessage: "My Applications",
+          id: "q04FCp",
           description: "Link text for breadcrumb to user applications page.",
         }),
         href: directIntakePaths.applications(userId),
@@ -143,11 +147,13 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
     <ProfileFormWrapper
       title={intl.formatMessage({
         defaultMessage: "My experience and skills",
+        id: "omBOZT",
         description: "Title for the experience profile form",
       })}
       description={intl.formatMessage({
         defaultMessage:
           "Here is where you can add experience and skills to your profile. This could be anything from helping community members troubleshoot their computers to full-time employment at an IT organization.",
+        id: "pFRKUT",
         description: "Description for the experience profile form",
       })}
       prefixBreadcrumbs={!poolAdvertisement}
@@ -172,6 +178,7 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
         <h2 data-h2-font-size="base(h3, 1)" data-h2-margin="base(x2, 0, x1, 0)">
           {intl.formatMessage({
             defaultMessage: "4. Additional information for this experience",
+            id: "Rgh/Qb",
             description: "Title for addition information on Experience form",
           })}
         </h2>
@@ -179,6 +186,7 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
           {intl.formatMessage({
             defaultMessage:
               "Anything else about this experience you would like to share.",
+            id: "h1wsiL",
             description:
               "Description blurb for additional information on Experience form",
           })}
@@ -187,6 +195,7 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
           id="details"
           label={intl.formatMessage({
             defaultMessage: "Additional Information",
+            id: "KmKbA6",
             description:
               "Label displayed on experience form for additional information input",
           })}
@@ -204,6 +213,7 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
               <TrashIcon style={{ width: "0.9rem" }} />{" "}
               {intl.formatMessage({
                 defaultMessage: "Delete experience from My Profile",
+                id: "uqoN4k",
                 description: "Label on button for delete this experience",
               })}
             </span>
@@ -222,6 +232,7 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
         leastDestructiveRef={cancelDeleteRef}
         title={intl.formatMessage({
           defaultMessage: "Are you sure?",
+          id: "AcsOrg",
           description: "Delete confirmation",
         })}
       >
@@ -229,6 +240,7 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
           {intl.formatMessage({
             defaultMessage:
               "Are you sure you would like to delete this experience from your profile? This action cannot be undone.",
+            id: "IhXvCe",
             description:
               "Question displayed when a user attempts to delete an experience from their profile",
           })}
@@ -243,6 +255,7 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
           >
             {intl.formatMessage({
               defaultMessage: "Cancel",
+              id: "KnE2Rk",
               description: "Cancel confirmation",
             })}
           </Button>
@@ -255,6 +268,7 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
             >
               {intl.formatMessage({
                 defaultMessage: "Delete",
+                id: "sBksyQ",
                 description: "Delete confirmation",
               })}
             </Button>
@@ -301,11 +315,13 @@ const ExperienceFormContainer: React.FunctionComponent<
       edit
         ? intl.formatMessage({
             defaultMessage: "Successfully updated experience!",
+            id: "jrjPWp",
             description:
               "Success message displayed after updating experience on profile",
           })
         : intl.formatMessage({
             defaultMessage: "Successfully added experience!",
+            id: "DZ775N",
             description:
               "Success message displayed after adding experience to profile",
           }),
@@ -317,11 +333,13 @@ const ExperienceFormContainer: React.FunctionComponent<
       edit
         ? intl.formatMessage({
             defaultMessage: "Error: updating experience failed",
+            id: "WyKJsK",
             description:
               "Message displayed to user after experience fails to be updated.",
           })
         : intl.formatMessage({
             defaultMessage: "Error: adding experience failed",
+            id: "moKAQP",
             description:
               "Message displayed to user after experience fails to be created.",
           }),
@@ -382,6 +400,7 @@ const ExperienceFormContainer: React.FunctionComponent<
         toast.success(
           intl.formatMessage({
             defaultMessage: "Experience Deleted",
+            id: "/qN7tM",
             description: "Message displayed to user after experience deleted.",
           }),
         );
@@ -419,6 +438,7 @@ const ExperienceFormContainer: React.FunctionComponent<
           <p>
             {intl.formatMessage({
               defaultMessage: "No experience found.",
+              id: "Yhd/hk",
               description:
                 "Message displayed when no experience is found for experience form.",
             })}

--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceSkills.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceSkills.tsx
@@ -66,6 +66,7 @@ const ExperienceSkills: React.FC<ExperienceSkillsProps> = ({ skills }) => {
       <h2 data-h2-font-size="base(h3, 1)" data-h2-margin="base(x2, 0, x1, 0)">
         {intl.formatMessage({
           defaultMessage: "2. Skills displayed during this experience",
+          id: "pYGf4h",
           description: "Title for skills on Experience form",
         })}
       </h2>
@@ -73,6 +74,7 @@ const ExperienceSkills: React.FC<ExperienceSkillsProps> = ({ skills }) => {
         {intl.formatMessage({
           defaultMessage:
             "Select skills that match the abilities you displayed during this experience period. You will explain how you used them in the next step.",
+          id: "csD/wq",
           description: "Description blurb for skills on Experience form",
         })}
       </p>

--- a/frontend/talentsearch/src/js/components/languageInformationForm/LanguageInformationForm.tsx
+++ b/frontend/talentsearch/src/js/components/languageInformationForm/LanguageInformationForm.tsx
@@ -144,6 +144,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
       >
         {intl.formatMessage({
           defaultMessage: "Government of Canada language evaluation.",
+          id: "Ugr5Yt",
           description: "Message on links to the language evaluation tests",
         })}
       </a>
@@ -170,6 +171,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
       value: "lookingForEnglish",
       label: intl.formatMessage({
         defaultMessage: "English positions",
+        id: "JBRqD9",
         description: "Message for the english positions option",
       }),
     },
@@ -177,6 +179,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
       value: "lookingForFrench",
       label: intl.formatMessage({
         defaultMessage: "French positions",
+        id: "5pQfyv",
         description: "Message for the french positions option",
       }),
     },
@@ -184,6 +187,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
       value: "lookingForBilingual",
       label: intl.formatMessage({
         defaultMessage: "Bilingual positions (English and French)",
+        id: "Mu+1pI",
         description: "Message for the bilingual positions option",
       }),
     },
@@ -198,6 +202,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
         {
           defaultMessage:
             "I am bilingual (En/Fr) and <strong>have</strong> completed an official <strong>ENGLISH</strong> <languageEvaluationPageLink></languageEvaluationPageLink>",
+          id: "ljnSYf",
           description:
             "Message for the completed english bilingual evaluation option",
         },
@@ -212,6 +217,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
         {
           defaultMessage:
             "I am bilingual (En/Fr) and <strong>have</strong> completed an official <strong>FRENCH</strong> <languageEvaluationPageLink></languageEvaluationPageLink>",
+          id: "pak8ye",
           description:
             "Message for the completed french bilingual evaluation option",
         },
@@ -226,6 +232,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
         {
           defaultMessage:
             "I am bilingual (En/Fr) and <strong>have NOT</strong> completed an official <languageEvaluationPageLink></languageEvaluationPageLink>",
+          id: "FfEyFv",
           description:
             "Message for the haven't completed bilingual evaluation option",
         },
@@ -257,6 +264,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
         label: intl.formatMessage({
           defaultMessage:
             "Beginner <gray>- I have basic reading, writing and verbal communication skills.</gray>",
+          id: "ZuFBx5",
           description: "Message for the beginner language ability option",
         }),
       },
@@ -265,6 +273,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
         label: intl.formatMessage({
           defaultMessage:
             "Intermediate <gray>- I have strong reading, writing and verbal communication skills.</gray>",
+          id: "t5G3Fz",
           description: "Message for the intermediate language ability option",
         }),
       },
@@ -272,6 +281,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
         value: EstimatedLanguageAbility.Advanced,
         label: intl.formatMessage({
           defaultMessage: "Advanced <gray>- I am completely fluent.</gray>",
+          id: "paLFgh",
           description: "Message for the advanced language ability option",
         }),
       },
@@ -282,6 +292,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
         {
           title: intl.formatMessage({
             defaultMessage: "My Applications",
+            id: "mq4G8h",
             description:
               "'My Applications' breadcrumb from applicant profile wrapper.",
           }),
@@ -293,6 +304,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
             application.poolAdvertisement?.name?.[locale] ||
             intl.formatMessage({
               defaultMessage: "Pool name not found",
+              id: "FmD1sL",
               description:
                 "Pools name breadcrumb from applicant profile wrapper if no name set.",
             }),
@@ -308,11 +320,13 @@ export const LanguageInformationForm: React.FunctionComponent<{
           description={intl.formatMessage({
             defaultMessage:
               "Use the form below to help us better understand your language preferences and capabilities",
+            id: "TGCq/w",
             description:
               "Description text for Profile Form wrapper in Language Information Form",
           })}
           title={intl.formatMessage({
             defaultMessage: "Language Information",
+            id: "R5aTZ9",
             description:
               "Title for Profile Form wrapper in Language Information Form",
           })}
@@ -324,6 +338,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
             {
               title: intl.formatMessage({
                 defaultMessage: "Language Information",
+                id: "/k21MP",
                 description:
                   "Display Text for Language Information Form Page Link",
               }),
@@ -341,6 +356,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
                 legend={intl.formatMessage({
                   defaultMessage:
                     "Select the positions you would like to be considered for",
+                  id: "ntUOoz",
                   description:
                     "Legend for considered position languages check list in language information form",
                 })}
@@ -358,6 +374,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
                     idPrefix="bilingualEvaluation"
                     legend={intl.formatMessage({
                       defaultMessage: "Bilingual evaluation",
+                      id: "X354at",
                       description:
                         "Legend bilingual evaluation status in language information form",
                     })}
@@ -374,6 +391,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
                       {intl.formatMessage({
                         defaultMessage:
                           "Please indicate the language levels you acquired from your Government of Canada language evaluation.",
+                        id: "Y7l4/n",
                         description:
                           "Text requesting language levels given from bilingual evaluation in language information form",
                       })}
@@ -385,11 +403,13 @@ export const LanguageInformationForm: React.FunctionComponent<{
                           name="comprehensionLevel"
                           label={intl.formatMessage({
                             defaultMessage: "Comprehension",
+                            id: "W4Svkd",
                             description:
                               "Label displayed on the language information form comprehension field.",
                           })}
                           nullSelection={intl.formatMessage({
                             defaultMessage: "Select a level...",
+                            id: "8QN6ZC",
                             description:
                               "Placeholder displayed on the language information form comprehension field.",
                           })}
@@ -407,11 +427,13 @@ export const LanguageInformationForm: React.FunctionComponent<{
                           name="writtenLevel"
                           label={intl.formatMessage({
                             defaultMessage: "Written",
+                            id: "x5C9Ab",
                             description:
                               "Label displayed on the language information form written field.",
                           })}
                           nullSelection={intl.formatMessage({
                             defaultMessage: "Select a level...",
+                            id: "aQJOd0",
                             description:
                               "Placeholder displayed on the language information form written field.",
                           })}
@@ -429,11 +451,13 @@ export const LanguageInformationForm: React.FunctionComponent<{
                           name="verbalLevel"
                           label={intl.formatMessage({
                             defaultMessage: "Verbal",
+                            id: "rywI3C",
                             description:
                               "Label displayed on the language information form verbal field.",
                           })}
                           nullSelection={intl.formatMessage({
                             defaultMessage: "Select a level...",
+                            id: "Y7jEXr",
                             description:
                               "Placeholder displayed on the language information form verbal field.",
                           })}
@@ -454,6 +478,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
                         {
                           defaultMessage:
                             "If you want to find out your language proficiency levels, <selfAssessmentLink>click here to find out.</selfAssessmentLink>",
+                          id: "nVh2Qh",
                           description:
                             "Text including link to language proficiency evaluation in language information form",
                         },
@@ -466,6 +491,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
                       idPrefix="estimatedLanguageAbility"
                       legend={intl.formatMessage({
                         defaultMessage: "Second language proficiency level",
+                        id: "T1TKNL",
                         description:
                           "Legend for second language proficiency level in language information form",
                       })}

--- a/frontend/talentsearch/src/js/components/loggedOut/LoggedOutPage.tsx
+++ b/frontend/talentsearch/src/js/components/loggedOut/LoggedOutPage.tsx
@@ -41,6 +41,7 @@ const LoggedOutPage: React.FC = () => {
         <h1 data-h2-margin="base(x2, 0)">
           {intl.formatMessage({
             defaultMessage: "See you next time!",
+            id: "cZmuts",
             description:
               "Title for the page users land on after successful logout.",
           })}
@@ -55,17 +56,20 @@ const LoggedOutPage: React.FC = () => {
           icon={<BellIcon style={{ width: "1rem" }} />}
           title={intl.formatMessage({
             defaultMessage: "You've successfully logged out of the platform",
+            id: "NamQ1+",
             description: "Title for the alert displayed after a user logs out",
           })}
           message={intl.formatMessage({
             defaultMessage:
               "Remember, to sign back in, you'll need to use your GC Key username and password. We hope to see you soon!",
+            id: "6UCzgs",
             description: "Message displayed to a user after logging out.",
           })}
         />
         <h2 data-h2-margin="base(x3, 0, x1, 0)">
           {intl.formatMessage({
             defaultMessage: "Quick Links",
+            id: "Igrveg",
             description:
               "Title displayed for helpful links on logged out page.",
           })}
@@ -74,6 +78,7 @@ const LoggedOutPage: React.FC = () => {
           {intl.formatMessage({
             defaultMessage:
               "Not ready to leave just yet? Head back to the homepage, check out new opportunities, or learn more about some of the research behind this platform.",
+            id: "248YQT",
             description:
               "Description of the links presented on the logged out page.",
           })}
@@ -87,6 +92,7 @@ const LoggedOutPage: React.FC = () => {
               <TileLink href={talentPaths.home()} color="primary">
                 {intl.formatMessage({
                   defaultMessage: "Return home",
+                  id: "Hgd/PL",
                   description: "Link text to return to the home page",
                 })}
               </TileLink>
@@ -95,6 +101,7 @@ const LoggedOutPage: React.FC = () => {
               <TileLink href={directIntakePaths.allPools()} color="primary">
                 {intl.formatMessage({
                   defaultMessage: "View open pools",
+                  id: "FtlwFY",
                   description: "Link text to view all open pools",
                 })}
               </TileLink>
@@ -107,6 +114,7 @@ const LoggedOutPage: React.FC = () => {
               >
                 {intl.formatMessage({
                   defaultMessage: "Talent Cloud report",
+                  id: "L9mWLV",
                   description: "Link text to read the report on talent cloud",
                 })}
               </TileLink>
@@ -123,6 +131,7 @@ const LoggedOutPage: React.FC = () => {
         }}
         title={intl.formatMessage({
           defaultMessage: "Logout",
+          id: "Hiv/2m",
           description:
             "Title for the modal that appears when an authenticated user lands on /logged-out.",
         })}
@@ -130,6 +139,7 @@ const LoggedOutPage: React.FC = () => {
         <p data-h2-font-size="base(h5, 1)">
           {intl.formatMessage({
             defaultMessage: "Are you sure you would like to logout?",
+            id: "Zx3BVC",
             description:
               "Question displayed when authenticated user lands on /logged-out.",
           })}
@@ -149,6 +159,7 @@ const LoggedOutPage: React.FC = () => {
             >
               {intl.formatMessage({
                 defaultMessage: "Cancel",
+                id: "AhNR6n",
                 description: "Link text to cancel logging out.",
               })}
             </Link>
@@ -163,6 +174,7 @@ const LoggedOutPage: React.FC = () => {
               >
                 {intl.formatMessage({
                   defaultMessage: "Logout",
+                  id: "6rhyxk",
                   description: "Link text to logout.",
                 })}
               </Button>

--- a/frontend/talentsearch/src/js/components/login/LoginPage.tsx
+++ b/frontend/talentsearch/src/js/components/login/LoginPage.tsx
@@ -38,6 +38,7 @@ const LoginPage: React.FC = () => {
         <h1 data-h2-margin="base(x2, 0)">
           {intl.formatMessage({
             defaultMessage: "Login using GC Key",
+            id: "Z3prc4",
             description: "Title for the login page for applicant profiles.",
           })}
         </h1>
@@ -48,6 +49,7 @@ const LoginPage: React.FC = () => {
             {intl.formatMessage({
               defaultMessage:
                 "You can log into your Digital Talent profile using your existing GC Key, even if you’ve never used this platform before.",
+              id: "K7wsxV",
               description: "Instructions on how to login with GC Key.",
             })}
           </p>
@@ -55,6 +57,7 @@ const LoginPage: React.FC = () => {
             {intl.formatMessage({
               defaultMessage:
                 "If you’re unsure whether you have an existing GC Key account, continue to the website and try logging in. If you can’t remember your password, you can also reset it there.",
+              id: "Q2+VXx",
               description:
                 "Instructions on what to do if user doesn't know if they have a GC Key",
             })}
@@ -64,6 +67,7 @@ const LoginPage: React.FC = () => {
               {
                 defaultMessage:
                   "<strong>Don't have a GC Key account?</strong> <a>Register for one.</a>",
+                id: "ofOoFQ",
                 description:
                   "Instruction on what to do if user does not have a GC Key.",
               },
@@ -88,6 +92,7 @@ const LoginPage: React.FC = () => {
               >
                 {intl.formatMessage({
                   defaultMessage: "Cancel",
+                  id: "OT0QP3",
                   description:
                     "Link text to cancel logging in and return to talent search home.",
                 })}
@@ -103,6 +108,7 @@ const LoginPage: React.FC = () => {
               >
                 {intl.formatMessage({
                   defaultMessage: "Continue to GC Key and Login",
+                  id: "CZcsxM",
                   description: "GC Key login link text on the login page.",
                 })}
               </Link>

--- a/frontend/talentsearch/src/js/components/myStatusForm/MyStatusForm.tsx
+++ b/frontend/talentsearch/src/js/components/myStatusForm/MyStatusForm.tsx
@@ -80,6 +80,7 @@ export const MyStatusForm: React.FC<MyStatusFormProps> = ({
             {intl.formatMessage({
               defaultMessage:
                 "Let us know if you want to be contacted for new jobs. Please update this status if your situation changes.",
+              id: "PIgh3U",
               description: "Description for My Status Form",
             })}
           </p>
@@ -100,6 +101,7 @@ export const MyStatusForm: React.FC<MyStatusFormProps> = ({
               {intl.formatMessage({
                 defaultMessage:
                   "<strong>Why can’t I change my status?</strong>",
+                id: "3quMA8",
                 description: "Message in My Status Form.",
               })}
             </p>
@@ -107,6 +109,7 @@ export const MyStatusForm: React.FC<MyStatusFormProps> = ({
               {intl.formatMessage({
                 defaultMessage:
                   "Please complete all required fields on your profile before setting your status as active.",
+                id: "+wdTbk",
                 description: "Message in My Status Form.",
               })}
             </p>
@@ -118,6 +121,7 @@ export const MyStatusForm: React.FC<MyStatusFormProps> = ({
             idPrefix="myStatus"
             legend={intl.formatMessage({
               defaultMessage: "My status",
+              id: "XBfLOu",
               description: "Legend for my status option in my status form",
             })}
             name="jobLookingStatus"
@@ -157,6 +161,7 @@ const MyStatusApi: React.FunctionComponent = () => {
       toast.success(
         intl.formatMessage({
           defaultMessage: "My Status updated successfully!",
+          id: "W7io0W",
           description:
             "Message displayed to user after user is updated successfully.",
         }),
@@ -171,6 +176,7 @@ const MyStatusApi: React.FunctionComponent = () => {
     toast.error(
       intl.formatMessage({
         defaultMessage: "Error: updating user failed",
+        id: "5FFRV2",
         description:
           "Message displayed to user after user fails to get updated.",
       }),

--- a/frontend/talentsearch/src/js/components/personalExperienceForm/PersonalExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/personalExperienceForm/PersonalExperienceForm.tsx
@@ -18,6 +18,7 @@ export const PersonalExperienceForm: React.FunctionComponent = () => {
       <h2 data-h2-font-size="base(h3, 1)" data-h2-margin="base(x2, 0, x1, 0)">
         {intl.formatMessage({
           defaultMessage: "1. Personal Experience Details",
+          id: "UDpZ1q",
           description: "Title for Personal Experience Details form",
         })}
       </h2>
@@ -25,6 +26,7 @@ export const PersonalExperienceForm: React.FunctionComponent = () => {
         {intl.formatMessage({
           defaultMessage:
             "People are more than just education and work experiences. We want to make space for you to share your learning from other experiences. To protect your privacy, please don't share sensitive information about yourself or others. A good measure would be if you are comfortable with all your colleagues knowing it.",
+          id: "knmaAL",
           description: "Description blurb for Personal Experience Details form",
         })}
       </p>
@@ -33,11 +35,13 @@ export const PersonalExperienceForm: React.FunctionComponent = () => {
           id="experienceTitle"
           label={intl.formatMessage({
             defaultMessage: "Short title for this experience",
+            id: "97UAb8",
             description:
               "Label displayed on Personal Experience form for experience title input",
           })}
           placeholder={intl.formatMessage({
             defaultMessage: "Write title here...",
+            id: "Q18B0y",
             description: "Placeholder for experience title input",
           })}
           name="experienceTitle"
@@ -49,11 +53,13 @@ export const PersonalExperienceForm: React.FunctionComponent = () => {
           id="experienceDescription"
           label={intl.formatMessage({
             defaultMessage: "Experience Description",
+            id: "q5rd9x",
             description:
               "Label displayed on Personal Experience form for experience description input",
           })}
           placeholder={intl.formatMessage({
             defaultMessage: "Describe experience details here...",
+            id: "Os+BwT",
             description: "Placeholder for experience description input",
           })}
           name="experienceDescription"
@@ -64,6 +70,7 @@ export const PersonalExperienceForm: React.FunctionComponent = () => {
             boundingBox
             boundingBoxLabel={intl.formatMessage({
               defaultMessage: "Disclaimer",
+              id: "sapxcU",
               description:
                 "Label displayed on Personal Experience form for disclaimer bounded box",
             })}
@@ -71,6 +78,7 @@ export const PersonalExperienceForm: React.FunctionComponent = () => {
             label={intl.formatMessage({
               defaultMessage:
                 "I agree to share this information with verified Government of Canada hiring managers and HR advisors who have access to this platform.",
+              id: "oURESC",
               description:
                 "Label displayed on Personal Experience form for disclaimer checkbox",
             })}
@@ -83,12 +91,14 @@ export const PersonalExperienceForm: React.FunctionComponent = () => {
           boundingBox
           boundingBoxLabel={intl.formatMessage({
             defaultMessage: "Current Experience",
+            id: "OAOnyY",
             description:
               "Label displayed on Personal Experience form for current experience bounded box",
           })}
           id="currentRole"
           label={intl.formatMessage({
             defaultMessage: "I am currently active in this experience",
+            id: "aemElP",
             description:
               "Label displayed on Personal Experience form for current experience input",
           })}
@@ -104,6 +114,7 @@ export const PersonalExperienceForm: React.FunctionComponent = () => {
               id="startDate"
               label={intl.formatMessage({
                 defaultMessage: "Start Date",
+                id: "NDunA+",
                 description:
                   "Label displayed on Personal Experience form for start date input",
               })}
@@ -119,6 +130,7 @@ export const PersonalExperienceForm: React.FunctionComponent = () => {
                 id="endDate"
                 label={intl.formatMessage({
                   defaultMessage: "End Date",
+                  id: "qhmriI",
                   description:
                     "Label displayed on Personal Experience form for end date input",
                 })}

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -55,6 +55,7 @@ const ApplyButton = ({ disabled, href }: ApplyButtonProps) => {
     >
       {intl.formatMessage({
         defaultMessage: "Apply for this process",
+        id: "W2YIEA",
         description: "Link text to apply for a pool advertisement",
       })}
     </Link>
@@ -131,6 +132,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
     {
       title: intl.formatMessage({
         defaultMessage: "Browse opportunities",
+        id: "NSuNSA",
         description: "Breadcrumb title for the browse pools page.",
       }),
       href: paths.home(),
@@ -145,6 +147,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
       id: "about-section",
       title: intl.formatMessage({
         defaultMessage: "About this process",
+        id: "18dDgn",
         description: "Title for the about section of a pool advertisement",
       }),
     },
@@ -152,6 +155,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
       id: "required-skills-section",
       title: intl.formatMessage({
         defaultMessage: "Need to have",
+        id: "WkX8Ge",
         description:
           "Title for the required skills section of a pool advertisement",
       }),
@@ -160,6 +164,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
       id: "optional-skills-section",
       title: intl.formatMessage({
         defaultMessage: "Nice to have",
+        id: "STLaIq",
         description:
           "Title for the optional skills section of a pool advertisement",
       }),
@@ -168,6 +173,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
       id: "requirements-section",
       title: intl.formatMessage({
         defaultMessage: "Requirements",
+        id: "iP8EMf",
         description:
           "Title for the requirements section of a pool advertisement",
       }),
@@ -176,6 +182,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
       id: "details-section",
       title: intl.formatMessage({
         defaultMessage: "Additional details",
+        id: "mNWpoy",
         description: "Title for the details section of a pool advertisement",
       }),
     },
@@ -183,6 +190,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
       id: "apply-section",
       title: intl.formatMessage({
         defaultMessage: "Apply now",
+        id: "C6YPk3",
         description:
           "Title for the apply button section of a pool advertisement",
       }),
@@ -265,6 +273,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
             <Accordion
               title={intl.formatMessage({
                 defaultMessage: "What are pool recruitments?",
+                id: "asP33b",
                 description:
                   "Title for according describing pool recruitment's",
               })}
@@ -273,6 +282,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 {intl.formatMessage({
                   defaultMessage:
                     "When you apply to this process, you are not applying for a specific position. This process is intended to create and maintain an inventory to staff various positions at the same level in different departments and agencies across the Government of Canada.",
+                  id: "kH4Jsf",
                   description: "Description of pool recruitment, paragraph one",
                 })}
               </p>
@@ -280,6 +290,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 {intl.formatMessage({
                   defaultMessage:
                     "When hiring managers have IT staffing needs and positions become available, applicants who meet the qualifications for this process may be contacted for further assessment. This means various managers may reach out to you about specific opportunities in the area of application development.",
+                  id: "m5hjaz",
                   description: "Description of pool recruitment, paragraph two",
                 })}
               </p>
@@ -290,6 +301,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                   {
                     defaultMessage:
                       "What does {classification}{genericTitle} mean?",
+                    id: "gpuTAV",
                     description:
                       "Title for description of a pool advertisements classification group/level",
                   },
@@ -309,6 +321,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 <IconTitle icon={LightningBoltIcon}>
                   {intl.formatMessage({
                     defaultMessage: "Your impact",
+                    id: "Kl5OX1",
                     description:
                       "Title for a pool advertisements impact section.",
                   })}
@@ -321,6 +334,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 <IconTitle icon={BriefcaseIconOutline}>
                   {intl.formatMessage({
                     defaultMessage: "Your work",
+                    id: "uv2lY0",
                     description:
                       "Title for a pool advertisements key tasks section.",
                   })}
@@ -338,6 +352,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 <IconTitle icon={ChipIcon}>
                   {intl.formatMessage({
                     defaultMessage: "Occupational skills",
+                    id: "zeC2K0",
                     description:
                       "Title for occupational skills on a pool advertisement",
                   })}
@@ -346,6 +361,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                   {intl.formatMessage({
                     defaultMessage:
                       "To be admitted into this process, you will need to submit sufficient information to verify your experience in <strong>all of these  skills (Need to have - Occupational)</strong> with your application.",
+                    id: "Y7AKYP",
                     description:
                       "Explanation of a pools required occupational skills",
                   })}
@@ -362,6 +378,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 <IconTitle icon={CloudIcon}>
                   {intl.formatMessage({
                     defaultMessage: "Transferrable skills",
+                    id: "0I8W8B",
                     description:
                       "Title for transferrable skills on a pool advertisement",
                   })}
@@ -370,6 +387,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                   {intl.formatMessage({
                     defaultMessage:
                       "To be admitted into this process, you will need to display  capability in these skills during the assessment process.",
+                    id: "7n838F",
                     description:
                       "Explanation of a pools required transferrable skills",
                   })}
@@ -391,6 +409,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 <IconTitle icon={ChipIcon}>
                   {intl.formatMessage({
                     defaultMessage: "Occupational skills",
+                    id: "zeC2K0",
                     description:
                       "Title for occupational skills on a pool advertisement",
                   })}
@@ -399,6 +418,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                   {intl.formatMessage({
                     defaultMessage:
                       "To strengthen your application, take into consideration these skills that many hiring managers are looking for.",
+                    id: "yu4yB8",
                     description:
                       "Explanation of a pools optional transferrable skills",
                   })}
@@ -415,6 +435,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 <IconTitle icon={CloudIcon}>
                   {intl.formatMessage({
                     defaultMessage: "Transferrable skills",
+                    id: "0I8W8B",
                     description:
                       "Title for transferrable skills on a pool advertisement",
                   })}
@@ -434,6 +455,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
             <IconTitle icon={LightBulbIcon}>
               {intl.formatMessage({
                 defaultMessage: "Experience and education",
+                id: "owzveI",
                 description:
                   "Title for experience and education pool requirements",
               })}
@@ -448,6 +470,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 style={{ width: "100%" }}
                 title={intl.formatMessage({
                   defaultMessage: "Combination Experience",
+                  id: "7o+Vzu",
                   description:
                     "Title for pool applicant experience requirements",
                 })}
@@ -456,6 +479,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                   {intl.formatMessage({
                     defaultMessage:
                       "2 or more years of combined experience in a related field including any of the following:",
+                    id: "s60QyR",
                     description:
                       "lead in to list of experience required for a pool applicant",
                   })}
@@ -464,6 +488,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                   <li>
                     {intl.formatMessage({
                       defaultMessage: "On-the-job learning",
+                      id: "qNL/Rp",
                       description:
                         "pool experience requirement, on job learning",
                     })}
@@ -471,6 +496,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                   <li>
                     {intl.formatMessage({
                       defaultMessage: "Non-conventional training",
+                      id: "YlWJ/N",
                       description:
                         "pool experience requirement, non-conventional training",
                     })}
@@ -478,6 +504,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                   <li>
                     {intl.formatMessage({
                       defaultMessage: "Formal education",
+                      id: "DydUje",
                       description:
                         "pool experience requirement, formal education",
                     })}
@@ -485,6 +512,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                   <li>
                     {intl.formatMessage({
                       defaultMessage: "Other field related experience",
+                      id: "GNvz2K",
                       description: "pool experience requirement, other",
                     })}
                   </li>
@@ -499,6 +527,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
               >
                 {intl.formatMessage({
                   defaultMessage: "or",
+                  id: "l9AK3C",
                   description:
                     "that appears between different experience requirements for a pool applicant",
                 })}
@@ -508,6 +537,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 color="ts-secondary"
                 title={intl.formatMessage({
                   defaultMessage: "2-Year Post-secondary Experience",
+                  id: "/Gu4zR",
                   description:
                     "Title for pool applicant education requirements",
                 })}
@@ -516,6 +546,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                   {intl.formatMessage({
                     defaultMessage:
                       "Successful completion of two years of post secondary education in computer science, information technology, information management or another specialty relevant to this position.",
+                    id: "r9FSaq",
                     description:
                       "post secondary education experience for pool advertisement",
                   })}
@@ -525,6 +556,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
             <IconTitle icon={CheckCircleIcon}>
               {intl.formatMessage({
                 defaultMessage: "Other requirements",
+                id: "cHJFcW",
                 description: "Title for other pool requirements",
               })}
             </IconTitle>
@@ -534,6 +566,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                   {
                     defaultMessage:
                       "Language requirement: {languageRequirement}",
+                    id: "fvJnoC",
                     description: "Pool advertisement language requirement",
                   },
                   {
@@ -545,6 +578,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 {intl.formatMessage(
                   {
                     defaultMessage: "Security clearance: {securityClearance}",
+                    id: "GYk6Nz",
                     description:
                       "Pool advertisement security clearance requirement",
                   },
@@ -557,6 +591,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 <li>
                   {intl.formatMessage({
                     defaultMessage: "Location: Remote",
+                    id: "+5cxyT",
                     description:
                       "Pool advertisement location requirement, Remote option",
                   })}
@@ -567,6 +602,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                     {intl.formatMessage(
                       {
                         defaultMessage: "Location: {location}",
+                        id: "HYm817",
                         description:
                           "Pool advertisement location requirement, English",
                       },
@@ -587,6 +623,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
             <IconTitle icon={PhoneIcon}>
               {intl.formatMessage({
                 defaultMessage: "Contact and Accommodations",
+                id: "W6dFND",
                 description:
                   "Title for contact information on pool advertisement",
               })}
@@ -595,6 +632,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
               {intl.formatMessage({
                 defaultMessage:
                   "Do you require accommodations, or do you have any questions about this process?",
+                id: "2K8q04",
                 description:
                   "Opening sentence asking if accommodations are needed",
               })}
@@ -603,6 +641,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
               {intl.formatMessage({
                 defaultMessage:
                   "Please contact the Digital Community Management Office if you require any accommodations during this application process.",
+                id: "JnhEcG",
                 description:
                   "Description of what to do when accommodations are needed",
               })}
@@ -612,6 +651,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 {
                   defaultMessage:
                     "<strong>Email</strong>: <anchorTag>{emailAddress}</anchorTag>",
+                  id: "Wnw+oz",
                   description: "An email address to contact for help",
                 },
                 {
@@ -623,6 +663,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
             <IconTitle icon={PhoneIcon}>
               {intl.formatMessage({
                 defaultMessage: "Hiring Policies",
+                id: "isfAkZ",
                 description:
                   "Title for hiring information on pool advertisement",
               })}
@@ -631,6 +672,7 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
               {intl.formatMessage({
                 defaultMessage:
                   "Preference will be given to veterans, Canadian citizens and to permanent residents.",
+                id: "IF1xj8",
                 description: "First hiring policy for pool advertisement",
               })}
             </p>
@@ -644,11 +686,13 @@ const PoolAdvertisement = ({ poolAdvertisement }: PoolAdvertisementProps) => {
                 ? intl.formatMessage({
                     defaultMessage:
                       "If this process looks like the right fit for you apply now!",
+                    id: "SuqyvD",
                     description:
                       "Message displayed when the pool advertisement can be applied to.",
                   })
                 : intl.formatMessage({
                     defaultMessage: "The deadline for submission has passed.",
+                    id: "U+ApNl",
                     description:
                       "Message displayed when the pool advertisement has expired.",
                   })}
@@ -692,6 +736,7 @@ const PoolAdvertisementPage = ({ id }: PoolAdvertisementPageProps) => {
         >
           {intl.formatMessage({
             defaultMessage: "Error, pool unable to be loaded",
+            id: "DcEinN",
             description: "Error message, placeholder",
           })}
         </NotFound>

--- a/frontend/talentsearch/src/js/components/pool/PoolApplicationThanksPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolApplicationThanksPage.tsx
@@ -26,6 +26,7 @@ const PoolApplicationThanks: React.FC<PoolApplicationThanksProps> = ({
     {
       title: intl.formatMessage({
         defaultMessage: "Pools Index",
+        id: "tf/wEc",
         description: "Breadcrumb title for the pools index link.",
       }),
       href: paths.home(),
@@ -39,6 +40,7 @@ const PoolApplicationThanks: React.FC<PoolApplicationThanksProps> = ({
     {
       title: intl.formatMessage({
         defaultMessage: "Apply",
+        id: "8/aBOG",
         description: "Breadcrumb title for the pool application link.",
       }),
       href: pool ? paths.poolApply(pool.id) : undefined,
@@ -47,6 +49,7 @@ const PoolApplicationThanks: React.FC<PoolApplicationThanksProps> = ({
     {
       title: intl.formatMessage({
         defaultMessage: "Thanks for Applying",
+        id: "Uyo9WO",
         description:
           "Breadcrumb title for the pools 'thanks for applying page' link.",
       }),
@@ -60,6 +63,7 @@ const PoolApplicationThanks: React.FC<PoolApplicationThanksProps> = ({
         {intl.formatMessage(
           {
             defaultMessage: "Thanks for applying to {poolName}",
+            id: "hDSk9d",
             description: "Title for page thanking user for applying to a pool",
           },
           {
@@ -75,6 +79,7 @@ const PoolApplicationThanks: React.FC<PoolApplicationThanksProps> = ({
       >
         {intl.formatMessage({
           defaultMessage: "Back to pools list",
+          id: "RdrUZz",
           description: "Label for button to the browse pools page",
         })}
       </Link>
@@ -103,6 +108,7 @@ const PoolApplicationThanksPage: React.FC<PoolApplicationThanksPageProps> = ({
           <p>
             {intl.formatMessage({
               defaultMessage: "Error, pool unable to be loaded",
+              id: "DcEinN",
               description: "Error message, placeholder",
             })}
           </p>

--- a/frontend/talentsearch/src/js/components/pool/PoolApplyPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolApplyPage.tsx
@@ -24,6 +24,7 @@ const PoolApply: React.FC<PoolApplyProps> = ({ pool }) => {
     {
       title: intl.formatMessage({
         defaultMessage: "Pools Index",
+        id: "tf/wEc",
         description: "Breadcrumb title for the pools index link.",
       }),
       href: paths.home(),
@@ -47,6 +48,7 @@ const PoolApply: React.FC<PoolApplyProps> = ({ pool }) => {
       >
         {intl.formatMessage({
           defaultMessage: "Back to pool",
+          id: "dHLkSE",
           description: "Label for button to return to view pool",
         })}
       </Link>
@@ -73,6 +75,7 @@ const PoolApplyPage: React.FC<PoolApplyPageProps> = ({ id }) => {
           <p>
             {intl.formatMessage({
               defaultMessage: "Error, pool unable to be loaded",
+              id: "DcEinN",
               description: "Error message, placeholder",
             })}
           </p>

--- a/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
@@ -50,6 +50,7 @@ const PoolInfoCard = ({
         <span>
           {intl.formatMessage({
             defaultMessage: "Closing date:",
+            id: "ojN4Si",
             description: "Label for pool advertisement closing date",
           })}{" "}
           {relativeExpiryDate(new Date(closingDate), intl)}
@@ -62,6 +63,7 @@ const PoolInfoCard = ({
         <span>
           {intl.formatMessage({
             defaultMessage: "Salary range:",
+            id: "ls7b2p",
             description: "Label for pool advertisement salary range",
           })}{" "}
           {localizeSalaryRange(salary.min, salary.max, locale)} (

--- a/frontend/talentsearch/src/js/components/profile/ProfilePage/CandidatePoolsSection.tsx
+++ b/frontend/talentsearch/src/js/components/profile/ProfilePage/CandidatePoolsSection.tsx
@@ -19,6 +19,7 @@ const CandidatePoolsSection: React.FunctionComponent<{
           {intl.formatMessage({
             defaultMessage:
               "You have not been accepted into any hiring pools yet.",
+            id: "gWEfA9",
             description: "Message for if user not part of any hiring pools",
           })}
         </p>
@@ -39,6 +40,7 @@ const CandidatePoolsSection: React.FunctionComponent<{
               <p>
                 {intl.formatMessage({
                   defaultMessage: "ID:",
+                  id: "CPRJ61",
                   description: "The ID and colon",
                 })}{" "}
                 {poolCandidate?.id}
@@ -48,6 +50,7 @@ const CandidatePoolsSection: React.FunctionComponent<{
               <p>
                 {intl.formatMessage({
                   defaultMessage: "Expiry Date:",
+                  id: "ZSAzrR",
                   description: "The expiry date label and colon",
                 })}{" "}
                 {poolCandidate?.expiryDate}

--- a/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
+++ b/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
@@ -48,6 +48,7 @@ export const ProfileForm: React.FC<ProfilePageProps> = ({
   ) {
     userName = intl.formatMessage({
       defaultMessage: "(Missing name)",
+      id: "4xzq2Y",
       description: "Message for Missing names in profile",
     });
   }

--- a/frontend/talentsearch/src/js/components/profile/profileMessages.ts
+++ b/frontend/talentsearch/src/js/components/profile/profileMessages.ts
@@ -4,18 +4,22 @@ const messages = defineMessages({
   profileCompleted: {
     defaultMessage:
       "All required fields are complete. You can now change your status.",
+    id: "hTJgV2",
     description: "Message displayed to user when user profile completed.",
   },
   updatingFailed: {
     defaultMessage: "Error: updating user failed",
+    id: "5FFRV2",
     description: "Message displayed to user after user fails to get updated.",
   },
   userNotFound: {
     defaultMessage: "User not found.",
+    id: "2cUBGT",
     description: "Message displayed for user not found.",
   },
   userUpdated: {
     defaultMessage: "User updated successfully!",
+    id: "evxvnW",
     description:
       "Message displayed to user after user is updated successfully.",
   },

--- a/frontend/talentsearch/src/js/components/register/RegisterPage.tsx
+++ b/frontend/talentsearch/src/js/components/register/RegisterPage.tsx
@@ -38,6 +38,7 @@ const RegisterPage: React.FC = () => {
         <h1 data-h2-margin="base(x2, 0)">
           {intl.formatMessage({
             defaultMessage: "Register using GC Key",
+            id: "zILELf",
             description:
               "Title for the registration page for applicant profiles.",
           })}
@@ -49,6 +50,7 @@ const RegisterPage: React.FC = () => {
             {intl.formatMessage({
               defaultMessage:
                 "You can log into your Digital Talent profile using your existing GC Key, even if you've never used this platform before.",
+              id: "c3CV4P",
               description: "Instructions on how to login with GC Key.",
             })}
           </p>
@@ -56,6 +58,7 @@ const RegisterPage: React.FC = () => {
             {intl.formatMessage({
               defaultMessage:
                 "If you're unsure whether you have an existing GC Key account, continue to the website and try logging in. If you can't remember your password, you can also reset it there.",
+              id: "pcnr9A",
               description:
                 "Instructions on what to do if user doesn't know if they have a GC Key",
             })}
@@ -65,6 +68,7 @@ const RegisterPage: React.FC = () => {
               {
                 defaultMessage:
                   "<strong>Don't have a GC Key account?</strong> <a>Register for one.</a>",
+                id: "ofOoFQ",
                 description:
                   "Instruction on what to do if user does not have a GC Key.",
               },
@@ -84,6 +88,7 @@ const RegisterPage: React.FC = () => {
               <Link href={loginPath} external>
                 {intl.formatMessage({
                   defaultMessage: "Log in instead",
+                  id: "rUFZwt",
                   description: "Login link text on the registration page.",
                 })}
               </Link>
@@ -98,6 +103,7 @@ const RegisterPage: React.FC = () => {
               >
                 {intl.formatMessage({
                   defaultMessage: "Continue to GC Key and Register",
+                  id: "9yMdpm",
                   description:
                     "GC Key registration link text on the registration page.",
                 })}

--- a/frontend/talentsearch/src/js/components/request/CreateRequest.tsx
+++ b/frontend/talentsearch/src/js/components/request/CreateRequest.tsx
@@ -151,6 +151,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
         toast.success(
           intl.formatMessage({
             defaultMessage: "Request created successfully!",
+            id: "gUb3PY",
             description:
               "Message displayed to user after a pool candidate request is created successfully.",
           }),
@@ -160,6 +161,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
         toast.error(
           intl.formatMessage({
             defaultMessage: "Error: creating request failed",
+            id: "9nIALc",
             description:
               "Message displayed to user after a pool candidate request fails to get created.",
           }),
@@ -196,6 +198,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
       <h2 data-h2-margin="base(0, 0, x1, 0)">
         {intl.formatMessage({
           defaultMessage: "Request Form",
+          id: "LOYv+/",
           description: "Heading for request form.",
         })}
       </h2>
@@ -203,6 +206,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "To submit a request, please provide the following information so we can contact you.",
+          id: "GHvRHc",
           description: "Explanation message for request form.",
         })}
       </p>
@@ -216,10 +220,12 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
                 name="fullName"
                 label={intl.formatMessage({
                   defaultMessage: "Full Name",
+                  id: "dRnKNR",
                   description: "Label for full name input in the request form",
                 })}
                 placeholder={intl.formatMessage({
                   defaultMessage: "Full name...",
+                  id: "OjhS6t",
                   description:
                     "Placeholder for full name input in the request form.",
                 })}
@@ -234,11 +240,13 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
                 name="department"
                 label={intl.formatMessage({
                   defaultMessage: "Department / Hiring Organization",
+                  id: "UUIb3j",
                   description:
                     "Label for department select input in the request form",
                 })}
                 nullSelection={intl.formatMessage({
                   defaultMessage: "Select a department...",
+                  id: "WE/Nu+",
                   description:
                     "Null selection for department select input in the request form.",
                 })}
@@ -255,11 +263,13 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
                 name="email"
                 label={intl.formatMessage({
                   defaultMessage: "Government e-mail",
+                  id: "mRNmrR",
                   description:
                     "Label for government email input in the request form",
                 })}
                 placeholder={intl.formatMessage({
                   defaultMessage: "example@canada.ca...",
+                  id: "N6+rnM",
                   description:
                     "Placeholder for government email input in the request form",
                 })}
@@ -275,10 +285,12 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
                 name="jobTitle"
                 label={intl.formatMessage({
                   defaultMessage: "What is the job title for this position?",
+                  id: "7lCUIL",
                   description: "Label for job title input in the request form",
                 })}
                 placeholder={intl.formatMessage({
                   defaultMessage: "Developer...",
+                  id: "zz9pwK",
                   description:
                     "Placeholder for job title input in the request form.",
                 })}
@@ -293,6 +305,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
               {intl.formatMessage({
                 defaultMessage:
                   "In this field please include any additional details and qualifications you are seeking from the candidates such as: programming languages, certifications, knowledge, or a specific work location.",
+                id: "Zzd/sJ",
                 description:
                   "Blurb before additional comments textarea in the request form.",
               })}
@@ -302,6 +315,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
               name="additionalComments"
               label={intl.formatMessage({
                 defaultMessage: "Additional Comments",
+                id: "FC5tje",
                 description:
                   "Label for additional comments textarea in the request form.",
               })}
@@ -311,6 +325,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
           <h2 data-h2-margin="base(x2, 0, x1, 0)">
             {intl.formatMessage({
               defaultMessage: "Summary of filters",
+              id: "emx1cK",
               description: "Title of Summary of filters section",
             })}
           </h2>
@@ -323,6 +338,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
               {
                 defaultMessage:
                   "Request for pool candidates: <primary>{candidateCountNumber, plural, =0 {no candidates} =1 {1 estimated candidate} other {{candidateCountNumber} estimated candidates}}</primary>",
+                id: "og5vUB",
                 description:
                   "Total estimated candidates message in summary of filters",
               },
@@ -349,6 +365,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
               >
                 {intl.formatMessage({
                   defaultMessage: "Back",
+                  id: "L8k+lC",
                   description:
                     "Back button located next to the submit button on the request form.",
                 })}
@@ -363,6 +380,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
                 mode="solid"
                 text={intl.formatMessage({
                   defaultMessage: "Submit Request",
+                  id: "eTTlR0",
                   description: "Submit button text on request form.",
                 })}
               />

--- a/frontend/talentsearch/src/js/components/request/RequestPage.tsx
+++ b/frontend/talentsearch/src/js/components/request/RequestPage.tsx
@@ -55,6 +55,7 @@ const RequestPage: React.FunctionComponent = () => {
         >
           {intl.formatMessage({
             defaultMessage: "Search the Digital Talent Pool",
+            id: "NXzsK4",
             description: "Main heading displayed at the top of request page.",
           })}
         </h1>

--- a/frontend/talentsearch/src/js/components/request/deprecated/CreateRequest.tsx
+++ b/frontend/talentsearch/src/js/components/request/deprecated/CreateRequest.tsx
@@ -141,6 +141,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
         toast.success(
           intl.formatMessage({
             defaultMessage: "Request created successfully!",
+            id: "gUb3PY",
             description:
               "Message displayed to user after a pool candidate request is created successfully.",
           }),
@@ -150,6 +151,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
         toast.error(
           intl.formatMessage({
             defaultMessage: "Error: creating request failed",
+            id: "9nIALc",
             description:
               "Message displayed to user after a pool candidate request fails to get created.",
           }),
@@ -173,6 +175,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
         name[locale] ??
         intl.formatMessage({
           defaultMessage: "Error: department name not found.",
+          id: "WbDLlc",
           description:
             "Error message when department name is not found on request page.",
         }),
@@ -187,6 +190,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
       <h2 data-h2-margin="base(0, 0, x1, 0)">
         {intl.formatMessage({
           defaultMessage: "Request Form",
+          id: "LOYv+/",
           description: "Heading for request form.",
         })}
       </h2>
@@ -194,6 +198,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "To submit a request, please provide the following information so we can contact you.",
+          id: "GHvRHc",
           description: "Explanation message for request form.",
         })}
       </p>
@@ -207,10 +212,12 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
                 name="fullName"
                 label={intl.formatMessage({
                   defaultMessage: "Full Name",
+                  id: "dRnKNR",
                   description: "Label for full name input in the request form",
                 })}
                 placeholder={intl.formatMessage({
                   defaultMessage: "Full name...",
+                  id: "OjhS6t",
                   description:
                     "Placeholder for full name input in the request form.",
                 })}
@@ -225,11 +232,13 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
                 name="department"
                 label={intl.formatMessage({
                   defaultMessage: "Department / Hiring Organization",
+                  id: "UUIb3j",
                   description:
                     "Label for department select input in the request form",
                 })}
                 nullSelection={intl.formatMessage({
                   defaultMessage: "Select a department...",
+                  id: "WE/Nu+",
                   description:
                     "Null selection for department select input in the request form.",
                 })}
@@ -246,11 +255,13 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
                 name="email"
                 label={intl.formatMessage({
                   defaultMessage: "Government e-mail",
+                  id: "mRNmrR",
                   description:
                     "Label for government email input in the request form",
                 })}
                 placeholder={intl.formatMessage({
                   defaultMessage: "example@canada.ca...",
+                  id: "N6+rnM",
                   description:
                     "Placeholder for government email input in the request form",
                 })}
@@ -266,10 +277,12 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
                 name="jobTitle"
                 label={intl.formatMessage({
                   defaultMessage: "What is the job title for this position?",
+                  id: "7lCUIL",
                   description: "Label for job title input in the request form",
                 })}
                 placeholder={intl.formatMessage({
                   defaultMessage: "Developer...",
+                  id: "zz9pwK",
                   description:
                     "Placeholder for job title input in the request form.",
                 })}
@@ -284,6 +297,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
               {intl.formatMessage({
                 defaultMessage:
                   "In this field please include any additional details and qualifications you are seeking from the candidates such as: programming languages, certifications, knowledge, or a specific work location.",
+                id: "Zzd/sJ",
                 description:
                   "Blurb before additional comments textarea in the request form.",
               })}
@@ -293,6 +307,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
               name="additionalComments"
               label={intl.formatMessage({
                 defaultMessage: "Additional Comments",
+                id: "FC5tje",
                 description:
                   "Label for additional comments textarea in the request form.",
               })}
@@ -302,6 +317,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
           <h2 data-h2-margin="base(x2, 0, x1, 0)">
             {intl.formatMessage({
               defaultMessage: "Summary of filters",
+              id: "emx1cK",
               description: "Title of Summary of filters section",
             })}
           </h2>
@@ -317,6 +333,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
               {
                 defaultMessage:
                   "Request for pool candidates: <span>{candidateCountNumber, plural, =0 {no candidates} =1 {1 estimated candidate} other {{candidateCountNumber} estimated candidates}}</span>",
+                id: "8fXduS",
                 description:
                   "Total estimated candidates message in summary of filters",
               },
@@ -344,6 +361,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
               >
                 {intl.formatMessage({
                   defaultMessage: "Back",
+                  id: "L8k+lC",
                   description:
                     "Back button located next to the submit button on the request form.",
                 })}
@@ -358,6 +376,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
                 mode="solid"
                 text={intl.formatMessage({
                   defaultMessage: "Submit Request",
+                  id: "eTTlR0",
                   description: "Submit button text on request form.",
                 })}
               />

--- a/frontend/talentsearch/src/js/components/roleSalaryForm/RoleSalaryForm.tsx
+++ b/frontend/talentsearch/src/js/components/roleSalaryForm/RoleSalaryForm.tsx
@@ -163,6 +163,7 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
         {
           title: intl.formatMessage({
             defaultMessage: "My Applications",
+            id: "mq4G8h",
             description:
               "'My Applications' breadcrumb from applicant profile wrapper.",
           }),
@@ -174,6 +175,7 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
             application.poolAdvertisement?.name?.[locale] ||
             intl.formatMessage({
               defaultMessage: "Pool name not found",
+              id: "FmD1sL",
               description:
                 "Pools name breadcrumb from applicant profile wrapper if no name set.",
             }),
@@ -186,11 +188,13 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
     <ProfileFormWrapper
       title={intl.formatMessage({
         defaultMessage: "Role and Salary Expectations",
+        id: "kCBLsJ",
         description: "Title role and salary expectations form",
       })}
       description={intl.formatMessage({
         defaultMessage:
           "Government classifications are labels that the Government of Canada uses to group similar types of work. In the Government of Canada salary is tied to how positions are classified.",
+        id: "uIpPFZ",
         description: "Description for the role and salary expectation form",
       })}
       cancelLink={{
@@ -201,6 +205,7 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
         {
           title: intl.formatMessage({
             defaultMessage: "Role and Salary Expectations",
+            id: "dgOYID",
             description: "Label for role and salary link",
           }),
         },
@@ -217,6 +222,7 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
           {intl.formatMessage({
             defaultMessage:
               "This platform is focused on hiring digital talent to work in positions classified as IT(Information Technology). Look at the following levels within the IT classification and <strong>select only</strong> the ones that represent the work you want to do.",
+            id: "n7UXz5",
             description: "Blurb describing the purpose of the form",
           })}
         </p>
@@ -225,6 +231,7 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
           legend={intl.formatMessage({
             defaultMessage:
               "I would like to be referred for jobs at the following levels:",
+            id: "DrR60L",
             description: "Legend for role and salary checklist form",
           })}
           rules={{
@@ -238,6 +245,7 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
                 {
                   defaultMessage:
                     "Level 1: Technician ($60,000 to $78,000). <openModal>Learn about IT-01</openModal>",
+                  id: "Zn10pO",
                   description:
                     "Checkbox label for Level IT-01 selection, ignore things in <> tags please",
                 },
@@ -253,6 +261,7 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
                 {
                   defaultMessage:
                     "Level 2: Analyst ($75,000 to $91,000). <openModal>Learn about IT-02</openModal>",
+                  id: "PcYOnN",
                   description:
                     "Checkbox label for Level IT-02 selection, ignore things in <> tags please",
                 },
@@ -268,6 +277,7 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
                 {
                   defaultMessage:
                     "Level 3: Team Leader ($88,000 to $110,000). <openModal>Learn about IT-03</openModal>",
+                  id: "hizC89",
                   description:
                     "Checkbox label for Level IT-03 leader selection, ignore things in <> tags please",
                 },
@@ -283,6 +293,7 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
                 {
                   defaultMessage:
                     "Level 3: Technical Advisor ($88,000 to $110,000). <openModal>Learn about IT-03</openModal>",
+                  id: "44bgIY",
                   description:
                     "Checkbox label for Level IT-03 advisor selection, ignore things in <> tags please",
                 },
@@ -298,6 +309,7 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
                 {
                   defaultMessage:
                     "Level 4: Senior Advisor ($101,000 to $126,000). <openModal>Learn about IT-04</openModal>",
+                  id: "FayQOt",
                   description:
                     "Checkbox label for Level IT-04 senior advisor selection, ignore things in <> tags please",
                 },
@@ -313,6 +325,7 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
                 {
                   defaultMessage:
                     "Level 4: Manager ($101,000 to $126,000). <openModal>Learn about IT-04</openModal>",
+                  id: "75nLSV",
                   description:
                     "Checkbox label for Level IT-04 manager selection, ignore things in <> tags please",
                 },
@@ -336,6 +349,7 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
                 {
                   defaultMessage:
                     "<link>Click here to learn more about classifications in the Government of Canada's Digital Community.</link>",
+                  id: "KT3jUW",
                   description: "Link to learn more about classifications",
                 },
                 {

--- a/frontend/talentsearch/src/js/components/roleSalaryForm/dialogs.tsx
+++ b/frontend/talentsearch/src/js/components/roleSalaryForm/dialogs.tsx
@@ -34,6 +34,7 @@ export const DialogLevelOne: React.FC<DialogLevelsProps> = ({
     <Dialog
       title={intl.formatMessage({
         defaultMessage: "Level 1: Technicians",
+        id: "aLMroa",
         description: "title for IT-01 dialog",
       })}
       color="ts-primary"
@@ -44,6 +45,7 @@ export const DialogLevelOne: React.FC<DialogLevelsProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "Technicians (IT-01) provide technical support in the development, implementation, integration, and maintenance of service delivery to clients and stakeholders",
+          id: "Z9Uex5",
           description: "blurb describing IT-01",
         })}
       </p>
@@ -51,6 +53,7 @@ export const DialogLevelOne: React.FC<DialogLevelsProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "IT Technicians are primarily found in three work streams: ",
+          id: "vQzmUH",
           description: "Preceding list description",
         })}
       </p>
@@ -58,18 +61,21 @@ export const DialogLevelOne: React.FC<DialogLevelsProps> = ({
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Infrastructure Operations",
+            id: "QZ9FZB",
             description: "work stream example",
           })}
         </li>
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Security",
+            id: "nrBkon",
             description: "work stream example",
           })}
         </li>
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Software Solutions",
+            id: "SDDp1t",
             description: "work stream example",
           })}
         </li>
@@ -82,6 +88,7 @@ export const DialogLevelOne: React.FC<DialogLevelsProps> = ({
           <CloseDialogButton close={onDismiss}>
             {intl.formatMessage({
               defaultMessage: "Close",
+              id: "qSxmx0",
               description: "Close Confirmations",
             })}
           </CloseDialogButton>
@@ -101,6 +108,7 @@ export const DialogLevelTwo: React.FC<DialogLevelsProps> = ({
     <Dialog
       title={intl.formatMessage({
         defaultMessage: "Level 2: Analysts",
+        id: "MNVv3A",
         description: "title for IT-02 dialog",
       })}
       color="ts-primary"
@@ -111,6 +119,7 @@ export const DialogLevelTwo: React.FC<DialogLevelsProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "Analysts (IT-02) provide technical services, advice, analysis, and research in their field of expertise to support service delivery to clients and stakeholders. IT analysts are found in all work streams.",
+          id: "raFdbB",
           description: "blurb describing IT-02",
         })}
       </p>
@@ -122,6 +131,7 @@ export const DialogLevelTwo: React.FC<DialogLevelsProps> = ({
           <CloseDialogButton close={onDismiss}>
             {intl.formatMessage({
               defaultMessage: "Close",
+              id: "qSxmx0",
               description: "Close Confirmations",
             })}
           </CloseDialogButton>
@@ -141,6 +151,7 @@ export const DialogLevelThreeLead: React.FC<DialogLevelsProps> = ({
     <Dialog
       title={intl.formatMessage({
         defaultMessage: "Level 3: Teams Leads",
+        id: "mTlHta",
         description: "title for IT-03 lead dialog",
       })}
       color="ts-primary"
@@ -151,6 +162,7 @@ export const DialogLevelThreeLead: React.FC<DialogLevelsProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "There are two types of IT-03 employees: those following a management path, and individual contributors.",
+          id: "hCgrxA",
           description: "IT-03 description precursor",
         })}
       </p>
@@ -158,6 +170,7 @@ export const DialogLevelThreeLead: React.FC<DialogLevelsProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "<strong>Management Path</strong>: IT Team Leads (IT-03) are responsible for supervising work and project teams for IT services and operations in their field of expertise to support service delivery to clients and stakeholders. IT Team Leads are found in all work streams.",
+          id: "+bC9lc",
           description:
             "IT-03 team lead path description, ignore things in <> tags please",
         })}
@@ -170,6 +183,7 @@ export const DialogLevelThreeLead: React.FC<DialogLevelsProps> = ({
           <CloseDialogButton close={onDismiss}>
             {intl.formatMessage({
               defaultMessage: "Close",
+              id: "qSxmx0",
               description: "Close Confirmations",
             })}
           </CloseDialogButton>
@@ -189,6 +203,7 @@ export const DialogLevelThreeAdvisor: React.FC<DialogLevelsProps> = ({
     <Dialog
       title={intl.formatMessage({
         defaultMessage: "Level 3: Technical Advisors",
+        id: "WE0OGe",
         description: "title for IT-03 advisor dialog",
       })}
       color="ts-primary"
@@ -199,6 +214,7 @@ export const DialogLevelThreeAdvisor: React.FC<DialogLevelsProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "There are two types of IT-03 employees: those following a management path, and individual contributors.",
+          id: "hCgrxA",
           description: "IT-03 description precursor",
         })}
       </p>
@@ -206,6 +222,7 @@ export const DialogLevelThreeAdvisor: React.FC<DialogLevelsProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "<strong>Individual Contributor</strong>: IT Technical Advisors (IT-03) provide specialized technical advice, recommendations and support on solutions and services in their field of expertise in support of service delivery to clients and stakeholders. IT Technical Advisors are found in all work streams.",
+          id: "u+9mg1",
           description:
             "IT-03 advisor description, ignore things in <> tags please",
         })}
@@ -218,6 +235,7 @@ export const DialogLevelThreeAdvisor: React.FC<DialogLevelsProps> = ({
           <CloseDialogButton close={onDismiss}>
             {intl.formatMessage({
               defaultMessage: "Close",
+              id: "qSxmx0",
               description: "Close Confirmations",
             })}
           </CloseDialogButton>
@@ -237,6 +255,7 @@ export const DialogLevelFourLead: React.FC<DialogLevelsProps> = ({
     <Dialog
       title={intl.formatMessage({
         defaultMessage: "Level 4: Manager",
+        id: "2KjiDn",
         description: "title for IT-04 manager dialog",
       })}
       color="ts-primary"
@@ -247,6 +266,7 @@ export const DialogLevelFourLead: React.FC<DialogLevelsProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "There are two types of IT-04 employees: those following a management path, and individual contributors.",
+          id: "87nFC8",
           description: "IT-04 description precursor",
         })}
       </p>
@@ -254,6 +274,7 @@ export const DialogLevelFourLead: React.FC<DialogLevelsProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "<strong>Management Path</strong>: IT Managers (IT-04) are responsible for managing the development and delivery of IT services and/or operations through subordinate team leaders, technical advisors, and project teams, for service delivery to clients and stakeholders. IT Managers are found in all work streams.",
+          id: "m21EOJ",
           description:
             "IT-04 manager path description, ignore things in <> tags please",
         })}
@@ -266,6 +287,7 @@ export const DialogLevelFourLead: React.FC<DialogLevelsProps> = ({
           <CloseDialogButton close={onDismiss}>
             {intl.formatMessage({
               defaultMessage: "Close",
+              id: "qSxmx0",
               description: "Close Confirmations",
             })}
           </CloseDialogButton>
@@ -285,6 +307,7 @@ export const DialogLevelFourAdvisor: React.FC<DialogLevelsProps> = ({
     <Dialog
       title={intl.formatMessage({
         defaultMessage: "Level 4: Senior Advisor",
+        id: "2VprXV",
         description: "title for IT-04 senior advisor dialog",
       })}
       color="ts-primary"
@@ -295,6 +318,7 @@ export const DialogLevelFourAdvisor: React.FC<DialogLevelsProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "There are two types of IT-04 employees: those following a management path, and individual contributors.",
+          id: "87nFC8",
           description: "IT-04 description precursor",
         })}
       </p>
@@ -302,6 +326,7 @@ export const DialogLevelFourAdvisor: React.FC<DialogLevelsProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "<strong>Individual Contributor</strong>: IT Senior Advisors (IT-04) provide expert technical advice and strategic direction in their field of expertise in the provision of solutions and services to internal or external clients, and stakeholders. IT Senior Advisors are primarily found in six work streams:",
+          id: "58BEeZ",
           description:
             "IT-04 senior advisor description precursor to work stream list, ignore things in <> tags please",
         })}
@@ -310,36 +335,42 @@ export const DialogLevelFourAdvisor: React.FC<DialogLevelsProps> = ({
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Infrastructure Operations",
+            id: "QZ9FZB",
             description: "work stream example",
           })}
         </li>
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Security",
+            id: "nrBkon",
             description: "work stream example",
           })}
         </li>
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Software Solutions",
+            id: "SDDp1t",
             description: "work stream example",
           })}
         </li>
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Database Management",
+            id: "6LTC0y",
             description: "work stream example",
           })}
         </li>
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Enterprise Architecture",
+            id: "oOcegG",
             description: "work stream example",
           })}
         </li>
         <li>
           {intl.formatMessage({
             defaultMessage: "IT Project Portfolio Management",
+            id: "tm3zLD",
             description: "work stream example",
           })}
         </li>
@@ -352,6 +383,7 @@ export const DialogLevelFourAdvisor: React.FC<DialogLevelsProps> = ({
           <CloseDialogButton close={onDismiss}>
             {intl.formatMessage({
               defaultMessage: "Close",
+              id: "qSxmx0",
               description: "Close Confirmations",
             })}
           </CloseDialogButton>

--- a/frontend/talentsearch/src/js/components/search/CandidateResults.tsx
+++ b/frontend/talentsearch/src/js/components/search/CandidateResults.tsx
@@ -48,6 +48,7 @@ const CandidateResults: React.FC<CandidateResultsProps> = ({
       <p>
         {intl.formatMessage({
           defaultMessage: "We can still help!",
+          id: "5U+V2Y",
           description:
             "Heading for helping user if no candidates matched the filters chosen.",
         })}
@@ -57,6 +58,7 @@ const CandidateResults: React.FC<CandidateResultsProps> = ({
           {
             defaultMessage:
               "If there are no matching candidates <a>Get in touch!</a>",
+            id: "+ZXZj+",
             description:
               "Message for helping user if no candidates matched the filters chosen.",
           },

--- a/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
+++ b/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
@@ -40,6 +40,7 @@ const EstimatedCandidates: React.FunctionComponent<
             >
               {intl.formatMessage({
                 defaultMessage: "Estimated Candidates",
+                id: "09x+E7",
                 description:
                   "Heading for total estimated candidates box next to search form.",
               })}
@@ -62,6 +63,7 @@ const EstimatedCandidates: React.FunctionComponent<
                         one {There is approximately <strong><testId>{candidateCount}</testId></strong> candidate right now who meets your criteria.}
                         other {There are approximately <strong><testId>{candidateCount}</testId></strong> candidates right now who meet your criteria.}
                       }`,
+                      id: "ID8FNk",
                       description:
                         "Message for total estimated candidates box next to search form.",
                     },

--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -125,6 +125,7 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
               >
                 {intl.formatMessage({
                   defaultMessage: "How to use this tool",
+                  id: "HvD7jI",
                   description:
                     "Heading displayed in the How To area of the hero section of the Search page.",
                 })}
@@ -133,6 +134,7 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
                 {intl.formatMessage({
                   defaultMessage:
                     "Use the filters below to specify your hiring needs. At any time you can look at the results located at the bottom of this page to see how many candidates match the requirements you have entered. When you are comfortable with the filters you have selected, click the Request Candidates button to add more details and submit a request form.",
+                  id: "Tg8a57",
                   description:
                     "Content displayed in the How To area of the hero section of the Search page.",
                 })}
@@ -175,6 +177,7 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
               {
                 defaultMessage:
                   "Results: <primary><testId>{candidateCount}</testId></primary> matching candidates",
+                id: "1xRst5",
                 description:
                   "Heading for total matching candidates in results section of search page.",
               },

--- a/frontend/talentsearch/src/js/components/search/SearchFilterAdvice.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchFilterAdvice.tsx
@@ -27,6 +27,7 @@ const SearchFilterAdvice: React.FC<{
             {
               defaultMessage:
                 "Classification Filters ({classificationFilterCount})",
+              id: "LRysDa",
             },
             { classificationFilterCount },
           )}
@@ -47,6 +48,7 @@ const SearchFilterAdvice: React.FC<{
             {
               defaultMessage:
                 "Conditions of Employment ({operationalRequirementFilterCount})",
+              id: "ky585k",
             },
             { operationalRequirementFilterCount },
           )}
@@ -59,6 +61,7 @@ const SearchFilterAdvice: React.FC<{
       {intl.formatMessage({
         defaultMessage:
           "To improve your results, try removing some of these filters:",
+        id: "zDzzb/",
         description:
           "Heading for total matching candidates in results section of search page.",
       })}{" "}

--- a/frontend/talentsearch/src/js/components/search/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchForm.tsx
@@ -71,19 +71,23 @@ export interface SearchFormRef {
 const classificationLabels: Record<string, MessageDescriptor> = defineMessages({
   "IT-01": {
     defaultMessage: "IT-01: Technician ($60,000 to $78,000)",
+    id: "ZuyuPO",
     description: "IT-01 classification label including titles and salaries",
   },
   "IT-02": {
     defaultMessage: "IT-02: Analyst ($75,000 to $91,000)",
+    id: "UN2Ncr",
     description: "IT-02 classification label including titles and salaries",
   },
   "IT-03": {
     defaultMessage:
       "IT-03: Technical Advisor or Team Leader ($88,000 to $110,000)",
+    id: "Aa8SIB",
     description: "IT-03 classification label including titles and salaries",
   },
   "IT-04": {
     defaultMessage: "IT-04: Senior Advisor or Manager ($101,000 to $126,000)",
+    id: "5YzNJj",
     description: "IT-04 classification label including titles and salaries",
   },
 });
@@ -201,12 +205,14 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             id="classificationsFilter"
             title={intl.formatMessage({
               defaultMessage: "Classification filter",
+              id: "TxVbLI",
               description:
                 "Heading for classification filter of the search form.",
             })}
             text={intl.formatMessage({
               defaultMessage:
                 "We use this filter to match candidates who express interest in a classification level, or certain expected salaries in these classifications.",
+              id: "dxv7Jx",
               description:
                 "Message describing the classification filter of the search form.",
             })}
@@ -215,10 +221,12 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
               id="classifications"
               label={intl.formatMessage({
                 defaultMessage: "Classification filter",
+                id: "V8v+/g",
                 description: "Label for classification filter in search form.",
               })}
               placeholder={intl.formatMessage({
                 defaultMessage: "Select one or more classification(s)",
+                id: "iNsxYi",
                 description:
                   "Placeholder for classification filter in search form.",
               })}
@@ -233,12 +241,14 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             id="educationRequirementFilter"
             title={intl.formatMessage({
               defaultMessage: "Education requirement for the job",
+              id: "AyP6Fr",
               description:
                 "Heading for education requirement filter of the search form.",
             })}
             text={intl.formatMessage({
               defaultMessage:
                 "Most jobs in the Digital community do not require a diploma, change this only if the job requires a diploma.",
+              id: "mhtcMd",
               description:
                 "Message describing the education requirement filter of the search form.",
             })}
@@ -247,6 +257,7 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
               idPrefix="education_requirement"
               legend={intl.formatMessage({
                 defaultMessage: "Education Requirement filter",
+                id: "/JQ6DD",
                 description:
                   "Legend for the Education Requirement filter radio group",
               })}
@@ -258,6 +269,7 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                   label: intl.formatMessage({
                     defaultMessage:
                       "Can accept a combination of work experience and education",
+                    id: "74WtLG",
                     description:
                       "Radio group option for education requirement filter in search form.",
                   }),
@@ -267,6 +279,7 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                   label: intl.formatMessage({
                     defaultMessage:
                       "Required diploma from post-secondary institution",
+                    id: "KoPFx4",
                     description:
                       "Radio group option for education requirement filter in search form.",
                   }),
@@ -279,12 +292,14 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             title={intl.formatMessage({
               defaultMessage:
                 "Conditions of employment / Operational requirements",
+              id: "laGCzG",
               description:
                 "Heading for operational requirements section of the search form.",
             })}
             text={intl.formatMessage({
               defaultMessage:
                 "The selected conditions of employment will be compared to those chosen by candidates in their applications.",
+              id: "IT6Djp",
               description:
                 "Message describing the operational requirements filter in the search form.",
             })}
@@ -293,6 +308,7 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
               idPrefix="operationalRequirements"
               legend={intl.formatMessage({
                 defaultMessage: "Conditions of employment",
+                id: "bKvvaI",
                 description:
                   "Legend for the Conditions of Employment filter checklist",
               })}
@@ -307,12 +323,14 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             id="locationPreferencesFilter"
             title={intl.formatMessage({
               defaultMessage: "Work location",
+              id: "uP+q43",
               description:
                 "Heading for work location section of the search form.",
             })}
             text={intl.formatMessage({
               defaultMessage:
                 "If you have more detailed work location requirement, let us know in the comment section of the submission form.",
+              id: "v7sYE7",
               description:
                 "Message describing the work location filter in the search form.",
             })}
@@ -322,10 +340,12 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
               name="locationPreferences"
               label={intl.formatMessage({
                 defaultMessage: "Region",
+                id: "F+WFWB",
                 description: "Label for work location filter in search form.",
               })}
               placeholder={intl.formatMessage({
                 defaultMessage: "Select a location...",
+                id: "asqSAJ",
                 description:
                   "Placeholder for work location filter in search form.",
               })}
@@ -339,12 +359,14 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             id="workingLanguageFilter"
             title={intl.formatMessage({
               defaultMessage: "Working language ability",
+              id: "p72C40",
               description:
                 "Heading for working language ability section of the search form.",
             })}
             text={intl.formatMessage({
               defaultMessage:
                 "Select the working language ability the candidate needs for this position.",
+              id: "RGzfes",
               description:
                 "Message describing the work language ability filter in the search form.",
             })}
@@ -353,6 +375,7 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
               idPrefix="languageAbility"
               legend={intl.formatMessage({
                 defaultMessage: "Language",
+                id: "sk9CeW",
                 description:
                   "Legend for the Working Language Ability radio buttons",
               })}
@@ -363,6 +386,7 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                   value: NullSelection,
                   label: intl.formatMessage({
                     defaultMessage: "Any language (English or French)",
+                    id: "YyHN1i",
                     description:
                       "No preference for language ability - will accept English or French",
                   }),
@@ -378,12 +402,14 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             id="employmentDurationFilter"
             title={intl.formatMessage({
               defaultMessage: "Employment Duration",
+              id: "VwVtqr",
               description:
                 "Heading for employment duration section of the search form.",
             })}
             text={intl.formatMessage({
               defaultMessage:
                 "The selected duration will be compared to the one chosen by candidates in their applications. Change this only if the job offer has a determined duration.",
+              id: "iN2H6J",
               description:
                 "Message describing the employment duration filter in the search form.",
             })}
@@ -399,6 +425,7 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                   label: intl.formatMessage({
                     defaultMessage:
                       "Any duration (short term, long term or indeterminate) (Recommended)",
+                    id: "8fQWTc",
                     description:
                       "No preference for employment duration - will accept any",
                   }),
@@ -422,12 +449,14 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             id="employmentEquityFilter"
             title={intl.formatMessage({
               defaultMessage: "Employment equity",
+              id: "ITkmBQ",
               description:
                 "Heading for employment equity section of the search form.",
             })}
             text={intl.formatMessage({
               defaultMessage:
                 "Managers can request candidates by employment equity group(s) to address current of future representation gaps in the workforce. (Categories reflect EE data defined under the Public Service Employment Act and collected through the PSC application process. For consistency, this platform reflects the PSC's category terminology.)",
+              id: "Za/qCZ",
               description:
                 "Message describing the employment equity filter in the search form.",
             })}
@@ -436,12 +465,14 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
               idPrefix="employmentEquity"
               legend={intl.formatMessage({
                 defaultMessage: "Employment equity groups",
+                id: "m3qn9l",
                 description: "Legend for the employment equity checklist",
               })}
               name="employmentEquity"
               context={intl.formatMessage({
                 defaultMessage:
                   "<strong>Note:</strong> If you select more than one employment equity group, ALL candidates who have self-declared as being members of ANY of the selected EE groups will be referred. If you have more detailed EE requirements, let us know in the comment section of the submission form.",
+                id: "GIPciq",
                 description:
                   "Context for employment equity filter in search form.",
               })}

--- a/frontend/talentsearch/src/js/components/search/SearchHeading.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchHeading.tsx
@@ -32,6 +32,7 @@ const SearchHeading: React.FunctionComponent = () => {
           >
             {intl.formatMessage({
               defaultMessage: "Search the Digital Talent Pool",
+              id: "SZTFJq",
               description:
                 "Title displayed in the hero section of the Search page.",
             })}
@@ -53,6 +54,7 @@ const SearchHeading: React.FunctionComponent = () => {
             >
               {intl.formatMessage({
                 defaultMessage: "About the Digital Talent Pool",
+                id: "9hdbFi",
                 description:
                   "Heading displayed in the About area of the hero section of the Search page.",
               })}
@@ -61,6 +63,7 @@ const SearchHeading: React.FunctionComponent = () => {
               {intl.formatMessage({
                 defaultMessage:
                   "This pool is open to most departments and agencies. Candidates in the pool vary from just starting their career to seasoned professionals with several years of work experience. This is an ongoing recruitment pool, which means new candidates are being added every week.",
+                id: "XSxaGk",
                 description:
                   "Content displayed in the About area of the hero section of the Search page.",
               })}

--- a/frontend/talentsearch/src/js/components/search/SearchPools.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchPools.tsx
@@ -32,6 +32,7 @@ const SearchPools: React.FunctionComponent<SearchPoolsProps> = ({
           {
             defaultMessage:
               "There are <heavyPrimary><testId>{candidateCount}</testId></heavyPrimary> matching candidates in this pool",
+            id: "Ba4Y8a",
             description:
               "Message for total estimated candidates box next to search form.",
           },
@@ -45,6 +46,7 @@ const SearchPools: React.FunctionComponent<SearchPoolsProps> = ({
         {intl.formatMessage(
           {
             defaultMessage: "Pool Owner: {firstName} {lastName}",
+            id: "/quEXs",
             description: "Text showing the owner of the HR pool.",
           },
           {
@@ -57,6 +59,7 @@ const SearchPools: React.FunctionComponent<SearchPoolsProps> = ({
       <Button color="cta" mode="solid" onClick={handleSubmit}>
         {intl.formatMessage({
           defaultMessage: "Request Candidates",
+          id: "6mDW+R",
           description:
             "Button link message on search page that takes user to the request form.",
         })}

--- a/frontend/talentsearch/src/js/components/search/deprecated/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/deprecated/SearchContainer.tsx
@@ -111,6 +111,7 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
         <p>
           {intl.formatMessage({
             defaultMessage: "We can still help!",
+            id: "5U+V2Y",
             description:
               "Heading for helping user if no candidates matched the filters chosen.",
           })}
@@ -120,6 +121,7 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
             {
               defaultMessage:
                 "If there are no matching candidates <a>Get in touch!</a>",
+              id: "+ZXZj+",
               description:
                 "Message for helping user if no candidates matched the filters chosen.",
             },
@@ -148,6 +150,7 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
               >
                 {intl.formatMessage({
                   defaultMessage: "How to use this tool",
+                  id: "HvD7jI",
                   description:
                     "Heading displayed in the How To area of the hero section of the Search page.",
                 })}
@@ -156,6 +159,7 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
                 {intl.formatMessage({
                   defaultMessage:
                     "Use the filters below to specify your hiring needs. At any time you can look at the results located at the bottom of this page to see how many candidates match the requirements you have entered. When you are comfortable with the filters you have selected, click the Request Candidates button to add more details and submit a request form.",
+                  id: "Tg8a57",
                   description:
                     "Content displayed in the How To area of the hero section of the Search page.",
                 })}
@@ -198,6 +202,7 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
               {
                 defaultMessage:
                   "Results: <primary><testId>{candidateCount}</testId></primary> matching candidates",
+                id: "1xRst5",
                 description:
                   "Heading for total matching candidates in results section of search page.",
               },

--- a/frontend/talentsearch/src/js/components/search/deprecated/SearchFilterAdvice.tsx
+++ b/frontend/talentsearch/src/js/components/search/deprecated/SearchFilterAdvice.tsx
@@ -33,6 +33,7 @@ const SearchFilterAdvice: React.FC<{
             {
               defaultMessage:
                 "Classification Filters ({classificationFilterCount})",
+              id: "LRysDa",
             },
             { classificationFilterCount },
           )}
@@ -53,6 +54,7 @@ const SearchFilterAdvice: React.FC<{
             {
               defaultMessage:
                 "Conditions of Employment ({operationalRequirementFilterCount})",
+              id: "ky585k",
             },
             { operationalRequirementFilterCount },
           )}
@@ -72,6 +74,7 @@ const SearchFilterAdvice: React.FC<{
           {intl.formatMessage(
             {
               defaultMessage: "Skills Filters ({cmoAssetFilterCount})",
+              id: "/DbKFl",
             },
             { cmoAssetFilterCount },
           )}
@@ -84,6 +87,7 @@ const SearchFilterAdvice: React.FC<{
       {intl.formatMessage({
         defaultMessage:
           "To improve your results, try removing some of these filters:",
+        id: "zDzzb/",
         description:
           "Heading for total matching candidates in results section of search page.",
       })}{" "}

--- a/frontend/talentsearch/src/js/components/search/deprecated/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/deprecated/SearchForm.tsx
@@ -86,19 +86,23 @@ export interface SearchFormRef {
 const classificationLabels: Record<string, MessageDescriptor> = defineMessages({
   "IT-01": {
     defaultMessage: "IT-01: Technician ($60,000 to $78,000)",
+    id: "ZuyuPO",
     description: "IT-01 classification label including titles and salaries",
   },
   "IT-02": {
     defaultMessage: "IT-02: Analyst ($75,000 to $91,000)",
+    id: "UN2Ncr",
     description: "IT-02 classification label including titles and salaries",
   },
   "IT-03": {
     defaultMessage:
       "IT-03: Technical Advisor or Team Leader ($88,000 to $110,000)",
+    id: "Aa8SIB",
     description: "IT-03 classification label including titles and salaries",
   },
   "IT-04": {
     defaultMessage: "IT-04: Senior Advisor or Manager ($101,000 to $126,000)",
+    id: "5YzNJj",
     description: "IT-04 classification label including titles and salaries",
   },
 });
@@ -215,6 +219,7 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             name[locale] ??
             intl.formatMessage({
               defaultMessage: "Error: name not loaded",
+              id: "m+d9ls",
               description: "Error message for cmo asset filer on search form.",
             }),
         })),
@@ -228,12 +233,14 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             id="classificationsFilter"
             title={intl.formatMessage({
               defaultMessage: "Classification filter",
+              id: "TxVbLI",
               description:
                 "Heading for classification filter of the search form.",
             })}
             text={intl.formatMessage({
               defaultMessage:
                 "We use this filter to match candidates who express interest in a classification level, or certain expected salaries in these classifications.",
+              id: "dxv7Jx",
               description:
                 "Message describing the classification filter of the search form.",
             })}
@@ -242,10 +249,12 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
               id="classifications"
               label={intl.formatMessage({
                 defaultMessage: "Classification filter",
+                id: "V8v+/g",
                 description: "Label for classification filter in search form.",
               })}
               placeholder={intl.formatMessage({
                 defaultMessage: "Select one or more classification(s)",
+                id: "iNsxYi",
                 description:
                   "Placeholder for classification filter in search form.",
               })}
@@ -260,12 +269,14 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             id="educationRequirementFilter"
             title={intl.formatMessage({
               defaultMessage: "Education requirement for the job",
+              id: "AyP6Fr",
               description:
                 "Heading for education requirement filter of the search form.",
             })}
             text={intl.formatMessage({
               defaultMessage:
                 "Most jobs in the Digital community do not require a diploma, change this only if the job requires a diploma.",
+              id: "mhtcMd",
               description:
                 "Message describing the education requirement filter of the search form.",
             })}
@@ -274,6 +285,7 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
               idPrefix="education_requirement"
               legend={intl.formatMessage({
                 defaultMessage: "Education Requirement filter",
+                id: "/JQ6DD",
                 description:
                   "Legend for the Education Requirement filter radio group",
               })}
@@ -285,6 +297,7 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                   label: intl.formatMessage({
                     defaultMessage:
                       "Can accept a combination of work experience and education",
+                    id: "74WtLG",
                     description:
                       "Radio group option for education requirement filter in search form.",
                   }),
@@ -294,6 +307,7 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                   label: intl.formatMessage({
                     defaultMessage:
                       "Required diploma from post-secondary institution",
+                    id: "KoPFx4",
                     description:
                       "Radio group option for education requirement filter in search form.",
                   }),
@@ -306,12 +320,14 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             title={intl.formatMessage({
               defaultMessage:
                 "Conditions of employment / Operational requirements",
+              id: "laGCzG",
               description:
                 "Heading for operational requirements section of the search form.",
             })}
             text={intl.formatMessage({
               defaultMessage:
                 "The selected conditions of employment will be compared to those chosen by candidates in their applications.",
+              id: "IT6Djp",
               description:
                 "Message describing the operational requirements filter in the search form.",
             })}
@@ -320,6 +336,7 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
               idPrefix="operationalRequirements"
               legend={intl.formatMessage({
                 defaultMessage: "Conditions of employment",
+                id: "bKvvaI",
                 description:
                   "Legend for the Conditions of Employment filter checklist",
               })}
@@ -336,12 +353,14 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             id="workLocationFilter"
             title={intl.formatMessage({
               defaultMessage: "Work location",
+              id: "uP+q43",
               description:
                 "Heading for work location section of the search form.",
             })}
             text={intl.formatMessage({
               defaultMessage:
                 "If you have more detailed work location requirement, let us know in the comment section of the submission form.",
+              id: "v7sYE7",
               description:
                 "Message describing the work location filter in the search form.",
             })}
@@ -351,10 +370,12 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
               name="workRegions"
               label={intl.formatMessage({
                 defaultMessage: "Region",
+                id: "F+WFWB",
                 description: "Label for work location filter in search form.",
               })}
               placeholder={intl.formatMessage({
                 defaultMessage: "Select a location...",
+                id: "asqSAJ",
                 description:
                   "Placeholder for work location filter in search form.",
               })}
@@ -368,12 +389,14 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             id="workingLanguageFilter"
             title={intl.formatMessage({
               defaultMessage: "Working language ability",
+              id: "p72C40",
               description:
                 "Heading for working language ability section of the search form.",
             })}
             text={intl.formatMessage({
               defaultMessage:
                 "Select the working language ability the candidate needs for this position.",
+              id: "RGzfes",
               description:
                 "Message describing the work language ability filter in the search form.",
             })}
@@ -382,6 +405,7 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
               idPrefix="languageAbility"
               legend={intl.formatMessage({
                 defaultMessage: "Language",
+                id: "sk9CeW",
                 description:
                   "Legend for the Working Language Ability radio buttons",
               })}
@@ -392,6 +416,7 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                   value: NullSelection,
                   label: intl.formatMessage({
                     defaultMessage: "Any language (English or French)",
+                    id: "YyHN1i",
                     description:
                       "No preference for language ability - will accept English or French",
                   }),
@@ -407,12 +432,14 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             id="employmentEquityFilter"
             title={intl.formatMessage({
               defaultMessage: "Employment equity",
+              id: "ITkmBQ",
               description:
                 "Heading for employment equity section of the search form.",
             })}
             text={intl.formatMessage({
               defaultMessage:
                 "Managers can request candidates by employment equity group(s) to address current of future representation gaps in the workforce. (Categories reflect EE data defined under the Public Service Employment Act and collected through the PSC application process. For consistency, this platform reflects the PSC's category terminology.)",
+              id: "Za/qCZ",
               description:
                 "Message describing the employment equity filter in the search form.",
             })}
@@ -421,12 +448,14 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
               idPrefix="employmentEquity"
               legend={intl.formatMessage({
                 defaultMessage: "Employment equity groups",
+                id: "m3qn9l",
                 description: "Legend for the employment equity checklist",
               })}
               name="employmentEquity"
               context={intl.formatMessage({
                 defaultMessage:
                   "<strong>Note:</strong> If you select more than one employment equity group, ALL candidates who have self-declared as being members of ANY of the selected EE groups will be referred. If you have more detailed EE requirements, let us know in the comment section of the submission form.",
+                id: "GIPciq",
                 description:
                   "Context for employment equity filter in search form.",
               })}
@@ -460,12 +489,14 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             id="cmoAssetFilter"
             title={intl.formatMessage({
               defaultMessage: "Skill filters",
+              id: "kAieVP",
               description:
                 "Heading for skill filters section of the search form.",
             })}
             text={intl.formatMessage({
               defaultMessage:
                 "All applicants in this pool have been assessed for several soft skills.",
+              id: "1EyeE7",
               description:
                 "Message describing the skill filter in the search form.",
             })}
@@ -474,6 +505,7 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
               idPrefix="cmoAssets"
               legend={intl.formatMessage({
                 defaultMessage: "Skills organized by stream",
+                id: "3nKkyo",
                 description: "Legend for Skills filter checklist",
               })}
               name="cmoAssets"

--- a/frontend/talentsearch/src/js/components/signAndSubmit/SignAndSubmitPage.tsx
+++ b/frontend/talentsearch/src/js/components/signAndSubmit/SignAndSubmitPage.tsx
@@ -19,21 +19,25 @@ const ImportantInfo = () => {
     intl.formatMessage({
       defaultMessage:
         "When you submit your application, a copy of your profile will be created.",
+      id: "ww86SN",
       description: "Important info list item on sign and submit page.",
     }),
     intl.formatMessage({
       defaultMessage:
         "This copy will be used for the initial application review.",
+      id: "wyxpjm",
       description: "Important info list item on sign and submit page.",
     }),
     intl.formatMessage({
       defaultMessage:
         "Changes made to your profile after submitting will not be updated on this copy.",
+      id: "4NzbMZ",
       description: "Important info list item on sign and submit page.",
     }),
     intl.formatMessage({
       defaultMessage:
         "You are still encouraged to keep your profile up to date, updated versions will be used at later steps of the hiring process.",
+      id: "qDYcDP",
       description: "Important info list item on sign and submit page.",
     }),
   ];
@@ -56,16 +60,19 @@ const Signature = ({ isNotComplete }: { isNotComplete: boolean }) => {
     intl.formatMessage({
       defaultMessage: `"I've reviewed everything written in my
         application`,
+      id: "aeI64y",
       description: "Signature list item on sign and submit page.",
     }),
     intl.formatMessage({
       defaultMessage: `"I understand that I am part of a community who trusts each
         other"`,
+      id: "dIZPra",
       description: "Signature list item on sign and submit page.",
     }),
     intl.formatMessage({
       defaultMessage: `"I promise that the information Ive provided is
         true"`,
+      id: "Lgo2iQ",
       description: "Signature list item on sign and submit page.",
     }),
   ];
@@ -80,6 +87,7 @@ const Signature = ({ isNotComplete }: { isNotComplete: boolean }) => {
           {intl.formatMessage({
             defaultMessage:
               "You made it! By signing your name below you confirm that:",
+            id: "i4CKlO",
             description:
               "Confirmation message before signature form on sign and submit page.",
           })}
@@ -99,6 +107,7 @@ const Signature = ({ isNotComplete }: { isNotComplete: boolean }) => {
             id="signature"
             label={intl.formatMessage({
               defaultMessage: "Signature",
+              id: "YZyNUJ",
               description:
                 "Label displayed for signature input in sign and submit page.",
             })}
@@ -120,6 +129,7 @@ const Signature = ({ isNotComplete }: { isNotComplete: boolean }) => {
               >
                 {intl.formatMessage({
                   defaultMessage: "Submit my application",
+                  id: "Knr0yc",
                   description: "Submit button label on sign and submit page.",
                 })}
                 <ArrowSmRightIcon
@@ -141,6 +151,7 @@ const Signature = ({ isNotComplete }: { isNotComplete: boolean }) => {
           >
             {intl.formatMessage({
               defaultMessage: "Back to previous step",
+              id: "SDQWZf",
               description: "Label for return link on sign and submit page.",
             })}
           </Link>
@@ -169,6 +180,7 @@ export const SignAndSubmitForm = ({
       id: "importantInformation",
       title: intl.formatMessage({
         defaultMessage: "Important information",
+        id: "/Mb8b6",
         description: "Toc navigation item on sign and submit page.",
       }),
       component: <ImportantInfo />,
@@ -178,6 +190,7 @@ export const SignAndSubmitForm = ({
       id: "signature",
       title: intl.formatMessage({
         defaultMessage: "Signature",
+        id: "Ledr63",
         description: "Toc navigation item on sign and submit page.",
       }),
       component: <Signature isNotComplete={isNotComplete} />,
@@ -191,12 +204,14 @@ export const SignAndSubmitForm = ({
       closingDate={closingDate}
       title={intl.formatMessage({
         defaultMessage: "My application profile",
+        id: "6p6syC",
         description: "Title for sign and submit page.",
       })}
       crumbs={[
         {
           title: intl.formatMessage({
             defaultMessage: "My applications",
+            id: "kjtiha",
             description: "Breadcrumb for sign and submit page.",
           }),
           href: paths.allPools(),
@@ -208,6 +223,7 @@ export const SignAndSubmitForm = ({
         {
           title: intl.formatMessage({
             defaultMessage: "Step 2",
+            id: "oOR4Rd",
             description: "Breadcrumb for sign and submit page.",
           }),
         },
@@ -219,6 +235,7 @@ export const SignAndSubmitForm = ({
             path: applicationRoute,
             label: intl.formatMessage({
               defaultMessage: "Step 1: Review my profile",
+              id: "LUEVdb",
               description: "Navigation step in sign and submit page.",
             }),
           },
@@ -226,6 +243,7 @@ export const SignAndSubmitForm = ({
             path: "#sign-and-submit",
             label: intl.formatMessage({
               defaultMessage: "Step 2: Sign and submit",
+              id: "LOh+c5",
               description: "Navigation step in sign and submit page.",
             }),
           },
@@ -281,6 +299,7 @@ const SignAndSubmitPage: React.FC<{ id: string }> = ({ id }) => {
           <p>
             {intl.formatMessage({
               defaultMessage: "Error, application unable to be loaded",
+              id: "0+hcuo",
               description: "Error message, placeholder",
             })}
           </p>

--- a/frontend/talentsearch/src/js/components/skills/AddSkillsToExperience/AddSkillsToExperience.tsx
+++ b/frontend/talentsearch/src/js/components/skills/AddSkillsToExperience/AddSkillsToExperience.tsx
@@ -93,14 +93,17 @@ const AddSkillsToExperience: React.FunctionComponent<
   const tabs = [
     intl.formatMessage({
       defaultMessage: "My frequent skills",
+      id: "fUQPUr",
       description: "Tab name for a list of frequently used skills",
     }),
     intl.formatMessage({
       defaultMessage: "Mainstream skills",
+      id: "RKdRiG",
       description: "Tab name for a list of mainstream skills",
     }),
     intl.formatMessage({
       defaultMessage: "Search by keyword",
+      id: "WjREkG",
       description: "Tab name for a box to search for skills",
     }),
   ];
@@ -118,6 +121,7 @@ const AddSkillsToExperience: React.FunctionComponent<
       <h4>
         {intl.formatMessage({
           defaultMessage: "Add Skills",
+          id: "2SNKYg",
           description: "Section header for adding skills to this experience",
         })}
       </h4>
@@ -135,6 +139,7 @@ const AddSkillsToExperience: React.FunctionComponent<
               title={intl.formatMessage(
                 {
                   defaultMessage: "Frequently used skills ({skillCount})",
+                  id: "EYCY8j",
                   description:
                     "Section header for a list of frequently used skills",
                 },
@@ -150,6 +155,7 @@ const AddSkillsToExperience: React.FunctionComponent<
             <Pagination
               ariaLabel={intl.formatMessage({
                 defaultMessage: "Frequent skills results",
+                id: "Y+d/yO",
               })}
               color="primary"
               mode="outline"
@@ -171,6 +177,7 @@ const AddSkillsToExperience: React.FunctionComponent<
               title={intl.formatMessage(
                 {
                   defaultMessage: "Results ({skillCount})",
+                  id: "l0IDWf",
                   description: "A title for a skill list of results",
                 },
                 {
@@ -185,6 +192,7 @@ const AddSkillsToExperience: React.FunctionComponent<
             <Pagination
               ariaLabel={intl.formatMessage({
                 defaultMessage: "Mainstream skills results",
+                id: "s4DN3G",
                 description:
                   "Accessibility label for a result set of skills, filtered to mainstream skills",
               })}
@@ -205,6 +213,7 @@ const AddSkillsToExperience: React.FunctionComponent<
               title={intl.formatMessage(
                 {
                   defaultMessage: "Results ({skillCount})",
+                  id: "nr62lc",
                   description: "A title for a list of results",
                 },
                 {
@@ -219,6 +228,7 @@ const AddSkillsToExperience: React.FunctionComponent<
             <Pagination
               ariaLabel={intl.formatMessage({
                 defaultMessage: "keyword search skills results",
+                id: "wziEOM",
                 description:
                   "Accessibility label for a result set of skills, searched by keyword",
               })}

--- a/frontend/talentsearch/src/js/components/skills/AddSkillsToFilter/AddSkillsToFilter.tsx
+++ b/frontend/talentsearch/src/js/components/skills/AddSkillsToFilter/AddSkillsToFilter.tsx
@@ -52,6 +52,7 @@ const AddSkillsToFilter: React.FC<AddSkillsToFilterProps> = ({ allSkills }) => {
       >
         {intl.formatMessage({
           defaultMessage: "Skills as filters",
+          id: "hEhmBF",
           description: "Title for the skill filters on search page.",
         })}
       </h3>
@@ -59,6 +60,7 @@ const AddSkillsToFilter: React.FC<AddSkillsToFilterProps> = ({ allSkills }) => {
         {intl.formatMessage({
           defaultMessage:
             "Find candidates with the right skills for the job. Use the following tabs to find skills that are necessary for the job and select them to use them as filters for matching candidates.",
+          id: "+cy2GO",
           description:
             "Describing how to use the skill filters on search page, paragraph one.",
         })}
@@ -67,6 +69,7 @@ const AddSkillsToFilter: React.FC<AddSkillsToFilterProps> = ({ allSkills }) => {
         {intl.formatMessage({
           defaultMessage:
             " Why are there a limited number of skills? It’s important that applicants and managers are pulling from the same list of skills in order to create matches.",
+          id: "BQ7cf/",
           description:
             "Describing how to use the skill filters on search page, paragraph two.",
         })}

--- a/frontend/talentsearch/src/js/components/skills/AddedSkills/AddedSkills.tsx
+++ b/frontend/talentsearch/src/js/components/skills/AddedSkills/AddedSkills.tsx
@@ -32,6 +32,7 @@ const AddedSkills: React.FunctionComponent<AddedSkillsProps> = ({
       >
         {intl.formatMessage({
           defaultMessage: "Selected skills",
+          id: "l7Hif/",
           description: "Section header for a list of skills selected",
         })}
       </h3>
@@ -56,6 +57,7 @@ const AddedSkills: React.FunctionComponent<AddedSkillsProps> = ({
           {intl.formatMessage({
             defaultMessage:
               "There are no skills selected yet. You can add some using the provided links.",
+            id: "AYlTUF",
             description:
               "Invitation to add skills when there aren't any added yet.",
           })}
@@ -76,6 +78,7 @@ const AddedSkills: React.FunctionComponent<AddedSkillsProps> = ({
               <strong>
                 {intl.formatMessage({
                   defaultMessage: "That's a lot of skills!",
+                  id: "yx7EDY",
                   description:
                     "Title of alert when there are many skills added.",
                 })}
@@ -86,6 +89,7 @@ const AddedSkills: React.FunctionComponent<AddedSkillsProps> = ({
                 {
                   defaultMessage:
                     "On the next step you will explain how you used each skill. Try to focus on a few of your top skills, we recommend <strong>less than six (6)</strong> skills per experience.",
+                  id: "QRGHI2",
                   description:
                     "Message of alert when there are many skills added recommending that fewer skills be selected.",
                 },

--- a/frontend/talentsearch/src/js/components/skills/SkillsInDetail/SkillsInDetail.tsx
+++ b/frontend/talentsearch/src/js/components/skills/SkillsInDetail/SkillsInDetail.tsx
@@ -35,6 +35,7 @@ const SkillsInDetail: React.FunctionComponent<SkillsInDetailProps> = ({
       <h2 data-h2-font-size="base(h3, 1)" data-h2-margin="base(x2, 0, x1, 0)">
         {intl.formatMessage({
           defaultMessage: "3. Skills in detail",
+          id: "AtZhfR",
           description:
             "Heading for skills in detail section of experience form.",
         })}
@@ -43,6 +44,7 @@ const SkillsInDetail: React.FunctionComponent<SkillsInDetailProps> = ({
         {intl.formatMessage({
           defaultMessage:
             "After adding some skills please explain how you used them, try answering one or more of these questions:",
+          id: "dTMBj9",
           description:
             "Description for skills in detail section of experience form.",
         })}
@@ -57,6 +59,7 @@ const SkillsInDetail: React.FunctionComponent<SkillsInDetailProps> = ({
           {intl.formatMessage({
             defaultMessage:
               "What did you accomplish, create or deliver using this skill?",
+            id: "Dy5kjx",
             description:
               "Question for user in skills in detail section of experience form.",
           })}
@@ -65,6 +68,7 @@ const SkillsInDetail: React.FunctionComponent<SkillsInDetailProps> = ({
           {intl.formatMessage({
             defaultMessage:
               "What tasks or activities did you do that relate to this skill?",
+            id: "d0qGas",
             description:
               "Question for user in skills in detail section of experience form.",
           })}
@@ -73,6 +77,7 @@ const SkillsInDetail: React.FunctionComponent<SkillsInDetailProps> = ({
           {intl.formatMessage({
             defaultMessage:
               "Were there any special techniques or approaches that you used?",
+            id: "PH8qp2",
             description:
               "Question for user in skills in detail section of experience form.",
           })}
@@ -81,6 +86,7 @@ const SkillsInDetail: React.FunctionComponent<SkillsInDetailProps> = ({
           {intl.formatMessage({
             defaultMessage:
               "How much responsibility did you have in this role?",
+            id: "b9/MXQ",
             description:
               "Question for user in skills in detail section of experience form.",
           })}
@@ -119,6 +125,7 @@ const SkillsInDetail: React.FunctionComponent<SkillsInDetailProps> = ({
                   >
                     {intl.formatMessage({
                       defaultMessage: "Remove from experience",
+                      id: "70bx4O",
                       description:
                         "Message in skills in details section to remove skill from the experience.",
                     })}
@@ -136,11 +143,13 @@ const SkillsInDetail: React.FunctionComponent<SkillsInDetailProps> = ({
                   id={`skill-in-detail-${id}`}
                   label={intl.formatMessage({
                     defaultMessage: "Skill in detail",
+                    id: "J5oMC8",
                     description:
                       "Label for the textarea in the skills in detail section.",
                   })}
                   placeholder={intl.formatMessage({
                     defaultMessage: "How I used this skill...",
+                    id: "i99arX",
                     description:
                       "Placeholder message for textarea in the skills in detail section.",
                   })}
@@ -178,6 +187,7 @@ const SkillsInDetail: React.FunctionComponent<SkillsInDetailProps> = ({
             {intl.formatMessage({
               defaultMessage:
                 "There are no skills attached to this experience yet. You can add some on the step above.",
+              id: "H05wXr",
               description:
                 "Message to user when no skills have been attached to experience.",
             })}

--- a/frontend/talentsearch/src/js/components/workExperienceForm/WorkExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/workExperienceForm/WorkExperienceForm.tsx
@@ -18,6 +18,7 @@ export const WorkExperienceForm: React.FunctionComponent = () => {
       <h2 data-h2-font-size="base(h3, 1)" data-h2-margin="base(x2, 0, x1, 0)">
         {intl.formatMessage({
           defaultMessage: "1. Work Experience Details",
+          id: "ciWrxr",
           description: "Title for Work Experience form",
         })}
       </h2>
@@ -25,6 +26,7 @@ export const WorkExperienceForm: React.FunctionComponent = () => {
         {intl.formatMessage({
           defaultMessage:
             "Share your experiences gained from full-time, part-time, self-employment, fellowships or internships.",
+          id: "i17oNt",
           description: "Description blurb for Work Experience form",
         })}
       </p>
@@ -35,6 +37,7 @@ export const WorkExperienceForm: React.FunctionComponent = () => {
               id="role"
               label={intl.formatMessage({
                 defaultMessage: "My Role",
+                id: "URHhMF",
                 description:
                   "Label displayed on Work Experience form for role input",
               })}
@@ -49,12 +52,14 @@ export const WorkExperienceForm: React.FunctionComponent = () => {
                 boundingBox
                 boundingBoxLabel={intl.formatMessage({
                   defaultMessage: "Current Role",
+                  id: "2t3Cqv",
                   description:
                     "Label displayed on Work Experience form for current role bounded box",
                 })}
                 id="currentRole"
                 label={intl.formatMessage({
                   defaultMessage: "I am currently active in this role",
+                  id: "8i+lzm",
                   description:
                     "Label displayed on Work Experience form for current role input",
                 })}
@@ -67,6 +72,7 @@ export const WorkExperienceForm: React.FunctionComponent = () => {
               id="organization"
               label={intl.formatMessage({
                 defaultMessage: "Organization",
+                id: "9UZ/eS",
                 description:
                   "Label displayed on Work Experience form for organization input",
               })}
@@ -82,6 +88,7 @@ export const WorkExperienceForm: React.FunctionComponent = () => {
                   id="startDate"
                   label={intl.formatMessage({
                     defaultMessage: "Start Date",
+                    id: "8VDBW/",
                     description:
                       "Label displayed on Work Experience form for start date input",
                   })}
@@ -99,6 +106,7 @@ export const WorkExperienceForm: React.FunctionComponent = () => {
                     id="endDate"
                     label={intl.formatMessage({
                       defaultMessage: "End Date",
+                      id: "09G0vg",
                       description:
                         "Label displayed on Work Experience form for end date input",
                     })}
@@ -129,6 +137,7 @@ export const WorkExperienceForm: React.FunctionComponent = () => {
               id="team"
               label={intl.formatMessage({
                 defaultMessage: "Team, Group, or Division",
+                id: "xJulQ4",
                 description:
                   "Label displayed on Work Experience form for team/group/division input",
               })}

--- a/frontend/talentsearch/src/js/components/workLocationPreferenceForm/WorkLocationPreferenceForm.tsx
+++ b/frontend/talentsearch/src/js/components/workLocationPreferenceForm/WorkLocationPreferenceForm.tsx
@@ -84,6 +84,7 @@ export const WorkLocationPreferenceForm: React.FC<
         {
           title: intl.formatMessage({
             defaultMessage: "My Applications",
+            id: "mq4G8h",
             description:
               "'My Applications' breadcrumb from applicant profile wrapper.",
           }),
@@ -95,6 +96,7 @@ export const WorkLocationPreferenceForm: React.FC<
             application.poolAdvertisement?.name?.[locale] ||
             intl.formatMessage({
               defaultMessage: "Pool name not found",
+              id: "FmD1sL",
               description:
                 "Pools name breadcrumb from applicant profile wrapper if no name set.",
             }),
@@ -108,11 +110,13 @@ export const WorkLocationPreferenceForm: React.FC<
       description={intl.formatMessage({
         defaultMessage:
           "Indicate all locations where you are willing to work, including your current location (if you are interested in working there).",
+        id: "8NJbCH",
         description:
           "Description text for Profile Form wrapper in Work Location Preferences Form",
       })}
       title={intl.formatMessage({
         defaultMessage: "Work location",
+        id: "nOE+8s",
         description:
           "Title for Profile Form wrapper  in Work Location Preferences Form",
       })}
@@ -124,6 +128,7 @@ export const WorkLocationPreferenceForm: React.FC<
         {
           title: intl.formatMessage({
             defaultMessage: "Work Location Preference",
+            id: "c/Qp8R",
             description:
               "Display Text for the current page in Work Location Preference Form Page",
           }),
@@ -146,6 +151,7 @@ export const WorkLocationPreferenceForm: React.FC<
                   idPrefix="work-location"
                   legend={intl.formatMessage({
                     defaultMessage: "Work location",
+                    id: "nueuS8",
                     description:
                       "Legend for optional work preferences check list in work preferences form",
                   })}
@@ -169,6 +175,7 @@ export const WorkLocationPreferenceForm: React.FC<
                   {intl.formatMessage({
                     defaultMessage:
                       "Indicate if there is a city that you would like to exclude from a region.",
+                    id: "1CuGS6",
                     description:
                       "Explanation text for Location exemptions field in work location preference form",
                   })}
@@ -177,6 +184,7 @@ export const WorkLocationPreferenceForm: React.FC<
                   {intl.formatMessage({
                     defaultMessage:
                       "E.g.: You want to be considered for the Quebec region, but not for Montréal.",
+                    id: "2K7dVp",
                     description:
                       "Example for Location exemptions field in work location preference form",
                   })}

--- a/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
+++ b/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
@@ -103,6 +103,7 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
         {
           title: intl.formatMessage({
             defaultMessage: "My Applications",
+            id: "mq4G8h",
             description:
               "'My Applications' breadcrumb from applicant profile wrapper.",
           }),
@@ -114,6 +115,7 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
             application.poolAdvertisement?.name?.[locale] ||
             intl.formatMessage({
               defaultMessage: "Pool name not found",
+              id: "FmD1sL",
               description:
                 "Pools name breadcrumb from applicant profile wrapper if no name set.",
             }),
@@ -127,11 +129,13 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
       description={intl.formatMessage({
         defaultMessage:
           "Certain jobs require you to work odd hours or perform tasks that are a little outside of the normal. Please indicate which special requirements you are comfortable with.",
+        id: "wKIVFc",
         description:
           "Description text for Profile Form wrapper  in Work Preferences Form",
       })}
       title={intl.formatMessage({
         defaultMessage: "Work preferences",
+        id: "k0++o0",
         description: "Title for Profile Form wrapper  in Work Preferences Form",
       })}
       cancelLink={{
@@ -142,6 +146,7 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
         {
           title: intl.formatMessage({
             defaultMessage: "Work Preferences",
+            id: "7OWQgZ",
             description: "Display Text for Work Preferences Form Page Link",
           }),
         },
@@ -161,6 +166,7 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
                   legend={intl.formatMessage({
                     defaultMessage:
                       "I would consider accepting a job that lasts for...",
+                    id: "/DCykA",
                     description:
                       "Legend Text for required work preferences options in work preferences form",
                   })}
@@ -174,6 +180,7 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
                       label: intl.formatMessage({
                         defaultMessage:
                           "...any duration (short term, long term, or indeterminate duration)",
+                        id: "X2Ivfb",
                         description:
                           "Label displayed on Work Preferences form for any duration option",
                       }),
@@ -183,6 +190,7 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
                       label: intl.formatMessage({
                         defaultMessage:
                           "...only those of an indeterminate duration. (permanent)",
+                        id: "9zqf5E",
                         description:
                           "Label displayed on Work Preferences form for indeterminate duration option.",
                       }),
@@ -201,6 +209,7 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
                   legend={intl.formatMessage({
                     defaultMessage:
                       "I would consider accepting a job that requires…",
+                    id: "yQ2dDL",
                     description:
                       "Legend for optional work preferences check list in work preferences form",
                   })}


### PR DESCRIPTION
Pulled this out of https://github.com/GCTC-NTGC/gc-digital-talent/issues/3402 when realized how awkward updating translation strings was.

Keeping this small, and only talentsearch for now, as it has high possibility for conflicts unless merged quickly.

With this, updating a string is more in-flow of code, and simple as:

1. change the text in vscode. (note the immediately eslint underline showing that id is out-of-date)
3. save the file, and id auto-updates (see GIF)
4. `git diff` to see the old ID v new (see diff below)
5. git grep old ID from diff, to find it in `fr.json` and update/delete as appropriate

## How it looks in vscode

![](http://g.recordit.co/vBBHfqqJkT.gif)

## Simple diff to see how ID changed

```diff
diff --git a/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx b/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
index b9837e202..63d7b9423 100644
--- a/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
+++ b/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
@@ -179,8 +179,8 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
                       value: "true",
                       label: intl.formatMessage({
                         defaultMessage:
-                          "...any duration (short term, long term, or indeterminate duration)",
-                        id: "X2Ivfb",
+                          "...any duration. (short term, long term, or indeterminate duration)",
+                        id: "oKaV/T",
                         description:
                           "Label displayed on Work Preferences form for any duration option",
                       }),
```

## Benefits
- changes in auto-gen IDs are highly visible immediately in both vscode and version control (diffs, etc)
- easier to spot proper changes in PR (each inline autogen ID should have a clear "old" and "new" value to help coordinate update of the french translation, even if not done right in the PR)
- no need to run npm scripts to manage translations

## Notes
- this rule ignores anything with the `.` in it (e.g. `.foo` or `common.bar`), so that's how custom IDs can still be used