### PR TITLE
Final translation batch for direct intake release

### DIFF
--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -2788,5 +2788,45 @@
   "wHX/8C": {
     "defaultMessage": "Admin",
     "description": "Title tag for Admin site"
+  },
+  "+tzO5t": {
+    "defaultMessage": "Possède un diplôme"
+  },
+  "8lCjAM": {
+    "defaultMessage": "Priorité"
+  },
+  "Aaas0w": {
+    "defaultMessage": "L’heure de clôture sera automatiquement fixée à 23 h 59 dans le fuseau horaire du Pacifique.",
+    "description": "Helper message for changing the pool closing date"
+  },
+  "Gr3BwB": {
+    "defaultMessage": "Équité en matière d’emploi"
+  },
+  "Ude1JQ": {
+    "defaultMessage": "Texte",
+    "description": "Title for the application’s profile snapshot."
+  },
+  "hGlM9B": {
+    "defaultMessage": "Date de clôture (fuseau horaire du Pacifique)",
+    "description": "Closing Date field label for publish pool dialog in the Pacific time zone"
+  },
+  "j6V32h": {
+    "defaultMessage": "Date de clôture (fuseau horaire du Pacifique)",
+    "description": "Label for a pool advertisements expiry date in the Pacific time zone"
+  },
+  "m0JFE/": {
+    "defaultMessage": "Code",
+    "description": "Title for the application’s profile snapshot."
+  },
+  "tQ674x": {
+    "defaultMessage": "Groupe des publications",
+    "description": "Label displayed on the edit pool form publishing group field."
+  },
+  "tzMNF3": {
+    "defaultMessage": "État"
+  },
+  "z0QI6A": {
+    "defaultMessage": "Tous les candidats du bassin",
+    "description": "Title for the admin pool candidates table"
   }
 }

--- a/frontend/admin/src/js/lang/whitelist.yml
+++ b/frontend/admin/src/js/lang/whitelist.yml
@@ -17,3 +17,4 @@
 - Yr4DW5 # 'Notes - {poolName}' Label for the notes field on the pool candidate application
 - ev6HnY # 'Notes' CSV Header, Notes column
 - npC3bT # 'Notes' Title for admin editing a pool candidates notes
+- m0JFE/ # 'Code' Title for the application's profile snapshot

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1795,5 +1795,145 @@
   "16AY+M": {
     "defaultMessage": "Incapable de postuler pour ce bassin",
     "description": "Message displayed when user attempts to apply to an unpublished pool"
+  },
+  "/I9tx9": {
+    "defaultMessage": "Cette demande ne peut pas être supprimée. Vous pouvez uniquement supprimer les demandes avant leur soumission.",
+    "description": "Error message that the application cannot be deleted."
+  },
+  "0p1W7Q": {
+    "defaultMessage": "Fils d’Ariane",
+    "description": "Label for the links to page ancestors"
+  },
+  "3e4sM7": {
+    "defaultMessage": "Le lieu doit être indiqué ou l’option “À distance” doit être sélectionnée",
+    "description": "Error message that the pool advertisement must have location filled."
+  },
+  "56WpMU": {
+    "defaultMessage": "Laissez les préférences de votre navigateur dicter le thème du site Web.",
+    "description": "Button text to set no theme mode"
+  },
+  "6O1sjV": {
+    "defaultMessage": "Impossible de mettre à jour – cet identifiant d’utilisateur (sub) est déjà utilisé.",
+    "description": "Error message that the given user identifier is already in use when updating."
+  },
+  "6wCHq2": {
+    "defaultMessage": "Activez le mode sombre",
+    "description": "Button text to set theme mode to dark"
+  },
+  "76QTNv": {
+    "defaultMessage": "La demande a déjà été soumise.",
+    "description": "Error message that the given application is already submitted."
+  },
+  "9CkDfr": {
+    "defaultMessage": "Aucune compétence trouvée.",
+    "description": "Message displayed when no skills were found in skill picker search"
+  },
+  "9nJi0W": {
+    "defaultMessage": "Activez le mode lumière",
+    "description": "Button text to set theme mode to light"
+  },
+  "A+dFlE": {
+    "defaultMessage": "La demande a déjà été archivée.",
+    "description": "Error message that the given application is already archived."
+  },
+  "AhQ6xv": {
+    "defaultMessage": "Ces compétences requises sont absentes de votre profil :",
+    "description": "Text that appears when a user is missing required skills on their profile."
+  },
+  "B89Ihf": {
+    "defaultMessage": "Compétences requises pour la demande",
+    "description": "Title that appears when a user is missing required skills on their profile."
+  },
+  "C8nrGM": {
+    "defaultMessage": "Emplois en TI",
+    "description": "The publishing group called IT Jobs"
+  },
+  "CJy0kS": {
+    "defaultMessage": "Compétences constituant un atout",
+    "description": "Title that appears when a user is missing optional skills on their profile."
+  },
+  "CVmEkf": {
+    "defaultMessage": "Création impossible – cet identifiant d’utilisateur (sub) est déjà utilisé",
+    "description": "Error message that the given user identifier is already in use when creating."
+  },
+  "J2V3XI": {
+    "defaultMessage": "Un champ obligatoire est vide : Exigence linguistique",
+    "description": "Error message that the pool advertisement must have an advertisement language."
+  },
+  "Mco0Km": {
+    "defaultMessage": "Vous devez posséder au moins une compétence essentielle.",
+    "description": "Error message that at least one Essential Skill is required"
+  },
+  "Mixlw/": {
+    "defaultMessage": "Postes de direction",
+    "description": "The publishing group called Executive Jobs"
+  },
+  "TjeaLS": {
+    "defaultMessage": "Cette demande ne peut pas être archivée. Vous ne pouvez archiver que les demandes ayant expiré.",
+    "description": "Error message that the application cannot be archived."
+  },
+  "V3ReC1": {
+    "defaultMessage": "Envisagez d’ajouter ces compétences constituant un atout à votre profil :",
+    "description": "Text that appears when a user is missing optional skills on their profile"
+  },
+  "VqrVpT": {
+    "defaultMessage": "Mise à jour impossible – cette adresse courriel est déjà utilisée.",
+    "description": "Error message that the given email address is already in use when updating."
+  },
+  "WUAAr1": {
+    "defaultMessage": "Création impossible – cette adresse courriel est déjà utilisée.",
+    "description": "Error message that the given user identifier is already in use when creating."
+  },
+  "Wwb8Lb": {
+    "defaultMessage": "Sélecteur de mode de couleur du thème",
+    "description": "Label for the group of buttons to change the current colour mode"
+  },
+  "XNDPQM": {
+    "defaultMessage": "Un champ obligatoire est vide : Date de fin",
+    "description": "Error message that the pool advertisement must have an expiry date."
+  },
+  "aMkZ80": {
+    "defaultMessage": "Vous devez indiquer le lieu précis en anglais et en français si l’annonce ne vise pas un poste à distance.",
+    "description": "Error message that advertisement locations must be filled in English and French."
+  },
+  "euwgms": {
+    "defaultMessage": "Un champ obligatoire est vide : Français – Votre travail",
+    "description": "Error message that Work Tasks in French must be filled"
+  },
+  "gU/2O6": {
+    "defaultMessage": "Le bassin doit avoir une date d’expiration postérieure à aujourd’hui.",
+    "description": "Error message that pool expiry isn't in the future."
+  },
+  "juklNA": {
+    "defaultMessage": "Un champ obligatoire est vide : Anglais – Votre incidence",
+    "description": "Error message that Your Impact in English must be filled"
+  },
+  "kg28xx": {
+    "defaultMessage": "Un champ obligatoire est vide : Français – Votre incidence",
+    "description": "Error message that Your Impact in French must be filled"
+  },
+  "l7Hif/": {
+    "defaultMessage": "Compétences sélectionnées",
+    "description": "Section header for a list of skills selected"
+  },
+  "mv7JO3": {
+    "defaultMessage": "Autre",
+    "description": "The publishing group called Other"
+  },
+  "nPKPFa": {
+    "defaultMessage": "Un champ obligatoire est vide : Groupe des publications",
+    "description": "Error message that the pool advertisement must have publishing group filled."
+  },
+  "r7x5H3": {
+    "defaultMessage": "S. O.",
+    "description": "Message displayed when specific information is not applicable"
+  },
+  "t4F/0R": {
+    "defaultMessage": "Un champ obligatoire est vide : Exigence relative à la sécurité",
+    "description": "Error message that the pool advertisement must have a security clearance."
+  },
+  "tW4k56": {
+    "defaultMessage": "Un champ obligatoire est vide : Anglais – Votre travail",
+    "description": "Error message that Work Tasks in English must be filled"
   }
 }

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -1532,7 +1532,7 @@
     "defaultMessage": "Groupes visés par l’équité en matière d’emploi",
     "description": "Legend for the employment equity checklist"
   },
-   "aWLo7o": {
+  "aWLo7o": {
     "defaultMessage": "{candidateCount, plural, =0 {Résultats : <testId>{candidateCount}</testId> candidats correspondants à vos critères} =1 {Résultats : <testId>{candidateCount}</testId> candidat correspondant à vos critères} other {Résultats : <testId>{candidateCount}</testId> candidats correspondants à vos critères}}",
     "description": "Heading for total matching candidates in results section of search page."
   },
@@ -2419,5 +2419,205 @@
   "mI6AeU": {
     "defaultMessage": "À venir",
     "description": "Text displayed for executive jobs on homepage, indicating it is not ready"
+  },
+  "+6QgII": {
+    "defaultMessage": "Conçu par la communauté autochtone, avec elle et pour elle, le programme recrute des candidats des Premières Nations, inuits et métis qui se passionnent pour les TI, pour des emplois de niveau débutant, ainsi que pour des possibilités d’apprentissage et de perfectionnement.",
+    "description": "Summary for Indigenous community job opportunities on Browse IT jobs page"
+  },
+  "/vsOxF": {
+    "defaultMessage": "Mettre à jour mon profil",
+    "description": "Link text to direct users to the profile page when logged in"
+  },
+  "094835": {
+    "defaultMessage": "Je cherche à...",
+    "description": "Support form subject field label"
+  },
+  "1zkApr": {
+    "defaultMessage": "Posez votre candidature dans le cadre de ce processus de recrutement<hidden> {name}</hidden>",
+    "description": "Message on link that say to apply to a recruitment advertisement"
+  },
+  "2UDONd": {
+    "defaultMessage": "Trouvez des occasions d’emploi pour les talents numériques au sein du gouvernement du Canada et posez votre candidature.",
+    "description": "Subtitle for the browse IT jobs page"
+  },
+  "3sbLPV": {
+    "defaultMessage": "Nous publions constamment de nouvelles offres. En créant votre profil dès maintenant, vous pourrez soumettre des demandes à la vitesse de l’éclair le moment venu.",
+    "description": "Text describing upcoming opportunities instructing users to create a profile when anonymous"
+  },
+  "3wbcnZ": {
+    "defaultMessage": "Voir les résultats",
+    "description": "A link to view the pools that contain matching talent."
+  },
+  "5r5XSh": {
+    "defaultMessage": "Veuillez vérifier votre courriel pour obtenir un résumé de votre soumission.",
+    "description": "Support form success paragraph two"
+  },
+  "6TX9CR": {
+    "defaultMessage": "(aucune activité)",
+    "description": "Message displayed when a pool has no stream"
+  },
+  "86Y8lx": {
+    "defaultMessage": "Votre nom",
+    "description": "Support form name field label"
+  },
+  "AwIGg0": {
+    "defaultMessage": "Vous avez une question précise? Vous souhaitez faire part de vos commentaires ou signaler un bogue? Envoyez-nous un message au moyen de ce formulaire.",
+    "description": "Support form paragraph one"
+  },
+  "BhfG7a": {
+    "defaultMessage": "Visitez la page de recherche de talents",
+    "description": "Link text to go to the search page on browse IT jobs page"
+  },
+  "CZ3wxJ": {
+    "defaultMessage": "Soumettez un nouveau message",
+    "description": "Support form success action"
+  },
+  "CbzWqJ": {
+    "defaultMessage": "L’Ambition numérique décrit l’engagement du gouvernement du Canada à créer des services numériques modernes et accessibles. La réalisation de ces priorités permettra au gouvernement de fournir des services et des programmes axés sur le numérique, centrés sur l’utilisateur et sans obstacle.",
+    "description": "Summary of the digital ambition featured item"
+  },
+  "EBmWyo": {
+    "defaultMessage": "Accueil",
+    "description": "Link text for the home link in breadcrumbs."
+  },
+  "EIHPGF": {
+    "defaultMessage": "Votre candidature à un processus de dotation sera examinée par notre équipe et, si elle correspond à ce que nous cherchons, vous serez invité à une évaluation. Une fois que votre candidature aura été acceptée, des gestionnaires pourront communiquer avec vous pour vous informer des possibilités d’emploi correspondant à vos compétences.",
+    "description": "Description of how the application process works, paragraph two"
+  },
+  "GZrICV": {
+    "defaultMessage": "Parcourez les offres dans le domaine des TI pour la communauté autochtone",
+    "description": "Title for Indigenous community job opportunities on Browse IT jobs page"
+  },
+  "Gil1Zj": {
+    "defaultMessage": "Lisez l’Ambition numérique",
+    "description": "Link text to read the Digital Ambition"
+  },
+  "Gp+70V": {
+    "defaultMessage": "Postulez d’ici le :",
+    "description": "Label for the pool expiry date"
+  },
+  "Hd0nHP": {
+    "defaultMessage": "(À déterminer)",
+    "description": "Message displayed when a pool has no expiry date yet"
+  },
+  "J2WrFI": {
+    "defaultMessage": "Parcourez les offres dans le domaine des TI",
+    "description": "Page title for the direct intake browse pools page."
+  },
+  "Jorewd": {
+    "defaultMessage": "Nous publions constamment de nouvelles offres. En tenant votre profil à jour, vous pourrez soumettre des demandes à la vitesse de l’éclair le moment venu.",
+    "description": "Text describing upcoming opportunities instructing users to update a profile when logged in"
+  },
+  "Ms6O4W": {
+    "defaultMessage": "Laissez notre équipe vous épargner du temps et de l’énergie en associant vos besoins à des professionnels des TI préalablement sélectionnés et possédant les compétences requises pour le poste. Tous les talents de nos bassins de dotation ont été sélectionnés à l’issue d’un processus concurrentiel. Vous pouvez donc passer directement à l’entrevue et décider s’ils conviennent à votre équipe.",
+    "description": "Summary for to go to the search page on Browse IT jobs page"
+  },
+  "OMDX09": {
+    "defaultMessage": "Préparez-vous en mettant à jour votre profil.",
+    "description": "Link text to update your profile for executive jobs in government"
+  },
+  "OdjW9z": {
+    "defaultMessage": "Nous ferons de notre mieux pour vous répondre dans les deux jours ouvrables suivants.",
+    "description": "Support form success paragraph one"
+  },
+  "QX1l/C": {
+    "defaultMessage": "En attendant, n’hésitez pas à consulter nos foires aux questions (FAQ) pour obtenir plus d’information.",
+    "description": "Support form success paragraph three"
+  },
+  "TrO4uL": {
+    "defaultMessage": "Échelle salariale :",
+    "description": "Label for the range of salary expected for a classification"
+  },
+  "V1DqDX": {
+    "defaultMessage": "Compétences requises :",
+    "description": "Label for the skills required for a pool"
+  },
+  "YImugL": {
+    "defaultMessage": "Processus actifs de recrutement de talents",
+    "description": "Title for the current jobs recruiting candidates"
+  },
+  "cYg+l1": {
+    "defaultMessage": "Vous recherchez des talents en TI de niveau débutant et vous désirez soutenir la diversité, l’inclusion et la réconciliation? Communiquez avec le programme d’apprentissage en TI pour les peuples autochtones et lancez le processus d’embauche de stagiaires autochtones dès aujourd’hui!",
+    "description": "Summary of the Indigenous Apprenticeship Program for the homepage"
+  },
+  "dIIccA": {
+    "defaultMessage": "J’ai découvert le Programme d’apprentissage pour les peuples autochtones sur talent.canada.ca et j’aimerais en savoir davantage sur la façon dont je peux embaucher des stagiaires pour mon équipe.",
+    "description": "Body of email for info on Indigenous Apprenticeship Program"
+  },
+  "fVAMSw": {
+    "defaultMessage": "Soumettez des commentaires",
+    "description": "Support form subject field feedback option label"
+  },
+  "g+JcDC": {
+    "defaultMessage": "D’autres offres seront bientôt affichées!",
+    "description": "Heading for message about upcoming opportunities"
+  },
+  "gG5eAt": {
+    "defaultMessage": "Communiquez avec le Programme d’apprentissage",
+    "description": "Link text to email about the Indigenous Apprenticeship Program"
+  },
+  "gtaSs1": {
+    "defaultMessage": "Cette plateforme vous permet de poser votre candidature à des processus de recrutement grâce auxquels les gestionnaires d’embauche pourront facilement vous trouver.",
+    "description": "Description of how the application process works, paragraph one"
+  },
+  "hL7Y6p": {
+    "defaultMessage": "(Aucune compétence requise)",
+    "description": "Message displayed when no skills are required for a pool"
+  },
+  "iiEGjW": {
+    "defaultMessage": "Nous avons bien reçu votre message.",
+    "description": "Support form success title"
+  },
+  "jHuiRm": {
+    "defaultMessage": "Billet créé avec succès!",
+    "description": "Support form toast message success"
+  },
+  "jTN0bg": {
+    "defaultMessage": "Embauchez des talents pour votre équipe",
+    "description": "Title for to go to the search page on Browse IT jobs page"
+  },
+  "msn4mz": {
+    "defaultMessage": "Posez une question",
+    "description": "Support form subject field question option label"
+  },
+  "mwEGU+": {
+    "defaultMessage": "Vous avez déjà postulé pour cela.",
+    "description": "Disabled button when a user already applied to a pool opportunity"
+  },
+  "nYA+Tj": {
+    "defaultMessage": "Nous embauchons des talents autochtones dans le domaine de la technologie",
+    "description": "Title for the Indigenous tech talent feature item"
+  },
+  "oXYnZN": {
+    "defaultMessage": "Communiquez avec nous",
+    "description": "Support form title"
+  },
+  "p/dXxz": {
+    "defaultMessage": "Je souhaite embaucher des stagiaires autochtones en TI pour mon équipe",
+    "description": "Subject of email for info on Indigenous Apprenticeship Program"
+  },
+  "qLYONf": {
+    "defaultMessage": "Préparez-vous en créant un profil",
+    "description": "Link text to create a profile for executive jobs in government"
+  },
+  "szLvj0": {
+    "defaultMessage": "Votre courriel",
+    "description": "Support form email field label"
+  },
+  "tTuBmE": {
+    "defaultMessage": "L’Ambition numérique",
+    "description": "Title for the digital ambition featured item"
+  },
+  "wIccbA": {
+    "defaultMessage": "Signaler un bogue",
+    "description": "Support form subject field bug option label"
+  },
+  "wPpvvm": {
+    "defaultMessage": "Créer un profil",
+    "description": "Link text to direct users to the profile page when anonymous"
+  },
+  "ywkgJx": {
+    "defaultMessage": "Details",
+    "description": "Support form details field label"
   }
 }

--- a/frontend/talentsearch/src/js/lang/whitelist.yml
+++ b/frontend/talentsearch/src/js/lang/whitelist.yml
@@ -3,3 +3,4 @@
 - rywI3C # Verbal (Label displayed on the language information form verbal field.)
 - Ledr63 # 'Signature' Toc navigation item on sign and submit page.
 - YZyNUJ # 'Signature' Label displayed for signature input in sign and submit page.
+- ywkgJx # 'Details' Support form details field label


### PR DESCRIPTION
Resolves #4115.

Adds the latest batch of translations.

Files sent for translation:
[admin-english-to-french.txt](https://github.com/GCTC-NTGC/gc-digital-talent/files/9913836/admin-english-to-french.txt)
[common-english-to-french.txt](https://github.com/GCTC-NTGC/gc-digital-talent/files/9913837/common-english-to-french.txt)
[talentsearch-english-to-french.txt](https://github.com/GCTC-NTGC/gc-digital-talent/files/9913838/talentsearch-english-to-french.txt)

Notes:
- The string with id "xgocDD" from talentsearch was returned with broken syntax. Tristan suggested refactoring the string to make it simpler for the translators to understand. Do we want a separate issue for this?
- The string with id "w2tWfH" from common was lost in transit. I have requested the translation for it which I expect to receive early tomorrow.