### PR TITLE
Feature - Remove request menu item

### DIFF
--- a/frontend/talentsearch/src/js/components/Router.tsx
+++ b/frontend/talentsearch/src/js/components/Router.tsx
@@ -504,15 +504,6 @@ export const Router: React.FC = () => {
         description: "Label displayed on the Search menu item.",
       })}
     />,
-    <MenuLink
-      key="request"
-      href={talentPaths.request()}
-      text={intl.formatMessage({
-        defaultMessage: "Request",
-        id: "i7hOcw",
-        description: "Label displayed on the Request menu item.",
-      })}
-    />,
   ];
 
   if (featureFlags.directIntake) {

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -170,10 +170,6 @@
     "defaultMessage": "Demande créée avec succès!",
     "description": "Message displayed to user after a pool candidate request is created successfully."
   },
-  "i7hOcw": {
-    "defaultMessage": "Demande",
-    "description": "Label displayed on the Request menu item."
-  },
   "iNsxYi": {
     "defaultMessage": "Sélectionnez une ou plusieurs classifications",
     "description": "Placeholder for classification filter in search form."


### PR DESCRIPTION
Resolves #3752.

## Summary
Removes **Request** menu item from talentsearch navigation.

## Screenshot
![Screen Shot 2022-09-14 at 10 53 49](https://user-images.githubusercontent.com/3046459/190189510-6476fdb1-fc0f-4e50-9182-ca689e1102e3.png)

## Testing

1. Compile intl `npm run intl-compile --workspace=talentsearch`
2. Build app `npm run production --workspace=talentsearch`
3. Navigate to /search
4. Confirm **Request** menu item is no longer present