### PR TITLE
a11y - 5423 - Fix Input Context w/ Assistive Technology

### DIFF
--- a/apps/web/src/components/Table/ApiManagedTable/TableHeader.tsx
+++ b/apps/web/src/components/Table/ApiManagedTable/TableHeader.tsx
@@ -104,6 +104,7 @@ function TableHeader<T extends Record<string, unknown>>({
                         </Dialog.Header>
                         <FormProvider {...methods}>
                           <Fieldset
+                            name="visibleColumns"
                             legend={intl.formatMessage({
                               defaultMessage: "Visible columns",
                               id: "H9rxOR",

--- a/apps/web/src/components/Table/ClientManagedTable/Table.tsx
+++ b/apps/web/src/components/Table/ClientManagedTable/Table.tsx
@@ -285,6 +285,7 @@ function Table<T extends Record<string, unknown>>({
                         </Dialog.Header>
                         <FormProvider {...methods}>
                           <Fieldset
+                            name="visibleColumns"
                             legend={intl.formatMessage({
                               defaultMessage: "Visible columns",
                               id: "H9rxOR",

--- a/frontend/common/src/components/form/Checkbox/Checkbox.tsx
+++ b/frontend/common/src/components/form/Checkbox/Checkbox.tsx
@@ -3,6 +3,7 @@ import get from "lodash/get";
 import { FieldError, RegisterOptions, useFormContext } from "react-hook-form";
 import { InputWrapper } from "../../inputPartials";
 import { useFieldStateStyles } from "../../../helpers/formUtils";
+import useInputDescribedBy from "../../../hooks/useInputDescribedBy";
 
 export interface CheckboxProps
   extends Omit<
@@ -25,6 +26,8 @@ export interface CheckboxProps
   boundingBoxLabel?: React.ReactNode;
   /** Determine if it should track unsaved changes and render it */
   trackUnsaved?: boolean;
+  /** Determine if it should track unsaved changes and render it */
+  isUnsaved?: boolean;
 }
 
 export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
@@ -33,11 +36,13 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
   name,
   rules = {},
   context,
+  isUnsaved,
   boundingBox = false,
   boundingBoxLabel = label,
   trackUnsaved = true,
   ...rest
 }) => {
+  const [isContextVisible, setContextVisible] = React.useState<boolean>(false);
   const {
     register,
     formState: { errors },
@@ -45,6 +50,14 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
   // To grab errors in nested objects we need to use lodash's get helper.
   const error = get(errors, name)?.message as FieldError;
+  const [descriptionIds, ariaDescribedBy] = useInputDescribedBy({
+    id,
+    show: {
+      error,
+      unsaved: trackUnsaved && isUnsaved,
+      context: context && isContextVisible,
+    },
+  });
 
   return (
     <div
@@ -61,6 +74,8 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
           context={context}
           error={error}
           trackUnsaved={trackUnsaved}
+          onContextToggle={setContextVisible}
+          descriptionIds={descriptionIds}
           data-h2-flex-direction="base(row)"
           data-h2-align-items="base(center)"
         >
@@ -85,6 +100,8 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
           context={context}
           error={error}
           trackUnsaved={trackUnsaved}
+          onContextToggle={setContextVisible}
+          descriptionIds={descriptionIds}
           fillLabel
         >
           <div
@@ -101,6 +118,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = ({
               {...register(name, rules)}
               type="checkbox"
               aria-invalid={error ? "true" : "false"}
+              aria-describedby={ariaDescribedBy}
               {...rest}
             />
             <span

--- a/frontend/common/src/components/form/Checklist/Checklist.tsx
+++ b/frontend/common/src/components/form/Checklist/Checklist.tsx
@@ -70,7 +70,7 @@ const Checklist: React.FunctionComponent<ChecklistProps> = ({
       disabled={disabled}
       hideOptional={hideOptional}
       trackUnsaved={trackUnsaved}
-      aria-describedby={error || isUnsaved ? `${name}-error` : undefined}
+      isUnsaved={isUnsaved}
       {...rest}
     >
       {items.map(({ value, label }) => {

--- a/frontend/common/src/components/form/Input/Input.tsx
+++ b/frontend/common/src/components/form/Input/Input.tsx
@@ -3,6 +3,7 @@ import get from "lodash/get";
 import { FieldError, RegisterOptions, useFormContext } from "react-hook-form";
 import { useFieldState, useFieldStateStyles } from "../../../helpers/formUtils";
 import { InputWrapper } from "../../inputPartials";
+import useInputDescribedBy from "../../../hooks/useInputDescribedBy";
 
 export interface InputProps
   extends Omit<
@@ -44,6 +45,7 @@ const Input: React.FunctionComponent<InputProps> = ({
   trackUnsaved = true,
   ...rest
 }) => {
+  const [isContextVisible, setContextVisible] = React.useState<boolean>(false);
   const {
     register,
     setValue,
@@ -54,6 +56,14 @@ const Input: React.FunctionComponent<InputProps> = ({
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
   const fieldState = useFieldState(id, !trackUnsaved);
   const isUnsaved = fieldState === "dirty" && trackUnsaved;
+  const [descriptionIds, ariaDescribedBy] = useInputDescribedBy({
+    id,
+    show: {
+      error,
+      unsaved: trackUnsaved && isUnsaved,
+      context: context && isContextVisible,
+    },
+  });
 
   const whitespaceTrimmer = (e: React.FocusEvent<HTMLInputElement>) => {
     if (whitespaceTrim) {
@@ -74,6 +84,8 @@ const Input: React.FunctionComponent<InputProps> = ({
         hideOptional={hideOptional}
         errorPosition={errorPosition}
         trackUnsaved={trackUnsaved}
+        onContextToggle={setContextVisible}
+        descriptionIds={descriptionIds}
       >
         <input
           data-h2-padding="base(x.25, x.5)"
@@ -90,7 +102,7 @@ const Input: React.FunctionComponent<InputProps> = ({
           readOnly={readOnly}
           aria-required={rules.required ? "true" : undefined}
           aria-invalid={error ? "true" : "false"}
-          aria-describedby={error || isUnsaved ? `${id}-error` : undefined}
+          aria-describedby={ariaDescribedBy}
           {...rest}
         />
       </InputWrapper>

--- a/frontend/common/src/components/form/RadioGroup/RadioGroup.tsx
+++ b/frontend/common/src/components/form/RadioGroup/RadioGroup.tsx
@@ -80,7 +80,7 @@ const RadioGroup: React.FunctionComponent<RadioGroupProps> = ({
       hideOptional={hideOptional}
       hideLegend={hideLegend}
       trackUnsaved={trackUnsaved}
-      aria-describedby={error || isUnsaved ? `${name}-error` : undefined}
+      isUnsaved={isUnsaved}
       {...rest}
     >
       <div data-h2-flex-grid="base(flex-start, x1, 0)">

--- a/frontend/common/src/components/form/Select/Select.tsx
+++ b/frontend/common/src/components/form/Select/Select.tsx
@@ -3,6 +3,7 @@ import { FieldError, RegisterOptions, useFormContext } from "react-hook-form";
 import get from "lodash/get";
 import { InputWrapper } from "../../inputPartials";
 import { useFieldState, useFieldStateStyles } from "../../../helpers/formUtils";
+import useInputDescribedBy from "../../../hooks/useInputDescribedBy";
 
 export interface Option {
   value: string | number;
@@ -41,6 +42,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
   trackUnsaved = true,
   ...rest
 }) => {
+  const [isContextVisible, setContextVisible] = React.useState<boolean>(false);
   const {
     register,
     formState: { errors },
@@ -49,6 +51,14 @@ const Select: React.FunctionComponent<SelectProps> = ({
   const error = get(errors, name)?.message as FieldError;
   const fieldState = useFieldState(id, !trackUnsaved);
   const isUnsaved = fieldState === "dirty" && trackUnsaved;
+  const [descriptionIds, ariaDescribedBy] = useInputDescribedBy({
+    id,
+    show: {
+      error,
+      unsaved: trackUnsaved && isUnsaved,
+      context: context && isContextVisible,
+    },
+  });
 
   return (
     <div data-h2-margin="base(x1, 0)">
@@ -60,6 +70,8 @@ const Select: React.FunctionComponent<SelectProps> = ({
         context={context}
         error={error}
         trackUnsaved={trackUnsaved}
+        onContextToggle={setContextVisible}
+        descriptionIds={descriptionIds}
       >
         <select
           data-h2-padding="base(x.25, x.5)"
@@ -70,7 +82,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
           {...register(name, rules)}
           aria-invalid={error ? "true" : "false"}
           aria-required={rules?.required ? "true" : undefined}
-          aria-describedby={error || isUnsaved ? `${id}-error` : undefined}
+          aria-describedby={ariaDescribedBy}
           {...rest}
           defaultValue=""
         >

--- a/frontend/common/src/components/form/Select/SelectFieldV2.tsx
+++ b/frontend/common/src/components/form/Select/SelectFieldV2.tsx
@@ -15,6 +15,7 @@ import { useIntl } from "react-intl";
 import { useFieldState, useFieldStateStyles } from "../../../helpers/formUtils";
 import { errorMessages } from "../../../messages";
 import { InputWrapper } from "../../inputPartials";
+import useInputDescribedBy from "../../../hooks/useInputDescribedBy";
 
 export type Option = { value: string | number; label: string };
 export type Group<T> = {
@@ -178,6 +179,7 @@ const SelectFieldV2 = ({
   trackUnsaved = true,
 }: SelectFieldV2Props): JSX.Element => {
   const { formatMessage } = useIntl();
+  const [isContextVisible, setContextVisible] = React.useState<boolean>(false);
 
   const defaultPlaceholder = formatMessage({
     defaultMessage: "Select...",
@@ -206,6 +208,15 @@ const SelectFieldV2 = ({
   // See: https://github.com/react-hook-form/react-hook-form/issues/458
   const rulesWithDefaults = useRulesWithDefaultMessages(label, rules);
 
+  const [descriptionIds, ariaDescribedBy] = useInputDescribedBy({
+    id,
+    show: {
+      error,
+      unsaved: trackUnsaved && isUnsaved,
+      context: context && isContextVisible,
+    },
+  });
+
   return (
     <div data-h2-margin="base(0, 0, x.125, 0)">
       <InputWrapper
@@ -214,6 +225,8 @@ const SelectFieldV2 = ({
         inputName={name}
         required={isRequired}
         trackUnsaved={trackUnsaved}
+        onContextToggle={setContextVisible}
+        descriptionIds={descriptionIds}
       >
         <div style={{ width: "100%" }}>
           <Controller
@@ -299,9 +312,7 @@ const SelectFieldV2 = ({
                   onChange={convertSingleOrMultiOptionsToValues}
                   aria-label={label}
                   aria-required={isRequired}
-                  ariaDescription={
-                    error || isUnsaved ? `${id}-error` : undefined
-                  }
+                  ariaDescription={ariaDescribedBy}
                   stateStyles={stateStyles}
                   styles={{
                     placeholder: (provided) => ({

--- a/frontend/common/src/components/form/TextArea/TextArea.tsx
+++ b/frontend/common/src/components/form/TextArea/TextArea.tsx
@@ -3,6 +3,7 @@ import get from "lodash/get";
 import { FieldError, RegisterOptions, useFormContext } from "react-hook-form";
 import { InputWrapper } from "../../inputPartials";
 import { useFieldState, useFieldStateStyles } from "../../../helpers/formUtils";
+import useInputDescribedBy from "../../../hooks/useInputDescribedBy";
 
 export interface TextAreaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -33,6 +34,7 @@ const TextArea: React.FunctionComponent<TextAreaProps> = ({
   whitespaceTrim = true,
   ...rest
 }) => {
+  const [isContextVisible, setContextVisible] = React.useState<boolean>(false);
   const {
     register,
     formState: { errors },
@@ -43,6 +45,14 @@ const TextArea: React.FunctionComponent<TextAreaProps> = ({
   const isUnsaved = fieldState === "dirty" && trackUnsaved;
   // To grab errors in nested objects we need to use lodash's get helper.
   const error = get(errors, name)?.message as FieldError;
+  const [descriptionIds, ariaDescribedBy] = useInputDescribedBy({
+    id,
+    show: {
+      error,
+      unsaved: trackUnsaved && isUnsaved,
+      context: context && isContextVisible,
+    },
+  });
 
   const whitespaceTrimmer = (e: React.FocusEvent<HTMLTextAreaElement>) => {
     if (whitespaceTrim) {
@@ -61,6 +71,8 @@ const TextArea: React.FunctionComponent<TextAreaProps> = ({
         context={context}
         error={error}
         trackUnsaved={trackUnsaved}
+        onContextToggle={setContextVisible}
+        descriptionIds={descriptionIds}
       >
         <textarea
           data-h2-padding="base(x.25, x.5)"
@@ -73,7 +85,7 @@ const TextArea: React.FunctionComponent<TextAreaProps> = ({
           onBlur={whitespaceTrimmer}
           aria-required={rules.required ? "true" : undefined}
           aria-invalid={error ? "true" : "false"}
-          aria-describedby={error || isUnsaved ? `${id}-error` : undefined}
+          aria-describedby={ariaDescribedBy}
           {...rest}
         />
         {children}

--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
@@ -104,6 +104,8 @@ const Fieldset: React.FC<FieldsetProps> = ({
               type="button"
               className="input-label-context-button"
               data-h2-margin="base(0, 0, 0, x.125)"
+              aria-controls={`context-${name}`}
+              aria-expanded={contextIsActive}
               onClick={() =>
                 setContextIsActive((currentState) => !currentState)
               }
@@ -156,6 +158,7 @@ const Fieldset: React.FC<FieldsetProps> = ({
           data-h2-margin="base(x.125, 0, 0, 0)"
         >
           <InputContext
+            id={`context-${name}`}
             isVisible={contextIsActive && !!context}
             context={context}
           />

--- a/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
+++ b/frontend/common/src/components/inputPartials/Fieldset/Fieldset.tsx
@@ -1,17 +1,19 @@
 import React, { useState } from "react";
 import { useIntl } from "react-intl";
 import { QuestionMarkCircleIcon, XCircleIcon } from "@heroicons/react/24/solid";
+
 import { useFieldState, useFieldStateStyles } from "../../../helpers/formUtils";
 import { commonMessages } from "../../../messages";
 import InputContext from "../InputContext/InputContext";
 import InputError, { type InputFieldError } from "../InputError/InputError";
 import InputUnsaved from "../InputUnsaved/InputUnsaved";
+import useInputDescribedBy from "../../../hooks/useInputDescribedBy";
 
 export interface FieldsetProps extends React.HTMLProps<HTMLFieldSetElement> {
   /** The text for the legend element. */
   legend: React.ReactNode;
   /** The name of this form control. */
-  name?: string;
+  name: string;
   /** Controls whether Required or Optional text appears above the fieldset. */
   required?: boolean;
   /** If an error string is provided, it will appear below the fieldset inputs. */
@@ -26,6 +28,8 @@ export interface FieldsetProps extends React.HTMLProps<HTMLFieldSetElement> {
   hideLegend?: boolean;
   /** Determine if it should track unsaved changes and render it */
   trackUnsaved?: boolean;
+  /** If true, the field set has unsaved changes */
+  isUnsaved?: boolean;
 }
 
 const Fieldset: React.FC<FieldsetProps> = ({
@@ -38,6 +42,7 @@ const Fieldset: React.FC<FieldsetProps> = ({
   hideOptional,
   hideLegend,
   children,
+  isUnsaved,
   trackUnsaved = true,
   ...rest
 }) => {
@@ -45,8 +50,14 @@ const Fieldset: React.FC<FieldsetProps> = ({
   const intl = useIntl();
   const fieldState = useFieldState(name ?? "");
   const stateStyles = useFieldStateStyles(name ?? "", !trackUnsaved);
-
-  const ariaDescription = rest["aria-describedby"];
+  const [descriptionIds, ariaDescribedBy] = useInputDescribedBy({
+    id: name,
+    show: {
+      error,
+      unsaved: trackUnsaved && isUnsaved,
+      context: context && contextIsActive,
+    },
+  });
 
   return (
     <fieldset
@@ -57,6 +68,7 @@ const Fieldset: React.FC<FieldsetProps> = ({
         padding: "0",
       }}
       data-h2-margin="base(0, 0, x.125, 0)"
+      aria-describedby={ariaDescribedBy}
       {...rest}
     >
       <legend data-h2-visually-hidden="base(invisible)">{legend}</legend>
@@ -141,7 +153,7 @@ const Fieldset: React.FC<FieldsetProps> = ({
         {children}
       </div>
       <InputUnsaved
-        id={ariaDescription}
+        id={descriptionIds.unsaved}
         isVisible={fieldState === "dirty" && trackUnsaved}
       />
       {error && (
@@ -149,16 +161,20 @@ const Fieldset: React.FC<FieldsetProps> = ({
           data-h2-display="base(block)"
           data-h2-margin="base(x.125, 0, 0, 0)"
         >
-          <InputError id={ariaDescription} isVisible={!!error} error={error} />
+          <InputError
+            id={descriptionIds.error}
+            isVisible={!!error}
+            error={error}
+          />
         </div>
       )}
       {contextIsActive && context && (
         <div
           data-h2-display="base(block)"
           data-h2-margin="base(x.125, 0, 0, 0)"
+          id={descriptionIds.context}
         >
           <InputContext
-            id={`context-${name}`}
             isVisible={contextIsActive && !!context}
             context={context}
           />

--- a/frontend/common/src/components/inputPartials/InputContext/InputContext.tsx
+++ b/frontend/common/src/components/inputPartials/InputContext/InputContext.tsx
@@ -3,14 +3,18 @@ import React from "react";
 export interface InputContextProps {
   isVisible: boolean;
   context: string | React.ReactNode;
+  id: string;
 }
 
 export const InputContext: React.FC<InputContextProps> = ({
   context,
   isVisible,
+  id,
 }) => {
   return isVisible ? (
     <span
+      id={id}
+      role="alert"
       data-h2-display="base(block)"
       data-h2-margin="base(x.25, 0, 0, 0)"
       data-h2-border="base(1px solid dt-primary.light)"
@@ -19,7 +23,6 @@ export const InputContext: React.FC<InputContextProps> = ({
       data-h2-padding="base(x.75)"
       data-h2-color="base(dt-primary)"
       data-h2-font-size="base(caption)"
-      role="alert"
     >
       {context}
     </span>

--- a/frontend/common/src/components/inputPartials/InputContext/InputContext.tsx
+++ b/frontend/common/src/components/inputPartials/InputContext/InputContext.tsx
@@ -3,18 +3,14 @@ import React from "react";
 export interface InputContextProps {
   isVisible: boolean;
   context: string | React.ReactNode;
-  id: string;
 }
 
 export const InputContext: React.FC<InputContextProps> = ({
   context,
   isVisible,
-  id,
 }) => {
   return isVisible ? (
     <span
-      id={id}
-      role="alert"
       data-h2-display="base(block)"
       data-h2-margin="base(x.25, 0, 0, 0)"
       data-h2-border="base(1px solid dt-primary.light)"

--- a/frontend/common/src/components/inputPartials/InputError/InputError.tsx
+++ b/frontend/common/src/components/inputPartials/InputError/InputError.tsx
@@ -17,6 +17,8 @@ export interface InputErrorProps extends React.HTMLProps<HTMLSpanElement> {
 const InputError = ({ error, isVisible, ...rest }: InputErrorProps) => {
   return isVisible ? (
     <span
+      role="alert"
+      aria-live="polite"
       data-h2-display="base(block)"
       data-h2-margin="base(x.25, 0, 0, 0)"
       data-h2-border="base(1px solid dt-error.light)"

--- a/frontend/common/src/components/inputPartials/InputError/InputError.tsx
+++ b/frontend/common/src/components/inputPartials/InputError/InputError.tsx
@@ -17,7 +17,6 @@ export interface InputErrorProps extends React.HTMLProps<HTMLSpanElement> {
 const InputError = ({ error, isVisible, ...rest }: InputErrorProps) => {
   return isVisible ? (
     <span
-      role="alert"
       data-h2-display="base(block)"
       data-h2-margin="base(x.25, 0, 0, 0)"
       data-h2-border="base(1px solid dt-error.light)"
@@ -26,7 +25,6 @@ const InputError = ({ error, isVisible, ...rest }: InputErrorProps) => {
       data-h2-padding="base(x.75)"
       data-h2-color="base(dt-error)"
       data-h2-font-size="base(caption)"
-      aria-live="polite"
       {...rest}
     >
       {error?.toString()}

--- a/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
+++ b/frontend/common/src/components/inputPartials/InputLabel/InputLabel.tsx
@@ -97,6 +97,8 @@ const InputLabel: React.FC<InputLabelProps> = ({
               type="button"
               className="input-label-context-button"
               data-h2-margin="base(0, 0, 0, x.125)"
+              aria-controls={`context-${inputId}`}
+              aria-expanded={contextIsActive}
               onClick={clickHandler}
             >
               <span data-h2-visually-hidden="base(invisible)">

--- a/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
+++ b/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
@@ -5,6 +5,7 @@ import InputError, { InputFieldError } from "../InputError/InputError";
 import InputLabel from "../InputLabel/InputLabel";
 import { useFieldState } from "../../../helpers/formUtils";
 import InputUnsaved from "../InputUnsaved/InputUnsaved";
+import { DescriptionIds } from "../../../hooks/useInputDescribedBy";
 
 export interface InputWrapperProps {
   inputId: string;
@@ -20,6 +21,8 @@ export interface InputWrapperProps {
   hideBottomMargin?: boolean;
   fillLabel?: boolean;
   trackUnsaved?: boolean;
+  descriptionIds?: DescriptionIds;
+  onContextToggle?: (visible: boolean) => void;
 }
 
 const InputWrapper: React.FC<InputWrapperProps> = ({
@@ -34,6 +37,8 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
   hideOptional,
   children,
   hideBottomMargin,
+  onContextToggle,
+  descriptionIds,
   fillLabel = false,
   trackUnsaved = true,
   ...rest
@@ -46,6 +51,13 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
   if (labelSize === "copy") {
     fontSize = { "data-h2-font-size": "base(copy)" };
   }
+
+  const handleContextToggle = (newContext: boolean) => {
+    setContextVisible(newContext);
+    if (onContextToggle) {
+      onContextToggle(newContext);
+    }
+  };
 
   return (
     <>
@@ -62,7 +74,7 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
           fillLabel={fillLabel}
           required={required}
           contextIsVisible={context !== undefined && context !== ""}
-          contextToggleHandler={setContextVisible}
+          contextToggleHandler={handleContextToggle}
           hideOptional={hideOptional}
           hideBottomMargin={hideBottomMargin}
         />
@@ -72,7 +84,7 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
             data-h2-margin="base(0, 0, x.125, 0)"
           >
             <InputError
-              id={`${inputId}-error`}
+              id={descriptionIds?.error}
               isVisible={!!error}
               error={error}
             />
@@ -80,14 +92,14 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
         )}
         {children}
       </div>
-      <InputUnsaved isVisible={isUnsaved} id={`${inputId}-error`} />
+      <InputUnsaved isVisible={isUnsaved} id={descriptionIds?.unsaved} />
       {error && errorPosition === "bottom" && (
         <div
           data-h2-display="base(block)"
           data-h2-margin="base(x.125, 0, 0, 0)"
         >
           <InputError
-            id={`${inputId}-error`}
+            id={descriptionIds?.error}
             isVisible={!!error}
             error={error}
           />
@@ -97,9 +109,9 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
         <div
           data-h2-display="base(block)"
           data-h2-margin="base(x.125, 0, 0, 0)"
+          id={descriptionIds?.context}
         >
           <InputContext
-            id={`context-${inputId}`}
             isVisible={contextVisible && !!context}
             context={context}
           />

--- a/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
+++ b/frontend/common/src/components/inputPartials/InputWrapper/InputWrapper.tsx
@@ -99,6 +99,7 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
           data-h2-margin="base(x.125, 0, 0, 0)"
         >
           <InputContext
+            id={`context-${inputId}`}
             isVisible={contextVisible && !!context}
             context={context}
           />

--- a/frontend/common/src/hooks/useInputDescribedBy.ts
+++ b/frontend/common/src/hooks/useInputDescribedBy.ts
@@ -1,0 +1,62 @@
+import React from "react";
+import { InputFieldError } from "../components/inputPartials/InputError/InputError";
+
+export type InputDescription = "error" | "context" | "unsaved";
+
+export type DescriptionIds = Record<InputDescription, string>;
+
+export type UseInputDescribedByArgs = {
+  id: string;
+  show: {
+    error?: InputFieldError;
+    context?: React.ReactNode;
+    unsaved?: boolean;
+  };
+};
+
+export type UseInputDescribedByReturn = [
+  descriptionIds: DescriptionIds,
+  ariaDescription?: string,
+];
+
+type UseInputDescribedBy = (
+  args: UseInputDescribedByArgs,
+) => UseInputDescribedByReturn;
+
+const useInputDescribedBy: UseInputDescribedBy = ({
+  show: { error, context, unsaved },
+  id,
+}) => {
+  const contextId = `context-${id}`;
+  const errorId = `error-${id}`;
+  const unsavedId = `unsaved-${id}`;
+
+  const ariaDescribedByArray = [];
+
+  if (error) {
+    ariaDescribedByArray.push(errorId);
+  }
+
+  if (context) {
+    ariaDescribedByArray.push(contextId);
+  }
+
+  if (unsaved) {
+    ariaDescribedByArray.push(unsavedId);
+  }
+
+  const ariaDescribedBy = ariaDescribedByArray.length
+    ? ariaDescribedByArray.join(" ")
+    : undefined;
+
+  return [
+    {
+      context: contextId,
+      error: errorId,
+      unsaved: unsavedId,
+    },
+    ariaDescribedBy,
+  ];
+};
+
+export default useInputDescribedBy;

--- a/frontend/common/src/hooks/useInputDescribedBy.ts
+++ b/frontend/common/src/hooks/useInputDescribedBy.ts
@@ -1,12 +1,16 @@
 import React from "react";
 import { InputFieldError } from "../components/inputPartials/InputError/InputError";
 
+/** Keys for the different types of descriptions we are using */
 export type InputDescription = "error" | "context" | "unsaved";
 
+/** Contains the IDs used for each description element */
 export type DescriptionIds = Record<InputDescription, string>;
 
 export type UseInputDescribedByArgs = {
+  /** Unique identifier for the input */
   id: string;
+  /** Determines if each description type is visible or not */
   show: {
     error?: InputFieldError;
     context?: React.ReactNode;
@@ -15,7 +19,9 @@ export type UseInputDescribedByArgs = {
 };
 
 export type UseInputDescribedByReturn = [
+  /** The IDs that will be assigned to each description element */
   descriptionIds: DescriptionIds,
+  /** A space separated string containing the IDs of each visible description element */
   ariaDescription?: string,
 ];
 
@@ -23,6 +29,20 @@ type UseInputDescribedBy = (
   args: UseInputDescribedByArgs,
 ) => UseInputDescribedByReturn;
 
+/**
+ * Use Input Description
+ *
+ * Calculates the `aria-describedby` attribute for
+ * and input based on the visible descriptions
+ *
+ * @param {UseInputDescribedByArgs} args
+ * @param {Object} args.show  The description elements and if they are visible
+ * @param {InputFieldError} args.show.error If the error description is visible
+ * @param {React.ReactNode} args.show.context If the context description is visible
+ * @param {boolean} args.show.unsaved If the unsaved changes description is visible
+ * @param {string}  args.id A unique identifier of the input
+ * @returns {UseInputDescribedByReturn}
+ */
 const useInputDescribedBy: UseInputDescribedBy = ({
   show: { error, context, unsaved },
   id,


### PR DESCRIPTION
🤖 Resolves #5423 

## 👋 Introduction

This fixes the input context being read out twice to JAWS.

## 🕵️ Details

We were using a collapsible element without the `aria-expanded` and `aria-controls` attributes which was causing the assistive technology to read out the context 2-3 times.

> **Note**
> This is technically not an alert but due to it being in an odd order in the DOM (has focusable items between the area and the control) other methods to get the text to work properly were not successful.

## ❓ Possible Future Solution

While this solution works, it may be better to [use the `aria-describedby` attribute to add the contextual text to the input](https://www.w3.org/TR/WCAG20-TECHS/ARIA1.html#:~:text=Example%202%3A%20Using%20aria%2Ddescribedby%20to%20associate%20instructions%20with%20form%20fields) rather than hiding it behind a button.

## 🧪 Testing

This will be difficult to test without JAWS.

1. Build the application `npm run build`
2. Navigate to `/users/{userId}/profile/about-me/edit`
3. Navigate to the Citizenship Status context box
4. Note it tells you that it is expandable
5. Open the menu
6. Expect to hear "Alert: Preference will be given to Canadian citizens and permanent residents of Canada"
7. Confirm it is read out exactly one time


