### PR TITLE
 UAT/4175 UAT seeder expand classifications for search

### DIFF
--- a/api/database/seeders/PoolSeederUat.php
+++ b/api/database/seeders/PoolSeederUat.php
@@ -61,7 +61,7 @@ class PoolSeederUat extends Seeder
         $digitalCareers->essentialCriteria()->sync($softAssets);
         $digitalCareers->assetCriteria()->sync($hardAssets);
 
-        $itClassifications = Classification::where('group', 'IT')->get();
+        $itClassifications = Classification::all();
         $digitalCareers->classifications()->sync($itClassifications);
     }
 }


### PR DESCRIPTION
resolves #4175 
no longer restricts classifications to IT for the seeded pool

test:
open up `/en/admin/pools/create` and `/en/search`
in your database tool of choice, run `php artisan db:seed --class=UatSeeder`
reload browser tabs, classifications should be in sync between the two