### PR TITLE
Bug - 4463 - Prevent application overwrite

### DIFF
--- a/api/app/GraphQL/Mutations/CreateApplication.php
+++ b/api/app/GraphQL/Mutations/CreateApplication.php
@@ -1,9 +1,11 @@
 <?php
 
 namespace App\GraphQL\Mutations;
+
 use App\Models\PoolCandidate;
 use App\Models\Pool;
 use Database\Helpers\ApiEnums;
+use Nuwave\Lighthouse\Exceptions\ValidationException;
 
 final class CreateApplication
 {
@@ -14,11 +16,28 @@ final class CreateApplication
      */
     public function __invoke($_, array $args)
     {
+        // Check to see if the pool is published (can't apply to draft or expired)
+        $pool = Pool::find($args['poolId']);
+        if (in_array($pool->status, [
+            ApiEnums::POOL_ADVERTISEMENT_IS_DRAFT,
+            ApiEnums::POOL_ADVERTISEMENT_IS_EXPIRED
+        ])) {
+            throw ValidationException::withMessages(['you are unable to apply to this pool']);
+        }
+
+        // Do not allow users to apply if they already have
+        $exists = PoolCandidate::where('user_id', $args['userId'])
+            ->where('pool_id', $args['poolId'])
+            ->exists();
+        if ($exists) {
+            throw ValidationException::withMessages(['you are unable to apply to this pool']);
+        }
+
         // attempt to find existing application, if found return that otherwise create new application
         $application = PoolCandidate::firstOrCreate([
             'user_id' => $args['userId'],
             'pool_id' => $args['poolId'],
-          ]);
+        ]);
 
         // draft expiry date is the same as the expiry of the pool it is attached to
         $poolExpiry = Pool::find($application->pool_id)->expiry_date;

--- a/api/app/GraphQL/Mutations/CreateApplication.php
+++ b/api/app/GraphQL/Mutations/CreateApplication.php
@@ -18,11 +18,11 @@ final class CreateApplication
     {
         // Check to see if the pool is published (can't apply to draft or expired)
         $pool = Pool::find($args['poolId']);
-        if (in_array($pool->status, [
+        if (in_array($pool->advertisement_status, [
             ApiEnums::POOL_ADVERTISEMENT_IS_DRAFT,
             ApiEnums::POOL_ADVERTISEMENT_IS_EXPIRED
         ])) {
-            throw ValidationException::withMessages(['you are unable to apply to this pool']);
+            throw ValidationException::withMessages(['You are unable to apply to this pool']);
         }
 
         // Do not allow users to apply if they already have
@@ -30,7 +30,7 @@ final class CreateApplication
             ->where('pool_id', $args['poolId'])
             ->exists();
         if ($exists) {
-            throw ValidationException::withMessages(['you are unable to apply to this pool']);
+            throw ValidationException::withMessages(['You have already applied to this pool']);
         }
 
         // attempt to find existing application, if found return that otherwise create new application

--- a/api/app/GraphQL/Validators/Mutation/CreateApplicationValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/CreateApplicationValidator.php
@@ -4,7 +4,6 @@ namespace App\GraphQL\Validators\Mutation;
 
 use App\Rules\NotAlreadyApplied;
 use App\Rules\PoolPublished;
-use Illuminate\Validation\Rule;
 use Nuwave\Lighthouse\Validation\Validator;
 
 final class CreateApplicationValidator extends Validator

--- a/api/app/GraphQL/Validators/Mutation/CreateApplicationValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/CreateApplicationValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\GraphQL\Validators\Mutation;
+
+use App\Rules\NotAlreadyApplied;
+use App\Rules\PoolPublished;
+use Illuminate\Validation\Rule;
+use Nuwave\Lighthouse\Validation\Validator;
+
+final class CreateApplicationValidator extends Validator
+{
+
+    public function __construct($poolId, $userId)
+    {
+        $this->poolId = $poolId;
+        $this->userId = $userId;
+    }
+
+    /**
+     * Return the validation rules.
+     *
+     * @return array<string, array<mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'userId' => [new NotAlreadyApplied($this->poolId)],
+            'poolId' => [new PoolPublished]
+        ];
+    }
+
+    public function messages(): array
+    {
+        return  [];
+    }
+}

--- a/api/app/Rules/NotAlreadyApplied.php
+++ b/api/app/Rules/NotAlreadyApplied.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Rules;
+
+use App\Models\PoolCandidate;
+use Illuminate\Contracts\Validation\Rule;
+
+class NotAlreadyApplied implements Rule
+{
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct($poolId)
+    {
+        $this->poolId = $poolId;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return !PoolCandidate::where('user_id', $value)
+            ->where('pool_id', $this->poolId)
+            ->exists();
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'AlreadyApplied';
+    }
+}

--- a/api/app/Rules/NotAlreadyApplied.php
+++ b/api/app/Rules/NotAlreadyApplied.php
@@ -38,6 +38,6 @@ class NotAlreadyApplied implements Rule
      */
     public function message()
     {
-        return 'AlreadyApplied';
+        return 'AlreadyAppliedToPool';
     }
 }

--- a/api/app/Rules/NotAlreadyApplied.php
+++ b/api/app/Rules/NotAlreadyApplied.php
@@ -3,6 +3,7 @@
 namespace App\Rules;
 
 use App\Models\PoolCandidate;
+use Database\Helpers\ApiEnums;
 use Illuminate\Contracts\Validation\Rule;
 
 class NotAlreadyApplied implements Rule
@@ -38,6 +39,6 @@ class NotAlreadyApplied implements Rule
      */
     public function message()
     {
-        return 'AlreadyAppliedToPool';
+        return ApiEnums::POOL_CANDIDATE_EXISTS;
     }
 }

--- a/api/app/Rules/PoolPublished.php
+++ b/api/app/Rules/PoolPublished.php
@@ -42,6 +42,6 @@ class PoolPublished implements Rule
      */
     public function message()
     {
-        return 'PoolNotPublished';
+        return ApiEnums::POOL_CANDIDATE_POOL_NOT_PUBLISHED;
     }
 }

--- a/api/app/Rules/PoolPublished.php
+++ b/api/app/Rules/PoolPublished.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use App\Models\Pool;
+use Database\Helpers\ApiEnums;
+
+class PoolPublished implements Rule
+{
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $pool = Pool::find($value);
+
+        return !in_array($pool->advertisement_status, [
+            ApiEnums::POOL_ADVERTISEMENT_IS_DRAFT,
+            ApiEnums::POOL_ADVERTISEMENT_IS_EXPIRED
+        ]);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'PoolNotPublished';
+    }
+}

--- a/api/database/helpers/ApiEnums.php
+++ b/api/database/helpers/ApiEnums.php
@@ -10,7 +10,7 @@ class ApiEnums
      *
      * @return string[]
      */
-    public static function operationalRequirements() : array
+    public static function operationalRequirements(): array
     {
         return [
             'SHIFT_WORK',
@@ -34,7 +34,7 @@ class ApiEnums
      *
      * @return string[]
      */
-    public static function languageAbilities() : array
+    public static function languageAbilities(): array
     {
         return [
             self::LANGUAGE_ABILITY_ENGLISH,
@@ -52,7 +52,7 @@ class ApiEnums
      *
      * @return string[]
      */
-    public static function govEmployeeTypes() : array
+    public static function govEmployeeTypes(): array
     {
         return [
             self::GOV_EMPLOYEE_TYPE_STUDENT,
@@ -70,7 +70,7 @@ class ApiEnums
      *
      * @return string[]
      */
-    public static function candidateExpiryFilters() : array
+    public static function candidateExpiryFilters(): array
     {
         return [
             self::CANDIDATE_EXPIRY_FILTER_ACTIVE,
@@ -86,7 +86,7 @@ class ApiEnums
      *
      * @return string[]
      */
-    public static function roles() : array
+    public static function roles(): array
     {
         return [
             self::ROLE_ADMIN,
@@ -99,7 +99,7 @@ class ApiEnums
      *
      * @return string[]
      */
-    public static function salaryRanges() : array
+    public static function salaryRanges(): array
     {
         return [
             '_50_59K',
@@ -127,7 +127,7 @@ class ApiEnums
     const CANDIDATE_STATUS_PLACED_INDETERMINATE = 'PLACED_INDETERMINATE';
     const CANDIDATE_STATUS_EXPIRED = 'EXPIRED';
 
-    public static function candidateStatuses() : array
+    public static function candidateStatuses(): array
     {
         return [
             self::CANDIDATE_STATUS_DRAFT,
@@ -160,7 +160,7 @@ class ApiEnums
      *
      * @return string[]
      */
-    public static function poolStatuses() : array
+    public static function poolStatuses(): array
     {
         return [
             self::POOL_STATUS_NOT_TAKING_APPLICATIONS,
@@ -179,7 +179,7 @@ class ApiEnums
      *
      * @return string[]
      */
-    public static function genericJobTitleKeys() : array
+    public static function genericJobTitleKeys(): array
     {
         return [
             self::GENERIC_JOB_TITLE_KEY_TECHNICIAN_IT01,
@@ -204,7 +204,7 @@ class ApiEnums
      *
      * @return string[]
      */
-    public static function workRegions() : array
+    public static function workRegions(): array
     {
         return [
             self::WORK_REGION_TELEWORK,
@@ -224,7 +224,7 @@ class ApiEnums
     const POOL_ADVERTISEMENT_IS_DRAFT = 'DRAFT';
     const POOL_ADVERTISEMENT_IS_PUBLISHED = 'PUBLISHED';
     const POOL_ADVERTISEMENT_IS_EXPIRED = 'EXPIRED';
-    public static function poolAdvertisementStatuses() : array
+    public static function poolAdvertisementStatuses(): array
     {
         return [
             self::POOL_ADVERTISEMENT_IS_DRAFT,
@@ -241,7 +241,7 @@ class ApiEnums
     const POOL_ADVERTISEMENT_VARIOUS = 'VARIOUS';
     const POOL_ADVERTISEMENT_BILINGUAL_INTERMEDIATE = 'BILINGUAL_INTERMEDIATE';
     const POOL_ADVERTISEMENT_BILINGUAL_ADVANCED = 'BILINGUAL_ADVANCED';
-    public static function poolAdvertisementLanguages() : array
+    public static function poolAdvertisementLanguages(): array
     {
         return [
             self::POOL_ADVERTISEMENT_ENGLISH,
@@ -258,7 +258,7 @@ class ApiEnums
     const POOL_ADVERTISEMENT_RELIABILITY = 'RELIABILITY';
     const POOL_ADVERTISEMENT_SECRET = 'SECRET';
     const POOL_ADVERTISEMENT_TOP_SECRET = 'TOP_SECRET';
-    public static function poolAdvertisementSecurity() : array
+    public static function poolAdvertisementSecurity(): array
     {
         return [
             self::POOL_ADVERTISEMENT_RELIABILITY,
@@ -278,7 +278,7 @@ class ApiEnums
     const POOL_STREAM_PROJECT_PORTFOLIO_MANAGEMENT = 'PROJECT_PORTFOLIO_MANAGEMENT';
     const POOL_STREAM_SECURITY = 'SECURITY';
     const POOL_STREAM_SOFTWARE_SOLUTIONS = 'SOFTWARE_SOLUTIONS';
-    public static function poolStreams() : array
+    public static function poolStreams(): array
     {
         return [
             self::POOL_STREAM_BUSINESS_ADVISORY_SERVICES,
@@ -298,7 +298,7 @@ class ApiEnums
     const CITIZENSHIP_CITIZEN = 'CITIZEN';
     const CITIZENSHIP_PR = 'PERMANENT_RESIDENT';
     const CITIZENSHIP_OTHER = 'OTHER';
-    public static function citizenshipStatuses() : array
+    public static function citizenshipStatuses(): array
     {
         return [
             self::CITIZENSHIP_CITIZEN,
@@ -313,7 +313,7 @@ class ApiEnums
     const ARMED_FORCES_VETERAN = 'VETERAN';
     const ARMED_FORCES_MEMBER = 'MEMBER';
     const ARMED_FORCES_NON_CAF = 'NON_CAF';
-    public static function armedForcesStatuses() : array
+    public static function armedForcesStatuses(): array
     {
         return [
             self::ARMED_FORCES_VETERAN,
@@ -322,19 +322,33 @@ class ApiEnums
         ];
     }
 
-     /**
+    /**
      * Publishing Groups
      */
     const PUBLISHING_GROUP_IT_JOBS = 'IT_JOBS';
     const PUBLISHING_GROUP_EXECUTIVE_JOBS = 'EXECUTIVE_JOBS';
     const PUBLISHING_GROUP_OTHER = 'OTHER';
 
-    public static function publishingGroups() : array
+    public static function publishingGroups(): array
     {
         return [
             self::PUBLISHING_GROUP_IT_JOBS,
             self::PUBLISHING_GROUP_EXECUTIVE_JOBS,
             self::PUBLISHING_GROUP_OTHER,
+        ];
+    }
+
+    /**
+     * Pool Application Errors
+     */
+    const POOL_CANDIDATE_EXISTS = 'APPLICATION_EXISTS';
+    const POOL_CANDIDATE_POOL_NOT_PUBLISHED = 'NOT_PUBLISHED';
+
+    public static function poolCandidateErrors(): array
+    {
+        return [
+            self::POOL_CANDIDATE_EXISTS,
+            self::POOL_CANDIDATE_POOL_NOT_PUBLISHED,
         ];
     }
 }

--- a/api/database/helpers/ApiEnums.php
+++ b/api/database/helpers/ApiEnums.php
@@ -342,7 +342,7 @@ class ApiEnums
      * Pool Application Errors
      */
     const POOL_CANDIDATE_EXISTS = 'APPLICATION_EXISTS';
-    const POOL_CANDIDATE_POOL_NOT_PUBLISHED = 'NOT_PUBLISHED';
+    const POOL_CANDIDATE_POOL_NOT_PUBLISHED = 'POOL_NOT_PUBLISHED';
 
     public static function poolCandidateErrors(): array
     {

--- a/api/tests/Feature/PoolApplicationTest.php
+++ b/api/tests/Feature/PoolApplicationTest.php
@@ -97,7 +97,7 @@ class PoolApplicationTest extends TestCase
                 'createApplication' => null
             ],
             'errors' => [[
-                'message' => 'AlreadyApplied',
+                'message' => 'AlreadyAppliedToPool',
             ]]
         ]);
 

--- a/api/tests/Feature/PoolApplicationTest.php
+++ b/api/tests/Feature/PoolApplicationTest.php
@@ -41,6 +41,7 @@ class PoolApplicationTest extends TestCase
         // create an unexpired Pool instance
         Pool::factory()->create([
             'id' => 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12',
+            'published_at' => config('constants.past_date'),
             'expiry_date' => config('constants.far_future_date'),
         ]);
 
@@ -96,10 +97,7 @@ class PoolApplicationTest extends TestCase
                 'createApplication' => null
             ],
             'errors' => [[
-                'message' => 'The given data was invalid.',
-                'extensions' => [
-                    'validation' => [["You have already applied to this pool"]]
-                ]
+                'message' => 'AlreadyApplied',
             ]]
         ]);
 
@@ -120,7 +118,7 @@ class PoolApplicationTest extends TestCase
         $newUser->save();
 
         Pool::factory()->create([
-            'id' => 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12',
+            'id' => '3ecf840d-b0ed-4207-8fc4-f45c4a865eaf',
             'published_at' => null,
             'expiry_date' => config('constants.far_future_date'),
         ]);
@@ -129,7 +127,7 @@ class PoolApplicationTest extends TestCase
             /** @lang Graphql */
             '
             mutation createApplication {
-                createApplication(userId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", poolId: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12") {
+                createApplication(userId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", poolId: "3ecf840d-b0ed-4207-8fc4-f45c4a865eaf") {
                     user {
                         id
                     }
@@ -145,10 +143,7 @@ class PoolApplicationTest extends TestCase
                 'createApplication' => null
             ],
             'errors' => [[
-                'message' => 'The given data was invalid.',
-                'extensions' => [
-                    'validation' => [["You are unable to apply to this pool"]]
-                ]
+                'message' => 'PoolNotPublished',
             ]]
         ]);
     }
@@ -163,7 +158,7 @@ class PoolApplicationTest extends TestCase
         $newUser->save();
 
         Pool::factory()->create([
-            'id' => 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12',
+            'id' => 'f755f7da-c490-4fe1-a1f0-a6c233796442',
             'published_at' => null,
             'expiry_date' => config('constants.far_past_date'),
         ]);
@@ -172,7 +167,7 @@ class PoolApplicationTest extends TestCase
             /** @lang Graphql */
             '
             mutation createApplication {
-                createApplication(userId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", poolId: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12") {
+                createApplication(userId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", poolId: "f755f7da-c490-4fe1-a1f0-a6c233796442") {
                     user {
                         id
                     }
@@ -188,10 +183,7 @@ class PoolApplicationTest extends TestCase
                 'createApplication' => null
             ],
             'errors' => [[
-                'message' => 'The given data was invalid.',
-                'extensions' => [
-                    'validation' => [["You are unable to apply to this pool"]]
-                ]
+                'message' => 'PoolNotPublished',
             ]]
         ]);
     }

--- a/api/tests/Feature/PoolApplicationTest.php
+++ b/api/tests/Feature/PoolApplicationTest.php
@@ -94,10 +94,17 @@ class PoolApplicationTest extends TestCase
         '
         )->assertJson([
             'data' => [
-                'createApplication' => null
+                'createApplication' => [
+                    'user' => [
+                        'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+                    ],
+                    'pool' => [
+                        'id' => 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12',
+                    ],
+                ]
             ],
             'errors' => [[
-                'message' => 'AlreadyAppliedToPool',
+                'message' => ApiEnums::POOL_CANDIDATE_EXISTS,
             ]]
         ]);
 
@@ -143,7 +150,7 @@ class PoolApplicationTest extends TestCase
                 'createApplication' => null
             ],
             'errors' => [[
-                'message' => 'PoolNotPublished',
+                'message' => ApiEnums::POOL_CANDIDATE_POOL_NOT_PUBLISHED,
             ]]
         ]);
     }
@@ -183,7 +190,7 @@ class PoolApplicationTest extends TestCase
                 'createApplication' => null
             ],
             'errors' => [[
-                'message' => 'PoolNotPublished',
+                'message' => ApiEnums::POOL_CANDIDATE_POOL_NOT_PUBLISHED,
             ]]
         ]);
     }

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1783,5 +1783,13 @@
   "z/J4uL": {
     "defaultMessage": "Statut de l’employé :",
     "description": "Label for applicant's employee status"
+  },
+  "0OPWbJ": {
+    "defaultMessage": "Vous avez déjà postulé dans ce bassin",
+    "description": "Message displayed when a user attempts to apply to pool more than once"
+  },
+  "16AY+M": {
+    "defaultMessage": "Incapable de postuler pour ce bassin",
+    "description": "Message displayed when user attempts to apply to an unpublished pool"
   }
 }

--- a/frontend/common/src/messages/apiMessages.ts
+++ b/frontend/common/src/messages/apiMessages.ts
@@ -150,6 +150,12 @@ export const messages: { [key: string]: MessageDescriptor } = defineMessages({
     description:
       "Error message that the pool advertisement must have publishing group filled.",
   },
+  AlreadyAppliedToPool: {
+    defaultMessage: "You have already applied to this pool",
+    description:
+      "Message displayed when a user attempts to apply to pool more than once",
+    id: "0OPWbJ",
+  },
 });
 
 export const tryFindMessageDescriptor = (

--- a/frontend/common/src/messages/apiMessages.ts
+++ b/frontend/common/src/messages/apiMessages.ts
@@ -156,6 +156,12 @@ export const messages: { [key: string]: MessageDescriptor } = defineMessages({
       "Message displayed when a user attempts to apply to pool more than once",
     id: "0OPWbJ",
   },
+  POOL_NOT_PUBLISHED: {
+    defaultMessage: "Unable to apply to this pool",
+    id: "16AY+M",
+    description:
+      "Message displayed when user attempts to apply to an unpublished pool",
+  },
 });
 
 export const tryFindMessageDescriptor = (

--- a/frontend/common/src/messages/apiMessages.ts
+++ b/frontend/common/src/messages/apiMessages.ts
@@ -150,7 +150,7 @@ export const messages: { [key: string]: MessageDescriptor } = defineMessages({
     description:
       "Error message that the pool advertisement must have publishing group filled.",
   },
-  AlreadyAppliedToPool: {
+  APPLICATION_EXISTS: {
     defaultMessage: "You have already applied to this pool",
     description:
       "Message displayed when a user attempts to apply to pool more than once",

--- a/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
+++ b/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
@@ -75,7 +75,6 @@ const CreateApplication = ({ poolId }: CreateApplicationProps) => {
     if (!poolId) {
       redirectPath = paths.allPools();
     }
-    console.log("no data");
     handleError();
   }
 
@@ -95,18 +94,13 @@ const CreateApplication = ({ poolId }: CreateApplicationProps) => {
             );
           } else if (result.error?.message) {
             const message = tryFindMessageDescriptor(result.error.message);
-            console.log("has message");
             handleError(message);
           } else {
             // Fallback to generic message
-            console.log("fallback");
             handleError();
           }
         })
-        .catch(() => {
-          console.log("error caught");
-          handleError();
-        });
+        .catch(handleError);
     }
   }, [isCreating, userId, poolId, executeMutation, handleError, paths, intl]);
 
@@ -114,6 +108,7 @@ const CreateApplication = ({ poolId }: CreateApplicationProps) => {
     createApplication();
   }, [createApplication]);
 
+  // Don't render the page if the mutation ran already
   if (hasMutationData) {
     return null;
   }

--- a/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
+++ b/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Loading from "@common/components/Pending/Loading";
 import { redirect } from "@common/helpers/router";
 import { useIntl } from "react-intl";
-import { toast } from "react-toastify";
+import { Id, toast } from "react-toastify";
 import { notEmpty } from "@common/helpers/util";
 import { tryFindMessageDescriptor } from "@common/messages/apiMessages";
 import {
@@ -23,6 +23,7 @@ interface CreateApplicationProps {
  */
 const CreateApplication = ({ poolId }: CreateApplicationProps) => {
   const intl = useIntl();
+  const errorToastId = React.useRef<Id>("");
   const paths = useDirectIntakeRoutes();
   const [{ data }] = useGetPoolAdvertisementQuery({
     variables: { id: poolId },
@@ -43,14 +44,22 @@ const CreateApplication = ({ poolId }: CreateApplicationProps) => {
   const handleError = React.useCallback(
     (msg?: React.ReactNode, path?: string) => {
       redirect(path || redirectPath);
-      toast.error(
-        msg ||
-          intl.formatMessage({
-            defaultMessage: "Error application creation failed",
-            id: "tlAiJm",
-            description: "Application creation failed",
-          }),
-      );
+      /**
+       * This is supposed to prevent the toast
+       * from firing twice, but it does not appear to
+       * work. Leaving it in, in the hopes
+       * it finally does 🤷‍♀️
+       */
+      if (!toast.isActive(errorToastId.current)) {
+        errorToastId.current = toast.error(
+          msg ||
+            intl.formatMessage({
+              defaultMessage: "Error application creation failed",
+              id: "tlAiJm",
+              description: "Application creation failed",
+            }),
+        );
+      }
       return null;
     },
     [intl, redirectPath],

--- a/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
+++ b/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
@@ -41,8 +41,8 @@ const CreateApplication = ({ poolId }: CreateApplicationProps) => {
    * @returns null
    */
   const handleError = React.useCallback(
-    (msg?: React.ReactNode) => {
-      redirect(redirectPath);
+    (msg?: React.ReactNode, path?: string) => {
+      redirect(path || redirectPath);
       toast.error(
         msg ||
           intl.formatMessage({
@@ -83,18 +83,26 @@ const CreateApplication = ({ poolId }: CreateApplicationProps) => {
       executeMutation({ userId, poolId })
         .then((result) => {
           if (result.data?.createApplication) {
-            // Redirect user to the application on success
-            redirect(paths.reviewApplication(result.data.createApplication.id));
-            toast.success(
-              intl.formatMessage({
-                defaultMessage: "Application created",
-                id: "U/ji+A",
-                description: "Application created successfully",
-              }),
+            const newPath = paths.reviewApplication(
+              result.data.createApplication.id,
             );
+            // Redirect user to the application if it exists
+            // Toast success or error
+            if (!result.error) {
+              redirect(newPath);
+              toast.success(
+                intl.formatMessage({
+                  defaultMessage: "Application created",
+                  id: "U/ji+A",
+                  description: "Application created successfully",
+                }),
+              );
+            } else {
+              const message = tryFindMessageDescriptor(result.error.message);
+              handleError(message, newPath);
+            }
           } else if (result.error?.message) {
-            const message = tryFindMessageDescriptor(result.error.message);
-            handleError(message);
+            handleError(tryFindMessageDescriptor(result.error.message));
           } else {
             // Fallback to generic message
             handleError();

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -396,11 +396,9 @@ const PoolAdvertisement = ({
                 </Text>
                 {essentialSkills[SkillCategory.Technical]?.map((skill) => (
                   <Accordion title={skill.name[locale] || ""} key={skill.id}>
-                    <p>
-                      <Text>
-                        {skill.description ? skill.description[locale] : ""}
-                      </Text>
-                    </p>
+                    <Text>
+                      {skill.description ? skill.description[locale] : ""}
+                    </Text>
                   </Accordion>
                 ))}
               </>


### PR DESCRIPTION
## 👋 Introduction

This rearranges the logic in the `CreateApplication` mutation to prevent users from overwriting existing applications. We now throw validation errors earlier. This helps to reduce the amount of business logic on the frontend and reduce odds of leaving users hanging.

## 🤯  Neat Stuff

GraphQL has the ability to return [partial errors](https://lighthouse-php.com/master/digging-deeper/error-handling.html#partial-errors). This PR uses that to return an `APPLICATION_EXISTS` along with the existing application so we can redirect a user to that existing application. 

## 🔨 WIP

- [x] Add new French strings once supplied

## ❓ Question

### Toast

On error, the toast is shown twice and using `toastId` is not preventing it for some reason. Is there a better way to prevent duplicate toasts?

## 🧪 Testing

1. Run PHPUnit tests
2. Reseed database
3. Build talent search `npm run production --workspace=talentsearch`
4. Login and navigate to the "Browse opportunities" page
5. Attempt to apply to a pool you have already applied to, you can do this by:
    1. Open the "Apply to this recruitment" link in two separate tabs
    2. Apply in the first tab
    3. Then, try to apply in the second tab
6. Ensure that the second application attempt fails

## 🤖 Robot Stuff

Resolves #4463 