### PR TITLE
Bug - 4057 - About Section Spacing

### DIFF
--- a/frontend/common/src/components/UserProfile/ProfileSections/AboutSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/AboutSection.tsx
@@ -189,34 +189,32 @@ const AboutSection: React.FC<AboutSectionProps> = ({
         !currentProvince ||
         !citizenship ||
         armedForcesStatus === null) && (
-        <div data-h2-flex-grid="base(flex-start, x2, x1)">
-          <div data-h2-flex-item="base(1of1)">
-            <p>
-              {editPath && (
-                <>
-                  {intl.formatMessage(messages.requiredFieldsMissing)}{" "}
-                  <a href={editPath}>
-                    {intl.formatMessage({
-                      defaultMessage: "Edit your about me options.",
-                      id: "L9AGk7",
-                      description:
-                        "Link text to edit about me section on profile.",
-                    })}
-                  </a>
-                </>
-              )}
-              {!editPath && (
-                <>
+        <div data-h2-margin="base(x1, 0, 0, 0)">
+          <p>
+            {editPath && (
+              <>
+                {intl.formatMessage(messages.requiredFieldsMissing)}{" "}
+                <a href={editPath}>
                   {intl.formatMessage({
-                    defaultMessage: "No information has been provided.",
-                    id: "NIEIAC",
+                    defaultMessage: "Edit your about me options.",
+                    id: "L9AGk7",
                     description:
-                      "Message on Admin side when user not filled about me section.",
+                      "Link text to edit about me section on profile.",
                   })}
-                </>
-              )}
-            </p>
-          </div>
+                </a>
+              </>
+            )}
+            {!editPath && (
+              <>
+                {intl.formatMessage({
+                  defaultMessage: "No information has been provided.",
+                  id: "NIEIAC",
+                  description:
+                    "Message on Admin side when user not filled about me section.",
+                })}
+              </>
+            )}
+          </p>
         </div>
       )}
     </Well>


### PR DESCRIPTION
Resolves #4057 

## Summary

This adds top margin to the required message to space it out from the content above.

## Screenshot

<img width="983" alt="Screen Shot 2022-09-29 at 9 13 18 AM" src="https://user-images.githubusercontent.com/4127998/193042062-0e239c43-1418-4d64-82bb-599bb404c96a.png">

## Testing

1. Build talentsearch `npm run production --workspace=talentsearch`
2. Ensure your user is missing one item from About
3. Go to the profile and confirm there is an appropriate amount of spacing in the About section