### PR TITLE
Restore view results link

### DIFF
--- a/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
+++ b/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
@@ -78,13 +78,6 @@ const EstimatedCandidates: React.FunctionComponent<
             {candidateCount > 0 && (
               <a
                 href="#results"
-                title={intl.formatMessage({
-                  defaultMessage:
-                    "View the pools that contain matching talent.",
-                  id: "7/Bn8u",
-                  description:
-                    "The title for a link to view the pools that contain matching talent.",
-                })}
                 data-h2-color="base(dt-black) base:hover(dt-primary)"
                 data-h2-transition="base:hover(color, .2s, ease, 0s)"
                 data-h2-display="base(inline-block)"

--- a/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
+++ b/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
@@ -78,7 +78,13 @@ const EstimatedCandidates: React.FunctionComponent<
             {candidateCount > 0 && (
               <a
                 href="#results"
-                title="View the pools that contain matching talent."
+                title={intl.formatMessage({
+                  defaultMessage:
+                    "View the pools that contain matching talent.",
+                  id: "7/Bn8u",
+                  description:
+                    "The title for a link to view the pools that contain matching talent.",
+                })}
                 data-h2-color="base(dt-black) base:hover(dt-primary)"
                 data-h2-transition="base:hover(color, .2s, ease, 0s)"
                 data-h2-display="base(inline-block)"

--- a/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
+++ b/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
@@ -75,6 +75,23 @@ const EstimatedCandidates: React.FunctionComponent<
                 </>
               )}
             </p>
+            {candidateCount > 0 && (
+              <a
+                href="#results"
+                title="View the pools that contain matching talent."
+                data-h2-color="base(dt-black) base:hover(dt-primary)"
+                data-h2-transition="base:hover(color, .2s, ease, 0s)"
+                data-h2-display="base(inline-block)"
+                data-h2-margin="base(x1, 0, 0, 0)"
+              >
+                {intl.formatMessage({
+                  defaultMessage: "View results",
+                  id: "3wbcnZ",
+                  description:
+                    "A link to view the pools that contain matching talent.",
+                })}
+              </a>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
This branch restores some partial work from the Hydrogen upgrade.  It adds a "view results" link to the new search page.

![image](https://user-images.githubusercontent.com/8978655/193828683-8d3b4969-3979-453f-9dea-feffc0950771.png)


Testing:
- [ ] "View results" link appears on search page
- [ ] Link disappears when 0 candidates are available
- [ ] Clicking the link scrolls down to the results section

Notes:
- It seems like there is a URL fragment issue on Firefox.  I opened #4195.
- This page is still behind a feature flag so no translation needed yet.

Closes #3826 