### PR TITLE
Debt - 3870 - Single Select Classification

### DIFF
--- a/frontend/cypress/integration/talentsearch/search-workflows.spec.js
+++ b/frontend/cypress/integration/talentsearch/search-workflows.spec.js
@@ -25,7 +25,7 @@ describe("Talent Search Workflow Tests", () => {
     // second request is properly filtered
     searchReturnsGreaterThanZeroApplicants();
 
-    cy.findByRole("combobox", { name: /Classification/i }).click().type('{downArrow}{enter}');
+    cy.findByRole("combobox", { name: /Classification/i }).select(1);
 
     cy.findByRole("radio", {
       name: /Required diploma from post-secondary institution/i,

--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -101,8 +101,6 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
   const searchRef = useRef<SearchFormRef>(null);
 
   const tryHandleSubmit = async () => {
-    console.log(applicantFilter);
-    console.log(classificationFilterCount);
     if (classificationFilterCount === 0) {
       // Validate all fields, and focus on the first one that is invalid.
       searchRef.current?.triggerValidation(undefined, { shouldFocus: true });
@@ -233,7 +231,6 @@ const SearchContainerApi: React.FC = () => {
 
   const paths = useTalentSearchRoutes();
   const onSubmit = async () => {
-    console.log({ applicantFilter, pool });
     // pool ID is not in the form so it must be added manually
     if (applicantFilter && pool) {
       applicantFilter.pools = [{ id: pool.id }];

--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -101,6 +101,8 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
   const searchRef = useRef<SearchFormRef>(null);
 
   const tryHandleSubmit = async () => {
+    console.log(applicantFilter);
+    console.log(classificationFilterCount);
     if (classificationFilterCount === 0) {
       // Validate all fields, and focus on the first one that is invalid.
       searchRef.current?.triggerValidation(undefined, { shouldFocus: true });
@@ -231,6 +233,7 @@ const SearchContainerApi: React.FC = () => {
 
   const paths = useTalentSearchRoutes();
   const onSubmit = async () => {
+    console.log({ applicantFilter, pool });
     // pool ID is not in the form so it must be added manually
     if (applicantFilter && pool) {
       applicantFilter.pools = [{ id: pool.id }];

--- a/frontend/talentsearch/src/js/components/search/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchForm.tsx
@@ -49,7 +49,7 @@ export type FormValues = Pick<
 > & {
   languageAbility: LanguageAbility | typeof NullSelection;
   employmentDuration: string | typeof NullSelection;
-  classifications: string[] | undefined;
+  classification: string | undefined;
   skills: string[] | undefined;
   employmentEquity: string[] | undefined;
   educationRequirement: "has_diploma" | "no_diploma";
@@ -130,11 +130,12 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
 
     React.useEffect(() => {
       const formValuesToData = (values: FormValues): ApplicantFilterInput => {
+        const expectedClassification = values.classification
+          ? classificationMap.get(values.classification)
+          : undefined;
         return {
-          expectedClassifications: values.classifications
-            ? values.classifications
-                ?.filter((id) => !!id)
-                .map((id) => (id ? classificationMap.get(id) : undefined))
+          expectedClassifications: expectedClassification
+            ? [expectedClassification]
             : [],
           skills: values.skills
             ? values.skills
@@ -235,8 +236,20 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                 description:
                   "Placeholder for classification filter in search form.",
               })}
-              name="classifications"
-              options={classificationOptions}
+              name="classification"
+              options={[
+                {
+                  value: "",
+                  disabled: true,
+                  label: intl.formatMessage({
+                    defaultMessage: "Select one or more classification(s)",
+                    id: "iNsxYi",
+                    description:
+                      "Placeholder for classification filter in search form.",
+                  }),
+                },
+                ...classificationOptions,
+              ]}
               rules={{
                 required: intl.formatMessage(errorMessages.required),
               }}

--- a/frontend/talentsearch/src/js/components/search/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchForm.tsx
@@ -3,7 +3,12 @@ import { FormProvider, useForm, UseFormTrigger } from "react-hook-form";
 import { defineMessages, MessageDescriptor, useIntl } from "react-intl";
 import debounce from "lodash/debounce";
 
-import { Checklist, MultiSelect, RadioGroup } from "@common/components/form";
+import {
+  Checklist,
+  MultiSelect,
+  RadioGroup,
+  Select,
+} from "@common/components/form";
 import { getLanguageAbility } from "@common/constants";
 import {
   getEmploymentEquityGroup,
@@ -217,7 +222,7 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                 "Message describing the classification filter of the search form.",
             })}
           >
-            <MultiSelect
+            <Select
               id="classifications"
               label={intl.formatMessage({
                 defaultMessage: "Classification filter",

--- a/frontend/talentsearch/src/js/components/search/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchForm.tsx
@@ -231,8 +231,8 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                 description: "Label for classification filter in search form.",
               })}
               placeholder={intl.formatMessage({
-                defaultMessage: "Select one or more classification(s)",
-                id: "iNsxYi",
+                defaultMessage: "Select a classification",
+                id: "HHEQgM",
                 description:
                   "Placeholder for classification filter in search form.",
               })}
@@ -242,8 +242,8 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                   value: "",
                   disabled: true,
                   label: intl.formatMessage({
-                    defaultMessage: "Select one or more classification(s)",
-                    id: "iNsxYi",
+                    defaultMessage: "Select a classification",
+                    id: "HHEQgM",
                     description:
                       "Placeholder for classification filter in search form.",
                   }),

--- a/frontend/talentsearch/src/js/components/search/deprecated/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/deprecated/SearchForm.tsx
@@ -65,7 +65,7 @@ export type FormValues = Pick<
   "workRegions" | "operationalRequirements"
 > & {
   languageAbility: LanguageAbility | typeof NullSelection;
-  classifications: string[] | undefined;
+  classification: string | undefined;
   cmoAssets: string[] | undefined;
   employmentEquity: string[] | undefined;
   educationRequirement: "has_diploma" | "no_diploma";
@@ -149,12 +149,11 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
       const formValuesToData = (
         values: FormValues,
       ): PoolCandidateFilterInput => {
+        const maybeClassification = values.classification
+          ? classificationMap.get(values.classification)
+          : undefined;
         return {
-          classifications: values.classifications
-            ? values.classifications?.map((id) =>
-                id ? classificationMap.get(id) : undefined,
-              )
-            : [],
+          classifications: maybeClassification ? [maybeClassification] : [],
           cmoAssets: values.cmoAssets
             ? values.cmoAssets?.map((id) => (id ? assetMap.get(id) : undefined))
             : [],
@@ -263,8 +262,20 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                 description:
                   "Placeholder for classification filter in search form.",
               })}
-              name="classifications"
-              options={classificationOptions}
+              name="classification"
+              options={[
+                {
+                  value: "",
+                  disabled: true,
+                  label: intl.formatMessage({
+                    defaultMessage: "Select one or more classification(s)",
+                    id: "iNsxYi",
+                    description:
+                      "Placeholder for classification filter in search form.",
+                  }),
+                },
+                ...classificationOptions,
+              ]}
               rules={{
                 required: intl.formatMessage(errorMessages.required),
               }}

--- a/frontend/talentsearch/src/js/components/search/deprecated/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/deprecated/SearchForm.tsx
@@ -257,7 +257,7 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                 description: "Label for classification filter in search form.",
               })}
               placeholder={intl.formatMessage({
-                defaultMessage: "Select one or more classification(s)",
+                defaultMessage: "Select a classification",
                 id: "iNsxYi",
                 description:
                   "Placeholder for classification filter in search form.",
@@ -268,7 +268,7 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                   value: "",
                   disabled: true,
                   label: intl.formatMessage({
-                    defaultMessage: "Select one or more classification(s)",
+                    defaultMessage: "Select a classification",
                     id: "iNsxYi",
                     description:
                       "Placeholder for classification filter in search form.",

--- a/frontend/talentsearch/src/js/components/search/deprecated/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/deprecated/SearchForm.tsx
@@ -1,7 +1,12 @@
 import React, { useImperativeHandle, useMemo } from "react";
 import { FormProvider, useForm, UseFormTrigger } from "react-hook-form";
 import { defineMessages, MessageDescriptor, useIntl } from "react-intl";
-import { Checklist, MultiSelect, RadioGroup } from "@common/components/form";
+import {
+  Checklist,
+  MultiSelect,
+  RadioGroup,
+  Select,
+} from "@common/components/form";
 import { getLocale } from "@common/helpers/localize";
 import { enumToOptions, unpackMaybes } from "@common/helpers/formUtils";
 import { getLanguageAbility } from "@common/constants";
@@ -245,7 +250,7 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                 "Message describing the classification filter of the search form.",
             })}
           >
-            <MultiSelect
+            <Select
               id="classifications"
               label={intl.formatMessage({
                 defaultMessage: "Classification filter",

--- a/frontend/talentsearch/src/js/components/search/deprecated/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/deprecated/SearchForm.tsx
@@ -258,7 +258,7 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
               })}
               placeholder={intl.formatMessage({
                 defaultMessage: "Select a classification",
-                id: "iNsxYi",
+                id: "HHEQgM",
                 description:
                   "Placeholder for classification filter in search form.",
               })}
@@ -269,7 +269,7 @@ export const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                   disabled: true,
                   label: intl.formatMessage({
                     defaultMessage: "Select a classification",
-                    id: "iNsxYi",
+                    id: "HHEQgM",
                     description:
                       "Placeholder for classification filter in search form.",
                   }),

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -1940,5 +1940,9 @@
   "zqBqj1": {
     "defaultMessage": "Ces renseignements seront utilisées pour vous faire correspondre aux emplois prioritaires.",
     "description": "Explanation on how employment equity information will be used, item two"
+  },
+  "HHEQgM": {
+    "defaultMessage": "Sélectionnez une classification",
+    "description": "Placeholder for classification filter in search form."
   }
 }


### PR DESCRIPTION
Resolves #3870 

## Summary

This changes both the new and deprecated search form to use `Select` instead of `MultiSelect` for the classification field.

## Screenshot

<img width="596" alt="Screen Shot 2022-09-08 at 9 32 07 AM" src="https://user-images.githubusercontent.com/4127998/189135480-152fbc28-b1df-41e0-be2f-48da41028de7.png">

## Testing

1. Build talentsearch
2. Navigate to `/search`
3. Confirm the classification field is not multi-select and works
4. Remove feature flag, rebuild container
6. Repeat steps 1-3