### PR TITLE
Copy - Job poster fixes

### DIFF
--- a/frontend/talentsearch/src/js/components/ClassificationDefinition/ITDefinitions.tsx
+++ b/frontend/talentsearch/src/js/components/ClassificationDefinition/ITDefinitions.tsx
@@ -5,47 +5,14 @@ const LevelOne = () => {
   const intl = useIntl();
 
   return (
-    <>
-      <p>
-        {intl.formatMessage({
-          defaultMessage:
-            "Technicians (IT-01) provide technical support in the development, implementation, integration, and maintenance of service delivery to clients and stakeholders",
-          id: "Z9Uex5",
-          description: "blurb describing IT-01",
-        })}
-      </p>
-      <p>
-        {intl.formatMessage({
-          defaultMessage:
-            "IT Technicians are primarily found in three work streams: ",
-          id: "vQzmUH",
-          description: "Preceding list description",
-        })}
-      </p>
-      <ul>
-        <li>
-          {intl.formatMessage({
-            defaultMessage: "IT Infrastructure Operations",
-            id: "QZ9FZB",
-            description: "work stream example",
-          })}
-        </li>
-        <li>
-          {intl.formatMessage({
-            defaultMessage: "IT Security",
-            id: "nrBkon",
-            description: "work stream example",
-          })}
-        </li>
-        <li>
-          {intl.formatMessage({
-            defaultMessage: "IT Software Solutions",
-            id: "SDDp1t",
-            description: "work stream example",
-          })}
-        </li>
-      </ul>
-    </>
+    <p>
+      {intl.formatMessage({
+        defaultMessage:
+          "Technicians (IT-01) provide technical support in the development, implementation, integration, and maintenance of service delivery to clients and stakeholders",
+        id: "Z9Uex5",
+        description: "blurb describing IT-01",
+      })}
+    </p>
   );
 };
 
@@ -158,56 +125,12 @@ const LevelFourAdvisor = (): JSX.Element => {
       <p>
         {intl.formatMessage({
           defaultMessage:
-            "<strong>Individual Contributor</strong>: IT Senior Advisors (IT-04) provide expert technical advice and strategic direction in their field of expertise in the provision of solutions and services to internal or external clients, and stakeholders. IT Senior Advisors are primarily found in six work streams:",
-          id: "58BEeZ",
+            "<strong>Individual Contributor</strong>: IT Senior Advisors (IT-04) provide expert technical advice and strategic direction in their field of expertise in the provision of solutions and services to internal or external clients, and stakeholders.",
+          id: "VQWGkh",
           description:
             "IT-04 senior advisor description precursor to work stream list, ignore things in <> tags please",
         })}
       </p>
-      <ul>
-        <li>
-          {intl.formatMessage({
-            defaultMessage: "IT Infrastructure Operations",
-            id: "QZ9FZB",
-            description: "work stream example",
-          })}
-        </li>
-        <li>
-          {intl.formatMessage({
-            defaultMessage: "IT Security",
-            id: "nrBkon",
-            description: "work stream example",
-          })}
-        </li>
-        <li>
-          {intl.formatMessage({
-            defaultMessage: "IT Software Solutions",
-            id: "SDDp1t",
-            description: "work stream example",
-          })}
-        </li>
-        <li>
-          {intl.formatMessage({
-            defaultMessage: "IT Database Management",
-            id: "6LTC0y",
-            description: "work stream example",
-          })}
-        </li>
-        <li>
-          {intl.formatMessage({
-            defaultMessage: "IT Enterprise Architecture",
-            id: "oOcegG",
-            description: "work stream example",
-          })}
-        </li>
-        <li>
-          {intl.formatMessage({
-            defaultMessage: "IT Project Portfolio Management",
-            id: "tm3zLD",
-            description: "work stream example",
-          })}
-        </li>
-      </ul>
     </>
   );
 };

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -624,8 +624,8 @@ export const PoolAdvertisementPoster = ({
                 style={{ width: "100%" }}
                 color="ts-secondary"
                 title={intl.formatMessage({
-                  defaultMessage: "2-Year Post-secondary Experience",
-                  id: "/Gu4zR",
+                  defaultMessage: "2-Year Post-secondary Education",
+                  id: "U6IroF",
                   description:
                     "Title for pool applicant education requirements",
                 })}

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -1545,7 +1545,7 @@
     "description": "IT-03 team lead path description, ignore things in <> tags please"
   },
   "58BEeZ": {
-    "defaultMessage": "<strong>Contributeur individuel</strong> : Les conseillers principaux en TI (TI-04) fournissent des conseils techniques et une orientation stratégique d'experts dans leur domaine d'expertise en matière de fourniture de solutions et de services à des clients internes ou externes et à des intervenants. Les conseillers principaux en TI se retrouvent principalement dans six volets de travail :",
+    "defaultMessage": "<strong>Contributeur individuel</strong> : Les conseillers principaux en TI (TI-04) fournissent des conseils techniques et une orientation stratégique d'experts dans leur domaine d'expertise en matière de fourniture de solutions et de services à des clients internes ou externes et à des intervenants.",
     "description": "IT-04 senior advisor description precursor to work stream list, ignore things in <> tags please"
   },
   "HPDqDV": {
@@ -1592,8 +1592,8 @@
     "defaultMessage": "Compétences techniques",
     "description": "Button text for the technical skills tab on skills filter"
   },
-  "/Gu4zR": {
-    "defaultMessage": "Expérience postsecondaire de deux ans",
+  "U6IroF": {
+    "defaultMessage": "Études postsecondaires de deux ans",
     "description": "Title for pool applicant education requirements"
   },
   "0FjYi+": {
@@ -2327,10 +2327,6 @@
   "25VYzu": {
     "defaultMessage": "Avez-vous un droit de priorité pour les candidatures du gouvernement du Canada? Ce statut est accordé par la Commission de la fonction publique du Canada. Pour en savoir plus, <priorityEntitlementLink>visitez le site de l'information sur les droits de priorité</priorityEntitlementLink>.",
     "description": "Sentence asking whether the user possesses priority entitlement"
-  },
-  "vQzmUH": {
-    "defaultMessage": "Les techniciens en TI se retrouvent principalement dans trois filières de travail :",
-    "description": "Preceding list description"
   },
   "w3Kkk2": {
     "defaultMessage": "Inscrivez-vous<hidden> au programme d’apprentissage destiné aux Autochtones</hidden> maintenant",


### PR DESCRIPTION
Resolves #4862 

## Notes 
- Adds 2 copy fixes to the Job Poster (Pool Advertisement). 
1) Remove list of streams at bottom of the text from the **"What does {stream} mean?"**
2) Change "2-Year Post-secondary **Experience**" -> "2-Year Post-secondary **Education**"

## Testing
- Go to admin homepage and then go to pools table 
- Open up an IT-01 and IT-04 pool and view the Pool Advertisement page.
![image](https://user-images.githubusercontent.com/22059495/203396842-b40b3152-a376-4571-87d8-71be56ae7a6a.png)
- Ensure that **"What does {stream} mean?"** accordion does not have list of streams at the bottom.
- Also, go to Requirements section and ensure title of education card has changed. 