### PR TITLE
Bug - 4031 - Fix search page gap

### DIFF
--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -112,10 +112,7 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
   };
 
   return (
-    <div
-      data-h2-background-color="base(dt-gray.15)"
-      data-h2-padding="base(0, 0, x3, 0)"
-    >
+    <div data-h2-padding="base(0, 0, x3, 0)">
       <div data-h2-container="base(center, medium, x1) p-tablet(center, medium, x2)">
         <div data-h2-flex-grid="base(stretch, x3)">
           <div data-h2-flex-item="base(1of1) p-tablet(3of5)">

--- a/frontend/talentsearch/src/js/components/search/SearchHeading.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchHeading.tsx
@@ -6,7 +6,7 @@ import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
 const SearchHeading: React.FunctionComponent = () => {
   const intl = useIntl();
   return (
-    <header data-h2-background-color="base(dt-gray.15)">
+    <header>
       <div
         data-h2-padding="base(x2.5, 0, x4, 0) p-tablet(x4, 0, x6, 0)"
         style={{

--- a/frontend/talentsearch/src/js/components/search/SearchPage.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchPage.tsx
@@ -10,7 +10,7 @@ const SearchPage: React.FunctionComponent = () => {
     ? SearchContainerApi
     : OldSearchContainerApi;
   return (
-    <section>
+    <section data-h2-background-color="base(dt-gray.15)">
       <SearchHeading />
       <SearchContainer />
     </section>

--- a/frontend/talentsearch/src/js/components/search/deprecated/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/deprecated/SearchContainer.tsx
@@ -136,10 +136,7 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
   }
 
   return (
-    <div
-      data-h2-background-color="base(dt-gray.15)"
-      data-h2-padding="base(0, 0, x3, 0)"
-    >
+    <div data-h2-padding="base(0, 0, x3, 0)">
       <div data-h2-container="base(center, medium, x1) p-tablet(center, medium, x2)">
         <div data-h2-flex-grid="base(stretch, x3)">
           <div data-h2-flex-item="base(1of1) p-tablet(3of5)">


### PR DESCRIPTION
Resolves #4031 

## Summary

This resolves an odd visual bug where there was some overlapping background colours on the search page.

## Screenshot

<img width="1181" alt="Screen Shot 2022-09-29 at 2 06 54 PM" src="https://user-images.githubusercontent.com/4127998/193109628-dae07dcd-0354-4354-a8cf-fda6c8af5b77.png">

## Testing

1. Build talentsearch `npm run production --workspace=talentsearch`
2. Navigate to `/search`
3. Ensure the odd overlap in the issue screenshot no longer appears