### PR TITLE
Align pool details pages

### DIFF
--- a/frontend/admin/src/js/components/pool/EditPool/PoolNameSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/PoolNameSection.tsx
@@ -133,9 +133,9 @@ export const PoolNameSection = ({
                 id="classification"
                 label={intl.formatMessage({
                   defaultMessage: "Classification",
-                  id: "jPlK9k",
+                  id: "w/qZsH",
                   description:
-                    "Label displayed on the edit pool form classification field.",
+                    "Label displayed on the pool form classification field.",
                 })}
                 name="classification"
                 options={classificationOptions}
@@ -147,9 +147,9 @@ export const PoolNameSection = ({
                 id="stream"
                 label={intl.formatMessage({
                   defaultMessage: "Streams/Job Titles",
-                  id: "7SOo+L",
+                  id: "PzijvH",
                   description:
-                    "Label displayed on the edit pool form stream/job title field.",
+                    "Label displayed on the pool form stream/job title field.",
                 })}
                 name="stream"
                 nullSelection={intl.formatMessage({

--- a/frontend/admin/src/js/components/pool/ViewPool.tsx
+++ b/frontend/admin/src/js/components/pool/ViewPool.tsx
@@ -77,9 +77,6 @@ export const ViewPoolPage = ({ pool }: ViewPoolPageProps): JSX.Element => {
 
   const poolName = pool.name ? pool.name[locale] : pageTitle;
   const classification = pool.classifications ? pool.classifications[0] : null;
-  const genericTitle = classification?.genericJobTitles?.length
-    ? classification.genericJobTitles[0]
-    : null;
 
   const essentialOccupationalSkills = pool.essentialSkills?.filter((skill) => {
     return skill.families?.some(

--- a/frontend/admin/src/js/components/pool/ViewPool.tsx
+++ b/frontend/admin/src/js/components/pool/ViewPool.tsx
@@ -26,6 +26,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import {
   getAdvertisementStatus,
   getLanguageRequirement,
+  getPoolStream,
   getSecurityClearance,
 } from "@common/constants/localizedConstants";
 import {
@@ -322,33 +323,39 @@ export const ViewPoolPage = ({ pool }: ViewPoolPageProps): JSX.Element => {
             <div data-h2-flex-grid="base(flex-start, x1, 0)">
               <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
                 <Input
-                  id="targetClassification"
-                  name="targetClassification"
+                  id="classification"
+                  name="classification"
                   type="text"
                   readOnly
                   hideOptional
-                  value={`${classification.group}-0${classification.level}`}
+                  value={`${classification.group}-0${
+                    classification.level
+                  }  (${getLocalizedName(classification.name, intl)})`}
                   label={intl.formatMessage({
-                    defaultMessage: "Target classification",
-                    id: "fhkgW2",
+                    defaultMessage: "Classification",
+                    id: "w/qZsH",
                     description:
-                      "Label for a pool advertisements classification group and level",
+                      "Label displayed on the pool form classification field.",
                   })}
                 />
               </div>
               <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
                 <Input
-                  id="genericTitle"
-                  name="genericTitle"
+                  id="stream"
+                  name="stream"
                   type="text"
                   readOnly
                   hideOptional
-                  value={getLocalizedName(genericTitle?.name, intl)}
+                  value={
+                    pool.stream
+                      ? intl.formatMessage(getPoolStream(pool.stream))
+                      : ""
+                  }
                   label={intl.formatMessage({
-                    defaultMessage: "Generic",
-                    id: "OumQY2",
+                    defaultMessage: "Streams/Job Titles",
+                    id: "PzijvH",
                     description:
-                      "Label for a pool advertisements generic title",
+                      "Label displayed on the pool form stream/job title field.",
                   })}
                 />
               </div>
@@ -359,7 +366,7 @@ export const ViewPoolPage = ({ pool }: ViewPoolPageProps): JSX.Element => {
                   type="text"
                   readOnly
                   hideOptional
-                  value={classification?.name?.en ?? ""}
+                  value={pool.name?.en ?? ""}
                   label={intl.formatMessage({
                     defaultMessage: "Specific Title (English)",
                     id: "fTwl6k",
@@ -375,7 +382,7 @@ export const ViewPoolPage = ({ pool }: ViewPoolPageProps): JSX.Element => {
                   type="text"
                   readOnly
                   hideOptional
-                  value={classification?.name?.fr ?? ""}
+                  value={pool.name?.fr ?? ""}
                   label={intl.formatMessage({
                     defaultMessage: "Specific Title (French)",
                     id: "MDjwSO",

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -2101,9 +2101,9 @@
     "defaultMessage": "Enregistrer les compétences utiles",
     "description": "Text on a button to save the pool asset skills"
   },
-  "jPlK9k": {
+  "w/qZsH": {
     "defaultMessage": "Classification",
-    "description": "Label displayed on the edit pool form classification field."
+    "description": "Label displayed on the pool form classification field."
   },
   "jdoFE6": {
     "defaultMessage": "Nom du bassin et classification de la cible",
@@ -2371,9 +2371,9 @@
     "defaultMessage": "Date de clôture",
     "description": "Closing Date field label for close pool dialog"
   },
-  "7SOo+L": {
+  "PzijvH": {
     "defaultMessage": "Volets/Titres de postes",
-    "description": "Label displayed on the edit pool form stream/job title field."
+    "description": "Label displayed on the pool form stream/job title field."
   },
   "83v9YH": {
     "defaultMessage": "Autochtones",


### PR DESCRIPTION
This branch updates the "view pool" page to align it with the "edit pool" page.

Compare "Edit" on the left with "View" on the right:

English:
![image](https://user-images.githubusercontent.com/8978655/199319552-288ac50b-e05b-492f-be60-f40896eb6f4a.png)

En Francais:
![image](https://user-images.githubusercontent.com/8978655/199319716-81b1674d-cb03-4504-8459-3f8b1b0e0fe5.png)

Closes #4475 