### PR TITLE
a11y - 4624 - Descriptive profile title

### DIFF
--- a/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
+++ b/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
@@ -64,10 +64,19 @@ export const ProfileForm: React.FC<ProfilePageProps> = ({
             textShadow: "0 3px 3px rgba(10, 10, 10, .3)",
           }}
         >
-          {getFullNameHtml(
-            profileDataInput.firstName,
-            profileDataInput.lastName,
-            intl,
+          {intl.formatMessage(
+            {
+              defaultMessage: "{name}'s profile",
+              id: "jslBEY",
+              description: "Title for a specific users profile page",
+            },
+            {
+              name: getFullNameHtml(
+                profileDataInput.firstName,
+                profileDataInput.lastName,
+                intl,
+              ),
+            },
           )}
         </h1>
       </div>

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -2823,5 +2823,9 @@
   "FkwGWO": {
     "defaultMessage": "Notre engagement envers la conception, l’élaboration et la prestation de services accessibles.",
     "description": "Subtitle for the accessibility statement page."
+  },
+  "jslBEY": {
+    "defaultMessage": "Profile de {name}",
+    "description": "Title for a specific users profile page"
   }
 }


### PR DESCRIPTION
## 👋 Introduction

This adds "profile" to the title of user profiles to make them more descriptive.

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Navigate to the profile
3. Confirm the title is "First Last's Profile" in English
4. Confirm the title is "Profile de First Last" in French

## 🤖 Robot Stuff

Resolves #4624 