### PR TITLE
add status sorting weight

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -28,6 +28,7 @@ use Illuminate\Database\Eloquent\Builder;
  * @property array $location_preferences
  * @property array $expected_salary
  * @property string $pool_candidate_status
+ * @property int $status_weight
  * @property int $pool_id
  * @property int $user_id
  * @property array $accepted_operational_requirements

--- a/api/database/migrations/2022_09_08_191031_generated_candidate_status_weight.php
+++ b/api/database/migrations/2022_09_08_191031_generated_candidate_status_weight.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+class GeneratedCandidateStatusWeight extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement("ALTER TABLE pool_candidates ADD COLUMN status_weight INT
+        GENERATED ALWAYS AS
+        (case
+        when pool_candidate_status = 'DRAFT' then 10
+        when pool_candidate_status = 'DRAFT_EXPIRED' then 20
+        when pool_candidate_status = 'NEW_APPLICATION' then 30
+        when pool_candidate_status = 'APPLICATION_REVIEW' then 40
+        when pool_candidate_status = 'SCREENED_IN' then 50
+        when pool_candidate_status = 'SCREENED_OUT_APPLICATION' then 60
+        when pool_candidate_status = 'UNDER_ASSESSMENT' then 70
+        when pool_candidate_status = 'SCREENED_OUT_ASSESSMENT' then 80
+        when pool_candidate_status = 'QUALIFIED_AVAILABLE' then 90
+        when pool_candidate_status = 'QUALIFIED_UNAVAILABLE' then 100
+        when pool_candidate_status = 'QUALIFIED_WITHDREW' then 110
+        when pool_candidate_status = 'PLACED_CASUAL' then 120
+        when pool_candidate_status = 'PLACED_TERM' then 130
+        when pool_candidate_status = 'PLACED_INDETERMINATE' then 140
+        when pool_candidate_status = 'EXPIRED' then 150
+        else null
+        end)
+        STORED;");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('pool_candidates', function (Blueprint $table) {
+            $table->dropColumn([
+                'status_weight',
+            ]);
+        });
+    }
+}

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -359,6 +359,7 @@ type PoolCandidate {
     cmoAssets: [CmoAsset] @belongsToMany
 
     status: PoolCandidateStatus @rename(attribute: "pool_candidate_status")
+    statusWeight: Int @rename(attribute: "status_weight")
     notes: String
     archivedAt: DateTime @rename(attribute: "archived_at")
     submittedAt: DateTime @rename(attribute: "submitted_at")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -824,6 +824,7 @@ type PoolCandidate {
   expectedClassifications: [Classification]
   cmoAssets: [CmoAsset]
   status: PoolCandidateStatus
+  statusWeight: Int
   notes: String
   archivedAt: DateTime
   submittedAt: DateTime

--- a/api/tests/Feature/ApplicantTest.php
+++ b/api/tests/Feature/ApplicantTest.php
@@ -929,9 +929,9 @@ class ApplicantTest extends TestCase
         ]);
     }
 
-    public function testPriorityDerivedStatusAccessor(): void
+    public function testPriorityWeight(): void
     {
-        // test derived property that exists on type User and Applicant from model User.php
+        // test generated property that exists on type User and Applicant from model User.php
 
         // create candidates
         $candidateOne = User::factory()->create([
@@ -959,7 +959,7 @@ class ApplicantTest extends TestCase
             'citizenship' => ApiEnums::CITIZENSHIP_OTHER,
         ]);
 
-        // Assert candidate one returns PRIORITY
+        // Assert candidate one returns 10
         $this->graphQL(/** @lang Graphql */ '
             query applicant($id: ID!) {
                 applicant(id: $id) {
@@ -976,7 +976,7 @@ class ApplicantTest extends TestCase
             ]
         ]);
 
-        // Assert candidate two returns VETERAN
+        // Assert candidate two returns 20
         $this->graphQL(/** @lang Graphql */ '
             query applicant($id: ID!) {
                 applicant(id: $id) {
@@ -993,7 +993,7 @@ class ApplicantTest extends TestCase
             ]
         ]);
 
-        // Assert candidate three returns CITIZEN/PR
+        // Assert candidate three returns 30
         $this->graphQL(/** @lang Graphql */ '
             query applicant($id: ID!) {
                 applicant(id: $id) {
@@ -1010,7 +1010,7 @@ class ApplicantTest extends TestCase
             ]
         ]);
 
-        // Assert candidate four returns OTHER
+        // Assert candidate four returns 40
         $this->graphQL(/** @lang Graphql */ '
             query applicant($id: ID!) {
                 applicant(id: $id) {
@@ -1023,6 +1023,390 @@ class ApplicantTest extends TestCase
             "data" => [
                 "applicant" => [
                     "priorityWeight" => 40,
+                ]
+            ]
+        ]);
+    }
+
+    public function testStatusWeight(): void {
+        // test generated property that exists on type PoolCandidate from model PoolCandidate.php
+
+        // create candidates for each status
+        $user = User::All()->first();
+        $pool1 = Pool::factory()->create([
+            'user_id' => $user['id']
+        ]);
+        $candidateOne = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+            'expiry_date' => config('constants.far_future_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_DRAFT,
+        ]);
+        $candidateTwo = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12',
+            'expiry_date' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_DRAFT_EXPIRED,
+        ]);
+        $candidateThree = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_NEW_APPLICATION,
+        ]);
+        $candidateFour = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_APPLICATION_REVIEW,
+        ]);
+        $candidateFive = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_SCREENED_IN,
+        ]);
+        $candidateSix = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_SCREENED_OUT_APPLICATION,
+        ]);
+        $candidateSeven = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_UNDER_ASSESSMENT,
+        ]);
+        $candidateEight = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a18',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_SCREENED_OUT_ASSESSMENT,
+        ]);
+        $candidateNine = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a19',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE,
+        ]);
+        $candidateTen = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a20',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_QUALIFIED_UNAVAILABLE,
+        ]);
+        $candidateEleven = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a21',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_QUALIFIED_WITHDREW,
+        ]);
+        $candidateTwelve = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL,
+        ]);
+        $candidateThirteen = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a23',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_PLACED_TERM,
+        ]);
+        $candidateFourteen = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a24',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_PLACED_INDETERMINATE,
+        ]);
+        $candidateFifteen = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a25',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_EXPIRED,
+        ]);
+
+        // Assert candidate one DRAFT is 10
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidate($id: ID!) {
+                poolCandidate(id: $id) {
+                    statusWeight
+                    status
+                }
+            }
+            ', [
+                'id' => $candidateOne->id,
+        ])->assertJson([
+            "data" => [
+                "poolCandidate" => [
+                    "statusWeight" => 10,
+                    "status" => ApiEnums::CANDIDATE_STATUS_DRAFT,
+                ]
+            ]
+        ]);
+        // Assert candidate two DRAFT_EXPIRED is 20
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidate($id: ID!) {
+                poolCandidate(id: $id) {
+                    statusWeight
+                    status
+                }
+            }
+            ', [
+                'id' => $candidateTwo->id,
+        ])->assertJson([
+            "data" => [
+                "poolCandidate" => [
+                    "statusWeight" => 20,
+                    "status" => ApiEnums::CANDIDATE_STATUS_DRAFT_EXPIRED,
+                ]
+            ]
+        ]);
+        // Assert candidate three NEW APPLICATION is 30
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidate($id: ID!) {
+                poolCandidate(id: $id) {
+                    statusWeight
+                    status
+                }
+            }
+            ', [
+                'id' => $candidateThree->id,
+        ])->assertJson([
+            "data" => [
+                "poolCandidate" => [
+                    "statusWeight" => 30,
+                    "status" => ApiEnums::CANDIDATE_STATUS_NEW_APPLICATION,
+                ]
+            ]
+        ]);
+        // Assert candidate four APPLICATION REVIEW is 40
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidate($id: ID!) {
+                poolCandidate(id: $id) {
+                    statusWeight
+                    status
+                }
+            }
+            ', [
+                'id' => $candidateFour->id,
+        ])->assertJson([
+            "data" => [
+                "poolCandidate" => [
+                    "statusWeight" => 40,
+                    "status" => ApiEnums::CANDIDATE_STATUS_APPLICATION_REVIEW,
+                ]
+            ]
+        ]);
+        // Assert candidate five SCREENED IN is 50
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidate($id: ID!) {
+                poolCandidate(id: $id) {
+                    statusWeight
+                    status
+                }
+            }
+            ', [
+                'id' => $candidateFive->id,
+        ])->assertJson([
+            "data" => [
+                "poolCandidate" => [
+                    "statusWeight" => 50,
+                    "status" => ApiEnums::CANDIDATE_STATUS_SCREENED_IN,
+                ]
+            ]
+        ]);
+        // Assert candidate six SCREENED OUT APPLICATION is 60
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidate($id: ID!) {
+                poolCandidate(id: $id) {
+                    statusWeight
+                    status
+                }
+            }
+            ', [
+                'id' => $candidateSix->id,
+        ])->assertJson([
+            "data" => [
+                "poolCandidate" => [
+                    "statusWeight" => 60,
+                    "status" => ApiEnums::CANDIDATE_STATUS_SCREENED_OUT_APPLICATION,
+                ]
+            ]
+        ]);
+        // Assert candidate seven UNDER ASSESSMENT is 70
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidate($id: ID!) {
+                poolCandidate(id: $id) {
+                    statusWeight
+                    status
+                }
+            }
+            ', [
+                'id' => $candidateSeven->id,
+        ])->assertJson([
+            "data" => [
+                "poolCandidate" => [
+                    "statusWeight" => 70,
+                    "status" => ApiEnums::CANDIDATE_STATUS_UNDER_ASSESSMENT,
+                ]
+            ]
+        ]);
+        // Assert candidate eight SCREENED OUT ASSESSMENT is 80
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidate($id: ID!) {
+                poolCandidate(id: $id) {
+                    statusWeight
+                    status
+                }
+            }
+            ', [
+                'id' => $candidateEight->id,
+        ])->assertJson([
+            "data" => [
+                "poolCandidate" => [
+                    "statusWeight" => 80,
+                    "status" => ApiEnums::CANDIDATE_STATUS_SCREENED_OUT_ASSESSMENT,
+                ]
+            ]
+        ]);
+        // Assert candidate nine QUALIFIED AVAILABLE is 90
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidate($id: ID!) {
+                poolCandidate(id: $id) {
+                    statusWeight
+                    status
+                }
+            }
+            ', [
+                'id' => $candidateNine->id,
+        ])->assertJson([
+            "data" => [
+                "poolCandidate" => [
+                    "statusWeight" => 90,
+                    "status" => ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE,
+                ]
+            ]
+        ]);
+        // Assert candidate ten QUALIFIED UNAVAILABLE is 100
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidate($id: ID!) {
+                poolCandidate(id: $id) {
+                    statusWeight
+                    status
+                }
+            }
+            ', [
+                'id' => $candidateTen->id,
+        ])->assertJson([
+            "data" => [
+                "poolCandidate" => [
+                    "statusWeight" => 100,
+                    "status" => ApiEnums::CANDIDATE_STATUS_QUALIFIED_UNAVAILABLE,
+                ]
+            ]
+        ]);
+        // Assert candidate eleven QUALIFIED WITHDREW is 110
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidate($id: ID!) {
+                poolCandidate(id: $id) {
+                    statusWeight
+                    status
+                }
+            }
+            ', [
+                'id' => $candidateEleven->id,
+        ])->assertJson([
+            "data" => [
+                "poolCandidate" => [
+                    "statusWeight" => 110,
+                    "status" => ApiEnums::CANDIDATE_STATUS_QUALIFIED_WITHDREW
+                ]
+            ]
+        ]);
+        // Assert candidate twelve PLACED CASUAL is 120
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidate($id: ID!) {
+                poolCandidate(id: $id) {
+                    statusWeight
+                    status
+                }
+            }
+            ', [
+                'id' => $candidateTwelve->id,
+        ])->assertJson([
+            "data" => [
+                "poolCandidate" => [
+                    "statusWeight" => 120,
+                    "status" => ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL,
+                ]
+            ]
+        ]);
+        // Assert candidate thirteen PLACED TERM is 130
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidate($id: ID!) {
+                poolCandidate(id: $id) {
+                    statusWeight
+                    status
+                }
+            }
+            ', [
+                'id' => $candidateThirteen->id,
+        ])->assertJson([
+            "data" => [
+                "poolCandidate" => [
+                    "statusWeight" => 130,
+                    "status" => ApiEnums::CANDIDATE_STATUS_PLACED_TERM,
+                ]
+            ]
+        ]);
+        // Assert candidate fourteen PLACED INDETERMINATE is 140
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidate($id: ID!) {
+                poolCandidate(id: $id) {
+                    statusWeight
+                    status
+                }
+            }
+            ', [
+                'id' => $candidateFourteen->id,
+        ])->assertJson([
+            "data" => [
+                "poolCandidate" => [
+                    "statusWeight" => 140,
+                    "status" => ApiEnums::CANDIDATE_STATUS_PLACED_INDETERMINATE,
+                ]
+            ]
+        ]);
+        // Assert candidate fifteen EXPIRED is 150
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidate($id: ID!) {
+                poolCandidate(id: $id) {
+                    statusWeight
+                    status
+                }
+            }
+            ', [
+                'id' => $candidateFifteen->id,
+        ])->assertJson([
+            "data" => [
+                "poolCandidate" => [
+                    "statusWeight" => 150,
+                    "status" => ApiEnums::CANDIDATE_STATUS_EXPIRED,
                 ]
             ]
         ]);


### PR DESCRIPTION
closes #3874 
Adds the generated column that is based off of candidate status. Updates the API to use it as well. 
Also, for a high degree of reliability I added testing to ensure every status returns the correct weight. 

Testing: 
Use this query, observe status and statusWeight. Change Status and then observe the query results again. 
```
query poolCandidate {
  poolCandidate(id: "ID") {
    status
    statusWeight
  }
}
```