### PR TITLE
bug/5287-clear-unsaved-changes-message

### DIFF
--- a/frontend/admin/src/js/components/poolCandidate/ApplicationStatusForm/ApplicationStatusForm.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/ApplicationStatusForm/ApplicationStatusForm.tsx
@@ -58,6 +58,20 @@ export const ApplicationStatusForm = ({
       notes: values.notes,
       expiryDate: values.expiryDate || emptyToNull(values.expiryDate),
     });
+
+    // recycle the field reset from Eric in UpdateSearchRequest.tsx
+    methods.resetField("status", {
+      keepDirty: false,
+      defaultValue: values.status,
+    });
+    methods.resetField("notes", {
+      keepDirty: false,
+      defaultValue: values.notes,
+    });
+    methods.resetField("expiryDate", {
+      keepDirty: false,
+      defaultValue: values.expiryDate,
+    });
   };
 
   const allowedStatuses = enumToOptions(PoolCandidateStatus).filter(


### PR DESCRIPTION
🤖 Resolves #5287 

## 👋 Introduction

Form state reset after submitting

## 🕵️ Details

Just recycling method from #5242 

## 🧪 Testing

1. Open an application in the admin dashboard (en/admin/candidates/:id/application)
2. Makes changes in the Application Status section and then submit
3. Assert form state is no longer dirty after submitting

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/40485260/211687731-d7e6d765-6afe-4432-9f0f-a7e6c92865a1.png)


