### PR TITLE
Accessibility - IAP page h1 tag

### DIFF
--- a/frontend/admin/src/js/components/classification/ClassificationTable.tsx
+++ b/frontend/admin/src/js/components/classification/ClassificationTable.tsx
@@ -87,7 +87,7 @@ export const ClassificationTable: React.FC<
           tableEditButtonAccessor(
             d.id,
             editUrlRoot,
-            `${d.name?.[locale]} ${d.group}-${d.level}`,
+            `${d.name?.[locale]} ${d.group}-0${d.level}`,
           ), // callback extracted to separate function to stabilize memoized component
       },
     ],

--- a/frontend/indigenousapprenticeship/src/js/components/Home/Home.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/Home/Home.tsx
@@ -33,12 +33,6 @@ const mailLink = (chunks: React.ReactNode): React.ReactNode => (
 const Home: React.FunctionComponent = () => {
   const intl = useIntl();
   const quote = useQuote();
-  const pageTitle = intl.formatMessage({
-    defaultMessage:
-      "IT Apprenticeship Program for Indigenous Peoples. Apply today to get started on your IT career journey.",
-    id: "qZvV7b",
-    description: "Homepage title for Indigenous Apprenticeship Program",
-  });
 
   /**
    * Language swapping is a little rough here,
@@ -91,9 +85,17 @@ const Home: React.FunctionComponent = () => {
                 INDIGENOUSAPPRENTICESHIP_APP_DIR,
                 `logo-${intl.locale}.svg`,
               )}
-              alt={pageTitle}
+              alt=""
             />
-            <span data-h2-visibility="base(invisible)">{pageTitle}</span>
+            <span data-h2-visibility="base(invisible)">
+              {intl.formatMessage({
+                defaultMessage:
+                  "IT Apprenticeship Program for Indigenous Peoples. Apply today to get started on your IT career journey.",
+                id: "qZvV7b",
+                description:
+                  "Homepage title for Indigenous Apprenticeship Program",
+              })}
+            </span>
           </h1>
         </div>
         <div

--- a/frontend/indigenousapprenticeship/src/js/components/Home/Home.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/Home/Home.tsx
@@ -33,6 +33,12 @@ const mailLink = (chunks: React.ReactNode): React.ReactNode => (
 const Home: React.FunctionComponent = () => {
   const intl = useIntl();
   const quote = useQuote();
+  const pageTitle = intl.formatMessage({
+    defaultMessage:
+      "IT Apprenticeship Program for Indigenous Peoples. Apply today to get started on your IT career journey.",
+    id: "qZvV7b",
+    description: "Homepage title for Indigenous Apprenticeship Program",
+  });
 
   /**
    * Language swapping is a little rough here,
@@ -78,20 +84,17 @@ const Home: React.FunctionComponent = () => {
           data-h2-offset="p-tablet(5%, auto, auto, 50%)"
           data-h2-width="base(100%) p-tablet(40vw)"
         >
-          <img
-            data-h2-width="base(100%)"
-            src={imageUrl(
-              INDIGENOUSAPPRENTICESHIP_APP_DIR,
-              `logo-${intl.locale}.svg`,
-            )}
-            alt={intl.formatMessage({
-              defaultMessage:
-                "IT Apprenticeship Program for Indigenous Peoples",
-              id: "Hu04cP",
-              description:
-                "Homepage title for Indigenous Apprenticeship Program",
-            })}
-          />
+          <h1>
+            <img
+              data-h2-width="base(100%)"
+              src={imageUrl(
+                INDIGENOUSAPPRENTICESHIP_APP_DIR,
+                `logo-${intl.locale}.svg`,
+              )}
+              alt={pageTitle}
+            />
+            <span data-h2-visibility="base(invisible)">{pageTitle}</span>
+          </h1>
         </div>
         <div
           className="hero-cta"

--- a/frontend/indigenousapprenticeship/src/js/lang/fr.json
+++ b/frontend/indigenousapprenticeship/src/js/lang/fr.json
@@ -107,8 +107,8 @@
     "defaultMessage": "Une fois votre demande présenté, un membre de l’équipe communiquera avec vous dans les 3 à 5 jours ouvrables qui suivent.",
     "description": "How it works, step 3 content sentence 2"
   },
-  "Hu04cP": {
-    "defaultMessage": "Programme d’apprentissage en TI pour les peuples autochtones",
+  "qZvV7b": {
+    "defaultMessage": "Programme d’apprentissage en TI pour les peuples autochtones. Postulez dès aujourd’hui pour entamer votre parcours de carrièr en TI.",
     "description": "Homepage title for Indigenous Apprenticeship Program"
   },
   "Ilot3b": {


### PR DESCRIPTION
Resolves #4718 

## Notes
- Wraps the image "header" in a `h1` tag, along with invisible text in a `span` for screen readers.

## Testing
- Go to IAP homepage. 
- Ensure that image is wrapped in `h1` along with invisible text in span.
- Switch to French and ensure it displays hidden text correctly.