### PR TITLE
Feature - 4795  - Create nested language provider

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -38,10 +38,13 @@ lightgray
 lightnavy
 lightpurple
 Métis
+Michif
+Mikmaq
 noninteractive
 nuage
 Nuwave
 OCIO
+Ojibway
 pgsql
 Queueable
 recruitmentimit

--- a/frontend/common/src/components/context/NestedLanguageProvider.tsx
+++ b/frontend/common/src/components/context/NestedLanguageProvider.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { IntlProvider, useIntl } from "react-intl";
+import { useSearchParams } from "react-router-dom";
+
+import defaultRichTextElements from "../../helpers/format";
+import { LanguageProviderProps } from "./LanguageProvider";
+
+/**
+ * Indigenous Language codes
+ *
+ * crg - Michif
+ * crk - Plains Cree
+ * ojw - Western Ojibway
+ * mic - Mikmaq
+ */
+type SecondaryLocale = "crg" | "crk" | "ojw" | "mic" | undefined;
+
+/**
+ * Nested Language Provider
+ *
+ * Providers a secondary language within the
+ * existing Language Provider.
+ *
+ * Note: This must be used within a LanguageProvider
+ *
+ * @param param0
+ */
+const NestedLanguageProvider = ({
+  messages,
+  children,
+}: LanguageProviderProps) => {
+  const intl = useIntl();
+  const [searchParams] = useSearchParams();
+  const locale = searchParams.get("locale") as SecondaryLocale;
+
+  // Return just children if there is no
+  // locale in the search params
+  if (!locale) {
+    return children as JSX.Element;
+  }
+
+  // Merge the messages
+  const nestedMessages = {
+    ...intl.messages,
+    ...messages,
+  };
+
+  return (
+    <IntlProvider
+      locale={locale}
+      key={locale}
+      messages={nestedMessages}
+      defaultRichTextElements={defaultRichTextElements}
+    >
+      {children}
+    </IntlProvider>
+  );
+};
+
+export default NestedLanguageProvider;

--- a/frontend/common/src/components/context/NestedLanguageProvider.tsx
+++ b/frontend/common/src/components/context/NestedLanguageProvider.tsx
@@ -3,7 +3,7 @@ import { IntlProvider, useIntl } from "react-intl";
 import { useSearchParams } from "react-router-dom";
 
 import defaultRichTextElements from "../../helpers/format";
-import { LanguageProviderProps } from "./LanguageProvider";
+import { Messages } from "./LanguageProvider";
 
 /**
  * Indigenous Language codes
@@ -13,7 +13,12 @@ import { LanguageProviderProps } from "./LanguageProvider";
  * ojw - Western Ojibway
  * mic - Mikmaq
  */
-type SecondaryLocale = "crg" | "crk" | "ojw" | "mic" | undefined;
+export type SecondaryLocale = "crg" | "crk" | "ojw" | "mic";
+
+interface NestedLanguageProvider {
+  messages: Map<string, Messages>;
+  children: React.ReactNode;
+}
 
 /**
  * Nested Language Provider
@@ -22,28 +27,27 @@ type SecondaryLocale = "crg" | "crk" | "ojw" | "mic" | undefined;
  * existing Language Provider.
  *
  * Note: This must be used within a LanguageProvider
- *
- * @param param0
  */
 const NestedLanguageProvider = ({
   messages,
   children,
-}: LanguageProviderProps) => {
-  const intl = useIntl();
+}: NestedLanguageProvider) => {
+  const { messages: fallbackMessages } = useIntl();
   const [searchParams] = useSearchParams();
   const locale = searchParams.get("locale") as SecondaryLocale;
+  const localeMessages = messages.get(locale);
 
   // Return just children if there is no
   // locale in the search params
-  if (!locale) {
+  if (!locale || !localeMessages) {
     return children as JSX.Element;
   }
 
   // Merge the messages
   const nestedMessages = {
-    ...intl.messages,
-    ...messages,
-  };
+    ...fallbackMessages,
+    ...localeMessages,
+  } as Messages;
 
   return (
     <IntlProvider

--- a/frontend/common/src/components/context/NestedLanguageProvider.tsx
+++ b/frontend/common/src/components/context/NestedLanguageProvider.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { IntlProvider, useIntl } from "react-intl";
 import { useSearchParams } from "react-router-dom";
 
-import { isSecondaryLocale } from "../../helpers/localize";
 import defaultRichTextElements from "../../helpers/format";
 import { Messages } from "./LanguageProvider";
 
@@ -28,9 +27,12 @@ const NestedLanguageProvider = ({
   const locale = searchParams.get("locale");
   const localeMessages = messages.get(locale || "");
 
-  // Return just children if there is no
-  // locale in the search params
-  if (!locale || !localeMessages || !isSecondaryLocale(locale)) {
+  /**
+   * If no locale is set or we cannot
+   * find the messages associated with the locale,
+   * just return the children
+   */
+  if (!locale || !localeMessages) {
     return children as JSX.Element;
   }
 

--- a/frontend/common/src/components/context/NestedLanguageProvider.tsx
+++ b/frontend/common/src/components/context/NestedLanguageProvider.tsx
@@ -2,18 +2,9 @@ import React from "react";
 import { IntlProvider, useIntl } from "react-intl";
 import { useSearchParams } from "react-router-dom";
 
+import { isSecondaryLocale } from "../../helpers/localize";
 import defaultRichTextElements from "../../helpers/format";
 import { Messages } from "./LanguageProvider";
-
-/**
- * Indigenous Language codes
- *
- * crg - Michif
- * crk - Plains Cree
- * ojw - Western Ojibway
- * mic - Mikmaq
- */
-export type SecondaryLocale = "crg" | "crk" | "ojw" | "mic";
 
 interface NestedLanguageProvider {
   messages: Map<string, Messages>;
@@ -34,12 +25,12 @@ const NestedLanguageProvider = ({
 }: NestedLanguageProvider) => {
   const { messages: fallbackMessages } = useIntl();
   const [searchParams] = useSearchParams();
-  const locale = searchParams.get("locale") as SecondaryLocale;
-  const localeMessages = messages.get(locale);
+  const locale = searchParams.get("locale");
+  const localeMessages = messages.get(locale || "");
 
   // Return just children if there is no
   // locale in the search params
-  if (!locale || !localeMessages) {
+  if (!locale || !localeMessages || !isSecondaryLocale(locale)) {
     return children as JSX.Element;
   }
 

--- a/frontend/common/src/helpers/localize.ts
+++ b/frontend/common/src/helpers/localize.ts
@@ -4,10 +4,27 @@ import type { LocalizedString, Maybe } from "../api/generated";
 
 export type Locales = "en" | "fr";
 
+/**
+ * Indigenous Language codes
+ *
+ * crg - Michif
+ * crk - Plains Cree
+ * ojw - Western Ojibway
+ * mic - Mikmaq
+ */
+export type SecondaryLocale = "crg" | "crk" | "ojw" | "mic";
+const secondaryLocales = ["crg", "crk", "ojw", "mic"];
+
 export const STORED_LOCALE = "stored_locale";
 
 export function isLocale(locale?: string): locale is Locales {
   return locale === "en" || locale === "fr";
+}
+
+export function isSecondaryLocale(
+  locale?: string | null,
+): locale is SecondaryLocale {
+  return locale ? secondaryLocales.includes(locale) : false;
 }
 
 export function getLocale(intl: IntlShape): Locales {

--- a/frontend/common/src/helpers/localize.ts
+++ b/frontend/common/src/helpers/localize.ts
@@ -4,27 +4,10 @@ import type { LocalizedString, Maybe } from "../api/generated";
 
 export type Locales = "en" | "fr";
 
-/**
- * Indigenous Language codes
- *
- * crg - Michif
- * crk - Plains Cree
- * ojw - Western Ojibway
- * mic - Mikmaq
- */
-export type SecondaryLocale = "crg" | "crk" | "ojw" | "mic";
-const secondaryLocales = ["crg", "crk", "ojw", "mic"];
-
 export const STORED_LOCALE = "stored_locale";
 
 export function isLocale(locale?: string): locale is Locales {
   return locale === "en" || locale === "fr";
-}
-
-export function isSecondaryLocale(
-  locale?: string | null,
-): locale is SecondaryLocale {
-  return locale ? secondaryLocales.includes(locale) : false;
 }
 
 export function getLocale(intl: IntlShape): Locales {


### PR DESCRIPTION
## 👋 Introduction

This creates the `NestedLanguageProvider` to support secondary languages based on a search param.

## 🕵️ Details

This uses `react-router` to get the search params and `LanguageProvider` so it must be used as a child of both. I believe the best place to use this is wrapping all items in the `<Layout>` component which is how it was done during testing.

## 🔧 Usage

Since we are use user input in search params, this makes use of maps for a more secure approach.

```tsx
import NestedLanguageProvider from "@common/components/context/NestedLanguageProvider";
import * as ojwMessages from "../lang/ojwCompiled.json";
import * as micMessages from "../lang/micCompiled.json";

const messages: Map<string, Messages> = new Map([
  ["ojw", ojwMessages],
  ["mic", micMessages],
]);

const Layout = () => {
  ...
  return (
     <NestedLanguageProvider messages={messages}>
        {...}
     </NestedLanguageProvider>
  );
}
```

## ❓ Question

I had some trouble with the message types so decided to cast the type. I'd prefer a better approach if anyone could provide some suggestions.

https://github.com/GCTC-NTGC/gc-digital-talent/blob/221af6de0dc20418118461a34d84c0d7c2c63dad/frontend/common/src/components/context/NestedLanguageProvider.tsx#L46-L50

## 🧪 Testing

Testing is difficult without additional languages yet. How I tested locally was the following:

1. Duplicate the `frCompiled.json` file in a project
2. Pick out strings where you know they exist for checking
3. Replace those strings with some phrase ("testing")
4. Add the `<NestedLanguageProvider>` to a project (I did IAP since that is where it will be used first)
5. Pass the new compiled file to the messages prop as it is done in the `<ContextContainer>` in main
6. Navigate to the page and confirm the normal functionality remains (EN, FR)
7. Add the locale as a search param to the URL (http://...?locale=xxx)
8. Confirm the strings you replaced show up and the rest fallback to the expected language (EN, FR)

### Sample Compiled File for Western Ojibway (ojw)

 This will replace the "About the Program" title on the IAP.

```json
{
  "CqLV19": [
    {
      "type": 0,
      "value": "Test OJW"
    }
  ]
}
```

## 🤖 Robot Stuff

Resolves #4795 