### PR TITLE
Bug - 5179 - Update Department # copy in French

### DIFF
--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -4,7 +4,7 @@
     "description": "Heading displayed above the Create Pool form."
   },
   "/YiBdv": {
-    "defaultMessage": "No de ministère",
+    "defaultMessage": "Numéro de ministère",
     "description": "Label displayed on the create a department form department number field."
   },
   "/uqLeF": {
@@ -200,7 +200,7 @@
     "description": "Label displayed on the Global Filter form Search field."
   },
   "QOvS1b": {
-    "defaultMessage": "No de ministère",
+    "defaultMessage": "Numéro de ministère",
     "description": "Title displayed for the Department table Department # column."
   },
   "QftM3f": {


### PR DESCRIPTION
🤖 Resolves #5179.

## 👋 Introduction

This PR solves an accessibility and language issue with how **Department #** is translated in French.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Compile French `npm run intl-compile --workspace=admin`
2. Build admin `npm run production --workspace=admin`
3. Turn on screen reader
4. Navigate to `/fr/admin/settings/departments`
5. Verify table has a **Numéro de ministère** column
6. Navigate to `/fr/admin/settings/departments`
7. Verify form has a field with **Numéro de ministère** as a label

## 📸 Screenshot

![Screen Shot 2022-12-21 at 10 20 39](https://user-images.githubusercontent.com/3046459/208940915-5bc6acaf-35cc-4662-b4ea-19ad0284a95d.png)
![Screen Shot 2022-12-21 at 10 21 34](https://user-images.githubusercontent.com/3046459/208940918-da854090-7731-4760-bceb-04edb3dadd89.png)



