### PR TITLE
Bug - 4592 - Fix skill separator logic

### DIFF
--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceSkills.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceSkills.tsx
@@ -119,6 +119,7 @@ const ExperienceSkills: React.FC<ExperienceSkillsProps> = ({
                 color="black"
                 data-h2-margin="base(x.5, 0)"
                 orientation="horizontal"
+                decorative
               />
               {poolAdvertisement.essentialSkills.map((skill, index: number) => (
                 <div key={skill.id} data-h2-padding="base(x0, x0, x0, x.5)">
@@ -130,8 +131,7 @@ const ExperienceSkills: React.FC<ExperienceSkillsProps> = ({
                     onAddSkill={handleAddSkill}
                     onRemoveSkill={handleRemoveSkill}
                   />
-                  {poolAdvertisement.essentialSkills &&
-                  index + 1 !== poolAdvertisement.essentialSkills.length ? (
+                  {index + 1 !== poolAdvertisement?.essentialSkills?.length ? (
                     <Separator
                       color="black"
                       data-h2-margin="base(x.5, 0)"
@@ -160,6 +160,7 @@ const ExperienceSkills: React.FC<ExperienceSkillsProps> = ({
                 color="black"
                 data-h2-margin="base(x.5, 0)"
                 orientation="horizontal"
+                decorative
               />
               {poolAdvertisement.nonessentialSkills.map(
                 (skill, index: number) => (
@@ -174,8 +175,8 @@ const ExperienceSkills: React.FC<ExperienceSkillsProps> = ({
                       onAddSkill={handleAddSkill}
                       onRemoveSkill={handleRemoveSkill}
                     />
-                    {poolAdvertisement.essentialSkills &&
-                    index + 1 !== poolAdvertisement.essentialSkills.length ? (
+                    {index + 1 !==
+                    poolAdvertisement?.nonessentialSkills?.length ? (
                       <Separator
                         color="black"
                         data-h2-margin="base(x.5, 0)"


### PR DESCRIPTION
## 👋 Introduction

This fixes a bug where we used the `essentialSkills` to check when to display separators for `nonEssentialSkills`.

**Bonus**: Adds `decorative` prop for the separator between headings and list items.

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Make sure you have a published pool advertisement with a different number of essential and non-essential skills
3. Create an application for that pool
4. Edit the skills and experiences on that application
5. Confirm the non-essential skills have the correct layout of separators

## 🤖 Robot stuff

Resolves #4592 