### PR TITLE
Bug - 5213 - Fix French typo, English descriptions

### DIFF
--- a/frontend/talentsearch/src/js/components/Browse/BrowsePoolsPage.tsx
+++ b/frontend/talentsearch/src/js/components/Browse/BrowsePoolsPage.tsx
@@ -89,8 +89,8 @@ export const BrowsePools: React.FC<BrowsePoolsProps> = ({
       <SEO
         title={intl.formatMessage({
           defaultMessage: "Browse opportunities",
-          id: "KJxmlD",
-          description: "Title for the brows pools page",
+          id: "1To4Kg",
+          description: "Title for the browse pools page",
         })}
       />
       <Hero

--- a/frontend/talentsearch/src/js/components/search/SearchPage.tsx
+++ b/frontend/talentsearch/src/js/components/search/SearchPage.tsx
@@ -14,8 +14,8 @@ const SearchPage = () => {
       <SEO
         title={intl.formatMessage({
           defaultMessage: "Search pools",
-          id: "WPkc5j",
-          description: "Page title for page",
+          id: "E2HkVa",
+          description: "Page title for the search page",
         })}
       />
       <section data-h2-background-color="base(dt-gray.15)">

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -2609,9 +2609,9 @@
     "defaultMessage": "Bienvenue",
     "description": "Title for the homepage"
   },
-  "KJxmlD": {
+  "1To4Kg": {
     "defaultMessage": "Parcourez les opportunités",
-    "description": "Title for the brows pools page"
+    "description": "Title for the browse pools page"
   },
   "E2HkVa": {
     "defaultMessage": "Rechercher les bassins de talents",

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -2613,9 +2613,9 @@
     "defaultMessage": "Parcourez les opportunités",
     "description": "Title for the brows pools page"
   },
-  "WPkc5j": {
+  "E2HkVa": {
     "defaultMessage": "Researche bassin de talents",
-    "description": "Page title for page"
+    "description": "Page title for the search page"
   },
   "ZxLDpB": {
     "defaultMessage": "Profil de candidature",

--- a/frontend/talentsearch/src/js/lang/fr.json
+++ b/frontend/talentsearch/src/js/lang/fr.json
@@ -2614,7 +2614,7 @@
     "description": "Title for the brows pools page"
   },
   "E2HkVa": {
-    "defaultMessage": "Researche bassin de talents",
+    "defaultMessage": "Rechercher les bassins de talents",
     "description": "Page title for the search page"
   },
   "ZxLDpB": {


### PR DESCRIPTION
🤖 Resolves #5213.

## 👋 Introduction

This PR fixes a typo in French, fixes a typo in English in a string description, and makes a string description more descriptive.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run intl-compile --workspace=talentsearch`
2. `npm run production --workspace=talentsearch`
3. Navigate to `/browse/pools`
4. Verify page title is _Browse opportunities_ in English and _Parcourez les opportunités_ in French
5. Navigate to `/search`
6. Verify page title is _Search pools_ in English and _Rechercher les bassins de talents_ in French