### PR TITLE
change pool seeding + cypress test tweak

### DIFF
--- a/api/database/seeders/PoolSeeder.php
+++ b/api/database/seeders/PoolSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Pool;
 use App\Models\User;
+use App\Models\Classification;
 use Database\Helpers\ApiEnums;
 use Illuminate\Database\Seeder;
 
@@ -50,7 +51,14 @@ class PoolSeeder extends Seeder
             ];
             $poolModel = Pool::where($identifier)->first();
             if (!$poolModel) {
-                Pool::factory()->create($poolData);
+                $createdPool = Pool::factory()->create($poolData);
+                // constrain CMO Digital Careers pool to predictable values
+                if ($identifier['key'] == 'digital_careers') {
+                    $classificationIT01Id = Classification::where('group', 'ilike', 'IT')->where('level', 1)->sole()['id'];
+                    $createdPool->classifications()->sync([$classificationIT01Id]);
+                    $createdPool->stream = ApiEnums::POOL_STREAM_BUSINESS_ADVISORY_SERVICES;
+                    $createdPool->save();
+                }
             } else {
                 $poolModel->update($poolData);
             }

--- a/frontend/cypress/e2e/talentsearch/search-workflows.cy.js
+++ b/frontend/cypress/e2e/talentsearch/search-workflows.cy.js
@@ -27,6 +27,9 @@ describe("Talent Search Workflow Tests", () => {
     cy.findByRole("combobox", { name: /Classification/i }).select(1);
     cy.wait("@gqlCountApplicantsAndCountPoolCandidatesByPoolQuery");
 
+    cy.findByRole("combobox", { name: /Stream/i }).select(1);
+    cy.wait("@gqlCountApplicantsAndCountPoolCandidatesByPoolQuery");
+
     cy.findByRole("radio", {
       name: /Required diploma from post-secondary institution/i,
     }).click();


### PR DESCRIPTION
two things I noticed

first: search workflow would fail sometimes due to chance, for this I constrained the seeded digital careers pool to be more predictable and adjusted the search workflow to look for it

second: stream requirement was merged in with #4864 but this was not reflected in the workflow, and it threw no errors probably due to this line below, I added stream selection into the workflow

![image](https://user-images.githubusercontent.com/40485260/203646048-ca9908a3-3241-4312-b5a6-416b01a3944d.png)

closes #4902 
