### PR TITLE
a11y - 3545 - Associate Errors with Inputs

### DIFF
--- a/frontend/common/src/components/form/Checkbox/Checkbox.tsx
+++ b/frontend/common/src/components/form/Checkbox/Checkbox.tsx
@@ -71,6 +71,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
             type="checkbox"
             aria-invalid={error ? "true" : "false"}
             aria-required={rules.required ? "true" : undefined}
+            aria-describedby={error ? `${id}-error` : undefined}
             {...rest}
           />
         </InputWrapper>

--- a/frontend/common/src/components/form/Checklist/Checklist.tsx
+++ b/frontend/common/src/components/form/Checklist/Checklist.tsx
@@ -66,6 +66,7 @@ const Checklist: React.FunctionComponent<ChecklistProps> = ({
       disabled={disabled}
       hideOptional={hideOptional}
       trackUnsaved={trackUnsaved}
+      aria-describedby={error ? `${name}-error` : undefined}
       {...rest}
     >
       {items.map(({ value, label }) => {

--- a/frontend/common/src/components/form/Input/Input.tsx
+++ b/frontend/common/src/components/form/Input/Input.tsx
@@ -87,6 +87,7 @@ const Input: React.FunctionComponent<InputProps> = ({
           readOnly={readOnly}
           aria-required={rules.required ? "true" : undefined}
           aria-invalid={error ? "true" : "false"}
+          aria-describedby={error ? `${id}-error` : undefined}
           {...rest}
         />
       </InputWrapper>

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
@@ -74,6 +74,7 @@ const MultiSelect = ({
                   (x) => field.onChange(x ? x.map((option) => option.value) : x) // If x is null or undefined, return it to form
                 }
                 aria-label={label}
+                aria-describedby={error ? `${id}-error` : undefined}
                 styles={{
                   placeholder: (provided) => ({
                     ...provided,

--- a/frontend/common/src/components/form/RadioGroup/RadioGroup.tsx
+++ b/frontend/common/src/components/form/RadioGroup/RadioGroup.tsx
@@ -78,6 +78,7 @@ const RadioGroup: React.FunctionComponent<RadioGroupProps> = ({
       hideOptional={hideOptional}
       hideLegend={hideLegend}
       trackUnsaved={trackUnsaved}
+      aria-describedby={error ? `${name}-error` : undefined}
       {...rest}
     >
       <div data-h2-flex-grid="base(flex-start, x1, 0)">

--- a/frontend/common/src/components/form/Select/Select.tsx
+++ b/frontend/common/src/components/form/Select/Select.tsx
@@ -67,6 +67,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
           {...register(name, rules)}
           aria-invalid={error ? "true" : "false"}
           aria-required={rules?.required ? "true" : undefined}
+          aria-describedby={error ? `${id}-error` : undefined}
           {...rest}
           defaultValue=""
         >

--- a/frontend/common/src/components/form/Select/SelectFieldV2.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.tsx
@@ -235,6 +235,7 @@ const SelectFieldV2 = ({
                   onChange={convertSingleOrMultiOptionsToValues}
                   aria-label={label}
                   aria-required={isRequired}
+                  aria-describedby={error ? `${id}-error` : undefined}
                   styles={{
                     placeholder: (provided) => ({
                       ...provided,

--- a/frontend/common/src/components/form/TextArea/TextArea.tsx
+++ b/frontend/common/src/components/form/TextArea/TextArea.tsx
@@ -70,6 +70,7 @@ const TextArea: React.FunctionComponent<TextAreaProps> = ({
           onBlur={whitespaceTrimmer}
           aria-required={rules.required ? "true" : undefined}
           aria-invalid={error ? "true" : "false"}
+          aria-describedby={error ? `${id}-error` : undefined}
           {...rest}
         />
         {children}

--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
@@ -147,7 +147,7 @@ const Fieldset: React.FC<FieldsetProps> = ({
           data-h2-display="base(block)"
           data-h2-margin="base(x.125, 0, 0, 0)"
         >
-          <InputError isVisible={!!error} error={error} />
+          <InputError id={`${name}-error`} isVisible={!!error} error={error} />
         </div>
       )}
       {contextIsActive && context && (

--- a/frontend/common/src/components/inputPartials/InputError/InputError.tsx
+++ b/frontend/common/src/components/inputPartials/InputError/InputError.tsx
@@ -9,12 +9,16 @@ export type InputFieldError =
   | Merge<FieldError, FieldErrorsImpl<any>>
   | undefined;
 
-export interface InputErrorProps {
+export interface InputErrorProps extends React.HTMLProps<HTMLSpanElement> {
   isVisible: boolean;
   error: InputFieldError;
 }
 
-const InputError: React.FC<InputErrorProps> = ({ error, isVisible }) => {
+const InputError: React.FC<InputErrorProps> = ({
+  error,
+  isVisible,
+  ...rest
+}) => {
   return isVisible ? (
     <span
       data-h2-display="base(block)"
@@ -25,7 +29,8 @@ const InputError: React.FC<InputErrorProps> = ({ error, isVisible }) => {
       data-h2-padding="base(x.75)"
       data-h2-color="base(dt-error)"
       data-h2-font-size="base(caption)"
-      role="alert"
+      aria-live="polite"
+      {...rest}
     >
       {error}
     </span>

--- a/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
+++ b/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
@@ -62,7 +62,11 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
             data-h2-display="base(block)"
             data-h2-margin="base(0, 0, x.125, 0)"
           >
-            <InputError isVisible={!!error} error={error} />
+            <InputError
+              id={`${inputId}-error`}
+              isVisible={!!error}
+              error={error}
+            />
           </div>
         )}
         {children}
@@ -72,7 +76,11 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
           data-h2-display="base(block)"
           data-h2-margin="base(x.125, 0, 0, 0)"
         >
-          <InputError isVisible={!!error} error={error} />
+          <InputError
+            id={`${inputId}-error`}
+            isVisible={!!error}
+            error={error}
+          />
         </div>
       )}
       {contextVisible && context && (


### PR DESCRIPTION
## 👋 Introduction

This adds an `id` to `InputError` and changes it to `aria-live="polite"` as well as adding an `aria-describedby` to `InputWrapper` and `Fieldset` so our errors are properly associated with their inputs.

## 🧪 Testing

1. Navigate to a form
2. Force an error on inputs (preferably as many as possible).
3. Confirm the error message as a unique `id`
4. Confirm the input element has an `aria-describedby` that matched the `id` on the error

## 🤖 Robot stuff

Resolves #3545 