### PR TITLE
Bug - 5261 - Fix watch command

### DIFF
--- a/frontend/admin/webpack.base.js
+++ b/frontend/admin/webpack.base.js
@@ -19,6 +19,9 @@ module.exports = {
       "./src/css/app.css",
     ],
   },
+  watchOptions: {
+    ignored: ['**/hydrogen.css'],
+  },
   plugins: [
     // Run Hydrogen on Webpack's compiler hooks
     new HydrogenPlugin({ outputFile: path.resolve(__dirname, "../common/src/css/hydrogen.css") }),

--- a/frontend/talentsearch/webpack.base.js
+++ b/frontend/talentsearch/webpack.base.js
@@ -19,6 +19,9 @@ module.exports = {
       "./src/css/app.css",
     ],
   },
+  watchOptions: {
+    ignored: ['**/hydrogen.css'],
+  },
   plugins: [
 
     // Run Hydrogen on Webpack's compiler hooks


### PR DESCRIPTION
🤖 Resolves #5261 

## 👋 Introduction

This fixes the watch commands infinite loop issue.

## 🕵️ Details

We updated how hydrogen is built but the old webpack configs need to keep the regen in it until they have been merged into apps/web. This tells them to ignore that file in watch mode so it does not re-trigger a built and enter an infinte loop.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run `npm run watch -- --filter=talentsearch`
2. Wait for it to complete
3. Edit a filter in `frontend/talentsearch`
4. Confirm it rebuilds **once**
5. Repeat steps 1-4 but in `admin`


