### PR TITLE
Bug - 4411 - Remove router 404 redirect

### DIFF
--- a/frontend/common/src/helpers/router.tsx
+++ b/frontend/common/src/helpers/router.tsx
@@ -107,7 +107,6 @@ export interface RouterArgs {
   };
   paths?: {
     welcomeRoute?: string;
-    notFoundRoute?: string;
   };
 }
 
@@ -128,7 +127,7 @@ export const useRouter = ({
     loggedInEmail,
     isLoaded: authorizationLoaded,
   } = React.useContext(AuthorizationContext);
-  const { welcomeRoute, notFoundRoute } = paths;
+  const { welcomeRoute } = paths;
   // Render the result of routing
   useEffect((): void => {
     router
@@ -193,19 +192,13 @@ export const useRouter = ({
           } else {
             setComponent(notAuthorized);
           }
-        } else if (notFoundRoute) {
-          navigate(notFoundRoute);
         } else {
           setComponent(notFound);
         }
         return null;
       })
       .catch(async () => {
-        if (notFoundRoute) {
-          navigate(notFoundRoute);
-        } else {
-          setComponent(notFound);
-        }
+        setComponent(notFound);
       });
   }, [
     apiRoutes,
@@ -218,7 +211,6 @@ export const useRouter = ({
     pathName,
     router,
     welcomeRoute,
-    notFoundRoute,
     authorizationLoaded,
   ]);
 

--- a/frontend/talentsearch/src/js/components/PageContainer.tsx
+++ b/frontend/talentsearch/src/js/components/PageContainer.tsx
@@ -12,8 +12,9 @@ import {
 import Header from "@common/components/Header";
 import Footer from "@common/components/Footer";
 import NotAuthorized from "@common/components/NotAuthorized";
-import Error404 from "./404/Error404";
 import { useApplicantProfileRoutes } from "../applicantProfileRoutes";
+
+const NotFoundPage = React.lazy(() => import("./404/Error404"));
 
 export const exactMatch = (ref: string | null, test: string): boolean =>
   ref === test;
@@ -96,7 +97,7 @@ const TalentSearchNotAuthorized: React.FC = () => {
   );
 };
 
-const notFound = <Error404 />;
+const notFound = <NotFoundPage />;
 const notAuthorized = <TalentSearchNotAuthorized />;
 
 export const PageContainer: React.FC<{

--- a/frontend/talentsearch/src/js/components/PageContainer.tsx
+++ b/frontend/talentsearch/src/js/components/PageContainer.tsx
@@ -3,7 +3,6 @@ import { Routes } from "universal-router";
 import { useIntl } from "react-intl";
 import NavMenu from "@common/components/NavMenu";
 import { Link } from "@common/components";
-import NotFound from "@common/components/NotFound";
 import {
   RouterResult,
   useLocation,
@@ -13,8 +12,8 @@ import {
 import Header from "@common/components/Header";
 import Footer from "@common/components/Footer";
 import NotAuthorized from "@common/components/NotAuthorized";
+import Error404 from "./404/Error404";
 import { useApplicantProfileRoutes } from "../applicantProfileRoutes";
-import { useTalentSearchRoutes } from "../talentSearchRoutes";
 
 export const exactMatch = (ref: string | null, test: string): boolean =>
   ref === test;
@@ -73,28 +72,6 @@ export const MenuLink: React.FC<MenuLinkProps> = ({
   );
 };
 
-const TalentSearchNotFound: React.FC = () => {
-  const intl = useIntl();
-  return (
-    <NotFound
-      headingMessage={intl.formatMessage({
-        description: "Heading for the message saying the page was not found.",
-        defaultMessage: "Sorry, we can't find the page you were looking for.",
-        id: "pBJzgi",
-      })}
-    >
-      <p>
-        {intl.formatMessage({
-          description: "Detailed message saying the page was not found.",
-          defaultMessage:
-            "Oops, it looks like you've landed on a page that either doesn't exist or has moved.",
-          id: "pgHTkX",
-        })}
-      </p>
-    </NotFound>
-  );
-};
-
 const TalentSearchNotAuthorized: React.FC = () => {
   const intl = useIntl();
   return (
@@ -119,7 +96,7 @@ const TalentSearchNotAuthorized: React.FC = () => {
   );
 };
 
-const notFound = <TalentSearchNotFound />;
+const notFound = <Error404 />;
 const notAuthorized = <TalentSearchNotAuthorized />;
 
 export const PageContainer: React.FC<{
@@ -129,7 +106,6 @@ export const PageContainer: React.FC<{
 }> = ({ menuItems, contentRoutes, authLinks }) => {
   const intl = useIntl();
   const paths = useApplicantProfileRoutes();
-  const tsPaths = useTalentSearchRoutes();
   const content = useRouter({
     routes: contentRoutes,
     components: {
@@ -138,7 +114,6 @@ export const PageContainer: React.FC<{
     },
     paths: {
       welcomeRoute: paths.createAccount(),
-      notFoundRoute: tsPaths.notFound(),
     },
   });
   return (


### PR DESCRIPTION
## 👋 Introduction

This removed the client redirect to `/404` in talent search. This was preventing users from clicking the back button. This removes that and updated the `notFound` component with the new 404 page.

## 🧪 Testing

1. Build talent search `npm run production --workspace`
2. Navigate to any page
3. Edit the url to be nonsense to trigger 404
4. Click the back button in your browser
5. Ensure you are properly sent back and are no longer on the 404 page

## 🤖 Robot Stuff

Resolves #4411 