### PR TITLE
Advertise correct jobs

### DIFF
--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Builder;
+use Carbon\Carbon;
 
 /**
  * Class Pool
@@ -129,5 +131,11 @@ class Pool extends Model
         } else {
             return null;
         }
+    }
+
+    public function scopeWasPublished(Builder $query, ?array $args)
+    {
+        $query->where('published_at', '<=', Carbon::now()->toDateTimeString());
+        return $query;
     }
 }

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -62,7 +62,7 @@ class Pool extends Model
      * The attributes that can be filled using mass-assignment.
      *
      * @var array
-    */
+     */
     protected $fillable = [
         'is_remote',
         'expiry_date',
@@ -120,18 +120,14 @@ class Pool extends Model
             $isPublished = false;
         }
 
-        if(!$isPublished){
+        if (!$isPublished) {
             return ApiEnums::POOL_ADVERTISEMENT_IS_DRAFT;
-
-        } elseif($isPublished && !$isExpired){
+        } elseif ($isPublished && !$isExpired) {
             return ApiEnums::POOL_ADVERTISEMENT_IS_PUBLISHED;
-
-        } elseif($isPublished && $isExpired){
+        } elseif ($isPublished && $isExpired) {
             return ApiEnums::POOL_ADVERTISEMENT_IS_EXPIRED;
-
-        } else{
+        } else {
             return null;
-
         }
     }
 }

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -20,6 +20,7 @@ use App\Models\EducationExperience;
 use App\Models\GenericJobTitle;
 use App\Models\PersonalExperience;
 use App\Models\WorkExperience;
+use Database\Factories\PoolFactory;
 use Faker;
 use Database\Helpers\ApiEnums;
 
@@ -45,6 +46,8 @@ class DatabaseSeeder extends Seeder
         $this->call(SkillSeeder::class);
         $this->call(UserSeederLocal::class);
         $this->call(PoolSeeder::class);
+
+        Pool::factory()->count(10)->create();
 
         User::factory([
             'roles' => [ApiEnums::ROLE_APPLICANT]

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -806,6 +806,8 @@ type Query {
   pool(id: ID! @eq): Pool @find
   poolAdvertisement(id: ID! @eq): PoolAdvertisement @find(model: "Pool")
   poolAdvertisements: [PoolAdvertisement]! @all(model: "Pool")
+  publishedPoolAdvertisements: [PoolAdvertisement!]!
+    @all(model: "Pool", scopes: ["wasPublished"])
   poolByKey(key: String! @eq): Pool @find
   pools: [Pool]! @all
   poolCandidate(id: ID! @eq): PoolCandidate

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -978,6 +978,7 @@ type Query {
   pool(id: ID!): Pool
   poolAdvertisement(id: ID!): PoolAdvertisement
   poolAdvertisements: [PoolAdvertisement]!
+  publishedPoolAdvertisements: [PoolAdvertisement!]!
   poolByKey(key: String!): Pool
   pools: [Pool]!
   poolCandidate(id: ID!): PoolCandidate

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -151,4 +151,34 @@ class PoolTest extends TestCase
         ]
     ]);
   }
+
+  // The publishedPoolAdvertisements query should only return pools that have been published
+  public function testPoolAdvertisementQueryReturnsOnlyPublished(): void
+  {
+    // this pool has been published so it should be returned in the publishedPool query
+    $publishedPool = Pool::factory()->create([
+        'published_at' => config('constants.past_date'),
+    ]);
+    // this pool is still a draft so it should not be returned in the publishedPool query
+    $draftPool = Pool::factory()->create([
+        'published_at' => null,
+    ]);
+
+    // Assert query will return only the published pool
+    $this->graphQL(/** @lang Graphql */ '
+        query browsePools {
+            publishedPoolAdvertisements {
+              id
+            }
+          }
+    ')->assertJson([
+         "data" => [
+            "publishedPoolAdvertisements" => [
+               [
+                   "id" => $publishedPool->id,
+               ],
+            ]
+        ]
+    ]);
+  }
 }

--- a/frontend/cypress/integration/admin/pools.spec.js
+++ b/frontend/cypress/integration/admin/pools.spec.js
@@ -129,8 +129,12 @@ describe("Pools", () => {
    */
    it("should update the pool", () => {
     // Navigate to edit pool page
-    cy.findByRole("link", { name: /edit test pool en/i })
-      .click();
+    cy.findByRole("textbox", { name: /search/i })
+      .clear()
+      .type("test");
+
+    const editLinks = cy.findAllByRole("link", { name: /edit test pool en/i });
+    editLinks.first().click();
 
     cy.wait("@gqlgetEditPoolDataQuery");
 
@@ -156,8 +160,13 @@ describe("Pools", () => {
    * Delete the Pool
    */
   it("should delete the pool", () => {
-    cy.findByRole("link", { name: /edit test pool en/i })
-      .click();
+    // Navigate to edit pool page
+    cy.findByRole("textbox", { name: /search/i })
+      .clear()
+      .type("test");
+
+    const editLinks = cy.findAllByRole("link", { name: /edit test pool en/i });
+    editLinks.first().click();
 
     cy.wait("@gqlgetEditPoolDataQuery");
 

--- a/frontend/cypress/integration/talentsearch/submit-application-workflows.spec.js
+++ b/frontend/cypress/integration/talentsearch/submit-application-workflows.spec.js
@@ -113,7 +113,7 @@ describe("Submit Application Workflow Tests", () => {
                     fr: "test location FR",
                   },
                   isRemote: true,
-                  publishingGroup: PublishingGroup.Other,
+                  publishingGroup: PublishingGroup.ItJobs,
                 }).then(() => {
                   cy.publishPoolAdvertisement(testPoolAdvertisementId);
                 });

--- a/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.test.tsx
+++ b/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * @jest-environment jsdom
+ */
+import "@testing-library/jest-dom";
+import { render, screen, act } from "@testing-library/react";
+import React from "react";
+import { IntlProvider, MessageFormatElement } from "react-intl";
+import { axeTest } from "@common/helpers/testUtils";
+import { BrowsePools, BrowsePoolsProps } from "./BrowsePoolsPage";
+import {
+  AdvertisementStatus,
+  PoolAdvertisement,
+  PublishingGroup,
+} from "../../api/generated";
+
+const publishedItJobsPool: PoolAdvertisement = {
+  id: "publishedItJobsPool",
+  publishingGroup: PublishingGroup.ItJobs,
+  advertisementStatus: AdvertisementStatus.Published,
+};
+
+const expiredItJobsPool: PoolAdvertisement = {
+  id: "expiredItJobsPool",
+  publishingGroup: PublishingGroup.ItJobs,
+  advertisementStatus: AdvertisementStatus.Expired,
+};
+
+const archivedItJobsPool: PoolAdvertisement = {
+  id: "archivedItJobsPool",
+  publishingGroup: PublishingGroup.ItJobs,
+  advertisementStatus: AdvertisementStatus.Archived,
+};
+
+const publishedExecJobsPool: PoolAdvertisement = {
+  id: "publishedExecJobsPool",
+  publishingGroup: PublishingGroup.ExecutiveJobs,
+  advertisementStatus: AdvertisementStatus.Published,
+};
+
+const renderWithReactIntl = (
+  component: React.ReactNode,
+  locale?: "en" | "fr",
+  messages?: Record<string, string> | Record<string, MessageFormatElement[]>,
+) => {
+  return render(
+    <IntlProvider locale={locale || "en"} messages={messages}>
+      {component}
+    </IntlProvider>,
+  );
+};
+
+const renderBrowsePoolsPage = ({ poolAdvertisements }: BrowsePoolsProps) =>
+  renderWithReactIntl(<BrowsePools poolAdvertisements={poolAdvertisements} />);
+
+describe("BrowsePoolsPage", () => {
+  it("should have no accessibility errors", async () => {
+    await act(async () => {
+      const { container } = renderBrowsePoolsPage({
+        poolAdvertisements: [publishedItJobsPool],
+      });
+      await axeTest(container);
+    });
+  });
+
+  it("should only show published jobs", async () => {
+    await act(async () => {
+      renderBrowsePoolsPage({
+        poolAdvertisements: [
+          // draft pools can not be returned by API query
+          publishedItJobsPool,
+          expiredItJobsPool,
+          archivedItJobsPool,
+        ],
+      });
+
+      const links = await screen.queryAllByRole("link", {
+        name: /Apply to this recruitment/i,
+      });
+
+      expect(links).toHaveLength(1);
+      expect(links[0]).toHaveAttribute(
+        "href",
+        expect.stringContaining(publishedItJobsPool.id),
+      );
+      expect(links[0]).not.toHaveAttribute(
+        "href",
+        expect.stringContaining(expiredItJobsPool.id),
+      );
+      expect(links[0]).not.toHaveAttribute(
+        "href",
+        expect.stringContaining(archivedItJobsPool.id),
+      );
+    });
+  });
+
+  it("should only show IT jobs", async () => {
+    await act(async () => {
+      renderBrowsePoolsPage({
+        poolAdvertisements: [publishedItJobsPool, publishedExecJobsPool],
+      });
+
+      const links = await screen.queryAllByRole("link", {
+        name: /Apply to this recruitment/i,
+      });
+
+      expect(links).toHaveLength(1);
+      expect(links[0]).toHaveAttribute(
+        "href",
+        expect.stringContaining(publishedItJobsPool.id),
+      );
+      expect(links[0]).not.toHaveAttribute(
+        "href",
+        expect.stringContaining(publishedExecJobsPool.id),
+      );
+    });
+  });
+
+  // sort logic: by expiry date whichever one expires first should appear first on the list
+  // sort logic: if they have the same expiry date, whichever one was published first should appear first
+  it("should properly sort jobs", async () => {
+    await act(async () => {
+      // should appear first: it expires first even though it was published later
+      const expiresFirst = {
+        ...publishedItJobsPool,
+        id: "expiresFirst",
+        publishedAt: "2000-02-01 00:00:00",
+        expiryDate: "2999-01-01 00:00:00",
+      };
+
+      // should appear second: tie for expiring second, has first publish date
+      const publishedFirst = {
+        ...publishedItJobsPool,
+        id: "publishedFirst",
+        publishedAt: "2000-01-01 00:00:00",
+        expiryDate: "2999-02-01 00:00:00",
+      };
+
+      // should appear third: tie for expiring second, has second publish date
+      const publishedSecond = {
+        ...publishedItJobsPool,
+        id: "publishedSecond",
+        publishedAt: "2000-01-02 00:00:00",
+        expiryDate: "2999-02-01 00:00:00",
+      };
+
+      renderBrowsePoolsPage({
+        // pass data to the page in an intentionally reversed order
+        poolAdvertisements: [publishedSecond, publishedFirst, expiresFirst],
+      });
+
+      // find the rendered links
+      const links = await screen.queryAllByRole("link", {
+        name: /Apply to this recruitment/i,
+      });
+
+      // ensure there are the right number and in the right order
+      expect(links).toHaveLength(3);
+      expect(links[0]).toHaveAttribute(
+        "href",
+        expect.stringContaining(expiresFirst.id),
+      );
+      expect(links[1]).toHaveAttribute(
+        "href",
+        expect.stringContaining(publishedFirst.id),
+      );
+      expect(links[2]).toHaveAttribute(
+        "href",
+        expect.stringContaining(publishedSecond.id),
+      );
+    });
+  });
+});

--- a/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.test.tsx
+++ b/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.test.tsx
@@ -4,7 +4,6 @@
 import "@testing-library/jest-dom";
 import { screen, act } from "@testing-library/react";
 import React from "react";
-import { IntlProvider, MessageFormatElement } from "react-intl";
 import { axeTest, render } from "@common/helpers/testUtils";
 import { BrowsePools, BrowsePoolsProps } from "./BrowsePoolsPage";
 import {

--- a/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.test.tsx
+++ b/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.test.tsx
@@ -2,10 +2,10 @@
  * @jest-environment jsdom
  */
 import "@testing-library/jest-dom";
-import { render, screen, act } from "@testing-library/react";
+import { screen, act } from "@testing-library/react";
 import React from "react";
 import { IntlProvider, MessageFormatElement } from "react-intl";
-import { axeTest } from "@common/helpers/testUtils";
+import { axeTest, render } from "@common/helpers/testUtils";
 import { BrowsePools, BrowsePoolsProps } from "./BrowsePoolsPage";
 import {
   AdvertisementStatus,
@@ -37,20 +37,8 @@ const publishedExecJobsPool: PoolAdvertisement = {
   advertisementStatus: AdvertisementStatus.Published,
 };
 
-const renderWithReactIntl = (
-  component: React.ReactNode,
-  locale?: "en" | "fr",
-  messages?: Record<string, string> | Record<string, MessageFormatElement[]>,
-) => {
-  return render(
-    <IntlProvider locale={locale || "en"} messages={messages}>
-      {component}
-    </IntlProvider>,
-  );
-};
-
 const renderBrowsePoolsPage = ({ poolAdvertisements }: BrowsePoolsProps) =>
-  renderWithReactIntl(<BrowsePools poolAdvertisements={poolAdvertisements} />);
+  render(<BrowsePools poolAdvertisements={poolAdvertisements} />);
 
 describe("BrowsePoolsPage", () => {
   it("should have no accessibility errors", async () => {

--- a/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.tsx
+++ b/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.tsx
@@ -49,7 +49,7 @@ export const BrowsePools: React.FC<BrowsePoolsProps> = ({
               key={poolAdvertisement.id}
               data-h2-margin="base(x0.5, 0, x0.5, 0)"
             >
-              <PoolCard pool={poolAdvertisement} />
+              <PoolCard pool={poolAdvertisement} headingLevel="h2" />
             </li>
           ))}
         </ul>

--- a/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.tsx
+++ b/frontend/talentsearch/src/js/components/browse/BrowsePoolsPage.tsx
@@ -4,17 +4,33 @@ import Pending from "@common/components/Pending";
 import NotFound from "@common/components/NotFound";
 import { commonMessages } from "@common/messages";
 import {
+  AdvertisementStatus,
+  PublishingGroup,
   PoolAdvertisement,
   useBrowsePoolAdvertisementsQuery,
 } from "../../api/generated";
 import PoolCard from "./PoolCard";
 
-interface BrowsePoolsProps {
-  poolAdvertisements?: PoolAdvertisement[];
+export interface BrowsePoolsProps {
+  poolAdvertisements: PoolAdvertisement[];
 }
 
-const BrowsePools: React.FC<BrowsePoolsProps> = ({ poolAdvertisements }) => {
+export const BrowsePools: React.FC<BrowsePoolsProps> = ({
+  poolAdvertisements,
+}) => {
   const intl = useIntl();
+
+  const filteredPoolAdvertisements = poolAdvertisements
+    .filter(
+      (p) =>
+        p.advertisementStatus === AdvertisementStatus.Published && // list jobs which have the PUBLISHED AdvertisementStatus
+        p.publishingGroup === PublishingGroup.ItJobs, // and which are meant to be published on the IT Jobs page
+    )
+    .sort(
+      (p1, p2) =>
+        (p1.expiryDate ?? "").localeCompare(p2.expiryDate ?? "") || // first level sort: by expiry date whichever one expires first should appear first on the list
+        (p1.publishedAt ?? "").localeCompare(p2.publishedAt ?? ""), // second level sort: whichever one was published first should appear first
+    );
 
   return (
     <>
@@ -25,9 +41,9 @@ const BrowsePools: React.FC<BrowsePoolsProps> = ({ poolAdvertisements }) => {
           description: "Page title for the direct intake browse pools page.",
         })}
       </h1>
-      {poolAdvertisements && poolAdvertisements.length ? (
+      {filteredPoolAdvertisements.length ? (
         <ul>
-          {poolAdvertisements.map((poolAdvertisement) => (
+          {filteredPoolAdvertisements.map((poolAdvertisement) => (
             <li
               data-h2-list-style="base(none)"
               key={poolAdvertisement.id}
@@ -56,7 +72,7 @@ const BrowsePools: React.FC<BrowsePoolsProps> = ({ poolAdvertisements }) => {
 const BrowsePoolsApi: React.FC = () => {
   const [{ data, fetching, error }] = useBrowsePoolAdvertisementsQuery();
 
-  const filteredPoolAdvertisements = data?.poolAdvertisements.filter(
+  const filteredPoolAdvertisements = data?.publishedPoolAdvertisements.filter(
     (poolAdvertisement) =>
       typeof poolAdvertisement !== undefined && !!poolAdvertisement,
   ) as PoolAdvertisement[];

--- a/frontend/talentsearch/src/js/components/browse/PoolCard.tsx
+++ b/frontend/talentsearch/src/js/components/browse/PoolCard.tsx
@@ -10,6 +10,7 @@ import {
 } from "@common/helpers/localize";
 import { formattedDateMonthDayYear } from "@common/helpers/dateUtils";
 import Heading, { type HeadingLevel } from "@common/components/Heading";
+import { hidden } from "@common/helpers/format";
 import { PoolAdvertisement } from "../../api/generated";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
 
@@ -178,7 +179,7 @@ const PoolCard = ({
                   "Message on link that say to apply to a recruitment advertisement",
                 id: "1zkApr",
               },
-              { name: classificationResult },
+              { name: classificationResult, hidden },
             )}
           </Link>
         </div>

--- a/frontend/talentsearch/src/js/components/browse/browseOperations.graphql
+++ b/frontend/talentsearch/src/js/components/browse/browseOperations.graphql
@@ -1,5 +1,5 @@
 query browsePoolAdvertisements {
-  poolAdvertisements {
+  publishedPoolAdvertisements {
     id
     name {
       en
@@ -89,6 +89,8 @@ query browsePoolAdvertisements {
     }
     stream
     processNumber
+    publishedAt
+    publishingGroup
   }
 }
 


### PR DESCRIPTION
## Introduction
This branch adds a new query in the schema scoped to only return pool advertisements that have been published.  The browse opportunities page also filters the pools to just unexpired IT Jobs and sorts them by published and expired dates.

## Testing
1. Run phpunit tests and observe that they all pass
2. Reseed your database
3. Run jest tests and observer that they all pass
4. Navigate to `http://localhost:8000/en/browse/pools` and observe that [the correct pools appear in the correct order](https://github.com/gctc-ntgc/gc-digital-talent/issues/4202)
5. Navigate to the admin site to ensure that all pools can still be managed as usual

A graphql query to help with testing:
```
query q {
  publishedPoolAdvertisements {
    id
    name {
      en
      fr
    }
    publishedAt
    expiryDate
    publishingGroup    
    advertisementStatus
  }
}
```

A SQL query to help with testing:
```
select id, name, publishing_group, published_at, expiry_date  
from pools
order by publishing_group, published_at, expiry_date
```


Closes #4202 