### PR TITLE
4825 skills not used for search page count

### DIFF
--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -59,6 +59,9 @@ const applicantFilterToQueryArgs = (
           ? pickMap(filter.expectedClassifications, ["group", "level"])
           : [],
         // TODO: pickMap the skills array as well?
+        // For now, while most candidates in production do not have skills populated, we want to ignore skill filters when showing a count to managers.
+        // TODO: Add skills back in when most candidates in production have populated skills.
+        skills: undefined,
 
         // Override the filter's pool if one is provided separately.
         pools: poolId ? [{ id: poolId }] : pickMap(filter?.pools, "id"),

--- a/frontend/talentsearch/src/js/components/skills/AddSkillsToFilter/AddSkillsToFilter.tsx
+++ b/frontend/talentsearch/src/js/components/skills/AddSkillsToFilter/AddSkillsToFilter.tsx
@@ -56,12 +56,21 @@ const AddSkillsToFilter: React.FC<AddSkillsToFilterProps> = ({
         id={linkId}
       >
         {intl.formatMessage({
-          defaultMessage: "Skills as filters",
-          id: "hEhmBF",
+          defaultMessage: "Skills selection",
+          id: "eFvsOG",
           description: "Title for the skill filters on search page.",
         })}
       </h3>
-      <p>
+      <p data-h2-margin="base(x.5, 0, x1, 0)">
+        {intl.formatMessage({
+          defaultMessage:
+            "Help us match you to the best candidates by sharing more information with our team on the exact skills you are looking for.",
+          id: "R75HsV",
+          description:
+            "Describing the purpose of the skill filters on the Search page.",
+        })}
+      </p>
+      {/* <p>
         {intl.formatMessage({
           defaultMessage:
             "Find candidates with the right skills for the job. Use the following tabs to find skills that are necessary for the job and select them to use them as filters for matching candidates.",
@@ -78,7 +87,7 @@ const AddSkillsToFilter: React.FC<AddSkillsToFilterProps> = ({
           description:
             "Describing how to use the skill filters on search page, paragraph two.",
         })}
-      </p>
+      </p> */}
       <SkillPicker
         skills={allSkills || []}
         onUpdateSelectedSkills={handleChange}


### PR DESCRIPTION
Resolves #4825.

Steps for testing:
0. Seed your local database, if neccesary.
1. Go to the search page. Add filters (not including skills) until the number of candidates is low.
2. Add a bunch of skills. Confirm that this does NOT affect the count number.
3. Continue to submit the request. Confirm that the skills you requested appear in the summary.
4. Go to the admin dashboard and view the request.
5. Confirm that all the skill filters were saved with the request, and are shown in the Request Summary.
6. Confirm that, with all the skills you added, no candidates meet the criteria and the users table is empty (probably)
7. Edit the table filters and remove all skills. Confirm that you now see the same number of candidates as you did on the public side.