### PR TITLE
Feature - 4828 - Hide skills details profile

### DIFF
--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.test.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.test.tsx
@@ -242,10 +242,6 @@ describe("ExperienceForm", () => {
     expect(
       screen.getByRole("heading", { name: /skills displayed/i }),
     ).toBeInTheDocument();
-
-    expect(
-      screen.getByRole("heading", { name: /skills in detail/i }),
-    ).toBeInTheDocument();
   });
 
   it("should render additional information", async () => {
@@ -260,8 +256,6 @@ describe("ExperienceForm", () => {
         skills: mockSkills,
       });
     });
-
-    expect(screen.getByRole("textbox", { name: /additional information/i }));
   });
 
   it("should not submit award with empty fields", async () => {
@@ -336,9 +330,6 @@ describe("ExperienceForm", () => {
       name: /add this skill/i,
     });
     fireEvent.click(skillResults[0]);
-    expect(
-      await screen.findByRole("textbox", { name: /skill in detail/i }),
-    ).toBeInTheDocument();
   });
 });
 

--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
@@ -211,23 +211,31 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
           skills={skills}
           poolAdvertisement={poolAdvertisement}
         />
-        <h2 data-h2-font-size="base(h3, 1)" data-h2-margin="base(x2, 0, x1, 0)">
-          {intl.formatMessage({
-            defaultMessage: "4. Additional information for this experience",
-            id: "Rgh/Qb",
-            description: "Title for addition information on Experience form",
-          })}
-        </h2>
-        <p>
-          {intl.formatMessage({
-            defaultMessage:
-              "Anything else about this experience you would like to share.",
-            id: "h1wsiL",
-            description:
-              "Description blurb for additional information on Experience form",
-          })}
-        </p>
-        <TextArea id="details" label={labels.details} name="details" />
+        {poolAdvertisement && (
+          <>
+            <h2
+              data-h2-font-size="base(h3, 1)"
+              data-h2-margin="base(x2, 0, x1, 0)"
+            >
+              {intl.formatMessage({
+                defaultMessage: "4. Additional information for this experience",
+                id: "Rgh/Qb",
+                description:
+                  "Title for addition information on Experience form",
+              })}
+            </h2>
+            <p>
+              {intl.formatMessage({
+                defaultMessage:
+                  "Anything else about this experience you would like to share.",
+                id: "h1wsiL",
+                description:
+                  "Description blurb for additional information on Experience form",
+              })}
+            </p>
+            <TextArea id="details" label={labels.details} name="details" />
+          </>
+        )}
         {edit && (
           <AlertDialog.Root>
             <AlertDialog.Trigger>

--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceSkills.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceSkills.tsx
@@ -196,10 +196,12 @@ const ExperienceSkills: React.FC<ExperienceSkillsProps> = ({
           selectedSkills={addedSkills || []}
         />
       )}
-      <SkillsInDetail
-        skills={fields as FormSkills}
-        onDelete={handleRemoveSkill}
-      />
+      {poolAdvertisement && (
+        <SkillsInDetail
+          skills={fields as FormSkills}
+          onDelete={handleRemoveSkill}
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
## 👋 Introduction

This hides steps 3 and 4 on the experience form when editing a user profile.

## 🧪 Testing

### Profile

1. Navigate to profile and add an experience
2. Confirm that Skills in Detail and Additional Information sections do not appear and you can still save the form

### Application

1. Start an application then add/edit an experience from the application review page
2. Confirm that Skills in Detail and Additional Information sections appear and you can still save the form

## 🤖 Robot stuff

Resolves #4828 