### PR TITLE
Bug 4110 - Empty candidate expiry date

### DIFF
--- a/frontend/admin/src/js/components/poolCandidate/ApplicationStatusForm/ApplicationStatusForm.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/ApplicationStatusForm/ApplicationStatusForm.tsx
@@ -13,6 +13,7 @@ import { enumToOptions } from "@common/helpers/formUtils";
 import { getPoolCandidateStatus } from "@common/constants/localizedConstants";
 import { strToFormDate } from "@common/helpers/dateUtils";
 import { commonMessages } from "@common/messages";
+import { emptyToNull } from "@common/helpers/util";
 import {
   PoolCandidateStatus,
   Scalars,
@@ -55,7 +56,7 @@ export const ApplicationStatusForm = ({
     onSubmit({
       status: values.status,
       notes: values.notes,
-      expiryDate: values.expiryDate,
+      expiryDate: values.expiryDate || emptyToNull(values.expiryDate),
     });
   };
 

--- a/frontend/cypress/integration/admin/pool-candidate.spec.js
+++ b/frontend/cypress/integration/admin/pool-candidate.spec.js
@@ -34,8 +34,8 @@ describe("Pool Candidates", () => {
     cy.wait("@gqlGetPoolCandidatesPaginatedQuery");
 
     cy.findAllByRole("button", { name: /availability/i })
-    .eq(0)
-    .click();
+      .eq(0)
+      .click();
     cy.wait("@gqlGetPoolCandidatesPaginatedQuery");
 
     cy.findAllByRole("link", { name: /view application/i })
@@ -58,6 +58,48 @@ describe("Pool Candidates", () => {
     cy.findByRole("textbox", { name: /notes/i })
       .clear()
       .type("New Notes")
+
+    cy.findByRole("button", { name: /save changes/i })
+      .click();
+
+    cy.wait("@gqlUpdatePoolCandidateStatusMutation")
+
+    cy.expectToast(/pool candidate status updated successfully/i);
+
+  });
+
+  it("should update pool candidate status with optional fields", () => {
+    cy.wait("@gqlgetPoolsQuery");
+
+    cy.findAllByRole("link", { name: /view candidates/i })
+      .eq(0)
+      .click();
+    cy.wait("@gqlGetPoolCandidatesPaginatedQuery");
+
+    cy.findAllByRole("button", { name: /availability/i })
+      .eq(0)
+      .click();
+    cy.wait("@gqlGetPoolCandidatesPaginatedQuery");
+
+    cy.findAllByRole("link", { name: /view application/i })
+      .eq(0)
+      .click();
+
+    cy.wait("@gqlgetPoolCandidateSnapshotQuery");
+    cy.wait("@gqlGetPoolCandidateStatusQuery");
+
+    cy.findByRole("combobox", { name: /candidate pool status/i })
+      .select("Screened In")
+      .within(() => {
+        cy.get("option:selected")
+          .should("have.text", "Screened In");
+      });
+
+    cy.findByLabelText(/Candidate expiry date/i)
+      .clear();
+
+    cy.findByRole("textbox", { name: /notes/i })
+      .clear();
 
     cy.findByRole("button", { name: /save changes/i })
       .click();


### PR DESCRIPTION
Resolves #4110 

## Summary

This allows admins to remove the expiry date for a pool candidate application. As well, it creates an `e2e` test for this scenario.

## Testing

1. Build the admin project `npm run production --workspace=admin`
2. Navigate to the admin pools page `/admin/pools`
3. Click "View candidates" for a pool
4. Click "View application" for a pool candidate
5. Empty out the expiry date field
6. Save changes
7. Ensure that the form submits properly