### PR TITLE
Bug - 5428 - Fix Search Request Pool Candidates Default Filters

### DIFF
--- a/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
@@ -236,7 +236,10 @@ const defaultState = {
       hasDiploma: undefined,
       languageAbility: undefined,
     },
-    poolCandidateStatus: [],
+    poolCandidateStatus: [
+      PoolCandidateStatus.PlacedCasual,
+      PoolCandidateStatus.QualifiedAvailable,
+    ],
     priorityWeight: [],
   },
 };

--- a/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
@@ -258,12 +258,13 @@ const PoolCandidatesTable: React.FC<{
         ...defaultState.filters,
         applicantFilter: {
           ...defaultState.filters.applicantFilter,
-          pools: initialFilterInput?.applicantFilter?.pools,
+          ...initialFilterInput?.applicantFilter,
         },
       },
     }),
     [initialFilterInput],
   );
+
   const [tableState, setTableState] = useTableState<
     Data,
     PoolCandidateSearchInput

--- a/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
@@ -236,10 +236,7 @@ const defaultState = {
       hasDiploma: undefined,
       languageAbility: undefined,
     },
-    poolCandidateStatus: [
-      PoolCandidateStatus.PlacedCasual,
-      PoolCandidateStatus.QualifiedAvailable,
-    ],
+    poolCandidateStatus: [],
     priorityWeight: [],
   },
 };
@@ -263,6 +260,7 @@ const PoolCandidatesTable: React.FC<{
           ...defaultState.filters.applicantFilter,
           ...initialFilterInput?.applicantFilter,
         },
+        poolCandidateStatus: initialFilterInput?.poolCandidateStatus,
       },
     }),
     [initialFilterInput],

--- a/frontend/admin/src/js/components/searchRequest/SingleSearchRequestTable.tsx
+++ b/frontend/admin/src/js/components/searchRequest/SingleSearchRequestTable.tsx
@@ -281,6 +281,10 @@ const transformPoolCandidateFilterToFilterInput = (
     },
     languageAbility: inputFilter?.languageAbility || undefined,
     locationPreferences: inputFilter?.workRegions,
+    poolCandidateStatus: [
+      PoolCandidateStatus.PlacedCasual,
+      PoolCandidateStatus.QualifiedAvailable,
+    ],
   };
 };
 


### PR DESCRIPTION
🤖 Resolves #5428 

## 👋 Introduction

This fixes the default filters being populated on the `PoolCandidatesTable` component.

## 🕵️ Details

We were only populating pools previously, this simply adjusts it to use all filters.

## 🐛 Request Classifications

While fixing this bug, I was able to determine that classifications are not being passed to the request mutation and stored. They appear under "Request Information" because they are coming from the `Pool` rather than the `SearchRequest`.

Is this a bug? Or expected behaviour? If so, should the filter for classifications follow suit and be populated from the pool or should it come from the request when searching?

https://github.com/GCTC-NTGC/gc-digital-talent/blob/e4bc365ba09e14f325c4fe65d469c984396155f5/frontend/common/src/components/SearchRequestFilters/SearchRequestFilters.tsx#L131-L147

## 🧪 Testing

> **Note**
> Classifications are not working due to a possible bug. See the previous section in the description for more info.

1. Build the application `npm run build`
2. Navigate to `/search`
3. Fill out the form, taking note of the filters you use
4. Submit a request
5. Navigate to `/admin/talent-requests`
6. Click "View Request" on the request you created in step 4
7. Scroll down to the  "Candidate Results" section
8. Open the "Filters" dialog
9. Confirm the filters you submitted appear pre-populated in the form

## 📸 Screenshot

![Screenshot 2023-01-24 134352](https://user-images.githubusercontent.com/4127998/214380848-f59f408e-3848-47bd-b492-a39fd0bf531f.png)



