### PR TITLE
Remove strings from fr.json not in en.json

### DIFF
--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -47,10 +47,6 @@
     "defaultMessage": "Identifiant du candidat",
     "description": "Title displayed on the single search request table id column."
   },
-  "29OmCu": {
-    "defaultMessage": "Expiration",
-    "description": "Title displayed for the Pool Candidates table Expiry column."
-  },
   "2wmzS1": {
     "defaultMessage": "Nom",
     "description": "Title displayed for the Department table Name column."
@@ -119,10 +115,6 @@
     "defaultMessage": "Gestionnaire",
     "description": "Title displayed on the search request table manager column."
   },
-  "7SWIeC": {
-    "defaultMessage": "Femme",
-    "description": "Title displayed for the Pool Candidates table Woman column."
-  },
   "7d/ot8": {
     "defaultMessage": "Basculer tout",
     "description": "Label displayed on the Table Columns toggle fieldset."
@@ -134,14 +126,6 @@
   "7wYPgC": {
     "defaultMessage": "Nom (anglais)",
     "description": "Label displayed on the classification form name (English) field."
-  },
-  "8AbNBq": {
-    "defaultMessage": "Bassin de candidats",
-    "description": "Heading displayed above the Pool Candidate Table component."
-  },
-  "8Hw3Zf": {
-    "defaultMessage": "Utilisateur",
-    "description": "Title displayed for the Pool Candidates table User column."
   },
   "8L5kDc": {
     "defaultMessage": "Téléphone",
@@ -195,17 +179,9 @@
     "defaultMessage": "Clé",
     "description": "Label displayed on the create a cmo asset form key field."
   },
-  "Bu20w5": {
-    "defaultMessage": "Minorité visible",
-    "description": "Title displayed for the Pool Candidates table Visible Minority column."
-  },
   "CcOlo0": {
     "defaultMessage": "Clé",
     "description": "Title displayed for the CMO Asset table Key column."
-  },
-  "CdXStL": {
-    "defaultMessage": "Téléphone",
-    "description": "Title displayed on the Pool Candidates table telephone column."
   },
   "D2DUgE": {
     "defaultMessage": "Sélectionner un ou plusieurs actifs du BGC...",
@@ -259,10 +235,6 @@
     "defaultMessage": "Ministère mis à jour avec succès!",
     "description": "Message displayed to user after department is updated successfully."
   },
-  "GZ7CVk": {
-    "defaultMessage": "Compétence linguistique",
-    "description": "Title displayed for the Pool Candidates table Language Ability column."
-  },
   "H5EJq1": {
     "defaultMessage": "Mettre à jour un bassin",
     "description": "Title displayed on the update a pool form."
@@ -294,14 +266,6 @@
   "Htqzxb": {
     "defaultMessage": "Bassin",
     "description": "Title displayed on the search request table pool column."
-  },
-  "IIX75o": {
-    "defaultMessage": "Diplôme",
-    "description": "Title displayed for the Pool Candidates table Diploma column."
-  },
-  "If8CeH": {
-    "defaultMessage": "Identifiant",
-    "description": "Title displayed on the Pool Candidates table ID column."
   },
   "IfWj5I": {
     "defaultMessage": "Toutes les demandes",
@@ -351,10 +315,6 @@
     "defaultMessage": "Créer un actif du BGC",
     "description": "Title displayed on the create a cmo asset form."
   },
-  "NZyO8h": {
-    "defaultMessage": "Autochtone",
-    "description": "Title displayed for the Pool Candidates table Indigenous column."
-  },
   "NhQGh5": {
     "defaultMessage": "Erreur : Échec de la création de l’actif du BGC",
     "description": "Message displayed to user after cmo asset fails to get created."
@@ -394,14 +354,6 @@
   "SqZuQS": {
     "defaultMessage": "Créer un bassin de candidats",
     "description": "Title displayed on the create a user form."
-  },
-  "T+Ak4D": {
-    "defaultMessage": "Clé",
-    "description": "Label displayed on the 'key' input field."
-  },
-  "TAyq5Q": {
-    "defaultMessage": "Handicap",
-    "description": "Title displayed for the Pool Candidates table Disability column."
   },
   "TkvUdX": {
     "defaultMessage": "Compétence linguistique",
@@ -450,10 +402,6 @@
   "W2qRX5": {
     "defaultMessage": "Erreur : Échec de la création du bassin",
     "description": "Message displayed to pool after pool fails to get created."
-  },
-  "W8RhSY": {
-    "defaultMessage": "Modifier",
-    "description": "Title displayed for the search request table edit column."
   },
   "W9DTVh": {
     "defaultMessage": "Nom au complet",
@@ -690,10 +638,6 @@
     "defaultMessage": "Préférences de lieu",
     "description": "Label displayed on the pool candidate form location preferences field."
   },
-  "n0pfBx": {
-    "defaultMessage": "Bassin",
-    "description": "Title displayed for the Pool Candidates table Pool column."
-  },
   "nXRLAX": {
     "defaultMessage": "Erreur : Échec de la mise à jour du ministère",
     "description": "Message displayed to user after department fails to get updated."
@@ -754,17 +698,9 @@
     "defaultMessage": "Affecter un utilisateur existant",
     "description": "Label for the existing user assignment option in the create pool candidate form."
   },
-  "sFl+Xl": {
-    "defaultMessage": "La « clé » est une chaîne qui identifie de manière unique un bassin. Elle doit être basée sur le nom anglais du bassin et doit être concise. Un bon exemple serait « digital_careers ». Elle peut être utilisée dans le code pour faire référence à ce bassin particulier, et ne peut donc pas être modifiée ultérieurement.",
-    "description": "Additional context describing the purpose of the Pool's 'key' field."
-  },
   "sZHcsV": {
     "defaultMessage": "Courriel",
     "description": "Label displayed on the user form email field."
-  },
-  "srzf65": {
-    "defaultMessage": "Modifier",
-    "description": "Title displayed for the Edit column."
   },
   "t3sEc+": {
     "defaultMessage": "Statut",
@@ -810,10 +746,6 @@
     "defaultMessage": "L’état de la demande a été réglé avec succès à Effectuée!",
     "description": "Message displayed to user after the request has been successfully set to done on the single search request page."
   },
-  "xxLs3C": {
-    "defaultMessage": "Nom",
-    "description": "Title displayed on the Pool Candidates table name column."
-  },
   "yGlG9e": {
     "defaultMessage": "Création du ministère réussie!",
     "description": "Message displayed to user after department is created successfully."
@@ -825,10 +757,6 @@
   "yoshF7": {
     "defaultMessage": "Création du bassin de candidats réussie!",
     "description": "Message displayed to user after pool candidate is created successfully."
-  },
-  "z+TEpN": {
-    "defaultMessage": "Créer un bassin de candidats",
-    "description": "Heading displayed above the Create Pool Candidate form."
   },
   "z2m2Gp": {
     "defaultMessage": "Modifier",
@@ -1038,10 +966,6 @@
     "defaultMessage": "La « clé » est une chaîne qui identifie de manière unique une compétence. Elle devrait être fondée sur le nom anglais de la compétence et devrait être concise. Un bon exemple serait « information_management ». Elle peut être utilisée dans le code pour faire référence à cette compétence particulière, et ne peut donc pas être modifiée ultérieurement.",
     "description": "Additional context describing the purpose of the skills 'key' field."
   },
-  "kY7te0": {
-    "defaultMessage": "Mots-clés",
-    "description": "Label displayed on the skill form keywords field."
-  },
   "ksMybU": {
     "defaultMessage": "Erreur : échec de la création de la compétence",
     "description": "Message displayed to user after skill fails to get created."
@@ -1158,25 +1082,9 @@
     "defaultMessage": "Familles de compétences",
     "description": "Label displayed on the skill families menu item."
   },
-  "59EwWA": {
-    "defaultMessage": "Afficher la demande<hidden>{name}</hidden>",
-    "description": "Link text for the view action of the latests requests table on the admin portal dashboard."
-  },
-  "5LWGeI": {
-    "defaultMessage": "Courriel",
-    "description": "Title displayed on the latest requests table email column."
-  },
-  "61vOnW": {
-    "defaultMessage": "Date de réception",
-    "description": "Title displayed on the latest requests table for the date column."
-  },
   "6EOrWk": {
     "defaultMessage": "Accueil",
     "description": "Title for homepage on the talent cloud admin portal."
-  },
-  "6rhyxk": {
-    "defaultMessage": "Déconnexion",
-    "description": "Link text to logout."
   },
   "7B+1RO": {
     "defaultMessage": "Sur cette page, vous pouvez trouver une liste des bassins actifs avec quelques détails sur leur statut.",
@@ -1185,10 +1093,6 @@
   "8Y+eEc": {
     "defaultMessage": "Vous êtes sur le point d'ajouter cet utilisateur à un autre bassin :",
     "description": "First section of text on the add user to pool dialog"
-  },
-  "98PjUH": {
-    "defaultMessage": "Retirer du bassin",
-    "description": "Confirmation button for removing candidate from pool dialog"
   },
   "9NDM+k": {
     "defaultMessage": "Fixer une date d'expiration pour ce candidat dans ce bassin :",
@@ -1201,10 +1105,6 @@
   "AauSuA": {
     "defaultMessage": "S.O.",
     "description": "Not available message."
-  },
-  "AhNR6n": {
-    "defaultMessage": "Annuler",
-    "description": "Link text to cancel logging out."
   },
   "AiOtNy": {
     "defaultMessage": "Tâches principales (en anglais)",
@@ -1233,10 +1133,6 @@
   "bqaNWT": {
     "defaultMessage": "Ajouter l'utilisateur au bassin",
     "description": "title for add to pool dialog on view-user page"
-  },
-  "Cbo1no": {
-    "defaultMessage": "Veuillez sélectionner une date",
-    "description": "Error displayed on the change candidate expiry date dialog if no date selected"
   },
   "CoUFQ5": {
     "defaultMessage": "Notes mises à jour pour le candidat dans le {poolName}",
@@ -1302,10 +1198,6 @@
     "defaultMessage": "Gérer les bassins",
     "description": "Text label for link to pools page on admin dashboard"
   },
-  "Hiv/2m": {
-    "defaultMessage": "Déconnexion",
-    "description": "Title for the modal that appears when an authenticated user lands on /logged-out."
-  },
   "HrXZ6X": {
     "defaultMessage": "Autochtone",
     "description": "Text on view-user page that the user is indigenous"
@@ -1325,10 +1217,6 @@
   "K3LEpl": {
     "defaultMessage": "Choisir un bassin :",
     "description": "Second section of text on the add user to pool dialog"
-  },
-  "KyMCYC": {
-    "defaultMessage": "Retirer du bassin",
-    "description": "title for change expiry date dialog on view-user page"
   },
   "Nfy1HK": {
     "defaultMessage": "Bienvenue à Talent numérique du GC, veuillez vous connecter pour continuer.",
@@ -1366,10 +1254,6 @@
     "defaultMessage": "Passer au contenu principal",
     "description": "Assistive technology skip link"
   },
-  "TZt+a5": {
-    "defaultMessage": "Ministère",
-    "description": "Title displayed on the latest requests table department column."
-  },
   "TxEV7S": {
     "defaultMessage": "Connexion",
     "description": "Text label for the login link to the talent cloud admin portal."
@@ -1402,10 +1286,6 @@
     "defaultMessage": "Détails sur le candidat",
     "description": "Title for the page when viewing an individual user."
   },
-  "YR/3EG": {
-    "defaultMessage": "Mesure",
-    "description": "Title displayed on the latest requests table for the action column."
-  },
   "YtEDfa": {
     "defaultMessage": "Accueil",
     "description": "Breadcrumb title for the home link."
@@ -1421,10 +1301,6 @@
   "Zbk4zf": {
     "defaultMessage": "Choisir un statut :",
     "description": "Third section of text on the change candidate status dialog"
-  },
-  "Zx3BVC": {
-    "defaultMessage": "Êtes-vous sûr(e) de vouloir vous déconnecter?",
-    "description": "Question displayed when authenticated user lands on /logged-out."
   },
   "aJVlIF": {
     "defaultMessage": "Bassins",
@@ -1454,25 +1330,13 @@
     "defaultMessage": "Utilisateurs",
     "description": "Breadcrumb title for the all users table link."
   },
-  "eaHqS2": {
-    "defaultMessage": "Veuillez sélectionner un statut",
-    "description": "Error displayed on the change candidate status dialog if no status selected"
-  },
   "eickbr": {
     "defaultMessage": "Minorité visible",
     "description": "Text on view-user page that the user is part of a visible minority"
   },
-  "+phJjJ": {
-    "defaultMessage": "Demandes les plus récentes",
-    "description": "Title for the latests requests table in the admin dashboard"
-  },
   "fu4Fen": {
     "defaultMessage": "Statut",
     "description": "Label displayed on the pool form status field."
-  },
-  "gCbb9X": {
-    "defaultMessage": "Soumission",
-    "description": "Text on submit button when submitting"
   },
   "gKyog2": {
     "defaultMessage": "Oups, on dirait que vous avez atterri sur une page que vous n'êtes pas autorisé(e) à consulter.",
@@ -1494,16 +1358,8 @@
     "defaultMessage": "Statut du bassin",
     "description": "Title of the 'Pool status' section of the view-user page"
   },
-  "hSgcxP": {
-    "defaultMessage": "Statut",
-    "description": "Title displayed on the latest requests table status column."
-  },
   "hlcd+5": {
     "defaultMessage": "Résultats du tableau"
-  },
-  "iIJ/rI": {
-    "defaultMessage": "Nom du bassin",
-    "description": "Title displayed on the latest requests table for the pool column."
   },
   "icYqDt": {
     "defaultMessage": "Bassin",
@@ -1529,10 +1385,6 @@
     "defaultMessage": "Mesures",
     "description": "Title of the 'Actions' column for the table on view-user page"
   },
-  "k2FnXH": {
-    "defaultMessage": "Veuillez sélectionner une date d'expiration",
-    "description": "Error displayed on the add user to pool dialog if no date selected"
-  },
   "kXAnJt": {
     "defaultMessage": "Échec de la mise à jour des notes pour le candidat dans le {poolName}",
     "description": "Toast notification for failed update of candidates notes in specified pool"
@@ -1544,10 +1396,6 @@
   "lIwJp4": {
     "defaultMessage": "Bon retour, {name}",
     "description": "Title for dashboard on the talent cloud admin portal."
-  },
-  "myqzYj": {
-    "defaultMessage": "Gestionnaire",
-    "description": "Title displayed on the latest requests table manager column."
   },
   "n+d6QE": {
     "defaultMessage": "Fixer une date d'expiration pour ce candidat dans ce bassin :",
@@ -1593,17 +1441,9 @@
     "defaultMessage": "Annuler et revenir en arrière",
     "description": "Close dialog button"
   },
-  "tmbdSb": {
-    "defaultMessage": "Candidat retiré avec succès",
-    "description": "Toast for successful removal of candidate from pool on view-user page"
-  },
   "u6GmEz": {
     "defaultMessage": "Portail du gestionnaire de portail",
     "description": "Title for the pool manager login link."
-  },
-  "uJSvlo": {
-    "defaultMessage": "Veuillez sélectionner un bassin",
-    "description": "Error displayed on the add user to pool dialog if no pool selected"
   },
   "jtEouE": {
     "defaultMessage": "Ajouter l'utilisateur au bassin",
@@ -1613,10 +1453,6 @@
     "defaultMessage": "Rôle et salaire escomptés",
     "description": "Title of the Role and salary expectations section"
   },
-  "uOtDuW": {
-    "defaultMessage": "Échec de la mise à jour de la date d'expiration",
-    "description": "Toast for failed removal of candidate from pool on view-user page"
-  },
   "usNShh": {
     "defaultMessage": "Sélectionner un statut de bassin...",
     "description": "Placeholder displayed on the status field of the change candidate status dialog."
@@ -1624,10 +1460,6 @@
   "uutH18": {
     "defaultMessage": "À propos",
     "description": "Title of the 'About' section of the view-user page"
-  },
-  "vyJpp2": {
-    "defaultMessage": "À partir du bassin suivant :",
-    "description": "Second section of text on the remove candidate from pool dialog"
   },
   "yBmBnd": {
     "defaultMessage": "Détails sur le bassin",
@@ -1640,10 +1472,6 @@
   "zDO6tt": {
     "defaultMessage": "Date d'expiration",
     "description": "title for change expiry date dialog on view-user page"
-  },
-  "0cEmmG": {
-    "defaultMessage": "Vous êtes sur le point de <strong>retirer l'utilisateur suivant :</strong>",
-    "description": "First section of text on the remove candidate from pool dialog, ignore things in <> tags please"
   },
   "ZLDt/c": {
     "defaultMessage": "<strong>{jobTitle}</strong> à <strong>{department}</strong>",
@@ -1676,10 +1504,6 @@
   "/6voUd": {
     "defaultMessage": "Modifier l'annonce du bassin",
     "description": "Header for page to edit pool advertisements"
-  },
-  "/7tcPl": {
-    "defaultMessage": "Votre travail (anglais)",
-    "description": "Title for English pool advertisement Work"
   },
   "/QUq6L": {
     "defaultMessage": "Vous êtes certain de vouloir continuer?",
@@ -1725,21 +1549,9 @@
     "defaultMessage": "Sélectionnez la classification prévue pour ce processus de recrutement.",
     "description": "Helper message for selecting a classification for the pool"
   },
-  "61XRUJ": {
-    "defaultMessage": "Clé",
-    "description": "Label displayed on the pool form name key field."
-  },
   "66MUMB": {
     "defaultMessage": "Enregistrer les autres exigences",
     "description": "Text on a button to save the pool other requirements"
-  },
-  "6BD4FK": {
-    "defaultMessage": "Votre impact (français)",
-    "description": "Title for French pool advertisement impact"
-  },
-  "6InelL": {
-    "defaultMessage": "Basculer vers filtrer par",
-    "description": "Title to toggle sorting order of a table"
   },
   "7N+tQw": {
     "defaultMessage": "Mes bassins",
@@ -1865,10 +1677,6 @@
     "defaultMessage": "Emplacement (anglais) : {locationEn}",
     "description": "Pool advertisement location requirement, English"
   },
-  "J3779Q": {
-    "defaultMessage": "Groupes de compétences",
-    "description": "A title for a list of skill families"
-  },
   "Jc0lds": {
     "defaultMessage": "Bassin archivé",
     "description": "Button to archive the pool in the archive pool dialog"
@@ -1876,18 +1684,6 @@
   "LccTZJ": {
     "defaultMessage": "Compétences essentielles (exigence)",
     "description": "Sub title for the pool essential skills"
-  },
-  "LfNNe4": {
-    "defaultMessage": "Par mot-clé",
-    "description": "Tab name for a box to search for skills"
-  },
-  "LvsYj+": {
-    "defaultMessage": "Votre impact (anglais)",
-    "description": "Title for English pool advertisement impact"
-  },
-  "M7s4wO": {
-    "defaultMessage": "Compétences professionnelles",
-    "description": "Tab name for a list of occupational skills"
   },
   "MDjwSO": {
     "defaultMessage": "Titre précis (français)",
@@ -1921,10 +1717,6 @@
     "defaultMessage": "Sélectionnez les compétences que vous recherchez chez les candidats. Toute compétence sélectionnée ici sera nécessaire aux candidats pour postuler. Pour accroître la diversité des candidatures, essayez de limiter au maximum le nombre de compétences sélectionnées",
     "description": "Helper message for filling in the pool essential skills"
   },
-  "OumQY2": {
-    "defaultMessage": "Générique",
-    "description": "Label for a pool advertisements generic title"
-  },
   "P5xgmH": {
     "defaultMessage": "Exigences",
     "description": "Title for a pool advertisement requirements"
@@ -1949,10 +1741,6 @@
     "defaultMessage": "Créer une nouvelle affiche de poste à partir de zéro",
     "description": "Form blurb describing create pool form"
   },
-  "Sjluby": {
-    "defaultMessage": "la clé est une chaîne qui identifie un bassin de manière unique. Elle est généré automatiquement en fonction du groupe et du titre du poste du bassin.",
-    "description": "Context displayed on the pool form key field."
-  },
   "TLl20s": {
     "defaultMessage": "Créer un nouveau bassin",
     "description": "Label displayed on submit button for new pool form."
@@ -1972,10 +1760,6 @@
   "VWz3+d": {
     "defaultMessage": "Date de clôture",
     "description": "Label for a pool advertisements expiry date"
-  },
-  "Vl09gv": {
-    "defaultMessage": "Actions sélectionnées :",
-    "description": "Label for action buttons in footer of admin table."
   },
   "VlI1K4": {
     "defaultMessage": "Tous les utilisateurs",
@@ -2057,10 +1841,6 @@
     "defaultMessage": "Titre précis (anglais)",
     "description": "Label for a pool advertisements specific English title"
   },
-  "fhkgW2": {
-    "defaultMessage": "Classification de la cible",
-    "description": "Label for a pool advertisements classification group and level"
-  },
   "fivWMs": {
     "defaultMessage": "Courriel",
     "description": "Label for user table search dropdown (email)."
@@ -2137,10 +1917,6 @@
     "defaultMessage": "Compétences utiles",
     "description": "Title optional skills for a pool advertisement"
   },
-  "l0IDWf": {
-    "defaultMessage": "Résultats ({skillCount})",
-    "description": "A title for a skill list of results"
-  },
   "lb7SoP": {
     "defaultMessage": "Anglais - Votre travail",
     "description": "Label for the English - Your Work textarea in the edit pool page."
@@ -2148,14 +1924,6 @@
   "nMYWzb": {
     "defaultMessage": "Exigence linguistique",
     "description": "Label displayed on the edit pool form language requirement field."
-  },
-  "nr62lc": {
-    "defaultMessage": "Résultats ({skillCount})",
-    "description": "A title for a list of results"
-  },
-  "pD2NXF": {
-    "defaultMessage": "Compétences transférables",
-    "description": "Tab name for a list of transferable skills"
   },
   "pFYfVv": {
     "defaultMessage": "Sélection de la rangée",
@@ -2181,10 +1949,6 @@
     "defaultMessage": "Enregistrer les tâches de travail",
     "description": "Text on a button to save the pool work tasks"
   },
-  "tv35lG": {
-    "defaultMessage": "Compétences essentielles sélectionnées ({skillCount})",
-    "description": "A title for an essential skill list"
-  },
   "uBA5mM": {
     "defaultMessage": "<heavyPrimary>Expirée</heavyPrimary>",
     "description": "Status name of a pool in EXPIRED status"
@@ -2193,25 +1957,13 @@
     "defaultMessage": "Publier le bassin",
     "description": "Button to publish the pool in the publish pool dialog"
   },
-  "v2mXcp": {
-    "defaultMessage": "Gérer les demandes",
-    "description": "Link text for button to manage requests of a specific pool"
-  },
   "v6qX/r": {
     "defaultMessage": "Retour au tableau de bord du bassin",
     "description": "Text on a link to navigate back to the pool dashboard page"
   },
-  "vZgTKh": {
-    "defaultMessage": "Toutes les compétences techniques",
-    "description": "The option label for 'no filter' on the list of occupational skills"
-  },
   "w9FYqi": {
     "defaultMessage": "Annonce du bassin",
     "description": "Sub title for admin view pool page"
-  },
-  "wcdkTU": {
-    "defaultMessage": "Toutes les compétences transférables",
-    "description": "The option label for 'no filter' on the list of transferable skills"
   },
   "xGjm2A": {
     "defaultMessage": "Sélectionnez les compétences qui amélioreront les chances de correspondre aux qualités recherchées par le les gestionnaire. Celles-ci peuvent généralement être appris en cours de travail et ne sont pas nécessaires pour être accepté dans le bassin",
@@ -2233,10 +1985,6 @@
     "defaultMessage": "Détails",
     "description": "Sub title for admin view pool page"
   },
-  "y3mLbv": {
-    "defaultMessage": "Votre travail (français)",
-    "description": "Title for French pool advertisement Work"
-  },
   "y9tCKP": {
     "defaultMessage": "Utilisez ces options pour publier ou clore votre annonce. Une annonce en direct permettra aux candidats de soumettre leur candidature pour ce bassin",
     "description": "Helper message for changing the pool advertisement status"
@@ -2244,14 +1992,6 @@
   "yYDzYE": {
     "defaultMessage": "Fermez le bassin maintenant",
     "description": "Button to close the pool in the close pool dialog"
-  },
-  "s4DN3G": {
-    "defaultMessage": "Résultats des compétences générales",
-    "description": "Accessibility label for a result set of skills, filtered to mainstream skills"
-  },
-  "wziEOM": {
-    "defaultMessage": "résultats des compétences, recherche par mot-clé",
-    "description": "Accessibility label for a result set of skills, searched by keyword"
   },
   "mxOuYK": {
     "defaultMessage": "Télécharger CSV",
@@ -2292,10 +2032,6 @@
   "+wG2Ap": {
     "defaultMessage": "Vue {name} <hidden>{hiddenLabel}</hidden>",
     "description": "Title displayed for the View Item column."
-  },
-  "u9JHS9": {
-    "defaultMessage": "demande",
-    "description": "Text displayed after View text for Latest Request table view action"
   },
   "gLtTaW": {
     "defaultMessage": "demande",

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -47,10 +47,6 @@
     "defaultMessage": "Identifiant du candidat",
     "description": "Title displayed on the single search request table id column."
   },
-  "29OmCu": {
-    "defaultMessage": "Expiration",
-    "description": "Title displayed for the Pool Candidates table Expiry column."
-  },
   "2wmzS1": {
     "defaultMessage": "Nom",
     "description": "Title displayed for the Department table Name column."
@@ -119,10 +115,6 @@
     "defaultMessage": "Gestionnaire",
     "description": "Title displayed on the search request table manager column."
   },
-  "7SWIeC": {
-    "defaultMessage": "Femme",
-    "description": "Title displayed for the Pool Candidates table Woman column."
-  },
   "7d/ot8": {
     "defaultMessage": "Basculer tout",
     "description": "Label displayed on the Table Columns toggle fieldset."
@@ -134,14 +126,6 @@
   "7wYPgC": {
     "defaultMessage": "Nom (anglais)",
     "description": "Label displayed on the classification form name (English) field."
-  },
-  "8AbNBq": {
-    "defaultMessage": "Bassin de candidats",
-    "description": "Heading displayed above the Pool Candidate Table component."
-  },
-  "8Hw3Zf": {
-    "defaultMessage": "Utilisateur",
-    "description": "Title displayed for the Pool Candidates table User column."
   },
   "8L5kDc": {
     "defaultMessage": "Téléphone",
@@ -195,17 +179,9 @@
     "defaultMessage": "Clé",
     "description": "Label displayed on the create a cmo asset form key field."
   },
-  "Bu20w5": {
-    "defaultMessage": "Minorité visible",
-    "description": "Title displayed for the Pool Candidates table Visible Minority column."
-  },
   "CcOlo0": {
     "defaultMessage": "Clé",
     "description": "Title displayed for the CMO Asset table Key column."
-  },
-  "CdXStL": {
-    "defaultMessage": "Téléphone",
-    "description": "Title displayed on the Pool Candidates table telephone column."
   },
   "D2DUgE": {
     "defaultMessage": "Sélectionner un ou plusieurs actifs du BGC...",
@@ -259,10 +235,6 @@
     "defaultMessage": "Ministère mis à jour avec succès!",
     "description": "Message displayed to user after department is updated successfully."
   },
-  "GZ7CVk": {
-    "defaultMessage": "Compétence linguistique",
-    "description": "Title displayed for the Pool Candidates table Language Ability column."
-  },
   "H5EJq1": {
     "defaultMessage": "Mettre à jour un bassin",
     "description": "Title displayed on the update a pool form."
@@ -294,14 +266,6 @@
   "Htqzxb": {
     "defaultMessage": "Bassin",
     "description": "Title displayed on the search request table pool column."
-  },
-  "IIX75o": {
-    "defaultMessage": "Diplôme",
-    "description": "Title displayed for the Pool Candidates table Diploma column."
-  },
-  "If8CeH": {
-    "defaultMessage": "Identifiant",
-    "description": "Title displayed on the Pool Candidates table ID column."
   },
   "IfWj5I": {
     "defaultMessage": "Toutes les demandes",
@@ -351,10 +315,6 @@
     "defaultMessage": "Créer un actif du BGC",
     "description": "Title displayed on the create a cmo asset form."
   },
-  "NZyO8h": {
-    "defaultMessage": "Autochtone",
-    "description": "Title displayed for the Pool Candidates table Indigenous column."
-  },
   "NhQGh5": {
     "defaultMessage": "Erreur : Échec de la création de l’actif du BGC",
     "description": "Message displayed to user after cmo asset fails to get created."
@@ -394,14 +354,6 @@
   "SqZuQS": {
     "defaultMessage": "Créer un bassin de candidats",
     "description": "Title displayed on the create a user form."
-  },
-  "T+Ak4D": {
-    "defaultMessage": "Clé",
-    "description": "Label displayed on the 'key' input field."
-  },
-  "TAyq5Q": {
-    "defaultMessage": "Handicap",
-    "description": "Title displayed for the Pool Candidates table Disability column."
   },
   "TkvUdX": {
     "defaultMessage": "Compétence linguistique",
@@ -450,10 +402,6 @@
   "W2qRX5": {
     "defaultMessage": "Erreur : Échec de la création du bassin",
     "description": "Message displayed to pool after pool fails to get created."
-  },
-  "W8RhSY": {
-    "defaultMessage": "Modifier",
-    "description": "Title displayed for the search request table edit column."
   },
   "W9DTVh": {
     "defaultMessage": "Nom au complet",
@@ -690,10 +638,6 @@
     "defaultMessage": "Préférences de lieu",
     "description": "Label displayed on the pool candidate form location preferences field."
   },
-  "n0pfBx": {
-    "defaultMessage": "Bassin",
-    "description": "Title displayed for the Pool Candidates table Pool column."
-  },
   "nXRLAX": {
     "defaultMessage": "Erreur : Échec de la mise à jour du ministère",
     "description": "Message displayed to user after department fails to get updated."
@@ -754,17 +698,9 @@
     "defaultMessage": "Affecter un utilisateur existant",
     "description": "Label for the existing user assignment option in the create pool candidate form."
   },
-  "sFl+Xl": {
-    "defaultMessage": "La « clé » est une chaîne qui identifie de manière unique un bassin. Elle doit être basée sur le nom anglais du bassin et doit être concise. Un bon exemple serait « digital_careers ». Elle peut être utilisée dans le code pour faire référence à ce bassin particulier, et ne peut donc pas être modifiée ultérieurement.",
-    "description": "Additional context describing the purpose of the Pool's 'key' field."
-  },
   "sZHcsV": {
     "defaultMessage": "Courriel",
     "description": "Label displayed on the user form email field."
-  },
-  "srzf65": {
-    "defaultMessage": "Modifier",
-    "description": "Title displayed for the Edit column."
   },
   "t3sEc+": {
     "defaultMessage": "Statut",
@@ -810,10 +746,6 @@
     "defaultMessage": "L’état de la demande a été réglé avec succès à Effectuée!",
     "description": "Message displayed to user after the request has been successfully set to done on the single search request page."
   },
-  "xxLs3C": {
-    "defaultMessage": "Nom",
-    "description": "Title displayed on the Pool Candidates table name column."
-  },
   "yGlG9e": {
     "defaultMessage": "Création du ministère réussie!",
     "description": "Message displayed to user after department is created successfully."
@@ -825,10 +757,6 @@
   "yoshF7": {
     "defaultMessage": "Création du bassin de candidats réussie!",
     "description": "Message displayed to user after pool candidate is created successfully."
-  },
-  "z+TEpN": {
-    "defaultMessage": "Créer un bassin de candidats",
-    "description": "Heading displayed above the Create Pool Candidate form."
   },
   "z2m2Gp": {
     "defaultMessage": "Modifier",
@@ -1038,10 +966,6 @@
     "defaultMessage": "La « clé » est une chaîne qui identifie de manière unique une compétence. Elle devrait être fondée sur le nom anglais de la compétence et devrait être concise. Un bon exemple serait « information_management ». Elle peut être utilisée dans le code pour faire référence à cette compétence particulière, et ne peut donc pas être modifiée ultérieurement.",
     "description": "Additional context describing the purpose of the skills 'key' field."
   },
-  "kY7te0": {
-    "defaultMessage": "Mots-clés",
-    "description": "Label displayed on the skill form keywords field."
-  },
   "ksMybU": {
     "defaultMessage": "Erreur : échec de la création de la compétence",
     "description": "Message displayed to user after skill fails to get created."
@@ -1158,25 +1082,9 @@
     "defaultMessage": "Familles de compétences",
     "description": "Label displayed on the skill families menu item."
   },
-  "59EwWA": {
-    "defaultMessage": "Afficher la demande<hidden>{name}</hidden>",
-    "description": "Link text for the view action of the latests requests table on the admin portal dashboard."
-  },
-  "5LWGeI": {
-    "defaultMessage": "Courriel",
-    "description": "Title displayed on the latest requests table email column."
-  },
-  "61vOnW": {
-    "defaultMessage": "Date de réception",
-    "description": "Title displayed on the latest requests table for the date column."
-  },
   "6EOrWk": {
     "defaultMessage": "Accueil",
     "description": "Title for homepage on the talent cloud admin portal."
-  },
-  "6rhyxk": {
-    "defaultMessage": "Déconnexion",
-    "description": "Link text to logout."
   },
   "7B+1RO": {
     "defaultMessage": "Sur cette page, vous pouvez trouver une liste des bassins actifs avec quelques détails sur leur statut.",
@@ -1201,10 +1109,6 @@
   "AauSuA": {
     "defaultMessage": "S.O.",
     "description": "Not available message."
-  },
-  "AhNR6n": {
-    "defaultMessage": "Annuler",
-    "description": "Link text to cancel logging out."
   },
   "AiOtNy": {
     "defaultMessage": "Tâches principales (en anglais)",
@@ -1302,10 +1206,6 @@
     "defaultMessage": "Gérer les bassins",
     "description": "Text label for link to pools page on admin dashboard"
   },
-  "Hiv/2m": {
-    "defaultMessage": "Déconnexion",
-    "description": "Title for the modal that appears when an authenticated user lands on /logged-out."
-  },
   "HrXZ6X": {
     "defaultMessage": "Autochtone",
     "description": "Text on view-user page that the user is indigenous"
@@ -1366,10 +1266,6 @@
     "defaultMessage": "Passer au contenu principal",
     "description": "Assistive technology skip link"
   },
-  "TZt+a5": {
-    "defaultMessage": "Ministère",
-    "description": "Title displayed on the latest requests table department column."
-  },
   "TxEV7S": {
     "defaultMessage": "Connexion",
     "description": "Text label for the login link to the talent cloud admin portal."
@@ -1402,10 +1298,6 @@
     "defaultMessage": "Détails sur le candidat",
     "description": "Title for the page when viewing an individual user."
   },
-  "YR/3EG": {
-    "defaultMessage": "Mesure",
-    "description": "Title displayed on the latest requests table for the action column."
-  },
   "YtEDfa": {
     "defaultMessage": "Accueil",
     "description": "Breadcrumb title for the home link."
@@ -1421,10 +1313,6 @@
   "Zbk4zf": {
     "defaultMessage": "Choisir un statut :",
     "description": "Third section of text on the change candidate status dialog"
-  },
-  "Zx3BVC": {
-    "defaultMessage": "Êtes-vous sûr(e) de vouloir vous déconnecter?",
-    "description": "Question displayed when authenticated user lands on /logged-out."
   },
   "aJVlIF": {
     "defaultMessage": "Bassins",
@@ -1462,10 +1350,6 @@
     "defaultMessage": "Minorité visible",
     "description": "Text on view-user page that the user is part of a visible minority"
   },
-  "+phJjJ": {
-    "defaultMessage": "Demandes les plus récentes",
-    "description": "Title for the latests requests table in the admin dashboard"
-  },
   "fu4Fen": {
     "defaultMessage": "Statut",
     "description": "Label displayed on the pool form status field."
@@ -1494,16 +1378,8 @@
     "defaultMessage": "Statut du bassin",
     "description": "Title of the 'Pool status' section of the view-user page"
   },
-  "hSgcxP": {
-    "defaultMessage": "Statut",
-    "description": "Title displayed on the latest requests table status column."
-  },
   "hlcd+5": {
     "defaultMessage": "Résultats du tableau"
-  },
-  "iIJ/rI": {
-    "defaultMessage": "Nom du bassin",
-    "description": "Title displayed on the latest requests table for the pool column."
   },
   "icYqDt": {
     "defaultMessage": "Bassin",
@@ -1544,10 +1420,6 @@
   "lIwJp4": {
     "defaultMessage": "Bon retour, {name}",
     "description": "Title for dashboard on the talent cloud admin portal."
-  },
-  "myqzYj": {
-    "defaultMessage": "Gestionnaire",
-    "description": "Title displayed on the latest requests table manager column."
   },
   "n+d6QE": {
     "defaultMessage": "Fixer une date d'expiration pour ce candidat dans ce bassin :",
@@ -1677,10 +1549,6 @@
     "defaultMessage": "Modifier l'annonce du bassin",
     "description": "Header for page to edit pool advertisements"
   },
-  "/7tcPl": {
-    "defaultMessage": "Votre travail (anglais)",
-    "description": "Title for English pool advertisement Work"
-  },
   "/QUq6L": {
     "defaultMessage": "Vous êtes certain de vouloir continuer?",
     "description": "Second paragraph for Delete pool dialog"
@@ -1725,17 +1593,9 @@
     "defaultMessage": "Sélectionnez la classification prévue pour ce processus de recrutement.",
     "description": "Helper message for selecting a classification for the pool"
   },
-  "61XRUJ": {
-    "defaultMessage": "Clé",
-    "description": "Label displayed on the pool form name key field."
-  },
   "66MUMB": {
     "defaultMessage": "Enregistrer les autres exigences",
     "description": "Text on a button to save the pool other requirements"
-  },
-  "6BD4FK": {
-    "defaultMessage": "Votre impact (français)",
-    "description": "Title for French pool advertisement impact"
   },
   "6InelL": {
     "defaultMessage": "Basculer vers filtrer par",
@@ -1865,10 +1725,6 @@
     "defaultMessage": "Emplacement (anglais) : {locationEn}",
     "description": "Pool advertisement location requirement, English"
   },
-  "J3779Q": {
-    "defaultMessage": "Groupes de compétences",
-    "description": "A title for a list of skill families"
-  },
   "Jc0lds": {
     "defaultMessage": "Bassin archivé",
     "description": "Button to archive the pool in the archive pool dialog"
@@ -1876,18 +1732,6 @@
   "LccTZJ": {
     "defaultMessage": "Compétences essentielles (exigence)",
     "description": "Sub title for the pool essential skills"
-  },
-  "LfNNe4": {
-    "defaultMessage": "Par mot-clé",
-    "description": "Tab name for a box to search for skills"
-  },
-  "LvsYj+": {
-    "defaultMessage": "Votre impact (anglais)",
-    "description": "Title for English pool advertisement impact"
-  },
-  "M7s4wO": {
-    "defaultMessage": "Compétences professionnelles",
-    "description": "Tab name for a list of occupational skills"
   },
   "MDjwSO": {
     "defaultMessage": "Titre précis (français)",
@@ -1921,10 +1765,6 @@
     "defaultMessage": "Sélectionnez les compétences que vous recherchez chez les candidats. Toute compétence sélectionnée ici sera nécessaire aux candidats pour postuler. Pour accroître la diversité des candidatures, essayez de limiter au maximum le nombre de compétences sélectionnées",
     "description": "Helper message for filling in the pool essential skills"
   },
-  "OumQY2": {
-    "defaultMessage": "Générique",
-    "description": "Label for a pool advertisements generic title"
-  },
   "P5xgmH": {
     "defaultMessage": "Exigences",
     "description": "Title for a pool advertisement requirements"
@@ -1949,10 +1789,6 @@
     "defaultMessage": "Créer une nouvelle affiche de poste à partir de zéro",
     "description": "Form blurb describing create pool form"
   },
-  "Sjluby": {
-    "defaultMessage": "la clé est une chaîne qui identifie un bassin de manière unique. Elle est généré automatiquement en fonction du groupe et du titre du poste du bassin.",
-    "description": "Context displayed on the pool form key field."
-  },
   "TLl20s": {
     "defaultMessage": "Créer un nouveau bassin",
     "description": "Label displayed on submit button for new pool form."
@@ -1972,10 +1808,6 @@
   "VWz3+d": {
     "defaultMessage": "Date de clôture",
     "description": "Label for a pool advertisements expiry date"
-  },
-  "Vl09gv": {
-    "defaultMessage": "Actions sélectionnées :",
-    "description": "Label for action buttons in footer of admin table."
   },
   "VlI1K4": {
     "defaultMessage": "Tous les utilisateurs",
@@ -2057,10 +1889,6 @@
     "defaultMessage": "Titre précis (anglais)",
     "description": "Label for a pool advertisements specific English title"
   },
-  "fhkgW2": {
-    "defaultMessage": "Classification de la cible",
-    "description": "Label for a pool advertisements classification group and level"
-  },
   "fivWMs": {
     "defaultMessage": "Courriel",
     "description": "Label for user table search dropdown (email)."
@@ -2137,10 +1965,6 @@
     "defaultMessage": "Compétences utiles",
     "description": "Title optional skills for a pool advertisement"
   },
-  "l0IDWf": {
-    "defaultMessage": "Résultats ({skillCount})",
-    "description": "A title for a skill list of results"
-  },
   "lb7SoP": {
     "defaultMessage": "Anglais - Votre travail",
     "description": "Label for the English - Your Work textarea in the edit pool page."
@@ -2149,21 +1973,9 @@
     "defaultMessage": "Exigence linguistique",
     "description": "Label displayed on the edit pool form language requirement field."
   },
-  "nr62lc": {
-    "defaultMessage": "Résultats ({skillCount})",
-    "description": "A title for a list of results"
-  },
-  "pD2NXF": {
-    "defaultMessage": "Compétences transférables",
-    "description": "Tab name for a list of transferable skills"
-  },
   "pFYfVv": {
     "defaultMessage": "Sélection de la rangée",
     "description": "Label for the row-selection column in the tables column-selection modal."
-  },
-  "UsFTGT": {
-    "defaultMessage": "Télécharger les profils",
-    "description": "Text label for button to print items in a table."
   },
   "rkPb6M": {
     "defaultMessage": "La clôture automatique de ce bassin est programmés pour le :",
@@ -2181,10 +1993,6 @@
     "defaultMessage": "Enregistrer les tâches de travail",
     "description": "Text on a button to save the pool work tasks"
   },
-  "tv35lG": {
-    "defaultMessage": "Compétences essentielles sélectionnées ({skillCount})",
-    "description": "A title for an essential skill list"
-  },
   "uBA5mM": {
     "defaultMessage": "<heavyPrimary>Expirée</heavyPrimary>",
     "description": "Status name of a pool in EXPIRED status"
@@ -2193,25 +2001,13 @@
     "defaultMessage": "Publier le bassin",
     "description": "Button to publish the pool in the publish pool dialog"
   },
-  "v2mXcp": {
-    "defaultMessage": "Gérer les demandes",
-    "description": "Link text for button to manage requests of a specific pool"
-  },
   "v6qX/r": {
     "defaultMessage": "Retour au tableau de bord du bassin",
     "description": "Text on a link to navigate back to the pool dashboard page"
   },
-  "vZgTKh": {
-    "defaultMessage": "Toutes les compétences techniques",
-    "description": "The option label for 'no filter' on the list of occupational skills"
-  },
   "w9FYqi": {
     "defaultMessage": "Annonce du bassin",
     "description": "Sub title for admin view pool page"
-  },
-  "wcdkTU": {
-    "defaultMessage": "Toutes les compétences transférables",
-    "description": "The option label for 'no filter' on the list of transferable skills"
   },
   "xGjm2A": {
     "defaultMessage": "Sélectionnez les compétences qui amélioreront les chances de correspondre aux qualités recherchées par le les gestionnaire. Celles-ci peuvent généralement être appris en cours de travail et ne sont pas nécessaires pour être accepté dans le bassin",
@@ -2233,10 +2029,6 @@
     "defaultMessage": "Détails",
     "description": "Sub title for admin view pool page"
   },
-  "y3mLbv": {
-    "defaultMessage": "Votre travail (français)",
-    "description": "Title for French pool advertisement Work"
-  },
   "y9tCKP": {
     "defaultMessage": "Utilisez ces options pour publier ou clore votre annonce. Une annonce en direct permettra aux candidats de soumettre leur candidature pour ce bassin",
     "description": "Helper message for changing the pool advertisement status"
@@ -2244,14 +2036,6 @@
   "yYDzYE": {
     "defaultMessage": "Fermez le bassin maintenant",
     "description": "Button to close the pool in the close pool dialog"
-  },
-  "s4DN3G": {
-    "defaultMessage": "Résultats des compétences générales",
-    "description": "Accessibility label for a result set of skills, filtered to mainstream skills"
-  },
-  "wziEOM": {
-    "defaultMessage": "résultats des compétences, recherche par mot-clé",
-    "description": "Accessibility label for a result set of skills, searched by keyword"
   },
   "mxOuYK": {
     "defaultMessage": "Télécharger CSV",
@@ -2292,10 +2076,6 @@
   "+wG2Ap": {
     "defaultMessage": "Vue {name} <hidden>{hiddenLabel}</hidden>",
     "description": "Title displayed for the View Item column."
-  },
-  "u9JHS9": {
-    "defaultMessage": "demande",
-    "description": "Text displayed after View text for Latest Request table view action"
   },
   "gLtTaW": {
     "defaultMessage": "demande",
@@ -2840,13 +2620,5 @@
   "z0QI6A": {
     "defaultMessage": "Tous les candidats du bassin",
     "description": "Title for the admin pool candidates table"
-  },
-  "/bwX1a": {
-    "defaultMessage": "Il est possible de trier les en-têtes de colonnes avec boutons",
-    "description": "Text displayed to instruct users how to sort table rows"
-  },
-  "k4xm25": {
-    "defaultMessage": "Téléchargement a échoué : Aucune rangée n’a été sélectionnée",
-    "description": "Alert message displayed when a user attempts to print without selecting items first"
   }
 }

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -47,6 +47,10 @@
     "defaultMessage": "Identifiant du candidat",
     "description": "Title displayed on the single search request table id column."
   },
+  "29OmCu": {
+    "defaultMessage": "Expiration",
+    "description": "Title displayed for the Pool Candidates table Expiry column."
+  },
   "2wmzS1": {
     "defaultMessage": "Nom",
     "description": "Title displayed for the Department table Name column."
@@ -115,6 +119,10 @@
     "defaultMessage": "Gestionnaire",
     "description": "Title displayed on the search request table manager column."
   },
+  "7SWIeC": {
+    "defaultMessage": "Femme",
+    "description": "Title displayed for the Pool Candidates table Woman column."
+  },
   "7d/ot8": {
     "defaultMessage": "Basculer tout",
     "description": "Label displayed on the Table Columns toggle fieldset."
@@ -126,6 +134,14 @@
   "7wYPgC": {
     "defaultMessage": "Nom (anglais)",
     "description": "Label displayed on the classification form name (English) field."
+  },
+  "8AbNBq": {
+    "defaultMessage": "Bassin de candidats",
+    "description": "Heading displayed above the Pool Candidate Table component."
+  },
+  "8Hw3Zf": {
+    "defaultMessage": "Utilisateur",
+    "description": "Title displayed for the Pool Candidates table User column."
   },
   "8L5kDc": {
     "defaultMessage": "Téléphone",
@@ -179,9 +195,17 @@
     "defaultMessage": "Clé",
     "description": "Label displayed on the create a cmo asset form key field."
   },
+  "Bu20w5": {
+    "defaultMessage": "Minorité visible",
+    "description": "Title displayed for the Pool Candidates table Visible Minority column."
+  },
   "CcOlo0": {
     "defaultMessage": "Clé",
     "description": "Title displayed for the CMO Asset table Key column."
+  },
+  "CdXStL": {
+    "defaultMessage": "Téléphone",
+    "description": "Title displayed on the Pool Candidates table telephone column."
   },
   "D2DUgE": {
     "defaultMessage": "Sélectionner un ou plusieurs actifs du BGC...",
@@ -235,6 +259,10 @@
     "defaultMessage": "Ministère mis à jour avec succès!",
     "description": "Message displayed to user after department is updated successfully."
   },
+  "GZ7CVk": {
+    "defaultMessage": "Compétence linguistique",
+    "description": "Title displayed for the Pool Candidates table Language Ability column."
+  },
   "H5EJq1": {
     "defaultMessage": "Mettre à jour un bassin",
     "description": "Title displayed on the update a pool form."
@@ -266,6 +294,14 @@
   "Htqzxb": {
     "defaultMessage": "Bassin",
     "description": "Title displayed on the search request table pool column."
+  },
+  "IIX75o": {
+    "defaultMessage": "Diplôme",
+    "description": "Title displayed for the Pool Candidates table Diploma column."
+  },
+  "If8CeH": {
+    "defaultMessage": "Identifiant",
+    "description": "Title displayed on the Pool Candidates table ID column."
   },
   "IfWj5I": {
     "defaultMessage": "Toutes les demandes",
@@ -315,6 +351,10 @@
     "defaultMessage": "Créer un actif du BGC",
     "description": "Title displayed on the create a cmo asset form."
   },
+  "NZyO8h": {
+    "defaultMessage": "Autochtone",
+    "description": "Title displayed for the Pool Candidates table Indigenous column."
+  },
   "NhQGh5": {
     "defaultMessage": "Erreur : Échec de la création de l’actif du BGC",
     "description": "Message displayed to user after cmo asset fails to get created."
@@ -354,6 +394,14 @@
   "SqZuQS": {
     "defaultMessage": "Créer un bassin de candidats",
     "description": "Title displayed on the create a user form."
+  },
+  "T+Ak4D": {
+    "defaultMessage": "Clé",
+    "description": "Label displayed on the 'key' input field."
+  },
+  "TAyq5Q": {
+    "defaultMessage": "Handicap",
+    "description": "Title displayed for the Pool Candidates table Disability column."
   },
   "TkvUdX": {
     "defaultMessage": "Compétence linguistique",
@@ -402,6 +450,10 @@
   "W2qRX5": {
     "defaultMessage": "Erreur : Échec de la création du bassin",
     "description": "Message displayed to pool after pool fails to get created."
+  },
+  "W8RhSY": {
+    "defaultMessage": "Modifier",
+    "description": "Title displayed for the search request table edit column."
   },
   "W9DTVh": {
     "defaultMessage": "Nom au complet",
@@ -638,6 +690,10 @@
     "defaultMessage": "Préférences de lieu",
     "description": "Label displayed on the pool candidate form location preferences field."
   },
+  "n0pfBx": {
+    "defaultMessage": "Bassin",
+    "description": "Title displayed for the Pool Candidates table Pool column."
+  },
   "nXRLAX": {
     "defaultMessage": "Erreur : Échec de la mise à jour du ministère",
     "description": "Message displayed to user after department fails to get updated."
@@ -698,9 +754,17 @@
     "defaultMessage": "Affecter un utilisateur existant",
     "description": "Label for the existing user assignment option in the create pool candidate form."
   },
+  "sFl+Xl": {
+    "defaultMessage": "La « clé » est une chaîne qui identifie de manière unique un bassin. Elle doit être basée sur le nom anglais du bassin et doit être concise. Un bon exemple serait « digital_careers ». Elle peut être utilisée dans le code pour faire référence à ce bassin particulier, et ne peut donc pas être modifiée ultérieurement.",
+    "description": "Additional context describing the purpose of the Pool's 'key' field."
+  },
   "sZHcsV": {
     "defaultMessage": "Courriel",
     "description": "Label displayed on the user form email field."
+  },
+  "srzf65": {
+    "defaultMessage": "Modifier",
+    "description": "Title displayed for the Edit column."
   },
   "t3sEc+": {
     "defaultMessage": "Statut",
@@ -746,6 +810,10 @@
     "defaultMessage": "L’état de la demande a été réglé avec succès à Effectuée!",
     "description": "Message displayed to user after the request has been successfully set to done on the single search request page."
   },
+  "xxLs3C": {
+    "defaultMessage": "Nom",
+    "description": "Title displayed on the Pool Candidates table name column."
+  },
   "yGlG9e": {
     "defaultMessage": "Création du ministère réussie!",
     "description": "Message displayed to user after department is created successfully."
@@ -757,6 +825,10 @@
   "yoshF7": {
     "defaultMessage": "Création du bassin de candidats réussie!",
     "description": "Message displayed to user after pool candidate is created successfully."
+  },
+  "z+TEpN": {
+    "defaultMessage": "Créer un bassin de candidats",
+    "description": "Heading displayed above the Create Pool Candidate form."
   },
   "z2m2Gp": {
     "defaultMessage": "Modifier",
@@ -966,6 +1038,10 @@
     "defaultMessage": "La « clé » est une chaîne qui identifie de manière unique une compétence. Elle devrait être fondée sur le nom anglais de la compétence et devrait être concise. Un bon exemple serait « information_management ». Elle peut être utilisée dans le code pour faire référence à cette compétence particulière, et ne peut donc pas être modifiée ultérieurement.",
     "description": "Additional context describing the purpose of the skills 'key' field."
   },
+  "kY7te0": {
+    "defaultMessage": "Mots-clés",
+    "description": "Label displayed on the skill form keywords field."
+  },
   "ksMybU": {
     "defaultMessage": "Erreur : échec de la création de la compétence",
     "description": "Message displayed to user after skill fails to get created."
@@ -1082,9 +1158,25 @@
     "defaultMessage": "Familles de compétences",
     "description": "Label displayed on the skill families menu item."
   },
+  "59EwWA": {
+    "defaultMessage": "Afficher la demande<hidden>{name}</hidden>",
+    "description": "Link text for the view action of the latests requests table on the admin portal dashboard."
+  },
+  "5LWGeI": {
+    "defaultMessage": "Courriel",
+    "description": "Title displayed on the latest requests table email column."
+  },
+  "61vOnW": {
+    "defaultMessage": "Date de réception",
+    "description": "Title displayed on the latest requests table for the date column."
+  },
   "6EOrWk": {
     "defaultMessage": "Accueil",
     "description": "Title for homepage on the talent cloud admin portal."
+  },
+  "6rhyxk": {
+    "defaultMessage": "Déconnexion",
+    "description": "Link text to logout."
   },
   "7B+1RO": {
     "defaultMessage": "Sur cette page, vous pouvez trouver une liste des bassins actifs avec quelques détails sur leur statut.",
@@ -1109,6 +1201,10 @@
   "AauSuA": {
     "defaultMessage": "S.O.",
     "description": "Not available message."
+  },
+  "AhNR6n": {
+    "defaultMessage": "Annuler",
+    "description": "Link text to cancel logging out."
   },
   "AiOtNy": {
     "defaultMessage": "Tâches principales (en anglais)",
@@ -1206,6 +1302,10 @@
     "defaultMessage": "Gérer les bassins",
     "description": "Text label for link to pools page on admin dashboard"
   },
+  "Hiv/2m": {
+    "defaultMessage": "Déconnexion",
+    "description": "Title for the modal that appears when an authenticated user lands on /logged-out."
+  },
   "HrXZ6X": {
     "defaultMessage": "Autochtone",
     "description": "Text on view-user page that the user is indigenous"
@@ -1266,6 +1366,10 @@
     "defaultMessage": "Passer au contenu principal",
     "description": "Assistive technology skip link"
   },
+  "TZt+a5": {
+    "defaultMessage": "Ministère",
+    "description": "Title displayed on the latest requests table department column."
+  },
   "TxEV7S": {
     "defaultMessage": "Connexion",
     "description": "Text label for the login link to the talent cloud admin portal."
@@ -1298,6 +1402,10 @@
     "defaultMessage": "Détails sur le candidat",
     "description": "Title for the page when viewing an individual user."
   },
+  "YR/3EG": {
+    "defaultMessage": "Mesure",
+    "description": "Title displayed on the latest requests table for the action column."
+  },
   "YtEDfa": {
     "defaultMessage": "Accueil",
     "description": "Breadcrumb title for the home link."
@@ -1313,6 +1421,10 @@
   "Zbk4zf": {
     "defaultMessage": "Choisir un statut :",
     "description": "Third section of text on the change candidate status dialog"
+  },
+  "Zx3BVC": {
+    "defaultMessage": "Êtes-vous sûr(e) de vouloir vous déconnecter?",
+    "description": "Question displayed when authenticated user lands on /logged-out."
   },
   "aJVlIF": {
     "defaultMessage": "Bassins",
@@ -1350,6 +1462,10 @@
     "defaultMessage": "Minorité visible",
     "description": "Text on view-user page that the user is part of a visible minority"
   },
+  "+phJjJ": {
+    "defaultMessage": "Demandes les plus récentes",
+    "description": "Title for the latests requests table in the admin dashboard"
+  },
   "fu4Fen": {
     "defaultMessage": "Statut",
     "description": "Label displayed on the pool form status field."
@@ -1378,8 +1494,16 @@
     "defaultMessage": "Statut du bassin",
     "description": "Title of the 'Pool status' section of the view-user page"
   },
+  "hSgcxP": {
+    "defaultMessage": "Statut",
+    "description": "Title displayed on the latest requests table status column."
+  },
   "hlcd+5": {
     "defaultMessage": "Résultats du tableau"
+  },
+  "iIJ/rI": {
+    "defaultMessage": "Nom du bassin",
+    "description": "Title displayed on the latest requests table for the pool column."
   },
   "icYqDt": {
     "defaultMessage": "Bassin",
@@ -1420,6 +1544,10 @@
   "lIwJp4": {
     "defaultMessage": "Bon retour, {name}",
     "description": "Title for dashboard on the talent cloud admin portal."
+  },
+  "myqzYj": {
+    "defaultMessage": "Gestionnaire",
+    "description": "Title displayed on the latest requests table manager column."
   },
   "n+d6QE": {
     "defaultMessage": "Fixer une date d'expiration pour ce candidat dans ce bassin :",
@@ -1549,6 +1677,10 @@
     "defaultMessage": "Modifier l'annonce du bassin",
     "description": "Header for page to edit pool advertisements"
   },
+  "/7tcPl": {
+    "defaultMessage": "Votre travail (anglais)",
+    "description": "Title for English pool advertisement Work"
+  },
   "/QUq6L": {
     "defaultMessage": "Vous êtes certain de vouloir continuer?",
     "description": "Second paragraph for Delete pool dialog"
@@ -1593,9 +1725,17 @@
     "defaultMessage": "Sélectionnez la classification prévue pour ce processus de recrutement.",
     "description": "Helper message for selecting a classification for the pool"
   },
+  "61XRUJ": {
+    "defaultMessage": "Clé",
+    "description": "Label displayed on the pool form name key field."
+  },
   "66MUMB": {
     "defaultMessage": "Enregistrer les autres exigences",
     "description": "Text on a button to save the pool other requirements"
+  },
+  "6BD4FK": {
+    "defaultMessage": "Votre impact (français)",
+    "description": "Title for French pool advertisement impact"
   },
   "6InelL": {
     "defaultMessage": "Basculer vers filtrer par",
@@ -1725,6 +1865,10 @@
     "defaultMessage": "Emplacement (anglais) : {locationEn}",
     "description": "Pool advertisement location requirement, English"
   },
+  "J3779Q": {
+    "defaultMessage": "Groupes de compétences",
+    "description": "A title for a list of skill families"
+  },
   "Jc0lds": {
     "defaultMessage": "Bassin archivé",
     "description": "Button to archive the pool in the archive pool dialog"
@@ -1732,6 +1876,18 @@
   "LccTZJ": {
     "defaultMessage": "Compétences essentielles (exigence)",
     "description": "Sub title for the pool essential skills"
+  },
+  "LfNNe4": {
+    "defaultMessage": "Par mot-clé",
+    "description": "Tab name for a box to search for skills"
+  },
+  "LvsYj+": {
+    "defaultMessage": "Votre impact (anglais)",
+    "description": "Title for English pool advertisement impact"
+  },
+  "M7s4wO": {
+    "defaultMessage": "Compétences professionnelles",
+    "description": "Tab name for a list of occupational skills"
   },
   "MDjwSO": {
     "defaultMessage": "Titre précis (français)",
@@ -1765,6 +1921,10 @@
     "defaultMessage": "Sélectionnez les compétences que vous recherchez chez les candidats. Toute compétence sélectionnée ici sera nécessaire aux candidats pour postuler. Pour accroître la diversité des candidatures, essayez de limiter au maximum le nombre de compétences sélectionnées",
     "description": "Helper message for filling in the pool essential skills"
   },
+  "OumQY2": {
+    "defaultMessage": "Générique",
+    "description": "Label for a pool advertisements generic title"
+  },
   "P5xgmH": {
     "defaultMessage": "Exigences",
     "description": "Title for a pool advertisement requirements"
@@ -1789,6 +1949,10 @@
     "defaultMessage": "Créer une nouvelle affiche de poste à partir de zéro",
     "description": "Form blurb describing create pool form"
   },
+  "Sjluby": {
+    "defaultMessage": "la clé est une chaîne qui identifie un bassin de manière unique. Elle est généré automatiquement en fonction du groupe et du titre du poste du bassin.",
+    "description": "Context displayed on the pool form key field."
+  },
   "TLl20s": {
     "defaultMessage": "Créer un nouveau bassin",
     "description": "Label displayed on submit button for new pool form."
@@ -1808,6 +1972,10 @@
   "VWz3+d": {
     "defaultMessage": "Date de clôture",
     "description": "Label for a pool advertisements expiry date"
+  },
+  "Vl09gv": {
+    "defaultMessage": "Actions sélectionnées :",
+    "description": "Label for action buttons in footer of admin table."
   },
   "VlI1K4": {
     "defaultMessage": "Tous les utilisateurs",
@@ -1889,6 +2057,10 @@
     "defaultMessage": "Titre précis (anglais)",
     "description": "Label for a pool advertisements specific English title"
   },
+  "fhkgW2": {
+    "defaultMessage": "Classification de la cible",
+    "description": "Label for a pool advertisements classification group and level"
+  },
   "fivWMs": {
     "defaultMessage": "Courriel",
     "description": "Label for user table search dropdown (email)."
@@ -1965,6 +2137,10 @@
     "defaultMessage": "Compétences utiles",
     "description": "Title optional skills for a pool advertisement"
   },
+  "l0IDWf": {
+    "defaultMessage": "Résultats ({skillCount})",
+    "description": "A title for a skill list of results"
+  },
   "lb7SoP": {
     "defaultMessage": "Anglais - Votre travail",
     "description": "Label for the English - Your Work textarea in the edit pool page."
@@ -1973,9 +2149,21 @@
     "defaultMessage": "Exigence linguistique",
     "description": "Label displayed on the edit pool form language requirement field."
   },
+  "nr62lc": {
+    "defaultMessage": "Résultats ({skillCount})",
+    "description": "A title for a list of results"
+  },
+  "pD2NXF": {
+    "defaultMessage": "Compétences transférables",
+    "description": "Tab name for a list of transferable skills"
+  },
   "pFYfVv": {
     "defaultMessage": "Sélection de la rangée",
     "description": "Label for the row-selection column in the tables column-selection modal."
+  },
+  "UsFTGT": {
+    "defaultMessage": "Télécharger les profils",
+    "description": "Text label for button to print items in a table."
   },
   "rkPb6M": {
     "defaultMessage": "La clôture automatique de ce bassin est programmés pour le :",
@@ -1993,6 +2181,10 @@
     "defaultMessage": "Enregistrer les tâches de travail",
     "description": "Text on a button to save the pool work tasks"
   },
+  "tv35lG": {
+    "defaultMessage": "Compétences essentielles sélectionnées ({skillCount})",
+    "description": "A title for an essential skill list"
+  },
   "uBA5mM": {
     "defaultMessage": "<heavyPrimary>Expirée</heavyPrimary>",
     "description": "Status name of a pool in EXPIRED status"
@@ -2001,13 +2193,25 @@
     "defaultMessage": "Publier le bassin",
     "description": "Button to publish the pool in the publish pool dialog"
   },
+  "v2mXcp": {
+    "defaultMessage": "Gérer les demandes",
+    "description": "Link text for button to manage requests of a specific pool"
+  },
   "v6qX/r": {
     "defaultMessage": "Retour au tableau de bord du bassin",
     "description": "Text on a link to navigate back to the pool dashboard page"
   },
+  "vZgTKh": {
+    "defaultMessage": "Toutes les compétences techniques",
+    "description": "The option label for 'no filter' on the list of occupational skills"
+  },
   "w9FYqi": {
     "defaultMessage": "Annonce du bassin",
     "description": "Sub title for admin view pool page"
+  },
+  "wcdkTU": {
+    "defaultMessage": "Toutes les compétences transférables",
+    "description": "The option label for 'no filter' on the list of transferable skills"
   },
   "xGjm2A": {
     "defaultMessage": "Sélectionnez les compétences qui amélioreront les chances de correspondre aux qualités recherchées par le les gestionnaire. Celles-ci peuvent généralement être appris en cours de travail et ne sont pas nécessaires pour être accepté dans le bassin",
@@ -2029,6 +2233,10 @@
     "defaultMessage": "Détails",
     "description": "Sub title for admin view pool page"
   },
+  "y3mLbv": {
+    "defaultMessage": "Votre travail (français)",
+    "description": "Title for French pool advertisement Work"
+  },
   "y9tCKP": {
     "defaultMessage": "Utilisez ces options pour publier ou clore votre annonce. Une annonce en direct permettra aux candidats de soumettre leur candidature pour ce bassin",
     "description": "Helper message for changing the pool advertisement status"
@@ -2036,6 +2244,14 @@
   "yYDzYE": {
     "defaultMessage": "Fermez le bassin maintenant",
     "description": "Button to close the pool in the close pool dialog"
+  },
+  "s4DN3G": {
+    "defaultMessage": "Résultats des compétences générales",
+    "description": "Accessibility label for a result set of skills, filtered to mainstream skills"
+  },
+  "wziEOM": {
+    "defaultMessage": "résultats des compétences, recherche par mot-clé",
+    "description": "Accessibility label for a result set of skills, searched by keyword"
   },
   "mxOuYK": {
     "defaultMessage": "Télécharger CSV",
@@ -2076,6 +2292,10 @@
   "+wG2Ap": {
     "defaultMessage": "Vue {name} <hidden>{hiddenLabel}</hidden>",
     "description": "Title displayed for the View Item column."
+  },
+  "u9JHS9": {
+    "defaultMessage": "demande",
+    "description": "Text displayed after View text for Latest Request table view action"
   },
   "gLtTaW": {
     "defaultMessage": "demande",
@@ -2620,5 +2840,13 @@
   "z0QI6A": {
     "defaultMessage": "Tous les candidats du bassin",
     "description": "Title for the admin pool candidates table"
+  },
+  "/bwX1a": {
+    "defaultMessage": "Il est possible de trier les en-têtes de colonnes avec boutons",
+    "description": "Text displayed to instruct users how to sort table rows"
+  },
+  "k4xm25": {
+    "defaultMessage": "Téléchargement a échoué : Aucune rangée n’a été sélectionnée",
+    "description": "Alert message displayed when a user attempts to print without selecting items first"
   }
 }

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -102,10 +102,6 @@
     "defaultMessage": "Avis",
     "description": "Label for the terms and conditions link in the Footer."
   },
-  "mZMdKM": {
-    "defaultMessage": "Soumettre des commentaires au Nuage de talents du GC par courriel.",
-    "description": "Title for the feedback link in the Footer."
-  },
   "h3lIyO": {
     "defaultMessage": "Français",
     "description": "The language French."
@@ -142,10 +138,6 @@
     "defaultMessage": "Région de l’Atlantique",
     "description": "The work region of Canada described as Atlantic."
   },
-  "9iOaI4": {
-    "defaultMessage": "Plus intéressé",
-    "description": "The pool candidate's status is No Longer Interested."
-  },
   "IANM2P": {
     "defaultMessage": "Période indéterminée",
     "description": "The pool candidate's status is Placed Indeterminate."
@@ -173,10 +165,6 @@
   "wCft6M": {
     "defaultMessage": "Colombie Britannique",
     "description": "The work region of Canada described as British Columbia."
-  },
-  "z9Gr7V": {
-    "defaultMessage": "Accessibles",
-    "description": "The pool candidate's status is Available."
   },
   "2eBm5y": {
     "defaultMessage": "Terminé avec succès (titre de compétence accordé)",
@@ -268,9 +256,6 @@
     "defaultMessage": "Autre",
     "description": "Other selection for education type input"
   },
-  "hello": {
-    "defaultMessage": "Bonjour"
-  },
   "jS69se": {
     "defaultMessage": "Certification",
     "description": "Certification selection for education type input"
@@ -355,10 +340,6 @@
     "defaultMessage": "Expiré",
     "description": "The pool candidate's status is Expired."
   },
-  "cQnjsM": {
-    "defaultMessage": "Non Disponible",
-    "description": "The pool candidate's status is Unavailable."
-  },
   "+O6J4u": {
     "defaultMessage": "(Aucun sélectionné)",
     "description": "Text shown when the filter was not selected"
@@ -410,9 +391,6 @@
   "4BpFoX": {
     "defaultMessage": "{title} émis par {issuedBy}",
     "description": "The award title is issued by some group"
-  },
-  "4CrCbD": {
-    "defaultMessage": "Communauté"
   },
   "4Xa7Pd": {
     "defaultMessage": "Aucune information n'a été fournie",
@@ -522,9 +500,6 @@
     "defaultMessage": "Chargement...",
     "description": "Message to display when a page is loading."
   },
-  "GcPFLS": {
-    "defaultMessage": "Travail"
-  },
   "HalXgi": {
     "defaultMessage": "Nouvelle-Écosse",
     "description": "Nova Scotia selection for province or territory input"
@@ -532,10 +507,6 @@
   "JerysR": {
     "defaultMessage": "Par compétences",
     "description": "Tab title for experiences sorted by skills in applicant profile."
-  },
-  "KFGBmb": {
-    "defaultMessage": "Octroyé à :",
-    "description": "The award was given to"
   },
   "MGqCaE": {
     "defaultMessage": "Demandeur",
@@ -553,16 +524,9 @@
     "defaultMessage": "Niveau 3 : Chef d'équipe",
     "description": "The name of the Team leader Analyst role."
   },
-  "NDx+B0": {
-    "defaultMessage": "Personnel"
-  },
   "Nc4sjC": {
     "defaultMessage": "Renseignements gouvernementaux",
     "description": "Title of the Government Information link section"
-  },
-  "OocJKH": {
-    "defaultMessage": "Portée :",
-    "description": "The scope of the award given"
   },
   "OvJwG6": {
     "defaultMessage": "Renseignements supplémentaires : {details}",
@@ -579,10 +543,6 @@
   "P6PD/I": {
     "defaultMessage": "Manitoba",
     "description": "Manitoba selection for province or territory input"
-  },
-  "PJhCQn": {
-    "defaultMessage": "à {institution}",
-    "description": "Study at institution"
   },
   "QdXUwo": {
     "defaultMessage": "Aller à la page :",
@@ -603,13 +563,6 @@
   "SCCX7B": {
     "defaultMessage": "Vous n'avez pas encore ajouté de renseignements ici.",
     "description": "Message for when no data exists for the section"
-  },
-  "SEZweh": {
-    "defaultMessage": "Prix"
-  },
-  "SZZeHq": {
-    "defaultMessage": "Non",
-    "description": "No, did not completed a language evaluation"
   },
   "SvcqPG": {
     "defaultMessage": "Alberta",
@@ -687,10 +640,6 @@
     "defaultMessage": "Langue de communication préférée :",
     "description": "Preferred Language for communication purposes label and colon"
   },
-  "cIHjFT": {
-    "defaultMessage": "Ministère : <strong>{department}</strong>",
-    "description": "Message to state what department user is in."
-  },
   "dQseX7": {
     "defaultMessage": "1 expérience",
     "description": "Pluralization for one experience"
@@ -750,9 +699,6 @@
   "jhImZp": {
     "defaultMessage": "Activer ou désactiver le contexte",
     "description": "Label to toggle the context description of an input."
-  },
-  "jtygmI": {
-    "defaultMessage": "Éducation"
   },
   "kjX7mF": {
     "defaultMessage": "Aucune information n'a été fournie.",
@@ -1002,17 +948,9 @@
     "defaultMessage": "<strong>Inactif</strong> – Je ne veux pas être contacté pour trouver des possibilités d'emploi",
     "description": "Job Looking Status described as Inactive."
   },
-  "FRyIG2": {
-    "defaultMessage": "Vous devez saisir un terme de recherche avant d'appuyer sur la touche « Entrée »",
-    "description": "Error message displayed when the search term length is less then 2 characters."
-  },
   "W6Jh6N": {
     "defaultMessage": "Retirer cette compétence<hidden> : {skillName}</hidden>",
     "description": "Button label to remove the adjacent skill on skill result block."
-  },
-  "JY6WhU": {
-    "defaultMessage": "Rechercher une compétence précise...",
-    "description": "Label for the skills search bar."
   },
   "PF4ya+": {
     "defaultMessage": "p. ex. Python, JavaScript, etc.",
@@ -1150,10 +1088,6 @@
     "defaultMessage": "Clôture demain à {time}",
     "description": "Text displayed when relative date is tomorrow."
   },
-  "GuMTqQ": {
-    "defaultMessage": "Familles de compétences",
-    "description": "Radio group legend for a list of skill families"
-  },
   "GzVxoB": {
     "defaultMessage": "<strong>Virtuel : </strong>Travaillez de chez vous, partout au Canada.",
     "description": "The work region of Canada described as Telework."
@@ -1161,10 +1095,6 @@
   "IW/eej": {
     "defaultMessage": "« Je m’identifie comme une femme »",
     "description": "Statement for when someone indicates they are a woman"
-  },
-  "IfCvm5": {
-    "defaultMessage": "{fieldLabel}: Ce champ est obligatoire",
-    "description": "Error message that this field must filled for the form to be valid."
   },
   "L9AGk7": {
     "defaultMessage": "Modifiez vos options à propos de moi.",
@@ -1202,10 +1132,6 @@
     "defaultMessage": "Personne handicapée",
     "description": "Group for when someone indicates they have a disability"
   },
-  "RBHmM6": {
-    "defaultMessage": "Autres compétences « utiles à avoir » que vous pourriez envisager d'ajouter à votre profil :",
-    "description": "Text that appears when a user is missing optional skills on their profile"
-  },
   "RQGy+0": {
     "defaultMessage": "Publiée",
     "description": "Published pool advertisement status"
@@ -1241,10 +1167,6 @@
   "b02Azd": {
     "defaultMessage": "IT-04 (gestionnaire)",
     "description": "The name of the Senior advisor classification with group and level."
-  },
-  "bOch3v": {
-    "defaultMessage": "Les compétences suivantes « exigence » <red>required</red> sont manquantes dans votre profil :",
-    "description": "Text that appears when a user is missing required skills on their profile"
   },
   "c39xT8": {
     "defaultMessage": "Modifier les options de votre expérience.",
@@ -1309,10 +1231,6 @@
   "s4y1nI": {
     "defaultMessage": "« Je m'identifie comme membre d'une minorité visible »",
     "description": "Statement for when someone indicates they are a visible minority"
-  },
-  "vO/SlS": {
-    "defaultMessage": "Disponibilité, volonté et capacité à faire des heures supplémentaires (dernière minute)",
-    "description": "The operational requirement described as short notice overtime."
   },
   "wFZLxf": {
     "defaultMessage": "IT-03 (chef d'équipe)",
@@ -1398,10 +1316,6 @@
     "defaultMessage": "Aucune définition fournie<hidden> pour {skillName}</hidden>",
     "description": "Message displayed when a skill has no definition"
   },
-  "hm95fj": {
-    "defaultMessage": "Chercher par mot-clé",
-    "description": "A label to show that this tab for searching by keyword"
-  },
   "c4r/Zv": {
     "defaultMessage": "Aucune compétence n’a été liée à cette expérience jusqu’à présent.",
     "description": "A message explaining that the experience has no associated skills"
@@ -1438,10 +1352,6 @@
     "defaultMessage": "Chercher les compétences par mot-clé",
     "description": "Label for the skills search bar."
   },
-  "SwsGvU": {
-    "defaultMessage": "Filtrer les compétences par type",
-    "description": "Label for the skills families dropdown"
-  },
   "2Ckihd": {
     "defaultMessage": "Trouvé <primary>{skillCount}</primary> compétences.",
     "description": "The number of skills found within the skill picker."
@@ -1474,10 +1384,6 @@
     "defaultMessage": "Simple",
     "description": "Sélection simple pour le type d’employé du gouvernement."
   },
-  "3GT1s/": {
-    "defaultMessage": "Vous devez avoir au moins une compétence essentielle.",
-    "description": "Error message that at least one essential skill must be selected."
-  },
   "48qVi9": {
     "defaultMessage": "Autre",
     "description": "user is neither a citizen or permanent resident of Canada"
@@ -1490,19 +1396,9 @@
     "defaultMessage": "Statut de citoyenneté:",
     "description": "Citizenship status label"
   },
-  "BiSzNu": {
-    "defaultMessage": "Compétences sélectionnées ({skillCount})",
-    "description": "A title for a skill list"
-  },
-  "CO50a/": {
-    "defaultMessage": "Durée (court terme, long terme ou durée indéterminée)"
-  },
   "CX/qKY": {
     "defaultMessage": "à {institution}",
     "description": "Study at institution"
-  },
-  "Ekwul3": {
-    "defaultMessage": "Durée (permanente)"
   },
   "FEfWEH": {
     "defaultMessage": "Ébauche",
@@ -1528,10 +1424,6 @@
     "defaultMessage": "Portée:",
     "description": "The scope of the award given"
   },
-  "J3779Q": {
-    "defaultMessage": "Groupes de compétences",
-    "description": "A title for a list of skill families"
-  },
   "JHgARn": {
     "defaultMessage": "Vous avez dépassé la limite de mots, {wordLimit}.",
     "description": "Text read out to assistive technology when over the word limit."
@@ -1539,10 +1431,6 @@
   "K80psp": {
     "defaultMessage": "Autre",
     "description": "Priority text for users with no priority"
-  },
-  "LfNNe4": {
-    "defaultMessage": "Par mot-clé",
-    "description": "Tab name for a box to search for skills"
   },
   "LjkK5G": {
     "defaultMessage": "Compétences comportementales",
@@ -1568,10 +1456,6 @@
     "defaultMessage": "Nouvelle candidature",
     "description": "The pool candidate's status is New Application."
   },
-  "OtOIXG": {
-    "defaultMessage": "déjà archivé",
-    "description": "Error message that the given model is already archived."
-  },
   "PmMr9l": {
     "defaultMessage": "Durée de l’emploi",
     "description": "Title for work language on summary of filters section"
@@ -1595,10 +1479,6 @@
   "S9BRBL": {
     "defaultMessage": "Durée (court terme, long terme)",
     "description": "Duration of a non-permanent length"
-  },
-  "Sx/Pzn": {
-    "defaultMessage": "Toutes les compétences comportementales",
-    "description": "The option label for 'no filter' on the list of behavioural skills"
   },
   "T49QiO": {
     "defaultMessage": "Type d’emploi :",
@@ -1640,10 +1520,6 @@
     "defaultMessage": "Ébauche expirée",
     "description": "The pool candidate's status is Expired Draft."
   },
-  "bhuMGL": {
-    "defaultMessage": "Vous devez saisir advertisement_location si l’annonce n’est pas à distance.",
-    "description": "Error message that the pool advertisement must have a location if it is not for remote work."
-  },
   "dnGlXQ": {
     "defaultMessage": "Accepté",
     "description": "The pool candidate's status is Screened In."
@@ -1668,14 +1544,6 @@
     "defaultMessage": "Compétences techniques",
     "description": "Tab name for a list of technical skills"
   },
-  "l0IDWf": {
-    "defaultMessage": "Résultats ({skillCount})",
-    "description": "A title for a skill list of results"
-  },
-  "l8p1el": {
-    "defaultMessage": "Cet identifiant d’utilisateur (sub) est déjà utilisé",
-    "description": "Error message that the given user identifier is already in use."
-  },
   "lr2+2R": {
     "defaultMessage": "Autre",
     "description": "declaring one to be neither a citizen or permanent resident of Canada"
@@ -1692,17 +1560,9 @@
     "defaultMessage": "Aucun nom fourni",
     "description": "Fallback for name value"
   },
-  "nDaEgr": {
-    "defaultMessage": "Cette adresse courriel est déjà utilisée",
-    "description": "Error message that the given email address is already in use."
-  },
   "nV57as": {
     "defaultMessage": "Département :",
     "description": "Label for applicants department"
-  },
-  "nr62lc": {
-    "defaultMessage": "Résultats ({skillCount})",
-    "description": "Un titre pour une liste de résultats"
   },
   "oMyc4e": {
     "defaultMessage": "Citoyen ou résident",
@@ -1728,10 +1588,6 @@
     "defaultMessage": "Durée indéterminée (permanente)",
     "description": "Duration that is permanent"
   },
-  "s4DN3G": {
-    "defaultMessage": "Résultats des compétences générales",
-    "description": "Accessibility label for a result set of skills, filtered to mainstream skills"
-  },
   "sfr5Pa": {
     "defaultMessage": "La date d’expiration doit être postérieure à aujourd’hui.",
     "description": "Error message that the given skill expiry date must be after today."
@@ -1756,10 +1612,6 @@
     "defaultMessage": "Ce champ ne peut pas utiliser de dates dans le futur.",
     "description": "Error message that the date cannot be in the future."
   },
-  "vZgTKh": {
-    "defaultMessage": "Toutes les compétences techniques",
-    "description": "The option label for 'no filter' on the list of occupational skills"
-  },
   "vgxxk0": {
     "defaultMessage": "Vétéran",
     "description": "user is a CAF veteran"
@@ -1767,10 +1619,6 @@
   "w2Jpt8": {
     "defaultMessage": "Étudiant",
     "description": "Simple student selection for government employee type."
-  },
-  "wziEOM": {
-    "defaultMessage": "résultats des compétences de recherche par mot-clé",
-    "description": "Accessibility label for a result set of skills, searched by keyword"
   },
   "x0FRH/": {
     "defaultMessage": "Je n’ai pas de droit de priorité",
@@ -1805,20 +1653,20 @@
     "description": "Heading for personal experiences in experience by type listing"
   },
   "iWD2Pz": {
-      "defaultMessage": "Expériences de la collectivité",
-      "description": "Heading for community experiences in experience by type listing"
+    "defaultMessage": "Expériences de la collectivité",
+    "description": "Heading for community experiences in experience by type listing"
   },
   "aBSEkP": {
-      "defaultMessage": "Expériences de travail",
-      "description": "Heading for personal experiences in experience by type listing"
+    "defaultMessage": "Expériences de travail",
+    "description": "Heading for personal experiences in experience by type listing"
   },
   "pV96Xv": {
-      "defaultMessage": "Expériences scolaires",
-      "description": "Heading for education experiences in experience by type listing"
+    "defaultMessage": "Expériences scolaires",
+    "description": "Heading for education experiences in experience by type listing"
   },
   "X0YPib": {
-      "defaultMessage": "Expériences relatives aux prix",
-      "description": "Heading for award experiences in experience by type listing"
+    "defaultMessage": "Expériences relatives aux prix",
+    "description": "Heading for award experiences in experience by type listing"
   },
   "/I9tx9": {
     "defaultMessage": "Cette demande ne peut pas être supprimée. Vous pouvez uniquement supprimer les demandes avant leur soumission.",

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -102,10 +102,6 @@
     "defaultMessage": "Avis",
     "description": "Label for the terms and conditions link in the Footer."
   },
-  "mZMdKM": {
-    "defaultMessage": "Soumettre des commentaires au Nuage de talents du GC par courriel.",
-    "description": "Title for the feedback link in the Footer."
-  },
   "h3lIyO": {
     "defaultMessage": "Français",
     "description": "The language French."
@@ -142,10 +138,6 @@
     "defaultMessage": "Région de l’Atlantique",
     "description": "The work region of Canada described as Atlantic."
   },
-  "9iOaI4": {
-    "defaultMessage": "Plus intéressé",
-    "description": "The pool candidate's status is No Longer Interested."
-  },
   "IANM2P": {
     "defaultMessage": "Période indéterminée",
     "description": "The pool candidate's status is Placed Indeterminate."
@@ -173,10 +165,6 @@
   "wCft6M": {
     "defaultMessage": "Colombie Britannique",
     "description": "The work region of Canada described as British Columbia."
-  },
-  "z9Gr7V": {
-    "defaultMessage": "Accessibles",
-    "description": "The pool candidate's status is Available."
   },
   "2eBm5y": {
     "defaultMessage": "Terminé avec succès (titre de compétence accordé)",
@@ -268,9 +256,6 @@
     "defaultMessage": "Autre",
     "description": "Other selection for education type input"
   },
-  "hello": {
-    "defaultMessage": "Bonjour"
-  },
   "jS69se": {
     "defaultMessage": "Certification",
     "description": "Certification selection for education type input"
@@ -355,10 +340,6 @@
     "defaultMessage": "Expiré",
     "description": "The pool candidate's status is Expired."
   },
-  "cQnjsM": {
-    "defaultMessage": "Non Disponible",
-    "description": "The pool candidate's status is Unavailable."
-  },
   "+O6J4u": {
     "defaultMessage": "(Aucun sélectionné)",
     "description": "Text shown when the filter was not selected"
@@ -410,9 +391,6 @@
   "4BpFoX": {
     "defaultMessage": "{title} émis par {issuedBy}",
     "description": "The award title is issued by some group"
-  },
-  "4CrCbD": {
-    "defaultMessage": "Communauté"
   },
   "4Xa7Pd": {
     "defaultMessage": "Aucune information n'a été fournie",
@@ -522,9 +500,6 @@
     "defaultMessage": "Chargement...",
     "description": "Message to display when a page is loading."
   },
-  "GcPFLS": {
-    "defaultMessage": "Travail"
-  },
   "HalXgi": {
     "defaultMessage": "Nouvelle-Écosse",
     "description": "Nova Scotia selection for province or territory input"
@@ -532,10 +507,6 @@
   "JerysR": {
     "defaultMessage": "Par compétences",
     "description": "Tab title for experiences sorted by skills in applicant profile."
-  },
-  "KFGBmb": {
-    "defaultMessage": "Octroyé à :",
-    "description": "The award was given to"
   },
   "MGqCaE": {
     "defaultMessage": "Demandeur",
@@ -553,16 +524,9 @@
     "defaultMessage": "Niveau 3 : Chef d'équipe",
     "description": "The name of the Team leader Analyst role."
   },
-  "NDx+B0": {
-    "defaultMessage": "Personnel"
-  },
   "Nc4sjC": {
     "defaultMessage": "Renseignements gouvernementaux",
     "description": "Title of the Government Information link section"
-  },
-  "OocJKH": {
-    "defaultMessage": "Portée :",
-    "description": "The scope of the award given"
   },
   "OvJwG6": {
     "defaultMessage": "Renseignements supplémentaires : {details}",
@@ -579,10 +543,6 @@
   "P6PD/I": {
     "defaultMessage": "Manitoba",
     "description": "Manitoba selection for province or territory input"
-  },
-  "PJhCQn": {
-    "defaultMessage": "à {institution}",
-    "description": "Study at institution"
   },
   "QdXUwo": {
     "defaultMessage": "Aller à la page :",
@@ -603,13 +563,6 @@
   "SCCX7B": {
     "defaultMessage": "Vous n'avez pas encore ajouté de renseignements ici.",
     "description": "Message for when no data exists for the section"
-  },
-  "SEZweh": {
-    "defaultMessage": "Prix"
-  },
-  "SZZeHq": {
-    "defaultMessage": "Non",
-    "description": "No, did not completed a language evaluation"
   },
   "SvcqPG": {
     "defaultMessage": "Alberta",
@@ -687,10 +640,6 @@
     "defaultMessage": "Langue de communication préférée :",
     "description": "Preferred Language for communication purposes label and colon"
   },
-  "cIHjFT": {
-    "defaultMessage": "Ministère : <strong>{department}</strong>",
-    "description": "Message to state what department user is in."
-  },
   "dQseX7": {
     "defaultMessage": "1 expérience",
     "description": "Pluralization for one experience"
@@ -750,9 +699,6 @@
   "jhImZp": {
     "defaultMessage": "Activer ou désactiver le contexte",
     "description": "Label to toggle the context description of an input."
-  },
-  "jtygmI": {
-    "defaultMessage": "Éducation"
   },
   "kjX7mF": {
     "defaultMessage": "Aucune information n'a été fournie.",
@@ -1002,17 +948,9 @@
     "defaultMessage": "<strong>Inactif</strong> – Je ne veux pas être contacté pour trouver des possibilités d'emploi",
     "description": "Job Looking Status described as Inactive."
   },
-  "FRyIG2": {
-    "defaultMessage": "Vous devez saisir un terme de recherche avant d'appuyer sur la touche « Entrée »",
-    "description": "Error message displayed when the search term length is less then 2 characters."
-  },
   "W6Jh6N": {
     "defaultMessage": "Retirer cette compétence<hidden> : {skillName}</hidden>",
     "description": "Button label to remove the adjacent skill on skill result block."
-  },
-  "JY6WhU": {
-    "defaultMessage": "Rechercher une compétence précise...",
-    "description": "Label for the skills search bar."
   },
   "PF4ya+": {
     "defaultMessage": "p. ex. Python, JavaScript, etc.",
@@ -1150,10 +1088,6 @@
     "defaultMessage": "Clôture demain à {time}",
     "description": "Text displayed when relative date is tomorrow."
   },
-  "GuMTqQ": {
-    "defaultMessage": "Familles de compétences",
-    "description": "Radio group legend for a list of skill families"
-  },
   "GzVxoB": {
     "defaultMessage": "<strong>Virtuel : </strong>Travaillez de chez vous, partout au Canada.",
     "description": "The work region of Canada described as Telework."
@@ -1161,10 +1095,6 @@
   "IW/eej": {
     "defaultMessage": "« Je m’identifie comme une femme »",
     "description": "Statement for when someone indicates they are a woman"
-  },
-  "IfCvm5": {
-    "defaultMessage": "{fieldLabel}: Ce champ est obligatoire",
-    "description": "Error message that this field must filled for the form to be valid."
   },
   "L9AGk7": {
     "defaultMessage": "Modifiez vos options à propos de moi.",
@@ -1202,10 +1132,6 @@
     "defaultMessage": "Personne handicapée",
     "description": "Group for when someone indicates they have a disability"
   },
-  "RBHmM6": {
-    "defaultMessage": "Autres compétences « utiles à avoir » que vous pourriez envisager d'ajouter à votre profil :",
-    "description": "Text that appears when a user is missing optional skills on their profile"
-  },
   "RQGy+0": {
     "defaultMessage": "Publiée",
     "description": "Published pool advertisement status"
@@ -1241,10 +1167,6 @@
   "b02Azd": {
     "defaultMessage": "IT-04 (gestionnaire)",
     "description": "The name of the Senior advisor classification with group and level."
-  },
-  "bOch3v": {
-    "defaultMessage": "Les compétences suivantes « exigence » <red>required</red> sont manquantes dans votre profil :",
-    "description": "Text that appears when a user is missing required skills on their profile"
   },
   "c39xT8": {
     "defaultMessage": "Modifier les options de votre expérience.",
@@ -1309,10 +1231,6 @@
   "s4y1nI": {
     "defaultMessage": "« Je m'identifie comme membre d'une minorité visible »",
     "description": "Statement for when someone indicates they are a visible minority"
-  },
-  "vO/SlS": {
-    "defaultMessage": "Disponibilité, volonté et capacité à faire des heures supplémentaires (dernière minute)",
-    "description": "The operational requirement described as short notice overtime."
   },
   "wFZLxf": {
     "defaultMessage": "IT-03 (chef d'équipe)",
@@ -1398,10 +1316,6 @@
     "defaultMessage": "Aucune définition fournie<hidden> pour {skillName}</hidden>",
     "description": "Message displayed when a skill has no definition"
   },
-  "hm95fj": {
-    "defaultMessage": "Chercher par mot-clé",
-    "description": "A label to show that this tab for searching by keyword"
-  },
   "c4r/Zv": {
     "defaultMessage": "Aucune compétence n’a été liée à cette expérience jusqu’à présent.",
     "description": "A message explaining that the experience has no associated skills"
@@ -1438,10 +1352,6 @@
     "defaultMessage": "Chercher les compétences par mot-clé",
     "description": "Label for the skills search bar."
   },
-  "SwsGvU": {
-    "defaultMessage": "Filtrer les compétences par type",
-    "description": "Label for the skills families dropdown"
-  },
   "2Ckihd": {
     "defaultMessage": "Trouvé <primary>{skillCount}</primary> compétences.",
     "description": "The number of skills found within the skill picker."
@@ -1474,10 +1384,6 @@
     "defaultMessage": "Simple",
     "description": "Sélection simple pour le type d’employé du gouvernement."
   },
-  "3GT1s/": {
-    "defaultMessage": "Vous devez avoir au moins une compétence essentielle.",
-    "description": "Error message that at least one essential skill must be selected."
-  },
   "48qVi9": {
     "defaultMessage": "Autre",
     "description": "user is neither a citizen or permanent resident of Canada"
@@ -1490,19 +1396,9 @@
     "defaultMessage": "Statut de citoyenneté:",
     "description": "Citizenship status label"
   },
-  "BiSzNu": {
-    "defaultMessage": "Compétences sélectionnées ({skillCount})",
-    "description": "A title for a skill list"
-  },
-  "CO50a/": {
-    "defaultMessage": "Durée (court terme, long terme ou durée indéterminée)"
-  },
   "CX/qKY": {
     "defaultMessage": "à {institution}",
     "description": "Study at institution"
-  },
-  "Ekwul3": {
-    "defaultMessage": "Durée (permanente)"
   },
   "FEfWEH": {
     "defaultMessage": "Ébauche",
@@ -1528,10 +1424,6 @@
     "defaultMessage": "Portée:",
     "description": "The scope of the award given"
   },
-  "J3779Q": {
-    "defaultMessage": "Groupes de compétences",
-    "description": "A title for a list of skill families"
-  },
   "JHgARn": {
     "defaultMessage": "Vous avez dépassé la limite de mots, {wordLimit}.",
     "description": "Text read out to assistive technology when over the word limit."
@@ -1539,10 +1431,6 @@
   "K80psp": {
     "defaultMessage": "Autre",
     "description": "Priority text for users with no priority"
-  },
-  "LfNNe4": {
-    "defaultMessage": "Par mot-clé",
-    "description": "Tab name for a box to search for skills"
   },
   "LjkK5G": {
     "defaultMessage": "Compétences comportementales",
@@ -1568,10 +1456,6 @@
     "defaultMessage": "Nouvelle candidature",
     "description": "The pool candidate's status is New Application."
   },
-  "OtOIXG": {
-    "defaultMessage": "déjà archivé",
-    "description": "Error message that the given model is already archived."
-  },
   "PmMr9l": {
     "defaultMessage": "Durée de l’emploi",
     "description": "Title for work language on summary of filters section"
@@ -1595,10 +1479,6 @@
   "S9BRBL": {
     "defaultMessage": "Durée (court terme, long terme)",
     "description": "Duration of a non-permanent length"
-  },
-  "Sx/Pzn": {
-    "defaultMessage": "Toutes les compétences comportementales",
-    "description": "The option label for 'no filter' on the list of behavioural skills"
   },
   "T49QiO": {
     "defaultMessage": "Type d’emploi :",
@@ -1640,10 +1520,6 @@
     "defaultMessage": "Ébauche expirée",
     "description": "The pool candidate's status is Expired Draft."
   },
-  "bhuMGL": {
-    "defaultMessage": "Vous devez saisir advertisement_location si l’annonce n’est pas à distance.",
-    "description": "Error message that the pool advertisement must have a location if it is not for remote work."
-  },
   "dnGlXQ": {
     "defaultMessage": "Accepté",
     "description": "The pool candidate's status is Screened In."
@@ -1668,14 +1544,6 @@
     "defaultMessage": "Compétences techniques",
     "description": "Tab name for a list of technical skills"
   },
-  "l0IDWf": {
-    "defaultMessage": "Résultats ({skillCount})",
-    "description": "A title for a skill list of results"
-  },
-  "l8p1el": {
-    "defaultMessage": "Cet identifiant d’utilisateur (sub) est déjà utilisé",
-    "description": "Error message that the given user identifier is already in use."
-  },
   "lr2+2R": {
     "defaultMessage": "Autre",
     "description": "declaring one to be neither a citizen or permanent resident of Canada"
@@ -1692,17 +1560,9 @@
     "defaultMessage": "Aucun nom fourni",
     "description": "Fallback for name value"
   },
-  "nDaEgr": {
-    "defaultMessage": "Cette adresse courriel est déjà utilisée",
-    "description": "Error message that the given email address is already in use."
-  },
   "nV57as": {
     "defaultMessage": "Département :",
     "description": "Label for applicants department"
-  },
-  "nr62lc": {
-    "defaultMessage": "Résultats ({skillCount})",
-    "description": "Un titre pour une liste de résultats"
   },
   "oMyc4e": {
     "defaultMessage": "Citoyen ou résident",
@@ -1728,10 +1588,6 @@
     "defaultMessage": "Durée indéterminée (permanente)",
     "description": "Duration that is permanent"
   },
-  "s4DN3G": {
-    "defaultMessage": "Résultats des compétences générales",
-    "description": "Accessibility label for a result set of skills, filtered to mainstream skills"
-  },
   "sfr5Pa": {
     "defaultMessage": "La date d’expiration doit être postérieure à aujourd’hui.",
     "description": "Error message that the given skill expiry date must be after today."
@@ -1756,10 +1612,6 @@
     "defaultMessage": "Ce champ ne peut pas utiliser de dates dans le futur.",
     "description": "Error message that the date cannot be in the future."
   },
-  "vZgTKh": {
-    "defaultMessage": "Toutes les compétences techniques",
-    "description": "The option label for 'no filter' on the list of occupational skills"
-  },
   "vgxxk0": {
     "defaultMessage": "Vétéran",
     "description": "user is a CAF veteran"
@@ -1767,10 +1619,6 @@
   "w2Jpt8": {
     "defaultMessage": "Étudiant",
     "description": "Simple student selection for government employee type."
-  },
-  "wziEOM": {
-    "defaultMessage": "résultats des compétences de recherche par mot-clé",
-    "description": "Accessibility label for a result set of skills, searched by keyword"
   },
   "x0FRH/": {
     "defaultMessage": "Je n’ai pas de droit de priorité",
@@ -1805,20 +1653,20 @@
     "description": "Heading for personal experiences in experience by type listing"
   },
   "iWD2Pz": {
-      "defaultMessage": "Expériences de la collectivité",
-      "description": "Heading for community experiences in experience by type listing"
+    "defaultMessage": "Expériences de la collectivité",
+    "description": "Heading for community experiences in experience by type listing"
   },
   "aBSEkP": {
-      "defaultMessage": "Expériences de travail",
-      "description": "Heading for personal experiences in experience by type listing"
+    "defaultMessage": "Expériences de travail",
+    "description": "Heading for personal experiences in experience by type listing"
   },
   "pV96Xv": {
-      "defaultMessage": "Expériences scolaires",
-      "description": "Heading for education experiences in experience by type listing"
+    "defaultMessage": "Expériences scolaires",
+    "description": "Heading for education experiences in experience by type listing"
   },
   "X0YPib": {
-      "defaultMessage": "Expériences relatives aux prix",
-      "description": "Heading for award experiences in experience by type listing"
+    "defaultMessage": "Expériences relatives aux prix",
+    "description": "Heading for award experiences in experience by type listing"
   },
   "/I9tx9": {
     "defaultMessage": "Cette demande ne peut pas être supprimée. Vous pouvez uniquement supprimer les demandes avant leur soumission.",
@@ -2031,9 +1879,5 @@
   "2iCpAL": {
     "defaultMessage": "Énoncé sur l’accessibilité",
     "description": "Title for the websites accessibility statement"
-  },
-  "Tw90Pi": {
-    "defaultMessage": "Enregistrement...",
-    "description": "Submitting text for save button."
   }
 }

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -102,6 +102,10 @@
     "defaultMessage": "Avis",
     "description": "Label for the terms and conditions link in the Footer."
   },
+  "mZMdKM": {
+    "defaultMessage": "Soumettre des commentaires au Nuage de talents du GC par courriel.",
+    "description": "Title for the feedback link in the Footer."
+  },
   "h3lIyO": {
     "defaultMessage": "Français",
     "description": "The language French."
@@ -138,6 +142,10 @@
     "defaultMessage": "Région de l’Atlantique",
     "description": "The work region of Canada described as Atlantic."
   },
+  "9iOaI4": {
+    "defaultMessage": "Plus intéressé",
+    "description": "The pool candidate's status is No Longer Interested."
+  },
   "IANM2P": {
     "defaultMessage": "Période indéterminée",
     "description": "The pool candidate's status is Placed Indeterminate."
@@ -165,6 +173,10 @@
   "wCft6M": {
     "defaultMessage": "Colombie Britannique",
     "description": "The work region of Canada described as British Columbia."
+  },
+  "z9Gr7V": {
+    "defaultMessage": "Accessibles",
+    "description": "The pool candidate's status is Available."
   },
   "2eBm5y": {
     "defaultMessage": "Terminé avec succès (titre de compétence accordé)",
@@ -256,6 +268,9 @@
     "defaultMessage": "Autre",
     "description": "Other selection for education type input"
   },
+  "hello": {
+    "defaultMessage": "Bonjour"
+  },
   "jS69se": {
     "defaultMessage": "Certification",
     "description": "Certification selection for education type input"
@@ -340,6 +355,10 @@
     "defaultMessage": "Expiré",
     "description": "The pool candidate's status is Expired."
   },
+  "cQnjsM": {
+    "defaultMessage": "Non Disponible",
+    "description": "The pool candidate's status is Unavailable."
+  },
   "+O6J4u": {
     "defaultMessage": "(Aucun sélectionné)",
     "description": "Text shown when the filter was not selected"
@@ -391,6 +410,9 @@
   "4BpFoX": {
     "defaultMessage": "{title} émis par {issuedBy}",
     "description": "The award title is issued by some group"
+  },
+  "4CrCbD": {
+    "defaultMessage": "Communauté"
   },
   "4Xa7Pd": {
     "defaultMessage": "Aucune information n'a été fournie",
@@ -500,6 +522,9 @@
     "defaultMessage": "Chargement...",
     "description": "Message to display when a page is loading."
   },
+  "GcPFLS": {
+    "defaultMessage": "Travail"
+  },
   "HalXgi": {
     "defaultMessage": "Nouvelle-Écosse",
     "description": "Nova Scotia selection for province or territory input"
@@ -507,6 +532,10 @@
   "JerysR": {
     "defaultMessage": "Par compétences",
     "description": "Tab title for experiences sorted by skills in applicant profile."
+  },
+  "KFGBmb": {
+    "defaultMessage": "Octroyé à :",
+    "description": "The award was given to"
   },
   "MGqCaE": {
     "defaultMessage": "Demandeur",
@@ -524,9 +553,16 @@
     "defaultMessage": "Niveau 3 : Chef d'équipe",
     "description": "The name of the Team leader Analyst role."
   },
+  "NDx+B0": {
+    "defaultMessage": "Personnel"
+  },
   "Nc4sjC": {
     "defaultMessage": "Renseignements gouvernementaux",
     "description": "Title of the Government Information link section"
+  },
+  "OocJKH": {
+    "defaultMessage": "Portée :",
+    "description": "The scope of the award given"
   },
   "OvJwG6": {
     "defaultMessage": "Renseignements supplémentaires : {details}",
@@ -543,6 +579,10 @@
   "P6PD/I": {
     "defaultMessage": "Manitoba",
     "description": "Manitoba selection for province or territory input"
+  },
+  "PJhCQn": {
+    "defaultMessage": "à {institution}",
+    "description": "Study at institution"
   },
   "QdXUwo": {
     "defaultMessage": "Aller à la page :",
@@ -563,6 +603,13 @@
   "SCCX7B": {
     "defaultMessage": "Vous n'avez pas encore ajouté de renseignements ici.",
     "description": "Message for when no data exists for the section"
+  },
+  "SEZweh": {
+    "defaultMessage": "Prix"
+  },
+  "SZZeHq": {
+    "defaultMessage": "Non",
+    "description": "No, did not completed a language evaluation"
   },
   "SvcqPG": {
     "defaultMessage": "Alberta",
@@ -640,6 +687,10 @@
     "defaultMessage": "Langue de communication préférée :",
     "description": "Preferred Language for communication purposes label and colon"
   },
+  "cIHjFT": {
+    "defaultMessage": "Ministère : <strong>{department}</strong>",
+    "description": "Message to state what department user is in."
+  },
   "dQseX7": {
     "defaultMessage": "1 expérience",
     "description": "Pluralization for one experience"
@@ -699,6 +750,9 @@
   "jhImZp": {
     "defaultMessage": "Activer ou désactiver le contexte",
     "description": "Label to toggle the context description of an input."
+  },
+  "jtygmI": {
+    "defaultMessage": "Éducation"
   },
   "kjX7mF": {
     "defaultMessage": "Aucune information n'a été fournie.",
@@ -948,9 +1002,17 @@
     "defaultMessage": "<strong>Inactif</strong> – Je ne veux pas être contacté pour trouver des possibilités d'emploi",
     "description": "Job Looking Status described as Inactive."
   },
+  "FRyIG2": {
+    "defaultMessage": "Vous devez saisir un terme de recherche avant d'appuyer sur la touche « Entrée »",
+    "description": "Error message displayed when the search term length is less then 2 characters."
+  },
   "W6Jh6N": {
     "defaultMessage": "Retirer cette compétence<hidden> : {skillName}</hidden>",
     "description": "Button label to remove the adjacent skill on skill result block."
+  },
+  "JY6WhU": {
+    "defaultMessage": "Rechercher une compétence précise...",
+    "description": "Label for the skills search bar."
   },
   "PF4ya+": {
     "defaultMessage": "p. ex. Python, JavaScript, etc.",
@@ -1088,6 +1150,10 @@
     "defaultMessage": "Clôture demain à {time}",
     "description": "Text displayed when relative date is tomorrow."
   },
+  "GuMTqQ": {
+    "defaultMessage": "Familles de compétences",
+    "description": "Radio group legend for a list of skill families"
+  },
   "GzVxoB": {
     "defaultMessage": "<strong>Virtuel : </strong>Travaillez de chez vous, partout au Canada.",
     "description": "The work region of Canada described as Telework."
@@ -1095,6 +1161,10 @@
   "IW/eej": {
     "defaultMessage": "« Je m’identifie comme une femme »",
     "description": "Statement for when someone indicates they are a woman"
+  },
+  "IfCvm5": {
+    "defaultMessage": "{fieldLabel}: Ce champ est obligatoire",
+    "description": "Error message that this field must filled for the form to be valid."
   },
   "L9AGk7": {
     "defaultMessage": "Modifiez vos options à propos de moi.",
@@ -1132,6 +1202,10 @@
     "defaultMessage": "Personne handicapée",
     "description": "Group for when someone indicates they have a disability"
   },
+  "RBHmM6": {
+    "defaultMessage": "Autres compétences « utiles à avoir » que vous pourriez envisager d'ajouter à votre profil :",
+    "description": "Text that appears when a user is missing optional skills on their profile"
+  },
   "RQGy+0": {
     "defaultMessage": "Publiée",
     "description": "Published pool advertisement status"
@@ -1167,6 +1241,10 @@
   "b02Azd": {
     "defaultMessage": "IT-04 (gestionnaire)",
     "description": "The name of the Senior advisor classification with group and level."
+  },
+  "bOch3v": {
+    "defaultMessage": "Les compétences suivantes « exigence » <red>required</red> sont manquantes dans votre profil :",
+    "description": "Text that appears when a user is missing required skills on their profile"
   },
   "c39xT8": {
     "defaultMessage": "Modifier les options de votre expérience.",
@@ -1231,6 +1309,10 @@
   "s4y1nI": {
     "defaultMessage": "« Je m'identifie comme membre d'une minorité visible »",
     "description": "Statement for when someone indicates they are a visible minority"
+  },
+  "vO/SlS": {
+    "defaultMessage": "Disponibilité, volonté et capacité à faire des heures supplémentaires (dernière minute)",
+    "description": "The operational requirement described as short notice overtime."
   },
   "wFZLxf": {
     "defaultMessage": "IT-03 (chef d'équipe)",
@@ -1316,6 +1398,10 @@
     "defaultMessage": "Aucune définition fournie<hidden> pour {skillName}</hidden>",
     "description": "Message displayed when a skill has no definition"
   },
+  "hm95fj": {
+    "defaultMessage": "Chercher par mot-clé",
+    "description": "A label to show that this tab for searching by keyword"
+  },
   "c4r/Zv": {
     "defaultMessage": "Aucune compétence n’a été liée à cette expérience jusqu’à présent.",
     "description": "A message explaining that the experience has no associated skills"
@@ -1352,6 +1438,10 @@
     "defaultMessage": "Chercher les compétences par mot-clé",
     "description": "Label for the skills search bar."
   },
+  "SwsGvU": {
+    "defaultMessage": "Filtrer les compétences par type",
+    "description": "Label for the skills families dropdown"
+  },
   "2Ckihd": {
     "defaultMessage": "Trouvé <primary>{skillCount}</primary> compétences.",
     "description": "The number of skills found within the skill picker."
@@ -1384,6 +1474,10 @@
     "defaultMessage": "Simple",
     "description": "Sélection simple pour le type d’employé du gouvernement."
   },
+  "3GT1s/": {
+    "defaultMessage": "Vous devez avoir au moins une compétence essentielle.",
+    "description": "Error message that at least one essential skill must be selected."
+  },
   "48qVi9": {
     "defaultMessage": "Autre",
     "description": "user is neither a citizen or permanent resident of Canada"
@@ -1396,9 +1490,19 @@
     "defaultMessage": "Statut de citoyenneté:",
     "description": "Citizenship status label"
   },
+  "BiSzNu": {
+    "defaultMessage": "Compétences sélectionnées ({skillCount})",
+    "description": "A title for a skill list"
+  },
+  "CO50a/": {
+    "defaultMessage": "Durée (court terme, long terme ou durée indéterminée)"
+  },
   "CX/qKY": {
     "defaultMessage": "à {institution}",
     "description": "Study at institution"
+  },
+  "Ekwul3": {
+    "defaultMessage": "Durée (permanente)"
   },
   "FEfWEH": {
     "defaultMessage": "Ébauche",
@@ -1424,6 +1528,10 @@
     "defaultMessage": "Portée:",
     "description": "The scope of the award given"
   },
+  "J3779Q": {
+    "defaultMessage": "Groupes de compétences",
+    "description": "A title for a list of skill families"
+  },
   "JHgARn": {
     "defaultMessage": "Vous avez dépassé la limite de mots, {wordLimit}.",
     "description": "Text read out to assistive technology when over the word limit."
@@ -1431,6 +1539,10 @@
   "K80psp": {
     "defaultMessage": "Autre",
     "description": "Priority text for users with no priority"
+  },
+  "LfNNe4": {
+    "defaultMessage": "Par mot-clé",
+    "description": "Tab name for a box to search for skills"
   },
   "LjkK5G": {
     "defaultMessage": "Compétences comportementales",
@@ -1456,6 +1568,10 @@
     "defaultMessage": "Nouvelle candidature",
     "description": "The pool candidate's status is New Application."
   },
+  "OtOIXG": {
+    "defaultMessage": "déjà archivé",
+    "description": "Error message that the given model is already archived."
+  },
   "PmMr9l": {
     "defaultMessage": "Durée de l’emploi",
     "description": "Title for work language on summary of filters section"
@@ -1479,6 +1595,10 @@
   "S9BRBL": {
     "defaultMessage": "Durée (court terme, long terme)",
     "description": "Duration of a non-permanent length"
+  },
+  "Sx/Pzn": {
+    "defaultMessage": "Toutes les compétences comportementales",
+    "description": "The option label for 'no filter' on the list of behavioural skills"
   },
   "T49QiO": {
     "defaultMessage": "Type d’emploi :",
@@ -1520,6 +1640,10 @@
     "defaultMessage": "Ébauche expirée",
     "description": "The pool candidate's status is Expired Draft."
   },
+  "bhuMGL": {
+    "defaultMessage": "Vous devez saisir advertisement_location si l’annonce n’est pas à distance.",
+    "description": "Error message that the pool advertisement must have a location if it is not for remote work."
+  },
   "dnGlXQ": {
     "defaultMessage": "Accepté",
     "description": "The pool candidate's status is Screened In."
@@ -1544,6 +1668,14 @@
     "defaultMessage": "Compétences techniques",
     "description": "Tab name for a list of technical skills"
   },
+  "l0IDWf": {
+    "defaultMessage": "Résultats ({skillCount})",
+    "description": "A title for a skill list of results"
+  },
+  "l8p1el": {
+    "defaultMessage": "Cet identifiant d’utilisateur (sub) est déjà utilisé",
+    "description": "Error message that the given user identifier is already in use."
+  },
   "lr2+2R": {
     "defaultMessage": "Autre",
     "description": "declaring one to be neither a citizen or permanent resident of Canada"
@@ -1560,9 +1692,17 @@
     "defaultMessage": "Aucun nom fourni",
     "description": "Fallback for name value"
   },
+  "nDaEgr": {
+    "defaultMessage": "Cette adresse courriel est déjà utilisée",
+    "description": "Error message that the given email address is already in use."
+  },
   "nV57as": {
     "defaultMessage": "Département :",
     "description": "Label for applicants department"
+  },
+  "nr62lc": {
+    "defaultMessage": "Résultats ({skillCount})",
+    "description": "Un titre pour une liste de résultats"
   },
   "oMyc4e": {
     "defaultMessage": "Citoyen ou résident",
@@ -1588,6 +1728,10 @@
     "defaultMessage": "Durée indéterminée (permanente)",
     "description": "Duration that is permanent"
   },
+  "s4DN3G": {
+    "defaultMessage": "Résultats des compétences générales",
+    "description": "Accessibility label for a result set of skills, filtered to mainstream skills"
+  },
   "sfr5Pa": {
     "defaultMessage": "La date d’expiration doit être postérieure à aujourd’hui.",
     "description": "Error message that the given skill expiry date must be after today."
@@ -1612,6 +1756,10 @@
     "defaultMessage": "Ce champ ne peut pas utiliser de dates dans le futur.",
     "description": "Error message that the date cannot be in the future."
   },
+  "vZgTKh": {
+    "defaultMessage": "Toutes les compétences techniques",
+    "description": "The option label for 'no filter' on the list of occupational skills"
+  },
   "vgxxk0": {
     "defaultMessage": "Vétéran",
     "description": "user is a CAF veteran"
@@ -1619,6 +1767,10 @@
   "w2Jpt8": {
     "defaultMessage": "Étudiant",
     "description": "Simple student selection for government employee type."
+  },
+  "wziEOM": {
+    "defaultMessage": "résultats des compétences de recherche par mot-clé",
+    "description": "Accessibility label for a result set of skills, searched by keyword"
   },
   "x0FRH/": {
     "defaultMessage": "Je n’ai pas de droit de priorité",
@@ -1653,20 +1805,20 @@
     "description": "Heading for personal experiences in experience by type listing"
   },
   "iWD2Pz": {
-    "defaultMessage": "Expériences de la collectivité",
-    "description": "Heading for community experiences in experience by type listing"
+      "defaultMessage": "Expériences de la collectivité",
+      "description": "Heading for community experiences in experience by type listing"
   },
   "aBSEkP": {
-    "defaultMessage": "Expériences de travail",
-    "description": "Heading for personal experiences in experience by type listing"
+      "defaultMessage": "Expériences de travail",
+      "description": "Heading for personal experiences in experience by type listing"
   },
   "pV96Xv": {
-    "defaultMessage": "Expériences scolaires",
-    "description": "Heading for education experiences in experience by type listing"
+      "defaultMessage": "Expériences scolaires",
+      "description": "Heading for education experiences in experience by type listing"
   },
   "X0YPib": {
-    "defaultMessage": "Expériences relatives aux prix",
-    "description": "Heading for award experiences in experience by type listing"
+      "defaultMessage": "Expériences relatives aux prix",
+      "description": "Heading for award experiences in experience by type listing"
   },
   "/I9tx9": {
     "defaultMessage": "Cette demande ne peut pas être supprimée. Vous pouvez uniquement supprimer les demandes avant leur soumission.",
@@ -1879,5 +2031,9 @@
   "2iCpAL": {
     "defaultMessage": "Énoncé sur l’accessibilité",
     "description": "Title for the websites accessibility statement"
+  },
+  "Tw90Pi": {
+    "defaultMessage": "Enregistrement...",
+    "description": "Submitting text for save button."
   }
 }

--- a/frontend/indigenousapprenticeship/src/js/lang/fr.json
+++ b/frontend/indigenousapprenticeship/src/js/lang/fr.json
@@ -1,4 +1,12 @@
 {
+  "pBJzgi": {
+    "defaultMessage": "Désolé, nous n’avons pas trouvé la page que vous cherchiez.",
+    "description": "Heading for the message saying the page was not found."
+  },
+  "pgHTkX": {
+    "defaultMessage": "Oups, il semble que la page de destination n’existe pas ou a été déplacée.",
+    "description": "Detailed message saying the page was not found."
+  },
   "+JIfBy": {
     "defaultMessage": "Dans quel ministère ou organisme les apprentis travailleront-ils?",
     "description": "Learn more dialog question nine heading"
@@ -326,6 +334,14 @@
   "74Sg+4": {
     "defaultMessage": "L’exigence minimale en matière d’études est un diplôme d’études générales ou secondaires. Il n’est pas nécessaire d’avoir fait des études collégiales ou universitaires.",
     "description": "Learn more dialog question twelve paragraph one"
+  },
+  "gKyog2": {
+    "defaultMessage": "Oups, on dirait que vous avez atterri sur une page que vous n'êtes pas autorisé(e) à consulter.",
+    "description": "Detailed message saying the page to view is not authorized."
+  },
+  "jPLaDk": {
+    "defaultMessage": "Désolé, vous n'êtes pas autorisé(e) à consulter cette page.",
+    "description": "Heading for the message saying the page to view is not authorized."
   },
   "khChKa": {
     "defaultMessage": "Le Programme s’adresse aux Premières Nations, aux Inuits et aux Métis. Si vous êtes un membre des Premières Nations, un Inuit ou un Métis et que vous avez une passion pour la technologie, ce programme est pour vous!",

--- a/frontend/indigenousapprenticeship/src/js/lang/fr.json
+++ b/frontend/indigenousapprenticeship/src/js/lang/fr.json
@@ -1,12 +1,4 @@
 {
-  "pBJzgi": {
-    "defaultMessage": "Désolé, nous n’avons pas trouvé la page que vous cherchiez.",
-    "description": "Heading for the message saying the page was not found."
-  },
-  "pgHTkX": {
-    "defaultMessage": "Oups, il semble que la page de destination n’existe pas ou a été déplacée.",
-    "description": "Detailed message saying the page was not found."
-  },
   "+JIfBy": {
     "defaultMessage": "Dans quel ministère ou organisme les apprentis travailleront-ils?",
     "description": "Learn more dialog question nine heading"
@@ -334,14 +326,6 @@
   "74Sg+4": {
     "defaultMessage": "L’exigence minimale en matière d’études est un diplôme d’études générales ou secondaires. Il n’est pas nécessaire d’avoir fait des études collégiales ou universitaires.",
     "description": "Learn more dialog question twelve paragraph one"
-  },
-  "gKyog2": {
-    "defaultMessage": "Oups, on dirait que vous avez atterri sur une page que vous n'êtes pas autorisé(e) à consulter.",
-    "description": "Detailed message saying the page to view is not authorized."
-  },
-  "jPLaDk": {
-    "defaultMessage": "Désolé, vous n'êtes pas autorisé(e) à consulter cette page.",
-    "description": "Heading for the message saying the page to view is not authorized."
   },
   "khChKa": {
     "defaultMessage": "Le Programme s’adresse aux Premières Nations, aux Inuits et aux Métis. Si vous êtes un membre des Premières Nations, un Inuit ou un Métis et que vous avez une passion pour la technologie, ce programme est pour vous!",

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -9,6 +9,10 @@
   "/DbKFl": {
     "defaultMessage": "Filtres de compétences ({cmoAssetFilterCount})"
   },
+  "086Xpp": {
+    "defaultMessage": "Personne handicapée",
+    "description": "Checklist option for employment equity filter in search form."
+  },
   "09x+E7": {
     "defaultMessage": "Nombre approximatif de candidats",
     "description": "Heading for total estimated candidates box next to search form."
@@ -25,6 +29,10 @@
     "defaultMessage": "Peut accepter une combinaison d’expérience de travail et d’études",
     "description": "Radio group option for education requirement filter in search form."
   },
+  "7FKma8": {
+    "defaultMessage": "Femme",
+    "description": "Checklist option for employment equity filter in search form."
+  },
   "7lCUIL": {
     "defaultMessage": "Quel est le titre du poste?",
     "description": "Label for job title input in the request form"
@@ -33,9 +41,21 @@
     "defaultMessage": "Erreur : Échec de la création de la demande",
     "description": "Message displayed to user after a pool candidate request fails to get created."
   },
+  "AvBSV+": {
+    "defaultMessage": "Oh non...",
+    "description": "Title displayed for a table error loading state."
+  },
+  "Avs6Xw": {
+    "defaultMessage": "Membre d’un groupe minoritaire visible",
+    "description": "Checklist option for employment equity filter in search form."
+  },
   "AyP6Fr": {
     "defaultMessage": "Exigences en matière d’études pour le poste",
     "description": "Heading for education requirement filter of the search form."
+  },
+  "B7fcr5": {
+    "defaultMessage": "Chargement...",
+    "description": "Title displayed for a table initial loading state."
   },
   "F+WFWB": {
     "defaultMessage": "Région",
@@ -129,6 +149,10 @@
     "defaultMessage": "Sélectionnez un lieu...",
     "description": "Placeholder for work location filter in search form."
   },
+  "cQNacY": {
+    "defaultMessage": "{type} {id} introuvable.",
+    "description": "Message displayed for when requested data fails to load."
+  },
   "dRnKNR": {
     "defaultMessage": "Nom complet",
     "description": "Label for full name input in the request form"
@@ -148,6 +172,10 @@
   "gUb3PY": {
     "defaultMessage": "Demande créée avec succès!",
     "description": "Message displayed to user after a pool candidate request is created successfully."
+  },
+  "iNsxYi": {
+    "defaultMessage": "Sélectionnez une ou plusieurs classifications",
+    "description": "Placeholder for classification filter in search form."
   },
   "kAieVP": {
     "defaultMessage": "Filtres de compétences",
@@ -169,6 +197,14 @@
     "defaultMessage": "Compétence linguistique au travail",
     "description": "Heading for working language ability section of the search form."
   },
+  "pBJzgi": {
+    "defaultMessage": "Désolé, nous n’avons pas trouvé la page que vous cherchiez.",
+    "description": "Heading for the message saying the page was not found."
+  },
+  "pgHTkX": {
+    "defaultMessage": "Oups, il semble que la page de destination n’existe pas ou a été déplacée.",
+    "description": "Detailed message saying the page was not found."
+  },
   "uP+q43": {
     "defaultMessage": "Lieu de travail",
     "description": "Heading for work location section of the search form."
@@ -180,6 +216,13 @@
   "zz9pwK": {
     "defaultMessage": "Développeur...",
     "description": "Placeholder for job title input in the request form."
+  },
+  "GJ95sc": {
+    "defaultMessage": "Autochtone",
+    "description": "Checklist option for employment equity filter in search form."
+  },
+  "LRysDa": {
+    "defaultMessage": "Filtres de classification ({classificationFilterCount})"
   },
   "ky585k": {
     "defaultMessage": "Conditions d’emploi ({operationalRequirementFilterCount})"
@@ -204,6 +247,14 @@
     "defaultMessage": "À propos du bassin de talents numériques",
     "description": "Heading displayed in the About area of the hero section of the Search page."
   },
+  "/sQHOb": {
+    "defaultMessage": "Date de début",
+    "description": "Label displayed on Education Experience form for start date input"
+  },
+  "09G0vg": {
+    "defaultMessage": "Date de fin",
+    "description": "Label displayed on Work Experience form for end date input"
+  },
   "0H0CLx": {
     "defaultMessage": "Accordé à",
     "description": "Label displayed on Award form for awarded to input"
@@ -211,6 +262,10 @@
   "0RlNw7": {
     "defaultMessage": "Projet/produit",
     "description": "Label displayed on Community Experience form for project input"
+  },
+  "2SNKYg": {
+    "defaultMessage": "Ajouter des compétences",
+    "description": "Section header for adding skills to this experience"
   },
   "3YyYDt": {
     "defaultMessage": "Choisir un...",
@@ -240,6 +295,10 @@
     "defaultMessage": "Écrire le titre ici...",
     "description": "Placeholder for thesis title input"
   },
+  "8VDBW/": {
+    "defaultMessage": "Date de début",
+    "description": "Label displayed on Work Experience form for start date input"
+  },
   "8i+lzm": {
     "defaultMessage": "Je suis actuellement actif(-ve) dans ce rôle.",
     "description": "Label displayed on Work Experience form for current role input"
@@ -268,6 +327,10 @@
     "defaultMessage": "Écrire le nom ici...",
     "description": "Placeholder for institution input"
   },
+  "EYCY8j": {
+    "defaultMessage": "Compétences utilisées fréquemment ({skillCount})",
+    "description": "Section header for a list of frequently used skills"
+  },
   "EfR7Rv": {
     "defaultMessage": "Écrire le nom du groupe ici...",
     "description": "Placeholder displayed on the Community Experience form for organization input"
@@ -275,6 +338,14 @@
   "N87bC7": {
     "defaultMessage": "Titre de la thèse",
     "description": "Label displayed on education form for thesis title input"
+  },
+  "NDunA+": {
+    "defaultMessage": "Date de début",
+    "description": "Label displayed on Personal Experience form for start date input"
+  },
+  "Nqwbu3": {
+    "defaultMessage": "Date de fin",
+    "description": "Label displayed on Education Experience form for end date input"
   },
   "OQhL7A": {
     "defaultMessage": "Statut",
@@ -292,6 +363,18 @@
     "defaultMessage": "Écrire le titre ici...",
     "description": "Placeholder for experience title input"
   },
+  "QRGHI2": {
+    "defaultMessage": "À la prochaine étape, vous expliquerez la façon dont vous avez utilisé chaque compétence. Tentez de vous concentrer sur quelques-unes de vos principales compétences; nous recommandons <strong>moins de six (6)</strong> compétences par expérience.",
+    "description": "Message of alert when there are many skills added recommending that fewer skills be selected."
+  },
+  "QYqjUQ": {
+    "defaultMessage": "Compétences se rapportant à cette expérience",
+    "description": "Section header for a list of skills attached to this experience"
+  },
+  "RKdRiG": {
+    "defaultMessage": "Compétences générales",
+    "description": "Tab name for a list of mainstream skills"
+  },
   "TSqr8X": {
     "defaultMessage": "Écrire le nom ici...",
     "description": "Placeholder for issuing organization input"
@@ -300,6 +383,10 @@
     "defaultMessage": "1. Détails de l’expérience personnelle",
     "description": "Title for Personal Experience Details form"
   },
+  "URHhMF": {
+    "defaultMessage": "Mon rôle",
+    "description": "Label displayed on Work Experience form for role input"
+  },
   "Uv9q53": {
     "defaultMessage": "Écrire le domaine d’étude ici...",
     "description": "Placeholder for area of study input"
@@ -307,6 +394,10 @@
   "W7LpsW": {
     "defaultMessage": "1. Détails des études",
     "description": "Title for Education Details Form"
+  },
+  "WjREkG": {
+    "defaultMessage": "Rechercher par mot clé",
+    "description": "Tab name for a box to search for skills"
   },
   "WjssQc": {
     "defaultMessage": "Choisir un...",
@@ -332,9 +423,17 @@
     "defaultMessage": "Type d’études",
     "description": "Label displayed on Education form for education type input"
   },
+  "fUQPUr": {
+    "defaultMessage": "Mes compétences fréquentes",
+    "description": "Tab name for a list of frequently used skills"
+  },
   "gDQZIQ": {
     "defaultMessage": "Expérience acquise en faisant partie d’une collectivité ou en lui rendant la pareille? Les personnes apprennent des compétences à partir d’un vaste éventail d’expériences comme le bénévolat et celles acquises dans des organismes sans but lucratif, des communautés autochtones ou des collaborations virtuelles.",
     "description": "Description blurb for Community Experience form"
+  },
+  "gy2UWG": {
+    "defaultMessage": "Il n’y a encore aucune compétence se rapportant à cette expérience. Vous pouvez en ajouter à l’aide des liens ci-dessous.",
+    "description": "Invitation to add skills when there aren't any added yet."
   },
   "i17oNt": {
     "defaultMessage": "Faites part de vos expériences acquises dans le cadre d’un emploi à temps plein, d’un emploi à temps partiel, d’un travail indépendant, de bourses de recherche ou de stages.",
@@ -348,6 +447,18 @@
     "defaultMessage": "Les personnes ne se résument pas à leur formation et à leur expérience professionnelle. Nous voulons vous permettre de faire part de ce que vous avez appris à partir d’autres expériences. Pour protéger votre vie privée, veuillez ne pas indiquer de renseignements sensibles sur vous-même ou sur d’autres personnes.",
     "description": "Description blurb for Personal Experience Details form"
   },
+  "l0IDWf": {
+    "defaultMessage": "Résultats ({skillCount})",
+    "description": "A title for a skill list of results"
+  },
+  "lRuuJ3": {
+    "defaultMessage": " Date de début",
+    "description": "Label displayed on Community Experience form for start date input"
+  },
+  "nr62lc": {
+    "defaultMessage": " Résultats ({skillCount})",
+    "description": "A title for a list of results"
+  },
   "nzw1ry": {
     "defaultMessage": "Domaine d’études",
     "description": "Label displayed on education form for area of study input"
@@ -360,6 +471,10 @@
     "defaultMessage": " J’accepte de faire part de ces renseignements avec les gestionnaires d’embauche et les conseillers en RH vérifiés du gouvernement du Canada qui ont accès à cette plateforme.",
     "description": "Label displayed on Personal Experience form for disclaimer checkbox"
   },
+  "p39ofW": {
+    "defaultMessage": " Date de fin",
+    "description": "Label displayed on Community Experience form for end date input"
+  },
   "q5rd9x": {
     "defaultMessage": " Description de l’expérience",
     "description": "Label displayed on Personal Experience form for experience description input"
@@ -368,9 +483,17 @@
     "defaultMessage": "Titre du prix",
     "description": "Label displayed on award form for award title input"
   },
+  "qhmriI": {
+    "defaultMessage": "Date de fin",
+    "description": "Label displayed on Personal Experience form for end date input"
+  },
   "sIM1t+": {
     "defaultMessage": "Choisir un...",
     "description": "Null selection for select input in the award scope form."
+  },
+  "tyPFpt": {
+    "defaultMessage": "Mon rôle/Titre de l’emploi",
+    "description": "Label displayed on Community Experience form for role input"
   },
   "wASF5V": {
     "defaultMessage": "Je suis actuellement actif dans ce rôle.",
@@ -383,6 +506,10 @@
   "xJulQ4": {
     "defaultMessage": "Équipe, groupe ou division",
     "description": "Label displayed on Work Experience form for team/group/division input"
+  },
+  "yx7EDY": {
+    "defaultMessage": "C’est beaucoup de compétences!",
+    "description": "Title of alert when there are many skills added."
   },
   "+wdTbk": {
     "defaultMessage": "Veuillez remplir tous les champs obligatoires de votre profil avant de définir votre statut comme actif.",
@@ -424,6 +551,10 @@
     "defaultMessage": "Indiquez s'il y a une ville que vous souhaitez exclure d'une région.",
     "description": "Explanation text for Location exemptions field in work location preference form"
   },
+  "1Yqt8K": {
+    "defaultMessage": "Vous êtes sur le point de supprimer une expérience de votre profil. Vous perdrez tous les renseignements qui y sont rattachés. Voulez-vous vraiment supprimer cette expérience?",
+    "description": "Warning prior to experience deletion"
+  },
   "248YQT": {
     "defaultMessage": "Pas encore prêt à partir? Retournez à la page d'accueil, découvrez de nouvelles possibilités, ou apprenez-en plus sur certaines recherches derrière cette plateforme.",
     "description": "Description of the links presented on the logged out page."
@@ -443,6 +574,10 @@
   "2cUBGT": {
     "defaultMessage": "Utilisateur introuvable.",
     "description": "Message displayed for user not found."
+  },
+  "2t3Cqv": {
+    "defaultMessage": "Rôle actuel",
+    "description": "Label displayed on Work Experience form for current role bounded box"
   },
   "3f9P13": {
     "defaultMessage": "En tant qu'employé, quel est votre statut d'emploi?",
@@ -476,6 +611,10 @@
     "defaultMessage": "Postes en français",
     "description": "Message for the french positions option"
   },
+  "6H4uc8": {
+    "defaultMessage": "« Je m'identifie comme une personne handicapée »",
+    "description": "Title for when someone indicates they have a disability on their profile"
+  },
   "6LTC0y": {
     "defaultMessage": "Gestion de la base de données de la TI",
     "description": "work stream example"
@@ -487,6 +626,9 @@
   "6cYs7i": {
     "defaultMessage": "Vous êtes membre d'un ou de plusieurs de ces groupes d'équité en matière d'emploi.",
     "description": "Instruction on when to fill out equity information, item one"
+  },
+  "6l1+3n": {
+    "defaultMessage": "résultats des compétences de la recherche par mot clé"
   },
   "6rhyxk": {
     "defaultMessage": "Déconnexion",
@@ -511,6 +653,10 @@
   "7qR4UK": {
     "defaultMessage": "Renseignements personnels",
     "description": "Title for Personal Information section of the About Me form"
+  },
+  "8/aBOG": {
+    "defaultMessage": "Postuler",
+    "description": "Breadcrumb title for the pool application link."
   },
   "87nFC8": {
     "defaultMessage": "Il y a deux types d'employés du TI-04 : ceux qui suivent un cheminement en gestion et les contributeurs individuels.",
@@ -572,6 +718,10 @@
     "defaultMessage": "Préférence linguistique pour la communication",
     "description": "Legend text for required language preference in About Me form"
   },
+  "DGnBW+": {
+    "defaultMessage": "Personnes handicapées",
+    "description": "Title for button to learn more information about disabled equity definition"
+  },
   "DK870a": {
     "defaultMessage": "Compte créé avec succès.",
     "description": "Message displayed to user if account is created successfully."
@@ -592,9 +742,21 @@
     "defaultMessage": "Qu'avez-vous accompli, créé ou produit en utilisant cette compétence?",
     "description": "Question for user in skills in detail section of experience form."
   },
+  "EzgYXr": {
+    "defaultMessage": "Peuples autochtones",
+    "description": "Title for equity dialog to add/remove indigenous category to profile"
+  },
+  "FTMoH9": {
+    "defaultMessage": "Femmes",
+    "description": "Title for button to learn more information about women equity definition"
+  },
   "FayQOt": {
     "defaultMessage": "Niveau 4 : Conseiller principal (101 000 $ à 126 000 $). <openModal>En savoir plus sur TI-04</openModal>",
     "description": "Checkbox label for Level IT-04 senior advisor selection, ignore things in <> tags please"
+  },
+  "Fj5UsM": {
+    "defaultMessage": "Personnes handicapées",
+    "description": "Title for equity dialog to add/remove having a disability category to profile"
   },
   "FmN1eN": {
     "defaultMessage": "+123243234",
@@ -628,6 +790,10 @@
     "defaultMessage": "Enregistrer et aller sur mon profil",
     "description": "Button label for submit button on create account form."
   },
+  "HZB4iF": {
+    "defaultMessage": "« Je m'identifie comme une femme »",
+    "description": "Title for when someone indicates they are a woman on their profile"
+  },
   "Hgd/PL": {
     "defaultMessage": "Retour à l'accueil",
     "description": "Link text to return to the home page"
@@ -635,6 +801,10 @@
   "Hiv/2m": {
     "defaultMessage": "Déconnexion",
     "description": "Title for the modal that appears when an authenticated user lands on /logged-out."
+  },
+  "IU0lH8": {
+    "defaultMessage": "Membre des minorités visibles",
+    "description": "Title for button to learn more information about visible minority equity definition"
   },
   "Igrveg": {
     "defaultMessage": "Liens rapides",
@@ -708,6 +878,10 @@
     "defaultMessage": "Postes bilingues (en anglais et en français)",
     "description": "Message for the bilingual positions option"
   },
+  "N+S2bh": {
+    "defaultMessage": "Vous aimeriez être pris(e) en considération pour les possibilités offertes aux groupes sous-représentés.",
+    "description": "Instruction on when to fill out equity information, item two"
+  },
   "NP/fsS": {
     "defaultMessage": "Pour quel ministère travaillez-vous?",
     "description": "Label for department select input in the request form"
@@ -776,6 +950,10 @@
     "defaultMessage": "Travail",
     "description": "Title for work experience form button."
   },
+  "RdrUZz": {
+    "defaultMessage": "Retour à la liste des bassins",
+    "description": "Label for button to the browse pools page"
+  },
   "Rgh/Qb": {
     "defaultMessage": "4. Renseignements complémentaires pour cette expérience",
     "description": "Title for addition information on Experience form"
@@ -828,6 +1006,10 @@
     "defaultMessage": "Renseignements du gouvernement",
     "description": "Display Text for Government Information Form Page Link"
   },
+  "Uyo9WO": {
+    "defaultMessage": "Merci d'avoir postulé",
+    "description": "Breadcrumb title for the pools 'thanks for applying page' link."
+  },
   "W4Svkd": {
     "defaultMessage": "Compréhension",
     "description": "Label displayed on the language information form comprehension field."
@@ -872,6 +1054,13 @@
     "defaultMessage": "Nous aimerions savoir ci-dessous si vous êtes déjà un(e) employé(e) du gouvernement du Canada. Nous recueillons ces renseignements parce qu'ils nous aident à comprendre, au niveau global, comment les compétences numériques sont réparties entre les ministères.",
     "description": "First message before is a government of canada radio group in create account form."
   },
+  "XkrePe": {
+    "defaultMessage": "Identité autochtone",
+    "description": "Title for button to learn more information about indigenous equity definition"
+  },
+  "Y+d/yO": {
+    "defaultMessage": "Résultats fréquents des compétences"
+  },
   "Y7jEXr": {
     "defaultMessage": "Sélectionnez un niveau...",
     "description": "Placeholder displayed on the language information form verbal field."
@@ -908,6 +1097,10 @@
     "defaultMessage": "Niveau 1 : Technicien(ne) (de 60 000 $ à 78 000 $). <openModal>En savoir plus sur TI-01</openModal>",
     "description": "Checkbox label for Level IT-01 selection, ignore things in <> tags please"
   },
+  "ZodXqQ": {
+    "defaultMessage": "Femme (Elle/Elle)",
+    "description": "Title for equity dialog to add/remove women category to profile"
+  },
   "Zx3BVC": {
     "defaultMessage": "Êtes-vous sûr(e) de vouloir vous déconnecter?",
     "description": "Question displayed when authenticated user lands on /logged-out."
@@ -927,6 +1120,10 @@
   "b9/MXQ": {
     "defaultMessage": "Quel était votre niveau de responsabilité dans ce rôle?",
     "description": "Question for user in skills in detail section of experience form."
+  },
+  "bUeJy1": {
+    "defaultMessage": "« Je m'identifie comme membre d'une minorité visible »",
+    "description": "Title for when someone indicates they are a visible minority on their profile"
   },
   "c/Qp8R": {
     "defaultMessage": "Préférence pour le lieu de travail",
@@ -976,9 +1173,16 @@
     "defaultMessage": "L'utilisateur a été mis à jour avec succès!",
     "description": "Message displayed to user after user is updated successfully."
   },
+  "fCQ4aB": {
+    "defaultMessage": "Utilisateur{applicantId} introuvable.",
+    "description": "Message displayed for user not found."
+  },
   "fK7jxe": {
     "defaultMessage": "Vous n'avez ajouté aucune option d'équité en matière d'emploi à votre profil.",
     "description": "Message displayed when a user has no employment equity information."
+  },
+  "fOCbBa": {
+    "defaultMessage": "Résultats pour les compétences fréquentes"
   },
   "gBWsuB": {
     "defaultMessage": "Téléphone",
@@ -1008,6 +1212,10 @@
     "defaultMessage": "Il y a deux types d'employés du TI-03 : ceux qui suivent un cheminement en gestion et les contributeurs individuels.",
     "description": "IT-03 description precursor"
   },
+  "hDSk9d": {
+    "defaultMessage": "Merci d'avoir postulé au {poolName}",
+    "description": "Title for page thanking user for applying to a pool"
+  },
   "hTJgV2": {
     "defaultMessage": "Tous les champs obligatoires sont remplis. Vous pouvez maintenant modifier votre statut.",
     "description": "Message displayed to user when user profile completed."
@@ -1023,6 +1231,14 @@
   "i99arX": {
     "defaultMessage": "Comment j'ai utilisé cette compétence...",
     "description": "Placeholder message for textarea in the skills in detail section."
+  },
+  "iCb9eG": {
+    "defaultMessage": "Les techniciens en TI se retrouvent principalement dans trois volets de travail :",
+    "description": "Preceding list description"
+  },
+  "jF5ZYY": {
+    "defaultMessage": "Membres des minorités visibles",
+    "description": "Title for equity dialog to add/remove visible minority category to profile"
   },
   "jPLaDk": {
     "defaultMessage": "Désolé, vous n'êtes pas autorisé(e) à consulter cette page.",
@@ -1052,9 +1268,17 @@
     "defaultMessage": "Ajouter une expérience",
     "description": "Display text for add experience form in breadcrumbs"
   },
+  "mMGycA": {
+    "defaultMessage": "Postuler",
+    "description": "Apply label for button to apply to pool"
+  },
   "mTlHta": {
     "defaultMessage": "Niveau 3 : Chef d'équipe",
     "description": "title for IT-03 lead dialog"
+  },
+  "mW0/n1": {
+    "defaultMessage": "Aucun bassin n'a été trouvé.",
+    "description": "Message displayed on the browse pools direct intake page when there are no pools."
   },
   "md7Klw": {
     "defaultMessage": "Connexion",
@@ -1095,6 +1319,14 @@
   "o/YTo0": {
     "defaultMessage": "Pour commencer",
     "description": "Main heading in create account page."
+  },
+  "oEFd6y": {
+    "defaultMessage": "« Je suis autochtone »",
+    "description": "Title for when someone indicates they are indigenous on their profile"
+  },
+  "oG9dAi": {
+    "defaultMessage": "Parcourir les bassins",
+    "description": "Page title for the direct intake browse pools page."
   },
   "oOcegG": {
     "defaultMessage": "Architecture intégrée de la TI ",
@@ -1151,6 +1383,10 @@
   "sapxcU": {
     "defaultMessage": "Avertissement",
     "description": "Label displayed on Personal Experience form for disclaimer bounded box"
+  },
+  "sifjUN": {
+    "defaultMessage": "Il n'y a pas encore d'expérience sur votre profil. Vous pouvez en ajouter quelques-unes en utilisant les liens ci-dessus.",
+    "description": "Message to user when no experiences have been attached to profile."
   },
   "t12bCU": {
     "defaultMessage": "Sauvegarder et revenir en arrière",
@@ -1224,6 +1460,10 @@
     "defaultMessage": "J'envisagerais d'accepter un emploi qui :",
     "description": "Legend for optional work preferences check list in work preferences form"
   },
+  "yfVLxM": {
+    "defaultMessage": "Rôle actuel",
+    "description": "Label displayed on Community Experience form for current role bounded box"
+  },
   "zILELf": {
     "defaultMessage": "S'inscrire à l'aide de la CléGC",
     "description": "Title for the registration page for applicant profiles."
@@ -1232,6 +1472,14 @@
     "defaultMessage": "Filtre des exigences en matière d'études",
     "description": "Legend for the Education Requirement filter radio group"
   },
+  "/h+Ub4": {
+    "defaultMessage": "Je m'identifie comme une femme.",
+    "description": "Label for the checkbox to identify as a woman under employment equity"
+  },
+  "07bCT2": {
+    "defaultMessage": "Je m'identifie comme une personne handicapée.",
+    "description": "Label for the checkbox to identify as a person with a disability under employment equity"
+  },
   "3nKkyo": {
     "defaultMessage": "Compétences organisées par volet",
     "description": "Legend for Skills filter checklist"
@@ -1239,6 +1487,10 @@
   "6danS7": {
     "defaultMessage": "Cette catégorie comprend les personnes dont le genre déclaré est féminin. Elle comprend les femmes cisgenres (cis) et les femmes transgenres (trans).",
     "description": "Definition of the Woman category from the StatsCan 'Classification of gender' page."
+  },
+  "Jtz3yb": {
+    "defaultMessage": "Je suis autochtone.",
+    "description": "Label for the checkbox to identify as indigenous under employment equity"
   },
   "F4K5RB": {
     "defaultMessage": "Minorité visible réfère au fait qu'une personne est ou non une minorité visible, tel que défini dans la Loi sur l'équité en matière d'emploi. Dans le cadre de la Loi sur l'équité en matière d'emploi, les minorités visibles sont définies comme « les personnes, autres que les Autochtones, qui ne sont pas de race blanche ou qui n'ont pas la peau blanche ». La population des minorités visibles est principalement composée des groupes suivants : Sud-Asiatique, Chinois, Noir, Philippin, Arabe, Latino-Américain, Asiatique du Sud-Est, Asiatique occidental, Coréen et Japonais.",
@@ -1251,6 +1503,10 @@
   "y5Z2Li": {
     "defaultMessage": "Réfère à une personne dont les activités quotidiennes sont limitées en raison d'un trouble ou d'une difficulté à accomplir certaines tâches. La seule exception à cet égard concerne les troubles du développement, le répondant qui a reçu un tel diagnostic étant considéré comme ayant une incapacité.",
     "description": "Definition of Person with a disability from the StatsCan 'Classification of Status of Disability' page."
+  },
+  "sdUnnh": {
+    "defaultMessage": "Je m'identifie comme faisant partie d'un ou de plusieurs groupes de minorités visibles.",
+    "description": "Label for the checkbox to identify as a visible minority under employment equity"
   },
   "z44LTK": {
     "defaultMessage": "Tel que défini par <link>Statistique Canada</link>.",
@@ -1332,6 +1588,14 @@
     "defaultMessage": "<strong>Remarque :</strong> Si vous sélectionnez plus d'un groupe visé par l'équité en matière d'emploi, TOUS les candidats qui se sont déclarés membres de N'IMPORTE LEQUEL des groupes visés par l'équité en matière d'emploi sélectionnés seront recommandés. Si vous avez des exigences plus détaillées concernant l'équité en matière d'emploi, veuillez nous en faire part dans la section des commentaires du formulaire de soumission.",
     "description": "Context for employment equity filter in search form."
   },
+  "+cy2GO": {
+    "defaultMessage": "Trouvez des candidats ayant les bonnes compétences pour le poste. Utilisez les onglets suivants pour trouver les compétences nécessaires à l'emploi et sélectionnez-les pour les utiliser comme filtres pour trouver les candidats correspondants.",
+    "description": "Describing how to use the skill filters on search page, paragraph one."
+  },
+  "+pWIcS": {
+    "defaultMessage": "Compétences techniques",
+    "description": "Button text for the technical skills tab on skills filter"
+  },
   "U6IroF": {
     "defaultMessage": "Études postsecondaires de deux ans",
     "description": "Title for pool applicant education requirements"
@@ -1352,6 +1616,10 @@
     "defaultMessage": "Avez-vous besoin de mesures d’adaptation, ou avez-vous des questions sur ce processus?",
     "description": "Opening sentence asking if accommodations are needed"
   },
+  "6OJhwM": {
+    "defaultMessage": "Trouver et sélectionner les compétences",
+    "description": "Subtitle for the skills filter on the search form."
+  },
   "7o+Vzu": {
     "defaultMessage": "Expérience combinée",
     "description": "Title for pool applicant experience requirements"
@@ -1359,6 +1627,10 @@
   "8fQWTc": {
     "defaultMessage": "Toute durée (court terme, long terme ou indéterminée) (recommandé)",
     "description": "No preference for employment duration - will accept any"
+  },
+  "AYlTUF": {
+    "defaultMessage": "Il n'y a pas encore de compétences sélectionnées. Vous pouvez en ajouter en utilisant les liens fournis",
+    "description": "Invitation to add skills when there aren't any added yet."
   },
   "C6YPk3": {
     "defaultMessage": "Postulez maintenant",
@@ -1379,6 +1651,10 @@
   "GNvz2K": {
     "defaultMessage": "Autre expérience liée au domaine",
     "description": "pool experience requirement, other"
+  },
+  "GR1ZQH": {
+    "defaultMessage": "Résultats des compétences transférables",
+    "description": "Title for transferable skills pagination"
   },
   "GYk6Nz": {
     "defaultMessage": "Autorisation de sécurité : {securityClearance}",
@@ -1408,9 +1684,25 @@
     "defaultMessage": "Parcourez les opportunités",
     "description": "Breadcrumb title for the browse pools page."
   },
+  "PBnlYi": {
+    "defaultMessage": "Possibilités de navigation",
+    "description": "Breadcrumb from applicant profile wrapper."
+  },
+  "QJQS42": {
+    "defaultMessage": "Pourquoi y a-t-il un nombre limité de compétences? Il est important que les candidats et les gestionnaires puisent dans la même liste de compétences afin de créer des correspondances.",
+    "description": "Describing how to use the skill filters on search page, paragraph two."
+  },
+  "S9BRBL": {
+    "defaultMessage": "Durée du terme (court terme, long terme)",
+    "description": "Duration of a non-permanent length"
+  },
   "STLaIq": {
     "defaultMessage": "Utile",
     "description": "Title for the optional skills section of a pool advertisement"
+  },
+  "Sb95gs": {
+    "defaultMessage": "Compétences transférables",
+    "description": "Button text for the transferable skills tab on skills filter"
   },
   "U+ApNl": {
     "defaultMessage": "La date limite des candidatures est passée.",
@@ -1464,6 +1756,10 @@
     "defaultMessage": "La <actLink>Loi sur l'équité en matière d'emploi</actLink> est actuellement <reviewLink>en cours de révision</reviewLink>.",
     "description": "Text that appears in Employment equity dialogs explaining the act is under review."
   },
+  "f/JJR5": {
+    "defaultMessage": "Résultats des compétences techniques",
+    "description": "Title for technical skills pagination"
+  },
   "fvJnoC": {
     "defaultMessage": "Exigence linguistique : {languageRequirement}",
     "description": "Pool advertisement language requirement"
@@ -1471,6 +1767,10 @@
   "gpuTAV": {
     "defaultMessage": "Que signifie {classification}{genericTitle}?",
     "description": "Title for description of a pool advertisements classification group/level"
+  },
+  "hEhmBF": {
+    "defaultMessage": "Les compétences comme filtres",
+    "description": "Title for the skill filters on search page."
   },
   "iN2H6J": {
     "defaultMessage": "La durée sélectionnée sera comparée à celle choisie par les candidats dans leur dossier de candidature. Ne modifiez cette option que si l'offre d'emploi a une durée déterminée.",
@@ -1487,6 +1787,10 @@
   "kH4Jsf": {
     "defaultMessage": "Lorsque vous postulez à ce processus, vous ne postulez pas pour un poste en particulier. Ce processus a pour but de créer et de maintenir un répertoire pour doter divers postes de même niveau dans différents ministères et organismes du gouvernement du Canada.",
     "description": "Description of pool recruitment, paragraph one"
+  },
+  "l7Hif/": {
+    "defaultMessage": "Compétences sélectionnées",
+    "description": "Section header for a list of skills selected"
   },
   "l9AK3C": {
     "defaultMessage": "ou",
@@ -1524,6 +1828,10 @@
     "defaultMessage": "Réussite de deux ans d'études postsecondaires en informatique, en technologie de l'information, en gestion de l'information ou dans une autre spécialité pertinente pour ce poste",
     "description": "post secondary education experience for pool advertisement"
   },
+  "rYodJu": {
+    "defaultMessage": "Durée indéterminée (permanente)",
+    "description": "Duration that is permanent"
+  },
   "s60QyR": {
     "defaultMessage": "2 ans ou plus d'expérience combinée dans un domaine connexe, y compris l'un des éléments suivants :",
     "description": "lead in to list of experience required for a pool applicant"
@@ -1531,6 +1839,10 @@
   "uv2lY0": {
     "defaultMessage": "Votre travail",
     "description": "Title for a pool advertisements key tasks section."
+  },
+  "vmyStM": {
+    "defaultMessage": "Par mot-clé",
+    "description": "Button text for the search skills tab on skills filter"
   },
   "yu4yB8": {
     "defaultMessage": "Pour renforcer votre candidature, prenez en compte ces compétences que de nombreux responsables d'embauche recherchent",
@@ -1547,6 +1859,14 @@
   "Wnw+oz": {
     "defaultMessage": "<strong>Courriel</strong> : <anchorTag>{emailAddress}</anchorTag>",
     "description": "An email address to contact for help"
+  },
+  "s4DN3G": {
+    "defaultMessage": "Résultats des compétences générales",
+    "description": "Accessibility label for a result set of skills, filtered to mainstream skills"
+  },
+  "wziEOM": {
+    "defaultMessage": "résultats des compétences, recherche par mot-clé",
+    "description": "Accessibility label for a result set of skills, searched by keyword"
   },
   "5YzNJj": {
     "defaultMessage": "IT-04: Conseiller principal ou Manager Gestionnaire (101 000 $ à 126 000 $)",
@@ -1704,6 +2024,10 @@
     "defaultMessage": "Créer un profil",
     "description": "Link text for users to create a profile"
   },
+  "7n838F": {
+    "defaultMessage": "Pour être admis dans ce processus, vous devrez faire preuve de capacités dans ces compétences au cours du processus d’évaluation",
+    "description": "Explanation of a pool required transferrable skills"
+  },
   "87FqAO": {
     "defaultMessage": "En savoir plus",
     "description": "Heading for the about section of the homepage"
@@ -1719,6 +2043,14 @@
   "AauSuA": {
     "defaultMessage": "s. o.",
     "description": "Not available message."
+  },
+  "BQ7cf/": {
+    "defaultMessage": "Pourquoi y a-t-il un nombre limité de compétences? Il est important que les candidats et les gestionnaires puisent dans la même liste de compétences afin de créer des correspondances.",
+    "description": "Describing how to use the skill filters on search page, paragraph two."
+  },
+  "Ba4Y8a": {
+    "defaultMessage": "Il y a des <heavyPrimary><testId>{candidateCount}</testId></heavyPrimary> candidats correspondants dans ce bassin",
+    "description": "Message for total estimated candidates box next to search form."
   },
   "Boze7x": {
     "defaultMessage": "Mes candidatures",
@@ -1796,6 +2128,10 @@
     "defaultMessage": "Talents numériques du GC",
     "description": "Application title"
   },
+  "MUpqIp": {
+    "defaultMessage": "En savoir plus<hidden> sur les femmes dans les STIM</hidden>",
+    "description": "Link text to learn more about women in STEM"
+  },
   "NjHXGh": {
     "defaultMessage": "En savoir plus<hidden> sur le Bureau de la dirigeante principale de l’information</hidden>",
     "description": "Link text for the Office of the Chief Information Officer"
@@ -1815,6 +2151,10 @@
   "Q7yh4j": {
     "defaultMessage": "Erreur, les candidatures ne peuvent pas être chargées",
     "description": "My applications error message, placeholder"
+  },
+  "QcrDDA": {
+    "defaultMessage": "Parcourir les emplois de cadres",
+    "description": "Link text to find executive jobs in government"
   },
   "SDQWZf": {
     "defaultMessage": "Retour à l’étape précédente",
@@ -1840,9 +2180,17 @@
     "defaultMessage": "Vous souhaitez être pris en considération pour les perspectives d’emploi adressées aux groupes sous-représentés.",
     "description": "Instruction on when to fill out equity information, item two"
   },
+  "XF8DsD": {
+    "defaultMessage": "Page actuelle :",
+    "description": "Message read to users with screen reader when page is active."
+  },
   "XR37x0": {
     "defaultMessage": "Programme d’apprentissage destiné aux Autochtones",
     "description": "Heading for the Indigenous Apprenticeship Program on home page"
+  },
+  "Y7AKYP": {
+    "defaultMessage": "Pour être admis dans ce processus, vous devrez soumettre des renseignements suffisants pour vérifier votre expérience dans <strong>toutes ces compétences (Obligatoire - Professionnel)</strong> avec votre candidature",
+    "description": "Explanation of a pools required occupational skills"
   },
   "YZyNUJ": {
     "defaultMessage": "Signature",
@@ -1912,6 +2260,10 @@
     "defaultMessage": "Erreur, le candidat du bassin n’a pas pu être chargé",
     "description": "Error message, placeholder"
   },
+  "jefAOX": {
+    "defaultMessage": "Apprenez-en plus<hidden> sur la fierté dans la technologie</hidden>",
+    "description": "Link text to learn about pride in tech"
+  },
   "kHypfJ": {
     "defaultMessage": "Du concept au code",
     "description": "Title for how the platform was created"
@@ -1924,6 +2276,10 @@
     "defaultMessage": "Mes candidatures",
     "description": "'My Applications' breadcrumb from applicant profile wrapper."
   },
+  "muwFhL": {
+    "defaultMessage": "La fierté dans la technologie",
+    "description": "Title for the pride in tech featured item"
+  },
   "nEMeaQ": {
     "defaultMessage": "Recrutement en cours",
     "description": "Heading for the recruitment opportunities"
@@ -1935,6 +2291,10 @@
   "oDyHaL": {
     "defaultMessage": "Erreur, titre du poste non trouvé.",
     "description": "Error message when job title isn't found."
+  },
+  "oMSsJd": {
+    "defaultMessage": "Les femmes dans les STIM",
+    "description": "Title for the Women in STEM feature item"
   },
   "oOR4Rd": {
     "defaultMessage": "Étape 2",
@@ -2100,6 +2460,10 @@
     "defaultMessage": "Veuillez vérifier votre courriel pour obtenir un résumé de votre soumission.",
     "description": "Support form success paragraph two"
   },
+  "6TX9CR": {
+    "defaultMessage": "(aucune activité)",
+    "description": "Message displayed when a pool has no stream"
+  },
   "86Y8lx": {
     "defaultMessage": "Votre nom",
     "description": "Support form name field label"
@@ -2163,6 +2527,10 @@
   "OdjW9z": {
     "defaultMessage": "Nous ferons de notre mieux pour vous répondre dans les deux jours ouvrables suivants.",
     "description": "Support form success paragraph one"
+  },
+  "QX1l/C": {
+    "defaultMessage": "En attendant, n’hésitez pas à consulter nos foires aux questions (FAQ) pour obtenir plus d’information.",
+    "description": "Support form success paragraph three"
   },
   "TrO4uL": {
     "defaultMessage": "Échelle salariale :",

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -9,10 +9,6 @@
   "/DbKFl": {
     "defaultMessage": "Filtres de compétences ({cmoAssetFilterCount})"
   },
-  "086Xpp": {
-    "defaultMessage": "Personne handicapée",
-    "description": "Checklist option for employment equity filter in search form."
-  },
   "09x+E7": {
     "defaultMessage": "Nombre approximatif de candidats",
     "description": "Heading for total estimated candidates box next to search form."
@@ -29,10 +25,6 @@
     "defaultMessage": "Peut accepter une combinaison d’expérience de travail et d’études",
     "description": "Radio group option for education requirement filter in search form."
   },
-  "7FKma8": {
-    "defaultMessage": "Femme",
-    "description": "Checklist option for employment equity filter in search form."
-  },
   "7lCUIL": {
     "defaultMessage": "Quel est le titre du poste?",
     "description": "Label for job title input in the request form"
@@ -41,21 +33,9 @@
     "defaultMessage": "Erreur : Échec de la création de la demande",
     "description": "Message displayed to user after a pool candidate request fails to get created."
   },
-  "AvBSV+": {
-    "defaultMessage": "Oh non...",
-    "description": "Title displayed for a table error loading state."
-  },
-  "Avs6Xw": {
-    "defaultMessage": "Membre d’un groupe minoritaire visible",
-    "description": "Checklist option for employment equity filter in search form."
-  },
   "AyP6Fr": {
     "defaultMessage": "Exigences en matière d’études pour le poste",
     "description": "Heading for education requirement filter of the search form."
-  },
-  "B7fcr5": {
-    "defaultMessage": "Chargement...",
-    "description": "Title displayed for a table initial loading state."
   },
   "F+WFWB": {
     "defaultMessage": "Région",
@@ -149,10 +129,6 @@
     "defaultMessage": "Sélectionnez un lieu...",
     "description": "Placeholder for work location filter in search form."
   },
-  "cQNacY": {
-    "defaultMessage": "{type} {id} introuvable.",
-    "description": "Message displayed for when requested data fails to load."
-  },
   "dRnKNR": {
     "defaultMessage": "Nom complet",
     "description": "Label for full name input in the request form"
@@ -172,10 +148,6 @@
   "gUb3PY": {
     "defaultMessage": "Demande créée avec succès!",
     "description": "Message displayed to user after a pool candidate request is created successfully."
-  },
-  "iNsxYi": {
-    "defaultMessage": "Sélectionnez une ou plusieurs classifications",
-    "description": "Placeholder for classification filter in search form."
   },
   "kAieVP": {
     "defaultMessage": "Filtres de compétences",
@@ -197,14 +169,6 @@
     "defaultMessage": "Compétence linguistique au travail",
     "description": "Heading for working language ability section of the search form."
   },
-  "pBJzgi": {
-    "defaultMessage": "Désolé, nous n’avons pas trouvé la page que vous cherchiez.",
-    "description": "Heading for the message saying the page was not found."
-  },
-  "pgHTkX": {
-    "defaultMessage": "Oups, il semble que la page de destination n’existe pas ou a été déplacée.",
-    "description": "Detailed message saying the page was not found."
-  },
   "uP+q43": {
     "defaultMessage": "Lieu de travail",
     "description": "Heading for work location section of the search form."
@@ -216,13 +180,6 @@
   "zz9pwK": {
     "defaultMessage": "Développeur...",
     "description": "Placeholder for job title input in the request form."
-  },
-  "GJ95sc": {
-    "defaultMessage": "Autochtone",
-    "description": "Checklist option for employment equity filter in search form."
-  },
-  "LRysDa": {
-    "defaultMessage": "Filtres de classification ({classificationFilterCount})"
   },
   "ky585k": {
     "defaultMessage": "Conditions d’emploi ({operationalRequirementFilterCount})"
@@ -247,14 +204,6 @@
     "defaultMessage": "À propos du bassin de talents numériques",
     "description": "Heading displayed in the About area of the hero section of the Search page."
   },
-  "/sQHOb": {
-    "defaultMessage": "Date de début",
-    "description": "Label displayed on Education Experience form for start date input"
-  },
-  "09G0vg": {
-    "defaultMessage": "Date de fin",
-    "description": "Label displayed on Work Experience form for end date input"
-  },
   "0H0CLx": {
     "defaultMessage": "Accordé à",
     "description": "Label displayed on Award form for awarded to input"
@@ -262,10 +211,6 @@
   "0RlNw7": {
     "defaultMessage": "Projet/produit",
     "description": "Label displayed on Community Experience form for project input"
-  },
-  "2SNKYg": {
-    "defaultMessage": "Ajouter des compétences",
-    "description": "Section header for adding skills to this experience"
   },
   "3YyYDt": {
     "defaultMessage": "Choisir un...",
@@ -295,10 +240,6 @@
     "defaultMessage": "Écrire le titre ici...",
     "description": "Placeholder for thesis title input"
   },
-  "8VDBW/": {
-    "defaultMessage": "Date de début",
-    "description": "Label displayed on Work Experience form for start date input"
-  },
   "8i+lzm": {
     "defaultMessage": "Je suis actuellement actif(-ve) dans ce rôle.",
     "description": "Label displayed on Work Experience form for current role input"
@@ -327,10 +268,6 @@
     "defaultMessage": "Écrire le nom ici...",
     "description": "Placeholder for institution input"
   },
-  "EYCY8j": {
-    "defaultMessage": "Compétences utilisées fréquemment ({skillCount})",
-    "description": "Section header for a list of frequently used skills"
-  },
   "EfR7Rv": {
     "defaultMessage": "Écrire le nom du groupe ici...",
     "description": "Placeholder displayed on the Community Experience form for organization input"
@@ -338,14 +275,6 @@
   "N87bC7": {
     "defaultMessage": "Titre de la thèse",
     "description": "Label displayed on education form for thesis title input"
-  },
-  "NDunA+": {
-    "defaultMessage": "Date de début",
-    "description": "Label displayed on Personal Experience form for start date input"
-  },
-  "Nqwbu3": {
-    "defaultMessage": "Date de fin",
-    "description": "Label displayed on Education Experience form for end date input"
   },
   "OQhL7A": {
     "defaultMessage": "Statut",
@@ -363,18 +292,6 @@
     "defaultMessage": "Écrire le titre ici...",
     "description": "Placeholder for experience title input"
   },
-  "QRGHI2": {
-    "defaultMessage": "À la prochaine étape, vous expliquerez la façon dont vous avez utilisé chaque compétence. Tentez de vous concentrer sur quelques-unes de vos principales compétences; nous recommandons <strong>moins de six (6)</strong> compétences par expérience.",
-    "description": "Message of alert when there are many skills added recommending that fewer skills be selected."
-  },
-  "QYqjUQ": {
-    "defaultMessage": "Compétences se rapportant à cette expérience",
-    "description": "Section header for a list of skills attached to this experience"
-  },
-  "RKdRiG": {
-    "defaultMessage": "Compétences générales",
-    "description": "Tab name for a list of mainstream skills"
-  },
   "TSqr8X": {
     "defaultMessage": "Écrire le nom ici...",
     "description": "Placeholder for issuing organization input"
@@ -383,10 +300,6 @@
     "defaultMessage": "1. Détails de l’expérience personnelle",
     "description": "Title for Personal Experience Details form"
   },
-  "URHhMF": {
-    "defaultMessage": "Mon rôle",
-    "description": "Label displayed on Work Experience form for role input"
-  },
   "Uv9q53": {
     "defaultMessage": "Écrire le domaine d’étude ici...",
     "description": "Placeholder for area of study input"
@@ -394,10 +307,6 @@
   "W7LpsW": {
     "defaultMessage": "1. Détails des études",
     "description": "Title for Education Details Form"
-  },
-  "WjREkG": {
-    "defaultMessage": "Rechercher par mot clé",
-    "description": "Tab name for a box to search for skills"
   },
   "WjssQc": {
     "defaultMessage": "Choisir un...",
@@ -423,17 +332,9 @@
     "defaultMessage": "Type d’études",
     "description": "Label displayed on Education form for education type input"
   },
-  "fUQPUr": {
-    "defaultMessage": "Mes compétences fréquentes",
-    "description": "Tab name for a list of frequently used skills"
-  },
   "gDQZIQ": {
     "defaultMessage": "Expérience acquise en faisant partie d’une collectivité ou en lui rendant la pareille? Les personnes apprennent des compétences à partir d’un vaste éventail d’expériences comme le bénévolat et celles acquises dans des organismes sans but lucratif, des communautés autochtones ou des collaborations virtuelles.",
     "description": "Description blurb for Community Experience form"
-  },
-  "gy2UWG": {
-    "defaultMessage": "Il n’y a encore aucune compétence se rapportant à cette expérience. Vous pouvez en ajouter à l’aide des liens ci-dessous.",
-    "description": "Invitation to add skills when there aren't any added yet."
   },
   "i17oNt": {
     "defaultMessage": "Faites part de vos expériences acquises dans le cadre d’un emploi à temps plein, d’un emploi à temps partiel, d’un travail indépendant, de bourses de recherche ou de stages.",
@@ -447,18 +348,6 @@
     "defaultMessage": "Les personnes ne se résument pas à leur formation et à leur expérience professionnelle. Nous voulons vous permettre de faire part de ce que vous avez appris à partir d’autres expériences. Pour protéger votre vie privée, veuillez ne pas indiquer de renseignements sensibles sur vous-même ou sur d’autres personnes.",
     "description": "Description blurb for Personal Experience Details form"
   },
-  "l0IDWf": {
-    "defaultMessage": "Résultats ({skillCount})",
-    "description": "A title for a skill list of results"
-  },
-  "lRuuJ3": {
-    "defaultMessage": " Date de début",
-    "description": "Label displayed on Community Experience form for start date input"
-  },
-  "nr62lc": {
-    "defaultMessage": " Résultats ({skillCount})",
-    "description": "A title for a list of results"
-  },
   "nzw1ry": {
     "defaultMessage": "Domaine d’études",
     "description": "Label displayed on education form for area of study input"
@@ -471,10 +360,6 @@
     "defaultMessage": " J’accepte de faire part de ces renseignements avec les gestionnaires d’embauche et les conseillers en RH vérifiés du gouvernement du Canada qui ont accès à cette plateforme.",
     "description": "Label displayed on Personal Experience form for disclaimer checkbox"
   },
-  "p39ofW": {
-    "defaultMessage": " Date de fin",
-    "description": "Label displayed on Community Experience form for end date input"
-  },
   "q5rd9x": {
     "defaultMessage": " Description de l’expérience",
     "description": "Label displayed on Personal Experience form for experience description input"
@@ -483,17 +368,9 @@
     "defaultMessage": "Titre du prix",
     "description": "Label displayed on award form for award title input"
   },
-  "qhmriI": {
-    "defaultMessage": "Date de fin",
-    "description": "Label displayed on Personal Experience form for end date input"
-  },
   "sIM1t+": {
     "defaultMessage": "Choisir un...",
     "description": "Null selection for select input in the award scope form."
-  },
-  "tyPFpt": {
-    "defaultMessage": "Mon rôle/Titre de l’emploi",
-    "description": "Label displayed on Community Experience form for role input"
   },
   "wASF5V": {
     "defaultMessage": "Je suis actuellement actif dans ce rôle.",
@@ -506,10 +383,6 @@
   "xJulQ4": {
     "defaultMessage": "Équipe, groupe ou division",
     "description": "Label displayed on Work Experience form for team/group/division input"
-  },
-  "yx7EDY": {
-    "defaultMessage": "C’est beaucoup de compétences!",
-    "description": "Title of alert when there are many skills added."
   },
   "+wdTbk": {
     "defaultMessage": "Veuillez remplir tous les champs obligatoires de votre profil avant de définir votre statut comme actif.",
@@ -551,10 +424,6 @@
     "defaultMessage": "Indiquez s'il y a une ville que vous souhaitez exclure d'une région.",
     "description": "Explanation text for Location exemptions field in work location preference form"
   },
-  "1Yqt8K": {
-    "defaultMessage": "Vous êtes sur le point de supprimer une expérience de votre profil. Vous perdrez tous les renseignements qui y sont rattachés. Voulez-vous vraiment supprimer cette expérience?",
-    "description": "Warning prior to experience deletion"
-  },
   "248YQT": {
     "defaultMessage": "Pas encore prêt à partir? Retournez à la page d'accueil, découvrez de nouvelles possibilités, ou apprenez-en plus sur certaines recherches derrière cette plateforme.",
     "description": "Description of the links presented on the logged out page."
@@ -574,10 +443,6 @@
   "2cUBGT": {
     "defaultMessage": "Utilisateur introuvable.",
     "description": "Message displayed for user not found."
-  },
-  "2t3Cqv": {
-    "defaultMessage": "Rôle actuel",
-    "description": "Label displayed on Work Experience form for current role bounded box"
   },
   "3f9P13": {
     "defaultMessage": "En tant qu'employé, quel est votre statut d'emploi?",
@@ -611,10 +476,6 @@
     "defaultMessage": "Postes en français",
     "description": "Message for the french positions option"
   },
-  "6H4uc8": {
-    "defaultMessage": "« Je m'identifie comme une personne handicapée »",
-    "description": "Title for when someone indicates they have a disability on their profile"
-  },
   "6LTC0y": {
     "defaultMessage": "Gestion de la base de données de la TI",
     "description": "work stream example"
@@ -626,9 +487,6 @@
   "6cYs7i": {
     "defaultMessage": "Vous êtes membre d'un ou de plusieurs de ces groupes d'équité en matière d'emploi.",
     "description": "Instruction on when to fill out equity information, item one"
-  },
-  "6l1+3n": {
-    "defaultMessage": "résultats des compétences de la recherche par mot clé"
   },
   "6rhyxk": {
     "defaultMessage": "Déconnexion",
@@ -653,10 +511,6 @@
   "7qR4UK": {
     "defaultMessage": "Renseignements personnels",
     "description": "Title for Personal Information section of the About Me form"
-  },
-  "8/aBOG": {
-    "defaultMessage": "Postuler",
-    "description": "Breadcrumb title for the pool application link."
   },
   "87nFC8": {
     "defaultMessage": "Il y a deux types d'employés du TI-04 : ceux qui suivent un cheminement en gestion et les contributeurs individuels.",
@@ -718,10 +572,6 @@
     "defaultMessage": "Préférence linguistique pour la communication",
     "description": "Legend text for required language preference in About Me form"
   },
-  "DGnBW+": {
-    "defaultMessage": "Personnes handicapées",
-    "description": "Title for button to learn more information about disabled equity definition"
-  },
   "DK870a": {
     "defaultMessage": "Compte créé avec succès.",
     "description": "Message displayed to user if account is created successfully."
@@ -742,21 +592,9 @@
     "defaultMessage": "Qu'avez-vous accompli, créé ou produit en utilisant cette compétence?",
     "description": "Question for user in skills in detail section of experience form."
   },
-  "EzgYXr": {
-    "defaultMessage": "Peuples autochtones",
-    "description": "Title for equity dialog to add/remove indigenous category to profile"
-  },
-  "FTMoH9": {
-    "defaultMessage": "Femmes",
-    "description": "Title for button to learn more information about women equity definition"
-  },
   "FayQOt": {
     "defaultMessage": "Niveau 4 : Conseiller principal (101 000 $ à 126 000 $). <openModal>En savoir plus sur TI-04</openModal>",
     "description": "Checkbox label for Level IT-04 senior advisor selection, ignore things in <> tags please"
-  },
-  "Fj5UsM": {
-    "defaultMessage": "Personnes handicapées",
-    "description": "Title for equity dialog to add/remove having a disability category to profile"
   },
   "FmN1eN": {
     "defaultMessage": "+123243234",
@@ -790,10 +628,6 @@
     "defaultMessage": "Enregistrer et aller sur mon profil",
     "description": "Button label for submit button on create account form."
   },
-  "HZB4iF": {
-    "defaultMessage": "« Je m'identifie comme une femme »",
-    "description": "Title for when someone indicates they are a woman on their profile"
-  },
   "Hgd/PL": {
     "defaultMessage": "Retour à l'accueil",
     "description": "Link text to return to the home page"
@@ -801,10 +635,6 @@
   "Hiv/2m": {
     "defaultMessage": "Déconnexion",
     "description": "Title for the modal that appears when an authenticated user lands on /logged-out."
-  },
-  "IU0lH8": {
-    "defaultMessage": "Membre des minorités visibles",
-    "description": "Title for button to learn more information about visible minority equity definition"
   },
   "Igrveg": {
     "defaultMessage": "Liens rapides",
@@ -878,10 +708,6 @@
     "defaultMessage": "Postes bilingues (en anglais et en français)",
     "description": "Message for the bilingual positions option"
   },
-  "N+S2bh": {
-    "defaultMessage": "Vous aimeriez être pris(e) en considération pour les possibilités offertes aux groupes sous-représentés.",
-    "description": "Instruction on when to fill out equity information, item two"
-  },
   "NP/fsS": {
     "defaultMessage": "Pour quel ministère travaillez-vous?",
     "description": "Label for department select input in the request form"
@@ -950,10 +776,6 @@
     "defaultMessage": "Travail",
     "description": "Title for work experience form button."
   },
-  "RdrUZz": {
-    "defaultMessage": "Retour à la liste des bassins",
-    "description": "Label for button to the browse pools page"
-  },
   "Rgh/Qb": {
     "defaultMessage": "4. Renseignements complémentaires pour cette expérience",
     "description": "Title for addition information on Experience form"
@@ -1006,10 +828,6 @@
     "defaultMessage": "Renseignements du gouvernement",
     "description": "Display Text for Government Information Form Page Link"
   },
-  "Uyo9WO": {
-    "defaultMessage": "Merci d'avoir postulé",
-    "description": "Breadcrumb title for the pools 'thanks for applying page' link."
-  },
   "W4Svkd": {
     "defaultMessage": "Compréhension",
     "description": "Label displayed on the language information form comprehension field."
@@ -1054,13 +872,6 @@
     "defaultMessage": "Nous aimerions savoir ci-dessous si vous êtes déjà un(e) employé(e) du gouvernement du Canada. Nous recueillons ces renseignements parce qu'ils nous aident à comprendre, au niveau global, comment les compétences numériques sont réparties entre les ministères.",
     "description": "First message before is a government of canada radio group in create account form."
   },
-  "XkrePe": {
-    "defaultMessage": "Identité autochtone",
-    "description": "Title for button to learn more information about indigenous equity definition"
-  },
-  "Y+d/yO": {
-    "defaultMessage": "Résultats fréquents des compétences"
-  },
   "Y7jEXr": {
     "defaultMessage": "Sélectionnez un niveau...",
     "description": "Placeholder displayed on the language information form verbal field."
@@ -1097,10 +908,6 @@
     "defaultMessage": "Niveau 1 : Technicien(ne) (de 60 000 $ à 78 000 $). <openModal>En savoir plus sur TI-01</openModal>",
     "description": "Checkbox label for Level IT-01 selection, ignore things in <> tags please"
   },
-  "ZodXqQ": {
-    "defaultMessage": "Femme (Elle/Elle)",
-    "description": "Title for equity dialog to add/remove women category to profile"
-  },
   "Zx3BVC": {
     "defaultMessage": "Êtes-vous sûr(e) de vouloir vous déconnecter?",
     "description": "Question displayed when authenticated user lands on /logged-out."
@@ -1120,10 +927,6 @@
   "b9/MXQ": {
     "defaultMessage": "Quel était votre niveau de responsabilité dans ce rôle?",
     "description": "Question for user in skills in detail section of experience form."
-  },
-  "bUeJy1": {
-    "defaultMessage": "« Je m'identifie comme membre d'une minorité visible »",
-    "description": "Title for when someone indicates they are a visible minority on their profile"
   },
   "c/Qp8R": {
     "defaultMessage": "Préférence pour le lieu de travail",
@@ -1173,16 +976,9 @@
     "defaultMessage": "L'utilisateur a été mis à jour avec succès!",
     "description": "Message displayed to user after user is updated successfully."
   },
-  "fCQ4aB": {
-    "defaultMessage": "Utilisateur{applicantId} introuvable.",
-    "description": "Message displayed for user not found."
-  },
   "fK7jxe": {
     "defaultMessage": "Vous n'avez ajouté aucune option d'équité en matière d'emploi à votre profil.",
     "description": "Message displayed when a user has no employment equity information."
-  },
-  "fOCbBa": {
-    "defaultMessage": "Résultats pour les compétences fréquentes"
   },
   "gBWsuB": {
     "defaultMessage": "Téléphone",
@@ -1212,10 +1008,6 @@
     "defaultMessage": "Il y a deux types d'employés du TI-03 : ceux qui suivent un cheminement en gestion et les contributeurs individuels.",
     "description": "IT-03 description precursor"
   },
-  "hDSk9d": {
-    "defaultMessage": "Merci d'avoir postulé au {poolName}",
-    "description": "Title for page thanking user for applying to a pool"
-  },
   "hTJgV2": {
     "defaultMessage": "Tous les champs obligatoires sont remplis. Vous pouvez maintenant modifier votre statut.",
     "description": "Message displayed to user when user profile completed."
@@ -1231,14 +1023,6 @@
   "i99arX": {
     "defaultMessage": "Comment j'ai utilisé cette compétence...",
     "description": "Placeholder message for textarea in the skills in detail section."
-  },
-  "iCb9eG": {
-    "defaultMessage": "Les techniciens en TI se retrouvent principalement dans trois volets de travail :",
-    "description": "Preceding list description"
-  },
-  "jF5ZYY": {
-    "defaultMessage": "Membres des minorités visibles",
-    "description": "Title for equity dialog to add/remove visible minority category to profile"
   },
   "jPLaDk": {
     "defaultMessage": "Désolé, vous n'êtes pas autorisé(e) à consulter cette page.",
@@ -1268,17 +1052,9 @@
     "defaultMessage": "Ajouter une expérience",
     "description": "Display text for add experience form in breadcrumbs"
   },
-  "mMGycA": {
-    "defaultMessage": "Postuler",
-    "description": "Apply label for button to apply to pool"
-  },
   "mTlHta": {
     "defaultMessage": "Niveau 3 : Chef d'équipe",
     "description": "title for IT-03 lead dialog"
-  },
-  "mW0/n1": {
-    "defaultMessage": "Aucun bassin n'a été trouvé.",
-    "description": "Message displayed on the browse pools direct intake page when there are no pools."
   },
   "md7Klw": {
     "defaultMessage": "Connexion",
@@ -1319,14 +1095,6 @@
   "o/YTo0": {
     "defaultMessage": "Pour commencer",
     "description": "Main heading in create account page."
-  },
-  "oEFd6y": {
-    "defaultMessage": "« Je suis autochtone »",
-    "description": "Title for when someone indicates they are indigenous on their profile"
-  },
-  "oG9dAi": {
-    "defaultMessage": "Parcourir les bassins",
-    "description": "Page title for the direct intake browse pools page."
   },
   "oOcegG": {
     "defaultMessage": "Architecture intégrée de la TI ",
@@ -1383,10 +1151,6 @@
   "sapxcU": {
     "defaultMessage": "Avertissement",
     "description": "Label displayed on Personal Experience form for disclaimer bounded box"
-  },
-  "sifjUN": {
-    "defaultMessage": "Il n'y a pas encore d'expérience sur votre profil. Vous pouvez en ajouter quelques-unes en utilisant les liens ci-dessus.",
-    "description": "Message to user when no experiences have been attached to profile."
   },
   "t12bCU": {
     "defaultMessage": "Sauvegarder et revenir en arrière",
@@ -1460,10 +1224,6 @@
     "defaultMessage": "J'envisagerais d'accepter un emploi qui :",
     "description": "Legend for optional work preferences check list in work preferences form"
   },
-  "yfVLxM": {
-    "defaultMessage": "Rôle actuel",
-    "description": "Label displayed on Community Experience form for current role bounded box"
-  },
   "zILELf": {
     "defaultMessage": "S'inscrire à l'aide de la CléGC",
     "description": "Title for the registration page for applicant profiles."
@@ -1472,14 +1232,6 @@
     "defaultMessage": "Filtre des exigences en matière d'études",
     "description": "Legend for the Education Requirement filter radio group"
   },
-  "/h+Ub4": {
-    "defaultMessage": "Je m'identifie comme une femme.",
-    "description": "Label for the checkbox to identify as a woman under employment equity"
-  },
-  "07bCT2": {
-    "defaultMessage": "Je m'identifie comme une personne handicapée.",
-    "description": "Label for the checkbox to identify as a person with a disability under employment equity"
-  },
   "3nKkyo": {
     "defaultMessage": "Compétences organisées par volet",
     "description": "Legend for Skills filter checklist"
@@ -1487,10 +1239,6 @@
   "6danS7": {
     "defaultMessage": "Cette catégorie comprend les personnes dont le genre déclaré est féminin. Elle comprend les femmes cisgenres (cis) et les femmes transgenres (trans).",
     "description": "Definition of the Woman category from the StatsCan 'Classification of gender' page."
-  },
-  "Jtz3yb": {
-    "defaultMessage": "Je suis autochtone.",
-    "description": "Label for the checkbox to identify as indigenous under employment equity"
   },
   "F4K5RB": {
     "defaultMessage": "Minorité visible réfère au fait qu'une personne est ou non une minorité visible, tel que défini dans la Loi sur l'équité en matière d'emploi. Dans le cadre de la Loi sur l'équité en matière d'emploi, les minorités visibles sont définies comme « les personnes, autres que les Autochtones, qui ne sont pas de race blanche ou qui n'ont pas la peau blanche ». La population des minorités visibles est principalement composée des groupes suivants : Sud-Asiatique, Chinois, Noir, Philippin, Arabe, Latino-Américain, Asiatique du Sud-Est, Asiatique occidental, Coréen et Japonais.",
@@ -1503,10 +1251,6 @@
   "y5Z2Li": {
     "defaultMessage": "Réfère à une personne dont les activités quotidiennes sont limitées en raison d'un trouble ou d'une difficulté à accomplir certaines tâches. La seule exception à cet égard concerne les troubles du développement, le répondant qui a reçu un tel diagnostic étant considéré comme ayant une incapacité.",
     "description": "Definition of Person with a disability from the StatsCan 'Classification of Status of Disability' page."
-  },
-  "sdUnnh": {
-    "defaultMessage": "Je m'identifie comme faisant partie d'un ou de plusieurs groupes de minorités visibles.",
-    "description": "Label for the checkbox to identify as a visible minority under employment equity"
   },
   "z44LTK": {
     "defaultMessage": "Tel que défini par <link>Statistique Canada</link>.",
@@ -1588,14 +1332,6 @@
     "defaultMessage": "<strong>Remarque :</strong> Si vous sélectionnez plus d'un groupe visé par l'équité en matière d'emploi, TOUS les candidats qui se sont déclarés membres de N'IMPORTE LEQUEL des groupes visés par l'équité en matière d'emploi sélectionnés seront recommandés. Si vous avez des exigences plus détaillées concernant l'équité en matière d'emploi, veuillez nous en faire part dans la section des commentaires du formulaire de soumission.",
     "description": "Context for employment equity filter in search form."
   },
-  "+cy2GO": {
-    "defaultMessage": "Trouvez des candidats ayant les bonnes compétences pour le poste. Utilisez les onglets suivants pour trouver les compétences nécessaires à l'emploi et sélectionnez-les pour les utiliser comme filtres pour trouver les candidats correspondants.",
-    "description": "Describing how to use the skill filters on search page, paragraph one."
-  },
-  "+pWIcS": {
-    "defaultMessage": "Compétences techniques",
-    "description": "Button text for the technical skills tab on skills filter"
-  },
   "U6IroF": {
     "defaultMessage": "Études postsecondaires de deux ans",
     "description": "Title for pool applicant education requirements"
@@ -1616,10 +1352,6 @@
     "defaultMessage": "Avez-vous besoin de mesures d’adaptation, ou avez-vous des questions sur ce processus?",
     "description": "Opening sentence asking if accommodations are needed"
   },
-  "6OJhwM": {
-    "defaultMessage": "Trouver et sélectionner les compétences",
-    "description": "Subtitle for the skills filter on the search form."
-  },
   "7o+Vzu": {
     "defaultMessage": "Expérience combinée",
     "description": "Title for pool applicant experience requirements"
@@ -1627,10 +1359,6 @@
   "8fQWTc": {
     "defaultMessage": "Toute durée (court terme, long terme ou indéterminée) (recommandé)",
     "description": "No preference for employment duration - will accept any"
-  },
-  "AYlTUF": {
-    "defaultMessage": "Il n'y a pas encore de compétences sélectionnées. Vous pouvez en ajouter en utilisant les liens fournis",
-    "description": "Invitation to add skills when there aren't any added yet."
   },
   "C6YPk3": {
     "defaultMessage": "Postulez maintenant",
@@ -1651,10 +1379,6 @@
   "GNvz2K": {
     "defaultMessage": "Autre expérience liée au domaine",
     "description": "pool experience requirement, other"
-  },
-  "GR1ZQH": {
-    "defaultMessage": "Résultats des compétences transférables",
-    "description": "Title for transferable skills pagination"
   },
   "GYk6Nz": {
     "defaultMessage": "Autorisation de sécurité : {securityClearance}",
@@ -1684,25 +1408,9 @@
     "defaultMessage": "Parcourez les opportunités",
     "description": "Breadcrumb title for the browse pools page."
   },
-  "PBnlYi": {
-    "defaultMessage": "Possibilités de navigation",
-    "description": "Breadcrumb from applicant profile wrapper."
-  },
-  "QJQS42": {
-    "defaultMessage": "Pourquoi y a-t-il un nombre limité de compétences? Il est important que les candidats et les gestionnaires puisent dans la même liste de compétences afin de créer des correspondances.",
-    "description": "Describing how to use the skill filters on search page, paragraph two."
-  },
-  "S9BRBL": {
-    "defaultMessage": "Durée du terme (court terme, long terme)",
-    "description": "Duration of a non-permanent length"
-  },
   "STLaIq": {
     "defaultMessage": "Utile",
     "description": "Title for the optional skills section of a pool advertisement"
-  },
-  "Sb95gs": {
-    "defaultMessage": "Compétences transférables",
-    "description": "Button text for the transferable skills tab on skills filter"
   },
   "U+ApNl": {
     "defaultMessage": "La date limite des candidatures est passée.",
@@ -1756,10 +1464,6 @@
     "defaultMessage": "La <actLink>Loi sur l'équité en matière d'emploi</actLink> est actuellement <reviewLink>en cours de révision</reviewLink>.",
     "description": "Text that appears in Employment equity dialogs explaining the act is under review."
   },
-  "f/JJR5": {
-    "defaultMessage": "Résultats des compétences techniques",
-    "description": "Title for technical skills pagination"
-  },
   "fvJnoC": {
     "defaultMessage": "Exigence linguistique : {languageRequirement}",
     "description": "Pool advertisement language requirement"
@@ -1767,10 +1471,6 @@
   "gpuTAV": {
     "defaultMessage": "Que signifie {classification}{genericTitle}?",
     "description": "Title for description of a pool advertisements classification group/level"
-  },
-  "hEhmBF": {
-    "defaultMessage": "Les compétences comme filtres",
-    "description": "Title for the skill filters on search page."
   },
   "iN2H6J": {
     "defaultMessage": "La durée sélectionnée sera comparée à celle choisie par les candidats dans leur dossier de candidature. Ne modifiez cette option que si l'offre d'emploi a une durée déterminée.",
@@ -1787,10 +1487,6 @@
   "kH4Jsf": {
     "defaultMessage": "Lorsque vous postulez à ce processus, vous ne postulez pas pour un poste en particulier. Ce processus a pour but de créer et de maintenir un répertoire pour doter divers postes de même niveau dans différents ministères et organismes du gouvernement du Canada.",
     "description": "Description of pool recruitment, paragraph one"
-  },
-  "l7Hif/": {
-    "defaultMessage": "Compétences sélectionnées",
-    "description": "Section header for a list of skills selected"
   },
   "l9AK3C": {
     "defaultMessage": "ou",
@@ -1828,10 +1524,6 @@
     "defaultMessage": "Réussite de deux ans d'études postsecondaires en informatique, en technologie de l'information, en gestion de l'information ou dans une autre spécialité pertinente pour ce poste",
     "description": "post secondary education experience for pool advertisement"
   },
-  "rYodJu": {
-    "defaultMessage": "Durée indéterminée (permanente)",
-    "description": "Duration that is permanent"
-  },
   "s60QyR": {
     "defaultMessage": "2 ans ou plus d'expérience combinée dans un domaine connexe, y compris l'un des éléments suivants :",
     "description": "lead in to list of experience required for a pool applicant"
@@ -1839,10 +1531,6 @@
   "uv2lY0": {
     "defaultMessage": "Votre travail",
     "description": "Title for a pool advertisements key tasks section."
-  },
-  "vmyStM": {
-    "defaultMessage": "Par mot-clé",
-    "description": "Button text for the search skills tab on skills filter"
   },
   "yu4yB8": {
     "defaultMessage": "Pour renforcer votre candidature, prenez en compte ces compétences que de nombreux responsables d'embauche recherchent",
@@ -1859,14 +1547,6 @@
   "Wnw+oz": {
     "defaultMessage": "<strong>Courriel</strong> : <anchorTag>{emailAddress}</anchorTag>",
     "description": "An email address to contact for help"
-  },
-  "s4DN3G": {
-    "defaultMessage": "Résultats des compétences générales",
-    "description": "Accessibility label for a result set of skills, filtered to mainstream skills"
-  },
-  "wziEOM": {
-    "defaultMessage": "résultats des compétences, recherche par mot-clé",
-    "description": "Accessibility label for a result set of skills, searched by keyword"
   },
   "5YzNJj": {
     "defaultMessage": "IT-04: Conseiller principal ou Manager Gestionnaire (101 000 $ à 126 000 $)",
@@ -2024,10 +1704,6 @@
     "defaultMessage": "Créer un profil",
     "description": "Link text for users to create a profile"
   },
-  "7n838F": {
-    "defaultMessage": "Pour être admis dans ce processus, vous devrez faire preuve de capacités dans ces compétences au cours du processus d’évaluation",
-    "description": "Explanation of a pool required transferrable skills"
-  },
   "87FqAO": {
     "defaultMessage": "En savoir plus",
     "description": "Heading for the about section of the homepage"
@@ -2043,14 +1719,6 @@
   "AauSuA": {
     "defaultMessage": "s. o.",
     "description": "Not available message."
-  },
-  "BQ7cf/": {
-    "defaultMessage": "Pourquoi y a-t-il un nombre limité de compétences? Il est important que les candidats et les gestionnaires puisent dans la même liste de compétences afin de créer des correspondances.",
-    "description": "Describing how to use the skill filters on search page, paragraph two."
-  },
-  "Ba4Y8a": {
-    "defaultMessage": "Il y a des <heavyPrimary><testId>{candidateCount}</testId></heavyPrimary> candidats correspondants dans ce bassin",
-    "description": "Message for total estimated candidates box next to search form."
   },
   "Boze7x": {
     "defaultMessage": "Mes candidatures",
@@ -2128,10 +1796,6 @@
     "defaultMessage": "Talents numériques du GC",
     "description": "Application title"
   },
-  "MUpqIp": {
-    "defaultMessage": "En savoir plus<hidden> sur les femmes dans les STIM</hidden>",
-    "description": "Link text to learn more about women in STEM"
-  },
   "NjHXGh": {
     "defaultMessage": "En savoir plus<hidden> sur le Bureau de la dirigeante principale de l’information</hidden>",
     "description": "Link text for the Office of the Chief Information Officer"
@@ -2151,10 +1815,6 @@
   "Q7yh4j": {
     "defaultMessage": "Erreur, les candidatures ne peuvent pas être chargées",
     "description": "My applications error message, placeholder"
-  },
-  "QcrDDA": {
-    "defaultMessage": "Parcourir les emplois de cadres",
-    "description": "Link text to find executive jobs in government"
   },
   "SDQWZf": {
     "defaultMessage": "Retour à l’étape précédente",
@@ -2180,17 +1840,9 @@
     "defaultMessage": "Vous souhaitez être pris en considération pour les perspectives d’emploi adressées aux groupes sous-représentés.",
     "description": "Instruction on when to fill out equity information, item two"
   },
-  "XF8DsD": {
-    "defaultMessage": "Page actuelle :",
-    "description": "Message read to users with screen reader when page is active."
-  },
   "XR37x0": {
     "defaultMessage": "Programme d’apprentissage destiné aux Autochtones",
     "description": "Heading for the Indigenous Apprenticeship Program on home page"
-  },
-  "Y7AKYP": {
-    "defaultMessage": "Pour être admis dans ce processus, vous devrez soumettre des renseignements suffisants pour vérifier votre expérience dans <strong>toutes ces compétences (Obligatoire - Professionnel)</strong> avec votre candidature",
-    "description": "Explanation of a pools required occupational skills"
   },
   "YZyNUJ": {
     "defaultMessage": "Signature",
@@ -2260,10 +1912,6 @@
     "defaultMessage": "Erreur, le candidat du bassin n’a pas pu être chargé",
     "description": "Error message, placeholder"
   },
-  "jefAOX": {
-    "defaultMessage": "Apprenez-en plus<hidden> sur la fierté dans la technologie</hidden>",
-    "description": "Link text to learn about pride in tech"
-  },
   "kHypfJ": {
     "defaultMessage": "Du concept au code",
     "description": "Title for how the platform was created"
@@ -2276,10 +1924,6 @@
     "defaultMessage": "Mes candidatures",
     "description": "'My Applications' breadcrumb from applicant profile wrapper."
   },
-  "muwFhL": {
-    "defaultMessage": "La fierté dans la technologie",
-    "description": "Title for the pride in tech featured item"
-  },
   "nEMeaQ": {
     "defaultMessage": "Recrutement en cours",
     "description": "Heading for the recruitment opportunities"
@@ -2291,10 +1935,6 @@
   "oDyHaL": {
     "defaultMessage": "Erreur, titre du poste non trouvé.",
     "description": "Error message when job title isn't found."
-  },
-  "oMSsJd": {
-    "defaultMessage": "Les femmes dans les STIM",
-    "description": "Title for the Women in STEM feature item"
   },
   "oOR4Rd": {
     "defaultMessage": "Étape 2",
@@ -2460,10 +2100,6 @@
     "defaultMessage": "Veuillez vérifier votre courriel pour obtenir un résumé de votre soumission.",
     "description": "Support form success paragraph two"
   },
-  "6TX9CR": {
-    "defaultMessage": "(aucune activité)",
-    "description": "Message displayed when a pool has no stream"
-  },
   "86Y8lx": {
     "defaultMessage": "Votre nom",
     "description": "Support form name field label"
@@ -2527,10 +2163,6 @@
   "OdjW9z": {
     "defaultMessage": "Nous ferons de notre mieux pour vous répondre dans les deux jours ouvrables suivants.",
     "description": "Support form success paragraph one"
-  },
-  "QX1l/C": {
-    "defaultMessage": "En attendant, n’hésitez pas à consulter nos foires aux questions (FAQ) pour obtenir plus d’information.",
-    "description": "Support form success paragraph three"
   },
   "TrO4uL": {
     "defaultMessage": "Échelle salariale :",


### PR DESCRIPTION
Resolves #4489.

## Description
Removes unused strings from fr.json files. Related to https://github.com/GCTC-NTGC/gc-digital-talent/pull/4920.

## Summary

- admin: 717-651 = 66
- common: 512-472 = 40
- indigenousapprenticeship: 93-89 = 4
- talentsearch: 714-621 = 93

203 unused strings removed from fr.json files! ✂️ 

## Steps to test

1. Delete all **en.json**, **newTranslations.json**, and **untranslated.json** files from within **/frontend** (these are untracked files and could have leftover work from other branches)
2. Extract admin `npm run intl-extract --workspace=admin`
3. Extract common `npm run intl-extract --workspace=common`
4. Extract indigenousapprenticeship `npm run intl-extract --workspace=indigenousapprenticeship`
5. Extract talentsearch `npm run intl-extract --workspace=talentsearch`
6. Check admin `npm run check-intl-admin --workspace=common`
7. Check common `npm run check-intl-common --workspace=common`
8. Check indigenousapprenticeship `npm run check-intl-indigenousapprenticeship --workspace=common`
9. Check talentsearch `npm run check-intl-talentsearch --workspace=common`
10. Verify there are no **newTranslations.json** or **untranslated.json** files generated in **/frontend**
11. Verify strings removed in fr.json files are not present in codebase by searching all files for their IDs

