### PR TITLE
Bug - 5380 - Fixes experience accordions skills null state

### DIFF
--- a/frontend/common/src/components/UserProfile/ExperienceAccordion/SkillList.tsx
+++ b/frontend/common/src/components/UserProfile/ExperienceAccordion/SkillList.tsx
@@ -36,7 +36,7 @@ interface SkillListProps {
 const SkillList = ({ skills }: SkillListProps) => {
   const intl = useIntl();
 
-  return skills ? (
+  return skills?.length ? (
     <ul data-h2-padding="base(0, 0, 0, x1)">
       {skills.map((skill) => (
         <SkillListItem


### PR DESCRIPTION
🤖 Resolves #5380.

## 👋 Introduction

This PR fixes a condition that did not allow for the null state (**No skills have been linked to this experience yet.**) for the `SkillList` component to be rendered on experience accordions.

## 📓 Note
Part of the acceptance criteria includes creating a "Storybook story of experience accordion with no skills". This already exists in the form of the story for **Experience Accordion > Accordion Award**.

## 🧪 Testing

1. `npm run storybook`
2. View **Experience Accordion > Accordion Award** story
3. Verify null state renders
4. View other **Experience Accordion** stories with skills
5. Verify null state does render

## 📸 Screenshot
![Screen Shot 2023-02-01 at 12 38 46](https://user-images.githubusercontent.com/3046459/216121016-f78506ff-7389-400d-a262-3fb582d2c7b0.png)