### PR TITLE
Bug - 4814 - Reset notes field on submission

### DIFF
--- a/frontend/admin/src/js/components/searchRequest/UpdateSearchRequest.tsx
+++ b/frontend/admin/src/js/components/searchRequest/UpdateSearchRequest.tsx
@@ -47,6 +47,13 @@ export const UpdateSearchRequestForm: React.FunctionComponent<
       adminNotes: data.adminNotes,
     })
       .then(() => {
+        // HACK: This marks the field as clean after
+        // submitting the data since the form is never
+        // submitted in the traditional sense
+        methods.resetField("adminNotes", {
+          keepDirty: false,
+          defaultValue: data.adminNotes,
+        });
         toast.success(
           intl.formatMessage({
             defaultMessage: "Notes saved successfully!",


### PR DESCRIPTION
🤖 Resolves #4814

## 👋 Introduction

This fixes an issue where the notes fields was not being cleaned after submission.

## 🕵️ Details

Since the request form is not a traditional form we are relying on a function to save notes rather than the submit action. This resets the field to the data it currently has as a way of cleaning it.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build admin `npm run production --admin`
2. Navigate to `/admin/talent-requests`
3. View a request
4. Edit the notes field, noting that it marks it as unsaved
5. Click the Save Notes button
6. Confirm the unsaved message disappears once the data has been saved


