### PR TITLE
testing/pool-candidate-workflow-issue TEST FIX

### DIFF
--- a/frontend/cypress/e2e/admin/pool-candidate.cy.js
+++ b/frontend/cypress/e2e/admin/pool-candidate.cy.js
@@ -28,15 +28,11 @@ describe("Pool Candidates", () => {
   it("should update pool candidate status", () => {
     cy.wait("@gqlgetPoolsQuery");
 
-    cy.findAllByRole("link", { name: /view candidates/i })
-      .eq(0)
-      .click();
-    cy.wait("@gqlGetPoolCandidatesPaginatedQuery");
+    cy.findByRole("combobox", { name: /page size/i }).select("Show 50");
 
-    cy.findAllByRole("button", { name: /availability/i })
-      .eq(0)
-      .click();
-    cy.wait("@gqlGetPoolCandidatesPaginatedQuery");
+    cy.findByRole("link", {
+      name: /view candidates for cmo digital careers/i,
+    }).click();
 
     cy.findAllByRole("link", { name: /view application/i })
       .eq(0)
@@ -65,15 +61,11 @@ describe("Pool Candidates", () => {
   it("should update pool candidate status with optional fields", () => {
     cy.wait("@gqlgetPoolsQuery");
 
-    cy.findAllByRole("link", { name: /view candidates/i })
-      .eq(0)
-      .click();
-    cy.wait("@gqlGetPoolCandidatesPaginatedQuery");
+    cy.findByRole("combobox", { name: /page size/i }).select("Show 50");
 
-    cy.findAllByRole("button", { name: /availability/i })
-      .eq(0)
-      .click();
-    cy.wait("@gqlGetPoolCandidatesPaginatedQuery");
+    cy.findByRole("link", {
+      name: /view candidates for cmo digital careers/i,
+    }).click();
 
     cy.findAllByRole("link", { name: /view application/i })
       .eq(0)
@@ -98,5 +90,4 @@ describe("Pool Candidates", () => {
 
     cy.expectToast(/pool candidate status updated successfully/i);
   });
-
 });


### PR DESCRIPTION
closes #5165 
resolves an issue with the e2e workflow failing
the workflow would fail sometimes on `pool-candidates.cy`, this was due to there sometimes not being a candidate for "view application" to work on

solution was to always select candidates for Digital Careers, given it has the most candidates seeded, it should almost always have someone to "view application" on
in the long run it is another test to revisit, but for now this should suffice
and make reviewing doable again!!!

testing:
re-run e2e a few times to see if it is all good