### PR TITLE
Bug - 4739 - Fix IAP Homepage Link

### DIFF
--- a/frontend/talentsearch/src/js/components/Home/partials/Opportunities/Opportunities.tsx
+++ b/frontend/talentsearch/src/js/components/Home/partials/Opportunities/Opportunities.tsx
@@ -122,7 +122,7 @@ const Opportunities = () => {
                   "Heading for the Indigenous Apprenticeship Program on home page",
               })}
               link={{
-                href: `${locale}/indigenous-it-apprentice`,
+                href: `/${locale}/indigenous-it-apprentice`,
                 external: true,
                 label: intl.formatMessage({
                   defaultMessage:


### PR DESCRIPTION
## 👋 Introduction

This adds a leading `/` to the link to the IAP on the homepage to prevent duplicate locales.

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Navigate to the homepage
3. Ensure the "Apply now" link under "Indigenous Apprenticeship Program" does not have a duplicate locale and links to the proper address in both English and French

## 🤖 Robot Stuff

Resolves #4739 