### PR TITLE
a11y - 4997 - Make TOC Nav Title a Heading

### DIFF
--- a/frontend/common/src/components/TableOfContents/Navigation.tsx
+++ b/frontend/common/src/components/TableOfContents/Navigation.tsx
@@ -11,7 +11,7 @@ const Navigation: React.FC = ({ children, ...rest }) => {
   return (
     <Sidebar>
       <div data-h2-text-align="base(left) l-tablet(right)" {...rest}>
-        <p
+        <h2
           id={`toc-heading-${id}`}
           data-h2-font-size="base(h5, 1)"
           data-h2-font-weight="base(700)"
@@ -22,7 +22,7 @@ const Navigation: React.FC = ({ children, ...rest }) => {
             id: "3Nd6dv",
             description: "Title for  pages table of contents.",
           })}
-        </p>
+        </h2>
         <nav
           aria-labelledby={`toc-heading-${id}`}
           data-h2-display="base(flex)"

--- a/frontend/common/src/components/TableOfContents/Sidebar.tsx
+++ b/frontend/common/src/components/TableOfContents/Sidebar.tsx
@@ -5,7 +5,7 @@ export interface SidebarProps {
 }
 
 const Sidebar = ({ children }: SidebarProps) => (
-  <div data-h2-flex-item="base(1of1) l-tablet(1of4)">
+  <aside data-h2-flex-item="base(1of1) l-tablet(1of4)">
     <div data-h2-height="base(100%)" data-h2-position="base(relative)">
       <div
         data-h2-position="base(sticky)"
@@ -14,7 +14,7 @@ const Sidebar = ({ children }: SidebarProps) => (
         {children}
       </div>
     </div>
-  </div>
+  </aside>
 );
 
 export default Sidebar;


### PR DESCRIPTION
## 👋 Introduction

Updates the title of the `<TableOfContents.Navigaton />` an `<h2 />`.

> **Note** 
> This also makes the `<Sidebar />` an `<aside />` to be semantically correct.
>
> This could also lead to false negatives on automated scans since it is [considered an exception for heading ranks](https://www.w3.org/WAI/tutorials/page-structure/headings/#exception-for-fixed-page-sections). 

## 🧪 Testing

1. Build all projects `npm run production --workspaces`
2. Navigate to any page that uses the `<TableOfContents />` component
3. Confirm the "On this page" text in the sidebar is wrapped in an `<h2 />`
4. Confirm the sidebar is wrapped in `<aside />`

## 🤖 Robot stuff

Resolves #4997 