### PR TITLE
Bug - Add intl.formatMessage for l10n on strings

### DIFF
--- a/frontend/admin/src/js/components/pool/EditPool/CloseDialog.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/CloseDialog.tsx
@@ -73,7 +73,11 @@ const CloseDialog = ({
       </p>
       <InputWrapper
         inputId="closingDate"
-        label="Closing Date"
+        label={intl.formatMessage({
+          defaultMessage: "Closing Date",
+          id: "7OQHcx",
+          description: "Closing Date field label for close pool dialog",
+        })}
         hideOptional
         required={false}
       >

--- a/frontend/admin/src/js/components/pool/EditPool/PublishDialog.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/PublishDialog.tsx
@@ -89,7 +89,11 @@ const PublishDialog = ({
       </p>
       <InputWrapper
         inputId="closingDate"
-        label="Closing Date"
+        label={intl.formatMessage({
+          defaultMessage: "Closing Date",
+          id: "K+roYh",
+          description: "Closing Date field label for publish pool dialog",
+        })}
         hideOptional
         required={false}
       >

--- a/frontend/talentsearch/src/js/components/workLocationPreferenceForm/WorkLocationPreferenceForm.tsx
+++ b/frontend/talentsearch/src/js/components/workLocationPreferenceForm/WorkLocationPreferenceForm.tsx
@@ -199,9 +199,19 @@ export const WorkLocationPreferenceForm: React.FC<
               <div data-h2-padding="base(0, x2, 0, 0)">
                 <TextArea
                   id="location-exemptions"
-                  label="Location exemptions"
+                  label={intl.formatMessage({
+                    defaultMessage: "Location exemptions",
+                    id: "0qNkIp",
+                    description:
+                      "Location Exemptions field label for work location preference form",
+                  })}
                   name="locationExemptions"
-                  placeholder="Optionally, add a city or village here..."
+                  placeholder={intl.formatMessage({
+                    defaultMessage: "Optionally, add a city or village here...",
+                    id: "OH5tTS",
+                    description:
+                      "Location Exemptions field placeholder for work location preference form",
+                  })}
                 />
               </div>
             </div>


### PR DESCRIPTION
Resolves #3991.

## Summary
Wraps several strings with `intl.formatMessage` to allow for their localization.