### PR TITLE
Bug - Fix admin suspense

### DIFF
--- a/frontend/admin/src/js/components/PoolDashboard.tsx
+++ b/frontend/admin/src/js/components/PoolDashboard.tsx
@@ -8,6 +8,7 @@ import { AuthenticationContext } from "@common/components/Auth";
 import { getLocale } from "@common/helpers/localize";
 import { checkFeatureFlag } from "@common/helpers/runtimeVariable";
 
+import Pending from "@common/components/Pending";
 import { AdminRoutes, useAdminRoutes } from "../adminRoutes";
 import { Role } from "../api/generated";
 
@@ -455,12 +456,12 @@ export const PoolDashboard: React.FC = () => {
   const paths = useAdminRoutes();
   const intl = useIntl();
   return (
-    <>
+    <Pending loading={false}>
       <Dashboard contentRoutes={routes(paths, loggedIn)} />
       <Helmet>
         <html lang={getLocale(intl)} />
       </Helmet>
-    </>
+    </Pending>
   );
 };
 

--- a/frontend/admin/src/js/components/PoolDashboard.tsx
+++ b/frontend/admin/src/js/components/PoolDashboard.tsx
@@ -456,7 +456,7 @@ export const PoolDashboard: React.FC = () => {
   const paths = useAdminRoutes();
   const intl = useIntl();
   return (
-    <Pending loading={false}>
+    <Pending fetching={false}>
       <Dashboard contentRoutes={routes(paths, loggedIn)} />
       <Helmet>
         <html lang={getLocale(intl)} />


### PR DESCRIPTION
## Summary

Did not think we needed the `Pending` component in `PoolDashboard` but we do, this reverts that change.

## Testing

1. Confirm `/admin` loads
2. Confirm storybook works