### PR TITLE
Bug - 4212 - Scroll to hash on load

### DIFF
--- a/frontend/common/src/components/Link/ScrollToLink.tsx
+++ b/frontend/common/src/components/Link/ScrollToLink.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { HISTORY } from "../../helpers/router";
+import { navigate } from "../../helpers/router";
 
 export interface ScrollToLinkProps
   extends Omit<React.HTMLProps<HTMLAnchorElement>, "href" | "onClick"> {
@@ -19,7 +19,7 @@ const ScrollToLink = ({ to, children, ...rest }: ScrollToLinkProps) => {
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (targetSection) {
       e.preventDefault();
-      HISTORY.push(`#${to}`);
+      navigate(`#${to}`);
       targetSection.scrollIntoView({
         behavior: "smooth",
         block: "start",

--- a/frontend/common/src/components/Link/ScrollToLink.tsx
+++ b/frontend/common/src/components/Link/ScrollToLink.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { HISTORY } from "../../helpers/router";
 
 export interface ScrollToLinkProps
   extends Omit<React.HTMLProps<HTMLAnchorElement>, "href" | "onClick"> {
@@ -18,6 +19,7 @@ const ScrollToLink = ({ to, children, ...rest }: ScrollToLinkProps) => {
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (targetSection) {
       e.preventDefault();
+      HISTORY.push(`#${to}`);
       targetSection.scrollIntoView({
         behavior: "smooth",
         block: "start",

--- a/frontend/common/src/helpers/router.tsx
+++ b/frontend/common/src/helpers/router.tsx
@@ -238,17 +238,61 @@ export function useQueryParams() {
   return parseUrlQueryParameters(location);
 }
 
-export const ScrollToTop: React.FC<{ children: React.ReactElement }> = ({
-  children,
-}): React.ReactElement => {
-  useEffect(() => {
-    window.scrollTo({
-      top: 0,
-      left: 0,
-      behavior: "auto",
+/**
+ * Wait for Element
+ *
+ * @param {string} selector The element sector
+ * @returns {Promise<Element | null>}  A promise containing the element if found, null if not
+ */
+const waitForElm = (selector: string): Promise<Element | null> => {
+  return new Promise((resolve) => {
+    // Return element if found without need of mutation observer
+    if (document.querySelector(selector)) {
+      resolve(document.querySelector(selector));
+    }
+
+    /**
+     * Create a mutation observer that waits for element to
+     * appear in the DOM, returning it and then disconnecting
+     * the observer
+     */
+    const observer = new MutationObserver(() => {
+      if (document.querySelector(selector)) {
+        resolve(document.querySelector(selector));
+        observer.disconnect();
+      }
     });
-  }, [children]);
-  return children;
+
+    // Start observing the body and its children
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  });
+};
+
+export const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    const { hash } = window.location;
+    // Scroll to hash if it exists
+    if (hash) {
+      waitForElm(hash).then((el) => {
+        if (el) {
+          el.scrollIntoView({
+            behavior: "smooth",
+            block: "start",
+          });
+        }
+      });
+    } else {
+      // If no has is present, just scroll to the top
+      window.scrollTo(0, 0);
+    }
+  }, [pathname]);
+
+  return null;
 };
 
 export function refresh() {

--- a/frontend/common/src/helpers/router.tsx
+++ b/frontend/common/src/helpers/router.tsx
@@ -281,7 +281,6 @@ export const ScrollToTop = () => {
       waitForElm(hash).then((el) => {
         if (el) {
           el.scrollIntoView({
-            behavior: "smooth",
             block: "start",
           });
         }

--- a/frontend/indigenousapprenticeship/src/js/components/PageContainer.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/PageContainer.tsx
@@ -111,32 +111,31 @@ export const PageContainer: React.FC<{
     notAuthorizedComponent.current,
   );
   return (
-    <ScrollToTop>
-      <>
-        <a href="#main" data-h2-visibility="base(hidden)">
-          {intl.formatMessage({
-            defaultMessage: "Skip to main content",
-            id: "Srs7a4",
-            description: "Assistive technology skip link",
-          })}
-        </a>
-        <div
-          className="container"
-          data-h2-display="base(flex)"
-          data-h2-flex-direction="base(column)"
-          style={{ height: "100vh", margin: "0" }}
-        >
-          <div>
-            <Header />
-            <NavMenu mainItems={menuItems} />
-          </div>
-          <main id="main">{content}</main>
-          <div style={{ marginTop: "auto" }}>
-            <Footer />
-          </div>
+    <>
+      <ScrollToTop />
+      <a href="#main" data-h2-visibility="base(hidden)">
+        {intl.formatMessage({
+          defaultMessage: "Skip to main content",
+          id: "Srs7a4",
+          description: "Assistive technology skip link",
+        })}
+      </a>
+      <div
+        className="container"
+        data-h2-display="base(flex)"
+        data-h2-flex-direction="base(column)"
+        style={{ height: "100vh", margin: "0" }}
+      >
+        <div>
+          <Header />
+          <NavMenu mainItems={menuItems} />
         </div>
-      </>
-    </ScrollToTop>
+        <main id="main">{content}</main>
+        <div style={{ marginTop: "auto" }}>
+          <Footer />
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/frontend/talentsearch/src/js/components/PageContainer.tsx
+++ b/frontend/talentsearch/src/js/components/PageContainer.tsx
@@ -135,37 +135,36 @@ export const PageContainer: React.FC<{
     paths.createAccount(),
   );
   return (
-    <ScrollToTop>
-      <>
-        <a
-          href="#main"
-          data-h2-visibility="base(invisible) base:focus-visible(visible)"
-        >
-          {intl.formatMessage({
-            defaultMessage: "Skip to main content",
-            id: "Srs7a4",
-            description: "Assistive technology skip link",
-          })}
-        </a>
-        <div
-          className="container"
-          data-h2-display="base(flex)"
-          data-h2-flex-direction="base(column)"
-          data-h2-height="base(100vh)"
-          data-h2-margin="base(0)"
-          data-h2-color="base(black) base:dark(white)"
-        >
-          <div>
-            <Header />
-            <NavMenu mainItems={menuItems} utilityItems={authLinks} />
-          </div>
-          <main id="main">{content}</main>
-          <div style={{ marginTop: "auto" }}>
-            <Footer />
-          </div>
+    <>
+      <ScrollToTop />
+      <a
+        href="#main"
+        data-h2-visibility="base(invisible) base:focus-visible(visible)"
+      >
+        {intl.formatMessage({
+          defaultMessage: "Skip to main content",
+          id: "Srs7a4",
+          description: "Assistive technology skip link",
+        })}
+      </a>
+      <div
+        className="container"
+        data-h2-display="base(flex)"
+        data-h2-flex-direction="base(column)"
+        data-h2-height="base(100vh)"
+        data-h2-margin="base(0)"
+        data-h2-color="base(black) base:dark(white)"
+      >
+        <div>
+          <Header />
+          <NavMenu mainItems={menuItems} utilityItems={authLinks} />
         </div>
-      </>
-    </ScrollToTop>
+        <main id="main">{content}</main>
+        <div style={{ marginTop: "auto" }}>
+          <Footer />
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -5,6 +5,7 @@ import { pushToStateThenNavigate } from "@common/helpers/router";
 import { notEmpty } from "@common/helpers/util";
 import pick from "lodash/pick";
 import { unpackMaybes } from "@common/helpers/formUtils";
+import Pending from "@common/components/Pending";
 import {
   Classification,
   CountApplicantsQueryVariables,
@@ -211,7 +212,7 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
 };
 
 const SearchContainerApi: React.FC = () => {
-  const [{ data }] = useGetSearchFormDataQuery({
+  const [{ data, fetching, error }] = useGetSearchFormDataQuery({
     variables: { poolKey: DIGITAL_CAREERS_POOL_KEY },
   });
   const pool = data?.poolByKey;
@@ -243,17 +244,19 @@ const SearchContainerApi: React.FC = () => {
   };
 
   return (
-    <SearchContainer
-      classifications={pool?.classifications?.filter(notEmpty) ?? []}
-      pool={pool ?? undefined}
-      skills={skills as Skill[]}
-      poolOwner={pool?.owner ?? undefined}
-      applicantFilter={applicantFilter}
-      candidateCount={candidateCount}
-      updatePending={countFetching}
-      onUpdateApplicantFilter={setApplicantFilter}
-      onSubmit={onSubmit}
-    />
+    <Pending {...{ fetching, error }}>
+      <SearchContainer
+        classifications={pool?.classifications?.filter(notEmpty) ?? []}
+        pool={pool ?? undefined}
+        skills={skills as Skill[]}
+        poolOwner={pool?.owner ?? undefined}
+        applicantFilter={applicantFilter}
+        candidateCount={candidateCount}
+        updatePending={countFetching}
+        onUpdateApplicantFilter={setApplicantFilter}
+        onSubmit={onSubmit}
+      />
+    </Pending>
   );
 };
 

--- a/frontend/talentsearch/src/js/components/search/deprecated/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/deprecated/SearchContainer.tsx
@@ -4,6 +4,7 @@ import { useIntl } from "react-intl";
 import pick from "lodash/pick";
 import { pushToStateThenNavigate } from "@common/helpers/router";
 import { unpackMaybes } from "@common/helpers/formUtils";
+import Pending from "@common/components/Pending";
 import {
   Classification,
   CmoAsset,
@@ -265,7 +266,7 @@ const candidateFilterToQueryArgs = (
 
 export const SearchContainerApi: React.FC = () => {
   const [initialValues, setInitialValues] = useState<FormValues | null>(null);
-  const [{ data }] = useGetSearchFormDataQuery({
+  const [{ data, fetching, error }] = useGetSearchFormDataQuery({
     variables: { poolKey: DIGITAL_CAREERS_POOL_KEY },
   });
   const pool = data?.poolByKey;
@@ -294,17 +295,19 @@ export const SearchContainerApi: React.FC = () => {
   };
 
   return (
-    <SearchContainer
-      classifications={pool?.classifications?.filter(notEmpty) ?? []}
-      cmoAssets={pool?.assetCriteria?.filter(notEmpty) ?? []}
-      pool={pool ?? undefined}
-      poolOwner={pool?.owner ?? undefined}
-      candidateFilter={candidateFilter}
-      candidateCount={candidateCount}
-      updatePending={countFetching}
-      updateCandidateFilter={setCandidateFilter}
-      updateInitialValues={setInitialValues}
-      handleSubmit={onSubmit}
-    />
+    <Pending {...{ fetching, error }}>
+      <SearchContainer
+        classifications={pool?.classifications?.filter(notEmpty) ?? []}
+        cmoAssets={pool?.assetCriteria?.filter(notEmpty) ?? []}
+        pool={pool ?? undefined}
+        poolOwner={pool?.owner ?? undefined}
+        candidateFilter={candidateFilter}
+        candidateCount={candidateCount}
+        updatePending={countFetching}
+        updateCandidateFilter={setCandidateFilter}
+        updateInitialValues={setInitialValues}
+        handleSubmit={onSubmit}
+      />
+    </Pending>
   );
 };


### PR DESCRIPTION
Resolves #4212 

## Summary

This fixes an issue with the page not scrolling to a hash on page load.

## Details

Our `<ScrollToTop />` component was forcing the page to the top on every page load. This adds some code to check for a hash then wait for the matching element to exist in the DOM before scrolling to it.

## Testing

> **Note**
> Please test in as many browsers you have available and note the browser and version you were using when you encounter any issues.

1. Build talentsearch `npm run production --workspace=talentsearch`
2. Navigate to `/search#results`
3. Ensure it scrolls to the results element