### PR TITLE
Feature - 4979 - Add Ongoing Recruitments Feature Flag

### DIFF
--- a/frontend/admin/.env.example
+++ b/frontend/admin/.env.example
@@ -47,3 +47,4 @@ OAUTH_LOGOUT_URI="http://localhost:8000/oxauth/endsession"
 # Feature flags
 FEATURE_DIRECTINTAKE=true
 FEATURE_APPLICANTSEARCH=true
+FEATURE_ONGOING_RECRUITMENTS=true

--- a/frontend/admin/public/config.ejs
+++ b/frontend/admin/public/config.ejs
@@ -15,6 +15,7 @@ const data = new Map([
     // Feature flags
     ["FEATURE_DIRECTINTAKE", filterUnusable("$FEATURE_DIRECTINTAKE") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_DIRECTINTAKE %>"],
     ["FEATURE_APPLICANTSEARCH", filterUnusable("$FEATURE_APPLICANTSEARCH") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_APPLICANTSEARCH %>"],
+    ["FEATURE_ONGOING_RECRUITMENTS", filterUnusable("$FEATURE_ONGOING_RECRUITMENTS") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_ONGOING_RECRUITMENTS %>"],
 
     // Azure application insights not used in dev
     ["APPLICATIONINSIGHTS_CONNECTION_STRING", filterUnusable("$APPLICATIONINSIGHTS_CONNECTION_STRING")],

--- a/frontend/common/src/helpers/runtimeVariable.ts
+++ b/frontend/common/src/helpers/runtimeVariable.ts
@@ -41,4 +41,5 @@ export const checkFeatureFlag = (name: string): boolean => {
 export const getFeatureFlags = () => ({
   applicantSearch: checkFeatureFlag("FEATURE_APPLICANTSEARCH"),
   directIntake: checkFeatureFlag("FEATURE_DIRECTINTAKE"),
+  ongoingRecruitments: checkFeatureFlag("FEATURE_ONGOING_RECRUITMENTS"),
 });

--- a/frontend/common/src/hooks/useFeatureFlags.ts
+++ b/frontend/common/src/hooks/useFeatureFlags.ts
@@ -3,6 +3,7 @@ import { getFeatureFlags } from "../helpers/runtimeVariable";
 export type FeatureFlags = {
   applicantSearch: boolean;
   directIntake: boolean;
+  ongoingRecruitments: boolean;
 };
 
 const useFeatureFlags = (): FeatureFlags => {

--- a/frontend/indigenousapprenticeship/public/config.ejs
+++ b/frontend/indigenousapprenticeship/public/config.ejs
@@ -15,6 +15,7 @@ const data = new Map([
     // Feature flags
     ["FEATURE_DIRECTINTAKE", filterUnusable("$FEATURE_DIRECTINTAKE") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_DIRECTINTAKE %>"],
     ["FEATURE_APPLICANTSEARCH", filterUnusable("$FEATURE_APPLICANTSEARCH") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_APPLICANTSEARCH %>"],
+    ["FEATURE_ONGOING_RECRUITMENTS", filterUnusable("$FEATURE_ONGOING_RECRUITMENTS") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_ONGOING_RECRUITMENTS %>"],
 
     // Azure application insights not used in dev
     ["APPLICATIONINSIGHTS_CONNECTION_STRING", filterUnusable("$APPLICATIONINSIGHTS_CONNECTION_STRING")],

--- a/frontend/talentsearch/.env.example
+++ b/frontend/talentsearch/.env.example
@@ -38,3 +38,4 @@ OAUTH_LOGOUT_URI="http://localhost:8000/oxauth/endsession"
 # Feature flags
 FEATURE_DIRECTINTAKE=true
 FEATURE_APPLICANTSEARCH=true
+FEATURE_ONGOING_RECRUITMENTS=true

--- a/frontend/talentsearch/public/config.ejs
+++ b/frontend/talentsearch/public/config.ejs
@@ -15,6 +15,7 @@ const data = new Map([
     // Feature flags
     ["FEATURE_DIRECTINTAKE", filterUnusable("$FEATURE_DIRECTINTAKE") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_DIRECTINTAKE %>"],
     ["FEATURE_APPLICANTSEARCH", filterUnusable("$FEATURE_APPLICANTSEARCH") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_APPLICANTSEARCH %>"],
+    ["FEATURE_ONGOING_RECRUITMENTS", filterUnusable("$FEATURE_ONGOING_RECRUITMENTS") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_ONGOING_RECRUITMENTS %>"],
 
     // Azure application insights not used in dev
     ["APPLICATIONINSIGHTS_CONNECTION_STRING", filterUnusable("$APPLICATIONINSIGHTS_CONNECTION_STRING")],

--- a/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
+++ b/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
@@ -10,7 +10,6 @@ import ExperienceSection from "@common/components/UserProfile/ExperienceSection"
 import UserProfile from "@common/components/UserProfile";
 import type { Applicant } from "@common/api/generated";
 
-import useFeatureFlags from "@common/hooks/useFeatureFlags";
 import MyStatusApi from "../../myStatusForm/MyStatusForm";
 import TALENTSEARCH_APP_DIR from "../../../talentSearchConstants";
 import useRoutes from "../../../hooks/useRoutes";

--- a/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
+++ b/frontend/talentsearch/src/js/components/profile/ProfilePage/ProfilePage.tsx
@@ -10,6 +10,7 @@ import ExperienceSection from "@common/components/UserProfile/ExperienceSection"
 import UserProfile from "@common/components/UserProfile";
 import type { Applicant } from "@common/api/generated";
 
+import useFeatureFlags from "@common/hooks/useFeatureFlags";
 import MyStatusApi from "../../myStatusForm/MyStatusForm";
 import TALENTSEARCH_APP_DIR from "../../../talentSearchConstants";
 import useRoutes from "../../../hooks/useRoutes";


### PR DESCRIPTION
## 👋 Introduction

This adds the `FEATURE_ONGOING_RECRUITMENTS` to `admin` and `talentsearch` and sets it to `true`.

## 🧪 Testing

1. Copy the `FEATURE_ONGOING_RECRUITMENTS=true` from `.env.example` into your `.env` file for `admin` and `talentsearch`
2. Rebuild the `webserver` docker image
    - `docker-compose stop webserver`
    - `docker-compose rm webserver`
    - `docker-compose up --detach --build`
4. Refresh the frontend (easer to do all)
    - `docker-compose run --rm maintenance bash refresh_all.sh`
5. Navigate to `/`
6. Open the javascript console to log `window.__SERVER_CONFIG__` to confirm new flag is in the map and true
7. Navigate to `/admin
8. Repeat step 6

> **Note**
> You can also temporarily `console.log` results of either `getRuntimeVariable("FEATURE_ONGOING_RECRUITMENTS")` or `useFeatureFlags` to confirm.

## 🚀 Deployment Notes

Add the `FEATURE_ONGOING_RECRUITMENTS` environment variable and presumable set it to `false`.

## 🤖 Robot Stuff

Resolves #4979 