### PR TITLE
a11y - 5466 - Focus Input on Error Link Click

### DIFF
--- a/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { useIntl } from "react-intl";
 
 import Hero from "@common/components/Hero/Hero";
@@ -286,10 +286,10 @@ type LocationState = {
 
 const CreateAccount: React.FunctionComponent = () => {
   const intl = useIntl();
-  const location = useLocation();
   const navigate = useNavigate();
   const paths = useRoutes();
-  const { from } = location.state as LocationState;
+  const [searchParams] = useSearchParams();
+  const from = searchParams.get("from");
   const authContext = React.useContext(AuthorizationContext);
   const meId = authContext.loggedInUser?.id;
 

--- a/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
@@ -280,10 +280,6 @@ export const CreateAccountForm: React.FunctionComponent<
   );
 };
 
-type LocationState = {
-  from?: string;
-};
-
 const CreateAccount: React.FunctionComponent = () => {
   const intl = useIntl();
   const navigate = useNavigate();

--- a/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useIntl } from "react-intl";
 
 import Hero from "@common/components/Hero/Hero";

--- a/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountRedirect.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountRedirect.tsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import {
+  createSearchParams,
+  Outlet,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
 
 import {
   AuthenticationContext,
@@ -38,10 +43,15 @@ const CreateAccountRedirect = () => {
       empty(loggedInEmail) &&
       isToCreateAccount
     ) {
-      navigate(paths.createAccount(), {
-        replace: true,
-        state: { from: pathname },
-      });
+      navigate(
+        {
+          pathname: paths.createAccount(),
+          search: createSearchParams({ from: pathname }).toString(),
+        },
+        {
+          replace: true,
+        },
+      );
     }
   }, [
     loggedIn,

--- a/frontend/common/src/components/Link/ScrollToLink.tsx
+++ b/frontend/common/src/components/Link/ScrollToLink.tsx
@@ -20,7 +20,8 @@ const ScrollToLink = ({
   ...rest
 }: ScrollToLinkProps) => {
   const navigate = useNavigate();
-  const { pathname, hash } = useLocation();
+  const location = useLocation();
+  const { hash, pathname } = location;
   const [targetSection, setTargetSection] = React.useState<HTMLElement | null>(
     null,
   );
@@ -48,7 +49,7 @@ const ScrollToLink = ({
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
     e.stopPropagation();
-    navigate(`#${to}`);
+    navigate({ ...location, hash: to });
     scrollToSection();
     if (onClick) {
       onClick(e, targetSection);

--- a/frontend/common/src/components/Link/ScrollToLink.tsx
+++ b/frontend/common/src/components/Link/ScrollToLink.tsx
@@ -1,13 +1,24 @@
 import React from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
+export type ScrollLinkClickFunc = (
+  e: React.MouseEvent<HTMLAnchorElement>,
+  section: HTMLElement | null,
+) => void;
+
 export interface ScrollToLinkProps
   extends Omit<React.HTMLProps<HTMLAnchorElement>, "href" | "onClick"> {
   to: string;
   children?: React.ReactNode;
+  onClick?: ScrollLinkClickFunc;
 }
 
-const ScrollToLink = ({ to, children, ...rest }: ScrollToLinkProps) => {
+const ScrollToLink = ({
+  to,
+  children,
+  onClick,
+  ...rest
+}: ScrollToLinkProps) => {
   const navigate = useNavigate();
   const { pathname, hash } = useLocation();
   const [targetSection, setTargetSection] = React.useState<HTMLElement | null>(
@@ -39,6 +50,9 @@ const ScrollToLink = ({ to, children, ...rest }: ScrollToLinkProps) => {
     e.stopPropagation();
     navigate(`#${to}`);
     scrollToSection();
+    if (onClick) {
+      onClick(e, targetSection);
+    }
   };
 
   return (

--- a/frontend/common/src/components/Link/ScrollToLink.tsx
+++ b/frontend/common/src/components/Link/ScrollToLink.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { useLocation, Link, LinkProps } from "react-router-dom";
 
+export type ScrollLinkClickFunc = (
+  e: React.MouseEvent<HTMLAnchorElement | undefined>,
+  section: HTMLElement | null,
+) => void;
+
 const scrollToSection = (section: HTMLElement | null) => {
   if (section) {
     setTimeout(() => {
@@ -14,9 +19,15 @@ const scrollToSection = (section: HTMLElement | null) => {
 
 export interface ScrollToLinkProps extends Omit<LinkProps, "to"> {
   to: string;
+  onScrollTo?: ScrollLinkClickFunc;
 }
 
-const ScrollToLink = ({ to, children, ...rest }: ScrollToLinkProps) => {
+const ScrollToLink = ({
+  to,
+  onScrollTo,
+  children,
+  ...rest
+}: ScrollToLinkProps) => {
   const { pathname, hash, search, state } = useLocation();
   const [targetSection, setTargetSection] = React.useState<HTMLElement | null>(
     null,
@@ -33,8 +44,11 @@ const ScrollToLink = ({ to, children, ...rest }: ScrollToLinkProps) => {
     setTargetSection(section);
   }, [to]);
 
-  const handleClick = () => {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement | undefined>) => {
     scrollToSection(targetSection);
+    if (onScrollTo) {
+      onScrollTo(e, targetSection);
+    }
   };
 
   return (

--- a/frontend/common/src/components/form/ErrorSummary.tsx
+++ b/frontend/common/src/components/form/ErrorSummary.tsx
@@ -5,7 +5,7 @@ import { useFormState } from "react-hook-form";
 import type { FieldLabels } from "./BasicForm";
 
 import Alert from "../Alert";
-import { ScrollToLink } from "../Link";
+import ScrollToLink, { ScrollLinkClickFunc } from "../Link/ScrollToLink";
 import { getLocale } from "../../helpers/localize";
 import { notEmpty } from "../../helpers/util";
 
@@ -57,6 +57,19 @@ const ErrorSummary = React.forwardRef<
     })
     .filter(notEmpty);
 
+  const handleErrorClick: ScrollLinkClickFunc = (_, target) => {
+    const singleInputTypes = ["input", "select", "textarea"];
+    if (target) {
+      // The input is not part of a group so just focus it directly
+      if (singleInputTypes.includes(target.nodeName.toLocaleLowerCase())) {
+        target.focus();
+      } else {
+        // Find the input in a RadioGroup or CheckList and focus it
+        target.querySelector("input")?.focus();
+      }
+    }
+  };
+
   return invalidFields.length > 0 ? (
     <Alert.Root type="error" ref={forwardedRef} tabIndex={0}>
       <Alert.Title>
@@ -77,7 +90,9 @@ const ErrorSummary = React.forwardRef<
       <ul data-h2-margin="base(x.5, 0, 0, 0)">
         {invalidFields.map((field) => (
           <li key={field.name}>
-            <ScrollToLink to={field.name}>{field.label}</ScrollToLink>
+            <ScrollToLink to={field.name} onClick={handleErrorClick}>
+              {field.label}
+            </ScrollToLink>
             {`${locale === "fr" ? ` : ` : `: `}${field.message}`}
           </li>
         ))}

--- a/frontend/common/src/components/form/ErrorSummary.tsx
+++ b/frontend/common/src/components/form/ErrorSummary.tsx
@@ -91,7 +91,7 @@ const ErrorSummary = React.forwardRef<
       <ul data-h2-margin="base(x.5, 0, 0, 0)">
         {invalidFields.map((field) => (
           <li key={field.name}>
-            <ScrollToLink to={field.name} onClick={handleErrorClick}>
+            <ScrollToLink to={field.name} onScrollTo={handleErrorClick}>
               {field.label}
             </ScrollToLink>
             {`${locale === "fr" ? ` : ` : `: `}${field.message}`}

--- a/frontend/common/src/components/form/ErrorSummary.tsx
+++ b/frontend/common/src/components/form/ErrorSummary.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useFormState } from "react-hook-form";
-import { useLocation } from "react-router-dom";
 
 import type { FieldLabels } from "./BasicForm";
 

--- a/frontend/common/src/components/form/ErrorSummary.tsx
+++ b/frontend/common/src/components/form/ErrorSummary.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useFormState } from "react-hook-form";
+import { useLocation } from "react-router-dom";
 
 import type { FieldLabels } from "./BasicForm";
 
@@ -57,7 +58,8 @@ const ErrorSummary = React.forwardRef<
     })
     .filter(notEmpty);
 
-  const handleErrorClick: ScrollLinkClickFunc = (_, target) => {
+  const handleErrorClick: ScrollLinkClickFunc = (e, target) => {
+    e.preventDefault();
     const singleInputTypes = ["input", "select", "textarea"];
     if (target) {
       // The input is not part of a group so just focus it directly


### PR DESCRIPTION
🤖 Resolves #5466 

## 👋 Introduction

This focuses the input when the link to the input is clicked within the error summary.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> **Note**
> For radio groups, you may need to temporarily set the default value to `undefined` to properly force an error.

1. Build the app `npm run build`
2. Navigate to the profile
3. Purposefully create some errors on every form input type
4. Submit the form and confirm the error summary appears
5. Click a link to the field in the error summary
6. Confirm focus is moved to the input and you can immediately interact with that input

