### PR TITLE
Copy - Remove space before colon in English

### DIFF
--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/AwardAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/AwardAccordion.tsx
@@ -34,16 +34,16 @@ export const AwardContent = ({
       </p>
       <p>
         {intl.formatMessage({
-          defaultMessage: "Awarded to : ",
-          id: "HWRZ/z",
+          defaultMessage: "Awarded to: ",
+          id: "3JL02L",
           description: "The award was given to",
         })}{" "}
         {awardedTo ? intl.formatMessage(getAwardedTo(awardedTo)) : ""}
       </p>
       <p>
         {intl.formatMessage({
-          defaultMessage: "Scope : ",
-          id: "IfsigK",
+          defaultMessage: "Scope: ",
+          id: "FAOzjP",
           description: "The scope of the award given",
         })}{" "}
         {awardedScope ? intl.formatMessage(getAwardedScope(awardedScope)) : ""}

--- a/frontend/common/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
@@ -132,7 +132,7 @@ const SkillAccordion: React.FunctionComponent<SkillAccordionProps> = ({
             defaultMessage: "Awarded to: ",
             id: "3JL02L",
             description: "The award was given to",
-          })}
+          })}{" "}
           {awardedTo ? intl.formatMessage(getAwardedTo(awardedTo)) : ""}
         </p>
         <p>
@@ -140,7 +140,7 @@ const SkillAccordion: React.FunctionComponent<SkillAccordionProps> = ({
             defaultMessage: "Scope: ",
             id: "FAOzjP",
             description: "The scope of the award given",
-          })}
+          })}{" "}
           {awardedScope
             ? intl.formatMessage(getAwardedScope(awardedScope))
             : ""}

--- a/frontend/common/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
@@ -129,16 +129,16 @@ const SkillAccordion: React.FunctionComponent<SkillAccordionProps> = ({
         </p>
         <p>
           {intl.formatMessage({
-            defaultMessage: "Awarded to : ",
-            id: "HWRZ/z",
+            defaultMessage: "Awarded to: ",
+            id: "3JL02L",
             description: "The award was given to",
           })}
           {awardedTo ? intl.formatMessage(getAwardedTo(awardedTo)) : ""}
         </p>
         <p>
           {intl.formatMessage({
-            defaultMessage: "Scope : ",
-            id: "IfsigK",
+            defaultMessage: "Scope: ",
+            id: "FAOzjP",
             description: "The scope of the award given",
           })}
           {awardedScope

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1416,11 +1416,11 @@
     "defaultMessage": "Retourner à ma demande",
     "description": "Link text for button to return to user application"
   },
-  "HWRZ/z": {
+  "3JL02L": {
     "defaultMessage": "Décerné à:",
     "description": "The award was given to"
   },
-  "IfsigK": {
+  "FAOzjP": {
     "defaultMessage": "Portée:",
     "description": "The scope of the award given"
   },


### PR DESCRIPTION
Resolves #4790.

## Steps to test

1. Compile common `npm run intl-compile --workspace=common`
2. Build talentsearch `npm run production --workspace=talentsearch`
3. Navigate to `/en/users/{profileId}/profile/experiences`
4. Verify there is no extra space before the colon in **Awarded to** and **Scope** in an _Award_ accordion