### PR TITLE
Bug - 5468 - Fix TOC  Links

### DIFF
--- a/frontend/common/src/components/Link/ScrollToLink.tsx
+++ b/frontend/common/src/components/Link/ScrollToLink.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 export interface ScrollToLinkProps
   extends Omit<React.HTMLProps<HTMLAnchorElement>, "href" | "onClick"> {
@@ -8,7 +8,8 @@ export interface ScrollToLinkProps
 }
 
 const ScrollToLink = ({ to, children, ...rest }: ScrollToLinkProps) => {
-  const { pathname, search, hash } = useLocation();
+  const navigate = useNavigate();
+  const { pathname, hash } = useLocation();
   const [targetSection, setTargetSection] = React.useState<HTMLElement | null>(
     null,
   );
@@ -36,7 +37,7 @@ const ScrollToLink = ({ to, children, ...rest }: ScrollToLinkProps) => {
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
     e.stopPropagation();
-    window.history.pushState({}, "", `${pathname}${search}#${to}`);
+    navigate(`#${to}`);
     scrollToSection();
   };
 


### PR DESCRIPTION
🤖 Resolves #5468 

## 👋 Introduction

Fixes the browser history for table of contents links.

## 🕵️ Details

We were using `window.history.pushState()` which adds to the history stack but breaks with `react-router` for navigation. This replaces that with `useNavigate` to do the same thing with `react-router`

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build the app `npm run build`
2. Navigate to the user profile
3. Click on a table of contents links
4. Go to any other page
5. Hit the browser back button
6. Confirm it actually navigates you

## 📸 Screenshot

Add a screenshot (if possible).


