### PR TITLE
a11y - 3701 - Improve Edit Link Context

### DIFF
--- a/frontend/admin/src/js/components/Table/TableEditButton.tsx
+++ b/frontend/admin/src/js/components/Table/TableEditButton.tsx
@@ -29,8 +29,8 @@ function TableEditButton({
     >
       {intl.formatMessage(
         {
-          defaultMessage: "Edit <hidden>{label}</hidden>",
-          id: "9flpmN",
+          defaultMessage: "Edit<hidden> {label}</hidden>",
+          id: "i9ND/M",
           description: "Title displayed for the Edit column.",
         },
         { label },

--- a/frontend/admin/src/js/components/classification/ClassificationTable.tsx
+++ b/frontend/admin/src/js/components/classification/ClassificationTable.tsx
@@ -82,7 +82,8 @@ export const ClassificationTable: React.FC<
           description:
             "Title displayed for the Classification table Edit column.",
         }),
-        accessor: (d) => tableEditButtonAccessor(d.id, editUrlRoot), // callback extracted to separate function to stabilize memoized component
+        accessor: (d) =>
+          tableEditButtonAccessor(d.id, editUrlRoot, d.name?.[locale]), // callback extracted to separate function to stabilize memoized component
       },
     ],
     [editUrlRoot, intl, locale],

--- a/frontend/admin/src/js/components/cmoAsset/CmoAssetTable.tsx
+++ b/frontend/admin/src/js/components/cmoAsset/CmoAssetTable.tsx
@@ -58,7 +58,8 @@ export const CmoAssetTable: React.FC<
           id: "z2m2Gp",
           description: "Title displayed for the CMO Asset table Edit column.",
         }),
-        accessor: (d) => tableEditButtonAccessor(d.id, editUrlRoot), // callback extracted to separate function to stabilize memoized component
+        accessor: (d) =>
+          tableEditButtonAccessor(d.id, editUrlRoot, d.name?.[locale]), // callback extracted to separate function to stabilize memoized component
       },
     ],
     [editUrlRoot, intl, locale],

--- a/frontend/admin/src/js/components/department/DepartmentTable.tsx
+++ b/frontend/admin/src/js/components/department/DepartmentTable.tsx
@@ -42,7 +42,8 @@ export const DepartmentTable: React.FC<
           id: "hTfHUv",
           description: "Title displayed for the Department table Edit column.",
         }),
-        accessor: (d) => tableEditButtonAccessor(d.id, editUrlRoot), // callback extracted to separate function to stabilize memoized component
+        accessor: (d) =>
+          tableEditButtonAccessor(d.id, editUrlRoot, d.name?.[locale]), // callback extracted to separate function to stabilize memoized component
       },
     ],
     [editUrlRoot, intl, locale],

--- a/frontend/admin/src/js/components/pool/PoolTable.tsx
+++ b/frontend/admin/src/js/components/pool/PoolTable.tsx
@@ -6,7 +6,7 @@ import { notEmpty } from "@common/helpers/util";
 import { getLocale } from "@common/helpers/localize";
 import { FromArray } from "@common/types/utilityTypes";
 import Pending from "@common/components/Pending";
-import { GetPoolsQuery, useGetPoolsQuery } from "../../api/generated";
+import { GetPoolsQuery, Maybe, useGetPoolsQuery } from "../../api/generated";
 import Table, { ColumnsOf, tableEditButtonAccessor } from "../Table";
 import { useAdminRoutes } from "../../adminRoutes";
 
@@ -16,6 +16,7 @@ type Data = NonNullable<FromArray<GetPoolsQuery["pools"]>>;
 function poolCandidatesLinkAccessor(
   poolCandidatesTableUrl: string,
   intl: IntlShape,
+  label?: Maybe<string>,
 ) {
   return (
     <Link
@@ -25,11 +26,14 @@ function poolCandidatesLinkAccessor(
       color="primary"
       data-h2-padding="base(0)"
     >
-      {intl.formatMessage({
-        defaultMessage: "View Candidates",
-        id: "aYYb0w",
-        description: "Text for a link to the Pool Candidates table",
-      })}
+      {intl.formatMessage(
+        {
+          defaultMessage: "View Candidates<hidden> for {label}</hidden>",
+          id: "6R9N+h",
+          description: "Text for a link to the Pool Candidates table",
+        },
+        { label },
+      )}
     </Link>
   );
 }
@@ -72,7 +76,11 @@ export const PoolTable: React.FC<GetPoolsQuery & { editUrlRoot: string }> = ({
             "Header for the View Candidates column of the Pools table",
         }),
         accessor: (pool) =>
-          poolCandidatesLinkAccessor(paths.poolCandidateTable(pool.id), intl),
+          poolCandidatesLinkAccessor(
+            paths.poolCandidateTable(pool.id),
+            intl,
+            pool.name ? pool.name[locale] : "",
+          ),
       },
       {
         Header: intl.formatMessage({

--- a/frontend/admin/src/js/components/searchRequest/SingleSearchRequestTable.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SingleSearchRequestTable.tsx
@@ -6,6 +6,7 @@ import { FromArray } from "@common/types/utilityTypes";
 import { getLocale } from "@common/helpers/localize";
 import { getOperationalRequirement } from "@common/constants/localizedConstants";
 import Pending from "@common/components/Pending";
+import { getFullNameLabel } from "@common/helpers/nameUtils";
 import {
   SearchPoolCandidatesQuery,
   useSearchPoolCandidatesQuery,
@@ -21,7 +22,8 @@ type Data = NonNullable<
 const TableEditButton: React.FC<{
   poolCandidateId?: string;
   poolId?: string;
-}> = ({ poolCandidateId, poolId }) => {
+  label?: string;
+}> = ({ poolCandidateId, poolId, label }) => {
   const intl = useIntl();
   const paths = useAdminRoutes();
   return (
@@ -31,17 +33,30 @@ const TableEditButton: React.FC<{
       mode="inline"
       href={paths.poolCandidateUpdate(poolId || "", poolCandidateId || "")}
     >
-      {intl.formatMessage({
-        defaultMessage: "Edit",
-        id: "srzf65",
-        description: "Title displayed for the Edit column.",
-      })}
+      {intl.formatMessage(
+        {
+          defaultMessage: "Edit<hidden> {label}</hidden>",
+          id: "i9ND/M",
+          description: "Title displayed for the Edit column.",
+        },
+        { label },
+      )}
     </Link>
   );
 };
 
-function tableEditButtonAccessor(poolCandidateId?: string, poolId?: string) {
-  return <TableEditButton poolCandidateId={poolCandidateId} poolId={poolId} />;
+function tableEditButtonAccessor(
+  poolCandidateId?: string,
+  poolId?: string,
+  label?: string,
+) {
+  return (
+    <TableEditButton
+      poolCandidateId={poolCandidateId}
+      poolId={poolId}
+      label={label}
+    />
+  );
 }
 
 export const SingleSearchRequestTable: React.FunctionComponent<
@@ -213,7 +228,12 @@ export const SingleSearchRequestTable: React.FunctionComponent<
           description:
             "Title displayed for the single search request table edit column.",
         }),
-        accessor: ({ id, pool }) => tableEditButtonAccessor(id, pool?.id),
+        accessor: ({ id, pool, user }) =>
+          tableEditButtonAccessor(
+            id,
+            pool?.id,
+            getFullNameLabel(user.firstName, user.lastName, intl),
+          ),
       },
     ],
     [intl, locale],

--- a/frontend/admin/src/js/components/skill/SkillTable.tsx
+++ b/frontend/admin/src/js/components/skill/SkillTable.tsx
@@ -85,7 +85,8 @@ export const SkillTable: React.FC<AllSkillsQuery & { editUrlRoot: string }> = ({
           id: "X4nVv/",
           description: "Title displayed for the skill table Edit column.",
         }),
-        accessor: (skill) => tableEditButtonAccessor(skill.id, editUrlRoot), // callback extracted to separate function to stabilize memoized component
+        accessor: (skill) =>
+          tableEditButtonAccessor(skill.id, editUrlRoot, skill.name?.[locale]), // callback extracted to separate function to stabilize memoized component
       },
     ],
     [editUrlRoot, intl, locale],

--- a/frontend/admin/src/js/components/skillFamily/SkillFamilyTable.tsx
+++ b/frontend/admin/src/js/components/skillFamily/SkillFamilyTable.tsx
@@ -76,7 +76,8 @@ export const SkillFamilyTable: React.FC<
           description:
             "Title displayed for the Skill Family table Edit column.",
         }),
-        accessor: (sf) => tableEditButtonAccessor(sf.id, editUrlRoot), // callback extracted to separate function to stabilize memoized component
+        accessor: (sf) =>
+          tableEditButtonAccessor(sf.id, editUrlRoot, sf.name?.[locale]), // callback extracted to separate function to stabilize memoized component
       },
     ],
     [editUrlRoot, intl, locale],

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -1426,8 +1426,8 @@
     "defaultMessage": "Bassins",
     "description": "Label displayed on the pools field of the add user to pool dialog"
   },
-  "aYYb0w": {
-    "defaultMessage": "Afficher les candidats",
+  "6R9N+h": {
+    "defaultMessage": "Voir les candidats<hidden> pour {label}</hidden>",
     "description": "Text for a link to the Pool Candidates table"
   },
   "aa7B7S": {

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -1769,8 +1769,8 @@
     "defaultMessage": "Utilisateurs",
     "description": "Title for users page on the admin portal."
   },
-  "9flpmN": {
-    "defaultMessage": "Éditer <hidden>{label}</hidden>",
+  "i9ND/M": {
+    "defaultMessage": "Éditer<hidden> {label}</hidden>",
     "description": "Title displayed for the Edit column."
   },
   "A2VzLX": {


### PR DESCRIPTION
Resolves #3701 

## Summary

This adds more context to the admin tables edit links using the label argument for the `tableEditButtonAccessor` function.

## Screenshot

<img width="1481" alt="Screen Shot 2022-09-27 at 8 57 46 AM" src="https://user-images.githubusercontent.com/4127998/192533218-02c38912-d000-4d03-af64-1cd9e0375de1.png">

## Testing

1. Build the admin project `npm run production --workspace=admin`
2. Navigate to the index for each admin section
3. Confirm the edit links content includes enough context (not just "edit")