### PR TITLE
Spike - 4741 - Check broken links

### DIFF
--- a/frontend/cypress/e2e/talentsearch/broken-links.cy.js
+++ b/frontend/cypress/e2e/talentsearch/broken-links.cy.js
@@ -1,0 +1,58 @@
+describe("Broken links", () => {
+
+  /**
+   * Make a request to a url and
+   * check that the status code is 200
+   *
+   * @param {string} url
+   */
+  const checkLink = (url) => {
+    cy.request({
+      url,
+      failOnStatusCode: false
+    })
+      .its('status', { timeout: 0 })
+      .should('eq', 200)
+  }
+
+  beforeEach(() => {
+    cy.loginByRole('applicant').then(() => {
+      cy.getMe().its("id").then(userId => {
+        cy.wrap(userId).as("userId");
+      });
+    })
+  })
+
+  it("has no broken links", () => {
+    // Hold visited URLS in an array to prevent double checks
+    let visited = [];
+
+    cy.fixture("urls/public.json").then(urls => {
+      urls.forEach(originalUrl => {
+        cy.get("@userId").then(userId => {
+          // Add current user ID to paths
+          let url = originalUrl.replace("{userId}", userId);
+
+          if (!visited.includes(url)) {
+            checkLink(url);
+
+            cy.visit(url).then(() => {
+              visited.push(url);
+              // Wait for all requests to be idle for 3s
+              cy.waitForNetworkIdle('*', '*', 3000)
+
+              cy.get("a:not([href*='mailto:]']").each(link => {
+                const href = link.prop('href');
+                const isValid = href.startsWith("http") && !href.includes("#");
+                if (isValid && !visited.includes(href)) {
+                  checkLink(href);
+                  visited.push(href);
+                }
+              })
+            })
+          }
+        });
+      });
+    });
+  });
+});

--- a/frontend/cypress/fixtures/urls/public.json
+++ b/frontend/cypress/fixtures/urls/public.json
@@ -1,0 +1,20 @@
+[
+  "/",
+  "/search",
+  "/browse/pools",
+  "/accessibility-statement",
+  "/support",
+  "/users/{userId}/profile",
+  "/users/{userId}/profile/about-me/edit",
+  "/users/{userId}/profile/language-info/edit",
+  "/users/{userId}/profile/government-info/edit",
+  "/users/{userId}/profile/work-location/edit",
+  "/users/{userId}/profile/work-preferences/edit",
+  "/users/{userId}/profile/employment-equity/edit",
+  "/users/{userId}/profile/experiences/award/create",
+  "/users/{userId}/profile/experiences/education/create",
+  "/users/{userId}/profile/experiences/community/create",
+  "/users/{userId}/profile/experiences/personal/create",
+  "/users/{userId}/profile/experiences/work/create",
+  "/users/{userId}/applications"
+]

--- a/frontend/cypress/support/e2e.js
+++ b/frontend/cypress/support/e2e.js
@@ -14,6 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
+import 'cypress-network-idle'
 import './commands'
 import './userCommands'
 import './poolAdvertisementCommands'

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "cy-verify-downloads": "^0.1.11",
         "cypress": "^10.11.0",
         "cypress-multi-reporters": "^1.6.1",
+        "cypress-network-idle": "^1.11.0",
         "cypress-terminal-report": "^3.5.2",
         "prettier": "^2.8.0"
       }
@@ -22197,6 +22198,12 @@
       "peerDependencies": {
         "mocha": ">=3.1.2"
       }
+    },
+    "node_modules/cypress-network-idle": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/cypress-network-idle/-/cypress-network-idle-1.11.0.tgz",
+      "integrity": "sha512-PFKM/We0bwzuNLWyQXI20IRk80TmBXH9mOWfhOL1T8adT3th6JeZZQuhxG1/nfic2A9d4qX7pc3mpA38n2y/+Q==",
+      "dev": true
     },
     "node_modules/cypress-terminal-report": {
       "version": "3.5.2",
@@ -53425,6 +53432,12 @@
         "debug": "^4.1.1",
         "lodash": "^4.17.15"
       }
+    },
+    "cypress-network-idle": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/cypress-network-idle/-/cypress-network-idle-1.11.0.tgz",
+      "integrity": "sha512-PFKM/We0bwzuNLWyQXI20IRk80TmBXH9mOWfhOL1T8adT3th6JeZZQuhxG1/nfic2A9d4qX7pc3mpA38n2y/+Q==",
+      "dev": true
     },
     "cypress-terminal-report": {
       "version": "3.5.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "cy-verify-downloads": "^0.1.11",
     "cypress": "^10.11.0",
     "cypress-multi-reporters": "^1.6.1",
+    "cypress-network-idle": "^1.11.0",
     "cypress-terminal-report": "^3.5.2",
     "prettier": "^2.8.0"
   }


### PR DESCRIPTION
## 👋 Introduction

This is initial work to check the site for broken links. 

> **Note**
> Admittedly, it is not as thorough as I'd hope but that is proving difficult with cypress.

## 🕵️ Details

This uses a fixture of top level links we know to exist in the application. It loops over the URLs making a request and checking the status code equals `200`. It then visits the page, getting all links on the page and making the same request/assertion on each. Every time this runs, it adds the url to an array to prevent double checking links.

The issue is, we do have some links hidden in dialogs, tabs and accordion that are difficult to check. 🤔 

## 🧪 Testing

1. Reinstall dependencies `npm i`
2. Build talent search `npm run production --workspace=talentsearch`
3. Open cypress `npm run e2e:open`
4. Run the broken links spec

