### PR TITLE
Copy - Change GC Talent to GC Digital Talent

### DIFF
--- a/frontend/admin/src/js/components/home/HomePage.tsx
+++ b/frontend/admin/src/js/components/home/HomePage.tsx
@@ -30,8 +30,8 @@ const HomePage: React.FC = () => {
           <p>
             {intl.formatMessage({
               defaultMessage:
-                "Welcome to GC Talent, please log in to continue.",
-              id: "LGo8fw",
+                "Welcome to GC Digital Talent, please log in to continue.",
+              id: "Nfy1HK",
               description:
                 "Instructional text for the talent cloud pool manager portal home page.",
             })}

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -1326,8 +1326,8 @@
     "defaultMessage": "Retirer du bassin",
     "description": "title for change expiry date dialog on view-user page"
   },
-  "LGo8fw": {
-    "defaultMessage": "Bienvenue à Talent GC, veuillez vous connecter pour continuer.",
+  "Nfy1HK": {
+    "defaultMessage": "Bienvenue à Talent numérique du GC, veuillez vous connecter pour continuer.",
     "description": "Instructional text for the talent cloud pool manager portal home page."
   },
   "O8U5Sz": {

--- a/frontend/talentsearch/webpack.base.js
+++ b/frontend/talentsearch/webpack.base.js
@@ -73,7 +73,7 @@ module.exports = {
 
     // generate an index.html file based on given template
     new HtmlWebpackPlugin({
-      title: "GC Talent",
+      title: "GC Digital Talent",
       template: path.resolve(__dirname, "public/index.html"),
     }),
   ],


### PR DESCRIPTION
Resolves #4485.

## Steps to test

1. Compile admin `npm run intl-compile --workspace=admin`
2. Build admin `npm run production --workspace=admin`
3. Navigate to **/en/admin**
4. Verify instructional text for the talent cloud pool manager portal home page includes **GC Digital Talent**
5. Navigate to **/fr/admin**
6. Verify instructional text for the talent cloud pool manager portal home page includes **Talent numérique du GC**
7. Build talentsearch `npm run production --workspace=talentsearch`
8. Navigate to **/en/search**
9. Verify page title is **GC Digital Talent**