### PR TITLE
Bug - 5409 - Fixes header id value to match aria-labelledby value

### DIFF
--- a/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
@@ -643,7 +643,10 @@ const PoolCandidatesTable: React.FC<{
 
   return (
     <div data-h2-margin="base(x1, 0)">
-      <h2 id="user-table-heading" data-h2-visually-hidden="base(invisible)">
+      <h2
+        id="pool-candidate-table-heading"
+        data-h2-visually-hidden="base(invisible)"
+      >
         {intl.formatMessage({
           defaultMessage: "All Pool Candidates",
           id: "z0QI6A",


### PR DESCRIPTION
🤖 Resolves #5409.

## 👋 Introduction

This PR fixes a `aria-labelledby` value that was broken since the element it referenced did not exist due to being named incorrectly.

## 🧪 Testing

1. Navigate to `/admin/pools/:poolId/pool-candidates`
2. Inspect elements of page
3. Verify table `aria-labelledby` is **pool-candidate-table-heading**


