### PR TITLE
Bug - 4905 - Indicate saving state, extend dialog

### DIFF
--- a/frontend/admin/src/js/components/pool/EditPool/ExtendDialog.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/ExtendDialog.tsx
@@ -5,7 +5,7 @@ import { PoolAdvertisement } from "@common/api/generated";
 import { Button } from "@common/components";
 import { FormProvider, useForm } from "react-hook-form";
 import { Input } from "@common/components/form";
-import { errorMessages } from "@common/messages";
+import { commonMessages, errorMessages } from "@common/messages";
 import { currentDate } from "@common/helpers/formUtils";
 import { convertDateTimeZone } from "@common/helpers/dateUtils";
 import { type UpdatePoolAdvertisementInput } from "../../../api/generated";
@@ -53,35 +53,11 @@ const ExtendDialog = ({
     },
   });
 
-  const { handleSubmit } = methods;
-  const Footer = React.useMemo(
-    () => (
-      <>
-        <div style={{ flexGrow: 2 } /* push other div to the right */}>
-          <Dialog.Close>
-            <Button mode="outline" color="secondary">
-              {intl.formatMessage({
-                defaultMessage: "Cancel and go back",
-                id: "tiF/jI",
-                description: "Close dialog button",
-              })}
-            </Button>
-          </Dialog.Close>
-        </div>
-        <div>
-          <Button mode="solid" color="secondary" type="submit">
-            {intl.formatMessage({
-              defaultMessage: "Extend closing date",
-              id: "OIk63O",
-              description:
-                "Button to extend the pool closing date in the extend pool closing date dialog",
-            })}
-          </Button>
-        </div>
-      </>
-    ),
-    [intl],
-  );
+  const {
+    handleSubmit,
+    formState: { isSubmitting },
+  } = methods;
+
   return (
     <Dialog.Root open={open} onOpenChange={setOpen}>
       <Dialog.Trigger>
@@ -136,7 +112,36 @@ const ExtendDialog = ({
                 },
               }}
             />
-            <Dialog.Footer>{Footer}</Dialog.Footer>
+            <Dialog.Footer>
+              <div style={{ flexGrow: 2 } /* push other div to the right */}>
+                <Dialog.Close>
+                  <Button mode="outline" color="secondary">
+                    {intl.formatMessage({
+                      defaultMessage: "Cancel and go back",
+                      id: "tiF/jI",
+                      description: "Close dialog button",
+                    })}
+                  </Button>
+                </Dialog.Close>
+              </div>
+              <div>
+                <Button
+                  mode="solid"
+                  color="secondary"
+                  type="submit"
+                  disabled={isSubmitting}
+                >
+                  {isSubmitting
+                    ? intl.formatMessage(commonMessages.saving)
+                    : intl.formatMessage({
+                        defaultMessage: "Extend closing date",
+                        id: "OIk63O",
+                        description:
+                          "Button to extend the pool closing date in the extend pool closing date dialog",
+                      })}
+                </Button>
+              </div>
+            </Dialog.Footer>
           </form>
         </FormProvider>
       </Dialog.Content>


### PR DESCRIPTION
## 👋 Introduction

This uses `formState.isSubmitting` to disable the save button and update its text to indicate to users the form is in the process of saving. It also removes the `useMemo` from the footer which cause preventing the button from reliably updating.

## 🧪 Testing

1. Build admin `npm run production --workspace=admin`
2. Navigate to a published pool edit page
3. Open the Extend date dialog and submit the form
4. Ensure the button is disabled and reads "Saving..."
5. Ensure it returns to normal state and dialog closes

## 🤖 Robot Stuff

Resolves #4905 