### PR TITLE
Feature/3694 hydrogen related copy changes

### DIFF
--- a/frontend/admin/src/js/components/pool/ViewPool.tsx
+++ b/frontend/admin/src/js/components/pool/ViewPool.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
-/* NOTE: This is temporary until we start the Candidates/Requests pages */
 import * as React from "react";
 import { useIntl } from "react-intl";
 import {
@@ -396,9 +394,9 @@ export const ViewPoolPage = ({ pool }: ViewPoolPageProps): JSX.Element => {
                 data-h2-font-size="base(h3)"
               >
                 {intl.formatMessage({
-                  defaultMessage: "Your Impact (English)",
-                  id: "LvsYj+",
-                  description: "Title for English pool advertisement impact",
+                  defaultMessage: "Your impact",
+                  id: "rGE0gj",
+                  description: "Title for pool advertisement impact section",
                 })}
               </h2>
             </div>
@@ -409,8 +407,8 @@ export const ViewPoolPage = ({ pool }: ViewPoolPageProps): JSX.Element => {
                 data-h2-font-size="base(h6)"
               >
                 {intl.formatMessage({
-                  defaultMessage: "Your Impact (English)",
-                  id: "LvsYj+",
+                  defaultMessage: "English impact text",
+                  id: "BzaGwp",
                   description: "Title for English pool advertisement impact",
                 })}
               </p>
@@ -425,8 +423,8 @@ export const ViewPoolPage = ({ pool }: ViewPoolPageProps): JSX.Element => {
                 data-h2-font-size="base(h6)"
               >
                 {intl.formatMessage({
-                  defaultMessage: "Your Impact (French)",
-                  id: "6BD4FK",
+                  defaultMessage: "French impact text",
+                  id: "CTnN9W",
                   description: "Title for French pool advertisement impact",
                 })}
               </p>
@@ -449,8 +447,8 @@ export const ViewPoolPage = ({ pool }: ViewPoolPageProps): JSX.Element => {
                 data-h2-font-size="base(h6)"
               >
                 {intl.formatMessage({
-                  defaultMessage: "Your Work (English)",
-                  id: "/7tcPl",
+                  defaultMessage: "English work text",
+                  id: "UjGx0m",
                   description: "Title for English pool advertisement Work",
                 })}
               </p>
@@ -465,8 +463,8 @@ export const ViewPoolPage = ({ pool }: ViewPoolPageProps): JSX.Element => {
                 data-h2-font-size="base(h6)"
               >
                 {intl.formatMessage({
-                  defaultMessage: "Your Work (French)",
-                  id: "y3mLbv",
+                  defaultMessage: "French work text",
+                  id: "88Haix",
                   description: "Title for French pool advertisement Work",
                 })}
               </p>

--- a/frontend/admin/src/js/components/pool/ViewPool.tsx
+++ b/frontend/admin/src/js/components/pool/ViewPool.tsx
@@ -437,7 +437,11 @@ export const ViewPoolPage = ({ pool }: ViewPoolPageProps): JSX.Element => {
                 data-h2-margin="base(x2, 0, 0, 0)"
                 data-h2-font-size="base(h3)"
               >
-                Your work
+                {intl.formatMessage({
+                  defaultMessage: "Your work",
+                  id: "Qp6B20",
+                  description: "Title for pool advertisement work text section",
+                })}
               </h2>
             </div>
             <div data-h2-flex-item="base(1of1) p-tablet(1of2)">

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -2280,5 +2280,9 @@
   "88Haix": {
     "defaultMessage": "Texte de travail en français",
     "description": "Title for French pool advertisement Work"
+  },
+  "Qp6B20": {
+    "defaultMessage": "Votre travail",
+    "description": "Title for pool advertisement work text section"
   }
 }

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -2260,5 +2260,25 @@
   "mxOuYK": {
     "defaultMessage": "Télécharger CSV",
     "description": "Text label for button to download a csv file of items in a table."
+  },
+  "rGE0gj": {
+    "defaultMessage": "Votre incidence",
+    "description": "Title for pool advertisement impact section"
+  },
+  "BzaGwp": {
+    "defaultMessage": "Texte anglais sur l’incidence",
+    "description": "Title for English pool advertisement impact"
+  },
+  "CTnN9W": {
+    "defaultMessage": "Texte français sur l’incidence",
+    "description": "Title for French pool advertisement impact"
+  },
+  "UjGx0m": {
+    "defaultMessage": "Texte de travail en anglais",
+    "description": "Title for English pool advertisement Work"
+  },
+  "88Haix": {
+    "defaultMessage": "Texte de travail en français",
+    "description": "Title for French pool advertisement Work"
   }
 }

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/AwardAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/AwardAccordion.tsx
@@ -120,7 +120,19 @@ const AwardAccordion: React.FunctionComponent<AwardAccordionProps> = ({
         data-h2-border="base(none)"
         data-h2-margin="base(x1, 0)"
       />
-      {skillsList?.length > 0 ? skillsList : undefined}
+      {skillsList?.length > 0 ? (
+        skillsList
+      ) : (
+        <p>
+          {intl.formatMessage({
+            defaultMessage:
+              "No skills have been linked to this experience yet.",
+            id: "c4r/Zv",
+            description:
+              "A message explaining that the experience has no associated skills",
+          })}
+        </p>
+      )}
       <hr
         data-h2-background-color="base(dt-gray)"
         data-h2-height="base(1px)"

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/CommunityAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/CommunityAccordion.tsx
@@ -103,7 +103,19 @@ const CommunityAccordion: React.FunctionComponent<CommunityAccordionProps> = ({
         data-h2-border="base(none)"
         data-h2-margin="base(x1, 0)"
       />
-      {skillsList?.length > 0 ? skillsList : undefined}
+      {skillsList?.length > 0 ? (
+        skillsList
+      ) : (
+        <p>
+          {intl.formatMessage({
+            defaultMessage:
+              "No skills have been linked to this experience yet.",
+            id: "c4r/Zv",
+            description:
+              "A message explaining that the experience has no associated skills",
+          })}
+        </p>
+      )}
       <hr
         data-h2-background-color="base(dt-gray)"
         data-h2-height="base(1px)"

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/EducationAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/EducationAccordion.tsx
@@ -123,7 +123,19 @@ const EducationAccordion: React.FunctionComponent<EducationAccordionProps> = ({
         data-h2-border="base(none)"
         data-h2-margin="base(x1, 0)"
       />
-      {skillsList?.length > 0 ? skillsList : undefined}
+      {skillsList?.length > 0 ? (
+        skillsList
+      ) : (
+        <p>
+          {intl.formatMessage({
+            defaultMessage:
+              "No skills have been linked to this experience yet.",
+            id: "c4r/Zv",
+            description:
+              "A message explaining that the experience has no associated skills",
+          })}
+        </p>
+      )}
       <hr
         data-h2-background-color="base(dt-gray)"
         data-h2-height="base(1px)"

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/PersonalAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/PersonalAccordion.tsx
@@ -84,7 +84,19 @@ const PersonalAccordion: React.FunctionComponent<PersonalAccordionProps> = ({
         data-h2-border="base(none)"
         data-h2-margin="base(x1, 0)"
       />
-      {skillsList?.length > 0 ? skillsList : undefined}
+      {skillsList?.length > 0 ? (
+        skillsList
+      ) : (
+        <p>
+          {intl.formatMessage({
+            defaultMessage:
+              "No skills have been linked to this experience yet.",
+            id: "c4r/Zv",
+            description:
+              "A message explaining that the experience has no associated skills",
+          })}
+        </p>
+      )}
       <hr
         data-h2-background-color="base(dt-gray)"
         data-h2-height="base(1px)"

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/WorkAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/WorkAccordion.tsx
@@ -103,7 +103,19 @@ const WorkAccordion: React.FunctionComponent<WorkAccordionProps> = ({
         data-h2-border="base(none)"
         data-h2-margin="base(x1, 0)"
       />
-      {skillsList?.length > 0 ? skillsList : undefined}
+      {skillsList?.length > 0 ? (
+        skillsList
+      ) : (
+        <p>
+          {intl.formatMessage({
+            defaultMessage:
+              "No skills have been linked to this experience yet.",
+            id: "c4r/Zv",
+            description:
+              "A message explaining that the experience has no associated skills",
+          })}
+        </p>
+      )}
       <hr
         data-h2-background-color="base(dt-gray)"
         data-h2-height="base(1px)"

--- a/frontend/common/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
@@ -275,7 +275,20 @@ const SkillAccordion: React.FunctionComponent<SkillAccordionProps> = ({
 
   function renderDetail() {
     if (experiences != null && experiences.length > 0) {
-      return renderWithExperience();
+      return (
+        <>
+          <p data-h2-font-weight="base(700)">
+            {intl.formatMessage({
+              defaultMessage:
+                "This skill has the following related experiences:",
+              id: "rcI/H3",
+              description:
+                "An introduction to a list of experiences associated with a skill",
+            })}
+          </p>
+          {renderWithExperience()}
+        </>
+      );
     }
     return renderNoExperience();
   }

--- a/frontend/common/src/components/skills/SkillPicker/SkillPicker.tsx
+++ b/frontend/common/src/components/skills/SkillPicker/SkillPicker.tsx
@@ -263,6 +263,14 @@ const SkillPicker = ({
               />
             </TabPanel>
             <TabPanel>
+              <p data-h2-font-weight="base(700)">
+                {intl.formatMessage({
+                  defaultMessage: "Search by keyword",
+                  id: "hm95fj",
+                  description:
+                    "A label to show that this tab for searching by keyword",
+                })}
+              </p>
               <SearchBar handleSearch={handleSearch} />
               <SkillResults
                 title={intl.formatMessage(

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1389,5 +1389,17 @@
   "YRhYqm": {
     "defaultMessage": "Aucune définition fournie",
     "description": "Message displayed when a skill has no definition"
+  },
+  "hm95fj": {
+    "defaultMessage": "Chercher par mot-clé",
+    "description": "A label to show that this tab for searching by keyword"
+  },
+  "c4r/Zv": {
+    "defaultMessage": "Aucune compétence n’a été liée à cette expérience jusqu’à présent.",
+    "description": "A message explaining that the experience has no associated skills"
+  },
+  "rcI/H3": {
+    "defaultMessage": "Cette compétence possède les expériences connexes suivantes :",
+    "description": "An introduction to a list of experiences associated with a skill"
   }
 }

--- a/frontend/talentsearch/src/js/components/skills/SkillFamiliesRadioList/SkillFamiliesRadioList.tsx
+++ b/frontend/talentsearch/src/js/components/skills/SkillFamiliesRadioList/SkillFamiliesRadioList.tsx
@@ -42,6 +42,7 @@ const SkillFamiliesRadioList: React.FC<SkillFamiliesRadioListProps> = ({
   callback,
 }) => {
   const [selected, setSelected] = React.useState<SkillFamily | null>(null);
+  const intl = useIntl();
 
   const handleSelection = (newSelection: SkillFamily | null) => {
     setSelected(newSelection);
@@ -50,7 +51,19 @@ const SkillFamiliesRadioList: React.FC<SkillFamiliesRadioListProps> = ({
 
   return (
     <div data-h2-flex-grid="base(flex-start, x.25)">
-      <div data-h2-flex-item="base(1of1)" />
+      <div data-h2-flex-item="base(1of1)">
+        <h4
+          data-h2-font-size="base(copy, 1)"
+          data-h2-font-weight="base(700)"
+          data-h2-margin="base(0, 0, x.5, 0)"
+        >
+          {intl.formatMessage({
+            defaultMessage: "Filter by",
+            id: "LzSC5k",
+            description: "A label for a list of possible filters",
+          })}
+        </h4>
+      </div>
       {skillFamilies.map((family) => (
         <div data-h2-flex-item="base(1of1)" key={family.key}>
           <Family

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -1947,5 +1947,9 @@
   "HHEQgM": {
     "defaultMessage": "Sélectionnez une classification",
     "description": "Placeholder for classification filter in search form."
+  },
+  "LzSC5k": {
+    "defaultMessage": "Filtrer par ordre de...",
+    "description": "A label for a list of possible filters"
   }
 }


### PR DESCRIPTION
This branch reapplies some changes from the Hydrogen upgrade and ensures they are translated.

## Testing
Check the copy on these pages in English and French
- [ ] Review _impact_ and _work_ changes on the admin "View Pool" page 
- [ ] Use the "My Profile" page to make an experience with no skills and review that message
- [ ] Also on profiles, select the skill tab and review the message listing the experiences
- [ ] Select the "search" tab on the skill picker to see that message
- [ ] For `frontend/talentsearch/src/js/components/skills/SkillFamiliesRadioList/SkillFamiliesRadioList.tsx` :shrug: I'm not sure this component is actually in use any longer.

Closes #3694 