### PR TITLE
Bug - 4474 - Remove skill picker on non-draft pool edit page

### DIFF
--- a/frontend/admin/src/js/components/pool/EditPool/AssetSkillsSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/AssetSkillsSection.tsx
@@ -4,6 +4,8 @@ import TableOfContents from "@common/components/TableOfContents";
 import { useIntl } from "react-intl";
 import { Button } from "@common/components";
 import SkillPicker from "@common/components/SkillPicker";
+import Chip, { Chips } from "@common/components/Chip";
+import { getLocalizedName } from "@common/helpers/localize";
 import {
   AdvertisementStatus,
   PoolAdvertisement,
@@ -61,35 +63,49 @@ export const AssetSkillsSection = ({
       <TableOfContents.Heading data-h2-margin="base(x3, 0, x1, 0)">
         {sectionMetadata.title}
       </TableOfContents.Heading>
-      <p data-h2-margin="base(x1, 0)">
-        {intl.formatMessage({
-          defaultMessage:
-            "Select skills that will improve the chances of quality matches with managers. These can typically be learned on the job and are not necessary to be accepted into the pool.",
-          id: "xGjm2A",
-          description: "Helper message for filling in the pool asset skills",
-        })}
-      </p>
-      <SkillPicker
-        selectedSkills={selectedSkills}
-        skills={skills}
-        onUpdateSelectedSkills={handleChangeSelectedSkills}
-      />
-
-      {!formDisabled && (
-        <p data-h2-margin="base(x1, 0)">
-          <Button
-            onClick={handleSave}
-            color="cta"
-            mode="solid"
-            disabled={isSubmitting}
-          >
+      {!formDisabled ? (
+        <>
+          {" "}
+          <p data-h2-margin="base(x1, 0)">
             {intl.formatMessage({
-              defaultMessage: "Save asset skills",
-              id: "j4G/wv",
-              description: "Text on a button to save the pool asset skills",
+              defaultMessage:
+                "Select skills that will improve the chances of quality matches with managers. These can typically be learned on the job and are not necessary to be accepted into the pool.",
+              id: "xGjm2A",
+              description:
+                "Helper message for filling in the pool asset skills",
             })}
-          </Button>
-        </p>
+          </p>
+          <SkillPicker
+            selectedSkills={selectedSkills}
+            skills={skills}
+            onUpdateSelectedSkills={handleChangeSelectedSkills}
+          />
+          <p data-h2-margin="base(x1, 0)">
+            <Button
+              onClick={handleSave}
+              color="cta"
+              mode="solid"
+              disabled={isSubmitting}
+            >
+              {intl.formatMessage({
+                defaultMessage: "Save asset skills",
+                id: "j4G/wv",
+                description: "Text on a button to save the pool asset skills",
+              })}
+            </Button>
+          </p>
+        </>
+      ) : (
+        <Chips>
+          {selectedSkills.map((skill) => (
+            <Chip
+              key={skill.id}
+              label={getLocalizedName(skill.name, intl)}
+              color="primary"
+              mode="outline"
+            />
+          ))}
+        </Chips>
       )}
     </TableOfContents.Section>
   );

--- a/frontend/admin/src/js/components/pool/EditPool/EssentialSkillsSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/EssentialSkillsSection.tsx
@@ -4,6 +4,8 @@ import TableOfContents from "@common/components/TableOfContents";
 import { useIntl } from "react-intl";
 import { Button } from "@common/components";
 import SkillPicker from "@common/components/SkillPicker";
+import { getLocalizedName } from "@common/helpers/localize";
+import Chip, { Chips } from "@common/components/Chip";
 import {
   AdvertisementStatus,
   PoolAdvertisement,
@@ -60,36 +62,50 @@ export const EssentialSkillsSection = ({
       <TableOfContents.Heading data-h2-margin="base(x3, 0, x1, 0)">
         {sectionMetadata.title}
       </TableOfContents.Heading>
-      <p data-h2-margin="base(x1, 0)">
-        {intl.formatMessage({
-          defaultMessage:
-            "Select the skills that you are looking for in applicants. Any skill selected here will be required for any applicant to apply. To increase the diversity of applications try to keep the selected number of skills to a minimum.",
-          id: "Om6ZoW",
-          description:
-            "Helper message for filling in the pool essential skills",
-        })}
-      </p>
-      <SkillPicker
-        selectedSkills={selectedSkills}
-        skills={skills}
-        onUpdateSelectedSkills={handleChangeSelectedSkills}
-      />
 
-      {!formDisabled && (
-        <p data-h2-margin="base(x1, 0)">
-          <Button
-            onClick={handleSave}
-            color="cta"
-            mode="solid"
-            disabled={isSubmitting}
-          >
+      {!formDisabled ? (
+        <>
+          <p data-h2-margin="base(x1, 0)">
             {intl.formatMessage({
-              defaultMessage: "Save essential skills",
-              id: "2asU3k",
-              description: "Text on a button to save the pool essential skills",
+              defaultMessage:
+                "Select the skills that you are looking for in applicants. Any skill selected here will be required for any applicant to apply. To increase the diversity of applications try to keep the selected number of skills to a minimum.",
+              id: "Om6ZoW",
+              description:
+                "Helper message for filling in the pool essential skills",
             })}
-          </Button>
-        </p>
+          </p>
+          <SkillPicker
+            selectedSkills={selectedSkills}
+            skills={skills}
+            onUpdateSelectedSkills={handleChangeSelectedSkills}
+          />
+          <p data-h2-margin="base(x1, 0)">
+            <Button
+              onClick={handleSave}
+              color="cta"
+              mode="solid"
+              disabled={isSubmitting}
+            >
+              {intl.formatMessage({
+                defaultMessage: "Save essential skills",
+                id: "2asU3k",
+                description:
+                  "Text on a button to save the pool essential skills",
+              })}
+            </Button>
+          </p>
+        </>
+      ) : (
+        <Chips>
+          {selectedSkills.map((skill) => (
+            <Chip
+              key={skill.id}
+              label={getLocalizedName(skill.name, intl)}
+              color="primary"
+              mode="outline"
+            />
+          ))}
+        </Chips>
       )}
     </TableOfContents.Section>
   );


### PR DESCRIPTION
## 👋 Introduction

This replaced the `<SkillPicker>` with `<Chips>` on the `EditPool` page when the `formDisabled` variable is `true`.

## 🧪 Testing

1. Build admin `npm run production --workspace=admin`
2. Navigate to pools index `/admin/pools`
3. Edit a pool that is **not** a draft
4. Confirm the skill picker does not appear

## 📷 Screenshot

<img width="1136" alt="Screenshot 2022-10-31 at 2 26 50 PM" src="https://user-images.githubusercontent.com/4127998/199082743-c86a03c5-eef7-4264-a81d-e6ac374aabef.png">

## 🤖 Robot Stuff

Resolves #4474 