### PR TITLE
Update instances of deprecated faker.unique to faker.helpers.unique

### DIFF
--- a/frontend/common/src/fakeData/fakeDepartments.ts
+++ b/frontend/common/src/fakeData/fakeDepartments.ts
@@ -8,7 +8,7 @@ export default (): Department[] => {
   return [
     {
       id: faker.datatype.uuid(),
-      departmentNumber: faker.unique(faker.datatype.number),
+      departmentNumber: faker.helpers.unique(faker.datatype.number),
       name: {
         en: "Public Service Commission",
         fr: "Commission de la fonction publique",
@@ -16,7 +16,7 @@ export default (): Department[] => {
     },
     {
       id: faker.datatype.uuid(),
-      departmentNumber: faker.unique(faker.datatype.number),
+      departmentNumber: faker.helpers.unique(faker.datatype.number),
       name: {
         en: "Finance (Department of)",
         fr: "Finances (Ministère des)",
@@ -24,7 +24,7 @@ export default (): Department[] => {
     },
     {
       id: faker.datatype.uuid(),
-      departmentNumber: faker.unique(faker.datatype.number),
+      departmentNumber: faker.helpers.unique(faker.datatype.number),
       name: {
         en: "Health (Department of)",
         fr: "Santé (Ministère de la)",
@@ -32,7 +32,7 @@ export default (): Department[] => {
     },
     {
       id: faker.datatype.uuid(),
-      departmentNumber: faker.unique(faker.datatype.number),
+      departmentNumber: faker.helpers.unique(faker.datatype.number),
       name: {
         en: "Transport (Department of)",
         fr: "Transports (Ministère des)",
@@ -40,7 +40,7 @@ export default (): Department[] => {
     },
     {
       id: faker.datatype.uuid(),
-      departmentNumber: faker.unique(faker.datatype.number),
+      departmentNumber: faker.helpers.unique(faker.datatype.number),
       name: {
         en: "Treasury Board Secretariat",
         fr: "Secrétariat du Conseil du Trésor",


### PR DESCRIPTION
Resolves #3929.

### Testing

- [ ]  Search repo for `faker.unique`
- [ ]  Verify there are no instances of faker.unique
- [ ]  Search repo for `.unique`
- [ ]  Verify the instances of `.unique` are part of `faker.helpers.unique`