### PR TITLE
Tweaks to handling of skills during application

### DIFF
--- a/frontend/common/src/components/MissingSkills/MissingSkills.stories.tsx
+++ b/frontend/common/src/components/MissingSkills/MissingSkills.stories.tsx
@@ -53,7 +53,7 @@ MissingSomeSkills.args = {
   requiredSkills: fakeRequiredSkills,
   optionalSkills: fakeOptionalSkills,
   addedSkills: [
-    ...fakeRequiredSkills.splice(0, skills.length / 2),
-    ...fakeOptionalSkills.splice(0, skills.length / 2),
+    ...fakeRequiredSkills.slice(0, fakeRequiredSkills.length / 2),
+    ...fakeOptionalSkills.slice(0, fakeOptionalSkills.length / 2),
   ],
 };

--- a/frontend/common/src/components/MissingSkills/MissingSkills.test.tsx
+++ b/frontend/common/src/components/MissingSkills/MissingSkills.test.tsx
@@ -101,4 +101,41 @@ describe("MissingSkills", () => {
       defaultProps.optionalSkills.length - 1, // Check that we are missing an item
     );
   });
+
+  it("should ignore added skills with empty experienceSkillRecords detail field", () => {
+    const element = renderMissingSkills({
+      // Adding one from each array to added skills
+      addedSkills: [
+        {
+          ...defaultProps.requiredSkills[0],
+          experienceSkillRecord: { details: null },
+        },
+        {
+          ...defaultProps.requiredSkills[0],
+          experienceSkillRecord: { details: "" },
+        },
+        {
+          ...defaultProps.optionalSkills[0],
+          experienceSkillRecord: { details: null },
+        },
+        {
+          ...defaultProps.optionalSkills[0],
+          experienceSkillRecord: { details: "" },
+        },
+      ],
+    });
+
+    const lists = element.getAllByRole("list");
+    expect(lists.length).toEqual(2);
+
+    const requiredListItems = within(lists[0]).queryAllByRole("listitem");
+    expect(requiredListItems.length).toEqual(
+      defaultProps.requiredSkills.length, // Check that we are not missing any items
+    );
+
+    const optionalListItems = within(lists[1]).queryAllByRole("listitem");
+    expect(optionalListItems.length).toEqual(
+      defaultProps.optionalSkills.length, // Check that we are not missing any items
+    );
+  });
 });

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/SkillList.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/SkillList.tsx
@@ -6,14 +6,12 @@ import { Maybe, Skill } from "../../../api/generated";
 
 interface SkillListItem {
   name: Skill["name"];
-  description: Skill["description"];
   record: Skill["experienceSkillRecord"];
 }
 
-const SkillListItem = ({ name, description, record }: SkillListItem) => {
+const SkillListItem = ({ name, record }: SkillListItem) => {
   const intl = useIntl();
   const localizedName = getLocalizedName(name, intl);
-  const localizedDesc = getLocalizedName(description, intl);
 
   return (
     <li>
@@ -25,9 +23,6 @@ const SkillListItem = ({ name, description, record }: SkillListItem) => {
         >
           {localizedName}
         </p>
-      )}
-      {localizedDesc && (
-        <p data-h2-margin="base(0, 0, x.25, 0)">{localizedDesc}</p>
       )}
       {record && record.details && <p>{record.details}</p>}
     </li>
@@ -47,7 +42,6 @@ const SkillList = ({ skills }: SkillListProps) => {
         <SkillListItem
           key={skill.id}
           name={skill.name}
-          description={skill.description}
           record={skill.experienceSkillRecord}
         />
       ))}

--- a/frontend/common/src/fakeData/fakeSkills.ts
+++ b/frontend/common/src/fakeData/fakeSkills.ts
@@ -26,6 +26,9 @@ const generateSkill = (skillFamilies: SkillFamily[]) => {
       ? faker.helpers.arrayElements<SkillFamily>(skillFamilies)
       : ([] as SkillFamily[]),
     experienceSkills: [],
+    experienceSkillRecord: {
+      details: `experienceSkillDetails ${faker.random.words()}`,
+    },
   };
 };
 

--- a/frontend/common/src/helpers/skillUtils.ts
+++ b/frontend/common/src/helpers/skillUtils.ts
@@ -135,7 +135,11 @@ export const getMissingSkills = (required: Skill[], added?: Skill[]) => {
   return !added?.length
     ? required
     : required.filter((skill) => {
-        return !added.find((addedSkill) => addedSkill.id === skill.id);
+        return !added.find(
+          (addedSkill) =>
+            addedSkill.id === skill.id &&
+            addedSkill.experienceSkillRecord?.details,
+        );
       });
 };
 


### PR DESCRIPTION
Resolves #4886.

Removes skill descriptions from accordions and made MissingSkills check for "skills in detail" being set for the skill.

To test:
1. Build the site
2. Look at a published pool advertisement and it's required skills but don't start an application to it.
3. Navigate to your profile
4. Confirm the experience accordions don't include the skill descriptions.
5. Add a new experience with one of the required skills from step 2 you don't already have.
6. Return to your profile
7. Confirm your new experience displays nothing instead "N/A" under the skill where the "Skills in detail" text would be displayed.
8. Start an application to the pool advertisement in step 2.
9. On the apply part one page: Confirm the skill added in step 5 is listed as missing from your profile.
10. Edit your new experience and fill out the "skills in detail" for the skill.
11. Return to the apply part one page.
12. Confirm the skill is no longer listed as missing from your profile.