### PR TITLE
Fixed missing/duplicate text on ChangeDateDialog

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4155,8 +4155,8 @@
     "defaultMessage": "Bon retour, {name}",
     "description": "Title for dashboard on the talent cloud admin portal."
   },
-  "n+d6QE": {
-    "defaultMessage": "Fixer une date d'expiration pour ce candidat dans ce bassin :",
+  "jIlwJ8": {
+    "defaultMessage": "Dans le bassin suivant :",
     "description": "Second section of text on the change candidate expiry date dialog"
   },
   "n9YPWe": {

--- a/apps/web/src/pages/Users/ViewUserPage/components/GeneralInformationTab/ChangeDateDialog.tsx
+++ b/apps/web/src/pages/Users/ViewUserPage/components/GeneralInformationTab/ChangeDateDialog.tsx
@@ -9,6 +9,7 @@ import { getFullNameHtml } from "@common/helpers/nameUtils";
 import { Input } from "@common/components/form";
 import { commonMessages, errorMessages } from "@common/messages";
 import { currentDate } from "@common/helpers/formUtils";
+import { getFullPoolAdvertisementTitle } from "@common/helpers/poolUtils";
 
 import {
   Applicant,
@@ -104,15 +105,19 @@ export const ChangeDateDialog: React.FC<ChangeDateDialogProps> = ({
               "First section of text on the change candidate expiry date dialog",
           })}
         </p>
-        <p>- {getFullNameHtml(user.firstName, user.lastName, intl)}</p>
+        <p data-h2-font-weight="base(800)">
+          - {getFullNameHtml(user.firstName, user.lastName, intl)}
+        </p>
         <p data-h2-margin="base(x1, 0, 0, 0)">
           {intl.formatMessage({
-            defaultMessage:
-              "Set an expiry date for this candidate on this pool:",
-            id: "n+d6QE",
+            defaultMessage: "On the following pool:",
+            id: "jIlwJ8",
             description:
               "Second section of text on the change candidate expiry date dialog",
           })}
+        </p>
+        <p data-h2-font-weight="base(800)">
+          - {getFullPoolAdvertisementTitle(intl, selectedCandidate.pool)}
         </p>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(submitForm)}>


### PR DESCRIPTION
🤖 Resolves #5375

## 👋 Introduction

Fixes a line in the expiry date modal to show the correct text. Also tweaks styling for the modal to match the other modals on the page.

## 🧪 Testing

1. Navigate to the users table `/admin/users`
2. Select a user
3. If the user is not in any pools add them to one
4. Click on the expiry date for one of the users pools to open the ChangeDateDialog
5. Confirm the "Set an expiry date..." line only appears once on the dialog
6. Confirm the pools name is listed on the dialog.

## 📸 Screenshot
![image](https://user-images.githubusercontent.com/49166751/216475195-b89cfb53-8682-42b4-b571-90bf7f3609a4.png)



