### PR TITLE
Modify search page to search across all pools 

### DIFF
--- a/frontend/common/src/constants/NonExecutiveITClassifications.tsx
+++ b/frontend/common/src/constants/NonExecutiveITClassifications.tsx
@@ -1,0 +1,50 @@
+import { Classification } from "../api/generated";
+
+export default (): Classification[] => {
+  return [
+    {
+      id: "IT-01",
+      name: {
+        en: "Information Technology",
+        fr: "Technologie de l'information",
+      },
+      group: "IT",
+      level: 1,
+      minSalary: 50000,
+      maxSalary: 80000,
+    },
+    {
+      id: "IT-02",
+      name: {
+        en: "Information Technology",
+        fr: "Technologie de l'information",
+      },
+      group: "IT",
+      level: 2,
+      minSalary: 65000,
+      maxSalary: 94000,
+    },
+    {
+      id: "IT-03",
+      name: {
+        en: "Information Technology",
+        fr: "Technologie de l'information",
+      },
+      group: "IT",
+      level: 3,
+      minSalary: 83000,
+      maxSalary: 113000,
+    },
+    {
+      id: "IT-04",
+      name: {
+        en: "Information Technology",
+        fr: "Technologie de l'information",
+      },
+      group: "IT",
+      level: 4,
+      minSalary: 94000,
+      maxSalary: 130000,
+    },
+  ];
+};

--- a/frontend/common/src/constants/NonExecutiveITClassifications.tsx
+++ b/frontend/common/src/constants/NonExecutiveITClassifications.tsx
@@ -1,50 +1,22 @@
 import { Classification } from "../api/generated";
 
-export default (): Classification[] => {
+export default (): Pick<Classification, "group" | "level">[] => {
   return [
     {
-      id: "IT-01",
-      name: {
-        en: "Information Technology",
-        fr: "Technologie de l'information",
-      },
       group: "IT",
       level: 1,
-      minSalary: 50000,
-      maxSalary: 80000,
     },
     {
-      id: "IT-02",
-      name: {
-        en: "Information Technology",
-        fr: "Technologie de l'information",
-      },
       group: "IT",
       level: 2,
-      minSalary: 65000,
-      maxSalary: 94000,
     },
     {
-      id: "IT-03",
-      name: {
-        en: "Information Technology",
-        fr: "Technologie de l'information",
-      },
       group: "IT",
       level: 3,
-      minSalary: 83000,
-      maxSalary: 113000,
     },
     {
-      id: "IT-04",
-      name: {
-        en: "Information Technology",
-        fr: "Technologie de l'information",
-      },
       group: "IT",
       level: 4,
-      minSalary: 94000,
-      maxSalary: 130000,
     },
   ];
 };

--- a/frontend/talentsearch/src/js/api/poolCandidateOperations.graphql
+++ b/frontend/talentsearch/src/js/api/poolCandidateOperations.graphql
@@ -71,4 +71,73 @@ query getSearchFormData($poolKey: String!) {
       }
     }
   }
+
+}
+
+query getSearchFormDataAcrossAllPools {
+  pools {
+    id
+    key
+    owner {
+      email
+      firstName
+      lastName
+    }
+    name {
+      en
+      fr
+    }
+    description {
+      en
+      fr
+    }
+    classifications {
+      id
+      group
+      level
+    }
+    assetCriteria {
+      id
+      key
+      name {
+        en
+        fr
+      }
+    }
+    essentialCriteria {
+      id
+      key
+      name {
+        en
+        fr
+      }
+    }
+    operationalRequirements
+  }
+  skills {
+    id
+    key
+    name {
+      en
+      fr
+    }
+    description {
+      en
+      fr
+    }
+    keywords {
+      en
+      fr
+    }
+    families {
+      id
+      key
+      category
+      name {
+        en
+        fr
+      }
+    }
+  }
+
 }

--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -67,7 +67,7 @@ const applicantFilterToQueryArgs = (
 };
 
 export interface SearchContainerProps {
-  classifications: Classification[];
+  classifications: Pick<Classification, "group" | "level">[];
   pool?: Pick<Pool, "name" | "description">;
   poolOwner?: Pick<UserPublicProfile, "firstName" | "lastName" | "email">;
   skills?: Skill[];
@@ -245,7 +245,7 @@ const SearchContainerApi: React.FC = () => {
   return (
     <Pending {...{ fetching, error }}>
       <SearchContainer
-        classifications={NonExecutiveITClassifications() as Classification[]}
+        classifications={NonExecutiveITClassifications()}
         skills={skills as Skill[]}
         applicantFilter={applicantFilter}
         candidateCount={candidateCount}

--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -2,10 +2,10 @@ import React, { useRef } from "react";
 import { useIntl } from "react-intl";
 
 import { pushToStateThenNavigate } from "@common/helpers/router";
-import { notEmpty } from "@common/helpers/util";
 import pick from "lodash/pick";
 import { unpackMaybes } from "@common/helpers/formUtils";
 import Pending from "@common/components/Pending";
+import NonExecutiveITClassifications from "@common/constants/NonExecutiveITClassifications";
 import {
   Classification,
   CountApplicantsQueryVariables,
@@ -14,8 +14,8 @@ import {
   ApplicantFilterInput,
   Skill,
   useCountApplicantsQuery,
-  useGetSearchFormDataQuery,
   UserPublicProfile,
+  useGetSearchFormDataAcrossAllPoolsQuery,
 } from "../../api/generated";
 import EstimatedCandidates from "./EstimatedCandidates";
 import SearchFilterAdvice from "./SearchFilterAdvice";
@@ -23,7 +23,6 @@ import Spinner from "../Spinner";
 import CandidateResults from "./CandidateResults";
 import SearchForm, { SearchFormRef } from "./SearchForm";
 import { useTalentSearchRoutes } from "../../talentSearchRoutes";
-import { DIGITAL_CAREERS_POOL_KEY } from "../../talentSearchConstants";
 
 const applicantFilterToQueryArgs = (
   filter?: ApplicantFilterInput,
@@ -221,10 +220,7 @@ export const SearchContainer: React.FC<SearchContainerProps> = ({
 };
 
 const SearchContainerApi: React.FC = () => {
-  const [{ data, fetching, error }] = useGetSearchFormDataQuery({
-    variables: { poolKey: DIGITAL_CAREERS_POOL_KEY },
-  });
-  const pool = data?.poolByKey;
+  const [{ data, fetching, error }] = useGetSearchFormDataAcrossAllPoolsQuery();
   const skills = data?.skills;
 
   const [applicantFilter, setApplicantFilter] = React.useState<
@@ -233,18 +229,12 @@ const SearchContainerApi: React.FC = () => {
 
   const [{ data: countData, fetching: countFetching }] =
     useCountApplicantsQuery({
-      variables: applicantFilterToQueryArgs(applicantFilter, pool?.id),
+      variables: applicantFilterToQueryArgs(applicantFilter),
     });
 
   const candidateCount = countData?.countApplicants ?? 0;
-
   const paths = useTalentSearchRoutes();
   const onSubmit = async () => {
-    // pool ID is not in the form so it must be added manually
-    if (applicantFilter && pool) {
-      applicantFilter.pools = [{ id: pool.id }];
-    }
-
     return pushToStateThenNavigate(paths.request(), {
       applicantFilter,
       candidateCount,
@@ -255,10 +245,8 @@ const SearchContainerApi: React.FC = () => {
   return (
     <Pending {...{ fetching, error }}>
       <SearchContainer
-        classifications={pool?.classifications?.filter(notEmpty) ?? []}
-        pool={pool ?? undefined}
+        classifications={NonExecutiveITClassifications() as Classification[]}
         skills={skills as Skill[]}
-        poolOwner={pool?.owner ?? undefined}
         applicantFilter={applicantFilter}
         candidateCount={candidateCount}
         updatePending={countFetching}


### PR DESCRIPTION
resolves #4374 

- Search page uses hard coded constants for the classifications named as NonExecutiveITConstants which are from IT-01 to IT-04. 
-  Eliminates pool id from the search
- Search page still filters by expected classifications as usual. No change on that in this PR.  
