### PR TITLE
Bug - Add `/api/support/tickets` endpoint to webserver

### DIFF
--- a/frontend/cypress/e2e/talentsearch/support-page.cy.js
+++ b/frontend/cypress/e2e/talentsearch/support-page.cy.js
@@ -25,6 +25,7 @@ describe("Support page", () => {
           subject
         },
       }).then((response) => {
+       // Note: normal to get a 500 status if the service (freshdesk) is not locally configured.
         if(response.status === 404) // verify if route exists.
           throw new Error("404: Not Found")
       })

--- a/frontend/cypress/e2e/talentsearch/support-page.cy.js
+++ b/frontend/cypress/e2e/talentsearch/support-page.cy.js
@@ -1,0 +1,33 @@
+describe("Support page", () => {
+
+  const name = "Test Person"
+  const email = "test@test.tld"
+  const details = "Test comments to send."
+  const subject = "question"
+
+  context('Support page', () => {
+    it('should exist', () => {
+      cy.visit('/en/support')
+      cy.findByRole('heading', { name: 'Contact and support', level: 1 }).should('exist')
+    })
+  })
+
+  context('Support form', () => {
+    it("should send POST request to existing api endpoint", () => {
+      cy.request({
+        method: "POST",
+        url: "/api/support/tickets",
+        failOnStatusCode: false,
+        body: {
+          name,
+          email,
+          details,
+          subject
+        },
+      }).then((response) => {
+        if(response.status === 404) // verify if route exists.
+          throw new Error("404: Not Found")
+      })
+    })
+  })
+})

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -63,6 +63,11 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
     }
+    location = /api/support/tickets {
+      fastcgi_pass 127.0.0.1:9000;
+      include fastcgi_params;
+      fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
+  }
 
     # rewrite root-level possible lang prefix to talentsearch index.html
     location ~ "^(?:/[a-z]{2})?/?$" {

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -63,11 +63,11 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
     }
-    location = /api/support/tickets {
-      fastcgi_pass 127.0.0.1:9000;
-      include fastcgi_params;
-      fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
-  }
+    location ~ "^/api(/(.*))?$" {
+        fastcgi_pass 127.0.0.1:9000;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
+    }
 
     # rewrite root-level possible lang prefix to talentsearch index.html
     location ~ "^(?:/[a-z]{2})?/?$" {

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -82,6 +82,11 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
     }
+    location = /api/support/tickets {
+        fastcgi_pass 127.0.0.1:9000;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
+    }
 
     # rewrite root-level possible lang prefix to talentsearch index.html
     location ~ "^(?:/[a-z]{2})?/?$" {

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -1,3 +1,4 @@
+
 # enable rewrite logging for debugging
 error_log /var/log/nginx/error.log notice;
 # rewrite_log on;
@@ -82,7 +83,7 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
     }
-    location = /api/support/tickets {
+    location ~ "^/api(/(.*))?$" {
         fastcgi_pass 127.0.0.1:9000;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;


### PR DESCRIPTION
Resolves #5037.

## Steps to test
1. Reload nginx `docker-compose exec webserver nginx -s reload`
2. Send a POST request to `/api/support/tickets` and verify the status code is not **404**