### PR TITLE
Bug -  4925 - Prevent caching chunk load error

### DIFF
--- a/frontend/admin/webpack.base.js
+++ b/frontend/admin/webpack.base.js
@@ -154,8 +154,8 @@ module.exports = {
   },
   output: {
     publicPath: "/admin/", // final path for routing
-    filename: "[name].js?id=[contenthash]", // file hashing for cache busting
-    chunkFilename: "[name].js?id=[contenthash]",
+    filename: "[hash].[name].js", // file hashing for cache busting
+    chunkFilename: "[hash].[name].js", // file hashing for cache busting
     path: path.resolve(__dirname, "dist"), // output folder
     clean: true, // delete existing files on recompile
   },

--- a/frontend/indigenousapprenticeship/webpack.base.js
+++ b/frontend/indigenousapprenticeship/webpack.base.js
@@ -154,8 +154,8 @@ module.exports = {
   },
   output: {
     publicPath: "/indigenous-it-apprentice", // final path for routing
-    filename: "[name].js?id=[contenthash]", // file hashing for cache busting
-    chunkFilename: "[name].js?id=[contenthash]",
+    filename: "[hash].[name].js", // file hashing for cache busting
+    chunkFilename: "[hash].[name].js", // file hashing for cache busting
     path: path.resolve(__dirname, "dist"), // output folder
     clean: true, // delete existing files on recompile
   },

--- a/frontend/talentsearch/webpack.base.js
+++ b/frontend/talentsearch/webpack.base.js
@@ -143,8 +143,8 @@ module.exports = {
   },
   output: {
     publicPath: "/talent/", // final path for routing
-    filename: "[name].js?id=[contenthash]", // file hashing for cache busting
-    chunkFilename: "[name].js?id=[contenthash]", // file hashing for cache busting
+    filename: "[hash].[name].js", // file hashing for cache busting
+    chunkFilename: "[hash].[name].js", // file hashing for cache busting
     path: path.resolve(__dirname, "dist"), // output folder
     clean: true, // delete existing files on recompile
   },

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -85,6 +85,8 @@ server {
 
     # rewrite root-level possible lang prefix to talentsearch index.html
     location ~ "^(?:/[a-z]{2})?/?$" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^(?:/[a-z]{2})?/?$" /frontend/talentsearch/dist/index.html break;
     }
 
@@ -95,6 +97,8 @@ server {
 
     # rewrite possible lang prefix then "admin" to admin index.html
     location ~ "^(?:/[a-z]{2})?/admin(/?.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^(?:/[a-z]{2})?/admin(/?.*|$)" /frontend/admin/dist/index.html break;
     }
 
@@ -105,71 +109,99 @@ server {
 
     # rewrite possible lang prefix then "talent" to talentsearch index.html
     location ~ "^(?:/[a-z]{2})?/talent(/.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^(?:/[a-z]{2})?/talent(/.*|$)" /frontend/talentsearch/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "users" to talentsearch index.html
     location ~ "^(?:/[a-z]{2})?/users(/.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^(?:/[a-z]{2})?/users(/.*|$)" /frontend/talentsearch/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "search" to talentsearch index.html
     location ~ "^(?:/[a-z]{2})?/search(/.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^(?:/[a-z]{2})?/search(/.*|$)" /frontend/talentsearch/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "logged-out" to talentsearch index.html
     location ~ "^(?:/[a-z]{2})?/logged-out(/.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^(?:/[a-z]{2})?/logged-out(/.*|$)" /frontend/talentsearch/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "browse" to talentsearch index.html
     location ~ "^(?:/[a-z]{2})?/browse(/.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^(?:/[a-z]{2})?/browse(/.*|$)" /frontend/talentsearch/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "404" to talentsearch index.html
     location ~ "^(?:/[a-z]{2})?/404(/.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^(?:/[a-z]{2})?/404(/.*|$)" /frontend/talentsearch/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "support" to talentsearch index.html
     location ~ "^(?:/[a-z]{2})?/support(/.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^(?:/[a-z]{2})?/support(/.*|$)" /frontend/talentsearch/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "accessibility-statement" to talentsearch index.html
     location ~ "^(?:/[a-z]{2})?/accessibility-statement(/.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^(?:/[a-z]{2})?/accessibility-statement(/.*|$)" /frontend/talentsearch/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "create-account" to talentsearch index.html
     location ~ "^(?:/[a-z]{2})?/create-account(/.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^(?:/[a-z]{2})?/create-account(/.*|$)" /frontend/talentsearch/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "register-info" to talentsearch index.html
     location ~ "^(?:/[a-z]{2})?/register-info(/.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^(?:/[a-z]{2})?/register-info(/.*|$)" /frontend/talentsearch/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "login-info" to talentsearch index.html
     location ~ "^(?:/[a-z]{2})?/login-info(/.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^(?:/[a-z]{2})?/login-info(/.*|$)" /frontend/talentsearch/dist/index.html break;
     }
 
     # rewrite talent static files to "indigenousapprenticeship/dist"
     location ~ "^/indigenous-it-apprentice/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|webmanifest))$" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^/indigenous-it-apprentice/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|webmanifest))$" /frontend/indigenousapprenticeship/dist/$1 break;
     }
 
     # rewrite possible lang prefix then "apprenti-autochtonne-ti" to indigenousapprenticeship index.html
     location ~ "^(?:/[a-z]{2})?/apprenti-autochtonne-ti(/.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^(?:/[a-z]{2})?/apprenti-autochtonne-ti(/.*|$)" /frontend/indigenousapprenticeship/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "indigenous-it-apprentice" to indigenousapprenticeship index.html
     location ~ "^(?:/[a-z]{2})?/indigenous-it-apprentice(/.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
         rewrite "^(?:/[a-z]{2})?/indigenous-it-apprentice(/.*|$)" /frontend/indigenousapprenticeship/dist/index.html break;
     }
 
@@ -189,6 +221,5 @@ server {
     location ~ ^/(.*)$ {
         rewrite ^/(.*)$ /tc-report/_site/$1/index.html break;
     }
-
 }
 


### PR DESCRIPTION
## 👋 Introduction

This does two things:

1. Adds a `Cache-Control: no-cache` header to reduce over-caching `index.html` files
2. Moves the `*.js` file hash to the file name rather than query param and changes it to `hash` instead of `contenthash`

The idea is that both of these will help reduce the chances old files will be cached in the client and users will not encounter `ChunkLoadErrors` after new changes are deployed.

## 🧪 Testing

@vd1992 is realy good at reproducing this issue locally but I haven't had much luck so I'm not sure how to test that it fixes `ChunkLoadError`. However, you can follow these steps to ensure the changes made were implmented:

1. Rebuild `webserver` docker image
    - `docker-compose stop webserver`
    - `docker-compose rm webserver`
    - `docker-compose up --detach --build`
2. Navigate to `/`
3. Check the response headers for `Cache-Control: no-cache`
4. Check the `*.js` files loaded and confirm they match the pattern `[hash].[name].js`

## 🤖 Robot stuff

Resolves #4925 