### PR TITLE
a11y - 4247 - Remove nested h2

### DIFF
--- a/frontend/admin/src/js/components/pool/EditPool/AssetSkillsSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/AssetSkillsSection.tsx
@@ -58,8 +58,8 @@ export const AssetSkillsSection = ({
 
   return (
     <TableOfContents.Section id={sectionMetadata.id}>
-      <TableOfContents.Heading>
-        <h2 data-h2-margin="base(x3, 0, x1, 0)">{sectionMetadata.title}</h2>
+      <TableOfContents.Heading data-h2-margin="base(x3, 0, x1, 0)">
+        {sectionMetadata.title}
       </TableOfContents.Heading>
       <p data-h2-margin="base(x1, 0)">
         {intl.formatMessage({

--- a/frontend/admin/src/js/components/pool/EditPool/ClosingDateSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/ClosingDateSection.tsx
@@ -65,8 +65,8 @@ export const ClosingDateSection = ({
 
   return (
     <TableOfContents.Section id={sectionMetadata.id}>
-      <TableOfContents.Heading>
-        <h2 data-h2-margin="base(x3, 0, 0, 0)">{sectionMetadata.title}</h2>
+      <TableOfContents.Heading data-h2-margin="base(x3, 0, 0, 0)">
+        {sectionMetadata.title}
       </TableOfContents.Heading>
       <FormProvider {...methods}>
         <form onSubmit={handleSubmit(handleSave)}>

--- a/frontend/admin/src/js/components/pool/EditPool/EssentialSkillsSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/EssentialSkillsSection.tsx
@@ -57,8 +57,8 @@ export const EssentialSkillsSection = ({
 
   return (
     <TableOfContents.Section id={sectionMetadata.id}>
-      <TableOfContents.Heading>
-        <h2 data-h2-margin="base(x3, 0, x1, 0)">{sectionMetadata.title}</h2>
+      <TableOfContents.Heading data-h2-margin="base(x3, 0, x1, 0)">
+        {sectionMetadata.title}
       </TableOfContents.Heading>
       <p data-h2-margin="base(x1, 0)">
         {intl.formatMessage({

--- a/frontend/admin/src/js/components/pool/EditPool/OtherRequirementsSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/OtherRequirementsSection.tsx
@@ -115,8 +115,8 @@ export const OtherRequirementsSection = ({
 
   return (
     <TableOfContents.Section id={sectionMetadata.id}>
-      <TableOfContents.Heading>
-        <h2 data-h2-margin="base(x3, 0, x1, 0)">{sectionMetadata.title}</h2>
+      <TableOfContents.Heading data-h2-margin="base(x3, 0, x1, 0)">
+        {sectionMetadata.title}
       </TableOfContents.Heading>
       <p data-h2-margin="base(x1, 0)">
         {intl.formatMessage({

--- a/frontend/admin/src/js/components/pool/EditPool/PoolNameSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/PoolNameSection.tsx
@@ -110,8 +110,8 @@ export const PoolNameSection = ({
 
   return (
     <TableOfContents.Section id={sectionMetadata.id}>
-      <TableOfContents.Heading>
-        <h2 data-h2-margin="base(x3, 0, x1, 0)">{sectionMetadata.title}</h2>
+      <TableOfContents.Heading data-h2-margin="base(x3, 0, x1, 0)">
+        {sectionMetadata.title}
       </TableOfContents.Heading>
       <p>
         {intl.formatMessage({

--- a/frontend/admin/src/js/components/pool/EditPool/StatusSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/StatusSection.tsx
@@ -52,8 +52,8 @@ export const StatusSection = ({
 
   return (
     <TableOfContents.Section id={sectionMetadata.id}>
-      <TableOfContents.Heading>
-        <h2 data-h2-margin="base(x3, 0, x1, 0)">{sectionMetadata.title}</h2>
+      <TableOfContents.Heading data-h2-margin="base(x3, 0, x1, 0)">
+        {sectionMetadata.title}
       </TableOfContents.Heading>
       <p data-h2-margin="base(x1, 0)">
         {intl.formatMessage({

--- a/frontend/admin/src/js/components/pool/EditPool/WorkTasksSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/WorkTasksSection.tsx
@@ -75,8 +75,8 @@ export const WorkTasksSection = ({
 
   return (
     <TableOfContents.Section id={sectionMetadata.id}>
-      <TableOfContents.Heading>
-        <h2 data-h2-margin="base(x3, 0, x1, 0)">{sectionMetadata.title}</h2>
+      <TableOfContents.Heading data-h2-margin="base(x3, 0, x1, 0)">
+        {sectionMetadata.title}
       </TableOfContents.Heading>
       <p>
         {intl.formatMessage({

--- a/frontend/admin/src/js/components/pool/EditPool/YourImpactSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/YourImpactSection.tsx
@@ -75,8 +75,8 @@ export const YourImpactSection = ({
 
   return (
     <TableOfContents.Section id={sectionMetadata.id}>
-      <TableOfContents.Heading>
-        <h2 data-h2-margin="base(x3, 0, x1, 0)">{sectionMetadata.title}</h2>
+      <TableOfContents.Heading data-h2-margin="base(x3, 0, x1, 0)">
+        {sectionMetadata.title}
       </TableOfContents.Heading>
       <p>
         {intl.formatMessage({

--- a/frontend/admin/src/js/components/user/UserProfile.tsx
+++ b/frontend/admin/src/js/components/user/UserProfile.tsx
@@ -23,6 +23,7 @@ const UserProfileApi: React.FunctionComponent<{
       {userData?.applicant ? (
         <UserProfile
           applicant={userData.applicant}
+          headingLevel="h3"
           sections={{
             about: {
               isVisible: true,

--- a/frontend/common/src/components/TableOfContents/Heading.tsx
+++ b/frontend/common/src/components/TableOfContents/Heading.tsx
@@ -6,16 +6,17 @@ import "./heading.css";
 
 export interface HeadingProps {
   as?: HeadingLevel;
+  size?: HeadingLevel;
   icon?: React.FC<React.HTMLAttributes<HTMLOrSVGElement>>;
 }
 
 const TOCHeading: React.FC<
   HeadingProps & Omit<HTMLAttributes<HTMLHeadingElement>, "color">
-> = ({ icon, children, as = "h2", ...rest }) => {
+> = ({ icon, children, as = "h2", size = "h3", ...rest }) => {
   const Icon = icon;
 
   return (
-    <Heading level={as} Icon={Icon} {...rest}>
+    <Heading level={as} size={size} Icon={Icon} {...rest}>
       {children}
     </Heading>
   );

--- a/frontend/common/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/common/src/components/UserProfile/UserProfile.tsx
@@ -23,6 +23,7 @@ import WorkPreferencesSection from "./ProfileSections/WorkPreferencesSection";
 import DiversityEquityInclusionSection from "./ProfileSections/DiversityEquityInclusionSection";
 import RoleSalarySection from "./ProfileSections/RoleSalarySection";
 import ExperienceSection from "./ExperienceSection";
+import type { HeadingLevel } from "../Heading";
 
 import { notEmpty } from "../../helpers/util";
 import type { Applicant } from "../../api/generated";
@@ -51,6 +52,7 @@ export interface UserProfileProps {
   };
   isNavigationVisible?: boolean;
   subTitle?: React.ReactNode;
+  headingLevel?: HeadingLevel;
 }
 
 const HeadingWrapper: React.FC<{ show: boolean }> = ({ children, show }) => {
@@ -93,6 +95,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
   applicant,
   sections,
   subTitle,
+  headingLevel = "h2",
   isNavigationVisible = true,
 }) => {
   const intl = useIntl();
@@ -212,7 +215,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading icon={LightBulbIcon}>
+                <TableOfContents.Heading as={headingLevel} icon={LightBulbIcon}>
                   {intl.formatMessage({
                     defaultMessage: "My Status",
                     id: "Cx3s+E",
@@ -248,7 +251,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading icon={UserGroupIcon}>
+                <TableOfContents.Heading as={headingLevel} icon={UserGroupIcon}>
                   {intl.formatMessage({
                     defaultMessage: "My hiring pools",
                     id: "fNOekV",
@@ -289,7 +292,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading icon={UserIcon}>
+                <TableOfContents.Heading as={headingLevel} icon={UserIcon}>
                   {intl.formatMessage({
                     defaultMessage: "About Me",
                     id: "CnB8IO",
@@ -333,7 +336,10 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading icon={ChatBubbleLeftRightIcon}>
+                <TableOfContents.Heading
+                  as={headingLevel}
+                  icon={ChatBubbleLeftRightIcon}
+                >
                   {intl.formatMessage({
                     defaultMessage: "Language Information",
                     id: "1pk/7X",
@@ -378,7 +384,10 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading icon={BuildingLibraryIcon}>
+                <TableOfContents.Heading
+                  as={headingLevel}
+                  icon={BuildingLibraryIcon}
+                >
                   {intl.formatMessage({
                     defaultMessage: "Government Information",
                     id: "l1cou8",
@@ -423,7 +432,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading icon={MapPinIcon}>
+                <TableOfContents.Heading as={headingLevel} icon={MapPinIcon}>
                   {intl.formatMessage({
                     defaultMessage: "Work Location",
                     id: "F9R74z",
@@ -467,7 +476,10 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading icon={HandThumbUpIcon}>
+                <TableOfContents.Heading
+                  as={headingLevel}
+                  icon={HandThumbUpIcon}
+                >
                   {intl.formatMessage({
                     defaultMessage: "Work Preferences",
                     id: "V89Ryn",
@@ -512,7 +524,10 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading as="h2" icon={UserCircleIcon}>
+                <TableOfContents.Heading
+                  as={headingLevel}
+                  icon={UserCircleIcon}
+                >
                   {intl.formatMessage({
                     defaultMessage: "Diversity, equity and inclusion",
                     id: "inzzdo",
@@ -558,10 +573,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-text-align="base(center) p-tablet(left)"
               >
                 <TableOfContents.Heading
-                  as="h2"
-                  data-h2-font-size="base(h3)"
-                  data-h2-font-weight="base(400)"
-                  data-h2-margin="base(x1.5, 0, x.25, 0)"
+                  as={headingLevel}
                   icon={CurrencyDollarIcon}
                 >
                   {intl.formatMessage({
@@ -608,13 +620,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading
-                  as="h2"
-                  data-h2-font-size="base(h3)"
-                  data-h2-font-weight="base(400)"
-                  data-h2-margin="base(x1.5, 0, x.25, 0)"
-                  icon={BoltIcon}
-                >
+                <TableOfContents.Heading as={headingLevel} icon={BoltIcon}>
                   {intl.formatMessage({
                     defaultMessage: "My skills and experience",
                     id: "Eui2Wf",

--- a/frontend/common/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/common/src/components/UserProfile/UserProfile.tsx
@@ -212,13 +212,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading
-                  as="h2"
-                  data-h2-font-size="base(h3)"
-                  data-h2-font-weight="base(400)"
-                  data-h2-margin="base(x1.5, 0, x.25, 0)"
-                  icon={LightBulbIcon}
-                >
+                <TableOfContents.Heading icon={LightBulbIcon}>
                   {intl.formatMessage({
                     defaultMessage: "My Status",
                     id: "Cx3s+E",
@@ -254,13 +248,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading
-                  as="h2"
-                  data-h2-font-size="base(h3)"
-                  data-h2-font-weight="base(400)"
-                  data-h2-margin="base(x1.5, 0, x.25, 0)"
-                  icon={UserGroupIcon}
-                >
+                <TableOfContents.Heading icon={UserGroupIcon}>
                   {intl.formatMessage({
                     defaultMessage: "My hiring pools",
                     id: "fNOekV",
@@ -301,13 +289,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading
-                  as="h2"
-                  data-h2-font-size="base(h3)"
-                  data-h2-font-weight="base(400)"
-                  data-h2-margin="base(x1.5, 0, x.25, 0)"
-                  icon={UserIcon}
-                >
+                <TableOfContents.Heading icon={UserIcon}>
                   {intl.formatMessage({
                     defaultMessage: "About Me",
                     id: "CnB8IO",
@@ -351,13 +333,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading
-                  as="h2"
-                  data-h2-font-size="base(h3)"
-                  data-h2-font-weight="base(400)"
-                  data-h2-margin="base(x1.5, 0, x.25, 0)"
-                  icon={ChatBubbleLeftRightIcon}
-                >
+                <TableOfContents.Heading icon={ChatBubbleLeftRightIcon}>
                   {intl.formatMessage({
                     defaultMessage: "Language Information",
                     id: "1pk/7X",
@@ -402,13 +378,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading
-                  as="h2"
-                  data-h2-font-size="base(h3)"
-                  data-h2-font-weight="base(400)"
-                  data-h2-margin="base(x1.5, 0, x.25, 0)"
-                  icon={BuildingLibraryIcon}
-                >
+                <TableOfContents.Heading icon={BuildingLibraryIcon}>
                   {intl.formatMessage({
                     defaultMessage: "Government Information",
                     id: "l1cou8",
@@ -453,13 +423,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading
-                  as="h2"
-                  data-h2-font-size="base(h3)"
-                  data-h2-font-weight="base(400)"
-                  data-h2-margin="base(x1.5, 0, x.25, 0)"
-                  icon={MapPinIcon}
-                >
+                <TableOfContents.Heading icon={MapPinIcon}>
                   {intl.formatMessage({
                     defaultMessage: "Work Location",
                     id: "F9R74z",
@@ -503,13 +467,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading
-                  as="h2"
-                  data-h2-font-size="base(h3)"
-                  data-h2-font-weight="base(400)"
-                  data-h2-margin="base(x1.5, 0, x.25, 0)"
-                  icon={HandThumbUpIcon}
-                >
+                <TableOfContents.Heading icon={HandThumbUpIcon}>
                   {intl.formatMessage({
                     defaultMessage: "Work Preferences",
                     id: "V89Ryn",
@@ -554,13 +512,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 data-h2-flex-item="base(1of1) p-tablet(fill)"
                 data-h2-text-align="base(center) p-tablet(left)"
               >
-                <TableOfContents.Heading
-                  as="h2"
-                  data-h2-font-size="base(h3)"
-                  data-h2-font-weight="base(400)"
-                  data-h2-margin="base(x1.5, 0, x.25, 0)"
-                  icon={UserCircleIcon}
-                >
+                <TableOfContents.Heading as="h2" icon={UserCircleIcon}>
                   {intl.formatMessage({
                     defaultMessage: "Diversity, equity and inclusion",
                     id: "inzzdo",


### PR DESCRIPTION
Resolves #4247 

## Summary

This removes the nested `<h2> elements on the `EditPool` page.

## Testing

1. Build admin `npm run production --workspace=admin`
2. Navigate to a pool `/admin/pools/{poolId}/edit`
3. Confirm there are no nested `<h2>` elements or errors in the console