### PR TITLE
Bug - Fix missing French translations

### DIFF
--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -1466,7 +1466,7 @@
     "defaultMessage": "Minorité visible",
     "description": "Text on view-user page that the user is part of a visible minority"
   },
-  "fYHTnt": {
+  "+phJjJ": {
     "defaultMessage": "Demandes les plus récentes",
     "description": "Title for the latests requests table in the admin dashboard"
   },

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -1588,7 +1588,7 @@
     "defaultMessage": "<strong>Vous n'avez pas de compte de CléGC?</strong> <a>Inscrivez-vous.</a>",
     "description": "Instruction on what to do if user does not have a GC Key."
   },
-  "Ba4Y8a": {
+  "ID8FNk": {
     "defaultMessage": "{candidateCount, plural, one {Il y a actuellement environ <heavyPrimary><testId>{candidateCount}</testId></heavyPrimary> candidat qui répond à vos critères.} other {Il y a actuellement environ <heavyPrimary><testId>{candidateCount}</testId></heavyPrimary> candidats qui répondent à vos critères.} }",
     "description": "Message for total estimated candidates box next to search form."
   },


### PR DESCRIPTION
Resolves #3989.

## Summary
Two strings were using old IDs that did not connect them to their English equivalents. This fixes both of them.

## Testing

1. Run `npm run intl-compile --workspace=admin`
2. Run `npm run production --workspace=admin`
3. Log in to /fr/admin/dashboard
4. Verify table header shows: "Il y a actuellement environ"...
5. Run `npm run intl-compile --workspace=talentsearch`
6. Run `npm run production --workspace=talentsearch`
7. Navigate to /fr/search
8. Verify table header shows: "Demandes les plus récentes"