### PR TITLE
ensure Digital Careers Pool can always be applied to

### DIFF
--- a/api/database/seeders/PoolSeeder.php
+++ b/api/database/seeders/PoolSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Pool;
 use App\Models\User;
+use Database\Helpers\ApiEnums;
 use Illuminate\Database\Seeder;
 
 class PoolSeeder extends Seeder
@@ -27,6 +28,9 @@ class PoolSeeder extends Seeder
                     'en' => 'Enjoy a meaningful Digital career at the Public Service of Canada! Join us and grow your Digital career with jobs and opportunities for career advancement across a broad range of specializations, throughout Canada and internationally. You\'ll have access to continuous learning through onboarding, on-the-job training, coaching, mentoring, interdepartmental placements, and many other opportunities! Enjoy a collaborative and horizontal work culture facilitated by the Government\'s digital collaboration tools.',
                     'fr' => 'Profitez d\'une carrière numérique significative à la fonction publique du Canada ! Joignez-vous à nous pour vous épanouir dans votre carrière numérique avec des emplois et des possibilités d\'avancement professionnel dans un large éventail de spécialisations, partout au Canada et à l\'étranger. Vous aurez accès à un apprentissage continu grâce à l\'orientation, à la formation en cours d\'emploi, au coaching, au mentorat, à des occasions de mobilité interministérielles et à bien plus ! Profitez d\'une culture de travail collaborative et horizontale facilitée par les outils de collaboration numérique du gouvernement.'
                 ],
+                'is_published' => true,
+                'expiry_date' => config('constants.far_future_date'),
+                'pool_status' => ApiEnums::POOL_STATUS_TAKING_APPLICATIONS,
             ],
             [
                 'name' => [


### PR DESCRIPTION
split this out of #4035 
ensuring a pool exists that can always be applied to was the less confusing problem going on with Cypress 

evaluation: run Cypress multiple times and ensure _Direct-Intake_ spec never fails, Search spec may fail