### PR TITLE
Bug - 3969 - Fix login page cancel link

### DIFF
--- a/frontend/talentsearch/src/js/components/login/LoginPage.tsx
+++ b/frontend/talentsearch/src/js/components/login/LoginPage.tsx
@@ -8,6 +8,7 @@ import { useApiRoutes } from "@common/hooks/useApiRoutes";
 
 import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
 import { useApplicantProfileRoutes } from "../../applicantProfileRoutes";
+import { useTalentSearchRoutes } from "../../talentSearchRoutes";
 
 const keyRegistrationLink = (path: string, ...chunks: React.ReactNode[]) => (
   <a href={path}>{chunks}</a>
@@ -17,6 +18,7 @@ const LoginPage: React.FC = () => {
   const intl = useIntl();
   const paths = useApiRoutes();
   const profilePaths = useApplicantProfileRoutes();
+  const searchPaths = useTalentSearchRoutes();
   const loginPath = paths.login(profilePaths.myProfile(), getLocale(intl));
 
   return (
@@ -85,7 +87,8 @@ const LoginPage: React.FC = () => {
           >
             <p>
               <Link
-                href={loginPath}
+                href={searchPaths.home()}
+                external
                 mode="outline"
                 color="secondary"
                 type="button"

--- a/frontend/talentsearch/src/js/components/search/SearchHeading.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchHeading.tsx
@@ -1,18 +1,17 @@
 import * as React from "react";
 import { imageUrl } from "@common/helpers/router";
 import { useIntl } from "react-intl";
-import { useTalentSearchRoutes } from "../../talentSearchRoutes";
+import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
 
 const SearchHeading: React.FunctionComponent = () => {
   const intl = useIntl();
-  const paths = useTalentSearchRoutes();
   return (
     <header data-h2-background-color="base(dt-gray.15)">
       <div
         data-h2-padding="base(x2.5, 0, x4, 0) p-tablet(x4, 0, x6, 0)"
         style={{
           background: `linear-gradient(70deg, rgba(103, 76, 144, 0.9), rgba(29, 44, 76, 1)), url(${imageUrl(
-            paths.home(),
+            TALENTSEARCH_APP_DIR,
             "hero-background-search.png",
           )})`,
           backgroundSize: "cover",

--- a/frontend/talentsearch/src/js/talentSearchRoutes.ts
+++ b/frontend/talentsearch/src/js/talentSearchRoutes.ts
@@ -1,12 +1,11 @@
 import { getLocale } from "@common/helpers/localize";
 import path from "path-browserify";
 import { useIntl } from "react-intl";
-import TALENTSEARCH_APP_DIR from "./talentSearchConstants";
 
 export type TalentSearchRoutes = ReturnType<typeof talentSearchRoutes>;
 
 const talentSearchRoutes = (lang: string) => {
-  const home = (): string => path.join("/", lang, TALENTSEARCH_APP_DIR); // leading slash in case empty base url
+  const home = (): string => path.join("/", lang); // leading slash in case empty base url
   return {
     home,
     search: (): string => path.join("/", lang, "search"),


### PR DESCRIPTION
Resolves #3969 

## Summary

This update the talent search home path as well as the cancel link at `/login-info`.

## Testing

1. Build talent search project `npm run production --workspace=talentsearch`
2. Navigate to `/search` and ensure heading image appears
3. Navigate to `/login-info`
4. Click **Cancel**
5. Ensure you land on the root route.