### PR TITLE
Feature - 5436 - Seed roles permissions

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -51,6 +51,7 @@ recruitmentimit
 recruitments
 recrutementgiti
 resumé
+rolepermission
 skillset
 subcomponents
 subquery

--- a/api/app/Models/Permission.php
+++ b/api/app/Models/Permission.php
@@ -24,5 +24,10 @@ class Permission extends LaratrustPermission
         'description' => 'array',
     ];
 
+    protected $fillable = [
+        'name',
+        'display_name'
+    ];
+
     public $guarded = [];
 }

--- a/api/app/Models/Role.php
+++ b/api/app/Models/Role.php
@@ -24,5 +24,10 @@ class Role extends LaratrustRole
         'description' => 'array',
     ];
 
+    protected $fillable = [
+        'name',
+        'display_name'
+    ];
+
     public $guarded = [];
 }

--- a/api/app/Models/Team.php
+++ b/api/app/Models/Team.php
@@ -24,5 +24,9 @@ class Team extends LaratrustTeam
         'description' => 'array',
     ];
 
+    protected $fillable = [
+        'name',
+    ];
+
     public $guarded = [];
 }

--- a/api/app/Models/Team.php
+++ b/api/app/Models/Team.php
@@ -26,6 +26,7 @@ class Team extends LaratrustTeam
 
     protected $fillable = [
         'name',
+        'display_name'
     ];
 
     public $guarded = [];

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -81,6 +81,11 @@ class User extends Model implements Authenticatable
         'indigenous_communities' => 'array',
     ];
 
+    protected $fillable = [
+        'email',
+        'sub'
+    ];
+
     public function pools(): HasMany
     {
         return $this->hasMany(Pool::class);

--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -25,7 +25,7 @@ class AppServiceProvider extends ServiceProvider
         // https://laravel.com/docs/9.x/eloquent#configuring-eloquent-strictness
         Model::shouldBeStrict(!$this->app->isProduction());
 
-        Relation::enforceMorphMap([
+        Relation::morphMap([
             'awardExperience' => \App\Models\AwardExperience::class,
             'communityExperience' => \App\Models\CommunityExperience::class,
             'educationExperience' => \App\Models\EducationExperience::class,

--- a/api/config/laratrust.php
+++ b/api/config/laratrust.php
@@ -226,7 +226,7 @@ return [
         | it will check only if the user has attached that role/permission ignoring the team.
         |
         */
-        'strict_check' => true,
+        'strict_check' => false,
     ],
 
     /*

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -1,0 +1,521 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Actions
+    |--------------------------------------------------------------------------
+    |
+    | A map of all actions available within the application.
+    |
+    */
+    'actions' => [
+        'v' => 'view',
+        'c' => 'create',
+        'u' => 'update',
+        'd' => 'delete',
+        'as' => 'assign',
+        'arc' => 'archive',
+        's' => 'submit',
+        'p' => 'publish'
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Scopes
+    |--------------------------------------------------------------------------
+    |
+    | A map of all scopes for different actions performed.
+    |
+    */
+    'scopes' => [
+        'o' => 'own',
+        'a' => 'any',
+        't' => 'team'
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Resources
+    |--------------------------------------------------------------------------
+    |
+    | A map of all resources that a specific action can be taken on.
+    |
+    */
+    'resources' => [
+        'clss' => 'classification',
+        'dpt' => 'department',
+        'sk' => 'skill',
+        'sf' => 'skillFamily',
+        'usr' => 'user',
+        'ubi' => 'userBasicInfo',
+        'pl' => 'pool',
+        'ppa' => 'publishedPoolAdvertisement',
+        'dp' => 'draftPool',
+        'pcd' => 'poolClosingDate',
+        'app' => 'application',
+        'sapp' => 'submittedApplication',
+        'aprf' => 'applicantProfile',
+        'dapp' => 'draftApplication',
+        'apps' => 'applicationStatus',
+        'ac' => 'applicantCount',
+        'sr' => 'searchRequest',
+        't' => 'team',
+        'tusrbi' => 'teamUsersBasicInfo',
+        'rle' => 'role'
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Permissions
+    |--------------------------------------------------------------------------
+    |
+    | A map of all permissions with $name => $display_name shape.
+    |
+    */
+    'permissions' => [
+        'view-any-classification' => [
+            'en' => 'View Any Classification',
+            'fr' => 'Afficher toute classification'
+        ],
+        'create-any-classification' => [
+            'en' => 'Create Any Classification',
+            'fr' => 'Créer n\'importe quelle classification'
+        ],
+        'update-any-classification' => [
+            'en' => 'Update Any Classification',
+            'fr' => 'Mise à jour de toute classification'
+        ],
+        'delete-any-classification' => [
+            'en' => 'Delete Any Classification',
+            'fr' => 'Supprimer toute classification'
+        ],
+
+        'view-any-department' => [
+            'en' => 'View Any Department',
+            'fr' => 'Voir n\'importe quel département'
+        ],
+        'create-any-department' => [
+            'en' => 'Create Any Department',
+            'fr' => 'Créer n\'importe quel département'
+        ],
+        'update-any-department' => [
+            'en' => 'Update Any Department',
+            'fr' => 'Mise à jour de n\'importe quel département'
+        ],
+        'delete-any-department' => [
+            'en' => 'Delete Any Department',
+            'fr' => 'Supprimer un département'
+        ],
+
+        'view-any-skill' => [
+            'en' => 'View Any Skill',
+            'fr' => 'Afficher n\'importe quelle compétence'
+        ],
+        'create-any-skill' => [
+            'en' => 'Create Any Skill',
+            'fr' => 'Créer n\'importe quelle compétence'
+        ],
+        'update-any-skill' => [
+            'en' => 'Update Any Skill',
+            'fr' => 'Mettre à jour n\'importe quelle compétence'
+        ],
+        'delete-any-skill' => [
+            'en' => 'Delete Any Skill',
+            'fr' => 'Supprimer toute compétence'
+        ],
+
+        'view-any-skillFamily' => [
+            'en' => 'View Any Skill Family',
+            'fr' => 'Voir n\'importe quelle famille de compétences'
+        ],
+        'create-any-skillFamily' => [
+            'en' => 'Create Any Skill Family',
+            'fr' => 'Créer n\'importe quelle famille de compétences'
+        ],
+        'update-any-skillFamily' => [
+            'en' => 'Update Any Skill Family',
+            'fr' => 'Mettre à jour n\'importe quelle famille de compétences'
+        ],
+        'delete-any-skillFamily' => [
+            'en' => 'Delete Any Skill Family',
+            'fr' => 'Supprimer toute famille de compétences'
+        ],
+
+        'view-any-user' => [
+            'en' => 'View Any User',
+            'fr' => 'Afficher tout utilisateur'
+        ],
+        'view-any-userBasicInfo' => [
+            'en' => 'View Any User Basic Info',
+            'fr' => 'Afficher les informations de base de tout utilisateur'
+        ],
+        'view-own-user' => [
+            'en' => 'View Own User',
+            'fr' => 'Voir son propre utilisateur'
+        ],
+        'update-any-user' => [
+            'en' => 'Update Any User',
+            'fr' => 'Mise à jour de tout utilisateur'
+        ],
+        'update-own-user' => [
+            'en' => 'Update Own User',
+            'fr' => 'Mettre à jour son propre utilisateur'
+        ],
+        'delete-any-user' => [
+            'en' => 'Delete Any User',
+            'fr' => 'Supprimer un utilisateur'
+        ],
+
+        'view-team-pool' => [
+            'en' => 'View Team Pool',
+            'fr' => 'Voir le pool d\'équipes'
+        ],
+        'view-any-publishedPoolAdvertisement' => [
+            'en' => 'View Any Published Pool Advertisement',
+            'fr' => 'Voir toute annonce publiée sur la piscine'
+        ],
+        'create-team-pool' => [
+            'en' => 'Create Team Pool',
+            'fr' => 'Créer un pool d\'équipes'
+        ],
+        'update-team-draftPool' => [
+            'en' => 'Update Team Draft Pool',
+            'fr' => 'Mise à jour du pool de sélection des équipes'
+        ],
+        'publish-team-pool' => [
+            'en' => 'Update Team Pool',
+            'fr' => 'Mise à jour du pool d\'équipes'
+        ],
+        'update-team-poolClosingDate' => [
+            'en' => 'Update Team Pool Closing Date',
+            'fr' => 'Mise à jour de la date de clôture de la réserve d\'équipes'
+        ],
+        'delete-team-draftPool' => [
+            'en' => 'Delete Team Draft Pool',
+            'fr' => 'Supprimer le pool de sélection d\'équipes'
+        ],
+
+        'view-own-application' => [
+            'en' => 'View Own Application',
+            'fr' => 'Afficher sa propre application'
+        ],
+        'view-team-submittedApplication' => [
+            'en' => 'View Team Submitted Application',
+            'fr' => 'Voir la demande soumise par l\'équipe'
+        ],
+        'view-team-applicantProfile' => [
+            'en' => 'View Team Applicant Profile',
+            'fr' => 'Voir le profil du candidat de l\'équipe'
+        ],
+        'create-own-draftApplication' => [
+            'en' => 'Create Own Draft Application',
+            'fr' => 'Créer son propre projet d\'application'
+        ],
+        'submit-own-application' => [
+            'en' => 'Submit Own Application',
+            'fr' => 'Soumettre sa propre demande'
+        ],
+        'update-team-applicationStatus' => [
+            'en' => 'Update Team Application Status',
+            'fr' => 'Mise à jour du statut de la demande de l\'équipe'
+        ],
+        'delete-own-draftApplication' => [
+            'en' => 'Delete Own Draft Application',
+            'fr' => 'Supprimer son propre projet de demande'
+        ],
+        'archive-own-submittedApplication' => [
+            'en' => 'Archive Own Submitted Application',
+            'fr' => 'Archiver sa propre demande'
+        ],
+        'view-any-applicantCount' => [
+            'en' => 'View Applicant Count',
+            'fr' => 'Voir le nombre de candidats'
+        ],
+
+        'create-any-searchRequest' => [
+            'en' => 'Create Any Search Request',
+            'fr' => 'Créer toute demande de recherche'
+        ],
+        'view-team-searchRequest' => [
+            'en' => 'Create Team Search Request',
+            'fr' => 'Créer une demande de recherche d\'équipe'
+        ],
+        'update-team-searchRequest' => [
+            'en' => 'Update Team Search Request',
+            'fr' => 'Mise à jour de la demande de recherche d\'équipe'
+        ],
+        'delete-team-searchRequest' => [
+            'en' => 'Delete Team Search Request',
+            'fr' => 'Supprimer une demande de recherche d\'équipe'
+        ],
+
+        'view-any-team' => [
+            'en' => 'View Any Team',
+            'fr' => 'Voir n\'importe quelle équipe'
+        ],
+        'view-any-teamUsersBasicInfo' => [
+            'en' => 'View Any Team Users Basic Info',
+            'fr' => 'Afficher les informations de base sur les utilisateurs de n\'importe quelle équipe'
+        ],
+        'view-team-teamUsersBasicInfo' => [
+            'en' => 'View Teams Team Users Basic Info',
+            'fr' => 'Afficher les informations de base sur les utilisateurs de l\'équipe'
+        ],
+        'create-any-team' => [
+            'en' => 'Create Any Team',
+            'fr' => 'Créer n\'importe quelle équipe'
+        ],
+        'update-any-team' => [
+            'en' => 'Update Any Team',
+            'fr' => 'Mise à jour de n\'importe quelle équipe'
+        ],
+        'update-team-team' => [
+            'en' => 'Update Team Team',
+            'fr' => 'Mise à jour de l\'équipe'
+        ],
+        'delete-any-team' => [
+            'en' => 'Delete Any Team',
+            'fr' => 'Supprimer une équipe'
+        ],
+
+        'view-any-role' => [
+            'en' => 'View Any Role',
+            'fr' => 'Voir tous les rôles'
+        ],
+        'assign-any-role' => [
+            'en' => 'Assign Any Role',
+            'fr' => 'Attribuer n\'importe quel rôle'
+        ],
+        'assign-team-role' => [
+            'en' => 'Assign Team Role',
+            'fr' => 'Attribuer un rôle à l\'équipe'
+        ],
+        'update-any-role' => [
+            'en' => 'Update Any Role',
+            'fr' => 'Mise à jour de n\'importe quel rôle'
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Roles
+    |--------------------------------------------------------------------------
+    |
+    | A map of all roles with the shape:
+    |
+    |   $name => [
+    |       'display_name' => LocalizedString,
+    |       'description' => LocalizedString,
+    |   ]
+    |
+    */
+    'roles' => [
+        'guest' => [
+            'display_name' => [
+                'en' => 'Guest',
+                'fr' => 'Guest'
+            ],
+            'description' => [
+                'en' => 'These permissions are available to anyone, even not logged in.',
+                'fr' => 'Ces autorisations sont accessibles à tous, même aux personnes non connectées.'
+            ]
+        ],
+
+        'base_user' => [
+            'display_name' => [
+                'en' => 'Base User',
+                'fr' => 'Utilisateur de base'
+            ],
+            'description' => [
+                'en' => 'Available to any logged-in user.',
+                'fr' => 'Disponible pour tout utilisateur connecté.'
+            ]
+        ],
+
+        'applicant' => [
+            'display_name' => [
+                'en' => 'Applicant',
+                'fr' => 'Candidat'
+            ],
+            'description' => [
+                'en' => 'Can edit their own profile and apply to jobs.',
+                'fr' => 'Ils peuvent modifier leur propre profil et postuler à des emplois.'
+            ]
+        ],
+
+        'team_admin' => [
+            'display_name' => [
+                'en' => 'Team Admin',
+                'fr' => 'Team Admin'
+            ],
+            'description' => [
+                'en' => 'Can update their Team, add users to their Team, process applications, process requests and work on and publish pools',
+                'fr' => 'Ils peuvent mettre à jour leur équipe, ajouter des utilisateurs à leur équipe, traiter des demandes, travailler sur des pools et les publier.'
+            ]
+        ],
+
+        'super_admin' => [
+            'display_name' => [
+                'en' => 'Super Admin',
+                'fr' => 'Super Admin'
+            ],
+            'description' => [
+                'en' => 'Makes teams, assigns roles to other users (including assigning users to orgs), manages lists of business data, and has the extraordinary ability to edit or delete other users.',
+                'fr' => 'Il crée des équipes, attribue des rôles à d\'autres utilisateurs (y compris l\'attribution d\'utilisateurs à des organisations), gère des listes de données commerciales et a la capacité extraordinaire de modifier ou de supprimer d\'autres utilisateurs.'
+            ]
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Seeders
+    |--------------------------------------------------------------------------
+    |
+    | A map of the values to seed with the shape:
+    |
+    |   'role_name' => [
+    |       'resource' => [
+    |           'scope' => [ 'actions' ]
+    |       ]
+    |   ]
+    |
+    */
+    'seeders' => [
+        'guest' => [
+            'clss' => [
+                'a' => ['v']
+            ],
+            'dpt' => [
+                'a' => ['v']
+            ],
+            'sk' => [
+                'a' => ['v']
+            ],
+            'sf' => [
+                'a' => ['v']
+            ],
+            'ppa' => [
+                'a' => ['v']
+            ],
+            'ac' => [
+                'a' => ['v']
+            ],
+            'sr' => [
+                'a' => ['c']
+            ],
+            't' => [
+                'a' => ['v']
+            ],
+        ],
+
+        'base_user' => [
+            'clss' => [
+                'a' => ['v']
+            ],
+            'dpt' => [
+                'a' => ['v']
+            ],
+            'sk' => [
+                'a' => ['v']
+            ],
+            'sf' => [
+                'a' => ['v']
+            ],
+            'usr' => [
+                'o' => ['v', 'u']
+            ],
+            'ppa' => [
+                'a' => ['v']
+            ],
+            'ac' => [
+                'a' => ['v']
+            ],
+            'sr' => [
+                'a' => ['c']
+            ],
+            't' => [
+                'a' => ['v']
+            ],
+        ],
+
+        'applicant' => [
+            'app' => [
+                'o' => ['v', 's']
+            ],
+            'dapp' => [
+                'o' => ['c', 'd']
+            ],
+            'sapp' => [
+                'o' => ['arc']
+            ]
+        ],
+
+        'team_admin' => [
+            'usr' => [
+                'a' => ['v']
+            ],
+            'pl' => [
+                't' => ['v', 'c', 'p']
+            ],
+            'dp' => [
+                't' => ['u', 'd']
+            ],
+            'pcd' => [
+                't' => ['u']
+            ],
+            'sapp' => [
+                't' => ['v']
+            ],
+            'aprf' => [
+                't' => ['v']
+            ],
+            'apps' => [
+                't' => ['u']
+            ],
+            'sr' => [
+                't' => ['v', 'u', 'd']
+            ],
+            'tusrbi' => [
+                't' => ['v']
+            ],
+            't' => [
+                't' => ['u']
+            ],
+            'rle' => [
+                'a' => ['v'],
+                't' => ['as'],
+            ],
+        ],
+
+        'super_admin' => [
+            'clss' => [
+                'a' => ['c', 'u', 'd']
+            ],
+            'dpt' => [
+                'a' => ['c', 'u', 'd']
+            ],
+            'sk' => [
+                'a' => ['c', 'u', 'd']
+            ],
+            'sf' => [
+                'a' => ['c', 'u', 'd']
+            ],
+            'usr' => [
+                'a' => ['v', 'u', 'd']
+            ],
+            'ubi' => [
+                'a' => ['v']
+            ],
+            'tusrbi' => [
+                'a' => ['v']
+            ],
+            't' => [
+                'a' => ['c', 'u', 'd']
+            ],
+            'rle' => [
+                'a' => ['v', 'as', 'u']
+            ]
+        ]
+    ]
+];

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| Role and Permissions Config
+|--------------------------------------------------------------------------
+|
+| Used by the RolePermissionSeeder, based on the Laratrust seeder
+|
+| REF:
+|
+*/
 return [
     /*
     |--------------------------------------------------------------------------
@@ -7,17 +17,18 @@ return [
     |--------------------------------------------------------------------------
     |
     | A map of all actions available within the application.
+    | This is effectively an enum.
     |
     */
     'actions' => [
-        'v' => 'view',
-        'c' => 'create',
-        'u' => 'update',
-        'd' => 'delete',
-        'as' => 'assign',
-        'arc' => 'archive',
-        's' => 'submit',
-        'p' => 'publish'
+        'view' => 'view',
+        'create' => 'create',
+        'update' => 'update',
+        'delete' => 'delete',
+        'assign' => 'assign',
+        'archive' => 'archive',
+        'submit' => 'submit',
+        'publish' => 'publish'
     ],
 
     /*
@@ -43,25 +54,25 @@ return [
     |
     */
     'resources' => [
-        'clss' => 'classification',
+        'cls' => 'classification',
         'dpt' => 'department',
-        'sk' => 'skill',
-        'sf' => 'skillFamily',
+        'skl' => 'skill',
+        'skf' => 'skillFamily',
         'usr' => 'user',
         'ubi' => 'userBasicInfo',
-        'pl' => 'pool',
+        'pol' => 'pool',
         'ppa' => 'publishedPoolAdvertisement',
-        'dp' => 'draftPool',
+        'dpl' => 'draftPool',
         'pcd' => 'poolClosingDate',
         'app' => 'application',
-        'sapp' => 'submittedApplication',
-        'aprf' => 'applicantProfile',
-        'dapp' => 'draftApplication',
-        'apps' => 'applicationStatus',
-        'ac' => 'applicantCount',
-        'sr' => 'searchRequest',
-        't' => 'team',
-        'tusrbi' => 'teamUsersBasicInfo',
+        'sap' => 'submittedApplication',
+        'apf' => 'applicantProfile',
+        'dap' => 'draftApplication',
+        'aps' => 'applicationStatus',
+        'act' => 'applicantCount',
+        'srq' => 'searchRequest',
+        'tem' => 'team',
+        'tub' => 'teamUsersBasicInfo',
         'rle' => 'role'
     ],
 
@@ -383,138 +394,138 @@ return [
     */
     'seeders' => [
         'guest' => [
-            'clss' => [
-                'a' => ['v']
+            'cls' => [
+                'a' => ['view']
             ],
             'dpt' => [
-                'a' => ['v']
+                'a' => ['view']
             ],
-            'sk' => [
-                'a' => ['v']
+            'skl' => [
+                'a' => ['view']
             ],
-            'sf' => [
-                'a' => ['v']
+            'skf' => [
+                'a' => ['view']
             ],
             'ppa' => [
-                'a' => ['v']
+                'a' => ['view']
             ],
-            'ac' => [
-                'a' => ['v']
+            'act' => [
+                'a' => ['view']
             ],
-            'sr' => [
-                'a' => ['c']
+            'srq' => [
+                'a' => ['create']
             ],
-            't' => [
-                'a' => ['v']
+            'tem' => [
+                'a' => ['view']
             ],
         ],
 
         'base_user' => [
-            'clss' => [
-                'a' => ['v']
+            'cls' => [
+                'a' => ['view']
             ],
             'dpt' => [
-                'a' => ['v']
+                'a' => ['view']
             ],
-            'sk' => [
-                'a' => ['v']
+            'skl' => [
+                'a' => ['view']
             ],
-            'sf' => [
-                'a' => ['v']
+            'skf' => [
+                'a' => ['view']
             ],
             'usr' => [
-                'o' => ['v', 'u']
+                'o' => ['view', 'update']
             ],
             'ppa' => [
-                'a' => ['v']
+                'a' => ['view']
             ],
-            'ac' => [
-                'a' => ['v']
+            'act' => [
+                'a' => ['view']
             ],
-            'sr' => [
-                'a' => ['c']
+            'srq' => [
+                'a' => ['create']
             ],
-            't' => [
-                'a' => ['v']
+            'tem' => [
+                'a' => ['view']
             ],
         ],
 
         'applicant' => [
             'app' => [
-                'o' => ['v', 's']
+                'o' => ['view', 'submit']
             ],
-            'dapp' => [
-                'o' => ['c', 'd']
+            'dap' => [
+                'o' => ['create', 'delete']
             ],
-            'sapp' => [
-                'o' => ['arc']
+            'sap' => [
+                'o' => ['archive']
             ]
         ],
 
         'team_admin' => [
             'usr' => [
-                'a' => ['v']
+                'a' => ['view']
             ],
-            'pl' => [
-                't' => ['v', 'c', 'p']
+            'pol' => [
+                't' => ['view', 'create', 'publish']
             ],
-            'dp' => [
-                't' => ['u', 'd']
+            'dpl' => [
+                't' => ['update', 'delete']
             ],
             'pcd' => [
-                't' => ['u']
+                't' => ['update']
             ],
-            'sapp' => [
-                't' => ['v']
+            'sap' => [
+                't' => ['view']
             ],
-            'aprf' => [
-                't' => ['v']
+            'apf' => [
+                't' => ['view']
             ],
-            'apps' => [
-                't' => ['u']
+            'aps' => [
+                't' => ['update']
             ],
-            'sr' => [
-                't' => ['v', 'u', 'd']
+            'srq' => [
+                't' => ['view', 'update', 'delete']
             ],
-            'tusrbi' => [
-                't' => ['v']
+            'tub' => [
+                't' => ['view']
             ],
-            't' => [
-                't' => ['u']
+            'tem' => [
+                't' => ['update']
             ],
             'rle' => [
-                'a' => ['v'],
-                't' => ['as'],
+                'a' => ['view'],
+                't' => ['assign'],
             ],
         ],
 
         'super_admin' => [
-            'clss' => [
-                'a' => ['c', 'u', 'd']
+            'cls' => [
+                'a' => ['create', 'update', 'delete']
             ],
             'dpt' => [
-                'a' => ['c', 'u', 'd']
+                'a' => ['create', 'update', 'delete']
             ],
-            'sk' => [
-                'a' => ['c', 'u', 'd']
+            'skl' => [
+                'a' => ['create', 'update', 'delete']
             ],
-            'sf' => [
-                'a' => ['c', 'u', 'd']
+            'skf' => [
+                'a' => ['create', 'update', 'delete']
             ],
             'usr' => [
-                'a' => ['v', 'u', 'd']
+                'a' => ['view', 'update', 'delete']
             ],
             'ubi' => [
-                'a' => ['v']
+                'a' => ['view']
             ],
-            'tusrbi' => [
-                'a' => ['v']
+            'tub' => [
+                'a' => ['view']
             ],
-            't' => [
-                'a' => ['c', 'u', 'd']
+            'tem' => [
+                'a' => ['create', 'update', 'delete']
             ],
             'rle' => [
-                'a' => ['v', 'as', 'u']
+                'a' => ['view', 'assign', 'update']
             ]
         ]
     ]

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -464,7 +464,7 @@ return [
         ],
 
         'team_admin' => [
-            'user' => [
+            'userBasicInfo' => [
                 'any' => ['view']
             ],
             'pool' => [

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -87,15 +87,15 @@ return [
     'permissions' => [
         'view-any-classification' => [
             'en' => 'View Any Classification',
-            'fr' => 'Afficher toute classification'
+            'fr' => 'Visionner toute classification'
         ],
         'create-any-classification' => [
             'en' => 'Create Any Classification',
-            'fr' => 'Créer n\'importe quelle classification'
+            'fr' => 'Créer toute classification'
         ],
         'update-any-classification' => [
             'en' => 'Update Any Classification',
-            'fr' => 'Mise à jour de toute classification'
+            'fr' => 'Mettre à jour toute classification'
         ],
         'delete-any-classification' => [
             'en' => 'Delete Any Classification',
@@ -104,32 +104,32 @@ return [
 
         'view-any-department' => [
             'en' => 'View Any Department',
-            'fr' => 'Voir n\'importe quel département'
+            'fr' => 'Visionner tout ministère'
         ],
         'create-any-department' => [
             'en' => 'Create Any Department',
-            'fr' => 'Créer n\'importe quel département'
+            'fr' => 'Créer tout ministère'
         ],
         'update-any-department' => [
             'en' => 'Update Any Department',
-            'fr' => 'Mise à jour de n\'importe quel département'
+            'fr' => 'Mettre à jour tout ministère'
         ],
         'delete-any-department' => [
             'en' => 'Delete Any Department',
-            'fr' => 'Supprimer un département'
+            'fr' => 'Supprimer tout ministère'
         ],
 
         'view-any-skill' => [
             'en' => 'View Any Skill',
-            'fr' => 'Afficher n\'importe quelle compétence'
+            'fr' => 'Visionner toute compétence'
         ],
         'create-any-skill' => [
             'en' => 'Create Any Skill',
-            'fr' => 'Créer n\'importe quelle compétence'
+            'fr' => 'Créer toute compétence'
         ],
         'update-any-skill' => [
             'en' => 'Update Any Skill',
-            'fr' => 'Mettre à jour n\'importe quelle compétence'
+            'fr' => 'Mettre à jour toute compétence'
         ],
         'delete-any-skill' => [
             'en' => 'Delete Any Skill',
@@ -138,15 +138,15 @@ return [
 
         'view-any-skillFamily' => [
             'en' => 'View Any Skill Family',
-            'fr' => 'Voir n\'importe quelle famille de compétences'
+            'fr' => 'Visionner toute famille de compétences'
         ],
         'create-any-skillFamily' => [
             'en' => 'Create Any Skill Family',
-            'fr' => 'Créer n\'importe quelle famille de compétences'
+            'fr' => 'Créer toute famille de compétences'
         ],
         'update-any-skillFamily' => [
             'en' => 'Update Any Skill Family',
-            'fr' => 'Mettre à jour n\'importe quelle famille de compétences'
+            'fr' => 'Mettre à jour toute famille de compétences'
         ],
         'delete-any-skillFamily' => [
             'en' => 'Delete Any Skill Family',
@@ -155,7 +155,7 @@ return [
 
         'view-any-user' => [
             'en' => 'View Any User',
-            'fr' => 'Afficher tout utilisateur'
+            'fr' => 'Visionner tout utilisateur'
         ],
         'view-any-userBasicInfo' => [
             'en' => 'View basic info of any User',
@@ -163,11 +163,11 @@ return [
         ],
         'view-own-user' => [
             'en' => 'View Own User',
-            'fr' => 'Voir son propre utilisateur'
+            'fr' => 'Visionner son propre utilisateur'
         ],
         'update-any-user' => [
             'en' => 'Update Any User',
-            'fr' => 'Mise à jour de tout utilisateur'
+            'fr' => 'Mettre à jour tout utilisateur'
         ],
         'update-own-user' => [
             'en' => 'Update Own User',
@@ -175,7 +175,7 @@ return [
         ],
         'delete-any-user' => [
             'en' => 'Delete Any User',
-            'fr' => 'Supprimer un utilisateur'
+            'fr' => 'Supprimer tout utilisateur'
         ],
 
         'view-team-pool' => [
@@ -184,7 +184,7 @@ return [
         ],
         'view-any-publishedPoolAdvertisement' => [
             'en' => 'View Any Published Pool Advertisement',
-            'fr' => 'Voir toute annonce publiée sur la piscine'
+            'fr' => 'Visionner toute annonce publiée dans un bassin'
         ],
         'create-team-pool' => [
             'en' => 'Create Pools in this Team',
@@ -209,7 +209,7 @@ return [
 
         'view-own-application' => [
             'en' => 'View Own Application',
-            'fr' => 'Afficher sa propre application'
+            'fr' => 'Visionner sa propre candidature'
         ],
         'view-team-submittedApplication' => [
             'en' => 'View Applications submitted to any of this Team\'s Pools',
@@ -221,7 +221,7 @@ return [
         ],
         'create-own-draftApplication' => [
             'en' => 'Begin my own Application to any Pool',
-            'fr' => 'Commencer ma propre candidature à une bassin'
+            'fr' => 'Créer sa propre candidature provisoire'
         ],
         'submit-own-application' => [
             'en' => 'Submit my own Application',
@@ -233,11 +233,11 @@ return [
         ],
         'delete-own-draftApplication' => [
             'en' => 'Delete Own Draft Application',
-            'fr' => 'Supprimer son propre projet de demande'
+            'fr' => 'Supprimer sa propre candidature provisoire'
         ],
         'archive-own-submittedApplication' => [
             'en' => 'Archive Own Submitted Application',
-            'fr' => 'Archiver sa propre demande'
+            'fr' => 'Archiver sa propre candidature présentée'
         ],
 
         'view-any-applicantCount' => [
@@ -259,12 +259,12 @@ return [
         ],
         'delete-team-searchRequest' => [
             'en' => 'Delete SearchRequests submitted to this Team',
-            'fr' => 'Supprimer les demandes de recherche soumises à cette équipe'
+            'fr' => 'Supprimer une demande de recherche d’équipe'
         ],
 
         'view-any-team' => [
             'en' => 'View Any Team',
-            'fr' => 'Voir n\'importe quelle équipe'
+            'fr' => 'Visionner toute équipe'
         ],
         'view-any-teamMembers' => [
             'en' => 'View who is a member of any Team',
@@ -276,24 +276,24 @@ return [
         ],
         'create-any-team' => [
             'en' => 'Create Any Team',
-            'fr' => 'Créer n\'importe quelle équipe'
+            'fr' => 'Créer toute équipe'
         ],
         'update-any-team' => [
             'en' => 'Update Any Team',
-            'fr' => 'Mise à jour de n\'importe quelle équipe'
+            'fr' => 'Mettre à jour toute équipe'
         ],
         'update-team-team' => [
             'en' => 'Update this Team',
-            'fr' => 'Mise à jour de cette équipe'
+            'fr' => 'Mettre à jour des équipes'
         ],
         'delete-any-team' => [
             'en' => 'Delete Any Team',
-            'fr' => 'Supprimer une équipe'
+            'fr' => 'Supprimer toute équipe'
         ],
 
         'view-any-role' => [
             'en' => 'View Any Role',
-            'fr' => 'Voir tous les rôles'
+            'fr' => 'Visionner tout rôle'
         ],
         'assign-any-role' => [
             'en' => 'Assign any Role to any User',
@@ -305,7 +305,7 @@ return [
         ],
         'update-any-role' => [
             'en' => 'Update Any Role',
-            'fr' => 'Mise à jour de n\'importe quel rôle'
+            'fr' => 'Mettre à jour tout rôle'
         ],
     ],
 
@@ -326,11 +326,11 @@ return [
         'guest' => [
             'display_name' => [
                 'en' => 'Guest',
-                'fr' => 'Guest'
+                'fr' => 'Invité'
             ],
             'description' => [
                 'en' => 'These permissions are available to anyone, even not logged in.',
-                'fr' => 'Ces autorisations sont accessibles à tous, même aux personnes non connectées.'
+                'fr' => 'Ces permissions sont accessibles à quiconque, même sans avoir ouvert de session.'
             ]
         ],
 
@@ -341,7 +341,7 @@ return [
             ],
             'description' => [
                 'en' => 'Available to any logged-in user.',
-                'fr' => 'Disponible pour tout utilisateur connecté.'
+                'fr' => 'Accessibles à tout utilisateur qui a ouvert une session.'
             ]
         ],
 
@@ -352,29 +352,29 @@ return [
             ],
             'description' => [
                 'en' => 'Can edit their own profile and apply to jobs.',
-                'fr' => 'Ils peuvent modifier leur propre profil et postuler à des emplois.'
+                'fr' => 'Peut modifier son propre profil et postuler des emplois.'
             ]
         ],
 
         'team_admin' => [
             'display_name' => [
                 'en' => 'Team Admin',
-                'fr' => 'Team Admin'
+                'fr' => 'Administrateur de l’équipe'
             ],
             'description' => [
                 'en' => 'Can update their Team, add users to their Team, process applications, process requests and work on and publish pools',
-                'fr' => 'Ils peuvent mettre à jour leur équipe, ajouter des utilisateurs à leur équipe, traiter des demandes, travailler sur des pools et les publier.'
+                'fr' => 'Peut mettre à jour son équipe, ajouter des utilisateurs à son équipe, traiter les candidatures, traiter les demandes et travailler aux bassins et les publier.'
             ]
         ],
 
         'super_admin' => [
             'display_name' => [
                 'en' => 'Super Admin',
-                'fr' => 'Super Admin'
+                'fr' => 'Super administrateur'
             ],
             'description' => [
                 'en' => 'Makes teams, assigns roles to other users (including assigning users to orgs), manages lists of business data, and has the extraordinary ability to edit or delete other users.',
-                'fr' => 'Il crée des équipes, attribue des rôles à d\'autres utilisateurs (y compris l\'attribution d\'utilisateurs à des organisations), gère des listes de données commerciales et a la capacité extraordinaire de modifier ou de supprimer d\'autres utilisateurs.'
+                'fr' => 'Crée des équipes, attribue des rôles à d’autres utilisateurs (y compris l’attribution d’utilisateurs à des organisations), gère des listes de données opérationnelles et a la capacité extraordinaire de modifier ou de supprimer d’autres utilisateurs.'
             ]
         ],
     ],

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -40,9 +40,9 @@ return [
     |
     */
     'scopes' => [
-        'o' => 'own',
-        'a' => 'any',
-        't' => 'team'
+        'own' => 'own',
+        'any' => 'any',
+        'team' => 'team'
     ],
 
     /*
@@ -54,26 +54,26 @@ return [
     |
     */
     'resources' => [
-        'cls' => 'classification',
-        'dpt' => 'department',
-        'skl' => 'skill',
-        'skf' => 'skillFamily',
-        'usr' => 'user',
-        'ubi' => 'userBasicInfo',
-        'pol' => 'pool',
-        'ppa' => 'publishedPoolAdvertisement',
-        'dpl' => 'draftPool',
-        'pcd' => 'poolClosingDate',
-        'app' => 'application',
-        'sap' => 'submittedApplication',
-        'apf' => 'applicantProfile',
-        'dap' => 'draftApplication',
-        'aps' => 'applicationStatus',
-        'act' => 'applicantCount',
-        'srq' => 'searchRequest',
-        'tem' => 'team',
-        'tub' => 'teamUsersBasicInfo',
-        'rle' => 'role'
+        'classification' => 'classification',
+        'department' => 'department',
+        'skill' => 'skill',
+        'skillFamily' => 'skillFamily',
+        'user' => 'user',
+        'userBasicInfo' => 'userBasicInfo',
+        'pool' => 'pool',
+        'publishedPoolAdvertisement' => 'publishedPoolAdvertisement',
+        'draftPool' => 'draftPool',
+        'poolClosingDate' => 'poolClosingDate',
+        'application' => 'application',
+        'submittedApplication' => 'submittedApplication',
+        'applicantProfile' => 'applicantProfile',
+        'draftApplication' => 'draftApplication',
+        'applicationStatus' => 'applicationStatus',
+        'applicantCount' => 'applicantCount',
+        'searchRequest' => 'searchRequest',
+        'team' => 'team',
+        'teamUsersBasicInfo' => 'teamUsersBasicInfo',
+        'role' => 'role'
     ],
 
     /*
@@ -394,138 +394,138 @@ return [
     */
     'seeders' => [
         'guest' => [
-            'cls' => [
-                'a' => ['view']
+            'classification' => [
+                'any' => ['view']
             ],
-            'dpt' => [
-                'a' => ['view']
+            'department' => [
+                'any' => ['view']
             ],
-            'skl' => [
-                'a' => ['view']
+            'skill' => [
+                'any' => ['view']
             ],
-            'skf' => [
-                'a' => ['view']
+            'skillFamily' => [
+                'any' => ['view']
             ],
-            'ppa' => [
-                'a' => ['view']
+            'publishedPoolAdvertisement' => [
+                'any' => ['view']
             ],
-            'act' => [
-                'a' => ['view']
+            'applicantCount' => [
+                'any' => ['view']
             ],
-            'srq' => [
-                'a' => ['create']
+            'searchRequest' => [
+                'any' => ['create']
             ],
-            'tem' => [
-                'a' => ['view']
+            'team' => [
+                'any' => ['view']
             ],
         ],
 
         'base_user' => [
-            'cls' => [
-                'a' => ['view']
+            'classification' => [
+                'any' => ['view']
             ],
-            'dpt' => [
-                'a' => ['view']
+            'department' => [
+                'any' => ['view']
             ],
-            'skl' => [
-                'a' => ['view']
+            'skill' => [
+                'any' => ['view']
             ],
-            'skf' => [
-                'a' => ['view']
+            'skillFamily' => [
+                'any' => ['view']
             ],
-            'usr' => [
-                'o' => ['view', 'update']
+            'user' => [
+                'own' => ['view', 'update']
             ],
-            'ppa' => [
-                'a' => ['view']
+            'publishedPoolAdvertisement' => [
+                'any' => ['view']
             ],
-            'act' => [
-                'a' => ['view']
+            'applicantCount' => [
+                'any' => ['view']
             ],
-            'srq' => [
-                'a' => ['create']
+            'searchRequest' => [
+                'any' => ['create']
             ],
-            'tem' => [
-                'a' => ['view']
+            'team' => [
+                'any' => ['view']
             ],
         ],
 
         'applicant' => [
-            'app' => [
-                'o' => ['view', 'submit']
+            'application' => [
+                'own' => ['view', 'submit']
             ],
-            'dap' => [
-                'o' => ['create', 'delete']
+            'draftApplication' => [
+                'own' => ['create', 'delete']
             ],
-            'sap' => [
-                'o' => ['archive']
+            'submittedApplication' => [
+                'own' => ['archive']
             ]
         ],
 
         'team_admin' => [
-            'usr' => [
-                'a' => ['view']
+            'user' => [
+                'any' => ['view']
             ],
-            'pol' => [
-                't' => ['view', 'create', 'publish']
+            'pool' => [
+                'team' => ['view', 'create', 'publish']
             ],
-            'dpl' => [
-                't' => ['update', 'delete']
+            'draftPool' => [
+                'team' => ['update', 'delete']
             ],
-            'pcd' => [
-                't' => ['update']
+            'poolClosingDate' => [
+                'team' => ['update']
             ],
-            'sap' => [
-                't' => ['view']
+            'submittedApplication' => [
+                'team' => ['view']
             ],
-            'apf' => [
-                't' => ['view']
+            'applicantProfile' => [
+                'team' => ['view']
             ],
-            'aps' => [
-                't' => ['update']
+            'applicationStatus' => [
+                'team' => ['update']
             ],
-            'srq' => [
-                't' => ['view', 'update', 'delete']
+            'searchRequest' => [
+                'team' => ['view', 'update', 'delete']
             ],
-            'tub' => [
-                't' => ['view']
+            'teamUsersBasicInfo' => [
+                'team' => ['view']
             ],
-            'tem' => [
-                't' => ['update']
+            'team' => [
+                'team' => ['update']
             ],
-            'rle' => [
-                'a' => ['view'],
-                't' => ['assign'],
+            'role' => [
+                'any' => ['view'],
+                'team' => ['assign'],
             ],
         ],
 
         'super_admin' => [
-            'cls' => [
-                'a' => ['create', 'update', 'delete']
+            'classification' => [
+                'any' => ['create', 'update', 'delete']
             ],
-            'dpt' => [
-                'a' => ['create', 'update', 'delete']
+            'department' => [
+                'any' => ['create', 'update', 'delete']
             ],
-            'skl' => [
-                'a' => ['create', 'update', 'delete']
+            'skill' => [
+                'any' => ['create', 'update', 'delete']
             ],
-            'skf' => [
-                'a' => ['create', 'update', 'delete']
+            'skillFamily' => [
+                'any' => ['create', 'update', 'delete']
             ],
-            'usr' => [
-                'a' => ['view', 'update', 'delete']
+            'user' => [
+                'any' => ['view', 'update', 'delete']
             ],
-            'ubi' => [
-                'a' => ['view']
+            'userBasicInfo' => [
+                'any' => ['view']
             ],
-            'tub' => [
-                'a' => ['view']
+            'teamUsersBasicInfo' => [
+                'any' => ['view']
             ],
-            'tem' => [
-                'a' => ['create', 'update', 'delete']
+            'team' => [
+                'any' => ['create', 'update', 'delete']
             ],
-            'rle' => [
-                'a' => ['view', 'assign', 'update']
+            'role' => [
+                'any' => ['view', 'assign', 'update']
             ]
         ]
     ]

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -72,7 +72,7 @@ return [
         'applicantCount' => 'applicantCount',
         'searchRequest' => 'searchRequest',
         'team' => 'team',
-        'teamUsersBasicInfo' => 'teamUsersBasicInfo',
+        'teamMembers' => 'teamMembers',
         'role' => 'role'
     ],
 
@@ -158,7 +158,7 @@ return [
             'fr' => 'Afficher tout utilisateur'
         ],
         'view-any-userBasicInfo' => [
-            'en' => 'View Any User Basic Info',
+            'en' => 'View basic info of any User',
             'fr' => 'Afficher les informations de base de tout utilisateur'
         ],
         'view-own-user' => [
@@ -179,32 +179,32 @@ return [
         ],
 
         'view-team-pool' => [
-            'en' => 'View Team Pool',
-            'fr' => 'Voir le pool d\'équipes'
+            'en' => 'View Pools in this Team',
+            'fr' => 'Voir les bassins de cette équipe'
         ],
         'view-any-publishedPoolAdvertisement' => [
             'en' => 'View Any Published Pool Advertisement',
             'fr' => 'Voir toute annonce publiée sur la piscine'
         ],
         'create-team-pool' => [
-            'en' => 'Create Team Pool',
-            'fr' => 'Créer un pool d\'équipes'
+            'en' => 'Create Pools in this Team',
+            'fr' => 'Créer des bassins dans cette équipe'
         ],
         'update-team-draftPool' => [
-            'en' => 'Update Team Draft Pool',
-            'fr' => 'Mise à jour du pool de sélection des équipes'
+            'en' => 'Update unpublished Pools in this Team',
+            'fr' => 'Mise à jour des bassins non publiés dans cette équipe'
         ],
         'publish-team-pool' => [
-            'en' => 'Update Team Pool',
-            'fr' => 'Mise à jour du pool d\'équipes'
+            'en' => 'Publish Pools in this Team',
+            'fr' => 'Publier des bassins dans cette équipe'
         ],
         'update-team-poolClosingDate' => [
-            'en' => 'Update Team Pool Closing Date',
-            'fr' => 'Mise à jour de la date de clôture de la réserve d\'équipes'
+            'en' => 'Update the closing date of published Pools in this Team',
+            'fr' => 'Mise à jour de la date de clôture des bassins publiés dans cette équipe'
         ],
         'delete-team-draftPool' => [
-            'en' => 'Delete Team Draft Pool',
-            'fr' => 'Supprimer le pool de sélection d\'équipes'
+            'en' => 'Delete draft Pools in this Team',
+            'fr' => 'Supprimer les pools de brouillons dans cette équipe'
         ],
 
         'view-own-application' => [
@@ -212,24 +212,24 @@ return [
             'fr' => 'Afficher sa propre application'
         ],
         'view-team-submittedApplication' => [
-            'en' => 'View Team Submitted Application',
-            'fr' => 'Voir la demande soumise par l\'équipe'
+            'en' => 'View Applications submitted to any of this Team\'s Pools',
+            'fr' => 'Voir les candidatures soumises à n\'importe quel bassin de cette équipe.'
         ],
         'view-team-applicantProfile' => [
-            'en' => 'View Team Applicant Profile',
-            'fr' => 'Voir le profil du candidat de l\'équipe'
+            'en' => 'View the Profile of a users accepted to any of this Team\'s Pools',
+            'fr' => 'Voir le profil d\'un utilisateur accepté dans l\'un des bassins de cette équipe.'
         ],
         'create-own-draftApplication' => [
-            'en' => 'Create Own Draft Application',
-            'fr' => 'Créer son propre projet d\'application'
+            'en' => 'Begin my own Application to any Pool',
+            'fr' => 'Commencer ma propre candidature à une bassin'
         ],
         'submit-own-application' => [
-            'en' => 'Submit Own Application',
-            'fr' => 'Soumettre sa propre demande'
+            'en' => 'Submit my own Application',
+            'fr' => 'Soumettre ma propre candidature'
         ],
         'update-team-applicationStatus' => [
-            'en' => 'Update Team Application Status',
-            'fr' => 'Mise à jour du statut de la demande de l\'équipe'
+            'en' => 'Update the status of Applications submitted to this Team\'s Pools',
+            'fr' => 'Mettre à jour le statut des demandes soumises aux bassins de cette équipe.'
         ],
         'delete-own-draftApplication' => [
             'en' => 'Delete Own Draft Application',
@@ -239,39 +239,40 @@ return [
             'en' => 'Archive Own Submitted Application',
             'fr' => 'Archiver sa propre demande'
         ],
+
         'view-any-applicantCount' => [
-            'en' => 'View Applicant Count',
-            'fr' => 'Voir le nombre de candidats'
+            'en' => 'View the count result of any filter-Applicant query',
+            'fr' => 'Visualiser le résultat du comptage de n\'importe quelle requête filtre-demandeur'
         ],
 
         'create-any-searchRequest' => [
-            'en' => 'Create Any Search Request',
+            'en' => 'Create Any SearchRequest',
             'fr' => 'Créer toute demande de recherche'
         ],
         'view-team-searchRequest' => [
-            'en' => 'Create Team Search Request',
-            'fr' => 'Créer une demande de recherche d\'équipe'
+            'en' => 'View SearchRequests submitted to this Team',
+            'fr' => 'Voir les demandes de recherche soumises à cette équipe'
         ],
         'update-team-searchRequest' => [
-            'en' => 'Update Team Search Request',
-            'fr' => 'Mise à jour de la demande de recherche d\'équipe'
+            'en' => 'Update the notes or status of SearchRequests submitted to this Team',
+            'fr' => 'Mettre à jour les notes ou le statut des demandes de recherche soumises à cette équipe.'
         ],
         'delete-team-searchRequest' => [
-            'en' => 'Delete Team Search Request',
-            'fr' => 'Supprimer une demande de recherche d\'équipe'
+            'en' => 'Delete SearchRequests submitted to this Team',
+            'fr' => 'Supprimer les demandes de recherche soumises à cette équipe'
         ],
 
         'view-any-team' => [
             'en' => 'View Any Team',
             'fr' => 'Voir n\'importe quelle équipe'
         ],
-        'view-any-teamUsersBasicInfo' => [
-            'en' => 'View Any Team Users Basic Info',
-            'fr' => 'Afficher les informations de base sur les utilisateurs de n\'importe quelle équipe'
+        'view-any-teamMembers' => [
+            'en' => 'View who is a member of any Team',
+            'fr' => 'Voir qui est membre de n\'import quell équipe'
         ],
-        'view-team-teamUsersBasicInfo' => [
-            'en' => 'View Teams Team Users Basic Info',
-            'fr' => 'Afficher les informations de base sur les utilisateurs de l\'équipe'
+        'view-team-teamMembers' => [
+            'en' => 'View who is a member of this Team',
+            'fr' => 'Voir qui est membre de cette équipe'
         ],
         'create-any-team' => [
             'en' => 'Create Any Team',
@@ -282,8 +283,8 @@ return [
             'fr' => 'Mise à jour de n\'importe quelle équipe'
         ],
         'update-team-team' => [
-            'en' => 'Update Team Team',
-            'fr' => 'Mise à jour de l\'équipe'
+            'en' => 'Update this Team',
+            'fr' => 'Mise à jour de cette équipe'
         ],
         'delete-any-team' => [
             'en' => 'Delete Any Team',
@@ -295,12 +296,12 @@ return [
             'fr' => 'Voir tous les rôles'
         ],
         'assign-any-role' => [
-            'en' => 'Assign Any Role',
-            'fr' => 'Attribuer n\'importe quel rôle'
+            'en' => 'Assign any Role to any User',
+            'fr' => 'Attribuer n\'importe quel rôle à n\'importe quel utilisateur'
         ],
         'assign-team-role' => [
-            'en' => 'Assign Team Role',
-            'fr' => 'Attribuer un rôle à l\'équipe'
+            'en' => 'Assign Roles associated with this Team to any User',
+            'fr' => 'Attribuer les rôles associés à cette équipe à tout utilisateur'
         ],
         'update-any-role' => [
             'en' => 'Update Any Role',
@@ -487,7 +488,7 @@ return [
             'searchRequest' => [
                 'team' => ['view', 'update', 'delete']
             ],
-            'teamUsersBasicInfo' => [
+            'teamMembers' => [
                 'team' => ['view']
             ],
             'team' => [
@@ -518,7 +519,7 @@ return [
             'userBasicInfo' => [
                 'any' => ['view']
             ],
-            'teamUsersBasicInfo' => [
+            'teamMembers' => [
                 'any' => ['view']
             ],
             'team' => [

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -37,6 +37,7 @@ class DatabaseSeeder extends Seeder
 
         $this->truncateTables();
 
+        $this->call(RolePermissionSeeder::class);
         $this->call(ClassificationSeeder::class);
         $this->call(DepartmentSeeder::class);
         $this->call(GenericJobTitleSeeder::class);

--- a/api/database/seeders/ProdSeeder.php
+++ b/api/database/seeders/ProdSeeder.php
@@ -13,6 +13,7 @@ class ProdSeeder extends Seeder
      */
     public function run()
     {
+        $this->call(RolePermissionSeeder::class);
         $this->call(ClassificationSeeder::class);
         $this->call(DepartmentSeeder::class);
         $this->call(SkillFamilySeeder::class);

--- a/api/database/seeders/RolePermissionSeeder.php
+++ b/api/database/seeders/RolePermissionSeeder.php
@@ -23,7 +23,9 @@ class RolePermissionSeeder extends Seeder
             'u' => 'update',
             'd' => 'delete',
             'as' => 'assign',
-            'arc'=> 'archive'
+            'arc'=> 'archive',
+            's' => 'submit',
+            'p' => 'publish'
         ];
 
         $scopeMap = [
@@ -353,34 +355,139 @@ class RolePermissionSeeder extends Seeder
         $seeders = [
             'guest' => [
                 'clss' => [
-                    'a' => [ 'v' ]
+                    'a' => ['v']
                 ],
                 'dpt' => [
-                    'a' => [ 'v' ]
+                    'a' => ['v']
                 ],
                 'sk' => [
-                    'a' => [ 'v' ]
+                    'a' => ['v']
                 ],
                 'sf' => [
-                    'a' => [ 'v' ]
+                    'a' => ['v']
                 ],
                 'ppa' => [
-                    'a' => [ 'v' ]
+                    'a' => ['v']
                 ],
                 'ac' => [
-                    'a' => [ 'v' ]
+                    'a' => ['v']
                 ],
                 'sr' => [
-                    'a' => [ 'c' ]
+                    'a' => ['c']
                 ],
                 't' => [
-                    'a' => [ 'v' ]
+                    'a' => ['v']
                 ],
             ],
 
-            // 'base_user'=> [
+            'base_user'=> [
+                'clss' => [
+                    'a' => ['v']
+                ],
+                'dpt' => [
+                    'a' => ['v']
+                ],
+                'sk' => [
+                    'a' => ['v']
+                ],
+                'sf' => [
+                    'a' => ['v']
+                ],
+                'usr' => [
+                    'o' => ['v','u']
+                ],
+                'ppa' => [
+                    'a' => ['v']
+                ],
+                'ac' => [
+                    'a' => ['v']
+                ],
+                'sr' => [
+                    'a' => ['c']
+                ],
+                't' => [
+                    'a' => ['v']
+                ],
+            ],
 
-            // ]
+            'applicant' => [
+                'app' => [
+                    'o' => ['v','s']
+                ],
+                'dapp' => [
+                    'o' => ['c','d']
+                ],
+                'sapp' => [
+                    'o' => ['arc']
+                ]
+            ],
+
+            'team_admin' => [
+                'usr' => [
+                    'a' => ['v']
+                ],
+                'pl' => [
+                    't' => ['v','c','p']
+                ],
+                'dp' => [
+                    't' => ['u','d']
+                ],
+                'pcd' => [
+                    't' => ['u']
+                ],
+                'sapp' => [
+                    't' => ['v']
+                ],
+                'aprf' => [
+                    't' => ['v']
+                ],
+                'apps' => [
+                    't' => ['u']
+                ],
+                'sr' => [
+                    't' => ['v','u','d']
+                ],
+                'tusrbi' => [
+                    't' => ['v']
+                ],
+                't' => [
+                    't' => ['u']
+                ],
+                'rle' => [
+                    'a' => ['v'],
+                    't' => ['as'],
+                ],
+            ],
+
+            'super_admin' => [
+                'clss' => [
+                    'a' => ['c','u','d']
+                ],
+                'dpt' => [
+                    'a' => ['c','u','d']
+                ],
+                'sk' => [
+                    'a' => ['c','u','d']
+                ],
+                'sf' => [
+                    'a' => ['c','u','d']
+                ],
+                'usr' => [
+                    'a' => ['v','u','d']
+                ],
+                'ubi' => [
+                    'a' => ['v']
+                ],
+                'tusrbi' => [
+                    'a' => ['v']
+                ],
+                't' => [
+                    'a' => ['c','u','d']
+                ],
+                'rle' => [
+                    'a' => ['v','as','u']
+                ]
+            ]
         ];
 
         foreach($seeders as $roleKey => $resources) {

--- a/api/database/seeders/RolePermissionSeeder.php
+++ b/api/database/seeders/RolePermissionSeeder.php
@@ -31,7 +31,6 @@ class RolePermissionSeeder extends Seeder
                 $this->command->error("Role with key $roleKey does not exist in role map");
             }
 
-            $this->command->info("Adding role $roleKey");
             $role = Role::updateOrCreate(
                 ['name' => $roleKey],
                 [
@@ -78,10 +77,7 @@ class RolePermissionSeeder extends Seeder
                 }
             }
 
-            $permissionIds = collect($permissions)->pluck('id');
-            $permissionCount = count($permissionIds);
-            $this->command->info("Syncing $permissionCount permissions to $roleKey");
-            $role->permissions()->sync($permissionIds);
+            $role->permissions()->sync(collect($permissions)->pluck('id'));
         }
     }
 }

--- a/api/database/seeders/RolePermissionSeeder.php
+++ b/api/database/seeders/RolePermissionSeeder.php
@@ -1,0 +1,441 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Permission;
+use App\Models\Role;
+
+class RolePermissionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+
+        $actionMap = [
+            'v'=> 'view',
+            'c' => 'create',
+            'u' => 'update',
+            'd' => 'delete',
+            'as' => 'assign',
+            'arc'=> 'archive'
+        ];
+
+        $scopeMap = [
+            'o' => 'own',
+            'a' => 'any',
+            't' => 'team'
+        ];
+
+        $resourceMap = [
+            'clss' => 'classification',
+            'dpt' => 'department',
+            'sk' => 'skill',
+            'sf' => 'skillFamily',
+            'usr' => 'user',
+            'ubi' => 'userBasicInfo',
+            'pl' => 'pool',
+            'ppa' => 'publishedPoolAdvertisement',
+            'dp' => 'draftPool',
+            'pcd' => 'poolClosingDate',
+            'app' => 'application',
+            'sapp' => 'submittedApplication',
+            'aprf' => 'applicantProfile',
+            'dapp' => 'draftApplication',
+            'apps' => 'applicationStatus',
+            'ac' => 'applicantCount',
+            'sr' => 'searchRequest',
+            't' => 'team',
+            'tusrbi' => 'teamUsersBasicInfo',
+            'rle' => 'role'
+        ];
+
+        $permissionMap = [
+            'view-any-classification' => [
+                'en' => 'View Any Classification',
+                'fr' => 'Afficher toute classification'
+            ],
+            'create-any-classification' => [
+                'en' => 'Create Any Classification',
+                'fr' => 'Créer n\'importe quelle classification'
+            ],
+            'update-any-classification' => [
+                'en' => 'Update Any Classification',
+                'fr' => 'Mise à jour de toute classification'
+            ],
+            'delete-any-classification' => [
+                'en' => 'Delete Any Classification',
+                'fr' => 'Supprimer toute classification'
+            ],
+
+            'view-any-department' => [
+                'en' => 'View Any Department',
+                'fr' => 'Voir n\'importe quel département'
+            ],
+            'create-any-department' => [
+                'en' => 'Create Any Department',
+                'fr' => 'Créer n\'importe quel département'
+            ],
+            'update-any-department' => [
+                'en' => 'Update Any Department',
+                'fr' => 'Mise à jour de n\'importe quel département'
+            ],
+            'delete-any-department' => [
+                'en' => 'Delete Any Department',
+                'fr' => 'Supprimer un département'
+            ],
+
+            'view-any-skill' => [
+                'en' => 'View Any Skill',
+                'fr' => 'Afficher n\'importe quelle compétence'
+            ],
+            'create-any-skill' => [
+                'en' => 'Create Any Skill',
+                'fr' => 'Créer n\'importe quelle compétence'
+            ],
+            'update-any-skill' => [
+                'en' => 'Update Any Skill',
+                'fr' => 'Mettre à jour n\'importe quelle compétence'
+            ],
+            'delete-any-skill' => [
+                'en' => 'Delete Any Skill',
+                'fr' => 'Supprimer toute compétence'
+            ],
+
+            'view-any-skillFamily' => [
+                'en' => 'View Any Skill Family',
+                'fr' => 'Voir n\'importe quelle famille de compétences'
+            ],
+            'create-any-skillFamily' => [
+                'en' => 'Create Any Skill Family',
+                'fr' => 'Créer n\'importe quelle famille de compétences'
+            ],
+            'update-any-skillFamily' => [
+                'en' => 'Update Any Skill Family',
+                'fr' => 'Mettre à jour n\'importe quelle famille de compétences'
+            ],
+            'delete-any-skillFamily' => [
+                'en' => 'Delete Any Skill Family',
+                'fr' => 'Supprimer toute famille de compétences'
+            ],
+
+            'view-any-user' => [
+                'en' => 'View Any User',
+                'fr' => 'Afficher tout utilisateur'
+            ],
+            'view-any-userBasicInfo' => [
+                'en' => 'View Any User Basic Info',
+                'fr' => 'Afficher les informations de base de tout utilisateur'
+            ],
+            'view-own-user' => [
+                'en' => 'View Own User',
+                'fr' => 'Voir son propre utilisateur'
+            ],
+            'update-any-user' => [
+                'en' => 'Update Any User',
+                'fr' => 'Mise à jour de tout utilisateur'
+            ],
+            'update-own-user' => [
+                'en' => 'Update Own User',
+                'fr' => 'Mettre à jour son propre utilisateur'
+            ],
+            'delete-any-user' => [
+                'en' => 'Delete Any User',
+                'fr' => 'Supprimer un utilisateur'
+            ],
+
+            'view-team-pool' => [
+                'en' => 'View Team Pool',
+                'fr' => 'Voir le pool d\'équipes'
+            ],
+            'view-any-publishedPoolAdvertisement' => [
+                'en' => 'View Any Published Pool Advertisement',
+                'fr' => 'Voir toute annonce publiée sur la piscine'
+            ],
+            'create-team-pool' => [
+                'en' => 'Create Team Pool',
+                'fr' => 'Créer un pool d\'équipes'
+            ],
+            'update-team-draftPool' => [
+                'en' => 'Update Team Draft Pool',
+                'fr' => 'Mise à jour du pool de sélection des équipes'
+            ],
+            'publish-team-pool' => [
+                'en' => 'Update Team Pool',
+                'fr' => 'Mise à jour du pool d\'équipes'
+            ],
+            'update-team-poolClosingDate' => [
+                'en' => 'Update Team Pool Closing Date',
+                'fr' => 'Mise à jour de la date de clôture de la réserve d\'équipes'
+            ],
+            'delete-team-draftPool' => [
+                'en' => 'Delete Team Draft Pool',
+                'fr' => 'Supprimer le pool de sélection d\'équipes'
+            ],
+
+            'view-own-application' => [
+                'en' => 'View Own Application',
+                'fr' => 'Afficher sa propre application'
+            ],
+            'view-team-submittedApplication' => [
+                'en' => 'View Team Submitted Application',
+                'fr' => 'Voir la demande soumise par l\'équipe'
+            ],
+            'view-team-applicantProfile' => [
+                'en' => 'View Team Applicant Profile',
+                'fr' => 'Voir le profil du candidat de l\'équipe'
+            ],
+            'create-own-draftApplication' => [
+                'en' => 'Create Own Draft Application',
+                'fr' => 'Créer son propre projet d\'application'
+            ],
+            'submit-own-application' => [
+                'en' => 'Submit Own Application',
+                'fr' => 'Soumettre sa propre demande'
+            ],
+            'update-team-applicationStatus' => [
+                'en' => 'Update Team Application Status',
+                'fr' => 'Mise à jour du statut de la demande de l\'équipe'
+            ],
+            'delete-own-draftApplication' => [
+                'en' => 'Delete Own Draft Application',
+                'fr' => 'Supprimer son propre projet de demande'
+            ],
+            'archive-own-submittedApplication' => [
+                'en' => 'Archive Own Submitted Application',
+                'fr' => 'Archiver sa propre demande'
+            ],
+            'view-any-applicantCount' => [
+                'en' => 'View Applicant Count',
+                'fr' => 'Voir le nombre de candidats'
+            ],
+
+            'create-any-searchRequest' => [
+                'en' => 'Create Any Search Request',
+                'fr' => 'Créer toute demande de recherche'
+            ],
+            'view-team-searchRequest' => [
+                'en' => 'Create Team Search Request',
+                'fr' => 'Créer une demande de recherche d\'équipe'
+            ],
+            'update-team-searchRequest' => [
+                'en' => 'Update Team Search Request',
+                'fr' => 'Mise à jour de la demande de recherche d\'équipe'
+            ],
+            'delete-team-searchRequest' => [
+                'en' => 'Delete Team Search Request',
+                'fr' => 'Supprimer une demande de recherche d\'équipe'
+            ],
+
+            'view-any-team' => [
+                'en' => 'View Any Team',
+                'fr' => 'Voir n\'importe quelle équipe'
+            ],
+            'view-any-teamUsersBasicInfo' => [
+                'en' => 'View Any Team Users Basic Info',
+                'fr' => 'Afficher les informations de base sur les utilisateurs de n\'importe quelle équipe'
+            ],
+            'view-team-teamUsersBasicInfo' => [
+                'en' => 'View Teams Team Users Basic Info',
+                'fr' => 'Afficher les informations de base sur les utilisateurs de l\'équipe'
+            ],
+            'create-any-team' => [
+                'en' => 'Create Any Team',
+                'fr' => 'Créer n\'importe quelle équipe'
+            ],
+            'update-any-team' => [
+                'en' => 'Update Any Team',
+                'fr' => 'Mise à jour de n\'importe quelle équipe'
+            ],
+            'update-team-team' => [
+                'en' => 'Update Team Team',
+                'fr' => 'Mise à jour de l\'équipe'
+            ],
+            'delete-any-team' => [
+                'en' => 'Delete Any Team',
+                'fr' => 'Supprimer une équipe'
+            ],
+
+            'view-any-role' => [
+                'en' => 'View Any Role',
+                'fr' => 'Voir tous les rôles'
+            ],
+            'assign-any-role' => [
+                'en' => 'Assign Any Role',
+                'fr' => 'Attribuer n\'importe quel rôle'
+            ],
+            'assign-team-role' => [
+                'en' => 'Assign Team Role',
+                'fr' => 'Attribuer un rôle à l\'équipe'
+            ],
+            'update-any-role' => [
+                'en' => 'Update Any Role',
+                'fr' => 'Mise à jour de n\'importe quel rôle'
+            ],
+        ];
+
+        $roleMap = [
+            'guest' => [
+                'display_name' => [
+                    'en' => 'Guest',
+                    'fr' => 'Guest'
+                ],
+                'description' => [
+                    'en' => 'These permissions are available to anyone, even not logged in.',
+                    'fr' => 'Ces autorisations sont accessibles à tous, même aux personnes non connectées.'
+                ]
+            ],
+
+            'base_user' => [
+                'display_name' => [
+                    'en' => 'Base User',
+                    'fr' => 'Utilisateur de base'
+                ],
+                'description' => [
+                    'en' => 'Available to any logged-in user.',
+                    'fr' => 'Disponible pour tout utilisateur connecté.'
+                ]
+            ],
+
+            'applicant' => [
+                'display_name' => [
+                    'en' => 'Applicant',
+                    'fr' => 'Candidat'
+                ],
+                'description' => [
+                    'en' => 'Can edit their own profile and apply to jobs.',
+                    'fr' => 'Ils peuvent modifier leur propre profil et postuler à des emplois.'
+                ]
+            ],
+
+            'team_admin' => [
+                'display_name' => [
+                    'en' => 'Team Admin',
+                    'fr' => 'Team Admin'
+                ],
+                'description' => [
+                    'en' => 'Can update their Team, add users to their Team, process applications, process requests and work on and publish pools',
+                    'fr' => 'Ils peuvent mettre à jour leur équipe, ajouter des utilisateurs à leur équipe, traiter des demandes, travailler sur des pools et les publier.'
+                ]
+            ],
+
+            'super_admin' => [
+                'display_name' => [
+                    'en' => 'Super Admin',
+                    'fr' => 'Super Admin'
+                ],
+                'description' => [
+                    'en' => 'Makes teams, assigns roles to other users (including assigning users to orgs), manages lists of business data, and has the extraordinary ability to edit or delete other users.',
+                    'fr' => 'Il crée des équipes, attribue des rôles à d\'autres utilisateurs (y compris l\'attribution d\'utilisateurs à des organisations), gère des listes de données commerciales et a la capacité extraordinaire de modifier ou de supprimer d\'autres utilisateurs.'
+                ]
+            ],
+
+        ];
+
+        /**
+         * Seeder Shape
+         *
+         * [
+         *      'role_name' => [
+         *          'resource' => [
+         *              'scope' => [
+         *                  'actions'
+         *              ]
+         *          ]
+         *      ]
+         * ]
+         */
+        $seeders = [
+            'guest' => [
+                'clss' => [
+                    'a' => [ 'v' ]
+                ],
+                'dpt' => [
+                    'a' => [ 'v' ]
+                ],
+                'sk' => [
+                    'a' => [ 'v' ]
+                ],
+                'sf' => [
+                    'a' => [ 'v' ]
+                ],
+                'ppa' => [
+                    'a' => [ 'v' ]
+                ],
+                'ac' => [
+                    'a' => [ 'v' ]
+                ],
+                'sr' => [
+                    'a' => [ 'c' ]
+                ],
+                't' => [
+                    'a' => [ 'v' ]
+                ],
+            ],
+
+            // 'base_user'=> [
+
+            // ]
+        ];
+
+        foreach($seeders as $roleKey => $resources) {
+            $roleArray = $roleMap[$roleKey];
+            if(!$roleArray) {
+                $this->command("Role with key $roleKey does not exist in role map");
+            }
+
+            $role = Role::updateOrCreate(
+                ['name' => $roleKey],
+                [
+                    'name' => $roleKey,
+                    'display_name' => json_encode($roleArray['display_name']),
+                    'description' => json_encode($roleArray['description']),
+                ]
+            );
+
+            $permissions = [];
+
+            foreach($resources as $resourceKey => $scopes) {
+                $resource = $resourceMap[$resourceKey];
+                if(!$resource) {
+                    $this->command("Resource with key $resourceKey does not exist in resource map");
+                }
+
+                foreach($scopes as $scopeKey => $actions) {
+                    $scope = $scopeMap[$scopeKey];
+                    if(!$scope) {
+                        $this->command("Scope with key $scopeKey does not exist in scope map");
+                    }
+
+                    foreach($actions as $actionKey) {
+                        $action = $actionMap[$actionKey];
+                        if(!$action) {
+                            $this->command("Action with key $actionKey does not exist in action map");
+                        }
+
+                        $permissionKey = "$action-$scope-$resource";
+                        $permission = $permissionMap[$permissionKey];
+                        if(!$permission) {
+                            $this->command("Action with key $permissionKey does not exist in permission map");
+                        }
+
+                        $permissions[] = Permission::updateOrCreate(
+                            ['name' => $permissionKey],
+                            [
+                                'name' => $permissionKey,
+                                'display_name' => json_encode($permission)
+                            ]
+                        );
+                    }
+                }
+            }
+
+            $role->permissions()->sync(collect($permissions)->pluck('id'));
+        }
+    }
+}

--- a/api/database/seeders/RolePermissionSeeder.php
+++ b/api/database/seeders/RolePermissionSeeder.php
@@ -16,486 +16,22 @@ class RolePermissionSeeder extends Seeder
      */
     public function run()
     {
+        $config = config('rolepermission');
 
-        $actionMap = [
-            'v'=> 'view',
-            'c' => 'create',
-            'u' => 'update',
-            'd' => 'delete',
-            'as' => 'assign',
-            'arc'=> 'archive',
-            's' => 'submit',
-            'p' => 'publish'
-        ];
-
-        $scopeMap = [
-            'o' => 'own',
-            'a' => 'any',
-            't' => 'team'
-        ];
-
-        $resourceMap = [
-            'clss' => 'classification',
-            'dpt' => 'department',
-            'sk' => 'skill',
-            'sf' => 'skillFamily',
-            'usr' => 'user',
-            'ubi' => 'userBasicInfo',
-            'pl' => 'pool',
-            'ppa' => 'publishedPoolAdvertisement',
-            'dp' => 'draftPool',
-            'pcd' => 'poolClosingDate',
-            'app' => 'application',
-            'sapp' => 'submittedApplication',
-            'aprf' => 'applicantProfile',
-            'dapp' => 'draftApplication',
-            'apps' => 'applicationStatus',
-            'ac' => 'applicantCount',
-            'sr' => 'searchRequest',
-            't' => 'team',
-            'tusrbi' => 'teamUsersBasicInfo',
-            'rle' => 'role'
-        ];
-
-        $permissionMap = [
-            'view-any-classification' => [
-                'en' => 'View Any Classification',
-                'fr' => 'Afficher toute classification'
-            ],
-            'create-any-classification' => [
-                'en' => 'Create Any Classification',
-                'fr' => 'Créer n\'importe quelle classification'
-            ],
-            'update-any-classification' => [
-                'en' => 'Update Any Classification',
-                'fr' => 'Mise à jour de toute classification'
-            ],
-            'delete-any-classification' => [
-                'en' => 'Delete Any Classification',
-                'fr' => 'Supprimer toute classification'
-            ],
-
-            'view-any-department' => [
-                'en' => 'View Any Department',
-                'fr' => 'Voir n\'importe quel département'
-            ],
-            'create-any-department' => [
-                'en' => 'Create Any Department',
-                'fr' => 'Créer n\'importe quel département'
-            ],
-            'update-any-department' => [
-                'en' => 'Update Any Department',
-                'fr' => 'Mise à jour de n\'importe quel département'
-            ],
-            'delete-any-department' => [
-                'en' => 'Delete Any Department',
-                'fr' => 'Supprimer un département'
-            ],
-
-            'view-any-skill' => [
-                'en' => 'View Any Skill',
-                'fr' => 'Afficher n\'importe quelle compétence'
-            ],
-            'create-any-skill' => [
-                'en' => 'Create Any Skill',
-                'fr' => 'Créer n\'importe quelle compétence'
-            ],
-            'update-any-skill' => [
-                'en' => 'Update Any Skill',
-                'fr' => 'Mettre à jour n\'importe quelle compétence'
-            ],
-            'delete-any-skill' => [
-                'en' => 'Delete Any Skill',
-                'fr' => 'Supprimer toute compétence'
-            ],
-
-            'view-any-skillFamily' => [
-                'en' => 'View Any Skill Family',
-                'fr' => 'Voir n\'importe quelle famille de compétences'
-            ],
-            'create-any-skillFamily' => [
-                'en' => 'Create Any Skill Family',
-                'fr' => 'Créer n\'importe quelle famille de compétences'
-            ],
-            'update-any-skillFamily' => [
-                'en' => 'Update Any Skill Family',
-                'fr' => 'Mettre à jour n\'importe quelle famille de compétences'
-            ],
-            'delete-any-skillFamily' => [
-                'en' => 'Delete Any Skill Family',
-                'fr' => 'Supprimer toute famille de compétences'
-            ],
-
-            'view-any-user' => [
-                'en' => 'View Any User',
-                'fr' => 'Afficher tout utilisateur'
-            ],
-            'view-any-userBasicInfo' => [
-                'en' => 'View Any User Basic Info',
-                'fr' => 'Afficher les informations de base de tout utilisateur'
-            ],
-            'view-own-user' => [
-                'en' => 'View Own User',
-                'fr' => 'Voir son propre utilisateur'
-            ],
-            'update-any-user' => [
-                'en' => 'Update Any User',
-                'fr' => 'Mise à jour de tout utilisateur'
-            ],
-            'update-own-user' => [
-                'en' => 'Update Own User',
-                'fr' => 'Mettre à jour son propre utilisateur'
-            ],
-            'delete-any-user' => [
-                'en' => 'Delete Any User',
-                'fr' => 'Supprimer un utilisateur'
-            ],
-
-            'view-team-pool' => [
-                'en' => 'View Team Pool',
-                'fr' => 'Voir le pool d\'équipes'
-            ],
-            'view-any-publishedPoolAdvertisement' => [
-                'en' => 'View Any Published Pool Advertisement',
-                'fr' => 'Voir toute annonce publiée sur la piscine'
-            ],
-            'create-team-pool' => [
-                'en' => 'Create Team Pool',
-                'fr' => 'Créer un pool d\'équipes'
-            ],
-            'update-team-draftPool' => [
-                'en' => 'Update Team Draft Pool',
-                'fr' => 'Mise à jour du pool de sélection des équipes'
-            ],
-            'publish-team-pool' => [
-                'en' => 'Update Team Pool',
-                'fr' => 'Mise à jour du pool d\'équipes'
-            ],
-            'update-team-poolClosingDate' => [
-                'en' => 'Update Team Pool Closing Date',
-                'fr' => 'Mise à jour de la date de clôture de la réserve d\'équipes'
-            ],
-            'delete-team-draftPool' => [
-                'en' => 'Delete Team Draft Pool',
-                'fr' => 'Supprimer le pool de sélection d\'équipes'
-            ],
-
-            'view-own-application' => [
-                'en' => 'View Own Application',
-                'fr' => 'Afficher sa propre application'
-            ],
-            'view-team-submittedApplication' => [
-                'en' => 'View Team Submitted Application',
-                'fr' => 'Voir la demande soumise par l\'équipe'
-            ],
-            'view-team-applicantProfile' => [
-                'en' => 'View Team Applicant Profile',
-                'fr' => 'Voir le profil du candidat de l\'équipe'
-            ],
-            'create-own-draftApplication' => [
-                'en' => 'Create Own Draft Application',
-                'fr' => 'Créer son propre projet d\'application'
-            ],
-            'submit-own-application' => [
-                'en' => 'Submit Own Application',
-                'fr' => 'Soumettre sa propre demande'
-            ],
-            'update-team-applicationStatus' => [
-                'en' => 'Update Team Application Status',
-                'fr' => 'Mise à jour du statut de la demande de l\'équipe'
-            ],
-            'delete-own-draftApplication' => [
-                'en' => 'Delete Own Draft Application',
-                'fr' => 'Supprimer son propre projet de demande'
-            ],
-            'archive-own-submittedApplication' => [
-                'en' => 'Archive Own Submitted Application',
-                'fr' => 'Archiver sa propre demande'
-            ],
-            'view-any-applicantCount' => [
-                'en' => 'View Applicant Count',
-                'fr' => 'Voir le nombre de candidats'
-            ],
-
-            'create-any-searchRequest' => [
-                'en' => 'Create Any Search Request',
-                'fr' => 'Créer toute demande de recherche'
-            ],
-            'view-team-searchRequest' => [
-                'en' => 'Create Team Search Request',
-                'fr' => 'Créer une demande de recherche d\'équipe'
-            ],
-            'update-team-searchRequest' => [
-                'en' => 'Update Team Search Request',
-                'fr' => 'Mise à jour de la demande de recherche d\'équipe'
-            ],
-            'delete-team-searchRequest' => [
-                'en' => 'Delete Team Search Request',
-                'fr' => 'Supprimer une demande de recherche d\'équipe'
-            ],
-
-            'view-any-team' => [
-                'en' => 'View Any Team',
-                'fr' => 'Voir n\'importe quelle équipe'
-            ],
-            'view-any-teamUsersBasicInfo' => [
-                'en' => 'View Any Team Users Basic Info',
-                'fr' => 'Afficher les informations de base sur les utilisateurs de n\'importe quelle équipe'
-            ],
-            'view-team-teamUsersBasicInfo' => [
-                'en' => 'View Teams Team Users Basic Info',
-                'fr' => 'Afficher les informations de base sur les utilisateurs de l\'équipe'
-            ],
-            'create-any-team' => [
-                'en' => 'Create Any Team',
-                'fr' => 'Créer n\'importe quelle équipe'
-            ],
-            'update-any-team' => [
-                'en' => 'Update Any Team',
-                'fr' => 'Mise à jour de n\'importe quelle équipe'
-            ],
-            'update-team-team' => [
-                'en' => 'Update Team Team',
-                'fr' => 'Mise à jour de l\'équipe'
-            ],
-            'delete-any-team' => [
-                'en' => 'Delete Any Team',
-                'fr' => 'Supprimer une équipe'
-            ],
-
-            'view-any-role' => [
-                'en' => 'View Any Role',
-                'fr' => 'Voir tous les rôles'
-            ],
-            'assign-any-role' => [
-                'en' => 'Assign Any Role',
-                'fr' => 'Attribuer n\'importe quel rôle'
-            ],
-            'assign-team-role' => [
-                'en' => 'Assign Team Role',
-                'fr' => 'Attribuer un rôle à l\'équipe'
-            ],
-            'update-any-role' => [
-                'en' => 'Update Any Role',
-                'fr' => 'Mise à jour de n\'importe quel rôle'
-            ],
-        ];
-
-        $roleMap = [
-            'guest' => [
-                'display_name' => [
-                    'en' => 'Guest',
-                    'fr' => 'Guest'
-                ],
-                'description' => [
-                    'en' => 'These permissions are available to anyone, even not logged in.',
-                    'fr' => 'Ces autorisations sont accessibles à tous, même aux personnes non connectées.'
-                ]
-            ],
-
-            'base_user' => [
-                'display_name' => [
-                    'en' => 'Base User',
-                    'fr' => 'Utilisateur de base'
-                ],
-                'description' => [
-                    'en' => 'Available to any logged-in user.',
-                    'fr' => 'Disponible pour tout utilisateur connecté.'
-                ]
-            ],
-
-            'applicant' => [
-                'display_name' => [
-                    'en' => 'Applicant',
-                    'fr' => 'Candidat'
-                ],
-                'description' => [
-                    'en' => 'Can edit their own profile and apply to jobs.',
-                    'fr' => 'Ils peuvent modifier leur propre profil et postuler à des emplois.'
-                ]
-            ],
-
-            'team_admin' => [
-                'display_name' => [
-                    'en' => 'Team Admin',
-                    'fr' => 'Team Admin'
-                ],
-                'description' => [
-                    'en' => 'Can update their Team, add users to their Team, process applications, process requests and work on and publish pools',
-                    'fr' => 'Ils peuvent mettre à jour leur équipe, ajouter des utilisateurs à leur équipe, traiter des demandes, travailler sur des pools et les publier.'
-                ]
-            ],
-
-            'super_admin' => [
-                'display_name' => [
-                    'en' => 'Super Admin',
-                    'fr' => 'Super Admin'
-                ],
-                'description' => [
-                    'en' => 'Makes teams, assigns roles to other users (including assigning users to orgs), manages lists of business data, and has the extraordinary ability to edit or delete other users.',
-                    'fr' => 'Il crée des équipes, attribue des rôles à d\'autres utilisateurs (y compris l\'attribution d\'utilisateurs à des organisations), gère des listes de données commerciales et a la capacité extraordinaire de modifier ou de supprimer d\'autres utilisateurs.'
-                ]
-            ],
-
-        ];
-
-        /**
-         * Seeder Shape
-         *
-         * [
-         *      'role_name' => [
-         *          'resource' => [
-         *              'scope' => [
-         *                  'actions'
-         *              ]
-         *          ]
-         *      ]
-         * ]
-         */
-        $seeders = [
-            'guest' => [
-                'clss' => [
-                    'a' => ['v']
-                ],
-                'dpt' => [
-                    'a' => ['v']
-                ],
-                'sk' => [
-                    'a' => ['v']
-                ],
-                'sf' => [
-                    'a' => ['v']
-                ],
-                'ppa' => [
-                    'a' => ['v']
-                ],
-                'ac' => [
-                    'a' => ['v']
-                ],
-                'sr' => [
-                    'a' => ['c']
-                ],
-                't' => [
-                    'a' => ['v']
-                ],
-            ],
-
-            'base_user'=> [
-                'clss' => [
-                    'a' => ['v']
-                ],
-                'dpt' => [
-                    'a' => ['v']
-                ],
-                'sk' => [
-                    'a' => ['v']
-                ],
-                'sf' => [
-                    'a' => ['v']
-                ],
-                'usr' => [
-                    'o' => ['v','u']
-                ],
-                'ppa' => [
-                    'a' => ['v']
-                ],
-                'ac' => [
-                    'a' => ['v']
-                ],
-                'sr' => [
-                    'a' => ['c']
-                ],
-                't' => [
-                    'a' => ['v']
-                ],
-            ],
-
-            'applicant' => [
-                'app' => [
-                    'o' => ['v','s']
-                ],
-                'dapp' => [
-                    'o' => ['c','d']
-                ],
-                'sapp' => [
-                    'o' => ['arc']
-                ]
-            ],
-
-            'team_admin' => [
-                'usr' => [
-                    'a' => ['v']
-                ],
-                'pl' => [
-                    't' => ['v','c','p']
-                ],
-                'dp' => [
-                    't' => ['u','d']
-                ],
-                'pcd' => [
-                    't' => ['u']
-                ],
-                'sapp' => [
-                    't' => ['v']
-                ],
-                'aprf' => [
-                    't' => ['v']
-                ],
-                'apps' => [
-                    't' => ['u']
-                ],
-                'sr' => [
-                    't' => ['v','u','d']
-                ],
-                'tusrbi' => [
-                    't' => ['v']
-                ],
-                't' => [
-                    't' => ['u']
-                ],
-                'rle' => [
-                    'a' => ['v'],
-                    't' => ['as'],
-                ],
-            ],
-
-            'super_admin' => [
-                'clss' => [
-                    'a' => ['c','u','d']
-                ],
-                'dpt' => [
-                    'a' => ['c','u','d']
-                ],
-                'sk' => [
-                    'a' => ['c','u','d']
-                ],
-                'sf' => [
-                    'a' => ['c','u','d']
-                ],
-                'usr' => [
-                    'a' => ['v','u','d']
-                ],
-                'ubi' => [
-                    'a' => ['v']
-                ],
-                'tusrbi' => [
-                    'a' => ['v']
-                ],
-                't' => [
-                    'a' => ['c','u','d']
-                ],
-                'rle' => [
-                    'a' => ['v','as','u']
-                ]
-            ]
-        ];
+        $actionMap = $config['actions'];
+        $scopeMap = $config['scopes'];
+        $resourceMap = $config['resources'];
+        $permissionMap = $config['permissions'];
+        $roleMap = $config['roles'];
+        $seeders = $config['seeders'];
 
         foreach($seeders as $roleKey => $resources) {
             $roleArray = $roleMap[$roleKey];
             if(!$roleArray) {
-                $this->command("Role with key $roleKey does not exist in role map");
+                $this->command->error("Role with key $roleKey does not exist in role map");
             }
 
+            $this->command->info("Adding role $roleKey");
             $role = Role::updateOrCreate(
                 ['name' => $roleKey],
                 [
@@ -510,25 +46,25 @@ class RolePermissionSeeder extends Seeder
             foreach($resources as $resourceKey => $scopes) {
                 $resource = $resourceMap[$resourceKey];
                 if(!$resource) {
-                    $this->command("Resource with key $resourceKey does not exist in resource map");
+                    $this->command->error("Resource with key $resourceKey does not exist in resource map");
                 }
 
                 foreach($scopes as $scopeKey => $actions) {
                     $scope = $scopeMap[$scopeKey];
                     if(!$scope) {
-                        $this->command("Scope with key $scopeKey does not exist in scope map");
+                        $this->command->error("Scope with key $scopeKey does not exist in scope map");
                     }
 
                     foreach($actions as $actionKey) {
                         $action = $actionMap[$actionKey];
                         if(!$action) {
-                            $this->command("Action with key $actionKey does not exist in action map");
+                            $this->command->error("Action with key $actionKey does not exist in action map");
                         }
 
                         $permissionKey = "$action-$scope-$resource";
                         $permission = $permissionMap[$permissionKey];
                         if(!$permission) {
-                            $this->command("Action with key $permissionKey does not exist in permission map");
+                            $this->command->error("Action with key $permissionKey does not exist in permission map");
                         }
 
                         $permissions[] = Permission::updateOrCreate(
@@ -542,7 +78,10 @@ class RolePermissionSeeder extends Seeder
                 }
             }
 
-            $role->permissions()->sync(collect($permissions)->pluck('id'));
+            $permissionIds = collect($permissions)->pluck('id');
+            $permissionCount = count($permissionIds);
+            $this->command->info("Syncing $permissionCount permissions to $roleKey");
+            $role->permissions()->sync($permissionIds);
         }
     }
 }

--- a/api/database/seeders/UatSeeder.php
+++ b/api/database/seeders/UatSeeder.php
@@ -13,6 +13,7 @@ class UatSeeder extends Seeder
      */
     public function run()
     {
+        $this->call(RolePermissionSeeder::class);
         $this->call(ClassificationSeeder::class);
         $this->call(DepartmentSeeder::class);
         $this->call(TeamSeeder::class);

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -187,6 +187,38 @@ class RolePermissionTest extends TestCase
         $this->cleanup();
     }
 
+    /**
+     * Test Strict Team Check
+     *
+     * @return void
+     */
+    public function test_strict_team_check()
+    {
+        $teamAdminRole = Role::where('name', 'team_admin')->sole();
+        $this->user->attachRole(
+            $teamAdminRole,
+            $this->ownedTeam
+        );
+
+        $guestRole = Role::where('name', 'guest')->sole();
+        $this->user->attachRole($guestRole);
+
+        $guestPermission = 'view-any-skill';
+        $teamPermission = 'view-any-role';
+
+        // This should be false because the user only has this permission in a team context
+        $this->assertFalse($this->user->isAbleTo($teamPermission, null));
+
+        // This is true because a user only has this permission outside of a team context
+        $this->assertTrue($this->user->isAbleTo($guestPermission, null));
+
+        // This should be true because the user has this permission in the team context
+        $this->assertTrue($this->user->isAbleTo($teamPermission, $this->ownedTeam));
+
+        // This is false because a user only has this permission outside of a team context
+        $this->assertFalse($this->user->isAbleTo($guestPermission, $this->ownedTeam));
+    }
+
     private function cleanup()
     {
         // Remove all roles from a user

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -119,7 +119,7 @@ class RolePermissionTest extends TestCase
         );
 
         $permissionsToCheck = [
-            'view-any-user',
+            'view-any-userBasicInfo',
             'view-team-pool',
             'create-team-pool',
             'publish-team-pool',

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -132,7 +132,7 @@ class RolePermissionTest extends TestCase
             'view-team-searchRequest',
             'update-team-searchRequest',
             'delete-team-searchRequest',
-            'view-team-teamUsersBasicInfo',
+            'view-team-teamMembers',
             'update-team-team',
             'view-any-role',
             'assign-team-role',

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -175,7 +175,7 @@ class RolePermissionTest extends TestCase
             'update-any-user',
             'delete-any-user',
             'view-any-userBasicInfo',
-            'view-any-teamUsersBasicInfo',
+            'view-any-teamMembers',
             'create-any-team',
             'update-any-team',
             'delete-any-team',

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+use App\Models\Role;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+
+class RolePermissionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $user;
+    private $ownedTeam;
+    private $unownedTeam;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(RolePermissionSeeder::class);
+
+        $this->user = User::create([
+            'email' => 'role-permission@test.com',
+            'sub' => 'role-permission@test.com',
+        ]);
+
+        $this->ownedTeam = Team::create([
+            'name' => 'owned-team'
+        ]);
+
+        $this->unownedTeam = Team::create([
+            'name' => 'unowned-team'
+        ]);
+    }
+
+    /**
+     * Test the Guest User Role
+     *
+     * @return void
+     */
+    public function test_guest_role()
+    {
+        $guestRole = Role::where('name', 'guest')->sole();
+        $this->user->attachRole($guestRole);
+
+        $this->assertTrue($this->user->hasRole('guest'));
+        $this->assertTrue($this->user->isAbleTo([
+            'view-any-classification',
+            'view-any-department',
+            'view-any-skill',
+            'view-any-skillFamily',
+            'view-any-publishedPoolAdvertisement',
+            'view-any-applicantCount',
+            'create-any-searchRequest',
+            'view-any-team'
+        ]));
+
+        $this->cleanup();
+    }
+
+    /**
+     * Test the Base User Role
+     *
+     * @return void
+     */
+    public function test_base_user_role()
+    {
+        $baseUserRole = Role::where('name', 'base_user')->sole();
+        $this->user->attachRole($baseUserRole);
+
+        $this->assertTrue($this->user->hasRole('base_user'));
+        $this->assertTrue($this->user->isAbleTo([
+            'view-own-user',
+            'update-own-user',
+        ]));
+
+        $this->cleanup();
+    }
+
+    /**
+     * Test the Applicant Role
+     *
+     * @return void
+     */
+    public function test_applicant_role()
+    {
+        $applicantRole = Role::where('name', 'applicant')->sole();
+        $this->user->attachRole($applicantRole);
+
+        $this->assertTrue($this->user->hasRole('applicant'));
+        $this->assertTrue($this->user->isAbleTo([
+            'view-own-applicant',
+            'submit-own-applicant',
+            'create-own-draftApplication',
+            'delete-own-draftApplication',
+            'archive-own-submittedApplication',
+        ]));
+
+        $this->cleanup();
+    }
+
+    /**
+     * Test the Team Admin Role
+     *
+     * @return void
+     */
+    public function test_team_admin_role()
+    {
+        $teamAdminRole = Role::where('name', 'team_admin')->sole();
+        $this->user->attachRole(
+            $teamAdminRole,
+            $this->ownedTeam
+        );
+
+        $permissionsToCheck = [
+            'view-any-user',
+            'view-team-pool',
+            'create-team-pool',
+            'publish-team-pool',
+            'update-team-draftPool',
+            'delete-team-draftPool',
+            'update-team-poolClosingDate',
+            'view-team-submittedApplication',
+            'view-team-applicantProfile',
+            'update-team-applicationStatus',
+            'view-team-searchRequest',
+            'update-team-searchRequest',
+            'delete-team-searchRequest',
+            'view-team-teamUsersBasicInfo',
+            'update-team-team',
+            'view-any-role',
+            'assign-team-role',
+        ];
+
+        $this->assertTrue($this->user->hasRole('team_admin',  $this->ownedTeam));
+        $this->assertTrue($this->user->isAbleTo($permissionsToCheck, $this->ownedTeam));
+
+        $this->assertFalse($this->user->hasRole('team_admin',  $this->unownedTeam));
+        $this->assertFalse($this->user->isAbleTo($permissionsToCheck, $this->unownedTeam));
+
+        $this->cleanup();
+    }
+
+    /**
+     * Test the Applicant Role
+     *
+     * @return void
+     */
+    public function test_super_admin_role()
+    {
+        $superAdminRole = Role::where('name', 'super_admin')->sole();
+        $this->user->attachRole($superAdminRole);
+
+        $this->assertTrue($this->user->hasRole('super_admin'));
+        $this->assertTrue($this->user->isAbleTo([
+            'create-any-classification',
+            'update-any-classification',
+            'delete-any-classification',
+            'create-any-department',
+            'update-any-department',
+            'delete-any-department',
+            'create-any-skill',
+            'update-any-skill',
+            'delete-any-skill',
+            'create-any-skillFamily',
+            'update-any-skillFamily',
+            'delete-any-skillFamily',
+            'view-any-user',
+            'update-any-user',
+            'delete-any-user',
+            'view-any-userBasicInfo',
+            'view-any-teamUsersBasicInfo',
+            'create-any-team',
+            'update-any-team',
+            'delete-any-team',
+            'view-any-role',
+            'assign-any-role',
+            'update-any-role',
+        ]));
+
+        $this->cleanup();
+    }
+
+    private function cleanup()
+    {
+        // Remove all roles from a user
+        $this->user->syncRoles([]);
+    }
+}

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -59,7 +59,7 @@ class RolePermissionTest extends TestCase
             'view-any-applicantCount',
             'create-any-searchRequest',
             'view-any-team'
-        ]));
+        ], true));
 
         $this->cleanup();
     }
@@ -78,7 +78,7 @@ class RolePermissionTest extends TestCase
         $this->assertTrue($this->user->isAbleTo([
             'view-own-user',
             'update-own-user',
-        ]));
+        ], true));
 
         $this->cleanup();
     }
@@ -95,12 +95,12 @@ class RolePermissionTest extends TestCase
 
         $this->assertTrue($this->user->hasRole('applicant'));
         $this->assertTrue($this->user->isAbleTo([
-            'view-own-applicant',
-            'submit-own-applicant',
+            'view-own-application',
+            'submit-own-application',
             'create-own-draftApplication',
             'delete-own-draftApplication',
             'archive-own-submittedApplication',
-        ]));
+        ], true));
 
         $this->cleanup();
     }
@@ -139,7 +139,7 @@ class RolePermissionTest extends TestCase
         ];
 
         $this->assertTrue($this->user->hasRole('team_admin',  $this->ownedTeam));
-        $this->assertTrue($this->user->isAbleTo($permissionsToCheck, $this->ownedTeam));
+        $this->assertTrue($this->user->isAbleTo($permissionsToCheck, $this->ownedTeam, true));
 
         $this->assertFalse($this->user->hasRole('team_admin',  $this->unownedTeam));
         $this->assertFalse($this->user->isAbleTo($permissionsToCheck, $this->unownedTeam));
@@ -182,7 +182,7 @@ class RolePermissionTest extends TestCase
             'view-any-role',
             'assign-any-role',
             'update-any-role',
-        ]));
+        ], true));
 
         $this->cleanup();
     }

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -206,10 +206,12 @@ class RolePermissionTest extends TestCase
         $guestPermission = 'view-any-skill';
         $teamPermission = 'view-any-role';
 
-        // This should be false because the user only has this permission in a team context
-        $this->assertFalse($this->user->isAbleTo($teamPermission, null));
+        // This should be true because even though the role is associated with a team context, we're asking about the permission outside of a team context.
+        // NOTE: this will fail if team_strict_check is true in the laratrust config.
+        $this->assertTrue($this->user->isAbleTo($teamPermission, null));
 
-        // This should be true because the user only has this permission outside of a team context
+        // This should be true because we're asking about the permission without a team context, and the user only has this permission outside of a team context anyway.
+        // That means this should pass regardless whether team_strict_check is true or false.
         $this->assertTrue($this->user->isAbleTo($guestPermission, null));
 
         // This should be true because the user has this permission in the team context

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -209,13 +209,13 @@ class RolePermissionTest extends TestCase
         // This should be false because the user only has this permission in a team context
         $this->assertFalse($this->user->isAbleTo($teamPermission, null));
 
-        // This is true because a user only has this permission outside of a team context
+        // This should be true because the user only has this permission outside of a team context
         $this->assertTrue($this->user->isAbleTo($guestPermission, null));
 
         // This should be true because the user has this permission in the team context
         $this->assertTrue($this->user->isAbleTo($teamPermission, $this->ownedTeam));
 
-        // This is false because a user only has this permission outside of a team context
+        // This should be false because the user only has this permission outside of a team context
         $this->assertFalse($this->user->isAbleTo($guestPermission, $this->ownedTeam));
     }
 


### PR DESCRIPTION
🤖 Resolves #5436
 
## 👋 Introduction

This adds the `Role` and `Permission` seeders along with a config file for them.

## 🕵️ Details

I believed the [laratrust seeder](https://laratrust.santigarcor.me/docs/7.x/usage/seeder.html#seeder-configuration-file) would not work with teams enabled based on their docs so created a custom one based off of theirs.

## 📋 TO DO

- [x] Add real translations
- [x] Write tests

> **Note**
> All French display names were translated by a 🤖 robot. I will be sending them off to get updated translations.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run the seeder
2. Inspect the database to check for permissions and roles

> **Note**
> My SQL is pretty bad so I would appreciate if someone could assist writing some sample queries to test that the relationships were created accurately 😆 



