### PR TITLE
Bug - 5533 - Updates User and Pool Candidate table columns

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -550,30 +550,6 @@ const PoolCandidatesTable: React.FC<{
       },
       {
         label: intl.formatMessage({
-          defaultMessage: "Preferred Spoken Interview Language",
-          id: "iRJV64",
-          description:
-            "Title displayed on the Pool Candidates table Preferred Spoken Language column.",
-        }),
-        id: "preferredLanguageForInterview",
-        accessor: ({ user }) =>
-          preferredLanguageAccessor(user?.preferredLanguageForInterview, intl),
-        sortColumnName: "PREFERRED_LANGUAGE_FOR_INTERVIEW",
-      },
-      {
-        label: intl.formatMessage({
-          defaultMessage: "Preferred Written Exam Language",
-          id: "5l+Ydz",
-          description:
-            "Title displayed on the Pool Candidates table Preferred Written Exam Language column.",
-        }),
-        id: "preferredLanguageForExam",
-        accessor: ({ user }) =>
-          preferredLanguageAccessor(user?.preferredLanguageForExam, intl),
-        sortColumnName: "PREFERRED_LANGUAGE_FOR_EXAM",
-      },
-      {
-        label: intl.formatMessage({
           defaultMessage: "Current Location",
           id: "1sPszf",
           description:

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -231,6 +231,7 @@ const provinceAccessor = (
 
 const defaultState = {
   ...TABLE_DEFAULTS,
+  hiddenColumnIds: ["preferredLang"],
   filters: {
     applicantFilter: {
       operationalRequirements: [],

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5439,10 +5439,6 @@
     "defaultMessage": "Sélectionnez une langue...",
     "description": "Placeholder displayed on the user form preferred communication language field."
   },
-  "5l+Ydz": {
-    "defaultMessage": "Langue préférée de l'examen écrit",
-    "description": "Title displayed on the Pool Candidates table Preferred Written Exam Language column."
-  },
   "CfXIqC": {
     "defaultMessage": "Langue de communication préférée",
     "description": "Title displayed for the User table Preferred Communication Language column."
@@ -5494,10 +5490,6 @@
   "fGAMy/": {
     "defaultMessage": "Sélectionnez une langue...",
     "description": "Placeholder displayed on the user form preferred spoken interview language field."
-  },
-  "iRJV64": {
-    "defaultMessage": "Langue parlée préférée pour l'entretien",
-    "description": "Title displayed on the Pool Candidates table Preferred Spoken Language column."
   },
   "zzwPOR": {
     "defaultMessage": "Langue préférée pour l'examen écrit :",

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -187,7 +187,12 @@ const emailLinkAccessor = (email: string | null, intl: IntlShape) => {
 
 const defaultState = {
   ...TABLE_DEFAULTS,
-  hiddenColumnIds: ["telephone", "createdDate", "updatedDate"],
+  hiddenColumnIds: [
+    "telephone",
+    "preferredLanguage",
+    "createdDate",
+    "updatedDate",
+  ],
   sortBy: {
     column: {
       id: "createdDate",

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -369,30 +369,6 @@ const UserTable = () => {
       },
       {
         label: intl.formatMessage({
-          defaultMessage: "Preferred Spoken Interview Language",
-          id: "iRJV64",
-          description:
-            "Title displayed on the Pool Candidates table Preferred Spoken Language column.",
-        }),
-        id: "preferredInterviewLanguage",
-        accessor: (user) =>
-          languageAccessor(user?.preferredLanguageForInterview, intl),
-        sortColumnName: "preferred_language_for_interview",
-      },
-      {
-        label: intl.formatMessage({
-          defaultMessage: "Preferred Written Exam Language",
-          id: "5l+Ydz",
-          description:
-            "Title displayed on the Pool Candidates table Preferred Written Exam Language column.",
-        }),
-        id: "preferredExamLanguage",
-        accessor: (user) =>
-          languageAccessor(user?.preferredLanguageForExam, intl),
-        sortColumnName: "preferred_language_for_exam",
-      },
-      {
-        label: intl.formatMessage({
           defaultMessage: "Edit",
           id: "qYH0du",
           description: "Title displayed for the User table Edit column.",


### PR DESCRIPTION
🤖 Resolves #5533.

## 👋 Introduction

This PR removes the **Preferred Spoken Interview Language** and **Preferred Written Exam Language** columns and hides the **Preferred Communication Language** column by default in the User and Pool Candidate tables.

## 🧪 Testing

1. `npm run build`
2. Navigate to User table `/admin/users`
3. Verify columns match acceptance criteria in #5533
4. Navigate to Pool Candidate table `/admin/pools/:poolId/pool-candidates`
5. Verify columns match acceptance criteria in #5533