### PR TITLE
Feature/5124 readd skill justification to profiles

### DIFF
--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.tsx
@@ -213,31 +213,23 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
           skills={skills}
           poolAdvertisement={poolAdvertisement}
         />
-        {poolAdvertisement && (
-          <>
-            <h2
-              data-h2-font-size="base(h3, 1)"
-              data-h2-margin="base(x2, 0, x1, 0)"
-            >
-              {intl.formatMessage({
-                defaultMessage: "4. Additional information for this experience",
-                id: "Rgh/Qb",
-                description:
-                  "Title for addition information on Experience form",
-              })}
-            </h2>
-            <p>
-              {intl.formatMessage({
-                defaultMessage:
-                  "Anything else about this experience you would like to share.",
-                id: "h1wsiL",
-                description:
-                  "Description blurb for additional information on Experience form",
-              })}
-            </p>
-            <TextArea id="details" label={labels.details} name="details" />
-          </>
-        )}
+        <h2 data-h2-font-size="base(h3, 1)" data-h2-margin="base(x2, 0, x1, 0)">
+          {intl.formatMessage({
+            defaultMessage: "4. Additional information for this experience",
+            id: "Rgh/Qb",
+            description: "Title for addition information on Experience form",
+          })}
+        </h2>
+        <p>
+          {intl.formatMessage({
+            defaultMessage:
+              "Anything else about this experience you would like to share.",
+            id: "h1wsiL",
+            description:
+              "Description blurb for additional information on Experience form",
+          })}
+        </p>
+        <TextArea id="details" label={labels.details} name="details" />
         {edit && (
           <AlertDialog.Root>
             <AlertDialog.Trigger>

--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceSkills.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceSkills.tsx
@@ -209,12 +209,11 @@ const ExperienceSkills: React.FC<ExperienceSkillsProps> = ({
           headingLevel="h3"
         />
       )}
-      {poolAdvertisement && (
-        <SkillsInDetail
-          skills={fields as FormSkills}
-          onDelete={handleRemoveSkill}
-        />
-      )}
+      <SkillsInDetail
+        skills={fields as FormSkills}
+        required={!!poolAdvertisement}
+        onDelete={handleRemoveSkill}
+      />
     </>
   );
 };

--- a/frontend/talentsearch/src/js/components/skills/SkillsInDetail/SkillsInDetail.tsx
+++ b/frontend/talentsearch/src/js/components/skills/SkillsInDetail/SkillsInDetail.tsx
@@ -19,11 +19,13 @@ type FormValues = {
 
 export interface SkillsInDetailProps {
   skills: FormSkills;
+  required?: boolean;
   onDelete: (id: string) => void;
 }
 
 const SkillsInDetail: React.FunctionComponent<SkillsInDetailProps> = ({
   skills,
+  required,
   onDelete,
 }) => {
   const intl = useIntl();
@@ -153,7 +155,9 @@ const SkillsInDetail: React.FunctionComponent<SkillsInDetailProps> = ({
                   })}
                   name={`skills.${index}.details`}
                   rules={{
-                    required: intl.formatMessage(errorMessages.required),
+                    required: required
+                      ? intl.formatMessage(errorMessages.required)
+                      : undefined,
                     validate: {
                       wordCount: (value: string) =>
                         countNumberOfWords(value) <= MAX_WORDS ||


### PR DESCRIPTION
## 👋 Introduction

Re-adds sections 3 and 4 of the experience forms when accessed from the profile. Also makes skill justifications optional on the profile.

## 🧪 Testing

1. Build talent search `npm run production --workspace=talentsearch`
2. Navigate to an experience form from your profile
3. Confirm sections 3 and 4 appear properly with optional fields
4. Navigate to an experience form through an application
5. Confirm sections 3 and 4 appear properly with the fields in 3 required

## 🤖 Robot Stuff

Resolves #5124 
