### PR TITLE
Bug - 5470 - Fix GC Notify Test

### DIFF
--- a/api/tests/Feature/NotifyTest.php
+++ b/api/tests/Feature/NotifyTest.php
@@ -33,7 +33,6 @@ class NotifyTest extends TestCase
      */
     public function test_email()
     {
-
         $response = Notify::sendEmail(
             'simulate-delivered@notification.canada.ca',
             $this->templates['test_email'],

--- a/api/tests/Feature/NotifyTest.php
+++ b/api/tests/Feature/NotifyTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use Tests\TestCase;
 use App\Facades\Notify;
+use App\Exceptions\ApiKeyNotFoundException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -20,6 +21,11 @@ class NotifyTest extends TestCase
         $this->username = "Test Name";
         $this->bulkName = "Bulk Test";
         $this->templates = config('notify.templates');
+
+        $apiKey = config('notify.client.apiKey');
+        if(!$apiKey) {
+            $this->markTestSkipped("API key not found");
+        }
     }
 
     /**
@@ -29,6 +35,7 @@ class NotifyTest extends TestCase
      */
     public function test_email()
     {
+
         $response = Notify::sendEmail(
             'simulate-delivered@notification.canada.ca',
             $this->templates['test_email'],
@@ -89,7 +96,7 @@ class NotifyTest extends TestCase
             $this->templates['test_bulk_sms']
         );
 
-       $this->assertBulkResponseSuccess($response);
+        $this->assertBulkResponseSuccess($response);
     }
     /**
      * Test sending Bulk Email
@@ -126,7 +133,7 @@ class NotifyTest extends TestCase
             $this->templates['test_bulk_email']
         );
 
-       $this->assertBulkResponseSuccess($response);
+        $this->assertBulkResponseSuccess($response);
     }
 
     /**
@@ -155,4 +162,5 @@ class NotifyTest extends TestCase
         $this->assertStringContainsStringIgnoringCase($this->bulkName, $json['original_file_name']);
         $this->assertEquals(3, $json['notification_count']);
     }
+
 }

--- a/api/tests/Feature/NotifyTest.php
+++ b/api/tests/Feature/NotifyTest.php
@@ -4,9 +4,7 @@ namespace Tests\Unit;
 
 use Tests\TestCase;
 use App\Facades\Notify;
-use App\Exceptions\ApiKeyNotFoundException;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Log;
 
 class NotifyTest extends TestCase
 {


### PR DESCRIPTION
🤖 Resolves #5470 

## 👋 Introduction

This skips the `NotifyTest` is an API key is not present. As well, it moves it to the feature namespace since it is an integration test.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. If you have GCNOTIFY_API_KEY set, comment it out
2. Run PHP unit
3. Confirm the tests skip
4. Add in an API key
5. Run PHP unit
6. Confirm the tests pass

## 📸 Screenshot
![Screenshot 2023-01-25 114746](https://user-images.githubusercontent.com/4127998/214625448-f0bb4dd7-632e-46c2-bf47-4464a0bc0f19.png)


