### PR TITLE
Bug - Set SelectFieldV2 menu z-index higher than input label

### DIFF
--- a/frontend/common/src/components/form/Select/SelectFieldV2.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.tsx
@@ -252,6 +252,8 @@ const SelectFieldV2 = ({
                       ...provided,
                       ...accessibleTextStyle,
                     }),
+                    // Setting the z-index to 11 since the InputLabel is set to 10.
+                    menu: (provided) => ({ ...provided, zIndex: 11 }),
                   }}
                 />
               );


### PR DESCRIPTION
Resolves #4400 

This custom sets the react-select menu [Style Object](https://react-select.com/styles#style-object) to have a higher z-index (11) than the [InputLabel](https://github.com/GCTC-NTGC/gc-digital-talent/blob/feature/3875-pool-candidates-fancy-filter/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx#L73) (10).