### PR TITLE
Candidate count, filtered by user, grouped per pool

### DIFF
--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -66,12 +66,12 @@ final class CountPoolCandidatesByPool
 
             // wouldAcceptTemporary
             if (array_key_exists('wouldAcceptTemporary', $filters)) {
-                User::filterByWouldAcceptTemporary($userQuery, $filters['wouldAcceptTemporary']);
+                User::scopeWouldAcceptTemporary($userQuery, $filters['wouldAcceptTemporary']);
             }
 
             // expectedClassifications
             if (array_key_exists('expectedClassifications', $filters)) {
-                User::filterByExpectedClassifications($userQuery, $filters['expectedClassifications']);
+                User::scopeClassifications($userQuery, $filters['expectedClassifications']);
             }
 
             // skills

--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\PoolCandidate;
+use App\Models\User;
+use Database\Helpers\ApiEnums;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Log;
+
+final class CountPoolCandidatesByPool
+{
+    /**
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $filters = $args["where"];
+
+        // query counts pool candidate rows, so start on that model
+        $queryBuilder = PoolCandidate::query();
+
+        // pool candidate filters go here
+
+        // candidate pool scope
+        if (array_key_exists('pools', $filters)) {
+            // pool candidate filter uses Pool while Applicant filter users IdInput
+            $pools = array_map(function ($id) {
+                return ['id' => $id];
+            }, $filters['pools']);
+            PoolCandidate::filterByPools($queryBuilder, $pools);
+        }
+
+        $queryBuilder->whereHas('user', function (Builder $userQuery) use ($filters) {
+            // user filters go here
+
+            // user status scope
+            User::scopeAvailableForOpportunities($userQuery);
+
+            // has diploma
+            if (array_key_exists('hasDiploma', $filters)) {
+                User::scopeHasDiploma($userQuery, $filters['hasDiploma']);
+            }
+
+            // equity
+            if (array_key_exists('equity', $filters)) {
+                User::filterByEquity($userQuery, $filters['equity']);
+            }
+
+            // languageAbility
+            if (array_key_exists('languageAbility', $filters)) {
+                User::filterByLanguageAbility($userQuery, $filters['languageAbility']);
+            }
+
+            // operationalRequirements
+            if (array_key_exists('operationalRequirements', $filters)) {
+                User::filterByOperationalRequirements($userQuery, $filters['operationalRequirements']);
+            }
+
+            // locationPreferences
+            if (array_key_exists('locationPreferences', $filters)) {
+                User::filterByLocationPreferences($userQuery, $filters['locationPreferences']);
+            }
+
+            // wouldAcceptTemporary
+            if (array_key_exists('wouldAcceptTemporary', $filters)) {
+                User::filterByWouldAcceptTemporary($userQuery, $filters['wouldAcceptTemporary']);
+            }
+
+            // expectedClassifications
+            if (array_key_exists('expectedClassifications', $filters)) {
+                User::filterByExpectedClassifications($userQuery, $filters['expectedClassifications']);
+            }
+
+            // skills
+            if (array_key_exists('skills', $filters)) {
+                User::filterBySkills($userQuery, $filters['skills']);
+            }
+        });
+
+        $databaseRows = $queryBuilder
+            ->selectRaw('count(*) as candidate_count, pool_id')
+            ->groupBy('pool_id')
+            ->get();
+
+        $resultSet = [];
+        foreach ($databaseRows as $row) {
+            array_push($resultSet, [
+                "poolId" => $row->pool_id,
+                "candidateCount" => $row->candidate_count,
+            ]);
+        }
+
+        return $resultSet;
+    }
+}

--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -7,6 +7,7 @@ use App\Models\User;
 use Database\Helpers\ApiEnums;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Log;
+use App\Models\Pool;
 
 final class CountPoolCandidatesByPool
 {
@@ -84,10 +85,15 @@ final class CountPoolCandidatesByPool
             ->groupBy('pool_id')
             ->get();
 
+        // would be nice to do this in the same query as above but alas...
+        $allPools = Pool::whereIn('id', $databaseRows->pluck('pool_id'))->get();
+
         $resultSet = [];
         foreach ($databaseRows as $row) {
             array_push($resultSet, [
-                "poolId" => $row->pool_id,
+                "pool" => $allPools->sole(function ($pool) use ($row) { // attach the matching full Pool model to the results
+                    return $pool->id == $row->pool_id;
+                }),
                 "candidateCount" => $row->candidate_count,
             ]);
         }

--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -79,23 +79,11 @@ final class CountPoolCandidatesByPool
         });
 
         $databaseRows = $queryBuilder
+            ->with('pool')
             ->selectRaw('count(*) as candidate_count, pool_id')
             ->groupBy('pool_id')
             ->get();
 
-        // would be nice to do this in the same query as above but alas...
-        $allPools = Pool::whereIn('id', $databaseRows->pluck('pool_id'))->get();
-
-        $resultSet = [];
-        foreach ($databaseRows as $row) {
-            array_push($resultSet, [
-                "pool" => $allPools->sole(function ($pool) use ($row) { // attach the matching full Pool model to the results
-                    return $pool->id == $row->pool_id;
-                }),
-                "candidateCount" => $row->candidate_count,
-            ]);
-        }
-
-        return $resultSet;
+        return $databaseRows;
     }
 }

--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -4,9 +4,7 @@ namespace App\GraphQL\Queries;
 
 use App\Models\PoolCandidate;
 use App\Models\User;
-use Database\Helpers\ApiEnums;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\Log;
 use App\Models\Pool;
 
 final class CountPoolCandidatesByPool
@@ -39,7 +37,7 @@ final class CountPoolCandidatesByPool
             // user status scope
             User::scopeAvailableForOpportunities($userQuery);
 
-            // has diploma
+            // hasDiploma
             if (array_key_exists('hasDiploma', $filters)) {
                 User::scopeHasDiploma($userQuery, $filters['hasDiploma']);
             }

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -249,7 +249,7 @@ RAWSQL2;
         });
         return $query;
     }
-    public function filterByPools(Builder $query, array $pools): Builder
+    public static function filterByPools(Builder $query, array $pools): Builder
     {
         if (empty($pools)) {
             return $query;

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -279,7 +279,7 @@ class User extends Model implements Authenticatable
                 'statuses' => [ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE, ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL]
             ];
         }
-        return $this->filterByPools($query, $poolFilters);
+        return self::filterByPools($query, $poolFilters);
     }
     public static function filterByLanguageAbility(Builder $query, ?string $languageAbility): Builder
     {
@@ -405,10 +405,10 @@ class User extends Model implements Authenticatable
                 }
             });
             $query->orWhere(function ($query) use ($classifications) {
-                $this->filterByClassificationToSalary($query, $classifications);
+                self::filterByClassificationToSalary($query, $classifications);
             });
             $query->orWhere(function ($query) use ($classifications) {
-                $this->filterByClassificationToGenericJobTitles($query, $classifications);
+                self::filterByClassificationToGenericJobTitles($query, $classifications);
             });
         });
 

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -170,7 +170,7 @@ class User extends Model implements Authenticatable
             return true;
         }
     }
-    public function scopeIsProfileComplete(Builder $query, ?bool $isProfileComplete): Builder
+    public static function scopeIsProfileComplete(Builder $query, ?bool $isProfileComplete): Builder
     {
         if ($isProfileComplete) {
             $query->whereNotNull('first_name');
@@ -216,7 +216,7 @@ class User extends Model implements Authenticatable
      * @param array $poolFilters Each pool filter must contain a poolId, and may contain expiryStatus and statuses fields.
      * @return Builder
      */
-    public function filterByPools(Builder $query, ?array $poolFilters): Builder
+    public static function filterByPools(Builder $query, ?array $poolFilters): Builder
     {
         if (empty($poolFilters)) {
             return $query;
@@ -266,7 +266,7 @@ class User extends Model implements Authenticatable
      * @param array $poolIds
      * @return Builder
      */
-    public function filterByAvailableInPools(Builder $query, ?array $poolIds): Builder
+    public static function filterByAvailableInPools(Builder $query, ?array $poolIds): Builder
     {
         if (empty($poolIds)) {
             return $query;
@@ -281,7 +281,7 @@ class User extends Model implements Authenticatable
         }
         return $this->filterByPools($query, $poolFilters);
     }
-    public function filterByLanguageAbility(Builder $query, ?string $languageAbility): Builder
+    public static function filterByLanguageAbility(Builder $query, ?string $languageAbility): Builder
     {
         // If filtering for a specific language the query should return candidates of that language OR bilingual.
         $query->where(function ($query) use ($languageAbility) {
@@ -292,7 +292,7 @@ class User extends Model implements Authenticatable
         });
         return $query;
     }
-    public function filterByOperationalRequirements(Builder $query, ?array $operationalRequirements): Builder
+    public static function filterByOperationalRequirements(Builder $query, ?array $operationalRequirements): Builder
     {
         // if no filters provided then return query unchanged
         if (empty($operationalRequirements)) {
@@ -303,7 +303,7 @@ class User extends Model implements Authenticatable
         $query->whereJsonContains('accepted_operational_requirements', $operationalRequirements);
         return $query;
     }
-    public function filterByLocationPreferences(Builder $query, array $workRegions): Builder
+    public static function filterByLocationPreferences(Builder $query, array $workRegions): Builder
     {
         if (empty($workRegions)) {
             return $query;
@@ -321,7 +321,7 @@ class User extends Model implements Authenticatable
         });
         return $query;
     }
-    public function filterByJobLookingStatus(Builder $query, ?array $statuses): Builder
+    public static function filterByJobLookingStatus(Builder $query, ?array $statuses): Builder
     {
         if (empty($statuses)) {
             return $query;
@@ -339,7 +339,7 @@ class User extends Model implements Authenticatable
         });
         return $query;
     }
-    public function filterBySkills(Builder $query, ?array $skills): Builder
+    public static function filterBySkills(Builder $query, ?array $skills): Builder
     {
         if (empty($skills)) {
             return $query;
@@ -380,7 +380,7 @@ class User extends Model implements Authenticatable
         });
         return $query;
     }
-    public function scopeClassifications(Builder $query, ?array $classifications): Builder
+    public static function scopeClassifications(Builder $query, ?array $classifications): Builder
     {
         // if no filters provided then return query unchanged
         if (empty($classifications)) {
@@ -414,7 +414,7 @@ class User extends Model implements Authenticatable
 
         return $query;
     }
-    public function filterByClassificationToGenericJobTitles(Builder $query, ?array $classifications): Builder
+    public static function filterByClassificationToGenericJobTitles(Builder $query, ?array $classifications): Builder
     {
         // if no filters provided then return query unchanged
         if (empty($classifications)) {
@@ -443,7 +443,7 @@ class User extends Model implements Authenticatable
 
         return $query;
     }
-    private function filterByClassificationToSalary(Builder $query, ?array $classifications): Builder
+    private static function filterByClassificationToSalary(Builder $query, ?array $classifications): Builder
     {
         // When managers search for a classification, also return any users whose expected salary
         // ranges overlap with the min/max salaries of any of those classifications.
@@ -512,14 +512,14 @@ RAWSQL2;
         return $query->whereRaw('EXISTS (' . $sql . ')', $parameters);
     }
 
-    public function scopeHasDiploma(Builder $query, ?bool $hasDiploma): Builder
+    public static function scopeHasDiploma(Builder $query, ?bool $hasDiploma): Builder
     {
         if ($hasDiploma) {
             $query->where('has_diploma', true);
         }
         return $query;
     }
-    public function scopeWouldAcceptTemporary(Builder $query, ?bool $wouldAcceptTemporary): Builder
+    public static function scopeWouldAcceptTemporary(Builder $query, ?bool $wouldAcceptTemporary): Builder
     {
         if ($wouldAcceptTemporary) {
             $query->where('would_accept_temporary', true);
@@ -528,7 +528,7 @@ RAWSQL2;
     }
 
 
-    public function filterByEquity(Builder $query, ?array $equity): Builder
+    public static function filterByEquity(Builder $query, ?array $equity): Builder
     {
         if (empty($equity)) {
             return $query;
@@ -564,7 +564,7 @@ RAWSQL2;
         return $query;
     }
 
-    public function filterByGeneralSearch(Builder $query, ?string $search): Builder
+    public static function filterByGeneralSearch(Builder $query, ?string $search): Builder
     {
         if ($search) {
             $query->where(function ($query) use ($search) {
@@ -577,7 +577,7 @@ RAWSQL2;
         return $query;
     }
 
-    public function filterByName(Builder $query, ?string $name): Builder
+    public static function filterByName(Builder $query, ?string $name): Builder
     {
         if ($name) {
             $splitName = explode(" ", $name);
@@ -591,7 +591,7 @@ RAWSQL2;
         return $query;
     }
 
-    public function scopeTelephone(Builder $query, ?string $telephone): Builder
+    public static function scopeTelephone(Builder $query, ?string $telephone): Builder
     {
         if ($telephone) {
             $query->where('telephone', 'ilike', "%{$telephone}%");
@@ -599,7 +599,7 @@ RAWSQL2;
         return $query;
     }
 
-    public function scopeEmail(Builder $query, ?string $email): Builder
+    public static function scopeEmail(Builder $query, ?string $email): Builder
     {
         if ($email) {
             $query->where('email', 'ilike', "%{$email}%");
@@ -607,7 +607,7 @@ RAWSQL2;
         return $query;
     }
 
-    public function scopeIsGovEmployee(Builder $query, ?bool $isGovEmployee): Builder
+    public static function scopeIsGovEmployee(Builder $query, ?bool $isGovEmployee): Builder
     {
         if ($isGovEmployee) {
             $query->where('is_gov_employee', true);
@@ -621,7 +621,7 @@ RAWSQL2;
      * @param Builder $query
      * @return Builder
      */
-    public function scopeAvailableForOpportunities(Builder $query): Builder
+    public static function scopeAvailableForOpportunities(Builder $query): Builder
     {
         $query->whereIn('job_looking_status', [ApiEnums::USER_STATUS_ACTIVELY_LOOKING, ApiEnums::USER_STATUS_OPEN_TO_OPPORTUNITIES]);
         return $query;

--- a/api/database/helpers/ApiEnums.php
+++ b/api/database/helpers/ApiEnums.php
@@ -5,6 +5,16 @@ namespace Database\Helpers;
 // TODO: any way to pull these directly from the graphql schema?
 class ApiEnums
 {
+    const OPERATIONAL_REQUIREMENT_SHIFT_WORK = 'SHIFT_WORK';
+    const OPERATIONAL_REQUIREMENT_ON_CALL = 'ON_CALL';
+    const OPERATIONAL_REQUIREMENT_TRAVEL = 'TRAVEL';
+    const OPERATIONAL_REQUIREMENT_TRANSPORT_EQUIPMENT = 'TRANSPORT_EQUIPMENT';
+    const OPERATIONAL_REQUIREMENT_DRIVERS_LICENSE = 'DRIVERS_LICENSE';
+    const OPERATIONAL_REQUIREMENT_WORK_WEEKENDS = 'WORK_WEEKENDS';
+    const OPERATIONAL_REQUIREMENT_OVERTIME_SCHEDULED = 'OVERTIME_SCHEDULED';
+    const OPERATIONAL_REQUIREMENT_OVERTIME_SHORT_NOTICE = 'OVERTIME_SHORT_NOTICE';
+    const OPERATIONAL_REQUIREMENT_OVERTIME_OCCASIONAL = 'OVERTIME_OCCASIONAL';
+    const OPERATIONAL_REQUIREMENT_OVERTIME_REGULAR = 'OVERTIME_REGULAR';
     /**
      * A collection of enums for operation_requirement in factories and seeders
      *
@@ -13,16 +23,16 @@ class ApiEnums
     public static function operationalRequirements() : array
     {
         return [
-            'SHIFT_WORK',
-            'ON_CALL',
-            'TRAVEL',
-            'TRANSPORT_EQUIPMENT',
-            'DRIVERS_LICENSE',
-            'WORK_WEEKENDS',
-            'OVERTIME_SCHEDULED',
-            'OVERTIME_SHORT_NOTICE',
-            'OVERTIME_OCCASIONAL',
-            'OVERTIME_REGULAR',
+            self::OPERATIONAL_REQUIREMENT_SHIFT_WORK,
+            self::OPERATIONAL_REQUIREMENT_ON_CALL,
+            self::OPERATIONAL_REQUIREMENT_TRAVEL,
+            self::OPERATIONAL_REQUIREMENT_TRANSPORT_EQUIPMENT,
+            self::OPERATIONAL_REQUIREMENT_DRIVERS_LICENSE,
+            self::OPERATIONAL_REQUIREMENT_WORK_WEEKENDS,
+            self::OPERATIONAL_REQUIREMENT_OVERTIME_SCHEDULED,
+            self::OPERATIONAL_REQUIREMENT_OVERTIME_SHORT_NOTICE,
+            self::OPERATIONAL_REQUIREMENT_OVERTIME_OCCASIONAL,
+            self::OPERATIONAL_REQUIREMENT_OVERTIME_REGULAR,
         ];
     }
 
@@ -151,6 +161,20 @@ class ApiEnums
     const USER_STATUS_ACTIVELY_LOOKING = 'ACTIVELY_LOOKING';
     const USER_STATUS_OPEN_TO_OPPORTUNITIES = 'OPEN_TO_OPPORTUNITIES';
     const USER_STATUS_INACTIVE = 'INACTIVE';
+
+    /**
+     * A collection of enums for user statuses in factories and seeders
+     *
+     * @return string[]
+     */
+    public static function userStatuses() : array
+    {
+        return [
+            self::USER_STATUS_ACTIVELY_LOOKING,
+            self::USER_STATUS_OPEN_TO_OPPORTUNITIES,
+            self::USER_STATUS_INACTIVE
+        ];
+    }
 
     const POOL_STATUS_NOT_TAKING_APPLICATIONS = 'NOT_TAKING_APPLICATIONS';
     const POOL_STATUS_TAKING_APPLICATIONS = 'TAKING_APPLICATIONS';

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -755,6 +755,7 @@ input UserFilterInput {
     @builder(method: "App\\Models\\User@filterByGeneralSearch")
 }
 
+# Changes to this input will require some manual updates to api/app/GraphQL/Queries/CountPoolCandidatesByPool.php since it doesn't use the directives for automatic resolution
 input ApplicantFilterInput {
   hasDiploma: Boolean @scope
   equity: EquitySelectionsInput
@@ -855,6 +856,8 @@ type Query {
     @orderBy(column: "created_at", direction: DESC)
     @guard
     @can(ability: "viewAny")
+  # This query lives at api/app/GraphQL/Queries/CountPoolCandidatesByPool.php.
+  # Returns the number of candidates by filtering their parent applicant, grouped by pool.
   countPoolCandidatesByPool(where: ApplicantFilterInput): [CandidateSearchPoolResult!]!
   classification(id: ID! @eq): Classification @find
   classifications: [Classification]! @all

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -777,8 +777,8 @@ input ApplicantFilterInput {
 }
 
 type CandidateSearchPoolResult {
-  poolId: ID
-  candidateCount: Int
+  pool: Pool!
+  candidateCount: Int!
 }
 
 type Query {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -779,7 +779,7 @@ input ApplicantFilterInput {
 
 type CandidateSearchPoolResult {
   pool: Pool!
-  candidateCount: Int!
+  candidateCount: Int! @rename(attribute: "candidate_count")
 }
 
 type Query {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -776,6 +776,11 @@ input ApplicantFilterInput {
     @builder(method: "App\\Models\\User@filterByAvailableInPools") # This field is [IdInput] instead of [ID] so that the output of an ApplicantFilter query can be used directly.
 }
 
+type CandidateSearchPoolResult {
+  poolId: ID
+  candidateCount: Int
+}
+
 type Query {
   me: User @auth
   user(id: ID! @eq): User @find @guard @can(ability: "view", query: true)
@@ -850,6 +855,7 @@ type Query {
     @orderBy(column: "created_at", direction: DESC)
     @guard
     @can(ability: "viewAny")
+  countPoolCandidatesByPool(where: ApplicantFilterInput): [CandidateSearchPoolResult!]!
   classification(id: ID! @eq): Classification @find
   classifications: [Classification]! @all
   cmoAsset(id: ID! @eq): CmoAsset @find

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -147,6 +147,11 @@ enum CandidateExpiryFilter {
   ALL
 }
 
+type CandidateSearchPoolResult {
+  poolId: ID
+  candidateCount: Int
+}
+
 enum CitizenshipStatus {
   CITIZEN
   PERMANENT_RESIDENT
@@ -979,6 +984,7 @@ type Query {
   poolCandidates(includeIds: [ID]): [PoolCandidate]!
   countPoolCandidates(where: PoolCandidateFilterInput): Int! @deprecated(reason: "Replaced by countApplicants")
   searchPoolCandidates(where: PoolCandidateFilterInput, orderBy: [OrderByClause!], expiryStatus: CandidateExpiryFilter): [PoolCandidate]!
+  countPoolCandidatesByPool(where: ApplicantFilterInput): [CandidateSearchPoolResult!]!
   classification(id: ID!): Classification
   classifications: [Classification]!
   cmoAsset(id: ID!): CmoAsset

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -148,8 +148,8 @@ enum CandidateExpiryFilter {
 }
 
 type CandidateSearchPoolResult {
-  poolId: ID
-  candidateCount: Int
+  pool: Pool!
+  candidateCount: Int!
 }
 
 enum CitizenshipStatus {

--- a/api/tests/Feature/CountPoolCandidatesByPoolTest.php
+++ b/api/tests/Feature/CountPoolCandidatesByPoolTest.php
@@ -1,0 +1,739 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AwardExperience;
+use App\Models\Classification;
+use App\Models\Pool;
+use App\Models\PoolCandidate;
+use App\Models\Skill;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+use Database\Helpers\ApiEnums;
+
+class CountPoolCandidatesByPoolTest extends TestCase
+{
+    use RefreshDatabase;
+    use MakesGraphQLRequests;
+    use ClearsSchemaCache;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->bootClearsSchemaCache();
+
+        // Create admin user we run tests as
+        $newUser = new User;
+        $newUser->email = 'admin@test.com';
+        $newUser->sub = 'admin@test.com';
+        $newUser->roles = ['ADMIN'];
+        $newUser->save();
+    }
+
+    // user (admin) not returned if no candidates
+    // the admin has no candidates so should get no results
+    public function testThatEmptyDoesNotReturnTheAdmin()
+    {
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+            query ($where: ApplicantFilterInput) {
+                countPoolCandidatesByPool(where: $where) {
+                  pool { id }
+                  candidateCount
+                }
+              }
+            ',
+            [
+                'where' => []
+            ]
+        )->assertSimilarJson([
+            'data' => [
+                'countPoolCandidatesByPool' => []
+            ]
+        ]);
+    }
+
+    // single candidate can be returned with no filters
+    // creates a single candidate and expects it to be returned
+    public function testThatEmptyReturnsACandidate()
+    {
+        $pool = Pool::factory()->create();
+        $user = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user->id
+        ]);
+
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+            query ($where: ApplicantFilterInput) {
+                countPoolCandidatesByPool(where: $where) {
+                  pool { id }
+                  candidateCount
+                }
+              }
+            ',
+            [
+                'where' => []
+            ]
+        )->assertSimilarJson([
+            'data' => [
+                'countPoolCandidatesByPool' => [
+                    [
+                        'pool' => ['id' => $pool->id],
+                        'candidateCount' => 1
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    // single user returns two candidate is returned with no filters
+    // creates one users with two candidates and expects both candidates to be returned
+    public function testThatEmptyReturnsTwoCandidatesForOneUser()
+    {
+        $pool1 = Pool::factory()->create();
+        $pool2 = Pool::factory()->create();
+        $user = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool1->id,
+            'user_id' => $user->id
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool2->id,
+            'user_id' => $user->id
+        ]);
+
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+                query ($where: ApplicantFilterInput) {
+                    countPoolCandidatesByPool(where: $where) {
+                      pool { id }
+                      candidateCount
+                    }
+                  }
+                ',
+            [
+                'where' => []
+            ]
+        )->assertSimilarJson([
+            'data' => [
+                'countPoolCandidatesByPool' => [
+                    [
+                        'pool' => ['id' => $pool1->id],
+                        'candidateCount' => 1
+                    ],
+                    [
+                        'pool' => ['id' => $pool2->id],
+                        'candidateCount' => 1
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    // test that available for opportunities scope is working
+    // creates a user for each user status and ensure that only the two come back
+    public function testAvailableForOpportunities()
+    {
+        $pool = Pool::factory()->create();
+        foreach (ApiEnums::userStatuses() as $status) {
+            $user = User::factory()->create([
+                'job_looking_status' => $status
+            ]);
+            PoolCandidate::factory()->create([
+                'pool_id' => $pool->id,
+                'user_id' => $user->id
+            ]);
+        }
+
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+                query ($where: ApplicantFilterInput) {
+                    countPoolCandidatesByPool(where: $where) {
+                      pool { id }
+                      candidateCount
+                    }
+                  }
+                ',
+            [
+                'where' => []
+            ]
+        )->assertSimilarJson([
+            'data' => [
+                'countPoolCandidatesByPool' => [
+                    [
+                        'pool' => ['id' => $pool->id],
+                        'candidateCount' => 2
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    // test has diploma
+    // creates three users with/without/null diploma and expects only one to come back
+    public function testHasDiploma()
+    {
+        $pool = Pool::factory()->create();
+        $user1 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'has_diploma' => true
+        ]);
+        $user2 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'has_diploma' => false
+        ]);
+        $user3 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'has_diploma' => null
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user1->id
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user2->id
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user3->id
+        ]);
+
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+                query ($where: ApplicantFilterInput) {
+                    countPoolCandidatesByPool(where: $where) {
+                      pool { id }
+                      candidateCount
+                    }
+                  }
+                ',
+            [
+                'where' => [
+                    'hasDiploma' => true
+                ]
+            ]
+        )->assertSimilarJson([
+            'data' => [
+                'countPoolCandidatesByPool' => [
+                    [
+                        'pool' => ['id' => $pool->id],
+                        'candidateCount' => 1
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    // test equity - Is woman
+    // creates three users with/without/null isWoman and expects only one to come back
+    public function testEquityIsWoman()
+    {
+        $pool = Pool::factory()->create();
+        $user1 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'is_woman' => true
+        ]);
+        $user2 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'is_woman' => false
+        ]);
+        $user3 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'is_woman' => null
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user1->id
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user2->id
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user3->id
+        ]);
+
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+                query ($where: ApplicantFilterInput) {
+                    countPoolCandidatesByPool(where: $where) {
+                      pool { id }
+                      candidateCount
+                    }
+                  }
+                ',
+            [
+                'where' => [
+                    'equity' => [
+                        'isWoman' => true
+                    ]
+                ]
+            ]
+        )->assertSimilarJson([
+            'data' => [
+                'countPoolCandidatesByPool' => [
+                    [
+                        'pool' => ['id' => $pool->id],
+                        'candidateCount' => 1
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    // no tests for the other equity fields yet - assume if one works then they all work
+
+    // test language ability
+    // creates a user for bilingual, english, and french then filter for english and expect two to come back
+    public function testLanguageAbility()
+    {
+        $pool = Pool::factory()->create();
+        $user1 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'language_ability' => ApiEnums::LANGUAGE_ABILITY_BILINGUAL
+        ]);
+        $user2 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'language_ability' => ApiEnums::LANGUAGE_ABILITY_ENGLISH
+        ]);
+        $user3 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'language_ability' => ApiEnums::LANGUAGE_ABILITY_FRENCH
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user1->id
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user2->id
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user3->id
+        ]);
+
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+                query ($where: ApplicantFilterInput) {
+                    countPoolCandidatesByPool(where: $where) {
+                      pool { id }
+                      candidateCount
+                    }
+                  }
+                ',
+            [
+                'where' => [
+                    'languageAbility' => ApiEnums::LANGUAGE_ABILITY_ENGLISH
+                ]
+            ]
+        )->assertSimilarJson([
+            'data' => [
+                'countPoolCandidatesByPool' => [
+                    [
+                        'pool' => ['id' => $pool->id],
+                        'candidateCount' => 2
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    // test operational requirements
+    // creates a three users with different op reqs, filter for a combination that two users have, expect to get 2 candidates
+    public function testOperationalRequirements()
+    {
+        $pool = Pool::factory()->create();
+        $user1 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'accepted_operational_requirements' => [
+                ApiEnums::OPERATIONAL_REQUIREMENT_DRIVERS_LICENSE,
+                ApiEnums::OPERATIONAL_REQUIREMENT_ON_CALL
+            ]
+        ]);
+        $user2 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'accepted_operational_requirements' => [
+                ApiEnums::OPERATIONAL_REQUIREMENT_DRIVERS_LICENSE,
+                ApiEnums::OPERATIONAL_REQUIREMENT_ON_CALL,
+                ApiEnums::OPERATIONAL_REQUIREMENT_OVERTIME_OCCASIONAL
+            ]
+        ]);
+        $user3 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'accepted_operational_requirements' => [
+                ApiEnums::OPERATIONAL_REQUIREMENT_OVERTIME_OCCASIONAL
+            ]
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user1->id
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user2->id
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user3->id
+        ]);
+
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+                query ($where: ApplicantFilterInput) {
+                    countPoolCandidatesByPool(where: $where) {
+                      pool { id }
+                      candidateCount
+                    }
+                  }
+                ',
+            [
+                'where' => [
+                    'operationalRequirements' => [
+                        ApiEnums::OPERATIONAL_REQUIREMENT_DRIVERS_LICENSE,
+                        ApiEnums::OPERATIONAL_REQUIREMENT_ON_CALL
+                    ]
+                ]
+            ]
+        )->assertSimilarJson([
+            'data' => [
+                'countPoolCandidatesByPool' => [
+                    [
+                        'pool' => ['id' => $pool->id],
+                        'candidateCount' => 2
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    // test location preferences
+    // creates a three users with different location preferences, filter for a combination that two users have, expect to get 2 candidates
+    public function testLocationPreferences()
+    {
+        $pool = Pool::factory()->create();
+        $user1 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'location_preferences' => [
+                ApiEnums::WORK_REGION_ATLANTIC,
+                ApiEnums::WORK_REGION_BRITISH_COLUMBIA
+            ]
+        ]);
+        $user2 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'location_preferences' => [
+                ApiEnums::WORK_REGION_ATLANTIC,
+                ApiEnums::WORK_REGION_BRITISH_COLUMBIA,
+                ApiEnums::WORK_REGION_NATIONAL_CAPITAL
+            ]
+        ]);
+        $user3 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'location_preferences' => [
+                ApiEnums::WORK_REGION_NATIONAL_CAPITAL
+            ]
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user1->id
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user2->id
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user3->id
+        ]);
+
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+                query ($where: ApplicantFilterInput) {
+                    countPoolCandidatesByPool(where: $where) {
+                      pool { id }
+                      candidateCount
+                    }
+                  }
+                ',
+            [
+                'where' => [
+                    'locationPreferences' => [
+                        ApiEnums::WORK_REGION_ATLANTIC,
+                        ApiEnums::WORK_REGION_BRITISH_COLUMBIA
+                    ]
+                ]
+            ]
+        )->assertSimilarJson([
+            'data' => [
+                'countPoolCandidatesByPool' => [
+                    [
+                        'pool' => ['id' => $pool->id],
+                        'candidateCount' => 2
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    // test would accept temporary
+    // creates a three users with/without/null would accept temporary and expects only one to come back
+    public function testWouldAcceptTemporary()
+    {
+        $pool = Pool::factory()->create();
+        $user1 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'would_accept_temporary' => true
+        ]);
+        $user2 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'would_accept_temporary' => false
+        ]);
+        $user3 = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+            'would_accept_temporary' => null
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user1->id
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user2->id
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool->id,
+            'user_id' => $user3->id
+        ]);
+
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+                query ($where: ApplicantFilterInput) {
+                    countPoolCandidatesByPool(where: $where) {
+                      pool { id }
+                      candidateCount
+                    }
+                  }
+                ',
+            [
+                'where' => [
+                    'wouldAcceptTemporary' => true
+                ]
+            ]
+        )->assertSimilarJson([
+            'data' => [
+                'countPoolCandidatesByPool' => [
+                    [
+                        'pool' => ['id' => $pool->id],
+                        'candidateCount' => 1
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    // test classifications
+    // creates a three users various expected classifications and filter for the classifications on two of them
+    public function testClassifications()
+    {
+        $pool = Pool::factory()->create();
+        $classifications = Classification::factory(3)
+            ->create(
+                ['min_salary' => 0,  'max_salary' => 0] // avoid classification/salary cross-matching
+            );
+        $users = User::factory(3)
+            ->afterCreating(function ($user) use ($pool) {
+                PoolCandidate::factory()->create([
+                    'pool_id' => $pool->id,
+                    'user_id' => $user->id,
+                ]);
+            })
+            ->create([
+                'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING
+            ]);
+        $users[0]->expectedClassifications()->sync([
+            $classifications[0]->id,
+            $classifications[1]->id
+        ]);
+        $users[1]->expectedClassifications()->sync([
+            $classifications[1]->id,
+            $classifications[2]->id
+        ]);
+        $users[2]->expectedClassifications()->sync([
+            $classifications[2]->id
+        ]);
+
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+                query ($where: ApplicantFilterInput) {
+                    countPoolCandidatesByPool(where: $where) {
+                      pool { id }
+                      candidateCount
+                    }
+                  }
+                ',
+            [
+                'where' => [
+                    'expectedClassifications' => [
+                        [
+                            'group' => $classifications[0]->group,
+                            'level' => $classifications[0]->level,
+                        ],
+                        [
+                            'group' => $classifications[1]->group,
+                            'level' => $classifications[1]->level,
+                        ]
+                    ]
+                ]
+            ]
+        )->assertSimilarJson([
+            'data' => [
+                'countPoolCandidatesByPool' => [
+                    [
+                        'pool' => ['id' => $pool->id],
+                        'candidateCount' => 2
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    // test skills
+    // creates a three users various skills and filter for the skills on two of them
+    public function testSkills()
+    {
+        $pool = Pool::factory()->create();
+        $skills = Skill::factory(3)->create();
+        $users = User::factory(3)
+            ->afterCreating(function ($user) use ($pool) {
+                $exp = AwardExperience::factory()->create(['user_id' => $user->id]);
+                print_r($exp);
+                PoolCandidate::factory()->create([
+                    'pool_id' => $pool->id,
+                    'user_id' => $user->id,
+                ]);
+            })
+            ->create(['job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING]);
+
+        $users[0]->awardExperiences()->sole()->skills()->sync([
+            $skills[0]->id,
+            $skills[1]->id
+        ]);
+        $users[1]->awardExperiences()->sole()->skills()->sync([
+            $skills[0]->id,
+            $skills[1]->id,
+            $skills[2]->id
+        ]);
+        $users[2]->awardExperiences()->sole()->skills()->sync([
+            $skills[2]->id
+        ]);
+
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+                query ($where: ApplicantFilterInput) {
+                    countPoolCandidatesByPool(where: $where) {
+                      pool { id }
+                      candidateCount
+                    }
+                  }
+                ',
+            [
+                'where' => [
+                    'skills' => [
+                        ['id' => $skills[0]->id],
+                        ['id' => $skills[1]->id]
+                    ]
+                ]
+            ]
+        )->assertSimilarJson([
+            'data' => [
+                'countPoolCandidatesByPool' => [
+                    [
+                        'pool' => ['id' => $pool->id],
+                        'candidateCount' => 2
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    // test pool filter
+    // creates three pools but filters on only 1 and 2
+    public function testPoolFilter()
+    {
+        $pool1 = Pool::factory()->create();
+        $pool2 = Pool::factory()->create();
+        $pool3 = Pool::factory()->create();
+        $user = User::factory()->create([
+            'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool1->id,
+            'user_id' => $user->id
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool2->id,
+            'user_id' => $user->id
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool3->id,
+            'user_id' => $user->id
+        ]);
+
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+                query ($where: ApplicantFilterInput) {
+                    countPoolCandidatesByPool(where: $where) {
+                      pool { id }
+                      candidateCount
+                    }
+                  }
+                ',
+            [
+                'where' => [
+                    "pools" => [
+                        ["id" => $pool1->id],
+                        ["id" => $pool2->id]
+                    ]
+                ]
+            ]
+        )->assertSimilarJson([
+            'data' => [
+                'countPoolCandidatesByPool' => [
+                    [
+                        'pool' => ['id' => $pool1->id],
+                        'candidateCount' => 1
+                    ],
+                    [
+                        'pool' => ['id' => $pool2->id],
+                        'candidateCount' => 1
+                    ]
+                ]
+            ]
+        ]);
+    }
+}

--- a/api/tests/Feature/CountPoolCandidatesByPoolTest.php
+++ b/api/tests/Feature/CountPoolCandidatesByPoolTest.php
@@ -629,7 +629,6 @@ class CountPoolCandidatesByPoolTest extends TestCase
         $users = User::factory(3)
             ->afterCreating(function ($user) use ($pool) {
                 $exp = AwardExperience::factory()->create(['user_id' => $user->id]);
-                print_r($exp);
                 PoolCandidate::factory()->create([
                     'pool_id' => $pool->id,
                     'user_id' => $user->id,


### PR DESCRIPTION
# :wave: Introduction
This branch adds a new query to the API for counting the number of pool candidates by filtering on their parent users and then groups them by pool.  I wasn't able to get a "natural implementation" based on the existing model and so it was implemented by a standalone query and manual query building.  H/t to @vd1992 for getting me started on the implementation.

I wasn't able to get it to also return the total number of users as originally defined in the issue.  I suggest issuing the existing user query at the same time in the same network request from the frontend.

# :test_tube: Testing
## :tipping_hand_man: Tips
- I like to uncomment the DB listener in api/app/Providers/AppServiceProvider.php and review the logged SQL.
- You'll need to use GraphQL Playground since there's no frontend usage for this yet.
```
query ($where: ApplicantFilterInput) {
  countPoolCandidatesByPool(where: $where) {
    pool { id }
    candidateCount
  }
}
------
{
  "where": {
    /* add some filters here */
  }  
}
```
## :notebook: Suggested Steps
- Run the PHPunit tests (don't forget to reseed afterwards)
- Run some manual tests in GraphQL Playground
- Search page still works well

# :robot: Robot Stuff
- Closes #4398 