### PR TITLE
Copy - 5426 - Updates experience type community in French

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1330,7 +1330,7 @@
     "description": "Message displayed to user after experience fails to be created."
   },
   "mrhpJS": {
-    "defaultMessage": "Collectivité",
+    "defaultMessage": "Communautaire",
     "description": "Title for community experience form button."
   },
   "nOE+8s": {

--- a/apps/web/src/pages/ExperienceAndSkillsPage/ExperienceAndSkills.tsx
+++ b/apps/web/src/pages/ExperienceAndSkillsPage/ExperienceAndSkills.tsx
@@ -223,9 +223,13 @@ export const ExperienceAndSkills: React.FunctionComponent<
             </p>
           </div>
           <div data-h2-flex-item="base(1of1)">
-            <div data-h2-flex-grid="base(center,x1) p-tablet(center, x.5)">
+            <div
+              data-h2-display="base(block) p-tablet(flex)"
+              data-h2-flex-wrap="base(wrap)"
+              data-h2-gap="base(x.5)"
+            >
               {links.map(({ title, href, icon }) => (
-                <div key={title} data-h2-flex-item="base(1of1) p-tablet(1of5)">
+                <div key={title} data-h2-margin-top="base(x.5) p-tablet(0)">
                   <IconLink
                     href={href}
                     type="button"

--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1633,7 +1633,7 @@
     "description": "Heading for personal experiences in experience by type listing"
   },
   "iWD2Pz": {
-    "defaultMessage": "Expériences de la collectivité",
+    "defaultMessage": "Expériences communautaires",
     "description": "Heading for community experiences in experience by type listing"
   },
   "aBSEkP": {


### PR DESCRIPTION
🤖 Resolves #5426.

## 👋 Introduction

This PR updates French copy for **Community** so that it is more consistent with related French copy for similar words related to **Experiences** types. Related to #5419.

## 🧪 Testing

1. Compile French `npm run intl-compile`
2. Build talentsearch `npm run dev`
3. Navigate to `/fr/users/:id/profile/experiences`
4. Verify button is **Communautaire**
5. Verify experience buttons layout has buttons with the same height (thanks @substrae!)
6. Navigate to `/fr/users/:id/profile/experiences`
7. Click on **Par type** to list by type
8. Verify heading is **Expériences communautaires**
