### PR TITLE
Tooling - 4036 - Update Faker Unique

### DIFF
--- a/frontend/common/src/fakeData/fakeDepartments.ts
+++ b/frontend/common/src/fakeData/fakeDepartments.ts
@@ -8,7 +8,7 @@ export default (): Department[] => {
   return [
     {
       id: faker.datatype.uuid(),
-      departmentNumber: faker.helpers.unique(faker.datatype.number),
+      departmentNumber: +faker.random.numeric(3),
       name: {
         en: "Public Service Commission",
         fr: "Commission de la fonction publique",
@@ -16,7 +16,7 @@ export default (): Department[] => {
     },
     {
       id: faker.datatype.uuid(),
-      departmentNumber: faker.helpers.unique(faker.datatype.number),
+      departmentNumber: +faker.random.numeric(3),
       name: {
         en: "Finance (Department of)",
         fr: "Finances (Ministère des)",
@@ -24,7 +24,7 @@ export default (): Department[] => {
     },
     {
       id: faker.datatype.uuid(),
-      departmentNumber: faker.helpers.unique(faker.datatype.number),
+      departmentNumber: +faker.random.numeric(3),
       name: {
         en: "Health (Department of)",
         fr: "Santé (Ministère de la)",
@@ -32,7 +32,7 @@ export default (): Department[] => {
     },
     {
       id: faker.datatype.uuid(),
-      departmentNumber: faker.helpers.unique(faker.datatype.number),
+      departmentNumber: +faker.random.numeric(3),
       name: {
         en: "Transport (Department of)",
         fr: "Transports (Ministère des)",
@@ -40,7 +40,7 @@ export default (): Department[] => {
     },
     {
       id: faker.datatype.uuid(),
-      departmentNumber: faker.helpers.unique(faker.datatype.number),
+      departmentNumber: +faker.random.numeric(3),
       name: {
         en: "Treasury Board Secretariat",
         fr: "Secrétariat du Conseil du Trésor",


### PR DESCRIPTION
Resolves #4036

## Summary

This replaces `faker.helpers.unique` with `faker.random.numeric` in the `fakeDepartments` helper to work around an issue with faker not being able to generate unique numbers.

> **Note:** A new issue is being created to update this once `faker.helpers.unique` works with numbers.

## Testing

1. Check that chromatic built properly
2. Confirm the **Department** stories work