### PR TITLE
Add touch to setup

### DIFF
--- a/maintenance/scripts/setup.sh
+++ b/maintenance/scripts/setup.sh
@@ -7,6 +7,7 @@ source ${parent_path}/lib/common.sh
 cd /var/www/html/api
 cp .env.example .env --preserve=all
 ${parent_path}/update_env_appkey.sh .env
+touch ./storage/logs/laravel.log
 composer install --prefer-dist
 php artisan key:generate
 php artisan migrate:fresh --seed


### PR DESCRIPTION
🤖 Resolves #5170 

## 👋 Introduction

This adds a `touch` command to the setup script to ensure that the log exists for owner and permission updates

## 🧪 Testing

1. Run setup on a new workspace
2. Run setup on an existing workspace
3. Ensure the laravel log is universally writable

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/8978655/217329306-d569b8e0-3ce2-450a-aa62-e5c82bdc2063.png)



