### PR TITLE
Add done date

### DIFF
--- a/api/app/Models/PoolCandidateSearchRequest.php
+++ b/api/app/Models/PoolCandidateSearchRequest.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Database\Helpers\ApiEnums;
 use Illuminate\Database\Eloquent\Model;

--- a/api/database/factories/PoolCandidateSearchRequestFactory.php
+++ b/api/database/factories/PoolCandidateSearchRequestFactory.php
@@ -30,7 +30,7 @@ class PoolCandidateSearchRequestFactory extends Factory
         'department_id' => Department::inRandomOrder()->first()->id,
         'job_title' => $this->faker->jobTitle(),
         'additional_comments' => $this->faker->text(),
-        'status' => $this->faker->randomElement(['PENDING', 'DONE']),
+        'done_at' => $this->faker->optional()->dateTimeBetween($startDate = '-3 years', $endDate = 'now'),
         'admin_notes' => $this->faker->text(),
         'pool_candidate_filter_id' => PoolCandidateFilter::factory(),
         'applicant_filter_id' => ApplicantFilter::factory(),

--- a/api/database/helpers/ApiEnums.php
+++ b/api/database/helpers/ApiEnums.php
@@ -378,4 +378,19 @@ class ApiEnums
             self::POOL_CANDIDATE_POOL_NOT_PUBLISHED,
         ];
     }
+
+    /**
+     * Pool Candidate Request Statuses
+     */
+    const POOL_CANDIDATE_SEARCH_STATUS_DONE = 'DONE';
+    const POOL_CANDIDATE_SEARCH_STATUS_PENDING = 'PENDING';
+
+    public static function poolCandidateSearchStatuses(): array
+    {
+        return [
+            self::POOL_CANDIDATE_SEARCH_STATUS_DONE,
+            self::POOL_CANDIDATE_SEARCH_STATUS_PENDING,
+        ];
+    }
+
 }

--- a/api/database/migrations/2022_11_17_173638_request_status_to_datetime.php
+++ b/api/database/migrations/2022_11_17_173638_request_status_to_datetime.php
@@ -21,7 +21,7 @@ class RequestStatusToDatetime extends Migration
             update pool_candidate_search_requests
                 set done_at =
                     case status
-                        when 'DONE' then TIMESTAMP 'now'
+                        when 'DONE' then coalesce(updated_at, TIMESTAMP 'now')
                         when 'PENDING' then null
                     end
         ");

--- a/api/database/migrations/2022_11_17_173638_request_status_to_datetime.php
+++ b/api/database/migrations/2022_11_17_173638_request_status_to_datetime.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+class RequestStatusToDatetime extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pool_candidate_search_requests', function (Blueprint $table) {
+            $table->timestamp('done_at')->nullable();
+        });
+        DB::statement("
+            update pool_candidate_search_requests
+                set done_at =
+                    case status
+                        when 'DONE' then TIMESTAMP 'now'
+                        when 'PENDING' then null
+                    end
+        ");
+        Schema::table('pool_candidate_search_requests', function (Blueprint $table) {
+            $table->dropColumn('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('pool_candidate_search_requests', function (Blueprint $table) {
+            $table->string('status')->nullable();
+        });
+        DB::statement("
+        update pool_candidate_search_requests
+            set status =
+                case
+                  when done_at <= TIMESTAMP 'now' then 'DONE'
+                  else 'PENDING'
+                end
+        ");
+        Schema::table('pool_candidate_search_requests', function (Blueprint $table) {
+            $table->dropColumn('done_at');
+        });
+    }
+}

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -533,6 +533,7 @@ type PoolCandidateSearchRequest {
   adminNotes: String @rename(attribute: "admin_notes")
   poolCandidateFilter: PoolCandidateFilter @belongsTo
   applicantFilter: ApplicantFilter @belongsTo
+  doneDate: DateTime @rename(attribute: "done_at")
 }
 
 enum SkillCategory {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -902,6 +902,7 @@ type PoolCandidateSearchRequest {
   adminNotes: String
   poolCandidateFilter: PoolCandidateFilter
   applicantFilter: ApplicantFilter
+  doneDate: DateTime
 }
 
 enum PoolCandidateSearchStatus {

--- a/frontend/admin/src/js/api/poolCandidateSearchRequestOperations.graphql
+++ b/frontend/admin/src/js/api/poolCandidateSearchRequestOperations.graphql
@@ -57,6 +57,7 @@ fragment poolCandidateSearchRequest on PoolCandidateSearchRequest {
   }
   requestedDate
   status
+  doneDate
   adminNotes
   applicantFilter {
     id

--- a/frontend/admin/src/js/components/searchRequest/SingleSearchRequest.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SingleSearchRequest.tsx
@@ -28,6 +28,7 @@ const ManagerInfo: React.FunctionComponent<{
     jobTitle,
     status,
     requestedDate,
+    doneDate,
     poolCandidateFilter,
     applicantFilter,
   } = searchRequest;
@@ -192,12 +193,20 @@ const ManagerInfo: React.FunctionComponent<{
                     description:
                       "Title for the date done block in the manager info section of the single search request view.",
                   })}
-                  content={intl.formatMessage({
-                    defaultMessage: "(Request is still pending)",
-                    id: "FxceQZ",
-                    description:
-                      "Text for when date done is pending in the manager info section of the single search request view.",
-                  })}
+                  content={
+                    doneDate
+                      ? formatDate({
+                          date: parseDateTimeUtc(doneDate),
+                          formatString: "PPP p",
+                          intl,
+                        })
+                      : intl.formatMessage({
+                          defaultMessage: "(Request is still pending)",
+                          id: "FxceQZ",
+                          description:
+                            "Text for when date done is pending in the manager info section of the single search request view.",
+                        })
+                  }
                 />
               </div>
             </div>

--- a/frontend/admin/src/js/components/searchRequest/UpdateSearchRequest.tsx
+++ b/frontend/admin/src/js/components/searchRequest/UpdateSearchRequest.tsx
@@ -38,7 +38,6 @@ export const UpdateSearchRequestForm: React.FunctionComponent<
   ) => {
     return handleUpdateSearchRequest(initialSearchRequest.id, {
       adminNotes: data.adminNotes,
-      status: data.status,
     })
       .then(() => {
         toast.success(


### PR DESCRIPTION
# :wave: Introduction
This branch adds a "Done Date" field to the search request model and converts the Status attribute to be derived from that date.  It also adds the new done date field to the request view in admin.
![image](https://user-images.githubusercontent.com/8978655/202742228-b88c397c-c9b3-4692-acfd-6831e8f41333.png)
> **Note**
> I noticed that the "save notes" button was reapplying the status every time.  That was a problem now that there's a timestamp so I fixed that.
# :test_tube: Testing
- [ ] Try the migration, try rolling back and forward and see how the default done date is set on migrate
<details>
  <summary>SQL for testing</summary>
  
```
select id, status, updated_at/*, done_at*/  
from pool_candidate_search_requests pcsr
order by id
```
</details>

- [ ] Try the new api changes in the Graphql playground
<details>
  <summary>Graphql for testing</summary>
  
```
query {
  poolCandidateSearchRequests {
    id
    status
    doneDate
  }
}
```
```
mutation updateStatus(
  $id: ID!
  $poolCandidateSearchRequest: UpdatePoolCandidateSearchRequestInput!
) {
  updatePoolCandidateSearchRequest(
    id: $id
    poolCandidateSearchRequest: $poolCandidateSearchRequest
  )
  {
    id
    adminNotes
    status
    doneDate
  }
}
###
{
  "id": "72201ddf-f10b-4316-8ac2-7c3fe254164a",
  "poolCandidateSearchRequest": {
    "adminNotes": "test",
    "status": "PENDING"    
  }
}
```
</details>

- [ ] Test the application manually
  - [ ] Can submit a new request from search
  - [ ] Can find request in admin and see that it is pending
  - [ ] Can add some notes to pending request
  - [ ] Can mark request as done
  - [ ] Can add some notes to done request

# :robot: Robot stuff
Closes #4549