### PR TITLE
Move tc-reports static files location block above apps/web static fil…

### DIFF
--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -92,6 +92,11 @@ server {
         alias /home/site/config-web.js;
     }
 
+    # rewrite tc-report static files to "tc-report/_site"
+    location ~ "^/tc-report/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" {
+        rewrite "^/tc-report/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" /tc-report/_site/$1 break;
+    }
+
     # rewrite talent static files to "apps/web/dist"
     location ~ "^(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" {
         rewrite "^(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" /apps/web/dist/$1 break;
@@ -198,11 +203,6 @@ server {
         add_header Cache-Control no-cache;
         expires 0;
         rewrite "^(?:/[a-z]{2})?/indigenous-it-apprentice(/.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite tc-report static files to "tc-report/_site"
-    location ~ "^/tc-report/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" {
-        rewrite "^/tc-report/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" /tc-report/_site/$1 break;
     }
 
     # fallback any other files to "tc-report/_site"

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -106,7 +106,12 @@ server {
         rewrite "^(?:/[a-z]{2})?/?$" /apps/web/dist/index.html break;
     }
 
-    # rewrite talent static files to "apps/web/dist"
+    # rewrite tc-report static files to "tc-report/_site"
+    location ~ "^/tc-report/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" {
+        rewrite "^/tc-report/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" /tc-report/_site/$1 break;
+    }
+
+     # rewrite talent static files to "apps/web/dist"
     location ~ "^(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" {
         rewrite "^(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" /apps/web/dist/$1 break;
     }
@@ -212,11 +217,6 @@ server {
         add_header Cache-Control no-cache;
         expires 0;
         rewrite "^(?:/[a-z]{2})?/indigenous-it-apprentice(/.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite tc-report static files to "tc-report/_site"
-    location ~ "^/tc-report/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" {
-        rewrite "^/tc-report/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" /tc-report/_site/$1 break;
     }
 
     # fallback any other files to "tc-report/_site"


### PR DESCRIPTION
🤖 Resolves #5477 

## 👋 Introduction

Fixes the broken tc-report pages. Currently, the pages are loading but all assets are 404'ing.

## 🧪 Testing

1. Locally test all apps (admin, talentsearch, iap, tc-report) and make sure they load pages correctly, and ensure all static files are loading.
2. We should also test this on the dev server as this it makes changes to the nginx deploy config as well.



