### PR TITLE
Debt - 4383 - Update set-output

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -34,7 +34,7 @@ jobs:
       DOCKER_BUILDKIT: 1
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/check-lighthouse-schema.yml
+++ b/.github/workflows/check-lighthouse-schema.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Error if changes
         if: steps.check_changes.outputs.changed != 0
         # See: https://github.com/actions/github-script
-        uses: actions/github-script@v5.1.0
+        uses: actions/github-script@v6
         with:
           script: |
             core.setFailed('Please update api/storage/app/lighthouse-schema.graphql')

--- a/.github/workflows/check-lighthouse-schema.yml
+++ b/.github/workflows/check-lighthouse-schema.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Check for uncommitted changes
         id: check_changes
-        run: echo "::set-output name=changed::$(git status --porcelain | wc -l)"
+        run: echo "changed=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
 
       - name: Error if changes
         if: steps.check_changes.outputs.changed != 0

--- a/.github/workflows/check-lighthouse-schema.yml
+++ b/.github/workflows/check-lighthouse-schema.yml
@@ -15,7 +15,7 @@ jobs:
   runner:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
 
       - name: Create admin .env file, which is referenced in docker-compose
         working-directory: frontend/admin

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -42,7 +42,7 @@ jobs:
         run: rm -rf /usr/local/android /usr/share/dotnet /usr/local/share/boost /opt/ghc
 
       - name: Checkout
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
 
       # We no longer user docker layer caching as it made runs take longer.
       # See: https://github.com/satackey/action-docker-layer-caching/issues/305

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -23,7 +23,7 @@ jobs:
         uses: SimenB/github-actions-cpu-cores@v1
         id: cpu-cores
 
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       NPM_VERSION: "8.3.0"
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -23,7 +23,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@2.17.0

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.17.0
+        uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
           extensions: bcmath

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       NPM_VERSION: '8.3.0'
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@3
         with:
           # Chromatic requires full git history.
           fetch-depth: 0

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       NPM_VERSION: '8.3.0'
     steps:
-      - uses: actions/checkout@3
+      - uses: actions/checkout@v3
         with:
           # Chromatic requires full git history.
           fetch-depth: 0

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -22,6 +22,10 @@ type LocalizedString {
   fr: String
 }
 
+type Test {
+  REMOVE: String
+}
+
 enum Language {
   EN @enum(value: "en")
   FR @enum(value: "fr")

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -22,10 +22,6 @@ type LocalizedString {
   fr: String
 }
 
-type Test {
-  REMOVE: String
-}
-
 enum Language {
   EN @enum(value: "en")
   FR @enum(value: "fr")


### PR DESCRIPTION
## 👋 Introduction

This updates the `set-output`  command in the schema workflow since it has been deprecated.

## 🧪 Testing

1. Check actions for deprecated warnings
    - [Checks](https://github.com/GCTC-NTGC/gc-digital-talent/pull/4547/checks)
3. Confirmed the failed schema check still outputs proper info
    - [Schema Fail](https://github.com/GCTC-NTGC/gc-digital-talent/actions/runs/3372005134)

## 🤖 Robot Stuff

Resolves #4383 and #4404

