### PR TITLE
FIx any users.armed_forces_status values which may have been migrated incorrectly

### DIFF
--- a/api/database/migrations/2022_09_20_213608_repair_users_armed_forces_status_column.php
+++ b/api/database/migrations/2022_09_20_213608_repair_users_armed_forces_status_column.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * The armed_forces_status column used to be a boolean column called "is_veteran".
+ * When it was renamed and converted to a string, non-null values were converted to the
+ * literal strings "true" and "false", instead of the expected ArmedForcesStatus enums.
+ */
+class RepairUsersArmedForcesStatusColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement("
+            update users
+                set armed_forces_status =
+                    case armed_forces_status
+                        when 'true' then 'VETERAN'
+                        when 'false' then 'NON_CAF'
+                        else armed_forces_status
+                    end
+        ");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // This migration isn't safely reversible.
+    }
+}


### PR DESCRIPTION
Resolves #4017 

Creates a new migration, which converts any "true" or "false" strings to "VETERAN" and "NON_CAF".