### PR TITLE
Bug -  4776 - Continue application if started

### DIFF
--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -16,7 +16,7 @@ import type { BreadcrumbsProps } from "@common/components/Breadcrumbs";
 import { ThrowNotFound } from "@common/components/NotFound";
 import Pending from "@common/components/Pending";
 import Card from "@common/components/Card";
-import { Link } from "@common/components";
+import { Button, Link } from "@common/components";
 import { getLocale } from "@common/helpers/localize";
 import imageUrl from "@common/helpers/imageUrl";
 import {
@@ -50,7 +50,7 @@ import TALENTSEARCH_APP_DIR, {
 } from "../../talentSearchConstants";
 import PoolInfoCard from "./PoolInfoCard";
 import ClassificationDefinition from "../ClassificationDefinition/ClassificationDefinition";
-import { isAdvertisementVisible } from "./utils";
+import { hasUserApplied, isAdvertisementVisible } from "./utils";
 
 interface ApplyButtonProps {
   poolId: Scalars["ID"];
@@ -100,6 +100,20 @@ const ContinueButton = ({ applicationId }: ContinueButtonProps) => {
   );
 };
 
+const AlreadyAppliedButton = () => {
+  const intl = useIntl();
+  return (
+    <Button type="button" color="primary" mode="solid" disabled>
+      {intl.formatMessage({
+        defaultMessage: "You have already applied to this.",
+        id: "mwEGU+",
+        description:
+          "Disabled button when a user already applied to a pool opportunity",
+      })}
+    </Button>
+  );
+};
+
 const Text = ({ children }: { children: React.ReactNode }) => (
   <p data-h2-margin="base(x0.5, 0, x.5, 0)">{children}</p>
 );
@@ -131,11 +145,13 @@ const anchorTag = (chunks: React.ReactNode): React.ReactNode => (
 interface PoolAdvertisementProps {
   poolAdvertisement: PoolAdvertisement;
   applicationId?: Scalars["ID"];
+  hasApplied?: boolean;
 }
 
 export const PoolAdvertisementPoster = ({
   poolAdvertisement,
   applicationId,
+  hasApplied,
 }: PoolAdvertisementProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -176,11 +192,14 @@ export const PoolAdvertisementPoster = ({
     poolAdvertisement.nonessentialSkills,
   );
 
-  const applyBtn = applicationId ? (
-    <ContinueButton applicationId={applicationId} />
-  ) : (
-    <ApplyButton poolId={poolAdvertisement.id} />
-  );
+  let applyBtn = <ApplyButton poolId={poolAdvertisement.id} />;
+  if (applicationId) {
+    applyBtn = !hasApplied ? (
+      <ContinueButton applicationId={applicationId} />
+    ) : (
+      <AlreadyAppliedButton />
+    );
+  }
 
   const links = [
     {
@@ -836,6 +855,7 @@ const PoolAdvertisementPage = () => {
         <PoolAdvertisementPoster
           poolAdvertisement={data?.poolAdvertisement}
           applicationId={application?.id}
+          hasApplied={notEmpty(application?.submittedAt)}
         />
       ) : (
         <ThrowNotFound

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -21,7 +21,6 @@ import { getLocale } from "@common/helpers/localize";
 import imageUrl from "@common/helpers/imageUrl";
 import {
   AdvertisementStatus,
-  PoolCandidate,
   Scalars,
   SkillCategory,
 } from "@common/api/generated";
@@ -38,11 +37,7 @@ import {
   getFullPoolAdvertisementTitle,
 } from "@common/helpers/poolUtils";
 import { AuthorizationContext } from "@common/components/Auth";
-import {
-  useGetPoolAdvertisementQuery,
-  Maybe,
-  GetPoolAdvertisementQuery,
-} from "../../api/generated";
+import { useGetPoolAdvertisementQuery } from "../../api/generated";
 import type { PoolAdvertisement } from "../../api/generated";
 import useRoutes from "../../hooks/useRoutes";
 import TALENTSEARCH_APP_DIR, {
@@ -50,7 +45,7 @@ import TALENTSEARCH_APP_DIR, {
 } from "../../talentSearchConstants";
 import PoolInfoCard from "./PoolInfoCard";
 import ClassificationDefinition from "../ClassificationDefinition/ClassificationDefinition";
-import { hasUserApplied, isAdvertisementVisible } from "./utils";
+import { isAdvertisementVisible } from "./utils";
 
 interface ApplyButtonProps {
   poolId: Scalars["ID"];

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -2843,5 +2843,9 @@
   "eFvsOG": {
     "defaultMessage": "Sélection des compétences",
     "description": "Title for the skill filters on search page."
+  },
+  "ugosop": {
+    "defaultMessage": "Continuer ma candidature",
+    "description": "Link text to continue an existing application"
   }
 }


### PR DESCRIPTION
## 👋 Introduction

This replaced the disabled button on pool advertisements with a "Continue my application" button when the current user has already started an application.

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Login and start an application to a pool
3. Navigate to the advertisement for that pool
4. Confirm the apply button has been replaced by "Continue my application" and it takes you to your existing application
5. Confirm the text updates to "Continuer ma candidature" in French

## 🤖 Robot Stuff

Resolves #4776 