### PR TITLE
Bug - 5541 - Fixes breadcrumbs in Application context

### DIFF
--- a/apps/web/src/pages/Profile/AboutMePage/components/AboutMeForm/AboutMeForm.tsx
+++ b/apps/web/src/pages/Profile/AboutMePage/components/AboutMeForm/AboutMeForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { SubmitHandler } from "react-hook-form";
 
 import { toast } from "@common/components/Toast";
@@ -67,6 +67,11 @@ const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();
+  const [searchParams] = useSearchParams();
+  const applicationId = searchParams.get("applicationId");
+  const applicationParam = applicationId
+    ? `?applicationId=${applicationId}`
+    : ``;
   const returnRoute = application
     ? paths.reviewApplication(application.id)
     : paths.profile(initialUser.id);
@@ -188,7 +193,15 @@ const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
         },
         {
           label: intl.formatMessage(navigationMessages.stepOne),
-          url: paths.reviewApplication(application.id),
+          url: paths.reviewApplication(applicationId ?? ""),
+        },
+        {
+          label: intl.formatMessage({
+            defaultMessage: "About Me",
+            id: "uG2MuI",
+            description: "Display text for About Me Form Page Link",
+          }),
+          url: `${paths.aboutMe(initialUser.id)}${applicationParam}`,
         },
       ]
     : [];
@@ -221,17 +234,20 @@ const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
         description: "Title for Profile Form wrapper in About me form",
       })}
       prefixBreadcrumbs={!application}
-      crumbs={[
-        ...applicationBreadcrumbs,
-        {
-          label: intl.formatMessage({
-            defaultMessage: "About Me",
-            id: "uG2MuI",
-            description: "Display text for About Me Form Page Link",
-          }),
-          url: paths.aboutMe(initialUser.id),
-        },
-      ]}
+      crumbs={
+        applicationBreadcrumbs?.length
+          ? applicationBreadcrumbs
+          : [
+              {
+                label: intl.formatMessage({
+                  defaultMessage: "About Me",
+                  id: "uG2MuI",
+                  description: "Display text for About Me Form Page Link",
+                }),
+                url: paths.aboutMe(initialUser.id),
+              },
+            ]
+      }
     >
       <BasicForm
         labels={labelMap}

--- a/apps/web/src/pages/Profile/AboutMePage/components/AboutMeForm/AboutMeForm.tsx
+++ b/apps/web/src/pages/Profile/AboutMePage/components/AboutMeForm/AboutMeForm.tsx
@@ -72,8 +72,8 @@ const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
   const applicationParam = applicationId
     ? `?applicationId=${applicationId}`
     : ``;
-  const returnRoute = application
-    ? paths.reviewApplication(application.id)
+  const returnRoute = applicationId
+    ? paths.reviewApplication(applicationId)
     : paths.profile(initialUser.id);
 
   const labelMap = {

--- a/apps/web/src/pages/Profile/EmploymentEquityPage/components/EmploymentEquityForm/EmploymentEquityForm.tsx
+++ b/apps/web/src/pages/Profile/EmploymentEquityPage/components/EmploymentEquityForm/EmploymentEquityForm.tsx
@@ -11,6 +11,7 @@ import ProfileFormWrapper, {
   ProfileFormFooter,
 } from "~/components/ProfileFormWrapper/ProfileFormWrapper";
 
+import { useSearchParams } from "react-router-dom";
 import EquityOptions from "./EquityOptions";
 import type { EmploymentEquityUpdateHandler, EquityKeys } from "../../types";
 
@@ -29,6 +30,11 @@ const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
 }) => {
   const intl = useIntl();
   const paths = useRoutes();
+  const [searchParams] = useSearchParams();
+  const applicationId = searchParams.get("applicationId");
+  const applicationParam = applicationId
+    ? `?applicationId=${applicationId}`
+    : ``;
   const returnRoute = application
     ? paths.reviewApplication(application.id)
     : paths.profile(user.id);
@@ -59,7 +65,16 @@ const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
         },
         {
           label: intl.formatMessage(navigationMessages.stepOne),
-          url: paths.reviewApplication(application.id),
+          url: paths.reviewApplication(applicationId ?? ""),
+        },
+        {
+          label: intl.formatMessage({
+            defaultMessage: "Diversity, equity and inclusion",
+            id: "pGTTrp",
+            description:
+              "Display Text for Diversity, equity and inclusion Page",
+          }),
+          url: `${paths.diversityEquityInclusion(user.id)}${applicationParam}`,
         },
       ]
     : [];
@@ -79,18 +94,21 @@ const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
         description:
           "Title for Profile Form wrapper  in DiversityEquityInclusionForm",
       })}
-      crumbs={[
-        ...applicationBreadcrumbs,
-        {
-          label: intl.formatMessage({
-            defaultMessage: "Diversity, equity and inclusion",
-            id: "pGTTrp",
-            description:
-              "Display Text for Diversity, equity and inclusion Page",
-          }),
-          url: paths.diversityEquityInclusion(user.id),
-        },
-      ]}
+      crumbs={
+        applicationBreadcrumbs?.length
+          ? applicationBreadcrumbs
+          : [
+              {
+                label: intl.formatMessage({
+                  defaultMessage: "Diversity, equity and inclusion",
+                  id: "pGTTrp",
+                  description:
+                    "Display Text for Diversity, equity and inclusion Page",
+                }),
+                url: paths.diversityEquityInclusion(user.id),
+              },
+            ]
+      }
       prefixBreadcrumbs={!application}
     >
       <p data-h2-margin="base(x1, 0)">

--- a/apps/web/src/pages/Profile/EmploymentEquityPage/components/EmploymentEquityForm/EmploymentEquityForm.tsx
+++ b/apps/web/src/pages/Profile/EmploymentEquityPage/components/EmploymentEquityForm/EmploymentEquityForm.tsx
@@ -35,8 +35,8 @@ const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
   const applicationParam = applicationId
     ? `?applicationId=${applicationId}`
     : ``;
-  const returnRoute = application
-    ? paths.reviewApplication(application.id)
+  const returnRoute = applicationId
+    ? paths.reviewApplication(applicationId)
     : paths.profile(user.id);
 
   const handleUpdate = (key: EquityKeys, value: unknown) => {

--- a/apps/web/src/pages/Profile/EmploymentEquityPage/components/EmploymentEquityForm/EmploymentEquityForm.tsx
+++ b/apps/web/src/pages/Profile/EmploymentEquityPage/components/EmploymentEquityForm/EmploymentEquityForm.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
+import { useSearchParams } from "react-router-dom";
 
 import Well from "@common/components/Well";
 import { navigationMessages } from "@common/messages";
@@ -11,7 +12,6 @@ import ProfileFormWrapper, {
   ProfileFormFooter,
 } from "~/components/ProfileFormWrapper/ProfileFormWrapper";
 
-import { useSearchParams } from "react-router-dom";
 import EquityOptions from "./EquityOptions";
 import type { EmploymentEquityUpdateHandler, EquityKeys } from "../../types";
 

--- a/apps/web/src/pages/Profile/ExperienceAndSkillsPage/components/ExperienceAndSkills.tsx
+++ b/apps/web/src/pages/Profile/ExperienceAndSkillsPage/components/ExperienceAndSkills.tsx
@@ -68,6 +68,9 @@ export const ExperienceAndSkills: React.FunctionComponent<
   const applicationParam = applicationId
     ? `?applicationId=${applicationId}`
     : ``;
+  const returnRoute = applicationId
+    ? paths.reviewApplication(applicationId)
+    : paths.profile(applicantId);
 
   const getEditPath = (id: string, type: ExperienceType) => {
     return `${paths.editExperience(applicantId, type, id)}${applicationParam}`;
@@ -131,48 +134,54 @@ export const ExperienceAndSkills: React.FunctionComponent<
 
   const hasExperiences = notEmpty(experiences);
 
-  let crumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Experience and Skills",
-        id: "PF2m1d",
-        description:
-          "Breadcrumb for experience and skills page in applicant profile.",
-      }),
-      url: paths.skillsAndExperiences(applicantId),
-    },
-  ];
-
-  if (poolAdvertisement) {
-    crumbs = [
-      {
-        label: intl.formatMessage({
-          defaultMessage: "My Applications",
-          id: "q04FCp",
-          description: "Link text for breadcrumb to user applications page.",
-        }),
-        url: paths.applications(applicantId),
-      },
-      {
-        label: getFullPoolAdvertisementTitle(intl, poolAdvertisement),
-        url: paths.pool(poolAdvertisement.id),
-      },
-      {
-        url: paths.reviewApplication(applicantId),
-        label: intl.formatMessage(navigationMessages.stepOne),
-      },
-      ...crumbs,
-    ];
-  }
-
-  const returnRoute = applicationId
-    ? paths.reviewApplication(applicationId)
-    : paths.profile(applicantId);
+  const applicationBreadcrumbs = poolAdvertisement
+    ? [
+        {
+          label: intl.formatMessage({
+            defaultMessage: "My Applications",
+            id: "q04FCp",
+            description: "Link text for breadcrumb to user applications page.",
+          }),
+          url: paths.applications(applicantId),
+        },
+        {
+          label: getFullPoolAdvertisementTitle(intl, poolAdvertisement),
+          url: paths.pool(poolAdvertisement.id),
+        },
+        {
+          label: intl.formatMessage(navigationMessages.stepOne),
+          url: paths.reviewApplication(applicationId ?? ""),
+        },
+        {
+          label: intl.formatMessage({
+            defaultMessage: "Experience and Skills",
+            id: "PF2m1d",
+            description:
+              "Breadcrumb for experience and skills page in applicant profile.",
+          }),
+          url: `${paths.skillsAndExperiences(applicantId)}${applicationParam}`,
+        },
+      ]
+    : [];
 
   return (
     <ProfileFormWrapper
+      crumbs={
+        applicationBreadcrumbs?.length
+          ? applicationBreadcrumbs
+          : [
+              {
+                label: intl.formatMessage({
+                  defaultMessage: "Experience and Skills",
+                  id: "PF2m1d",
+                  description:
+                    "Breadcrumb for experience and skills page in applicant profile.",
+                }),
+                url: paths.skillsAndExperiences(applicantId),
+              },
+            ]
+      }
       prefixBreadcrumbs={!poolAdvertisement}
-      crumbs={crumbs}
       description={intl.formatMessage({
         defaultMessage:
           "Here is where you can add experiences and skills to your profile. This could be anything from helping community members troubleshoot their computers to full-time employment at an IT organization.",

--- a/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
+++ b/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { IntlShape, useIntl } from "react-intl";
 import { SubmitHandler, useFormContext } from "react-hook-form";
 
@@ -517,6 +517,11 @@ const GovernmentInfoForm: React.FunctionComponent<GovernmentInfoFormProps> = ({
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();
+  const [searchParams] = useSearchParams();
+  const applicationId = searchParams.get("applicationId");
+  const applicationParam = applicationId
+    ? `?applicationId=${applicationId}`
+    : ``;
   const returnRoute = application
     ? paths.reviewApplication(application.id)
     : paths.profile(initialData.id);
@@ -554,7 +559,18 @@ const GovernmentInfoForm: React.FunctionComponent<GovernmentInfoFormProps> = ({
         },
         {
           label: intl.formatMessage(navigationMessages.stepOne),
-          url: paths.reviewApplication(application.id),
+          url: paths.reviewApplication(applicationId ?? ""),
+        },
+        {
+          label: intl.formatMessage({
+            defaultMessage: "Government Information",
+            id: "Uh9Yj4",
+            description:
+              "Display Text for Government Information Form Page Link",
+          }),
+          url: `${paths.governmentInformation(
+            initialData.id,
+          )}${applicationParam}`,
         },
       ]
     : [];
@@ -574,18 +590,21 @@ const GovernmentInfoForm: React.FunctionComponent<GovernmentInfoFormProps> = ({
         description:
           "Title for Profile Form Wrapper in Government Information Form",
       })}
-      crumbs={[
-        ...applicationBreadcrumbs,
-        {
-          label: intl.formatMessage({
-            defaultMessage: "Government Information",
-            id: "Uh9Yj4",
-            description:
-              "Display Text for Government Information Form Page Link",
-          }),
-          url: paths.governmentInformation(initialData.id),
-        },
-      ]}
+      crumbs={
+        applicationBreadcrumbs?.length
+          ? applicationBreadcrumbs
+          : [
+              {
+                label: intl.formatMessage({
+                  defaultMessage: "Government Information",
+                  id: "Uh9Yj4",
+                  description:
+                    "Display Text for Government Information Form Page Link",
+                }),
+                url: paths.governmentInformation(initialData.id),
+              },
+            ]
+      }
       prefixBreadcrumbs={!application}
     >
       <BasicForm

--- a/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
+++ b/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
@@ -522,8 +522,8 @@ const GovernmentInfoForm: React.FunctionComponent<GovernmentInfoFormProps> = ({
   const applicationParam = applicationId
     ? `?applicationId=${applicationId}`
     : ``;
-  const returnRoute = application
-    ? paths.reviewApplication(application.id)
+  const returnRoute = applicationId
+    ? paths.reviewApplication(applicationId)
     : paths.profile(initialData.id);
 
   const labels = getGovernmentInfoLabels(intl);

--- a/apps/web/src/pages/Profile/LanguageInfoPage/components/LanguageInformationForm/LanguageInformationForm.tsx
+++ b/apps/web/src/pages/Profile/LanguageInfoPage/components/LanguageInformationForm/LanguageInformationForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { SubmitHandler } from "react-hook-form";
 import compact from "lodash/compact";
 import omit from "lodash/omit";
@@ -104,6 +104,11 @@ const LanguageInformationForm: React.FunctionComponent<{
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();
+  const [searchParams] = useSearchParams();
+  const applicationId = searchParams.get("applicationId");
+  const applicationParam = applicationId
+    ? `?applicationId=${applicationId}`
+    : ``;
   const returnRoute = application
     ? paths.reviewApplication(application.id)
     : paths.profile(initialData.id);
@@ -206,7 +211,17 @@ const LanguageInformationForm: React.FunctionComponent<{
         },
         {
           label: intl.formatMessage(navigationMessages.stepOne),
-          url: paths.reviewApplication(application.id),
+          url: paths.reviewApplication(applicationId ?? ""),
+        },
+        {
+          label: intl.formatMessage({
+            defaultMessage: "Language Information",
+            id: "/k21MP",
+            description: "Display Text for Language Information Form Page Link",
+          }),
+          url: `${paths.languageInformation(
+            initialData.id,
+          )}${applicationParam}`,
         },
       ]
     : [];
@@ -231,17 +246,21 @@ const LanguageInformationForm: React.FunctionComponent<{
         description:
           "Title for Profile Form wrapper in Language Information Form",
       })}
-      crumbs={[
-        ...applicationBreadcrumbs,
-        {
-          label: intl.formatMessage({
-            defaultMessage: "Language Information",
-            id: "/k21MP",
-            description: "Display Text for Language Information Form Page Link",
-          }),
-          url: paths.languageInformation(initialData.id),
-        },
-      ]}
+      crumbs={
+        applicationBreadcrumbs?.length
+          ? applicationBreadcrumbs
+          : [
+              {
+                label: intl.formatMessage({
+                  defaultMessage: "Language Information",
+                  id: "/k21MP",
+                  description:
+                    "Display Text for Language Information Form Page Link",
+                }),
+                url: paths.languageInformation(initialData.id),
+              },
+            ]
+      }
       prefixBreadcrumbs={!application}
     >
       {missingLanguageRequirements.length ? (

--- a/apps/web/src/pages/Profile/LanguageInfoPage/components/LanguageInformationForm/LanguageInformationForm.tsx
+++ b/apps/web/src/pages/Profile/LanguageInfoPage/components/LanguageInformationForm/LanguageInformationForm.tsx
@@ -109,8 +109,8 @@ const LanguageInformationForm: React.FunctionComponent<{
   const applicationParam = applicationId
     ? `?applicationId=${applicationId}`
     : ``;
-  const returnRoute = application
-    ? paths.reviewApplication(application.id)
+  const returnRoute = applicationId
+    ? paths.reviewApplication(applicationId)
     : paths.profile(initialData.id);
 
   const labels = {

--- a/apps/web/src/pages/Profile/RoleSalaryPage/components/RoleSalaryForm/RoleSalaryForm.tsx
+++ b/apps/web/src/pages/Profile/RoleSalaryPage/components/RoleSalaryForm/RoleSalaryForm.tsx
@@ -90,8 +90,8 @@ const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
   const applicationParam = applicationId
     ? `?applicationId=${applicationId}`
     : ``;
-  const returnRoute = application
-    ? paths.reviewApplication(application.id)
+  const returnRoute = applicationId
+    ? paths.reviewApplication(applicationId)
     : paths.myProfile();
 
   const labels = {

--- a/apps/web/src/pages/Profile/RoleSalaryPage/components/RoleSalaryForm/RoleSalaryForm.tsx
+++ b/apps/web/src/pages/Profile/RoleSalaryPage/components/RoleSalaryForm/RoleSalaryForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { InformationCircleIcon } from "@heroicons/react/24/solid";
 
 import { BasicForm, Checklist } from "@common/components/form";
@@ -85,6 +85,11 @@ const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();
+  const [searchParams] = useSearchParams();
+  const applicationId = searchParams.get("applicationId");
+  const applicationParam = applicationId
+    ? `?applicationId=${applicationId}`
+    : ``;
   const returnRoute = application
     ? paths.reviewApplication(application.id)
     : paths.myProfile();
@@ -148,7 +153,17 @@ const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
         },
         {
           label: intl.formatMessage(navigationMessages.stepOne),
-          url: paths.reviewApplication(application.id),
+          url: paths.reviewApplication(applicationId ?? ""),
+        },
+        {
+          label: intl.formatMessage({
+            defaultMessage: "Role and Salary Expectations",
+            id: "dgOYID",
+            description: "Label for role and salary link",
+          }),
+          url: initialData.me?.id
+            ? `${paths.roleSalary(initialData.me.id)}${applicationParam}`
+            : "#",
         },
       ]
     : [];
@@ -166,17 +181,22 @@ const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
         id: "uIpPFZ",
         description: "Description for the role and salary expectation form",
       })}
-      crumbs={[
-        ...applicationBreadcrumbs,
-        {
-          label: intl.formatMessage({
-            defaultMessage: "Role and Salary Expectations",
-            id: "dgOYID",
-            description: "Label for role and salary link",
-          }),
-          url: initialData.me?.id ? paths.roleSalary(initialData.me.id) : "#",
-        },
-      ]}
+      crumbs={
+        applicationBreadcrumbs?.length
+          ? applicationBreadcrumbs
+          : [
+              {
+                label: intl.formatMessage({
+                  defaultMessage: "Role and Salary Expectations",
+                  id: "dgOYID",
+                  description: "Label for role and salary link",
+                }),
+                url: initialData.me?.id
+                  ? paths.roleSalary(initialData.me.id)
+                  : "#",
+              },
+            ]
+      }
       prefixBreadcrumbs={!application}
     >
       <BasicForm

--- a/apps/web/src/pages/Profile/WorkLocationPage/components/WorkLocationForm/WorkLocationForm.tsx
+++ b/apps/web/src/pages/Profile/WorkLocationPage/components/WorkLocationForm/WorkLocationForm.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { SubmitHandler } from "react-hook-form";
 import { useIntl } from "react-intl";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { BasicForm, Checklist, TextArea } from "@common/components/form";
 import { getWorkRegionsDetailed } from "@common/constants/localizedConstants";
@@ -46,6 +46,11 @@ const WorkLocationForm: React.FC<WorkLocationFormProps> = ({
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();
+  const [searchParams] = useSearchParams();
+  const applicationId = searchParams.get("applicationId");
+  const applicationParam = applicationId
+    ? `?applicationId=${applicationId}`
+    : ``;
   const returnRoute = application
     ? paths.reviewApplication(application.id)
     : paths.profile(initialData.id);
@@ -111,7 +116,16 @@ const WorkLocationForm: React.FC<WorkLocationFormProps> = ({
         },
         {
           label: intl.formatMessage(navigationMessages.stepOne),
-          url: paths.reviewApplication(application.id),
+          url: paths.reviewApplication(applicationId ?? ""),
+        },
+        {
+          label: intl.formatMessage({
+            defaultMessage: "Work Location Preference",
+            id: "c/Qp8R",
+            description:
+              "Display Text for the current page in Work Location Preference Form Page",
+          }),
+          url: `${paths.workLocation(initialData.id)}${applicationParam}`,
         },
       ]
     : [];
@@ -131,18 +145,21 @@ const WorkLocationForm: React.FC<WorkLocationFormProps> = ({
         description:
           "Title for Profile Form wrapper  in Work Location Preferences Form",
       })}
-      crumbs={[
-        ...applicationBreadcrumbs,
-        {
-          label: intl.formatMessage({
-            defaultMessage: "Work Location Preference",
-            id: "c/Qp8R",
-            description:
-              "Display Text for the current page in Work Location Preference Form Page",
-          }),
-          url: paths.workLocation(initialData.id),
-        },
-      ]}
+      crumbs={
+        applicationBreadcrumbs?.length
+          ? applicationBreadcrumbs
+          : [
+              {
+                label: intl.formatMessage({
+                  defaultMessage: "Work Location Preference",
+                  id: "c/Qp8R",
+                  description:
+                    "Display Text for the current page in Work Location Preference Form Page",
+                }),
+                url: paths.workLocation(initialData.id),
+              },
+            ]
+      }
       prefixBreadcrumbs={!application}
     >
       <BasicForm

--- a/apps/web/src/pages/Profile/WorkLocationPage/components/WorkLocationForm/WorkLocationForm.tsx
+++ b/apps/web/src/pages/Profile/WorkLocationPage/components/WorkLocationForm/WorkLocationForm.tsx
@@ -51,8 +51,8 @@ const WorkLocationForm: React.FC<WorkLocationFormProps> = ({
   const applicationParam = applicationId
     ? `?applicationId=${applicationId}`
     : ``;
-  const returnRoute = application
-    ? paths.reviewApplication(application.id)
+  const returnRoute = applicationId
+    ? paths.reviewApplication(applicationId)
     : paths.profile(initialData.id);
 
   const labels = {

--- a/apps/web/src/pages/Profile/WorkPreferencesPage/components/WorkPreferencesForm/WorkPreferencesForm.tsx
+++ b/apps/web/src/pages/Profile/WorkPreferencesPage/components/WorkPreferencesForm/WorkPreferencesForm.tsx
@@ -188,17 +188,21 @@ const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
         id: "64Pv6e",
         description: "Title for Profile Form wrapper in Work Preferences Form",
       })}
-      crumbs={[
-        ...applicationBreadcrumbs,
-        {
-          label: intl.formatMessage({
-            defaultMessage: "Work Preferences",
-            id: "7OWQgZ",
-            description: "Display Text for Work Preferences Form Page Link",
-          }),
-          url: paths.workPreferences(initialData.id),
-        },
-      ]}
+      crumbs={
+        applicationBreadcrumbs?.length
+          ? applicationBreadcrumbs
+          : [
+              {
+                label: intl.formatMessage({
+                  defaultMessage: "Work Preferences",
+                  id: "7OWQgZ",
+                  description:
+                    "Display Text for Work Preferences Form Page Link",
+                }),
+                url: paths.workPreferences(initialData.id),
+              },
+            ]
+      }
       prefixBreadcrumbs={!application}
     >
       <BasicForm

--- a/apps/web/src/pages/Profile/WorkPreferencesPage/components/WorkPreferencesForm/WorkPreferencesForm.tsx
+++ b/apps/web/src/pages/Profile/WorkPreferencesPage/components/WorkPreferencesForm/WorkPreferencesForm.tsx
@@ -78,8 +78,8 @@ const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
   const applicationParam = applicationId
     ? `?applicationId=${applicationId}`
     : ``;
-  const returnRoute = application
-    ? paths.reviewApplication(application.id)
+  const returnRoute = applicationId
+    ? paths.reviewApplication(applicationId)
     : paths.profile(initialData.id);
 
   const labels = {

--- a/apps/web/src/pages/Profile/WorkPreferencesPage/components/WorkPreferencesForm/WorkPreferencesForm.tsx
+++ b/apps/web/src/pages/Profile/WorkPreferencesPage/components/WorkPreferencesForm/WorkPreferencesForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { SubmitHandler } from "react-hook-form";
 
 import { errorMessages, navigationMessages } from "@common/messages";
@@ -73,6 +73,11 @@ const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();
+  const [searchParams] = useSearchParams();
+  const applicationId = searchParams.get("applicationId");
+  const applicationParam = applicationId
+    ? `?applicationId=${applicationId}`
+    : ``;
   const returnRoute = application
     ? paths.reviewApplication(application.id)
     : paths.profile(initialData.id);
@@ -156,7 +161,15 @@ const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
         },
         {
           label: intl.formatMessage(navigationMessages.stepOne),
-          url: paths.reviewApplication(application.id),
+          url: paths.reviewApplication(applicationId ?? ""),
+        },
+        {
+          label: intl.formatMessage({
+            defaultMessage: "Work Preferences",
+            id: "7OWQgZ",
+            description: "Display Text for Work Preferences Form Page Link",
+          }),
+          url: `${paths.workPreferences(initialData.id)}${applicationParam}`,
         },
       ]
     : [];


### PR DESCRIPTION
🤖 Resolves #5541.

## 👋 Introduction

This PR fixes breadcrumbs for profile forms so that they link correctly in an Application context.

## 🕵️ Details

Also, `returnRoute` was standardized to use **applicationId** from `searchParams` instead of from a prop as it had been in some cases.

## 🧪 Testing

Test all segments of the breadcrumbs, specifically the following ones.

### Application context

1. Start an application
2. Click **Edit _Section Name_**  
3. Click on the last breadcrumb in the list
4. Verify the page is the same and the breadcrumbs are in an application context
5. Click on the **Step 1** breadcrumb in the list
6. Verify the page returns to the **My application profile** page
7. Repeat for all sections

### Profile context

1. Click **My Profile**
2. Click **Edit _Section Name_**  
3. Click on the last breadcrumb in the list
4. Verify the page is the same and the breadcrumbs are in a profile context
5. Repeat for all sections