### PR TITLE
Tests - 5283 - Replaces `ClearsSchemaCache` with `RefreshesSchemaCache`

### DIFF
--- a/api/tests/Feature/ApplicantFilterTest.php
+++ b/api/tests/Feature/ApplicantFilterTest.php
@@ -15,7 +15,7 @@ use Database\Seeders\PoolSeeder;
 use Database\Seeders\SkillFamilySeeder;
 use Database\Seeders\SkillSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 
@@ -23,13 +23,13 @@ class ApplicantFilterTest extends TestCase
 {
     use RefreshDatabase;
     use MakesGraphQLRequests;
-    use ClearsSchemaCache;
+    use RefreshesSchemaCache;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->bootClearsSchemaCache();
+        $this->bootRefreshesSchemaCache();
 
         // Create admin user we run tests as
         // Note: this extra user does change the results of a couple queries

--- a/api/tests/Feature/ApplicantTest.php
+++ b/api/tests/Feature/ApplicantTest.php
@@ -10,7 +10,7 @@ use App\Models\CommunityExperience;
 use App\Models\PersonalExperience;
 use App\Models\WorkExperience;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 use Database\Helpers\ApiEnums;
@@ -19,12 +19,12 @@ class ApplicantTest extends TestCase
 {
     use RefreshDatabase;
     use MakesGraphQLRequests;
-    use ClearsSchemaCache;
+    use RefreshesSchemaCache;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->bootClearsSchemaCache();
+        $this->bootRefreshesSchemaCache();
 
         // Create admin user we run tests as
         // Note: this extra user does change the results of a couple queries

--- a/api/tests/Feature/CountPoolCandidatesByPoolTest.php
+++ b/api/tests/Feature/CountPoolCandidatesByPoolTest.php
@@ -9,7 +9,7 @@ use App\Models\PoolCandidate;
 use App\Models\Skill;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 use Database\Helpers\ApiEnums;
@@ -18,13 +18,13 @@ class CountPoolCandidatesByPoolTest extends TestCase
 {
     use RefreshDatabase;
     use MakesGraphQLRequests;
-    use ClearsSchemaCache;
+    use RefreshesSchemaCache;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->bootClearsSchemaCache();
+        $this->bootRefreshesSchemaCache();
 
         // Create admin user we run tests as
         $newUser = new User;

--- a/api/tests/Feature/PoolApplicationTest.php
+++ b/api/tests/Feature/PoolApplicationTest.php
@@ -8,7 +8,7 @@ use App\Models\User;
 use App\Models\Skill;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Testing\Fluent\AssertableJson;
-use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 use Database\Helpers\ApiEnums;
@@ -20,12 +20,12 @@ class PoolApplicationTest extends TestCase
 {
     use RefreshDatabase;
     use MakesGraphQLRequests;
-    use ClearsSchemaCache;
+    use RefreshesSchemaCache;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->bootClearsSchemaCache();
+        $this->bootRefreshesSchemaCache();
     }
 
     public function testApplicationCreation(): void

--- a/api/tests/Feature/PoolCandidateSearchRequestTest.php
+++ b/api/tests/Feature/PoolCandidateSearchRequestTest.php
@@ -5,7 +5,7 @@ namespace Tests\Feature;
 use App\Models\Department;
 use Database\Seeders\DepartmentSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 use Illuminate\Testing\Fluent\AssertableJson;
@@ -13,7 +13,7 @@ use Illuminate\Testing\Fluent\AssertableJson;
 class PoolCandidateSearchRequestTest extends TestCase {
     use RefreshDatabase;
     use MakesGraphQLRequests;
-    use ClearsSchemaCache;
+    use RefreshesSchemaCache;
 
     /**
      * Default required fields
@@ -28,7 +28,7 @@ class PoolCandidateSearchRequestTest extends TestCase {
     {
         parent::setUp();
 
-        $this->bootClearsSchemaCache();
+        $this->bootRefreshesSchemaCache();
     }
 
     /**

--- a/api/tests/Feature/PoolCandidateSearchTest.php
+++ b/api/tests/Feature/PoolCandidateSearchTest.php
@@ -4,7 +4,7 @@ use App\Models\User;
 use App\Models\Pool;
 use App\Models\PoolCandidate;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 use Database\Helpers\ApiEnums;
@@ -13,12 +13,12 @@ class PoolCandidateSearchTest extends TestCase
 {
     use RefreshDatabase;
     use MakesGraphQLRequests;
-    use ClearsSchemaCache;
+    use RefreshesSchemaCache;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->bootClearsSchemaCache();
+        $this->bootRefreshesSchemaCache();
 
         // Create admin user we run tests as
         // Note: this extra user does change the results of a couple queries

--- a/api/tests/Feature/PoolCandidateTest.php
+++ b/api/tests/Feature/PoolCandidateTest.php
@@ -6,7 +6,7 @@ use App\Models\PoolCandidate;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Database\Eloquent\Factories\Sequence;
-use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 use Database\Helpers\ApiEnums;
@@ -16,12 +16,12 @@ class PoolCandidateTest extends TestCase
 {
   use RefreshDatabase;
   use MakesGraphQLRequests;
-  use ClearsSchemaCache;
+  use RefreshesSchemaCache;
 
   protected function setUp(): void
   {
     parent::setUp();
-    $this->bootClearsSchemaCache();
+    $this->bootRefreshesSchemaCache();
   }
 
   public function testFilterByClassification(): void

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -3,7 +3,7 @@
 use App\Models\Pool;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 use Database\Helpers\ApiEnums;
@@ -12,12 +12,12 @@ class PoolTest extends TestCase
 {
   use RefreshDatabase;
   use MakesGraphQLRequests;
-  use ClearsSchemaCache;
+  use RefreshesSchemaCache;
 
   protected function setUp(): void
   {
     parent::setUp();
-    $this->bootClearsSchemaCache();
+    $this->bootRefreshesSchemaCache();
 
     $newUser = new User;
     $newUser->email = 'admin@test.com';

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -12,7 +12,7 @@ use App\Models\PersonalExperience;
 use App\Models\WorkExperience;
 use App\Models\GenericJobTitle;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Nuwave\Lighthouse\Testing\ClearsSchemaCache;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 use Database\Helpers\ApiEnums;
@@ -23,12 +23,12 @@ class UserTest extends TestCase
 {
     use RefreshDatabase;
     use MakesGraphQLRequests;
-    use ClearsSchemaCache;
+    use RefreshesSchemaCache;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->bootClearsSchemaCache();
+        $this->bootRefreshesSchemaCache();
 
         // Create admin user we run tests as
         // Note: this extra user does change the results of a couple queries


### PR DESCRIPTION
🤖 Resolves #5283.

## 👋 Introduction

This PR replaces the deprecated Lighthouse PHP trait `ClearsSchemaCache` with `RefreshesSchemaCache`.

## 🧪 Testing

1. Run PHPUnit `docker-compose exec -w /home/site/wwwroot/api webserver sh -c "vendor/bin/phpunit --verbose"`
2. Verify tests run normally

## 📸 Screenshot

![Screen Shot 2023-01-24 at 16 17 27](https://user-images.githubusercontent.com/3046459/214418597-4528790d-37db-4925-a816-4a7fc21761d6.png)


