### PR TITLE
a11y - 4497 - Improve self assessment link context

### DIFF
--- a/frontend/talentsearch/src/js/components/languageInformationForm/ConsideredLanguages.tsx
+++ b/frontend/talentsearch/src/js/components/languageInformationForm/ConsideredLanguages.tsx
@@ -283,7 +283,7 @@ const ConsideredLanguages = ({ labels }: ConsideredLanguagesProps) => {
               {
                 defaultMessage:
                   "You can find out find out your levels with a <selfAssessmentLink>language proficiency self-assessment</selfAssessmentLink>.",
-                id: "SNY1Qo",
+                id: "1F7at9",
                 description:
                   "Text including link to language proficiency evaluation in language information form",
               },

--- a/frontend/talentsearch/src/js/components/languageInformationForm/ConsideredLanguages.tsx
+++ b/frontend/talentsearch/src/js/components/languageInformationForm/ConsideredLanguages.tsx
@@ -282,8 +282,8 @@ const ConsideredLanguages = ({ labels }: ConsideredLanguagesProps) => {
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "If you want to find out your language proficiency levels, <selfAssessmentLink>click here to find out.</selfAssessmentLink>",
-                id: "nVh2Qh",
+                  "You can find out find out your levels with a <selfAssessmentLink>language proficiency self assessment</selfAssessmentLink>.",
+                id: "SNY1Qo",
                 description:
                   "Text including link to language proficiency evaluation in language information form",
               },

--- a/frontend/talentsearch/src/js/components/languageInformationForm/ConsideredLanguages.tsx
+++ b/frontend/talentsearch/src/js/components/languageInformationForm/ConsideredLanguages.tsx
@@ -282,7 +282,7 @@ const ConsideredLanguages = ({ labels }: ConsideredLanguagesProps) => {
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "You can find out find out your levels with a <selfAssessmentLink>language proficiency self assessment</selfAssessmentLink>.",
+                  "You can find out find out your levels with a <selfAssessmentLink>language proficiency self-assessment</selfAssessmentLink>.",
                 id: "SNY1Qo",
                 description:
                   "Text including link to language proficiency evaluation in language information form",

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -1296,8 +1296,8 @@
     "defaultMessage": "Lieu de travail",
     "description": "Title for Profile Form wrapper  in Work Location Preferences Form"
   },
-  "nVh2Qh": {
-    "defaultMessage": "Si vous voulez connaître votre niveau de compétence linguistique, <selfAssessmentLink>cliquez ici pour le savoir</selfAssessmentLink>.",
+  "SNY1Qo": {
+    "defaultMessage": "Vous pouvez découvrir vos niveaux à l’aide d’une <selfAssessmentLink>auto-évaluation des aptitudes linguistiques</selfAssessmentLink>.",
     "description": "Text including link to language proficiency evaluation in language information form"
   },
   "nrBkon": {

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -1296,7 +1296,7 @@
     "defaultMessage": "Lieu de travail",
     "description": "Title for Profile Form wrapper  in Work Location Preferences Form"
   },
-  "SNY1Qo": {
+  "1F7at9": {
     "defaultMessage": "Vous pouvez découvrir vos niveaux à l’aide d’une <selfAssessmentLink>auto-évaluation des aptitudes linguistiques</selfAssessmentLink>.",
     "description": "Text including link to language proficiency evaluation in language information form"
   },


### PR DESCRIPTION
## 👋 Introduction

This updates the link test for the language proficient self assessment link for users of assistive technology.

## ✅ TO DO

- [x] Add translations once supplied

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Navigate to the language information form
3. Select "Bilingual positions"
4. Select "I am bilingual (En/Fr) and have NOT completed an official..."
5. Confirm the link text is "language proficiency self assessment" and the sentence makes grammatical sense
6. Confirm the French has been updated as well

## 🤖 Robot Stuff

Resolves #4497 