### PR TITLE
bug/5377-create-profile-redirect

### DIFF
--- a/apps/web/src/pages/BrowsePoolsPage/BrowsePoolsPage.tsx
+++ b/apps/web/src/pages/BrowsePoolsPage/BrowsePoolsPage.tsx
@@ -183,7 +183,7 @@ export const BrowsePools: React.FC<BrowsePoolsProps> = ({
                     mode="outline"
                     type="button"
                     weight="bold"
-                    href={paths.myProfile()}
+                    href={loggedIn ? paths.myProfile() : paths.login()}
                     style={{ whiteSpace: "nowrap" }}
                   >
                     {loggedIn


### PR DESCRIPTION
🤖 Resolves #5377 

## 👋 Introduction

Resolve the confusion of the login button immediately taking a user off site for browse page.
If you're logged in, you proceed to /profile directly.
If you're not, you are taken to login-info, which already redirects someone to /profile afterwards.

## 🧪 Testing

1. navigate to the section seen below at /en/browse/pools, while not logged in
2. you should see a button with "create a profile", click it and be lead to /login-info
3. login and you should end up at /profile
4. head back to the section at /browse again, this time it should be "update my profile"
5. click it and be lead straight to /profile

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/40485260/214710994-51a96e88-3870-450b-ad60-d6c9d9bd1f42.png)




