### PR TITLE
Bug - Search page queries

### DIFF
--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -34,6 +34,10 @@ final class CountPoolCandidatesByPool
         // available candidates scope (scope CANDIDATE_STATUS_QUALIFIED_AVAILABLE or CANDIDATE_STATUS_PLACED_CASUAL)
         PoolCandidate::scopeAvailable($queryBuilder);
 
+        // expiry status filter (filter active pool candidates)
+        PoolCandidate::scopeExpiryFilter($queryBuilder, [ 'expiryStatus' => ApiEnums::CANDIDATE_EXPIRY_FILTER_ACTIVE ]);
+
+
         $queryBuilder->whereHas('user', function (Builder $userQuery) use ($filters) {
             // user filters go here
 
@@ -80,9 +84,6 @@ final class CountPoolCandidatesByPool
                 User::filterBySkills($userQuery, $filters['skills']);
             }
         });
-
-        // expiry status filter (filter active pool candidates)
-        PoolCandidate::scopeExpiryFilter($queryBuilder, [ 'expiryStatus' => ApiEnums::CANDIDATE_EXPIRY_FILTER_ACTIVE ]);
 
         $databaseRows = $queryBuilder
             ->with('pool')

--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -20,19 +20,16 @@ final class CountPoolCandidatesByPool
         // query counts pool candidate rows, so start on that model
         $queryBuilder = PoolCandidate::query();
 
-        // pool candidate filters go here
-
-        // candidate pool scope
-        if (array_key_exists('pools', $filters)) {
-            // pool candidate filter uses Pool while Applicant filter users IdInput
-            $pools = array_map(function ($id) {
-                return ['id' => $id];
-            }, $filters['pools']);
-            PoolCandidate::filterByPools($queryBuilder, $pools);
-        }
-
         $queryBuilder->whereHas('user', function (Builder $userQuery) use ($filters) {
             // user filters go here
+
+            if (array_key_exists('pools', $filters)) {
+                // pool candidate filter uses Pool while Applicant filter users IdInput
+                $pools = array_map(function ($id) {
+                    return ['id' => $id];
+                }, $filters['pools']);
+                User::filterByAvailableInPools($userQuery, $pools);
+            }
 
             // user status scope
             User::scopeAvailableForOpportunities($userQuery);

--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -23,6 +23,7 @@ final class CountPoolCandidatesByPool
         $queryBuilder->whereHas('user', function (Builder $userQuery) use ($filters) {
             // user filters go here
 
+            // available in pools
             if (array_key_exists('pools', $filters)) {
                 // pool candidate filter uses Pool while Applicant filter users IdInput
                 $pools = array_map(function ($id) {

--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -34,9 +34,6 @@ final class CountPoolCandidatesByPool
         // available candidates scope (scope CANDIDATE_STATUS_QUALIFIED_AVAILABLE or CANDIDATE_STATUS_PLACED_CASUAL)
         PoolCandidate::scopeAvailable($queryBuilder);
 
-        // expiry status filter (filter active pool candidates)
-        PoolCandidate::scopeExpiryFilter($queryBuilder, [ 'expiryStatus' => ApiEnums::CANDIDATE_EXPIRY_FILTER_ACTIVE ]);
-
         $queryBuilder->whereHas('user', function (Builder $userQuery) use ($filters) {
             // user filters go here
 
@@ -83,6 +80,9 @@ final class CountPoolCandidatesByPool
                 User::filterBySkills($userQuery, $filters['skills']);
             }
         });
+
+        // expiry status filter (filter active pool candidates)
+        PoolCandidate::scopeExpiryFilter($queryBuilder, [ 'expiryStatus' => ApiEnums::CANDIDATE_EXPIRY_FILTER_ACTIVE ]);
 
         $databaseRows = $queryBuilder
             ->with('pool')

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -361,7 +361,8 @@ RAWSQL2;
     {
         $expiryStatus = isset($args['expiryStatus']) ? $args['expiryStatus'] : ApiEnums::CANDIDATE_EXPIRY_FILTER_ACTIVE;
         if ($expiryStatus == ApiEnums::CANDIDATE_EXPIRY_FILTER_ACTIVE) {
-            $query->whereDate('expiry_date', '>=', date("Y-m-d"));
+            $query->whereDate('expiry_date', '>=', date("Y-m-d"))
+            ->orWhereNull('expiry_date');
         } else if (array_key_exists('expiryStatus', $args) && $expiryStatus == ApiEnums::CANDIDATE_EXPIRY_FILTER_EXPIRED) {
             $query->whereDate('expiry_date', '<', date("Y-m-d"));
         }

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -361,9 +361,11 @@ RAWSQL2;
     {
         $expiryStatus = isset($args['expiryStatus']) ? $args['expiryStatus'] : ApiEnums::CANDIDATE_EXPIRY_FILTER_ACTIVE;
         if ($expiryStatus == ApiEnums::CANDIDATE_EXPIRY_FILTER_ACTIVE) {
-            $query->whereDate('expiry_date', '>=', date("Y-m-d"))
-            ->orWhereNull('expiry_date');
-        } else if (array_key_exists('expiryStatus', $args) && $expiryStatus == ApiEnums::CANDIDATE_EXPIRY_FILTER_EXPIRED) {
+            $query->where(function ($query) {
+                $query->whereDate('expiry_date', '>=', date("Y-m-d"))
+                    ->orWhereNull('expiry_date');
+            });
+        } else if ($expiryStatus == ApiEnums::CANDIDATE_EXPIRY_FILTER_EXPIRED) {
             $query->whereDate('expiry_date', '<', date("Y-m-d"));
         }
         return $query;

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -337,7 +337,7 @@ RAWSQL2;
         return $query;
     }
 
-    public function scopeAvailable(Builder $query): Builder
+    public static function scopeAvailable(Builder $query): Builder
     {
         return $query->whereIn('pool_candidate_status', [ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE, ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL]);
     }
@@ -357,13 +357,12 @@ RAWSQL2;
         return $query;
     }
 
-    public function scopeExpiryFilter(Builder $query, ?array $args)
+    public static function scopeExpiryFilter(Builder $query, ?array $args)
     {
         $expiryStatus = isset($args['expiryStatus']) ? $args['expiryStatus'] : ApiEnums::CANDIDATE_EXPIRY_FILTER_ACTIVE;
         if ($expiryStatus == ApiEnums::CANDIDATE_EXPIRY_FILTER_ACTIVE) {
-            $query->whereDate('expiry_date', '>=', date("Y-m-d"))
-                ->orWhereNull('expiry_date');
-        } else if ($expiryStatus == ApiEnums::CANDIDATE_EXPIRY_FILTER_EXPIRED) {
+            $query->whereDate('expiry_date', '>=', date("Y-m-d"));
+        } else if (array_key_exists('expiryStatus', $args) && $expiryStatus == ApiEnums::CANDIDATE_EXPIRY_FILTER_EXPIRED) {
             $query->whereDate('expiry_date', '<', date("Y-m-d"));
         }
         return $query;

--- a/api/tests/Feature/CountPoolCandidatesByPoolTest.php
+++ b/api/tests/Feature/CountPoolCandidatesByPoolTest.php
@@ -691,7 +691,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
         PoolCandidate::factory()->create($this->poolCandidateData($pool3, $user, false));
 
         // Create a placed casual pool candidate with inactive expiry date in Pool 3. Should not appear in response.
-        PoolCandidate::factory()->create($this->poolCandidateData($pool3, $user2, false));
+        PoolCandidate::factory()->create($this->poolCandidateData($pool3, $user2, true, false));
 
         $this->graphQL(
             /** @lang GraphQL */

--- a/api/tests/Feature/CountPoolCandidatesByPoolTest.php
+++ b/api/tests/Feature/CountPoolCandidatesByPoolTest.php
@@ -34,6 +34,15 @@ class CountPoolCandidatesByPoolTest extends TestCase
         $newUser->save();
     }
 
+    public function poolCandidateData(Pool $pool, User $user, ?bool $available = true, ?bool $futureDate = true) {
+        return [
+            'pool_id' => $pool,
+            'user_id' => $user,
+            'pool_candidate_status' => $available ? ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE : ApiEnums::CANDIDATE_STATUS_SCREENED_OUT_APPLICATION,
+            'expiry_date' => $futureDate ? config('constants.far_future_date') : config('constants.past_date') ,
+        ];
+    }
+
     // user (admin) not returned if no candidates
     // the admin has no candidates so should get no results
     public function testThatEmptyDoesNotReturnTheAdmin()
@@ -66,10 +75,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
         $user = User::factory()->create([
             'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING
         ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user->id
-        ]);
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user));
 
         $this->graphQL(
             /** @lang GraphQL */
@@ -109,10 +115,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
         $user = User::factory()->create([
             'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING
         ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user->id
-        ]);
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user));
 
         $this->graphQL(
             /** @lang GraphQL */
@@ -157,14 +160,8 @@ class CountPoolCandidatesByPoolTest extends TestCase
         $user = User::factory()->create([
             'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING
         ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool1->id,
-            'user_id' => $user->id
-        ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool2->id,
-            'user_id' => $user->id
-        ]);
+        PoolCandidate::factory()->create($this->poolCandidateData($pool1, $user));
+        PoolCandidate::factory()->create($this->poolCandidateData($pool2, $user));
 
         $this->graphQL(
             /** @lang GraphQL */
@@ -204,10 +201,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
             $user = User::factory()->create([
                 'job_looking_status' => $status
             ]);
-            PoolCandidate::factory()->create([
-                'pool_id' => $pool->id,
-                'user_id' => $user->id
-            ]);
+            PoolCandidate::factory()->create($this->poolCandidateData($pool, $user));
         }
 
         $this->graphQL(
@@ -252,18 +246,9 @@ class CountPoolCandidatesByPoolTest extends TestCase
             'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
             'has_diploma' => null
         ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user1->id
-        ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user2->id
-        ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user3->id
-        ]);
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user1));
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user2));
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user3));
 
         $this->graphQL(
             /** @lang GraphQL */
@@ -309,18 +294,9 @@ class CountPoolCandidatesByPoolTest extends TestCase
             'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
             'is_woman' => null
         ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user1->id
-        ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user2->id
-        ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user3->id
-        ]);
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user1));
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user2));
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user3));
 
         $this->graphQL(
             /** @lang GraphQL */
@@ -370,18 +346,9 @@ class CountPoolCandidatesByPoolTest extends TestCase
             'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
             'language_ability' => ApiEnums::LANGUAGE_ABILITY_FRENCH
         ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user1->id
-        ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user2->id
-        ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user3->id
-        ]);
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user1));
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user2));
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user3));
 
         $this->graphQL(
             /** @lang GraphQL */
@@ -436,18 +403,9 @@ class CountPoolCandidatesByPoolTest extends TestCase
                 ApiEnums::OPERATIONAL_REQUIREMENT_OVERTIME_OCCASIONAL
             ]
         ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user1->id
-        ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user2->id
-        ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user3->id
-        ]);
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user1));
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user2));
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user3));
 
         $this->graphQL(
             /** @lang GraphQL */
@@ -505,18 +463,9 @@ class CountPoolCandidatesByPoolTest extends TestCase
                 ApiEnums::WORK_REGION_NATIONAL_CAPITAL
             ]
         ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user1->id
-        ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user2->id
-        ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user3->id
-        ]);
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user1));
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user2));
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user3));
 
         $this->graphQL(
             /** @lang GraphQL */
@@ -565,18 +514,9 @@ class CountPoolCandidatesByPoolTest extends TestCase
             'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
             'would_accept_temporary' => null
         ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user1->id
-        ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user2->id
-        ]);
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool->id,
-            'user_id' => $user3->id
-        ]);
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user1));
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user2));
+        PoolCandidate::factory()->create($this->poolCandidateData($pool, $user3));
 
         $this->graphQL(
             /** @lang GraphQL */
@@ -616,10 +556,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
             );
         $users = User::factory(3)
             ->afterCreating(function ($user) use ($pool) {
-                PoolCandidate::factory()->create([
-                    'pool_id' => $pool->id,
-                    'user_id' => $user->id,
-                ]);
+                PoolCandidate::factory()->create($this->poolCandidateData($pool, $user));
             })
             ->create([
                 'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING
@@ -681,10 +618,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
         $users = User::factory(3)
             ->afterCreating(function ($user) use ($pool) {
                 $exp = AwardExperience::factory()->create(['user_id' => $user->id]);
-                PoolCandidate::factory()->create([
-                    'pool_id' => $pool->id,
-                    'user_id' => $user->id,
-                ]);
+                PoolCandidate::factory()->create($this->poolCandidateData($pool, $user));
             })
             ->create(['job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING]);
 
@@ -748,36 +682,16 @@ class CountPoolCandidatesByPoolTest extends TestCase
         ]);
 
         // Create a qualified available pool candidate with active expiry date in Pool 1.
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool1->id,
-            'user_id' => $user->id,
-            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE,
-            'expiry_date' => config('constants.far_future_date'),
-        ]);
+        PoolCandidate::factory()->create($this->poolCandidateData($pool1, $user));
 
         // Create a placed casual pool candidate with active expiry date in Pool 2.
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool2->id,
-            'user_id' => $user->id,
-            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL,
-            'expiry_date' => config('constants.far_future_date'),
-        ]);
+        PoolCandidate::factory()->create($this->poolCandidateData($pool2, $user));
 
         // Create a screened out pool candidate with active expiry date in Pool 3. Should not appear in response.
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool3->id,
-            'user_id' => $user->id,
-            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_SCREENED_OUT_APPLICATION,
-            'expiry_date' => config('constants.far_future_date'),
-        ]);
+        PoolCandidate::factory()->create($this->poolCandidateData($pool3, $user, false));
 
         // Create a placed casual pool candidate with inactive expiry date in Pool 3. Should not appear in response.
-        PoolCandidate::factory()->create([
-            'pool_id' => $pool3->id,
-            'user_id' => $user2->id,
-            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL,
-            'expiry_date' => config('constants.past_date'),
-        ]);
+        PoolCandidate::factory()->create($this->poolCandidateData($pool3, $user2, false));
 
         $this->graphQL(
             /** @lang GraphQL */

--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -47,13 +47,7 @@ const applicantFilterToQueryArgs = (
     return {
       where: {
         ...filter,
-        // TODO: does recreating the equity object serve any purpose?
-        equity: {
-          hasDisability: filter?.equity?.hasDisability,
-          isIndigenous: filter?.equity?.isIndigenous,
-          isVisibleMinority: filter?.equity?.isVisibleMinority,
-          isWoman: filter?.equity?.isWoman,
-        },
+        equity: { ...filter?.equity },
         expectedClassifications: filter?.expectedClassifications
           ? pickMap(filter.expectedClassifications, ["group", "level"])
           : [],


### PR DESCRIPTION
Resolves #4557 

## Notes
- Alright, I believe the solution was filtering by the [available users in pools](https://github.com/GCTC-NTGC/gc-digital-talent/blob/bug/4557-search-page-queries/api/app/Models/User.php#L260-L283) in the CountPoolCandidatesByPool query builder. This ensures the pool candidates are QUALIFIED_AVAILABLE or PLACED_CASUAL, and ensures the pool candidate hasn't expired. 
```php
    public static function filterByAvailableInPools(Builder $query, ?array $poolIds): Builder
    {
        if (empty($poolIds)) {
            return $query;
        }
        $poolFilters = [];
        foreach ($poolIds as $index => $poolId) {
            $poolFilters[$index] = [
                'poolId' => $poolId,
                'expiryStatus' => ApiEnums::CANDIDATE_EXPIRY_FILTER_ACTIVE,
                'statuses' => [ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE, ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL]
            ];
        }
        return self::filterByPools($query, $poolFilters);
    }
```

## Testing
- Go to [search page](http://localhost:8000/en/search) and fill out filters. View TOTAL number of candidates, and the number of candidates in each pool. The TOTAL number should never be greater than the sum of all the pool card totals. This is because one applicant can be found in multiple pools.
- Submit a request for candidates.
- Next, on the admin side check to see if the number of candidates is also correct. 
- Go to Requests table. Then click the request you created, scroll down to the table, and ensure that the correct number of candidates show up.

Please feel free to reach out to me for any help testing 🧪 