### PR TITLE
Bug - Fix French copy for workRegionsDetailed North

### DIFF
--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -927,7 +927,7 @@
     "description": "The operational requirement described as regular overtime."
   },
   "/nMdQr": {
-    "defaultMessage": "<strong>Virtuel :</strong> Travailler de la maison, partout au Canada.",
+    "defaultMessage": "<strong>Région du Nord :</strong> Yukon, Territoires du Nord-Ouest et Nunavut.",
     "description": "The work region of Canada described as North."
   },
   "cnFVR1": {


### PR DESCRIPTION
Resolves #4311.

## Steps to test
1. Compile French `npm run intl-compile --workspace=common`
2. Build talentsearch `npm run production --workspace=talentsearch`
3. Navigate to My Profile > Work Location Preference
4. Toggle language to French
5. Verify there is checkbox with a label **Région du Nord** : Yukon, Territoires du Nord-Ouest et Nunavut.

## Screenshot
<img width="786" alt="Screen Shot 2022-10-20 at 13 59 30" src="https://user-images.githubusercontent.com/3046459/197023907-195301aa-8764-4c86-9d56-d7e16e61c402.png">
