### PR TITLE
a11y - 4484 - New Tab Indicators

### DIFF
--- a/frontend/talentsearch/src/js/components/languageInformationForm/LanguageInformationForm.tsx
+++ b/frontend/talentsearch/src/js/components/languageInformationForm/LanguageInformationForm.tsx
@@ -11,6 +11,7 @@ import { checkFeatureFlag } from "@common/helpers/runtimeVariable";
 import { navigate } from "@common/helpers/router";
 import { toast } from "react-toastify";
 import { BriefcaseIcon } from "@heroicons/react/24/solid";
+import { ExternalLink } from "@common/components/Link";
 import {
   BilingualEvaluation,
   EstimatedLanguageAbility,
@@ -135,9 +136,8 @@ export const LanguageInformationForm: React.FunctionComponent<{
 
   const languageEvaluationPageLink = () => {
     return (
-      <a
-        target="_blank"
-        rel="noopener noreferrer"
+      <ExternalLink
+        newTab
         href={
           locale === "en"
             ? "https://www.canada.ca/en/public-service-commission/services/second-language-testing-public-service.html"
@@ -149,15 +149,14 @@ export const LanguageInformationForm: React.FunctionComponent<{
           id: "Ugr5Yt",
           description: "Message on links to the language evaluation tests",
         })}
-      </a>
+      </ExternalLink>
     );
   };
 
   const selfAssessmentLink = (msg: React.ReactNode): React.ReactNode => {
     return (
-      <a
-        target="_blank"
-        rel="noopener noreferrer"
+      <ExternalLink
+        newTab
         href={
           locale === "en"
             ? "https://www.canada.ca/en/public-service-commission/services/second-language-testing-public-service/self-assessment-tests.html"
@@ -165,7 +164,7 @@ export const LanguageInformationForm: React.FunctionComponent<{
         }
       >
         {msg}
-      </a>
+      </ExternalLink>
     );
   };
 


### PR DESCRIPTION
## 👋 Introduction

This updates the links on `LanguageInformationForm` to use the `ExternalLink` component which includes the indicators for when a link opens in a new tab.

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Navigate to the language information form on a profile
3. Confirm the links next to "Bilingual evaluation" options have the new tab indicators
4. Select "I am bilingual (En/Fr) and have NOT..." option
5. Confirm the link for self assessment also has the indicators

## 📷 Screenshot

<img width="1025" alt="Screenshot 2022-10-28 at 1 27 39 PM" src="https://user-images.githubusercontent.com/4127998/198696967-baa34ee1-76b3-4480-aaa5-a80f3f114f1b.png">

## 🤖 Robot Stuff

Resolves #4484 