### PR TITLE
Feature - 4087 - Role, Salary Form External Link

### DIFF
--- a/frontend/talentsearch/src/js/components/roleSalaryForm/RoleSalaryForm.tsx
+++ b/frontend/talentsearch/src/js/components/roleSalaryForm/RoleSalaryForm.tsx
@@ -14,6 +14,7 @@ import { toast } from "react-toastify";
 import { getLocale } from "@common/helpers/localize";
 import { checkFeatureFlag } from "@common/helpers/runtimeVariable";
 import Well from "@common/components/Well";
+import { ExternalLink } from "@common/components/Link";
 import {
   DialogLevelOne,
   DialogLevelTwo,
@@ -147,7 +148,11 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
 
   // intl styling functions section
   function link(msg: string, url: string) {
-    return <a href={url}>{msg}</a>;
+    return (
+      <ExternalLink newTab href={url}>
+        {msg}
+      </ExternalLink>
+    );
   }
 
   function openModal(msg: string, setOpenStateFn: (state: boolean) => void) {


### PR DESCRIPTION
Resolves #4087 

## Summary

This updates the "Learn more" link on the Role and Salary Expectations form to open in a new tab.

## Screenshot

<img width="973" alt="Screen Shot 2022-09-30 at 10 05 41 AM" src="https://user-images.githubusercontent.com/4127998/193287577-2350634d-5841-4ccc-8c5c-2dfe81ea754e.png">

## Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Navigate to `users/{userId}/profile/role-salary-expectations/edit`
3. Confirm that the Learn more link has (opens in a new tab) text and icon
4. Click link and confirm a new tab opens
