### PR TITLE
Bug - 4055 - Normalize profile section wrapper

### DIFF
--- a/frontend/admin/src/js/components/poolCandidate/ApplicationStatusForm/ApplicationStatusForm.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/ApplicationStatusForm/ApplicationStatusForm.tsx
@@ -6,6 +6,7 @@ import { Input, Select, Submit, TextArea } from "@common/components/form";
 import Pending from "@common/components/Pending";
 import NotFound from "@common/components/NotFound";
 import Heading from "@common/components/Heading";
+import Well from "@common/components/Well";
 import { CalendarIcon, PencilSquareIcon } from "@heroicons/react/24/outline";
 import { getLocalizedName } from "@common/helpers/localize";
 import { enumToOptions } from "@common/helpers/formUtils";
@@ -82,11 +83,7 @@ export const ApplicationStatusForm = ({
           description: "Title for admins to edit an applications status.",
         })}
       </Heading>
-      <div
-        data-h2-background-color="base(light.dt-gray)"
-        data-h2-radius="base(x1)"
-        data-h2-padding="base(x1, x1, x1, x1)"
-      >
+      <Well>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(handleFormSubmit)}>
             <Heading
@@ -203,7 +200,7 @@ export const ApplicationStatusForm = ({
             />
           </form>
         </FormProvider>
-      </div>
+      </Well>
     </div>
   );
 };

--- a/frontend/admin/src/js/components/poolCandidate/PoolCandidateDetailsSection.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/PoolCandidateDetailsSection.tsx
@@ -1,10 +1,12 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import Well from "@common/components/Well";
 import {
   getJobLookingStatus,
   getPoolCandidatePriorities,
   getPoolCandidateStatus,
 } from "@common/constants/localizedConstants";
-import React from "react";
-import { useIntl } from "react-intl";
 
 import { PoolCandidate } from "../../api/generated";
 
@@ -24,11 +26,7 @@ const PoolCandidateDetailsSection: React.FC<
 
   return (
     <div data-h2-flex-item="base(1of1) p-tablet(3of4)">
-      <div
-        data-h2-background-color="base(light.dt-gray)"
-        data-h2-padding="base(x1)"
-        data-h2-radius="base(s)"
-      >
+      <Well>
         <p>
           {intl.formatMessage({
             defaultMessage: "Status:",
@@ -101,7 +99,7 @@ const PoolCandidateDetailsSection: React.FC<
           })}{" "}
           <span data-h2-font-weight="base(700)">{archivedAt || ""}</span>
         </p>
-      </div>
+      </Well>
     </div>
   );
 };

--- a/frontend/admin/src/js/components/user/AdminAboutSection.tsx
+++ b/frontend/admin/src/js/components/user/AdminAboutSection.tsx
@@ -1,10 +1,12 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import Well from "@common/components/Well";
 import {
   getArmedForcesStatusesAdmin,
   getCitizenshipStatusesAdmin,
 } from "@common/constants/localizedConstants";
 import { getFullNameHtml } from "@common/helpers/nameUtils";
-import React from "react";
-import { useIntl } from "react-intl";
 
 import { Applicant } from "../../api/generated";
 
@@ -22,11 +24,7 @@ const AdminAboutSection: React.FC<AdminAboutSectionProps> = ({
 
   return (
     <div data-h2-flex-item="base(1of1) p-tablet(3of4)">
-      <div
-        data-h2-background-color="base(light.dt-gray)"
-        data-h2-padding="base(x1)"
-        data-h2-radius="base(s)"
-      >
+      <Well>
         {(!!firstName || !!lastName) && (
           <p>
             {intl.formatMessage({
@@ -77,7 +75,7 @@ const AdminAboutSection: React.FC<AdminAboutSectionProps> = ({
         ) : (
           ""
         )}
-      </div>
+      </Well>
     </div>
   );
 };

--- a/frontend/admin/src/js/components/user/GeneralInformationTab/GeneralInformationTab.tsx
+++ b/frontend/admin/src/js/components/user/GeneralInformationTab/GeneralInformationTab.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import TableOfContents from "@common/components/TableOfContents";
+import { isEmpty } from "lodash";
+import { toast } from "react-toastify";
 import {
   CalculatorIcon,
   InformationCircleIcon,
@@ -8,6 +9,9 @@ import {
   UserIcon,
   CheckIcon,
 } from "@heroicons/react/24/outline";
+
+import TableOfContents from "@common/components/TableOfContents";
+import Well from "@common/components/Well";
 import {
   getArmedForcesStatusesAdmin,
   getCitizenshipStatusesAdmin,
@@ -16,14 +20,12 @@ import {
   getProvinceOrTerritory,
 } from "@common/constants/localizedConstants";
 import { getLocale } from "@common/helpers/localize";
-import { isEmpty } from "lodash";
 import { Button } from "@common/components";
 import Pending from "@common/components/Pending";
 import NotFound from "@common/components/NotFound";
 import { commonMessages } from "@common/messages";
 import { BasicForm, TextArea } from "@common/components/form";
 import { unpackMaybes } from "@common/helpers/formUtils";
-import { toast } from "react-toastify";
 import Heading from "@common/components/Heading";
 import { getFullNameHtml } from "@common/helpers/nameUtils";
 import {
@@ -82,18 +84,14 @@ const PoolStatusTable: React.FC<BasicSectionProps> = ({ user }) => {
 
   if (isEmpty(user.poolCandidates)) {
     return (
-      <div
-        data-h2-background-color="base(light.dt-gray)"
-        data-h2-padding="base(x1)"
-        data-h2-radius="base(s)"
-      >
+      <Well>
         {intl.formatMessage({
           defaultMessage: "This user is not in any pools yet",
           id: "W58QTT",
           description:
             "Message on view-user page that the user is not in any pools",
         })}
-      </div>
+      </Well>
     );
   }
   return (
@@ -353,11 +351,7 @@ const CandidateStatusSection: React.FC<SectionWithPoolsProps> = ({
             "Title of the 'Personal status' section of the view-user page",
         })}
       </Heading>
-      <div
-        data-h2-background-color="base(light.dt-gray)"
-        data-h2-padding="base(x1)"
-        data-h2-radius="base(s)"
-      >
+      <Well>
         {user.jobLookingStatus === JobLookingStatus.ActivelyLooking &&
           intl.formatMessage({
             defaultMessage:
@@ -382,7 +376,7 @@ const CandidateStatusSection: React.FC<SectionWithPoolsProps> = ({
             description:
               "Text in view user page saying they currently have the 'Inactive' status, ignore things in <> tags please",
           })}
-      </div>
+      </Well>
       <Heading level="h4" data-h2-margin="base(x2, 0, x1, 0)">
         {intl.formatMessage({
           defaultMessage: "Pool status",
@@ -496,19 +490,14 @@ const NotesSection: React.FC<BasicSectionProps> = ({ user }) => {
         })}
       </p>
       {isEmpty(user.poolCandidates) ? (
-        <div
-          data-h2-margin="base(x1, 0)"
-          data-h2-background-color="base(light.dt-gray)"
-          data-h2-padding="base(x.5)"
-          data-h2-radius="base(s)"
-        >
+        <Well>
           {intl.formatMessage({
             defaultMessage: "This user is not in any pools yet",
             id: "W58QTT",
             description:
               "Message on view-user page that the user is not in any pools",
           })}
-        </div>
+        </Well>
       ) : (
         <BasicForm onSubmit={handleSubmit}>
           {user?.poolCandidates?.map((candidate) => {
@@ -557,11 +546,7 @@ const EmploymentEquitySection: React.FC<BasicSectionProps> = ({ user }) => {
   const intl = useIntl();
 
   return (
-    <div
-      data-h2-background-color="base(light.dt-gray)"
-      data-h2-padding="base(x.125, x.5)"
-      data-h2-radius="base(s)"
-    >
+    <Well>
       {!user.isIndigenous &&
         !user.hasDisability &&
         !user.isVisibleMinority &&
@@ -619,7 +604,7 @@ const EmploymentEquitySection: React.FC<BasicSectionProps> = ({ user }) => {
           })}
         </div>
       )}
-    </div>
+    </Well>
   );
 };
 

--- a/frontend/admin/src/js/components/user/GeneralInformationTab/GeneralInformationTab.tsx
+++ b/frontend/admin/src/js/components/user/GeneralInformationTab/GeneralInformationTab.tsx
@@ -219,11 +219,7 @@ const AboutSection: React.FC<BasicSectionProps> = ({ user }) => {
   const intl = useIntl();
 
   return (
-    <div
-      data-h2-background-color="base(light.dt-gray)"
-      data-h2-padding="base(x1)"
-      data-h2-radius="base(s)"
-    >
+    <Well>
       <div data-h2-flex-grid="base(normal, x1, x.5)">
         {/* Name */}
         <div data-h2-flex-item="base(1of1) p-tablet(1of2) desktop(1of3)">
@@ -329,7 +325,7 @@ const AboutSection: React.FC<BasicSectionProps> = ({ user }) => {
           </p>
         </div>
       </div>
-    </div>
+    </Well>
   );
 };
 

--- a/frontend/common/src/components/UserProfile/ProfileSections/AboutSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/AboutSection.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
+import Well from "../../Well";
 import { getFullNameHtml } from "../../../helpers/nameUtils";
 import messages from "../../../messages/commonMessages";
 import {
@@ -43,11 +44,7 @@ const AboutSection: React.FC<AboutSectionProps> = ({
 }) => {
   const intl = useIntl();
   return (
-    <div
-      data-h2-background-color="base(light.dt-gray)"
-      data-h2-padding="base(x1)"
-      data-h2-radius="base(s)"
-    >
+    <Well>
       <div data-h2-flex-grid="base(flex-start, x2, x1)">
         {(!!firstName || !!lastName) && (
           <div data-h2-flex-item="base(1of1) p-tablet(1of2) desktop(1of3)">
@@ -222,7 +219,7 @@ const AboutSection: React.FC<AboutSectionProps> = ({
           </div>
         </div>
       )}
-    </div>
+    </Well>
   );
 };
 

--- a/frontend/common/src/components/UserProfile/ProfileSections/CandidatePoolsSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/CandidatePoolsSection.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
+import Well from "../../Well";
 import { unpackMaybes } from "../../../helpers/formUtils";
 import type { Applicant } from "../../../api/generated";
 import { getLocale } from "../../../helpers/localize";
@@ -15,12 +16,9 @@ const CandidatePoolsSection: React.FC<CandidatePoolsSectionProps> = ({
   const intl = useIntl();
   const locale = getLocale(intl);
   const poolCandidates = unpackMaybes(applicant.poolCandidates);
+
   return (
-    <div
-      data-h2-background-color="base(light.dt-gray)"
-      data-h2-padding="base(x1)"
-      data-h2-radius="base(s)"
-    >
+    <Well>
       {(!poolCandidates || poolCandidates.length === 0) && (
         <p data-h2-color="base(dt-gray.dark)">
           {intl.formatMessage({
@@ -65,7 +63,7 @@ const CandidatePoolsSection: React.FC<CandidatePoolsSectionProps> = ({
             </div>
           </div>
         ))}
-    </div>
+    </Well>
   );
 };
 

--- a/frontend/common/src/components/UserProfile/ProfileSections/DiversityEquityInclusionSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/DiversityEquityInclusionSection.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
+
+import Well from "../../Well";
 import { getEmploymentEquityStatement } from "../../../constants";
 import { Applicant } from "../../../api/generated";
 
@@ -17,11 +19,7 @@ const DiversityEquityInclusionSection: React.FunctionComponent<{
     isWoman || isIndigenous || isVisibleMinority || hasDisability;
 
   return (
-    <div
-      data-h2-background-color="base(light.dt-gray)"
-      data-h2-padding="base(x1)"
-      data-h2-radius="base(s)"
-    >
+    <Well>
       <div data-h2-flex-grid="base(flex-start, x2, x1)">
         {!anyCriteriaSelected && editPath && (
           <div data-h2-flex-item="base(1of1)">
@@ -102,7 +100,7 @@ const DiversityEquityInclusionSection: React.FunctionComponent<{
           </div>
         )}
       </div>
-    </div>
+    </Well>
   );
 };
 

--- a/frontend/common/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
+
+import Well from "../../Well";
 import { enumToOptions } from "../../../helpers/formUtils";
 import messages from "../../../messages/commonMessages";
 import { getGovEmployeeType } from "../../../constants/localizedConstants";
@@ -25,11 +27,7 @@ const GovernmentInformationSection: React.FunctionComponent<{
       (govEmployeeType) => govEmployeeType.value === applicant.govEmployeeType,
     )?.value || "";
   return (
-    <div
-      data-h2-background-color="base(light.dt-gray)"
-      data-h2-padding="base(x1)"
-      data-h2-radius="base(s)"
-    >
+    <Well>
       {applicant.isGovEmployee && (
         <div data-h2-flex-grid="base(flex-start, x2, x1)">
           <div data-h2-flex-item="base(1of1)">
@@ -234,7 +232,7 @@ const GovernmentInformationSection: React.FunctionComponent<{
             </div>
           </div>
         )}
-    </div>
+    </Well>
   );
 };
 

--- a/frontend/common/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
+
+import Well from "../../Well";
 import { Applicant, BilingualEvaluation } from "../../../api/generated";
 import messages from "../../../messages/commonMessages";
 import {
@@ -35,11 +37,7 @@ const LanguageInformationSection: React.FunctionComponent<{
   } = applicant;
 
   return (
-    <div
-      data-h2-background-color="base(light.dt-gray)"
-      data-h2-padding="base(x1)"
-      data-h2-radius="base(s)"
-    >
+    <Well>
       <div data-h2-flex-grid="base(flex-start, x2, x1)">
         {lookingForEnglish && !lookingForFrench && !lookingForBilingual && (
           <div data-h2-flex-item="base(1of1)">
@@ -225,7 +223,7 @@ const LanguageInformationSection: React.FunctionComponent<{
           </div>
         )}
       </div>
-    </div>
+    </Well>
   );
 };
 

--- a/frontend/common/src/components/UserProfile/ProfileSections/RoleSalarySection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/RoleSalarySection.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { isEmpty } from "lodash";
+
+import Well from "../../Well";
 import messages from "../../../messages/commonMessages";
 import { getGenericJobTitles } from "../../../constants/localizedConstants";
 import { Applicant } from "../../../api/generated";
@@ -22,72 +24,64 @@ const RoleSalarySection: React.FunctionComponent<{
   const anyCriteriaSelected = !isEmpty(expectedClassificationArray);
 
   return (
-    <div id="role-and-salary-expectations">
-      <div
-        data-h2-background-color="base(light.dt-gray)"
-        data-h2-padding="base(x1)"
-        data-h2-radius="base(s)"
-      >
-        <div data-h2-flex-grid="base(flex-start, x2, x1)">
-          {anyCriteriaSelected && (
-            <div data-h2-flex-item="base(1of1)">
-              <p>
+    <Well>
+      <div data-h2-flex-grid="base(flex-start, x2, x1)">
+        {anyCriteriaSelected && (
+          <div data-h2-flex-item="base(1of1)">
+            <p>
+              {intl.formatMessage({
+                defaultMessage:
+                  "I would like to be referred for jobs at the following levels:",
+                id: "e2Rfn/",
+                description: "Label for Role and salary expectations sections",
+              })}
+            </p>
+            <ul data-h2-padding="base(0, 0, 0, x2)">
+              {expectedClassificationArray}
+            </ul>
+          </div>
+        )}
+        {!anyCriteriaSelected && editPath && (
+          <div data-h2-flex-item="base(1of1)">
+            <p data-h2-color="base(dt-gray.dark)">
+              {intl.formatMessage({
+                defaultMessage: "You haven't added any information here yet.",
+                id: "SCCX7B",
+                description: "Message for when no data exists for the section",
+              })}
+            </p>
+          </div>
+        )}
+        {!anyCriteriaSelected && editPath && (
+          <div data-h2-flex-item="base(1of1)">
+            <p data-h2-color="base(dt-gray.dark)">
+              {intl.formatMessage(messages.requiredFieldsMissing)}{" "}
+              <a href={editPath}>
                 {intl.formatMessage({
                   defaultMessage:
-                    "I would like to be referred for jobs at the following levels:",
-                  id: "e2Rfn/",
+                    "Edit your role and salary expectation options.",
+                  id: "BPiMTY",
                   description:
-                    "Label for Role and salary expectations sections",
+                    "Link text to edit role and salary expectations on profile.",
                 })}
-              </p>
-              <ul data-h2-padding="base(0, 0, 0, x2)">
-                {expectedClassificationArray}
-              </ul>
-            </div>
-          )}
-          {!anyCriteriaSelected && editPath && (
-            <div data-h2-flex-item="base(1of1)">
-              <p data-h2-color="base(dt-gray.dark)">
-                {intl.formatMessage({
-                  defaultMessage: "You haven't added any information here yet.",
-                  id: "SCCX7B",
-                  description:
-                    "Message for when no data exists for the section",
-                })}
-              </p>
-            </div>
-          )}
-          {!anyCriteriaSelected && editPath && (
-            <div data-h2-flex-item="base(1of1)">
-              <p data-h2-color="base(dt-gray.dark)">
-                {intl.formatMessage(messages.requiredFieldsMissing)}{" "}
-                <a href={editPath}>
-                  {intl.formatMessage({
-                    defaultMessage:
-                      "Edit your role and salary expectation options.",
-                    id: "BPiMTY",
-                    description:
-                      "Link text to edit role and salary expectations on profile.",
-                  })}
-                </a>
-              </p>
-            </div>
-          )}
-          {!anyCriteriaSelected && !editPath && (
-            <div data-h2-flex-item="base(1of1)">
-              <p>
-                {intl.formatMessage({
-                  defaultMessage: "No information has been provided.",
-                  id: "kjX7mF",
-                  description:
-                    "Message on Admin side when user not filled RoleSalary section.",
-                })}
-              </p>
-            </div>
-          )}
-        </div>
+              </a>
+            </p>
+          </div>
+        )}
+        {!anyCriteriaSelected && !editPath && (
+          <div data-h2-flex-item="base(1of1)">
+            <p>
+              {intl.formatMessage({
+                defaultMessage: "No information has been provided.",
+                id: "kjX7mF",
+                description:
+                  "Message on Admin side when user not filled RoleSalary section.",
+              })}
+            </p>
+          </div>
+        )}
       </div>
-    </div>
+    </Well>
   );
 };
 

--- a/frontend/common/src/components/UserProfile/ProfileSections/SkillExperienceSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/SkillExperienceSection.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
+
+import Well from "../../Well";
 import messages from "../../../messages/commonMessages";
 import { notEmpty } from "../../../helpers/util";
 import { Applicant } from "../../../api/generated";
@@ -30,42 +32,33 @@ const SkillExperienceSection: React.FunctionComponent<{
       }
     : null;
 
-  return (
-    <div>
-      {" "}
-      {!experiences || experiences?.length === 0 ? (
-        <div
-          data-h2-background-color="base(light.dt-gray)"
-          data-h2-padding="base(x1)"
-          data-h2-radius="base(s)"
-        >
-          <p>
-            {intl.formatMessage({
-              defaultMessage: "You haven't added any information here yet.",
-              id: "SCCX7B",
-              description: "Message for when no data exists for the section",
-            })}
-          </p>
-          <p>
-            {intl.formatMessage(messages.requiredFieldsMissing)}{" "}
-            <a href={editPath}>
-              {intl.formatMessage({
-                defaultMessage: "Edit your skill and experience options.",
-                id: "hDupu9",
-                description:
-                  "Link text for editing skills and experiences on profile.",
-              })}
-            </a>
-          </p>
-        </div>
-      ) : (
-        <div data-h2-padding="base(x1)" data-h2-radius="base(s)">
-          <ExperienceSection
-            experiences={experiences?.filter(notEmpty)}
-            experienceEditPaths={experienceEditPaths as ExperiencePaths}
-          />
-        </div>
-      )}
+  return !experiences || experiences?.length === 0 ? (
+    <Well>
+      <p>
+        {intl.formatMessage({
+          defaultMessage: "You haven't added any information here yet.",
+          id: "SCCX7B",
+          description: "Message for when no data exists for the section",
+        })}
+      </p>
+      <p>
+        {intl.formatMessage(messages.requiredFieldsMissing)}{" "}
+        <a href={editPath}>
+          {intl.formatMessage({
+            defaultMessage: "Edit your skill and experience options.",
+            id: "hDupu9",
+            description:
+              "Link text for editing skills and experiences on profile.",
+          })}
+        </a>
+      </p>
+    </Well>
+  ) : (
+    <div data-h2-padding="base(x1)" data-h2-radius="base(s)">
+      <ExperienceSection
+        experiences={experiences?.filter(notEmpty)}
+        experienceEditPaths={experienceEditPaths as ExperiencePaths}
+      />
     </div>
   );
 };

--- a/frontend/common/src/components/UserProfile/ProfileSections/WorkLocationSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/WorkLocationSection.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { isEmpty } from "lodash";
+
+import Well from "../../Well";
 import messages from "../../../messages/commonMessages";
 import { getWorkRegion } from "../../../constants/localizedConstants";
 import { insertBetween } from "../../../helpers/util";
@@ -21,12 +23,9 @@ const WorkLocationSection: React.FunctionComponent<{
     : "";
 
   const anyCriteriaSelected = !isEmpty(regionPreferences);
+
   return (
-    <div
-      data-h2-background-color="base(light.dt-gray)"
-      data-h2-padding="base(x1)"
-      data-h2-radius="base(s)"
-    >
+    <Well>
       <div data-h2-flex-grid="base(flex-start, x2, x1)">
         {anyCriteriaSelected && (
           <div data-h2-flex-item="base(1of1)">
@@ -92,7 +91,7 @@ const WorkLocationSection: React.FunctionComponent<{
           </div>
         )}
       </div>
-    </div>
+    </Well>
   );
 };
 

--- a/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { isEmpty } from "lodash";
+
+import Well from "../../Well";
 import messages from "../../../messages/commonMessages";
 import { getOperationalRequirement } from "../../../constants/localizedConstants";
 import { Applicant, OperationalRequirement } from "../../../api/generated";
@@ -60,11 +62,7 @@ const WorkPreferencesSection: React.FunctionComponent<{
     : null;
 
   return (
-    <div
-      data-h2-background-color="base(light.dt-gray)"
-      data-h2-padding="base(x1)"
-      data-h2-radius="base(s)"
-    >
+    <Well>
       <div data-h2-flex-grid="base(flex-start, x2, x1)">
         {wouldAcceptTemporary === null && (
           <div data-h2-flex-item="base(1of1)">
@@ -214,7 +212,7 @@ const WorkPreferencesSection: React.FunctionComponent<{
           </div>
         )}
       </div>
-    </div>
+    </Well>
   );
 };
 

--- a/frontend/common/src/components/Well/Well.stories.tsx
+++ b/frontend/common/src/components/Well/Well.stories.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import type { ComponentMeta, ComponentStory } from "@storybook/react";
+import Well from "./Well";
+
+type ComponentType = typeof Well;
+type Meta = ComponentMeta<ComponentType>;
+type Story = ComponentStory<ComponentType>;
+
+export default {
+  component: Well,
+  title: "Components/Well",
+  args: {
+    content:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eget condimentum nunc.",
+  },
+} as Meta;
+
+const Template: Story = (args) => {
+  const { content } = args;
+  return (
+    <Well>
+      <p>{content}</p>
+    </Well>
+  );
+};
+
+export const Default = Template.bind({});

--- a/frontend/common/src/components/Well/Well.tsx
+++ b/frontend/common/src/components/Well/Well.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export interface WellProps extends React.HTMLProps<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+const Well = ({ children, ...rest }: WellProps) => (
+  <div
+    data-h2-background-color="base(light.dt-gray)"
+    data-h2-padding="base(x1)"
+    data-h2-radius="base(s)"
+    {...rest}
+  >
+    {children}
+  </div>
+);
+
+export default Well;

--- a/frontend/common/src/components/Well/index.ts
+++ b/frontend/common/src/components/Well/index.ts
@@ -1,0 +1,4 @@
+import Well, { type WellProps } from "./Well";
+
+export default Well;
+export type { WellProps };

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/EmploymentEquityForm.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/EmploymentEquityForm.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import { useIntl } from "react-intl";
+import { BriefcaseIcon } from "@heroicons/react/24/solid";
+
+import Well from "@common/components/Well";
 import { navigationMessages } from "@common/messages";
 import { getLocale } from "@common/helpers/localize";
 import { checkFeatureFlag } from "@common/helpers/runtimeVariable";
-import { BriefcaseIcon } from "@heroicons/react/24/solid";
+
 import ProfileFormWrapper from "../applicantProfile/ProfileFormWrapper";
 import EquityOptions from "./EquityOptions";
 import type { EmploymentEquityUpdateHandler, EquityKeys } from "./types";
@@ -120,12 +123,7 @@ export const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
           description: "List of the employment equity categories",
         })}
       </p>
-      <div
-        data-h2-background-color="base(light.dt-gray)"
-        data-h2-margin="base(x2, 0, 0, 0)"
-        data-h2-radius="base(s)"
-        data-h2-padding="base(x1)"
-      >
+      <Well data-h2-margin="base(x2, 0, 0, 0)">
         <p data-h2-margin="base(0, 0, x.5, 0)">
           {intl.formatMessage({
             defaultMessage:
@@ -155,7 +153,7 @@ export const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
             })}
           </li>
         </ul>
-      </div>
+      </Well>
       <h2 data-h2-font-size="base(h5, 1)" data-h2-margin="base(x2, 0, x1, 0)">
         {intl.formatMessage({
           defaultMessage: "How will this data be used?",

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/EquityOptions.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/EquityOptions.tsx
@@ -2,12 +2,13 @@ import React from "react";
 import { useIntl } from "react-intl";
 import { toast } from "react-toastify";
 
-import type { Maybe } from "@common/api/generated";
-
+import Well from "@common/components/Well";
 import {
   getEmploymentEquityGroup,
   getEmploymentEquityStatement,
 } from "@common/constants";
+import type { Maybe } from "@common/api/generated";
+
 import profileMessages from "../profile/profileMessages";
 import Spinner from "../Spinner";
 import EquityOption from "./EquityOption";
@@ -137,11 +138,7 @@ const EquityOptions: React.FC<EquityOptionsProps> = ({
                 )}
               </div>
             ) : (
-              <div
-                data-h2-background-color="base(light.dt-gray)"
-                data-h2-radius="base(s)"
-                data-h2-padding="base(x1)"
-              >
+              <Well>
                 <p data-h2-margin="base(0)">
                   {intl.formatMessage({
                     defaultMessage:
@@ -151,7 +148,7 @@ const EquityOptions: React.FC<EquityOptionsProps> = ({
                       "Message displayed when a user has no employment equity information.",
                   })}
                 </p>
-              </div>
+              </Well>
             )}
           </div>
           <div data-h2-flex-item="l-tablet(1of2)">
@@ -209,11 +206,7 @@ const EquityOptions: React.FC<EquityOptionsProps> = ({
                 )}
               </div>
             ) : (
-              <div
-                data-h2-background-color="base(light.dt-gray)"
-                data-h2-radius="base(s)"
-                data-h2-padding="base(x1)"
-              >
+              <Well>
                 <p data-h2-margin="base(0)">
                   {intl.formatMessage({
                     defaultMessage:
@@ -223,7 +216,7 @@ const EquityOptions: React.FC<EquityOptionsProps> = ({
                       "Message displayed when there are no employment equity categories available to be added.",
                   })}
                 </p>
-              </div>
+              </Well>
             )}
           </div>
         </div>

--- a/frontend/talentsearch/src/js/components/experienceAndSkills/ExperienceAndSkills.tsx
+++ b/frontend/talentsearch/src/js/components/experienceAndSkills/ExperienceAndSkills.tsx
@@ -7,15 +7,18 @@ import {
   UserGroupIcon,
 } from "@heroicons/react/24/solid";
 import { useIntl } from "react-intl";
+
 import ExperienceSection from "@common/components/UserProfile/ExperienceSection";
 import { IconLink } from "@common/components/Link";
-import { notEmpty } from "@common/helpers/util";
 import MissingSkills from "@common/components/skills/MissingSkills";
+import Well from "@common/components/Well";
+import { notEmpty } from "@common/helpers/util";
 import { navigationMessages } from "@common/messages";
 import { useQueryParams } from "@common/helpers/router";
 import { BreadcrumbsProps } from "@common/components/Breadcrumbs";
 import { flattenExperienceSkills } from "@common/types/ExperienceUtils";
 import { checkFeatureFlag } from "@common/helpers/runtimeVariable";
+
 import {
   AwardExperience,
   CommunityExperience,
@@ -250,11 +253,7 @@ export const ExperienceAndSkills: React.FunctionComponent<
         </div>
       )}
       {!hasExperiences ? (
-        <div
-          data-h2-radius="base(s)"
-          data-h2-background-color="base(light.dt-gray)"
-          data-h2-padding="base(x1)"
-        >
+        <Well>
           <p data-h2-font-style="base(italic)">
             {intl.formatMessage({
               defaultMessage:
@@ -264,7 +263,7 @@ export const ExperienceAndSkills: React.FunctionComponent<
                 "Message to user when no experiences have been attached to profile.",
             })}
           </p>
-        </div>
+        </Well>
       ) : (
         <ExperienceSection
           experiences={experiences}

--- a/frontend/talentsearch/src/js/components/profile/ProfilePage/CandidatePoolsSection.tsx
+++ b/frontend/talentsearch/src/js/components/profile/ProfilePage/CandidatePoolsSection.tsx
@@ -1,19 +1,19 @@
 import React from "react";
-import { getLocale } from "@common/helpers/localize";
 import { useIntl } from "react-intl";
-import { PoolCandidate } from "talentsearch/src/js/api/generated";
+
+import Well from "@common/components/Well";
+import { getLocale } from "@common/helpers/localize";
+
+import { PoolCandidate } from "../../../api/generated";
 
 const CandidatePoolsSection: React.FunctionComponent<{
   poolCandidates: PoolCandidate[];
 }> = ({ poolCandidates }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
+
   return (
-    <div
-      data-h2-background-color="base(light.dt-gray)"
-      data-h2-padding="base(x1)"
-      data-h2-radius="base(s)"
-    >
+    <Well>
       {(!poolCandidates || poolCandidates.length === 0) && (
         <p data-h2-color="base(dt-gray.dark)">
           {intl.formatMessage({
@@ -58,7 +58,7 @@ const CandidatePoolsSection: React.FunctionComponent<{
             </div>
           </div>
         ))}
-    </div>
+    </Well>
   );
 };
 

--- a/frontend/talentsearch/src/js/components/reviewMyApplication/ReviewMyApplicationPage.tsx
+++ b/frontend/talentsearch/src/js/components/reviewMyApplication/ReviewMyApplicationPage.tsx
@@ -1,16 +1,19 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
+import { ArrowSmallRightIcon } from "@heroicons/react/24/solid";
+
 import UserProfile from "@common/components/UserProfile";
 import Pending from "@common/components/Pending";
 import NotFound from "@common/components/NotFound";
-import { commonMessages, navigationMessages } from "@common/messages";
 import MissingSkills from "@common/components/skills/MissingSkills";
-import { notEmpty } from "@common/helpers/util";
 import ExperienceSection from "@common/components/UserProfile/ExperienceSection";
+import Well from "@common/components/Well";
+import { commonMessages, navigationMessages } from "@common/messages";
+import { notEmpty } from "@common/helpers/util";
 import { Link } from "@common/components";
-import { ArrowSmallRightIcon } from "@heroicons/react/24/solid";
 import { flattenExperienceSkills } from "@common/types/ExperienceUtils";
 import { getMissingSkills } from "@common/helpers/skillUtils";
+
 import {
   Applicant,
   PoolAdvertisement,
@@ -178,11 +181,7 @@ export const ReviewMyApplication: React.FunctionComponent<
                     />
                   )}
                   {!hasExperiences && (
-                    <div
-                      data-h2-radius="base(s)"
-                      data-h2-background-color="base(light.dt-gray)"
-                      data-h2-padding="base(x1)"
-                    >
+                    <Well>
                       <p data-h2-font-style="base(italic)">
                         {intl.formatMessage({
                           id: "XzUzZz",
@@ -192,7 +191,7 @@ export const ReviewMyApplication: React.FunctionComponent<
                             "Message to user when no experiences have been attached to profile.",
                         })}
                       </p>
-                    </div>
+                    </Well>
                   )}
                 </div>
                 {hasExperiences && (

--- a/frontend/talentsearch/src/js/components/skills/SkillsInDetail/SkillsInDetail.tsx
+++ b/frontend/talentsearch/src/js/components/skills/SkillsInDetail/SkillsInDetail.tsx
@@ -1,13 +1,15 @@
+import * as React from "react";
+import { useIntl } from "react-intl";
+import { useForm, useWatch } from "react-hook-form";
+import { TrashIcon } from "@heroicons/react/24/solid";
+
 import { Button } from "@common/components";
 import { TextArea } from "@common/components/form";
+import Well from "@common/components/Well";
 import WordCounter from "@common/components/WordCounter/WordCounter";
 import { countNumberOfWords } from "@common/helpers/formUtils";
 import { getLocale } from "@common/helpers/localize";
 import { errorMessages } from "@common/messages";
-import { TrashIcon } from "@heroicons/react/24/solid";
-import * as React from "react";
-import { useForm, useWatch } from "react-hook-form";
-import { useIntl } from "react-intl";
 
 import type { FormSkills } from "../../experienceForm/types";
 
@@ -92,11 +94,7 @@ const SkillsInDetail: React.FunctionComponent<SkillsInDetailProps> = ({
           })}
         </li>
       </ul>
-      <div
-        data-h2-padding="base(x1, x1, 1px, x1)"
-        data-h2-background-color="base(light.dt-gray)"
-        data-h2-radius="base(s)"
-      >
+      <Well>
         {skills.length > 0 ? (
           skills.map(({ id, name, skillId }, index) => (
             <React.Fragment key={id}>
@@ -193,7 +191,7 @@ const SkillsInDetail: React.FunctionComponent<SkillsInDetailProps> = ({
             })}
           </p>
         )}
-      </div>
+      </Well>
     </section>
   );
 };


### PR DESCRIPTION
Resolves #4055 

## Summary

This introduces a new `<Well />` component that wraps content in a rounded gray box.

## `<Well />`

```tsx
export interface WellProps extends React.HTMLProps<HTMLDivElement> {
  children: React.ReactNode;
}
```

## Screenshot

<img width="624" alt="Screen Shot 2022-09-27 at 2 44 45 PM" src="https://user-images.githubusercontent.com/4127998/192610270-5133f07f-06b8-49d3-b034-47827e769532.png">

## Testing

1. Review the chromatic snapshots for diff
2. Build all projects `npm run production --workspaces`
3. Review the following pages
    - `/admin/users/{userId}`
    - `/users/{userId}/profile`
4. Ensure colour, rounding and padding are consistent for each section