### PR TITLE
Bug - 5550 - Adds missing `MINIMAL_VIEWPORTS`

### DIFF
--- a/apps/web/.storybook/preview.js
+++ b/apps/web/.storybook/preview.js
@@ -1,5 +1,5 @@
 
-import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
+import { INITIAL_VIEWPORTS, MINIMAL_VIEWPORTS } from "@storybook/addon-viewport";
 import { setIntlConfig, withIntl } from 'storybook-addon-intl';
 
 import defaultRichTextElements from "@common/helpers/format";
@@ -32,7 +32,10 @@ export const parameters = {
   },
   viewport: {
     // for possible values: https://github.com/storybookjs/storybook/blob/master/addons/viewport/src/defaults.ts
-    viewports: INITIAL_VIEWPORTS
+    viewports: {
+      ...INITIAL_VIEWPORTS,
+      ...MINIMAL_VIEWPORTS,
+    },
   },
 }
 

--- a/frontend/common/.storybook/preview.js
+++ b/frontend/common/.storybook/preview.js
@@ -6,7 +6,7 @@ import defaultRichTextElements from "../src/helpers/format";
 import MockGraphqlDecorator from "../../common/.storybook/decorators/MockGraphqlDecorator";
 import withThemeProvider, { theme } from "./decorators/ThemeDecorator";
 import withRouter from "./decorators/RouterDecorator";
-import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
+import { INITIAL_VIEWPORTS, MINIMAL_VIEWPORTS } from "@storybook/addon-viewport";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -23,7 +23,10 @@ export const parameters = {
   },
   viewport: {
     // for possible values: https://github.com/storybookjs/storybook/blob/master/addons/viewport/src/defaults.ts
-    viewports: INITIAL_VIEWPORTS
+    viewports: {
+      ...INITIAL_VIEWPORTS,
+      ...MINIMAL_VIEWPORTS,
+    },
   },
 }
 


### PR DESCRIPTION
🤖 Resolves #5550.

## 👋 Introduction

This PR adds the missing `MINIMAL_VIEWPORTS` for storybook that references one of its attributes, `mobile1` in a **Checkbox** story.

## 🧪 Testing

1. `npm run storybook`
2. Open browser console
3. Visit **Long Text Checkbox** story
4. Verify story has viewport set to _Small Mobile_
5. Verify no console warnings

## 📓 Notes

- This PR is a stopgap for properly dealing with viewports, see: https://github.com/GCTC-NTGC/gc-digital-talent/issues/5589.
- Working on this surfaced: https://github.com/GCTC-NTGC/gc-digital-talent/issues/5590
