### PR TITLE
a11y - 4206 - Increase chip touch area

### DIFF
--- a/frontend/common/src/components/Chip/Chip.stories.tsx
+++ b/frontend/common/src/components/Chip/Chip.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
 import Chip from "./Chip";
+import Chips from "./Chips";
 import type { ChipProps } from "./Chip";
 
 export default {
@@ -36,13 +37,13 @@ const TemplateNoDismissChip: Story<ChipProps> = (args) => {
 
 const TemplateMultiChip: Story<ChipProps> = (args) => {
   return (
-    <>
+    <Chips>
       <Chip {...args} />
       <Chip {...args} />
       <Chip {...args} />
       <Chip {...args} />
       <Chip {...args} />
-    </>
+    </Chips>
   );
 };
 

--- a/frontend/common/src/components/Chip/Chip.tsx
+++ b/frontend/common/src/components/Chip/Chip.tsx
@@ -16,38 +16,6 @@ export interface ChipProps extends React.HTMLProps<HTMLElement> {
   label: string;
 }
 
-type ChipColor = "primary" | "secondary" | "neutral";
-
-const colorMap: Record<
-  ChipColor,
-  Record<"solid" | "outline", Record<string, string>>
-> = {
-  primary: {
-    solid: {
-      "data-h2-color": "base(dt-white)",
-    },
-    outline: {
-      "data-h2-color": "base(dark.dt-primary)",
-    },
-  },
-  secondary: {
-    solid: {
-      "data-h2-color": "base(dt-white)",
-    },
-    outline: {
-      "data-h2-color": "base(dark.dt-secondary)",
-    },
-  },
-  neutral: {
-    solid: {
-      "data-h2-color": "base(dt-white)",
-    },
-    outline: {
-      "data-h2-color": "base(dark.dt-gray)",
-    },
-  },
-};
-
 const ChipDismiss = (props: React.ComponentProps<"button">) => (
   <button
     type="button"

--- a/frontend/common/src/components/Chip/Chip.tsx
+++ b/frontend/common/src/components/Chip/Chip.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { XCircleIcon } from "@heroicons/react/24/outline";
+import { useIntl } from "react-intl";
 import Pill from "../Pill";
+
+import "./chip.css";
 
 export interface ChipProps extends React.HTMLProps<HTMLElement> {
   /** The style type of the element. */
@@ -13,8 +16,10 @@ export interface ChipProps extends React.HTMLProps<HTMLElement> {
   label: string;
 }
 
+type ChipColor = "primary" | "secondary" | "neutral";
+
 const colorMap: Record<
-  "primary" | "secondary" | "neutral",
+  ChipColor,
   Record<"solid" | "outline", Record<string, string>>
 > = {
   primary: {
@@ -43,32 +48,63 @@ const colorMap: Record<
   },
 };
 
+const ChipDismiss = (props: React.ComponentProps<"button">) => (
+  <button
+    type="button"
+    data-h2-background-color="base(transparent)"
+    data-h2-border="base(none)"
+    data-h2-cursor="base(pointer)"
+    data-h2-padding="base(0)"
+    data-h2-radius="base(m)"
+    data-h2-shadow="base(none) base:hover(s)"
+    {...props}
+  />
+);
+
 const Chip: React.FC<ChipProps> = ({
   color,
   mode,
   onDismiss,
   label,
 }): React.ReactElement => {
+  const intl = useIntl();
+  const wrapperProps = onDismiss
+    ? {
+        className: `Chip__Dismiss Chip__Dismiss--${color}`,
+        onClick: onDismiss,
+        "aria-label": intl.formatMessage(
+          {
+            defaultMessage: "Remove {label}",
+            id: "rsxrMs",
+            description: "Button text for a dismissible chip",
+          },
+          {
+            label,
+          },
+        ),
+      }
+    : {};
+
+  const Wrapper = onDismiss ? ChipDismiss : React.Fragment;
+
   return (
-    <Pill
-      color={color}
-      mode={mode}
-      role="listitem"
-      data-h2-padding="base(x.25, x.5)"
-    >
-      {label}
-      {onDismiss && (
-        <XCircleIcon
-          data-h2-cursor="base(pointer)"
-          data-h2-width="base(1rem)"
-          data-h2-margin="base(0, 0, 0, x.25)"
-          data-h2-vertical-align="base(middle)"
-          {...colorMap[color][mode]}
-          role="button"
-          onClick={onDismiss}
-        />
-      )}
-    </Pill>
+    <Wrapper {...wrapperProps}>
+      <Pill
+        color={color}
+        mode={mode}
+        role="listitem"
+        data-h2-padding="base(x.25, x.5)"
+      >
+        {label}
+        {onDismiss && (
+          <XCircleIcon
+            data-h2-width="base(1rem)"
+            data-h2-margin="base(0, 0, 0, x.25)"
+            data-h2-vertical-align="base(middle)"
+          />
+        )}
+      </Pill>
+    </Wrapper>
   );
 };
 

--- a/frontend/common/src/components/Chip/chip.css
+++ b/frontend/common/src/components/Chip/chip.css
@@ -1,0 +1,16 @@
+.Chip__Dismiss:focus-visible {
+  outline: 2px solid;
+  outline-offset: 2px;
+}
+
+.Chip__Dismiss--primary:focus-visible {
+  outline-color: var(--h2-color-dt-primary);
+}
+
+.Chip__Dismiss--secondary:focus-visible {
+  outline-color: var(--h2-color-dt-secondary);
+}
+
+.Chip__Dismiss--gray:focus-visible {
+  outline-color: var(--h2-color-dt-gray);
+}

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1437,5 +1437,9 @@
   "2Ckihd": {
     "defaultMessage": "Trouvé <primary>{skillCount}</primary> compétences.",
     "description": "The number of skills found within the skill picker."
+  },
+  "rsxrMs": {
+    "defaultMessage": "Retirer {label}",
+    "description": "Button text for a dismissible chip"
   }
 }

--- a/frontend/talentsearch/src/js/components/skills/AddedSkills/AddedSkills.test.tsx
+++ b/frontend/talentsearch/src/js/components/skills/AddedSkills/AddedSkills.test.tsx
@@ -56,9 +56,8 @@ describe("AddedSkills tests", () => {
     const onDismiss = jest.fn();
     const skill = fakeSkills()[0];
     renderContainer([skill], onDismiss);
-    const chip = screen.getByRole("listitem");
-    const dismissButton = chip.querySelector("[role='button']"); // not sure why getByRole doesn't work here
-    if (dismissButton) fireEvent.click(dismissButton);
+    const chip = screen.getByRole("button");
+    if (chip) fireEvent.click(chip);
     expect(onDismiss).toHaveBeenCalledWith(skill.id);
   });
 });


### PR DESCRIPTION
Resolves #4206 

## Summary

This wraps a dismissible chip in a button, increasing the touch area. As well, it adds an `aria-label` to improve context for the button action.

## Testing

1. Run storybook `npm run storybook --workspace=common`
2. Open the "Chip Dismiss" story
3. Confirm the following
    - you can click on any area of the 
    - has focus indicator
    - has hover indicator 