### PR TITLE
4660 language ability null

### DIFF
--- a/api/app/GraphQL/Directives/PluckDirective.php
+++ b/api/app/GraphQL/Directives/PluckDirective.php
@@ -30,9 +30,6 @@ directive @pluck(
 GRAPHQL;
     }
 
-    /**
-     * Remove whitespace from the beginning and end of a given input.
-     */
     public function transform($argumentValue)
     {
         $output = Utils::mapEach(
@@ -44,8 +41,11 @@ GRAPHQL;
         return $output;
     }
 
-    protected function pluckFromArgumentSet(ArgumentSet $argumentSet)
+    protected function pluckFromArgumentSet(?ArgumentSet $argumentSet)
     {
+        if (empty($argumentSet)) {
+            return $argumentSet;
+        }
         $key = $this->directiveArgValue('key');
         return $argumentSet->arguments[$key]->value;
     }

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -283,6 +283,9 @@ class User extends Model implements Authenticatable
     }
     public static function filterByLanguageAbility(Builder $query, ?string $languageAbility): Builder
     {
+        if (empty($languageAbility)) {
+            return $query;
+        }
         // If filtering for a specific language the query should return candidates of that language OR bilingual.
         $query->where(function ($query) use ($languageAbility) {
             $query->where('language_ability', $languageAbility);
@@ -303,7 +306,7 @@ class User extends Model implements Authenticatable
         $query->whereJsonContains('accepted_operational_requirements', $operationalRequirements);
         return $query;
     }
-    public static function filterByLocationPreferences(Builder $query, array $workRegions): Builder
+    public static function filterByLocationPreferences(Builder $query, ?array $workRegions): Builder
     {
         if (empty($workRegions)) {
             return $query;

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -2825,4 +2825,79 @@ class UserTest extends TestCase
             ]
         ]);
     }
+
+    public function testNullFiltersEqualToUndefined(): void {
+        // Create users to test filters on
+        User::factory(60)->create();
+
+        // Assert that using an empty (ie undefined) filter returns all users
+        $this->graphQL(
+            /** @lang Graphql */
+            '
+            query getUsersPaginated($where: UserFilterInput) {
+                usersPaginated(where: $where) {
+                    paginatorInfo {
+                        total
+                    }
+                }
+            }
+        ',
+            [
+                'where' => []
+            ]
+        )->assertJson([
+            'data' => [
+                'usersPaginated' => [
+                    'paginatorInfo' => [
+                        'total' => 61
+                    ]
+                ]
+            ]
+        ]);
+
+        // Assert that setting every value to null also returns all users
+        $this->graphQL(
+            /** @lang Graphql */
+            '
+            query getUsersPaginated($where: UserFilterInput) {
+                usersPaginated(where: $where) {
+                    paginatorInfo {
+                        total
+                    }
+                }
+            }
+        ',
+            [
+                'where' => [
+                    'applicantFilter' => [
+                        'hasDiploma' => null,
+                        'equity' => null,
+                        'languageAbility' => null,
+                        'operationalRequirements' => null,
+                        'locationPreferences' => null,
+                        'wouldAcceptTemporary' => null,
+                        'expectedClassifications' => null,
+                        'skills' => null,
+                        'pools' => null,
+                    ],
+                    'poolFilters' => null,
+                    'jobLookingStatus' => null,
+                    'isProfileComplete' => null,
+                    'isGovEmployee' => null,
+                    'telephone' => null,
+                    'email' => null,
+                    'name' => null,
+                    'generalSearch' => null
+                ]
+            ]
+        )->assertJson([
+            'data' => [
+                'usersPaginated' => [
+                    'paginatorInfo' => [
+                        'total' => 61
+                    ]
+                ]
+            ]
+        ]);
+    }
 }


### PR DESCRIPTION
Resolves #4660.

I wrote a regression test for this! Which actually found a similar bug in a directive I wrote.

Testing:
1. seed the database (`docker-compose exec -w /var/www/html/api php php artisan db:seed`)
2. Run the following two queries against our api. I used http://localhost:8000/graphql-playground.
```
query {
  countApplicants(where:{
    languageAbility: null
  })
}
``` 
```
query {
  countApplicants(where:{})
}
``` 
Or you can run them with one query using _aliases_ 😉 
```
query {
  nullLang: countApplicants(where:{
    languageAbility: null
  })
  undefinedLang: countApplicants(where:{})
}
```
3. Both queries should return the same number. (And it shouldn't be zero!)