### PR TITLE
Bug/4162 archive link on archived card issue

### DIFF
--- a/frontend/talentsearch/src/js/components/applications/ApplicationCard.test.tsx
+++ b/frontend/talentsearch/src/js/components/applications/ApplicationCard.test.tsx
@@ -6,6 +6,7 @@ import { screen } from "@testing-library/react";
 import React from "react";
 import { axeTest, render } from "@common/helpers/testUtils";
 import { fakePoolCandidates } from "@common/fakeData";
+import { FAR_PAST_DATE } from "@common/helpers/dateUtils";
 
 import ApplicationCard, { type ApplicationCardProps } from "./ApplicationCard";
 import { PoolCandidateStatus } from "../../api/generated";
@@ -65,6 +66,7 @@ describe("ApplicationCard", () => {
       application: {
         ...mockApplication,
         status: PoolCandidateStatus.ScreenedOutApplication,
+        archivedAt: null,
       },
     });
 
@@ -80,6 +82,7 @@ describe("ApplicationCard", () => {
       application: {
         ...mockApplication,
         status: PoolCandidateStatus.ScreenedOutAssessment,
+        archivedAt: null,
       },
     });
 
@@ -95,6 +98,7 @@ describe("ApplicationCard", () => {
       application: {
         ...mockApplication,
         status: PoolCandidateStatus.Expired,
+        archivedAt: null,
       },
     });
 
@@ -103,5 +107,21 @@ describe("ApplicationCard", () => {
     });
 
     expect(archiveLink).toBeInTheDocument();
+  });
+
+  it("should not show archive link if already archived", () => {
+    renderApplicationCard({
+      application: {
+        ...mockApplication,
+        status: PoolCandidateStatus.Expired,
+        archivedAt: FAR_PAST_DATE,
+      },
+    });
+
+    const archiveLink = screen.queryByRole("button", {
+      name: /archive/i,
+    });
+
+    expect(archiveLink).toBeNull();
   });
 });

--- a/frontend/talentsearch/src/js/components/applications/ApplicationCard.tsx
+++ b/frontend/talentsearch/src/js/components/applications/ApplicationCard.tsx
@@ -22,7 +22,10 @@ const ApplicationCard = ({ application }: ApplicationCardProps) => {
   const intl = useIntl();
 
   const applicationIsDraft = isDraft(application.status);
-  const applicationCanBeArchived = canBeArchived(application.status);
+  const applicationCanBeArchived = canBeArchived(
+    application.status,
+    application.archivedAt,
+  );
   const applicationCanBeDeleted = canBeDeleted(application.status);
 
   let borderKey: BorderMapKey = "dt-gray";

--- a/frontend/talentsearch/src/js/components/applications/utils.ts
+++ b/frontend/talentsearch/src/js/components/applications/utils.ts
@@ -4,13 +4,16 @@ export const isDraft = (status: Maybe<PoolCandidateStatus>): boolean => {
   return status === PoolCandidateStatus.Draft;
 };
 
-export const canBeArchived = (status: Maybe<PoolCandidateStatus>): boolean => {
+export const canBeArchived = (
+  status: Maybe<PoolCandidateStatus>,
+  archivedAt: Maybe<string>,
+): boolean => {
   return status
     ? [
         PoolCandidateStatus.Expired,
         PoolCandidateStatus.ScreenedOutApplication,
         PoolCandidateStatus.ScreenedOutAssessment,
-      ].includes(status)
+      ].includes(status) && !archivedAt
     : false;
 };
 


### PR DESCRIPTION
resolves #4162 
adds another condition that the `archivedAt` value for an application must be null in order to render the archive action
adds a Jest test for it too

testing:
create an application that can be archived (submit application in /talentsearch then switch it to screened out in /admin)
assert application can be archived, and after archiving can no longer be archived 