### PR TITLE
Import talentsearch french strings into merged Storybook (hosted on Chromatic)

### DIFF
--- a/frontend/admin/.storybook/preview.js
+++ b/frontend/admin/.storybook/preview.js
@@ -4,6 +4,7 @@ import "../src/css/app.css"
 import { setIntlConfig, withIntl } from 'storybook-addon-intl';
 import AdminFrench from "../src/js/lang/frCompiled.json";
 import CommonFrench from "../../common/src/lang";
+import TalentFrench from "../../talentsearch/src/js/lang/frCompiled.json";
 import defaultRichTextElements from "../../common/src/helpers/format";
 import MockGraphqlDecorator from "../../common/.storybook/decorators/MockGraphqlDecorator";
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
@@ -31,7 +32,16 @@ export const parameters = {
   },
 }
 
-const messages = {en: null, fr: {...AdminFrench, ...CommonFrench}};
+const messages = {
+  en: null,
+  fr: {
+    ...AdminFrench,
+    ...CommonFrench,
+    // Technically only needed when envvar MERGE_STORYBOOKS=true is used.
+    ...TalentFrench,
+  }
+};
+
 setIntlConfig({
     locales: ["en", "fr"],
     defaultLocale: "en",

--- a/frontend/admin/.storybook/preview.js
+++ b/frontend/admin/.storybook/preview.js
@@ -5,6 +5,7 @@ import { setIntlConfig, withIntl } from 'storybook-addon-intl';
 import AdminFrench from "../src/js/lang/frCompiled.json";
 import CommonFrench from "../../common/src/lang";
 import TalentFrench from "../../talentsearch/src/js/lang/frCompiled.json";
+import IndigenousFrench from "../../indigenousapprenticeship/src/js/lang/frCompiled.json";
 import defaultRichTextElements from "../../common/src/helpers/format";
 import MockGraphqlDecorator from "../../common/.storybook/decorators/MockGraphqlDecorator";
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
@@ -39,6 +40,7 @@ const messages = {
     ...CommonFrench,
     // Technically only needed when envvar MERGE_STORYBOOKS=true is used.
     ...TalentFrench,
+    ...IndigenousFrench,
   }
 };
 

--- a/frontend/indigenousapprenticeship/src/js/components/Home/Home.stories.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/Home/Home.stories.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import type { Meta, Story } from "@storybook/react";
-import { IntlProvider } from "react-intl";
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
 import { widthOf, heightOf } from "@common/helpers/storybookUtils";
-import * as IAPFrench from "../../lang/frCompiled.json";
 import Home from "./Home";
 
 export default {
@@ -16,29 +14,11 @@ export default {
   },
 } as Meta;
 
-const TemplateEnglishHome: Story = () => <Home />;
-
-const TemplateFrenchHome: Story = () => {
-  return (
-    <IntlProvider locale="fr" key="fr" messages={IAPFrench}>
-      <Home />
-    </IntlProvider>
-  );
-};
+const Template: Story = () => <Home />;
 
 const VIEWPORTS = [
   widthOf(INITIAL_VIEWPORTS.iphonex), // Modern iPhone
   heightOf(INITIAL_VIEWPORTS.ipad12p), // Most common viewport size that falls within chromatic range
 ];
 
-export const EnglishHomeStory = TemplateEnglishHome.bind({});
-
-EnglishHomeStory.parameters = {
-  chromatic: { viewports: VIEWPORTS },
-};
-
-export const FrenchHomeStory = TemplateFrenchHome.bind({});
-
-FrenchHomeStory.parameters = {
-  chromatic: { viewports: VIEWPORTS },
-};
+export const Default = Template.bind({});


### PR DESCRIPTION
talentsearch french string weren't being merged into the omni-storybook during build, and so storybook wasn't properly reflecting live app translations.

## Before

<img width="1188" alt="Screen Shot 2022-09-07 at 10 40 15 AM" src="https://user-images.githubusercontent.com/305339/188907210-5ce9e0ef-01bd-4fd5-a592-8e0af4636b78.png">

https://main--61e099a1bb1465003a73d3ce.chromatic.com/?path=/story/workpreferencesform--individual-work-preferences

## After

<img width="1246" alt="Screen Shot 2022-09-07 at 10 39 39 AM" src="https://user-images.githubusercontent.com/305339/188907186-2533e0f2-fade-4705-a93e-43a07c3c2597.png">