### PR TITLE
Fix create account 

### DIFF
--- a/apps/e2e/cypress/e2e/talentsearch/create-account.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/create-account.cy.js
@@ -1,0 +1,54 @@
+describe("Create account tests", () => {
+  it("Logging in as a new user goes to create-account and then to profile", () => {
+    const uniqueTestId = (
+      Math.floor(Math.random() * Number.MAX_SAFE_INTEGER) + 1
+    ).toString();
+
+    cy.loginBySubject(uniqueTestId);
+    cy.visit("/en/users/me");
+
+    // should go to the create-account page
+    cy.findByRole("heading", {
+      name: "Welcome to Digital Talent",
+      level: 1,
+    }).should("exist");
+
+    cy.findByRole("textbox", { name: /First Name/i }).then((textbox) => {
+      cy.wrap(textbox).type("Cypress");
+    });
+    cy.findByRole("textbox", { name: /Last Name/i }).then((textbox) => {
+      cy.wrap(textbox).type(uniqueTestId);
+    });
+    cy.findByRole("textbox", { name: /Which email do you like to be contacted at/i }).then((textbox) => {
+      cy.wrap(textbox).type(`cypress-${uniqueTestId}@example.org`);
+    });
+    cy.findByRole("group", {
+      name: /What is your preferred contact language/i,
+    }).within(() => {
+      cy.findByRole("radio", {
+        name: /English/i,
+      }).click();
+    });
+    cy.findByRole("group", {
+      name: /Do you currently work for the government of Canada/i,
+    }).within(() => {
+      cy.findByRole("radio", {
+        name: /No/i,
+      }).click();
+    });
+    cy.findByRole("group", {
+      name: /Priority Entitlement/i,
+    }).within(() => {
+      cy.findByRole("radio", {
+        name: /I do not have a priority entitlement/i,
+      }).click();
+    });
+    cy.findByRole("button", { name: "Save and go to my profile" }).click();
+
+    // should go to the profile page
+    cy.findByRole("heading", {
+      name: `Cypress ${uniqueTestId}'s profile`,
+      level: 1,
+    }).should("exist");
+  });
+});

--- a/frontend/talentsearch/src/js/components/createAccount/CreateAccountPage.tsx
+++ b/frontend/talentsearch/src/js/components/createAccount/CreateAccountPage.tsx
@@ -13,6 +13,7 @@ import { emptyToNull, notEmpty } from "@common/helpers/util";
 import SEO from "@common/components/SEO/SEO";
 import Pending from "@common/components/Pending";
 
+import { AuthorizationContext } from "@common/components/Auth/AuthorizationContainer";
 import TALENTSEARCH_APP_DIR from "../../talentSearchConstants";
 import {
   Language,
@@ -307,11 +308,11 @@ const CreateAccount: React.FunctionComponent = () => {
   const navigate = useNavigate();
   const paths = useRoutes();
   const { from } = location.state as LocationState;
+  const authContext = React.useContext(AuthorizationContext);
+  const meId = authContext.loggedInUser?.id;
 
   const [lookUpResult] = useGetCreateAccountFormDataQuery();
   const { data: lookupData, fetching, error } = lookUpResult;
-  const meInfo = lookupData?.me;
-  const meId = meInfo?.id;
   const departments: Department[] | [] =
     lookupData?.departments.filter(notEmpty) ?? [];
   const classifications: Classification[] | [] =
@@ -346,7 +347,6 @@ const CreateAccount: React.FunctionComponent = () => {
     }
     await handleCreateAccount(meId, data)
       .then(() => {
-        navigate(from || paths.profile(meId));
         toast.success(
           intl.formatMessage({
             defaultMessage: "Account successfully created.",
@@ -355,6 +355,7 @@ const CreateAccount: React.FunctionComponent = () => {
               "Message displayed to user if account is created successfully.",
           }),
         );
+        // navigation will happen on useEffect after authorization context has updated
       })
       .catch(() => {
         toast.error(
@@ -368,8 +369,17 @@ const CreateAccount: React.FunctionComponent = () => {
       });
   };
 
+  // OK to navigate to profile once we have a user ID and an email
+  const shouldNavigate = meId && authContext.loggedInEmail;
+  const navigationTarget = from || paths.profile(meId || "");
+  React.useEffect(() => {
+    if (shouldNavigate) {
+      navigate(navigationTarget);
+    }
+  }, [navigate, navigationTarget, shouldNavigate]);
+
   return (
-    <Pending fetching={fetching} error={error}>
+    <Pending fetching={fetching || !authContext.isLoaded} error={error}>
       <CreateAccountForm
         cacheKey={`create-account-${meId}`}
         departments={departments}

--- a/frontend/talentsearch/src/js/components/createAccount/createAccountOperations.graphql
+++ b/frontend/talentsearch/src/js/components/createAccount/createAccountOperations.graphql
@@ -1,7 +1,4 @@
 query getCreateAccountFormData {
-  me {
-    id
-  }
   classifications {
     id
     name {


### PR DESCRIPTION
🤖 Resolves #5286 

## 👋 Introduction

This branch corrects the the behavior of the create-account redirect and page.

## 🕵️ Details

Previously, if you logged in as a new user you would be taken to the Create Account page as usual.  However, once you submitted the form you would be taken back the Create Account page a second time.  It seems like the React Router `navigate` command after submitting the form was running synchronously and the redirect decision was being made before the authorization context provider had a chance to update it's own state with the new details.  I've moved the navigate command out of the mutation promise and into a useEffect that runs after rendering.

## 🧪 Testing

1. Log in as a new user, fill out the create account form, observe that you are forwarded to your profile page
2. Log in as an existing user, observe that you are forwarded directly to your profile page

## :bug: Bug

I found a new bug while working on this.  If you apply to a pool while not logged in you do get forwarded to your application and it gets created but it applies twice and you get an error toast.  I think this is related to the React 18 Strict Mode change.  Since you end up with where you expected with an application and it probably won't happen in production I created an issue for it and I'll submit this branch as is.
#5352

