### PR TITLE
bug/4742-requests-date-received update formatting

### DIFF
--- a/frontend/admin/src/js/components/dashboard/LatestRequestsTable.tsx
+++ b/frontend/admin/src/js/components/dashboard/LatestRequestsTable.tsx
@@ -10,6 +10,7 @@ import type { PoolCandidateSearchStatus } from "@common/api/generated";
 import { notEmpty } from "@common/helpers/util";
 import Pending from "@common/components/Pending";
 import Heading from "@common/components/Heading";
+import { formatDate, parseDateTimeUtc } from "@common/helpers/dateUtils";
 import Table, { tableViewItemButtonAccessor } from "../Table";
 import type { ColumnsOf } from "../Table";
 
@@ -115,7 +116,14 @@ const LatestRequestsTable: React.FC<LatestRequestsTableProps> = ({ data }) => {
         description:
           "Title displayed on the latest requests table for the date column.",
       }),
-      accessor: "requestedDate",
+      accessor: ({ requestedDate }) =>
+        requestedDate
+          ? formatDate({
+              date: parseDateTimeUtc(requestedDate),
+              formatString: "PPP p",
+              intl,
+            })
+          : null,
     },
     {
       Header: intl.formatMessage({

--- a/frontend/admin/src/js/components/searchRequest/SearchRequestTable.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SearchRequestTable.tsx
@@ -6,6 +6,7 @@ import { getLocale } from "@common/helpers/localize";
 import { getPoolCandidateSearchStatus } from "@common/constants/localizedConstants";
 import { PoolCandidateSearchStatus } from "@common/api/generated";
 import Pending from "@common/components/Pending";
+import { formatDate, parseDateTimeUtc } from "@common/helpers/dateUtils";
 import {
   GetPoolCandidateSearchRequestsQuery,
   useGetPoolCandidateSearchRequestsQuery,
@@ -72,7 +73,14 @@ export const SearchRequestTable: React.FunctionComponent<
           description:
             "Title displayed on the search request table requested date column.",
         }),
-        accessor: "requestedDate",
+        accessor: ({ requestedDate }) =>
+          requestedDate
+            ? formatDate({
+                date: parseDateTimeUtc(requestedDate),
+                formatString: "PPP p",
+                intl,
+              })
+            : null,
       },
       {
         Header: intl.formatMessage({


### PR DESCRIPTION
closes #4742 
Updates date formatting to mirror this #4682 

testing:
open `/dashboard` , `/talent-requests` , and pick one request and open it up
ensure date looks identical across all three places