### PR TITLE
Fix token tests

### DIFF
--- a/api/tests/Unit/OpenIdBearerTokenTest.php
+++ b/api/tests/Unit/OpenIdBearerTokenTest.php
@@ -56,7 +56,6 @@ class OpenIdBearerTokenTest extends TestCase
      */
     public function testAcceptsGoodTokenAndReturnsCorrectSub()
     {
-        $this->markTestSkipped('must be revisited.');
         $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoyMTQ3NDgzNjQ3LCJpYXQiOjB9.qiOmlGVi-7K0B8eeZNYY21yZnXDn5pZWFMSLM6UH2uHUQ8mdcN0Ocd36Sq1vKvWeOgTvEm_MCl5GGCert16huUoEiILnlmf9F4i7L7wa1HIgPZnXKxKFbShbUUFMSn-6WxEQxF5g-s6cr77Lu6H_y2_osD39MFcpxTy5k5zJE8EXwQ2FGxmYhW4_qpNF3WQcMge5dfhaPaLpxH1lSrYHkCqnfGJkcTMRg3TPkQe1KWV4VUf2uGl06FleWCXuPgO__LSWeA2YHsyCV7tMPVDlOIOtiyZA1Pk4G_p2ur8a403NyIjdcXOscwIHd55vw--GOdMGSurLMS_rHfz0FD6bRSzW_6AWfBa4KQJVkoM_U6aUZ5yBEbzbsNh2u1H-OyEVBgu4R5XoyXfcn8-Z8nq_ciER8UyvVXTj9WnU--ELEZ_0Qxn4ovKqjXdL7eGwwQ5YercEh-iGiaHikEi2pD1YpfbpXE_uS3Wl2Acd8f_4sIzyQfbBfGoqIZb_cPKIm-gRhJlJn-dRdO_Hzy0rCkDngbSEg_VAeQQv-JAvOlQimI73scyWyLGLzuyOZV33Sy0NAsdOJ0xiM0C5HT_-Wc-ZFHW3uYWzixu60c0yRiJ2vV0-o-VTvpkALYPmy5n8SXSKKP59psvGzSydiX4dq5bk2XGq8wTsUGBOObTVZEN_j9E';
         /** analyze token at https://jwt.io/
         {
@@ -194,7 +193,6 @@ class OpenIdBearerTokenTest extends TestCase
      */
     public function testAcceptsExpiredTokenWithinAllowableSkew()
     {
-        $this->markTestSkipped('must be revisited.');
         $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoxNTc3ODM2ODYwLCJpYXQiOjB9.zI4EHjfWyZP3G8DFRAMJXF9mZrA65RizQMrnQGVuKFYm0cwMusBToaH5k4feB0b2WPfBkl3-gHOJ5qKoNcR50RI_t5LEZbBVZrGhCDfpCDVlO5ZnwABhQo48NUi2ZbMb1ZoDTa_802hifvpjhOtEE0V9_zCsDZ1pcA9G4rsqEv5T3N35JV_xwgD_PqToZrxCMNuJOG5k8suoIKazzN5eJm3adKi7UsOqh-DJTni7-z88A95UycS0ONw5APFYU-IE3kL5UL1K6OwvXEgpD0md06qB3GUmkkjXeGumDefokT8RouAIbX8p37cfvxeuctJ1WtKZJ3IrJx0E4y-15JCLaPQ3tmv4XQ7lfHf9Yblith7Sw4T4upO7wtynogg2Y_Oget7zLksvaza77SRkXLf8Si3lGJ9ydqSlkLKqo8aX5nQJAkUnRY72eIz5jEEdBBrkpTQdQRG4g2-R9xXd9rGCscdAt2S3COJEFhO2FrgwUiD0piHah-PlMVN5fw3wr2ISN9OYfd5_e15UxLgo0Qw99_mKaakXBf20umTkk2TGi8YmMZLvbOS6yI7eS1wo3rFPzdTOPT7WoW6iPl_kW0FdGZYQQb1GxI2RrjFl6Ud4axKqJbtv1dV9ml1Z9PPawBcIP2B702uLwc9RZrX8b3S3Cnq72-7iCWJVvET9IQr1ess';
         /** analyze token at https://jwt.io/
         {

--- a/api/tests/Unit/resources/README.md
+++ b/api/tests/Unit/resources/README.md
@@ -3,3 +3,7 @@ They keys in this folder are only used for automated testing. They do not need t
 To generate more, use the following command:
 `openssl req -x509 -newkey rsa:4096 -keyout key1.pem -out key1-cert.pem -sha256 -days 99999 -nodes -subj '/CN=localhost'`
 This can be done in the maintenance container.
+
+The key modulus "n" must be Base64urlUInt-encoded, not regular Base64 encoded.
+https://www.rfc-editor.org/rfc/rfc7518#section-6.3.1.1
+https://stackoverflow.com/a/34285088

--- a/api/tests/Unit/resources/jwks.json
+++ b/api/tests/Unit/resources/jwks.json
@@ -3,7 +3,7 @@
       "kty" : "RSA",
       "use" : "sig",
       "kid" : "key1",
-      "n"   : "zW0RhzZzEYnnrhkdHTsq+lrXbHwdMiwi8rfownC+xPX8Y+qtL2/fWRDJjZLg099TrGOmgPxl/Pe3U1mFPD+GbKZvBpvYOqrJNSd6FnMO3DSCt2FWDN1sar7KEvEGBEUpNUt8ztyZLYM9yTZYLyxFHWKOXhfb7NHRUht3YfYdBq5O8CJ5jhuwrhaqjb/QQZYuXoteR4NwA/AOMbhVcgyCdDamYNMRlapENlDtAyhoodnhJBpwIcactXYRHpJhD5svlBJYiZN+pOnYCmXIsIWjMGDxp1TzCP7gRPJMKk5eo7EYCNtRSQPwCFE4QVogPUvjAnbVJgjJ5TXQds9bT9h55/hJ6/Arw1dNVrPzO6bVf/ktIM05P9UX10Q/evZtWeSwHjOBrNTbU0T8dw1dyUz7w9DIJYhcf+EZz80oCTtNa3B+sl/b7cahc2MY9+XbOKIOirHcivYdHt49cq7MAHyqFPzyHehPoVSvlbCUWu5DagpGAbPJ1j9PBlBVHRqTpoZWs3XKWab7a0NTeT/5MjxozlwioI1HxyiTJmiyMNamTBRFunaGN3aMMkU3tnADUfS+22rtiVqy8t6I67hgsWKkwHaM9Fc2sUI/XW/Hoh2lvc8mB8Sn0xgqMThcPOFxxRLut7O42l2itzHK58e2amKD/A+Be7G8ZWdeJFj51dnHus0=",
+      "n"   : "zW0RhzZzEYnnrhkdHTsq-lrXbHwdMiwi8rfownC-xPX8Y-qtL2_fWRDJjZLg099TrGOmgPxl_Pe3U1mFPD-GbKZvBpvYOqrJNSd6FnMO3DSCt2FWDN1sar7KEvEGBEUpNUt8ztyZLYM9yTZYLyxFHWKOXhfb7NHRUht3YfYdBq5O8CJ5jhuwrhaqjb_QQZYuXoteR4NwA_AOMbhVcgyCdDamYNMRlapENlDtAyhoodnhJBpwIcactXYRHpJhD5svlBJYiZN-pOnYCmXIsIWjMGDxp1TzCP7gRPJMKk5eo7EYCNtRSQPwCFE4QVogPUvjAnbVJgjJ5TXQds9bT9h55_hJ6_Arw1dNVrPzO6bVf_ktIM05P9UX10Q_evZtWeSwHjOBrNTbU0T8dw1dyUz7w9DIJYhcf-EZz80oCTtNa3B-sl_b7cahc2MY9-XbOKIOirHcivYdHt49cq7MAHyqFPzyHehPoVSvlbCUWu5DagpGAbPJ1j9PBlBVHRqTpoZWs3XKWab7a0NTeT_5MjxozlwioI1HxyiTJmiyMNamTBRFunaGN3aMMkU3tnADUfS-22rtiVqy8t6I67hgsWKkwHaM9Fc2sUI_XW_Hoh2lvc8mB8Sn0xgqMThcPOFxxRLut7O42l2itzHK58e2amKD_A-Be7G8ZWdeJFj51dnHus0=",
       "e"   : "AQAB",
       "exp" : 2147483647,
       "alg" : "RS256"
@@ -12,7 +12,7 @@
       "kty" : "RSA",
       "use" : "sig",
       "kid" : "key2",
-      "n"   : "1Xg99scnMiFwFBgzgVGv49K7G1+b0v/wh002OUH6s3N7FXrlzruFxNi0tQt9FgWayBdDw8zMRhVWPle8g95t1pyIPTxIxVveYhcb0YFk503y66peNMgUIaqCBHCzp4evESHFfoZUZXEcsIeMCmYnUjPL8y4T+ag0T/YDMFwdaKwhp7SV+FkFdL45kJ+q5uMVdUi3auOh/eNDe+ZAQ+giCOQVo6zxqSf5XdVO3ax1uetPrjauDqEoTPlhEh7ObMBSt0nZKPHWq36oHFjv8JzJH8auPrIa/WFklsU/zVfkH4ycG7JSoPiPL0a5bdE1ZiXI20uynTYbMSEy5KI3zYeqIhhymIdm9KzwjyZdeRuxqis0HYIV2rjQc7xCCgE+H/6khwfyTlDCD+j31O8JE2euKSAfKYNPqPh6HXsnos3Pttv8Xc/0xgtjb0Fycenbw81RQjz3D4hsp9tv2w40b8pBvmAoqb3GZ791yR8VlMzlPb0RPt+2/2Cl/t74nbm+X74zDrHiuRlhHokDzTDyiVX5scPYtraPyiVhS0b891qjhD5QZ/qz5w2ZVFXsTDhx4hhjoV4rP8oPpMpX5fsPZWRLgYYOsvQhck1hHUmqgz3SY2RzBgRrNt1HOYrA6zN3xUO/aHfdxkHjzBRtroRhMrEZ2ggImPyp8erI+7vbS342jl0=",
+      "n"   : "1Xg99scnMiFwFBgzgVGv49K7G1-b0v_wh002OUH6s3N7FXrlzruFxNi0tQt9FgWayBdDw8zMRhVWPle8g95t1pyIPTxIxVveYhcb0YFk503y66peNMgUIaqCBHCzp4evESHFfoZUZXEcsIeMCmYnUjPL8y4T-ag0T_YDMFwdaKwhp7SV-FkFdL45kJ-q5uMVdUi3auOh_eNDe-ZAQ-giCOQVo6zxqSf5XdVO3ax1uetPrjauDqEoTPlhEh7ObMBSt0nZKPHWq36oHFjv8JzJH8auPrIa_WFklsU_zVfkH4ycG7JSoPiPL0a5bdE1ZiXI20uynTYbMSEy5KI3zYeqIhhymIdm9KzwjyZdeRuxqis0HYIV2rjQc7xCCgE-H_6khwfyTlDCD-j31O8JE2euKSAfKYNPqPh6HXsnos3Pttv8Xc_0xgtjb0Fycenbw81RQjz3D4hsp9tv2w40b8pBvmAoqb3GZ791yR8VlMzlPb0RPt-2_2Cl_t74nbm-X74zDrHiuRlhHokDzTDyiVX5scPYtraPyiVhS0b891qjhD5QZ_qz5w2ZVFXsTDhx4hhjoV4rP8oPpMpX5fsPZWRLgYYOsvQhck1hHUmqgz3SY2RzBgRrNt1HOYrA6zN3xUO_aHfdxkHjzBRtroRhMrEZ2ggImPyp8erI-7vbS342jl0=",
       "e"   : "AQAB",
       "exp" : 2147483647,
       "alg" : "RS256"


### PR DESCRIPTION
This branch updates the modulus values advertised in the mock jwks file.  It seems that this value should be base64url encoded and our new library is more strict about this.

Testing: 
- disabled tests are enabled
- PHPunit tests reliably pass