### PR TITLE
bug/4619-hidden-tag-whitespace firefox

### DIFF
--- a/frontend/admin/src/js/components/Table/TableEditButton.tsx
+++ b/frontend/admin/src/js/components/Table/TableEditButton.tsx
@@ -26,6 +26,7 @@ function TableEditButton({
       mode="inline"
       color="black"
       data-h2-padding="base(0)"
+      style={{ whiteSpace: "pre" }}
     >
       {intl.formatMessage(
         {

--- a/frontend/admin/src/js/components/Table/TableViewItemButton.tsx
+++ b/frontend/admin/src/js/components/Table/TableViewItemButton.tsx
@@ -19,7 +19,13 @@ function TableViewItemButton({
 }: TableViewItemButtonProps): React.ReactElement {
   const intl = useIntl();
   return (
-    <Link href={viewUrl} type="button" mode="inline" data-h2-padding="base(0)">
+    <Link
+      href={viewUrl}
+      type="button"
+      mode="inline"
+      data-h2-padding="base(0)"
+      style={{ whiteSpace: "pre" }}
+    >
       {intl.formatMessage(
         {
           defaultMessage: "View {name} <hidden>{hiddenLabel}</hidden>",

--- a/frontend/admin/src/js/components/pool/PoolTable.tsx
+++ b/frontend/admin/src/js/components/pool/PoolTable.tsx
@@ -33,6 +33,7 @@ function poolCandidatesLinkAccessor(
       mode="inline"
       color="black"
       data-h2-padding="base(0)"
+      style={{ whiteSpace: "pre" }}
     >
       {intl.formatMessage(
         {

--- a/frontend/admin/src/js/components/searchRequest/SingleSearchRequestTable.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SingleSearchRequestTable.tsx
@@ -43,6 +43,7 @@ const TableEditButton: React.FC<{
       color="black"
       mode="inline"
       href={paths.poolCandidateUpdate(poolId || "", poolCandidateId || "")}
+      style={{ whiteSpace: "pre" }}
     >
       {intl.formatMessage(
         {

--- a/frontend/common/src/components/Header/Header.tsx
+++ b/frontend/common/src/components/Header/Header.tsx
@@ -98,6 +98,7 @@ const Header = ({ width }: HeaderProps) => {
                   setLocale(changeToLang);
                 }}
                 lang={changeToLang === "en" ? "en" : "fr"}
+                style={{ whiteSpace: "pre" }}
               >
                 {intl.formatMessage({
                   defaultMessage:

--- a/frontend/common/src/components/SkillPicker/SkillBlock.tsx
+++ b/frontend/common/src/components/SkillPicker/SkillBlock.tsx
@@ -80,7 +80,7 @@ const SkillBlock = ({
           data-h2-gap="base(x.5, 0)"
           style={{ flexShrink: 0 }}
         >
-          <div>
+          <div style={{ whiteSpace: "pre" }}>
             <Button
               color="primary"
               mode="inline"
@@ -112,7 +112,7 @@ const SkillBlock = ({
                   )}
             </Button>
           </div>
-          <div>
+          <div style={{ whiteSpace: "pre" }}>
             {definition ? (
               <Collapsible.Trigger asChild>
                 <Button

--- a/frontend/talentsearch/src/js/components/Browse/BrowsePoolsPage.tsx
+++ b/frontend/talentsearch/src/js/components/Browse/BrowsePoolsPage.tsx
@@ -254,6 +254,7 @@ export const BrowsePools: React.FC<BrowsePoolsProps> = ({
             data-h2-display="base(grid)"
             data-h2-grid-template-columns="base(1fr) p-tablet(repeat(2, minmax(0, 1fr)))"
             data-h2-gap="base(x2) p-tablet(x3)"
+            style={{ whiteSpace: "pre" }}
           >
             <CardFlat
               color="purple"

--- a/frontend/talentsearch/src/js/components/Browse/PoolCard/PoolCard.tsx
+++ b/frontend/talentsearch/src/js/components/Browse/PoolCard/PoolCard.tsx
@@ -222,6 +222,7 @@ const PoolCard = ({ pool, headingLevel = "h3" }: PoolCardProps) => {
                 href={paths.pool(pool.id)}
                 data-h2-text-align="base(center)"
                 data-h2-display="base(inline-block)"
+                style={{ whiteSpace: "pre" }}
               >
                 {intl.formatMessage(
                   {

--- a/frontend/talentsearch/src/js/components/Home/partials/About/About.tsx
+++ b/frontend/talentsearch/src/js/components/Home/partials/About/About.tsx
@@ -37,6 +37,7 @@ const About = () => {
               data-h2-grid-template-columns="base(1fr) p-tablet(repeat(2, minmax(0, 1fr))) l-tablet(repeat(3, minmax(0, 1fr)))"
               data-h2-gap="base(x2) p-tablet(x3)"
               data-h2-padding="base(x2, 0, 0, 0) p-tablet(x3, 0, 0, 0)"
+              style={{ whiteSpace: "pre" }}
             >
               <CardFlat
                 color="black"

--- a/frontend/talentsearch/src/js/components/Home/partials/Opportunities/Opportunities.tsx
+++ b/frontend/talentsearch/src/js/components/Home/partials/Opportunities/Opportunities.tsx
@@ -82,6 +82,7 @@ const Opportunities = () => {
             data-h2-grid-template-columns="base(1fr) p-tablet(repeat(2, minmax(0, 1fr))) l-tablet(repeat(3, minmax(0, 1fr)))"
             data-h2-gap="base(x2) p-tablet(x3)"
             data-h2-padding="base(x2, 0, 0, 0) p-tablet(x3, 0, 0, 0)"
+            style={{ whiteSpace: "pre" }}
           >
             <CardFlat
               color="yellow"

--- a/frontend/talentsearch/src/js/components/applications/ApplicationCard/ApplicationActions.tsx
+++ b/frontend/talentsearch/src/js/components/applications/ApplicationCard/ApplicationActions.tsx
@@ -27,7 +27,10 @@ const ContinueAction = ({ show, application }: ContinueActionProps) => {
   }
 
   return (
-    <Link href={paths.reviewApplication(application.id)}>
+    <Link
+      href={paths.reviewApplication(application.id)}
+      style={{ whiteSpace: "pre" }}
+    >
       {intl.formatMessage(
         {
           defaultMessage: "Continue my application<hidden> {name}</hidden>",
@@ -58,7 +61,7 @@ const SeeAdvertisementAction = ({
   }
 
   return (
-    <Link href={paths.pool(advertisement.id)}>
+    <Link href={paths.pool(advertisement.id)} style={{ whiteSpace: "pre" }}>
       {intl.formatMessage(
         {
           defaultMessage: "See advertisement<hidden> {name}</hidden>",
@@ -92,7 +95,7 @@ const DeleteAction = ({ show, application, onDelete }: DeleteActionProps) => {
   return (
     <AlertDialog.Root>
       <AlertDialog.Trigger>
-        <Button mode="inline" color="black">
+        <Button mode="inline" color="black" style={{ whiteSpace: "pre" }}>
           {intl.formatMessage(
             {
               defaultMessage: "Delete<hidden> application {name}</hidden>",
@@ -180,7 +183,7 @@ const ArchiveAction = ({
   return (
     <AlertDialog.Root>
       <AlertDialog.Trigger>
-        <Button mode="inline" color="black">
+        <Button mode="inline" color="black" style={{ whiteSpace: "pre" }}>
           {intl.formatMessage(
             {
               defaultMessage: "Archive<hidden> application {name}</hidden>",

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/EquityOptions.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/EquityOptions.tsx
@@ -87,6 +87,7 @@ const EquityOptions: React.FC<EquityOptionsProps> = ({
             <div
               data-h2-display="base(flex)"
               data-h2-flex-direction="base(column)"
+              style={{ whiteSpace: "pre" }}
             >
               {resolvedWoman && (
                 <EquityOption
@@ -167,6 +168,7 @@ const EquityOptions: React.FC<EquityOptionsProps> = ({
             <div
               data-h2-display="base(flex)"
               data-h2-flex-direction="base(column)"
+              style={{ whiteSpace: "pre" }}
             >
               {!resolvedWoman && (
                 <EquityOption

--- a/frontend/talentsearch/src/js/components/experienceAndSkills/ExperienceAndSkills.tsx
+++ b/frontend/talentsearch/src/js/components/experienceAndSkills/ExperienceAndSkills.tsx
@@ -233,6 +233,7 @@ export const ExperienceAndSkills: React.FunctionComponent<
                     color="primary"
                     icon={icon}
                     block
+                    style={{ whiteSpace: "pre" }}
                   >
                     {intl.formatMessage(
                       {


### PR DESCRIPTION
closes #4619 
adds something to preserve whitespace in elements that contain something with `<hidden>`

testing will be a bit tedious
- check chromatic
- checks the link text and accessiblity text across multiple places
- repeat for another browser (recommend Firefox because that is the source of the bug, and quickly another browser to ensure no other bugs creeped in)

some places with `<hidden>` text to check, check files tab if you want to see all the places
`/en/admin/pools` see "View Candidates" and "Edit"
`/en/admin/dashboard` see "View Request"
`/en/browse/pools` see "Apply Now"
`/en/users/:id/profile/employment-equity/edit` see buttons
