### PR TITLE
Remove extra space in defaultMessage values

### DIFF
--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -399,8 +399,8 @@ const PoolAdvertisement = ({
                 <Text>
                   {intl.formatMessage({
                     defaultMessage:
-                      "To be admitted into this process, you will need to submit sufficient information to verify your experience in <strong>all of these  skills (Need to have - Occupational)</strong> with your application.",
-                    id: "Y7AKYP",
+                      "To be admitted into this process, you will need to submit sufficient information to verify your experience in <strong>all of these skills (Need to have - Occupational)</strong> with your application.",
+                    id: "mbtf3h",
                     description:
                       "Explanation of a pools required occupational skills",
                   })}
@@ -427,8 +427,8 @@ const PoolAdvertisement = ({
                 <Text>
                   {intl.formatMessage({
                     defaultMessage:
-                      "To be admitted into this process, you will need to display  capability in these skills during the assessment process.",
-                    id: "7n838F",
+                      "To be admitted into this process, you will need to display capability in these skills during the assessment process.",
+                    id: "0FjYi+",
                     description:
                       "Explanation of a pools required transferrable skills",
                   })}


### PR DESCRIPTION
Resolves #4177, #4176.

## Summary
The text following the **Compétences professionnelles** heading and the **Compétences transférables** heading has been fixed so it is in French. The ID was different between the English and French string as an extra space had been added to the English string which changed the hashed ID.

## Testing
1. Compile languages `npm run intl-compile --workspace="talentsearch"`
2. Build admin `npm run production --workspace="talentsearch"`
3. Navigate to **Browse opportunities** page
4. Click on a pool name
5. Change language to French
6. Confirm the text following the **Compétences professionnelles** heading is not in English
7. Confirm the text following the **Compétences transférables** heading is not in English