### PR TITLE
pool searches stream enum

### DIFF
--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -157,12 +157,12 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
         }),
         accessor: (d) => {
           if (d.name && d.name.en && locale === "en") {
-            return `${d.name.en} ${
+            return `${d.name.en.toLowerCase()} ${
               d.stream ? intl.formatMessage(getPoolStream(d.stream)) : ""
             }`;
           }
           if (d.name && d.name.fr && locale === "fr") {
-            return `${d.name.fr} ${
+            return `${d.name.fr.toLowerCase()} ${
               d.stream ? intl.formatMessage(getPoolStream(d.stream)) : ""
             }`;
           }

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -6,7 +6,10 @@ import { notEmpty } from "@common/helpers/util";
 import { getLocale } from "@common/helpers/localize";
 import { FromArray } from "@common/types/utilityTypes";
 import Pending from "@common/components/Pending";
-import { getAdvertisementStatus } from "@common/constants/localizedConstants";
+import {
+  getAdvertisementStatus,
+  getPoolStream,
+} from "@common/constants/localizedConstants";
 import { commonMessages } from "@common/messages";
 import { getFullPoolAdvertisementTitle } from "@common/helpers/poolUtils";
 import { formatDate, parseDateTimeUtc } from "@common/helpers/dateUtils";
@@ -154,10 +157,14 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
         }),
         accessor: (d) => {
           if (d.name && d.name.en && locale === "en") {
-            return `${d.name.en} ${d.stream ? d.stream : ""}`;
+            return `${d.name.en} ${
+              d.stream ? intl.formatMessage(getPoolStream(d.stream)) : ""
+            }`;
           }
           if (d.name && d.name.fr && locale === "fr") {
-            return `${d.name.fr} ${d.stream ? d.stream : ""}`;
+            return `${d.name.fr} ${
+              d.stream ? intl.formatMessage(getPoolStream(d.stream)) : ""
+            }`;
           }
           return "";
         },


### PR DESCRIPTION
🤖 Resolves (my own urge to rectify something that may never be an issue)

## 👋 Introduction

Realized after merging in PR #5631 and playing with pools table that things could be a little better. 
Stream in the accessor was using enums, therefore was not searchable in french. Which was a little sloppy of me to leave in, sorry ☹️ 

## 🕵️ Details

Stream in pool name is now localized from enums, therefore searchable in proper text in english AND french 

## 🧪 Testing

1. play with search in english and french on /pools

## 📸 Screenshot

BEFORE

![gif](http://g.recordit.co/2B7tqF786F.gif)

AFTER
(website is being glitchy with gif creation so this one is a link)

https://recordit.co/yyEX75AfwJ/

