### PR TITLE
bug/4572-manage-candidates-link 

### DIFF
--- a/frontend/admin/src/js/components/pool/ViewPool.tsx
+++ b/frontend/admin/src/js/components/pool/ViewPool.tsx
@@ -181,7 +181,7 @@ export const ViewPoolPage = ({ pool }: ViewPoolPageProps): JSX.Element => {
               mode="solid"
               color="secondary"
               type="button"
-              href={adminPaths.poolEdit(pool.id)}
+              href={adminPaths.poolCandidateTable(pool.id)}
               icon={UserGroupIcon}
             >
               {intl.formatMessage({


### PR DESCRIPTION
closes #4572 
updates the link to be pointed at the candidates table

testing:
go to `/en/admin/pools/:id`
and check the links