### PR TITLE
Repair French text translation

### DIFF
--- a/frontend/talentsearch/src/js/components/search/SearchPools.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchPools.tsx
@@ -33,9 +33,9 @@ const SearchPools: React.FunctionComponent<SearchPoolsProps> = ({
           {
             defaultMessage:
               "There are <heavyPrimary><testId>{candidateCount}</testId></heavyPrimary> matching candidates in this pool",
-            id: "Ba4Y8a",
+            id: "ICPJ8D",
             description:
-              "Message for total estimated candidates box next to search form.",
+              "Message for total estimated matching candidates in pool",
           },
           {
             testId,

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -1532,9 +1532,9 @@
     "defaultMessage": "Résultats : <primary><testId>{candidateCount}</testId></primary> candidats correspondants à vos critères",
     "description": "Heading for total matching candidates in results section of search page."
   },
-  "thdckE": {
-    "defaultMessage": "Il y a <strong>{candidateCount}</strong> candidats qui répondent à vos critères dans ce bassin",
-    "description": "Message for total estimated candidates box next to search form."
+  "ICPJ8D": {
+    "defaultMessage": "Il y a <heavyPrimary><testId>{candidateCount}</testId></heavyPrimary> candidats qui répondent à vos critères dans ce bassin",
+    "description": "Message for total estimated matching candidates in pool"
   },
   "pak8ye": {
     "defaultMessage": "Je suis bilingue (En/Fr) et <strong>j'ai</strong> terminé une <languageEvaluationPageLink></languageEvaluationPageLink> officielle en <strong>FRANÇAIS</strong>",


### PR DESCRIPTION
Resolves #4198.

## Summary
The text following the Pool name heading has been fixed so it is in French. The ID was different between the English and French string as as` <testId>` tags wrapping `{candidateCount}` been added to the English string which changed the hashed ID.

## Testing
1. Compile languages `npm run intl-compile --workspace="talentsearch"`
2. Build admin `npm run production --workspace="talentsearch"`
3. Navigate to /fr/search
4. Confirm the text following the Pool name heading in the Résultats (Results) box is not in English