### PR TITLE
Bug - Fix Sign and Submit page typos

### DIFF
--- a/frontend/talentsearch/src/js/components/signAndSubmit/SignAndSubmitPage.tsx
+++ b/frontend/talentsearch/src/js/components/signAndSubmit/SignAndSubmitPage.tsx
@@ -110,9 +110,9 @@ const SignatureForm = ({
       description: "Signature list item on sign and submit page.",
     }),
     intl.formatMessage({
-      defaultMessage: `"I promise that the information Ive provided is
+      defaultMessage: `"I promise that the information I've provided is
         true"`,
-      id: "Lgo2iQ",
+      id: "9Eke1a",
       description: "Signature list item on sign and submit page.",
     }),
   ];

--- a/frontend/talentsearch/src/js/components/signAndSubmit/SignAndSubmitPage.tsx
+++ b/frontend/talentsearch/src/js/components/signAndSubmit/SignAndSubmitPage.tsx
@@ -99,8 +99,8 @@ const SignatureForm = ({
   const confirmations = [
     intl.formatMessage({
       defaultMessage: `"I've reviewed everything written in my
-        application`,
-      id: "aeI64y",
+        application"`,
+      id: "voTvve",
       description: "Signature list item on sign and submit page.",
     }),
     intl.formatMessage({


### PR DESCRIPTION
Resolves #4303.

### Notes
For whoever (possibly @petertgiles as part of #4025) is adding in the as of yet added French translation string, the IDs have changed for these strings have changed so there with have to be some manually work done to create the connection.

### Steps to test
1. Compile translations `npm run intl-compile --workspace=talentsearch`
2. Build talentsearch `npm run production --workspace=talentsearch`
3. Start storybook `npm run storybook --workspace=talentsearch`
4. Navigate to **Sign and Submit page** story
5. Verify signature list items on Sign and Submit page are correct

### Screenshot
![Screen Shot 2022-10-14 at 09 59 02](https://user-images.githubusercontent.com/3046459/195865546-78c05734-61b4-4d19-847c-10ec7506ba7a.png)