### PR TITLE
Remove hidden text from Apply button

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2461,8 +2461,8 @@
     "defaultMessage": "Je cherche à...",
     "description": "Support form subject field label"
   },
-  "1zkApr": {
-    "defaultMessage": "Posez votre candidature dans le cadre de ce processus de recrutement<hidden> {name}</hidden>",
+  "cUmFnk": {
+    "defaultMessage": "Posez votre candidature dans le cadre de ce processus de recrutement ({name})",
     "description": "Message on link that say to apply to a recruitment advertisement"
   },
   "2UDONd": {

--- a/apps/web/src/pages/BrowsePoolsPage/PoolCard/PoolCard.tsx
+++ b/apps/web/src/pages/BrowsePoolsPage/PoolCard/PoolCard.tsx
@@ -225,9 +225,8 @@ const PoolCard = ({ pool, headingLevel = "h3" }: PoolCardProps) => {
               >
                 {intl.formatMessage(
                   {
-                    id: "1zkApr",
-                    defaultMessage:
-                      "Apply to this recruitment<hidden> {name}</hidden>",
+                    id: "cUmFnk",
+                    defaultMessage: "Apply to this recruitment ({name})",
                     description:
                       "Message on link that say to apply to a recruitment advertisement",
                   },


### PR DESCRIPTION
🤖 Resolves #5358 

## 👋 Introduction

It was discovered that hidden text can interfere with Voice Control on iPhone.  It was decided to remove the hidden text as an interim solution.

## 🕵️ Details

This branch takes the classification out of hidden text and concatenates to the end in parenthesis.

## 🧪 Testing

> **Warning**
> This can be a bit tricky to set up!

1. Enable and turn on Voice Control on your TBS iPhone.  https://support.apple.com/en-ca/guide/iphone/iph2c21a3c88/ios
2. Figure out the IP address of your workstation on your local network (like 192.168.x.x)
3. Connect your TBS iPhone to your local network and browse to the site (like http://192.168.x.x:8000) in Safari
    - You might have to adjust some .env setting from _localhost_ to _192.168.x.x_ to make this work
    - You may want to try this from a second computer if you run into problems so you can check the browser dev tools
5. Navigate to the Browse Opportunities page
6. "Show numbers" and ensure a number was allocated for the Apply button (like 11)
7. "Tap 11" and ensure navigation occurred

## 📸 Screenshot

![20230127_130733](https://user-images.githubusercontent.com/8978655/215162782-2eec0f57-9fb5-4cf4-b461-59363922464b.jpg)


