### PR TITLE
Bug - 5319 - Fix Classification Table

### DIFF
--- a/frontend/admin/src/js/components/classification/ClassificationTable.tsx
+++ b/frontend/admin/src/js/components/classification/ClassificationTable.tsx
@@ -15,9 +15,13 @@ import { useAdminRoutes } from "../../adminRoutes";
 
 type Data = NonNullable<FromArray<GetClassificationsQuery["classifications"]>>;
 
-export const ClassificationTable: React.FC<
-  GetClassificationsQuery & { editUrlRoot: string }
-> = ({ classifications, editUrlRoot }) => {
+interface ClassificationTableProps {
+  classifications: GetClassificationsQuery["classifications"];
+}
+
+export const ClassificationTable = ({
+  classifications,
+}: ClassificationTableProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
   const paths = useAdminRoutes();
@@ -86,12 +90,12 @@ export const ClassificationTable: React.FC<
         accessor: (d) =>
           tableEditButtonAccessor(
             d.id,
-            editUrlRoot,
+            paths.classificationTable(),
             `${d.name?.[locale]} ${d.group}-0${d.level}`,
           ), // callback extracted to separate function to stabilize memoized component
       },
     ],
-    [editUrlRoot, intl, locale],
+    [intl, locale, paths],
   );
 
   const memoizedData = useMemo(
@@ -127,14 +131,10 @@ export const ClassificationTableApi: React.FunctionComponent = () => {
     context,
   });
   const { data, fetching, error } = result;
-  const { pathname } = useLocation();
 
   return (
     <Pending fetching={fetching} error={error}>
-      <ClassificationTable
-        classifications={data?.classifications ?? []}
-        editUrlRoot={pathname}
-      />
+      <ClassificationTable classifications={data?.classifications ?? []} />
     </Pending>
   );
 };

--- a/frontend/admin/src/js/components/classification/ClassificationTable.tsx
+++ b/frontend/admin/src/js/components/classification/ClassificationTable.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from "react";
 import { useIntl } from "react-intl";
-import { useLocation } from "react-router-dom";
 import { notEmpty } from "@common/helpers/util";
 import { FromArray } from "@common/types/utilityTypes";
 import { getLocale } from "@common/helpers/localize";

--- a/frontend/admin/src/js/stories/Classification.stories.tsx
+++ b/frontend/admin/src/js/stories/Classification.stories.tsx
@@ -17,7 +17,7 @@ const classificationData = fakeClassifications();
 const stories = storiesOf("Classifications", module);
 
 stories.add("Classifications Table", () => (
-  <ClassificationTable classifications={classificationData} editUrlRoot="#" />
+  <ClassificationTable classifications={classificationData} />
 ));
 
 stories.add("Create Classification Form", () => (


### PR DESCRIPTION
🤖 Resolves #5319

## 👋 Introduction

Fixes the `ClassificationTable` crashing.

## 🕵️ Details

Removes unnecessary edit url path prop that was causing infinite re-renders.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build the app `npm run build`
2. Navigate to `/admin/settings/classifications`
3. Confirm the page loads properly and no update depth error in console


