### PR TITLE
Feature - 4823 - Move search employment conditions

### DIFF
--- a/frontend/talentsearch/src/js/components/search/SearchForm.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchForm.tsx
@@ -367,39 +367,6 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             />
           </FilterBlock>
           <FilterBlock
-            id="operationalRequirementFilter"
-            title={intl.formatMessage({
-              defaultMessage:
-                "Conditions of employment / Operational requirements",
-              id: "laGCzG",
-              description:
-                "Heading for operational requirements section of the search form.",
-            })}
-            text={intl.formatMessage({
-              defaultMessage:
-                "The selected conditions of employment will be compared to those chosen by candidates in their applications.",
-              id: "IT6Djp",
-              description:
-                "Message describing the operational requirements filter in the search form.",
-            })}
-          >
-            <Checklist
-              idPrefix="operationalRequirements"
-              legend={intl.formatMessage({
-                defaultMessage: "Conditions of employment",
-                id: "bKvvaI",
-                description:
-                  "Legend for the Conditions of Employment filter checklist",
-              })}
-              name="operationalRequirements"
-              items={OperationalRequirementV2.map((value) => ({
-                value,
-                label: intl.formatMessage(getOperationalRequirement(value)),
-              }))}
-              trackUnsaved={false}
-            />
-          </FilterBlock>
-          <FilterBlock
             id="locationPreferencesFilter"
             title={intl.formatMessage({
               defaultMessage: "Work location",
@@ -589,6 +556,39 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             />
           </FilterBlock>
           <AddSkillsToFilter allSkills={skills ?? []} linkId="skillFilter" />
+          <FilterBlock
+            id="operationalRequirementFilter"
+            title={intl.formatMessage({
+              defaultMessage:
+                "Conditions of employment / Operational requirements",
+              id: "laGCzG",
+              description:
+                "Heading for operational requirements section of the search form.",
+            })}
+            text={intl.formatMessage({
+              defaultMessage:
+                "The selected conditions of employment will be compared to those chosen by candidates in their applications.",
+              id: "IT6Djp",
+              description:
+                "Message describing the operational requirements filter in the search form.",
+            })}
+          >
+            <Checklist
+              idPrefix="operationalRequirements"
+              legend={intl.formatMessage({
+                defaultMessage: "Conditions of employment",
+                id: "bKvvaI",
+                description:
+                  "Legend for the Conditions of Employment filter checklist",
+              })}
+              name="operationalRequirements"
+              items={OperationalRequirementV2.map((value) => ({
+                value,
+                label: intl.formatMessage(getOperationalRequirement(value)),
+              }))}
+              trackUnsaved={false}
+            />
+          </FilterBlock>
         </form>
       </FormProvider>
     );


### PR DESCRIPTION
## 👋 Introduction

This moves the conditions of employment section to the bottom of the search form.

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Navigate to search page
3. Confirm "Conditions of employment / Operational requirements" shows up at the bottom

## 🤖 Robot Stuff

Resolves #4823 