### PR TITLE
2404 prep for react 18

### DIFF
--- a/frontend/admin/src/js/components/DashboardContentContainer.tsx
+++ b/frontend/admin/src/js/components/DashboardContentContainer.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
-export const DashboardContentContainer: React.FC = ({
-  children,
-}): React.ReactElement => {
+export const DashboardContentContainer: React.FC<{
+  children?: React.ReactNode;
+}> = ({ children }): React.ReactElement => {
   return (
     <div data-h2-min-height="base(100%)">
       <div data-h2-container="base(center, full, x2)">

--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-no-useless-fragment */
 /* eslint-disable react/jsx-key */
 import "regenerator-runtime/runtime"; // Hack: Needed for react-table?
 import React, { HTMLAttributes, ReactElement } from "react";
@@ -238,14 +237,12 @@ function Table<T extends Record<string, unknown>>({
                                 data-h2-margin="base(x.125, 0)"
                               >
                                 <label htmlFor={column.Header?.toString()}>
-                                  <>
-                                    <input
-                                      id={column.Header?.toString()}
-                                      type="checkbox"
-                                      {...column.getToggleHiddenProps()}
-                                    />{" "}
-                                    {column.Header}
-                                  </>
+                                  <input
+                                    id={column.Header?.toString()}
+                                    type="checkbox"
+                                    {...column.getToggleHiddenProps()}
+                                  />{" "}
+                                  {column.Header}
                                 </label>
                               </div>
                             ))}

--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-useless-fragment */
 /* eslint-disable react/jsx-key */
 import "regenerator-runtime/runtime"; // Hack: Needed for react-table?
 import React, { HTMLAttributes, ReactElement } from "react";
@@ -237,12 +238,14 @@ function Table<T extends Record<string, unknown>>({
                                 data-h2-margin="base(x.125, 0)"
                               >
                                 <label htmlFor={column.Header?.toString()}>
-                                  <input
-                                    id={column.Header?.toString()}
-                                    type="checkbox"
-                                    {...column.getToggleHiddenProps()}
-                                  />{" "}
-                                  {column.Header}
+                                  <>
+                                    <input
+                                      id={column.Header?.toString()}
+                                      type="checkbox"
+                                      {...column.getToggleHiddenProps()}
+                                    />{" "}
+                                    {column.Header}
+                                  </>
                                 </label>
                               </div>
                             ))}

--- a/frontend/admin/src/js/components/Table/tableComponents.tsx
+++ b/frontend/admin/src/js/components/Table/tableComponents.tsx
@@ -34,7 +34,9 @@ export const IndeterminateCheckbox: React.FC<
   );
 };
 
-export const Spacer: React.FC = ({ children }) => (
+export const Spacer: React.FC<{ children?: React.ReactNode }> = ({
+  children,
+}) => (
   <div data-h2-margin="base(0, 0, 0, x.5)" style={{ flexShrink: 0 }}>
     {children}
   </div>

--- a/frontend/admin/src/js/components/apiManagedTable/useFilterOptions.test.tsx
+++ b/frontend/admin/src/js/components/apiManagedTable/useFilterOptions.test.tsx
@@ -1,12 +1,13 @@
 /**
  * @jest-environment jsdom
  */
+import { renderHook } from "@testing-library/react-hooks";
 import React from "react";
 import "@testing-library/jest-dom";
 import { IntlProvider } from "react-intl";
 import { Provider as GraphqlProvider } from "urql";
 import { pipe, fromValue, delay } from "wonka";
-import { waitFor, renderHook } from "@testing-library/react";
+import { waitFor } from "@testing-library/react";
 import { fakeSkills, fakePools, fakeClassifications } from "@common/fakeData";
 import useFilterOptions from "./useFilterOptions";
 

--- a/frontend/admin/src/js/components/apiManagedTable/useFilterOptions.test.tsx
+++ b/frontend/admin/src/js/components/apiManagedTable/useFilterOptions.test.tsx
@@ -1,13 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-import { renderHook } from "@testing-library/react-hooks";
 import React from "react";
 import "@testing-library/jest-dom";
 import { IntlProvider } from "react-intl";
 import { Provider as GraphqlProvider } from "urql";
 import { pipe, fromValue, delay } from "wonka";
-import { waitFor } from "@testing-library/react";
+import { waitFor, renderHook } from "@testing-library/react";
 import { fakeSkills, fakePools, fakeClassifications } from "@common/fakeData";
 import useFilterOptions from "./useFilterOptions";
 

--- a/frontend/admin/src/js/components/pool/PoolTable.tsx
+++ b/frontend/admin/src/js/components/pool/PoolTable.tsx
@@ -55,6 +55,14 @@ function viewLinkAccessor(editUrlRoot: string, pool: Pool, intl: IntlShape) {
   );
 }
 
+// wrap something in a React element for rendering
+const wrapInAReactElement = (
+  value: string | JSX.Element[] | null | undefined,
+) => {
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{value}</>;
+};
+
 export const PoolTable: React.FC<GetPoolsQuery & { editUrlRoot: string }> = ({
   pools,
   editUrlRoot,
@@ -157,13 +165,15 @@ export const PoolTable: React.FC<GetPoolsQuery & { editUrlRoot: string }> = ({
         }),
         accessor: "createdDate",
         Cell: ({ value }) =>
-          value
-            ? formatDate({
-                date: parseDateTimeUtc(value),
-                formatString: "PPP p",
-                intl,
-              })
-            : null,
+          wrapInAReactElement(
+            value
+              ? formatDate({
+                  date: parseDateTimeUtc(value),
+                  formatString: "PPP p",
+                  intl,
+                })
+              : null,
+          ),
       },
     ],
     [editUrlRoot, intl, paths, locale],

--- a/frontend/admin/src/js/components/pool/PoolTable.tsx
+++ b/frontend/admin/src/js/components/pool/PoolTable.tsx
@@ -55,14 +55,6 @@ function viewLinkAccessor(editUrlRoot: string, pool: Pool, intl: IntlShape) {
   );
 }
 
-// wrap something in a React element for rendering
-const wrapInAReactElement = (
-  value: string | JSX.Element[] | null | undefined,
-) => {
-  // eslint-disable-next-line react/jsx-no-useless-fragment
-  return <>{value}</>;
-};
-
 export const PoolTable: React.FC<GetPoolsQuery & { editUrlRoot: string }> = ({
   pools,
   editUrlRoot,
@@ -165,15 +157,13 @@ export const PoolTable: React.FC<GetPoolsQuery & { editUrlRoot: string }> = ({
         }),
         accessor: "createdDate",
         Cell: ({ value }) =>
-          wrapInAReactElement(
-            value
-              ? formatDate({
-                  date: parseDateTimeUtc(value),
-                  formatString: "PPP p",
-                  intl,
-                })
-              : null,
-          ),
+          value
+            ? formatDate({
+                date: parseDateTimeUtc(value),
+                formatString: "PPP p",
+                intl,
+              })
+            : null,
       },
     ],
     [editUrlRoot, intl, paths, locale],

--- a/frontend/admin/src/js/components/poolCandidate/PoolCandidateDocument.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/PoolCandidateDocument.tsx
@@ -22,7 +22,9 @@ import { PoolCandidate } from "../../api/generated";
 import AdminAboutSection from "../user/AdminAboutSection";
 import PoolCandidateDetailsSection from "./PoolCandidateDetailsSection";
 
-const HeadingWrapper: React.FC = ({ children }) => {
+const HeadingWrapper: React.FC<{ children?: React.ReactNode }> = ({
+  children,
+}) => {
   return (
     <div style={{ display: "flex", alignItems: "baseline" }}>{children}</div>
   );

--- a/frontend/admin/src/js/components/searchRequest/SearchRequestTable.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SearchRequestTable.tsx
@@ -33,14 +33,6 @@ const statusAccessor = (
     ? intl.formatMessage(getPoolCandidateSearchStatus(status as string))
     : "";
 
-// wrap something in a React element for rendering
-const wrapInAReactElement = (
-  value: string | JSX.Element[] | null | undefined,
-) => {
-  // eslint-disable-next-line react/jsx-no-useless-fragment
-  return <>{value}</>;
-};
-
 interface SearchRequestTableProps {
   poolCandidateSearchRequests: Array<Maybe<PoolCandidateSearchRequest>>;
 }
@@ -100,18 +92,16 @@ export const SearchRequestTable = ({
           const pools =
             original?.applicantFilter?.pools ??
             original?.poolCandidateFilter?.pools;
-          return wrapInAReactElement(
-            pools?.filter(notEmpty).map(
-              (pool, index) =>
-                pool && (
-                  <React.Fragment key={pool.id}>
-                    <a href={paths.poolCandidateTable(pool.id)}>
-                      {localizedTransformPoolToPosterTitle(pool)}
-                    </a>
-                    {index > 0 && ", "}
-                  </React.Fragment>
-                ),
-            ),
+          return pools?.filter(notEmpty).map(
+            (pool, index) =>
+              pool && (
+                <React.Fragment key={pool.id}>
+                  <a href={paths.poolCandidateTable(pool.id)}>
+                    {localizedTransformPoolToPosterTitle(pool)}
+                  </a>
+                  {index > 0 && ", "}
+                </React.Fragment>
+              ),
           );
         },
       },
@@ -132,15 +122,13 @@ export const SearchRequestTable = ({
         }),
         accessor: "requestedDate",
         Cell: ({ value }) =>
-          wrapInAReactElement(
-            value
-              ? formatDate({
-                  date: parseDateTimeUtc(value),
-                  formatString: "PPP p",
-                  intl,
-                })
-              : null,
-          ),
+          value
+            ? formatDate({
+                date: parseDateTimeUtc(value),
+                formatString: "PPP p",
+                intl,
+              })
+            : null,
       },
       {
         Header: intl.formatMessage({

--- a/frontend/admin/src/js/components/searchRequest/SearchRequestTable.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SearchRequestTable.tsx
@@ -19,8 +19,8 @@ import { useAdminRoutes } from "../../adminRoutes";
 
 interface IRow {
   original: {
-    poolCandidateFilter?: PoolCandidateFilter;
-    applicantFilter?: ApplicantFilter;
+    poolCandidateFilter?: Maybe<PoolCandidateFilter>;
+    applicantFilter?: Maybe<ApplicantFilter>;
   };
 }
 
@@ -32,6 +32,14 @@ const statusAccessor = (
   status
     ? intl.formatMessage(getPoolCandidateSearchStatus(status as string))
     : "";
+
+// wrap something in a React element for rendering
+const wrapInAReactElement = (
+  value: string | JSX.Element[] | null | undefined,
+) => {
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{value}</>;
+};
 
 interface SearchRequestTableProps {
   poolCandidateSearchRequests: Array<Maybe<PoolCandidateSearchRequest>>;
@@ -92,16 +100,18 @@ export const SearchRequestTable = ({
           const pools =
             original?.applicantFilter?.pools ??
             original?.poolCandidateFilter?.pools;
-          return pools?.filter(notEmpty).map(
-            (pool, index) =>
-              pool && (
-                <React.Fragment key={pool.id}>
-                  <a href={paths.poolCandidateTable(pool.id)}>
-                    {localizedTransformPoolToPosterTitle(pool)}
-                  </a>
-                  {index > 0 && ", "}
-                </React.Fragment>
-              ),
+          return wrapInAReactElement(
+            pools?.filter(notEmpty).map(
+              (pool, index) =>
+                pool && (
+                  <React.Fragment key={pool.id}>
+                    <a href={paths.poolCandidateTable(pool.id)}>
+                      {localizedTransformPoolToPosterTitle(pool)}
+                    </a>
+                    {index > 0 && ", "}
+                  </React.Fragment>
+                ),
+            ),
           );
         },
       },
@@ -122,13 +132,15 @@ export const SearchRequestTable = ({
         }),
         accessor: "requestedDate",
         Cell: ({ value }) =>
-          value
-            ? formatDate({
-                date: parseDateTimeUtc(value),
-                formatString: "PPP p",
-                intl,
-              })
-            : null,
+          wrapInAReactElement(
+            value
+              ? formatDate({
+                  date: parseDateTimeUtc(value),
+                  formatString: "PPP p",
+                  intl,
+                })
+              : null,
+          ),
       },
       {
         Header: intl.formatMessage({

--- a/frontend/admin/src/js/components/user/UserProfileDocument.tsx
+++ b/frontend/admin/src/js/components/user/UserProfileDocument.tsx
@@ -21,7 +21,9 @@ import PrintExperienceByType from "@common/components/UserProfile/PrintExperienc
 import { Applicant } from "../../api/generated";
 import AdminAboutSection from "./AdminAboutSection";
 
-const HeadingWrapper: React.FC = ({ children }) => {
+const HeadingWrapper: React.FC<{ children?: React.ReactNode }> = ({
+  children,
+}) => {
   return (
     <div style={{ display: "flex", alignItems: "baseline" }}>{children}</div>
   );

--- a/frontend/admin/src/js/components/user/UserProfilePrintButton.tsx
+++ b/frontend/admin/src/js/components/user/UserProfilePrintButton.tsx
@@ -12,6 +12,7 @@ export interface UserProfilePrintButtonProps {
 
 export const UserProfilePrintButton: React.FunctionComponent<{
   applicant: Applicant;
+  children?: React.ReactNode;
 }> = ({ applicant, children }) => {
   const intl = useIntl();
 

--- a/frontend/common/src/components/Auth/AuthenticationContainer.tsx
+++ b/frontend/common/src/components/Auth/AuthenticationContainer.tsx
@@ -127,6 +127,7 @@ interface AuthenticationContainerProps {
   tokenRefreshPath: string;
   logoutUri: string;
   logoutRedirectUri: string;
+  children?: React.ReactNode;
 }
 
 const AuthenticationContainer: React.FC<AuthenticationContainerProps> = ({

--- a/frontend/common/src/components/Auth/AuthorizationContainer.tsx
+++ b/frontend/common/src/components/Auth/AuthorizationContainer.tsx
@@ -24,6 +24,7 @@ interface AuthorizationContainerProps {
   email?: MaybeEmail;
   currentUser?: PossibleUser;
   isLoaded: boolean;
+  children?: React.ReactNode;
 }
 
 const AuthorizationContainer: React.FC<AuthorizationContainerProps> = ({

--- a/frontend/common/src/components/CardLink/CardLink.tsx
+++ b/frontend/common/src/components/CardLink/CardLink.tsx
@@ -14,6 +14,7 @@ export interface CardLinkProps {
   icon?: React.FC<{ className: string }>;
   className?: string;
   external?: boolean;
+  children?: React.ReactNode;
 }
 
 export const colorMap: Record<Color, Record<string, string>> = {

--- a/frontend/common/src/components/ClientProvider/ClientProvider.tsx
+++ b/frontend/common/src/components/ClientProvider/ClientProvider.tsx
@@ -90,10 +90,10 @@ const willAuthError = ({ authState }: { authState: AuthState | null }) => {
   return false;
 };
 
-const ClientProvider: React.FC<{ client?: Client }> = ({
-  client,
-  children,
-}) => {
+const ClientProvider: React.FC<{
+  client?: Client;
+  children?: React.ReactNode;
+}> = ({ client, children }) => {
   const intl = useIntl();
   const authContext = useContext(AuthenticationContext);
   // Create a mutable object to hold the auth state
@@ -103,8 +103,10 @@ const ClientProvider: React.FC<{ client?: Client }> = ({
     authRef.current = authContext;
   }, [authContext]);
 
-  const getAuth = useCallback(
-    async ({ authState: existingAuthState }): Promise<AuthState | null> => {
+  const getAuth: (params: {
+    authState: AuthState | null;
+  }) => Promise<AuthState | null> = useCallback(
+    async ({ authState: existingAuthState }) => {
       // getAuth could be called for the first request or as the result of an error
 
       // At runtime, get the current auth state

--- a/frontend/common/src/components/Link/ScrollToLink.tsx
+++ b/frontend/common/src/components/Link/ScrollToLink.tsx
@@ -4,6 +4,7 @@ import { useLocation } from "react-router-dom";
 export interface ScrollToLinkProps
   extends Omit<React.HTMLProps<HTMLAnchorElement>, "href" | "onClick"> {
   to: string;
+  children?: React.ReactNode;
 }
 
 const ScrollToLink = ({ to, children, ...rest }: ScrollToLinkProps) => {

--- a/frontend/common/src/components/NavMenu/NavMenu.tsx
+++ b/frontend/common/src/components/NavMenu/NavMenu.tsx
@@ -6,7 +6,7 @@ export interface NavMenuProps {
   utilityItems?: ReactElement[];
 }
 
-const ListItem: React.FC = ({ children }) => (
+const ListItem: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
   <li data-h2-flex-item="base(content)">
     <span
       data-h2-display="base(block)"

--- a/frontend/common/src/components/PageHeader/PageHeader.tsx
+++ b/frontend/common/src/components/PageHeader/PageHeader.tsx
@@ -4,6 +4,7 @@ import Heading from "../Heading";
 export interface PageHeaderProps {
   icon?: React.FC<{ className: string }>;
   subtitle?: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 const PageHeader: React.FC<PageHeaderProps> = ({

--- a/frontend/common/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/frontend/common/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -26,6 +26,7 @@ export type SimpleClassification = Pick<Classification, "group" | "level">;
 export interface FilterBlockProps {
   title: string;
   content?: Maybe<string> | Maybe<string[]>;
+  children?: React.ReactNode;
 }
 
 const FilterBlock: React.FunctionComponent<FilterBlockProps> = ({

--- a/frontend/common/src/components/SideMenu/SideMenu.tsx
+++ b/frontend/common/src/components/SideMenu/SideMenu.tsx
@@ -15,6 +15,7 @@ export interface SideMenuProps {
   onDismiss?: () => void;
   header?: React.ReactNode;
   footer?: JSX.Element;
+  children?: React.ReactNode;
 }
 
 const SideMenu: React.FC<SideMenuProps> = ({

--- a/frontend/common/src/components/SideMenu/SideMenuContentWrapper.tsx
+++ b/frontend/common/src/components/SideMenu/SideMenuContentWrapper.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
-const SideMenuContentWrapper: React.FC = ({ children }) => (
-  <div data-h2-flex-item="base(fill)">{children}</div>
-);
+const SideMenuContentWrapper: React.FC<{ children?: React.ReactNode }> = ({
+  children,
+}) => <div data-h2-flex-item="base(fill)">{children}</div>;
 
 export default SideMenuContentWrapper;

--- a/frontend/common/src/components/TableOfContents/Content.tsx
+++ b/frontend/common/src/components/TableOfContents/Content.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const Content: React.FC = ({ children, ...rest }) => (
+const Content: React.FC<{
+  children?: React.ReactNode;
+}> = ({ children, ...rest }) => (
   <div data-h2-flex-item="base(1of1) l-tablet(3of4)" {...rest}>
     <div>{children}</div>
   </div>

--- a/frontend/common/src/components/TableOfContents/Navigation.tsx
+++ b/frontend/common/src/components/TableOfContents/Navigation.tsx
@@ -4,7 +4,9 @@ import { useIntl } from "react-intl";
 
 import Sidebar from "./Sidebar";
 
-const Navigation: React.FC = ({ children, ...rest }) => {
+const Navigation: React.FC<{
+  children?: React.ReactNode;
+}> = ({ children, ...rest }) => {
   const intl = useIntl();
   const id = uniqueId();
 

--- a/frontend/common/src/components/TableOfContents/Wrapper.tsx
+++ b/frontend/common/src/components/TableOfContents/Wrapper.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const Wrapper: React.FC = ({ children }) => (
+const Wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
   <div data-h2-padding="base(0, 0, x3, 0)">
     <div data-h2-container="base(center, full, 0)">
       <div data-h2-flex-grid="base(flex-start, x2, 0) l-tablet(stretch, x3)">

--- a/frontend/common/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/common/src/components/UserProfile/UserProfile.tsx
@@ -55,7 +55,10 @@ export interface UserProfileProps {
   headingLevel?: HeadingLevel;
 }
 
-const HeadingWrapper: React.FC<{ show: boolean }> = ({ children, show }) => {
+const HeadingWrapper: React.FC<{
+  children?: React.ReactNode;
+  show: boolean;
+}> = ({ children, show }) => {
   if (!show && children) {
     return (
       <div data-h2-padding="base(x1, 0, x1, 0)">

--- a/frontend/common/src/components/context/AuthenticationProvider.tsx
+++ b/frontend/common/src/components/context/AuthenticationProvider.tsx
@@ -4,7 +4,9 @@ import { AuthenticationContainer } from "../Auth";
 import { useApiRoutes } from "../../hooks/useApiRoutes";
 import { getRuntimeVariableNotNull } from "../../helpers/runtimeVariable";
 
-const AuthenticationProvider: React.FC = ({ children }) => {
+const AuthenticationProvider: React.FC<{
+  children?: React.ReactNode;
+}> = ({ children }) => {
   const apiPaths = useApiRoutes();
   const refreshTokenSetPath = apiPaths.refreshAccessToken();
 

--- a/frontend/common/src/components/context/AuthorizationProvider.tsx
+++ b/frontend/common/src/components/context/AuthorizationProvider.tsx
@@ -4,7 +4,9 @@ import { AuthorizationContainer } from "../Auth";
 import { useGetMeQuery } from "../../api/generated";
 import Pending from "../Pending";
 
-const AuthorizationProvider: React.FC = ({ children }) => {
+const AuthorizationProvider: React.FC<{
+  children?: React.ReactNode;
+}> = ({ children }) => {
   const [{ data, fetching, stale }] = useGetMeQuery();
   const isLoaded = !fetching && !stale;
 

--- a/frontend/common/src/components/form/Checklist/Checklist.tsx
+++ b/frontend/common/src/components/form/Checklist/Checklist.tsx
@@ -53,7 +53,7 @@ const Checklist: React.FunctionComponent<ChecklistProps> = ({
   const {
     register,
     formState: { errors },
-  } = useFormContext<any>();
+  } = useFormContext();
   // To grab errors in nested objects we need to use lodash's get helper.
   const error = get(errors, name)?.message as FieldError;
   const required = !!rules.required;

--- a/frontend/common/src/components/form/Checklist/Checklist.tsx
+++ b/frontend/common/src/components/form/Checklist/Checklist.tsx
@@ -53,7 +53,7 @@ const Checklist: React.FunctionComponent<ChecklistProps> = ({
   const {
     register,
     formState: { errors },
-  } = useFormContext();
+  } = useFormContext<any>();
   // To grab errors in nested objects we need to use lodash's get helper.
   const error = get(errors, name)?.message as FieldError;
   const required = !!rules.required;

--- a/frontend/common/src/components/form/ErrorSummary.tsx
+++ b/frontend/common/src/components/form/ErrorSummary.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-useless-fragment */
 import React from "react";
 import { useIntl } from "react-intl";
 import { useFormState } from "react-hook-form";
@@ -77,8 +78,11 @@ const ErrorSummary = React.forwardRef<
       <ul data-h2-margin="base(x.5, 0, 0, 0)">
         {invalidFields.map((field) => (
           <li key={field.name}>
-            <ScrollToLink to={field.name}>{field.label}</ScrollToLink>
-            {locale === "fr" && " "}: {field.message}
+            <>
+              {/* complains about needing to have a single child */}
+              <ScrollToLink to={field.name}>{field.label}</ScrollToLink>
+              {locale === "fr" && " "}: {field.message}
+            </>
           </li>
         ))}
       </ul>

--- a/frontend/common/src/components/form/ErrorSummary.tsx
+++ b/frontend/common/src/components/form/ErrorSummary.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-no-useless-fragment */
 import React from "react";
 import { useIntl } from "react-intl";
 import { useFormState } from "react-hook-form";
@@ -78,11 +77,8 @@ const ErrorSummary = React.forwardRef<
       <ul data-h2-margin="base(x.5, 0, 0, 0)">
         {invalidFields.map((field) => (
           <li key={field.name}>
-            <>
-              {/* complains about needing to have a single child */}
-              <ScrollToLink to={field.name}>{field.label}</ScrollToLink>
-              {locale === "fr" && " "}: {field.message}
-            </>
+            <ScrollToLink to={field.name}>{field.label}</ScrollToLink>
+            {locale === "fr" && " "}: {field.message}
           </li>
         ))}
       </ul>

--- a/frontend/common/src/components/inputPartials/InputError/InputError.tsx
+++ b/frontend/common/src/components/inputPartials/InputError/InputError.tsx
@@ -10,8 +10,8 @@ export type InputFieldError =
   | undefined;
 
 export interface InputErrorProps extends React.HTMLProps<HTMLSpanElement> {
-  isVisible: boolean;
   error: InputFieldError;
+  isVisible: boolean;
 }
 
 const InputError: React.FC<InputErrorProps> = ({
@@ -33,7 +33,7 @@ const InputError: React.FC<InputErrorProps> = ({
       aria-live="polite"
       {...rest}
     >
-      {error}
+      {error as unknown as string}
     </span>
   ) : null;
 };

--- a/frontend/common/src/components/inputPartials/InputError/InputError.tsx
+++ b/frontend/common/src/components/inputPartials/InputError/InputError.tsx
@@ -33,7 +33,7 @@ const InputError: React.FC<InputErrorProps> = ({
       aria-live="polite"
       {...rest}
     >
-      {error as unknown as string}
+      {error}
     </span>
   ) : null;
 };

--- a/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
+++ b/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
@@ -16,6 +16,7 @@ export interface InputWrapperProps {
   errorPosition?: "top" | "bottom";
   context?: string;
   hideOptional?: boolean;
+  children?: React.ReactNode;
   hideBottomMargin?: boolean;
   fillLabel?: boolean;
   trackUnsaved?: boolean;

--- a/frontend/common/src/helpers/format.tsx
+++ b/frontend/common/src/helpers/format.tsx
@@ -11,7 +11,7 @@ import React from "react";
  *
  * @param text text to wrap.
  */
-export const strong = (text: React.ReactNode): React.ReactNode => (
+export const strong = (text: React.ReactNode) => (
   <span data-h2-font-weight="base(700)">{text}</span>
 );
 
@@ -19,7 +19,7 @@ export const strong = (text: React.ReactNode): React.ReactNode => (
  * Wraps text in span to make invisible to sighted users
  * @param text text to wrap.
  */
-export const hidden = (text: React.ReactNode): React.ReactNode => (
+export const hidden = (text: React.ReactNode) => (
   <span data-h2-visibility="base(invisible)" style={{ whiteSpace: "pre" }}>
     {text}
   </span>
@@ -29,7 +29,7 @@ export const hidden = (text: React.ReactNode): React.ReactNode => (
  * Wraps text in tags to make it the primary color with a heavy weight
  * @param text text to wrap.
  */
-export const heavyPrimary = (text: React.ReactNode): React.ReactNode => (
+export const heavyPrimary = (text: React.ReactNode) => (
   <span data-h2-color="base(dt-primary)" data-h2-font-weight="base(700)">
     {text}
   </span>
@@ -39,7 +39,7 @@ export const heavyPrimary = (text: React.ReactNode): React.ReactNode => (
  * Wraps text in tags to make it the primary color
  * @param text text to wrap.
  */
-export const primary = (text: React.ReactNode): React.ReactNode => (
+export const primary = (text: React.ReactNode) => (
   <span data-h2-color="base(dt-primary)">{text}</span>
 );
 
@@ -47,7 +47,7 @@ export const primary = (text: React.ReactNode): React.ReactNode => (
  * Wraps text in tags to make it red
  * @param text  text to wrap
  */
-export const red = (text: React.ReactNode): React.ReactNode => (
+export const red = (text: React.ReactNode) => (
   <span data-h2-color="base(dark.dt-error)">{text}</span>
 );
 
@@ -55,7 +55,7 @@ export const red = (text: React.ReactNode): React.ReactNode => (
  * Wraps text in tags to make it gray
  * @param text  text to wrap
  */
-export const gray = (text: React.ReactNode): React.ReactNode => (
+export const gray = (text: React.ReactNode) => (
   <span data-h2-color="base(dt-gray.dark)">{text}</span>
 );
 

--- a/frontend/common/src/helpers/testUtils.tsx
+++ b/frontend/common/src/helpers/testUtils.tsx
@@ -6,7 +6,7 @@ import IntlProvider from "react-intl/src/components/provider";
 import { BrowserRouter } from "react-router-dom";
 import defaultRichTextElements from "./format";
 
-const Providers: React.FC = ({ children }) => {
+const Providers: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   window.history.pushState({}, "Test page", "/");
 
   return (

--- a/frontend/indigenousapprenticeship/src/js/components/Banner/Banner.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/Banner/Banner.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const Banner: React.FC = ({ children }) => (
+const Banner: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
   <div
     data-h2-display="base(inline-block)"
     data-h2-position="base(relative)"

--- a/frontend/indigenousapprenticeship/src/js/components/Card/Card.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/Card/Card.tsx
@@ -3,8 +3,9 @@ import React from "react";
 import Heading from "../Heading/Heading";
 
 interface CardProps {
-  Icon?: React.FC<React.HTMLAttributes<HTMLOrSVGElement>>;
   title: string;
+  Icon?: React.FC<React.HTMLAttributes<HTMLOrSVGElement>>;
+  children?: React.ReactNode;
 }
 
 const Card: React.FC<CardProps> = ({ title, Icon, children }) => (

--- a/frontend/indigenousapprenticeship/src/js/components/Dialog/ApplyDialog.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/Dialog/ApplyDialog.tsx
@@ -7,7 +7,7 @@ import CloseButton from "./CloseButton";
 
 import { BasicDialogProps } from "./types";
 
-const mailAccessor = (chunks: React.ReactNode): React.ReactNode => (
+const mailAccessor = (chunks: React.ReactNode) => (
   <a
     href="mailto:edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca"
     data-h2-color="base(ia-primary) base:hover(dark.ia-primary)"

--- a/frontend/indigenousapprenticeship/src/js/components/Heading/Heading.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/Heading/Heading.tsx
@@ -5,6 +5,7 @@ interface HeadingProps {
   color?: "pink" | "white";
   className?: string;
   light?: boolean;
+  children?: React.ReactNode;
 }
 
 const Heading: React.FC<HeadingProps> = ({

--- a/frontend/indigenousapprenticeship/src/js/components/Home/Home.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/Home/Home.tsx
@@ -27,7 +27,7 @@ import CTAButtons from "../CallToAction/CTAButtons";
 
 import "./home.css";
 
-const mailLink = (chunks: React.ReactNode): React.ReactNode => (
+const mailLink = (chunks: React.ReactNode) => (
   <a href="mailto:edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca">{chunks}</a>
 );
 

--- a/frontend/indigenousapprenticeship/src/js/components/Step/Step.tsx
+++ b/frontend/indigenousapprenticeship/src/js/components/Step/Step.tsx
@@ -5,6 +5,7 @@ import Heading from "../Heading/Heading";
 interface StepProps {
   position: string;
   title: string;
+  children?: React.ReactNode;
 }
 
 const Step: React.FC<StepProps> = ({ position, title, children }) => (

--- a/frontend/indigenousapprenticeship/src/js/hooks/useQuote.tsx
+++ b/frontend/indigenousapprenticeship/src/js/hooks/useQuote.tsx
@@ -24,7 +24,7 @@ const useQuote = (): Quote => {
           description: "testimonial number one",
         },
         {
-          b: (chunks: React.ReactNode): React.ReactNode => (
+          b: (chunks: React.ReactNode) => (
             <span style={{ color: "#FFDCA7" }}>{chunks}</span>
           ),
         },

--- a/frontend/talentsearch/src/js/components/AccessibilityStatement/AccessibilityStatement.tsx
+++ b/frontend/talentsearch/src/js/components/AccessibilityStatement/AccessibilityStatement.tsx
@@ -11,10 +11,7 @@ import useBreadcrumbs from "../../hooks/useBreadcrumbs";
 import useRoutes from "../../hooks/useRoutes";
 import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
 
-const digitalStandardsLink = (
-  locale: Locales,
-  chunks: React.ReactNode,
-): React.ReactNode => (
+const digitalStandardsLink = (locale: Locales, chunks: React.ReactNode) => (
   <ExternalLink
     newTab
     href={
@@ -45,7 +42,7 @@ const fableLink = (chunks: React.ReactNode) => (
   </ExternalLink>
 );
 
-const acaLink = (locale: Locales, chunks: React.ReactNode): React.ReactNode => (
+const acaLink = (locale: Locales, chunks: React.ReactNode) => (
   <ExternalLink
     newTab
     href={
@@ -71,10 +68,7 @@ const acrLink = (locale: Locales, chunks: React.ReactNode): React.ReactNode => (
   </ExternalLink>
 );
 
-const complaintsLink = (
-  locale: Locales,
-  chunks: React.ReactNode,
-): React.ReactNode => (
+const complaintsLink = (locale: Locales, chunks: React.ReactNode) => (
   <ExternalLink
     newTab
     href={
@@ -87,10 +81,7 @@ const complaintsLink = (
   </ExternalLink>
 );
 
-const crtcLink = (
-  locale: Locales,
-  chunks: React.ReactNode,
-): React.ReactNode => (
+const crtcLink = (locale: Locales, chunks: React.ReactNode) => (
   <ExternalLink
     newTab
     href={
@@ -103,10 +94,7 @@ const crtcLink = (
   </ExternalLink>
 );
 
-const crtcActLink = (
-  locale: Locales,
-  chunks: React.ReactNode,
-): React.ReactNode => (
+const crtcActLink = (locale: Locales, chunks: React.ReactNode) => (
   <ExternalLink
     newTab
     href={
@@ -119,10 +107,7 @@ const crtcActLink = (
   </ExternalLink>
 );
 
-const chrcLink = (
-  locale: Locales,
-  chunks: React.ReactNode,
-): React.ReactNode => (
+const chrcLink = (locale: Locales, chunks: React.ReactNode) => (
   <ExternalLink
     newTab
     href={
@@ -135,10 +120,7 @@ const chrcLink = (
   </ExternalLink>
 );
 
-const chraLink = (
-  locale: Locales,
-  chunks: React.ReactNode,
-): React.ReactNode => (
+const chraLink = (locale: Locales, chunks: React.ReactNode) => (
   <ExternalLink
     newTab
     href={
@@ -151,7 +133,7 @@ const chraLink = (
   </ExternalLink>
 );
 
-const ctaLink = (locale: Locales, chunks: React.ReactNode): React.ReactNode => (
+const ctaLink = (locale: Locales, chunks: React.ReactNode) => (
   <ExternalLink
     newTab
     href={
@@ -164,10 +146,7 @@ const ctaLink = (locale: Locales, chunks: React.ReactNode): React.ReactNode => (
   </ExternalLink>
 );
 
-const relationsLink = (
-  locale: Locales,
-  chunks: React.ReactNode,
-): React.ReactNode => (
+const relationsLink = (locale: Locales, chunks: React.ReactNode) => (
   <ExternalLink
     newTab
     href={
@@ -180,10 +159,7 @@ const relationsLink = (
   </ExternalLink>
 );
 
-const relayServiceLink = (
-  locale: Locales,
-  chunks: React.ReactNode,
-): React.ReactNode => (
+const relayServiceLink = (locale: Locales, chunks: React.ReactNode) => (
   <ExternalLink
     newTab
     href={
@@ -274,7 +250,7 @@ const AccessibilityStatement = () => {
                 description: "Paragraph describing accessibility standards",
               },
               {
-                digitalStandardsLink: (chunks) =>
+                digitalStandardsLink: (chunks: React.ReactNode) =>
                   digitalStandardsLink(locale, chunks),
               },
             )}
@@ -461,9 +437,10 @@ const AccessibilityStatement = () => {
                 description: "Text describing accessibility commissioner",
               },
               {
-                acaLink: (chunks) => acaLink(locale, chunks),
-                acrLink: (chunks) => acrLink(locale, chunks),
-                complaintsLink: (chunks) => complaintsLink(locale, chunks),
+                acaLink: (chunks: React.ReactNode) => acaLink(locale, chunks),
+                acrLink: (chunks: React.ReactNode) => acrLink(locale, chunks),
+                complaintsLink: (chunks: React.ReactNode) =>
+                  complaintsLink(locale, chunks),
               },
             )}
           </p>
@@ -487,8 +464,10 @@ const AccessibilityStatement = () => {
                     "Description of complaints to the Canadian Radio-television and Telecommunications Commission",
                 },
                 {
-                  crtcLink: (chunks) => crtcLink(locale, chunks),
-                  crtcActLink: (chunks) => crtcActLink(locale, chunks),
+                  crtcLink: (chunks: React.ReactNode) =>
+                    crtcLink(locale, chunks),
+                  crtcActLink: (chunks: React.ReactNode) =>
+                    crtcActLink(locale, chunks),
                 },
               )}
             </li>
@@ -502,8 +481,10 @@ const AccessibilityStatement = () => {
                     "Description of complaints to the Canadian Human Rights Commission",
                 },
                 {
-                  chrcLink: (chunks) => chrcLink(locale, chunks),
-                  chraLink: (chunks) => chraLink(locale, chunks),
+                  chrcLink: (chunks: React.ReactNode) =>
+                    chrcLink(locale, chunks),
+                  chraLink: (chunks: React.ReactNode) =>
+                    chraLink(locale, chunks),
                 },
               )}
             </li>
@@ -517,7 +498,7 @@ const AccessibilityStatement = () => {
                     "Description of complaints to the Canadian Transportation Agency",
                 },
                 {
-                  ctaLink: (chunks) => ctaLink(locale, chunks),
+                  ctaLink: (chunks: React.ReactNode) => ctaLink(locale, chunks),
                 },
               )}
             </li>
@@ -530,7 +511,10 @@ const AccessibilityStatement = () => {
                   description:
                     "Description of complaints to the Federal Public Sector Labour Relations and Employment Board<",
                 },
-                { relationsLink: (chunks) => relationsLink(locale, chunks) },
+                {
+                  relationsLink: (chunks: React.ReactNode) =>
+                    relationsLink(locale, chunks),
+                },
               )}
             </li>
           </ul>
@@ -582,7 +566,7 @@ const AccessibilityStatement = () => {
                   description: "VRS contact info",
                 },
                 {
-                  relayServiceLink: (chunks) =>
+                  relayServiceLink: (chunks: React.ReactNode) =>
                     relayServiceLink(locale, chunks),
                 },
               )}

--- a/frontend/talentsearch/src/js/components/GovernmentInfoForm/GovernmentInfoForm.tsx
+++ b/frontend/talentsearch/src/js/components/GovernmentInfoForm/GovernmentInfoForm.tsx
@@ -42,10 +42,7 @@ type FormValues = {
   priorityEntitlementNumber?: string;
 };
 
-const priorityEntitlementLink = (
-  locale: string,
-  chunks: React.ReactNode,
-): React.ReactNode => {
+const priorityEntitlementLink = (locale: string, chunks: React.ReactNode) => {
   const href =
     locale === "en"
       ? "https://www.canada.ca/en/public-service-commission/services/information-priority-administration.html"
@@ -452,7 +449,7 @@ export const GovernmentInfoForm: React.FunctionComponent<
                 "Sentence asking whether the user possesses priority entitlement",
             },
             {
-              priorityEntitlementLink: (chunks) =>
+              priorityEntitlementLink: (chunks: React.ReactNode) =>
                 priorityEntitlementLink(locale, chunks),
             },
           )}

--- a/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormFooter.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormFooter.tsx
@@ -4,6 +4,7 @@ import SaveButton from "./SaveButton";
 
 export interface ProfileFormFooterProps {
   mode: "cancelButton" | "saveButton" | "bothButtons";
+  children?: React.ReactNode;
   cancelLink?: CancelButtonProps;
 }
 

--- a/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormWrapper.tsx
+++ b/frontend/talentsearch/src/js/components/applicantProfile/ProfileFormWrapper.tsx
@@ -16,6 +16,7 @@ export interface ProfileFormWrapperProps {
   title: string;
   metaTitle?: string; // Used to override <head><title /></head>
   cancelLink?: CancelButtonProps;
+  children?: React.ReactNode;
   prefixBreadcrumbs?: boolean;
 }
 

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/Definition.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/Definition.tsx
@@ -3,10 +3,7 @@ import { useIntl } from "react-intl";
 
 import { ExternalLink } from "@common/components/Link";
 
-const statCanLink = (
-  href: string,
-  chunks: React.ReactNode,
-): React.ReactNode => (
+const statCanLink = (href: string, chunks: React.ReactNode) => (
   <ExternalLink newTab href={href}>
     {chunks}
   </ExternalLink>
@@ -30,7 +27,7 @@ const Definition: React.FC<DefinitionProps> = ({ url }) => {
             "Link to Statistics Canada's employment equity definitions",
         },
         {
-          link: (chunks) => statCanLink(url, chunks),
+          link: (chunks: React.ReactNode) => statCanLink(url, chunks),
         },
       )}
     </p>

--- a/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/UnderReview.tsx
+++ b/frontend/talentsearch/src/js/components/employmentEquityForm/dialogs/UnderReview.tsx
@@ -3,7 +3,7 @@ import { useIntl } from "react-intl";
 import { ExternalLink } from "@common/components/Link";
 import { getLocale } from "@common/helpers/localize";
 
-const actLink = (locale: string, chunks: React.ReactNode): React.ReactNode => {
+const actLink = (locale: string, chunks: React.ReactNode) => {
   const href =
     locale === "en"
       ? "https://laws-lois.justice.gc.ca/eng/acts/e-5.401/"
@@ -14,10 +14,7 @@ const actLink = (locale: string, chunks: React.ReactNode): React.ReactNode => {
     </ExternalLink>
   );
 };
-const reviewLink = (
-  locale: string,
-  chunks: React.ReactNode,
-): React.ReactNode => {
+const reviewLink = (locale: string, chunks: React.ReactNode) => {
   const href =
     locale === "en"
       ? "https://www.canada.ca/en/employment-social-development/corporate/portfolio/labour/programs/employment-equity/task-force.html"
@@ -44,8 +41,8 @@ const UnderReview: React.FC = () => {
             "Text that appears in Employment equity dialogs explaining the act is under review.",
         },
         {
-          actLink: (chunks) => actLink(locale, chunks),
-          reviewLink: (chunks) => reviewLink(locale, chunks),
+          actLink: (chunks: React.ReactNode) => actLink(locale, chunks),
+          reviewLink: (chunks: React.ReactNode) => reviewLink(locale, chunks),
         },
       )}
     </p>

--- a/frontend/talentsearch/src/js/components/languageInformationForm/ConsideredLanguages.tsx
+++ b/frontend/talentsearch/src/js/components/languageInformationForm/ConsideredLanguages.tsx
@@ -51,7 +51,7 @@ const ConsideredLanguages = ({ labels }: ConsideredLanguagesProps) => {
     );
   };
 
-  const selfAssessmentLink = (msg: React.ReactNode): React.ReactNode => {
+  const selfAssessmentLink = (msg: React.ReactNode) => {
     return (
       <ExternalLink
         newTab

--- a/frontend/talentsearch/src/js/components/login/LoginPage.tsx
+++ b/frontend/talentsearch/src/js/components/login/LoginPage.tsx
@@ -10,10 +10,9 @@ import SEO from "@common/components/SEO/SEO";
 import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
 import useRoutes from "../../hooks/useRoutes";
 
-const keyRegistrationLink = (
-  path: string,
-  chunks: React.ReactNode,
-): React.ReactNode => <a href={path}>{chunks}</a>;
+const keyRegistrationLink = (path: string, chunks: React.ReactNode) => (
+  <a href={path}>{chunks}</a>
+);
 
 const LoginPage: React.FC = () => {
   const intl = useIntl();
@@ -75,7 +74,8 @@ const LoginPage: React.FC = () => {
                   "Instruction on what to do if user does not have a GC Key.",
               },
               {
-                a: (chunks) => keyRegistrationLink(loginPath, chunks),
+                a: (chunks: React.ReactNode) =>
+                  keyRegistrationLink(loginPath, chunks),
               },
             )}
           </p>

--- a/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
+++ b/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
@@ -9,6 +9,7 @@ import { notEmpty } from "@common/helpers/util";
 import { tryFindMessageDescriptor } from "@common/messages/apiMessages";
 import { AuthorizationContext } from "@common/components/Auth";
 
+import { commonMessages, errorMessages } from "@common/messages";
 import useRoutes from "../../hooks/useRoutes";
 import { Scalars, useCreateApplicationMutation } from "../../api/generated";
 
@@ -107,11 +108,23 @@ const CreateApplication = () => {
                 }),
               );
             } else {
-              const message = tryFindMessageDescriptor(result.error.message);
+              const messageDescriptor = tryFindMessageDescriptor(
+                result.error.message,
+              );
+              const message = intl.formatMessage(
+                messageDescriptor ??
+                  errorMessages.unknownErrorRequestErrorTitle,
+              );
               handleError(message, newPath);
             }
           } else if (result.error?.message) {
-            handleError(tryFindMessageDescriptor(result.error.message));
+            const messageDescriptor = tryFindMessageDescriptor(
+              result.error.message,
+            );
+            const message = intl.formatMessage(
+              messageDescriptor ?? errorMessages.unknownErrorRequestErrorTitle,
+            );
+            handleError(message);
           } else {
             // Fallback to generic message
             handleError();

--- a/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
+++ b/frontend/talentsearch/src/js/components/pool/CreateApplication.tsx
@@ -9,7 +9,7 @@ import { notEmpty } from "@common/helpers/util";
 import { tryFindMessageDescriptor } from "@common/messages/apiMessages";
 import { AuthorizationContext } from "@common/components/Auth";
 
-import { commonMessages, errorMessages } from "@common/messages";
+import { errorMessages } from "@common/messages";
 import useRoutes from "../../hooks/useRoutes";
 import { Scalars, useCreateApplicationMutation } from "../../api/generated";
 

--- a/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolAdvertisementPage.tsx
@@ -134,7 +134,7 @@ const IconTitle = ({ children, icon }: IconTitleProps) => {
   );
 };
 
-const anchorTag = (chunks: React.ReactNode): React.ReactNode => (
+const anchorTag = (chunks: React.ReactNode) => (
   <a href={`mailto:${TALENTSEARCH_RECRUITMENT_EMAIL}`}>{chunks}</a>
 );
 

--- a/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
+++ b/frontend/talentsearch/src/js/components/pool/PoolInfoCard.tsx
@@ -19,7 +19,7 @@ export interface PoolInfoCardProps {
   };
 }
 
-const P: React.FC = ({ children }) => (
+const P: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
   <p
     data-h2-display="base(flex)"
     data-h2-align-items="base(center)"

--- a/frontend/talentsearch/src/js/components/register/RegisterPage.tsx
+++ b/frontend/talentsearch/src/js/components/register/RegisterPage.tsx
@@ -10,10 +10,9 @@ import { useApiRoutes } from "@common/hooks/useApiRoutes";
 import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
 import useRoutes from "../../hooks/useRoutes";
 
-const keyRegistrationLink = (
-  path: string,
-  chunks: React.ReactNode,
-): React.ReactNode => <a href={path}>{chunks}</a>;
+const keyRegistrationLink = (path: string, chunks: React.ReactNode) => (
+  <a href={path}>{chunks}</a>
+);
 
 const RegisterPage: React.FC = () => {
   const intl = useIntl();
@@ -75,7 +74,8 @@ const RegisterPage: React.FC = () => {
                   "Instruction on what to do if user does not have a GC Key.",
               },
               {
-                a: (chunks) => keyRegistrationLink(loginPath, chunks),
+                a: (chunks: React.ReactNode) =>
+                  keyRegistrationLink(loginPath, chunks),
               },
             )}
           </p>

--- a/frontend/talentsearch/src/js/components/roleSalaryForm/RoleSalaryForm.tsx
+++ b/frontend/talentsearch/src/js/components/roleSalaryForm/RoleSalaryForm.tsx
@@ -121,7 +121,7 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
   };
 
   // intl styling functions section
-  function link(chunks: React.ReactNode, url: string): React.ReactNode {
+  function link(chunks: React.ReactNode, url: string) {
     return (
       <ExternalLink newTab href={url}>
         {chunks}
@@ -320,7 +320,7 @@ export const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
                 description: "Link to learn more about classifications",
               },
               {
-                link: (chunks: React.ReactNode): React.ReactNode =>
+                link: (chunks: React.ReactNode) =>
                   link(
                     chunks,
                     intl.locale === "en"

--- a/frontend/talentsearch/src/js/components/search/CandidateResults.tsx
+++ b/frontend/talentsearch/src/js/components/search/CandidateResults.tsx
@@ -6,7 +6,7 @@ import SearchPools, { type SearchPoolsProps } from "./SearchPools";
 
 type CandidateResultsProps = SearchPoolsProps;
 
-const mailLink = (chunks: React.ReactNode): React.ReactNode => (
+const mailLink = (chunks: React.ReactNode) => (
   <a
     href={`mailto:${TALENTSEARCH_RECRUITMENT_EMAIL}`}
     data-h2-font-weight="base(700)"

--- a/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
+++ b/frontend/talentsearch/src/js/components/search/EstimatedCandidates.tsx
@@ -10,7 +10,7 @@ interface EstimatedCandidatesProps {
   updatePending?: boolean;
 }
 
-const testId = (chunks: React.ReactNode): React.ReactNode => (
+const testId = (chunks: React.ReactNode) => (
   <span data-testid="candidateCount">{chunks}</span>
 );
 

--- a/frontend/talentsearch/src/js/components/search/FilterBlock.tsx
+++ b/frontend/talentsearch/src/js/components/search/FilterBlock.tsx
@@ -4,6 +4,7 @@ interface FilterBlockProps {
   id: string;
   title: string | React.ReactNode;
   text: string;
+  children?: React.ReactNode;
 }
 
 const FilterBlock: React.FC<FilterBlockProps> = ({

--- a/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchContainer.tsx
@@ -70,7 +70,7 @@ const applicantFilterToQueryArgs = (
   return {};
 };
 
-function a(chunks: React.ReactNode): React.ReactNode {
+function a(chunks: React.ReactNode) {
   return (
     <a
       href={`mailto:${TALENTSEARCH_RECRUITMENT_EMAIL}`}
@@ -162,7 +162,7 @@ export interface SearchContainerProps {
   ) => Promise<void>;
 }
 
-const testId = (chunks: React.ReactNode): React.ReactNode => (
+const testId = (chunks: React.ReactNode) => (
   <span data-testid="candidateCount">{chunks}</span>
 );
 

--- a/frontend/talentsearch/src/js/components/support/SupportForm.tsx
+++ b/frontend/talentsearch/src/js/components/support/SupportForm.tsx
@@ -34,7 +34,7 @@ interface SupportFormSuccessProps {
   onFormToggle: (show: boolean) => void;
 }
 
-const anchorTag = (chunks: React.ReactNode): React.ReactNode => (
+const anchorTag = (chunks: React.ReactNode) => (
   <a href={`mailto:${TALENTSEARCH_SUPPORT_EMAIL}`}>{chunks}</a>
 );
 

--- a/frontend/talentsearch/src/js/tests/testUtils.tsx
+++ b/frontend/talentsearch/src/js/tests/testUtils.tsx
@@ -3,7 +3,7 @@ import { render, RenderOptions } from "@testing-library/react";
 import { axe } from "jest-axe";
 import IntlProvider from "react-intl/src/components/provider";
 
-const AllTheProviders: FC = ({ children }) => {
+const AllTheProviders: FC<{ children?: React.ReactNode }> = ({ children }) => {
   return <IntlProvider locale="en">{children}</IntlProvider>;
 };
 


### PR DESCRIPTION
## 👋 Introduction

This branch is prep work for the React 18 upgrade.  The type definitions are a little more strict at that version and so this branch preemptively knocks out most of the compile-time errors.

## 🕵️ Details

90% of the changes are related to two things:
- The `children` prop must be explicitly declared. Ref: https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions
- FormatMessage is more strict about its types.  Ref: https://github.com/formatjs/formatjs/issues/3633#issuecomment-1245103640

## 🧪 Testing

1. Rebuild the project
2. No changes to how the site works.