### PR TITLE
backend sort of pool candidates with pagination

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -326,6 +326,11 @@ RAWSQL2;
         return $query;
     }
 
+    public function scopeNotDraft(Builder $query): Builder
+    {
+        return $query->whereNotIn('pool_candidate_status', ['DRAFT', 'DRAFT_EXPIRED']);
+    }
+
    /* accessor to obtain pool candidate status, additional logic exists to override database field sometimes*/
    // pool_candidate_status database value passed into accessor as an argument
    public function getPoolCandidateStatusAttribute($candidateStatus)

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -743,7 +743,7 @@ type Query {
     pools: [Pool]! @all
     poolCandidate(id: ID! @eq): PoolCandidate @find @guard @can(ability: "view", query: true)
     poolCandidates(includeIds: [ID] @in(key: "id")): [PoolCandidate]! @all @guard @can(ability: "viewAny")
-    poolCandidatesPaginated(where: PaginatedPoolCandidateFilterInput): [PoolCandidate]! @paginate(defaultCount: 10, maxCount: 1000 ) @guard @can(ability: "viewAny")
+    poolCandidatesPaginated(where: PaginatedPoolCandidateFilterInput, orderBy: _ @orderBy(relations: [ {relation: "user", columns: ["priority_weight"] }])): [PoolCandidate]! @paginate(defaultCount: 10, maxCount: 1000 ) @guard @can(ability: "viewAny")
     # countPoolCandidates returns the number of candidates matching its filters, and requires no special permissions.
     countPoolCandidates(where: PoolCandidateFilterInput): Int! @deprecated(reason: "Replaced by countApplicants") @count(model: "PoolCandidate" scopes: ["expiryFilter", "available"])
     # searchPoolCandidates returns the actual candidates matching a filter, and requires permissions.

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -743,7 +743,7 @@ type Query {
     pools: [Pool]! @all
     poolCandidate(id: ID! @eq): PoolCandidate @find @guard @can(ability: "view", query: true)
     poolCandidates(includeIds: [ID] @in(key: "id")): [PoolCandidate]! @all @guard @can(ability: "viewAny")
-    poolCandidatesPaginated(where: PaginatedPoolCandidateFilterInput, orderBy: _ @orderBy(relations: [ {relation: "user", columns: ["priority_weight"] }])): [PoolCandidate]! @paginate(defaultCount: 10, maxCount: 1000 ) @guard @can(ability: "viewAny")
+    poolCandidatesPaginated(where: PaginatedPoolCandidateFilterInput, orderBy: _ @orderBy(relations: [ {relation: "user", columns: ["priority_weight"] }])): [PoolCandidate]! @paginate(defaultCount: 10, maxCount: 1000, scopes: ["notDraft"] ) @guard @can(ability: "viewAny")
     # countPoolCandidates returns the number of candidates matching its filters, and requires no special permissions.
     countPoolCandidates(where: PoolCandidateFilterInput): Int! @deprecated(reason: "Replaced by countApplicants") @count(model: "PoolCandidate" scopes: ["expiryFilter", "available"])
     # searchPoolCandidates returns the actual candidates matching a filter, and requires permissions.

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1001,6 +1001,7 @@ type Query {
   ): UserPaginator
   poolCandidatesPaginated(
     where: PaginatedPoolCandidateFilterInput
+    orderBy: [QueryPoolCandidatesPaginatedOrderByRelationOrderByClause!]
 
     """Limits number of fetched items. Maximum allowed value: 1000."""
     first: Int = 10
@@ -1008,6 +1009,34 @@ type Query {
     """The offset from which items are returned."""
     page: Int
   ): PoolCandidatePaginator
+}
+
+"""Order by clause for Query.poolCandidatesPaginated.orderBy."""
+input QueryPoolCandidatesPaginatedOrderByRelationOrderByClause {
+  """The column that is used for ordering."""
+  column: String
+
+  """The direction that is used for ordering."""
+  order: SortOrder!
+
+  """Aggregate specification."""
+  user: QueryPoolCandidatesPaginatedOrderByUser
+}
+
+"""
+Aggregate specification for Query.poolCandidatesPaginated.orderBy.user.
+"""
+input QueryPoolCandidatesPaginatedOrderByUser {
+  """The aggregate function to apply to the column."""
+  aggregate: OrderByRelationWithColumnAggregateFunction!
+
+  """Name of the column to use."""
+  column: QueryPoolCandidatesPaginatedOrderByUserColumn
+}
+
+"""Allowed column names for Query.poolCandidatesPaginated.orderBy."""
+enum QueryPoolCandidatesPaginatedOrderByUserColumn {
+  PRIORITY_WEIGHT
 }
 
 enum Role {

--- a/frontend/admin/src/js/components/poolCandidate/poolCandidatesOperations.graphql
+++ b/frontend/admin/src/js/components/poolCandidate/poolCandidatesOperations.graphql
@@ -292,7 +292,15 @@ query GetPoolCandidatesPaginated(
   $first: Int
   $page: Int
 ) {
-  poolCandidatesPaginated(where: $where, first: $first, page: $page) {
+  poolCandidatesPaginated(
+    where: $where
+    first: $first
+    page: $page
+    orderBy: [
+      { user: { aggregate: MAX, column: PRIORITY_WEIGHT }, order: ASC }
+      { column: "status_weight", order: ASC }
+    ]
+  ) {
     data {
       ...poolCandidateTable
     }


### PR DESCRIPTION
closes #3951 
candidates are sorted in the pagination query, DRAFT not retrieved 

testing:
head to `/admin/pools/:id/pool-candidates`
view the order of table rows
