### PR TITLE
Bump Jest test timeout

### DIFF
--- a/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.test.tsx
+++ b/frontend/talentsearch/src/js/components/experienceForm/ExperienceForm.test.tsx
@@ -20,7 +20,7 @@ const renderExperienceForm = (props: ExperienceFormProps) =>
   render(<ExperienceForm {...props} />);
 
 describe("ExperienceForm", () => {
-  jest.setTimeout(10000); // TODO: remove in #4755
+  jest.setTimeout(30000); // TODO: remove in #4755
   it("award type should have no accessibility errors", async () => {
     const { container } = renderExperienceForm({
       userId: mockUserId,


### PR DESCRIPTION
This branch further bumps the timeout on a set of slow Jest tests.  When one of these tests times out it results in a series of "Axe is already running" errors in the Jest logs.

Eventually we'll improve these tests in issue #4755 but for now this will help the CI continue to run reliably.