### PR TITLE
Bug - Fix missing decorator import

### DIFF
--- a/frontend/common/.storybook/preview.js
+++ b/frontend/common/.storybook/preview.js
@@ -5,6 +5,7 @@ import frCompiled from "../src/lang/frCompiled.json";
 import defaultRichTextElements from "../src/helpers/format";
 import MockGraphqlDecorator from "../../common/.storybook/decorators/MockGraphqlDecorator";
 import withThemeProvider, { theme } from "./decorators/ThemeDecorator";
+import withRouter from "./decorators/RouterDecorator";
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
 
 export const parameters = {


### PR DESCRIPTION
## 👋 Introduction

This adds a missing import for the `withRouter` decorator for `common` stories.

## 🧪 Testing

1. Run common storybook `npm run storybook --workspace=common`
2. Ensure it loads properly