### PR TITLE
Add null check for pool closing date

### DIFF
--- a/frontend/admin/src/js/components/pool/EditPool/ClosingDateSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/ClosingDateSection.tsx
@@ -4,7 +4,7 @@ import { useIntl } from "react-intl";
 import { Input, Submit } from "@common/components/form";
 import { FormProvider, useForm } from "react-hook-form";
 import { useDeepCompareEffect } from "@common/hooks/useDeepCompareEffect";
-import { strToDateTimeTz } from "@common/helpers/dateUtils";
+import { strToDateTimeTz, strToFormDate } from "@common/helpers/dateUtils";
 import {
   AdvertisementStatus,
   PoolAdvertisement,
@@ -36,8 +36,11 @@ export const ClosingDateSection = ({
   const { isSubmitting } = useEditPoolContext();
 
   const dataToFormValues = (initialData: PoolAdvertisement): FormValues => {
-    const parsedDate = new Date(initialData.expiryDate);
-    return { endDate: parsedDate.toISOString().split("T")[0] };
+    return {
+      endDate: initialData.expiryDate
+        ? strToFormDate(initialData.expiryDate.split("T")[0]) // don't need time and offset for this form
+        : null,
+    };
   };
 
   const suppliedValues = dataToFormValues(poolAdvertisement);


### PR DESCRIPTION
Adds a null check for the closing date on the edit pool form.

## Testing
1. Navigate to http://localhost:8000/en/admin/pools/create .
2. Create a new pool and observe that the End Date field is populated with the standard "mm / dd / yyyy" placeholder.
3. Pick a date and click "Save closing date"
4. Refresh the page and observe that the selected date was preserved

Closes #4167 