### PR TITLE
Bug - 3944 - Fix Application Card Continue Link

### DIFF
--- a/frontend/talentsearch/src/js/components/applications/ApplicationActions.tsx
+++ b/frontend/talentsearch/src/js/components/applications/ApplicationActions.tsx
@@ -36,7 +36,7 @@ const ContinueAction = ({ show, application }: ContinueActionProps) => {
   }
 
   return (
-    <Link href={paths.poolApply(application.id)}>
+    <Link href={paths.reviewApplication(application.id)}>
       {intl.formatMessage(
         {
           defaultMessage: "Continue my application<hidden> {name}</hidden>",


### PR DESCRIPTION
Resolves #3944 

## Summary

This updates the path of the "Continue my application" link to go to the proper page (`/browse/applications/:id/apply`).

## Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Login as `applicant@test.com`
3. Navigate to "My Applications"
4. Obtain the ID of the application
5. Use the ID to find the application in the `pool_candidates` table in the database
6. Ensure the application is part of an open, not expired pool and has the status `DRAFT`
7. Go back to an refresh the "My Applications" page
8. Click on the "Continue my application" link
9. Ensure if goes to the application page