### PR TITLE
Feature - 3696 - Make Chromatic project token into variable

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -58,7 +58,7 @@ jobs:
         env:
           MERGE_STORYBOOKS: true
         with:
-          projectToken: 87148152bdff
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           # Auto-accept UI Tests on Chromatic platform.
           # We use this setting because we're not relying on UI Tests at the
           # moment, and want the GitHub status check in PRs (for "UI Tests") to

--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -34,7 +34,6 @@
     "production": "npm run build",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "chromatic": "npx chromatic --project-token=87148152bdff --auto-accept-changes",
     "codegen": "graphql-codegen",
     "intl-extract": "formatjs extract './src/js/**/*.{ts,tsx}' --ignore './**/*.d.ts' --out-file src/js/lang/en.json --id-interpolation-pattern [sha512:contenthash:base64:6]",
     "intl-compile": "formatjs compile ./src/js/lang/fr.json --ast --out-file ./src/js/lang/frCompiled.json",


### PR DESCRIPTION
🤖 Resolves #3696.

## 👋 Introduction

This PR removes a hardcoded project token and replaces it with a dynamic and secret variable to avoid potential malicious use.

## 🕵️ Details

In order to see the Chromatic project token and associated GitHub secret, the reviewer must be an owner of the Chromatic account and the GitHub repository respectively.

## 🧪 Testing

1. Verify old chromatic project token does not work locally `npx chromatic --project-token=87148152bdff --auto-accept-changes`
2. Verify Chromatic GitHub workflow runs successfully on this PR
3. Verify Chromatic GitHub workflow logs do not expose project token
