### PR TITLE
Update language used for first_name, last_name labels

### DIFF
--- a/frontend/talentsearch/src/js/components/aboutMeForm/AboutMeForm.tsx
+++ b/frontend/talentsearch/src/js/components/aboutMeForm/AboutMeForm.tsx
@@ -342,10 +342,9 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
               name="firstName"
               type="text"
               label={intl.formatMessage({
-                defaultMessage: "First Name and Middle Name",
-                id: "g097KT",
-                description:
-                  "Label for first and middle name field in About Me form",
+                defaultMessage: "First Name",
+                id: "btydLe",
+                description: "Label for first name field in About Me form",
               })}
               rules={{
                 required: intl.formatMessage(errorMessages.required),

--- a/frontend/talentsearch/src/js/components/aboutMeForm/AboutMeForm.tsx
+++ b/frontend/talentsearch/src/js/components/aboutMeForm/AboutMeForm.tsx
@@ -355,8 +355,8 @@ export const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
               name="lastName"
               type="text"
               label={intl.formatMessage({
-                defaultMessage: "Last Name(s)",
-                id: "rGNWy6",
+                defaultMessage: "Last Name",
+                id: "wrHSMx",
                 description: "Label for last name field in About Me form",
               })}
               rules={{

--- a/frontend/talentsearch/src/js/components/createAccount/CreateAccountPage.test.tsx
+++ b/frontend/talentsearch/src/js/components/createAccount/CreateAccountPage.test.tsx
@@ -44,11 +44,11 @@ describe("Create Account Form tests", () => {
     });
 
     expect(
-      screen.getByRole("textbox", { name: /given name/i }),
+      screen.getByRole("textbox", { name: /first name/i }),
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole("textbox", { name: /surname/i }),
+      screen.getByRole("textbox", { name: /last name/i }),
     ).toBeInTheDocument();
 
     expect(screen.getByRole("textbox", { name: /email/i })).toBeInTheDocument();
@@ -85,10 +85,10 @@ describe("Create Account Form tests", () => {
       handleCreateAccount: mockSave,
     });
 
-    const firstName = screen.getByRole("textbox", { name: /given name/i });
+    const firstName = screen.getByRole("textbox", { name: /first name/i });
     fireEvent.change(firstName, { target: { value: "FirstName" } });
 
-    const lastName = screen.getByRole("textbox", { name: /surname/i });
+    const lastName = screen.getByRole("textbox", { name: /last name/i });
     fireEvent.change(lastName, { target: { value: "LastName" } });
 
     const email = screen.getByRole("textbox", { name: /email/i });

--- a/frontend/talentsearch/src/js/components/createAccount/CreateAccountPage.tsx
+++ b/frontend/talentsearch/src/js/components/createAccount/CreateAccountPage.tsx
@@ -156,8 +156,8 @@ export const CreateAccountForm: React.FunctionComponent<
                     name="firstName"
                     type="text"
                     label={intl.formatMessage({
-                      defaultMessage: "Given name(s)",
-                      id: "WpRB7Z",
+                      defaultMessage: "First Name",
+                      id: "IEkhMc",
                       description:
                         "Label displayed for the first name field in create account form.",
                     })}

--- a/frontend/talentsearch/src/js/components/createAccount/CreateAccountPage.tsx
+++ b/frontend/talentsearch/src/js/components/createAccount/CreateAccountPage.tsx
@@ -178,8 +178,8 @@ export const CreateAccountForm: React.FunctionComponent<
                     name="lastName"
                     type="text"
                     label={intl.formatMessage({
-                      defaultMessage: "Surname(s)",
-                      id: "h9q52R",
+                      defaultMessage: "Last Name",
+                      id: "UxF291",
                       description:
                         "Label displayed for the last name field in create account form.",
                     })}

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -1022,10 +1022,6 @@
     "defaultMessage": "Niveau 3 : Conseillers techniques",
     "description": "title for IT-03 advisor dialog"
   },
-  "WpRB7Z": {
-    "defaultMessage": "Prénom(s)",
-    "description": "Label displayed for the first name field in create account form."
-  },
   "WyKJsK": {
     "defaultMessage": "Erreur : échec de la mise à jour de l'expérience",
     "description": "Message displayed to user after experience fails to be updated."
@@ -1187,10 +1183,6 @@
   },
   "fOCbBa": {
     "defaultMessage": "Résultats pour les compétences fréquentes"
-  },
-  "g097KT": {
-    "defaultMessage": "Prénom et second prénom",
-    "description": "Label for first and middle name field in About Me form"
   },
   "gBWsuB": {
     "defaultMessage": "Téléphone",
@@ -1939,5 +1931,13 @@
   "HHEQgM": {
     "defaultMessage": "Sélectionnez une classification",
     "description": "Placeholder for classification filter in search form."
+  },
+  "IEkhMc": {
+    "defaultMessage": "Prénom",
+    "description": "Label displayed for the first name field in create account form."
+  },
+  "btydLe": {
+    "defaultMessage": "Prénom",
+    "description": "Label for first name field in About Me form"
   }
 }

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -1208,10 +1208,6 @@
     "defaultMessage": "Toute autre chose au sujet de cette expérience que vous aimeriez partager.",
     "description": "Description blurb for additional information on Experience form"
   },
-  "h9q52R": {
-    "defaultMessage": "Nom(s) de famille",
-    "description": "Label displayed for the last name field in create account form."
-  },
   "hCgrxA": {
     "defaultMessage": "Il y a deux types d'employés du TI-03 : ceux qui suivent un cheminement en gestion et les contributeurs individuels.",
     "description": "IT-03 description precursor"
@@ -1367,10 +1363,6 @@
   "r4PFx0": {
     "defaultMessage": "Province ou territoire actuel",
     "description": "Label for current province or territory field in About Me form"
-  },
-  "rGNWy6": {
-    "defaultMessage": "Nom(s) de famille",
-    "description": "Label for last name field in About Me form"
   },
   "rJMWiV": {
     "defaultMessage": "<strong>Non</strong>, je ne suis pas un(e) employé(e) du gouvernement du Canada",
@@ -1939,5 +1931,13 @@
   "btydLe": {
     "defaultMessage": "Prénom",
     "description": "Label for first name field in About Me form"
+  },
+  "UxF291": {
+    "defaultMessage": "Nom de famille",
+    "description": "Label displayed for the last name field in create account form."
+  },
+  "wrHSMx": {
+    "defaultMessage": "Nom de famille",
+    "description": "Label for last name field in About Me form"
   }
 }


### PR DESCRIPTION
Resolves #4056.

## Summary
This makes the language used for labels of `first_name` and `last_name` fields consistent.

## Testing
1. Compile languages `npm run intl-compile --workspace="talentsearch"`
2. Build talentsearch `npm run production --workspace="talentsearch"`
3. Navigate to /en/create-account
4. Confirm the first name and last name fields have the correct labels (First Name, Last Name)
5. Switch to French
6. Confirm the first name and last name fields have the correct labels (Prénom, Nom de famille)
7. Navigate to My Profile > About Me section
8. Confirm the first name and last name fields have the correct labels (First Name, Last Name)
9. Switch to French
10. Confirm the first name and last name fields have the correct labels (Prénom, Nom de famille)