### PR TITLE
Experiment - 5352 - Stabilize Create Application

### DIFF
--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -741,11 +741,7 @@ const createRoute = (locale: Locales, client: Client, user: PossibleUser) =>
                         {
                           path: "create-application",
                           loader: applicationLoader(client, user?.id),
-                          element: (
-                            <RequireAuth roles={[LegacyRole.Applicant]}>
-                              <CreateApplicationPage />
-                            </RequireAuth>
-                          ),
+                          element: <CreateApplicationPage />,
                         },
                       ],
                     },

--- a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
+++ b/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
@@ -30,6 +30,7 @@ export type RouteParams = {
 export const loader =
   (client: Client, userId: Scalars["UUID"]): LoaderFunction =>
   async ({ params, request }) => {
+    const url = new URL(request.url);
     const { poolId } = params;
 
     /**
@@ -39,11 +40,13 @@ export const loader =
     const me = await client
       .query(`query IsLoggedIn { me { id } }`, {})
       .toPromise()
-      .then((res) => res.data.me.id);
+      .then((res) => res.data.me);
 
     // Redirect to login if we got this far (we shouldn't)
-    if (!me.id) {
-      redirect(`/login?from=${request.url}&locale=en`);
+    if (!me) {
+      return window.location.replace(
+        `/login?from=${encodeURI(url.pathname)}&locale=en`,
+      );
     }
 
     const application = client


### PR DESCRIPTION
> **Note**
> For now, this is just an experiment to see what people think. It has some hardcoded values and could use a really good refactor to clean things up.

## 👋 Introduction

This doesn't fix the bug where applications are submitted twice when navigating to the create application page directly. 

## 🕵️ Details

 - #5352 This does not prevent the double application for some reason even with no `useEffect` 😖 
 - #4545 Possibly solve this but unsure 🤷‍♀️ 
 - #5361 Is one option to use `urql` in loaders without hooks

## ❗ Problem

I'm wondering if this should be moved to an `action` and we remove some of the magic around application creation. 

For example, we don't even show the button to apply and instead tell the user to login to apply and bring them back to the advertisement after logging in. We could then move the logic currently in the loader to an `action` and convert the button to a `Form` with hidden inputs for `poolId` and `userId`. Since it is in an action, there is less magic and it should stop the mutation running twice.

## 🚶‍♀️ Walkthrough

### Pass Client to Router

We start by getting the client and passing it into our router creation so we can access it in our loaders.

https://github.com/GCTC-NTGC/gc-digital-talent/blob/4f46166f16ada0dd59785b2db361cb5d2235078a/apps/web/src/components/Router.tsx#L1175-L1177

### Create Loader with Client

Then, we can use a wrapper function to create a loader function that has access to the `client` and current `userId`.

> **Note**
> We don't really need to pass the `userId` here, we could include it in the params as well.

REF: [loader](https://reactrouter.com/en/main/route/loader)

https://github.com/GCTC-NTGC/gc-digital-talent/blob/4f46166f16ada0dd59785b2db361cb5d2235078a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx#L30-L32

### Authorize Operation

We can check if the user exists and boot them over to login if they do not. This means, we no longer need the `RequireAuth` wrapper for this.

> **Note**
> There is [an RFC to implement middleware to add context to a loaders](https://github.com/remix-run/react-router/discussions/9564). When this is released, we can check for auth there to reduce this type of boilerplate.

https://github.com/GCTC-NTGC/gc-digital-talent/blob/4f46166f16ada0dd59785b2db361cb5d2235078a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx#L36-L50

### Create the Application

Once we know the user exists, we can create the application and `defer` the data. 

REF: [Deferred Data](https://reactrouter.com/en/main/guides/deferred)

https://github.com/GCTC-NTGC/gc-digital-talent/blob/4f46166f16ada0dd59785b2db361cb5d2235078a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx#L52-L60

### Get the Data

We retrieve the deferred data in the page component (essentially anything returned from the loader).

https://github.com/GCTC-NTGC/gc-digital-talent/blob/4f46166f16ada0dd59785b2db361cb5d2235078a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx#L70

### Render the Page

Here we are rendering the page. Since this is essentially middleware to create an application, we only ever render one of three things:

- Loading spinner while the deferred data resolves
- Redirect to pool advertisement on error
- Redirect to application on success

> **Note**
>  Since we are using partial errors with `graphql` the `createApplication` mutation returns the existing application (if it does) so we can redirect to it even with errors 😄 

https://github.com/GCTC-NTGC/gc-digital-talent/blob/4f46166f16ada0dd59785b2db361cb5d2235078a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx#L82-L104

## ❓ What does this mean

### No More API Wrappers

If we follow a similar pattern for all pages, we would no longer need those API wrappers and can essentially move all of that code to `loaders` and `actions`.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build the app `npm run dev`
2. Ensure you are logged out
3. Navigate to a pool advertisement
4. Start an application
5. Note that the mutation still runs twice regardless of no `useEffect`

