### PR TITLE
Bug - 4123 - Fix inconsistent table action links

### DIFF
--- a/frontend/admin/src/js/components/Table/TableEditButton.tsx
+++ b/frontend/admin/src/js/components/Table/TableEditButton.tsx
@@ -24,7 +24,7 @@ function TableEditButton({
       href={href}
       type="button"
       mode="inline"
-      color="primary"
+      color="black"
       data-h2-padding="base(0)"
     >
       {intl.formatMessage(

--- a/frontend/admin/src/js/components/pool/PoolTable.tsx
+++ b/frontend/admin/src/js/components/pool/PoolTable.tsx
@@ -23,7 +23,7 @@ function poolCandidatesLinkAccessor(
       href={poolCandidatesTableUrl}
       type="button"
       mode="inline"
-      color="primary"
+      color="black"
       data-h2-padding="base(0)"
     >
       {intl.formatMessage(

--- a/frontend/admin/src/js/components/searchRequest/SingleSearchRequestTable.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SingleSearchRequestTable.tsx
@@ -29,7 +29,7 @@ const TableEditButton: React.FC<{
   return (
     <Link
       type="button"
-      color="primary"
+      color="black"
       mode="inline"
       href={paths.poolCandidateUpdate(poolId || "", poolCandidateId || "")}
     >


### PR DESCRIPTION
Resolves #4123 

## Summary

This updates the action links in admin tables to all be black rather than purple.

## Screenshot 

<img width="1180" alt="Screen Shot 2022-09-29 at 2 29 57 PM" src="https://user-images.githubusercontent.com/4127998/193113883-b74b4ca4-7216-4df1-b812-9de248ec07e7.png">

## Testing

1. Build admin `npm run production --workspace=admin`
2. Navigate to the following pages and ensure all links in tables are black
    - `/admin/dashboard`
    - `/admin/pools`
    - `/admin/pools/{poolId}/pool-candidates`
    - `/admin/users`
    - `/admin/talent-requests`
    - `/admin/talent-requests/{requestId}`
    - `/admin/settings/classifications`
    - `/admin/cmo-assets`
    - `/admin/settings/departments`
    - `/admin/settings/skills/families`
    - `/admin/settings/skills`