### PR TITLE
Bug - 3824 - Table print warn no selection

### DIFF
--- a/frontend/admin/src/js/components/apiManagedTable/TableFooter.tsx
+++ b/frontend/admin/src/js/components/apiManagedTable/TableFooter.tsx
@@ -45,10 +45,10 @@ function TableFooter({
 
   const handlePrint = () => {
     if (disableActions) {
-      toast.warning(
+      toast.error(
         intl.formatMessage({
-          defaultMessage: "No rows selected to print.",
-          id: "H6oeBv",
+          defaultMessage: "Print failed: No rows selected",
+          id: "x/sZcv",
           description:
             "Alert message displayed when a user attempts to print without selecting items first",
         }),

--- a/frontend/admin/src/js/components/apiManagedTable/TableFooter.tsx
+++ b/frontend/admin/src/js/components/apiManagedTable/TableFooter.tsx
@@ -47,8 +47,8 @@ function TableFooter({
     if (disableActions) {
       toast.error(
         intl.formatMessage({
-          defaultMessage: "Print failed: No rows selected",
-          id: "x/sZcv",
+          defaultMessage: "Download failed: No rows selected",
+          id: "k4xm25",
           description:
             "Alert message displayed when a user attempts to print without selecting items first",
         }),
@@ -103,10 +103,10 @@ function TableFooter({
                       onClick={handlePrint}
                     >
                       {intl.formatMessage({
-                        defaultMessage: "Print",
-                        id: "pLCv50",
+                        defaultMessage: "Download Profiles",
+                        id: "UsFTGT",
                         description:
-                          "Text label for button to print items in a table.",
+                          "Text label for button to download items in a table.",
                       })}
                     </Button>
                   </div>

--- a/frontend/admin/src/js/components/apiManagedTable/TableFooter.tsx
+++ b/frontend/admin/src/js/components/apiManagedTable/TableFooter.tsx
@@ -4,6 +4,7 @@ import Pagination from "@common/components/Pagination";
 import Pending from "@common/components/Pending";
 import { Button } from "@common/components";
 import { DownloadCsv, type DownloadCsvProps } from "@common/components/Link";
+import { toast } from "@common/components/Toast";
 import { CombinedError } from "urql";
 import { PaginatorInfo } from "../../api/generated";
 
@@ -41,6 +42,21 @@ function TableFooter({
   selectionError,
 }: TableFooterProps): ReactElement {
   const intl = useIntl();
+
+  const handlePrint = () => {
+    if (disableActions) {
+      toast.warning(
+        intl.formatMessage({
+          defaultMessage: "No rows selected to print.",
+          id: "H6oeBv",
+          description:
+            "Alert message displayed when a user attempts to print without selecting items first",
+        }),
+      );
+    } else if (onPrint) {
+      onPrint();
+    }
+  };
 
   return (
     <div
@@ -83,8 +99,8 @@ function TableFooter({
                       type="button"
                       mode="inline"
                       color="white"
-                      disabled={disableActions}
-                      onClick={onPrint}
+                      data-h2-font-weight="base(400)"
+                      onClick={handlePrint}
                     >
                       {intl.formatMessage({
                         defaultMessage: "Print",

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -2840,5 +2840,9 @@
   "z0QI6A": {
     "defaultMessage": "Tous les candidats du bassin",
     "description": "Title for the admin pool candidates table"
+  },
+  "x/sZcv": {
+    "defaultMessage": "L’impression a échoué : Aucune rangée n’a été sélectionnée",
+    "description": "Alert message displayed when a user attempts to print without selecting items first"
   }
 }

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -2161,8 +2161,8 @@
     "defaultMessage": "Sélection de la rangée",
     "description": "Label for the row-selection column in the tables column-selection modal."
   },
-  "pLCv50": {
-    "defaultMessage": "Imprimer",
+  "UsFTGT": {
+    "defaultMessage": "Télécharger les profils",
     "description": "Text label for button to print items in a table."
   },
   "rkPb6M": {
@@ -2841,8 +2841,8 @@
     "defaultMessage": "Tous les candidats du bassin",
     "description": "Title for the admin pool candidates table"
   },
-  "x/sZcv": {
-    "defaultMessage": "L’impression a échoué : Aucune rangée n’a été sélectionnée",
+  "k4xm25": {
+    "defaultMessage": "Téléchargement a échoué : Aucune rangée n’a été sélectionnée",
     "description": "Alert message displayed when a user attempts to print without selecting items first"
   }
 }

--- a/frontend/common/src/components/Toast/Toast.tsx
+++ b/frontend/common/src/components/Toast/Toast.tsx
@@ -74,12 +74,12 @@ export const toast = {
       icon: <ExclamationTriangleIcon {...iconStyles} />,
       ...options,
     }),
-  warning: (message: React.ReactNode, options: ToastOptions) =>
+  warning: (message: React.ReactNode, options?: ToastOptions) =>
     toastify.warning(<ToastMessage>{message}</ToastMessage>, {
       icon: <ExclamationCircleIcon {...iconStyles} />,
       ...options,
     }),
-  info: (message: React.ReactNode, options: ToastOptions) =>
+  info: (message: React.ReactNode, options?: ToastOptions) =>
     toastify.info(<ToastMessage>{message}</ToastMessage>, {
       icon: <EyeIcon {...iconStyles} />,
       ...options,


### PR DESCRIPTION
## 👋 Introduction

This updates the print button on the api table to show a toast when a user attempts to print with no rows selected. Also, it updates the font weight to match the CSV link.

## 📋 TO DO

- [x] Send off new text for translation
- [x] Add translations

## 🧪 Testing

1. Build admin `npm run production --workspace=admin`
2. Navigate to the users table
3. Click "print" in the footer without selecting rows
4. Confirm toast appears with error message
5. Select from rows and attempt to print again
6. Confirm print window appears

## 🤖 Robot Stuff

Resolves #3824 