### PR TITLE
Bug - Pool advertisement page padding

### DIFF
--- a/frontend/common/src/components/TableOfContents/Content.tsx
+++ b/frontend/common/src/components/TableOfContents/Content.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
-const Content: React.FC = ({ children }) => (
-  <div data-h2-flex-item="base(1of1) l-tablet(3of4)">
+const Content: React.FC = ({ children, ...rest }) => (
+  <div data-h2-flex-item="base(1of1) l-tablet(3of4)" {...rest}>
     <div>{children}</div>
   </div>
 );

--- a/frontend/common/src/components/TableOfContents/Navigation.tsx
+++ b/frontend/common/src/components/TableOfContents/Navigation.tsx
@@ -3,12 +3,12 @@ import { useIntl } from "react-intl";
 
 import Sidebar from "./Sidebar";
 
-const Navigation: React.FC = ({ children }) => {
+const Navigation: React.FC = ({ children, ...rest }) => {
   const intl = useIntl();
 
   return (
     <Sidebar>
-      <div data-h2-text-align="base(left) l-tablet(right)">
+      <div data-h2-text-align="base(left) l-tablet(right)" {...rest}>
         <p
           id="toc-heading"
           data-h2-font-size="base(h5, 1)"

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -284,7 +284,7 @@ const PoolAdvertisement = ({
         </div>
       </div>
       <TableOfContents.Wrapper>
-        <TableOfContents.Navigation>
+        <TableOfContents.Navigation data-h2-padding="base(0, x2, 0, x2) l-tablet(0, 0, 0, 0)">
           <TableOfContents.AnchorLink id={sections.about.id}>
             {sections.about.title}
           </TableOfContents.AnchorLink>
@@ -304,7 +304,7 @@ const PoolAdvertisement = ({
             {sections.apply.title}
           </TableOfContents.AnchorLink>
         </TableOfContents.Navigation>
-        <TableOfContents.Content>
+        <TableOfContents.Content data-h2-padding="base(0, x2, 0, x2) l-tablet(0, x2, 0, 0)">
           <TableOfContents.Section id={sections.about.id}>
             <TableOfContents.Heading>
               {sections.about.title}


### PR DESCRIPTION
Resolves #4211 

## Notes
Fix for small styling bug Jerbo flagged. This fixes the right hand padding on the pool advertisement page and also makes it responsive.

## Testing
- Setup your environment with new changes
- Go to a Pool Advertisement page `http://localhost:8000/en/browse/pools/{poolId}`, and see padding on right hand side fixed.
- Also, try checking to see if responsive by shrinking/expanding screen size.