### PR TITLE
Bug - 5178 - Fix French string, descriptions

### DIFF
--- a/frontend/common/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
@@ -54,8 +54,9 @@ const GovernmentInformationSection: React.FunctionComponent<{
               <p>
                 {intl.formatMessage({
                   defaultMessage: "Department:",
-                  id: "nV57as",
-                  description: "Label for applicants department",
+                  id: "ny/ddo",
+                  description:
+                    "Label for applicant's Government of Canada department",
                 })}
                 <br />
                 <span data-h2-font-weight="base(700)">

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1553,7 +1553,7 @@
     "description": "Fallback for name value"
   },
   "nV57as": {
-    "defaultMessage": "Département :",
+    "defaultMessage": "Ministère :",
     "description": "Label for applicants department"
   },
   "oMyc4e": {

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1552,9 +1552,9 @@
     "defaultMessage": "Aucun nom fourni",
     "description": "Fallback for name value"
   },
-  "nV57as": {
+  "ny/ddo": {
     "defaultMessage": "Ministère :",
-    "description": "Label for applicants department"
+    "description": "Label for applicant's Government of Canada department"
   },
   "oMyc4e": {
     "defaultMessage": "Citoyen ou résident",


### PR DESCRIPTION
🤖 Resolves #5178.

## 👋 Introduction

This PR fixes an incorrectly translated string in French and updates a string description to be more descriptive.

## 🧪 Testing

1. `npm run intl-compile --workspace=common`
2. `npm run production --workspace=talentsearch`
3. `npm run production --workspace=admin`
4. Navigate to `/users/:id#government-section`
5. Verify department field label is **Department:** in English and **Ministère :** in French
6. Navigate to `/admin/users/:id#government-section` in the Candidate Profile tab
7. Verify department field label is **Department:** in English and **Ministère :** in French

## 📸 Screenshots
<img width="1195" alt="Screen Shot 2022-12-28 at 10 35 59" src="https://user-images.githubusercontent.com/3046459/209836368-e8d2c60a-4343-4e88-889d-a1f9763d3cf2.png">
<img width="1407" alt="Screen Shot 2022-12-28 at 10 38 00" src="https://user-images.githubusercontent.com/3046459/209836369-0df51a4a-3783-49dd-83b6-7ff97e0f21ca.png">
