### PR TITLE
Feature -  5042 - Themed Accordions

### DIFF
--- a/frontend/common/src/components/Accordion/Accordion.docs.mdx
+++ b/frontend/common/src/components/Accordion/Accordion.docs.mdx
@@ -72,6 +72,26 @@ const ExampleAccordionMultipleOpen = () => (
 
 ## Props
 
+### Root
+
+All props from the `@radix-ui/accordion` `Root` component as well as additional style props.
+
+See: [Documentation](https://www.radix-ui.com/docs/primitives/components/accordion#root)
+
+### Definition
+
+```tsx
+type AccordionMode = "card" | "simple";
+
+type RootProps = React.ComponentPropsWithoutRef<
+  typeof AccordionPrimitive.Root
+> & {
+  mode?: AccordionMode;
+};
+```
+- `mode`: Determine how the accordion is displayed
+  - See: [Accordion Design File](https://github.com/GCTC-NTGC/gc-digital-talent/discussions/5522)
+
 ### Trigger
 
 All props from the `@radix-ui/accordion` `Trigger` component as well as additional style props.

--- a/frontend/common/src/components/Accordion/Accordion.docs.mdx
+++ b/frontend/common/src/components/Accordion/Accordion.docs.mdx
@@ -118,5 +118,5 @@ interface AccordionTriggerProps
 
 ## Links
 
- - [Documentation](https://www.radix-ui.com/docs/primitives/components/accordion
+ - [Documentation](https://www.radix-ui.com/docs/primitives/components/accordion)
  - [Accessibility](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/)

--- a/frontend/common/src/components/Accordion/Accordion.stories.tsx
+++ b/frontend/common/src/components/Accordion/Accordion.stories.tsx
@@ -65,6 +65,14 @@ Default.args = {
   children: <Text />,
 };
 
+export const Simple = Template.bind({});
+Simple.args = {
+  type: "single",
+  mode: "simple",
+  collapsible: true,
+  children: <Text />,
+};
+
 export const DefaultOpen = Template.bind({});
 DefaultOpen.args = {
   defaultValue: "one",
@@ -80,11 +88,7 @@ Nested.args = {
   children: (
     <>
       <Text />
-      <Accordion.Root
-        type="single"
-        collapsible
-        data-h2-margin="base(x1, 0, 0, 0)"
-      >
+      <Accordion.Root type="single" collapsible mode="simple">
         <Accordion.Item value="two">
           <Accordion.Trigger Icon={AcademicCapIcon} subtitle="Subtitle">
             Accordion Two

--- a/frontend/common/src/components/Accordion/Accordion.stories.tsx
+++ b/frontend/common/src/components/Accordion/Accordion.stories.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
-import { AcademicCapIcon } from "@heroicons/react/24/solid";
+import {
+  AcademicCapIcon,
+  Cog8ToothIcon,
+  GlobeAmericasIcon,
+} from "@heroicons/react/24/solid";
 
 import { faker } from "@faker-js/faker";
 import AccordionDocs from "./Accordion.docs.mdx";
@@ -33,6 +37,18 @@ const Template: ComponentStory<typeof Accordion.Root> = ({
       <Accordion.Item value="one">
         <Accordion.Trigger Icon={AcademicCapIcon} subtitle="Subtitle">
           Accordion One
+        </Accordion.Trigger>
+        <Accordion.Content>{children}</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="two">
+        <Accordion.Trigger Icon={Cog8ToothIcon} subtitle="Subtitle">
+          Accordion Two
+        </Accordion.Trigger>
+        <Accordion.Content>{children}</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="three">
+        <Accordion.Trigger Icon={GlobeAmericasIcon} subtitle="Subtitle">
+          Accordion Three
         </Accordion.Trigger>
         <Accordion.Content>{children}</Accordion.Content>
       </Accordion.Item>

--- a/frontend/common/src/components/Accordion/Accordion.tsx
+++ b/frontend/common/src/components/Accordion/Accordion.tsx
@@ -57,17 +57,19 @@ const StyledTrigger = React.forwardRef<
   <AccordionPrimitive.Trigger
     className="Accordion__Trigger"
     data-h2-align-items="base(flex-start)"
-    data-h2-background-color="base(transparent)"
+    data-h2-background-color="base(transparent) base:focus-visible:children[.Accordion__Chevron](focus)"
     data-h2-cursor="base(pointer)"
     data-h2-display="base(flex)"
     data-h2-gap="base(0, x1)"
+    data-h2-outline="base(none)"
     data-h2-padding="base(0 0 x1 0)"
     data-h2-justify-content="base(space-between)"
     data-h2-text-align="base(left)"
     data-h2-width="base(100%)"
+    data-h2-shadow="base:focus-visible:children[.Accordion__Chevron](focus)"
     data-h2-transform="
-      base:children[.Accordion__Chevron](rotate(0deg))
-      base:selectors[[data-state='open']]:children[.Accordion__Chevron](rotate(90deg))"
+      base:children[.Accordion__Chevron__Icon](rotate(0deg))
+      base:selectors[[data-state='open']]:children[.Accordion__Chevron__Icon](rotate(90deg))"
     ref={forwardedRef}
     {...props}
   />
@@ -98,12 +100,14 @@ const Trigger = React.forwardRef<
         <Header data-h2-line-height="base(1)">
           <StyledTrigger ref={forwardedRef} {...rest}>
             <div
+              className="Accordion__Chevron"
               data-h2-display="base(flex)"
               data-h2-align-items="base(center)"
               data-h2-flex-shrink="base(0)"
+              data-h2-radius="base(circle)"
             >
               <ChevronRightIcon
-                className="Accordion__Chevron"
+                className="Accordion__Chevron__Icon"
                 data-h2-width="base(x1)"
                 data-h2-transition="base(100ms ease-in)"
               />
@@ -166,11 +170,10 @@ const Content = React.forwardRef<
     {...rest}
   >
     <hr
+      className="Accordion__Separator"
       data-h2-background-color="base(dt-gray)"
-      data-h2-height="base(1px)"
       data-h2-width="base(100%)"
       data-h2-border="base(none)"
-      data-h2-margin="base(0, 0, x1, 0)"
     />
     {children}
   </AccordionPrimitive.Content>

--- a/frontend/common/src/components/Accordion/Accordion.tsx
+++ b/frontend/common/src/components/Accordion/Accordion.tsx
@@ -31,7 +31,6 @@ const Item = React.forwardRef<
 >((props, forwardedRef) => (
   <AccordionPrimitive.Item
     className="Accordion__Item"
-    data-h2-margin="base(x.5, 0)"
     data-h2-overflow="base(hidden)"
     data-h2-transition="base(100ms ease-in)"
     ref={forwardedRef}
@@ -58,6 +57,7 @@ const StyledTrigger = React.forwardRef<
     className="Accordion__Trigger"
     data-h2-align-items="base(flex-start)"
     data-h2-background-color="base(transparent) base:focus-visible:children[.Accordion__Chevron](focus)"
+    data-h2-color="base:focus-visible:children[.Accordion__Chevron](black)"
     data-h2-cursor="base(pointer)"
     data-h2-display="base(flex)"
     data-h2-gap="base(0, x1)"
@@ -127,6 +127,7 @@ const Trigger = React.forwardRef<
               </span>
               {subtitle && (
                 <span
+                  className="Accordion__Subtitle"
                   data-h2-display="base(block)"
                   data-h2-font-size="base(h6, 1)"
                   data-h2-margin="base(x.25, 0, 0, 0)"
@@ -165,7 +166,6 @@ const Content = React.forwardRef<
 >(({ children, ...rest }, forwardedRef) => (
   <AccordionPrimitive.Content
     className="Accordion__Content"
-    data-h2-background-color="base(dt-white)"
     ref={forwardedRef}
     {...rest}
   >

--- a/frontend/common/src/components/Accordion/Accordion.tsx
+++ b/frontend/common/src/components/Accordion/Accordion.tsx
@@ -6,20 +6,35 @@ import { ChevronRightIcon } from "@heroicons/react/24/solid";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 
 import type { HeadingRank } from "../../types/primitiveTypes";
+import { styleMap } from "./styles";
+
+export type AccordionColor =
+  | "primary"
+  | "secondary"
+  | "tertiary"
+  | "quaternary"
+  | "quinary"
+  | "white"
+  | "black";
+
+export type AccordionMode = "card" | "simple";
+
+type RootProps = React.ComponentPropsWithoutRef<
+  typeof AccordionPrimitive.Root
+> & {
+  color?: AccordionColor;
+  mode?: AccordionMode;
+};
 
 const Root = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Root>,
-  | AccordionPrimitive.AccordionMultipleProps
-  | AccordionPrimitive.AccordionSingleProps
->((props, forwardedRef) => (
-  <AccordionPrimitive.Root
-    className="Accordion"
-    data-h2-display="base(flex)"
-    data-h2-flex-direction="base(column)"
-    ref={forwardedRef}
-    {...props}
-  />
-));
+  RootProps
+>(({ color = "primary", mode = "simple", ...rest }, forwardedRef) => {
+  const colours = styleMap.get(mode);
+  const styles = colours?.get(color);
+
+  return <AccordionPrimitive.Root {...styles} {...rest} ref={forwardedRef} />;
+});
 
 const Item = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Item>,

--- a/frontend/common/src/components/Accordion/Accordion.tsx
+++ b/frontend/common/src/components/Accordion/Accordion.tsx
@@ -61,7 +61,6 @@ const StyledTrigger = React.forwardRef<
     data-h2-display="base(flex)"
     data-h2-gap="base(0, x1)"
     data-h2-outline="base(none)"
-    data-h2-padding="base(0 0 x1 0)"
     data-h2-justify-content="base(space-between)"
     data-h2-text-align="base(left)"
     data-h2-width="base(100%)"

--- a/frontend/common/src/components/Accordion/Accordion.tsx
+++ b/frontend/common/src/components/Accordion/Accordion.tsx
@@ -2,7 +2,7 @@
  * Documentation: https://www.radix-ui.com/docs/primitives/components/accordion
  */
 import React from "react";
-import { ChevronRightIcon } from "@heroicons/react/24/solid";
+import { ChevronDownIcon } from "@heroicons/react/24/solid";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 
 import type { HeadingRank } from "../../types/primitiveTypes";
@@ -32,7 +32,7 @@ const Item = React.forwardRef<
   <AccordionPrimitive.Item
     className="Accordion__Item"
     data-h2-overflow="base(hidden)"
-    data-h2-transition="base(100ms ease-in)"
+    data-h2-transition="base(border 150ms ease)"
     ref={forwardedRef}
     {...props}
   />
@@ -69,7 +69,7 @@ const StyledTrigger = React.forwardRef<
     data-h2-shadow="base:focus-visible:children[.Accordion__Chevron](focus)"
     data-h2-transform="
       base:children[.Accordion__Chevron__Icon](rotate(0deg))
-      base:selectors[[data-state='open']]:children[.Accordion__Chevron__Icon](rotate(90deg))"
+      base:selectors[[data-state='open']]:children[.Accordion__Chevron__Icon](rotate(-180deg))"
     ref={forwardedRef}
     {...props}
   />
@@ -106,10 +106,10 @@ const Trigger = React.forwardRef<
               data-h2-flex-shrink="base(0)"
               data-h2-radius="base(circle)"
             >
-              <ChevronRightIcon
+              <ChevronDownIcon
                 className="Accordion__Chevron__Icon"
+                data-h2-transition="base(transform 150ms ease)"
                 data-h2-width="base(x1)"
-                data-h2-transition="base(100ms ease-in)"
               />
             </div>
             <div

--- a/frontend/common/src/components/Accordion/Accordion.tsx
+++ b/frontend/common/src/components/Accordion/Accordion.tsx
@@ -44,7 +44,7 @@ const Item = React.forwardRef<
     data-h2-border-left="
       base(x.5 solid dt-secondary)
       base:selectors[[data-state='open']](x.5 solid dt-primary)"
-    data-h2-margin="base(x.25, 0)"
+    data-h2-margin="base(x.5, 0)"
     data-h2-shadow="base(l)"
     data-h2-radius="base(0px, s, s, 0px)"
     data-h2-overflow="base(hidden)"

--- a/frontend/common/src/components/Accordion/Accordion.tsx
+++ b/frontend/common/src/components/Accordion/Accordion.tsx
@@ -6,32 +6,21 @@ import { ChevronRightIcon } from "@heroicons/react/24/solid";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 
 import type { HeadingRank } from "../../types/primitiveTypes";
-import { styleMap } from "./styles";
-
-export type AccordionColor =
-  | "primary"
-  | "secondary"
-  | "tertiary"
-  | "quaternary"
-  | "quinary"
-  | "white"
-  | "black";
+import styleMap from "./styles";
 
 export type AccordionMode = "card" | "simple";
 
 type RootProps = React.ComponentPropsWithoutRef<
   typeof AccordionPrimitive.Root
 > & {
-  color?: AccordionColor;
   mode?: AccordionMode;
 };
 
 const Root = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Root>,
   RootProps
->(({ color = "primary", mode = "simple", ...rest }, forwardedRef) => {
-  const colours = styleMap.get(mode);
-  const styles = colours?.get(color);
+>(({ mode = "card", ...rest }, forwardedRef) => {
+  const styles = styleMap?.get(mode);
 
   return <AccordionPrimitive.Root {...styles} {...rest} ref={forwardedRef} />;
 });
@@ -41,12 +30,8 @@ const Item = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
 >((props, forwardedRef) => (
   <AccordionPrimitive.Item
-    data-h2-border-left="
-      base(x.5 solid dt-secondary)
-      base:selectors[[data-state='open']](x.5 solid dt-primary)"
+    className="Accordion__Item"
     data-h2-margin="base(x.5, 0)"
-    data-h2-shadow="base(l)"
-    data-h2-radius="base(0px, s, s, 0px)"
     data-h2-overflow="base(hidden)"
     data-h2-transition="base(100ms ease-in)"
     ref={forwardedRef}
@@ -70,12 +55,13 @@ const StyledTrigger = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
 >((props, forwardedRef) => (
   <AccordionPrimitive.Trigger
-    data-h2-align-items="base(center)"
-    data-h2-background-color="base(dt-white)"
+    className="Accordion__Trigger"
+    data-h2-align-items="base(flex-start)"
+    data-h2-background-color="base(transparent)"
     data-h2-cursor="base(pointer)"
     data-h2-display="base(flex)"
-    data-h2-gap="base(0, x.5)"
-    data-h2-padding="base(x1, x1, x1, x.5)"
+    data-h2-gap="base(0, x1)"
+    data-h2-padding="base(0 0 x1 0)"
     data-h2-justify-content="base(space-between)"
     data-h2-text-align="base(left)"
     data-h2-width="base(100%)"
@@ -111,14 +97,23 @@ const Trigger = React.forwardRef<
       <StyledHeader asChild>
         <Header data-h2-line-height="base(1)">
           <StyledTrigger ref={forwardedRef} {...rest}>
-            <div data-h2-margin="base(0, x.25, 0, 0)" style={{ flexShrink: 0 }}>
+            <div
+              data-h2-display="base(flex)"
+              data-h2-align-items="base(center)"
+              data-h2-flex-shrink="base(0)"
+            >
               <ChevronRightIcon
                 className="Accordion__Chevron"
-                data-h2-width="base(x1.5)"
+                data-h2-width="base(x1)"
                 data-h2-transition="base(100ms ease-in)"
               />
             </div>
-            <div data-h2-flex-grow="base(1)">
+            <div
+              data-h2-flex-grow="base(1)"
+              data-h2-display="base(flex)"
+              data-h2-flex-direction="base(column)"
+              data-h2-gap="base(x.5 0)"
+            >
               <span
                 data-h2-display="base(block)"
                 data-h2-font-size="base(h6, 1)"
@@ -129,7 +124,7 @@ const Trigger = React.forwardRef<
               {subtitle && (
                 <span
                   data-h2-display="base(block)"
-                  data-h2-font-size="base(copy, 1)"
+                  data-h2-font-size="base(h6, 1)"
                   data-h2-margin="base(x.25, 0, 0, 0)"
                 >
                   {subtitle}
@@ -170,16 +165,14 @@ const Content = React.forwardRef<
     ref={forwardedRef}
     {...rest}
   >
-    <div data-h2-padding="base(0, x1, x1, x2.5)">
-      <hr
-        data-h2-background-color="base(dt-gray)"
-        data-h2-height="base(1px)"
-        data-h2-width="base(100%)"
-        data-h2-border="base(none)"
-        data-h2-margin="base(0, 0, x1, 0)"
-      />
-      {children}
-    </div>
+    <hr
+      data-h2-background-color="base(dt-gray)"
+      data-h2-height="base(1px)"
+      data-h2-width="base(100%)"
+      data-h2-border="base(none)"
+      data-h2-margin="base(0, 0, x1, 0)"
+    />
+    {children}
   </AccordionPrimitive.Content>
 ));
 

--- a/frontend/common/src/components/Accordion/Accordion.tsx
+++ b/frontend/common/src/components/Accordion/Accordion.tsx
@@ -32,7 +32,6 @@ const Item = React.forwardRef<
   <AccordionPrimitive.Item
     className="Accordion__Item"
     data-h2-overflow="base(hidden)"
-    data-h2-transition="base(border 150ms ease)"
     ref={forwardedRef}
     {...props}
   />

--- a/frontend/common/src/components/Accordion/styles.ts
+++ b/frontend/common/src/components/Accordion/styles.ts
@@ -36,7 +36,8 @@ const simpleStyles: AccordionStyles = {
   "data-h2-display":
     "base:selectors[>.Accordion__Item .Accordion__Separator](none)",
   "data-h2-padding": `
-    base:selectors[>.Accordion__Item](x1 x2 0 x1)
+    base:selectors[>.Accordion__Item](x.5 x2 0 x1)
+    base:selectors[>.Accordion__Item .Accordion__Trigger](0 0 x.5 0)
     base:selectors[>.Accordion__Item .Accordion__Content](0 0 x1 x2)
   `,
 };

--- a/frontend/common/src/components/Accordion/styles.ts
+++ b/frontend/common/src/components/Accordion/styles.ts
@@ -4,10 +4,14 @@ type AccordionStyles = Record<string, string | undefined>;
 
 const cardStyles: AccordionStyles = {
   "data-h2-background-color": "base(white)",
+  "data-h2-color": "base:children[.Accordion__Separator](dt-gray)",
   "data-h2-border-left": `
     base:children[.Accordion__Item](x.5 solid tm-blue)
     base:children[.Accordion__Item[data-state='open']](x.5 solid tm-purple)
+    base:focus:children[.Accordion__Item](x.5 solid focus)
   `,
+  "data-h2-height": "base:children[.Accordion__Separator](1px)",
+  "data-h2-margin": "base:children[.Accordion__Separator](-x.25 0 x.5 0)",
   "data-h2-padding": `
       base:children[.Accordion__Item](x1 x2 0 x1)
       base:children[.Accordion__Content](0 0 x1 x2)

--- a/frontend/common/src/components/Accordion/styles.ts
+++ b/frontend/common/src/components/Accordion/styles.ts
@@ -7,8 +7,10 @@ const cardStyles: AccordionStyles = {
   "data-h2-color":
     "base:selectors[>.Accordion__Item .Accordion__Separator](dt-gray) base:selectors[>.Accordion__Item .Accordion__Chevron](black)",
   "data-h2-border-left": `
-  base:selectors[>.Accordion__Item](x.5 solid tm-blue)
-  base:selectors[>.Accordion__Item[data-state='open']](x.5 solid tm-purple)
+  base:selectors[>.Accordion__Item .Accordion__Trigger](x.5 solid tm-blue)
+  base:selectors[>.Accordion__Item .Accordion__Content](x.5 solid tm-blue)
+  base:selectors[>.Accordion__Item[data-state='open'] .Accordion__Trigger](x.5 solid tm-purple)
+  base:selectors[>.Accordion__Item[data-state='open'] .Accordion__Content](x.5 solid tm-purple)
   `,
   "data-h2-height":
     "base:selectors[>.Accordion__Item .Accordion__Separator](1px)",
@@ -17,7 +19,7 @@ const cardStyles: AccordionStyles = {
     base:selectors[>.Accordion__Item .Accordion__Separator](-x.25 0 x.5 0)
   `,
   "data-h2-padding": `
-      base:selectors[>.Accordion__Item](x1 x2 0 x1)
+      base:selectors[>.Accordion__Item .Accordion__Trigger](x1 x2 x1 x1)
       base:selectors[>.Accordion__Item .Accordion__Content](0 0 x1 x2)
   `,
   "data-h2-radius":

--- a/frontend/common/src/components/Accordion/styles.ts
+++ b/frontend/common/src/components/Accordion/styles.ts
@@ -5,35 +5,37 @@ type AccordionStyles = Record<string, string | undefined>;
 const cardStyles: AccordionStyles = {
   "data-h2-background-color": "base(white)",
   "data-h2-color":
-    "base:children[.Accordion__Separator](dt-gray) base:children[.Accordion__Chevron](dt-gray)",
+    "base:selectors[>.Accordion__Item .Accordion__Separator](dt-gray) base:selectors[>.Accordion__Item .Accordion__Chevron](dt-gray)",
   "data-h2-border-left": `
-  base:children[.Accordion__Item](x.5 solid tm-blue)
-  base:children[.Accordion__Item[data-state='open']](x.5 solid tm-purple)
+  base:selectors[>.Accordion__Item](x.5 solid tm-blue)
+  base:selectors[>.Accordion__Item[data-state='open']](x.5 solid tm-purple)
   `,
-  "data-h2-height": "base:children[.Accordion__Separator](1px)",
+  "data-h2-height":
+    "base:selectors[>.Accordion__Item .Accordion__Separator](1px)",
   "data-h2-margin": `
-    base:children[.Accordion__Item](x.5, 0)
-    base:children[.Accordion__Separator](-x.25 0 x.5 0)
+    base:selectors[>.Accordion__Item](x.5, 0)
+    base:selectors[>.Accordion__Item .Accordion__Separator](-x.25 0 x.5 0)
   `,
   "data-h2-padding": `
-      base:children[.Accordion__Item](x1 x2 0 x1)
-      base:children[.Accordion__Content](0 0 x1 x2)
+      base:selectors[>.Accordion__Item](x1 x2 0 x1)
+      base:selectors[>.Accordion__Item .Accordion__Content](0 0 x1 x2)
   `,
   "data-h2-radius":
-    "base:children[.Accordion__Item](0px, rounded, rounded, 0px)",
-  "data-h2-shadow": "base:children[.Accordion__Item](l)",
+    "base:selectors[>.Accordion__Item](0px, rounded, rounded, 0px)",
+  "data-h2-shadow": "base:selectors[>.Accordion__Item](l)",
 };
 
 const simpleStyles: AccordionStyles = {
   "data-h2-color": `
-    base:children[.Accordion__Separator](tm-blue)
-    base:children[.Accordion__Chevron](tm-blue)
-    base:children[.Accordion__Subtitle](tm-blue)
+    base:selectors[>.Accordion__Item .Accordion__Separator](tm-blue)
+    base:selectors[>.Accordion__Item .Accordion__Chevron](tm-blue)
+    base:selectors[>.Accordion__Item .Accordion__Subtitle](tm-blue)
   `,
-  "data-h2-display": "base:children[.Accordion__Separator](none)",
+  "data-h2-display":
+    "base:selectors[>.Accordion__Item .Accordion__Separator](none)",
   "data-h2-padding": `
-    base:children[.Accordion__Item](x1 x2 0 x1)
-    base:children[.Accordion__Content](0 0 x1 x2)
+    base:selectors[>.Accordion__Item](x1 x2 0 x1)
+    base:selectors[>.Accordion__Item .Accordion__Content](0 0 x1 x2)
   `,
 };
 

--- a/frontend/common/src/components/Accordion/styles.ts
+++ b/frontend/common/src/components/Accordion/styles.ts
@@ -1,29 +1,27 @@
-import { AccordionColor, AccordionMode } from "./Accordion";
+import { AccordionMode } from "./Accordion";
 
-type HydrogenDataAttrs = Record<string, string>;
-type ColorMap = Map<AccordionColor, HydrogenDataAttrs>;
+type AccordionStyles = Record<string, string | undefined>;
 
-export const cardColorMap: ColorMap = new Map([
-  ["primary", {}],
-  ["secondary", {}],
-  ["tertiary", {}],
-  ["quaternary", {}],
-  ["quinary", {}],
-  ["white", {}],
-  ["black", {}],
+const cardStyles: AccordionStyles = {
+  "data-h2-background-color": "base(white)",
+  "data-h2-border-left": `
+    base:children[.Accordion__Item](x.5 solid tm-blue)
+    base:children[.Accordion__Item[data-state='open']](x.5 solid tm-purple)
+  `,
+  "data-h2-padding": `
+      base:children[.Accordion__Item](x1 x2 0 x1)
+      base:children[.Accordion__Content](0 0 x1 x2)
+  `,
+  "data-h2-radius":
+    "base:children[.Accordion__Item](0px, rounded, rounded, 0px)",
+  "data-h2-shadow": "base:children[.Accordion__Item](l)",
+};
+
+const simpleStyles: AccordionStyles = {};
+
+const styleMap: Map<AccordionMode, AccordionStyles> = new Map([
+  ["card", cardStyles],
+  ["simple", simpleStyles],
 ]);
 
-export const simpleColourMap: ColorMap = new Map([
-  ["primary", {}],
-  ["secondary", {}],
-  ["tertiary", {}],
-  ["quaternary", {}],
-  ["quinary", {}],
-  ["white", {}],
-  ["black", {}],
-]);
-
-export const styleMap: Map<AccordionMode, ColorMap> = new Map([
-  ["card", cardColorMap],
-  ["simple", simpleColourMap],
-]);
+export default styleMap;

--- a/frontend/common/src/components/Accordion/styles.ts
+++ b/frontend/common/src/components/Accordion/styles.ts
@@ -7,20 +7,20 @@ const cardStyles: AccordionStyles = {
   "data-h2-color":
     "base:selectors[>.Accordion__Item .Accordion__Separator](dt-gray) base:selectors[>.Accordion__Item .Accordion__Chevron](black)",
   "data-h2-border-left": `
-  base:selectors[>.Accordion__Item .Accordion__Trigger](x.5 solid tm-blue)
-  base:selectors[>.Accordion__Item .Accordion__Content](x.5 solid tm-blue)
-  base:selectors[>.Accordion__Item[data-state='open'] .Accordion__Trigger](x.5 solid tm-purple)
-  base:selectors[>.Accordion__Item[data-state='open'] .Accordion__Content](x.5 solid tm-purple)
+  base:selectors[>.Accordion__Item > .Accordion__Header > .Accordion__Trigger](x.5 solid tm-blue)
+  base:selectors[>.Accordion__Item > .Accordion__Content](x.5 solid tm-blue)
+  base:selectors[>.Accordion__Item[data-state='open'] > .Accordion__Header > .Accordion__Trigger](x.5 solid tm-purple)
+  base:selectors[>.Accordion__Item[data-state='open'] > .Accordion__Content](x.5 solid tm-purple)
   `,
   "data-h2-height":
     "base:selectors[>.Accordion__Item .Accordion__Separator](1px)",
   "data-h2-margin": `
     base:selectors[>.Accordion__Item](x.5, 0)
-    base:selectors[>.Accordion__Item .Accordion__Separator](-x.25 0 x.5 0)
+    base:selectors[>.Accordion__Item  > .Accordion__Content > .Accordion__Separator](-x.25 0 x.5 0)
   `,
   "data-h2-padding": `
-      base:selectors[>.Accordion__Item .Accordion__Trigger](x1 x2 x1 x1)
-      base:selectors[>.Accordion__Item .Accordion__Content](0 0 x1 x2)
+      base:selectors[>.Accordion__Item > .Accordion__Header > .Accordion__Trigger](x1 x2 x1 x1)
+      base:selectors[>.Accordion__Item > .Accordion__Content](0 0 x1 x2)
   `,
   "data-h2-radius":
     "base:selectors[>.Accordion__Item](0px, rounded, rounded, 0px)",
@@ -29,16 +29,16 @@ const cardStyles: AccordionStyles = {
 
 const simpleStyles: AccordionStyles = {
   "data-h2-color": `
-    base:selectors[>.Accordion__Item .Accordion__Separator](tm-blue)
-    base:selectors[>.Accordion__Item .Accordion__Chevron](tm-blue)
-    base:selectors[>.Accordion__Item .Accordion__Subtitle](tm-blue)
+    base:selectors[>.Accordion__Item > .Accordion__Content > .Accordion__Separator](tm-blue)
+    base:selectors[>.Accordion__Item  > .Accordion__Header > .Accordion__Trigger > .Accordion__Chevron](tm-blue)
+    base:selectors[>.Accordion__Item > .Accordion__Header > .Accordion__Trigger .Accordion__Subtitle](tm-blue)
   `,
   "data-h2-display":
     "base:selectors[>.Accordion__Item .Accordion__Separator](none)",
   "data-h2-padding": `
     base:selectors[>.Accordion__Item](x.5 x2 0 x1)
-    base:selectors[>.Accordion__Item .Accordion__Trigger](0 0 x.5 0)
-    base:selectors[>.Accordion__Item .Accordion__Content](0 0 x1 x2)
+    base:selectors[>.Accordion__Item  > .Accordion__Header > .Accordion__Trigger](0 0 x.5 0)
+    base:selectors[>.Accordion__Item > .Accordion__Content](0 0 x1 x2)
   `,
 };
 

--- a/frontend/common/src/components/Accordion/styles.ts
+++ b/frontend/common/src/components/Accordion/styles.ts
@@ -5,7 +5,7 @@ type AccordionStyles = Record<string, string | undefined>;
 const cardStyles: AccordionStyles = {
   "data-h2-background-color": "base(white)",
   "data-h2-color":
-    "base:selectors[>.Accordion__Item .Accordion__Separator](dt-gray) base:selectors[>.Accordion__Item .Accordion__Chevron](dt-gray)",
+    "base:selectors[>.Accordion__Item .Accordion__Separator](dt-gray) base:selectors[>.Accordion__Item .Accordion__Chevron](black)",
   "data-h2-border-left": `
   base:selectors[>.Accordion__Item](x.5 solid tm-blue)
   base:selectors[>.Accordion__Item[data-state='open']](x.5 solid tm-purple)

--- a/frontend/common/src/components/Accordion/styles.ts
+++ b/frontend/common/src/components/Accordion/styles.ts
@@ -1,0 +1,29 @@
+import { AccordionColor, AccordionMode } from "./Accordion";
+
+type HydrogenDataAttrs = Record<string, string>;
+type ColorMap = Map<AccordionColor, HydrogenDataAttrs>;
+
+export const cardColorMap: ColorMap = new Map([
+  ["primary", {}],
+  ["secondary", {}],
+  ["tertiary", {}],
+  ["quaternary", {}],
+  ["quinary", {}],
+  ["white", {}],
+  ["black", {}],
+]);
+
+export const simpleColourMap: ColorMap = new Map([
+  ["primary", {}],
+  ["secondary", {}],
+  ["tertiary", {}],
+  ["quaternary", {}],
+  ["quinary", {}],
+  ["white", {}],
+  ["black", {}],
+]);
+
+export const styleMap: Map<AccordionMode, ColorMap> = new Map([
+  ["card", cardColorMap],
+  ["simple", simpleColourMap],
+]);

--- a/frontend/common/src/components/Accordion/styles.ts
+++ b/frontend/common/src/components/Accordion/styles.ts
@@ -4,14 +4,17 @@ type AccordionStyles = Record<string, string | undefined>;
 
 const cardStyles: AccordionStyles = {
   "data-h2-background-color": "base(white)",
-  "data-h2-color": "base:children[.Accordion__Separator](dt-gray)",
+  "data-h2-color":
+    "base:children[.Accordion__Separator](dt-gray) base:children[.Accordion__Chevron](dt-gray)",
   "data-h2-border-left": `
-    base:children[.Accordion__Item](x.5 solid tm-blue)
-    base:children[.Accordion__Item[data-state='open']](x.5 solid tm-purple)
-    base:focus:children[.Accordion__Item](x.5 solid focus)
+  base:children[.Accordion__Item](x.5 solid tm-blue)
+  base:children[.Accordion__Item[data-state='open']](x.5 solid tm-purple)
   `,
   "data-h2-height": "base:children[.Accordion__Separator](1px)",
-  "data-h2-margin": "base:children[.Accordion__Separator](-x.25 0 x.5 0)",
+  "data-h2-margin": `
+    base:children[.Accordion__Item](x.5, 0)
+    base:children[.Accordion__Separator](-x.25 0 x.5 0)
+  `,
   "data-h2-padding": `
       base:children[.Accordion__Item](x1 x2 0 x1)
       base:children[.Accordion__Content](0 0 x1 x2)
@@ -21,7 +24,18 @@ const cardStyles: AccordionStyles = {
   "data-h2-shadow": "base:children[.Accordion__Item](l)",
 };
 
-const simpleStyles: AccordionStyles = {};
+const simpleStyles: AccordionStyles = {
+  "data-h2-color": `
+    base:children[.Accordion__Separator](tm-blue)
+    base:children[.Accordion__Chevron](tm-blue)
+    base:children[.Accordion__Subtitle](tm-blue)
+  `,
+  "data-h2-display": "base:children[.Accordion__Separator](none)",
+  "data-h2-padding": `
+    base:children[.Accordion__Item](x1 x2 0 x1)
+    base:children[.Accordion__Content](0 0 x1 x2)
+  `,
+};
 
 const styleMap: Map<AccordionMode, AccordionStyles> = new Map([
   ["card", cardStyles],

--- a/hydrogen.config.json
+++ b/hydrogen.config.json
@@ -540,6 +540,12 @@
           "default": {
             "shadow": "0 0.7rem 1.5rem -0.3rem rgba(0, 0, 0, .2)"
           }
+        },
+        {
+          "key": "focus",
+          "default": {
+            "shadow": "0 0 0 0.25rem #6492ff"
+          }
         }
       ],
       "transitions": {


### PR DESCRIPTION
🤖 Resolves #5042

## 👋 Introduction

This updates the accordions to allow choosing a mode (simple, card) to use.

## 🕵️ Details

### ❗ Nested Accordion Issues

~~There are some issues with nesting the accordions right now. The issue is, the nested accordions are inheriting the styles from the root accordion so when we nest the card styles, we cannot use simple accordions inside. This may be my lack of experience with hydrogen.~~

~~I'm not sure how often we nest accordion and the priority of getting this working, do we have the time for me to get some assistance form @substrae on this? Or, do we want to break out the nested accordion styles into a new issue and sort that out at a later time once they have been completed?~~

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> **Warning**
> For the card style, there is a known issue with hydrogen `border-radius` so they are not rounded. This will be fixed with the upgrade to hydrogen in progress.

1. Run storybook `npm run storybook`
2. Navigate to the Accordion stories
3. Confirm they match the provided designs https://github.com/GCTC-NTGC/gc-digital-talent/discussions/5522

## 📸 Screenshot

### Card

<img width="1263" alt="Screenshot 2023-01-31 at 4 14 09 PM" src="https://user-images.githubusercontent.com/4127998/215884802-01e03e38-dfdb-48a8-9540-26c75855aa05.png">

### Simple

<img width="1267" alt="Screenshot 2023-01-31 at 4 14 22 PM" src="https://user-images.githubusercontent.com/4127998/215884845-d47abb06-ef47-4198-9a66-e5adb35bfdc4.png">

### Nested

![Screenshot 2023-02-01 120015](https://user-images.githubusercontent.com/4127998/216110828-2c15503f-cf49-4fe5-8645-ce720b5f9d69.png)


