### PR TITLE
Feature - pool candidates search filter dropdown

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -334,6 +334,40 @@ RAWSQL2;
         return $query;
     }
 
+    public static function filterByName(Builder $query, ?string $name): Builder
+    {
+        if ($name) {
+            $splitName = explode(" ", $name);
+            $query->whereExists(function ($query) use ($splitName) {
+                $query->select('id')
+                    ->from('users')
+                    ->whereColumn('users.id', 'pool_candidates.user_id')
+                    ->where(function ($query) use ($splitName) {
+                        foreach ($splitName as $index => $value) {
+                            $query->where('first_name', "ilike", "%{$value}%")
+                                ->orWhere('last_name', "ilike", "%{$value}%");
+                        }
+                    });
+            });
+        }
+        return $query;
+    }
+
+    public static function scopeEmail(Builder $query, ?string $email): Builder
+    {
+        if ($email) {
+            $query->whereExists(function ($query) use ($email) {
+                $query->select('id')
+                    ->from('users')
+                    ->whereColumn('users.id', 'pool_candidates.user_id')
+                    ->where(function ($query) use ($email) {
+                        $query->where('email', 'ilike', "%{$email}%");
+                    });
+            });
+        }
+        return $query;
+    }
+
 
     public function scopePoolCandidateStatuses(Builder $query, ?array $poolCandidateStatuses): Builder
     {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -727,6 +727,8 @@ input PoolCandidateFilterInput {
   expectedClassifications: [ClassificationFilterInput]
     @scope(name: "classifications")
   generalSearch: String @builder(method: "App\\Models\\PoolCandidate@filterByGeneralSearch")
+  email: String @scope
+  name: String @builder(method: "App\\Models\\PoolCandidate@filterByName")
   hasDiploma: Boolean @scope
   languageAbility: LanguageAbility
     @builder(method: "App\\Models\\PoolCandidate@filterByLanguageAbility")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -870,6 +870,8 @@ input PoolCandidateFilterInput {
   equity: EquitySelectionsInput
   expectedClassifications: [ClassificationFilterInput]
   generalSearch: String
+  email: String
+  name: String
   hasDiploma: Boolean
   languageAbility: LanguageAbility
   locationPreferences: [WorkRegion]

--- a/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
@@ -268,6 +268,8 @@ const PoolCandidatesTable: React.FC<{ poolId: string }> = ({ poolId }) => {
     return {
       // search bar
       generalSearch: searchBarTerm && !searchType ? searchBarTerm : undefined,
+      email: searchType === "email" ? searchBarTerm : undefined,
+      name: searchType === "name" ? searchBarTerm : undefined,
 
       // from fancy filter
       pools: [{ id: poolId }],
@@ -549,6 +551,24 @@ const PoolCandidatesTable: React.FC<{ poolId: string }> = ({ poolId }) => {
             type,
           });
         }}
+        searchBy={[
+          {
+            label: intl.formatMessage({
+              defaultMessage: "Name",
+              id: "36k+Da",
+              description: "Label for user table search dropdown (name).",
+            }),
+            value: "name",
+          },
+          {
+            label: intl.formatMessage({
+              defaultMessage: "Email",
+              id: "fivWMs",
+              description: "Label for user table search dropdown (email).",
+            }),
+            value: "email",
+          },
+        ]}
         addBtn={{
           label: intl.formatMessage({
             defaultMessage: "Create Pool Candidate",


### PR DESCRIPTION
Resolves #4621 

## Notes
- Adds dropdown to Pool Candidates table.
- Dropdown should include the options: All Table (name AND email), Name, and Email.

## Testing
- Go to [Admin page](http://localhost:8000/en/admin) and login as admin.
- Go to [Pools table](http://localhost:8000/en/admin/pools) and select "View Candidates" on any of the pools.
- Play around with the Search filter making sure to test all three options (All table, name, and email)