### PR TITLE
Bug - 5031 - Require skill details application

### DIFF
--- a/frontend/common/src/components/MissingSkills/MissingSkills.test.tsx
+++ b/frontend/common/src/components/MissingSkills/MissingSkills.test.tsx
@@ -126,15 +126,23 @@ describe("MissingSkills", () => {
     });
 
     const lists = element.getAllByRole("list");
-    expect(lists.length).toEqual(2);
+    expect(lists.length).toEqual(4);
 
-    const requiredListItems = within(lists[0]).queryAllByRole("listitem");
-    expect(requiredListItems.length).toEqual(
+    const requiredSkillsListItems = within(lists[0]).queryAllByRole("listitem");
+    const requiredDetailsListItems = within(lists[1]).queryAllByRole(
+      "listitem",
+    );
+    expect(
+      requiredSkillsListItems.length + requiredDetailsListItems.length,
+    ).toEqual(
       defaultProps.requiredSkills.length, // Check that we are not missing any items
     );
 
-    const optionalListItems = within(lists[1]).queryAllByRole("listitem");
-    expect(optionalListItems.length).toEqual(
+    const optionSkillsListItems = within(lists[2]).queryAllByRole("listitem");
+    const optionDetailsListItems = within(lists[3]).queryAllByRole("listitem");
+    expect(
+      optionSkillsListItems.length + optionDetailsListItems.length,
+    ).toEqual(
       defaultProps.optionalSkills.length, // Check that we are not missing any items
     );
   });

--- a/frontend/common/src/components/MissingSkills/MissingSkills.tsx
+++ b/frontend/common/src/components/MissingSkills/MissingSkills.tsx
@@ -7,27 +7,42 @@ import {
 } from "@heroicons/react/24/solid";
 import Chip, { Chips } from "../Chip";
 
-import { getMissingSkills } from "../../helpers/skillUtils";
+import {
+  differentiateMissingSkills,
+  getMissingSkills,
+} from "../../helpers/skillUtils";
 import { getLocale } from "../../helpers/localize";
 import type { Maybe, Skill } from "../../api/generated";
 import { PillColor, PillMode } from "../Pill";
 
+interface MissingSkillsBlockProps {
+  pillType: { color: PillColor; mode: PillMode };
+  title: React.ReactNode;
+  skillsBlurb: React.ReactNode;
+  detailsBlurb: React.ReactNode;
+  icon: React.ReactNode;
+  missingSkills: Skill[];
+  addedSkills?: Skill[];
+}
+
 const MissingSkillsBlock = ({
   pillType,
   title,
-  blurb,
+  skillsBlurb,
+  detailsBlurb,
   icon,
   missingSkills,
+  addedSkills,
   ...rest
-}: {
-  pillType: { color: PillColor; mode: PillMode };
-  title: React.ReactNode;
-  blurb: React.ReactNode;
-  icon: React.ReactNode;
-  missingSkills: Skill[];
-}) => {
+}: MissingSkillsBlockProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
+
+  const [skills, details] = differentiateMissingSkills(
+    missingSkills,
+    addedSkills,
+  );
+
   return (
     <div
       data-h2-display="base(flex)"
@@ -40,18 +55,36 @@ const MissingSkillsBlock = ({
         <p data-h2-margin="base(0, 0, x.5, 0)">
           <strong>{title}</strong>
         </p>
-        <p data-h2-margin="base(0, 0, x.25, 0)">{blurb}</p>
-        <Chips>
-          {missingSkills.map((skill: Skill) => (
-            <Chip
-              key={skill.id}
-              color={pillType.color}
-              mode={pillType.mode}
-              label={skill.name[locale] ?? ""}
-              data-h2-margin="base(x.25, x.25, 0, 0)"
-            />
-          ))}
-        </Chips>
+        {skills.length ? (
+          <>
+            <p data-h2-margin="base(x.5, 0, x.25, 0)">{skillsBlurb}</p>
+            <Chips>
+              {skills.map((skill: Skill) => (
+                <Chip
+                  key={skill.id}
+                  color={pillType.color}
+                  mode={pillType.mode}
+                  label={skill.name[locale] ?? ""}
+                />
+              ))}
+            </Chips>
+          </>
+        ) : null}
+        {details.length ? (
+          <>
+            <p data-h2-margin="base(x.5, 0, x.25, 0)">{detailsBlurb}</p>
+            <Chips>
+              {details.map((skill: Skill) => (
+                <Chip
+                  key={skill.id}
+                  color={pillType.color}
+                  mode={pillType.mode}
+                  label={skill.name[locale] ?? ""}
+                />
+              ))}
+            </Chips>
+          </>
+        ) : null}
       </div>
     </div>
   );
@@ -102,15 +135,22 @@ const MissingSkills = ({
             description:
               "Title that appears when a user is missing required skills on their profile.",
           })}
-          blurb={intl.formatMessage({
+          skillsBlurb={intl.formatMessage({
             defaultMessage:
               "These required skills are missing from your profile:",
             id: "AhQ6xv",
             description:
               "Text that appears when a user is missing required skills on their profile.",
           })}
+          detailsBlurb={intl.formatMessage({
+            defaultMessage: "These required skills are missing information:",
+            id: "w6jDaJ",
+            description:
+              "Text that appears when a user is missing required skills on their profile.",
+          })}
           icon={<ExclamationTriangleIcon style={{ width: "1.2rem" }} />}
           missingSkills={missingRequiredSkills}
+          addedSkills={addedSkills}
         />
       ) : null}
       {missingOptionalSkills.length ? (
@@ -123,15 +163,23 @@ const MissingSkills = ({
             description:
               "Title that appears when a user is missing optional skills on their profile.",
           })}
-          blurb={intl.formatMessage({
+          skillsBlurb={intl.formatMessage({
             defaultMessage:
               "Consider adding these asset skills to your profile:",
             id: "V3ReC1",
             description:
               "Text that appears when a user is missing optional skills on their profile",
           })}
+          detailsBlurb={intl.formatMessage({
+            defaultMessage:
+              "Consider adding information to these asset skills:",
+            id: "FckGRB",
+            description:
+              "Text that appears when a user is missing optional skills on their profile",
+          })}
           icon={<LightBulbIcon style={{ width: "1.2rem" }} />}
           missingSkills={missingOptionalSkills}
+          addedSkills={addedSkills}
         />
       ) : null}
     </>

--- a/frontend/common/src/components/MissingSkills/MissingSkills.tsx
+++ b/frontend/common/src/components/MissingSkills/MissingSkills.tsx
@@ -17,11 +17,17 @@ import { PillColor, PillMode } from "../Pill";
 
 interface MissingSkillsBlockProps {
   pillType: { color: PillColor; mode: PillMode };
+  /** Title for the block */
   title: React.ReactNode;
+  /** Message displayed before skills that are missing from application */
   skillsBlurb: React.ReactNode;
+  /** Message displayed before skills that are present but missing details */
   detailsBlurb: React.ReactNode;
+  /** Icon displayed next to the title */
   icon: React.ReactNode;
+  /** Skills missing from the application */
   missingSkills: Skill[];
+  /** Skills the user as already added */
   addedSkills?: Skill[];
 }
 
@@ -38,6 +44,7 @@ const MissingSkillsBlock = ({
   const intl = useIntl();
   const locale = getLocale(intl);
 
+  /** Determine which skills are missing vs present but missing details */
   const [skills, details] = differentiateMissingSkills(
     missingSkills,
     addedSkills,

--- a/frontend/common/src/helpers/skillUtils.ts
+++ b/frontend/common/src/helpers/skillUtils.ts
@@ -143,4 +143,24 @@ export const getMissingSkills = (required: Skill[], added?: Skill[]) => {
       });
 };
 
+export const differentiateMissingSkills = (
+  missingSkills: Skill[],
+  addedSkills?: Skill[],
+) => {
+  const skills: Skill[] = [];
+  const details: Skill[] = [];
+
+  missingSkills.forEach((skill) => {
+    const addedSkill = addedSkills?.find((added) => added.id === skill.id);
+
+    if (addedSkill && !addedSkill.experienceSkillRecord?.details) {
+      details.push(skill);
+    } else {
+      skills.push(skill);
+    }
+  });
+
+  return [skills, details];
+};
+
 export default { invertSkillSkillFamilyTree, invertSkillExperienceTree };

--- a/frontend/common/src/helpers/skillUtils.ts
+++ b/frontend/common/src/helpers/skillUtils.ts
@@ -143,6 +143,18 @@ export const getMissingSkills = (required: Skill[], added?: Skill[]) => {
       });
 };
 
+/**
+ * Differentiate Missing Skills
+ *
+ * Determines if a skill is missing or present but
+ * simply missing details
+ *
+ * @param missingSkills Skill[] Array of skills that are missing from the application
+ * @param addedSkills Skill[] Array of skills added to a users profile
+ * @returns [skills: Skill[], details: Skill[]] Tuple where first index is the skills
+ *          That are completely missing and second index are the skills that are present
+ *          but missing details
+ */
 export const differentiateMissingSkills = (
   missingSkills: Skill[],
   addedSkills?: Skill[],

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1907,5 +1907,13 @@
   "1YuZjR": {
     "defaultMessage": "Emplois en TI (en cours)",
     "description": "The publishing group called IT Jobs for ongoing recruitments"
+  },
+  "FckGRB": {
+    "defaultMessage": "Songez à ajouter des renseignements à ces compétences représentant un atout :",
+    "description": "Text that appears when a user is missing optional skills on their profile"
+  },
+  "w6jDaJ": {
+    "defaultMessage": "Il manque des renseignements à ces compétences nécessaires :",
+    "description": "Text that appears when a user is missing required skills on their profile."
   }
 }


### PR DESCRIPTION
## 👋 Introduction

This updated missing skills to differentiate between skills that are entirely missing from a profile and those that are only missing details.

> **Note**
> Part of the acceptance criteria was to prevent submission when missing details. However, this was fixed with #4957 but has yet to be deployed so that is not included in this PR.

## ✅ TODO

- [x] Confirm AC with @Jerryescandon 
- [x] Send off for translations
- [x] Add translations

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Create or navigate to an existing application
3. Check missing skills
4. Add a missing skill **_from your profile, not the application page_** (we want one that is added but had no details)
5. Refresh the application reivew page
6. Confirm the new skill appears under the label "These required skills are missing information:"

## 🤖 Robot Stuff

Resolves #5031 