### PR TITLE
Bug/4762 view draft advertisement poster

### DIFF
--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisement.stories.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisement.stories.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import { fakePoolAdvertisements } from "@common/fakeData";
+import { PoolAdvertisementPoster } from "./PoolAdvertisementPage";
+
+const fakeAdvertisement = fakePoolAdvertisements()[0];
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const nullAdvertisement: any = {};
+Object.keys(fakeAdvertisement).forEach((key) => {
+  nullAdvertisement[key] = null;
+});
+
+export default {
+  component: PoolAdvertisementPoster,
+  title: "Pool/PoolAdvertisementPoster",
+} as Meta;
+
+const TemplatePoolAdvertisementPoster: Story = (...args) => (
+  <PoolAdvertisementPoster poolAdvertisement={args[0].poolAdvertisement} />
+);
+
+export const CompletedPoolPoster = TemplatePoolAdvertisementPoster.bind({});
+CompletedPoolPoster.args = { poolAdvertisement: fakeAdvertisement };
+
+export const NullPoolPoster = TemplatePoolAdvertisementPoster.bind({});
+NullPoolPoster.args = { poolAdvertisement: nullAdvertisement };

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -121,7 +121,7 @@ interface PoolAdvertisementProps {
   hasApplied?: boolean;
 }
 
-const PoolAdvertisement = ({
+export const PoolAdvertisementPoster = ({
   poolAdvertisement,
   hasApplied,
 }: PoolAdvertisementProps) => {
@@ -817,7 +817,7 @@ const PoolAdvertisementPage = ({ id }: PoolAdvertisementPageProps) => {
   return (
     <Pending fetching={fetching} error={error}>
       {data?.poolAdvertisement && isVisible ? (
-        <PoolAdvertisement
+        <PoolAdvertisementPoster
           poolAdvertisement={data?.poolAdvertisement}
           hasApplied={hasApplied}
         />

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -147,13 +147,17 @@ export const PoolAdvertisementPoster = ({
     poolAdvertisement.advertisementStatus &&
     poolAdvertisement.advertisementStatus === AdvertisementStatus.Published;
 
-  const languageRequirement = intl.formatMessage(
-    getLanguageRequirement(poolAdvertisement.advertisementLanguage ?? ""),
-  );
+  const languageRequirement = poolAdvertisement.advertisementLanguage
+    ? intl.formatMessage(
+        getLanguageRequirement(poolAdvertisement.advertisementLanguage),
+      )
+    : "";
 
-  const securityClearance = intl.formatMessage(
-    getSecurityClearance(poolAdvertisement.securityClearance ?? ""),
-  );
+  const securityClearance = poolAdvertisement.securityClearance
+    ? intl.formatMessage(
+        getSecurityClearance(poolAdvertisement.securityClearance),
+      )
+    : "";
 
   const essentialSkills = categorizeSkill(poolAdvertisement.essentialSkills);
   const nonEssentialSkills = categorizeSkill(


### PR DESCRIPTION
closes #4762 
updates some functions to account for possible null values passed in
adds a story file for that component since as far as I could tell there wasn't one for the poster view
renamed the component so it is no longer named the same as the type

check it out by going to `/en/browse/pools/:id` for both a complete and newly created pool