### PR TITLE
Hydrogen 2.0.0-beta.39

### DIFF
--- a/.vscode/hydrogen.code-snippets
+++ b/.vscode/hydrogen.code-snippets
@@ -4,6 +4,11 @@
     "body": ["${1:query}${2::modifiers}(${3:css})"],
     "description": "Adds a query to an existing Hydrogen attribute."
   },
+  "hydrogen-property": {
+    "prefix": "h2-property",
+    "body": ["data-h2-${1:property}=\"${2:query}${3::modifiers}(${4:css})\""],
+    "description": "A quick way of adding any Hydrogen property."
+  },
   "hydrogen-accent-color": {
     "prefix": "data-h2-accent-color",
     "body": ["data-h2-accent-color=\"${1:query}${2::modifiers}(${3:css})\""]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -57,7 +57,7 @@
     "@graphql-codegen/typescript": "^2.8.7",
     "@graphql-codegen/typescript-operations": "^2.5.12",
     "@graphql-codegen/typescript-urql": "^3.7.3",
-    "@hydrogen-css/hydrogen": "2.0.0-beta.38",
+    "@hydrogen-css/hydrogen": "2.0.0-beta.39",
     "@storybook/addon-actions": "^6.5.14",
     "@storybook/addon-viewport": "^6.5.14",
     "@storybook/builder-webpack5": "^6.5.14",

--- a/apps/web/src/pages/SearchPage/EstimatedCandidates.tsx
+++ b/apps/web/src/pages/SearchPage/EstimatedCandidates.tsx
@@ -85,7 +85,7 @@ const EstimatedCandidates: React.FunctionComponent<
               <ScrollToLink
                 to="results"
                 data-h2-color="base(dt-black) base:hover(dt-primary)"
-                data-h2-transition="base:hover(color, .2s, ease, 0s)"
+                data-h2-transition="base:hover(color .2s ease 0s)"
                 data-h2-display="base(inline-block)"
                 data-h2-margin="base(x1, 0, 0, 0)"
               >

--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -58,7 +58,7 @@
     "@graphql-codegen/typescript": "^2.8.7",
     "@graphql-codegen/typescript-operations": "^2.5.12",
     "@graphql-codegen/typescript-urql": "^3.7.3",
-    "@hydrogen-css/hydrogen": "2.0.0-beta.38",
+    "@hydrogen-css/hydrogen": "2.0.0-beta.39",
     "@storybook/addon-actions": "6.5.14",
     "@storybook/addon-essentials": "6.5.14",
     "@storybook/addon-links": "6.5.14",

--- a/frontend/common/package.json
+++ b/frontend/common/package.json
@@ -100,7 +100,7 @@
     "@graphql-codegen/typescript": "^2.8.7",
     "@graphql-codegen/typescript-operations": "^2.5.12",
     "@graphql-codegen/typescript-urql": "^3.7.3",
-    "@hydrogen-css/hydrogen": "2.0.0-beta.38",
+    "@hydrogen-css/hydrogen": "2.0.0-beta.39",
     "@storybook/addon-actions": "6.5.14",
     "@storybook/addon-essentials": "6.5.14",
     "@storybook/addon-links": "6.5.14",

--- a/frontend/common/src/components/Accordion/Accordion.tsx
+++ b/frontend/common/src/components/Accordion/Accordion.tsx
@@ -33,7 +33,7 @@ const Item = React.forwardRef<
     data-h2-shadow="base(l)"
     data-h2-radius="base(0px, s, s, 0px)"
     data-h2-overflow="base(hidden)"
-    data-h2-transition="base(all, 100ms, ease-in)"
+    data-h2-transition="base(100ms ease-in)"
     ref={forwardedRef}
     {...props}
   />
@@ -100,7 +100,7 @@ const Trigger = React.forwardRef<
               <ChevronRightIcon
                 className="Accordion__Chevron"
                 data-h2-width="base(x1.5)"
-                data-h2-transition="base(all, 100ms, ease-in)"
+                data-h2-transition="base(100ms ease-in)"
               />
             </div>
             <div data-h2-flex-grow="base(1)">

--- a/frontend/common/src/components/Alert/Alert.tsx
+++ b/frontend/common/src/components/Alert/Alert.tsx
@@ -117,7 +117,7 @@ const Alert = React.forwardRef<React.ElementRef<"div">, AlertProps>(
                 data-h2-location="base(x1.15, x.5, auto, auto) p-tablet(x.5, x.5, auto, auto)"
                 data-h2-cursor="base(pointer)"
                 data-h2-padding="base(x.25)"
-                data-h2-transition="base(all, 100ms, ease-in)"
+                data-h2-transition="base(100ms ease-in)"
                 data-h2-z-index="base(9)"
                 {...dismissStyleMap[type]}
                 onClick={close}

--- a/frontend/common/src/components/Button/Button.tsx
+++ b/frontend/common/src/components/Button/Button.tsx
@@ -289,7 +289,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         data-h2-radius="base(s)"
         data-h2-font-size="base(copy)"
         data-h2-font-weight="base(700)"
-        data-h2-transition="base:hover(background, .2s, ease, 0s)"
+        data-h2-transition="base:hover(background .2s ease 0s)"
         data-h2-cursor="base(pointer)"
         {...(block
           ? { "data-h2-display": "base(block)" }

--- a/frontend/common/src/components/CardLink/CardLink.tsx
+++ b/frontend/common/src/components/CardLink/CardLink.tsx
@@ -44,7 +44,7 @@ const Link = ({ href, external, children }: LinkProps) => {
     "data-h2-display": "base(inline-block)",
     "data-h2-radius": "base(s)",
     "data-h2-shadow": "base(m) base:hover(xl)",
-    "data-h2-transition": "base:hover(box-shadow, .2s, ease, 0s)",
+    "data-h2-transition": "base:hover(box-shadow .2s ease 0s)",
   };
 
   if (external) {

--- a/frontend/common/src/components/ScrollArea/ScrollArea.tsx
+++ b/frontend/common/src/components/ScrollArea/ScrollArea.tsx
@@ -40,7 +40,7 @@ const Scrollbar = React.forwardRef<
     data-h2-flex-direction="base:selectors[[data-orientation='horizontal']](column)"
     data-h2-height="base:selectors[[data-orientation='horizontal']](10px)"
     data-h2-width="base:selectors[[data-orientation='vertical']](10px)"
-    data-h2-transition="base(background, 100ms, ease-out)"
+    data-h2-transition="base(background 100ms ease-out)"
     style={{
       touchAction: "none",
       userSelect: "none",

--- a/frontend/common/src/components/Switch/Switch.tsx
+++ b/frontend/common/src/components/Switch/Switch.tsx
@@ -35,7 +35,7 @@ const Thumb = React.forwardRef<
     data-h2-position="base(absolute)"
     data-h2-radius="base(9999px)"
     data-h2-shadow="base(s)"
-    data-h2-transition="base(transform, 100ms, ease-in-out)"
+    data-h2-transition="base(transform 100ms ease-in-out)"
     data-h2-transform="
       base(translate(-0.1rem, -50%))
       base:selectors[[data-state='checked']](translate(calc(100% + 0.1rem), -50%))"

--- a/frontend/common/src/components/Tabs/Tabs.tsx
+++ b/frontend/common/src/components/Tabs/Tabs.tsx
@@ -37,7 +37,7 @@ const Trigger = React.forwardRef<
     data-h2-position="base(relative)"
     data-h2-location="base(1px, auto, auto, auto)"
     data-h2-radius="base(s, s, 0, 0)"
-    data-h2-transition="base(border, 100ms, ease)"
+    data-h2-transition="base(border 100ms ease)"
     ref={forwardedRef}
     {...props}
   />

--- a/frontend/common/src/components/TileLink/TileLink.tsx
+++ b/frontend/common/src/components/TileLink/TileLink.tsx
@@ -60,7 +60,7 @@ const Link = ({ href, color, external, children, ...rest }: LinkProps) => {
     "data-h2-shadow": "base(m) base:hover(xl)",
     "data-h2-padding": "base(x.5)",
     "data-h2-justify-content": "base(space-between)",
-    "data-h2-transition": "base(box-shadow, .2s, ease, 0s)",
+    "data-h2-transition": "base(box-shadow .2s ease 0s)",
     ...colorMap[color],
     ...rest,
   };

--- a/frontend/common/src/components/Toast/Toast.tsx
+++ b/frontend/common/src/components/Toast/Toast.tsx
@@ -29,7 +29,7 @@ const CloseButton = ({ type, closeToast, ariaLabel }: CloseButtonProps) => (
     data-h2-align-items="base(center)"
     data-h2-location="base(x1, x1, auto, auto)"
     data-h2-cursor="base(pointer)"
-    data-h2-transition="base(all, 100ms, ease-in)"
+    data-h2-transition="base(all 100ms ease-in)"
     data-h2-z-index="base(9)"
     aria-label={ariaLabel}
     {...closeButtonStyles[type]}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "devDependencies": {
         "@graphql-codegen/cli": "2.16.4",
-        "@hydrogen-css/hydrogen": "2.0.0-beta.38",
+        "@hydrogen-css/hydrogen": "2.0.0-beta.39",
         "eslint-config-custom": "*",
         "prettier": "^2.8.3",
         "turbo": "~1.6.3"
@@ -81,7 +81,7 @@
         "@graphql-codegen/typescript": "^2.8.7",
         "@graphql-codegen/typescript-operations": "^2.5.12",
         "@graphql-codegen/typescript-urql": "^3.7.3",
-        "@hydrogen-css/hydrogen": "2.0.0-beta.38",
+        "@hydrogen-css/hydrogen": "2.0.0-beta.39",
         "@storybook/addon-actions": "^6.5.14",
         "@storybook/addon-viewport": "^6.5.14",
         "@storybook/builder-webpack5": "^6.5.14",
@@ -153,7 +153,7 @@
         "@graphql-codegen/typescript": "^2.8.7",
         "@graphql-codegen/typescript-operations": "^2.5.12",
         "@graphql-codegen/typescript-urql": "^3.7.3",
-        "@hydrogen-css/hydrogen": "2.0.0-beta.38",
+        "@hydrogen-css/hydrogen": "2.0.0-beta.39",
         "@storybook/addon-actions": "6.5.14",
         "@storybook/addon-essentials": "6.5.14",
         "@storybook/addon-links": "6.5.14",
@@ -265,7 +265,7 @@
         "@graphql-codegen/typescript": "^2.8.7",
         "@graphql-codegen/typescript-operations": "^2.5.12",
         "@graphql-codegen/typescript-urql": "^3.7.3",
-        "@hydrogen-css/hydrogen": "2.0.0-beta.38",
+        "@hydrogen-css/hydrogen": "2.0.0-beta.39",
         "@storybook/addon-actions": "6.5.14",
         "@storybook/addon-essentials": "6.5.14",
         "@storybook/addon-links": "6.5.14",
@@ -11875,8 +11875,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@hydrogen-css/hydrogen": {
-      "version": "2.0.0-beta.38",
-      "license": "MIT",
+      "version": "2.0.0-beta.39",
+      "resolved": "https://registry.npmjs.org/@hydrogen-css/hydrogen/-/hydrogen-2.0.0-beta.39.tgz",
+      "integrity": "sha512-VuIHH2yyFd6VZ8mACCOK8j9W15/xbXhxSLPLqs5+NfjT1ThwnsrJ1I2lnGSeHpKkOhdiu6YS3gzzeH4YkCeBkg==",
       "dependencies": {
         "autoprefixer": "^10.4.13",
         "browserlist": "^1.0.1",
@@ -39028,7 +39029,7 @@
         "@graphql-codegen/typescript-urql": "^3.7.3",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.13",
-        "@hydrogen-css/hydrogen": "2.0.0-beta.38",
+        "@hydrogen-css/hydrogen": "2.0.0-beta.39",
         "@microsoft/applicationinsights-react-js": "^3.4.0",
         "@microsoft/applicationinsights-web": "^2.8.9",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -39148,7 +39149,7 @@
         "@graphql-codegen/typescript-operations": "^2.5.12",
         "@graphql-codegen/typescript-urql": "^3.7.3",
         "@heroicons/react": "^2.0.13",
-        "@hydrogen-css/hydrogen": "2.0.0-beta.38",
+        "@hydrogen-css/hydrogen": "2.0.0-beta.39",
         "@microsoft/applicationinsights-react-js": "^3.4.0",
         "@microsoft/applicationinsights-web": "^2.8.9",
         "@storybook/addon-actions": "^6.5.14",
@@ -39814,7 +39815,9 @@
       "devOptional": true
     },
     "@hydrogen-css/hydrogen": {
-      "version": "2.0.0-beta.38",
+      "version": "2.0.0-beta.39",
+      "resolved": "https://registry.npmjs.org/@hydrogen-css/hydrogen/-/hydrogen-2.0.0-beta.39.tgz",
+      "integrity": "sha512-VuIHH2yyFd6VZ8mACCOK8j9W15/xbXhxSLPLqs5+NfjT1ThwnsrJ1I2lnGSeHpKkOhdiu6YS3gzzeH4YkCeBkg==",
       "requires": {
         "autoprefixer": "^10.4.13",
         "browserlist": "^1.0.1",
@@ -44164,7 +44167,7 @@
         "@graphql-codegen/typescript-operations": "^2.5.12",
         "@graphql-codegen/typescript-urql": "^3.7.3",
         "@heroicons/react": "^2.0.13",
-        "@hydrogen-css/hydrogen": "2.0.0-beta.38",
+        "@hydrogen-css/hydrogen": "2.0.0-beta.39",
         "@storybook/addon-actions": "6.5.14",
         "@storybook/addon-essentials": "6.5.14",
         "@storybook/addon-links": "6.5.14",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@graphql-codegen/cli": "2.16.4",
-    "@hydrogen-css/hydrogen": "2.0.0-beta.38",
+    "@hydrogen-css/hydrogen": "2.0.0-beta.39",
     "eslint-config-custom": "*",
     "prettier": "^2.8.3",
     "turbo": "~1.6.3"


### PR DESCRIPTION
## 👋 Introduction

Updates Hydrogen with a handful of bugfixes and a pinch of love.

## 🕵️ Details

The biggest change here is twofold:
- `data-h2-transition` takes standard CSS syntax now instead of the original comma separated values - this was because commas are used in native CSS transition to allow for transitioning multiple properties by comma separating a list
- No one has probably used this yet, but you used to be forced to use the opposite color modifier in dark mode if automated modifiers were enabled - this was because dark mode was swapping the value of the CSS variable, so in dark mode, the `lighter` variable was being swapped to `darker` automatically for you, but this also meant that using `:dark(lighter)` would spit out the darker color... which is not intuitive, so now, `:dark(lighter)` spits out the lighter color as you'd expect :)
- Small thing, but Hydrogen now tells you what version is running to help create clarity on the currently installed dependency

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Update your dependencies using the setup script
2. Run dev or storybook and ensure Hydrogen compiles properly and displays `v2.0.0-beta.39`



