### PR TITLE
Bug - 4831 - Fix unsaved changes styles

### DIFF
--- a/frontend/common/src/components/SkillPicker/SkillPicker.tsx
+++ b/frontend/common/src/components/SkillPicker/SkillPicker.tsx
@@ -121,7 +121,6 @@ const SkillPicker = ({
       <InputLabel
         required={false}
         inputId="query"
-        trackUnsaved={false}
         label={intl.formatMessage({
           defaultMessage: "Search skills by keyword",
           id: "ARqO1j",

--- a/frontend/common/src/components/form/Checkbox/Checkbox.tsx
+++ b/frontend/common/src/components/form/Checkbox/Checkbox.tsx
@@ -54,6 +54,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
       {!boundingBox ? (
         <InputWrapper
           inputId={id}
+          inputName={name}
           label={label}
           labelSize="copy"
           required={!!rules.required}
@@ -78,6 +79,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
       ) : (
         <InputWrapper
           inputId={id}
+          inputName={name}
           label={boundingBoxLabel}
           required={!!rules.required}
           context={context}

--- a/frontend/common/src/components/form/Checklist/Checklist.tsx
+++ b/frontend/common/src/components/form/Checklist/Checklist.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 import get from "lodash/get";
 import { FieldError, RegisterOptions, useFormContext } from "react-hook-form";
+
 import Checkbox from "../Checkbox";
+import { useFieldState } from "../../../helpers/formUtils";
 import { InputWrapper, Fieldset } from "../../inputPartials";
 
 export type Checkbox = {
@@ -55,6 +57,8 @@ const Checklist: React.FunctionComponent<ChecklistProps> = ({
   // To grab errors in nested objects we need to use lodash's get helper.
   const error = get(errors, name)?.message as FieldError;
   const required = !!rules.required;
+  const fieldState = useFieldState(name, !trackUnsaved);
+  const isUnsaved = fieldState === "dirty" && trackUnsaved;
 
   return (
     <Fieldset
@@ -66,7 +70,7 @@ const Checklist: React.FunctionComponent<ChecklistProps> = ({
       disabled={disabled}
       hideOptional={hideOptional}
       trackUnsaved={trackUnsaved}
-      aria-describedby={error ? `${name}-error` : undefined}
+      aria-describedby={error || isUnsaved ? `${name}-error` : undefined}
       {...rest}
     >
       {items.map(({ value, label }) => {

--- a/frontend/common/src/components/form/Input/Input.tsx
+++ b/frontend/common/src/components/form/Input/Input.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import get from "lodash/get";
 import { FieldError, RegisterOptions, useFormContext } from "react-hook-form";
-import { useFieldStateStyles } from "../../../helpers/formUtils";
+import { useFieldState, useFieldStateStyles } from "../../../helpers/formUtils";
 import { InputWrapper } from "../../inputPartials";
 
 export interface InputProps
@@ -52,6 +52,8 @@ const Input: React.FunctionComponent<InputProps> = ({
   // To grab errors in nested objects we need to use lodash's get helper.
   const error = get(errors, name)?.message as FieldError;
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
+  const fieldState = useFieldState(id, !trackUnsaved);
+  const isUnsaved = fieldState === "dirty" && trackUnsaved;
 
   const whitespaceTrimmer = (e: React.FocusEvent<HTMLInputElement>) => {
     if (whitespaceTrim) {
@@ -86,7 +88,7 @@ const Input: React.FunctionComponent<InputProps> = ({
           })}
           readOnly={readOnly}
           aria-required={rules.required ? "true" : undefined}
-          aria-invalid={error ? "true" : "false"}
+          aria-invalid={error || isUnsaved ? "true" : "false"}
           aria-describedby={error ? `${id}-error` : undefined}
           {...rest}
         />

--- a/frontend/common/src/components/form/Input/Input.tsx
+++ b/frontend/common/src/components/form/Input/Input.tsx
@@ -66,6 +66,7 @@ const Input: React.FunctionComponent<InputProps> = ({
     <div data-h2-margin="base(x1, 0)">
       <InputWrapper
         inputId={id}
+        inputName={name}
         label={label}
         required={!!rules.required}
         context={context}

--- a/frontend/common/src/components/form/Input/Input.tsx
+++ b/frontend/common/src/components/form/Input/Input.tsx
@@ -88,8 +88,8 @@ const Input: React.FunctionComponent<InputProps> = ({
           })}
           readOnly={readOnly}
           aria-required={rules.required ? "true" : undefined}
-          aria-invalid={error || isUnsaved ? "true" : "false"}
-          aria-describedby={error ? `${id}-error` : undefined}
+          aria-invalid={error ? "true" : "false"}
+          aria-describedby={error || isUnsaved ? `${id}-error` : undefined}
           {...rest}
         />
       </InputWrapper>

--- a/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
+++ b/frontend/common/src/components/form/MultiSelect/MultiSelect.tsx
@@ -58,6 +58,7 @@ const MultiSelect = ({
       <InputWrapper
         {...{ label, context, error }}
         inputId={id}
+        inputName={name}
         required={isRequired}
       >
         <div style={{ width: "100%" }}>

--- a/frontend/common/src/components/form/RadioGroup/RadioGroup.tsx
+++ b/frontend/common/src/components/form/RadioGroup/RadioGroup.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import get from "lodash/get";
 import { FieldError, RegisterOptions, useFormContext } from "react-hook-form";
+import { useFieldState } from "../../../helpers/formUtils";
 import { InputWrapper, Fieldset } from "../../inputPartials";
 
 export type Radio = { value: string | number; label: string | React.ReactNode };
@@ -60,6 +61,8 @@ const RadioGroup: React.FunctionComponent<RadioGroupProps> = ({
   // To grab errors in nested objects we need to use lodash's get helper.
   const error = get(errors, name)?.message as FieldError;
   const required = !!rules.required;
+  const fieldState = useFieldState(name, !trackUnsaved);
+  const isUnsaved = fieldState === "dirty" && trackUnsaved;
 
   let columnValue = { "data-h2-flex-item": "base(1of1)" };
   if (columns === 2) {
@@ -77,7 +80,7 @@ const RadioGroup: React.FunctionComponent<RadioGroupProps> = ({
       hideOptional={hideOptional}
       hideLegend={hideLegend}
       trackUnsaved={trackUnsaved}
-      aria-describedby={error ? `${name}-error` : undefined}
+      aria-describedby={error || isUnsaved ? `${name}-error` : undefined}
       {...rest}
     >
       <div data-h2-flex-grid="base(flex-start, x1, 0)">

--- a/frontend/common/src/components/form/Select/Select.tsx
+++ b/frontend/common/src/components/form/Select/Select.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { FieldError, RegisterOptions, useFormContext } from "react-hook-form";
 import get from "lodash/get";
 import { InputWrapper } from "../../inputPartials";
-import { useFieldStateStyles } from "../../../helpers/formUtils";
+import { useFieldState, useFieldStateStyles } from "../../../helpers/formUtils";
 
 export interface Option {
   value: string | number;
@@ -46,8 +46,10 @@ const Select: React.FunctionComponent<SelectProps> = ({
     formState: { errors },
   } = useFormContext();
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
-
   const error = get(errors, name)?.message as FieldError;
+  const fieldState = useFieldState(id, !trackUnsaved);
+  const isUnsaved = fieldState === "dirty" && trackUnsaved;
+
   return (
     <div data-h2-margin="base(x1, 0)">
       <InputWrapper
@@ -67,7 +69,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
           {...register(name, rules)}
           aria-invalid={error ? "true" : "false"}
           aria-required={rules?.required ? "true" : undefined}
-          aria-describedby={error ? `${id}-error` : undefined}
+          aria-describedby={error || isUnsaved ? `${id}-error` : undefined}
           {...rest}
           defaultValue=""
         >

--- a/frontend/common/src/components/form/Select/Select.tsx
+++ b/frontend/common/src/components/form/Select/Select.tsx
@@ -54,6 +54,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
     <div data-h2-margin="base(x1, 0)">
       <InputWrapper
         inputId={id}
+        inputName={name}
         label={label}
         required={!!rules?.required}
         context={context}

--- a/frontend/common/src/components/form/Select/SelectFieldV2.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.tsx
@@ -208,6 +208,7 @@ const SelectFieldV2 = ({
       <InputWrapper
         {...{ label, context, error }}
         inputId={name}
+        inputName={name}
         required={isRequired}
         trackUnsaved={trackUnsaved}
       >

--- a/frontend/common/src/components/form/Select/SelectFieldV2.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.tsx
@@ -12,7 +12,7 @@ import type { NoticeProps, GroupBase, OptionsOrGroups } from "react-select";
 import camelCase from "lodash/camelCase";
 import flatMap from "lodash/flatMap";
 import { useIntl } from "react-intl";
-import { useFieldStateStyles } from "../../../helpers/formUtils";
+import { useFieldState, useFieldStateStyles } from "../../../helpers/formUtils";
 import { errorMessages } from "../../../messages";
 import { InputWrapper } from "../../inputPartials";
 
@@ -193,6 +193,8 @@ const SelectFieldV2 = ({
   } = useFormContext();
 
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
+  const fieldState = useFieldState(name, !trackUnsaved);
+  const isUnsaved = fieldState === "dirty" && trackUnsaved;
 
   const error = errors[name]?.message as FieldError;
   const isRequired = !!rules?.required;
@@ -292,7 +294,9 @@ const SelectFieldV2 = ({
                   onChange={convertSingleOrMultiOptionsToValues}
                   aria-label={label}
                   aria-required={isRequired}
-                  ariaDescription={error ? `${id}-error` : undefined}
+                  ariaDescription={
+                    error || isUnsaved ? `${id}-error` : undefined
+                  }
                   stateStyles={stateStyles}
                   styles={{
                     placeholder: (provided) => ({

--- a/frontend/common/src/components/form/TextArea/TextArea.tsx
+++ b/frontend/common/src/components/form/TextArea/TextArea.tsx
@@ -55,6 +55,7 @@ const TextArea: React.FunctionComponent<TextAreaProps> = ({
     <div data-h2-margin="base(x1, 0)">
       <InputWrapper
         inputId={id}
+        inputName={name}
         label={label}
         required={!!rules.required}
         context={context}

--- a/frontend/common/src/components/form/TextArea/TextArea.tsx
+++ b/frontend/common/src/components/form/TextArea/TextArea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import get from "lodash/get";
 import { FieldError, RegisterOptions, useFormContext } from "react-hook-form";
 import { InputWrapper } from "../../inputPartials";
-import { useFieldStateStyles } from "../../../helpers/formUtils";
+import { useFieldState, useFieldStateStyles } from "../../../helpers/formUtils";
 
 export interface TextAreaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -39,6 +39,8 @@ const TextArea: React.FunctionComponent<TextAreaProps> = ({
     setValue,
   } = useFormContext();
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
+  const fieldState = useFieldState(id, !trackUnsaved);
+  const isUnsaved = fieldState === "dirty" && trackUnsaved;
   // To grab errors in nested objects we need to use lodash's get helper.
   const error = get(errors, name)?.message as FieldError;
 
@@ -70,7 +72,7 @@ const TextArea: React.FunctionComponent<TextAreaProps> = ({
           onBlur={whitespaceTrimmer}
           aria-required={rules.required ? "true" : undefined}
           aria-invalid={error ? "true" : "false"}
-          aria-describedby={error ? `${id}-error` : undefined}
+          aria-describedby={error || isUnsaved ? `${id}-error` : undefined}
           {...rest}
         />
         {children}

--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
@@ -5,6 +5,7 @@ import { useFieldState, useFieldStateStyles } from "../../../helpers/formUtils";
 import { commonMessages } from "../../../messages";
 import InputContext from "../InputContext/InputContext";
 import InputError, { type InputFieldError } from "../InputError/InputError";
+import InputUnsaved from "../InputUnsaved/InputUnsaved";
 
 export interface FieldsetProps extends React.HTMLProps<HTMLFieldSetElement> {
   /** The text for the legend element. */
@@ -97,15 +98,6 @@ const Fieldset: React.FC<FieldsetProps> = ({
               </span>
             )
           }
-          {fieldState === "dirty" && trackUnsaved && (
-            <span
-              data-h2-font-size="base(caption)"
-              data-h2-margin="base(0, 0, 0, x.125)"
-              data-h2-color="base(darkest.tm-yellow)"
-            >
-              {intl.formatMessage(commonMessages.unSaved)}
-            </span>
-          )}
           {context && (
             <button
               type="button"
@@ -145,6 +137,10 @@ const Fieldset: React.FC<FieldsetProps> = ({
       >
         {children}
       </div>
+      <InputUnsaved
+        id={ariaDescription}
+        isVisible={fieldState === "dirty" && trackUnsaved}
+      />
       {error && (
         <div
           data-h2-display="base(block)"

--- a/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
+++ b/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { QuestionMarkCircleIcon, XCircleIcon } from "@heroicons/react/24/solid";
 import { useIntl } from "react-intl";
 import { commonMessages } from "../../../messages";
-import { useFieldState } from "../../../helpers/formUtils";
 
 import "./input-label.css";
 
@@ -16,7 +15,6 @@ export interface InputLabelProps {
   hideOptional?: boolean;
   hideBottomMargin?: boolean;
   fillLabel?: boolean;
-  trackUnsaved?: boolean;
 }
 
 const InputLabel: React.FC<InputLabelProps> = ({
@@ -24,7 +22,6 @@ const InputLabel: React.FC<InputLabelProps> = ({
   label,
   labelSize,
   fillLabel = false,
-  trackUnsaved = true,
   required,
   contextToggleHandler = () => {
     /* returns nothing */
@@ -39,9 +36,7 @@ const InputLabel: React.FC<InputLabelProps> = ({
     setContextIsActive((currentState) => !currentState);
   };
   const intl = useIntl();
-  const fieldState = useFieldState(inputId, !trackUnsaved);
-  const appendLabel =
-    required || !hideOptional || contextIsVisible || fieldState !== "unset";
+  const appendLabel = required || !hideOptional || contextIsVisible;
 
   const labelStyles = {
     "data-h2-margin": "base(0, x.125, 0, 0)",
@@ -96,16 +91,6 @@ const InputLabel: React.FC<InputLabelProps> = ({
               </span>
             )
           }
-          {fieldState === "dirty" && trackUnsaved && (
-            <span
-              data-h2-font-size="base(caption)"
-              data-h2-display="base(inline-block)"
-              data-h2-margin="base(0, 0, 0, x.125)"
-              data-h2-color="base(darkest.tm-blue)"
-            >
-              {intl.formatMessage(commonMessages.unSaved)}
-            </span>
-          )}
           {contextIsVisible && (
             <button
               type="button"

--- a/frontend/common/src/components/inputPartials/InputUnsaved/InputUnsaved.tsx
+++ b/frontend/common/src/components/inputPartials/InputUnsaved/InputUnsaved.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import { commonMessages } from "../../../messages";
+
+interface InputUnsavedProps
+  extends Omit<React.HTMLProps<HTMLSpanElement>, "children"> {
+  isVisible?: boolean;
+}
+
+const InputUnsaved = ({ isVisible, ...rest }: InputUnsavedProps) => {
+  const intl = useIntl();
+
+  return isVisible ? (
+    <span
+      data-h2-font-size="base(caption)"
+      data-h2-display="base(inline-block)"
+      data-h2-margin="base(0, 0, 0, x.125)"
+      data-h2-color="base(darkest.tm-blue)"
+      {...rest}
+    >
+      {intl.formatMessage(commonMessages.unSaved)}
+    </span>
+  ) : null;
+};
+
+export default InputUnsaved;

--- a/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.stories.tsx
+++ b/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.stories.tsx
@@ -25,6 +25,7 @@ export const InputWrapperWithTextInput = TemplateInputWrapper.bind({});
 
 InputWrapperWithTextInput.args = {
   inputId: "firstName",
+  inputName: "firstName",
   label: "First Name",
   required: true,
   error: "This input is required",

--- a/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
+++ b/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
@@ -1,7 +1,10 @@
 import React, { useState } from "react";
+
 import InputContext from "../InputContext/InputContext";
 import InputError, { InputFieldError } from "../InputError/InputError";
 import InputLabel from "../InputLabel/InputLabel";
+import { useFieldState } from "../../../helpers/formUtils";
+import InputUnsaved from "../InputUnsaved/InputUnsaved";
 
 export interface InputWrapperProps {
   inputId: string;
@@ -33,10 +36,14 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
   ...rest
 }) => {
   const [contextVisible, setContextVisible] = useState(false);
+  const fieldState = useFieldState(inputId, !trackUnsaved);
+  const isUnsaved = fieldState === "dirty" && trackUnsaved;
+
   let fontSize = { "data-h2-font-size": "base(caption)" };
   if (labelSize === "copy") {
     fontSize = { "data-h2-font-size": "base(copy)" };
   }
+
   return (
     <>
       <div
@@ -55,7 +62,6 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
           contextToggleHandler={setContextVisible}
           hideOptional={hideOptional}
           hideBottomMargin={hideBottomMargin}
-          trackUnsaved={trackUnsaved}
         />
         {error && errorPosition === "top" && (
           <div
@@ -71,6 +77,7 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
         )}
         {children}
       </div>
+      <InputUnsaved isVisible={isUnsaved} id={`${inputId}-error`} />
       {error && errorPosition === "bottom" && (
         <div
           data-h2-display="base(block)"

--- a/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
+++ b/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
@@ -8,6 +8,7 @@ import InputUnsaved from "../InputUnsaved/InputUnsaved";
 
 export interface InputWrapperProps {
   inputId: string;
+  inputName?: string;
   label: string | React.ReactNode;
   labelSize?: string;
   required: boolean;
@@ -22,6 +23,7 @@ export interface InputWrapperProps {
 
 const InputWrapper: React.FC<InputWrapperProps> = ({
   inputId,
+  inputName,
   label,
   labelSize,
   required,
@@ -36,7 +38,7 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
   ...rest
 }) => {
   const [contextVisible, setContextVisible] = useState(false);
-  const fieldState = useFieldState(inputId, !trackUnsaved);
+  const fieldState = useFieldState(inputName || "", !trackUnsaved);
   const isUnsaved = fieldState === "dirty" && trackUnsaved;
 
   let fontSize = { "data-h2-font-size": "base(caption)" };

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1816,8 +1816,8 @@
     "defaultMessage": "Vous avez des modifications non sauvegardées",
     "description": "Title for unsaved changes warning on profile forms"
   },
-  "rsrNSC": {
-    "defaultMessage": "Modifications non sauvegardées",
+  "9u6ULg": {
+    "defaultMessage": "Vous avez des modifications non sauvegardées",
     "description": "Displayed next to form inputs when they have been changed but not saved."
   },
   "DdOEWx": {

--- a/frontend/common/src/messages/commonMessages.ts
+++ b/frontend/common/src/messages/commonMessages.ts
@@ -27,8 +27,8 @@ const messages = defineMessages({
     description: "Displayed next to optional form inputs.",
   },
   unSaved: {
-    defaultMessage: "Unsaved changes",
-    id: "rsrNSC",
+    defaultMessage: "You have unsaved changes",
+    id: "9u6ULg",
     description:
       "Displayed next to form inputs when they have been changed but not saved.",
   },

--- a/frontend/common/src/styles/formStyles.ts
+++ b/frontend/common/src/styles/formStyles.ts
@@ -13,6 +13,5 @@ export const fieldStateStyles: Record<FieldState, Record<string, string>> = {
   },
   dirty: {
     "data-h2-border": "base(all, 2px, solid, dark.tm-blue)",
-    "data-h2-background-color": "base(lightest.tm-blue)",
   },
 };


### PR DESCRIPTION
## 👋 Introduction

This removes the background colour for inputs with unsaved changes as well as moving the message below the input.

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Modify form fields in the profile forms
3. Confirm different field types:
    1. Have no background colour
    2. Have unsaved changes message below input

## 🤖 Robot stuff

Resolves #5027