### PR TITLE
Set CSpell to ignore message IDs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,5 +69,8 @@
     ".eslintrc",
     "hydrogen.config.json"
   ],
-  "jest.jestCommandLine": "test"
+  "jest.jestCommandLine": "test",
+  "cSpell.ignoreRegExpList": [
+    "/id\\: \\\"[A-Za-z0-9+\\/]{6}\\\"/g"
+  ]
 }


### PR DESCRIPTION
Low priority review.  :smile: 

This branch updates the CSpell settings to ignore the message descriptor IDs in the code and reduce false-positive errors.

Resources:
https://regex101.com/r/r9rbNY/1
https://stackoverflow.com/a/475217

Testing:
- [ ] Does it ignore your message descriptors?
- [ ] Does it flag other things wrongly?