### PR TITLE
Fix e2e admin workflow

### DIFF
--- a/frontend/cypress/integration/admin/admin-workflows.spec.js
+++ b/frontend/cypress/integration/admin/admin-workflows.spec.js
@@ -49,7 +49,7 @@ describe("Admin Workflow Tests", () => {
 
     cy.findByRole("table")
       .findByRole("row", { name: /applicant test/i })
-      .findByText("applicant@test.com") // findByRole link doesn't work here
+      .findByRole("link", {name: /view applicant test/i}) // findByRole link doesn't work here
       .click();
 
     // exercise profile page

--- a/frontend/cypress/integration/admin/admin-workflows.spec.js
+++ b/frontend/cypress/integration/admin/admin-workflows.spec.js
@@ -49,7 +49,7 @@ describe("Admin Workflow Tests", () => {
 
     cy.findByRole("table")
       .findByRole("row", { name: /applicant test/i })
-      .findByRole("link", {name: /view applicant test/i}) // findByRole link doesn't work here
+      .findByRole("link", {name: /view applicant test/i})
       .click();
 
     // exercise profile page


### PR DESCRIPTION
## Summary

Due to the `e2e` tests being skipped, silently failing test was introduced in between fixes. This fixes that bug to get tests working again.