### PR TITLE
Debt - 2793 - Remove Profile Feature Flag

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -1,6 +1,5 @@
 alertdialog
 Analyser
-APPLICANTPROFILE
 APPLICANTSEARCH
 Assertable
 Authenticatable

--- a/documentation/environment-variables.md
+++ b/documentation/environment-variables.md
@@ -22,5 +22,5 @@ For deployment in production there needs to be a way to change variables in the 
 3) `docker-compose up --detach`
 
 To check if a particular environment variable is set in a container, a command like this could be used:
-`docker-compose exec php printenv FEATURE_APPLICANTPROFILE`
+`docker-compose exec php printenv FEATURE_DIRECTINTAKE`
 

--- a/frontend/.apache_env
+++ b/frontend/.apache_env
@@ -6,6 +6,5 @@ OAUTH_LOGOUT_URI="http://localhost:8000/oxauth/endsession"
 # OAUTH_LOGOUT_URI="https://te-auth.id.tbs-sct.gc.ca/oxauth/restv1/end_session"
 
 # Feature flags
-FEATURE_APPLICANTPROFILE=true
 FEATURE_DIRECTINTAKE=true
 FEATURE_APPLICANTSEARCH=true

--- a/frontend/common/src/hooks/useFeatureFlags.ts
+++ b/frontend/common/src/hooks/useFeatureFlags.ts
@@ -2,7 +2,6 @@ import { checkFeatureFlag } from "../helpers/runtimeVariable";
 
 const useFeatureFlags = () => {
   return {
-    applicantProfile: checkFeatureFlag("FEATURE_APPLICANTPROFILE"),
     applicantSearch: checkFeatureFlag("FEATURE_APPLICANTSEARCH"),
     directIntake: checkFeatureFlag("FEATURE_DIRECTINTAKE"),
   };

--- a/frontend/talentsearch/public/.htaccess
+++ b/frontend/talentsearch/public/.htaccess
@@ -34,6 +34,5 @@ AddOutputFilter INCLUDES .shtml .sjs
 # Make certain environment variables available for SSI
 PassEnv OAUTH_POST_LOGOUT_REDIRECT
 PassEnv OAUTH_LOGOUT_URI
-PassEnv FEATURE_APPLICANTPROFILE
 PassEnv FEATURE_DIRECTINTAKE
 PassEnv FEATURE_APPLICANTSEARCH

--- a/frontend/talentsearch/public/config.sjs
+++ b/frontend/talentsearch/public/config.sjs
@@ -12,7 +12,6 @@ const filterEmpty = (value) => value != "(none)" ? value : undefined;
 const data = new Map([
     ["OAUTH_POST_LOGOUT_REDIRECT", filterEmpty("<!--#echo var="OAUTH_POST_LOGOUT_REDIRECT" -->")],
     ["OAUTH_LOGOUT_URI", filterEmpty("<!--#echo var="OAUTH_LOGOUT_URI" -->")],
-    ["FEATURE_APPLICANTPROFILE", filterEmpty("<!--#echo var="FEATURE_APPLICANTPROFILE" -->")],
     ["FEATURE_DIRECTINTAKE", filterEmpty("<!--#echo var="FEATURE_DIRECTINTAKE" -->")],
     ["FEATURE_APPLICANTSEARCH", filterEmpty("<!--#echo var="FEATURE_APPLICANTSEARCH" -->")],
 ]);

--- a/frontend/talentsearch/src/js/components/Router.tsx
+++ b/frontend/talentsearch/src/js/components/Router.tsx
@@ -529,7 +529,7 @@ export const Router: React.FC = () => {
     }
   }
 
-  if (featureFlags.applicantProfile && loggedIn && data?.me?.id) {
+  if (loggedIn && data?.me?.id) {
     menuItems.push(
       <MenuLink
         key="myProfile"
@@ -590,9 +590,7 @@ export const Router: React.FC = () => {
         contentRoutes={[
           ...talentRoutes(talentPaths),
           ...authRoutes(authPaths),
-          ...(featureFlags.applicantProfile
-            ? profileRoutes(profilePaths, data?.me?.id)
-            : []),
+          ...profileRoutes(profilePaths, data?.me?.id),
           ...(featureFlags.directIntake
             ? directIntakeRoutes(directIntakePaths)
             : []),


### PR DESCRIPTION
Resolves #2793 

## Summary

This removes the `FEATURE_APPLICANTPROFILE` feature flag, enabling the feature.

## Testing

1. Rebuild the php container
    - `docker-compose stop php`
    - `docker-compose rm php`
    - `docker-compose up --build --detach`
2. Navigate to `/talent/profile`
3. Ensure all profile features are enabled
    - [ ] Ensure the flag no longer exists `docker-compose exec php printenv FEATURE_APPLICANTPROFILE`
    - [ ] My Profile navigation link
    - [ ] Can navigate to and edit profile