### PR TITLE
Disable docker layer caching in github action

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -47,6 +47,10 @@ jobs:
       # This uses GitHub Action cache for docker container layers
       # See: https://github.com/marketplace/actions/docker-layer-caching
       - uses: satackey/action-docker-layer-caching@v0.0.11
+        # Disable for now, to avoid storage space error.
+        # #TODO investigate how to run this without error.
+        # See: https://github.com/GCTC-NTGC/gc-digital-talent/issues/4035#issuecomment-1261116699
+        if: false
         # Ignore a failure of this step and avoid terminating the job.
         continue-on-error: true
         # By default, this cache is keyed to the workflow name. We ar

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,22 +44,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.0.2
 
-      # This uses GitHub Action cache for docker container layers
-      # See: https://github.com/marketplace/actions/docker-layer-caching
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        # Disable for now, to avoid storage space error.
-        # #TODO investigate how to run this without error.
-        # See: https://github.com/GCTC-NTGC/gc-digital-talent/issues/4035#issuecomment-1261116699
-        if: false
-        # Ignore a failure of this step and avoid terminating the job.
-        continue-on-error: true
-        # By default, this cache is keyed to the workflow name. We ar
-        # setting a shared key for the docker cache to be shared
-        # across multiple workflows.
-        with:
-          key: docker-{hash}
-          restore-keys: |
-            docker-
+      # We no longer user docker layer caching as it made runs take longer.
+      # See: https://github.com/satackey/action-docker-layer-caching/issues/305
 
       - name: Serve app via docker-compose
         # Need to include --build as we're caching layers.


### PR DESCRIPTION
Spun out from: https://github.com/GCTC-NTGC/gc-digital-talent/issues/4035#issuecomment-1261116699 h/t @mnigh 

This was causing e2e-tests to show as "skipped", and rarely showing the proper pass/fail status, which makes the e2e tests pretty useless.

Disabling docker layer cache for now, to avoid the github action "out of storage" error. We'll see in the github action run whether it makes the workflow run significantly longer (20-25 min seems to be regular).