### PR TITLE
Bug - 5637 - Fixes `Dialog` close button not visible

### DIFF
--- a/frontend/common/src/components/Dialog/Dialog.tsx
+++ b/frontend/common/src/components/Dialog/Dialog.tsx
@@ -81,6 +81,7 @@ const Content = React.forwardRef<
               data-h2-padding="base(x.5)"
               data-h2-position="base(absolute)"
               data-h2-radius="base(circle)"
+              data-h2-z-index="base(9)"
               aria-label={intl.formatMessage({
                 defaultMessage: "Close dialog",
                 id: "g2X8Fx",


### PR DESCRIPTION
🤖 Resolves #5637.

## 👋 Introduction

This PR adds `z-index` for close button in `Dialog` for the close button to be visible.

## 🧪 Testing

1. `npm run build`
2. Navigate to /indigenous-it-apprentice/
3. Click **Apply Now** button
4. Ensure close dialog **x** button is visible
5. Check for any other instances of where the `Dialog` component is used
6. Ensure close dialog **x** button is visible in all instances

## 📸 Screenshots

![Screen Shot 2023-02-07 at 12 21 39](https://user-images.githubusercontent.com/3046459/217319169-0a082ef3-bb74-4b6e-be32-5bdf8ad7cf1a.png)
![Screen Shot 2023-02-07 at 12 20 39](https://user-images.githubusercontent.com/3046459/217319172-6cbd6340-61c2-4611-a69b-175e6f36e861.png)