### PR TITLE
Feature - Change ubuntu-latest to ubuntu-22.04

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   runner:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       NPM_VERSION: '8.3.0'
       # Used to write status check on PRs within upstream repo.

--- a/.github/workflows/check-lighthouse-schema.yml
+++ b/.github/workflows/check-lighthouse-schema.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   runner:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       NPM_VERSION: "8.3.0"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   run-linters:
     name: Run linters
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       NPM_VERSION: "8.3.0"
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   phpunit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: kirschbaumdevelopment/laravel-test-runner:7.3
 

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -16,7 +16,7 @@ jobs:
     # 1. Always run for commits on main branch, and for any other commits...
     # 2. Never run automatically on first trigger event, only on manual re-run.
     if: ${{ github.ref_name == 'main' || github.run_attempt > 1 }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       NPM_VERSION: '8.3.0'
     steps:


### PR DESCRIPTION
Resolves #4102.

## Details
The **ubuntu-latest** and **ubuntu-22.04** [labels](https://github.com/actions/runner-images#available-images) currently represent the same image:

![Screen Shot 2022-12-15 at 16 17 01](https://user-images.githubusercontent.com/3046459/207969098-14fce716-054c-405c-9483-4f81f1652899.png)

## Steps to test
1. Verify there are no instance of **ubuntu-latest** in the codebase.