### PR TITLE
Change default request policy to avoid incorrectly-cached empty lists

### DIFF
--- a/frontend/admin/src/js/components/classification/ClassificationTable.tsx
+++ b/frontend/admin/src/js/components/classification/ClassificationTable.tsx
@@ -112,14 +112,12 @@ export const ClassificationTable: React.FC<
   );
 };
 
+const context: Partial<OperationContext> = {
+  additionalTypenames: ["Classification"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
+  requestPolicy: "cache-first", // The list of classifications will rarely change, so we override default request policy to avoid unnecessary cache updates.
+};
+
 export const ClassificationTableApi: React.FunctionComponent = () => {
-  const context = useMemo<Partial<OperationContext>>(
-    () => ({
-      additionalTypenames: ["Classification"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
-      requestPolicy: "cache-first", // The list of classifications will rarely change, so we override default request policy to avoid unnecessary cache updates.
-    }),
-    [],
-  );
   const [result] = useGetClassificationsQuery({
     context,
   });

--- a/frontend/admin/src/js/components/classification/ClassificationTable.tsx
+++ b/frontend/admin/src/js/components/classification/ClassificationTable.tsx
@@ -5,6 +5,7 @@ import { notEmpty } from "@common/helpers/util";
 import { FromArray } from "@common/types/utilityTypes";
 import { getLocale } from "@common/helpers/localize";
 import Pending from "@common/components/Pending";
+import { OperationContext } from "urql";
 import {
   GetClassificationsQuery,
   useGetClassificationsQuery,
@@ -112,7 +113,15 @@ export const ClassificationTable: React.FC<
 };
 
 export const ClassificationTableApi: React.FunctionComponent = () => {
-  const [result] = useGetClassificationsQuery();
+  const context = useMemo<Partial<OperationContext>>(
+    () => ({
+      requestPolicy: "cache-first", // The list of classifications will rarely change, so we override default request policy to avoid unnecessary cache updates.
+    }),
+    [],
+  );
+  const [result] = useGetClassificationsQuery({
+    context,
+  });
   const { data, fetching, error } = result;
   const { pathname } = useLocation();
 

--- a/frontend/admin/src/js/components/classification/ClassificationTable.tsx
+++ b/frontend/admin/src/js/components/classification/ClassificationTable.tsx
@@ -115,6 +115,7 @@ export const ClassificationTable: React.FC<
 export const ClassificationTableApi: React.FunctionComponent = () => {
   const context = useMemo<Partial<OperationContext>>(
     () => ({
+      additionalTypenames: ["Classification"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
       requestPolicy: "cache-first", // The list of classifications will rarely change, so we override default request policy to avoid unnecessary cache updates.
     }),
     [],

--- a/frontend/admin/src/js/components/skill/SkillTable.tsx
+++ b/frontend/admin/src/js/components/skill/SkillTable.tsx
@@ -110,14 +110,12 @@ export const SkillTable: React.FC<AllSkillsQuery & { editUrlRoot: string }> = ({
   );
 };
 
+const context: Partial<OperationContext> = {
+  additionalTypenames: ["Skill", "SkillFamily"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
+  requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
+};
+
 export const SkillTableApi: React.FunctionComponent = () => {
-  const context = useMemo<Partial<OperationContext>>(
-    () => ({
-      additionalTypenames: ["Skill", "SkillFamily"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
-      requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
-    }),
-    [],
-  );
   const [result] = useAllSkillsQuery({
     context,
   });

--- a/frontend/admin/src/js/components/skill/SkillTable.tsx
+++ b/frontend/admin/src/js/components/skill/SkillTable.tsx
@@ -6,6 +6,7 @@ import { notEmpty } from "@common/helpers/util";
 import { FromArray } from "@common/types/utilityTypes";
 import { Pill } from "@common/components";
 import Pending from "@common/components/Pending";
+import { OperationContext } from "urql";
 import { AllSkillsQuery, useAllSkillsQuery } from "../../api/generated";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
 import { useAdminRoutes } from "../../adminRoutes";
@@ -110,7 +111,15 @@ export const SkillTable: React.FC<AllSkillsQuery & { editUrlRoot: string }> = ({
 };
 
 export const SkillTableApi: React.FunctionComponent = () => {
-  const [result] = useAllSkillsQuery();
+  const context = useMemo<Partial<OperationContext>>(
+    () => ({
+      requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
+    }),
+    [],
+  );
+  const [result] = useAllSkillsQuery({
+    context,
+  });
   const { data, fetching, error } = result;
   const { pathname } = useLocation();
 

--- a/frontend/admin/src/js/components/skill/SkillTable.tsx
+++ b/frontend/admin/src/js/components/skill/SkillTable.tsx
@@ -113,6 +113,7 @@ export const SkillTable: React.FC<AllSkillsQuery & { editUrlRoot: string }> = ({
 export const SkillTableApi: React.FunctionComponent = () => {
   const context = useMemo<Partial<OperationContext>>(
     () => ({
+      additionalTypenames: ["Skill", "SkillFamily"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
       requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
     }),
     [],

--- a/frontend/admin/src/js/components/user/useFilterOptions.tsx
+++ b/frontend/admin/src/js/components/user/useFilterOptions.tsx
@@ -25,6 +25,11 @@ import {
   useGetPoolsQuery,
 } from "../../api/generated";
 
+const context: Partial<OperationContext> = {
+  additionalTypenames: ["Skill", "SkillFamily"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
+  requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
+};
+
 // TODO: Remove this toggle after data model settles.
 // See: https://www.figma.com/proto/XS4Ag6GWcgdq2dBlLzBkay?node-id=1064:5862#224617157
 export default function useFilterOptions(enableEducationType = false) {
@@ -33,13 +38,6 @@ export default function useFilterOptions(enableEducationType = false) {
   // TODO: Implement way to return `fetching` states from hook, so that can pass
   // to react-select's `isLoading` prop on <Select />.
   // See: https://react-select.com/props#select-props
-  const context = useMemo<Partial<OperationContext>>(
-    () => ({
-      additionalTypenames: ["Skill", "SkillFamily"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
-      requestPolicy: "cache-first", // The list of skills and classifications will rarely change, so we override default request policy to avoid unnecessary cache updates.
-    }),
-    [],
-  );
   const [skillsRes] = useAllSkillsQuery({
     context,
   });

--- a/frontend/admin/src/js/components/user/useFilterOptions.tsx
+++ b/frontend/admin/src/js/components/user/useFilterOptions.tsx
@@ -13,7 +13,6 @@ import { notEmpty } from "@common/helpers/util";
 import mapValues from "lodash/mapValues";
 import { useIntl } from "react-intl";
 import useLocale from "@common/hooks/useLocale";
-import { useMemo } from "react";
 import { OperationContext } from "urql";
 import {
   WorkRegion,

--- a/frontend/admin/src/js/components/user/useFilterOptions.tsx
+++ b/frontend/admin/src/js/components/user/useFilterOptions.tsx
@@ -35,6 +35,7 @@ export default function useFilterOptions(enableEducationType = false) {
   // See: https://react-select.com/props#select-props
   const context = useMemo<Partial<OperationContext>>(
     () => ({
+      additionalTypenames: ["Skill", "SkillFamily"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
       requestPolicy: "cache-first", // The list of skills and classifications will rarely change, so we override default request policy to avoid unnecessary cache updates.
     }),
     [],

--- a/frontend/admin/src/js/components/user/useFilterOptions.tsx
+++ b/frontend/admin/src/js/components/user/useFilterOptions.tsx
@@ -13,6 +13,8 @@ import { notEmpty } from "@common/helpers/util";
 import mapValues from "lodash/mapValues";
 import { useIntl } from "react-intl";
 import useLocale from "@common/hooks/useLocale";
+import { useMemo } from "react";
+import { OperationContext } from "urql";
 import {
   WorkRegion,
   EducationType,
@@ -31,8 +33,18 @@ export default function useFilterOptions(enableEducationType = false) {
   // TODO: Implement way to return `fetching` states from hook, so that can pass
   // to react-select's `isLoading` prop on <Select />.
   // See: https://react-select.com/props#select-props
-  const [skillsRes] = useAllSkillsQuery();
-  const [classificationsRes] = useGetClassificationsQuery();
+  const context = useMemo<Partial<OperationContext>>(
+    () => ({
+      requestPolicy: "cache-first", // The list of skills and classifications will rarely change, so we override default request policy to avoid unnecessary cache updates.
+    }),
+    [],
+  );
+  const [skillsRes] = useAllSkillsQuery({
+    context,
+  });
+  const [classificationsRes] = useGetClassificationsQuery({
+    context,
+  });
   const [poolsRes] = useGetPoolsQuery();
 
   const yesOption = {

--- a/frontend/common/src/components/ClientProvider/ClientProvider.tsx
+++ b/frontend/common/src/components/ClientProvider/ClientProvider.tsx
@@ -212,6 +212,7 @@ const ClientProvider: React.FC<{ client?: Client }> = ({
       client ??
       createClient({
         url: apiUri,
+        requestPolicy: "cache-and-network",
         exchanges: [
           /**
            * Commented out to stop urql errors being displayed in toasts

--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
@@ -359,6 +359,7 @@ const ExperienceFormContainer: React.FunctionComponent<
 
   const context = useMemo<Partial<OperationContext>>(
     () => ({
+      additionalTypenames: ["Skill", "SkillFamily"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
       requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
     }),
     [],

--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { useIntl } from "react-intl";
 import { toast } from "react-toastify";
 import { SubmitHandler } from "react-hook-form";

--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
@@ -280,6 +280,11 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
   );
 };
 
+const context: Partial<OperationContext> = {
+  additionalTypenames: ["Skill", "SkillFamily"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
+  requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
+};
+
 export interface ExperienceFormContainerProps {
   userId: string;
   experienceType: ExperienceType;
@@ -357,13 +362,6 @@ const ExperienceFormContainer: React.FunctionComponent<
   const { data: experienceData, fetching: fetchingExperience } =
     experiencesResult;
 
-  const context = useMemo<Partial<OperationContext>>(
-    () => ({
-      additionalTypenames: ["Skill", "SkillFamily"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
-      requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
-    }),
-    [],
-  );
   const [skillResults] = useGetSkillsQuery({
     context,
   });

--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useIntl } from "react-intl";
 import { toast } from "react-toastify";
 import { SubmitHandler } from "react-hook-form";
@@ -15,6 +15,7 @@ import Pending from "@common/components/Pending";
 import { commonMessages } from "@common/messages";
 import { notEmpty } from "@common/helpers/util";
 import { BreadcrumbsProps } from "@common/components/Breadcrumbs";
+import { OperationContext } from "urql";
 import ProfileFormWrapper from "../applicantProfile/ProfileFormWrapper";
 import ProfileFormFooter from "../applicantProfile/ProfileFormFooter";
 
@@ -356,7 +357,15 @@ const ExperienceFormContainer: React.FunctionComponent<
   const { data: experienceData, fetching: fetchingExperience } =
     experiencesResult;
 
-  const [skillResults] = useGetSkillsQuery();
+  const context = useMemo<Partial<OperationContext>>(
+    () => ({
+      requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
+    }),
+    [],
+  );
+  const [skillResults] = useGetSkillsQuery({
+    context,
+  });
   const {
     data: skillsData,
     fetching: fetchingSkills,


### PR DESCRIPTION
Resolves #3705 

Changes the default urql [request policy](https://formidable.com/open-source/urql/docs/basics/document-caching/#request-policies) to `cache-and-network`, to make really sure we always have up-to-date data, and as an easy way to avoid [this known issue](https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas). 

Following a [slack conversation](https://talent-cloud.slack.com/archives/C0259G6KXJ6/p1664213144566129), where we realized we could optimize certain queries to use a different request policy, I've set requests for Skills and for Classifications as examples on how to use the `cache-first` request policy where it makes sense to do so.