### PR TITLE
Feature/5585 create update team mutation

### DIFF
--- a/api/app/Policies/TeamPolicy.php
+++ b/api/app/Policies/TeamPolicy.php
@@ -23,4 +23,33 @@ class TeamPolicy
         }
         return false;
     }
+
+    /**
+     * Determine whether the user can create models.
+     *
+     * @param  \App\Models\User|null  $user
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function create(User $user = null)
+    {
+        if ($user) {
+            return $user->isAdmin();
+        }
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update models.
+     * Likely to be updated later to allow the team admin to update their own team
+     *
+     * @param  \App\Models\User|null  $user
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function update(User $user = null)
+    {
+        if ($user) {
+            return $user->isAdmin();
+        }
+        return false;
+    }
 }

--- a/api/app/Policies/TeamPolicy.php
+++ b/api/app/Policies/TeamPolicy.php
@@ -25,6 +25,22 @@ class TeamPolicy
     }
 
     /**
+     * Determine whether the user can view a specific model.
+     * To be sketched in later with roles and permissions work
+     *
+     * @param  \App\Models\User|null  $user
+     * @param \App\Models\Team|null $team
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function view(User $user = null, Team $team = null)
+    {
+        if ($user) {
+            return $user->isAdmin();
+        }
+        return false;
+    }
+
+    /**
      * Determine whether the user can create models.
      *
      * @param  \App\Models\User|null  $user

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1310,23 +1310,23 @@ input DepartmentBelongsTo {
   connect: ID!
 }
 
-input DepartmentsBelongsToMany {
-  sync: [ID]
+input DepartmentBelongsToMany {
+  sync: [ID!]
 }
 
 input CreateTeamInput {
   name: String!
-  displayName: LocalizedString @rename(attribute: "display_name")
-  description: LocalizedString
-  departments: DepartmentsBelongsToMany
+  displayName: LocalizedStringInput @rename(attribute: "display_name")
+  description: LocalizedStringInput
+  departments: DepartmentBelongsToMany
   contactEmail: Email @rename(attribute: "contact_email")
 }
 
 input UpdateTeamInput {
   name: String
-  displayName: LocalizedString @rename(attribute: "display_name")
-  description: LocalizedString
-  departments: DepartmentsBelongsToMany
+  displayName: LocalizedStringInput @rename(attribute: "display_name")
+  description: LocalizedStringInput
+  departments: DepartmentBelongsToMany
   contactEmail: Email @rename(attribute: "contact_email")
 }
 
@@ -1740,8 +1740,10 @@ type Mutation {
   submitApplication(id: ID!, signature: String!): PoolCandidate
 
   # Teams mutations
-  createTeam(team: CreateTeamInput!): Team @create @can(ability: "create")
-  updateTeam(id: UUID!, team: UpdateTeamInput!): Team
+  createTeam(team: CreateTeamInput! @spread): Team
+    @create
+    @can(ability: "create")
+  updateTeam(id: UUID!, team: UpdateTeamInput! @spread): Team
     @update
     @can(ability: "update")
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1740,6 +1740,8 @@ type Mutation {
   submitApplication(id: ID!, signature: String!): PoolCandidate
 
   # Teams mutations
-  createTeam(team: CreateTeamInput): Team @create
-  updateTeam(id: UUID!, team: UpdateTeamInput): Team @update
+  createTeam(team: CreateTeamInput!): Team @create @can(ability: "create")
+  updateTeam(id: UUID!, team: UpdateTeamInput!): Team
+    @update
+    @can(ability: "update")
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -970,7 +970,7 @@ type Query {
   skills: [Skill]! @all
   genericJobTitle(id: UUID! @eq): GenericJobTitle @find
   genericJobTitles: [GenericJobTitle]! @all
-  team(id: UUID! @eq): Team @find @can(ability: "viewAny")
+  team(id: UUID! @eq): Team @find @can(ability: "view", query: true)
   teams: [Team]! @all @can(ability: "viewAny")
 }
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -970,6 +970,7 @@ type Query {
   skills: [Skill]! @all
   genericJobTitle(id: UUID! @eq): GenericJobTitle @find
   genericJobTitles: [GenericJobTitle]! @all
+  team(id: UUID! @eq): Team @find @can(ability: "viewAny")
   teams: [Team]! @all @can(ability: "viewAny")
 }
 
@@ -1307,6 +1308,26 @@ input PoolBelongsToMany {
 
 input DepartmentBelongsTo {
   connect: ID!
+}
+
+input DepartmentsBelongsToMany {
+  sync: [ID]
+}
+
+input CreateTeamInput {
+  name: String!
+  displayName: LocalizedString @rename(attribute: "display_name")
+  description: LocalizedString
+  departments: DepartmentsBelongsToMany
+  contactEmail: Email @rename(attribute: "contact_email")
+}
+
+input UpdateTeamInput {
+  name: String
+  displayName: LocalizedString @rename(attribute: "display_name")
+  description: LocalizedString
+  departments: DepartmentsBelongsToMany
+  contactEmail: Email @rename(attribute: "contact_email")
 }
 
 input CreatePoolCandidateFilterInput {
@@ -1717,4 +1738,8 @@ type Mutation {
     @guard
     @can(ability: "deleteApplication", find: "id", model: "PoolCandidate")
   submitApplication(id: ID!, signature: String!): PoolCandidate
+
+  # Teams mutations
+  createTeam(team: CreateTeamInput): Team @create
+  updateTeam(id: UUID!, team: UpdateTeamInput): Team @update
 }

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -314,6 +314,14 @@ input CreateSkillInput {
   keywords: SkillKeywordsInput
 }
 
+input CreateTeamInput {
+  name: String!
+  displayName: LocalizedString
+  description: LocalizedString
+  departments: DepartmentsBelongsToMany
+  contactEmail: Email
+}
+
 """When creating a User, name is required."""
 input CreateUserInput {
   sub: String
@@ -381,6 +389,10 @@ type Department {
 
 input DepartmentBelongsTo {
   connect: ID!
+}
+
+input DepartmentsBelongsToMany {
+  sync: [ID]
 }
 
 type EducationExperience implements Experience {
@@ -619,6 +631,8 @@ type Mutation {
   createApplication(userId: ID!, poolId: ID!): PoolCandidate
   deleteApplication(id: ID!): Boolean
   submitApplication(id: ID!, signature: String!): PoolCandidate
+  createTeam(team: CreateTeamInput): Team
+  updateTeam(id: UUID!, team: UpdateTeamInput): Team
 }
 
 """e.g. Overtime as Required, Shift Work, Travel as Required, etc."""
@@ -1000,6 +1014,7 @@ type Query {
   skills: [Skill]!
   genericJobTitle(id: UUID!): GenericJobTitle
   genericJobTitles: [GenericJobTitle]!
+  team(id: UUID!): Team
   teams: [Team]!
   usersPaginated(
     where: UserFilterInput
@@ -1302,6 +1317,14 @@ input UpdateSkillInput {
   description: LocalizedStringInput
   families: SkillFamilyBelongsToMany
   keywords: SkillKeywordsInput
+}
+
+input UpdateTeamInput {
+  name: String
+  displayName: LocalizedString
+  description: LocalizedString
+  departments: DepartmentsBelongsToMany
+  contactEmail: Email
 }
 
 """When updating a User, all fields are optional"""

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -316,9 +316,9 @@ input CreateSkillInput {
 
 input CreateTeamInput {
   name: String!
-  displayName: LocalizedString
-  description: LocalizedString
-  departments: DepartmentsBelongsToMany
+  displayName: LocalizedStringInput
+  description: LocalizedStringInput
+  departments: DepartmentBelongsToMany
   contactEmail: Email
 }
 
@@ -391,8 +391,8 @@ input DepartmentBelongsTo {
   connect: ID!
 }
 
-input DepartmentsBelongsToMany {
-  sync: [ID]
+input DepartmentBelongsToMany {
+  sync: [ID!]
 }
 
 type EducationExperience implements Experience {
@@ -1321,9 +1321,9 @@ input UpdateSkillInput {
 
 input UpdateTeamInput {
   name: String
-  displayName: LocalizedString
-  description: LocalizedString
-  departments: DepartmentsBelongsToMany
+  displayName: LocalizedStringInput
+  description: LocalizedStringInput
+  departments: DepartmentBelongsToMany
   contactEmail: Email
 }
 

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -631,8 +631,8 @@ type Mutation {
   createApplication(userId: ID!, poolId: ID!): PoolCandidate
   deleteApplication(id: ID!): Boolean
   submitApplication(id: ID!, signature: String!): PoolCandidate
-  createTeam(team: CreateTeamInput): Team
-  updateTeam(id: UUID!, team: UpdateTeamInput): Team
+  createTeam(team: CreateTeamInput!): Team
+  updateTeam(id: UUID!, team: UpdateTeamInput!): Team
 }
 
 """e.g. Overtime as Required, Shift Work, Travel as Required, etc."""

--- a/api/tests/Feature/TeamsTest.php
+++ b/api/tests/Feature/TeamsTest.php
@@ -191,9 +191,7 @@ class TeamsTest extends TestCase
     $this->seed(DepartmentSeeder::class);
     $departmentId = Department::inRandomOrder()->first()->id;
 
-    $teamOne = Team::factory()->create([
-      'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
-    ]);
+    $teamOne = Team::factory()->create();
 
     // Assert team update successful across all input fields
     $this->graphQL(

--- a/api/tests/Feature/TeamsTest.php
+++ b/api/tests/Feature/TeamsTest.php
@@ -185,4 +185,76 @@ class TeamsTest extends TestCase
       ]
     );
   }
+
+  public function testTeamUpdateMutation(): void
+  {
+    $this->seed(DepartmentSeeder::class);
+    $departmentId = Department::inRandomOrder()->first()->id;
+
+    $teamOne = Team::factory()->create([
+      'id' => 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+    ]);
+
+    // Assert team update successful across all input fields
+    $this->graphQL(
+      /** @lang GraphQL */
+      '
+      mutation updateTeam($id: UUID!, $team: UpdateTeamInput!) {
+          updateTeam(id: $id, team: $team) {
+            name
+            displayName {
+              en
+              fr
+            }
+            description {
+              en
+              fr
+            }
+            contactEmail
+            departments {
+              id
+            }
+          }
+      }
+      ',
+      [
+        'id' => $teamOne->id,
+        'team' => [
+          'name'=> 'team one',
+          'displayName' => [
+            'en' => 'en',
+            'fr' => 'fr',
+          ],
+          'description' => [
+            'en' => 'en',
+            'fr' => 'fr',
+          ],
+          'contactEmail' => 'test@test.com',
+          'departments' => [
+            "sync" => [$departmentId],
+          ],
+        ]
+      ]
+    )->assertJson([
+      'data' => [
+        'updateTeam' => [
+          'name' => 'team one',
+          'displayName' => [
+            'en' => 'en',
+            'fr' => 'fr',
+          ],
+          'description' => [
+            'en' => 'en',
+            'fr' => 'fr',
+          ],
+          'contactEmail' => 'test@test.com',
+          'departments' => [
+            [
+              'id' => $departmentId,
+            ],
+          ],
+        ]
+      ]
+    ]);
+  }
 }


### PR DESCRIPTION
🤖 Resolves #5585 

## 👋 Introduction

Add createTeam and updateTeam mutations.

## 🕵️ Details

Adds the new mutations, with policies, as well as unit testing.
I also threw in a query to grab a specific team since I imagine we'll need it soon. 

## 🧪 Testing

1. play around with the new queries/mutations

```
query team($id: UUID!) {
  team(id: $id) {
    id
    name
  }
}
```

```
mutation createTeam($team: CreateTeamInput!) {
  createTeam(team: $team) {
        name
        id
        displayName {
           en
           fr
         }
         description {
           en
           fr
         }
         contactEmail
         departments {
           id
         }
  }
}
```


```
mutation updateTeam($id: UUID!, $team: UpdateTeamInput!) {
     updateTeam(id: $id, team: $team) {
        name
        id
        displayName {
           en
           fr
         }
         description {
           en
           fr
         }
         contactEmail
         departments {
           id
         }
     }
}
```


