### PR TITLE
Test - 4309 - Fix Pool Candidate e2e

### DIFF
--- a/frontend/cypress/integration/admin/pool-candidate.spec.js
+++ b/frontend/cypress/integration/admin/pool-candidate.spec.js
@@ -103,6 +103,7 @@ describe("Pool Candidates", () => {
 
       cy.expectToast(/pool candidate status updated successfully/i);
     });
+
   } else {
     it("should edit and update pool candidate (FEATURE_APPLICANTSEARCH:off)", () => {
       cy.wait("@gqlgetPoolsQuery");
@@ -124,6 +125,8 @@ describe("Pool Candidates", () => {
         .and("be.visible");
 
       cy.findByLabelText(/expiry date/i).type("2023-12-01");
+
+      cy.findByLabelText(/language ability/i).select("English only");
 
       cy.findByLabelText(/status/i).select("Placed Casual");
 


### PR DESCRIPTION
Resolves #4309 

## Summary

This fixes the `should edit and update pool candidate (FEATURE_APPLICANTSEARCH:off)` for pool candidates.

## Details

If the first user has no language ability selected (previously required field) then it is not possible to submit the old form. This just selects "English only" to fill out all required fields.

## Testing

1. Make sure `FEATURE_APPLICANTSEARCH` feature flag is off
2. Run the cypress tests and confirm all `pool-candidate.spec.js` tests pass