### PR TITLE
Feature - 5621 - Updates max words limit for pool your work textareas

### DIFF
--- a/apps/web/src/pages/Pools/EditPoolPage/components/WorkTasksSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/WorkTasksSection.tsx
@@ -35,7 +35,7 @@ interface WorkTasksSectionProps {
   onSave: (submitData: WorkTasksSubmitData) => void;
 }
 
-const TEXT_AREA_MAX_WORDS = 200;
+const TEXT_AREA_MAX_WORDS = 400;
 const TEXT_AREA_ROWS = 15;
 
 const WorkTasksSection = ({


### PR DESCRIPTION
🤖 Resolves #5621.

## 👋 Introduction

This PR increases the max words limit for **English - Your work** and **French - Your work** textareas from 200 to 400.

## 🧪 Testing

1. `npm run build`
2. Navigate to **Work tasks** section of Edit Pool `/admin/pools/:poolId/edit#work-tasks`
3. Observe word counter value is 400 (when textarea is empty) below **English - Your work**, **French - Your work** textareas

## 📸 Screenshot

![Screen Shot 2023-02-07 at 09 57 02](https://user-images.githubusercontent.com/3046459/217281218-21d67abc-196a-452a-a9b9-3dd83846862e.png)