### PR TITLE
Bug - 4269 - Prevent classification wrapping

### DIFF
--- a/frontend/admin/src/js/components/pool/PoolTable.tsx
+++ b/frontend/admin/src/js/components/pool/PoolTable.tsx
@@ -117,7 +117,7 @@ export const PoolTable: React.FC<GetPoolsQuery & { editUrlRoot: string }> = ({
                 color="primary"
                 mode="outline"
               >
-                {`${classification?.group}-${classification?.level}`}
+                {classification?.group}&#8209;{classification?.level}
               </Pill>
             );
           }),


### PR DESCRIPTION
## 👋 Introduction

This replaces the normal hyphen for classifications on the `/admin/pools` page with a non-breaking hyphen ("&#8209;") to prevent it from wrapping on smaller screen sizes.

## 🧪 Testing

1. Build admin `npm run production --workspace=admin`
2. Navigate to `/admin/pools`
3. Reduce screen size to mobile width
4. Confirm classifications are not wrapping

## 📷 Screenshot

<img width="451" alt="Screenshot 2022-11-14 at 3 34 52 PM" src="https://user-images.githubusercontent.com/4127998/201760427-2cc7bb0d-75ac-40f4-89f9-0fc41a048f2a.png">

## 🤖 Robot Stuff

Resolves #4269