### PR TITLE
a11y - 3833 - Unique TOC IDs

### DIFF
--- a/frontend/common/src/components/TableOfContents/Navigation.tsx
+++ b/frontend/common/src/components/TableOfContents/Navigation.tsx
@@ -1,16 +1,18 @@
 import React from "react";
+import uniqueId from "lodash/uniqueId";
 import { useIntl } from "react-intl";
 
 import Sidebar from "./Sidebar";
 
 const Navigation: React.FC = ({ children, ...rest }) => {
   const intl = useIntl();
+  const id = uniqueId();
 
   return (
     <Sidebar>
       <div data-h2-text-align="base(left) l-tablet(right)" {...rest}>
         <p
-          id="toc-heading"
+          id={`toc-heading-${id}`}
           data-h2-font-size="base(h5, 1)"
           data-h2-font-weight="base(700)"
           data-h2-padding="base(x3, 0, x1, 0)"
@@ -22,7 +24,7 @@ const Navigation: React.FC = ({ children, ...rest }) => {
           })}
         </p>
         <nav
-          aria-labelledby="toc-heading"
+          aria-labelledby={`toc-heading-${id}`}
           data-h2-display="base(flex)"
           data-h2-flex-direction="base(column)"
           data-h2-align-items="base(flex-start) l-tablet(flex-end)"


### PR DESCRIPTION
Resolves #3833 

## Summary

This makes the `id` in the `TableOfContents.Navigation` component unique so that it can be used more than once on a page.

## Testing

1. Build admin `npm run production --workspace=admin`
2. Navigate to `/admin/users`
3. Click "View" link on any user
4. Run axeDevtools and confirm no errors appear
5. Inspect the "On this page" headings in the tabs to ensure they contain unique `id` attributes