### PR TITLE
Bug - 4559 - Remove label from prop spread on CardFlat Link

### DIFF
--- a/frontend/common/src/components/Card/CardFlat/CardFlat.tsx
+++ b/frontend/common/src/components/Card/CardFlat/CardFlat.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import omit from "lodash/omit";
 
 import Heading from "../../Heading";
 import type { Color } from "../../Button";
@@ -52,7 +53,12 @@ const CardFlat = ({ color, link, title, children }: CardFlatProps) => (
     )}
     {link && (
       <div>
-        <Link color={color} type="button" weight="bold" {...link}>
+        <Link
+          color={color}
+          type="button"
+          weight="bold"
+          {...omit(link, "label")}
+        >
           {link.label}
         </Link>
       </div>


### PR DESCRIPTION
## 👋 Introduction

This uses `lodash/omit` to remove the label attribute from being spread onto the `<Link>` found in `<CardFlat>`.

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Navigate to `/browse`
3. Inspect the Indigenous IT Apprenticeship link near the bottom of the page and confirm it has no `label` attribute. 

## 🤖 Robot Stuff

Resolves #4559 