### PR TITLE
Copy - Add missing space before colon in French strings

### DIFF
--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1393,7 +1393,7 @@
     "description": "declaring one to be a Canadian citizen"
   },
   "92hwzj": {
-    "defaultMessage": "Statut de citoyenneté:",
+    "defaultMessage": "Statut de citoyenneté :",
     "description": "Citizenship status label"
   },
   "CX/qKY": {
@@ -1417,11 +1417,11 @@
     "description": "Link text for button to return to user application"
   },
   "3JL02L": {
-    "defaultMessage": "Décerné à:",
+    "defaultMessage": "Décerné à :",
     "description": "The award was given to"
   },
   "FAOzjP": {
-    "defaultMessage": "Portée:",
+    "defaultMessage": "Portée :",
     "description": "The scope of the award given"
   },
   "JHgARn": {


### PR DESCRIPTION
Resolves #4789.

## Steps to test

1. Compile common `npm run intl-compile --workspace=common`
2. Build talentsearch `npm run production --workspace=talentsearch`
3. Navigate to `/fr/users/{profileId}/profile/experiences`
4. Verify there is a space before the colon in **Décerné à** and **Portée** in an _Prix_ accordion
5. Navigate to `/fr/users/{profileId}/profile#about-section`
6. Verify there is a space before the colon in **Statut de citoyenneté** in the section _À propos de moi_