### PR TITLE
bug/4875-no-adding users to unpublished pools

### DIFF
--- a/frontend/admin/src/js/components/user/GeneralInformationTab/GeneralInfoTabDialogs.tsx
+++ b/frontend/admin/src/js/components/user/GeneralInformationTab/GeneralInfoTabDialogs.tsx
@@ -13,6 +13,7 @@ import { toast } from "@common/components/Toast";
 import { getFullNameHtml } from "@common/helpers/nameUtils";
 import { getFullPoolAdvertisementTitle } from "@common/helpers/poolUtils";
 import {
+  AdvertisementStatus,
   CreatePoolCandidateAsAdminInput,
   Pool,
   PoolCandidate,
@@ -713,6 +714,11 @@ export const AddToPoolDialog: React.FC<{
                 </option>
                 {pools.map((pool) => {
                   if (currentPools.includes(pool.id)) {
+                    return null;
+                  }
+                  if (
+                    pool.advertisementStatus !== AdvertisementStatus.Published
+                  ) {
                     return null;
                   }
                   return (

--- a/frontend/admin/src/js/components/user/GeneralInformationTab/GeneralInfoTabDialogs.tsx
+++ b/frontend/admin/src/js/components/user/GeneralInformationTab/GeneralInfoTabDialogs.tsx
@@ -713,10 +713,8 @@ export const AddToPoolDialog: React.FC<{
                   })}
                 </option>
                 {pools.map((pool) => {
-                  if (currentPools.includes(pool.id)) {
-                    return null;
-                  }
                   if (
+                    currentPools.includes(pool.id) ||
                     pool.advertisementStatus !== AdvertisementStatus.Published
                   ) {
                     return null;

--- a/frontend/admin/src/js/components/user/GeneralInformationTab/generalInfoOperations.graphql
+++ b/frontend/admin/src/js/components/user/GeneralInformationTab/generalInfoOperations.graphql
@@ -52,5 +52,6 @@ query GetGeneralInfo($id: ID!) {
       group
       level
     }
+    advertisementStatus
   }
 }


### PR DESCRIPTION
closes #4875 
restricts the pools you can add a user to - to only published ones

make sure to run codegen
open up `http://localhost:8000/en/admin/pools` and some user `http://localhost:8000/en/admin/users/:id`
ensure you can only add that user to pools that have the published status