### PR TITLE
Bug - 4195 - Fix anchors in Firefox

### DIFF
--- a/frontend/common/src/components/Link/ScrollToLink.tsx
+++ b/frontend/common/src/components/Link/ScrollToLink.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+export interface ScrollToLinkProps
+  extends Omit<React.HTMLProps<HTMLAnchorElement>, "href" | "onClick"> {
+  to: string;
+}
+
+const ScrollToLink = ({ to, children, ...rest }: ScrollToLinkProps) => {
+  const [targetSection, setTargetSection] = React.useState<HTMLElement | null>(
+    null,
+  );
+
+  React.useEffect(() => {
+    const section = document.getElementById(to);
+    setTargetSection(section);
+  }, [to]);
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (targetSection) {
+      e.preventDefault();
+      targetSection.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
+  };
+
+  return (
+    <a href={`#${to}`} onClick={handleClick} {...rest}>
+      {children}
+    </a>
+  );
+};
+
+export default ScrollToLink;

--- a/frontend/common/src/components/Link/index.ts
+++ b/frontend/common/src/components/Link/index.ts
@@ -2,11 +2,19 @@ import DownloadCsv from "./DownloadCsv";
 import ExternalLink from "./ExternalLink";
 import Link from "./Link";
 import IconLink from "./IconLink";
+import ScrollToLink from "./ScrollToLink";
 import type { ExternalLinkProps } from "./ExternalLink";
 import type { LinkProps } from "./Link";
 import type { IconLinkProps } from "./IconLink";
 import type { DownloadCsvProps } from "./DownloadCsv";
+import type { ScrollToLinkProps } from "./ScrollToLink";
 
 export default Link;
-export { DownloadCsv, ExternalLink, IconLink };
-export type { DownloadCsvProps, ExternalLinkProps, LinkProps, IconLinkProps };
+export { DownloadCsv, ExternalLink, IconLink, ScrollToLink };
+export type {
+  DownloadCsvProps,
+  ExternalLinkProps,
+  LinkProps,
+  IconLinkProps,
+  ScrollToLinkProps,
+};

--- a/frontend/common/src/components/TableOfContents/AnchorLink.tsx
+++ b/frontend/common/src/components/TableOfContents/AnchorLink.tsx
@@ -1,38 +1,14 @@
 import React, { HTMLAttributes } from "react";
+import { ScrollToLink } from "../Link";
 
 export interface AnchorLinkProps extends HTMLAttributes<HTMLAnchorElement> {
   id: string;
 }
 
-const AnchorLink: React.FC<AnchorLinkProps> = ({ id, children }) => {
-  const [targetSection, setTargetSection] = React.useState<HTMLElement | null>(
-    null,
-  );
-
-  React.useEffect(() => {
-    const section = document.getElementById(id);
-    setTargetSection(section);
-  }, [id]);
-
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    if (targetSection) {
-      e.preventDefault();
-      targetSection.scrollIntoView({
-        behavior: "smooth",
-        block: "start",
-      });
-    }
-  };
-
-  return (
-    <a
-      href={`#${id}`}
-      data-h2-margin="base(0, 0, x.5, 0)"
-      onClick={handleClick}
-    >
-      {children}
-    </a>
-  );
-};
+const AnchorLink: React.FC<AnchorLinkProps> = ({ id, children }) => (
+  <ScrollToLink to={id} data-h2-margin="base(0, 0, x.5, 0)">
+    {children}
+  </ScrollToLink>
+);
 
 export default AnchorLink;

--- a/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
+++ b/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
@@ -1,5 +1,8 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
+
+import { ScrollToLink } from "@common/components/Link";
+
 import Spinner from "../Spinner";
 
 interface EstimatedCandidatesProps {
@@ -76,8 +79,8 @@ const EstimatedCandidates: React.FunctionComponent<
               )}
             </p>
             {candidateCount > 0 && (
-              <a
-                href="#results"
+              <ScrollToLink
+                to="results"
                 data-h2-color="base(dt-black) base:hover(dt-primary)"
                 data-h2-transition="base:hover(color, .2s, ease, 0s)"
                 data-h2-display="base(inline-block)"
@@ -89,7 +92,7 @@ const EstimatedCandidates: React.FunctionComponent<
                   description:
                     "A link to view the pools that contain matching talent.",
                 })}
-              </a>
+              </ScrollToLink>
             )}
           </div>
         </div>


### PR DESCRIPTION
Resolves #4195 

## Summary

This adds a `<ScrollToLink />` component that implements smooth scrolling and fixes a bug with `href="#id"` links in Firefox.

## Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Navigate to `/search` in firefox
3. Confirm "View results" smooth scrolls on first click
4. Navigate to `/talent/profile`
5. Confirm "On this page" links still function