### PR TITLE
add missing dependencies in lockfile

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2335,6 +2335,8 @@
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "^2.0.10",
+        "@microsoft/applicationinsights-react-js": "^3.4.0",
+        "@microsoft/applicationinsights-web": "^2.8.7",
         "core-js": "^3.25.1",
         "debounce": "^1.2.1",
         "dotenv": "^16.0.2",
@@ -7637,6 +7639,131 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/@microsoft/applicationinsights-analytics-js": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.8.7.tgz",
+      "integrity": "sha512-WEsbh3yOzjo1DnH6NyVS/W9uXEWJkb0mgOHTnq3An2nvyT7HPzd56hqRfyJsWR2KAU6hvZ09l7OK85AjkfEqJA==",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "2.8.7",
+        "@microsoft/applicationinsights-core-js": "2.8.7",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-channel-js": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.8.7.tgz",
+      "integrity": "sha512-Ee2zp6Ij/Btnc9P8bVBXUIa4/X8HH1hNYpL2ALGfhwbWOUxoR+1+0FZpj+/H9vf2PP/8eS5r28MCoksbGUH+8A==",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "2.8.7",
+        "@microsoft/applicationinsights-core-js": "2.8.7",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-common": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.8.7.tgz",
+      "integrity": "sha512-bODgacISioOVZIYho1QUADVZh4jjFRQhfVokHbFUgDsJ1NgfpDdNlv+idxH9oriBEuf9odWnOM9jfr3OMcVicA==",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "2.8.7",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-core-js": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.7.tgz",
+      "integrity": "sha512-y7USumU+a/kbDeORr/dnDFAxcS5+KOFJSM5oUkS8tBu7CYcX1QAGF4X11gdH2NjrGgHjgxhERhYRa/YhwY1NOQ==",
+      "dependencies": {
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-dependencies-js": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.8.7.tgz",
+      "integrity": "sha512-lLRZPCi4Aq+sJThiO6QeFfZguuvZkH8VbceMz3jNF8S1KvPC0174eVcihMPDrjErPXGcquH1fKvJn3PionhZuw==",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "2.8.7",
+        "@microsoft/applicationinsights-core-js": "2.8.7",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-properties-js": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.8.7.tgz",
+      "integrity": "sha512-wEa2XJ3PAymFLcOajl7KwhLS2JGFW3SbF2lYsGeP/efIJewTRbB1l+6QgbNWiOCvPd4cpiq2jRdrgKaQpJN37Q==",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "2.8.7",
+        "@microsoft/applicationinsights-core-js": "2.8.7",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-react-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-react-js/-/applicationinsights-react-js-3.4.0.tgz",
+      "integrity": "sha512-digniwtei4TRUGnbwOQ40aaA8in52R4tp6OUyWGDNGw9V9i9VJUeckys4yR4dUDk03dxtcKksW52pN7xFT6H1g==",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "^2.8.5",
+        "@microsoft/applicationinsights-core-js": "^2.8.5",
+        "@microsoft/applicationinsights-shims": "^2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      },
+      "peerDependencies": {
+        "history": ">= 4.10.1",
+        "react": ">= 17.0.1",
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-shims": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz",
+      "integrity": "sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ=="
+    },
+    "node_modules/@microsoft/applicationinsights-web": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.8.7.tgz",
+      "integrity": "sha512-m0GufymksDAOarHnUzQ72d0RIAS2faY9xNnwAb7J08qOuDRqgnKamDH5U6af6Tjla4N1Ql2nOGLqQYg88/QjrQ==",
+      "dependencies": {
+        "@microsoft/applicationinsights-analytics-js": "2.8.7",
+        "@microsoft/applicationinsights-channel-js": "2.8.7",
+        "@microsoft/applicationinsights-common": "2.8.7",
+        "@microsoft/applicationinsights-core-js": "2.8.7",
+        "@microsoft/applicationinsights-dependencies-js": "2.8.7",
+        "@microsoft/applicationinsights-properties-js": "2.8.7",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/dynamicproto-js": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.6.tgz",
+      "integrity": "sha512-D1Oivw1A4bIXhzBIy3/BBPn3p2On+kpO2NiYt9shICDK7L/w+cR6FFBUsBZ05l6iqzTeL+Jm8lAYn0g6G7DmDg=="
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -39078,6 +39205,105 @@
       "version": "1.6.22",
       "dev": true
     },
+    "@microsoft/applicationinsights-analytics-js": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.8.7.tgz",
+      "integrity": "sha512-WEsbh3yOzjo1DnH6NyVS/W9uXEWJkb0mgOHTnq3An2nvyT7HPzd56hqRfyJsWR2KAU6hvZ09l7OK85AjkfEqJA==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.8.7",
+        "@microsoft/applicationinsights-core-js": "2.8.7",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      }
+    },
+    "@microsoft/applicationinsights-channel-js": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.8.7.tgz",
+      "integrity": "sha512-Ee2zp6Ij/Btnc9P8bVBXUIa4/X8HH1hNYpL2ALGfhwbWOUxoR+1+0FZpj+/H9vf2PP/8eS5r28MCoksbGUH+8A==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.8.7",
+        "@microsoft/applicationinsights-core-js": "2.8.7",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      }
+    },
+    "@microsoft/applicationinsights-common": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.8.7.tgz",
+      "integrity": "sha512-bODgacISioOVZIYho1QUADVZh4jjFRQhfVokHbFUgDsJ1NgfpDdNlv+idxH9oriBEuf9odWnOM9jfr3OMcVicA==",
+      "requires": {
+        "@microsoft/applicationinsights-core-js": "2.8.7",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      }
+    },
+    "@microsoft/applicationinsights-core-js": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.7.tgz",
+      "integrity": "sha512-y7USumU+a/kbDeORr/dnDFAxcS5+KOFJSM5oUkS8tBu7CYcX1QAGF4X11gdH2NjrGgHjgxhERhYRa/YhwY1NOQ==",
+      "requires": {
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      }
+    },
+    "@microsoft/applicationinsights-dependencies-js": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.8.7.tgz",
+      "integrity": "sha512-lLRZPCi4Aq+sJThiO6QeFfZguuvZkH8VbceMz3jNF8S1KvPC0174eVcihMPDrjErPXGcquH1fKvJn3PionhZuw==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.8.7",
+        "@microsoft/applicationinsights-core-js": "2.8.7",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      }
+    },
+    "@microsoft/applicationinsights-properties-js": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.8.7.tgz",
+      "integrity": "sha512-wEa2XJ3PAymFLcOajl7KwhLS2JGFW3SbF2lYsGeP/efIJewTRbB1l+6QgbNWiOCvPd4cpiq2jRdrgKaQpJN37Q==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.8.7",
+        "@microsoft/applicationinsights-core-js": "2.8.7",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      }
+    },
+    "@microsoft/applicationinsights-react-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-react-js/-/applicationinsights-react-js-3.4.0.tgz",
+      "integrity": "sha512-digniwtei4TRUGnbwOQ40aaA8in52R4tp6OUyWGDNGw9V9i9VJUeckys4yR4dUDk03dxtcKksW52pN7xFT6H1g==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "^2.8.5",
+        "@microsoft/applicationinsights-core-js": "^2.8.5",
+        "@microsoft/applicationinsights-shims": "^2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      }
+    },
+    "@microsoft/applicationinsights-shims": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz",
+      "integrity": "sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ=="
+    },
+    "@microsoft/applicationinsights-web": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.8.7.tgz",
+      "integrity": "sha512-m0GufymksDAOarHnUzQ72d0RIAS2faY9xNnwAb7J08qOuDRqgnKamDH5U6af6Tjla4N1Ql2nOGLqQYg88/QjrQ==",
+      "requires": {
+        "@microsoft/applicationinsights-analytics-js": "2.8.7",
+        "@microsoft/applicationinsights-channel-js": "2.8.7",
+        "@microsoft/applicationinsights-common": "2.8.7",
+        "@microsoft/applicationinsights-core-js": "2.8.7",
+        "@microsoft/applicationinsights-dependencies-js": "2.8.7",
+        "@microsoft/applicationinsights-properties-js": "2.8.7",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      }
+    },
+    "@microsoft/dynamicproto-js": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.6.tgz",
+      "integrity": "sha512-D1Oivw1A4bIXhzBIy3/BBPn3p2On+kpO2NiYt9shICDK7L/w+cR6FFBUsBZ05l6iqzTeL+Jm8lAYn0g6G7DmDg=="
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "dev": true,
@@ -51720,6 +51946,8 @@
         "@graphql-codegen/typescript-urql": "^3.7.0",
         "@heroicons/react": "^2.0.10",
         "@hydrogen-css/hydrogen": "^2.0.0-beta.27",
+        "@microsoft/applicationinsights-react-js": "^3.4.0",
+        "@microsoft/applicationinsights-web": "^2.8.7",
         "@storybook/addon-actions": "6.5.9",
         "@storybook/addon-essentials": "6.5.9",
         "@storybook/addon-links": "6.5.9",


### PR DESCRIPTION
### Problem
https://github.com/GCTC-NTGC/gc-digital-talent/runs/8359805257
### RootCause
```
npm ERR! Missing: @microsoft/applicationinsights-react-js@3.4.0 from lock file
npm ERR! Missing: @microsoft/applicationinsights-web@2.8.7 from lock file
npm ERR! Missing: @microsoft/applicationinsights-common@2.8.7 from lock file
npm ERR! Missing: @microsoft/applicationinsights-core-js@2.8.7 from lock file
npm ERR! Missing: @microsoft/applicationinsights-shims@2.0.1 from lock file
npm ERR! Missing: @microsoft/dynamicproto-js@1.1.6 from lock file
npm ERR! Missing: @microsoft/applicationinsights-analytics-js@2.8.7 from lock file
npm ERR! Missing: @microsoft/applicationinsights-channel-js@2.8.7 from lock file
npm ERR! Missing: @microsoft/applicationinsights-dependencies-js@2.8.7 from lock file
npm ERR! Missing: @microsoft/applicationinsights-properties-js@2.8.7 from lock file
```
### Solution 
 Generate new lock file with those dependencies by deleting node modules and do npm i . 
