### PR TITLE
Fix Experience Date off by 1 error

### DIFF
--- a/frontend/common/src/helpers/dateUtils.ts
+++ b/frontend/common/src/helpers/dateUtils.ts
@@ -8,6 +8,7 @@ export function formattedDate(date: Scalars["Date"], locale: Locales) {
   const formatter = new Intl.DateTimeFormat(locale, {
     year: "numeric",
     month: "short",
+    timeZone: "UTC",
   });
   const formatDate = formatter.format(new Date(date));
   const formattedMonth = formatDate.substring(0, 4).toUpperCase();


### PR DESCRIPTION
Resolves #4100.

We're already saving dates to the API and database in a sensible way, as timezone-agnostic YYYY-mm-dd strings. We just need to be careful about how we present dates in the frontend.

It seems that `new Date(date_string)` will assume `date_string` is a UTC date, but then convert it into local time. That's reasonable when working with times strings, but less so when the original string is just a date. An easy way to get around the issue is to display/format the date as if we were also in UTC timezone.