### PR TITLE
Turn autocomplete off for skill picker search

### DIFF
--- a/frontend/common/src/components/SkillPicker/SkillPicker.tsx
+++ b/frontend/common/src/components/SkillPicker/SkillPicker.tsx
@@ -151,6 +151,7 @@ const SkillPicker = ({
             id: "PF4ya+",
             description: "Placeholder for the skills search bar.",
           })}
+          autoComplete="off"
         />
         <MultiSelectFieldV2
           id="skillFamilies"


### PR DESCRIPTION
## Introduction
This branch turns off autocomplete for the skill picker search box.
![image](https://user-images.githubusercontent.com/8978655/195912408-57d01bec-3318-4e5e-9c1b-9cfed1e1d5e5.png)

## Testing
1. Navigate to your profile
2. Add an experience
3. Type in the skill search input and observe there is no autocomplete

Closes #4286 