### PR TITLE
Bug - 3316 - Add `tel:` link and `aria-label` to phone numbers

### DIFF
--- a/frontend/admin/src/js/components/user/GeneralInformationTab/GeneralInformationTab.tsx
+++ b/frontend/admin/src/js/components/user/GeneralInformationTab/GeneralInformationTab.tsx
@@ -194,7 +194,18 @@ const AboutSection: React.FC<BasicSectionProps> = ({ user }) => {
               description: "Display text for the phone number field on users",
             })}
           </p>
-          <p>{user.telephone}</p>
+          <p>
+            {user.telephone ? (
+              <a
+                href={`tel:${user.telephone}`}
+                aria-label={user.telephone.replace(/.{1}/g, "$& ")}
+              >
+                {user.telephone}
+              </a>
+            ) : (
+              ""
+            )}
+          </p>
         </div>
         {/* Current location */}
         <div data-h2-flex-item="base(1of1) p-tablet(1of2) desktop(1of3)">

--- a/frontend/admin/src/js/components/user/UserTable.tsx
+++ b/frontend/admin/src/js/components/user/UserTable.tsx
@@ -135,6 +135,20 @@ const languageAccessor = (
   </span>
 );
 
+const phoneAccessor = (telephone: string | null | undefined) => {
+  if (telephone) {
+    return (
+      <a
+        href={`tel:${telephone}`}
+        aria-label={telephone.replace(/.{1}/g, "$& ")}
+      >
+        {telephone}
+      </a>
+    );
+  }
+  return "";
+};
+
 const emailLinkAccessor = (email: string | null, intl: IntlShape) => {
   if (email) {
     return (
@@ -312,7 +326,7 @@ export const UserTable = ({ initialFilterInput }: UserTableProps) => {
           id: "fXMsoK",
           description: "Title displayed for the User table Telephone column.",
         }),
-        accessor: (user) => user.telephone,
+        accessor: (user) => phoneAccessor(user.telephone),
         id: "telephone",
         sortColumnName: "telephone",
       },

--- a/frontend/common/src/components/UserProfile/ProfileSections/AboutSection.tsx
+++ b/frontend/common/src/components/UserProfile/ProfileSections/AboutSection.tsx
@@ -83,7 +83,16 @@ const AboutSection: React.FC<AboutSectionProps> = ({
                 description: "Phone label and colon",
               })}
               <br />
-              <span data-h2-font-weight="base(700)">{telephone}</span>
+              {telephone ? (
+                <a
+                  href={`tel:${telephone}`}
+                  aria-label={telephone.replace(/.{1}/g, "$& ")}
+                >
+                  <span data-h2-font-weight="base(700)">{telephone}</span>
+                </a>
+              ) : (
+                ""
+              )}
             </p>
           </div>
         )}


### PR DESCRIPTION
🤖 Resolves #3316.

## 👋 Introduction

This PR adds an aria-label for phone numbers with space after each character for screen readers so that phone numbers are not read out as single long numbers.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Visit `/admin/users` and show the Telephone column
3. Visit `/users/:id/profile` and scroll to About me section and Phone
4. Verify with a screen reader that phone numbers are read out as expected
