### PR TITLE
Admin - Fix untranslatable strings

### DIFF
--- a/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
@@ -424,7 +424,11 @@ const PoolCandidatesTable: React.FC<{ poolId: string }> = ({ poolId }) => {
   const handlePrint = useReactToPrint({
     content: () => componentRef.current,
     pageStyle: printStyles,
-    documentTitle: "Candidate Profiles",
+    documentTitle: intl.formatMessage({
+      defaultMessage: "Candidate Profiles",
+      id: "UmTNmR",
+      description: "Document title for printing Pool Candidate table results",
+    }),
   });
   const selectedCandidates =
     selectedCandidatesData?.poolCandidates.filter(notEmpty) ?? [];

--- a/frontend/admin/src/js/components/user/UserProfilePrintButton.tsx
+++ b/frontend/admin/src/js/components/user/UserProfilePrintButton.tsx
@@ -25,7 +25,11 @@ export const UserProfilePrintButton: React.FunctionComponent<{
   const handlePrint = useReactToPrint({
     content: () => componentRef.current,
     pageStyle: printStyles,
-    documentTitle: "Candidate Profile",
+    documentTitle: intl.formatMessage({
+      defaultMessage: "Candidate Profile",
+      id: "Thf4og",
+      description: "Document title for printing User profile",
+    }),
   });
 
   const userData = initialData;

--- a/frontend/admin/src/js/components/user/UserTable.tsx
+++ b/frontend/admin/src/js/components/user/UserTable.tsx
@@ -253,7 +253,11 @@ export const UserTable: React.FC = () => {
   const handlePrint = useReactToPrint({
     content: () => componentRef.current,
     pageStyle: printStyles,
-    documentTitle: "Candidate Profiles",
+    documentTitle: intl.formatMessage({
+      defaultMessage: "Candidate Profiles",
+      id: "IE82VM",
+      description: "Document title for printing User table results",
+    }),
   });
   const selectedApplicants =
     selectedUsersData?.applicants.filter(notEmpty) ?? [];

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -2296,5 +2296,9 @@
   "gLtTaW": {
     "defaultMessage": "demande",
     "description": "Text displayed after View text for Search Request table view action"
+  },
+  "Thf4og": {
+    "defaultMessage": "Profil du candidat",
+    "description": "Document title for printing User profile"
   }
 }

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -2300,5 +2300,13 @@
   "Thf4og": {
     "defaultMessage": "Profil du candidat",
     "description": "Document title for printing User profile"
+  },
+  "UmTNmR": {
+    "defaultMessage": "Profils des candidats",
+    "description": "Document title for printing Pool Candidate table results"
+  },
+  "IE82VM": {
+    "defaultMessage": "Profils des candidats",
+    "description": "Document title for printing User table results"
   }
 }


### PR DESCRIPTION
Resolves #4380.

## Steps to test

1. Compile French `npm run intl-compile --workspace=admin`
2. Build admin `npm run production --workspace=admin`
3. Navigate and login at `/fr/admin`
4. Verify Document title for printing User profile is _Profil du candidat_
5. Verify Document title for printing Pool Candidate table results is _Profils de candidats_
6. Verify Document title for printing User table results is _Profils de candidats_

## Notes
Since these components are already live on the production site, I have [added the French string for _Candidate Profile_](https://github.com/GCTC-NTGC/gc-digital-talent/pull/4382/commits/077b92965a110b1a996db24f10aa365e873ea6be) based on another equivalent that was already in the fr.json file and the [French strings for _Candidate Profiles_](https://github.com/GCTC-NTGC/gc-digital-talent/pull/4382/commits/64e77534dabbb0918e8a34cfb169d3a2bd145b32). <strike>I am not sure what</strike> the plural, _Candidate Profiles_, should be translated as:

1. Profils des candidats (thanks @gobyrne!)
5. <strike>Profils de candidats</strike>