### PR TITLE
Remove 'New User' button from user table

### DIFF
--- a/frontend/admin/src/js/components/user/UserTable.tsx
+++ b/frontend/admin/src/js/components/user/UserTable.tsx
@@ -332,15 +332,6 @@ export const UserTable: React.FC = () => {
           });
         }}
         columns={columns}
-        addBtn={{
-          label: intl.formatMessage({
-            defaultMessage: "New user",
-            id: "+OSYz7",
-            description:
-              "Text label for link to create new user on admin table",
-          }),
-          path: paths.userCreate(),
-        }}
         searchBy={[
           {
             label: intl.formatMessage({

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -1661,10 +1661,6 @@
     "defaultMessage": "<heavyPrimary>Archivé</heavyPrimary>",
     "description": "Status name of a pool in ARCHIVED status"
   },
-  "+OSYz7": {
-    "defaultMessage": "Nouvel utilisateur",
-    "description": "Text label for link to create new user on admin table"
-  },
   "+svnC6": {
     "defaultMessage": "Publier",
     "description": "Heading for the publish pool dialog"


### PR DESCRIPTION
Resolves #4472 

Removes 'New User' button from user table. This does not remove the page for creating a user.

To test:
1. Navigate to users table `/admin/users`
2. Confirm there's no New User button above the table