### PR TITLE
Feature - update missing skills style

### DIFF
--- a/frontend/common/src/components/MissingSkills/MissingSkills.tsx
+++ b/frontend/common/src/components/MissingSkills/MissingSkills.tsx
@@ -1,11 +1,61 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
+import {
+  ExclamationTriangleIcon,
+  LightBulbIcon,
+} from "@heroicons/react/24/solid";
 import Chip, { Chips } from "../Chip";
 
 import { getMissingSkills } from "../../helpers/skillUtils";
 import { getLocale } from "../../helpers/localize";
 import type { Maybe, Skill } from "../../api/generated";
+import { PillColor, PillMode } from "../Pill";
+
+const MissingSkillsBlock = ({
+  pillType,
+  title,
+  blurb,
+  icon,
+  missingSkills,
+  ...rest
+}: {
+  pillType: { color: PillColor; mode: PillMode };
+  title: string;
+  blurb: string;
+  icon: React.ReactNode;
+  missingSkills: Skill[];
+}) => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
+  return (
+    <div
+      data-h2-display="base(flex)"
+      data-h2-padding="base(x1)"
+      data-h2-radius="base(rounded)"
+      {...rest}
+    >
+      <span data-h2-margin="base(0, x1, 0, 0)">{icon}</span>
+      <div>
+        <p data-h2-margin="base(0, 0, x.5, 0)">
+          <strong>{title}</strong>
+        </p>
+        <p data-h2-margin="base(0, 0, x.25, 0)">{blurb}</p>
+        <Chips>
+          {missingSkills.map((skill: Skill) => (
+            <Chip
+              key={skill.id}
+              color={pillType.color}
+              mode={pillType.mode}
+              label={skill.name[locale] ?? ""}
+              data-h2-margin="base(x.25, x.25, 0, 0)"
+            />
+          ))}
+        </Chips>
+      </div>
+    </div>
+  );
+};
 
 export interface MissingSkillsProps {
   requiredSkills?: Skill[];
@@ -42,50 +92,47 @@ const MissingSkills = ({
   return (
     <>
       {missingRequiredSkills.length ? (
-        <>
-          <p>
-            {intl.formatMessage({
-              defaultMessage:
-                'The following "Need to have" <red>required</red> skills are missing from your profile:',
-              id: "bOch3v",
-              description:
-                "Text that appears when a user is missing required skills on their profile",
-            })}
-          </p>
-          <Chips>
-            {missingRequiredSkills.map((skill: Skill) => (
-              <Chip
-                key={skill.id}
-                color="primary"
-                mode="outline"
-                label={skill.name[locale] ?? ""}
-              />
-            ))}
-          </Chips>
-        </>
+        <MissingSkillsBlock
+          data-h2-background-color="base(light.dt-error.05)"
+          data-h2-margin="base(0, 0, x.5, 0)"
+          pillType={{ color: "error", mode: "outline" }}
+          title={intl.formatMessage({
+            defaultMessage: "Required application skills",
+            id: "B89Ihf",
+            description:
+              "Title that appears when a user is missing required skills on their profile.",
+          })}
+          blurb={intl.formatMessage({
+            defaultMessage:
+              "These required skills are missing from your profile:",
+            id: "AhQ6xv",
+            description:
+              "Text that appears when a user is missing required skills on their profile.",
+          })}
+          icon={<ExclamationTriangleIcon style={{ width: "1.2rem" }} />}
+          missingSkills={missingRequiredSkills}
+        />
       ) : null}
       {missingOptionalSkills.length ? (
-        <>
-          <p>
-            {intl.formatMessage({
-              defaultMessage:
-                'Other "Nice to have" skills you may want to consider adding to your profile:',
-              id: "RBHmM6",
-              description:
-                "Text that appears when a user is missing optional skills on their profile",
-            })}
-          </p>
-          <Chips>
-            {missingOptionalSkills.map((skill: Skill) => (
-              <Chip
-                key={skill.id}
-                color="primary"
-                mode="outline"
-                label={skill.name[locale] ?? ""}
-              />
-            ))}
-          </Chips>
-        </>
+        <MissingSkillsBlock
+          data-h2-background-color="base(light.dt-primary.1)"
+          pillType={{ color: "primary", mode: "outline" }}
+          title={intl.formatMessage({
+            defaultMessage: "Nice to have skills",
+            id: "CJy0kS",
+            description:
+              "Title that appears when a user is missing optional skills on their profile.",
+          })}
+          blurb={intl.formatMessage({
+            defaultMessage:
+              "Consider adding these asset skills to your profile:",
+            id: "V3ReC1",
+            description:
+              "Text that appears when a user is missing optional skills on their profile",
+          })}
+          icon={<LightBulbIcon style={{ width: "1.2rem" }} />}
+          missingSkills={missingOptionalSkills}
+        />
       ) : null}
     </>
   );

--- a/frontend/common/src/components/MissingSkills/MissingSkills.tsx
+++ b/frontend/common/src/components/MissingSkills/MissingSkills.tsx
@@ -21,8 +21,8 @@ const MissingSkillsBlock = ({
   ...rest
 }: {
   pillType: { color: PillColor; mode: PillMode };
-  title: string;
-  blurb: string;
+  title: React.ReactNode;
+  blurb: React.ReactNode;
   icon: React.ReactNode;
   missingSkills: Skill[];
 }) => {

--- a/frontend/common/src/components/Pill/Pill.tsx
+++ b/frontend/common/src/components/Pill/Pill.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 export type PillSize = "sm" | "md" | "lg";
-export type PillColor = "primary" | "secondary" | "neutral" | "blue";
+export type PillColor = "primary" | "secondary" | "neutral" | "blue" | "error";
 export type PillMode = "solid" | "outline";
 
 export interface PillProps
@@ -16,7 +16,7 @@ export interface PillProps
 }
 
 const colorMap: Record<
-  "primary" | "secondary" | "neutral" | "blue",
+  PillColor,
   Record<"solid" | "outline", Record<string, string>>
 > = {
   primary: {
@@ -66,6 +66,18 @@ const colorMap: Record<
       "data-h2-border": "base(all, 1px, solid, dark.dt-gray)",
       "data-h2-background-color": "base(dt-gray.1)",
       "data-h2-color": "base(dark.dt-gray)",
+    },
+  },
+  error: {
+    solid: {
+      "data-h2-border": "base(all, 1px, solid, dark.dt-error)",
+      "data-h2-background-color": "base(dark.dt-error)",
+      "data-h2-color": "base(dt-white)",
+    },
+    outline: {
+      "data-h2-border": "base(all, 1px, solid, dark.dt-error)",
+      "data-h2-background-color": "base(light.dt-error.1)",
+      "data-h2-color": "base(dark.dt-black)",
     },
   },
 };

--- a/frontend/talentsearch/src/js/components/experienceAndSkills/ExperienceAndSkills.tsx
+++ b/frontend/talentsearch/src/js/components/experienceAndSkills/ExperienceAndSkills.tsx
@@ -197,6 +197,17 @@ export const ExperienceAndSkills: React.FunctionComponent<
         ),
       }}
     >
+      {missingSkills && (
+        <div data-h2-margin="base(x1, 0)">
+          <MissingSkills
+            addedSkills={
+              hasExperiences ? flattenExperienceSkills(experiences) : []
+            }
+            requiredSkills={missingSkills.requiredSkills}
+            optionalSkills={missingSkills.optionalSkills}
+          />
+        </div>
+      )}
       <div data-h2-margin="base(x2, 0)">
         <div data-h2-flex-grid="base(flex-start, x.5)">
           <div data-h2-flex-item="base(1of1)">
@@ -241,17 +252,6 @@ export const ExperienceAndSkills: React.FunctionComponent<
           </div>
         </div>
       </div>
-      {missingSkills && (
-        <div data-h2-margin="base(x1, 0)">
-          <MissingSkills
-            addedSkills={
-              hasExperiences ? flattenExperienceSkills(experiences) : []
-            }
-            requiredSkills={missingSkills.requiredSkills}
-            optionalSkills={missingSkills.optionalSkills}
-          />
-        </div>
-      )}
       {!hasExperiences ? (
         <Well>
           <p data-h2-font-style="base(italic)">

--- a/frontend/talentsearch/src/js/components/reviewMyApplication/ReviewMyApplicationPage.tsx
+++ b/frontend/talentsearch/src/js/components/reviewMyApplication/ReviewMyApplicationPage.tsx
@@ -163,12 +163,7 @@ export const ReviewMyApplication: React.FunctionComponent<
             ),
             override: (
               <>
-                <div
-                  data-h2-background-color="base(dt-gray.light)"
-                  data-h2-padding="base(x1)"
-                  data-h2-radius="base(s)"
-                  data-h2-margin="base(0, 0, x1, 0)"
-                >
+                <div data-h2-margin="base(0, 0, x1, 0)">
                   {missingSkills && (
                     <MissingSkills
                       addedSkills={


### PR DESCRIPTION
Resolves #4390 

# Notes
- Updates the `<MissingSkills />` component styling to match the new design. 
- Moves the component above the "Add Experience" button on the ExperienceAndSkills page.
- Adds new red `error` color to the Pill component.

# Testing
- Login
- Go to [Browse Pools](http://localhost:8000/en/browse/pools) and apply to job
- Scroll down to ExperienceAndSkills section on apply page and see new changes to component (`/en/browse/applications/{REPLACE_WITH_POOLCANDIDATEID}/apply`)
- Click on edit Experience and Skills button and see new changes to component (`en/users/{REPLACE_WITH_USERID}/profile/experiences?applicationId={REPLACE_WITH_POOLCANDIDATEID}`)

UPDATE: Need to talk to Jerbo about the [design ](https://www.figma.com/proto/spDwyr56BgQKrSdRiHztPL/Skills-and-EX---Poster-and-application-V2?page-id=0%3A1&node-id=138%3A2829&viewport=-176%2C-5109%2C0.49&scaling=scale-down-width&starting-point-node-id=226%3A4567)as it has changed from the one I was given.
