### PR TITLE
Feature - Update Support Form error

### DIFF
--- a/frontend/talentsearch/.env.example
+++ b/frontend/talentsearch/.env.example
@@ -9,6 +9,7 @@ TALENTSEARCH_APP_DIR="/talent"
 APPLICANTPROFILE_APP_DIR="/talent/profile"
 TALENTSEARCH_ASSET_URL="/talent"
 TALENTSEARCH_RECRUITMENT_EMAIL="recruitmentimit-recrutementgiti@tbs-sct.gc.ca"
+TALENTSEARCH_SUPPORT_EMAIL="gctalent-talentgc@support-soutien.gc.ca"
 
 NODE_ENV=development
 

--- a/frontend/talentsearch/src/js/components/support/SupportForm.tsx
+++ b/frontend/talentsearch/src/js/components/support/SupportForm.tsx
@@ -256,6 +256,7 @@ const SupportFormApi = () => {
             },
           )}
         </>,
+        { autoClose: 20000 },
       );
       return Promise.reject(response.status);
     });

--- a/frontend/talentsearch/src/js/components/support/SupportForm.tsx
+++ b/frontend/talentsearch/src/js/components/support/SupportForm.tsx
@@ -10,7 +10,10 @@ import Pending from "@common/components/Pending";
 import { useState } from "react";
 import Button from "@common/components/Button";
 import { useGetMeQuery, User } from "../../api/generated";
-import { API_SUPPORT_ENDPOINT } from "../../talentSearchConstants";
+import {
+  API_SUPPORT_ENDPOINT,
+  TALENTSEARCH_SUPPORT_EMAIL,
+} from "../../talentSearchConstants";
 
 export type FormValues = {
   name: string;
@@ -240,7 +243,7 @@ const SupportFormApi = () => {
             description: "Support form toast message error",
           },
           {
-            emailAddress: "gctalent-talentgc@support-soutien.gc.ca",
+            emailAddress: TALENTSEARCH_SUPPORT_EMAIL,
             errorCode: response.status,
           },
         ),

--- a/frontend/talentsearch/src/js/components/support/SupportForm.tsx
+++ b/frontend/talentsearch/src/js/components/support/SupportForm.tsx
@@ -21,6 +21,7 @@ export type FormValues = {
   description: string;
   subject: string;
 };
+
 interface SupportFormProps {
   showSupportForm: boolean;
   onFormToggle: (show: boolean) => void;
@@ -31,6 +32,10 @@ interface SupportFormProps {
 interface SupportFormSuccessProps {
   onFormToggle: (show: boolean) => void;
 }
+
+const anchorTag = (chunks: React.ReactNode): React.ReactNode => (
+  <a href={`mailto:${TALENTSEARCH_SUPPORT_EMAIL}`}>{chunks}</a>
+);
 
 const SupportFormSuccess = ({ onFormToggle }: SupportFormSuccessProps) => {
   const intl = useIntl();
@@ -236,17 +241,21 @@ const SupportFormApi = () => {
         return Promise.resolve(response.status);
       }
       toast.error(
-        intl.formatMessage(
-          {
-            defaultMessage: `Sorry, something went wrong. Please email {emailAddress} and mention this error code: {errorCode}.`,
-            id: "tZLItl",
-            description: "Support form toast message error",
-          },
-          {
-            emailAddress: TALENTSEARCH_SUPPORT_EMAIL,
-            errorCode: response.status,
-          },
-        ),
+        <>
+          {intl.formatMessage(
+            {
+              defaultMessage:
+                "Sorry, something went wrong. Please email <anchorTag>{emailAddress}</anchorTag> and mention this error code: {errorCode}.",
+              id: "rNVDaA",
+              description: "Support form toast message error",
+            },
+            {
+              anchorTag,
+              emailAddress: TALENTSEARCH_SUPPORT_EMAIL,
+              errorCode: response.status,
+            },
+          )}
+        </>,
       );
       return Promise.reject(response.status);
     });

--- a/frontend/talentsearch/src/js/components/support/SupportForm.tsx
+++ b/frontend/talentsearch/src/js/components/support/SupportForm.tsx
@@ -235,11 +235,14 @@ const SupportFormApi = () => {
       toast.error(
         intl.formatMessage(
           {
-            defaultMessage: `Error: creating ticket failed (code {errorCode})`,
-            id: "C3Lv2t",
+            defaultMessage: `Sorry, something went wrong. Please email {emailAddress} and mention this error code: {errorCode}.`,
+            id: "tZLItl",
             description: "Support form toast message error",
           },
-          { errorCode: response.status },
+          {
+            emailAddress: "gctalent-talentgc@support-soutien.gc.ca",
+            errorCode: response.status,
+          },
         ),
       );
       return Promise.reject(response.status);

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -2387,5 +2387,9 @@
   "jRmRd+": {
     "defaultMessage": "Talent numérique du GC est la nouvelle plateforme de recrutement pour les emplois numériques et technologiques au gouvernement du Canada. Postulez maintenant!",
     "description": "Meta tag description for Talent Search site"
+  },
+  "tZLItl": {
+    "defaultMessage": "Désolé. Une erreur s'est produite. Veuillez envoyer un courriel à {emailAddress} et mentionner ce code d’erreur : {errorCode}.",
+    "description": "Support form toast message error"
   }
 }

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -2388,8 +2388,8 @@
     "defaultMessage": "Talent numérique du GC est la nouvelle plateforme de recrutement pour les emplois numériques et technologiques au gouvernement du Canada. Postulez maintenant!",
     "description": "Meta tag description for Talent Search site"
   },
-  "tZLItl": {
-    "defaultMessage": "Désolé. Une erreur s'est produite. Veuillez envoyer un courriel à {emailAddress} et mentionner ce code d’erreur : {errorCode}.",
+  "rNVDaA": {
+    "defaultMessage": "Désolé. Une erreur s'est produite. Veuillez envoyer un courriel à <anchorTag>{emailAddress}</anchorTag> et mentionner ce code d’erreur : {errorCode}.",
     "description": "Support form toast message error"
   }
 }

--- a/frontend/talentsearch/src/js/talentSearchConstants.ts
+++ b/frontend/talentsearch/src/js/talentSearchConstants.ts
@@ -8,5 +8,8 @@ export const DIRECTINTAKE_APP_DIR =
 export const TALENTSEARCH_RECRUITMENT_EMAIL =
   (process.env.TALENTSEARCH_RECRUITMENT_EMAIL as string) ??
   "recruitmentimit-recrutementgiti@tbs-sct.gc.ca";
+export const TALENTSEARCH_SUPPORT_EMAIL =
+  (process.env.TALENTSEARCH_SUPPORT_EMAIL as string) ??
+  "gctalent-talentgc@support-soutien.gc.ca";
 export const API_SUPPORT_ENDPOINT =
   (process.env.API_SUPPORT_ENDPOINT as string) ?? "/api/support/tickets";

--- a/frontend/talentsearch/webpack.base.js
+++ b/frontend/talentsearch/webpack.base.js
@@ -67,6 +67,7 @@ module.exports = {
         TALENTSEARCH_APP_DIR: JSON.stringify(process.env.TALENTSEARCH_APP_DIR),
         BUILD_DATE: JSON.stringify(new Date()),
         API_SUPPORT_ENDPOINT: JSON.stringify(process.env.API_SUPPORT_ENDPOINT),
+        TALENTSEARCH_SUPPORT_EMAIL: JSON.stringify(process.env.TALENTSEARCH_SUPPORT_EMAIL),
       },
     }),
 


### PR DESCRIPTION
Resolves #4231.

## Notes
In addition to updating the support form error message in English and adding its French string translation, this also [adds TALENTSEARCH_SUPPORT_EMAIL environment variable](https://github.com/GCTC-NTGC/gc-digital-talent/commit/71ce5a00a17a6fd15444f3c2912a0bcc6333df82).

## Steps to test

1. Compile talentsearch `npm run intl-compile --workspace=talentsearch`
2. Build talentsearch `npm run production --workspace=talentsearch`
3. Navigate to **/support**
4. Force an error by commenting out required `email` parameter in [SupportController](https://github.com/GCTC-NTGC/gc-digital-talent/blob/main/api/app/Http/Controllers/SupportController.php#L15)
5. Submit form 
6. Verify error toast message in English and French