### PR TITLE
Bug - 4820 - Throw 404 on pool advertisement page error

### DIFF
--- a/frontend/common/src/helpers/util.ts
+++ b/frontend/common/src/helpers/util.ts
@@ -119,20 +119,3 @@ export const emptyToUndefined = (s: InputMaybe<string>): string | undefined =>
 export function uniqueItems<T>(arr: T[]): T[] {
   return Array.from(new Set(arr));
 }
-
-/**
- * Determines if a given string is a UUID
- *
- * @param id  string  ID to test
- * @returns   boolean If the string is a UUID
- */
-export function isUUID(id?: string): boolean {
-  // IDs from router can be undefined
-  if (!id) return false;
-
-  // Regular expression to check if string is a valid UUID
-  const regexExp =
-    /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
-
-  return regexExp.test(id);
-}

--- a/frontend/common/src/helpers/util.ts
+++ b/frontend/common/src/helpers/util.ts
@@ -119,3 +119,20 @@ export const emptyToUndefined = (s: InputMaybe<string>): string | undefined =>
 export function uniqueItems<T>(arr: T[]): T[] {
   return Array.from(new Set(arr));
 }
+
+/**
+ * Determines if a given string is a UUID
+ *
+ * @param id  string  ID to test
+ * @returns   boolean If the string is a UUID
+ */
+export function isUUID(id?: string): boolean {
+  // IDs from router can be undefined
+  if (!id) return false;
+
+  // Regular expression to check if string is a valid UUID
+  const regexExp =
+    /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
+
+  return regexExp.test(id);
+}

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -821,6 +821,20 @@ export const PoolAdvertisementPoster = ({
   );
 };
 
+const PoolNotFound = () => {
+  const intl = useIntl();
+
+  return (
+    <ThrowNotFound
+      message={intl.formatMessage({
+        defaultMessage: "Error, pool unable to be loaded",
+        id: "DcEinN",
+        description: "Error message, placeholder",
+      })}
+    />
+  );
+};
+
 type RouteParams = {
   poolId: Scalars["ID"];
 };
@@ -844,6 +858,10 @@ const PoolAdvertisementPage = () => {
     (candidate) => candidate?.pool.id === data.poolAdvertisement?.id,
   );
 
+  if (error) {
+    return <PoolNotFound />;
+  }
+
   return (
     <Pending fetching={fetching} error={error}>
       {data?.poolAdvertisement && isVisible ? (
@@ -853,13 +871,7 @@ const PoolAdvertisementPage = () => {
           hasApplied={notEmpty(application?.submittedAt)}
         />
       ) : (
-        <ThrowNotFound
-          message={intl.formatMessage({
-            defaultMessage: "Error, pool unable to be loaded",
-            id: "DcEinN",
-            description: "Error message, placeholder",
-          })}
-        />
+        <PoolNotFound />
       )}
     </Pending>
   );

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -31,7 +31,7 @@ import {
   getSecurityClearance,
 } from "@common/constants/localizedConstants";
 import { categorizeSkill } from "@common/helpers/skillUtils";
-import { isUUID, notEmpty } from "@common/helpers/util";
+import { notEmpty } from "@common/helpers/util";
 import {
   formatClassificationString,
   getFullPoolAdvertisementTitle,
@@ -842,14 +842,12 @@ type RouteParams = {
 const PoolAdvertisementPage = () => {
   const { poolId } = useParams<RouteParams>();
   const auth = React.useContext(AuthorizationContext);
-  const isValidId = isUUID(poolId);
 
   const [{ data, fetching, error }] = useGetPoolAdvertisementQuery({
     variables: { id: poolId || "" },
-    pause: !isValidId, // Don't run query if we don't have a valid ID
   });
 
-  if (!isValidId) {
+  if (error) {
     return <PoolNotFound />;
   }
 

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -840,7 +840,6 @@ type RouteParams = {
 };
 
 const PoolAdvertisementPage = () => {
-  const intl = useIntl();
   const { poolId } = useParams<RouteParams>();
   const auth = React.useContext(AuthorizationContext);
 

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -31,7 +31,7 @@ import {
   getSecurityClearance,
 } from "@common/constants/localizedConstants";
 import { categorizeSkill } from "@common/helpers/skillUtils";
-import { notEmpty } from "@common/helpers/util";
+import { isUUID, notEmpty } from "@common/helpers/util";
 import {
   formatClassificationString,
   getFullPoolAdvertisementTitle,
@@ -842,10 +842,16 @@ type RouteParams = {
 const PoolAdvertisementPage = () => {
   const { poolId } = useParams<RouteParams>();
   const auth = React.useContext(AuthorizationContext);
+  const isValidId = isUUID(poolId);
 
   const [{ data, fetching, error }] = useGetPoolAdvertisementQuery({
     variables: { id: poolId || "" },
+    pause: !isValidId, // Don't run query if we don't have a valid ID
   });
+
+  if (!isValidId) {
+    return <PoolNotFound />;
+  }
 
   const isVisible = isAdvertisementVisible(
     auth?.loggedInUserRoles?.filter(notEmpty) || [],
@@ -856,10 +862,6 @@ const PoolAdvertisementPage = () => {
   const application = data?.me?.poolCandidates?.find(
     (candidate) => candidate?.pool.id === data.poolAdvertisement?.id,
   );
-
-  if (error) {
-    return <PoolNotFound />;
-  }
 
   return (
     <Pending fetching={fetching} error={error}>


### PR DESCRIPTION
## 👋 Introduction

This returns 404 if there is an error loading the pool on the `/browse/pools/{poolId}` page.

> **Note**
> This may be too generic since it happens on any error, thoughts?

> **Note**
> This may be an issue on other pages also. We should maybe sweep through the pages and make sure we throw errors when necessary.

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Navigtate to `/browse/pools/anything-but-a-vaild-id`
3. Confirm you see the 404 page

## 🤖 Robot Stuff

Resolves #4820 