### PR TITLE
Bug - 5259 - Fix `deploy.sh` script

### DIFF
--- a/infrastructure/bin/deploy.sh
+++ b/infrastructure/bin/deploy.sh
@@ -34,43 +34,12 @@ sudo chmod -R 775 ./ ./storage
 php artisan lighthouse:print-schema --write
 
 ### Install all npm dependencies
-cd $ROOT_DIR/frontend
+cd $ROOT_DIR
 npm ci --include=dev
 
-# Run h2-build using workspace command from /frontend
-npm run h2-build --workspace common
-
-### Common
-
-cd $ROOT_DIR/frontend/common
-npm run codegen
-npm run intl-compile
-
-### Talentsearch
-
-cd $ROOT_DIR/frontend/talentsearch
-npm run codegen
-npm run intl-compile
-npm run production
-
-### Admin
-
-cd $ROOT_DIR/frontend/admin
-npm run codegen
-npm run intl-compile
-npm run production
-
-### Indigenous Apprenticeship
-
-cd $ROOT_DIR
-npm install
-npm run codegen
-npm run intl-compile
+### Build frontend
 npm run build
+chmod -R a+r,a+w node_modules
 
-
-### Cleanup /frontend npm dependencies
-cd $ROOT_DIR
-npm prune --production
-cd $ROOT_DIR/frontend
+### Cleanup frontend npm dependencies
 npm prune --production


### PR DESCRIPTION
🤖 Resolves #5259 

## 👋 Introduction

Fixed the `deploy.sh` script with new commands.

## 🕵️ Details

When we started the process to merge projects, we changes the `npm` scripts up a bit and they are now called in the root folder only once instead of individually. This updates our `deploy.sh` script to change how the frontend is built.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. ???

