### PR TITLE
View snapshot page

### DIFF
--- a/frontend/admin/src/js/adminRoutes.ts
+++ b/frontend/admin/src/js/adminRoutes.ts
@@ -35,6 +35,8 @@ const adminRoutes = (lang: string) => {
         poolCandidateId,
         "edit",
       ),
+    candidateApplication: (poolCandidateId: string): string =>
+      path.join(home(), "candidates", poolCandidateId, "application"),
     candidateProfile: (): string => path.join(home(), "candidate-profile"),
 
     userTable: (): string => path.join(home(), "users"),

--- a/frontend/admin/src/js/components/PoolDashboard.tsx
+++ b/frontend/admin/src/js/components/PoolDashboard.tsx
@@ -48,6 +48,9 @@ const CreatePoolCandidate = React.lazy(
 const UpdatePoolCandidate = React.lazy(
   () => import("./poolCandidate/UpdatePoolCandidate"),
 );
+const ViewPoolCandidatePage = React.lazy(
+  () => import("./poolCandidate/ViewPoolCandidate/ViewPoolCandidatePage"),
+);
 
 /** Pools */
 const PoolPage = React.lazy(() => import("./pool/PoolPage"));
@@ -214,6 +217,17 @@ const routes = (
     action: ({ params }) => ({
       component: (
         <UpdatePoolCandidate poolCandidateId={params.candidateId as string} />
+      ),
+      authorizedRoles: [Role.Admin],
+    }),
+  },
+  {
+    path: paths.candidateApplication(":poolCandidateId"),
+    action: ({ params }) => ({
+      component: (
+        <ViewPoolCandidatePage
+          poolCandidateId={params.poolCandidateId as string}
+        />
       ),
       authorizedRoles: [Role.Admin],
     }),

--- a/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from "react";
 import { IntlShape, useIntl } from "react-intl";
 import { notEmpty } from "@common/helpers/util";
-import { useLocation } from "@common/helpers/router";
 import { FromArray } from "@common/types/utilityTypes";
 import { getLocale } from "@common/helpers/localize";
 import {

--- a/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
@@ -18,8 +18,9 @@ import {
 import Table, {
   ColumnsOf,
   tableBooleanAccessor,
-  tableEditButtonAccessor,
+  tableViewItemButtonAccessor,
 } from "../Table";
+import { useAdminRoutes } from "../../adminRoutes";
 
 type Data = NonNullable<FromArray<GetPoolCandidatesQuery["poolCandidates"]>>;
 
@@ -43,10 +44,11 @@ const preferredLanguageAccessor = (
   </span>
 );
 
-const PoolCandidatesTable: React.FC<
-  GetPoolCandidatesQuery & { editUrlRoot: string }
-> = ({ poolCandidates, editUrlRoot }) => {
+const PoolCandidatesTable: React.FC<GetPoolCandidatesQuery> = ({
+  poolCandidates,
+}) => {
   const intl = useIntl();
+  const adminRoutes = useAdminRoutes();
   const columns = useMemo<ColumnsOf<Data>>(
     () => [
       {
@@ -170,15 +172,24 @@ const PoolCandidatesTable: React.FC<
       },
       {
         Header: intl.formatMessage({
-          defaultMessage: "Edit",
-          id: "aGEisH",
+          defaultMessage: "View Application",
+          id: "beiFJG",
           description:
-            "Title displayed for the Pool Candidates table Edit column.",
+            "Title displayed for the Pool Candidates table View Application column.",
         }),
-        accessor: (d) => tableEditButtonAccessor(d.id, editUrlRoot), // callback extracted to separate function to stabilize memoized component
+        accessor: (d) =>
+          tableViewItemButtonAccessor(
+            adminRoutes.candidateApplication(d.id),
+            intl.formatMessage({
+              defaultMessage: "Application",
+              id: "uibBHA",
+              description:
+                "Title displayed for the Pool Candidates table View Application column.",
+            }),
+          ),
       },
     ],
-    [intl, editUrlRoot],
+    [intl, adminRoutes],
   );
 
   const memoizedData = useMemo(
@@ -204,14 +215,10 @@ export const PoolCandidatesTableApi: React.FC<{ poolId: string }> = ({
     variables: { id: poolId },
   });
   const { data, fetching, error } = result;
-  const { pathname } = useLocation();
 
   return (
     <Pending fetching={fetching} error={error}>
-      <PoolCandidatesTable
-        poolCandidates={data?.pool?.poolCandidates ?? []}
-        editUrlRoot={pathname}
-      />
+      <PoolCandidatesTable poolCandidates={data?.pool?.poolCandidates ?? []} />
     </Pending>
   );
 };

--- a/frontend/admin/src/js/components/poolCandidate/ViewPoolCandidate/ViewPoolCandidatePage.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/ViewPoolCandidate/ViewPoolCandidatePage.tsx
@@ -1,5 +1,178 @@
 import * as React from "react";
-import { Scalars } from "admin/src/js/api/generated";
+import { useIntl } from "react-intl";
+import NotFound from "@common/components/NotFound";
+import Pending from "@common/components/Pending";
+import { commonMessages } from "@common/messages";
+import { Link } from "@common/components";
+import PageHeader from "@common/components/PageHeader";
+import { UserCircleIcon } from "@heroicons/react/24/outline";
+import { ArrowLeftCircleIcon } from "@heroicons/react/24/solid";
+import Breadcrumbs, { BreadcrumbsProps } from "@common/components/Breadcrumbs";
+import { getLocalizedName } from "@common/helpers/localize";
+import UserProfile from "@common/components/UserProfile";
+import { useAdminRoutes } from "admin/src/js/adminRoutes";
+import {
+  Scalars,
+  useGetPoolCandidateSnapshotQuery,
+  PoolCandidate,
+  Maybe,
+} from "../../../api/generated";
+import DashboardContentContainer from "../../DashboardContentContainer";
+
+export interface ViewPoolCandidateProps {
+  poolCandidate: PoolCandidate;
+}
+
+type SpacerProps = React.HTMLProps<HTMLDivElement>;
+
+const Spacer = ({ children, ...rest }: SpacerProps) => (
+  <div data-h2-padding-bottom="base(1.5rem)" {...rest}>
+    {children}
+  </div>
+);
+
+export const ViewPoolCandidate = ({
+  poolCandidate,
+}: ViewPoolCandidateProps): JSX.Element => {
+  const intl = useIntl();
+  const adminPaths = useAdminRoutes();
+
+  const links = [
+    {
+      title: intl.formatMessage({
+        defaultMessage: "My pools",
+        id: "0Y4Dt4",
+        description: "Breadcrumb title for the pools page link.",
+      }),
+      href: adminPaths.poolTable(),
+    },
+    {
+      title: getLocalizedName(poolCandidate.pool.name, intl),
+      href: adminPaths.poolView(poolCandidate.pool.id),
+    },
+    {
+      title: intl.formatMessage({
+        defaultMessage: "All candidates",
+        id: "e9FNqp",
+        description: "Breadcrumb title for the All Candidates page link.",
+      }),
+      href: adminPaths.poolCandidateTable(poolCandidate.pool.id),
+    },
+    {
+      title: `${poolCandidate.user.firstName} ${poolCandidate.user.lastName}`,
+    },
+  ] as BreadcrumbsProps["links"];
+
+  const parsedSnapshot: Maybe<PoolCandidate> = JSON.parse(
+    poolCandidate.profileSnapshot,
+  );
+
+  return (
+    <>
+      <PageHeader icon={UserCircleIcon}>
+        {intl.formatMessage({
+          defaultMessage: "Candidate information",
+          id: "69/cNW",
+          description:
+            "Heading displayed above the pool candidate application page.",
+        })}
+      </PageHeader>
+      <Spacer>
+        <Breadcrumbs links={links} />
+      </Spacer>
+      <Spacer>
+        <h3>{`${poolCandidate.user.firstName} ${poolCandidate.user.lastName}`}</h3>
+      </Spacer>
+      <Spacer>
+        <p>
+          {intl.formatMessage(
+            {
+              defaultMessage:
+                "This is the profile submitted on {submittedAt} for the pool: {poolName}",
+              id: "D24NyA",
+              description:
+                "Snapshot details displayed above the pool candidate application page.",
+            },
+            {
+              submittedAt: poolCandidate.submittedAt,
+              poolName: getLocalizedName(poolCandidate.pool?.name, intl),
+            },
+          )}
+        </p>
+      </Spacer>
+      <Spacer>
+        <Link
+          mode="solid"
+          color="primary"
+          data-h2-display="base(inline-flex)"
+          data-h2-align-items="base(center)"
+          href={adminPaths.poolView(poolCandidate.pool.id)}
+        >
+          <ArrowLeftCircleIcon
+            style={{ height: "1em", width: "1rem" }}
+            data-h2-margin="base(0, x.25, 0, 0)"
+          />
+          <span>
+            {intl.formatMessage({
+              defaultMessage: "Go back to All candidates",
+              id: "Z2KhWS",
+              description: "Navigation link back to All candidates.",
+            })}
+          </span>
+        </Link>
+      </Spacer>
+      <h2>
+        {intl.formatMessage({
+          defaultMessage: "Application’s profile snapshot",
+          id: "rqXJfW",
+          description: "Title for the application's profile snapshot.",
+        })}
+      </h2>
+
+      {parsedSnapshot?.user ? (
+        <UserProfile
+          applicant={parsedSnapshot?.user}
+          sections={{
+            myStatus: { isVisible: false },
+            hiringPools: { isVisible: false },
+            about: { isVisible: true },
+            language: {
+              isVisible: true,
+            },
+            government: {
+              isVisible: true,
+            },
+            workLocation: {
+              isVisible: true,
+            },
+            workPreferences: {
+              isVisible: true,
+            },
+            employmentEquity: {
+              isVisible: true,
+            },
+            roleSalary: { isVisible: true },
+            skillsExperience: {
+              isVisible: true,
+            },
+          }}
+          isNavigationVisible={false}
+        />
+      ) : (
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          {" "}
+          <p>
+            {intl.formatMessage({
+              defaultMessage: "Profile snapshot not found.",
+              id: "JH2+tK",
+              description: "Message displayed for profile snapshot not found.",
+            })}
+          </p>
+        </NotFound>
+      )}
+    </>
+  );
+};
 
 interface ViewPoolCandidatePageProps {
   poolCandidateId: Scalars["ID"];
@@ -8,7 +181,36 @@ interface ViewPoolCandidatePageProps {
 export const ViewPoolCandidatePage = ({
   poolCandidateId,
 }: ViewPoolCandidatePageProps) => {
-  return <>{poolCandidateId}</>;
+  const intl = useIntl();
+  const [{ data, fetching, error }] = useGetPoolCandidateSnapshotQuery({
+    variables: { poolCandidateId },
+  });
+
+  return (
+    <Pending fetching={fetching} error={error}>
+      <DashboardContentContainer>
+        {data?.poolCandidate ? (
+          <ViewPoolCandidate poolCandidate={data.poolCandidate} />
+        ) : (
+          <NotFound
+            headingMessage={intl.formatMessage(commonMessages.notFound)}
+          >
+            <p>
+              {intl.formatMessage(
+                {
+                  defaultMessage: "Candidate {poolCandidateId} not found.",
+                  id: "GrfidX",
+                  description:
+                    "Message displayed for pool candidate not found.",
+                },
+                { poolCandidateId },
+              )}
+            </p>
+          </NotFound>
+        )}
+      </DashboardContentContainer>
+    </Pending>
+  );
 };
 
 export default ViewPoolCandidatePage;

--- a/frontend/admin/src/js/components/poolCandidate/ViewPoolCandidate/ViewPoolCandidatePage.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/ViewPoolCandidate/ViewPoolCandidatePage.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { Scalars } from "admin/src/js/api/generated";
+
+interface ViewPoolCandidatePageProps {
+  poolCandidateId: Scalars["ID"];
+}
+
+export const ViewPoolCandidatePage = ({
+  poolCandidateId,
+}: ViewPoolCandidatePageProps) => {
+  return <>{poolCandidateId}</>;
+};
+
+export default ViewPoolCandidatePage;

--- a/frontend/admin/src/js/components/poolCandidate/ViewPoolCandidate/ViewPoolCandidatePage.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/ViewPoolCandidate/ViewPoolCandidatePage.tsx
@@ -106,7 +106,14 @@ export const ViewPoolCandidate = ({
       />
     );
   } else if (snapshotUserPropertyExists && !preferRichView) {
-    mainContent = <pre>{JSON.stringify(parsedSnapshot, null, 2)}</pre>;
+    mainContent = (
+      <pre
+        data-h2-background-color="base(light.dt-gray)"
+        data-h2-overflow="base(scroll, auto)"
+      >
+        {JSON.stringify(parsedSnapshot, null, 2)}
+      </pre>
+    );
   } else {
     mainContent = (
       <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>

--- a/frontend/admin/src/js/components/poolCandidate/ViewPoolCandidate/viewPoolCandidatePage.graphql
+++ b/frontend/admin/src/js/components/poolCandidate/ViewPoolCandidate/viewPoolCandidatePage.graphql
@@ -1,0 +1,19 @@
+query getPoolCandidateSnapshot($poolCandidateId: ID!) {
+  poolCandidate(id: $poolCandidateId) {
+    id
+    user {
+      id
+      firstName
+      lastName
+    }
+    profileSnapshot
+    submittedAt
+    pool {
+      id
+      name {
+        en
+        fr
+      }
+    }
+  }
+}

--- a/frontend/admin/src/js/stories/PoolCandidate.stories.tsx
+++ b/frontend/admin/src/js/stories/PoolCandidate.stories.tsx
@@ -32,7 +32,7 @@ const poolCandidateData = fakePoolCandidates();
 const stories = storiesOf("Pool Candidates", module);
 
 stories.add("Pool Candidates Table", () => (
-  <PoolCandidatesTable poolCandidates={poolCandidateData} editUrlRoot="#" />
+  <PoolCandidatesTable poolCandidates={poolCandidateData} />
 ));
 
 stories.add("Create Pool Candidate Form", () => (

--- a/frontend/common/src/components/UserProfile/ProfileSections/AboutSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/AboutSection.tsx
@@ -194,14 +194,29 @@ const AboutSection: React.FC<AboutSectionProps> = ({
         <div data-h2-flex-grid="base(flex-start, x2, x1)">
           <div data-h2-flex-item="base(1of1)">
             <p>
-              {intl.formatMessage(messages.requiredFieldsMissing)}{" "}
-              <a href={editPath}>
-                {intl.formatMessage({
-                  defaultMessage: "Edit your about me options.",
-                  id: "L9AGk7",
-                  description: "Link text to edit about me section on profile.",
-                })}
-              </a>
+              {editPath && (
+                <>
+                  {intl.formatMessage(messages.requiredFieldsMissing)}{" "}
+                  <a href={editPath}>
+                    {intl.formatMessage({
+                      defaultMessage: "Edit your about me options.",
+                      id: "L9AGk7",
+                      description:
+                        "Link text to edit about me section on profile.",
+                    })}
+                  </a>
+                </>
+              )}
+              {!editPath && (
+                <>
+                  {intl.formatMessage({
+                    defaultMessage: "No information has been provided.",
+                    id: "NIEIAC",
+                    description:
+                      "Message on Admin side when user not filled about me section.",
+                  })}
+                </>
+              )}
             </p>
           </div>
         </div>

--- a/frontend/common/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/common/src/components/UserProfile/UserProfile.tsx
@@ -49,6 +49,7 @@ export interface UserProfileProps {
     workLocation?: SectionControl;
     workPreferences?: SectionControl;
   };
+  isNavigationVisible?: boolean;
 }
 
 const HeadingWrapper: React.FC<{ show: boolean }> = ({ children, show }) => {
@@ -67,7 +68,11 @@ const HeadingWrapper: React.FC<{ show: boolean }> = ({ children, show }) => {
   );
 };
 
-const UserProfile: React.FC<UserProfileProps> = ({ applicant, sections }) => {
+const UserProfile: React.FC<UserProfileProps> = ({
+  applicant,
+  sections,
+  isNavigationVisible = true,
+}) => {
   const intl = useIntl();
   const { experiences } = applicant;
 
@@ -80,101 +85,104 @@ const UserProfile: React.FC<UserProfileProps> = ({ applicant, sections }) => {
   return (
     <div data-h2-container="base(center, large, x1) p-tablet(center, large, x2)">
       <TableOfContents.Wrapper>
-        <TableOfContents.Navigation>
-          {showSection("myStatus") && (
-            <TableOfContents.AnchorLink id="status-section">
-              {intl.formatMessage({
-                defaultMessage: "My Status",
-                id: "TLgbZm",
-                description: "Title of the My Status section",
-              })}
-            </TableOfContents.AnchorLink>
-          )}
-          {showSection("hiringPools") && (
-            <TableOfContents.AnchorLink id="pools-section">
-              {intl.formatMessage({
-                defaultMessage: "My Hiring Pools",
-                id: "xUl9pz",
-                description: "Title of the My Hiring Pools section",
-              })}
-            </TableOfContents.AnchorLink>
-          )}
-          {showSection("about") && (
-            <TableOfContents.AnchorLink id="about-section">
-              {intl.formatMessage({
-                defaultMessage: "About Me",
-                id: "4sJvia",
-                description: "Title of the About link section",
-              })}
-            </TableOfContents.AnchorLink>
-          )}
-          {showSection("language") && (
-            <TableOfContents.AnchorLink id="language-section">
-              {intl.formatMessage({
-                defaultMessage: "Language Information",
-                id: "B9x0ZV",
-                description: "Title of the Language Information link section",
-              })}
-            </TableOfContents.AnchorLink>
-          )}
-          {showSection("government") && (
-            <TableOfContents.AnchorLink id="government-section">
-              {intl.formatMessage({
-                defaultMessage: "Government Information",
-                id: "Nc4sjC",
-                description: "Title of the Government Information link section",
-              })}
-            </TableOfContents.AnchorLink>
-          )}
-          {showSection("workLocation") && (
-            <TableOfContents.AnchorLink id="work-location-section">
-              {intl.formatMessage({
-                defaultMessage: "Work Location",
-                id: "9WxeNz",
-                description: "Title of the Work Location link section",
-              })}
-            </TableOfContents.AnchorLink>
-          )}
-          {showSection("workPreferences") && (
-            <TableOfContents.AnchorLink id="work-preferences-section">
-              {intl.formatMessage({
-                defaultMessage: "Work Preferences",
-                id: "0DzlCc",
-                description: "Title of the Work Preferences link section",
-              })}
-            </TableOfContents.AnchorLink>
-          )}
-          {showSection("employmentEquity") && (
-            <TableOfContents.AnchorLink id="diversity-equity-inclusion-section">
-              {intl.formatMessage({
-                defaultMessage: "Diversity, equity and inclusion",
-                id: "e2R6fy",
-                description:
-                  "Title of the Diversity, equity and inclusion link section",
-              })}
-            </TableOfContents.AnchorLink>
-          )}
-          {showSection("roleSalary") && (
-            <TableOfContents.AnchorLink id="role-and-salary-section">
-              {intl.formatMessage({
-                defaultMessage: "Role and salary expectations",
-                id: "95OYVk",
-                description:
-                  "Title of the Role and salary expectations link section",
-              })}
-            </TableOfContents.AnchorLink>
-          )}
-          {showSection("skillsExperience") && (
-            <TableOfContents.AnchorLink id="skills-and-experience-section">
-              {intl.formatMessage({
-                defaultMessage: "My skills and experience",
-                id: "fqIEKE",
-                description:
-                  "Title of the My skills and experience link section",
-              })}
-            </TableOfContents.AnchorLink>
-          )}
-        </TableOfContents.Navigation>
+        {isNavigationVisible && (
+          <TableOfContents.Navigation>
+            {showSection("myStatus") && (
+              <TableOfContents.AnchorLink id="status-section">
+                {intl.formatMessage({
+                  defaultMessage: "My Status",
+                  id: "TLgbZm",
+                  description: "Title of the My Status section",
+                })}
+              </TableOfContents.AnchorLink>
+            )}
+            {showSection("hiringPools") && (
+              <TableOfContents.AnchorLink id="pools-section">
+                {intl.formatMessage({
+                  defaultMessage: "My Hiring Pools",
+                  id: "xUl9pz",
+                  description: "Title of the My Hiring Pools section",
+                })}
+              </TableOfContents.AnchorLink>
+            )}
+            {showSection("about") && (
+              <TableOfContents.AnchorLink id="about-section">
+                {intl.formatMessage({
+                  defaultMessage: "About Me",
+                  id: "4sJvia",
+                  description: "Title of the About link section",
+                })}
+              </TableOfContents.AnchorLink>
+            )}
+            {showSection("language") && (
+              <TableOfContents.AnchorLink id="language-section">
+                {intl.formatMessage({
+                  defaultMessage: "Language Information",
+                  id: "B9x0ZV",
+                  description: "Title of the Language Information link section",
+                })}
+              </TableOfContents.AnchorLink>
+            )}
+            {showSection("government") && (
+              <TableOfContents.AnchorLink id="government-section">
+                {intl.formatMessage({
+                  defaultMessage: "Government Information",
+                  id: "Nc4sjC",
+                  description:
+                    "Title of the Government Information link section",
+                })}
+              </TableOfContents.AnchorLink>
+            )}
+            {showSection("workLocation") && (
+              <TableOfContents.AnchorLink id="work-location-section">
+                {intl.formatMessage({
+                  defaultMessage: "Work Location",
+                  id: "9WxeNz",
+                  description: "Title of the Work Location link section",
+                })}
+              </TableOfContents.AnchorLink>
+            )}
+            {showSection("workPreferences") && (
+              <TableOfContents.AnchorLink id="work-preferences-section">
+                {intl.formatMessage({
+                  defaultMessage: "Work Preferences",
+                  id: "0DzlCc",
+                  description: "Title of the Work Preferences link section",
+                })}
+              </TableOfContents.AnchorLink>
+            )}
+            {showSection("employmentEquity") && (
+              <TableOfContents.AnchorLink id="diversity-equity-inclusion-section">
+                {intl.formatMessage({
+                  defaultMessage: "Diversity, equity and inclusion",
+                  id: "e2R6fy",
+                  description:
+                    "Title of the Diversity, equity and inclusion link section",
+                })}
+              </TableOfContents.AnchorLink>
+            )}
+            {showSection("roleSalary") && (
+              <TableOfContents.AnchorLink id="role-and-salary-section">
+                {intl.formatMessage({
+                  defaultMessage: "Role and salary expectations",
+                  id: "95OYVk",
+                  description:
+                    "Title of the Role and salary expectations link section",
+                })}
+              </TableOfContents.AnchorLink>
+            )}
+            {showSection("skillsExperience") && (
+              <TableOfContents.AnchorLink id="skills-and-experience-section">
+                {intl.formatMessage({
+                  defaultMessage: "My skills and experience",
+                  id: "fqIEKE",
+                  description:
+                    "Title of the My skills and experience link section",
+                })}
+              </TableOfContents.AnchorLink>
+            )}
+          </TableOfContents.Navigation>
+        )}
         <TableOfContents.Content>
           {showSection("myStatus") && (
             <TableOfContents.Section id="status-section">


### PR DESCRIPTION
This branch adds the ability to open the admin site, choose a pool candidate (application) and review the snapshot.

## Notes
- The box on the left to change the status is part of #3691
- The designs call for a toggle to switch between rich and raw views but we don't have a toggle component yet.
  - I added #3980 to create the component
  - I added #3981 to update this page

## Suggested testing steps
1) Navigate to /admin/pools
1) Publish a pool
1) Open a new tab at /talent/profile
1) Finish your profile and switch to "actively looking"
1) Navigate to /browse/pools
1) Select the pool you published
1) Add "/view" to the end of the url :shrug: 
1) Click "apply to the pool"
1) Add any missing skills to an existing experience
1) Sign and submit application
1) Switch back to your admin tab
1) Click "view candidates" for your published pool
1) Find your application at the end of the list and click "view application"
1) Confirm the profile matches what's on the other tab
1) Try toggling to the JSON view
1) Open another pool candidate and observe the "not found" message

Closes #3690 