### PR TITLE
Debt - 4646 - Remove error log to do comment

### DIFF
--- a/frontend/common/src/components/ClientProvider/ClientProvider.tsx
+++ b/frontend/common/src/components/ClientProvider/ClientProvider.tsx
@@ -214,16 +214,8 @@ const ClientProvider: React.FC<{ client?: Client }> = ({
         url: apiUri,
         requestPolicy: "cache-and-network",
         exchanges: [
-          /**
-           * Commented out to stop urql errors being displayed in toasts
-           *
-           * TODO: Confirm errors are being logged on the server
-           * before removing console.error
-           */
           errorExchange({
             onError: (error: CombinedError) => {
-              // toast.error(error.message);
-
               const validationErrorMessages =
                 extractValidationErrorMessages(error);
               const validationErrorMessageNode =


### PR DESCRIPTION
## 👋 Introduction

This removed the comment about removing the `console.error(err)` from our client provider. Decision was made to keep the log. Also, removed the unused toast line.

## 🧪 Testing

1. Make sure the comment has been removed 😄 

## 🤖 Robot Stuff

Resolves #4646 