### PR TITLE
Bug - 5525 - Fix `NotifyTest` namepsace

### DIFF
--- a/api/tests/Feature/NotifyTest.php
+++ b/api/tests/Feature/NotifyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use App\Facades\Notify;


### PR DESCRIPTION
🤖 Resolves #5525 

## 👋 Introduction

Updates the `NotifyTest` namespace to comply with PSR-4.

## 🕵️ Details

We moved the `NotifyTest` to the feature namespace but never changed the defined namespace. This updates it to comply with PSR-4.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run `PHPUnit`
2. Confirm the warning is gone and `NotifyTest` runs


