### PR TITLE
Fixed 404 routing for admin and talentsearch

### DIFF
--- a/frontend/admin/src/js/components/Router.tsx
+++ b/frontend/admin/src/js/components/Router.tsx
@@ -226,12 +226,12 @@ const SingleSearchRequestPage = React.lazy(() =>
 
 const router = createBrowserRouter([
   {
-    path: "/:locale",
+    path: `/`,
     element: <Layout />,
     errorElement: <ErrorPage />,
     children: [
       {
-        path: "admin",
+        path: ":locale/admin",
         errorElement: <ErrorPage />,
         children: [
           {
@@ -541,6 +541,12 @@ const router = createBrowserRouter([
                 ],
               },
             ],
+          },
+          {
+            path: "*",
+            loader: () => {
+              throw new Response("Not Found", { status: 404 });
+            },
           },
         ],
       },

--- a/frontend/talentsearch/src/js/components/Router.tsx
+++ b/frontend/talentsearch/src/js/components/Router.tsx
@@ -471,11 +471,13 @@ const router = createBrowserRouter([
               </RequireAuth>
             ),
           },
+          {
+            path: "*",
+            loader: () => {
+              throw new Response("Not Found", { status: 404 });
+            },
+          },
         ],
-      },
-      {
-        path: "*",
-        element: <ErrorPage />,
       },
     ],
   },


### PR DESCRIPTION
Resolves #4822.

Fixes routing for handing 404s in admin and talentsearch.

To test:
1. Refresh the site
2. Navigate to a non-existent route (ex. `/en/oops`)
3. Confirm the 404 page displays as expected.
4. Navigate to a non-existent admin route (ex. `/en/admin/oops`)
5. Confirm the admin 404 page displays as expected.

Notes:
- We don't currently have an error page for the IAP stuff so currently navigation to non-existent pages there (ex. `/en/indigenous-it-apprentice/oops`) will result in the default react router error page.