### PR TITLE
bug/4782-browse-breadcrumbs-unclickable update layering

### DIFF
--- a/frontend/talentsearch/src/js/components/Browse/BrowsePoolsPage.tsx
+++ b/frontend/talentsearch/src/js/components/Browse/BrowsePoolsPage.tsx
@@ -39,6 +39,7 @@ const getFlourishStyles = (isTop: boolean) => ({
   "data-h2-position": "base(absolute)",
   "data-h2-width": "base(25vw)",
   "data-h2-offset": isTop ? "base(0, 0, auto, auto)" : "base(auto, auto, 0, 0)",
+  "data-h2-z-index": "base(-1)",
 });
 
 export interface BrowsePoolsProps {


### PR DESCRIPTION
closes #4782 
sets a z-index value per Eric's suggestion

to test, ensure your browse page is in null state (no opportunities) as that is the case where the overlap happens otherwise you won't replicate the bug
head to `/en/browse/pools` and ensure links work and nothing got messed visually