### PR TITLE
Batch change status for pool candidates

### DIFF
--- a/frontend/admin/src/js/components/poolCandidate/poolCandidatesOperations.graphql
+++ b/frontend/admin/src/js/components/poolCandidate/poolCandidatesOperations.graphql
@@ -333,7 +333,6 @@ mutation updatePoolCandidate(
   $poolCandidate: UpdatePoolCandidateAsAdminInput!
 ) {
   updatePoolCandidateAsAdmin(id: $id, poolCandidate: $poolCandidate) {
-    id
     cmoIdentifier
     expiryDate
     status

--- a/frontend/admin/src/js/components/poolCandidate/poolCandidatesOperations.graphql
+++ b/frontend/admin/src/js/components/poolCandidate/poolCandidatesOperations.graphql
@@ -333,6 +333,7 @@ mutation updatePoolCandidate(
   $poolCandidate: UpdatePoolCandidateAsAdminInput!
 ) {
   updatePoolCandidateAsAdmin(id: $id, poolCandidate: $poolCandidate) {
+    id
     cmoIdentifier
     expiryDate
     status

--- a/frontend/admin/src/js/components/user/GeneralInformationTab/GeneralInformationTab.tsx
+++ b/frontend/admin/src/js/components/user/GeneralInformationTab/GeneralInformationTab.tsx
@@ -45,7 +45,7 @@ interface SectionWithPoolsProps {
   pools: Pool[];
 }
 
-const PoolStatusTable: React.FC<BasicSectionProps> = ({ user }) => {
+const PoolStatusTable: React.FC<SectionWithPoolsProps> = ({ user, pools }) => {
   const intl = useIntl();
   const routes = useAdminRoutes();
 
@@ -122,6 +122,7 @@ const PoolStatusTable: React.FC<BasicSectionProps> = ({ user }) => {
                   <ChangeStatusDialog
                     selectedCandidate={candidate}
                     user={user}
+                    pools={pools}
                   />
                 </td>
                 <td
@@ -316,7 +317,7 @@ const CandidateStatusSection: React.FC<SectionWithPoolsProps> = ({
             "Title of the 'Pool status' section of the view-user page",
         })}
       </Heading>
-      <PoolStatusTable user={user} />
+      <PoolStatusTable user={user} pools={pools} />
       <h5 data-h2-margin="base(x2, 0, x1, 0)">
         {intl.formatMessage({
           defaultMessage: "Add user to pool",

--- a/frontend/admin/src/js/lang/fr.json
+++ b/frontend/admin/src/js/lang/fr.json
@@ -2300,5 +2300,17 @@
   "VCl+IZ": {
     "defaultMessage": "<heavyPrimary>Fermée</heavyPrimary>",
     "description": "Status name of a pool in CLOSED status"
+  },
+  "8V8WwR": {
+    "defaultMessage": "Bassins additionnels",
+    "description": "Label displayed on the additional pools field of the change candidate status dialog"
+  },
+  "vtXnOQ": {
+    "defaultMessage": "Sélectionnez d’autres bassins additionnels...",
+    "description": "Placeholder displayed on the additional pools field of the change candidate status dialog."
+  },
+  "wiUfZL": {
+    "defaultMessage": "Si vous souhaitez voir ce message d’état changer à l’échelle de divers bassins, veuillez les sélectionner à partir d’ici :",
+    "description": "Header for section to add additional pools to the change status operation"
   }
 }


### PR DESCRIPTION
🤖 Resolves #5132 

## 👋 Introduction

This branch adds the ability to change the pool candidate status for multiple pool candidates at the same time.  It's closely related to PR #5256.

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

1. Log into the admin site
2. Find a user, preferably with several pool candidates
3. Click the __change status__ link beside one of pools and change the status of that pool candidate
4. Click the __change status__ link beside one of pools and change the status of multiple pool candidates together
5. If you inject a junk pool in the code you can trigger an error
![image](https://user-images.githubusercontent.com/8978655/211078730-8896bc9c-0280-4727-9aae-fb5c2ea2ece2.png)


## 📸 Screenshot

![image](https://user-images.githubusercontent.com/8978655/211078584-e956cf6a-748b-48ea-84d6-3c80f558d5c6.png)


![image](https://user-images.githubusercontent.com/8978655/211078030-9aa72c85-a30b-43bb-8a79-b4a44125f26d.png)


