### PR TITLE
Bug - 5473 - Fix translation workflow

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -75,7 +75,7 @@ jobs:
         if: always()
         working-directory: apps/web/src/lang
         run: >
-          if test -f ".untranslated.json"; then
+          if test -f "untranslated.json"; then
             echo ":x: Web has untranslated strings" | tee -a $GITHUB_STEP_SUMMARY;
             exit 1;
           else

--- a/frontend/common/package.json
+++ b/frontend/common/package.json
@@ -24,7 +24,7 @@
     "check-intl-admin": "node ./src/tooling/checkIntl.js --en ../admin/src/js/lang/en.json --fr ../admin/src/js/lang/fr.json --rm-orphaned --output-untranslated ../admin/src/js/lang/untranslated.json --whitelist ../admin/src/js/lang/whitelist.yml",
     "check-intl-admin-merge": "node ./src/tooling/checkIntl.js --en ../admin/src/js/lang/en.json --fr ../admin/src/js/lang/fr.json --rm-orphaned --output-untranslated ../admin/src/js/lang/untranslated.json --whitelist ../admin/src/js/lang/whitelist.yml --merge-fr ../admin/src/js/lang/newTranslations.json",
     "check-intl-web": "node ./src/tooling/checkIntl.js --en ../../apps/web/src/lang/en.json --fr ../../apps/web/src/lang/fr.json --rm-orphaned --output-untranslated ../../apps/web/src/lang/untranslated.json --whitelist ../../apps/web/src/lang/whitelist.yml",
-    "check-intl-web-merge": "node ./src/tooling/checkIntl.js --en ../../apps/web/src/lang/src/lang/en.json --fr ../../apps/web/src/lang/src/lang/fr.json --rm-orphaned --output-untranslated ../../apps/web/src/lang/untranslated.json --whitelist ../../apps/web/src/lang/whitelist.yml --merge-fr ../../apps/web/src/lang/newTranslations.json",
+    "check-intl-web-merge": "node ./src/tooling/checkIntl.js --en ../../apps/web/src/lang/en.json --fr ../../apps/web/src/lang/fr.json --rm-orphaned --output-untranslated ../../apps/web/src/lang/untranslated.json --whitelist ../../apps/web/src/lang/whitelist.yml --merge-fr ../../apps/web/src/lang/newTranslations.json",
     "check-integrity": "node ./src/tooling/checkIntegrity.js --lock-file ../package-lock.json --allow common admin"
   },
   "repository": {


### PR DESCRIPTION
🤖 Resolves #5473

## 👋 Introduction

This fixes a type in the `untranslated.json` file name causing the test to always pass.

## 🕵️ Details

@petertgiles is working on re-adding the translations after they were lost during the merge. Once this is approved and his is merged, we can merge this one.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Confirm the translations action failed

