### PR TITLE
Update straggler LoginIcon after @heroicon update

### DIFF
--- a/frontend/common/src/components/SideMenu/SideMenu.stories.tsx
+++ b/frontend/common/src/components/SideMenu/SideMenu.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Story, Meta } from "@storybook/react";
 import { HomeIcon } from "@heroicons/react/24/outline";
 
-import { LoginIcon } from "@heroicons/react/24/solid";
+import { ArrowRightOnRectangleIcon } from "@heroicons/react/24/solid";
 import SideMenuComponent from "./SideMenu";
 import SideMenuItem from "./SideMenuItem";
 
@@ -40,7 +40,7 @@ const TemplateSideMenu: Story = (args) => {
         isOpen={isOpen}
         onToggle={handleToggle}
         footer={
-          <SideMenuItem as="button" icon={LoginIcon}>
+          <SideMenuItem as="button" icon={ArrowRightOnRectangleIcon}>
             Login
           </SideMenuItem>
         }


### PR DESCRIPTION
Was missing this update after https://github.com/GCTC-NTGC/gc-digital-talent/pull/3849, and `npm run tsc` was giving a warning

This sort of thing should probably be caught is our linting workflow?