### PR TITLE
Feature - 5625 - Removes search request table pool column

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3317,10 +3317,6 @@
     "defaultMessage": "Nom du bassin",
     "description": "Title displayed for the Pool table pool name column."
   },
-  "Htqzxb": {
-    "defaultMessage": "Bassin",
-    "description": "Title displayed on the search request table pool column."
-  },
   "IfWj5I": {
     "defaultMessage": "Toutes les demandes",
     "description": "Heading displayed above the search request component."


### PR DESCRIPTION
🤖 Resolves #5625.

## 👋 Introduction

This PR removes the **Pool** column from the search request table.

## 🧪 Testing

1. `npm run build`
2. Navigate to /admin/dashboard
3. Ensure **Pool** column is not rendered by default and is not in the list of Table columns
4. Navigate to /admin/talent-requests
5. Ensure **Pool** column is not rendered by default and is not in the list of Table columns

## 📸 Screenshots

![Screen Shot 2023-02-07 at 11 50 03](https://user-images.githubusercontent.com/3046459/217312019-8ff368c5-389d-4e24-a776-9ce91bdea6c3.png)
![Screen Shot 2023-02-07 at 11 49 51](https://user-images.githubusercontent.com/3046459/217312022-f257e368-a71f-484a-8f1a-471466ec13c0.png)