### PR TITLE
Feature - 4392 - Combine skill picker inputs

### DIFF
--- a/frontend/common/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/frontend/common/src/components/DropdownMenu/DropdownMenu.tsx
@@ -172,7 +172,7 @@ const ItemIndicator = React.forwardRef<
   />
 ));
 
-const { Root, RadioGroup } = DropdownMenuPrimitive;
+const { Root, RadioGroup, Group } = DropdownMenuPrimitive;
 
 /**
  * @name DropdownMenu
@@ -235,6 +235,12 @@ const DropdownMenu = {
    * @see [Documentation](https://www.radix-ui.com/docs/primitives/components/dropdown-menu#label)
    */
   Label,
+  /**
+   * @name Group
+   * @desc Used to group multiple DropdownMenu.Items.
+   * @see [Documentation](https://www.radix-ui.com/docs/primitives/components/dropdown-menu#group)
+   */
+  Group,
   /**
    * @name Separator
    * @desc Used to visually separate items in the dropdown menu.

--- a/frontend/common/src/components/ScrollArea/ScrollArea.tsx
+++ b/frontend/common/src/components/ScrollArea/ScrollArea.tsx
@@ -11,7 +11,6 @@ const Root = React.forwardRef<
   <ScrollAreaPrimitive.Root
     data-h2-overflow="base(hidden)"
     data-h2-radius="base(rounded)"
-    data-h2-shadow="base(s)"
     ref={forwardedRef}
     {...props}
   />

--- a/frontend/common/src/components/SkillPicker/FamilyPicker.tsx
+++ b/frontend/common/src/components/SkillPicker/FamilyPicker.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import { CheckIcon, ChevronDownIcon } from "@heroicons/react/24/solid";
+
+import Button from "../Button";
+import DropdownMenu from "../DropdownMenu";
+
+import { getLocalizedName } from "../../helpers/localize";
+import { SkillCategory, SkillFamily } from "../../api/generated";
+
+interface FamilyPickerProps {
+  families: Array<SkillFamily>;
+  selectedFamilies: Array<SkillFamily["id"]>;
+  onCheckedFamilyChange: (
+    id: SkillFamily["id"],
+    checked: boolean | "indeterminate",
+  ) => void;
+}
+
+const FamilyPicker = ({
+  families,
+  selectedFamilies,
+  onCheckedFamilyChange,
+}: FamilyPickerProps) => {
+  const intl = useIntl();
+
+  const skillFamilyOptions = React.useMemo(() => {
+    return [
+      {
+        id: "technical",
+        label: intl.formatMessage({
+          defaultMessage: "Technical skills",
+          id: "kxseH4",
+          description: "Tab name for a list of technical skills",
+        }),
+        options: families
+          .filter((sf) => sf.category === SkillCategory.Technical)
+          .map((family) => ({
+            value: family.id,
+            label: getLocalizedName(family.name, intl),
+          })),
+      },
+      {
+        id: "behavioural",
+        label: intl.formatMessage({
+          defaultMessage: "Behavioural skills",
+          id: "LjkK5G",
+          description: "Tab name for a list of behavioural skills",
+        }),
+        options: families
+          .filter((sf) => sf.category === SkillCategory.Behavioural)
+          .map((family) => ({
+            value: family.id,
+            label: getLocalizedName(family.name, intl),
+          })),
+      },
+    ];
+  }, [families, intl]);
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger>
+        <Button
+          color="primary"
+          mode="outline"
+          data-h2-align-items="base(center)"
+          data-h2-display="base(flex)"
+          data-h2-flex-shrink="base(0)"
+          data-h2-gap="base(x.25, 0)"
+          data-h2-radius="base(s, none, none, s)"
+          data-h2-margin-right="base(0)"
+          style={{ borderRightWidth: 0 }}
+        >
+          <span>
+            {intl.formatMessage({
+              defaultMessage: "Families",
+              id: "JyUPiu",
+              description: "Label for the skill picker family filter",
+            })}
+          </span>
+          {selectedFamilies.length > 0 ? (
+            <span
+              data-h2-radius="base(9999px)"
+              data-h2-background-color="base(dt-primary)"
+              data-h2-font-weight="base(400)"
+              data-h2-color="base(dt-white)"
+              data-h2-padding="base(x.15, x.25)"
+              data-h2-font-size="base(caption, 1)"
+            >
+              {selectedFamilies.length}
+            </span>
+          ) : null}
+          <ChevronDownIcon
+            data-h2-height="base(1em)"
+            data-h2-width="base(1em)"
+          />
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        {skillFamilyOptions.map((category, index) => (
+          <React.Fragment key={category.id}>
+            <DropdownMenu.Label>{category.label}</DropdownMenu.Label>
+            <DropdownMenu.Group>
+              {category.options.map((option) => (
+                <DropdownMenu.CheckboxItem
+                  key={option.value}
+                  checked={selectedFamilies.includes(option.value)}
+                  onCheckedChange={(checked) =>
+                    onCheckedFamilyChange(option.value, checked)
+                  }
+                  onSelect={(e) => {
+                    // Prevent dropdown closing on select
+                    e.preventDefault();
+                  }}
+                >
+                  <DropdownMenu.ItemIndicator>
+                    <CheckIcon />
+                  </DropdownMenu.ItemIndicator>
+                  {option.label}
+                </DropdownMenu.CheckboxItem>
+              ))}
+            </DropdownMenu.Group>
+            {index + 1 < skillFamilyOptions.length && (
+              <DropdownMenu.Separator />
+            )}
+          </React.Fragment>
+        ))}
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  );
+};
+
+export default FamilyPicker;

--- a/frontend/common/src/components/SkillPicker/FamilyPicker.tsx
+++ b/frontend/common/src/components/SkillPicker/FamilyPicker.tsx
@@ -4,6 +4,7 @@ import { CheckIcon, ChevronDownIcon } from "@heroicons/react/24/solid";
 
 import Button from "../Button";
 import DropdownMenu from "../DropdownMenu";
+import ScrollArea from "../ScrollArea";
 
 import { getLocalizedName } from "../../helpers/localize";
 import { Scalars, SkillCategory, SkillFamily } from "../../api/generated";
@@ -85,45 +86,58 @@ const FamilyPicker = ({ families, onSelectFamily }: FamilyPickerProps) => {
           />
         </Button>
       </DropdownMenu.Trigger>
-      <DropdownMenu.Content>
-        <DropdownMenu.RadioGroup
-          value={currentFamilyId}
-          onValueChange={setCurrentFamilyId}
+      <DropdownMenu.Content data-h2-padding="base(0)">
+        <ScrollArea.Root
+          data-h2-width="base(100%)"
+          data-h2-height="base(320px)"
+          data-h2-max-height="base(50vh)"
         >
-          <DropdownMenu.RadioItem
-            value=""
-            onSelect={() => {
-              onSelectFamily("");
-            }}
-          >
-            <DropdownMenu.ItemIndicator>
-              <CheckIcon />
-            </DropdownMenu.ItemIndicator>
-            {allSkillsLabel}
-          </DropdownMenu.RadioItem>
-          {skillFamilyOptions.map((category, index) => (
-            <React.Fragment key={category.id}>
-              <DropdownMenu.Label>{category.label}</DropdownMenu.Label>
-              {category.options.map((option) => (
+          <ScrollArea.Viewport data-h2-background-color="base(white)">
+            <div data-h2-padding="base(x.5, x1, x.5, x.5)">
+              <DropdownMenu.RadioGroup
+                value={currentFamilyId}
+                onValueChange={setCurrentFamilyId}
+              >
                 <DropdownMenu.RadioItem
-                  value={option.value}
-                  key={option.value}
+                  value=""
                   onSelect={() => {
-                    onSelectFamily(option.value);
+                    onSelectFamily("");
                   }}
                 >
                   <DropdownMenu.ItemIndicator>
                     <CheckIcon />
                   </DropdownMenu.ItemIndicator>
-                  {option.label}
+                  {allSkillsLabel}
                 </DropdownMenu.RadioItem>
-              ))}
-              {index + 1 < skillFamilyOptions.length && (
-                <DropdownMenu.Separator />
-              )}
-            </React.Fragment>
-          ))}
-        </DropdownMenu.RadioGroup>
+                {skillFamilyOptions.map((category, index) => (
+                  <React.Fragment key={category.id}>
+                    <DropdownMenu.Label>{category.label}</DropdownMenu.Label>
+                    {category.options.map((option) => (
+                      <DropdownMenu.RadioItem
+                        value={option.value}
+                        key={option.value}
+                        onSelect={() => {
+                          onSelectFamily(option.value);
+                        }}
+                      >
+                        <DropdownMenu.ItemIndicator>
+                          <CheckIcon />
+                        </DropdownMenu.ItemIndicator>
+                        {option.label}
+                      </DropdownMenu.RadioItem>
+                    ))}
+                    {index + 1 < skillFamilyOptions.length && (
+                      <DropdownMenu.Separator />
+                    )}
+                  </React.Fragment>
+                ))}
+              </DropdownMenu.RadioGroup>
+            </div>
+          </ScrollArea.Viewport>
+          <ScrollArea.Scrollbar orientation="vertical">
+            <ScrollArea.Thumb />
+          </ScrollArea.Scrollbar>
+        </ScrollArea.Root>
       </DropdownMenu.Content>
     </DropdownMenu.Root>
   );

--- a/frontend/common/src/components/SkillPicker/FamilyPicker.tsx
+++ b/frontend/common/src/components/SkillPicker/FamilyPicker.tsx
@@ -6,23 +6,26 @@ import Button from "../Button";
 import DropdownMenu from "../DropdownMenu";
 
 import { getLocalizedName } from "../../helpers/localize";
-import { SkillCategory, SkillFamily } from "../../api/generated";
+import { Scalars, SkillCategory, SkillFamily } from "../../api/generated";
 
 interface FamilyPickerProps {
   families: Array<SkillFamily>;
-  selectedFamilies: Array<SkillFamily["id"]>;
-  onCheckedFamilyChange: (
-    id: SkillFamily["id"],
-    checked: boolean | "indeterminate",
-  ) => void;
+  onSelectFamily: (id: SkillFamily["id"]) => void;
 }
 
-const FamilyPicker = ({
-  families,
-  selectedFamilies,
-  onCheckedFamilyChange,
-}: FamilyPickerProps) => {
+const FamilyPicker = ({ families, onSelectFamily }: FamilyPickerProps) => {
   const intl = useIntl();
+  const [currentFamilyId, setCurrentFamilyId] =
+    React.useState<Scalars["ID"]>("");
+  const currentFamily = families.find(
+    (family) => family.id === currentFamilyId,
+  );
+
+  const allSkillsLabel = intl.formatMessage({
+    defaultMessage: "All skills",
+    id: "6uce1H",
+    description: "Label for the skill picker family filter",
+  });
 
   const skillFamilyOptions = React.useMemo(() => {
     return [
@@ -72,24 +75,10 @@ const FamilyPicker = ({
           style={{ borderRightWidth: 0 }}
         >
           <span>
-            {intl.formatMessage({
-              defaultMessage: "All skills",
-              id: "6uce1H",
-              description: "Label for the skill picker family filter",
-            })}
+            {currentFamily
+              ? getLocalizedName(currentFamily.name, intl)
+              : allSkillsLabel}
           </span>
-          {selectedFamilies.length > 0 ? (
-            <span
-              data-h2-radius="base(9999px)"
-              data-h2-background-color="base(dt-primary)"
-              data-h2-font-weight="base(400)"
-              data-h2-color="base(dt-white)"
-              data-h2-padding="base(x.15, x.25)"
-              data-h2-font-size="base(caption, 1)"
-            >
-              {selectedFamilies.length}
-            </span>
-          ) : null}
           <ChevronDownIcon
             data-h2-height="base(1em)"
             data-h2-width="base(1em)"
@@ -97,34 +86,44 @@ const FamilyPicker = ({
         </Button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content>
-        {skillFamilyOptions.map((category, index) => (
-          <React.Fragment key={category.id}>
-            <DropdownMenu.Label>{category.label}</DropdownMenu.Label>
-            <DropdownMenu.Group>
+        <DropdownMenu.RadioGroup
+          value={currentFamilyId}
+          onValueChange={setCurrentFamilyId}
+        >
+          <DropdownMenu.RadioItem
+            value=""
+            onSelect={() => {
+              onSelectFamily("");
+            }}
+          >
+            <DropdownMenu.ItemIndicator>
+              <CheckIcon />
+            </DropdownMenu.ItemIndicator>
+            {allSkillsLabel}
+          </DropdownMenu.RadioItem>
+          {skillFamilyOptions.map((category, index) => (
+            <React.Fragment key={category.id}>
+              <DropdownMenu.Label>{category.label}</DropdownMenu.Label>
               {category.options.map((option) => (
-                <DropdownMenu.CheckboxItem
+                <DropdownMenu.RadioItem
+                  value={option.value}
                   key={option.value}
-                  checked={selectedFamilies.includes(option.value)}
-                  onCheckedChange={(checked) =>
-                    onCheckedFamilyChange(option.value, checked)
-                  }
-                  onSelect={(e) => {
-                    // Prevent dropdown closing on select
-                    e.preventDefault();
+                  onSelect={() => {
+                    onSelectFamily(option.value);
                   }}
                 >
                   <DropdownMenu.ItemIndicator>
                     <CheckIcon />
                   </DropdownMenu.ItemIndicator>
                   {option.label}
-                </DropdownMenu.CheckboxItem>
+                </DropdownMenu.RadioItem>
               ))}
-            </DropdownMenu.Group>
-            {index + 1 < skillFamilyOptions.length && (
-              <DropdownMenu.Separator />
-            )}
-          </React.Fragment>
-        ))}
+              {index + 1 < skillFamilyOptions.length && (
+                <DropdownMenu.Separator />
+              )}
+            </React.Fragment>
+          ))}
+        </DropdownMenu.RadioGroup>
       </DropdownMenu.Content>
     </DropdownMenu.Root>
   );

--- a/frontend/common/src/components/SkillPicker/FamilyPicker.tsx
+++ b/frontend/common/src/components/SkillPicker/FamilyPicker.tsx
@@ -73,8 +73,8 @@ const FamilyPicker = ({
         >
           <span>
             {intl.formatMessage({
-              defaultMessage: "Families",
-              id: "JyUPiu",
+              defaultMessage: "All skills",
+              id: "6uce1H",
               description: "Label for the skill picker family filter",
             })}
           </span>

--- a/frontend/common/src/components/SkillPicker/SkillPicker.tsx
+++ b/frontend/common/src/components/SkillPicker/SkillPicker.tsx
@@ -11,7 +11,6 @@ import SkillBlock from "./SkillBlock";
 
 import { Scalars, Skill, SkillFamily } from "../../api/generated";
 import { getLocalizedName } from "../../helpers/localize";
-import { notEmpty } from "../../helpers/util";
 import {
   filterSkillsByNameOrKeywords,
   invertSkillSkillFamilyTree,
@@ -167,6 +166,7 @@ const SkillPicker = ({
         data-h2-width="base(100%)"
         data-h2-height="base(320px)"
         data-h2-max-height="base(50vh)"
+        data-h2-shadow="base(s)"
       >
         <ScrollArea.Viewport data-h2-background-color="base(white)">
           <div data-h2-padding="base(x.5, x1, x.5, x.5)">

--- a/frontend/common/src/components/SkillPicker/SkillPicker.tsx
+++ b/frontend/common/src/components/SkillPicker/SkillPicker.tsx
@@ -142,8 +142,11 @@ const SkillPicker = ({
             type="text"
             autoComplete="off"
             {...methods.register("query")}
+            data-h2-background-color="base(white) base:focus-visible(lighter.dt-primary.10)"
+            data-h2-outline="base(none)"
+            data-h2-shadow="base:focus-visible(s, dt-primary.30)"
             data-h2-flex-grow="base(1)"
-            data-h2-border="base(all, 1px, solid, dt-primary)"
+            data-h2-border="base(all, 1px, solid, dt-primary) base:focus-visible(all, 1px, solid, dark.dt-primary)"
             data-h2-radius="base(0, input, input, 0)"
             data-h2-padding="base(x.5, x1)"
             placeholder={intl.formatMessage({

--- a/frontend/common/src/components/SkillPicker/SkillPicker.tsx
+++ b/frontend/common/src/components/SkillPicker/SkillPicker.tsx
@@ -22,12 +22,12 @@ type Skills = Array<Skill>;
 
 interface FormValues {
   query: string;
-  skillFamilies: Array<Scalars["ID"]>;
+  skillFamily: Scalars["ID"];
 }
 
 const defaultValues: FormValues = {
   query: "",
-  skillFamilies: [],
+  skillFamily: "",
 };
 export interface SkillPickerProps {
   skills: Skills;
@@ -52,10 +52,10 @@ const SkillPicker = ({
   const { watch } = methods;
 
   React.useEffect(() => {
-    const subscription = watch(({ query, skillFamilies }) => {
+    const subscription = watch(({ query, skillFamily }) => {
       setValidData({
         query: query ?? "",
-        skillFamilies: skillFamilies ? skillFamilies?.filter(notEmpty) : [],
+        skillFamily: skillFamily ?? "",
       });
     });
 
@@ -79,9 +79,9 @@ const SkillPicker = ({
   const filteredSkills = React.useMemo(() => {
     return filterSkillsByNameOrKeywords(skills, validData.query, intl).filter(
       (skill) => {
-        if (validData.skillFamilies.length) {
-          return skill?.families?.some((family) =>
-            validData.skillFamilies.includes(family.id),
+        if (validData.skillFamily) {
+          return skill?.families?.some(
+            (family) => family.id === validData.skillFamily,
           );
         }
 
@@ -103,19 +103,8 @@ const SkillPicker = ({
     handleSkillUpdate(newSkills);
   };
 
-  const handleCheckFamily = (
-    id: SkillFamily["id"],
-    checked: boolean | string,
-  ) => {
-    const currentFamilies = methods.getValues("skillFamilies");
-    let newFamilies = [];
-    if (!checked) {
-      newFamilies = currentFamilies.filter((value) => value !== id);
-    } else {
-      newFamilies = [...currentFamilies, id];
-    }
-
-    methods.setValue("skillFamilies", newFamilies);
+  const handleCheckFamily = (id: SkillFamily["id"]) => {
+    methods.setValue("skillFamily", id);
   };
 
   return (
@@ -133,8 +122,7 @@ const SkillPicker = ({
         />
         <div data-h2-display="base(flex)" data-h2-margin="base(x.25, 0, 0, 0)">
           <FamilyPicker
-            selectedFamilies={methods.getValues("skillFamilies")}
-            onCheckedFamilyChange={handleCheckFamily}
+            onSelectFamily={handleCheckFamily}
             families={allSkillFamilies}
           />
           <input

--- a/frontend/common/src/components/SkillPicker/SkillPicker.tsx
+++ b/frontend/common/src/components/SkillPicker/SkillPicker.tsx
@@ -6,17 +6,17 @@ import type { HeadingLevel } from "../Heading";
 import Chip, { Chips } from "../Chip";
 import Separator from "../Separator";
 import ScrollArea from "../ScrollArea";
-import { Input } from "../form";
-import MultiSelectFieldV2 from "../form/MultiSelect/MultiSelectFieldV2";
+import { InputLabel } from "../inputPartials";
 import SkillBlock from "./SkillBlock";
 
-import { Scalars, Skill, SkillCategory } from "../../api/generated";
+import { Scalars, Skill, SkillFamily } from "../../api/generated";
 import { getLocalizedName } from "../../helpers/localize";
 import { notEmpty } from "../../helpers/util";
 import {
   filterSkillsByNameOrKeywords,
   invertSkillSkillFamilyTree,
 } from "../../helpers/skillUtils";
+import FamilyPicker from "./FamilyPicker";
 
 type Skills = Array<Skill>;
 
@@ -103,67 +103,56 @@ const SkillPicker = ({
     handleSkillUpdate(newSkills);
   };
 
-  const skillFamilyOptions = React.useMemo(() => {
-    return [
-      {
-        label: intl.formatMessage({
-          defaultMessage: "Technical skills",
-          id: "kxseH4",
-          description: "Tab name for a list of technical skills",
-        }),
-        options: allSkillFamilies
-          .filter((sf) => sf.category === SkillCategory.Technical)
-          .map((family) => ({
-            value: family.id,
-            label: getLocalizedName(family.name, intl),
-          })),
-      },
-      {
-        label: intl.formatMessage({
-          defaultMessage: "Behavioural skills",
-          id: "LjkK5G",
-          description: "Tab name for a list of behavioural skills",
-        }),
-        options: allSkillFamilies
-          .filter((sf) => sf.category === SkillCategory.Behavioural)
-          .map((family) => ({
-            value: family.id,
-            label: getLocalizedName(family.name, intl),
-          })),
-      },
-    ];
-  }, [allSkillFamilies, intl]);
+  const handleCheckFamily = (
+    id: SkillFamily["id"],
+    checked: boolean | string,
+  ) => {
+    const currentFamilies = methods.getValues("skillFamilies");
+    let newFamilies = [];
+    if (!checked) {
+      newFamilies = currentFamilies.filter((value) => value !== id);
+    } else {
+      newFamilies = [...currentFamilies, id];
+    }
+
+    methods.setValue("skillFamilies", newFamilies);
+  };
 
   return (
     <>
       <FormProvider {...methods}>
-        <Input
-          id="query"
-          name="query"
-          type="text"
+        <InputLabel
+          required={false}
+          inputId="query"
+          trackUnsaved={false}
           label={intl.formatMessage({
             defaultMessage: "Search skills by keyword",
             id: "ARqO1j",
             description: "Label for the skills search bar.",
           })}
-          placeholder={intl.formatMessage({
-            defaultMessage: "e.g. Python, JavaScript, etc.",
-            id: "PF4ya+",
-            description: "Placeholder for the skills search bar.",
-          })}
-          autoComplete="off"
-          trackUnsaved={false}
         />
-        <MultiSelectFieldV2
-          id="skillFamilies"
-          name="skillFamilies"
-          label={intl.formatMessage({
-            defaultMessage: "Filter skills by type",
-            description: "Label for the skills families dropdown",
-            id: "SwsGvU",
-          })}
-          options={skillFamilyOptions}
-        />
+        <div data-h2-display="base(flex)" data-h2-margin="base(x.25, 0, 0, 0)">
+          <FamilyPicker
+            selectedFamilies={methods.getValues("skillFamilies")}
+            onCheckedFamilyChange={handleCheckFamily}
+            families={allSkillFamilies}
+          />
+          <input
+            id="query"
+            type="text"
+            autoComplete="off"
+            {...methods.register("query")}
+            data-h2-flex-grow="base(1)"
+            data-h2-border="base(all, 1px, solid, dt-primary)"
+            data-h2-radius="base(0, input, input, 0)"
+            data-h2-padding="base(x.5, x1)"
+            placeholder={intl.formatMessage({
+              defaultMessage: "e.g. Python, JavaScript, etc.",
+              id: "PF4ya+",
+              description: "Placeholder for the skills search bar.",
+            })}
+          />
+        </div>
       </FormProvider>
       <p
         aria-live="polite"

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1975,5 +1975,9 @@
   "DdOEWx": {
     "defaultMessage": "Erreur : nom pas chargé",
     "description": "Message when name value not found"
+  },
+  "6uce1H": {
+    "defaultMessage": "Toutes les compétences",
+    "description": "Label for the skill picker family filter"
   }
 }


### PR DESCRIPTION
## 👋 Introduction

This combines the inputs for filtering the skill picker into a single line (dropdown, input).

## ✅ TO DO

- [x] Request translations
- [x] Update translations once received

## ❓ Questions

> **Note**
> @Jerryescandon answered all my questions, leaving them here for a paper trail. 👍
>
>  tldr; We will not be supporting multiple options for now.

### Labels/Copy

I'm unsure of the best terminology to use in the button. In the mockup it said "All skills", which makes sense initially. However, once you select any number of families, it makes less sense. 

**_What should the button text be once any number of families have been selected?_**

### Functionality

Since we can select multiple families, I have forced the dropdown to stay open when a familiy selected. Just confirming that this is how we prefer it to work.

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Navigate to the create experience form
3. Use the dropdown to filter by family and confirm the skills return match expected results
4. Bonus: Do all of this with assistive technology (keyboard only, screen reader)

## 📷 Screenshot

<img width="1287" alt="Screenshot 2022-11-09 at 12 57 11 PM" src="https://user-images.githubusercontent.com/4127998/200905000-e2a2481e-aafb-415d-bfc8-7859c347fc5b.png">

## 🤖 Robot Stuff

Resolves #4392 