### PR TITLE
bug/5296-reset-page-number-filtering

### DIFF
--- a/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
+++ b/frontend/admin/src/js/components/poolCandidate/PoolCandidatesTable.tsx
@@ -391,7 +391,10 @@ const PoolCandidatesTable: React.FC<{
       }),
     };
 
-    setTableState({ filters: transformedData });
+    setTableState({
+      filters: transformedData,
+      currentPage: defaultState.currentPage,
+    });
   };
 
   useEffect(() => {

--- a/frontend/admin/src/js/components/user/UserTable.tsx
+++ b/frontend/admin/src/js/components/user/UserTable.tsx
@@ -254,7 +254,10 @@ export const UserTable = () => {
   const handleFilterSubmit: SubmitHandler<FormValues> = (data) => {
     const transformedData = transformFormValuesToUserFilterInput(data);
     // this state lives in the UserTable component, this step also acts like a formValuesToSubmitData function
-    setTableState({ filters: transformedData });
+    setTableState({
+      filters: transformedData,
+      currentPage: defaultState.currentPage,
+    });
   };
 
   useEffect(() => {


### PR DESCRIPTION
🤖 Resolves #5296 

## 👋 Introduction

On the API managed tables, updating filtering doesn't reset the current page. This creates odd situations where you might be on page 5 for results that only span 3 pages.

## 🕵️ Details

Updated both instances to reset current page to default upon submit of new filter values.

## 🧪 Testing

1. visit the api managed tables (users and pool candidates)
2. navigate to a later page 
3. submit new filters that would significantly drop results returned
4. confirm you are bumped back to page 1

