### PR TITLE
a11y - 4860 - Use full month name for skill accordions

### DIFF
--- a/frontend/common/src/components/UserProfile/accordionUtils.tsx
+++ b/frontend/common/src/components/UserProfile/accordionUtils.tsx
@@ -5,7 +5,7 @@ import { Maybe, Scalars } from "../../api/generated";
 export function formattedDate(date: Scalars["Date"], intl: IntlShape) {
   return formatDate({
     date: new Date(date),
-    formatString: "MMM RRRR",
+    formatString: "MMMM RRRR",
     intl,
   });
 }


### PR DESCRIPTION
🤖 Resolves #4860 

## 👋 Introduction

This changes the skill accordions to present months with their full name rather than abbreviations.

## 🕵️ Details

The month name abbreviations do not match the guidelines for Canadian month abbreviations and are less helpful than presenting the full month name. For this reason, we are no longer using abbreviations for month names.

## 🧪 Testing

1. Build the app `npm run build`
2. Navigate to the user profile `/talent/profile`
3. Scroll to the accordions in the "My skills and experience" section
4. Confirm the months are the full name in both French and English

## 📸 Screenshot

<img width="865" alt="Screenshot 2023-01-04 at 4 47 34 PM" src="https://user-images.githubusercontent.com/4127998/210656490-d1e3a5de-767f-41db-b2dd-da7e5d1092e5.png">



