### PR TITLE
Bug - Adds missing wouldAcceptTemporary to CreateRequest

### DIFF
--- a/api/database/factories/ApplicantFilterFactory.php
+++ b/api/database/factories/ApplicantFilterFactory.php
@@ -31,7 +31,7 @@ class ApplicantFilterFactory extends Factory
             'is_indigenous' => $this->faker->boolean(),
             'is_visible_minority' => $this->faker->boolean(),
             'is_woman' => $this->faker->boolean(),
-            'would_accept_temporary' => $this->faker->boolean(),
+            'would_accept_temporary' => $this->faker->optional(0.5, null)->randomElement([true]), // null or true.
             'language_ability' => $this->faker->randomElement(ApiEnums::languageAbilities()),
             'location_preferences' => $this->faker->randomElements(
                 ApiEnums::workRegions(),

--- a/frontend/talentsearch/src/js/components/request/CreateRequest.tsx
+++ b/frontend/talentsearch/src/js/components/request/CreateRequest.tsx
@@ -48,6 +48,7 @@ type FormValues = {
       sync?: Array<Maybe<Skill["id"]>>;
     };
     hasDiploma?: ApplicantFilterInput["hasDiploma"];
+    wouldAcceptTemporary?: ApplicantFilterInput["wouldAcceptTemporary"];
     equity?: EquitySelections;
     languageAbility?: ApplicantFilter["languageAbility"];
     operationalRequirements?: Array<Maybe<OperationalRequirement>>;
@@ -102,6 +103,9 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
       additionalComments: values.additionalComments,
       applicantFilter: {
         create: {
+          wouldAcceptTemporary: applicantFilter?.wouldAcceptTemporary
+            ? applicantFilter?.wouldAcceptTemporary
+            : null,
           hasDiploma: applicantFilter?.hasDiploma
             ? applicantFilter?.hasDiploma
             : false,


### PR DESCRIPTION
Resolves #4659.

## Summary

- [Adds missing wouldAcceptTemporary to CreateRequest](https://github.com/GCTC-NTGC/gc-digital-talent/commit/3988933b24423fd89c6095e3498d7536c64b1d35)
- [Fixes would_accept_temporary to be true or null since false is never an option based on the CreateRequest form value](https://github.com/GCTC-NTGC/gc-digital-talent/commit/a6d9ea45e23cc3318d45319aed98417883355c4a)