### PR TITLE
a11y - 4913 - Adjust admin heading ranks

### DIFF
--- a/frontend/admin/src/js/components/classification/CreateClassification.tsx
+++ b/frontend/admin/src/js/components/classification/CreateClassification.tsx
@@ -6,6 +6,7 @@ import { useIntl } from "react-intl";
 import { Input, Select, Submit } from "@common/components/form";
 import { toast } from "@common/components/Toast";
 import { errorMessages } from "@common/messages";
+import Heading from "@common/components/Heading/Heading";
 import {
   CreateClassificationInput,
   useCreateClassificationMutation,
@@ -61,13 +62,13 @@ export const CreateClassificationForm: React.FunctionComponent<
   };
   return (
     <section data-h2-container="base(left, s)">
-      <h2 data-h2-font-weight="base(700)" data-h2-padding="base(x2, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Create Classification",
           id: "D8Pgbs",
           description: "Title displayed on the create a classification form.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/admin/src/js/components/classification/UpdateClassification.tsx
+++ b/frontend/admin/src/js/components/classification/UpdateClassification.tsx
@@ -10,6 +10,7 @@ import { Input, Select, Submit } from "@common/components/form";
 import { errorMessages, commonMessages } from "@common/messages";
 import Pending from "@common/components/Pending";
 import NotFound from "@common/components/NotFound";
+import Heading from "@common/components/Heading/Heading";
 
 import { useAdminRoutes } from "../../adminRoutes";
 import {
@@ -77,13 +78,13 @@ export const UpdateClassificationForm: React.FunctionComponent<
   };
   return (
     <section data-h2-container="base(left, s)">
-      <h2 data-h2-font-weight="base(700)" data-h2-padding="base(x2, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Update Classification",
           id: "U+WqrO",
           description: "Title displayed on the update a classification form.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/admin/src/js/components/cmoAsset/CreateCmoAsset.tsx
+++ b/frontend/admin/src/js/components/cmoAsset/CreateCmoAsset.tsx
@@ -7,6 +7,7 @@ import { toast } from "@common/components/Toast";
 import { Input, Submit, TextArea } from "@common/components/form";
 import { errorMessages } from "@common/messages";
 import { keyStringRegex } from "@common/constants/regularExpressions";
+import Heading from "@common/components/Heading/Heading";
 
 import { useAdminRoutes } from "../../adminRoutes";
 import {
@@ -55,13 +56,13 @@ export const CreateCmoAssetForm: React.FunctionComponent<
   };
   return (
     <section data-h2-container="base(left, s)">
-      <h2 data-h2-font-weight="base(700)" data-h2-padding="base(x2, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Create CMO Asset",
           id: "MpB5zS",
           description: "Title displayed on the create a cmo asset form.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/admin/src/js/components/cmoAsset/UpdateCmoAsset.tsx
+++ b/frontend/admin/src/js/components/cmoAsset/UpdateCmoAsset.tsx
@@ -9,6 +9,7 @@ import { Input, Submit, TextArea } from "@common/components/form";
 import { errorMessages, commonMessages } from "@common/messages";
 import Pending from "@common/components/Pending";
 import NotFound from "@common/components/NotFound";
+import Heading from "@common/components/Heading/Heading";
 
 import { useAdminRoutes } from "../../adminRoutes";
 import {
@@ -61,13 +62,13 @@ export const UpdateCmoAssetForm: React.FunctionComponent<
   };
   return (
     <section data-h2-container="base(left, s)">
-      <h2 data-h2-font-weight="base(700)" data-h2-padding="base(x2, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Update CMO Asset",
           id: "5JRGJY",
           description: "Title displayed on the update a cmo asset form.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/admin/src/js/components/department/CreateDepartment.tsx
+++ b/frontend/admin/src/js/components/department/CreateDepartment.tsx
@@ -6,6 +6,7 @@ import { useIntl } from "react-intl";
 import { toast } from "@common/components/Toast";
 import { Input, Submit } from "@common/components/form";
 import { errorMessages } from "@common/messages";
+import Heading from "@common/components/Heading/Heading";
 
 import { useAdminRoutes } from "../../adminRoutes";
 import {
@@ -62,13 +63,13 @@ export const CreateDepartmentForm: React.FunctionComponent<
 
   return (
     <section data-h2-container="base(left, s)">
-      <h2 data-h2-font-weight="base(700)" data-h2-padding="base(x2, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Create Department",
           id: "XBY4Fq",
           description: "Title displayed on the create a department form.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/admin/src/js/components/department/UpdateDepartment.tsx
+++ b/frontend/admin/src/js/components/department/UpdateDepartment.tsx
@@ -9,6 +9,7 @@ import { Input, Submit } from "@common/components/form";
 import { errorMessages, commonMessages } from "@common/messages";
 import Pending from "@common/components/Pending";
 import NotFound from "@common/components/NotFound";
+import Heading from "@common/components/Heading/Heading";
 
 import { useAdminRoutes } from "../../adminRoutes";
 import {
@@ -75,13 +76,13 @@ export const UpdateDepartmentForm: React.FunctionComponent<
 
   return (
     <section data-h2-container="base(left, s)">
-      <h2 data-h2-font-weight="base(700)" data-h2-padding="base(x2, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Update Department",
           id: "KSNNgE",
           description: "Title displayed on the update a department form.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/admin/src/js/components/pool/EditPool/AssetSkillsSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/AssetSkillsSection.tsx
@@ -79,6 +79,7 @@ export const AssetSkillsSection = ({
             skills={skills}
             onUpdateSelectedSkills={handleChangeSelectedSkills}
             handleSave={handleSave}
+            headingLevel="h3"
             submitButtonText={intl.formatMessage({
               defaultMessage: "Save asset skills",
               id: "j4G/wv",

--- a/frontend/admin/src/js/components/pool/EditPool/EssentialSkillsSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/EssentialSkillsSection.tsx
@@ -78,6 +78,7 @@ export const EssentialSkillsSection = ({
             skills={skills}
             onUpdateSelectedSkills={handleChangeSelectedSkills}
             handleSave={handleSave}
+            headingLevel="h3"
             submitButtonText={intl.formatMessage({
               defaultMessage: "Save essential skills",
               id: "2asU3k",

--- a/frontend/admin/src/js/components/pool/deprecated/CreatePool.tsx
+++ b/frontend/admin/src/js/components/pool/deprecated/CreatePool.tsx
@@ -21,6 +21,7 @@ import {
   OperationalRequirementV2,
 } from "@common/constants/localizedConstants";
 import Pending from "@common/components/Pending";
+import Heading from "@common/components/Heading/Heading";
 
 import { useAdminRoutes } from "../../../adminRoutes";
 import {
@@ -135,13 +136,13 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
 
   return (
     <section data-h2-container="base(left, small, 0)">
-      <h2 data-h2-font-weight="base(700)" data-h2-margin="base(x3, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Create Pool",
           id: "ekKb+G",
           description: "Title displayed on the create a pool form.",
         })}
-      </h2>
+      </Heading>
       <div data-h2-margin="base(x2, 0, 0, 0)">
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/admin/src/js/components/pool/deprecated/UpdatePool.tsx
+++ b/frontend/admin/src/js/components/pool/deprecated/UpdatePool.tsx
@@ -23,6 +23,7 @@ import {
 } from "@common/constants/localizedConstants";
 import Pending from "@common/components/Pending";
 import NotFound from "@common/components/NotFound";
+import Heading from "@common/components/Heading/Heading";
 
 import { useAdminRoutes } from "../../../adminRoutes";
 import {
@@ -160,13 +161,13 @@ export const UpdatePoolForm: React.FunctionComponent<UpdatePoolFormProps> = ({
 
   return (
     <section data-h2-container="base(left, small, 0)">
-      <h2 data-h2-font-weight="base(700)" data-h2-padding="base(x2, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Update Pool",
           id: "H5EJq1",
           description: "Title displayed on the update a pool form.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/CreatePoolCandidate.tsx
@@ -31,6 +31,7 @@ import {
 } from "@common/constants/localizedConstants";
 import { commonMessages, errorMessages } from "@common/messages";
 import Pending from "@common/components/Pending";
+import Heading from "@common/components/Heading/Heading";
 
 import { useAdminRoutes } from "../../adminRoutes";
 import {
@@ -356,27 +357,23 @@ export const CreatePoolCandidateForm: React.FunctionComponent<
 
   return (
     <section data-h2-container="base(left, s)">
-      <h2 data-h2-font-weight="base(700)" data-h2-padding="base(x2, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Create Pool Candidate",
           id: "SqZuQS",
           description: "Title displayed on the create a user form.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>
-            <h3
-              data-h2-font-size="base(h4)"
-              data-h2-font-weight="base(300)"
-              data-h2-margin="base(x2, 0, x1, 0)"
-            >
+            <Heading level="h2" size="h4">
               {intl.formatMessage({
                 description: "Heading for the user information section",
                 defaultMessage: "User Information",
                 id: "mv+9jt",
               })}
-            </h3>
+            </Heading>
             <RadioGroup
               idPrefix="userMode"
               legend="User Assignment"
@@ -406,17 +403,13 @@ export const CreatePoolCandidateForm: React.FunctionComponent<
               }}
             />
             <UserFormSection control={control} userOptions={userOptions} />
-            <h3
-              data-h2-font-size="base(h4)"
-              data-h2-font-weight="base(300)"
-              data-h2-margin="base(x2, 0, x1, 0)"
-            >
+            <Heading level="h2" size="h4">
               {intl.formatMessage({
                 description: "Heading for the candidate information section",
                 defaultMessage: "Candidate Information",
                 id: "1THfui",
               })}
-            </h3>
+            </Heading>
             <Select
               id="pool"
               label={intl.formatMessage({

--- a/frontend/admin/src/js/components/poolCandidate/UpdatePoolCandidate.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/UpdatePoolCandidate.tsx
@@ -12,6 +12,7 @@ import {
   MultiSelect,
   Checkbox,
 } from "@common/components/form";
+import Heading from "@common/components/Heading/Heading";
 import { notEmpty } from "@common/helpers/util";
 import {
   unpackIds,
@@ -173,27 +174,23 @@ export const UpdatePoolCandidateForm: React.FunctionComponent<
 
   return (
     <section data-h2-container="base(left, s)">
-      <h2 data-h2-font-weight="base(700)" data-h2-padding="base(x2, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Update Pool Candidate",
           id: "cy2UdP",
           description: "Title displayed on the update a user form.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>
-            <h3
-              data-h2-font-size="base(h4)"
-              data-h2-font-weight="base(300)"
-              data-h2-margin="base(x2, 0, x1, 0)"
-            >
+            <Heading level="h2" size="h4">
               {intl.formatMessage({
                 description: "Heading for the user information section",
                 defaultMessage: "User Information",
                 id: "mv+9jt",
               })}
-            </h3>
+            </Heading>
             <Input
               id="email"
               label={intl.formatMessage({
@@ -263,17 +260,13 @@ export const UpdatePoolCandidateForm: React.FunctionComponent<
                 label: intl.formatMessage(getLanguage(value)),
               }))}
             />
-            <h3
-              data-h2-font-size="base(h4)"
-              data-h2-font-weight="base(300)"
-              data-h2-margin="base(x2, 0, x1, 0)"
-            >
+            <Heading level="h2" size="h4">
               {intl.formatMessage({
                 description: "Heading for the candidate information section",
                 defaultMessage: "Candidate Information",
                 id: "1THfui",
               })}
-            </h3>
+            </Heading>
             <Input
               id="cmoIdentifier"
               label={intl.formatMessage({

--- a/frontend/admin/src/js/components/searchRequest/SingleSearchRequest.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SingleSearchRequest.tsx
@@ -9,6 +9,7 @@ import Pending from "@common/components/Pending";
 import NotFound from "@common/components/NotFound";
 import { formatDate, parseDateTimeUtc } from "@common/helpers/dateUtils";
 import { getFullPoolAdvertisementTitle } from "@common/helpers/poolUtils";
+import Heading from "@common/components/Heading/Heading";
 import {
   PoolCandidateSearchRequest,
   useGetPoolCandidateSearchRequestQuery,
@@ -41,17 +42,14 @@ const ManagerInfo: React.FunctionComponent<{
 
   return (
     <>
-      <h2
-        data-h2-margin="base(x2, 0, x.5, 0)"
-        data-h2-font-size="base(h4, 1.3)"
-      >
+      <Heading level="h2" size="h4">
         {intl.formatMessage({
           defaultMessage: "Manager Information",
           id: "UEsexn",
           description:
             "Heading for the manager info section of the single search request view.",
         })}
-      </h2>
+      </Heading>
       <div data-h2-background-color="base(lightest.dt-gray)">
         <div data-h2-padding="base(x1)">
           <div
@@ -249,17 +247,14 @@ export const SingleSearchRequest: React.FunctionComponent<
       </p>
       <ManagerInfo searchRequest={searchRequest} />
       <div>
-        <h2
-          data-h2-margin="base(x2, 0, x.5, 0)"
-          data-h2-font-size="base(h4, 1.3)"
-        >
+        <Heading level="h2" size="h4">
           {intl.formatMessage({
             defaultMessage: "Request Information",
             id: "AAmd5G",
             description:
               "Heading for the request information section of the single search request view.",
           })}
-        </h2>
+        </Heading>
         <div
           data-h2-padding="base(x1)"
           data-h2-background-color="base(lightest.dt-gray)"
@@ -283,17 +278,14 @@ export const SingleSearchRequest: React.FunctionComponent<
         </div>
       </div>
       <div>
-        <h2
-          data-h2-margin="base(x2, 0, 0, 0)"
-          data-h2-font-size="base(h4, 1.3)"
-        >
+        <Heading level="h2" size="h4">
           {intl.formatMessage({
             defaultMessage: "Candidate Results",
             id: "Duswz0",
             description:
               "Heading for the candidate results section of the single search request view.",
           })}
-        </h2>
+        </Heading>
         {abstractFilter ? (
           <SingleSearchRequestTableApi filter={abstractFilter} />
         ) : (

--- a/frontend/admin/src/js/components/searchRequest/SingleSearchRequestPage.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SingleSearchRequestPage.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useParams } from "react-router-dom";
+
+import Heading from "@common/components/Heading/Heading";
+
 import { Scalars } from "../../api/generated";
 import { SingleSearchRequestApi } from "./SingleSearchRequest";
 
@@ -16,18 +19,14 @@ export const SingleSearchRequestPage = () => {
       <div data-h2-padding="base(0, 0, x3, 0)">
         <div data-h2-container="base(center, large, x2)">
           <header>
-            <h1
-              data-h2-font-weight="base(400)"
-              data-h2-margin="base(x2, 0, x1, 0)"
-              style={{ letterSpacing: "-2px" }}
-            >
+            <Heading level="h1" size="h2">
               {intl.formatMessage({
                 defaultMessage: "View Request",
                 id: "HkC8XB",
                 description:
                   "Heading displayed above the single search request component.",
               })}
-            </h1>
+            </Heading>
           </header>
           <SingleSearchRequestApi searchRequestId={searchRequestId || ""} />
         </div>

--- a/frontend/admin/src/js/components/searchRequest/UpdateSearchRequest.tsx
+++ b/frontend/admin/src/js/components/searchRequest/UpdateSearchRequest.tsx
@@ -7,6 +7,7 @@ import { PoolCandidateSearchRequest } from "@common/api/generated";
 import { Button } from "@common/components";
 import { Submit, TextArea } from "@common/components/form";
 import { toast } from "@common/components/Toast";
+import Heading from "@common/components/Heading/Heading";
 
 import { useAdminRoutes } from "../../adminRoutes";
 import {
@@ -95,17 +96,14 @@ export const UpdateSearchRequestForm: React.FunctionComponent<
 
   return (
     <section>
-      <h2
-        data-h2-margin="base(x2, 0, x.5, 0)"
-        data-h2-font-size="base(h4, 1.3)"
-      >
+      <Heading level="h2" size="h4">
         {intl.formatMessage({
           defaultMessage: "Personal Notes",
           id: "l05aVF",
           description:
             "Heading for the personal notes section of the single search request view.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(handleStatusChangeToDone)}>

--- a/frontend/admin/src/js/components/skill/CreateSkill.tsx
+++ b/frontend/admin/src/js/components/skill/CreateSkill.tsx
@@ -11,6 +11,7 @@ import { notEmpty } from "@common/helpers/util";
 import { keyStringRegex } from "@common/constants/regularExpressions";
 import { errorMessages } from "@common/messages";
 import Pending from "@common/components/Pending";
+import Heading from "@common/components/Heading/Heading";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Skill,
@@ -112,13 +113,13 @@ export const CreateSkillForm: React.FunctionComponent<CreateSkillFormProps> = ({
 
   return (
     <section data-h2-container="base(left, s)">
-      <h2 data-h2-font-weight="base(700)" data-h2-padding="base(x2, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Create Skill",
           id: "qZd17O",
           description: "Title displayed on the create a skill form.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/admin/src/js/components/skill/UpdateSkill.tsx
+++ b/frontend/admin/src/js/components/skill/UpdateSkill.tsx
@@ -13,6 +13,7 @@ import { unpackIds } from "@common/helpers/formUtils";
 import { errorMessages, commonMessages } from "@common/messages";
 import Pending from "@common/components/Pending";
 import NotFound from "@common/components/NotFound";
+import Heading from "@common/components/Heading/Heading";
 
 import { useAdminRoutes } from "../../adminRoutes";
 import {
@@ -131,13 +132,13 @@ export const UpdateSkillForm: React.FunctionComponent<UpdateSkillFormProps> = ({
 
   return (
     <section data-h2-container="base(left, s)">
-      <h2 data-h2-font-weight="base(700)" data-h2-padding="base(x2, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Update Skill",
           id: "WoAuKA",
           description: "Title displayed on the update a skill form.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/admin/src/js/components/skillFamily/CreateSkillFamily.tsx
+++ b/frontend/admin/src/js/components/skillFamily/CreateSkillFamily.tsx
@@ -18,6 +18,7 @@ import { enumToOptions } from "@common/helpers/formUtils";
 import { errorMessages } from "@common/messages";
 import { getSkillCategory } from "@common/constants/localizedConstants";
 import Pending from "@common/components/Pending";
+import Heading from "@common/components/Heading/Heading";
 
 import { useAdminRoutes } from "../../adminRoutes";
 import {
@@ -107,13 +108,13 @@ export const CreateSkillFamilyForm: React.FunctionComponent<
 
   return (
     <section data-h2-container="base(left, s)">
-      <h2 data-h2-font-weight="base(700)" data-h2-padding="base(x2, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Create Skill Family",
           id: "5Al53V",
           description: "Title displayed on the create a skill family form.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/admin/src/js/components/skillFamily/UpdateSkillFamily.tsx
+++ b/frontend/admin/src/js/components/skillFamily/UpdateSkillFamily.tsx
@@ -21,6 +21,7 @@ import { errorMessages, commonMessages } from "@common/messages";
 import { getSkillCategory } from "@common/constants/localizedConstants";
 import Pending from "@common/components/Pending";
 import NotFound from "@common/components/NotFound";
+import Heading from "@common/components/Heading/Heading";
 import { useAdminRoutes } from "../../adminRoutes";
 import {
   Skill,
@@ -122,13 +123,13 @@ export const UpdateSkillFamilyForm: React.FunctionComponent<
 
   return (
     <section data-h2-container="base(left, s)">
-      <h2 data-h2-font-weight="base(700)" data-h2-padding="base(x2, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Update Skill Family",
           id: "GQskY1",
           description: "Title displayed on the update a skillFamily form.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/admin/src/js/components/user/CreateUser.tsx
+++ b/frontend/admin/src/js/components/user/CreateUser.tsx
@@ -9,6 +9,7 @@ import { enumToOptions } from "@common/helpers/formUtils";
 import { getLanguage, getRole } from "@common/constants/localizedConstants";
 import { errorMessages } from "@common/messages";
 import { emptyToNull, emptyToUndefined } from "@common/helpers/util";
+import Heading from "@common/components/Heading/Heading";
 
 import { useAdminRoutes } from "../../adminRoutes";
 import {
@@ -72,13 +73,13 @@ export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
 
   return (
     <section data-h2-container="base(left, s)">
-      <h2 data-h2-font-weight="base(700)" data-h2-padding="base(x2, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Create User",
           id: "/uqLeF",
           description: "Title displayed on the create a user form.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/admin/src/js/components/user/UpdateUser.tsx
+++ b/frontend/admin/src/js/components/user/UpdateUser.tsx
@@ -12,6 +12,7 @@ import { getLanguage, getRole } from "@common/constants/localizedConstants";
 import { emptyToNull } from "@common/helpers/util";
 import NotFound from "@common/components/NotFound";
 import Pending from "@common/components/Pending";
+import Heading from "@common/components/Heading/Heading";
 
 import { useAdminRoutes } from "../../adminRoutes";
 import {
@@ -97,13 +98,13 @@ export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
 
   return (
     <section data-h2-container="base(left, s)">
-      <h2 data-h2-font-weight="base(700)" data-h2-padding="base(x2, 0, x1, 0)">
+      <Heading level="h1" size="h2">
         {intl.formatMessage({
           defaultMessage: "Update User",
           id: "DguVoT",
           description: "Title displayed on the update a user form.",
         })}
-      </h2>
+      </Heading>
       <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)}>


### PR DESCRIPTION
## 👋 Introduction

This updates the headings on the admin app to meet the [guidelines for heading ranks](https://www.w3.org/WAI/tutorials/page-structure/headings/#heading-ranks).

## 🧪 Testing

> **Note**
> The [axe Browser Extension](https://www.deque.com/axe/browser-extensions/) will be very helpful here

1. Build admin `npm run production --workspace=admin`
2. Navite to every page in admin
3. Ensure each page starts with a `<h1>` and headings only increase by one at a time

## 🤖 Robot Stuff

Resolves #4913 