### PR TITLE
Bug - 4446 - Fix auth browse page

### DIFF
--- a/frontend/cypress/integration/talentsearch/direct-intake.spec.js
+++ b/frontend/cypress/integration/talentsearch/direct-intake.spec.js
@@ -6,46 +6,18 @@ describe("Talentsearch Direct Intake Page", () => {
       aliasQuery(req, "getPoolAdvertisement");
     });
   });
-  // Helpers
-  const onAuthLoginPage = () => {
-    cy.url().should('contain', Cypress.config().authServerRoot + '/authorize')
-  }
 
   context('Anonymous visitor', () => {
-    it('redirects restricted pages to login', () => {
+    it('renders page', () => {
       [
         '/en/browse/pools',
       ].forEach(restrictedPath => {
         cy.visit(restrictedPath)
-        onAuthLoginPage()
+        cy.findByRole("heading", { name: /browse it jobs/i })
+          .should("exist")
+          .and("be.visible");
       })
 
     })
-  })
-
-  context('logged in but no applicant role', () => {
-    beforeEach(() => cy.loginByRole('noroles'))
-
-    it('displays not authorized', () => {
-      [
-        '/en/browse/pools',
-      ].forEach(restrictedPath => {
-        cy.visit(restrictedPath)
-        cy.contains('not authorized');
-      })
-
-    })
-  })
-
-  context('logged in with no email', () => {
-    beforeEach(() => cy.loginByRole('noemail'));
-
-    it("redirects to create account", () => {
-      cy.visit('/en/browse/pools');
-
-      cy.location('pathname').should('eq', '/en/create-account');
-      cy.contains("successfully logged in");
-    });
-  })
-
+  });
 });

--- a/frontend/cypress/integration/talentsearch/submit-application-workflows.spec.js
+++ b/frontend/cypress/integration/talentsearch/submit-application-workflows.spec.js
@@ -143,7 +143,7 @@ describe("Submit Application Workflow Tests", () => {
     cy.findByRole("heading", { name: /Apply now/i })
       .should("exist")
       .and("be.visible");
-    cy.findAllByRole("button", { name: /Apply for this process/i })
+    cy.findAllByRole("link", { name: /Apply for this process/i })
       .first()
       .click();
     cy.wait("@gqlcreateApplicationMutation");

--- a/frontend/talentsearch/src/js/components/Router.tsx
+++ b/frontend/talentsearch/src/js/components/Router.tsx
@@ -80,6 +80,7 @@ const BrowsePoolsPage = React.lazy(() => import("./Browse/BrowsePoolsPage"));
 const PoolAdvertisementPage = React.lazy(
   () => import("./pool/PoolAdvertisementPage"),
 );
+const CreateApplication = React.lazy(() => import("./pool/CreateApplication"));
 const SignAndSubmitPage = React.lazy(
   () => import("./signAndSubmit/SignAndSubmitPage"),
 );
@@ -431,6 +432,16 @@ const directIntakeRoutes = (
       const poolId = context.params.id as string;
       return {
         component: <PoolAdvertisementPage id={poolId} />,
+      };
+    },
+  },
+  {
+    path: directIntakePaths.createApplication(":id"),
+    action: (context) => {
+      const poolId = context.params.id as string;
+      return {
+        component: <CreateApplication id={poolId} />,
+        authorizedRoles: [Role.Applicant],
       };
     },
   },

--- a/frontend/talentsearch/src/js/components/Router.tsx
+++ b/frontend/talentsearch/src/js/components/Router.tsx
@@ -423,7 +423,6 @@ const directIntakeRoutes = (
     path: directIntakePaths.allPools(),
     action: () => ({
       component: <BrowsePoolsPage />,
-      authorizedRoles: [Role.Applicant],
     }),
   },
   {

--- a/frontend/talentsearch/src/js/components/Router.tsx
+++ b/frontend/talentsearch/src/js/components/Router.tsx
@@ -440,7 +440,7 @@ const directIntakeRoutes = (
     action: (context) => {
       const poolId = context.params.id as string;
       return {
-        component: <CreateApplication id={poolId} />,
+        component: <CreateApplication poolId={poolId} />,
         authorizedRoles: [Role.Applicant],
       };
     },

--- a/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
+++ b/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import Loading from "@common/components/Pending/Loading";
+import { redirect } from "@common/helpers/router";
+import { notEmpty } from "@common/helpers/util";
+import { useIntl } from "react-intl";
+import { toast } from "react-toastify";
+import {
+  Maybe,
+  PoolCandidate,
+  Scalars,
+  useCreateApplicationMutation,
+  useGetPoolAdvertisementQuery,
+} from "../../api/generated";
+import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
+import { hasUserApplied, isAdvertisementVisible } from "./utils";
+
+interface CreateApplicationProps {
+  id: Scalars["ID"];
+}
+
+/**
+ * Note: This is not a real page
+ * it exists only to create an application
+ * and forward a user on
+ */
+const CreateApplication = ({ id }: CreateApplicationProps) => {
+  const intl = useIntl();
+  const paths = useDirectIntakeRoutes();
+  const [{ data }] = useGetPoolAdvertisementQuery({
+    variables: { id },
+  });
+  const [{ fetching: creating, data: mutationData }, executeMutation] =
+    useCreateApplicationMutation();
+
+  // Store pool path to redirect to later on
+  const poolPath = paths.pool(id);
+
+  /**
+   * There is a possibility someone navigates
+   * directly to this, so check if they should
+   * be able to view/apply to it
+   */
+  const isVisible = isAdvertisementVisible(
+    data?.me?.roles?.filter(notEmpty) || [],
+    data?.poolAdvertisement?.advertisementStatus ?? null,
+  );
+  const hasApplied = hasUserApplied(
+    (data?.me?.poolCandidates as Maybe<PoolCandidate>[]) || [],
+    data?.poolAdvertisement?.id,
+  );
+
+  /**
+   * Check to see if the application even exists
+   */
+  const application = data?.me?.poolCandidates?.find((candidate) => {
+    return candidate?.pool.id === data?.poolAdvertisement?.id;
+  });
+
+  /**
+   * Store if the application can be created
+   *
+   * !creating - Not currently running a mutation
+   * !mutationData - The mutation has not previously ran
+   * userId - We need a user ID to run the mutation
+   * id - We need a pool ID to run the mutation
+   * isVisible - Should't run it if user cannot view it
+   * !hasApplied - Users can only apply to a single pool advertisement
+   */
+  const userId = data?.me?.id;
+  const canCreate =
+    !creating && !mutationData && userId && id && isVisible && !hasApplied;
+
+  /**
+   * Actually run the mutation
+   */
+  if (canCreate) {
+    /**
+     * Handle any errors that occur during mutation
+     *
+     * @returns null
+     */
+    const handleError = () => {
+      redirect(poolPath);
+      toast.error(
+        intl.formatMessage({
+          defaultMessage: "Error application creation failed",
+          id: "tlAiJm",
+          description: "Application creation failed",
+        }),
+      );
+      return null;
+    };
+
+    if (userId) {
+      executeMutation({ userId, poolId: id })
+        .then((result) => {
+          if (result.data?.createApplication) {
+            // Redirect user to the application on success
+            redirect(paths.reviewApplication(result.data.createApplication.id));
+            toast.success(
+              intl.formatMessage({
+                defaultMessage: "Application created",
+                id: "U/ji+A",
+                description: "Application created successfully",
+              }),
+            );
+            return null;
+          }
+          return handleError();
+        })
+        .catch(handleError);
+    }
+  }
+
+  // If a pool is not visible, you can create one
+  // So redirect them back to the pool page
+  if (!isVisible) {
+    redirect(poolPath);
+  }
+
+  // If a user has already applied, redirect to the existing application
+  // Or, back to the pool page if we cannot find it
+  if (hasApplied && !creating) {
+    const redirectPath = application
+      ? paths.reviewApplication(application.id)
+      : poolPath;
+    redirect(redirectPath);
+  }
+
+  /**
+   * Render the loading spinner while we do
+   * the necessary work
+   *
+   * Note: This component should always redirect to a path
+   * based on the logic, so no need to render anything but
+   * a loading spinner
+   */
+  return <Loading />;
+};
+
+export default CreateApplication;

--- a/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
+++ b/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
@@ -15,7 +15,7 @@ import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
 import { hasUserApplied, isAdvertisementVisible } from "./utils";
 
 interface CreateApplicationProps {
-  id: Scalars["ID"];
+  poolId: Scalars["ID"];
 }
 
 /**
@@ -23,17 +23,17 @@ interface CreateApplicationProps {
  * it exists only to create an application
  * and forward a user on
  */
-const CreateApplication = ({ id }: CreateApplicationProps) => {
+const CreateApplication = ({ poolId }: CreateApplicationProps) => {
   const intl = useIntl();
   const paths = useDirectIntakeRoutes();
   const [{ data }] = useGetPoolAdvertisementQuery({
-    variables: { id },
+    variables: { id: poolId },
   });
   const [{ fetching: creating, data: mutationData }, executeMutation] =
     useCreateApplicationMutation();
 
   // Store pool path to redirect to later on
-  const poolPath = paths.pool(id);
+  const poolPath = paths.pool(poolId);
 
   /**
    * There is a possibility someone navigates
@@ -68,7 +68,7 @@ const CreateApplication = ({ id }: CreateApplicationProps) => {
    */
   const userId = data?.me?.id;
   const canCreate =
-    !creating && !mutationData && userId && id && isVisible && !hasApplied;
+    !creating && !mutationData && userId && poolId && isVisible && !hasApplied;
 
   /**
    * Actually run the mutation
@@ -92,7 +92,7 @@ const CreateApplication = ({ id }: CreateApplicationProps) => {
     };
 
     if (userId) {
-      executeMutation({ userId, poolId: id })
+      executeMutation({ userId, poolId })
         .then((result) => {
           if (result.data?.createApplication) {
             // Redirect user to the application on success

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -6,11 +6,16 @@ import type { BreadcrumbsProps } from "@common/components/Breadcrumbs";
 import NotFound from "@common/components/NotFound";
 import Pending from "@common/components/Pending";
 import Card from "@common/components/Card";
-import { Button } from "@common/components";
+import { Button, Link } from "@common/components";
 import { getLocale } from "@common/helpers/localize";
-import { imageUrl, navigate } from "@common/helpers/router";
+import { imageUrl } from "@common/helpers/router";
 
-import { AdvertisementStatus, SkillCategory } from "@common/api/generated";
+import {
+  AdvertisementStatus,
+  PoolCandidate,
+  Scalars,
+  SkillCategory,
+} from "@common/api/generated";
 import TableOfContents from "@common/components/TableOfContents";
 import {
   BoltIcon,
@@ -28,12 +33,9 @@ import {
 } from "@common/constants/localizedConstants";
 import { categorizeSkill } from "@common/helpers/skillUtils";
 import commonMessages from "@common/messages/commonMessages";
-import { toast } from "react-toastify";
-import {
-  Role,
-  useGetPoolAdvertisementQuery,
-  useCreateApplicationMutation,
-} from "../../api/generated";
+
+import { notEmpty } from "@common/helpers/util";
+import { useGetPoolAdvertisementQuery, Maybe } from "../../api/generated";
 import type { PoolAdvertisement } from "../../api/generated";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
 import TALENTSEARCH_APP_DIR, {
@@ -42,28 +44,29 @@ import TALENTSEARCH_APP_DIR, {
 import PoolInfoCard from "./PoolInfoCard";
 import ClassificationDefinition from "../ClassificationDefinition/ClassificationDefinition";
 import getFullPoolAdvertisementTitle from "./getFullPoolAdvertisementTitle";
+import { hasUserApplied, isAdvertisementVisible } from "./utils";
 
 interface ApplyButtonProps {
-  disabled: boolean;
-  onClick: () => void;
+  poolId: Scalars["ID"];
 }
 
-const ApplyButton = ({ disabled, onClick }: ApplyButtonProps) => {
+const ApplyButton = ({ poolId }: ApplyButtonProps) => {
   const intl = useIntl();
+  const paths = useDirectIntakeRoutes();
+
   return (
-    <Button
+    <Link
       type="button"
-      color="primary"
       mode="solid"
-      disabled={disabled}
-      onClick={onClick}
+      color="primary"
+      href={paths.createApplication(poolId)}
     >
       {intl.formatMessage({
         defaultMessage: "Apply for this process",
         id: "W2YIEA",
         description: "Link text to apply for a pool advertisement",
       })}
-    </Button>
+    </Link>
   );
 };
 
@@ -111,14 +114,12 @@ const anchorTag = (chunks: React.ReactNode): React.ReactNode => (
 
 interface PoolAdvertisementProps {
   poolAdvertisement: PoolAdvertisement;
-  userId: string;
-  hasUserApplied?: boolean;
+  hasApplied?: boolean;
 }
 
 const PoolAdvertisement = ({
   poolAdvertisement,
-  userId,
-  hasUserApplied,
+  hasApplied,
 }: PoolAdvertisementProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -149,38 +150,10 @@ const PoolAdvertisement = ({
     poolAdvertisement.nonessentialSkills,
   );
 
-  const [, executeMutation] = useCreateApplicationMutation();
-  const handleCreateApplication = () =>
-    executeMutation({ userId, poolId: poolAdvertisement.id })
-      .then((result) => {
-        if (result.data?.createApplication) {
-          navigate(paths.reviewApplication(result.data.createApplication.id));
-          toast.success(
-            intl.formatMessage({
-              defaultMessage: "Application created",
-              id: "U/ji+A",
-              description: "Application created successfully",
-            }),
-          );
-          return result.data?.createApplication.id;
-        }
-        return result.data?.createApplication;
-      })
-      .catch((result) => {
-        toast.error(
-          intl.formatMessage({
-            defaultMessage: "Error application creation failed",
-            id: "tlAiJm",
-            description: "Application creation failed",
-          }),
-        );
-        return Promise.reject(result.error);
-      });
-
-  const applyBtn = hasUserApplied ? (
+  const applyBtn = hasApplied ? (
     <AlreadyAppliedButton />
   ) : (
-    <ApplyButton disabled={!canApply} onClick={handleCreateApplication} />
+    <ApplyButton poolId={poolAdvertisement.id} />
   );
 
   const links = [
@@ -779,40 +752,23 @@ const PoolAdvertisementPage = ({ id }: PoolAdvertisementPageProps) => {
     variables: { id },
   });
 
-  let visible = data?.me?.roles?.includes(Role.Admin) ?? false;
-  if (
-    data?.poolAdvertisement?.advertisementStatus !== AdvertisementStatus.Draft
-  ) {
-    visible = true;
-  }
+  const isVisible = isAdvertisementVisible(
+    data?.me?.roles?.filter(notEmpty) || [],
+    data?.poolAdvertisement?.advertisementStatus ?? null,
+  );
 
   // grab pool candidates of Me, then check whether a pool candidate exists that matches the advertisement AND is submitted
-  const meDataResponse = data?.me;
-  let hasUserApplied = false;
-  if (meDataResponse?.poolCandidates) {
-    const mePoolCandidates = meDataResponse.poolCandidates;
-    mePoolCandidates.map((candidate) => {
-      if (
-        candidate?.pool.id === data?.poolAdvertisement?.id &&
-        candidate?.submittedAt
-      ) {
-        hasUserApplied = true;
-      }
-      return candidate;
-    });
-  }
-
-  // enforce type of userId as String
-  const dataMe = data?.me ? data.me : undefined;
-  const userId = dataMe?.id ? dataMe.id : "";
+  const hasApplied = hasUserApplied(
+    (data?.me?.poolCandidates as Maybe<PoolCandidate>[]) || [],
+    data?.poolAdvertisement?.id,
+  );
 
   return (
     <Pending fetching={fetching} error={error}>
-      {data?.poolAdvertisement && visible ? (
+      {data?.poolAdvertisement && isVisible ? (
         <PoolAdvertisement
           poolAdvertisement={data?.poolAdvertisement}
-          userId={userId}
-          hasUserApplied={hasUserApplied}
+          hasApplied={hasApplied}
         />
       ) : (
         <NotFound

--- a/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
+++ b/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
@@ -13,6 +13,7 @@ query getPoolAdvertisement($id: ID!) {
     roles
     id
     poolCandidates {
+      id
       pool {
         id
       }

--- a/frontend/talentsearch/src/js/components/pool/utils.ts
+++ b/frontend/talentsearch/src/js/components/pool/utils.ts
@@ -8,7 +8,7 @@ import {
 
 /**
  * Determine if the advertisement can be
- * viewed based on user roles and statu
+ * viewed based on user roles and status
  *
  * @param roles
  * @param status

--- a/frontend/talentsearch/src/js/components/pool/utils.ts
+++ b/frontend/talentsearch/src/js/components/pool/utils.ts
@@ -1,0 +1,47 @@
+import {
+  AdvertisementStatus,
+  Maybe,
+  PoolCandidate,
+  Role,
+  Scalars,
+} from "../../api/generated";
+
+/**
+ * Determine if the advertisement can be
+ * viewed based on user roles and statu
+ *
+ * @param roles
+ * @param status
+ * @returns boolean
+ */
+export const isAdvertisementVisible = (
+  roles: Maybe<Role>[],
+  status?: Maybe<AdvertisementStatus>,
+) => {
+  let visible = roles.includes(Role.Admin) ?? false;
+  if (status !== AdvertisementStatus.Draft) {
+    visible = true;
+  }
+
+  return visible;
+};
+
+/**
+ * See if the user has already applied
+ * to this pool or not
+ *
+ * @param candidates
+ * @param id
+ * @returns
+ */
+export const hasUserApplied = (
+  candidates: Maybe<PoolCandidate>[],
+  id: Maybe<Scalars["ID"]>,
+) => {
+  let hasApplied = false;
+  if (candidates && id) {
+    hasApplied = candidates.some((candidate) => candidate?.pool?.id === id);
+  }
+
+  return hasApplied;
+};

--- a/frontend/talentsearch/src/js/directIntakeRoutes.ts
+++ b/frontend/talentsearch/src/js/directIntakeRoutes.ts
@@ -14,6 +14,7 @@ const directIntakeRoutes = (lang: string) => {
     home,
     allPools: (): string => path.join(home(), "pools"),
     pool: (id: string) => path.join(home(), "pools", id),
+    createApplication: (id: string) => path.join(home(), "pools", id, "create"),
     signAndSubmit: (id: string) =>
       path.join(home(), "applications", id, "submit"),
     applications: (userId: string) =>

--- a/frontend/talentsearch/src/js/directIntakeRoutes.ts
+++ b/frontend/talentsearch/src/js/directIntakeRoutes.ts
@@ -14,7 +14,8 @@ const directIntakeRoutes = (lang: string) => {
     home,
     allPools: (): string => path.join(home(), "pools"),
     pool: (id: string) => path.join(home(), "pools", id),
-    createApplication: (id: string) => path.join(home(), "pools", id, "create"),
+    createApplication: (id: string) =>
+      path.join(home(), "pools", id, "create-application"),
     signAndSubmit: (id: string) =>
       path.join(home(), "applications", id, "submit"),
     applications: (userId: string) =>


### PR DESCRIPTION
Resolves #4446 #4445

## 📋 Summary

This removes the requirement to be logged in to browse pools and updates the logic to create an application to support anonymous users.

## 🕵️ Details

This may be over engineered and could be simplified but it seemed the best way to handle all possible states if someone navigates directly to create an application. Essentially when a user clicks on "Apply for this process" the following happens behind a loading spinner:

1. Navigates to `/browse/pools/{poolId}/create`
2. If the application can be created, mutation fires and redirected to application
3. If user is not an admin, or pool is draft they are redirected back to the pool where it shows "not found"
4. If the user has applied and mutation is not running, they are redirected to either the application or pool advertisement

In order for a user to be able to create an application, all must be true:

- Not currently creating one (mutation running)
- Application does not already exist for current user (in any state)
- User is currently logged in
- Pool exists
- Pool is published

### Why is this a route?

This was the easiest way to handle the request that a user be redirected to login and then retunr to the application after. It easily enables the following workflow:

1. Anonymous user clicks "apply"
2. Redirected to login
3. Successful login redirects to the from argument `browse/pools/{poolId}/create`
4. Logic runs to create application

I initially attempted to do this using search params in the `apiPaths.login(from)` to get back to creating the application but that broke the login flow.

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
6. Make sure you are not logged in
7. Navigate to `/browse/pools`
8. Ensure you are not asked to login to view
9. Attempt to apply to a pool
10. Ensure you are asked to login before the application is created
11. Ensure you are properly redirected to the application
12. Navigate back to the pool advertisement page and ensure the apply button is disabled and indicates you have already applied