### PR TITLE
Feature -  5457 - Add Advanced Filter Accordions to Search Page

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5506,5 +5506,9 @@
   "zzwPOR": {
     "defaultMessage": "Langue préférée pour l'examen écrit :",
     "description": "Display text for the preferred written exam language field on users"
+  },
+  "eozWFc": {
+    "defaultMessage": "Filtres avancés",
+    "description": "Title for the additional filters"
   }
 }

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3508,6 +3508,10 @@
     "defaultMessage": "S.O.",
     "description": "Text shown when the filter was not selected"
   },
+  "+O6J4u": {
+    "defaultMessage": "(Aucun sélectionné)",
+    "description": "Text shown when the filter was not selected"
+  },
   "jJCDGc": {
     "defaultMessage": "Mise à jour de la classification réussie!",
     "description": "Message displayed to user after classification is updated successfully."

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/AdvancedFilters.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/AdvancedFilters.tsx
@@ -162,7 +162,7 @@ const AdvancedFilters = () => {
 
   return (
     <>
-      <Heading level="h3" size="h5" data-h2-font-weight="base(700)">
+      <Heading level="h3" size="h6" data-h2-font-weight="base(700)">
         {intl.formatMessage({
           defaultMessage: "Advanced filters",
           id: "eozWFc",

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/AdvancedFilters.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/AdvancedFilters.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { IntlShape, useIntl } from "react-intl";
 import { useFormContext } from "react-hook-form";
+import isArray from "lodash/isArray";
 
 import Accordion from "@common/components/Accordion/Accordion";
 import Heading from "@common/components/Heading";
@@ -15,7 +16,6 @@ import {
 
 import { NullSelection } from "~/types/searchRequest";
 
-import { isArray } from "lodash";
 import FilterBlock from "./FilterBlock";
 
 interface FieldOption {

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/AdvancedFilters.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/AdvancedFilters.tsx
@@ -1,0 +1,312 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { IntlShape, useIntl } from "react-intl";
+import { useFormContext } from "react-hook-form";
+
+import Accordion from "@common/components/Accordion/Accordion";
+import Heading from "@common/components/Heading";
+import { Checklist, RadioGroup } from "@common/components/form";
+import {
+  getOperationalRequirement,
+  getEmploymentDuration,
+  EmploymentDuration,
+  OperationalRequirementV2,
+} from "@common/constants/localizedConstants";
+
+import { NullSelection } from "~/types/searchRequest";
+
+import { isArray } from "lodash";
+import FilterBlock from "./FilterBlock";
+
+interface FieldOption {
+  value: string;
+  label: string;
+}
+
+const getFieldLabel = (
+  value: string | string[],
+  options: Array<FieldOption>,
+  intl: IntlShape,
+) => {
+  let label;
+  if (isArray(value)) {
+    const labels = options
+      .filter((option) => value.includes(option.value))
+      .map((option) => option.label);
+
+    label = labels.join(", ");
+  } else {
+    const fieldOption = options.find((option) => option.value === value);
+
+    label = fieldOption?.label;
+  }
+
+  return (
+    label ||
+    intl.formatMessage({
+      defaultMessage: "(None selected)",
+      id: "+O6J4u",
+      description: "Text shown when the filter was not selected",
+    })
+  );
+};
+
+const animationVariants = {
+  open: {
+    height: "auto",
+    opacity: 1,
+  },
+  closed: {
+    height: 0,
+    opacity: 0,
+  },
+};
+
+interface AnimatedContentProps
+  extends React.ComponentPropsWithoutRef<typeof Accordion.Content> {
+  isOpen: boolean;
+}
+
+const AnimatedContent = React.forwardRef<
+  React.ElementRef<typeof Accordion.Content>,
+  AnimatedContentProps
+>(({ isOpen, children, ...rest }, forwardedRef) => (
+  <Accordion.Content asChild forceMount ref={forwardedRef} {...rest}>
+    <motion.div
+      className="Accordion__Content"
+      animate={isOpen ? "open" : "closed"}
+      variants={animationVariants}
+      transition={{ duration: 0.2, type: "tween" }}
+    >
+      {children}
+    </motion.div>
+  </Accordion.Content>
+));
+
+type AdvancedFilter =
+  | "educationRequirement"
+  | "employmentDuration"
+  | "operationalRequirements";
+
+type AdvancedFilterOptions = Array<AdvancedFilter>;
+
+const AdvancedFilters = () => {
+  const intl = useIntl();
+  const [currentAdvancedFilters, setCurrentAdvancedFilters] =
+    React.useState<AdvancedFilterOptions>([]);
+  const { watch } = useFormContext();
+  const [educationRequirement, employmentDuration, operationalRequirements] =
+    watch([
+      "educationRequirement",
+      "employmentDuration",
+      "operationalRequirements",
+    ]);
+
+  const educationRequirementOptions = [
+    {
+      value: "no_diploma",
+      label: intl.formatMessage({
+        defaultMessage:
+          "Can accept a combination of work experience and education",
+        id: "74WtLG",
+        description:
+          "Radio group option for education requirement filter in search form.",
+      }),
+    },
+    {
+      value: "has_diploma",
+      label: intl.formatMessage({
+        defaultMessage: "Required diploma from post-secondary institution",
+        id: "KoPFx4",
+        description:
+          "Radio group option for education requirement filter in search form.",
+      }),
+    },
+  ];
+
+  const employmentDurationOptions = [
+    {
+      value: NullSelection,
+      label: intl.formatMessage({
+        defaultMessage:
+          "Any duration (short term, long term or indeterminate) (Recommended)",
+        id: "8fQWTc",
+        description: "No preference for employment duration - will accept any",
+      }),
+    },
+    {
+      value: EmploymentDuration.Term,
+      label: intl.formatMessage(getEmploymentDuration(EmploymentDuration.Term)),
+    },
+    {
+      value: EmploymentDuration.Indeterminate,
+      label: intl.formatMessage(
+        getEmploymentDuration(EmploymentDuration.Indeterminate),
+      ),
+    },
+  ];
+
+  const operationalRequirementOptions = OperationalRequirementV2.map(
+    (value) => ({
+      value,
+      label: intl.formatMessage(getOperationalRequirement(value)),
+    }),
+  );
+
+  const operationalRequirementOptionsShort = OperationalRequirementV2.map(
+    (value) => ({
+      value,
+      label: intl.formatMessage(getOperationalRequirement(value, "short")),
+    }),
+  );
+
+  return (
+    <>
+      <Heading level="h3" size="h5" data-h2-font-weight="base(700)">
+        {intl.formatMessage({
+          defaultMessage: "Advanced filters",
+          id: "eozWFc",
+          description: "Title for the additional filters",
+        })}
+      </Heading>
+      <Accordion.Root
+        type="multiple"
+        mode="simple"
+        value={currentAdvancedFilters}
+        onValueChange={(newValue: AdvancedFilterOptions) => {
+          setCurrentAdvancedFilters(newValue);
+        }}
+      >
+        <Accordion.Item value="educationRequirement">
+          <Accordion.Trigger
+            subtitle={getFieldLabel(
+              educationRequirement,
+              educationRequirementOptions,
+              intl,
+            )}
+          >
+            {intl.formatMessage({
+              defaultMessage: "Education requirement for the job",
+              id: "AyP6Fr",
+              description:
+                "Heading for education requirement filter of the search form.",
+            })}
+          </Accordion.Trigger>
+          <AnimatedContent
+            isOpen={currentAdvancedFilters.includes("educationRequirement")}
+          >
+            <FilterBlock
+              id="educationRequirementFilter"
+              text={intl.formatMessage({
+                defaultMessage:
+                  "Most jobs in the Digital community do not require a diploma, change this only if the job requires a diploma.",
+                id: "mhtcMd",
+                description:
+                  "Message describing the education requirement filter of the search form.",
+              })}
+            >
+              <RadioGroup
+                idPrefix="education_requirement"
+                legend={intl.formatMessage({
+                  defaultMessage: "Education Requirement filter",
+                  id: "/JQ6DD",
+                  description:
+                    "Legend for the Education Requirement filter radio group",
+                })}
+                name="educationRequirement"
+                defaultSelected="no_diploma"
+                items={educationRequirementOptions}
+                trackUnsaved={false}
+              />
+            </FilterBlock>
+          </AnimatedContent>
+        </Accordion.Item>
+        <Accordion.Item value="employmentDuration">
+          <Accordion.Trigger
+            subtitle={getFieldLabel(
+              employmentDuration,
+              employmentDurationOptions,
+              intl,
+            )}
+          >
+            {intl.formatMessage({
+              defaultMessage: "Employment Duration",
+              id: "VwVtqr",
+              description:
+                "Heading for employment duration section of the search form.",
+            })}
+          </Accordion.Trigger>
+          <AnimatedContent
+            isOpen={currentAdvancedFilters.includes("employmentDuration")}
+          >
+            <FilterBlock
+              id="employmentDurationFilter"
+              text={intl.formatMessage({
+                defaultMessage:
+                  "The selected duration will be compared to the one chosen by candidates in their applications. Change this only if the job offer has a determined duration.",
+                id: "iN2H6J",
+                description:
+                  "Message describing the employment duration filter in the search form.",
+              })}
+            >
+              <RadioGroup
+                idPrefix="employmentDuration"
+                legend="Duration"
+                name="employmentDuration"
+                defaultSelected={NullSelection}
+                items={employmentDurationOptions}
+                trackUnsaved={false}
+              />
+            </FilterBlock>
+          </AnimatedContent>
+        </Accordion.Item>
+        <Accordion.Item value="operationalRequirements">
+          <Accordion.Trigger
+            subtitle={getFieldLabel(
+              operationalRequirements,
+              operationalRequirementOptionsShort,
+              intl,
+            )}
+          >
+            {intl.formatMessage({
+              defaultMessage:
+                "Conditions of employment / Operational requirements",
+              id: "laGCzG",
+              description:
+                "Heading for operational requirements section of the search form.",
+            })}
+          </Accordion.Trigger>
+          <AnimatedContent
+            isOpen={currentAdvancedFilters.includes("operationalRequirements")}
+          >
+            <FilterBlock
+              id="operationalRequirementFilter"
+              text={intl.formatMessage({
+                defaultMessage:
+                  "The selected conditions of employment will be compared to those chosen by candidates in their applications.",
+                id: "IT6Djp",
+                description:
+                  "Message describing the operational requirements filter in the search form.",
+              })}
+            >
+              <Checklist
+                idPrefix="operationalRequirements"
+                legend={intl.formatMessage({
+                  defaultMessage: "Conditions of employment",
+                  id: "bKvvaI",
+                  description:
+                    "Legend for the Conditions of Employment filter checklist",
+                })}
+                name="operationalRequirements"
+                items={operationalRequirementOptions}
+                trackUnsaved={false}
+              />
+            </FilterBlock>
+          </AnimatedContent>
+        </Accordion.Item>
+      </Accordion.Root>
+    </>
+  );
+};
+
+export default AdvancedFilters;

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/FilterBlock.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/FilterBlock.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 
+import { HeadingLevel } from "@common/components/Heading/Heading";
+
 interface FilterBlockProps {
   id: string;
-  title: string | React.ReactNode;
+  title?: string | React.ReactNode;
   text: string;
   children?: React.ReactNode;
+  headingLevel?: HeadingLevel;
 }
 
 const FilterBlock: React.FC<FilterBlockProps> = ({
@@ -12,19 +15,25 @@ const FilterBlock: React.FC<FilterBlockProps> = ({
   title,
   text,
   children,
-}) => (
-  <div>
-    <h3
-      id={id}
-      data-h2-font-size="base(h6, 1)"
-      data-h2-font-weight="base(700)"
-      data-h2-margin="base(x3, 0, x1, 0)"
-    >
-      {title}
-    </h3>
-    <p data-h2-margin="base(0, 0, x1, 0)">{text}</p>
-    {children && <div>{children}</div>}
-  </div>
-);
+  headingLevel = "h3",
+}) => {
+  const Heading = headingLevel;
+  return (
+    <div>
+      {title && (
+        <Heading
+          id={id}
+          data-h2-font-size="base(h6, 1)"
+          data-h2-font-weight="base(700)"
+          data-h2-margin="base(x3, 0, x1, 0)"
+        >
+          {title}
+        </Heading>
+      )}
+      <p data-h2-margin="base(0, 0, x1, 0)">{text}</p>
+      {children && <div>{children}</div>}
+    </div>
+  );
+};
 
 export default FilterBlock;

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -37,6 +37,7 @@ import {
   Option,
 } from "~/types/searchRequest";
 
+import AdvancedFilters from "./AdvancedFilters";
 import AddSkillsToFilter from "./AddSkillsToFilter";
 import FilterBlock from "./FilterBlock";
 
@@ -104,6 +105,7 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
   ({ classifications, skills, pools, onUpdateApplicantFilter }, ref) => {
     const intl = useIntl();
     const location = useLocation();
+
     const classificationMap = React.useMemo(() => {
       return mapObjectsByKey(classificationToKey, classifications);
     }, [classifications]);
@@ -313,96 +315,6 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
           </FilterBlock>
           <AddSkillsToFilter allSkills={skills ?? []} linkId="skillFilter" />
           <FilterBlock
-            id="educationRequirementFilter"
-            title={intl.formatMessage({
-              defaultMessage: "Education requirement for the job",
-              id: "AyP6Fr",
-              description:
-                "Heading for education requirement filter of the search form.",
-            })}
-            text={intl.formatMessage({
-              defaultMessage:
-                "Most jobs in the Digital community do not require a diploma, change this only if the job requires a diploma.",
-              id: "mhtcMd",
-              description:
-                "Message describing the education requirement filter of the search form.",
-            })}
-          >
-            <RadioGroup
-              idPrefix="education_requirement"
-              legend={intl.formatMessage({
-                defaultMessage: "Education Requirement filter",
-                id: "/JQ6DD",
-                description:
-                  "Legend for the Education Requirement filter radio group",
-              })}
-              name="educationRequirement"
-              defaultSelected="no_diploma"
-              items={[
-                {
-                  value: "no_diploma",
-                  label: intl.formatMessage({
-                    defaultMessage:
-                      "Can accept a combination of work experience and education",
-                    id: "74WtLG",
-                    description:
-                      "Radio group option for education requirement filter in search form.",
-                  }),
-                },
-                {
-                  value: "has_diploma",
-                  label: intl.formatMessage({
-                    defaultMessage:
-                      "Required diploma from post-secondary institution",
-                    id: "KoPFx4",
-                    description:
-                      "Radio group option for education requirement filter in search form.",
-                  }),
-                },
-              ]}
-              trackUnsaved={false}
-            />
-          </FilterBlock>
-          <FilterBlock
-            id="locationPreferencesFilter"
-            title={intl.formatMessage({
-              defaultMessage: "Work location",
-              id: "uP+q43",
-              description:
-                "Heading for work location section of the search form.",
-            })}
-            text={intl.formatMessage({
-              defaultMessage:
-                "If you have more detailed work location requirement, let us know in the comment section of the submission form.",
-              id: "v7sYE7",
-              description:
-                "Message describing the work location filter in the search form.",
-            })}
-          >
-            <MultiSelectField
-              id="locationPreferences"
-              name="locationPreferences"
-              label={intl.formatMessage({
-                defaultMessage: "Region",
-                id: "F+WFWB",
-                description: "Label for work location filter in search form.",
-              })}
-              placeholder={intl.formatMessage({
-                defaultMessage: "Select a location...",
-                id: "asqSAJ",
-                description:
-                  "Placeholder for work location filter in search form.",
-              })}
-              options={enumToOptions(WorkRegion).map(({ value }) => ({
-                value,
-                label: intl.formatMessage(getWorkRegion(value)),
-              }))}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-            />
-          </FilterBlock>
-          <FilterBlock
             id="workingLanguageFilter"
             title={intl.formatMessage({
               defaultMessage: "Working language ability",
@@ -442,54 +354,6 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                   value,
                   label: intl.formatMessage(getLanguageAbility(value)),
                 })),
-              ]}
-              trackUnsaved={false}
-            />
-          </FilterBlock>
-          <FilterBlock
-            id="employmentDurationFilter"
-            title={intl.formatMessage({
-              defaultMessage: "Employment Duration",
-              id: "VwVtqr",
-              description:
-                "Heading for employment duration section of the search form.",
-            })}
-            text={intl.formatMessage({
-              defaultMessage:
-                "The selected duration will be compared to the one chosen by candidates in their applications. Change this only if the job offer has a determined duration.",
-              id: "iN2H6J",
-              description:
-                "Message describing the employment duration filter in the search form.",
-            })}
-          >
-            <RadioGroup
-              idPrefix="employmentDuration"
-              legend="Duration"
-              name="employmentDuration"
-              defaultSelected={NullSelection}
-              items={[
-                {
-                  value: NullSelection,
-                  label: intl.formatMessage({
-                    defaultMessage:
-                      "Any duration (short term, long term or indeterminate) (Recommended)",
-                    id: "8fQWTc",
-                    description:
-                      "No preference for employment duration - will accept any",
-                  }),
-                },
-                {
-                  value: EmploymentDuration.Term,
-                  label: intl.formatMessage(
-                    getEmploymentDuration(EmploymentDuration.Term),
-                  ),
-                },
-                {
-                  value: EmploymentDuration.Indeterminate,
-                  label: intl.formatMessage(
-                    getEmploymentDuration(EmploymentDuration.Indeterminate),
-                  ),
-                },
               ]}
               trackUnsaved={false}
             />
@@ -553,38 +417,46 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             />
           </FilterBlock>
           <FilterBlock
-            id="operationalRequirementFilter"
+            id="locationPreferencesFilter"
             title={intl.formatMessage({
-              defaultMessage:
-                "Conditions of employment / Operational requirements",
-              id: "laGCzG",
+              defaultMessage: "Work location",
+              id: "uP+q43",
               description:
-                "Heading for operational requirements section of the search form.",
+                "Heading for work location section of the search form.",
             })}
             text={intl.formatMessage({
               defaultMessage:
-                "The selected conditions of employment will be compared to those chosen by candidates in their applications.",
-              id: "IT6Djp",
+                "If you have more detailed work location requirement, let us know in the comment section of the submission form.",
+              id: "v7sYE7",
               description:
-                "Message describing the operational requirements filter in the search form.",
+                "Message describing the work location filter in the search form.",
             })}
           >
-            <Checklist
-              idPrefix="operationalRequirements"
-              legend={intl.formatMessage({
-                defaultMessage: "Conditions of employment",
-                id: "bKvvaI",
-                description:
-                  "Legend for the Conditions of Employment filter checklist",
+            <MultiSelectField
+              id="locationPreferences"
+              name="locationPreferences"
+              label={intl.formatMessage({
+                defaultMessage: "Region",
+                id: "F+WFWB",
+                description: "Label for work location filter in search form.",
               })}
-              name="operationalRequirements"
-              items={OperationalRequirementV2.map((value) => ({
+              placeholder={intl.formatMessage({
+                defaultMessage: "Select a location...",
+                id: "asqSAJ",
+                description:
+                  "Placeholder for work location filter in search form.",
+              })}
+              options={enumToOptions(WorkRegion).map(({ value }) => ({
                 value,
-                label: intl.formatMessage(getOperationalRequirement(value)),
+                label: intl.formatMessage(getWorkRegion(value)),
               }))}
-              trackUnsaved={false}
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
             />
           </FilterBlock>
+
+          <AdvancedFilters />
         </form>
       </FormProvider>
     );

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -8,11 +8,8 @@ import { Checklist, RadioGroup, Select } from "@common/components/form";
 import { getLanguageAbility } from "@common/constants";
 import {
   getEmploymentEquityGroup,
-  getOperationalRequirement,
   getWorkRegion,
-  getEmploymentDuration,
   EmploymentDuration,
-  OperationalRequirementV2,
   getPoolStream,
 } from "@common/constants/localizedConstants";
 import MultiSelectField from "@common/components/form/MultiSelect/MultiSelectField";

--- a/frontend/common/src/components/Accordion/Accordion.tsx
+++ b/frontend/common/src/components/Accordion/Accordion.tsx
@@ -167,13 +167,15 @@ const Content = React.forwardRef<
     ref={forwardedRef}
     {...rest}
   >
-    <hr
-      className="Accordion__Separator"
-      data-h2-background-color="base(dt-gray)"
-      data-h2-width="base(100%)"
-      data-h2-border="base(none)"
-    />
-    {children}
+    <>
+      <hr
+        className="Accordion__Separator"
+        data-h2-background-color="base(dt-gray)"
+        data-h2-width="base(100%)"
+        data-h2-border="base(none)"
+      />
+      {children}
+    </>
   </AccordionPrimitive.Content>
 ));
 

--- a/frontend/common/src/components/Accordion/styles.ts
+++ b/frontend/common/src/components/Accordion/styles.ts
@@ -29,9 +29,9 @@ const cardStyles: AccordionStyles = {
 
 const simpleStyles: AccordionStyles = {
   "data-h2-color": `
-    base:selectors[>.Accordion__Item > .Accordion__Content > .Accordion__Separator](tm-blue)
-    base:selectors[>.Accordion__Item  > .Accordion__Header > .Accordion__Trigger > .Accordion__Chevron](tm-blue)
-    base:selectors[>.Accordion__Item > .Accordion__Header > .Accordion__Trigger .Accordion__Subtitle](tm-blue)
+    base:selectors[>.Accordion__Item > .Accordion__Content > .Accordion__Separator](tm-blue.dark)
+    base:selectors[>.Accordion__Item  > .Accordion__Header > .Accordion__Trigger > .Accordion__Chevron](tm-blue.dark)
+    base:selectors[>.Accordion__Item > .Accordion__Header > .Accordion__Trigger .Accordion__Subtitle](tm-blue.dark)
   `,
   "data-h2-display":
     "base:selectors[>.Accordion__Item .Accordion__Separator](none)",


### PR DESCRIPTION
🤖 Resolves #5457 

## 👋 Introduction

This moves some filters on the search page into accordions.

## 🕵️ Details

I had to darken the subtitle for the accordions slightly for accessibility.

REF: https://webaim.org/resources/contrastchecker/?fcolor=1A9A8B&bcolor=F5F5F5

## 📋  TO DO

- [x] Add translation

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build the project `npm run build`
2. Navigate to `/search`
3. Confirm the advanced filters exist at the bottom in accordions
4. Confirm the form still functions as expected

## 📸 Screenshot
![Screenshot 2023-02-02 135058](https://user-images.githubusercontent.com/4127998/216422572-3a4d8603-a828-4e5d-a95d-c24745fe09e3.png)




