### PR TITLE
a11y - 5099 - Missing Skills Heading

### DIFF
--- a/frontend/common/src/components/MissingSkills/MissingSkills.tsx
+++ b/frontend/common/src/components/MissingSkills/MissingSkills.tsx
@@ -11,6 +11,7 @@ import { getMissingSkills } from "../../helpers/skillUtils";
 import { getLocale } from "../../helpers/localize";
 import type { Maybe, Skill } from "../../api/generated";
 import { PillColor, PillMode } from "../Pill";
+import Heading, { HeadingLevel } from "../Heading/Heading";
 
 const MissingSkillsBlock = ({
   pillType,
@@ -18,6 +19,7 @@ const MissingSkillsBlock = ({
   blurb,
   icon,
   missingSkills,
+  headingLevel = "h2",
   ...rest
 }: {
   pillType: { color: PillColor; mode: PillMode };
@@ -25,6 +27,7 @@ const MissingSkillsBlock = ({
   blurb: React.ReactNode;
   icon: React.ReactNode;
   missingSkills: Skill[];
+  headingLevel?: HeadingLevel;
 }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -37,9 +40,13 @@ const MissingSkillsBlock = ({
     >
       <span data-h2-margin="base(0, x1, 0, 0)">{icon}</span>
       <div>
-        <p data-h2-margin="base(0, 0, x.5, 0)">
-          <strong>{title}</strong>
-        </p>
+        <Heading
+          level={headingLevel}
+          size="h6"
+          data-h2-margin="base(0, 0, x.5, 0)"
+        >
+          {title}
+        </Heading>
         <p data-h2-margin="base(0, 0, x.25, 0)">{blurb}</p>
         <Chips>
           {missingSkills.map((skill: Skill) => (
@@ -61,12 +68,14 @@ export interface MissingSkillsProps {
   requiredSkills?: Skill[];
   optionalSkills?: Skill[];
   addedSkills?: Skill[];
+  headingLevel?: HeadingLevel;
 }
 
 const MissingSkills = ({
   requiredSkills,
   optionalSkills,
   addedSkills,
+  headingLevel = "h2",
 }: MissingSkillsProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -96,6 +105,7 @@ const MissingSkills = ({
           data-h2-background-color="base(light.dt-error.05)"
           data-h2-margin="base(0, 0, x.5, 0)"
           pillType={{ color: "error", mode: "outline" }}
+          headingLevel={headingLevel}
           title={intl.formatMessage({
             defaultMessage: "Required application skills",
             id: "B89Ihf",
@@ -117,6 +127,7 @@ const MissingSkills = ({
         <MissingSkillsBlock
           data-h2-background-color="base(light.dt-primary.10)"
           pillType={{ color: "primary", mode: "outline" }}
+          headingLevel={headingLevel}
           title={intl.formatMessage({
             defaultMessage: "Nice to have skills",
             id: "CJy0kS",

--- a/frontend/talentsearch/src/js/components/reviewMyApplication/ReviewMyApplicationPage.tsx
+++ b/frontend/talentsearch/src/js/components/reviewMyApplication/ReviewMyApplicationPage.tsx
@@ -155,6 +155,7 @@ export const ReviewMyApplication: React.FunctionComponent<
                   <div data-h2-margin="base(0, 0, x1, 0)">
                     {missingSkills && (
                       <MissingSkills
+                        headingLevel="h3"
                         addedSkills={
                           hasExperiences
                             ? flattenExperienceSkills(experiences)


### PR DESCRIPTION
## 👋 Introduction

This makes the title for the `<MissingSkills />` block a heading as well as adding a prop to select which rank it is render as.

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Navigate to an application with missing skills
3. Confirm the title in the Missing Skills section is wrapped in a heading
4. Run axe dev tools to confirm there is no heading rank error
5. While still on the application, click "Edit Skills and Experience"
6. Repeat steps 3 + 4

## 🤖 Robot Stuff

Resolves #5099 