### PR TITLE
a11y - 3836 - Remove nested labels, checkbox

### DIFF
--- a/frontend/admin/src/js/components/pool/EditPool/EditPool.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/EditPool.tsx
@@ -206,10 +206,7 @@ export const EditPoolForm = ({
       <Breadcrumbs links={links} />
       <div data-h2-container="base(left, large, 0)">
         <TableOfContents.Wrapper>
-          <TableOfContents.Navigation
-            data-h2-background-color="base(dt-gray.light)"
-            data-h2-radius="base(s)"
-          >
+          <TableOfContents.Navigation>
             <TableOfContents.AnchorLink id={sectionMetadata.poolName.id}>
               {sectionMetadata.poolName.title}
             </TableOfContents.AnchorLink>

--- a/frontend/common/src/components/form/Checkbox/Checkbox.tsx
+++ b/frontend/common/src/components/form/Checkbox/Checkbox.tsx
@@ -82,21 +82,19 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
             data-h2-align-items="base(center)"
             style={{ width: "100%" }}
           >
-            <label htmlFor={id}>
-              <input
-                id={id}
-                {...register(name, rules)}
-                type="checkbox"
-                aria-invalid={error ? "true" : "false"}
-                {...rest}
-              />
-              <span
-                data-h2-margin="base(0, 0, 0, x.25)"
-                data-h2-font-size="base(copy)"
-              >
-                {label}
-              </span>
-            </label>
+            <input
+              id={id}
+              {...register(name, rules)}
+              type="checkbox"
+              aria-invalid={error ? "true" : "false"}
+              {...rest}
+            />
+            <span
+              data-h2-margin="base(0, 0, 0, x.25)"
+              data-h2-font-size="base(copy)"
+            >
+              {label}
+            </span>
           </div>
         </InputWrapper>
       )}

--- a/frontend/common/src/components/form/Checkbox/Checkbox.tsx
+++ b/frontend/common/src/components/form/Checkbox/Checkbox.tsx
@@ -42,7 +42,10 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
   const error = get(errors, name)?.message;
 
   return (
-    <div data-h2-margin="base(0, 0, x.125, 0)">
+    <div
+      data-h2-position="base(relative)"
+      data-h2-margin="base(0, 0, x.125, 0)"
+    >
       {!boundingBox ? (
         <InputWrapper
           inputId={id}
@@ -72,6 +75,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
           required={!!rules.required}
           context={context}
           error={error}
+          fillLabel
         >
           <div
             data-h2-background-color="base(dt-white)"

--- a/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
+++ b/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
@@ -40,7 +40,7 @@ const InputLabel: React.FC<InputLabelProps> = ({
 
   const labelStyles = {
     "data-h2-margin": "base(0, x.125, 0, 0)",
-    "data-h2-flex-grow": appendLabel ? "base(1)" : undefined,
+    "data-h2-flex-grow": appendLabel ? undefined : "base(1)",
     ...labelSize,
   };
 

--- a/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
+++ b/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
@@ -3,6 +3,8 @@ import { QuestionMarkCircleIcon, XCircleIcon } from "@heroicons/react/24/solid";
 import { useIntl } from "react-intl";
 import { commonMessages } from "../../../messages";
 
+import "./input-label.css";
+
 export interface InputLabelProps {
   inputId: string;
   label: string | React.ReactNode;
@@ -12,12 +14,14 @@ export interface InputLabelProps {
   contextToggleHandler?: (contextIsActive: boolean) => void;
   hideOptional?: boolean;
   hideBottomMargin?: boolean;
+  fillLabel?: boolean;
 }
 
 const InputLabel: React.FC<InputLabelProps> = ({
   inputId,
   label,
   labelSize,
+  fillLabel = false,
   required,
   contextToggleHandler = () => {
     /* returns nothing */
@@ -34,6 +38,12 @@ const InputLabel: React.FC<InputLabelProps> = ({
   const intl = useIntl();
   const appendLabel = required || !hideOptional || contextIsVisible;
 
+  const labelStyles = {
+    "data-h2-margin": "base(0, x.125, 0, 0)",
+    "data-h2-flex-grow": appendLabel ? "base(1)" : undefined,
+    ...labelSize,
+  };
+
   return (
     <div
       data-h2-display="base(flex)"
@@ -44,19 +54,24 @@ const InputLabel: React.FC<InputLabelProps> = ({
       {...(!hideBottomMargin && {
         "data-h2-margin": "base(0, 0, x.125, 0)",
       })}
+      {...(!hideBottomMargin && {
+        "data-h2-margin": "base(0, 0, x.125, 0)",
+      })}
     >
       <label
-        {...labelSize}
-        data-h2-margin="base(0, x.125, 0, 0)"
-        {...(!appendLabel && {
-          "data-h2-flex-grow": "base(1)",
-        })}
+        className={`InputLabel${fillLabel ? " InputLabel--fill" : ""}`}
+        {...labelStyles}
         htmlFor={inputId}
       >
         {label}
       </label>
       {appendLabel && (
-        <div data-h2-display="base(flex)" data-h2-align-items="base(center)">
+        <div
+          data-h2-position="base(relative)"
+          data-h2-display="base(flex)"
+          data-h2-align-items="base(center)"
+          style={{ zIndex: 10 }}
+        >
           {
             /** If hideOptional is true, only show text if required is true. */
             (required || !hideOptional) && (

--- a/frontend/common/src/components/inputPartials/InputLabel/input-label.css
+++ b/frontend/common/src/components/inputPartials/InputLabel/input-label.css
@@ -1,0 +1,14 @@
+.InputLabel {
+  z-index: 1;
+}
+
+.InputLabel--fill:after {
+  bottom: 0;
+  content: "";
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 100%;
+  z-index: 1;
+}

--- a/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
+++ b/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
@@ -13,6 +13,7 @@ export interface InputWrapperProps {
   context?: string;
   hideOptional?: boolean;
   hideBottomMargin?: boolean;
+  fillLabel?: boolean;
 }
 
 const InputWrapper: React.FC<InputWrapperProps> = ({
@@ -26,6 +27,7 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
   hideOptional,
   children,
   hideBottomMargin,
+  fillLabel = false,
   ...rest
 }) => {
   const [contextVisible, setContextVisible] = useState(false);
@@ -45,6 +47,7 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
           inputId={inputId}
           label={label}
           labelSize={fontSize}
+          fillLabel={fillLabel}
           required={required}
           contextIsVisible={context !== undefined && context !== ""}
           contextToggleHandler={setContextVisible}

--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.test.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.test.tsx
@@ -179,10 +179,10 @@ describe("ExperienceForm", () => {
       screen.getByRole("textbox", { name: /experience description/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("checkbox", { name: /i agree/i }),
+      screen.getByRole("checkbox", { name: /disclaimer/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("checkbox", { name: /currently active/i }),
+      screen.getByRole("checkbox", { name: /current experience/i }),
     ).toBeInTheDocument();
 
     expect(screen.getByLabelText("Start Date")).toBeInTheDocument();
@@ -208,7 +208,7 @@ describe("ExperienceForm", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: /team/i })).toBeInTheDocument();
     expect(
-      screen.getByRole("checkbox", { name: /currently active/i }),
+      screen.getByRole("checkbox", { name: /current role/i }),
     ).toBeInTheDocument();
 
     expect(screen.getByLabelText("Start Date")).toBeInTheDocument();


### PR DESCRIPTION
Resolves #3836 

## Summary

This removes the wrapping `<label>` element which was providing a second label to the checkbox when `boundingBox={true}` .

## Testing

1. Build talentsearch `npm run production --workspace=talentsearch`
2. Navigate to the following experience forms and confirm is only one label for the bonding box checkboxes
    - Community
    - Education
    - Personal
    - Work