### PR TITLE
a11y - 5357 - Enable Application Submit

### DIFF
--- a/apps/web/src/pages/Applications/SignAndSubmitPage/SignAndSubmitPage.stories.tsx
+++ b/apps/web/src/pages/Applications/SignAndSubmitPage/SignAndSubmitPage.stories.tsx
@@ -13,7 +13,6 @@ export default {
     userId: "1",
     closingDate: FAR_FUTURE_DATE,
     jobTitle: "Application Developer - React (IT-01)",
-    isApplicationComplete: true,
     handleSubmitApplication: async (id, signature) => {
       await new Promise((resolve) => {
         setTimeout(resolve, 1000);
@@ -28,9 +27,4 @@ const Template: ComponentStory<typeof SignAndSubmitForm> = (args) => {
   return <SignAndSubmitForm {...args} />;
 };
 
-export const ApplicationIsComplete = Template.bind({});
-export const ApplicationIsIncomplete = Template.bind({});
-
-ApplicationIsIncomplete.args = {
-  isApplicationComplete: false,
-};
+export const Default = Template.bind({});

--- a/apps/web/src/pages/Applications/SignAndSubmitPage/SignAndSubmitPage.tsx
+++ b/apps/web/src/pages/Applications/SignAndSubmitPage/SignAndSubmitPage.tsx
@@ -17,17 +17,12 @@ import Pending from "@common/components/Pending";
 import SEO from "@common/components/SEO/SEO";
 import TableOfContents from "@common/components/TableOfContents";
 import { errorMessages } from "@common/messages";
-import { notEmpty } from "@common/helpers/util";
-import { categorizeSkill, getMissingSkills } from "@common/helpers/skillUtils";
-import { getMissingLanguageRequirements } from "@common/helpers/languageUtils";
-import { flattenExperienceSkills } from "@common/types/ExperienceUtils";
 import { getFullPoolAdvertisementTitle } from "@common/helpers/poolUtils";
 
 import useRoutes from "~/hooks/useRoutes";
 import {
   PoolAdvertisement,
   Scalars,
-  SkillCategory,
   SubmitApplicationMutation,
   useGetApplicationDataQuery,
   useSubmitApplicationMutation,
@@ -87,7 +82,6 @@ type FormValues = {
 type SignatureFormProps = {
   applicationId: string;
   userId: string;
-  isApplicationComplete: boolean;
   handleSubmitApplication: (
     id: string,
     signature: string,
@@ -97,7 +91,6 @@ type SignatureFormProps = {
 const SignatureForm = ({
   applicationId,
   userId,
-  isApplicationComplete,
   handleSubmitApplication,
 }: SignatureFormProps) => {
   const intl = useIntl();
@@ -186,7 +179,6 @@ const SignatureForm = ({
             rules={{
               required: intl.formatMessage(errorMessages.required),
             }}
-            disabled={!isApplicationComplete}
           />
         </div>
         <div data-h2-text-align="base(center) p-tablet(left)">
@@ -211,7 +203,6 @@ const SignatureForm = ({
                 />
               </span>
             }
-            disabled={!isApplicationComplete}
           />
           <Link
             href={paths.reviewApplication(applicationId)}
@@ -237,7 +228,6 @@ export interface SignAndSubmitFormProps {
   userId: string;
   closingDate: PoolAdvertisement["closingDate"];
   jobTitle: string;
-  isApplicationComplete: boolean;
   handleSubmitApplication: (
     id: string,
     signature: string,
@@ -250,7 +240,6 @@ export const SignAndSubmitForm = ({
   userId,
   closingDate,
   jobTitle,
-  isApplicationComplete,
   handleSubmitApplication,
 }: SignAndSubmitFormProps) => {
   const intl = useIntl();
@@ -278,7 +267,6 @@ export const SignAndSubmitForm = ({
         <SignatureForm
           applicationId={applicationId}
           userId={userId}
-          isApplicationComplete={isApplicationComplete}
           handleSubmitApplication={handleSubmitApplication}
         />
       ),
@@ -401,26 +389,6 @@ const SignAndSubmitPage = () => {
         description: "Error message when job title isn't found.",
       });
 
-  const isProfileComplete = data?.poolCandidate?.user.isProfileComplete;
-  const experiences = data?.poolCandidate?.user.experiences?.filter(notEmpty);
-  const hasExperiences = notEmpty(experiences);
-  const technicalRequiredSkills = categorizeSkill(
-    data?.poolCandidate?.poolAdvertisement?.essentialSkills,
-  )[SkillCategory.Technical];
-
-  const isApplicationComplete =
-    isProfileComplete === true &&
-    getMissingSkills(
-      technicalRequiredSkills || [],
-      hasExperiences
-        ? flattenExperienceSkills(experiences).filter(notEmpty)
-        : [],
-    ).length === 0 &&
-    getMissingLanguageRequirements(
-      data?.poolCandidate?.user,
-      data?.poolCandidate?.poolAdvertisement,
-    ).length === 0;
-
   const [, executeMutation] = useSubmitApplicationMutation();
   const handleSubmitApplication = (applicationId: string, signature: string) =>
     executeMutation({ id: applicationId, signature }).then((result) => {
@@ -439,7 +407,6 @@ const SignAndSubmitPage = () => {
           userId={data.poolCandidate.user.id}
           closingDate={data.poolCandidate.poolAdvertisement?.closingDate}
           jobTitle={jobTitle}
-          isApplicationComplete={isApplicationComplete}
           handleSubmitApplication={handleSubmitApplication}
         />
       ) : (


### PR DESCRIPTION
🤖 Resolves #5357 

## 👋 Introduction

This removed the `disabled` attr regardless of the users profile completion status.

## 🕵️ Details

This is to handle an extreme edge case where a user navigates to the sign and submit step of an application even when their profile is incomplete.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Create an application with an incomplete profile
2. Navigate directly to `/browse/applications/{applicationId}/submit`
3. Ensure the submit button is enabled
4. Attempt the submit the form
5. Ensure you get an error toast with nice messages

## 📸 Screenshot

![Screenshot 2023-02-06 092008](https://user-images.githubusercontent.com/4127998/216997816-c26ebca2-ef54-4a69-bd9d-f0d99c1f7301.png)



