### PR TITLE
Feature - 5366 - Changes pagination `pageSizes` options

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -270,11 +270,11 @@ type Applicant {
 
   # Experiences
   experiences: [Experience] @with(relation: "awardExperiences") @with(relation: "communityExperiences") @with(relation: "educationExperiences") @with(relation: "personalExperiences") @with(relation: "workExperiences")
-  awardExperiences: [AwardExperience]
-  communityExperiences: [CommunityExperience]
-  educationExperiences: [EducationExperience]
-  personalExperiences: [PersonalExperience]
-  workExperiences: [WorkExperience]
+  awardExperiences: [AwardExperience] @hasMany
+  communityExperiences: [CommunityExperience] @hasMany
+  educationExperiences: [EducationExperience] @hasMany
+  personalExperiences: [PersonalExperience] @hasMany
+  workExperiences: [WorkExperience] @hasMany
 
   isProfileComplete: Boolean
   expectedGenericJobTitles: [GenericJobTitle] @belongsToMany

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -269,7 +269,7 @@ type Applicant {
   positionDuration: [PositionDuration] @rename(attribute: "position_duration")
 
   # Experiences
-  experiences: [Experience]
+  experiences: [Experience] @with(relation: "awardExperiences") @with(relation: "communityExperiences") @with(relation: "educationExperiences") @with(relation: "personalExperiences") @with(relation: "workExperiences")
   awardExperiences: [AwardExperience]
   communityExperiences: [CommunityExperience]
   educationExperiences: [EducationExperience]

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -110,7 +110,7 @@ type User {
   # Pool info
   poolCandidates: [PoolCandidate] @hasMany # PoolsCandidate objects associate the user with a pool
   # Experiences
-  experiences: [Experience] # All experiences that a user owns
+  experiences: [Experience] @with(relation: "awardExperiences") @with(relation: "communityExperiences") @with(relation: "educationExperiences") @with(relation: "personalExperiences") @with(relation: "workExperiences") # All experiences that a user owns
   awardExperiences: [AwardExperience] @hasMany # Award experiences that a user owns
   communityExperiences: [CommunityExperience] @hasMany # Community experiences that a user owns
   educationExperiences: [EducationExperience] @hasMany # Education experiences that a user owns

--- a/frontend/admin/src/js/components/Table/Table.tsx
+++ b/frontend/admin/src/js/components/Table/Table.tsx
@@ -436,7 +436,7 @@ function Table<T extends Record<string, unknown>>({
                     }
                     onPageSizeChange={setPageSize}
                     pageSize={pageSize}
-                    pageSizes={[10, 20, 30, 40, 50]}
+                    pageSizes={[10, 20, 50, 100, 500]}
                     totalCount={rows.length}
                     ariaLabel={intl.formatMessage({
                       defaultMessage: "Table results",

--- a/frontend/admin/src/js/components/apiManagedTable/TableFooter.tsx
+++ b/frontend/admin/src/js/components/apiManagedTable/TableFooter.tsx
@@ -120,7 +120,7 @@ function TableFooter({
               onCurrentPageChange={onCurrentPageChange}
               onPageSizeChange={onPageSizeChange}
               pageSize={paginatorInfo.perPage}
-              pageSizes={[10, 20, 30, 40, 50]}
+              pageSizes={[10, 20, 50, 100, 500]}
               totalCount={paginatorInfo.total}
               ariaLabel={intl.formatMessage({
                 defaultMessage: "Table results",


### PR DESCRIPTION
🤖 Resolves #5366.

## 👋 Introduction

This PR changes the pagination options for items per page from `10, 20, 30, 40, 50` to `10, 20, 50, 100, 500`.

## 🕵️ Details

Technically speaking, a user can already control the items per page via a url query parameter (ex. `/admin/users?pageSize=1000`) though there is a limit on two of the queries:

### `usersPaginated`
https://github.com/GCTC-NTGC/gc-digital-talent/blob/aa89339bf525d760050427d7da7057ffe03798c6/api/graphql/schema.graphql#L812

### `poolCandidatesPaginated`
https://github.com/GCTC-NTGC/gc-digital-talent/blob/aa89339bf525d760050427d7da7057ffe03798c6/api/graphql/schema.graphql#L866

## 🧪 Testing

1. Navigate to `/admin/pools`
2. Interact with the pagination select element in the table footer
3. Ensure it functions as expected
4. Navigate to `/admin/users`
5. Interact with the pagination select element in the table footer
6. Ensure it functions as expected

## 📸 Screenshot

![Screen Shot 2023-01-26 at 16 24 02](https://user-images.githubusercontent.com/3046459/214953821-0482c687-48e7-4ec1-93e3-a116c5c1ff82.png)



