### PR TITLE
Force eslint workflow to fail build when even one warning

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,4 +45,5 @@ jobs:
 
       - name: "Run ESlint: all workspaces"
         working-directory: frontend
-        run: npm run lint --workspaces --if-present
+        # Pass arg to eslint so that any warnings will raise error code and fail workflow.
+        run: npm run lint --workspaces --if-present -- --max-warnings=0


### PR DESCRIPTION
Closes https://github.com/GCTC-NTGC/gc-digital-talent/issues/3682

Quick fix, and no more merges with eslint issues :)