### PR TITLE
bug/4575-manage-requests-disabled hide the button

### DIFF
--- a/frontend/admin/src/js/components/pool/ViewPool.tsx
+++ b/frontend/admin/src/js/components/pool/ViewPool.tsx
@@ -5,7 +5,6 @@ import {
   ClipboardIcon,
   CogIcon,
   ArrowTopRightOnSquareIcon,
-  TicketIcon,
   UserGroupIcon,
   Squares2X2Icon,
 } from "@heroicons/react/24/outline";
@@ -192,6 +191,8 @@ export const ViewPoolPage = ({ pool }: ViewPoolPageProps): JSX.Element => {
               })}
             </IconLink>
           </Spacer>
+          {/*
+          TODO - uncomment once something to link to exists and reimport TicketIcon
           <Spacer>
             <IconLink
               mode="solid"
@@ -209,6 +210,7 @@ export const ViewPoolPage = ({ pool }: ViewPoolPageProps): JSX.Element => {
               })}
             </IconLink>
           </Spacer>
+          */}
           <Spacer>
             <IconLink
               mode="solid"


### PR DESCRIPTION
closes #4575 
issue adjusted to hide the button for the time being (https://github.com/GCTC-NTGC/gc-digital-talent/issues/4575#issuecomment-1309080352)

test:
navigate to `/en/admin/pools/:id`
assert the Manage Requests button is gone and things are otherwise fine

