### PR TITLE
Bug - 5310 - Admin Edit Pool page duplicate id, label

### DIFF
--- a/frontend/admin/src/js/components/pool/EditPool/AssetSkillsSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/AssetSkillsSection.tsx
@@ -86,6 +86,7 @@ export const AssetSkillsSection = ({
               description: "Text on a button to save the pool asset skills",
             })}
             isSubmitting={isSubmitting}
+            skillType="asset"
           />
         </>
       ) : (

--- a/frontend/admin/src/js/components/pool/EditPool/EssentialSkillsSection.tsx
+++ b/frontend/admin/src/js/components/pool/EditPool/EssentialSkillsSection.tsx
@@ -11,7 +11,6 @@ import {
   Skill,
   UpdatePoolAdvertisementInput,
 } from "../../../api/generated";
-
 import { SectionMetadata } from "./EditPool";
 import { useEditPoolContext } from "./EditPoolContext";
 
@@ -85,6 +84,7 @@ export const EssentialSkillsSection = ({
               description: "Text on a button to save the pool essential skills",
             })}
             isSubmitting={isSubmitting}
+            skillType="essential"
           />
         </>
       ) : (

--- a/frontend/common/src/components/SkillPicker/SkillPicker.tsx
+++ b/frontend/common/src/components/SkillPicker/SkillPicker.tsx
@@ -30,8 +30,6 @@ const defaultValues: FormValues = {
   query: "",
   skillFamily: "",
 };
-
-const skipToHeadingId = `selected-skills-heading-${uniqueId()}`;
 export interface SkillPickerProps {
   skills: Skills;
   selectedSkills?: Skills;
@@ -40,6 +38,7 @@ export interface SkillPickerProps {
   handleSave?: () => void;
   submitButtonText?: string;
   isSubmitting?: boolean;
+  skillType?: string;
 }
 
 const SkillPicker = ({
@@ -50,6 +49,7 @@ const SkillPicker = ({
   handleSave,
   submitButtonText,
   isSubmitting,
+  skillType,
 }: SkillPickerProps) => {
   const intl = useIntl();
   const Heading = headingLevel;
@@ -59,6 +59,8 @@ const SkillPicker = ({
     defaultValues,
   });
   const { watch, handleSubmit } = methods;
+  const skipToHeadingId = `selected-skills-heading-${skillType || uniqueId}`;
+  const queryInputId = `query-${skillType || uniqueId}`;
 
   React.useEffect(() => {
     const subscription = watch(({ query, skillFamily }) => {
@@ -120,7 +122,7 @@ const SkillPicker = ({
     <FormProvider {...methods}>
       <InputLabel
         required={false}
-        inputId="query"
+        inputId={queryInputId}
         label={intl.formatMessage({
           defaultMessage: "Search skills by keyword",
           id: "ARqO1j",
@@ -133,7 +135,7 @@ const SkillPicker = ({
           families={allSkillFamilies}
         />
         <input
-          id="query"
+          id={queryInputId}
           type="text"
           autoComplete="off"
           {...methods.register("query")}


### PR DESCRIPTION
🤖 Resolves #5310.

## 👋 Introduction

This PR solves some invalid HTML markup that is also related to a11y for duplicate id and duplicate labels on HTML elements.

## 🕵️ Details

The `SkillPicker` component was not designed to have multiple instances on the same page. `SkillPickerProps` now has an optional prop called `skillType` that allows for uniqueness when there are two SkillPickers on a single page (unless there are two skill pickers on the same page that have the same `skillType` value, but this would be a very peculiar implementation).

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/admin/pools/create`
2. Create a new pool
3. Run axe devtools browser extension
4. Observe no duplicate id and label errors
5. Make sure that the **query** input in both Skill pickers function properly
6. Make sure that the **Search Skills by Keyword** heading in both Skill pickers function properly


