### PR TITLE
Bug - 5544 - Fixes FR for Title at organization

### DIFF
--- a/frontend/common/src/lang/fr.json
+++ b/frontend/common/src/lang/fr.json
@@ -1145,7 +1145,7 @@
     "description": "displayed when localized string not available"
   },
   "UPx6kk": {
-    "defaultMessage": "<primary>{titre}</primary> à {organization}",
+    "defaultMessage": "<primary>{title}</primary> à {organization}",
     "description": "Title at organization"
   },
   "ZWR/F3": {


### PR DESCRIPTION
🤖 Resolves #5544.

## 👋 Introduction

Fixes a variable that was mistakenly translated into French in **Title at organization**.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run intl-compile`
2. `npm run storybook`
3. Open **Accordion Community Example** story in FR locale
4. Verify no console errors related to i18n
5. Verify no EN text in title

## 📸 Screenshots

### Before fix
![Screen Shot 2023-01-31 at 11 52 25](https://user-images.githubusercontent.com/3046459/215832933-2c621b8a-4621-41ff-a05d-1a451f136fdf.png)

### After fix
![Screen Shot 2023-01-31 at 12 06 42](https://user-images.githubusercontent.com/3046459/215832966-71c9fed2-555a-4308-8b84-1bae831b4321.png)
