### PR TITLE
Bug - 5552 - Adds white background value for `Home Page/IAP` story

### DIFF
--- a/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
@@ -10,6 +10,7 @@ export default {
   parameters: {
     backgrounds: {
       default: "white",
+      values: [{ name: "white", value: "#fff" }],
     },
   },
 } as Meta;


### PR DESCRIPTION
🤖 Resolves #5552.

h/t @patcon for [storybook docs](https://storybook.js.org/docs/react/essentials/backgrounds).

## 👋 Introduction

This PR fixes a missing background value for `Home Page/IAP` story in storybook.

## 🧪 Testing

1. `npm run storybook`
2. Open browser console
3. View **Home Page/IAP** story
4. Verify **Home Page/IAP** story has white background
5. Verify no console errors related to missing background value
