### PR TITLE
Allow admins to add users to published AND expired pools

### DIFF
--- a/frontend/admin/src/js/components/user/GeneralInformationTab/AddToPoolDialog.tsx
+++ b/frontend/admin/src/js/components/user/GeneralInformationTab/AddToPoolDialog.tsx
@@ -153,7 +153,8 @@ export const AddToPoolDialog: React.FC<AddToPoolDialogProps> = ({
                   .filter(
                     (pool) =>
                       pool.advertisementStatus ===
-                      AdvertisementStatus.Published,
+                        AdvertisementStatus.Published ||
+                      pool.advertisementStatus === AdvertisementStatus.Expired,
                   )
                   .map((pool) => {
                     return {


### PR DESCRIPTION
Resolves #5049 

Display Published _and_ Expired pools in the AddToPool dialog.
Note that we don't have a way of Archiving pools yet, but when we do, archived pools will NOT appear here.

Testing steps:
1. Log in as an admin.
2. Visit http://localhost:8000/en/admin/pools, and note the name of one Draft pool, one Published pool, and one Expired pool. (If any of these do not exist, you may need to run seeders or create them.)
3. Visit http://localhost:8000/en/admin/users
4. Click View on any user
5. On the User page, click "Add user to Pool"
6. In the dialog, confirm that the Draft pool does not appear
7. In the dialog, confirm that the Published pool appears and you can add the user to it
8. In the dialog, confirm the Expired pool appears and you can add the user to it