### PR TITLE
Use refresh token from local storage

### DIFF
--- a/frontend/common/src/components/Auth/AuthenticationContainer.tsx
+++ b/frontend/common/src/components/Auth/AuthenticationContainer.tsx
@@ -71,9 +71,14 @@ const logoutAndRefreshPage = (
 
 const refreshTokenSet = async (
   refreshPath: string,
-  refreshToken: string,
+  // refreshToken: string,
   setTokens: (tokens: TokenSet) => void,
 ): Promise<TokenSet | null> => {
+  // Local storage should be most up to date, especially if a refresh happened in a different tab.
+  // This is a bit hacky.  It would be better to have the refreshToken passed in as parameter like before.
+  // The provider state could be kept in sync with something like storage events (https://dev.to/cassiolacerda/how-to-syncing-react-state-across-multiple-tabs-with-usestate-hook-4bdm)
+  const refreshToken = localStorage.getItem(REFRESH_TOKEN);
+
   const response = await fetch(`${refreshPath}?refresh_token=${refreshToken}`);
   if (response.ok) {
     const responseBody: {
@@ -176,7 +181,10 @@ const AuthenticationContainer: React.FC<AuthenticationContainerProps> = ({
           },
       refreshTokenSet: () =>
         tokens.refreshToken
-          ? refreshTokenSet(tokenRefreshPath, tokens.refreshToken, setTokens)
+          ? refreshTokenSet(
+              tokenRefreshPath,
+              /* tokens.refreshToken, */ setTokens,
+            )
           : Promise.resolve(null),
     };
   }, [


### PR DESCRIPTION
# :wave: Introduction
This branch solves the problem where an auth refresh in one tab causes the refresh to fail in a second tab by loading the refresh token from local storage instead of the provider state.
# :warning: Warning
This is a "2 point" solution suggested by Tristan in the issue.  It has the downside of blocking the UI while the token is retrieved from storage and issuing a useless refresh request.  A better solution eventually would be to keep the provider state in sync between tabs using something like storage events.  Or even switching to an auth library that handles this in a worker thread.
# :test_tube: Testing
1. Set up your environment for log in and log out with Sign In Canada
   - Set the log out endpoint in frontend/.apache_env
   - Set the client settings in api/.env
2.  Open a tab and log into the app
3. Open a second tab and log into the app (should go through without prompting for password again
4. Wait at least 10 minutes
5. Go to the first tab and navigate to a different page in the site, note that a refresh occurred in your network viewer
6. Go to the second tab and navigate to a different page in the site, note that another refresh occurred but it was successful
# :robot: Robot Stuff
Closes #4523 