### PR TITLE
A11y - 4793 - Fix table sort markup

### DIFF
--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -9,6 +9,8 @@ import {
   useSortBy,
   Column,
   usePagination,
+  TableHeaderProps,
+  HeaderGroup,
 } from "react-table";
 import { Button, Link } from "@common/components";
 import Pagination from "@common/components/Pagination";
@@ -77,6 +79,50 @@ const ButtonIcon: React.FC<{
       style={{ height: "1em", width: "1rem" }}
       data-h2-margin="base(0, x.5, 0, 0)"
     />
+  );
+};
+
+const getSortAttr = (isSorted: boolean, isSortedDesc?: boolean) => {
+  if (!isSorted) {
+    return undefined;
+  }
+
+  return isSortedDesc ? "descending" : "ascending";
+};
+
+interface HeaderWrapperProps<T extends object = {}> {
+  column: HeaderGroup<T>;
+  children: React.ReactNode;
+}
+
+const HeaderWrapper = <T extends object = {}>({
+  column,
+  children,
+}: HeaderWrapperProps<T>) => {
+  if (!column.canSort) {
+    return children as JSX.Element;
+  }
+
+  return (
+    <button
+      {...column.getSortByToggleProps({
+        title: undefined, // Title is unnecessary
+      })}
+      type="button"
+      data-h2-offset="base(0)"
+      data-h2-background-color="base(transparent) base:hover(dt-secondary.lightest) base:focus-visible(focus)"
+      data-h2-color="base(dt-white) base:hover(dt-black)"
+      data-h2-display="base(flex)"
+      data-h2-radius="base(s)"
+      data-h2-padding="base(x.25, x.5)"
+      data-h2-align-items="base(center)"
+      data-h2-text-align="base(left)"
+      data-h2-justify-content="base(space-between)"
+      data-h2-width="base(100%)"
+      data-h2-outline="base(none)"
+    >
+      {children}
+    </button>
   );
 };
 
@@ -237,28 +283,37 @@ function Table<T extends Record<string, unknown>>({
             data-h2-width="base(100%)"
             {...getTableProps()}
           >
+            <caption>
+              <span data-h2-visibility="base(invisible)">
+                {intl.formatMessage({
+                  defaultMessage: "Column headers with buttons are sortable",
+                  id: "/bwX1a",
+                  description:
+                    "Text displayed to instruct users how to sort table rows",
+                })}
+              </span>
+            </caption>
             <thead>
               {headerGroups.map((headerGroup) => (
                 <tr {...headerGroup.getHeaderGroupProps()}>
                   {headerGroup.headers.map((column) => (
                     <th
-                      {...column.getHeaderProps(column.getSortByToggleProps())}
+                      {...column.getHeaderProps()}
                       key={column.id}
                       data-h2-background-color="base(dt-secondary.light)"
-                      data-h2-padding="base(x.5, x1)"
+                      data-h2-padding="base(x.15, x.2)"
+                      title={undefined}
+                      aria-sort={getSortAttr(
+                        column.isSorted,
+                        column.isSortedDesc,
+                      )}
                     >
-                      <span
-                        data-h2-color="base(dt-white)"
-                        data-h2-display="base(flex)"
-                        data-h2-padding="base(x.5, 0)"
-                        data-h2-align-items="base(center)"
-                        data-h2-text-align="base(left)"
-                      >
-                        <span>{column.render("Header")}</span>
+                      <HeaderWrapper column={column}>
+                        {column.render("Header")}
                         {column.isSorted && (
                           <SortIcon isSortedDesc={column.isSortedDesc} />
                         )}
-                      </span>
+                      </HeaderWrapper>
                     </th>
                   ))}
                 </tr>

--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -9,7 +9,6 @@ import {
   useSortBy,
   Column,
   usePagination,
-  TableHeaderProps,
   HeaderGroup,
 } from "react-table";
 import { Button, Link } from "@common/components";
@@ -90,12 +89,12 @@ const getSortAttr = (isSorted: boolean, isSortedDesc?: boolean) => {
   return isSortedDesc ? "descending" : "ascending";
 };
 
-interface HeaderWrapperProps<T extends object = {}> {
+interface HeaderWrapperProps<T extends object> {
   column: HeaderGroup<T>;
   children: React.ReactNode;
 }
 
-const HeaderWrapper = <T extends object = {}>({
+const HeaderWrapper = <T extends object>({
   column,
   children,
 }: HeaderWrapperProps<T>) => {

--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -110,14 +110,13 @@ const HeaderWrapper = <T extends object = {}>({
       })}
       type="button"
       data-h2-offset="base(0)"
-      data-h2-background-color="base(transparent) base:hover(dt-secondary.lightest) base:focus-visible(focus)"
-      data-h2-color="base(dt-white) base:hover(dt-black)"
+      data-h2-background-color="base(transparent) base:hover(dt-secondary.lightest.35) base:focus-visible(focus)"
+      data-h2-color="base(dt-white)"
       data-h2-display="base(flex)"
       data-h2-radius="base(s)"
       data-h2-padding="base(x.25, x.5)"
       data-h2-align-items="base(center)"
       data-h2-text-align="base(left)"
-      data-h2-justify-content="base(space-between)"
       data-h2-width="base(100%)"
       data-h2-outline="base(none)"
     >
@@ -301,7 +300,7 @@ function Table<T extends Record<string, unknown>>({
                       {...column.getHeaderProps()}
                       key={column.id}
                       data-h2-background-color="base(dt-secondary.light)"
-                      data-h2-padding="base(x.15, x.2)"
+                      data-h2-padding="base(x.5, x1)"
                       title={undefined}
                       aria-sort={getSortAttr(
                         column.isSorted,

--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -81,7 +81,10 @@ const ButtonIcon: React.FC<{
   );
 };
 
-const getSortAttr = (isSorted: boolean, isSortedDesc?: boolean) => {
+const getSortAttr = (
+  isSorted: boolean,
+  isSortedDesc?: boolean,
+): React.AriaAttributes["aria-sort"] => {
   if (!isSorted) {
     return undefined;
   }

--- a/frontend/admin/src/js/components/apiManagedTable/BasicTable.tsx
+++ b/frontend/admin/src/js/components/apiManagedTable/BasicTable.tsx
@@ -79,6 +79,16 @@ function BasicTable<T extends RecordWithId>({
       data-h2-max-width="base(100%)"
     >
       <table aria-labelledby={labelledBy} data-h2-width="base(100%)">
+        <caption>
+          <span data-h2-visibility="base(invisible)">
+            {intl.formatMessage({
+              defaultMessage: "Column headers with buttons are sortable",
+              id: "/bwX1a",
+              description:
+                "Text displayed to instruct users how to sort table rows",
+            })}
+          </span>
+        </caption>
         <thead>
           <tr>
             {columns
@@ -103,12 +113,6 @@ function BasicTable<T extends RecordWithId>({
                         disabled={
                           !column.sortColumnName && column.id !== "selection"
                         }
-                        title={intl.formatMessage({
-                          defaultMessage: "Toggle SortBy",
-                          id: "6InelL",
-                          description:
-                            "Title to toggle sorting order of a table",
-                        })}
                         onClick={() => handleColumnSelect(column)}
                       >
                         {label}

--- a/frontend/admin/src/js/components/apiManagedTable/BasicTable.tsx
+++ b/frontend/admin/src/js/components/apiManagedTable/BasicTable.tsx
@@ -107,9 +107,14 @@ function BasicTable<T extends RecordWithId>({
                       <Button
                         data-h2-display="base(flex)"
                         data-h2-align-items="base(center)"
+                        data-h2-background-color="base(transparent) base:hover(dt-secondary.lightest.35) base:focus-visible(focus)"
+                        data-h2-color="base(dt-white)"
+                        data-h2-outline="base(none)"
+                        data-h2-padding="base(x.25, x.5)"
                         type="button"
                         mode="tableHeader"
                         color="secondary"
+                        block
                         disabled={
                           !column.sortColumnName && column.id !== "selection"
                         }

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -2840,5 +2840,9 @@
   "z0QI6A": {
     "defaultMessage": "Tous les candidats du bassin",
     "description": "Title for the admin pool candidates table"
+  },
+  "/bwX1a": {
+    "defaultMessage": "Il est possible de trier les en-têtes de colonnes avec boutons",
+    "description": "Text displayed to instruct users how to sort table rows"
   }
 }


### PR DESCRIPTION
## 👋 Introduction

This follows the [ARIA Authoring Practices Guideline for Sortable Tables](https://www.w3.org/WAI/ARIA/apg/example-index/table/sortable-table) to improve the a11y for our `<Table>` components sort logic.

## 🕵️ Details

- Adds `<caption>` with help text describing sorting
- Adds an `aria-sort` property to the table headers to indicate the sort order
- Adds a `<button>` element and moves sort props to the button
- Updates the styling to show `:hover` and `:focus-visible` styles
- Removes the `title` attribute

## 🧪 Testing

1. Build admin `npm run production --workspace=admin`
2. Navigate to the `/fr/dashboard`
3. Inspect the table and ensure the English text is no longer present (`th[title="Toggle SortBy"]`)
4. Ensure the caption is present
5. Ensure `:hover` and `:focus-visible` styles are present
6. Ensure the `th[aria-sort]` attribute works as expected

## 🤖 Robot Stuff

Resolves #4793 