### PR TITLE
Restore French text translation

### DIFF
--- a/frontend/talentsearch/src/js/components/createAccount/CreateAccountPage.tsx
+++ b/frontend/talentsearch/src/js/components/createAccount/CreateAccountPage.tsx
@@ -139,8 +139,8 @@ export const CreateAccountForm: React.FunctionComponent<
             <p data-h2-padding="base(0, 0, x1, 0)">
               {intl.formatMessage({
                 defaultMessage:
-                  "Before we take you to your profile, we need to collect some required information to complete your account set up. ",
-                id: "bYg+MM",
+                  "Before we take you to your profile, we need to collect some required information to complete your account set up.",
+                id: "x6saT3",
                 description:
                   "Message after main heading in create account page.",
               })}


### PR DESCRIPTION
Resolves #4120.

## Summary
The text following the **Pour commencer** heading has been fixed so it is in French. The ID was different between the English and French string as an extra space had been added to the English string which changed the hashed ID.

## Testing
1. Compile languages `npm run intl-compile --workspace="talentsearch"`
2. Build admin `npm run production --workspace="talentsearch"`
3. Navigate to /fr/create-account
4. Confirm the text following the **Pour commencer** heading is not in English