### PR TITLE
Add Placed-Casual to search

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -305,7 +305,7 @@ RAWSQL2;
 
     public function scopeAvailable(Builder $query): Builder
     {
-        return $query->where('pool_candidate_status', ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE);
+        return $query->whereIn('pool_candidate_status', [ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE, ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL]);
     }
 
     public function scopeHasDiploma(Builder $query, bool $hasDiploma): Builder

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -276,7 +276,7 @@ class User extends Model implements Authenticatable
             $poolFilters[$index] = [
                 'poolId' => $poolId,
                 'expiryStatus' => ApiEnums::CANDIDATE_EXPIRY_FILTER_ACTIVE,
-                'statuses' => [ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE]
+                'statuses' => [ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE, ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL]
             ];
         }
         return $this->filterByPools($query, $poolFilters);

--- a/api/database/factories/PoolCandidateFactory.php
+++ b/api/database/factories/PoolCandidateFactory.php
@@ -61,7 +61,7 @@ class PoolCandidateFactory extends Factory
                 3
             ),
             'pool_candidate_status' => $this->faker->boolean() ?
-                                                            ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE :
+                                                            $this->faker->randomElement([ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE, ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL])  :
                                                             ApiEnums::candidateStatuses()[array_rand((ApiEnums::candidateStatuses()))],
             'user_id' => User::factory(),
             'pool_id' => Pool::factory(),

--- a/api/tests/Feature/PoolCandidateTest.php
+++ b/api/tests/Feature/PoolCandidateTest.php
@@ -1360,4 +1360,28 @@ class PoolCandidateTest extends TestCase
       ]
     ]);
   }
+
+  public function testAllStatuses(): void
+  {
+    // Create initial data.
+    foreach(ApiEnums::candidateStatuses() as $candidateStatus) {
+      PoolCandidate::factory()->create([
+        'expiry_date' => config('constants.far_future_date'), // ensure no candidates are expired for this test
+        'pool_candidate_status' => $candidateStatus,
+      ]);
+    }
+
+    // Assert query with no explicit filter will return only 2 candidates: Placed - Casual and Qualified - Available
+    $this->graphQL(/** @lang Graphql */ '
+      query countPoolCandidates($where: PoolCandidateFilterInput) {
+        countPoolCandidates(where: $where)
+      }
+    ', [
+      'where' => []
+    ])->assertJson([
+      'data' => [
+        'countPoolCandidates' => 2
+      ]
+    ]);
+  }
 }


### PR DESCRIPTION
This branch includes candidates in the Placed-Casual status to the default search results.

## Testing
- [ ] Run the php tests, ensure they pass
- [ ] Reseed your database
- [ ] Open the search page and note the number of candidates returned
- [ ] Switch the APPLICANTSEARCH feature flag to see the old search page and note the number of candidates returned
- [ ] Run the following SQL query to ensure the right numbers were shown

```
-- new search query with user "job looking status"
select pc.pool_candidate_status, count(*)
from users u
join pool_candidates pc on u.id = pc.user_id  
where pc.pool_id = (select id from pools where name->>'en' = 'CMO Digital Careers')
and (pc.expiry_date is null or pc.expiry_date > current_date)
and u.job_looking_status in ('ACTIVELY_LOOKING', 'OPEN_TO_OPPORTUNITIES') /* comment out this line for old search */
group by pc.pool_candidate_status
order by pc.pool_candidate_status

-- old search query against pool candidates only
select pc.pool_candidate_status, count(*)
from pool_candidates pc  
where pc.pool_id = (select id from pools where name->>'en' = 'CMO Digital Careers')
and (pc.expiry_date is null or pc.expiry_date > current_date)
group by pc.pool_candidate_status
order by pc.pool_candidate_status
```
![image](https://user-images.githubusercontent.com/8978655/193101684-0095b7bc-bfd6-4330-a9e8-dcea212fd66b.png)


Closes #4113