### PR TITLE
Tooling/5513 dcm seeding team

### DIFF
--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -42,6 +42,7 @@ class DatabaseSeeder extends Seeder
         $this->call(GenericJobTitleSeeder::class);
         $this->call(SkillFamilySeeder::class);
         $this->call(SkillSeeder::class);
+        $this->call(TeamSeeder::class);
         $this->call(UserSeederLocal::class);
         $this->call(PoolSeeder::class);
 

--- a/api/database/seeders/ProdSeeder.php
+++ b/api/database/seeders/ProdSeeder.php
@@ -17,5 +17,6 @@ class ProdSeeder extends Seeder
         $this->call(DepartmentSeeder::class);
         $this->call(SkillFamilySeeder::class);
         $this->call(SkillSeeder::class);
+        $this->call(TeamSeeder::class);
     }
 }

--- a/api/database/seeders/TeamSeeder.php
+++ b/api/database/seeders/TeamSeeder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Team;
+use Illuminate\Database\Seeder;
+
+class TeamSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $teams = [
+            'name' => 'digital-community-management',
+            'display_name' => [
+                'en' => 'Digital Community Management',
+                'fr' => 'Gestion de la collectivité numérique',
+            ],
+        ];
+
+        foreach ($teams as $team) {
+            $identifier = [
+                'name' => $team['name'],
+            ];
+            Team::updateOrCreate($identifier, $team);
+        }
+    }
+}

--- a/api/database/seeders/TeamSeeder.php
+++ b/api/database/seeders/TeamSeeder.php
@@ -15,10 +15,12 @@ class TeamSeeder extends Seeder
     public function run()
     {
         $teams = [
-            'name' => 'digital-community-management',
-            'display_name' => [
-                'en' => 'Digital Community Management',
-                'fr' => 'Gestion de la collectivité numérique',
+            [
+                'name' => 'digital-community-management',
+                'display_name' => [
+                    'en' => 'Digital Community Management',
+                    'fr' => 'Gestion de la collectivité numérique',
+                ],
             ],
         ];
 

--- a/api/database/seeders/UatSeeder.php
+++ b/api/database/seeders/UatSeeder.php
@@ -15,6 +15,7 @@ class UatSeeder extends Seeder
     {
         $this->call(ClassificationSeeder::class);
         $this->call(DepartmentSeeder::class);
+        $this->call(TeamSeeder::class);
         $this->call(UserSeederUat::class);
         $this->call(PoolSeederUat::class);
     }


### PR DESCRIPTION
🤖 Resolves #5513 

## 👋 Introduction

Adds a new seeder file for the purpose of seeding Teams.

## 🕵️ Details

Currently only seeds one team, DCM. But given it is an array of objects, further essential teams can be added to it.

## 🧪 Testing

1. run a migrate fresh and seed command
2. open up your adminer instance and head to the `teams` table
3. assert the team is present
4. execute `php artisan db:seed --class=ProdSeeder` multiple times
5. assert there is still just the one team present unchanged in the table

## 🖥️ DEPLOYMENT
Run `php artisan db:seed --class=ProdSeeder` to run the prod seeder
Run `php artisan db:seed --class=UatSeeder` to run the UAT seeder
Run `php artisan db:seed --class=TeamSeeder` to run just the Teams seeder
