### PR TITLE
Bug - 5372 - Fixes `SkillPicker` component id

### DIFF
--- a/frontend/common/src/components/SkillPicker/SkillPicker.tsx
+++ b/frontend/common/src/components/SkillPicker/SkillPicker.tsx
@@ -1,7 +1,6 @@
-import React from "react";
+import React, { useId } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
-import uniqueId from "lodash/uniqueId";
 
 import type { HeadingLevel } from "../Heading";
 import Chip, { Chips } from "../Chip";
@@ -59,8 +58,9 @@ const SkillPicker = ({
     defaultValues,
   });
   const { watch, handleSubmit } = methods;
-  const skipToHeadingId = `selected-skills-heading-${skillType || uniqueId}`;
-  const queryInputId = `query-${skillType || uniqueId}`;
+  const staticId = useId();
+  const skipToHeadingId = `selected-skills-heading-${skillType || staticId}`;
+  const queryInputId = `query-${skillType || staticId}`;
 
   React.useEffect(() => {
     const subscription = watch(({ query, skillFamily }) => {


### PR DESCRIPTION
🤖 Resolves #5372.

## 👋 Introduction

This PR fixes the `SkillPicker` component for the case where the `skillType` prop is empty.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to /search scroll to **Skills selection** heading
2. Tab through to **Skip list of skills** link
3. Verify that the link skips the list of skills and focuses on the **Selected skills** heading