### PR TITLE
Bug - 5542 - Fixes `Application Cards` story

### DIFF
--- a/apps/web/src/pages/MyApplicationsPage/ApplicationCard/ApplicationCard.stories.tsx
+++ b/apps/web/src/pages/MyApplicationsPage/ApplicationCard/ApplicationCard.stories.tsx
@@ -42,7 +42,9 @@ const Template: Story = () => {
         data-h2-gap="base(x0.5, 0)"
       >
         {applications.map((application) => (
-          <div key={application.id}>
+          <div
+            key={`${application.id}-${application.status}-${application.archivedAt}`}
+          >
             <h2 data-h2-margin="base(x1, 0, x0.5, 0)">
               {application.archivedAt && "(ARCHIVED) "}
               {application.status}


### PR DESCRIPTION
🤖 Resolves #5542.

## 👋 Introduction

This PR fixes the `key` prop for the `Application Cards` story to be unique.

## ❓Question
Is there a reason all the card variations are in one story instead of making a story for each one?

## 🧪 Testing

1. `npm run storybook`
2. Verify no error is present in console for **Application Cards** story