### PR TITLE
Bug - 5163 - Fix status field option labels

### DIFF
--- a/frontend/admin/src/js/components/user/GeneralInformationTab/ChangeStatusDialog.tsx
+++ b/frontend/admin/src/js/components/user/GeneralInformationTab/ChangeStatusDialog.tsx
@@ -10,6 +10,7 @@ import { getFullPoolAdvertisementTitle } from "@common/helpers/poolUtils";
 import { Select } from "@common/components/form";
 import { commonMessages, errorMessages } from "@common/messages";
 import { enumToOptions } from "@common/helpers/formUtils";
+import { getPoolCandidateStatus } from "@common/constants/localizedConstants";
 import {
   Applicant,
   PoolCandidate,
@@ -145,7 +146,12 @@ export const ChangeStatusDialog: React.FC<ChangeStatusDialogProps> = ({
                 rules={{
                   required: intl.formatMessage(errorMessages.required),
                 }}
-                options={enumToOptions(PoolCandidateStatus)}
+                options={enumToOptions(PoolCandidateStatus).map(
+                  ({ value }) => ({
+                    value,
+                    label: intl.formatMessage(getPoolCandidateStatus(value)),
+                  }),
+                )}
               />
             </div>
             <Dialog.Footer>


### PR DESCRIPTION
## 👋 Introduction

This PR fixes the `ChangeStatusDialog` status field labels to show correct values for i18n.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to /en/admin/users/:id
2. Click on **Change status** link
3. Verify **Pool status** field options are human readable
4. Navigate to /fr/admin/users/:id
5. Click on **Modifier le statut** link
6. Verify **Statut du bassin** field options are human readable and in French

## 📸 Screenshots
![Screen Shot 2022-12-16 at 10 28 52](https://user-images.githubusercontent.com/3046459/208132321-b92cf9c3-93f2-4ef3-adc9-036ea7a2095b.png)
![Screen Shot 2022-12-16 at 10 29 08](https://user-images.githubusercontent.com/3046459/208132324-63a25754-1106-43af-986e-c62f737d8998.png)

## 🤖 Robot Stuff

Resolves #5163.
