### PR TITLE
Bug - Remove Theme Provider

### DIFF
--- a/frontend/common/src/components/context/ContextContainer.tsx
+++ b/frontend/common/src/components/context/ContextContainer.tsx
@@ -5,7 +5,8 @@ import { Messages } from "../LanguageRedirectContainer";
 import AuthenticationProvider from "./AuthenticationProvider";
 import AuthorizationProvider from "./AuthorizationProvider";
 import LanguageRedirectProvider from "./LanguageRedirectProvider";
-import ThemeProvider from "../Theme";
+// Note: Commented out until we have dark mode styles properly implemented
+// import ThemeProvider from "../Theme";
 
 export interface ContextContainerProps {
   messages: Messages;
@@ -16,13 +17,13 @@ const ContextContainer: React.FC<ContextContainerProps> = ({
   children,
 }) => (
   <LanguageRedirectProvider messages={messages}>
-    <ThemeProvider>
-      <AuthenticationProvider>
-        <ClientProvider>
-          <AuthorizationProvider>{children}</AuthorizationProvider>
-        </ClientProvider>
-      </AuthenticationProvider>
-    </ThemeProvider>
+    {/* <ThemeProvider> */}
+    <AuthenticationProvider>
+      <ClientProvider>
+        <AuthorizationProvider>{children}</AuthorizationProvider>
+      </ClientProvider>
+    </AuthenticationProvider>
+    {/* </ThemeProvider> */}
   </LanguageRedirectProvider>
 );
 


### PR DESCRIPTION
## Summary

We added a `ThemeProvider` that controls dark mode recently with half baked dark mode. This removes the `ThemeProvider` until we can fully bake dark mode 🧑‍🍳 🍰 

## Testing

1. Build all projects `npm run production --workspaces`
2. Confirm the header and footer are not dark when `(prefers-color-scheme: dark)`