### PR TITLE
Add `restart: always` to webserver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
   webserver:
     # All images: https://mcr.microsoft.com/v2/appsvc/php/tags/list
     image: mcr.microsoft.com/appsvc/php:8.1-fpm-xdebug_20221027.1.tuxprod
+    restart: always
     volumes:
       - ./:/home/site/wwwroot
       - ./infrastructure/conf/nginx-conf-local:/etc/nginx/sites-available/


### PR DESCRIPTION
## Steps to test
1. Stop all docker containers
2. Restart machine
3. Verify docker containers are all started automatically