### PR TITLE
Bug - 5603 - Fix Anchor Link Scrolling

### DIFF
--- a/frontend/common/src/components/Link/ScrollToLink.tsx
+++ b/frontend/common/src/components/Link/ScrollToLink.tsx
@@ -1,50 +1,52 @@
 import React from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, Link, LinkProps } from "react-router-dom";
 
-export interface ScrollToLinkProps
-  extends Omit<React.HTMLProps<HTMLAnchorElement>, "href" | "onClick"> {
+const scrollToSection = (section: HTMLElement | null) => {
+  if (section) {
+    setTimeout(() => {
+      section.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }, 10);
+  }
+};
+
+export interface ScrollToLinkProps extends Omit<LinkProps, "to"> {
   to: string;
-  children?: React.ReactNode;
 }
 
 const ScrollToLink = ({ to, children, ...rest }: ScrollToLinkProps) => {
-  const navigate = useNavigate();
   const { pathname, hash } = useLocation();
   const [targetSection, setTargetSection] = React.useState<HTMLElement | null>(
     null,
   );
 
-  const scrollToSection = React.useCallback(() => {
-    if (targetSection) {
-      targetSection.scrollIntoView({
-        behavior: "smooth",
-        block: "start",
-      });
-    }
-  }, [targetSection]);
-
   React.useEffect(() => {
     if (hash && hash === `#${to}`) {
-      scrollToSection();
+      scrollToSection(targetSection);
     }
-  }, [pathname, hash, to, scrollToSection]);
+  }, [pathname, hash, to, targetSection]);
 
   React.useEffect(() => {
-    const section = document.getElementById(to);
+    const section = document.getElementById(to.toString());
     setTargetSection(section);
   }, [to]);
 
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-    navigate(`#${to}`);
-    scrollToSection();
+  const handleClick = () => {
+    scrollToSection(targetSection);
   };
 
   return (
-    <a href={`#${to}`} onClick={handleClick} {...rest}>
+    <Link
+      to={{ hash: to }}
+      replace
+      preventScrollReset={false}
+      {...rest}
+      onClick={handleClick}
+    >
       {children}
-    </a>
+    </Link>
   );
 };
 

--- a/frontend/common/src/components/Link/ScrollToLink.tsx
+++ b/frontend/common/src/components/Link/ScrollToLink.tsx
@@ -17,7 +17,7 @@ export interface ScrollToLinkProps extends Omit<LinkProps, "to"> {
 }
 
 const ScrollToLink = ({ to, children, ...rest }: ScrollToLinkProps) => {
-  const { pathname, hash } = useLocation();
+  const { pathname, hash, search, state } = useLocation();
   const [targetSection, setTargetSection] = React.useState<HTMLElement | null>(
     null,
   );
@@ -39,7 +39,12 @@ const ScrollToLink = ({ to, children, ...rest }: ScrollToLinkProps) => {
 
   return (
     <Link
-      to={{ hash: to }}
+      to={{
+        pathname,
+        search,
+        hash: to,
+      }}
+      state={state}
       replace
       preventScrollReset={false}
       {...rest}


### PR DESCRIPTION
🤖 Resolves #5603 

## 👋 Introduction

This fixes a bug where the `ScrollToLink` component only worked if the hash did not already exist in the URL.

## 🕵️ Details

The scroll event was happening at the same time as `react-router` was adjusting scroll position from the `ScrollRestoration` component. We have added a very short timeout to get around this.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to /profile
2. Click a link in the "On this Page" section
3. Scroll up
4. Click the link again
5. Confirm the page still scrolls
