### PR TITLE
Feature - 4481 - Update default isRemote option

### DIFF
--- a/frontend/admin/src/js/components/pool/EditPool/OtherRequirementsSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/OtherRequirementsSection.tsx
@@ -9,6 +9,7 @@ import {
   getPublishingGroup,
   getSecurityClearance,
 } from "@common/constants/localizedConstants";
+import { empty } from "@common/helpers/util";
 import {
   AdvertisementStatus,
   LocalizedString,
@@ -59,12 +60,18 @@ export const OtherRequirementsSection = ({
   const intl = useIntl();
   const { isSubmitting } = useEditPoolContext();
 
+  const getLocationOption = (isRemote: Maybe<boolean>) => {
+    if (empty(isRemote) || isRemote) {
+      return LocationOption.RemoteOptional;
+    }
+
+    return LocationOption.SpecificLocation;
+  };
+
   const dataToFormValues = (initialData: PoolAdvertisement): FormValues => ({
     languageRequirement: initialData.advertisementLanguage,
     securityRequirement: initialData.securityClearance,
-    locationOption: initialData.isRemote
-      ? LocationOption.RemoteOptional
-      : LocationOption.SpecificLocation,
+    locationOption: getLocationOption(initialData.isRemote),
     specificLocationEn: initialData.advertisementLocation?.en,
     specificLocationFr: initialData.advertisementLocation?.fr,
     publishingGroup: initialData.publishingGroup,


### PR DESCRIPTION
## 👋 Introduction

This updates the default value for location on the edit pool page to be remote.

## 🧪 Testing

1. Build admin `npm run production --workspace-admin`
2. Create a new pool in admin
3. Scroll down to the location option in other requirements
4. Confirm the default is "Remote optional (Recommended)"

## 🤖 Robot Stuff

Resolves #4481 