### PR TITLE
Tooling/4898 no seeding candidates draft

### DIFF
--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -59,9 +59,10 @@ class DatabaseSeeder extends Seeder
                 $genericJobTitles = GenericJobTitle::inRandomOrder()->limit(2)->pluck('id')->toArray();
                 $user->expectedGenericJobTitles()->sync($genericJobTitles);
 
-                // pick a pool in which to place this user
+                // pick a published pool in which to place this user
                 // temporarily rig seeding to be biased towards slotting pool candidates into Digital Talent
-                $randomPool = Pool::inRandomOrder()->limit(1)->first();
+                // digital careers is always published and strictly defined in PoolSeeder
+                $randomPool = Pool::whereNotNull('published_at')->inRandomOrder()->limit(1)->first();
                 $digitalTalentPool = Pool::where('key', "digital_careers")->first();
                 $pool = $faker->boolean(25) ? $digitalTalentPool : $randomPool;
 

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -62,7 +62,7 @@ class DatabaseSeeder extends Seeder
                 // pick a published pool in which to place this user
                 // temporarily rig seeding to be biased towards slotting pool candidates into Digital Talent
                 // digital careers is always published and strictly defined in PoolSeeder
-                $randomPool = Pool::whereNotNull('published_at')->inRandomOrder()->limit(1)->first();
+                $randomPool = Pool::whereNotNull('published_at')->inRandomOrder()->first();
                 $digitalTalentPool = Pool::where('key', "digital_careers")->first();
                 $pool = $faker->boolean(25) ? $digitalTalentPool : $randomPool;
 
@@ -92,7 +92,7 @@ class DatabaseSeeder extends Seeder
             ->create();
 
         $applicant = User::where('email', 'applicant@test.com')->first();
-        $pool = Pool::inRandomOrder()->first();
+        $pool = Pool::whereNotNull('published_at')->inRandomOrder()->first();
         $this->seedPoolCandidate($applicant, $pool);
 
         // add experiences to all the users


### PR DESCRIPTION
closes #4898 
updates seeder to only add pool candidates to published pools

test:
build and seed fresh
ensure the query suggested by Peter returns no results
```
select p.id, count(*) 
from pools p 
join pool_candidates pc on pc.pool_id = p.id
where p.published_at is null
group by p.id
```
navigate around pools stuff in /admin as well as /search and look around 