### PR TITLE
Bug - 4203 - Remove data-h2 from react-helmet

### DIFF
--- a/frontend/admin/src/js/components/PoolDashboard.tsx
+++ b/frontend/admin/src/js/components/PoolDashboard.tsx
@@ -8,7 +8,6 @@ import { AuthenticationContext } from "@common/components/Auth";
 import { getLocale } from "@common/helpers/localize";
 import { checkFeatureFlag } from "@common/helpers/runtimeVariable";
 
-import Pending from "@common/components/Pending";
 import { AdminRoutes, useAdminRoutes } from "../adminRoutes";
 import { Role } from "../api/generated";
 

--- a/frontend/admin/src/js/components/PoolDashboard.tsx
+++ b/frontend/admin/src/js/components/PoolDashboard.tsx
@@ -456,12 +456,12 @@ export const PoolDashboard: React.FC = () => {
   const paths = useAdminRoutes();
   const intl = useIntl();
   return (
-    <Pending fetching={false}>
+    <>
       <Dashboard contentRoutes={routes(paths, loggedIn)} />
       <Helmet>
-        <html lang={getLocale(intl)} data-h2 />
+        <html lang={getLocale(intl)} />
       </Helmet>
-    </Pending>
+    </>
   );
 };
 

--- a/frontend/indigenousapprenticeship/src/js/components/Router.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/Router.tsx
@@ -79,7 +79,7 @@ export const Router: React.FC = () => {
         contentRoutes={routes(indigenousApprenticeshipPaths, locale)}
       />
       <Helmet>
-        <html lang={locale} data-h2 />
+        <html lang={locale} />
       </Helmet>
       <Toast />
     </ClientProvider>


### PR DESCRIPTION
Resolves #4203 

## Summary

This removes the `data-h2` attribute from `react-helment` components so it is always on the `html` element.

## Details 

We had `data-h2` on the html and within `<Helmet />` . This allowed `react-helmet` to take responsibility for it causing it to be removed while it figured out the locale. Removing it from `<Helmet />` gave the `index.html` responsibility and it never gets removed now.

## Testing

1. Build admin `npm run production --admin`
2. Navigate to `/admin`
3. Navigate to different pages and ensure hydrogen styles are always applied to the `<Loading />` spinner