### PR TITLE
a11y - 5008 - Adjust Experience Skill Accordion Heading Ranks

### DIFF
--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/ExperienceAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/ExperienceAccordion.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable no-underscore-dangle */
 import React from "react";
 import { useIntl } from "react-intl";
+import { HeadingLevel } from "../../Heading";
 import Accordion from "../../Accordion";
 import AwardAccordion from "./individualExperienceAccordions/AwardAccordion";
 import CommunityAccordion from "./individualExperienceAccordions/CommunityAccordion";
@@ -28,11 +29,13 @@ export interface ExperiencePaths {
 export interface AccordionProps {
   experience: AnyExperience;
   editPaths?: ExperiencePaths;
+  headingLevel?: HeadingLevel;
 }
 
 const ExperienceAccordion: React.FunctionComponent<AccordionProps> = ({
   experience,
   editPaths,
+  headingLevel = "h2",
 }) => {
   const intl = useIntl();
 
@@ -43,6 +46,7 @@ const ExperienceAccordion: React.FunctionComponent<AccordionProps> = ({
     return AwardAccordion({
       ...experience,
       editUrl,
+      headingLevel,
     });
   }
   if (isCommunityExperience(experience)) {
@@ -52,6 +56,7 @@ const ExperienceAccordion: React.FunctionComponent<AccordionProps> = ({
     return CommunityAccordion({
       ...experience,
       editUrl,
+      headingLevel,
     });
   }
   if (isEducationExperience(experience)) {
@@ -61,6 +66,7 @@ const ExperienceAccordion: React.FunctionComponent<AccordionProps> = ({
     return EducationAccordion({
       ...experience,
       editUrl,
+      headingLevel,
     });
   }
   if (isPersonalExperience(experience)) {
@@ -70,6 +76,7 @@ const ExperienceAccordion: React.FunctionComponent<AccordionProps> = ({
     return PersonalAccordion({
       ...experience,
       editUrl,
+      headingLevel,
     });
   }
   if (isWorkExperience(experience)) {
@@ -77,13 +84,14 @@ const ExperienceAccordion: React.FunctionComponent<AccordionProps> = ({
     return WorkAccordion({
       ...experience,
       editUrl,
+      headingLevel,
     });
   }
 
   // not one of the 5 experience types
   return (
     <Accordion.Item value="none">
-      <Accordion.Trigger headerAs="h3">
+      <Accordion.Trigger headerAs={headingLevel}>
         {intl.formatMessage({
           defaultMessage: "Unknown Experience",
           id: "U/Lv8i",

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/ExperienceAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/ExperienceAccordion.tsx
@@ -83,7 +83,7 @@ const ExperienceAccordion: React.FunctionComponent<AccordionProps> = ({
   // not one of the 5 experience types
   return (
     <Accordion.Item value="none">
-      <Accordion.Trigger>
+      <Accordion.Trigger headerAs="h3">
         {intl.formatMessage({
           defaultMessage: "Unknown Experience",
           id: "U/Lv8i",

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/AwardAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/AwardAccordion.tsx
@@ -93,6 +93,7 @@ const AwardAccordion = ({ editUrl, ...rest }: AwardAccordionProps) => {
           startDate: awardedDate,
           intl,
         })}
+        headerAs="h3"
         context={
           skills?.length === 1
             ? intl.formatMessage({

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/AwardAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/AwardAccordion.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import StarIcon from "@heroicons/react/24/solid/StarIcon";
 import { useIntl } from "react-intl";
 import Accordion from "../../../Accordion";
+import { HeadingLevel } from "../../../Heading";
 import { Link } from "../../..";
 import SkillList from "../SkillList";
 import {
@@ -78,10 +79,15 @@ export const AwardContent = ({
 };
 
 interface AwardAccordionProps extends AwardExperience {
+  headingLevel?: HeadingLevel;
   editUrl?: string; // A link to edit the experience will only appear if editUrl is defined.
 }
 
-const AwardAccordion = ({ editUrl, ...rest }: AwardAccordionProps) => {
+const AwardAccordion = ({
+  editUrl,
+  headingLevel = "h2",
+  ...rest
+}: AwardAccordionProps) => {
   const intl = useIntl();
   const { id, title, awardedDate, issuedBy, skills } = rest;
 
@@ -93,7 +99,7 @@ const AwardAccordion = ({ editUrl, ...rest }: AwardAccordionProps) => {
           startDate: awardedDate,
           intl,
         })}
-        headerAs="h3"
+        headerAs={headingLevel}
         context={
           skills?.length === 1
             ? intl.formatMessage({

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/CommunityAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/CommunityAccordion.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useIntl } from "react-intl";
 import UserGroupIcon from "@heroicons/react/24/solid/UserGroupIcon";
 import Accordion from "../../../Accordion";
+import { HeadingLevel } from "../../../Heading";
 import { Link } from "../../..";
 import { CommunityExperience } from "../../../../api/generated";
 import { getDateRange } from "../../accordionUtils";
@@ -59,17 +60,22 @@ export const CommunityContent = ({
 };
 
 type CommunityAccordionProps = CommunityExperience & {
+  headingLevel?: HeadingLevel;
   editUrl?: string; // A link to edit the experience will only appear if editUrl is defined.
 };
 
-const CommunityAccordion = ({ editUrl, ...rest }: CommunityAccordionProps) => {
+const CommunityAccordion = ({
+  editUrl,
+  headingLevel = "h2",
+  ...rest
+}: CommunityAccordionProps) => {
   const intl = useIntl();
   const { id, endDate, startDate, skills, title, organization } = rest;
 
   return (
     <Accordion.Item value={id}>
       <Accordion.Trigger
-        headerAs="h3"
+        headerAs={headingLevel}
         subtitle={getDateRange({ endDate, startDate, intl })}
         Icon={UserGroupIcon}
         context={

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/CommunityAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/CommunityAccordion.tsx
@@ -69,6 +69,7 @@ const CommunityAccordion = ({ editUrl, ...rest }: CommunityAccordionProps) => {
   return (
     <Accordion.Item value={id}>
       <Accordion.Trigger
+        headerAs="h3"
         subtitle={getDateRange({ endDate, startDate, intl })}
         Icon={UserGroupIcon}
         context={

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/EducationAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/EducationAccordion.tsx
@@ -91,6 +91,7 @@ const EducationAccordion = ({ editUrl, ...rest }: EducationAccordionProps) => {
     <Accordion.Item value={id}>
       <Accordion.Trigger
         subtitle={getDateRange({ endDate, startDate, intl })}
+        headerAs="h3"
         context={
           skills?.length === 1
             ? intl.formatMessage({

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/EducationAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/EducationAccordion.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import BookOpenIcon from "@heroicons/react/24/solid/BookOpenIcon";
 import { useIntl } from "react-intl";
 import Accordion from "../../../Accordion";
+import { HeadingLevel } from "../../../Heading";
 import { Link } from "../../..";
 import { EducationExperience } from "../../../../api/generated";
 import {
@@ -80,10 +81,15 @@ export const EducationContent = ({
 };
 
 type EducationAccordionProps = EducationExperience & {
+  headingLevel?: HeadingLevel;
   editUrl?: string; // A link to edit the experience will only appear if editUrl is defined.
 };
 
-const EducationAccordion = ({ editUrl, ...rest }: EducationAccordionProps) => {
+const EducationAccordion = ({
+  editUrl,
+  headingLevel = "h2",
+  ...rest
+}: EducationAccordionProps) => {
   const intl = useIntl();
   const { id, areaOfStudy, institution, startDate, endDate, skills } = rest;
 
@@ -91,7 +97,7 @@ const EducationAccordion = ({ editUrl, ...rest }: EducationAccordionProps) => {
     <Accordion.Item value={id}>
       <Accordion.Trigger
         subtitle={getDateRange({ endDate, startDate, intl })}
-        headerAs="h3"
+        headerAs={headingLevel}
         context={
           skills?.length === 1
             ? intl.formatMessage({

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/PersonalAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/PersonalAccordion.tsx
@@ -58,6 +58,7 @@ const PersonalAccordion = ({ editUrl, ...rest }: PersonalAccordionProps) => {
     <Accordion.Item value={id}>
       <Accordion.Trigger
         subtitle={getDateRange({ endDate, startDate, intl })}
+        headerAs="h3"
         context={
           skills?.length === 1
             ? intl.formatMessage({

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/PersonalAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/PersonalAccordion.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useIntl } from "react-intl";
 import LightBulbIcon from "@heroicons/react/24/solid/LightBulbIcon";
 import Accordion from "../../../Accordion";
+import { HeadingLevel } from "../../../Heading";
 import { Link } from "../../..";
 import { getDateRange } from "../../accordionUtils";
 import { PersonalExperience } from "../../../../api/generated";
@@ -47,10 +48,15 @@ export const PersonalContent = ({
 };
 
 type PersonalAccordionProps = PersonalExperience & {
+  headingLevel?: HeadingLevel;
   editUrl?: string; // A link to edit the experience will only appear if editUrl is defined.
 };
 
-const PersonalAccordion = ({ editUrl, ...rest }: PersonalAccordionProps) => {
+const PersonalAccordion = ({
+  editUrl,
+  headingLevel = "h2",
+  ...rest
+}: PersonalAccordionProps) => {
   const intl = useIntl();
   const { id, title, startDate, endDate, skills } = rest;
 
@@ -58,7 +64,7 @@ const PersonalAccordion = ({ editUrl, ...rest }: PersonalAccordionProps) => {
     <Accordion.Item value={id}>
       <Accordion.Trigger
         subtitle={getDateRange({ endDate, startDate, intl })}
-        headerAs="h3"
+        headerAs={headingLevel}
         context={
           skills?.length === 1
             ? intl.formatMessage({

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/WorkAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/WorkAccordion.tsx
@@ -73,6 +73,7 @@ const WorkAccordion: React.FunctionComponent<WorkAccordionProps> = ({
     <Accordion.Item value={id}>
       <Accordion.Trigger
         subtitle={getDateRange({ endDate, startDate, intl })}
+        headerAs="h3"
         context={
           skills?.length === 1
             ? intl.formatMessage({

--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/WorkAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/individualExperienceAccordions/WorkAccordion.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import BriefCaseIcon from "@heroicons/react/24/solid/BriefcaseIcon";
 import { useIntl } from "react-intl";
 import Accordion from "../../../Accordion";
+import { HeadingLevel } from "../../../Heading";
 import { Link } from "../../..";
 import { getDateRange } from "../../accordionUtils";
 import { WorkExperience } from "../../../../api/generated";
@@ -59,11 +60,13 @@ export const WorkContent = ({
 };
 
 type WorkAccordionProps = WorkExperience & {
+  headingLevel?: HeadingLevel;
   editUrl?: string; // A link to edit the experience will only appear if editUrl is defined.
 };
 
 const WorkAccordion: React.FunctionComponent<WorkAccordionProps> = ({
   editUrl,
+  headingLevel,
   ...rest
 }) => {
   const intl = useIntl();
@@ -73,7 +76,7 @@ const WorkAccordion: React.FunctionComponent<WorkAccordionProps> = ({
     <Accordion.Item value={id}>
       <Accordion.Trigger
         subtitle={getDateRange({ endDate, startDate, intl })}
-        headerAs="h3"
+        headerAs={headingLevel}
         context={
           skills?.length === 1
             ? intl.formatMessage({

--- a/frontend/common/src/components/UserProfile/ExperienceByTypeListing.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceByTypeListing.tsx
@@ -20,13 +20,21 @@ import {
 } from "../../types/ExperienceUtils";
 import { AwardExperience, Experience } from "../../api/generated";
 import Accordion from "../Accordion";
+import { HeadingLevel } from "../Heading";
 
 const ExperienceByType: React.FunctionComponent<{
   title: string;
+  headingLevel?: HeadingLevel;
   icon: React.ReactNode;
   experiences: Experience[];
   experienceEditPaths?: ExperiencePaths; // If experienceEditPaths is not defined, links to edit experiences will not appear.
-}> = ({ title, icon, experiences, experienceEditPaths }) => {
+}> = ({
+  title,
+  headingLevel = "h2",
+  icon,
+  experiences,
+  experienceEditPaths,
+}) => {
   return (
     <div className="experience-category">
       <div
@@ -44,6 +52,7 @@ const ExperienceByType: React.FunctionComponent<{
               key={experience.id}
               experience={experience}
               editPaths={experienceEditPaths}
+              headingLevel={headingLevel}
             />
           ))}
         </Accordion.Root>
@@ -53,12 +62,13 @@ const ExperienceByType: React.FunctionComponent<{
 };
 export interface ExperienceSectionProps {
   experiences?: Experience[];
+  headingLevel?: HeadingLevel;
   editPaths?: ExperiencePaths;
 }
 
 const ExperienceByTypeListing: React.FunctionComponent<
   ExperienceSectionProps
-> = ({ experiences, editPaths }) => {
+> = ({ experiences, editPaths, headingLevel = "h2" }) => {
   const intl = useIntl();
 
   const awardExperiences =
@@ -93,6 +103,7 @@ const ExperienceByTypeListing: React.FunctionComponent<
               "Heading for personal experiences in experience by type listing",
           })}
           icon={<LightBulbIcon style={{ width: "1.5rem" }} />}
+          headingLevel={headingLevel}
           experiences={personalExperiences}
           experienceEditPaths={editPaths}
         />
@@ -106,6 +117,7 @@ const ExperienceByTypeListing: React.FunctionComponent<
               description:
                 "Heading for community experiences in experience by type listing",
             })}
+            headingLevel={headingLevel}
             icon={<UserGroupIcon style={{ width: "1.5rem" }} />}
             experiences={communityExperiences}
             experienceEditPaths={editPaths}
@@ -121,6 +133,7 @@ const ExperienceByTypeListing: React.FunctionComponent<
               description:
                 "Heading for personal experiences in experience by type listing",
             })}
+            headingLevel={headingLevel}
             icon={<BriefcaseIcon style={{ width: "1.5rem" }} />}
             experiences={workExperiences}
             experienceEditPaths={editPaths}
@@ -136,6 +149,7 @@ const ExperienceByTypeListing: React.FunctionComponent<
               description:
                 "Heading for education experiences in experience by type listing",
             })}
+            headingLevel={headingLevel}
             icon={<BookOpenIcon style={{ width: "1.5rem" }} />}
             experiences={educationExperiences}
             experienceEditPaths={editPaths}
@@ -151,6 +165,7 @@ const ExperienceByTypeListing: React.FunctionComponent<
               description:
                 "Heading for award experiences in experience by type listing",
             })}
+            headingLevel={headingLevel}
             icon={<StarIcon style={{ width: "1.5rem" }} />}
             experiences={awardExperiences}
             experienceEditPaths={editPaths}

--- a/frontend/common/src/components/UserProfile/ExperienceSection.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceSection.tsx
@@ -18,17 +18,20 @@ import {
 } from "../../types/ExperienceUtils";
 import { AwardExperience, Experience } from "../../api/generated";
 import ExperienceByTypeListing from "./ExperienceByTypeListing";
+import { HeadingLevel } from "../Heading";
 
 export interface ExperienceSectionProps {
   experiences?: Experience[];
   experienceEditPaths?: ExperiencePaths; //  If experienceEditPaths is not defined, links to edit experiences will not appear.
   editPath?: string;
+  headingLevel?: HeadingLevel;
 }
 
 const ExperienceSection: React.FunctionComponent<ExperienceSectionProps> = ({
   experiences,
   experienceEditPaths,
   editPath,
+  headingLevel = "h3",
 }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -140,6 +143,7 @@ const ExperienceSection: React.FunctionComponent<ExperienceSectionProps> = ({
         <Accordion.Root type="single" collapsible>
           {sortedByDate.map((experience) => (
             <ExperienceAccordion
+              headingLevel={headingLevel}
               key={experience.id}
               experience={experience}
               editPaths={experienceEditPaths}
@@ -149,6 +153,7 @@ const ExperienceSection: React.FunctionComponent<ExperienceSectionProps> = ({
       </Tabs.Content>
       <Tabs.Content value="1">
         <ExperienceByTypeListing
+          headingLevel={headingLevel}
           experiences={experiences}
           editPaths={experienceEditPaths}
         />
@@ -156,7 +161,11 @@ const ExperienceSection: React.FunctionComponent<ExperienceSectionProps> = ({
       <Tabs.Content value="2">
         <Accordion.Root type="multiple">
           {sortedBySkills.map((skill) => (
-            <SkillAccordion key={skill.id} skill={skill} />
+            <SkillAccordion
+              key={skill.id}
+              skill={skill}
+              headingLevel={headingLevel}
+            />
           ))}
         </Accordion.Root>
       </Tabs.Content>

--- a/frontend/common/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
@@ -302,6 +302,7 @@ const SkillAccordion: React.FunctionComponent<SkillAccordionProps> = ({
   return (
     <Accordion.Item value={skill.id}>
       <Accordion.Trigger
+        headerAs="h3"
         context={
           experiences?.length === 1
             ? intl.formatMessage({

--- a/frontend/common/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
+++ b/frontend/common/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import * as React from "react";
 import { useIntl } from "react-intl";
+import { HeadingLevel } from "../../Heading";
 import { getLocale } from "../../../helpers/localize";
 import Accordion from "../../Accordion";
 import {
@@ -29,10 +30,12 @@ import {
 
 export interface SkillAccordionProps {
   skill: Skill;
+  headingLevel?: HeadingLevel;
 }
 
 const SkillAccordion: React.FunctionComponent<SkillAccordionProps> = ({
   skill,
+  headingLevel = "h2",
 }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -302,7 +305,7 @@ const SkillAccordion: React.FunctionComponent<SkillAccordionProps> = ({
   return (
     <Accordion.Item value={skill.id}>
       <Accordion.Trigger
-        headerAs="h3"
+        headerAs={headingLevel}
         context={
           experiences?.length === 1
             ? intl.formatMessage({

--- a/frontend/talentsearch/src/js/components/experienceAndSkills/ExperienceAndSkills.tsx
+++ b/frontend/talentsearch/src/js/components/experienceAndSkills/ExperienceAndSkills.tsx
@@ -265,6 +265,7 @@ export const ExperienceAndSkills: React.FunctionComponent<
         <ExperienceSection
           experiences={experiences}
           experienceEditPaths={experienceEditPaths}
+          headingLevel="h2"
         />
       )}
       <ProfileFormFooter


### PR DESCRIPTION
## 👋 Introduction

This reduced the heading rank for experience and skill accordions to `<h3 />` to provide [semantic structure.](https://webaim.org/techniques/semanticstructure/).

## 🧪 Testing

1. Build all projects `npm run production --workspaces`
2. Navigate to `/admin/users`
3. View a user and open the "Candidate Profile" tab
4. Run axe dev tools and confirm there are no heading rank warnings
5. Open the "By Skills" tab and repeat step 6
6. Navigate to `/talent/profile`
7. Repeat steps 4 + 5

## 🤖 Robot Stuff

Resolves #5008 