### PR TITLE
Bug - 4980 - Prevent unsaved changes while editing

### DIFF
--- a/frontend/common/src/components/form/BasicForm.tsx
+++ b/frontend/common/src/components/form/BasicForm.tsx
@@ -43,6 +43,8 @@ export function BasicForm<TFieldValues extends FieldValues>({
   labels,
 }: BasicFormProps<TFieldValues>): ReactElement {
   const errorSummaryRef = React.useRef<HTMLDivElement>(null);
+  const [showUnsavedChanges, setShowUnsavedChanges] =
+    React.useState<boolean>(false);
   const methods = useForm({
     mode: "onChange",
     shouldFocusError: false,
@@ -108,6 +110,7 @@ export function BasicForm<TFieldValues extends FieldValues>({
             }
           }
         });
+        setShowUnsavedChanges(true);
       }
     }
   }, [cacheKey, options, methods]);
@@ -116,7 +119,11 @@ export function BasicForm<TFieldValues extends FieldValues>({
     <FormProvider {...methods}>
       <form onSubmit={methods.handleSubmit(handleSubmit)}>
         {errors && <ErrorSummary ref={errorSummaryRef} labels={labels} />}
-        {cacheKey && isDirty && <UnsavedChanges labels={labels} />}
+        <UnsavedChanges
+          labels={labels}
+          show={!!(cacheKey && isDirty && showUnsavedChanges)}
+          onDismiss={() => setShowUnsavedChanges(false)}
+        />
         {children}
       </form>
     </FormProvider>

--- a/frontend/common/src/components/form/UnsavedChanges.tsx
+++ b/frontend/common/src/components/form/UnsavedChanges.tsx
@@ -10,14 +10,16 @@ import { notEmpty } from "../../helpers/util";
 
 interface UnsavedChangesProps {
   labels?: FieldLabels;
+  show: boolean;
+  onDismiss: () => void;
 }
 
-const UnsavedChanges = ({ labels }: UnsavedChangesProps) => {
+const UnsavedChanges = ({ labels, onDismiss, show }: UnsavedChangesProps) => {
   const intl = useIntl();
   const { isDirty, dirtyFields, errors } = useFormState();
 
   // Don't show if the form is clean
-  if (!isDirty) return null;
+  if (!isDirty || !show) return null;
 
   const unsavedFields = Object.keys(dirtyFields)
     .map((field) => {
@@ -44,7 +46,7 @@ const UnsavedChanges = ({ labels }: UnsavedChangesProps) => {
     .filter(notEmpty);
 
   return unsavedFields.length > 0 ? (
-    <Alert.Root type="info">
+    <Alert.Root type="info" dismissible onDismiss={onDismiss}>
       <Alert.Title>
         {intl.formatMessage({
           defaultMessage: "You have unsaved changes",


### PR DESCRIPTION
## 👋 Introduction

This updated the `<BasicForm />` to only show the `<UnsavedChanges />` alert on the initial render if it has unsaved changes by using internal `useState`. It also allows users to dismiss the alert if they wish.

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Navigate to a form on the profile
3. Make some changes to the form
4. Confirm the alert at the top of the form does not appear
5. Refresh the page
6. Confirm the alert appears and can be dismissed
7. Dismiss the alert and make more changes
8. Confirm the alert does not reappear

## 🤖 Robot Stuff

Resolves #4980 