### PR TITLE
Experiment/new pool candidates paginated (NO MERGING)

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -511,4 +511,18 @@ RAWSQL2;
         }
         return $query;
     }
+
+    public function filterBySkills(Builder $query, ?array $skills): Builder
+    {
+        if (empty($skills)) {
+            return $query;
+        }
+
+        // call the skillFilter off connected user
+        $query->whereHas('user', function (Builder $userQuery) use ($skills) {
+            User::filterBySkills($userQuery, $skills);
+        });
+
+        return $query;
+    }
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -824,6 +824,29 @@ input ApplicantFilterInput {
     @builder(method: "App\\Models\\User@filterByAvailableInPools") # This field is [IdInput] instead of [ID] so that the output of an ApplicantFilter query can be used directly.
 }
 
+input ApplicantFilterOnPoolCandidateInput {
+  hasDiploma: Boolean @scope
+  equity: EquitySelectionsInput
+    @builder(method: "App\\Models\\PoolCandidate@filterByEquity")
+  languageAbility: LanguageAbility
+    @builder(method: "App\\Models\\PoolCandidate@filterByLanguageAbility")
+  operationalRequirements: [OperationalRequirement]
+    @builder(
+      method: "App\\Models\\PoolCandidate@filterByOperationalRequirements"
+    )
+  locationPreferences: [WorkRegion]
+    @builder(method: "App\\Models\\PoolCandidate@filterByLocationPreferences")
+  positionDuration: [PositionDuration] @scope
+  expectedClassifications: [ClassificationFilterInput]
+    @scope(name: "classifications")
+  skills: [IdInput]
+    @pluck(key: "id")
+    @builder(method: "App\\Models\\PoolCandidate@filterBySkills")
+  pools: [IdInput]
+    @pluck(key: "id")
+    @builder(method: "App\\Models\\PoolCandidate@filterByAvailableInPools")
+}
+
 type CandidateSearchPoolResult {
   pool: Pool!
   candidateCount: Int! @rename(attribute: "candidate_count")
@@ -873,6 +896,28 @@ type Query {
     @can(ability: "viewAny")
   poolCandidatesPaginated(
     where: PoolCandidateFilterInput
+    orderBy: _
+      @orderBy(
+        relations: [
+          {
+            relation: "user"
+            columns: [
+              "priority_weight"
+              "job_looking_status"
+              "first_name"
+              "email"
+              "preferred_lang"
+              "current_city"
+            ]
+          }
+        ]
+      )
+  ): [PoolCandidate]!
+    @paginate(defaultCount: 10, maxCount: 1000, scopes: ["notDraft"])
+    @guard
+    @can(ability: "viewAny")
+  poolCandidatesPaginatedApplicantFilter(
+    where: ApplicantFilterOnPoolCandidateInput
     orderBy: _
       @orderBy(
         relations: [

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -89,6 +89,18 @@ input ApplicantFilterInput {
   pools: [IdInput]
 }
 
+input ApplicantFilterOnPoolCandidateInput {
+  hasDiploma: Boolean
+  equity: EquitySelectionsInput
+  languageAbility: LanguageAbility
+  operationalRequirements: [OperationalRequirement]
+  locationPreferences: [WorkRegion]
+  positionDuration: [PositionDuration]
+  expectedClassifications: [ClassificationFilterInput]
+  skills: [IdInput]
+  pools: [IdInput]
+}
+
 enum ArmedForcesStatus {
   VETERAN
   MEMBER
@@ -1050,6 +1062,53 @@ type Query {
     """The offset from which items are returned."""
     page: Int
   ): PoolCandidatePaginator
+  poolCandidatesPaginatedApplicantFilter(
+    where: ApplicantFilterOnPoolCandidateInput
+    orderBy: [QueryPoolCandidatesPaginatedApplicantFilterOrderByRelationOrderByClause!]
+
+    """Limits number of fetched items. Maximum allowed value: 1000."""
+    first: Int = 10
+
+    """The offset from which items are returned."""
+    page: Int
+  ): PoolCandidatePaginator
+}
+
+"""
+Order by clause for Query.poolCandidatesPaginatedApplicantFilter.orderBy.
+"""
+input QueryPoolCandidatesPaginatedApplicantFilterOrderByRelationOrderByClause {
+  """The column that is used for ordering."""
+  column: String
+
+  """The direction that is used for ordering."""
+  order: SortOrder!
+
+  """Aggregate specification."""
+  user: QueryPoolCandidatesPaginatedApplicantFilterOrderByUser
+}
+
+"""
+Aggregate specification for Query.poolCandidatesPaginatedApplicantFilter.orderBy.user.
+"""
+input QueryPoolCandidatesPaginatedApplicantFilterOrderByUser {
+  """The aggregate function to apply to the column."""
+  aggregate: OrderByRelationWithColumnAggregateFunction!
+
+  """Name of the column to use."""
+  column: QueryPoolCandidatesPaginatedApplicantFilterOrderByUserColumn
+}
+
+"""
+Allowed column names for Query.poolCandidatesPaginatedApplicantFilter.orderBy.
+"""
+enum QueryPoolCandidatesPaginatedApplicantFilterOrderByUserColumn {
+  PRIORITY_WEIGHT
+  JOB_LOOKING_STATUS
+  FIRST_NAME
+  EMAIL
+  PREFERRED_LANG
+  CURRENT_CITY
 }
 
 """Order by clause for Query.poolCandidatesPaginated.orderBy."""

--- a/api/tests/Feature/PoolCandidatesApplicantFilterTest.php
+++ b/api/tests/Feature/PoolCandidatesApplicantFilterTest.php
@@ -1,0 +1,195 @@
+<?php
+
+use App\Models\User;
+use App\Models\Pool;
+use App\Models\PoolCandidate;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Tests\TestCase;
+use Database\Helpers\ApiEnums;
+
+class PoolCandidatesApplicantFilterTest extends TestCase
+{
+    use RefreshDatabase;
+    use MakesGraphQLRequests;
+    use ClearsSchemaCache;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->bootClearsSchemaCache();
+
+        // Create admin user we run tests as
+        // Note: this extra user does change the results of a couple queries
+        $newUser = new User;
+        $newUser->email = 'admin@test.com';
+        $newUser->sub = 'admin@test.com';
+        $newUser->roles = ['ADMIN'];
+        $newUser->save();
+    }
+
+    public function testPoolCandidatesPaginatedApplicantFilter(): void
+    {
+        //
+        // recycled from testSortingStatusThenPriority on ApplicantTest.php
+        //
+
+        $user = User::All()->first();
+        $pool1 = Pool::factory()->create([
+            'user_id' => $user['id']
+        ]);
+
+        // DRAFT, NOT PRESENT
+        $candidateOne = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+            'expiry_date' => config('constants.far_future_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_DRAFT,
+            'user_id' => User::factory([
+                'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+                'has_priority_entitlement' => true,
+                'armed_forces_status' => ApiEnums::ARMED_FORCES_VETERAN,
+                'citizenship' => ApiEnums::CITIZENSHIP_CITIZEN,
+                'has_diploma' => false,
+                'is_woman' => false,
+            ])
+        ]);
+        // NEW APPLICATION, NO PRIORITY SO SECOND
+        $candidateTwo = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_NEW_APPLICATION,
+            'user_id' => User::factory([
+                'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+                'has_priority_entitlement' => false,
+                'armed_forces_status' => ApiEnums::ARMED_FORCES_NON_CAF,
+                'citizenship' => ApiEnums::CITIZENSHIP_OTHER,
+                'has_diploma' => false,
+                'is_woman' => false,
+            ])
+        ]);
+        // APPLICATION REVIEW, NO PRIORITY SO THIRD
+        $candidateThree = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_APPLICATION_REVIEW,
+            'user_id' => User::factory([
+                'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+                'has_priority_entitlement' => false,
+                'armed_forces_status' => ApiEnums::ARMED_FORCES_NON_CAF,
+                'citizenship' => ApiEnums::CITIZENSHIP_OTHER,
+                'has_diploma' => false,
+                'is_woman' => false,
+            ])
+        ]);
+
+        // NEW APPLICATION, VETERAN SO FIRST
+        // has diploma and is woman
+        $candidateFour = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_NEW_APPLICATION,
+            'user_id' => User::factory([
+                'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+                'has_priority_entitlement' => false,
+                'armed_forces_status' => ApiEnums::ARMED_FORCES_VETERAN,
+                'citizenship' => ApiEnums::CITIZENSHIP_CITIZEN,
+                'has_diploma' => true,
+                'is_woman' => true,
+            ])
+        ]);
+        // QUALIFIED AVAILABLE, HAS ENTITLEMENT FOURTH
+        // has diploma and is woman
+        $candidateFive = PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15',
+            'expiry_date' => config('constants.far_future_date'),
+            'submitted_at' => config('constants.past_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE,
+            'user_id' => User::factory([
+                'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
+                'has_priority_entitlement' => true,
+                'armed_forces_status' => ApiEnums::ARMED_FORCES_VETERAN,
+                'citizenship' => ApiEnums::CITIZENSHIP_CITIZEN,
+                'has_diploma' => true,
+                'is_woman' => true,
+            ])
+        ]);
+
+        // Assert the order is correct
+        // candidate one not present due to being DRAFT
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidatesPaginatedApplicantFilter {
+                poolCandidatesPaginatedApplicantFilter (orderBy: [
+                    { column: "status_weight", order: ASC }
+                    { user: { aggregate: MAX, column: PRIORITY_WEIGHT }, order: ASC }
+                  ])
+                {
+                    data
+                    {
+                        id
+                    }
+                }
+            }
+            ')->assertJson([
+            "data" => [
+                "poolCandidatesPaginatedApplicantFilter" => [
+                    "data" => [
+                        ["id" => $candidateFour->id,],
+                        ["id" => $candidateTwo->id,],
+                        ["id" => $candidateThree->id,],
+                        ["id" => $candidateFive->id,],
+                    ]
+                ]
+            ]
+        ]);
+
+        // Assert that
+        // PoolCandidates are filtered out by data on User, must have Diploma and be Woman
+        // Candidate Four always precedes Candidate Five due to ORDERING
+        $this->graphQL(/** @lang Graphql */ '
+            query poolCandidatesPaginatedApplicantFilter ($where: ApplicantFilterOnPoolCandidateInput) {
+                poolCandidatesPaginatedApplicantFilter (
+                    where: $where
+                    orderBy: [
+                    { column: "status_weight", order: ASC }
+                    { user: { aggregate: MAX, column: PRIORITY_WEIGHT }, order: ASC }
+                  ])
+                {
+                    data
+                    {
+                        id
+                    }
+                }
+            }
+            ',
+            [
+                'where' => [
+                    'hasDiploma' => true,
+                    'equity' => [
+                        'isWoman' => true,
+                        'hasDisability' => false,
+                        'isIndigenous' => false,
+                        'isVisibleMinority' => false,
+                    ],
+                ]
+            ]
+            )->assertJson([
+            "data" => [
+                "poolCandidatesPaginatedApplicantFilter" => [
+                    "data" => [
+                        ["id" => $candidateFour->id,],
+                        ["id" => $candidateFive->id,],
+                    ]
+                ]
+            ]
+        ]);
+    }
+}


### PR DESCRIPTION
experimenting with an alternative method of a new `poolCandidatesPaginated` query

given we want to return `PoolCandidates` but filter with `ApplicantFilter` instead of `PoolCandidateFilter`...
try adding a new input `ApplicantFilterOnPoolCandidate` that copies the fields of `ApplicantFilter` but routes them through the `PoolCandidate` model enabling returning `[PoolCandidates] @paginated` thru `ApplicantFilter` fields

the prior paginated query would be deprecated
feel free to pluck anything of interest @yonikid15 
this PR will be closed later

- PoolCandidate.php updated to filter with skills
- new pagination query added utilizing new `ApplicantFilterOnPoolCandidate` that routes filtering thru pool candidates
- unit test to try it out included