### PR TITLE
Bug - 4809 - Prevent error summary while editing

### DIFF
--- a/frontend/common/src/components/form/BasicForm.tsx
+++ b/frontend/common/src/components/form/BasicForm.tsx
@@ -42,6 +42,8 @@ export function BasicForm<TFieldValues extends FieldValues>({
   cacheKey,
   labels,
 }: BasicFormProps<TFieldValues>): ReactElement {
+  const [showErrorSummary, setShowErrorSummary] =
+    React.useState<boolean>(false);
   const errorSummaryRef = React.useRef<HTMLDivElement>(null);
   const methods = useForm({
     mode: "onChange",
@@ -61,10 +63,16 @@ export function BasicForm<TFieldValues extends FieldValues>({
 
   React.useEffect(() => {
     // After during submit, if there are errors, focus the summary
-    if (errors && isSubmitting && errorSummaryRef.current) {
+    if (errors && isSubmitting) {
+      setShowErrorSummary(true);
+    }
+  }, [isSubmitting, errors]);
+
+  React.useEffect(() => {
+    if (errorSummaryRef.current) {
       errorSummaryRef.current.focus();
     }
-  }, [isSubmitting, errors, errorSummaryRef]);
+  }, [showErrorSummary, errorSummaryRef]);
 
   const handleSubmit = (data: TFieldValues) => {
     // Reset form to clear dirty values
@@ -115,7 +123,11 @@ export function BasicForm<TFieldValues extends FieldValues>({
   return (
     <FormProvider {...methods}>
       <form onSubmit={methods.handleSubmit(handleSubmit)}>
-        {errors && <ErrorSummary ref={errorSummaryRef} labels={labels} />}
+        <ErrorSummary
+          ref={errorSummaryRef}
+          labels={labels}
+          show={errors && showErrorSummary}
+        />
         {cacheKey && isDirty && <UnsavedChanges labels={labels} />}
         {children}
       </form>

--- a/frontend/common/src/components/form/ErrorSummary.tsx
+++ b/frontend/common/src/components/form/ErrorSummary.tsx
@@ -11,6 +11,7 @@ import { notEmpty } from "../../helpers/util";
 
 interface ErrorSummaryProps {
   labels?: FieldLabels;
+  show: boolean;
 }
 
 const a = (chunks: React.ReactNode) => (
@@ -20,14 +21,14 @@ const a = (chunks: React.ReactNode) => (
 const ErrorSummary = React.forwardRef<
   React.ElementRef<"div">,
   ErrorSummaryProps
->(({ labels }, forwardedRef) => {
+>(({ labels, show }, forwardedRef) => {
   const intl = useIntl();
 
   const locale = getLocale(intl);
   const { errors } = useFormState();
 
   // Don't show if the form is valid
-  if (!errors) return null;
+  if (!errors || !show) return null;
 
   const invalidFields = Object.keys(errors)
     .map((field) => {

--- a/frontend/common/src/components/inputPartials/InputError/InputError.tsx
+++ b/frontend/common/src/components/inputPartials/InputError/InputError.tsx
@@ -21,6 +21,7 @@ const InputError: React.FC<InputErrorProps> = ({
 }) => {
   return isVisible ? (
     <span
+      role="alert"
       data-h2-display="base(block)"
       data-h2-margin="base(x.25, 0, 0, 0)"
       data-h2-border="base(all, 1px, solid, dt-error.light)"


### PR DESCRIPTION
## 👋 Introduction

This uses the same logic in #5097 to make the `<ErrorSummary />` only appear after a user attempts to submit a form. It also adds `role="alert"` back to `<InputError />` to announce errors to a user as they type (this was removed to prevent duplicate announcements when summary was also appearing while editing).

## 🧪 Testing 

1. Build talent search npm run production --workspace=talentsearch
2. Navigate to a form on the profile
3. Make some changes to the form
4. Confirm the alert at the top of the form does not appear
5. Attempt to submit the form with errors
6. Confirm the alert appears

## 🤖 Robot Stuff

Resolves #4809 