### PR TITLE
Bug - 4765 - Fix Application Request Priority

### DIFF
--- a/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
+++ b/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
@@ -5,11 +5,8 @@ import { useIntl } from "react-intl";
 import { Id, toast } from "react-toastify";
 import { notEmpty } from "@common/helpers/util";
 import { tryFindMessageDescriptor } from "@common/messages/apiMessages";
-import {
-  Scalars,
-  useCreateApplicationMutation,
-  useGetPoolAdvertisementQuery,
-} from "../../api/generated";
+import { AuthorizationContext } from "@common/components/Auth";
+import { Scalars, useCreateApplicationMutation } from "../../api/generated";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
 
 interface CreateApplicationProps {
@@ -25,9 +22,7 @@ const CreateApplication = ({ poolId }: CreateApplicationProps) => {
   const intl = useIntl();
   const errorToastId = React.useRef<Id>("");
   const paths = useDirectIntakeRoutes();
-  const [{ data }] = useGetPoolAdvertisementQuery({
-    variables: { id: poolId },
-  });
+  const auth = React.useContext(AuthorizationContext);
   const [
     { fetching: creating, data: mutationData, operation },
     executeMutation,
@@ -75,7 +70,7 @@ const CreateApplication = ({ poolId }: CreateApplicationProps) => {
    * isVisible - Should't run it if user cannot view it
    * !hasApplied - Users can only apply to a single pool advertisement
    */
-  const userId = data?.me?.id;
+  const userId = auth.loggedInUser?.id;
   const hasMutationData = notEmpty(mutationData);
   const isCreating = creating || hasMutationData || operation?.key;
   const hasRequiredData = userId && poolId;

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -39,6 +39,7 @@ import {
   formatClassificationString,
   getFullPoolAdvertisementTitle,
 } from "@common/helpers/poolUtils";
+import { AuthorizationContext } from "@common/components/Auth";
 import { useGetPoolAdvertisementQuery, Maybe } from "../../api/generated";
 import type { PoolAdvertisement } from "../../api/generated";
 import { useDirectIntakeRoutes } from "../../directIntakeRoutes";
@@ -796,13 +797,14 @@ interface PoolAdvertisementPageProps {
 
 const PoolAdvertisementPage = ({ id }: PoolAdvertisementPageProps) => {
   const intl = useIntl();
+  const auth = React.useContext(AuthorizationContext);
 
   const [{ data, fetching, error }] = useGetPoolAdvertisementQuery({
     variables: { id },
   });
 
   const isVisible = isAdvertisementVisible(
-    data?.me?.roles?.filter(notEmpty) || [],
+    auth?.loggedInUserRoles?.filter(notEmpty) || [],
     data?.poolAdvertisement?.advertisementStatus ?? null,
   );
 

--- a/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
+++ b/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
@@ -10,7 +10,6 @@ query getPool($id: ID!) {
 
 query getPoolAdvertisement($id: ID!) {
   me {
-    roles
     id
     poolCandidates {
       id


### PR DESCRIPTION
## 👋 Introduction

This removes `roles` from the `getPoolAdvertisementQuery` and favours the `AuthorizationContext` to fix an issue where users could not apply to pools in French.

## 🕵️ Details

We were querying roles in two places at the same time. The query we were using was being cancelled in favour of the top level query. This uses the top level query instead to prevent it from being cancelled. The root of the issue was a re-render happening at the `LanguageRedirectContainer` level where our `useLocation` hook is causing unecessary re-renders. This works around that issue but will be better resolved by #4597 

## 🧪 Testing

1. Run codegen `npm run codegen --workspaces`
2. Build talent search `npm run production --workspace=talentsearch`
3. Attempt to apply to a pool on the French site while anonymous (not logged in)
4. Confirm the application is successful

## 🤖 Robot Stuff

Resolves #4765 