### PR TITLE
Bug - 5543 - Fixes `SkillsInDetail` stories

### DIFF
--- a/apps/web/src/components/SkillsInDetail/SkillsInDetail.stories.tsx
+++ b/apps/web/src/components/SkillsInDetail/SkillsInDetail.stories.tsx
@@ -38,6 +38,7 @@ NoSkills.args = {
 
 FewSkills.args = {
   skills: fakeSkills(2).map((skill) => ({
+    id: skill.id,
     skillId: skill.id,
     name: skill.name,
     details: skill.experienceSkillRecord?.details || "",
@@ -46,6 +47,7 @@ FewSkills.args = {
 
 ManySkills.args = {
   skills: fakeSkills(5).map((skill) => ({
+    id: skill.id,
     skillId: skill.id,
     name: skill.name,
     details: skill.experienceSkillRecord?.details || "",


### PR DESCRIPTION
🤖 Resolves #5543.

## 👋 Introduction

This PR adds a missing `id` prop for `SkillsInDetail` stories.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run storybook`
2. Verify no error is present in console for **Few Skills** and **Many Skills** **SkillsInDetail** stories


