### PR TITLE
a11y - 3835 - Label landmarks

### DIFF
--- a/frontend/common/src/components/Footer/Footer.tsx
+++ b/frontend/common/src/components/Footer/Footer.tsx
@@ -68,7 +68,14 @@ const Footer: React.FunctionComponent<{
             data-h2-flex-item="base(1of1) l-tablet(1of2)"
             data-h2-text-align="base(center) l-tablet(left)"
           >
-            <nav>
+            <nav
+              aria-label={intl.formatMessage({
+                defaultMessage: "Policy and feedback",
+                id: "xdojyj",
+                description:
+                  "Label for the policy, conditions and feedback navigation",
+              })}
+            >
               <ul style={{ gap: "1rem" }} className="reset-ul">
                 {links.map(({ route, label }) => (
                   <li

--- a/frontend/common/src/components/NavMenu/NavMenu.tsx
+++ b/frontend/common/src/components/NavMenu/NavMenu.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from "react";
+import { useIntl } from "react-intl";
 
 export interface NavMenuProps {
   mainItems: ReactElement[];
@@ -21,12 +22,19 @@ const NavMenu: React.FunctionComponent<NavMenuProps> = ({
   mainItems,
   utilityItems,
 }) => {
+  const intl = useIntl();
   return (
     <div data-h2-container="base(center, large, x1) p-tablet(center, large, x2)">
       <div data-h2-padding="base(x1, 0)">
         <div data-h2-flex-grid="base(center, x3, 0)">
           <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-            <nav>
+            <nav
+              aria-label={intl.formatMessage({
+                defaultMessage: "Main menu",
+                id: "SY1LIh",
+                description: "Label for the main navigation",
+              })}
+            >
               <ul
                 data-h2-list-style="base(none)"
                 data-h2-flex-grid="base(flex-start, x1, 0)"
@@ -40,7 +48,13 @@ const NavMenu: React.FunctionComponent<NavMenuProps> = ({
           </div>
           {utilityItems && utilityItems.length > 0 ? (
             <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-              <nav>
+              <nav
+                aria-label={intl.formatMessage({
+                  defaultMessage: "Utility",
+                  id: "HkzjEV",
+                  description: "Label for the utility link navigation",
+                })}
+              >
                 <ul
                   data-h2-list-style="base(none)"
                   data-h2-flex-grid="base(flex-start, x1, 0)"

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1401,5 +1401,17 @@
   "rcI/H3": {
     "defaultMessage": "Cette compétence possède les expériences connexes suivantes :",
     "description": "An introduction to a list of experiences associated with a skill"
+  },
+  "xdojyj": {
+    "defaultMessage": "Politique et rétroaction",
+    "description": "Label for the policy, conditions and feedback navigation"
+  },
+  "SY1LIh": {
+    "defaultMessage": "Menu principal",
+    "description": "Label for the main navigation"
+  },
+  "HkzjEV": {
+    "defaultMessage": "Utilitaire",
+    "description": "Label for the utility link navigation"
   }
 }


### PR DESCRIPTION
Resolves #3835 

## Summary

This adds `aria-label` to our `nav` elements to make them unique.

## Testing

1. Compile languages `npm run intl-compile --workspaces`
2. Build applications `npm run production --workspaces`
3. Confirm the `nav` elements in the header and footer have both English and French labels
4. Run axe DevTools and confirm the error "Ensures landmarks are unique" does not appear