### PR TITLE
Bug - Fix extend pool closing date

### DIFF
--- a/frontend/admin/src/js/components/pool/EditPool/EditPool.test.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/EditPool.test.tsx
@@ -223,7 +223,7 @@ describe("Edit Pool tests", () => {
   });
 
   it("should have an extend button that pops a modal and emits an event when the status is published", async () => {
-    const handleEvent = jest.fn();
+    const handleEvent = jest.fn(() => Promise.resolve());
     const props = {
       ...EditPoolStory.args,
       ...PublishedAdvertisement.args,
@@ -278,7 +278,7 @@ describe("Edit Pool tests", () => {
   });
 
   it("should have an extend button that pops a modal and emits an event when the status is expired", async () => {
-    const handleEvent = jest.fn();
+    const handleEvent = jest.fn(() => Promise.resolve());
     const props = {
       ...EditPoolStory.args,
       ...ExpiredAdvertisement.args,

--- a/frontend/admin/src/js/components/pool/EditPool/EditPool.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/EditPool.tsx
@@ -60,7 +60,7 @@ export interface EditPoolFormProps {
   onPublish: () => void;
   onDelete: () => void;
   onClose: () => void;
-  onExtend: (submitData: ExtendSubmitData) => void;
+  onExtend: (submitData: ExtendSubmitData) => Promise<void>;
   onArchive: () => void;
 }
 

--- a/frontend/admin/src/js/components/pool/EditPool/ExtendDialog.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/ExtendDialog.tsx
@@ -18,7 +18,7 @@ export type ExtendSubmitData = Pick<UpdatePoolAdvertisementInput, "expiryDate">;
 
 type ExtendDialogProps = {
   expiryDate: PoolAdvertisement["expiryDate"];
-  onExtend: (submitData: ExtendSubmitData) => void;
+  onExtend: (submitData: ExtendSubmitData) => Promise<void>;
 };
 
 const ExtendDialog = ({
@@ -26,9 +26,10 @@ const ExtendDialog = ({
   onExtend,
 }: ExtendDialogProps): JSX.Element => {
   const intl = useIntl();
+  const [open, setOpen] = React.useState(false);
 
   const handleExtend = useCallback(
-    (formValues: FormValues) => {
+    async (formValues: FormValues) => {
       const expiryDateInUtc = formValues.endDate
         ? convertDateTimeZone(
             `${formValues.endDate} 23:59:59`,
@@ -37,15 +38,19 @@ const ExtendDialog = ({
           )
         : null;
 
-      onExtend({
+      await onExtend({
         expiryDate: expiryDateInUtc,
-      });
+      }).then(() => setOpen(false));
     },
     [onExtend],
   );
 
   const methods = useForm<FormValues>({
-    defaultValues: { endDate: expiryDate },
+    defaultValues: {
+      endDate: expiryDate
+        ? new Date(expiryDate).toISOString().split("T")[0]
+        : "",
+    },
   });
 
   const { handleSubmit } = methods;
@@ -64,23 +69,21 @@ const ExtendDialog = ({
           </Dialog.Close>
         </div>
         <div>
-          <Dialog.Close>
-            <Button mode="solid" color="secondary" type="submit">
-              {intl.formatMessage({
-                defaultMessage: "Extend closing date",
-                id: "OIk63O",
-                description:
-                  "Button to extend the pool closing date in the extend pool closing date dialog",
-              })}
-            </Button>
-          </Dialog.Close>
+          <Button mode="solid" color="secondary" type="submit">
+            {intl.formatMessage({
+              defaultMessage: "Extend closing date",
+              id: "OIk63O",
+              description:
+                "Button to extend the pool closing date in the extend pool closing date dialog",
+            })}
+          </Button>
         </div>
       </>
     ),
     [intl],
   );
   return (
-    <Dialog.Root>
+    <Dialog.Root open={open} onOpenChange={setOpen}>
       <Dialog.Trigger>
         <Button color="secondary" mode="solid">
           {intl.formatMessage({

--- a/frontend/admin/src/js/components/pool/EditPool/StatusSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/StatusSection.tsx
@@ -24,7 +24,7 @@ interface StatusSectionProps {
   onPublish: () => void;
   onDelete: () => void;
   onClose: () => void;
-  onExtend: (submitData: ExtendSubmitData) => void;
+  onExtend: (submitData: ExtendSubmitData) => Promise<void>;
   onArchive: () => void;
 }
 

--- a/frontend/admin/src/js/components/pool/EditPool/useMutations.ts
+++ b/frontend/admin/src/js/components/pool/EditPool/useMutations.ts
@@ -32,11 +32,11 @@ const useMutations = () => {
     );
   };
 
-  const update = (
+  const update = async (
     id: string,
     poolAdvertisement: UpdatePoolAdvertisementInput,
   ) => {
-    executeUpdateMutation({ id, poolAdvertisement })
+    await executeUpdateMutation({ id, poolAdvertisement })
       .then((result) => {
         if (result.data?.updatePoolAdvertisement) {
           toast.success(


### PR DESCRIPTION
Resolves #4775 

## Notes
- Fixes the broken form submission on extend pool closing date on Edit Pool page. 
- The reason for it not working was the Dialog closing (removed from the DOM) before the form could submit. I followed the suggestions from Dialog radix docs to fix [asynchronous form submissions](https://www.radix-ui.com/docs/primitives/components/dialog#close-after-asynchronous-form-submission).
- Also, adds a fix for `endDate` defaultValue not showing up on the `date` input. Removing the time from the date was the solution.

## Testing
- Go to admin page  and go to Pools table.
- Edit a pool with status Expired/Published. If none exist close a pool early, or create a new one.
- Scroll to bottom and try extending the pool date.
- Ensure default value shows up on date input. 
- Ensure form is submitted before the dialog closes.
- Make sure correct date shows up after submission. 