### PR TITLE
Fix up work preferences copy (form and profile section)

### DIFF
--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -64,7 +64,7 @@
     "description": "Message displayed to user after classification is created successfully."
   },
   "3F6QqF": {
-    "defaultMessage": "Commencer à écrire ici…",
+    "defaultMessage": "Commencer à écrire ici...",
     "description": "Placeholder displayed on the Global Filter form Search field."
   },
   "3b6cy/": {
@@ -1107,7 +1107,7 @@
     "description": "Label displayed on the pool candidate form process number field."
   },
   "/MBeNc": {
-    "defaultMessage": "Commencez à écrire vos notes ici…",
+    "defaultMessage": "Commencez à écrire vos notes ici...",
     "description": "Placeholder text for a pool candidates notes field"
   },
   "/fv4O0": {
@@ -1395,7 +1395,7 @@
     "description": "Label displayed on the date field of the change candidate expiry date dialog"
   },
   "X198m3": {
-    "defaultMessage": "Sélectionner un bassin…",
+    "defaultMessage": "Sélectionner un bassin...",
     "description": "Placeholder displayed on the pool field of the add user to pool dialog."
   },
   "XtBhGo": {
@@ -1578,7 +1578,7 @@
     "description": "Toast for failed expiry date update on view-user page"
   },
   "qr5RPo": {
-    "defaultMessage": "Sélectionnez un statut…",
+    "defaultMessage": "Sélectionnez un statut...",
     "description": "Placeholder displayed on the pool form status field."
   },
   "sICXeM": {
@@ -1622,7 +1622,7 @@
     "description": "Toast for failed removal of candidate from pool on view-user page"
   },
   "usNShh": {
-    "defaultMessage": "Sélectionner un statut de bassin…",
+    "defaultMessage": "Sélectionner un statut de bassin...",
     "description": "Placeholder displayed on the status field of the change candidate status dialog."
   },
   "uutH18": {

--- a/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
@@ -21,10 +21,7 @@ const WorkPreferencesSection: React.FunctionComponent<{
         <li key={opRequirement}>
           {opRequirement
             ? intl.formatMessage(
-                getOperationalRequirement(
-                  opRequirement,
-                  "candidateDescription",
-                ),
+                getOperationalRequirement(opRequirement, "firstPerson"),
               )
             : ""}
         </li>
@@ -55,10 +52,7 @@ const WorkPreferencesSection: React.FunctionComponent<{
         <li key={opRequirement}>
           {opRequirement
             ? intl.formatMessage(
-                getOperationalRequirement(
-                  opRequirement,
-                  "candidateDescription",
-                ),
+                getOperationalRequirement(opRequirement, "firstPerson"),
               )
             : ""}
         </li>

--- a/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
@@ -20,7 +20,12 @@ const WorkPreferencesSection: React.FunctionComponent<{
     ? acceptedOperationalRequirements.map((opRequirement) => (
         <li key={opRequirement}>
           {opRequirement
-            ? intl.formatMessage(getOperationalRequirement(opRequirement))
+            ? intl.formatMessage(
+                getOperationalRequirement(
+                  opRequirement,
+                  "candidateDescription",
+                ),
+              )
             : ""}
         </li>
       ))
@@ -49,7 +54,8 @@ const WorkPreferencesSection: React.FunctionComponent<{
     ? unselectedOperationalArray.map((opRequirement) => (
         <li key={opRequirement}>
           {opRequirement
-            ? getOperationalRequirement(opRequirement).defaultMessage
+            ? getOperationalRequirement(opRequirement, "candidateDescription")
+                .defaultMessage
             : ""}
         </li>
       ))

--- a/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
@@ -105,10 +105,10 @@ const WorkPreferencesSection: React.FunctionComponent<{
               <li>
                 {intl.formatMessage({
                   defaultMessage:
-                    "Any duration (short, long term, or indeterminate duration)",
-                  id: "ihYM2v",
+                    "any duration. (short term, long term, or indeterminate duration)",
+                  id: "uHx3G7",
                   description:
-                    "Duration of any length is good, specified three example lengths",
+                    "Label displayed on Work Preferences form for any duration option",
                 })}
               </li>
             </ul>

--- a/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
@@ -54,8 +54,12 @@ const WorkPreferencesSection: React.FunctionComponent<{
     ? unselectedOperationalArray.map((opRequirement) => (
         <li key={opRequirement}>
           {opRequirement
-            ? getOperationalRequirement(opRequirement, "candidateDescription")
-                .defaultMessage
+            ? intl.formatMessage(
+                getOperationalRequirement(
+                  opRequirement,
+                  "candidateDescription",
+                ),
+              )
             : ""}
         </li>
       ))

--- a/frontend/common/src/constants/localizedConstants.tsx
+++ b/frontend/common/src/constants/localizedConstants.tsx
@@ -905,60 +905,58 @@ export const getEducationType = (
 
 export const operationalRequirementLabelCandidateDescription = defineMessages({
   [OperationalRequirement.ShiftWork]: {
-    defaultMessage: "...has <strong>shift-work</strong>.",
-    id: "/ndqmQ",
+    defaultMessage: "has <strong>shift-work</strong>.",
+    id: "9rn/MG",
     description: "The operational requirement described as shift work.",
   },
   [OperationalRequirement.OnCall]: {
-    defaultMessage: "...has <strong>24/7 on call-shifts</strong>.",
-    id: "7L6frW",
+    defaultMessage: "has <strong>24/7 on call-shifts</strong>.",
+    id: "X/hYMf",
     description: "The operational requirement described as 24/7 on-call.",
   },
   [OperationalRequirement.Travel]: {
-    defaultMessage: "...requires me to <strong>travel</strong>.",
-    id: "MZwZ0y",
+    defaultMessage: "requires me to <strong>travel</strong>.",
+    id: "qnYbyw",
     description: "The operational requirement described as travel as required.",
   },
   [OperationalRequirement.TransportEquipment]: {
     defaultMessage:
-      "...requires me to <strong>transport, lift and set down equipment weighing up to 20kg</strong>.",
-    id: "dLI4Nb",
+      "requires me to <strong>transport, lift and set down equipment weighing up to 20kg</strong>.",
+    id: "dIZ4oj",
     description:
       "The operational requirement described as transport equipment up to 20kg.",
   },
   [OperationalRequirement.DriversLicense]: {
     defaultMessage:
-      "...requires me to <strong>have a valid driver's license</strong> or personal mobility to the degree normally associated with the possession of a valid driver's license.",
-    id: "gmHam8",
+      "requires me to <strong>have a valid driver's license</strong> or personal mobility to the degree normally associated with the possession of a valid driver's license.",
+    id: "duwt+A",
     description: "The operational requirement described as driver's license.",
   },
   [OperationalRequirement.WorkWeekends]: {
-    defaultMessage: "...requires me to <strong>work weekends</strong>.",
-    id: "fmSaPm",
+    defaultMessage: "requires me to <strong>work weekends</strong>.",
+    id: "CFAc15",
     description: "The operational requirement described as work weekends.",
   },
   [OperationalRequirement.OvertimeScheduled]: {
-    defaultMessage:
-      "...requires me to <strong>work scheduled overtime</strong>.",
-    id: "qLy7xu",
+    defaultMessage: "requires me to <strong>work scheduled overtime</strong>.",
+    id: "1RTwS3",
     description: "The operational requirement described as scheduled overtime.",
   },
   [OperationalRequirement.OvertimeShortNotice]: {
     defaultMessage:
-      "...requires me to <strong>work overtime on short notice</strong>.",
-    id: "hjr9df",
+      "requires me to <strong>work overtime on short notice</strong>.",
+    id: "cnFVR1",
     description: "The operational requirement described as overtime.",
   },
   [OperationalRequirement.OvertimeOccasional]: {
-    defaultMessage:
-      "...requires me to <strong>work occasional overtime</strong>.",
-    id: "EXOS0V",
+    defaultMessage: "requires me to <strong>work occasional overtime</strong>.",
+    id: "RYg7vl",
     description:
       "The operational requirement described as occasional overtime.",
   },
   [OperationalRequirement.OvertimeRegular]: {
-    defaultMessage: "...requires me to <strong>work regular overtime</strong>.",
-    id: "PQ3bhH",
+    defaultMessage: "requires me to <strong>work regular overtime</strong>.",
+    id: "cEB0aW",
     description: "The operational requirement described as regular overtime.",
   },
 });

--- a/frontend/common/src/constants/localizedConstants.tsx
+++ b/frontend/common/src/constants/localizedConstants.tsx
@@ -903,7 +903,7 @@ export const getEducationType = (
     `Invalid educationType ${educationTypeId}`,
   );
 
-export const operationalRequirementLabelCandidateDescription = defineMessages({
+export const operationalRequirementLabelFirstPerson = defineMessages({
   [OperationalRequirement.ShiftWork]: {
     defaultMessage: "has <strong>shift-work</strong>.",
     id: "9rn/MG",
@@ -1121,10 +1121,10 @@ export const operationalRequirementLabelShort = defineMessages({
 
 export const getOperationalRequirement = (
   operationalRequirementId: string | number,
-  format: "candidateDescription" | "full" | "short" = "full",
+  format: "firstPerson" | "full" | "short" = "full",
 ): MessageDescriptor => {
   const messageDictionary = {
-    candidateDescription: operationalRequirementLabelCandidateDescription,
+    firstPerson: operationalRequirementLabelFirstPerson,
     full: operationalRequirementLabelFull,
     short: operationalRequirementLabelShort,
   };

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -727,9 +727,9 @@
     "defaultMessage": "Projet : {project}",
     "description": "Project Name"
   },
-  "ihYM2v": {
-    "defaultMessage": "Toute durée (à court terme, à long terme ou indéterminée)",
-    "description": "Duration of any length is good, specified three example lengths"
+  "uHx3G7": {
+    "defaultMessage": "de toute durée. (à court terme, à long terme ou indéterminée)",
+    "description": "Label displayed on Work Preferences form for any duration option"
   },
   "inzzdo": {
     "defaultMessage": "Diversité, équité et inclusion",
@@ -930,24 +930,24 @@
     "defaultMessage": "<strong>Virtuel :</strong> Travailler de la maison, partout au Canada.",
     "description": "The work region of Canada described as North."
   },
-  "hjr9df": {
-    "defaultMessage": "… m'oblige à faire des <strong>heures supplémentaires sans préavis</strong>.",
+  "cnFVR1": {
+    "defaultMessage": "m'oblige à faire des <strong>heures supplémentaires sans préavis</strong>.",
     "description": "The operational requirement described as overtime."
   },
   "oU4OmU": {
     "defaultMessage": "<strong>Région de l'Ontario :</strong> à l'exclusion d'Ottawa.",
     "description": "The work region of Canada described as Ontario."
   },
-  "gmHam8": {
-    "defaultMessage": "… m'oblige à <strong>avoir un permis de conduire valide</strong> ou une mobilité personnelle dans la mesure normalement associée à la possession d'un permis de conduire valide.",
+  "duwt+A": {
+    "defaultMessage": "m'oblige à <strong>avoir un permis de conduire valide</strong> ou une mobilité personnelle dans la mesure normalement associée à la possession d'un permis de conduire valide.",
     "description": "The operational requirement described as driver's license."
   },
   "eYak7E": {
     "defaultMessage": "<strong>Région de la capitale nationale :</strong> Ottawa (Ont.) et Gatineau (Qc).",
     "description": "The work region of Canada described as National Capital."
   },
-  "qLy7xu": {
-    "defaultMessage": "… nécessite que je fasse des <strong>heures supplémentaires planifiées</strong>.",
+  "1RTwS3": {
+    "defaultMessage": "nécessite que je fasse des <strong>heures supplémentaires planifiées</strong>.",
     "description": "The operational requirement described as scheduled overtime."
   },
   "Gw2JKz": {
@@ -962,32 +962,32 @@
     "defaultMessage": "<strong>Région de la Colombie-Britannique</strong>",
     "description": "The work region of Canada described as British Columbia."
   },
-  "dLI4Nb": {
-    "defaultMessage": "… m'oblige à <strong>transporter, soulever et installer des équipements pesant jusqu'à 20 kg</strong>.",
+  "dIZ4oj": {
+    "defaultMessage": "m'oblige à <strong>transporter, soulever et installer des équipements pesant jusqu'à 20 kg</strong>.",
     "description": "The operational requirement described as transport equipment up to 20kg."
   },
   "ubXVBC": {
     "defaultMessage": "<strong>Région de l'Atlantique :</strong> Nouveau-Brunswick, Terre-Neuve-et-Labrador, Nouvelle-Écosse et Île-du-Prince-Édouard.",
     "description": "The work region of Canada described as Atlantic."
   },
-  "7L6frW": {
-    "defaultMessage": "… a<strong> des quarts de travail sur appel 24 heures sur 24, 7 jours sur 7 </strong>.",
+  "X/hYMf": {
+    "defaultMessage": "a<strong> des quarts de travail sur appel 24 heures sur 24, 7 jours sur 7 </strong>.",
     "description": "The operational requirement described as 24/7 on-call."
   },
-  "MZwZ0y": {
-    "defaultMessage": "… m'oblige à <strong>voyager</strong>.",
+  "qnYbyw": {
+    "defaultMessage": "m'oblige à <strong>voyager</strong>.",
     "description": "The operational requirement described as travel as required."
   },
   "ZcvDAo": {
     "defaultMessage": "Il manque des champs <red>obligatoires</red>.",
     "description": "Message that there are required fields missing. Please ignore things in <> tags."
   },
-  "/ndqmQ": {
-    "defaultMessage": "… a un <strong>travail par quart</strong>.",
+  "9rn/MG": {
+    "defaultMessage": "a un <strong>travail par quart</strong>.",
     "description": "The operational requirement described as shift work."
   },
-  "fmSaPm": {
-    "defaultMessage": "… m'oblige à <strong>travailler les fins de semaine</strong>.",
+  "CFAc15": {
+    "defaultMessage": "m'oblige à <strong>travailler les fins de semaine</strong>.",
     "description": "The operational requirement described as work weekends."
   },
   "TR0Kxz": {
@@ -1134,8 +1134,8 @@
     "defaultMessage": "Débutant",
     "description": "Beginner, skill level"
   },
-  "EXOS0V": {
-    "defaultMessage": "… m'oblige à <strong>faire des heures supplémentaires occasionnelles</strong>.",
+  "RYg7vl": {
+    "defaultMessage": "m'oblige à <strong>faire des heures supplémentaires occasionnelles</strong>.",
     "description": "The operational requirement described as occasional overtime."
   },
   "F3/88e": {
@@ -1186,8 +1186,8 @@
     "defaultMessage": "(s'ouvre dans un nouvel onglet)",
     "description": "Text that appears in links that open in a new tab."
   },
-  "PQ3bhH": {
-    "defaultMessage": "… m'oblige à <strong>faire des heures supplémentaires régulièrement</strong>.",
+  "cEB0aW": {
+    "defaultMessage": "m'oblige à <strong>faire des heures supplémentaires régulièrement</strong>.",
     "description": "The operational requirement described as regular overtime."
   },
   "PzyMeM": {

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1135,7 +1135,7 @@
     "description": "Beginner, skill level"
   },
   "EXOS0V": {
-    "defaultMessage": "...m'oblige à <strong>faire des heures supplémentaires occasionnelles</strong>.",
+    "defaultMessage": "… m'oblige à <strong>faire des heures supplémentaires occasionnelles</strong>.",
     "description": "The operational requirement described as occasional overtime."
   },
   "F3/88e": {
@@ -1187,7 +1187,7 @@
     "description": "Text that appears in links that open in a new tab."
   },
   "PQ3bhH": {
-    "defaultMessage": "...m'oblige à <strong>faire des heures supplémentaires régulièrement</strong>.",
+    "defaultMessage": "… m'oblige à <strong>faire des heures supplémentaires régulièrement</strong>.",
     "description": "The operational requirement described as regular overtime."
   },
   "PzyMeM": {

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -519,7 +519,7 @@
     "description": "Text on link to update a users work location."
   },
   "FTJdsa": {
-    "defaultMessage": "Chargement…",
+    "defaultMessage": "Chargement...",
     "description": "Message to display when a page is loading."
   },
   "GcPFLS": {

--- a/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
+++ b/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
@@ -240,10 +240,7 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
                     label: (
                       <WithEllipsisPrefix>
                         {intl.formatMessage(
-                          getOperationalRequirement(
-                            value,
-                            "candidateDescription",
-                          ),
+                          getOperationalRequirement(value, "firstPerson"),
                         )}
                       </WithEllipsisPrefix>
                     ),

--- a/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
+++ b/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
@@ -165,8 +165,8 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
                   idPrefix="required-work-preferences"
                   legend={intl.formatMessage({
                     defaultMessage:
-                      "I would consider accepting a job that lasts for...",
-                    id: "/DCykA",
+                      "I would consider accepting a job that lasts for:",
+                    id: "GNtu/7",
                     description:
                       "Legend Text for required work preferences options in work preferences form",
                   })}
@@ -179,8 +179,8 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
                       value: "true",
                       label: intl.formatMessage({
                         defaultMessage:
-                          "...any duration (short term, long term, or indeterminate duration)",
-                        id: "X2Ivfb",
+                          "...any duration. (short term, long term, or indeterminate duration)",
+                        id: "oKaV/T",
                         description:
                           "Label displayed on Work Preferences form for any duration option",
                       }),
@@ -189,8 +189,8 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
                       value: "false",
                       label: intl.formatMessage({
                         defaultMessage:
-                          "...only those of an indeterminate duration. (permanent)",
-                        id: "9zqf5E",
+                          "...indeterminate duration only. (permanent only)",
+                        id: "sYqIp5",
                         description:
                           "Label displayed on Work Preferences form for indeterminate duration option.",
                       }),
@@ -207,9 +207,8 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
                 <Checklist
                   idPrefix="optional-work-preferences"
                   legend={intl.formatMessage({
-                    defaultMessage:
-                      "I would consider accepting a job that requires…",
-                    id: "yQ2dDL",
+                    defaultMessage: "I would consider accepting a job that:",
+                    id: "Vvb8tu",
                     description:
                       "Legend for optional work preferences check list in work preferences form",
                   })}

--- a/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
+++ b/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
@@ -39,6 +39,24 @@ export interface WorkPreferencesFormProps {
   ) => Promise<UpdateWorkPreferencesMutation["updateUserAsUser"]>;
 }
 
+interface WithEllipsisPrefixProps {
+  children: React.ReactNode;
+}
+const WithEllipsisPrefix = ({ children }: WithEllipsisPrefixProps) => {
+  const { formatMessage } = useIntl();
+  const ellipsisPrefix = formatMessage({
+    defaultMessage: "...",
+    id: ".ellipsis",
+  });
+
+  return (
+    <>
+      {ellipsisPrefix}
+      {children}
+    </>
+  );
+};
+
 export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
   initialData,
   application,
@@ -177,13 +195,17 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
                   items={[
                     {
                       value: "true",
-                      label: intl.formatMessage({
-                        defaultMessage:
-                          "...any duration. (short term, long term, or indeterminate duration)",
-                        id: "oKaV/T",
-                        description:
-                          "Label displayed on Work Preferences form for any duration option",
-                      }),
+                      label: (
+                        <WithEllipsisPrefix>
+                          {intl.formatMessage({
+                            defaultMessage:
+                              "any duration. (short term, long term, or indeterminate duration)",
+                            id: "uHx3G7",
+                            description:
+                              "Label displayed on Work Preferences form for any duration option",
+                          })}
+                        </WithEllipsisPrefix>
+                      ),
                     },
                     {
                       value: "false",
@@ -215,8 +237,15 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
                   name="acceptedOperationalRequirements"
                   items={OperationalRequirementV2.map((value) => ({
                     value,
-                    label: intl.formatMessage(
-                      getOperationalRequirement(value, "candidateDescription"),
+                    label: (
+                      <WithEllipsisPrefix>
+                        {intl.formatMessage(
+                          getOperationalRequirement(
+                            value,
+                            "candidateDescription",
+                          ),
+                        )}
+                      </WithEllipsisPrefix>
                     ),
                   }))}
                 />

--- a/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
+++ b/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
@@ -42,6 +42,12 @@ export interface WorkPreferencesFormProps {
 interface WithEllipsisPrefixProps {
   children: React.ReactNode;
 }
+/**
+ * Helps prepend ellipses to other strings.
+ * (Whitespace conventions for using the ellipsis varies between languages.)
+ *
+ * @see https://www.btb.termiumplus.gc.ca/tcdnstyl-chap?lang=eng&lettr=chapsect17&info0=17.07
+ */
 const WithEllipsisPrefix = ({ children }: WithEllipsisPrefixProps) => {
   const { formatMessage } = useIntl();
   const ellipsisPrefix = formatMessage({

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -1,4 +1,7 @@
 {
+  ".ellipsis": {
+    "defaultMessage": "… "
+  },
   "+ZXZj+": {
     "defaultMessage": "S’il n’y a aucun candidat qui répond à vos critères <a>Communiquez avec nous! </a>",
     "description": "Message for helping user if no candidates matched the filters chosen."
@@ -1035,8 +1038,8 @@
     "defaultMessage": "Erreur : échec de la mise à jour de l'expérience",
     "description": "Message displayed to user after experience fails to be updated."
   },
-  "oKaV/T": {
-    "defaultMessage": "… de toute durée. (à court terme, à long terme ou indéterminée)",
+  "uHx3G7": {
+    "defaultMessage": "de toute durée. (à court terme, à long terme ou indéterminée)",
     "description": "Label displayed on Work Preferences form for any duration option"
   },
   "X354at": {

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -524,8 +524,8 @@
     "defaultMessage": "Ajouter <hidden>{title} </hidden>au profil",
     "description": "Text label for button to add employment equity category to profile."
   },
-  "/DCykA": {
-    "defaultMessage": "J'envisagerais d'accepter un emploi d'une durée de…",
+  "GNtu/7": {
+    "defaultMessage": "J'envisagerais d'accepter un emploi :",
     "description": "Legend Text for required work preferences options in work preferences form"
   },
   "/K1/1n": {
@@ -683,8 +683,8 @@
     "defaultMessage": "Continuer vers CléGC et s'inscrire",
     "description": "GC Key registration link text on the registration page."
   },
-  "9zqf5E": {
-    "defaultMessage": "… seulement ceux d'une durée indéterminée. (permanent)",
+  "sYqIp5": {
+    "defaultMessage": "… d'une durée indéterminée seulement. (permanent seulement)",
     "description": "Label displayed on Work Preferences form for indeterminate duration option."
   },
   "AcsOrg": {
@@ -1035,8 +1035,8 @@
     "defaultMessage": "Erreur : échec de la mise à jour de l'expérience",
     "description": "Message displayed to user after experience fails to be updated."
   },
-  "X2Ivfb": {
-    "defaultMessage": "… toute durée (à court terme, à long terme ou indéterminée)",
+  "oKaV/T": {
+    "defaultMessage": "… de toute durée. (à court terme, à long terme ou indéterminée)",
     "description": "Label displayed on Work Preferences form for any duration option"
   },
   "X354at": {
@@ -1485,8 +1485,8 @@
     "defaultMessage": "Commencez à écrire ici…",
     "description": "Placeholder displayed on the About Me form current city field."
   },
-  "yQ2dDL": {
-    "defaultMessage": "J'envisagerais d'accepter un emploi qui exige…",
+  "Vvb8tu": {
+    "defaultMessage": "J'envisagerais d'accepter un emploi qui :",
     "description": "Legend for optional work preferences check list in work preferences form"
   },
   "yfVLxM": {

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -679,7 +679,7 @@
     "description": "Description text for Profile Form wrapper in Work Location Preferences Form"
   },
   "8QN6ZC": {
-    "defaultMessage": "Sélectionnez un niveau…",
+    "defaultMessage": "Sélectionnez un niveau...",
     "description": "Placeholder displayed on the language information form comprehension field."
   },
   "9yMdpm": {
@@ -687,7 +687,7 @@
     "description": "GC Key registration link text on the registration page."
   },
   "sYqIp5": {
-    "defaultMessage": "… d'une durée indéterminée seulement. (permanent seulement)",
+    "defaultMessage": "... d'une durée indéterminée seulement. (permanent seulement)",
     "description": "Label displayed on Work Preferences form for indeterminate duration option."
   },
   "AcsOrg": {
@@ -867,7 +867,7 @@
     "description": "Button text to close employment equity form."
   },
   "M6PbPI": {
-    "defaultMessage": "Sélectionner une province ou un territoire…",
+    "defaultMessage": "Sélectionner une province ou un territoire...",
     "description": "Placeholder displayed on the About Me form province or territory field."
   },
   "MNVv3A": {
@@ -1074,7 +1074,7 @@
     "defaultMessage": "Résultats fréquents des compétences"
   },
   "Y7jEXr": {
-    "defaultMessage": "Sélectionnez un niveau…",
+    "defaultMessage": "Sélectionnez un niveau...",
     "description": "Placeholder displayed on the language information form verbal field."
   },
   "Y7l4/n": {
@@ -1126,7 +1126,7 @@
     "description": "title for IT-01 dialog"
   },
   "aQJOd0": {
-    "defaultMessage": "Sélectionnez un niveau…",
+    "defaultMessage": "Sélectionnez un niveau...",
     "description": "Placeholder displayed on the language information form written field."
   },
   "b9/MXQ": {
@@ -1281,7 +1281,7 @@
     "description": "Title role and salary expectations form"
   },
   "lai6E5": {
-    "defaultMessage": "Enregistrement…",
+    "defaultMessage": "Enregistrement...",
     "description": "Submitting text for save button on profile form."
   },
   "mJ1HE4": {
@@ -1465,7 +1465,7 @@
     "description": "Description of how the Government of Canada uses employment equity categories in hiring."
   },
   "w6vHXf": {
-    "defaultMessage": "Recherche…",
+    "defaultMessage": "Recherche...",
     "description": "Message to display when a search is in progress."
   },
   "wKIVFc": {
@@ -1485,7 +1485,7 @@
     "description": "Title for Profile Form Wrapper in Government Information Form"
   },
   "xq6TbG": {
-    "defaultMessage": "Commencez à écrire ici…",
+    "defaultMessage": "Commencez à écrire ici...",
     "description": "Placeholder displayed on the About Me form current city field."
   },
   "Vvb8tu": {

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -1,6 +1,6 @@
 {
   ".ellipsis": {
-    "defaultMessage": "… "
+    "defaultMessage": "... "
   },
   "+ZXZj+": {
     "defaultMessage": "S’il n’y a aucun candidat qui répond à vos critères <a>Communiquez avec nous! </a>",


### PR DESCRIPTION
Resolves https://github.com/GCTC-NTGC/gc-digital-talent/issues/3402

## To Do
- [x] 4392a0c9f8f8b2 use `candidateDescription` variant for operationalReqs on profile workpref section
- [x] b1f75eaaba6da3bea2e806c5ad9fc921e922625c update colons and ellipsis as requested for french
- [x] 2a176dda306f794d4c05733d3a744b7a724f2a59 fix french ellipsis whitespace 
- [x] 9cafb4cc7b0000038a12789c7e29d70410db2571 de-dup some strings we wanted same, but description was diff
- [x] lowercase strings we want to use in a few places
- [x] 9cafb4cc7b0000038a12789c7e29d70410db2571 Extract "..." from strings into separate formatting component `<WithEllipsisPrefix>` which can wrap translated strings
- [x] c870e8b4375de178d7339e51d46fcc3070017d10 fix formatting of negation sub-section
- [x] 6375028 rename operationalReqs variant to be more descriptive, from `candidateDescription` to `firstPerson` 
- [x] 01cf18f 1180ae6 converted all single-char ellipsis to 3-char variant

## To Review
- visit each User Profile stories and scroll to Work Pref section. Flip between FR and EN and note all changing.
  - in negation sub-section, note that formatting renders properly
  - mainline story: https://main--61e099a1bb1465003a73d3ce.chromatic.com/?path=/story/admin-user-profile--user-profile-story-5
  - PR story:  https://61e099a1bb1465003a73d3ce-caujsixcak.chromatic.com/?path=/story/admin-user-profile--user-profile-story-5
- visit WorkPreferencesForm story and cycle between EN and FR (links: [mainline story](https://main--61e099a1bb1465003a73d3ce.chromatic.com/?path=/story/workpreferencesform--individual-work-preferences) / [PR story](https://61e099a1bb1465003a73d3ce-caujsixcak.chromatic.com/?path=/story/workpreferencesform--individual-work-preferences))
  - note all the mistakes and inconsistencies in French, fixed in English
  - In options, note that all option text is same as in WorkPref section of UserProfile, but with no ellipses
  - In labels, note that colons are used with proper space before