### PR TITLE
bug/5312-ErrorSummary-formatting

### DIFF
--- a/frontend/common/src/components/form/ErrorSummary.tsx
+++ b/frontend/common/src/components/form/ErrorSummary.tsx
@@ -6,7 +6,6 @@ import type { FieldLabels } from "./BasicForm";
 
 import Alert from "../Alert";
 import { ScrollToLink } from "../Link";
-import { getLocale } from "../../helpers/localize";
 import { notEmpty } from "../../helpers/util";
 
 interface ErrorSummaryProps {
@@ -24,7 +23,6 @@ const ErrorSummary = React.forwardRef<
 >(({ labels, show }, forwardedRef) => {
   const intl = useIntl();
 
-  const locale = getLocale(intl);
   const { errors } = useFormState();
 
   // Don't show if the form is valid
@@ -78,7 +76,7 @@ const ErrorSummary = React.forwardRef<
         {invalidFields.map((field) => (
           <li key={field.name}>
             <ScrollToLink to={field.name}>{field.label}</ScrollToLink>
-            {`${locale === "fr" && ` `}${field.message}`}
+            {`${` `}${field.message}`}
           </li>
         ))}
       </ul>

--- a/frontend/common/src/components/form/ErrorSummary.tsx
+++ b/frontend/common/src/components/form/ErrorSummary.tsx
@@ -6,6 +6,7 @@ import type { FieldLabels } from "./BasicForm";
 
 import Alert from "../Alert";
 import { ScrollToLink } from "../Link";
+import { getLocale } from "../../helpers/localize";
 import { notEmpty } from "../../helpers/util";
 
 interface ErrorSummaryProps {
@@ -23,6 +24,7 @@ const ErrorSummary = React.forwardRef<
 >(({ labels, show }, forwardedRef) => {
   const intl = useIntl();
 
+  const locale = getLocale(intl);
   const { errors } = useFormState();
 
   // Don't show if the form is valid
@@ -76,7 +78,7 @@ const ErrorSummary = React.forwardRef<
         {invalidFields.map((field) => (
           <li key={field.name}>
             <ScrollToLink to={field.name}>{field.label}</ScrollToLink>
-            {`${` `}${field.message}`}
+            {`${locale === "fr" ? ` : ` : `: `}${field.message}`}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
🤖 Resolves #5312 

## 👋 Introduction

Solves this

![image](https://user-images.githubusercontent.com/40485260/212161052-4dadd020-725b-4634-b9c0-9295ff25d603.png)

## 🕵️ Details

Introduce a colon with variable spacing

## 🧪 Testing

1. Go to places with ErrorSummary being rendered, such as creating an experience for your profile
2. Fill out nothing and immediately try to submit, ensure the error summary component renders correctly

## 📸 Screenshot

Correctly in

French
![image](https://user-images.githubusercontent.com/40485260/212170000-b90a133b-ad68-4404-9144-0e9863b580d4.png)

