### PR TITLE
Bug -  4786 - Improve code splitting

### DIFF
--- a/frontend/admin/src/js/components/Router.tsx
+++ b/frontend/admin/src/js/components/Router.tsx
@@ -181,7 +181,7 @@ const DeprecatedCreatePool = React.lazy(() =>
   lazyRetry(
     () =>
       import(
-        /* webpackChunkName: "adminCreatePool" */ "./pool/deprecated/CreatePool"
+        /* webpackChunkName: "adminDeprecatedCreatePool" */ "./pool/deprecated/CreatePool"
       ),
   ),
 );

--- a/frontend/admin/src/js/components/Router.tsx
+++ b/frontend/admin/src/js/components/Router.tsx
@@ -173,7 +173,7 @@ const DeprecatedUpdatePool = React.lazy(() =>
   lazyRetry(
     () =>
       import(
-        /* webpackChunkName: "adminUpdatePool" */ "./pool/deprecated/UpdatePool"
+        /* webpackChunkName: "adminDeprecatedUpdatePool" */ "./pool/deprecated/UpdatePool"
       ),
   ),
 );

--- a/frontend/admin/src/js/components/Router.tsx
+++ b/frontend/admin/src/js/components/Router.tsx
@@ -9,92 +9,197 @@ import Layout from "./Layout";
 
 import { Role } from "../api/generated";
 
-const HomePage = React.lazy(() => import("./home/HomePage"));
-const ErrorPage = React.lazy(() => import("./Error/ErrorPage"));
-const DashboardPage = React.lazy(() => import("./dashboard/DashboardPage"));
+const HomePage = React.lazy(
+  () => import(/* webpackChunkName: "adminHomePage" */ "./home/HomePage"),
+);
+const ErrorPage = React.lazy(
+  () => import(/* webpackChunkName: "adminErrorPage" */ "./Error/ErrorPage"),
+);
+const DashboardPage = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "adminDashboardPage" */ "./dashboard/DashboardPage"
+    ),
+);
 
 /** Users */
-const UserPage = React.lazy(() => import("./user/UserPage"));
-const CreateUser = React.lazy(() => import("./user/CreateUser"));
-const UpdateUser = React.lazy(() => import("./user/UpdateUser"));
-const ViewUser = React.lazy(() => import("./user/ViewUser"));
+const UserPage = React.lazy(
+  () => import(/* webpackChunkName: "adminUserPage" */ "./user/UserPage"),
+);
+const CreateUser = React.lazy(
+  () => import(/* webpackChunkName: "adminCreateUser" */ "./user/CreateUser"),
+);
+const UpdateUser = React.lazy(
+  () => import(/* webpackChunkName: "adminUpdateUser" */ "./user/UpdateUser"),
+);
+const ViewUser = React.lazy(
+  () => import(/* webpackChunkName: "adminViewUser" */ "./user/ViewUser"),
+);
 
 /** Classifications */
 const ClassificationPage = React.lazy(
-  () => import("./classification/ClassificationPage"),
+  () =>
+    import(
+      /* webpackChunkName: "adminClassificationPage" */ "./classification/ClassificationPage"
+    ),
 );
 const CreateClassification = React.lazy(
-  () => import("./classification/CreateClassification"),
+  () =>
+    import(
+      /* webpackChunkName: "adminCreateClassification" */ "./classification/CreateClassification"
+    ),
 );
 const UpdateClassification = React.lazy(
-  () => import("./classification/UpdateClassification"),
+  () =>
+    import(
+      /* webpackChunkName: "adminUpdateClassification" */ "./classification/UpdateClassification"
+    ),
 );
 
 /** CMO Assets */
-const CmoAssetPage = React.lazy(() => import("./cmoAsset/CmoAssetPage"));
-const CreateCmoAsset = React.lazy(() => import("./cmoAsset/CreateCmoAsset"));
-const UpdateCmoAsset = React.lazy(() => import("./cmoAsset/UpdateCmoAsset"));
+const CmoAssetPage = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "adminCmoAssetsPage" */ "./cmoAsset/CmoAssetPage"
+    ),
+);
+const CreateCmoAsset = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "adminCreateCmoAsset" */ "./cmoAsset/CreateCmoAsset"
+    ),
+);
+const UpdateCmoAsset = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "adminUpdateCmoAsset" */ "./cmoAsset/UpdateCmoAsset"
+    ),
+);
 
 /** Pool Candidates */
 const PoolCandidatePage = React.lazy(
-  () => import("./poolCandidate/PoolCandidatePage"),
+  () =>
+    import(
+      /* webpackChunkName: "adminPoolCandidatePage" */ "./poolCandidate/PoolCandidatePage"
+    ),
 );
 const CreatePoolCandidate = React.lazy(
-  () => import("./poolCandidate/CreatePoolCandidate"),
+  () =>
+    import(
+      /* webpackChunkName: "adminCreatePoolCandidate" */ "./poolCandidate/CreatePoolCandidate"
+    ),
 );
 const UpdatePoolCandidate = React.lazy(
-  () => import("./poolCandidate/UpdatePoolCandidate"),
+  () =>
+    import(
+      /* webpackChunkName: "adminUpdatePoolCandidate" */ "./poolCandidate/UpdatePoolCandidate"
+    ),
 );
 const ViewPoolCandidatePage = React.lazy(
-  () => import("./poolCandidate/ViewPoolCandidate/ViewPoolCandidatePage"),
+  () =>
+    import(
+      /* webpackChunkName: "adminViewPoolCandidate" */ "./poolCandidate/ViewPoolCandidate/ViewPoolCandidatePage"
+    ),
 );
 
 /** Pools */
-const PoolPage = React.lazy(() => import("./pool/PoolPage"));
-const CreatePool = React.lazy(() => import("./pool/CreatePool"));
-const EditPool = React.lazy(() => import("./pool/EditPool/EditPool"));
-const ViewPool = React.lazy(() => import("./pool/ViewPool"));
+const PoolPage = React.lazy(
+  () => import(/* webpackChunkName: "adminPoolPage" */ "./pool/PoolPage"),
+);
+const CreatePool = React.lazy(
+  () => import(/* webpackChunkName: "adminCreatePool" */ "./pool/CreatePool"),
+);
+const EditPool = React.lazy(
+  () =>
+    import(/* webpackChunkName: "adminEditPool" */ "./pool/EditPool/EditPool"),
+);
+const ViewPool = React.lazy(
+  () => import(/* webpackChunkName: "adminViewPool" */ "./pool/ViewPool"),
+);
 const DeprecatedViewPool = React.lazy(
-  () => import("./pool/deprecated/ViewPool"),
+  () =>
+    import(
+      /* webpackChunkName: "adminDeprecatedViewPool" */ "./pool/deprecated/ViewPool"
+    ),
 );
 const DeprecatedUpdatePool = React.lazy(
-  () => import("./pool/deprecated/UpdatePool"),
+  () =>
+    import(
+      /* webpackChunkName: "adminUpdatePool" */ "./pool/deprecated/UpdatePool"
+    ),
 );
 const DeprecatedCreatePool = React.lazy(
-  () => import("./pool/deprecated/CreatePool"),
+  () =>
+    import(
+      /* webpackChunkName: "adminCreatePool" */ "./pool/deprecated/CreatePool"
+    ),
 );
 
 /** Departments */
-const DepartmentPage = React.lazy(() => import("./department/DepartmentPage"));
+const DepartmentPage = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "adminDepartmentPage" */ "./department/DepartmentPage"
+    ),
+);
 const CreateDepartment = React.lazy(
-  () => import("./department/CreateDepartment"),
+  () =>
+    import(
+      /* webpackChunkName: "adminCreateDepartment" */ "./department/CreateDepartment"
+    ),
 );
 const UpdateDepartment = React.lazy(
-  () => import("./department/UpdateDepartment"),
+  () =>
+    import(
+      /* webpackChunkName: "adminUpdateDepartment" */ "./department/UpdateDepartment"
+    ),
 );
 
 /** Skill Families */
 const SkillFamilyPage = React.lazy(
-  () => import("./skillFamily/SkillFamilyPage"),
+  () =>
+    import(
+      /* webpackChunkName: "adminSkillFamilyPage" */ "./skillFamily/SkillFamilyPage"
+    ),
 );
 const CreateSkillFamily = React.lazy(
-  () => import("./skillFamily/CreateSkillFamily"),
+  () =>
+    import(
+      /* webpackChunkName: "adminCreateSkillFamily" */ "./skillFamily/CreateSkillFamily"
+    ),
 );
 const UpdateSkillFamily = React.lazy(
-  () => import("./skillFamily/UpdateSkillFamily"),
+  () =>
+    import(
+      /* webpackChunkName: "adminUpdateSkillFamily" */ "./skillFamily/UpdateSkillFamily"
+    ),
 );
 
 /** Skills */
-const SkillPage = React.lazy(() => import("./skill/SkillPage"));
-const CreateSkill = React.lazy(() => import("./skill/CreateSkill"));
-const UpdateSkill = React.lazy(() => import("./skill/UpdateSkill"));
+const SkillPage = React.lazy(
+  () => import(/* webpackChunkName: "adminSkillPage" */ "./skill/SkillPage"),
+);
+const CreateSkill = React.lazy(
+  () =>
+    import(/* webpackChunkName: "adminCreateSkill" */ "./skill/CreateSkill"),
+);
+const UpdateSkill = React.lazy(
+  () =>
+    import(/* webpackChunkName: "adminUpdateSkill" */ "./skill/UpdateSkill"),
+);
 
 /** Search Requests */
 const SearchRequestPage = React.lazy(
-  () => import("./searchRequest/SearchRequestPage"),
+  () =>
+    import(
+      /* webpackChunkName: "adminSearchRequestPage" */ "./searchRequest/SearchRequestPage"
+    ),
 );
 const SingleSearchRequestPage = React.lazy(
-  () => import("./searchRequest/SingleSearchRequestPage"),
+  () =>
+    import(
+      /* webpackChunkName: "adminSingleSearchRequestPage" */ "./searchRequest/SingleSearchRequestPage"
+    ),
 );
 
 interface CreateRouterArgs {

--- a/frontend/admin/src/js/components/Router.tsx
+++ b/frontend/admin/src/js/components/Router.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
+import lazyRetry from "@common/helpers/lazyRetry";
 import Loading from "@common/components/Pending/Loading";
 import RequireAuth from "@common/components/RequireAuth/RequireAuth";
 import useFeatureFlags, { FeatureFlags } from "@common/hooks/useFeatureFlags";
@@ -9,197 +10,269 @@ import Layout from "./Layout";
 
 import { Role } from "../api/generated";
 
-const HomePage = React.lazy(
-  () => import(/* webpackChunkName: "adminHomePage" */ "./home/HomePage"),
+const HomePage = React.lazy(() =>
+  lazyRetry(
+    () => import(/* webpackChunkName: "adminHomePage" */ "./home/HomePage"),
+  ),
 );
-const ErrorPage = React.lazy(
-  () => import(/* webpackChunkName: "adminErrorPage" */ "./Error/ErrorPage"),
+const ErrorPage = React.lazy(() =>
+  lazyRetry(
+    () => import(/* webpackChunkName: "adminErrorPage" */ "./Error/ErrorPage"),
+  ),
 );
-const DashboardPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminDashboardPage" */ "./dashboard/DashboardPage"
-    ),
+const DashboardPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminDashboardPage" */ "./dashboard/DashboardPage"
+      ),
+  ),
 );
 
 /** Users */
-const UserPage = React.lazy(
-  () => import(/* webpackChunkName: "adminUserPage" */ "./user/UserPage"),
+const UserPage = React.lazy(() =>
+  lazyRetry(
+    () => import(/* webpackChunkName: "adminUserPage" */ "./user/UserPage"),
+  ),
 );
-const CreateUser = React.lazy(
-  () => import(/* webpackChunkName: "adminCreateUser" */ "./user/CreateUser"),
+const CreateUser = React.lazy(() =>
+  lazyRetry(
+    () => import(/* webpackChunkName: "adminCreateUser" */ "./user/CreateUser"),
+  ),
 );
-const UpdateUser = React.lazy(
-  () => import(/* webpackChunkName: "adminUpdateUser" */ "./user/UpdateUser"),
+const UpdateUser = React.lazy(() =>
+  lazyRetry(
+    () => import(/* webpackChunkName: "adminUpdateUser" */ "./user/UpdateUser"),
+  ),
 );
-const ViewUser = React.lazy(
-  () => import(/* webpackChunkName: "adminViewUser" */ "./user/ViewUser"),
+const ViewUser = React.lazy(() =>
+  lazyRetry(
+    () => import(/* webpackChunkName: "adminViewUser" */ "./user/ViewUser"),
+  ),
 );
 
 /** Classifications */
-const ClassificationPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminClassificationPage" */ "./classification/ClassificationPage"
-    ),
+const ClassificationPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminClassificationPage" */ "./classification/ClassificationPage"
+      ),
+  ),
 );
-const CreateClassification = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminCreateClassification" */ "./classification/CreateClassification"
-    ),
+const CreateClassification = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminCreateClassification" */ "./classification/CreateClassification"
+      ),
+  ),
 );
-const UpdateClassification = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminUpdateClassification" */ "./classification/UpdateClassification"
-    ),
+const UpdateClassification = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminUpdateClassification" */ "./classification/UpdateClassification"
+      ),
+  ),
 );
 
 /** CMO Assets */
-const CmoAssetPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminCmoAssetsPage" */ "./cmoAsset/CmoAssetPage"
-    ),
+const CmoAssetPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminCmoAssetsPage" */ "./cmoAsset/CmoAssetPage"
+      ),
+  ),
 );
-const CreateCmoAsset = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminCreateCmoAsset" */ "./cmoAsset/CreateCmoAsset"
-    ),
+const CreateCmoAsset = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminCreateCmoAsset" */ "./cmoAsset/CreateCmoAsset"
+      ),
+  ),
 );
-const UpdateCmoAsset = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminUpdateCmoAsset" */ "./cmoAsset/UpdateCmoAsset"
-    ),
+const UpdateCmoAsset = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminUpdateCmoAsset" */ "./cmoAsset/UpdateCmoAsset"
+      ),
+  ),
 );
 
 /** Pool Candidates */
-const PoolCandidatePage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminPoolCandidatePage" */ "./poolCandidate/PoolCandidatePage"
-    ),
+const PoolCandidatePage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminPoolCandidatePage" */ "./poolCandidate/PoolCandidatePage"
+      ),
+  ),
 );
-const CreatePoolCandidate = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminCreatePoolCandidate" */ "./poolCandidate/CreatePoolCandidate"
-    ),
+const CreatePoolCandidate = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminCreatePoolCandidate" */ "./poolCandidate/CreatePoolCandidate"
+      ),
+  ),
 );
-const UpdatePoolCandidate = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminUpdatePoolCandidate" */ "./poolCandidate/UpdatePoolCandidate"
-    ),
+const UpdatePoolCandidate = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminUpdatePoolCandidate" */ "./poolCandidate/UpdatePoolCandidate"
+      ),
+  ),
 );
-const ViewPoolCandidatePage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminViewPoolCandidate" */ "./poolCandidate/ViewPoolCandidate/ViewPoolCandidatePage"
-    ),
+const ViewPoolCandidatePage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminViewPoolCandidate" */ "./poolCandidate/ViewPoolCandidate/ViewPoolCandidatePage"
+      ),
+  ),
 );
 
 /** Pools */
-const PoolPage = React.lazy(
-  () => import(/* webpackChunkName: "adminPoolPage" */ "./pool/PoolPage"),
+const PoolPage = React.lazy(() =>
+  lazyRetry(
+    () => import(/* webpackChunkName: "adminPoolPage" */ "./pool/PoolPage"),
+  ),
 );
-const CreatePool = React.lazy(
-  () => import(/* webpackChunkName: "adminCreatePool" */ "./pool/CreatePool"),
+const CreatePool = React.lazy(() =>
+  lazyRetry(
+    () => import(/* webpackChunkName: "adminCreatePool" */ "./pool/CreatePool"),
+  ),
 );
-const EditPool = React.lazy(
-  () =>
-    import(/* webpackChunkName: "adminEditPool" */ "./pool/EditPool/EditPool"),
+const EditPool = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminEditPool" */ "./pool/EditPool/EditPool"
+      ),
+  ),
 );
-const ViewPool = React.lazy(
-  () => import(/* webpackChunkName: "adminViewPool" */ "./pool/ViewPool"),
+const ViewPool = React.lazy(() =>
+  lazyRetry(
+    () => import(/* webpackChunkName: "adminViewPool" */ "./pool/ViewPool"),
+  ),
 );
-const DeprecatedViewPool = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminDeprecatedViewPool" */ "./pool/deprecated/ViewPool"
-    ),
+const DeprecatedViewPool = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminDeprecatedViewPool" */ "./pool/deprecated/ViewPool"
+      ),
+  ),
 );
-const DeprecatedUpdatePool = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminUpdatePool" */ "./pool/deprecated/UpdatePool"
-    ),
+const DeprecatedUpdatePool = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminUpdatePool" */ "./pool/deprecated/UpdatePool"
+      ),
+  ),
 );
-const DeprecatedCreatePool = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminCreatePool" */ "./pool/deprecated/CreatePool"
-    ),
+const DeprecatedCreatePool = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminCreatePool" */ "./pool/deprecated/CreatePool"
+      ),
+  ),
 );
 
 /** Departments */
-const DepartmentPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminDepartmentPage" */ "./department/DepartmentPage"
-    ),
+const DepartmentPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminDepartmentPage" */ "./department/DepartmentPage"
+      ),
+  ),
 );
-const CreateDepartment = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminCreateDepartment" */ "./department/CreateDepartment"
-    ),
+const CreateDepartment = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminCreateDepartment" */ "./department/CreateDepartment"
+      ),
+  ),
 );
-const UpdateDepartment = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminUpdateDepartment" */ "./department/UpdateDepartment"
-    ),
+const UpdateDepartment = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminUpdateDepartment" */ "./department/UpdateDepartment"
+      ),
+  ),
 );
 
 /** Skill Families */
-const SkillFamilyPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminSkillFamilyPage" */ "./skillFamily/SkillFamilyPage"
-    ),
+const SkillFamilyPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminSkillFamilyPage" */ "./skillFamily/SkillFamilyPage"
+      ),
+  ),
 );
-const CreateSkillFamily = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminCreateSkillFamily" */ "./skillFamily/CreateSkillFamily"
-    ),
+const CreateSkillFamily = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminCreateSkillFamily" */ "./skillFamily/CreateSkillFamily"
+      ),
+  ),
 );
-const UpdateSkillFamily = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminUpdateSkillFamily" */ "./skillFamily/UpdateSkillFamily"
-    ),
+const UpdateSkillFamily = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminUpdateSkillFamily" */ "./skillFamily/UpdateSkillFamily"
+      ),
+  ),
 );
 
 /** Skills */
-const SkillPage = React.lazy(
-  () => import(/* webpackChunkName: "adminSkillPage" */ "./skill/SkillPage"),
+const SkillPage = React.lazy(() =>
+  lazyRetry(
+    () => import(/* webpackChunkName: "adminSkillPage" */ "./skill/SkillPage"),
+  ),
 );
-const CreateSkill = React.lazy(
-  () =>
-    import(/* webpackChunkName: "adminCreateSkill" */ "./skill/CreateSkill"),
+const CreateSkill = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(/* webpackChunkName: "adminCreateSkill" */ "./skill/CreateSkill"),
+  ),
 );
-const UpdateSkill = React.lazy(
-  () =>
-    import(/* webpackChunkName: "adminUpdateSkill" */ "./skill/UpdateSkill"),
+const UpdateSkill = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(/* webpackChunkName: "adminUpdateSkill" */ "./skill/UpdateSkill"),
+  ),
 );
 
 /** Search Requests */
-const SearchRequestPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminSearchRequestPage" */ "./searchRequest/SearchRequestPage"
-    ),
+const SearchRequestPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminSearchRequestPage" */ "./searchRequest/SearchRequestPage"
+      ),
+  ),
 );
-const SingleSearchRequestPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "adminSingleSearchRequestPage" */ "./searchRequest/SingleSearchRequestPage"
-    ),
+const SingleSearchRequestPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminSingleSearchRequestPage" */ "./searchRequest/SingleSearchRequestPage"
+      ),
+  ),
 );
 
 interface CreateRouterArgs {

--- a/frontend/common/src/helpers/lazyRetry.ts
+++ b/frontend/common/src/helpers/lazyRetry.ts
@@ -16,7 +16,10 @@ import { getFromLocalStorage, setInLocalStorage } from "./storageUtils";
  * @param name  string    Name the component (only needed when using multiple components on same page)
  * @returns
  */
-const lazyRetry = <T extends ComponentType<unknown>>(
+// Note: Using any because it comes from react-types
+// Ref: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/209ad4dd77c99181de178fba15ad8ff01841b4ef/types/react/index.d.ts#L846-L848
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const lazyRetry = <T extends ComponentType<any>>(
   componentImport: () => Promise<{ default: T }>,
   name?: string,
 ): Promise<{ default: T }> => {

--- a/frontend/common/src/helpers/lazyRetry.ts
+++ b/frontend/common/src/helpers/lazyRetry.ts
@@ -16,7 +16,7 @@ import { getFromLocalStorage, setInLocalStorage } from "./storageUtils";
  * @param name  string    Name the component (only needed when using multiple components on same page)
  * @returns
  */
-const lazyRetry = <T extends ComponentType<any>>(
+const lazyRetry = <T extends ComponentType<unknown>>(
   componentImport: () => Promise<{ default: T }>,
   name?: string,
 ): Promise<{ default: T }> => {

--- a/frontend/common/src/helpers/lazyRetry.ts
+++ b/frontend/common/src/helpers/lazyRetry.ts
@@ -1,0 +1,56 @@
+import { ComponentType } from "react";
+import { getFromLocalStorage, setInLocalStorage } from "./storageUtils";
+
+/**
+ * Lazy with Retry
+ *
+ * This forces a refresh when a chunk
+ * is not loaded properly in order to get
+ * the latest un-cached version
+ *
+ * Helps to prevent ChunkLoadError
+ *
+ * REF: https://www.codemzy.com/blog/fix-chunkloaderror-react
+ *
+ * @param componentImport () => Promise<{default: T}> The component being imported
+ * @param name  string    Name the component (only needed when using multiple components on same page)
+ * @returns
+ */
+const lazyRetry = <T extends ComponentType<any>>(
+  componentImport: () => Promise<{ default: T }>,
+  name?: string,
+): Promise<{ default: T }> => {
+  return new Promise((resolve, reject) => {
+    const storageKey = name
+      ? `component-${name}-refreshed`
+      : `component-refreshed`;
+    /**
+     * Track if the page has already refresh to prevent loop
+     * in the case that the file actually does not exist
+     */
+    const hasRefreshed = JSON.parse(getFromLocalStorage(storageKey, "false"));
+
+    /**
+     * Attempt to load the component
+     */
+    componentImport()
+      .then((component) => {
+        // Success so unset refresh and resolve component
+        setInLocalStorage(storageKey, "false");
+        resolve(component);
+      })
+      .catch((error: Error) => {
+        if (!hasRefreshed) {
+          /**
+           * Could not load chunk so refresh the page
+           * and store it so we don't keep refreshing
+           */
+          setInLocalStorage(storageKey, "true");
+          return window.location.reload();
+        }
+        return reject(error);
+      });
+  });
+};
+
+export default lazyRetry;

--- a/frontend/talentsearch/src/js/components/Router.tsx
+++ b/frontend/talentsearch/src/js/components/Router.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
+import lazyRetry from "@common/helpers/lazyRetry";
 import Loading from "@common/components/Pending/Loading";
 import RequireAuth from "@common/components/RequireAuth/RequireAuth";
 
@@ -12,149 +13,205 @@ import ProfileRedirect from "./Redirects/ProfileRedirect";
 import CreateAccountRedirect from "./createAccount/CreateAccountRedirect";
 
 /** Home */
-const HomePage = React.lazy(
-  () => import(/* webpackChunkName: "tsHomePage" */ "./Home/HomePage"),
+const HomePage = React.lazy(() =>
+  lazyRetry(
+    () => import(/* webpackChunkName: "tsHomePage" */ "./Home/HomePage"),
+  ),
 );
-const ErrorPage = React.lazy(
-  () => import(/* webpackChunkName: "tsErrorPage" */ "./Error/ErrorPage"),
+const ErrorPage = React.lazy(() =>
+  lazyRetry(
+    () => import(/* webpackChunkName: "tsErrorPage" */ "./Error/ErrorPage"),
+  ),
 );
-const SupportPage = React.lazy(
-  () => import(/* webpackChunkName: "tsSupportPage" */ "./support/SupportPage"),
+const SupportPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(/* webpackChunkName: "tsSupportPage" */ "./support/SupportPage"),
+  ),
 );
-const AccessibilityPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsAccessibilityPage" */ "./AccessibilityStatement/AccessibilityStatement"
-    ),
+const AccessibilityPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsAccessibilityPage" */ "./AccessibilityStatement/AccessibilityStatement"
+      ),
+  ),
 );
 
 /** Search */
-const SearchPage = React.lazy(
-  () => import(/* webpackChunkName: "tsSearchPage" */ "./search/SearchPage"),
+const SearchPage = React.lazy(() =>
+  lazyRetry(
+    () => import(/* webpackChunkName: "tsSearchPage" */ "./search/SearchPage"),
+  ),
 );
-const RequestPage = React.lazy(
-  () => import(/* webpackChunkName: "tsRequestPage" */ "./request/RequestPage"),
+const RequestPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(/* webpackChunkName: "tsRequestPage" */ "./request/RequestPage"),
+  ),
 );
 
 /** Auth */
-const RegisterPage = React.lazy(
-  () =>
-    import(/* webpackChunkName: "tsRegisterPage" */ "./register/RegisterPage"),
+const RegisterPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsRegisterPage" */ "./register/RegisterPage"
+      ),
+  ),
 );
-const LoggedOutPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsLoggedOutPage" */ "./loggedOut/LoggedOutPage"
-    ),
+const LoggedOutPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsLoggedOutPage" */ "./loggedOut/LoggedOutPage"
+      ),
+  ),
 );
-const LoginPage = React.lazy(
-  () => import(/* webpackChunkName: "tsLoginPage" */ "./login/LoginPage"),
+const LoginPage = React.lazy(() =>
+  lazyRetry(
+    () => import(/* webpackChunkName: "tsLoginPage" */ "./login/LoginPage"),
+  ),
 );
 
 /** Profile */
-const CreateAccount = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsCreateAccountPage" */ "./createAccount/CreateAccountPage"
-    ),
+const CreateAccount = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsCreateAccountPage" */ "./createAccount/CreateAccountPage"
+      ),
+  ),
 );
-const ProfilePage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsProfilePage" */ "./profile/ProfilePage/ProfilePage"
-    ),
+const ProfilePage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsProfilePage" */ "./profile/ProfilePage/ProfilePage"
+      ),
+  ),
 );
-const GovernmentInfoFormPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsGovInfoPage" */ "./GovernmentInfoForm/GovernmentInfoFormPage"
-    ),
+const GovernmentInfoFormPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsGovInfoPage" */ "./GovernmentInfoForm/GovernmentInfoFormPage"
+      ),
+  ),
 );
-const LanguageInformationFormPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsLangInfoPage" */ "./languageInformationForm/LanguageInformationFormPage"
-    ),
+const LanguageInformationFormPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsLangInfoPage" */ "./languageInformationForm/LanguageInformationFormPage"
+      ),
+  ),
 );
-const WorkLocationPreferenceFormPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsWorkLocationPage" */ "./workLocationPreferenceForm/WorkLocationPreferenceFormPage"
-    ),
+const WorkLocationPreferenceFormPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsWorkLocationPage" */ "./workLocationPreferenceForm/WorkLocationPreferenceFormPage"
+      ),
+  ),
 );
-const RoleSalaryFormPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsRoleSalaryPage" */ "./roleSalaryForm/RoleSalaryFormPage"
-    ),
+const RoleSalaryFormPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsRoleSalaryPage" */ "./roleSalaryForm/RoleSalaryFormPage"
+      ),
+  ),
 );
-const ExperienceFormPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsEditExperiencePage" */ "./experienceForm/ExperienceForm"
-    ),
+const ExperienceFormPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsEditExperiencePage" */ "./experienceForm/ExperienceForm"
+      ),
+  ),
 );
-const WorkPreferencesFormPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsWorkPrefPage" */ "./workPreferencesForm/WorkPreferencesFormPage"
-    ),
+const WorkPreferencesFormPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsWorkPrefPage" */ "./workPreferencesForm/WorkPreferencesFormPage"
+      ),
+  ),
 );
-const AboutMeFormPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsAboutMePage" */ "./aboutMeForm/AboutMeFormPage"
-    ),
+const AboutMeFormPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsAboutMePage" */ "./aboutMeForm/AboutMeFormPage"
+      ),
+  ),
 );
-const EmploymentEquityFormPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsEquityPage" */ "./employmentEquityForm/EmploymentEquityFormPage"
-    ),
+const EmploymentEquityFormPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsEquityPage" */ "./employmentEquityForm/EmploymentEquityFormPage"
+      ),
+  ),
 );
-const ExperienceAndSkillsPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsExperienceSkillsPage" */ "./experienceAndSkills/ExperienceAndSkillsPage"
-    ),
+const ExperienceAndSkillsPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsExperienceSkillsPage" */ "./experienceAndSkills/ExperienceAndSkillsPage"
+      ),
+  ),
 );
 
 /** Direct Intake */
-const BrowsePoolsPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsBrowsePoolsPage" */ "./Browse/BrowsePoolsPage"
-    ),
+const BrowsePoolsPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsBrowsePoolsPage" */ "./Browse/BrowsePoolsPage"
+      ),
+  ),
 );
-const PoolAdvertisementPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsPoolAdvertPage" */ "./pool/PoolAdvertisementPage"
-    ),
+const PoolAdvertisementPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsPoolAdvertPage" */ "./pool/PoolAdvertisementPage"
+      ),
+  ),
 );
-const CreateApplication = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsCreateApplicationPage" */ "./pool/CreateApplication"
-    ),
+const CreateApplication = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsCreateApplicationPage" */ "./pool/CreateApplication"
+      ),
+  ),
 );
-const SignAndSubmitPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsSignSubmitPage" */ "./signAndSubmit/SignAndSubmitPage"
-    ),
+const SignAndSubmitPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsSignSubmitPage" */ "./signAndSubmit/SignAndSubmitPage"
+      ),
+  ),
 );
-const MyApplicationsPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsMyApplicationsPage" */ "./applications/MyApplicationsPage"
-    ),
+const MyApplicationsPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsMyApplicationsPage" */ "./applications/MyApplicationsPage"
+      ),
+  ),
 );
-const ReviewMyApplicationPage = React.lazy(
-  () =>
-    import(
-      /* webpackChunkName: "tsReviewApplicationPage" */ "./reviewMyApplication/ReviewMyApplicationPage"
-    ),
+const ReviewMyApplicationPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsReviewApplicationPage" */ "./reviewMyApplication/ReviewMyApplicationPage"
+      ),
+  ),
 );
 
 const router = createBrowserRouter([

--- a/frontend/talentsearch/src/js/components/Router.tsx
+++ b/frontend/talentsearch/src/js/components/Router.tsx
@@ -12,71 +12,149 @@ import ProfileRedirect from "./Redirects/ProfileRedirect";
 import CreateAccountRedirect from "./createAccount/CreateAccountRedirect";
 
 /** Home */
-const HomePage = React.lazy(() => import("./Home/HomePage"));
-const ErrorPage = React.lazy(() => import("./Error/ErrorPage"));
-const SupportPage = React.lazy(() => import("./support/SupportPage"));
+const HomePage = React.lazy(
+  () => import(/* webpackChunkName: "tsHomePage" */ "./Home/HomePage"),
+);
+const ErrorPage = React.lazy(
+  () => import(/* webpackChunkName: "tsErrorPage" */ "./Error/ErrorPage"),
+);
+const SupportPage = React.lazy(
+  () => import(/* webpackChunkName: "tsSupportPage" */ "./support/SupportPage"),
+);
 const AccessibilityPage = React.lazy(
-  () => import("./AccessibilityStatement/AccessibilityStatement"),
+  () =>
+    import(
+      /* webpackChunkName: "tsAccessibilityPage" */ "./AccessibilityStatement/AccessibilityStatement"
+    ),
 );
 
 /** Search */
-const SearchPage = React.lazy(() => import("./search/SearchPage"));
-const RequestPage = React.lazy(() => import("./request/RequestPage"));
+const SearchPage = React.lazy(
+  () => import(/* webpackChunkName: "tsSearchPage" */ "./search/SearchPage"),
+);
+const RequestPage = React.lazy(
+  () => import(/* webpackChunkName: "tsRequestPage" */ "./request/RequestPage"),
+);
 
 /** Auth */
-const RegisterPage = React.lazy(() => import("./register/RegisterPage"));
-const LoggedOutPage = React.lazy(() => import("./loggedOut/LoggedOutPage"));
-const LoginPage = React.lazy(() => import("./login/LoginPage"));
+const RegisterPage = React.lazy(
+  () =>
+    import(/* webpackChunkName: "tsRegisterPage" */ "./register/RegisterPage"),
+);
+const LoggedOutPage = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "tsLoggedOutPage" */ "./loggedOut/LoggedOutPage"
+    ),
+);
+const LoginPage = React.lazy(
+  () => import(/* webpackChunkName: "tsLoginPage" */ "./login/LoginPage"),
+);
 
 /** Profile */
 const CreateAccount = React.lazy(
-  () => import("./createAccount/CreateAccountPage"),
+  () =>
+    import(
+      /* webpackChunkName: "tsCreateAccountPage" */ "./createAccount/CreateAccountPage"
+    ),
 );
 const ProfilePage = React.lazy(
-  () => import("./profile/ProfilePage/ProfilePage"),
+  () =>
+    import(
+      /* webpackChunkName: "tsProfilePage" */ "./profile/ProfilePage/ProfilePage"
+    ),
 );
 const GovernmentInfoFormPage = React.lazy(
-  () => import("./GovernmentInfoForm/GovernmentInfoFormPage"),
+  () =>
+    import(
+      /* webpackChunkName: "tsGovInfoPage" */ "./GovernmentInfoForm/GovernmentInfoFormPage"
+    ),
 );
 const LanguageInformationFormPage = React.lazy(
-  () => import("./languageInformationForm/LanguageInformationFormPage"),
+  () =>
+    import(
+      /* webpackChunkName: "tsLangInfoPage" */ "./languageInformationForm/LanguageInformationFormPage"
+    ),
 );
 const WorkLocationPreferenceFormPage = React.lazy(
-  () => import("./workLocationPreferenceForm/WorkLocationPreferenceFormPage"),
+  () =>
+    import(
+      /* webpackChunkName: "tsWorkLocationPage" */ "./workLocationPreferenceForm/WorkLocationPreferenceFormPage"
+    ),
 );
 const RoleSalaryFormPage = React.lazy(
-  () => import("./roleSalaryForm/RoleSalaryFormPage"),
+  () =>
+    import(
+      /* webpackChunkName: "tsRoleSalaryPage" */ "./roleSalaryForm/RoleSalaryFormPage"
+    ),
 );
 const ExperienceFormPage = React.lazy(
-  () => import("./experienceForm/ExperienceForm"),
+  () =>
+    import(
+      /* webpackChunkName: "tsEditExperiencePage" */ "./experienceForm/ExperienceForm"
+    ),
 );
 const WorkPreferencesFormPage = React.lazy(
-  () => import("./workPreferencesForm/WorkPreferencesFormPage"),
+  () =>
+    import(
+      /* webpackChunkName: "tsWorkPrefPage" */ "./workPreferencesForm/WorkPreferencesFormPage"
+    ),
 );
 const AboutMeFormPage = React.lazy(
-  () => import("./aboutMeForm/AboutMeFormPage"),
+  () =>
+    import(
+      /* webpackChunkName: "tsAboutMePage" */ "./aboutMeForm/AboutMeFormPage"
+    ),
 );
 const EmploymentEquityFormPage = React.lazy(
-  () => import("./employmentEquityForm/EmploymentEquityFormPage"),
+  () =>
+    import(
+      /* webpackChunkName: "tsEquityPage" */ "./employmentEquityForm/EmploymentEquityFormPage"
+    ),
 );
 const ExperienceAndSkillsPage = React.lazy(
-  () => import("./experienceAndSkills/ExperienceAndSkillsPage"),
+  () =>
+    import(
+      /* webpackChunkName: "tsExperienceSkillsPage" */ "./experienceAndSkills/ExperienceAndSkillsPage"
+    ),
 );
 
 /** Direct Intake */
-const BrowsePoolsPage = React.lazy(() => import("./Browse/BrowsePoolsPage"));
-const PoolAdvertisementPage = React.lazy(
-  () => import("./pool/PoolAdvertisementPage"),
+const BrowsePoolsPage = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "tsBrowsePoolsPage" */ "./Browse/BrowsePoolsPage"
+    ),
 );
-const CreateApplication = React.lazy(() => import("./pool/CreateApplication"));
+const PoolAdvertisementPage = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "tsPoolAdvertPage" */ "./pool/PoolAdvertisementPage"
+    ),
+);
+const CreateApplication = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "tsCreateApplicationPage" */ "./pool/CreateApplication"
+    ),
+);
 const SignAndSubmitPage = React.lazy(
-  () => import("./signAndSubmit/SignAndSubmitPage"),
+  () =>
+    import(
+      /* webpackChunkName: "tsSignSubmitPage" */ "./signAndSubmit/SignAndSubmitPage"
+    ),
 );
 const MyApplicationsPage = React.lazy(
-  () => import("./applications/MyApplicationsPage"),
+  () =>
+    import(
+      /* webpackChunkName: "tsMyApplicationsPage" */ "./applications/MyApplicationsPage"
+    ),
 );
 const ReviewMyApplicationPage = React.lazy(
-  () => import("./reviewMyApplication/ReviewMyApplicationPage"),
+  () =>
+    import(
+      /* webpackChunkName: "tsReviewApplicationPage" */ "./reviewMyApplication/ReviewMyApplicationPage"
+    ),
 );
 
 const router = createBrowserRouter([


### PR DESCRIPTION
## 👋 Introduction

This implements a retry function for dynamic imports to help prevent `ChunkLoadError`

## 🕵️ Details

When we serve our chunks, they are cached in the browser. The `ChunkLoadError` occurs when the browser looks for the file and it does not exists for any number of reasons (original cached file no longer exists, renamed, etc.).

This PR does two things

1. Names our chunks (previously randomly generated)
2. Implements a retry function for loading chunks

### Naming Chunks

By naming chunks, we make debugging easier since file names are human readable and mirror the component name. Also, when the browser caches the file, the name remains the same for all builds so it should be able to find it more consistently.

### Retry Lazy

In the event that the file could not be found we force a browser refresh to hopefully clear the cache and look for the file again. We story this in locale storage to prevent an infinite loop in the case that the file actually does not exist. If it really does not exist, we throw an error and display the `errorElement` with an unknown error.

## 🧪 Testing

1. Build all projects `npm run production --workspaces`
2. Confirm Admin and Talent Search function normally
3. Open the `dist` folder and delete a `*.js` file of a page
4. Visit that page and make sure a nice error message appears
5. Watch the locale storage and confirm `component-refreshed` updates as we look for the component

## 🤖 Robot Stuff

Resolves #4786 