### PR TITLE
Bug - 4897 - Fix user table mail links

### DIFF
--- a/frontend/admin/src/js/components/user/UserTable.tsx
+++ b/frontend/admin/src/js/components/user/UserTable.tsx
@@ -128,7 +128,7 @@ const languageAccessor = (
 const emailLinkAccessor = (email: string | null, intl: IntlShape) => {
   if (email) {
     return (
-      <Link
+      <a
         href={`mailto:${email}`}
         title={intl.formatMessage({
           defaultMessage: "Link to user email",
@@ -137,7 +137,7 @@ const emailLinkAccessor = (email: string | null, intl: IntlShape) => {
         })}
       >
         {email}
-      </Link>
+      </a>
     );
   }
   return (

--- a/frontend/admin/src/js/components/user/UserTable.tsx
+++ b/frontend/admin/src/js/components/user/UserTable.tsx
@@ -8,7 +8,6 @@ import { getLanguage } from "@common/constants/localizedConstants";
 import Pending from "@common/components/Pending";
 import printStyles from "@common/constants/printStyles";
 import { useReactToPrint } from "react-to-print";
-import { Link } from "@common/components";
 import { SubmitHandler } from "react-hook-form";
 import { useAdminRoutes } from "../../adminRoutes";
 import {


### PR DESCRIPTION
## 👋 Introduction

This updates the user table mail links to use a normal `<a>` tag rather than the `<Link>` component that is meant for internal links only.

## 🧪 Testing

1. Build admin `npm run production --workspace=admin`
2. Navigate to `/admin/users`
3. Click on the of the email links and confirm it opens your mail client with the proper address

## 🤖 Robot Stuff

Resolves #4897 