### PR TITLE
Pool publishing group

### DIFF
--- a/api/app/GraphQL/Validators/Mutation/PublishPoolAdvertisementValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/PublishPoolAdvertisementValidator.php
@@ -46,6 +46,7 @@ final class PublishPoolAdvertisementValidator extends Validator
             'is_remote' => ['required', 'boolean'],
             'advertisement_location.en' => ['required_if:is_remote,false', 'required_with:advertisement_location.fr', 'string'],
             'advertisement_location.fr' => ['required_if:is_remote,false', 'required_with:advertisement_location.en', 'string'],
+            'publishing_group' => ['required', Rule::in(ApiEnums::publishingGroups())],
         ];
     }
 

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -28,6 +28,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property boolean $is_published
  * @property string $stream
  * @property string $process_number
+ * @property string $publishing_group
  * @property Illuminate\Support\Carbon $created_at
  * @property Illuminate\Support\Carbon $updated_at
  * @property Illuminate\Support\Carbon $expiry_date

--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -46,6 +46,7 @@ class PoolFactory extends Factory
             'is_remote' => $isRemote,
             'stream' => $this->faker->optional->randomElement(ApiEnums::poolStreams()),
             'process_number' => $this->faker->optional->word(),
+            'publishing_group' => $this->faker->optional->randomElement(ApiEnums::publishingGroups()),
         ];
     }
 

--- a/api/database/helpers/ApiEnums.php
+++ b/api/database/helpers/ApiEnums.php
@@ -321,4 +321,20 @@ class ApiEnums
             self::ARMED_FORCES_NON_CAF,
         ];
     }
+
+     /**
+     * Publishing Groups
+     */
+    const PUBLISHING_GROUP_IT_JOBS = 'IT_JOBS';
+    const PUBLISHING_GROUP_EXECUTIVE_JOBS = 'EXECUTIVE_JOBS';
+    const PUBLISHING_GROUP_OTHER = 'OTHER';
+
+    public static function publishingGroups() : array
+    {
+        return [
+            self::PUBLISHING_GROUP_IT_JOBS,
+            self::PUBLISHING_GROUP_EXECUTIVE_JOBS,
+            self::PUBLISHING_GROUP_OTHER,
+        ];
+    }
 }

--- a/api/database/migrations/2022_10_06_130017_create_pool_publishing_group.php
+++ b/api/database/migrations/2022_10_06_130017_create_pool_publishing_group.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+// Create a new pool publishing group column #4200
+class CreatePoolPublishingGroup extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pools', function (Blueprint $table) {
+            $table->string('publishing_group')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('pools', function (Blueprint $table) {
+            $table->dropColumn('publishing_group');
+        });
+    }
+}

--- a/api/database/seeders/PoolSeeder.php
+++ b/api/database/seeders/PoolSeeder.php
@@ -31,6 +31,7 @@ class PoolSeeder extends Seeder
                 'is_published' => true,
                 'expiry_date' => config('constants.far_future_date'),
                 'pool_status' => ApiEnums::POOL_STATUS_TAKING_APPLICATIONS,
+                'publishing_group' => ApiEnums::PUBLISHING_GROUP_IT_JOBS,
             ],
             [
                 'name' => [
@@ -39,6 +40,7 @@ class PoolSeeder extends Seeder
                 ],
                 'key' => 'indigenous_apprenticeship',
                 'user_id' => User::where('email', 'admin@test.com')->first()->id,
+                'publishing_group' => ApiEnums::PUBLISHING_GROUP_OTHER,
             ],
         ];
 

--- a/api/database/seeders/PoolSeederUat.php
+++ b/api/database/seeders/PoolSeederUat.php
@@ -42,7 +42,8 @@ class PoolSeederUat extends Seeder
                 //     'en' => '',
                 //     'fr' => ''
                 // ], // TODO: Replace with real world text.
-                'pool_status' => ApiEnums::POOL_STATUS_NOT_TAKING_APPLICATIONS
+                'pool_status' => ApiEnums::POOL_STATUS_NOT_TAKING_APPLICATIONS,
+                'publishing_group' => ApiEnums::PUBLISHING_GROUP_IT_JOBS,
             ]
         );
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -269,6 +269,7 @@ type Pool {
     @rename(attribute: "advertisement_status")
   stream: PoolStream
   processNumber: String @rename(attribute: "process_number")
+  publishingGroup: PublishingGroup @rename(attribute: "publishing_group")
 }
 
 enum PoolStatus {
@@ -308,6 +309,7 @@ type PoolAdvertisement {
   nonessentialSkills: [Skill!] @belongsToMany
   stream: PoolStream
   processNumber: String @rename(attribute: "process_number")
+  publishingGroup: PublishingGroup @rename(attribute: "publishing_group")
 }
 
 enum AdvertisementStatus {
@@ -347,6 +349,12 @@ enum PoolAdvertisementLanguage {
   VARIOUS
   BILINGUAL_INTERMEDIATE
   BILINGUAL_ADVANCED
+}
+
+enum PublishingGroup {
+  IT_JOBS
+  EXECUTIVE_JOBS
+  OTHER
 }
 
 type PoolCandidate {
@@ -1175,6 +1183,7 @@ input CreatePoolInput {
   keyTasks: LocalizedStringInput @rename(attribute: "key_tasks")
   status: PoolStatus = NOT_TAKING_APPLICATIONS @rename(attribute: "pool_status")
   processNumber: String @rename(attribute: "process_number")
+  publishingGroup: PublishingGroup @rename(attribute: "publishing_group")
 }
 
 input UpdateClassificationInput {
@@ -1221,6 +1230,7 @@ input UpdatePoolInput {
   status: PoolStatus @rename(attribute: "pool_status")
   stream: PoolStream
   processNumber: String @rename(attribute: "process_number")
+  publishingGroup: PublishingGroup @rename(attribute: "publishing_group")
 }
 
 input CreateDepartmentInput {
@@ -1449,6 +1459,7 @@ input UpdatePoolAdvertisementInput {
   advertisementLocation: LocalizedStringInput
     @rename(attribute: "advertisement_location")
   isRemote: Boolean @rename(attribute: "is_remote")
+  publishingGroup: PublishingGroup @rename(attribute: "publishing_group")
 }
 
 type Mutation {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -318,6 +318,7 @@ input CreatePoolInput {
   keyTasks: LocalizedStringInput
   status: PoolStatus = NOT_TAKING_APPLICATIONS
   processNumber: String
+  publishingGroup: PublishingGroup
 }
 
 input CreateSkillFamilyInput {
@@ -785,6 +786,7 @@ type Pool {
   advertisementStatus: AdvertisementStatus
   stream: PoolStream
   processNumber: String
+  publishingGroup: PublishingGroup
 }
 
 type PoolAdvertisement {
@@ -805,6 +807,7 @@ type PoolAdvertisement {
   nonessentialSkills: [Skill!]
   stream: PoolStream
   processNumber: String
+  publishingGroup: PublishingGroup
 }
 
 enum PoolAdvertisementLanguage {
@@ -957,6 +960,12 @@ enum ProvinceOrTerritory {
   YUKON
   NORTHWEST_TERRITORIES
   NUNAVUT
+}
+
+enum PublishingGroup {
+  IT_JOBS
+  EXECUTIVE_JOBS
+  OTHER
 }
 
 type Query {
@@ -1247,6 +1256,7 @@ input UpdatePoolAdvertisementInput {
   securityClearance: SecurityStatus
   advertisementLocation: LocalizedStringInput
   isRemote: Boolean
+  publishingGroup: PublishingGroup
 }
 
 input UpdatePoolCandidateAsAdminInput {
@@ -1284,6 +1294,7 @@ input UpdatePoolInput {
   status: PoolStatus
   stream: PoolStream
   processNumber: String
+  publishingGroup: PublishingGroup
 }
 
 input UpdateSkillFamilyInput {

--- a/frontend/admin/src/js/components/pool/EditPool/OtherRequirementsSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/OtherRequirementsSection.tsx
@@ -107,7 +107,9 @@ export const OtherRequirementsSection = ({
           : null,
       isRemote: formValues.locationOption === LocationOption.RemoteOptional,
       securityClearance: formValues.securityRequirement,
-      publishingGroup: formValues.publishingGroup,
+      publishingGroup: formValues.publishingGroup
+        ? formValues.publishingGroup
+        : undefined, // can't be set to null, assume not updating if empty
     });
   };
 

--- a/frontend/admin/src/js/components/pool/EditPool/OtherRequirementsSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/OtherRequirementsSection.tsx
@@ -6,13 +6,16 @@ import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { enumToOptions } from "@common/helpers/formUtils";
 import {
   getLanguageRequirement,
+  getPublishingGroup,
   getSecurityClearance,
 } from "@common/constants/localizedConstants";
 import {
   AdvertisementStatus,
   LocalizedString,
+  Maybe,
   PoolAdvertisement,
   PoolAdvertisementLanguage,
+  PublishingGroup,
   SecurityStatus,
   UpdatePoolAdvertisementInput,
 } from "../../../api/generated";
@@ -30,6 +33,7 @@ type FormValues = {
   locationOption: LocationOption;
   specificLocationEn?: LocalizedString["en"];
   specificLocationFr?: LocalizedString["fr"];
+  publishingGroup: Maybe<PublishingGroup>;
 };
 
 export type OtherRequirementsSubmitData = Pick<
@@ -38,6 +42,7 @@ export type OtherRequirementsSubmitData = Pick<
   | "advertisementLocation"
   | "securityClearance"
   | "isRemote"
+  | "publishingGroup"
 >;
 
 interface OtherRequirementsSectionProps {
@@ -62,6 +67,7 @@ export const OtherRequirementsSection = ({
       : LocationOption.SpecificLocation,
     specificLocationEn: initialData.advertisementLocation?.en,
     specificLocationFr: initialData.advertisementLocation?.fr,
+    publishingGroup: initialData.publishingGroup,
   });
 
   const methods = useForm<FormValues>({
@@ -101,6 +107,7 @@ export const OtherRequirementsSection = ({
           : null,
       isRemote: formValues.locationOption === LocationOption.RemoteOptional,
       securityClearance: formValues.securityRequirement,
+      publishingGroup: formValues.publishingGroup,
     });
   };
 
@@ -247,6 +254,26 @@ export const OtherRequirementsSection = ({
               </div>
             </>
           ) : undefined}
+          <div data-h2-display="base(flex)">
+            <Spacer style={{ flex: 1 }}>
+              <Select
+                id="publishingGroup"
+                label={intl.formatMessage({
+                  defaultMessage: "Publishing group",
+                  id: "tQ674x",
+                  description:
+                    "Label displayed on the edit pool form publishing group field.",
+                })}
+                name="publishingGroup"
+                options={enumToOptions(PublishingGroup).map(({ value }) => ({
+                  value,
+                  label: intl.formatMessage(getPublishingGroup(value)),
+                }))}
+                disabled={formDisabled}
+              />
+            </Spacer>
+            <Spacer style={{ flex: 1 }} />
+          </div>
 
           {!formDisabled && (
             <Submit

--- a/frontend/admin/src/js/components/pool/EditPool/editPoolOperations.graphql
+++ b/frontend/admin/src/js/components/pool/EditPool/editPoolOperations.graphql
@@ -85,6 +85,7 @@ query getEditPoolData($poolId: ID!) {
     }
     stream
     processNumber
+    publishingGroup
   }
 
   # all classifications to populate form dropdown

--- a/frontend/common/src/constants/localizedConstants.tsx
+++ b/frontend/common/src/constants/localizedConstants.tsx
@@ -26,6 +26,7 @@ import {
   ArmedForcesStatus,
   BilingualEvaluation,
   PoolStream,
+  PublishingGroup,
 } from "../api/generated";
 import { getOrThrowError } from "../helpers/util";
 
@@ -1520,4 +1521,31 @@ export const getPoolCandidatePriorities = (
     poolCandidatePriorities,
     priorityWeight,
     `Invalid Candidate Priority Weight '${priorityWeight}'`,
+  );
+
+export const publishingGroups = defineMessages({
+  [PublishingGroup.ExecutiveJobs]: {
+    defaultMessage: "Executive Jobs",
+    id: "Mixlw/",
+    description: "The publishing group called Executive Jobs",
+  },
+  [PublishingGroup.ItJobs]: {
+    defaultMessage: "IT Jobs",
+    id: "C8nrGM",
+    description: "The publishing group called IT Jobs",
+  },
+  [PublishingGroup.Other]: {
+    defaultMessage: "Other",
+    id: "mv7JO3",
+    description: "The publishing group called Other",
+  },
+});
+
+export const getPublishingGroup = (
+  publishingGroup: string | number,
+): MessageDescriptor =>
+  getOrThrowError(
+    publishingGroups,
+    publishingGroup,
+    `Invalid publishing group '${publishingGroup}'`,
   );

--- a/frontend/common/src/fakeData/fakePools.ts
+++ b/frontend/common/src/fakeData/fakePools.ts
@@ -7,6 +7,7 @@ import {
   UserPublicProfile,
   PoolStatus,
   PoolStream,
+  PublishingGroup,
 } from "../api/generated";
 import fakeUsers from "./fakeUsers";
 import fakeClassifications from "./fakeClassifications";
@@ -45,6 +46,9 @@ const generatePool = (
     status: faker.helpers.arrayElement<PoolStatus>(Object.values(PoolStatus)),
     stream: faker.helpers.arrayElement<PoolStream>(Object.values(PoolStream)),
     processNumber: faker.helpers.maybe(() => faker.lorem.word()),
+    publishingGroup: faker.helpers.maybe(() =>
+      faker.helpers.arrayElement(Object.values(PublishingGroup)),
+    ),
   };
 };
 

--- a/frontend/common/src/messages/apiMessages.ts
+++ b/frontend/common/src/messages/apiMessages.ts
@@ -144,6 +144,12 @@ export const messages: { [key: string]: MessageDescriptor } = defineMessages({
     description:
       "Error message that the pool advertisement must have location filled.",
   },
+  "publishing group required": {
+    defaultMessage: "You are missing a required field: Publishing group",
+    id: "nPKPFa",
+    description:
+      "Error message that the pool advertisement must have publishing group filled.",
+  },
 });
 
 export const tryFindMessageDescriptor = (

--- a/frontend/cypress/integration/admin/pools.spec.js
+++ b/frontend/cypress/integration/admin/pools.spec.js
@@ -112,6 +112,14 @@ describe("Pools", () => {
           .should('have.text', securityRequirement);
       });
 
+    const publishingGroup = "Other"
+    cy.findByRole("combobox", { name: /publishing group/i })
+      .select(publishingGroup)
+      .within(() => {
+        cy.get("option:selected")
+          .should('have.text', publishingGroup);
+      });
+
     cy.findByRole("button", { name: /save other requirements/i }).click();
     expectUpdate();
   });

--- a/frontend/cypress/integration/talentsearch/submit-application-workflows.spec.js
+++ b/frontend/cypress/integration/talentsearch/submit-application-workflows.spec.js
@@ -4,6 +4,7 @@ import {
   PoolAdvertisementLanguage,
   PoolStream,
   ProvinceOrTerritory,
+  PublishingGroup,
   SecurityStatus,
   WorkRegion,
 } from "../../../admin/src/js/api/generated";
@@ -112,6 +113,7 @@ describe("Submit Application Workflow Tests", () => {
                     fr: "test location FR",
                   },
                   isRemote: true,
+                  publishingGroup: PublishingGroup.Other,
                 }).then(() => {
                   cy.publishPoolAdvertisement(testPoolAdvertisementId);
                 });


### PR DESCRIPTION
This branch adds a publishing group field to pool advertisement.

## Testing
1. Test migrations and seeders, observe there is a new `publishing_group` column on `pools`
```
php artisan migrate
php artisan migrate:rollback --step=1
php artisan migrate:fresh --seed
```
2. Open storybook and confirm that the Edit Pool Form stories show a populated value
1. Build and launch the site, create a new pool candidate, observe that field starts empty
1. Fill and save all the other fields, try to publish, observe an error messages tells you to fill it
1. Fill the field, save, observe that it is saved
1. Change the field, save, observe that it is saved
1. Publish the pool, observe that it is successful
1. Run the e2e tests and confirm no failures

Closes #4200 