### PR TITLE
work preferences prefill bug

### DIFF
--- a/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
+++ b/frontend/talentsearch/src/js/components/workPreferencesForm/WorkPreferencesForm.tsx
@@ -84,9 +84,10 @@ export const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
     };
 
     return {
-      wouldAcceptTemporary: data.wouldAcceptTemporary
-        ? boolToString(data.wouldAcceptTemporary)
-        : undefined,
+      wouldAcceptTemporary:
+        typeof data.wouldAcceptTemporary === "boolean"
+          ? boolToString(data.wouldAcceptTemporary)
+          : undefined,
       acceptedOperationalRequirements: data.acceptedOperationalRequirements,
     };
   };


### PR DESCRIPTION
closes #4086 
the issue was that the `data.wouldAcceptTemporary` condition meant `boolToString()` only ran when the variable was true, needs to run when it is either true or false so boolean 

testing: 
ensure form prefills for either option in the "I would consider accepting a job that lasts for:" selection
