### PR TITLE
Change docker db version and install extensions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   postgres:
-    image: postgres:13.2
+    image: postgres:12.11
     restart: always
     environment:
       POSTGRES_PASSWORD: password1234

--- a/infrastructure/db/create-tc-db.sql
+++ b/infrastructure/db/create-tc-db.sql
@@ -9,3 +9,8 @@ CREATE DATABASE gctalent
         CONNECTION LIMIT = 25;
 GRANT CONNECT, TEMPORARY ON DATABASE gctalent TO public;
 GRANT ALL ON DATABASE gctalent TO postgres;
+
+\c gctalent;
+-- Add extensions to match what's in production
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH VERSION '1.0';
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH VERSION '1.3';


### PR DESCRIPTION
This branch downgrades the version of postgres used in the docker compose network.  It should match the versions and extensions in use in production.  It shouldn't affect the deployed applications at all.

## Setup (and instructions for updating your local environment)

Note 1: This will wipe your local database!  You will need to re-seed (or rerun the setup script).
Note 2: Your pgdata volume will have a different name depending on the directory you cloned into.  That's why step 2 is a listing of volumes.

1) docker-compose down
1) docker volume ls
1) docker volume rm gc-digital-talent_pgdata
1) docker-compose up --detach --build
1) docker-compose logs postgres

In the logs you should see some lines like this:
```
postgres_1     | You are now connected to database "gctalent" as user "postgres".
postgres_1     | psql:/docker-entrypoint-initdb.d/create-tc-db.sql:15: NOTICE:  extension "plpgsql" already exists, skipping
postgres_1     | CREATE EXTENSION
postgres_1     | CREATE EXTENSION
```

## Testing
- [x] Can rerun environment setup
- [x] Can run php unit tests
- [x] App behaves normally

Closes #3827 