### PR TITLE
Feature - Add `Created` column to Admin pools table

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -301,6 +301,7 @@ type Pool {
   stream: PoolStream
   processNumber: String @rename(attribute: "process_number")
   publishingGroup: PublishingGroup @rename(attribute: "publishing_group")
+  createdDate: DateTime @rename(attribute: "created_at")
 }
 
 enum PoolStatus {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -797,6 +797,7 @@ type Pool {
   stream: PoolStream
   processNumber: String
   publishingGroup: PublishingGroup
+  createdDate: DateTime
 }
 
 type PoolAdvertisement {

--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -37,6 +37,7 @@ export interface TableProps<
   pagination?: boolean;
   hiddenCols?: string[];
   labelledBy?: string;
+  sortBy?: Array<{ id: string; desc: boolean }>;
 }
 
 const IndeterminateCheckbox: React.FC<
@@ -137,6 +138,7 @@ function Table<T extends Record<string, unknown>>({
   search = true,
   pagination = true,
   hiddenCols = [],
+  sortBy = [],
 }: TableProps<T>): ReactElement {
   const {
     getTableProps,
@@ -157,6 +159,7 @@ function Table<T extends Record<string, unknown>>({
       data,
       initialState: {
         hiddenColumns: hiddenCols,
+        sortBy,
       },
     },
     useGlobalFilter,

--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -37,7 +37,7 @@ export interface TableProps<
   pagination?: boolean;
   hiddenCols?: string[];
   labelledBy?: string;
-  sortBy?: Array<{ id: string; desc: boolean }>;
+  initialSortBy?: Array<{ id: string; desc: boolean }>;
 }
 
 const IndeterminateCheckbox: React.FC<
@@ -138,7 +138,7 @@ function Table<T extends Record<string, unknown>>({
   search = true,
   pagination = true,
   hiddenCols = [],
-  sortBy = [],
+  initialSortBy = [],
 }: TableProps<T>): ReactElement {
   const {
     getTableProps,
@@ -159,7 +159,7 @@ function Table<T extends Record<string, unknown>>({
       data,
       initialState: {
         hiddenColumns: hiddenCols,
-        sortBy,
+        sortBy: initialSortBy,
       },
     },
     useGlobalFilter,

--- a/frontend/admin/src/js/components/pool/PoolTable.tsx
+++ b/frontend/admin/src/js/components/pool/PoolTable.tsx
@@ -9,6 +9,7 @@ import Pending from "@common/components/Pending";
 import { getAdvertisementStatus } from "@common/constants/localizedConstants";
 import { commonMessages } from "@common/messages";
 import { getFullPoolAdvertisementTitle } from "@common/helpers/poolUtils";
+import { formatDate, parseDateTimeUtc } from "@common/helpers/dateUtils";
 import {
   GetPoolsQuery,
   Maybe,
@@ -148,6 +149,22 @@ export const PoolTable: React.FC<GetPoolsQuery & { editUrlRoot: string }> = ({
             d.name ? d.name[locale] : "",
           ), // callback extracted to separate function to stabilize memoized component
       },
+      {
+        Header: intl.formatMessage({
+          defaultMessage: "Created",
+          id: "zAqJMe",
+          description: "Title displayed on the Pool table Date Created column",
+        }),
+        accessor: "createdDate",
+        Cell: ({ value }) =>
+          value
+            ? formatDate({
+                date: parseDateTimeUtc(value),
+                formatString: "PPP p",
+                intl,
+              })
+            : null,
+      },
     ],
     [editUrlRoot, intl, paths, locale],
   );
@@ -158,7 +175,7 @@ export const PoolTable: React.FC<GetPoolsQuery & { editUrlRoot: string }> = ({
     <Table
       data={data}
       columns={columns}
-      hiddenCols={["id", "description"]}
+      hiddenCols={["id", "description", "createdDate"]}
       search={false}
       addBtn={{
         path: paths.poolCreate(),
@@ -168,6 +185,12 @@ export const PoolTable: React.FC<GetPoolsQuery & { editUrlRoot: string }> = ({
           description: "Heading displayed above the Create Pool form.",
         }),
       }}
+      sortBy={[
+        {
+          id: "createdDate",
+          desc: true,
+        },
+      ]}
     />
   );
 };

--- a/frontend/admin/src/js/components/pool/PoolTable.tsx
+++ b/frontend/admin/src/js/components/pool/PoolTable.tsx
@@ -185,7 +185,7 @@ export const PoolTable: React.FC<GetPoolsQuery & { editUrlRoot: string }> = ({
           description: "Heading displayed above the Create Pool form.",
         }),
       }}
-      sortBy={[
+      initialSortBy={[
         {
           id: "createdDate",
           desc: true,

--- a/frontend/admin/src/js/components/pool/poolOperations.graphql
+++ b/frontend/admin/src/js/components/pool/poolOperations.graphql
@@ -166,6 +166,7 @@ query getPools {
     advertisementStatus
     stream
     processNumber
+    createdDate
   }
 }
 

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -2432,5 +2432,9 @@
   "zwYuly": {
     "defaultMessage": "Créer un bassin",
     "description": "Page title for the pool creation page"
+  },
+  "zAqJMe": {
+    "defaultMessage": "Créé",
+    "description": "Title displayed on the Pool table Date Created column"
   }
 }


### PR DESCRIPTION
Resolves #5112.


## Steps to test

1. Re-generate lighthouse schema `php artisan lighthouse:print-schema --write`
2. Generate code from your GraphQL schema and GraphQL operations `npm run codegen --workspace=admin`
3. Compile French `npm run intl-compile --workspace=admin`
4. Build admin `npm run production --workspace=admin`
5. Navigate to `/admin/pools`
6. Verify **Created** column is hidden
7. Click columns button and toggle **Created**
8. Verify table is ordered by **Created** in descending order (newest dates at the top)
9. Toggle to French
10. Verify translation for **Created** is **Créé** and date format is correct in French.
