### PR TITLE
Change pool expired to closed

### DIFF
--- a/api/app/GraphQL/Mutations/ChangePoolClosingDate.php
+++ b/api/app/GraphQL/Mutations/ChangePoolClosingDate.php
@@ -4,7 +4,7 @@ namespace App\GraphQL\Mutations;
 
 use App\Models\Pool;
 
-final class ChangePoolExpiryDate
+final class ChangePoolClosingDate
 {
     /**
      * Extends the pool advertisements closing date.
@@ -14,7 +14,7 @@ final class ChangePoolExpiryDate
     public function __invoke($_, array $args)
     {
         $poolAdvertisement = Pool::find($args['id']);
-        $poolAdvertisement->update(['expiry_date' => $args['new_expiry_date']]);
+        $poolAdvertisement->update(['closing_date' => $args['new_closing_date']]);
         return $poolAdvertisement;
     }
 }

--- a/api/app/GraphQL/Mutations/ClosePoolAdvertisement.php
+++ b/api/app/GraphQL/Mutations/ClosePoolAdvertisement.php
@@ -8,14 +8,14 @@ use Illuminate\Support\Carbon;
 final class ClosePoolAdvertisement
 {
     /**
-     * Closes the pool advertisements by setting the expiry_date to now().
+     * Closes the pool advertisements by setting the closing_date to now().
      * @param  null  $_
      * @param  array{}  $args
      */
     public function __invoke($_, array $args)
     {
         $poolAdvertisement = Pool::find($args['id']);
-        $poolAdvertisement->update(['expiry_date' => Carbon::now()]);
+        $poolAdvertisement->update(['closing_date' => Carbon::now()]);
         return $poolAdvertisement;
     }
 }

--- a/api/app/GraphQL/Validators/Mutation/PublishPoolAdvertisementValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/PublishPoolAdvertisementValidator.php
@@ -25,8 +25,8 @@ final class PublishPoolAdvertisementValidator extends Validator
             'classifications.*.id' => ['required', 'uuid', 'exists:classifications,id'],
             'stream' => ['required', 'string'],
 
-            // Closing date (Note: Form should return unzoned datetime.)
-            'expiry_date' => ['required', /*'date_format:Y-m-d H:i:s',*/ 'after:' . $endOfDay], // TODO: Fix date_format validation
+            // Closing date
+            'closing_date' => ['required', /*'date_format:Y-m-d H:i:s',*/ 'after:' . $endOfDay],
 
             // Your Impact and Work tasks
             'your_impact.en' => ['required', 'string'],
@@ -55,7 +55,7 @@ final class PublishPoolAdvertisementValidator extends Validator
         return  [
             'required' => ':attribute required',
             'exists' => ':attribute does not exist.',
-            'expiry_date.after' => 'Expiry Date must be after today.',
+            'closing_date.after' => 'Closing date must be after today.',
             'advertisement_location.*.required_if' => 'AdvertisementLocationRequired',
             'advertisement_location.*.required_with' => 'You must enter both french and english fields for the advertisement_location',
             'in' => ':attribute does not contain a valid value.',

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -32,7 +32,7 @@ use Carbon\Carbon;
  * @property string $publishing_group
  * @property Illuminate\Support\Carbon $created_at
  * @property Illuminate\Support\Carbon $updated_at
- * @property Illuminate\Support\Carbon $expiry_date
+ * @property Illuminate\Support\Carbon $closing_date
  * @property Illuminate\Support\Carbon $published_at
  */
 
@@ -55,7 +55,7 @@ class Pool extends Model
         'key_tasks' => 'array',
         'advertisement_location' => 'array',
         'your_impact' => 'array',
-        'expiry_date' => 'datetime',
+        'closing_date' => 'datetime',
         'published_at' => 'datetime',
         'is_remote' => 'boolean'
     ];
@@ -67,7 +67,7 @@ class Pool extends Model
      */
     protected $fillable = [
         'is_remote',
-        'expiry_date',
+        'closing_date',
         'published_at',
         'name',
         'key_tasks',
@@ -118,13 +118,13 @@ class Pool extends Model
     {
         // given database is functioning in UTC, all backend should consistently enforce the same timezone
         $publishedDate = $this->published_at;
-        $expiryDate = $this->expiry_date;
+        $closedDate = $this->closing_date;
         $currentTime = date("Y-m-d H:i:s");
-        if ($expiryDate != null) {
-            $isExpired = $currentTime >= $expiryDate ? true : false;
+        if ($closedDate != null) {
+            $isClosed = $currentTime >= $closedDate ? true : false;
         }
         else {
-            $isExpired = false;
+            $isClosed = false;
         }
         if ($publishedDate != null) {
             $isPublished = $currentTime >= $publishedDate ? true : false;
@@ -135,10 +135,10 @@ class Pool extends Model
 
         if (!$isPublished) {
             return ApiEnums::POOL_ADVERTISEMENT_IS_DRAFT;
-        } elseif ($isPublished && !$isExpired) {
+        } elseif ($isPublished && !$isClosed) {
             return ApiEnums::POOL_ADVERTISEMENT_IS_PUBLISHED;
-        } elseif ($isPublished && $isExpired) {
-            return ApiEnums::POOL_ADVERTISEMENT_IS_EXPIRED;
+        } elseif ($isPublished && $isClosed) {
+            return ApiEnums::POOL_ADVERTISEMENT_IS_CLOSED;
         } else {
             return null;
         }

--- a/api/app/Policies/PoolPolicy.php
+++ b/api/app/Policies/PoolPolicy.php
@@ -101,13 +101,13 @@ class PoolPolicy
     }
 
     /**
-     * Determine whether the user can change the pool's expiry date.
+     * Determine whether the user can change the pool's closing date.
      *
      * @param  \App\Models\User  $user
      * @param  \App\Models\Pool  $pool
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function changePoolExpiryDate(User $user)
+    public function changePoolClosingDate(User $user)
     {
         return $user->isAdmin();
     }

--- a/api/app/Rules/PoolPublished.php
+++ b/api/app/Rules/PoolPublished.php
@@ -31,7 +31,7 @@ class PoolPublished implements Rule
 
         return !in_array($pool->advertisement_status, [
             ApiEnums::POOL_ADVERTISEMENT_IS_DRAFT,
-            ApiEnums::POOL_ADVERTISEMENT_IS_EXPIRED
+            ApiEnums::POOL_ADVERTISEMENT_IS_CLOSED
         ]);
     }
 

--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -39,7 +39,7 @@ class PoolFactory extends Factory
             'your_impact' => ['en' => $this->faker->paragraph() . ' EN', 'fr' => $this->faker->paragraph() . ' FR'],
             'pool_status' => $this->faker->randomElement(ApiEnums::poolStatuses()),
             'published_at' => $this->faker->boolean() ? $this->faker->dateTimeBetween('-30 days', '-1 days') : null,
-            'expiry_date' => $this->faker->dateTimeBetween('-1 months', '1 months', 'America/Vancouver'),
+            'closing_date' => $this->faker->dateTimeBetween('-1 months', '1 months'),
             'security_clearance' => $this->faker->randomElement(ApiEnums::poolAdvertisementSecurity()),
             'advertisement_language' => $this->faker->randomElement(ApiEnums::poolAdvertisementLanguages()),
             'advertisement_location' => !$isRemote ? ['en' => $this->faker->country(), 'fr' => $this->faker->country()] : null,

--- a/api/database/helpers/ApiEnums.php
+++ b/api/database/helpers/ApiEnums.php
@@ -247,13 +247,13 @@ class ApiEnums
      */
     const POOL_ADVERTISEMENT_IS_DRAFT = 'DRAFT';
     const POOL_ADVERTISEMENT_IS_PUBLISHED = 'PUBLISHED';
-    const POOL_ADVERTISEMENT_IS_EXPIRED = 'EXPIRED';
+    const POOL_ADVERTISEMENT_IS_CLOSED = 'CLOSED';
     public static function poolAdvertisementStatuses(): array
     {
         return [
             self::POOL_ADVERTISEMENT_IS_DRAFT,
             self::POOL_ADVERTISEMENT_IS_PUBLISHED,
-            self::POOL_ADVERTISEMENT_IS_EXPIRED,
+            self::POOL_ADVERTISEMENT_IS_CLOSED,
         ];
     }
 

--- a/api/database/migrations/2022_12_16_163656_rename_pool_expiry_closing.php
+++ b/api/database/migrations/2022_12_16_163656_rename_pool_expiry_closing.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pools', function (Blueprint $table) {
+            $table->renameColumn('expiry_date', 'closing_date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('pools', function (Blueprint $table) {
+            $table->renameColumn('closing_date', 'expiry_date');
+        });
+    }
+};

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -225,7 +225,7 @@ class DatabaseSeeder extends Seeder
                     Pool::factory()->afterCreating(function ($pool) use ($classification, $faker) {
                         $pool->classifications()->sync([$classification->id]);
                     })->create([
-                        'expiry_date' => $date,
+                        'closing_date' => $date,
                         'publishing_group' => $publishingGroup,
                         'published_at' => $faker->dateTimeBetween('-1 year', 'now')
                     ]);

--- a/api/database/seeders/PoolSeeder.php
+++ b/api/database/seeders/PoolSeeder.php
@@ -30,7 +30,7 @@ class PoolSeeder extends Seeder
                     'fr' => 'Profitez d\'une carrière numérique significative à la fonction publique du Canada ! Joignez-vous à nous pour vous épanouir dans votre carrière numérique avec des emplois et des possibilités d\'avancement professionnel dans un large éventail de spécialisations, partout au Canada et à l\'étranger. Vous aurez accès à un apprentissage continu grâce à l\'orientation, à la formation en cours d\'emploi, au coaching, au mentorat, à des occasions de mobilité interministérielles et à bien plus ! Profitez d\'une culture de travail collaborative et horizontale facilitée par les outils de collaboration numérique du gouvernement.'
                 ],
                 'published_at' => config('constants.past_date'),
-                'expiry_date' => config('constants.far_future_date'),
+                'closing_date' => config('constants.far_future_date'),
                 'pool_status' => ApiEnums::POOL_STATUS_TAKING_APPLICATIONS,
                 'publishing_group' => ApiEnums::PUBLISHING_GROUP_IT_JOBS,
             ],

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -329,7 +329,7 @@ type PoolAdvertisement {
   id: ID!
   key: KeyString
   owner: UserPublicProfile @belongsTo(relation: "user")
-  expiryDate: DateTime @rename(attribute: "expiry_date")
+  closingDate: DateTime @rename(attribute: "closing_date")
   publishedAt: DateTime @rename(attribute: "published_at")
   name: LocalizedString
   description: LocalizedString
@@ -354,7 +354,7 @@ type PoolAdvertisement {
 enum AdvertisementStatus {
   DRAFT
   PUBLISHED
-  EXPIRED
+  CLOSED
   ARCHIVED
 }
 
@@ -1477,11 +1477,11 @@ input UpdatePoolAdvertisementInput {
   stream: PoolStream
   processNumber: String @rename(attribute: "process_number")
   # Closing date
-  expiryDate: DateTime
-    @rename(attribute: "expiry_date")
+  closingDate: DateTime
+    @rename(attribute: "closing_date")
     @rules(
       apply: ["after:today"]
-      messages: [{ rule: "after", message: "UpdatePoolExpiryDate" }]
+      messages: [{ rule: "after", message: "UpdatePoolClosingDate" }]
     )
   # Your impact
   yourImpact: LocalizedStringInput @rename(attribute: "your_impact")
@@ -1684,17 +1684,17 @@ type Mutation {
   publishPoolAdvertisement(id: ID!): PoolAdvertisement
     @guard
     @can(ability: "publish", find: "id", model: "Pool")
-  changePoolExpiryDate(
+  changePoolClosingDate(
     id: ID!
-    newExpiryDate: DateTime!
-      @rename(attribute: "new_expiry_date")
+    newClosingDate: DateTime!
+      @rename(attribute: "new_closing_date")
       @rules(
         apply: ["after:today"]
-        messages: [{ rule: "after", message: "UpdatePoolExpiryDate" }]
+        messages: [{ rule: "after", message: "UpdatePoolClosingDate" }]
       )
   ): PoolAdvertisement
     @guard
-    @can(ability: "changePoolExpiryDate", find: "id", model: "Pool")
+    @can(ability: "changePoolClosingDate", find: "id", model: "Pool")
   closePoolAdvertisement(id: ID!): PoolAdvertisement
     @guard
     @can(ability: "closePoolAdvertisement", find: "id", model: "Pool")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1,7 +1,7 @@
 enum AdvertisementStatus {
   DRAFT
   PUBLISHED
-  EXPIRED
+  CLOSED
   ARCHIVED
 }
 
@@ -626,7 +626,7 @@ type Mutation {
   createPoolAdvertisement(userId: ID!, poolAdvertisement: CreatePoolAdvertisementInput!): PoolAdvertisement
   updatePoolAdvertisement(id: ID!, poolAdvertisement: UpdatePoolAdvertisementInput!): PoolAdvertisement
   publishPoolAdvertisement(id: ID!): PoolAdvertisement
-  changePoolExpiryDate(id: ID!, newExpiryDate: DateTime!): PoolAdvertisement
+  changePoolClosingDate(id: ID!, newClosingDate: DateTime!): PoolAdvertisement
   closePoolAdvertisement(id: ID!): PoolAdvertisement
   deletePoolAdvertisement(id: ID!): PoolAdvertisement
   archiveApplication(id: ID!): PoolCandidate
@@ -792,7 +792,7 @@ type PoolAdvertisement {
   id: ID!
   key: KeyString
   owner: UserPublicProfile
-  expiryDate: DateTime
+  closingDate: DateTime
   publishedAt: DateTime
   name: LocalizedString
   description: LocalizedString
@@ -1256,7 +1256,7 @@ input UpdatePoolAdvertisementInput {
   classifications: ClassificationBelongsToMany
   stream: PoolStream
   processNumber: String
-  expiryDate: DateTime
+  closingDate: DateTime
   yourImpact: LocalizedStringInput
   keyTasks: LocalizedStringInput
   essentialSkills: SkillBelongsToMany

--- a/api/tests/Feature/PoolApplicationTest.php
+++ b/api/tests/Feature/PoolApplicationTest.php
@@ -42,7 +42,7 @@ class PoolApplicationTest extends TestCase
         Pool::factory()->create([
             'id' => 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12',
             'published_at' => config('constants.past_date'),
-            'expiry_date' => config('constants.far_future_date'),
+            'closing_date' => config('constants.far_future_date'),
         ]);
 
         // Assert creating a pool application succeeds
@@ -127,7 +127,7 @@ class PoolApplicationTest extends TestCase
         Pool::factory()->create([
             'id' => '3ecf840d-b0ed-4207-8fc4-f45c4a865eaf',
             'published_at' => null,
-            'expiry_date' => config('constants.far_future_date'),
+            'closing_date' => config('constants.far_future_date'),
         ]);
 
         $this->graphQL(
@@ -167,7 +167,7 @@ class PoolApplicationTest extends TestCase
         Pool::factory()->create([
             'id' => 'f755f7da-c490-4fe1-a1f0-a6c233796442',
             'published_at' => null,
-            'expiry_date' => config('constants.far_past_date'),
+            'closing_date' => config('constants.far_past_date'),
         ]);
 
         $this->graphQL(

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -32,22 +32,22 @@ class PoolTest extends TestCase
     $pool1 = Pool::factory()->create([
         'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
         'published_at' => config('constants.past_date'),
-        'expiry_date' => config('constants.far_future_date'),
+        'closing_date' => config('constants.far_future_date'),
     ]);
     $pool2 = Pool::factory()->create([
         'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12',
         'published_at' => config('constants.past_date'),
-        'expiry_date' => config('constants.past_date'),
+        'closing_date' => config('constants.past_date'),
     ]);
     $pool3 = Pool::factory()->create([
         'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13',
         'published_at' => null,
-        'expiry_date' => config('constants.far_future_date'),
+        'closing_date' => config('constants.far_future_date'),
     ]);
     $pool4 = Pool::factory()->create([
         'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14',
         'published_at' => null,
-        'expiry_date' => config('constants.past_date'),
+        'closing_date' => config('constants.past_date'),
     ]);
 
     // Assert query with pool 1 will return accessor as published
@@ -65,7 +65,7 @@ class PoolTest extends TestCase
         ]
     ]);
 
-    // Assert query with pool 2 will return accessor as expired
+    // Assert query with pool 2 will return accessor as closed
     $this->graphQL(/** @lang Graphql */ '
         query poolAdvertisement {
             poolAdvertisement(id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12") {
@@ -75,7 +75,7 @@ class PoolTest extends TestCase
     ')->assertJson([
          "data" => [
             "poolAdvertisement" => [
-                "advertisementStatus" => ApiEnums::POOL_ADVERTISEMENT_IS_EXPIRED,
+                "advertisementStatus" => ApiEnums::POOL_ADVERTISEMENT_IS_CLOSED,
             ]
         ]
     ]);
@@ -120,12 +120,12 @@ class PoolTest extends TestCase
     $pool1 = Pool::factory()->create([
         'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
         'published_at' => config('constants.past_date'),
-        'expiry_date' => $expireInHour,
+        'closing_date' => $expireInHour,
     ]);
     $pool2 = Pool::factory()->create([
         'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12',
         'published_at' => config('constants.past_date'),
-        'expiry_date' => $expiredLastHour,
+        'closing_date' => $expiredLastHour,
     ]);
 
     // Assert query with pool 1 will still be published
@@ -143,7 +143,7 @@ class PoolTest extends TestCase
         ]
     ]);
 
-    // Assert query with pool 2 will return as expired
+    // Assert query with pool 2 will return as closed
     $this->graphQL(/** @lang Graphql */ '
         query poolAdvertisement {
             poolAdvertisement(id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12") {
@@ -153,7 +153,7 @@ class PoolTest extends TestCase
     ')->assertJson([
          "data" => [
             "poolAdvertisement" => [
-               "advertisementStatus" => ApiEnums::POOL_ADVERTISEMENT_IS_EXPIRED,
+               "advertisementStatus" => ApiEnums::POOL_ADVERTISEMENT_IS_CLOSED,
             ]
         ]
     ]);

--- a/frontend/admin/src/js/components/pool/EditPool/CloseDialog.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/CloseDialog.tsx
@@ -8,12 +8,12 @@ import { Button } from "@common/components";
 import { FormProvider, useForm } from "react-hook-form";
 
 type CloseDialogProps = {
-  expiryDate: PoolAdvertisement["expiryDate"];
+  closingDate: PoolAdvertisement["closingDate"];
   onClose: () => void;
 };
 
 const CloseDialog = ({
-  expiryDate,
+  closingDate,
   onClose,
 }: CloseDialogProps): JSX.Element => {
   const intl = useIntl();
@@ -99,9 +99,9 @@ const CloseDialog = ({
               data-h2-padding="base(x.25)"
               data-h2-radius="base(s)"
             >
-              {expiryDate
+              {closingDate
                 ? formatDate({
-                    date: parseDateTimeUtc(expiryDate),
+                    date: parseDateTimeUtc(closingDate),
                     formatString: "PPP",
                     intl,
                     timeZone: "Canada/Pacific",

--- a/frontend/admin/src/js/components/pool/EditPool/ClosingDateSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/ClosingDateSection.tsx
@@ -17,12 +17,12 @@ import { SectionMetadata, Spacer } from "./EditPool";
 import { useEditPoolContext } from "./EditPoolContext";
 
 type FormValues = {
-  endDate?: PoolAdvertisement["expiryDate"];
+  endDate?: PoolAdvertisement["closingDate"];
 };
 
 export type ClosingDateSubmitData = Pick<
   UpdatePoolAdvertisementInput,
-  "expiryDate"
+  "closingDate"
 >;
 interface ClosingDateSectionProps {
   poolAdvertisement: PoolAdvertisement;
@@ -39,14 +39,14 @@ export const ClosingDateSection = ({
   const { isSubmitting } = useEditPoolContext();
 
   const dataToFormValues = (initialData: PoolAdvertisement): FormValues => {
-    const expiryDateInPacific = initialData.expiryDate
+    const closingDateInPacific = initialData.closingDate
       ? convertDateTimeToDate(
-          convertDateTimeZone(initialData.expiryDate, "UTC", "Canada/Pacific"),
+          convertDateTimeZone(initialData.closingDate, "UTC", "Canada/Pacific"),
         )
       : null;
 
     return {
-      endDate: expiryDateInPacific,
+      endDate: closingDateInPacific,
     };
   };
 
@@ -61,7 +61,7 @@ export const ClosingDateSection = ({
   }, [suppliedValues, reset]);
 
   const handleSave = (formValues: FormValues) => {
-    const expiryDateInUtc = formValues.endDate
+    const closingDateInUtc = formValues.endDate
       ? convertDateTimeZone(
           `${formValues.endDate} 23:59:59`,
           "Canada/Pacific",
@@ -70,7 +70,7 @@ export const ClosingDateSection = ({
       : null;
 
     onSave({
-      expiryDate: expiryDateInUtc,
+      closingDate: closingDateInUtc,
     });
     methods.reset(formValues, {
       keepDirty: false,

--- a/frontend/admin/src/js/components/pool/EditPool/EditPool.stories.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/EditPool.stories.tsx
@@ -50,7 +50,7 @@ PublishedAdvertisement.args = {
     ...poolAdvertisement,
     publishedAt: FAR_PAST_DATE,
     advertisementStatus: AdvertisementStatus.Published,
-    expiryDate: FAR_FUTURE_DATE,
+    closingDate: FAR_FUTURE_DATE,
   },
 };
 
@@ -59,7 +59,7 @@ ExpiredAdvertisement.args = {
   poolAdvertisement: {
     ...poolAdvertisement,
     publishedAt: FAR_PAST_DATE,
-    advertisementStatus: AdvertisementStatus.Expired,
-    expiryDate: FAR_PAST_DATE,
+    advertisementStatus: AdvertisementStatus.Closed,
+    closingDate: FAR_PAST_DATE,
   },
 };

--- a/frontend/admin/src/js/components/pool/EditPool/ExtendDialog.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/ExtendDialog.tsx
@@ -11,18 +11,21 @@ import { convertDateTimeZone } from "@common/helpers/dateUtils";
 import { type UpdatePoolAdvertisementInput } from "../../../api/generated";
 
 type FormValues = {
-  endDate?: PoolAdvertisement["expiryDate"];
+  endDate?: PoolAdvertisement["closingDate"];
 };
 
-export type ExtendSubmitData = Pick<UpdatePoolAdvertisementInput, "expiryDate">;
+export type ExtendSubmitData = Pick<
+  UpdatePoolAdvertisementInput,
+  "closingDate"
+>;
 
 type ExtendDialogProps = {
-  expiryDate: PoolAdvertisement["expiryDate"];
+  closingDate: PoolAdvertisement["closingDate"];
   onExtend: (submitData: ExtendSubmitData) => Promise<void>;
 };
 
 const ExtendDialog = ({
-  expiryDate,
+  closingDate,
   onExtend,
 }: ExtendDialogProps): JSX.Element => {
   const intl = useIntl();
@@ -30,7 +33,7 @@ const ExtendDialog = ({
 
   const handleExtend = useCallback(
     async (formValues: FormValues) => {
-      const expiryDateInUtc = formValues.endDate
+      const closingDateInUtc = formValues.endDate
         ? convertDateTimeZone(
             `${formValues.endDate} 23:59:59`,
             "Canada/Pacific",
@@ -39,7 +42,7 @@ const ExtendDialog = ({
         : null;
 
       await onExtend({
-        expiryDate: expiryDateInUtc,
+        closingDate: closingDateInUtc,
       }).then(() => setOpen(false));
     },
     [onExtend],
@@ -47,8 +50,8 @@ const ExtendDialog = ({
 
   const methods = useForm<FormValues>({
     defaultValues: {
-      endDate: expiryDate
-        ? new Date(expiryDate).toISOString().split("T")[0]
+      endDate: closingDate
+        ? new Date(closingDate).toISOString().split("T")[0]
         : "",
     },
   });

--- a/frontend/admin/src/js/components/pool/EditPool/PublishDialog.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/PublishDialog.tsx
@@ -6,17 +6,17 @@ import { InputWrapper } from "@common/components/inputPartials";
 import { PoolAdvertisement } from "@common/api/generated";
 import {
   parseDateTimeUtc,
-  relativeExpiryDate,
+  relativeClosingDate,
 } from "@common/helpers/dateUtils";
 import { FormProvider, useForm } from "react-hook-form";
 
 type PublishDialogProps = {
-  expiryDate: PoolAdvertisement["expiryDate"];
+  closingDate: PoolAdvertisement["closingDate"];
   onPublish: () => void;
 };
 
 const PublishDialog = ({
-  expiryDate,
+  closingDate,
   onPublish,
 }: PublishDialogProps): JSX.Element => {
   const intl = useIntl();
@@ -60,14 +60,14 @@ const PublishDialog = ({
 
   let closingStringLocal;
   let closingStringPacific;
-  if (expiryDate) {
-    const expiryDateObject = parseDateTimeUtc(expiryDate);
-    closingStringLocal = relativeExpiryDate({
-      expiryDate: expiryDateObject,
+  if (closingDate) {
+    const closingDateObject = parseDateTimeUtc(closingDate);
+    closingStringLocal = relativeClosingDate({
+      closingDate: closingDateObject,
       intl,
     });
-    closingStringPacific = relativeExpiryDate({
-      expiryDate: expiryDateObject,
+    closingStringPacific = relativeClosingDate({
+      closingDate: closingDateObject,
       intl,
       timeZone: "Canada/Pacific",
     });

--- a/frontend/admin/src/js/components/pool/EditPool/StatusSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/StatusSection.tsx
@@ -96,7 +96,7 @@ export const StatusSection = ({
               </div>
             </div>
             <PublishDialog
-              expiryDate={poolAdvertisement.expiryDate}
+              closingDate={poolAdvertisement.closingDate}
               onPublish={onPublish}
             />
             <DeleteDialog onDelete={onDelete} />
@@ -147,19 +147,19 @@ export const StatusSection = ({
               </div>
             </div>
             <CloseDialog
-              expiryDate={poolAdvertisement.expiryDate}
+              closingDate={poolAdvertisement.closingDate}
               onClose={onClose}
             />
             <ExtendDialog
-              expiryDate={poolAdvertisement.expiryDate}
+              closingDate={poolAdvertisement.closingDate}
               onExtend={onExtend}
             />
           </>
         ) : undefined}
 
-        {/* Expired status */}
+        {/* Closed status */}
         {poolAdvertisement.advertisementStatus ===
-        AdvertisementStatus.Expired ? (
+        AdvertisementStatus.Closed ? (
           <>
             <div
               data-h2-background-color="base(dt-gray.light)"
@@ -182,9 +182,9 @@ export const StatusSection = ({
                 <span>
                   {intl.formatMessage(
                     {
-                      defaultMessage: "<heavyPrimary>Expired</heavyPrimary>",
-                      id: "uBA5mM",
-                      description: "Status name of a pool in EXPIRED status",
+                      defaultMessage: "<heavyPrimary>Closed</heavyPrimary>",
+                      id: "VCl+IZ",
+                      description: "Status name of a pool in CLOSED status",
                     },
                     { heavyPrimary },
                   )}
@@ -193,15 +193,15 @@ export const StatusSection = ({
                   {intl.formatMessage({
                     defaultMessage:
                       "This pool is being advertised but no longer accepting applications.",
-                    id: "dG1EJO",
+                    id: "3AmNSJ",
                     description:
-                      "Status description of a pool in EXPIRED status",
+                      "Status description of a pool in CLOSED status",
                   })}
                 </span>
               </div>
             </div>
             <ExtendDialog
-              expiryDate={poolAdvertisement.expiryDate}
+              closingDate={poolAdvertisement.closingDate}
               onExtend={onExtend}
             />
             <ArchiveDialog onArchive={onArchive} />

--- a/frontend/admin/src/js/components/pool/EditPool/editPoolOperations.graphql
+++ b/frontend/admin/src/js/components/pool/EditPool/editPoolOperations.graphql
@@ -7,7 +7,7 @@ query getEditPoolData($poolId: UUID!) {
       en
       fr
     }
-    expiryDate
+    closingDate
     advertisementStatus
     advertisementLanguage
     securityClearance
@@ -149,7 +149,7 @@ mutation publishPoolAdvertisement($id: ID!) {
 mutation closePoolAdvertisement($id: ID!) {
   closePoolAdvertisement(id: $id) {
     id
-    expiryDate
+    closingDate
   }
 }
 

--- a/frontend/admin/src/js/components/pool/ViewPool.tsx
+++ b/frontend/admin/src/js/components/pool/ViewPool.tsx
@@ -30,7 +30,7 @@ import {
 } from "@common/constants/localizedConstants";
 import {
   parseDateTimeUtc,
-  relativeExpiryDate,
+  relativeClosingDate,
 } from "@common/helpers/dateUtils";
 import { getFullPoolAdvertisementTitle } from "@common/helpers/poolUtils";
 import SEO from "@common/components/SEO/SEO";
@@ -146,14 +146,14 @@ export const ViewPoolPage = ({ pool }: ViewPoolPageProps): JSX.Element => {
 
   let closingStringLocal;
   let closingStringPacific;
-  if (pool.expiryDate) {
-    const expiryDateObject = parseDateTimeUtc(pool.expiryDate);
-    closingStringLocal = relativeExpiryDate({
-      expiryDate: expiryDateObject,
+  if (pool.closingDate) {
+    const closingDateObject = parseDateTimeUtc(pool.closingDate);
+    closingStringLocal = relativeClosingDate({
+      closingDate: closingDateObject,
       intl,
     });
-    closingStringPacific = relativeExpiryDate({
-      expiryDate: expiryDateObject,
+    closingStringPacific = relativeClosingDate({
+      closingDate: closingDateObject,
       intl,
       timeZone: "Canada/Pacific",
     });

--- a/frontend/admin/src/js/components/pool/poolOperations.graphql
+++ b/frontend/admin/src/js/components/pool/poolOperations.graphql
@@ -62,7 +62,7 @@ query getPoolAdvertisement($id: UUID!) {
       en
       fr
     }
-    expiryDate
+    closingDate
     advertisementStatus
     advertisementLanguage
     securityClearance

--- a/frontend/admin/src/js/components/user/GeneralInformationTab/AddToPoolDialog.tsx
+++ b/frontend/admin/src/js/components/user/GeneralInformationTab/AddToPoolDialog.tsx
@@ -154,7 +154,7 @@ export const AddToPoolDialog: React.FC<AddToPoolDialogProps> = ({
                     (pool) =>
                       pool.advertisementStatus ===
                         AdvertisementStatus.Published ||
-                      pool.advertisementStatus === AdvertisementStatus.Expired,
+                      pool.advertisementStatus === AdvertisementStatus.Closed,
                   )
                   .map((pool) => {
                     return {

--- a/frontend/common/src/constants/localizedConstants.tsx
+++ b/frontend/common/src/constants/localizedConstants.tsx
@@ -1426,10 +1426,10 @@ export const advertisementStatus = defineMessages({
     id: "RQGy+0",
     description: "Published pool advertisement status",
   },
-  [AdvertisementStatus.Expired]: {
-    defaultMessage: "Expired",
-    id: "gfzfP6",
-    description: "Expired pool advertisement status",
+  [AdvertisementStatus.Closed]: {
+    defaultMessage: "Closed",
+    id: "/UBSoB",
+    description: "Closed pool advertisement status",
   },
 });
 

--- a/frontend/common/src/fakeData/fakePoolAdvertisements.ts
+++ b/frontend/common/src/fakeData/fakePoolAdvertisements.ts
@@ -38,7 +38,7 @@ const generatePoolAdvertisement = (
         max: 10,
       }),
     ),
-    expiryDate: faker.date
+    closingDate: faker.date
       .between(FAR_PAST_DATE, FAR_FUTURE_DATE)
       .toISOString(),
     id: faker.datatype.uuid(),

--- a/frontend/common/src/helpers/dateUtils.test.ts
+++ b/frontend/common/src/helpers/dateUtils.test.ts
@@ -8,10 +8,10 @@ import {
   convertDateTimeToDate,
   convertDateTimeZone,
   parseDateTimeUtc,
-  relativeExpiryDate,
+  relativeClosingDate,
 } from "./dateUtils";
 
-describe("relativeExpiryDate tests", () => {
+describe("relativeClosingDate tests", () => {
   const intlCache = createIntlCache();
   const intl = createIntl(
     {
@@ -19,11 +19,11 @@ describe("relativeExpiryDate tests", () => {
     },
     intlCache,
   );
-  const f = relativeExpiryDate;
+  const f = relativeClosingDate;
 
   test("expired", () => {
     const s = f({
-      expiryDate: new Date("2021-12-31"),
+      closingDate: new Date("2021-12-31"),
       now: new Date("2022-01-01"),
       intl,
     });
@@ -32,7 +32,7 @@ describe("relativeExpiryDate tests", () => {
 
   test("today", () => {
     const s = f({
-      expiryDate: new Date("2021-12-31 23:59:59"),
+      closingDate: new Date("2021-12-31 23:59:59"),
       now: new Date("2021-12-31 23:00:00"),
       intl,
     });
@@ -42,7 +42,7 @@ describe("relativeExpiryDate tests", () => {
   // tomorrow might not be 24 hours away
   test("tomorrow", () => {
     const s = f({
-      expiryDate: new Date("2021-12-31 00:59:59"),
+      closingDate: new Date("2021-12-31 00:59:59"),
       now: new Date("2021-12-30 23:59:59"),
       intl,
     });
@@ -51,7 +51,7 @@ describe("relativeExpiryDate tests", () => {
 
   test("future days", () => {
     const s = f({
-      expiryDate: new Date("2021-12-31 00:59:59"),
+      closingDate: new Date("2021-12-31 00:59:59"),
       now: new Date("2021-12-01"),
       intl,
     });
@@ -61,7 +61,9 @@ describe("relativeExpiryDate tests", () => {
   // https://dateful.com/convert/pacific-time-pt?t=1159pm&d=2021-12-31&tz2=Eastern-Time-ET
   test("today in a different time zone", () => {
     const s = f({
-      expiryDate: toDate("2021-12-31 23:59:59", { timeZone: "Canada/Pacific" }),
+      closingDate: toDate("2021-12-31 23:59:59", {
+        timeZone: "Canada/Pacific",
+      }),
       now: toDate("2022-01-01 1:00:00", { timeZone: "Canada/Eastern" }),
       intl,
       timeZone: "Canada/Pacific",
@@ -72,7 +74,9 @@ describe("relativeExpiryDate tests", () => {
   // https://dateful.com/convert/pacific-time-pt?t=1159pm&d=2021-12-31&tz2=Eastern-Time-ET
   test("tomorrow in a different time zone", () => {
     const s = f({
-      expiryDate: toDate("2021-12-31 23:59:59", { timeZone: "Canada/Pacific" }),
+      closingDate: toDate("2021-12-31 23:59:59", {
+        timeZone: "Canada/Pacific",
+      }),
       now: toDate("2021-12-31 00:00:00", { timeZone: "Canada/Eastern" }),
       intl,
       timeZone: "Canada/Pacific",
@@ -83,7 +87,9 @@ describe("relativeExpiryDate tests", () => {
   // https://dateful.com/convert/pacific-time-pt?t=1159pm&d=2021-12-31&tz2=Eastern-Time-ET
   test("future days in a different time zone", () => {
     const s = f({
-      expiryDate: toDate("2021-12-31 23:59:59", { timeZone: "Canada/Pacific" }),
+      closingDate: toDate("2021-12-31 23:59:59", {
+        timeZone: "Canada/Pacific",
+      }),
       now: toDate("2021-12-01", { timeZone: "Canada/Eastern" }),
       intl,
       timeZone: "Canada/Pacific",

--- a/frontend/common/src/helpers/dateUtils.ts
+++ b/frontend/common/src/helpers/dateUtils.ts
@@ -40,9 +40,9 @@ export const formatDate = ({
   return result;
 };
 
-// parameters for the relativeExpiryDate function
-export type relativeExpiryDateOptions = {
-  expiryDate: Date;
+// parameters for the relativeClosingDate function
+export type relativeClosingDateOptions = {
+  closingDate: Date;
   now?: Date;
   intl: IntlShape;
   timeZone?: string;
@@ -52,12 +52,12 @@ export type relativeExpiryDateOptions = {
  * Calculate a friendly date/time string, optionally in a different time zone
  * @returns string of formatted date
  */
-export const relativeExpiryDate = ({
-  expiryDate,
+export const relativeClosingDate = ({
+  closingDate,
   now = new Date(),
   intl,
   timeZone,
-}: relativeExpiryDateOptions): string => {
+}: relativeClosingDateOptions): string => {
   // A date formatting function that can use time zones optionally
   const myFormatFunc = timeZone
     ? (date: Date, formatPattern: string, options?: { locale?: Locale }) =>
@@ -67,24 +67,24 @@ export const relativeExpiryDate = ({
 
   const strLocale = getLocale(intl);
   const locale = strLocale === "fr" ? fr : undefined;
-  const time = myFormatFunc(expiryDate, `pp`, {
+  const time = myFormatFunc(closingDate, `pp`, {
     locale,
   });
-  const dateTime = myFormatFunc(expiryDate, `PPP p`, {
+  const dateTime = myFormatFunc(closingDate, `PPP p`, {
     locale,
   });
 
-  if (now > expiryDate) {
+  if (now > closingDate) {
     return intl.formatMessage({
       defaultMessage: "The deadline for submission has passed.",
-      id: "PzyMeM",
-      description: "Message displayed when a date has expired.",
+      id: "8WC+Ty",
+      description: "Message displayed when a closing date has passed.",
     });
   }
 
   if (
     myFormatFunc(now, DATE_FORMAT_STRING) ===
-    myFormatFunc(expiryDate, DATE_FORMAT_STRING)
+    myFormatFunc(closingDate, DATE_FORMAT_STRING)
   ) {
     return intl.formatMessage(
       {
@@ -100,7 +100,7 @@ export const relativeExpiryDate = ({
 
   if (
     myFormatFunc(add(now, { days: 1 }), DATE_FORMAT_STRING) ===
-    myFormatFunc(expiryDate, DATE_FORMAT_STRING)
+    myFormatFunc(closingDate, DATE_FORMAT_STRING)
   ) {
     return intl.formatMessage(
       {

--- a/frontend/common/src/messages/apiMessages.ts
+++ b/frontend/common/src/messages/apiMessages.ts
@@ -67,18 +67,19 @@ export const messages: { [key: string]: MessageDescriptor } = defineMessages({
     description: "Error message that the application cannot be deleted.",
   },
 
-  "validator:expiry_date.after": {
-    defaultMessage: "Expiry Date must be after today.",
-    id: "sfr5Pa",
+  "validator:closing_date.after": {
+    defaultMessage: "Closing date must be after today.",
+    id: "csLjMi",
     description:
-      "Error message that the given skill expiry date must be after today.",
+      "Error message that the given skill closing date must be after today.",
   },
 
   // pool updating
-  UpdatePoolExpiryDate: {
-    defaultMessage: "The pool must have an expiry date after today.",
-    id: "gU/2O6",
-    description: "Error message that pool expiry isn't in the future.",
+  UpdatePoolClosingDate: {
+    defaultMessage: "The pool must have a closing date after today.",
+    id: "qmEyxS",
+    description:
+      "Error message that the pool closing date isn't in the future.",
   },
 
   // pool publishing validation

--- a/frontend/cypress/e2e/talentsearch/submit-application-workflows.cy.js
+++ b/frontend/cypress/e2e/talentsearch/submit-application-workflows.cy.js
@@ -105,7 +105,7 @@ describe("Submit Application Workflow Tests", () => {
                     fr: "Cypress Test Pool FR",
                   },
                   stream: PoolStream.BusinessAdvisoryServices,
-                  expiryDate: `${FAR_FUTURE_DATE} 00:00:00`,
+                  closingDate: `${FAR_FUTURE_DATE} 00:00:00`,
                   yourImpact: { en: "test impact EN", fr: "test impact FR" },
                   keyTasks: { en: "key task EN", fr: "key task FR" },
                   essentialSkills: {

--- a/frontend/cypress/support/poolAdvertisementHelpers.js
+++ b/frontend/cypress/support/poolAdvertisementHelpers.js
@@ -24,7 +24,7 @@ export function createAndPublishPoolAdvertisement({
             fr: `Cypress Test Pool FR ${Date.now().valueOf()}`,
           },
           stream: PoolStream.BusinessAdvisoryServices,
-          expiryDate: `${FAR_FUTURE_DATE} 00:00:00`,
+          closingDate: `${FAR_FUTURE_DATE} 00:00:00`,
           yourImpact: {
             en: "test impact EN",
             fr: "test impact FR",

--- a/frontend/talentsearch/src/js/api/poolAdvertisementOperations.graphql
+++ b/frontend/talentsearch/src/js/api/poolAdvertisementOperations.graphql
@@ -25,15 +25,15 @@ mutation publishPoolAdvertisement($id: ID!) {
   }
 }
 
-mutation changePoolExpiryDate($id: ID!, $newExpiryDate: DateTime!) {
-  changePoolExpiryDate(id: $id, newExpiryDate: $newExpiryDate) {
-    expiryDate
+mutation changePoolClosingDate($id: ID!, $newClosingDate: DateTime!) {
+  changePoolClosingDate(id: $id, newClosingDate: $newClosingDate) {
+    closingDate
   }
 }
 
 mutation closePoolAdvertisement($id: ID!) {
   closePoolAdvertisement(id: $id) {
-    expiryDate
+    closingDate
   }
 }
 

--- a/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.tsx
+++ b/frontend/talentsearch/src/js/components/ApplicationPageWrapper/ApplicationPageWrapper.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs, { BreadcrumbsProps } from "@common/components/Breadcrumbs";
 import imageUrl from "@common/helpers/imageUrl";
 import {
   parseDateTimeUtc,
-  relativeExpiryDate,
+  relativeClosingDate,
 } from "@common/helpers/dateUtils";
 
 import { CalendarIcon } from "@heroicons/react/24/outline";
@@ -19,7 +19,7 @@ export interface ApplicationPageWrapperProps {
   subtitle?: string;
   crumbs?: BreadcrumbsProps["links"];
   navigation?: ApplicationNavigationProps;
-  closingDate: PoolAdvertisement["expiryDate"];
+  closingDate: PoolAdvertisement["closingDate"];
   children: React.ReactNode;
 }
 
@@ -113,8 +113,8 @@ const ApplicationPageWrapper = ({
                 })}
                 <br />
                 {closingDate
-                  ? relativeExpiryDate({
-                      expiryDate: parseDateTimeUtc(closingDate),
+                  ? relativeClosingDate({
+                      closingDate: parseDateTimeUtc(closingDate),
                       intl,
                     })
                   : ""}

--- a/frontend/talentsearch/src/js/components/Browse/ActiveRecruitmentSection.test.tsx
+++ b/frontend/talentsearch/src/js/components/Browse/ActiveRecruitmentSection.test.tsx
@@ -39,11 +39,11 @@ describe("BrowsePoolsPage", () => {
   it("should properly sort jobs", async () => {
     await act(async () => {
       // should appear first: it expires first even though it was published later
-      const expiresFirst = {
+      const closesFirst = {
         ...publishedPool,
-        id: "expiresFirst",
+        id: "closesFirst",
         publishedAt: "2000-02-01 00:00:00",
-        expiryDate: "2999-01-01 00:00:00",
+        closingDate: "2999-01-01 00:00:00",
       };
 
       // should appear second: tie for expiring second, has first publish date
@@ -51,7 +51,7 @@ describe("BrowsePoolsPage", () => {
         ...publishedPool,
         id: "publishedFirst",
         publishedAt: "2000-01-01 00:00:00",
-        expiryDate: "2999-02-01 00:00:00",
+        closingDate: "2999-02-01 00:00:00",
       };
 
       // should appear third: tie for expiring second, has second publish date
@@ -59,12 +59,12 @@ describe("BrowsePoolsPage", () => {
         ...publishedPool,
         id: "publishedSecond",
         publishedAt: "2000-01-02 00:00:00",
-        expiryDate: "2999-02-01 00:00:00",
+        closingDate: "2999-02-01 00:00:00",
       };
 
       renderBrowsePoolsPage({
         // pass data to the page in an intentionally reversed order
-        pools: [publishedSecond, publishedFirst, expiresFirst],
+        pools: [publishedSecond, publishedFirst, closesFirst],
       });
 
       // find the rendered links
@@ -76,7 +76,7 @@ describe("BrowsePoolsPage", () => {
       expect(links).toHaveLength(3);
       expect(links[0]).toHaveAttribute(
         "href",
-        expect.stringContaining(expiresFirst.id),
+        expect.stringContaining(closesFirst.id),
       );
       expect(links[1]).toHaveAttribute(
         "href",

--- a/frontend/talentsearch/src/js/components/Browse/ActiveRecruitmentSection.tsx
+++ b/frontend/talentsearch/src/js/components/Browse/ActiveRecruitmentSection.tsx
@@ -16,7 +16,7 @@ export const ActiveRecruitmentSection = ({
 
   pools.sort(
     (p1, p2) =>
-      (p1.expiryDate ?? "").localeCompare(p2.expiryDate ?? "") || // first level sort: by expiry date whichever one expires first should appear first on the list
+      (p1.closingDate ?? "").localeCompare(p2.closingDate ?? "") || // first level sort: by closing date whichever one closes first should appear first on the list
       (p1.publishedAt ?? "").localeCompare(p2.publishedAt ?? ""), // second level sort: whichever one was published first should appear first
   );
 

--- a/frontend/talentsearch/src/js/components/Browse/BrowsePoolsPage.test.tsx
+++ b/frontend/talentsearch/src/js/components/Browse/BrowsePoolsPage.test.tsx
@@ -21,7 +21,7 @@ const publishedItJobsPool: PoolAdvertisement = {
 const expiredItJobsPool: PoolAdvertisement = {
   id: "expiredItJobsPool",
   publishingGroup: PublishingGroup.ItJobs,
-  advertisementStatus: AdvertisementStatus.Expired,
+  advertisementStatus: AdvertisementStatus.Closed,
 };
 
 const archivedItJobsPool: PoolAdvertisement = {

--- a/frontend/talentsearch/src/js/components/Browse/OngoingRecruitmentSection.test.tsx
+++ b/frontend/talentsearch/src/js/components/Browse/OngoingRecruitmentSection.test.tsx
@@ -42,22 +42,22 @@ describe("BrowsePoolsPage", () => {
   it("should properly sort jobs", async () => {
     await act(async () => {
       // should appear first: it expires first even though it was published later
-      const expiresFirst = {
+      const closesFirst = {
         ...publishedPool,
-        id: "expiresFirst",
-        expiryDate: "2999-01-01 00:00:00",
+        id: "closesFirst",
+        closingDate: "2999-01-01 00:00:00",
       };
 
       // should appear second: tie for expiring second, has first publish date
-      const expiresSecond = {
+      const closesSecond = {
         ...publishedPool,
-        id: "expiresSecond",
-        expiryDate: "2999-02-01 00:00:00",
+        id: "closesSecond",
+        closingDate: "2999-02-01 00:00:00",
       };
 
       renderBrowsePoolsPage({
         // pass data to the page in an intentionally reversed order
-        pools: [expiresSecond, expiresFirst],
+        pools: [closesSecond, closesFirst],
       });
 
       fireEvent.click(
@@ -75,7 +75,7 @@ describe("BrowsePoolsPage", () => {
       expect(links).toHaveLength(1);
       expect(links[0]).toHaveAttribute(
         "href",
-        expect.stringContaining(expiresSecond.id),
+        expect.stringContaining(closesSecond.id),
       );
     });
   });

--- a/frontend/talentsearch/src/js/components/Browse/OngoingRecruitmentSection.tsx
+++ b/frontend/talentsearch/src/js/components/Browse/OngoingRecruitmentSection.tsx
@@ -36,9 +36,10 @@ const selectPoolForSection = (
 ): PoolAdvertisement | undefined => {
   return (
     pools
-      // last expiry date first to be selected
+      // last closing date first to be selected
       .sort((p1, p2) =>
-        (p1.expiryDate ?? FAR_FUTURE_DATE) < (p2.expiryDate ?? FAR_FUTURE_DATE)
+        (p1.closingDate ?? FAR_FUTURE_DATE) <
+        (p2.closingDate ?? FAR_FUTURE_DATE)
           ? 1
           : -1,
       )

--- a/frontend/talentsearch/src/js/components/Browse/PoolCard/PoolCard.tsx
+++ b/frontend/talentsearch/src/js/components/Browse/PoolCard/PoolCard.tsx
@@ -198,9 +198,9 @@ const PoolCard = ({ pool, headingLevel = "h3" }: PoolCardProps) => {
                 description: "Label for the pool expiry date",
               })}
             >
-              {pool.expiryDate
+              {pool.closingDate
                 ? formatDate({
-                    date: parseDateTimeUtc(pool.expiryDate),
+                    date: parseDateTimeUtc(pool.closingDate),
                     formatString: "PPP p",
                     intl,
                   })

--- a/frontend/talentsearch/src/js/components/Browse/browseOperations.graphql
+++ b/frontend/talentsearch/src/js/components/Browse/browseOperations.graphql
@@ -9,7 +9,7 @@ query browsePoolAdvertisements {
       en
       fr
     }
-    expiryDate
+    closingDate
     advertisementStatus
     advertisementLanguage
     securityClearance

--- a/frontend/talentsearch/src/js/components/applications/ApplicationCard/ApplicationCard.tsx
+++ b/frontend/talentsearch/src/js/components/applications/ApplicationCard/ApplicationCard.tsx
@@ -4,7 +4,7 @@ import { useIntl } from "react-intl";
 import { getPoolCandidateStatus } from "@common/constants/localizedConstants";
 import {
   parseDateTimeUtc,
-  relativeExpiryDate,
+  relativeClosingDate,
 } from "@common/helpers/dateUtils";
 
 import { notEmpty } from "@common/helpers/util";
@@ -97,10 +97,10 @@ export const ApplicationCard = ({
                 data-h2-font-weight="base(800)"
                 data-h2-color="base(dt-primary)"
               >
-                {application.poolAdvertisement.expiryDate
-                  ? relativeExpiryDate({
-                      expiryDate: parseDateTimeUtc(
-                        application.poolAdvertisement.expiryDate,
+                {application.poolAdvertisement.closingDate
+                  ? relativeClosingDate({
+                      closingDate: parseDateTimeUtc(
+                        application.poolAdvertisement.closingDate,
                       ),
                       intl,
                     })

--- a/frontend/talentsearch/src/js/components/applications/applicationOperations.graphql
+++ b/frontend/talentsearch/src/js/components/applications/applicationOperations.graphql
@@ -8,7 +8,7 @@ query MyApplications {
       archivedAt
       poolAdvertisement {
         id
-        expiryDate
+        closingDate
         name {
           en
           fr

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -302,7 +302,7 @@ export const PoolAdvertisementPoster = ({
           >
             <div>
               <PoolInfoCard
-                closingDate={poolAdvertisement.expiryDate}
+                closingDate={poolAdvertisement.closingDate}
                 classification={classificationSuffix}
                 salary={{
                   min: classification?.minSalary,

--- a/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
@@ -5,13 +5,13 @@ import { CalendarIcon, CurrencyDollarIcon } from "@heroicons/react/24/solid";
 import { getLocale, localizeSalaryRange } from "@common/helpers/localize";
 import {
   parseDateTimeUtc,
-  relativeExpiryDate,
+  relativeClosingDate,
 } from "@common/helpers/dateUtils";
 
 import type { Maybe, PoolAdvertisement } from "../../api/generated";
 
 export interface PoolInfoCardProps {
-  closingDate: PoolAdvertisement["expiryDate"];
+  closingDate: PoolAdvertisement["closingDate"];
   classification: string;
   salary: {
     min: Maybe<number>;
@@ -57,8 +57,8 @@ const PoolInfoCard = ({
             description: "Label for pool advertisement closing date",
           })}{" "}
           {closingDate
-            ? relativeExpiryDate({
-                expiryDate: parseDateTimeUtc(closingDate),
+            ? relativeClosingDate({
+                closingDate: parseDateTimeUtc(closingDate),
                 intl,
               })
             : ""}

--- a/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
+++ b/frontend/talentsearch/src/js/components/pool/poolOperations.graphql
@@ -51,7 +51,7 @@ query getPoolAdvertisement($id: UUID!) {
       maxSalary
     }
     stream
-    expiryDate
+    closingDate
     advertisementStatus
     advertisementLanguage
     securityClearance

--- a/frontend/talentsearch/src/js/components/reviewMyApplication/ReviewMyApplicationPage.stories.tsx
+++ b/frontend/talentsearch/src/js/components/reviewMyApplication/ReviewMyApplicationPage.stories.tsx
@@ -22,7 +22,7 @@ export default {
     poolAdvertisement,
     applicant,
     applicationId: poolCandidate.id,
-    closingDate: poolCandidate.poolAdvertisement?.expiryDate,
+    closingDate: poolCandidate.poolAdvertisement?.closingDate,
   },
 } as ComponentMeta<typeof ReviewMyApplication>;
 

--- a/frontend/talentsearch/src/js/components/reviewMyApplication/ReviewMyApplicationPage.tsx
+++ b/frontend/talentsearch/src/js/components/reviewMyApplication/ReviewMyApplicationPage.tsx
@@ -32,7 +32,7 @@ interface ReviewMyApplicationProps {
   applicant: Applicant;
   poolAdvertisement: PoolAdvertisement;
   applicationId: string;
-  closingDate: PoolAdvertisement["expiryDate"];
+  closingDate: PoolAdvertisement["closingDate"];
 }
 
 export const ReviewMyApplication: React.FunctionComponent<
@@ -269,7 +269,7 @@ const ReviewMyApplicationPage = () => {
           poolAdvertisement={data.poolCandidate.poolAdvertisement}
           applicant={data.poolCandidate.user as Applicant}
           applicationId={data.poolCandidate.id}
-          closingDate={data.poolCandidate.poolAdvertisement?.expiryDate}
+          closingDate={data.poolCandidate.poolAdvertisement?.closingDate}
         />
       ) : (
         <ApplicationNotFound />

--- a/frontend/talentsearch/src/js/components/reviewMyApplication/reviewMyApplicationOperations.graphql
+++ b/frontend/talentsearch/src/js/components/reviewMyApplication/reviewMyApplicationOperations.graphql
@@ -156,7 +156,7 @@ query getReviewMyApplicationPageData($id: UUID!) {
         fr
       }
       stream
-      expiryDate
+      closingDate
       classifications {
         id
         group

--- a/frontend/talentsearch/src/js/components/signAndSubmit/SignAndSubmitPage.tsx
+++ b/frontend/talentsearch/src/js/components/signAndSubmit/SignAndSubmitPage.tsx
@@ -233,7 +233,7 @@ export interface SignAndSubmitFormProps {
   applicationId: string;
   poolAdvertisementId: string;
   userId: string;
-  closingDate: PoolAdvertisement["expiryDate"];
+  closingDate: PoolAdvertisement["closingDate"];
   jobTitle: string;
   isApplicationComplete: boolean;
   handleSubmitApplication: (
@@ -430,7 +430,7 @@ const SignAndSubmitPage = () => {
           applicationId={data.poolCandidate.id}
           poolAdvertisementId={data.poolCandidate.poolAdvertisement?.id}
           userId={data.poolCandidate.user.id}
-          closingDate={data.poolCandidate.poolAdvertisement?.expiryDate}
+          closingDate={data.poolCandidate.poolAdvertisement?.closingDate}
           jobTitle={jobTitle}
           isApplicationComplete={isApplicationComplete}
           handleSubmitApplication={handleSubmitApplication}

--- a/frontend/talentsearch/src/js/components/signAndSubmit/signAndSubmitOperations.graphql
+++ b/frontend/talentsearch/src/js/components/signAndSubmit/signAndSubmitOperations.graphql
@@ -51,7 +51,7 @@ query getApplicationData($id: UUID!) {
         group
         level
       }
-      expiryDate
+      closingDate
       essentialSkills {
         ...poolAdvertisementSkills
       }


### PR DESCRIPTION
> **Warning**
> Waiting on translations

## 👋 Introduction

This PR changes the pool status "Expired" to "Closed".  This led to changes in the database, schema, validators, frontend typescript, and tests.

## :monocle_face: Quirks and Features

I think this is the first PR that runs the translation workflow for admin and common so you'll see a lot of orphaned strings removed that are not related to the issue.

## 🧪 Testing

### Backend:
- [ ] migrate works on existing workspace
- [ ] fresh setup with seeding works
- [ ] phpunit tests work

### Talent Search:
-  [ ] browse opportunity cards look good
- [ ] pool advertisement page looks good
- [ ] pool application page looks good

### Admin:
- [ ] view pool
- [ ] edit pool
  - [ ] set closing date
  - [ ] extend closing date
  - [ ] close manually
- [ ] add user to pool

### Tests:
- [ ] jest tests pass
- [ ] cypress tests pass

### Lang:
- [ ] translations look good

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/8978655/208182093-1f95fbf9-bb88-43e7-890a-34eb1eb190cc.png)

## 🤖 Robot Stuff

Resolves #5111 
