### PR TITLE
Copy - 4548 - Format request date

### DIFF
--- a/frontend/admin/src/js/components/searchRequest/SingleSearchRequest.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SingleSearchRequest.tsx
@@ -7,6 +7,7 @@ import { commonMessages } from "@common/messages";
 import { getPoolCandidateSearchStatus } from "@common/constants/localizedConstants";
 import Pending from "@common/components/Pending";
 import NotFound from "@common/components/NotFound";
+import { formatDate, parseDateTimeUtc } from "@common/helpers/dateUtils";
 import {
   PoolCandidateSearchRequest,
   useGetPoolCandidateSearchRequestQuery,
@@ -171,7 +172,15 @@ const ManagerInfo: React.FunctionComponent<{
                     description:
                       "Title for the date requested block in the manager info section of the single search request view.",
                   })}
-                  content={requestedDate}
+                  content={
+                    requestedDate
+                      ? formatDate({
+                          date: parseDateTimeUtc(requestedDate),
+                          formatString: "PPP p",
+                          intl,
+                        })
+                      : null
+                  }
                 />
                 <FilterBlock
                   title={intl.formatMessage({


### PR DESCRIPTION
## 👋 Introduction

This uses the new `dateUtils` to format the search request date.

## 🧪 Testing

1. Build admin `npm run production --workspace=admin`
2. Navigate to a search request
3. Confirm "Date Requested" is formatted in local timezone

## 🤖 Robot stuff

Resolves #4548 