### PR TITLE
Bug - 5600 - Update table accessors

### DIFF
--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -17,6 +17,7 @@ import useRoutes from "~/hooks/useRoutes";
 import Table, {
   ColumnsOf,
   tableViewItemButtonAccessor,
+  IndividualCell,
 } from "~/components/Table/ClientManagedTable";
 
 // callbacks extracted to separate function to stabilize memoized component
@@ -40,6 +41,8 @@ function dateAccessor(value: Maybe<string>, intl: IntlShape) {
   ) : null;
 }
 
+type Cell = IndividualCell<PoolCandidateSearchRequest>;
+
 interface SearchRequestTableProps {
   poolCandidateSearchRequests: Array<Maybe<PoolCandidateSearchRequest>>;
 }
@@ -60,16 +63,18 @@ export const SearchRequestTable = ({
             "Title displayed for the search request table edit column.",
         }),
         id: "action", // required when accessor is a function
-        accessor: ({ id, fullName }) =>
+        accessor: (d) => `Action ${d.id}`,
+        disableGlobalFilter: true,
+        Cell: ({ row: { original: searchRequest } }: Cell) =>
           tableViewItemButtonAccessor(
-            paths.searchRequestView(id),
+            paths.searchRequestView(searchRequest.id),
             intl.formatMessage({
               defaultMessage: "request",
               id: "gLtTaW",
               description:
                 "Text displayed after View text for Search Request table view action",
             }),
-            fullName || "",
+            searchRequest.fullName || "",
           ),
       },
       {

--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -11,6 +11,7 @@ import { formatDate, parseDateTimeUtc } from "@common/helpers/dateUtils";
 import {
   Maybe,
   PoolCandidateSearchRequest,
+  Scalars,
   useGetPoolCandidateSearchRequestsQuery,
 } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
@@ -29,14 +30,16 @@ const statusAccessor = (
     ? intl.formatMessage(getPoolCandidateSearchStatus(status as string))
     : "";
 
-function dateAccessor(value: Maybe<string>, intl: IntlShape) {
-  return value
-    ? formatDate({
-        date: parseDateTimeUtc(value),
+function dateCell(date: Maybe<Scalars["DateTime"]>, intl: IntlShape) {
+  return date ? (
+    <span>
+      {formatDate({
+        date: parseDateTimeUtc(date),
         formatString: "PPP p",
         intl,
-      })
-    : null;
+      })}
+    </span>
+  ) : null;
 }
 
 type SearchRequestCell = Cell<PoolCandidateSearchRequest>;
@@ -90,7 +93,10 @@ export const SearchRequestTable = ({
           description:
             "Title displayed on the search request table requested date column.",
         }),
-        accessor: ({ requestedDate }) => dateAccessor(requestedDate, intl),
+        accessor: ({ requestedDate }) =>
+          requestedDate ? parseDateTimeUtc(requestedDate).valueOf() : null,
+        Cell: ({ row: { original: searchRequest } }: SearchRequestCell) =>
+          dateCell(searchRequest.requestedDate, intl),
       },
       {
         Header: intl.formatMessage({

--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -17,7 +17,7 @@ import useRoutes from "~/hooks/useRoutes";
 import Table, {
   ColumnsOf,
   tableViewItemButtonAccessor,
-  IndividualCell,
+  Cell,
 } from "~/components/Table/ClientManagedTable";
 
 // callbacks extracted to separate function to stabilize memoized component
@@ -39,7 +39,7 @@ function dateAccessor(value: Maybe<string>, intl: IntlShape) {
     : null;
 }
 
-type Cell = IndividualCell<PoolCandidateSearchRequest>;
+type SearchRequestCell = Cell<PoolCandidateSearchRequest>;
 
 interface SearchRequestTableProps {
   poolCandidateSearchRequests: Array<Maybe<PoolCandidateSearchRequest>>;
@@ -63,7 +63,7 @@ export const SearchRequestTable = ({
         id: "action", // required when accessor is a function
         accessor: (d) => `Action ${d.id}`,
         disableGlobalFilter: true,
-        Cell: ({ row: { original: searchRequest } }: Cell) =>
+        Cell: ({ row: { original: searchRequest } }: SearchRequestCell) =>
           tableViewItemButtonAccessor(
             paths.searchRequestView(searchRequest.id),
             intl.formatMessage({

--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -30,15 +30,13 @@ const statusAccessor = (
     : "";
 
 function dateAccessor(value: Maybe<string>, intl: IntlShape) {
-  return value ? (
-    <span>
-      {formatDate({
+  return value
+    ? formatDate({
         date: parseDateTimeUtc(value),
         formatString: "PPP p",
         intl,
-      })}
-    </span>
-  ) : null;
+      })
+    : null;
 }
 
 type Cell = IndividualCell<PoolCandidateSearchRequest>;
@@ -92,8 +90,7 @@ export const SearchRequestTable = ({
           description:
             "Title displayed on the search request table requested date column.",
         }),
-        accessor: "requestedDate",
-        Cell: ({ value }) => dateAccessor(value, intl),
+        accessor: ({ requestedDate }) => dateAccessor(requestedDate, intl),
       },
       {
         Header: intl.formatMessage({

--- a/apps/web/src/components/Table/ClientManagedTable/index.ts
+++ b/apps/web/src/components/Table/ClientManagedTable/index.ts
@@ -7,7 +7,7 @@ import tableActionsAccessor from "./TableActionButtons";
 
 import type { TableProps, ColumnsOf } from "./Table";
 import type { TableEditButtonProps } from "./TableEditButton";
-import type { IndividualCell } from "./types";
+import type { Cell } from "./types";
 
 export default Table;
 export {
@@ -17,4 +17,4 @@ export {
   tableViewItemButtonAccessor,
   tableActionsAccessor,
 };
-export type { ColumnsOf, TableProps, TableEditButtonProps, IndividualCell };
+export type { ColumnsOf, TableProps, TableEditButtonProps, Cell };

--- a/apps/web/src/components/Table/ClientManagedTable/index.ts
+++ b/apps/web/src/components/Table/ClientManagedTable/index.ts
@@ -7,6 +7,7 @@ import tableActionsAccessor from "./TableActionButtons";
 
 import type { TableProps, ColumnsOf } from "./Table";
 import type { TableEditButtonProps } from "./TableEditButton";
+import type { IndividualCell } from "./types";
 
 export default Table;
 export {
@@ -16,4 +17,4 @@ export {
   tableViewItemButtonAccessor,
   tableActionsAccessor,
 };
-export type { ColumnsOf, TableProps, TableEditButtonProps };
+export type { ColumnsOf, TableProps, TableEditButtonProps, IndividualCell };

--- a/apps/web/src/components/Table/ClientManagedTable/types.ts
+++ b/apps/web/src/components/Table/ClientManagedTable/types.ts
@@ -1,0 +1,8 @@
+export type IndividualRow<T> = {
+  original: T;
+};
+
+export type IndividualCell<T> = {
+  row: IndividualRow<T>;
+  value: string;
+};

--- a/apps/web/src/components/Table/ClientManagedTable/types.ts
+++ b/apps/web/src/components/Table/ClientManagedTable/types.ts
@@ -1,8 +1,8 @@
-export type IndividualRow<T> = {
+export type Row<T> = {
   original: T;
 };
 
-export type IndividualCell<T> = {
-  row: IndividualRow<T>;
+export type Cell<T> = {
+  row: Row<T>;
   value: string;
 };

--- a/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
+++ b/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
@@ -16,12 +16,12 @@ import useRoutes from "~/hooks/useRoutes";
 import Table, {
   ColumnsOf,
   tableEditButtonAccessor,
-  IndividualCell,
+  Cell,
 } from "~/components/Table/ClientManagedTable";
 
 type Data = NonNullable<FromArray<GetClassificationsQuery["classifications"]>>;
 
-type Cell = IndividualCell<Classification>;
+type ClassificationCell = Cell<Classification>;
 
 interface ClassificationTableProps {
   classifications: GetClassificationsQuery["classifications"];
@@ -98,7 +98,7 @@ export const ClassificationTable = ({
         id: "edit",
         accessor: (d) => `Edit ${d.id}`,
         disableGlobalFilter: true,
-        Cell: ({ row: { original: classification } }: Cell) =>
+        Cell: ({ row: { original: classification } }: ClassificationCell) =>
           tableEditButtonAccessor(
             classification.id,
             paths.classificationTable(),

--- a/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
+++ b/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
@@ -10,14 +10,18 @@ import Pending from "@common/components/Pending";
 import {
   GetClassificationsQuery,
   useGetClassificationsQuery,
+  Classification,
 } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
 import Table, {
   ColumnsOf,
   tableEditButtonAccessor,
+  IndividualCell,
 } from "~/components/Table/ClientManagedTable";
 
 type Data = NonNullable<FromArray<GetClassificationsQuery["classifications"]>>;
+
+type Cell = IndividualCell<Classification>;
 
 interface ClassificationTableProps {
   classifications: GetClassificationsQuery["classifications"];
@@ -91,11 +95,14 @@ export const ClassificationTable = ({
           description:
             "Title displayed for the Classification table Edit column.",
         }),
-        accessor: (d) =>
+        id: "edit",
+        accessor: (d) => `Edit ${d.id}`,
+        disableGlobalFilter: true,
+        Cell: ({ row: { original: classification } }: Cell) =>
           tableEditButtonAccessor(
-            d.id,
+            classification.id,
             paths.classificationTable(),
-            `${d.name?.[locale]} ${d.group}-0${d.level}`,
+            `${classification.name?.[locale]} ${classification.group}-0${classification.level}`,
           ), // callback extracted to separate function to stabilize memoized component
       },
     ],

--- a/apps/web/src/pages/Departments/components/DepartmentTable.tsx
+++ b/apps/web/src/pages/Departments/components/DepartmentTable.tsx
@@ -10,7 +10,10 @@ import useRoutes from "~/hooks/useRoutes";
 import Table, {
   ColumnsOf,
   tableEditButtonAccessor,
+  IndividualCell,
 } from "~/components/Table/ClientManagedTable";
+
+type Cell = IndividualCell<Department>;
 
 interface DepartmentTableProps {
   departments: Array<Department>;
@@ -45,12 +48,15 @@ export const DepartmentTable = ({ departments }: DepartmentTableProps) => {
           id: "hTfHUv",
           description: "Title displayed for the Department table Edit column.",
         }),
-        accessor: (d) =>
+        id: "edit",
+        accessor: (d) => `Edit ${d.id}`,
+        disableGlobalFilter: true,
+        Cell: ({ row: { original: department } }: Cell) =>
           tableEditButtonAccessor(
-            d.id,
+            department.id,
             paths.departmentTable(),
-            d.name?.[locale],
-          ), // callback extracted to separate function to stabilize memoized component
+            department.name?.[locale],
+          ),
       },
     ],
     [paths, intl, locale],

--- a/apps/web/src/pages/Departments/components/DepartmentTable.tsx
+++ b/apps/web/src/pages/Departments/components/DepartmentTable.tsx
@@ -10,10 +10,10 @@ import useRoutes from "~/hooks/useRoutes";
 import Table, {
   ColumnsOf,
   tableEditButtonAccessor,
-  IndividualCell,
+  Cell,
 } from "~/components/Table/ClientManagedTable";
 
-type Cell = IndividualCell<Department>;
+type DepartmentCell = Cell<Department>;
 
 interface DepartmentTableProps {
   departments: Array<Department>;
@@ -51,7 +51,7 @@ export const DepartmentTable = ({ departments }: DepartmentTableProps) => {
         id: "edit",
         accessor: (d) => `Edit ${d.id}`,
         disableGlobalFilter: true,
-        Cell: ({ row: { original: department } }: Cell) =>
+        Cell: ({ row: { original: department } }: DepartmentCell) =>
           tableEditButtonAccessor(
             department.id,
             paths.departmentTable(),

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -26,9 +26,11 @@ import {
 import Table, {
   ColumnsOf,
   tableEditButtonAccessor,
+  IndividualCell,
 } from "~/components/Table/ClientManagedTable";
 
 type Data = NonNullable<FromArray<GetPoolsQuery["pools"]>>;
+type Cell = IndividualCell<Pool>;
 
 // callbacks extracted to separate function to stabilize memoized component
 function poolCandidatesLinkAccessor(
@@ -128,12 +130,6 @@ interface PoolTableProps {
   pools: GetPoolsQuery["pools"];
 }
 
-interface IndividualCell {
-  row: {
-    original: Pool;
-  };
-}
-
 export const PoolTable = ({ pools }: PoolTableProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -168,7 +164,7 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
           }
           return "";
         },
-        Cell: ({ row }: IndividualCell) =>
+        Cell: ({ row }: Cell) =>
           viewLinkAccessor(paths.poolView(row.original.id), row.original, intl),
       },
       {
@@ -178,11 +174,10 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
           description:
             "Header for the View Candidates column of the Pools table",
         }),
-        accessor: (d) => {
-          return d.id;
-        },
+        id: "candidates",
+        accessor: (d) => `Candidates ${d.id}`,
         disableGlobalFilter: true,
-        Cell: ({ row }: IndividualCell) =>
+        Cell: ({ row }: Cell) =>
           poolCandidatesLinkAccessor(
             paths.poolCandidateTable(row.original.id),
             intl,
@@ -222,7 +217,7 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
           }
           return classificationsString;
         },
-        Cell: ({ row }: IndividualCell) => {
+        Cell: ({ row }: Cell) => {
           return classificationsCell(row.original.classifications);
         },
         sortType: (rowA, rowB, id, desc) => {
@@ -274,7 +269,7 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
             d.owner && d.owner.lastName ? d.owner.lastName.toLowerCase() : "";
           return `${firstName} ${lastName}`;
         },
-        Cell: ({ row }: IndividualCell) => fullNameCell(row.original, intl),
+        Cell: ({ row }: Cell) => fullNameCell(row.original, intl),
         id: "ownerName",
       },
       {
@@ -286,7 +281,7 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
         accessor: (d) => {
           return d.owner && d.owner.email ? d.owner.email.toLowerCase() : "";
         },
-        Cell: ({ row }: IndividualCell) =>
+        Cell: ({ row }: Cell) =>
           emailLinkAccessor(
             row.original.owner && row.original.owner.email
               ? row.original.owner.email
@@ -301,11 +296,10 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
           id: "tpzt/B",
           description: "Title displayed for the Pool table Edit column.",
         }),
-        accessor: () => {
-          return "Edit";
-        },
+        id: "edit",
+        accessor: (d) => `Edit ${d.id}`,
         disableGlobalFilter: true,
-        Cell: ({ row }: IndividualCell) =>
+        Cell: ({ row }: Cell) =>
           tableEditButtonAccessor(
             row.original.id,
             paths.poolTable(),

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -67,15 +67,13 @@ function viewLinkAccessor(url: string, pool: Pool, intl: IntlShape) {
 }
 
 function dateAccessor(value: Maybe<string>, intl: IntlShape) {
-  return value ? (
-    <span>
-      {formatDate({
+  return value
+    ? formatDate({
         date: parseDateTimeUtc(value),
         formatString: "PPP p",
         intl,
-      })}
-    </span>
-  ) : null;
+      })
+    : "";
 }
 
 const fullNameCell = (pool: Pool, intl: IntlShape) => {
@@ -312,8 +310,7 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
           id: "zAqJMe",
           description: "Title displayed on the Pool table Date Created column",
         }),
-        accessor: "createdDate",
-        Cell: ({ value }) => dateAccessor(value, intl),
+        accessor: ({ createdDate }) => dateAccessor(createdDate, intl),
       },
     ],
     [intl, paths, locale],

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -26,11 +26,11 @@ import {
 import Table, {
   ColumnsOf,
   tableEditButtonAccessor,
-  IndividualCell,
+  Cell,
 } from "~/components/Table/ClientManagedTable";
 
 type Data = NonNullable<FromArray<GetPoolsQuery["pools"]>>;
-type Cell = IndividualCell<Pool>;
+type PoolCell = Cell<Pool>;
 
 // callbacks extracted to separate function to stabilize memoized component
 function poolCandidatesLinkAccessor(
@@ -164,7 +164,7 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
           }
           return "";
         },
-        Cell: ({ row }: Cell) =>
+        Cell: ({ row }: PoolCell) =>
           viewLinkAccessor(paths.poolView(row.original.id), row.original, intl),
       },
       {
@@ -177,7 +177,7 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
         id: "candidates",
         accessor: (d) => `Candidates ${d.id}`,
         disableGlobalFilter: true,
-        Cell: ({ row }: Cell) =>
+        Cell: ({ row }: PoolCell) =>
           poolCandidatesLinkAccessor(
             paths.poolCandidateTable(row.original.id),
             intl,
@@ -217,7 +217,7 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
           }
           return classificationsString;
         },
-        Cell: ({ row }: Cell) => {
+        Cell: ({ row }: PoolCell) => {
           return classificationsCell(row.original.classifications);
         },
         sortType: (rowA, rowB, id, desc) => {
@@ -269,7 +269,7 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
             d.owner && d.owner.lastName ? d.owner.lastName.toLowerCase() : "";
           return `${firstName} ${lastName}`;
         },
-        Cell: ({ row }: Cell) => fullNameCell(row.original, intl),
+        Cell: ({ row }: PoolCell) => fullNameCell(row.original, intl),
         id: "ownerName",
       },
       {
@@ -281,7 +281,7 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
         accessor: (d) => {
           return d.owner && d.owner.email ? d.owner.email.toLowerCase() : "";
         },
-        Cell: ({ row }: Cell) =>
+        Cell: ({ row }: PoolCell) =>
           emailLinkAccessor(
             row.original.owner && row.original.owner.email
               ? row.original.owner.email
@@ -299,7 +299,7 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
         id: "edit",
         accessor: (d) => `Edit ${d.id}`,
         disableGlobalFilter: true,
-        Cell: ({ row }: Cell) =>
+        Cell: ({ row }: PoolCell) =>
           tableEditButtonAccessor(
             row.original.id,
             paths.poolTable(),

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -21,6 +21,7 @@ import {
   GetPoolsQuery,
   Maybe,
   Pool,
+  Scalars,
   useGetPoolsQuery,
 } from "~/api/generated";
 import Table, {
@@ -66,14 +67,16 @@ function viewLinkAccessor(url: string, pool: Pool, intl: IntlShape) {
   );
 }
 
-function dateAccessor(value: Maybe<string>, intl: IntlShape) {
-  return value
-    ? formatDate({
-        date: parseDateTimeUtc(value),
+function dateCell(date: Maybe<Scalars["DateTime"]>, intl: IntlShape) {
+  return date ? (
+    <span>
+      {formatDate({
+        date: parseDateTimeUtc(date),
         formatString: "PPP p",
         intl,
-      })
-    : "";
+      })}
+    </span>
+  ) : null;
 }
 
 const fullNameCell = (pool: Pool, intl: IntlShape) => {
@@ -310,7 +313,10 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
           id: "zAqJMe",
           description: "Title displayed on the Pool table Date Created column",
         }),
-        accessor: ({ createdDate }) => dateAccessor(createdDate, intl),
+        accessor: ({ createdDate }) =>
+          createdDate ? parseDateTimeUtc(createdDate).valueOf() : null,
+        Cell: ({ row: { original: searchRequest } }: PoolCell) =>
+          dateCell(searchRequest.createdDate, intl),
       },
     ],
     [intl, paths, locale],

--- a/apps/web/src/pages/SearchRequests/IndexSearchRequestPage/searchRequestOperations.graphql
+++ b/apps/web/src/pages/SearchRequests/IndexSearchRequestPage/searchRequestOperations.graphql
@@ -7,6 +7,7 @@ query searchPoolCandidates($poolCandidateFilter: PoolCandidateFilterInput) {
       firstName
       lastName
       expectedClassifications {
+        id
         group
         level
       }

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -27,10 +27,7 @@ import {
   OperationalRequirement,
   Applicant,
 } from "~/api/generated";
-import Table, {
-  ColumnsOf,
-  IndividualCell,
-} from "~/components/Table/ClientManagedTable";
+import Table, { ColumnsOf, Cell } from "~/components/Table/ClientManagedTable";
 import useRoutes from "~/hooks/useRoutes";
 import PoolCandidatesTable from "~/components/PoolCandidatesTable/PoolCandidatesTable";
 
@@ -38,7 +35,7 @@ type Data = NonNullable<
   FromArray<SearchPoolCandidatesQuery["searchPoolCandidates"]>
 >;
 
-type Cell = IndividualCell<PoolCandidate>;
+type CandidateCell = Cell<PoolCandidate>;
 
 const TableEditButton: React.FC<{
   poolCandidateId?: string;
@@ -235,7 +232,7 @@ export const SingleSearchRequestTable: React.FunctionComponent<
           description:
             "Title displayed on the single search request table classifications column.",
         }),
-        Cell: ({ row }: Cell) => {
+        Cell: ({ row }: CandidateCell) => {
           return classificationsCell(row.original.user.expectedClassifications);
         },
         accessor: (d) => {
@@ -300,7 +297,7 @@ export const SingleSearchRequestTable: React.FunctionComponent<
           description:
             "Title displayed on the single search request table operational requirements column.",
         }),
-        Cell: ({ row: { original: poolCandidate } }: Cell) =>
+        Cell: ({ row: { original: poolCandidate } }: CandidateCell) =>
           operationalRequirementsCell(
             poolCandidate.user.acceptedOperationalRequirements,
             intl,
@@ -326,7 +323,7 @@ export const SingleSearchRequestTable: React.FunctionComponent<
             "Title displayed on the single search request table employment equity column.",
         }),
         accessor: ({ user }) => employmentEquityAccessor(user, intl),
-        Cell: ({ row: { original: poolCandidate } }: Cell) =>
+        Cell: ({ row: { original: poolCandidate } }: CandidateCell) =>
           employmentEquityCell(poolCandidate.user, intl),
       },
       {
@@ -342,7 +339,7 @@ export const SingleSearchRequestTable: React.FunctionComponent<
           row: {
             original: { user, id, pool },
           },
-        }: Cell) =>
+        }: CandidateCell) =>
           tableEditButtonAccessor(
             id,
             pool?.id,

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -198,7 +198,9 @@ const employmentEquityAccessor = (user: Applicant, intl: IntlShape) =>
           description:
             "Error message displayed on the single search request table employment equity column.",
         }),
-    );
+    )
+    .sort()
+    .join("-");
 
 export const SingleSearchRequestTable: React.FunctionComponent<
   SearchPoolCandidatesQuery

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -336,7 +336,7 @@ export const SingleSearchRequestTable: React.FunctionComponent<
           description:
             "Title displayed for the single search request table edit column.",
         }),
-        accessor: "id",
+        accessor: (d) => `Edit ${d.id}`,
         disableGlobalFilter: true,
         Cell: ({
           row: {

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -303,17 +303,20 @@ export const SingleSearchRequestTable: React.FunctionComponent<
             intl,
           ),
         accessor: ({ user }) =>
-          user.acceptedOperationalRequirements?.map((operationalRequirement) =>
-            intl.formatMessage(
-              operationalRequirement
-                ? getOperationalRequirement(operationalRequirement)
-                : {
-                    defaultMessage: "Error: Name not found.",
-                    description:
-                      "Error message displayed on the single search request table operational requirements column.",
-                  },
-            ),
-          ),
+          user.acceptedOperationalRequirements
+            ?.map((operationalRequirement) =>
+              intl.formatMessage(
+                operationalRequirement
+                  ? getOperationalRequirement(operationalRequirement)
+                  : {
+                      defaultMessage: "Error: Name not found.",
+                      description:
+                        "Error message displayed on the single search request table operational requirements column.",
+                    },
+              ),
+            )
+            .sort()
+            .join(", "),
       },
       {
         Header: intl.formatMessage({

--- a/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
+++ b/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
@@ -19,11 +19,7 @@ import Table, {
 const categoryAccessor = (
   category: SkillCategory | null | undefined,
   intl: IntlShape,
-) => (
-  <span>
-    {category ? intl.formatMessage(getSkillCategory(category as string)) : ""}
-  </span>
-);
+) => (category ? intl.formatMessage(getSkillCategory(category as string)) : "");
 
 type Cell = IndividualCell<SkillFamily>;
 

--- a/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
+++ b/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
@@ -12,6 +12,7 @@ import { SkillFamily, useAllSkillFamiliesQuery } from "~/api/generated";
 import Table, {
   ColumnsOf,
   tableEditButtonAccessor,
+  IndividualCell,
 } from "~/components/Table/ClientManagedTable";
 
 // callbacks extracted to separate function to stabilize memoized component
@@ -23,6 +24,8 @@ const categoryAccessor = (
     {category ? intl.formatMessage(getSkillCategory(category as string)) : ""}
   </span>
 );
+
+type Cell = IndividualCell<SkillFamily>;
 
 interface SkillFamilyTableProps {
   skillFamilies: Array<SkillFamily>;
@@ -76,12 +79,15 @@ export const SkillFamilyTable = ({ skillFamilies }: SkillFamilyTableProps) => {
           description:
             "Title displayed for the Skill Family table Edit column.",
         }),
-        accessor: (sf) =>
+        id: "edit",
+        accessor: (d) => `Edit ${d.id}`,
+        disableGlobalFilter: true,
+        Cell: ({ row: { original: skillFamily } }: Cell) =>
           tableEditButtonAccessor(
-            sf.id,
+            skillFamily.id,
             paths.skillFamilyTable(),
-            sf.name?.[locale],
-          ), // callback extracted to separate function to stabilize memoized component
+            skillFamily.name?.[locale],
+          ),
       },
     ],
     [paths, intl, locale],

--- a/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
+++ b/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
@@ -12,7 +12,7 @@ import { SkillFamily, useAllSkillFamiliesQuery } from "~/api/generated";
 import Table, {
   ColumnsOf,
   tableEditButtonAccessor,
-  IndividualCell,
+  Cell,
 } from "~/components/Table/ClientManagedTable";
 
 // callbacks extracted to separate function to stabilize memoized component
@@ -21,7 +21,7 @@ const categoryAccessor = (
   intl: IntlShape,
 ) => (category ? intl.formatMessage(getSkillCategory(category as string)) : "");
 
-type Cell = IndividualCell<SkillFamily>;
+type SkillFamilyCell = Cell<SkillFamily>;
 
 interface SkillFamilyTableProps {
   skillFamilies: Array<SkillFamily>;
@@ -78,7 +78,7 @@ export const SkillFamilyTable = ({ skillFamilies }: SkillFamilyTableProps) => {
         id: "edit",
         accessor: (d) => `Edit ${d.id}`,
         disableGlobalFilter: true,
-        Cell: ({ row: { original: skillFamily } }: Cell) =>
+        Cell: ({ row: { original: skillFamily } }: SkillFamilyCell) =>
           tableEditButtonAccessor(
             skillFamily.id,
             paths.skillFamilyTable(),

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -96,7 +96,9 @@ export const SkillTable = ({ skills }: SkillTableProps) => {
         accessor: (skill) =>
           skill.families
             ?.map((family) => family?.name?.[locale])
-            .filter(notEmpty),
+            .filter(notEmpty)
+            .sort()
+            .join(", "),
       },
       {
         Header: intl.formatMessage({

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -12,7 +12,7 @@ import { Maybe, Skill, SkillFamily, useAllSkillsQuery } from "~/api/generated";
 import Table, {
   ColumnsOf,
   tableEditButtonAccessor,
-  IndividualCell,
+  Cell,
 } from "~/components/Table/ClientManagedTable";
 
 const skillFamiliesCell = (
@@ -28,7 +28,7 @@ const skillFamiliesCell = (
   return families ? <span>{families}</span> : null;
 };
 
-type Cell = IndividualCell<Skill>;
+type SkillCell = Cell<Skill>;
 
 interface SkillTableProps {
   skills: Array<Skill>;
@@ -91,7 +91,7 @@ export const SkillTable = ({ skills }: SkillTableProps) => {
           description:
             "Title displayed for the skill table Skill Families column.",
         }),
-        Cell: ({ row: { original: skill } }: Cell) =>
+        Cell: ({ row: { original: skill } }: SkillCell) =>
           skillFamiliesCell(skill.families, locale),
         accessor: (skill) =>
           skill.families
@@ -107,7 +107,7 @@ export const SkillTable = ({ skills }: SkillTableProps) => {
         id: "edit",
         accessor: (d) => `Edit ${d.id}`,
         disableGlobalFilter: true,
-        Cell: ({ row: { original: skill } }: Cell) =>
+        Cell: ({ row: { original: skill } }: SkillCell) =>
           tableEditButtonAccessor(
             skill.id,
             paths.skillTable(),

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
@@ -11,18 +11,14 @@ import useRoutes from "~/hooks/useRoutes";
 import Table, {
   ColumnsOf,
   tableActionsAccessor,
+  IndividualCell,
 } from "~/components/Table/ClientManagedTable";
 
 interface TeamTableProps {
   teams: Array<Team>;
 }
 
-interface ICell {
-  value: string;
-  row: {
-    original: Team;
-  };
-}
+type Cell = IndividualCell<Team>;
 
 const viewAccessor = (url: string, label: Maybe<string>, intl: IntlShape) => (
   <Link href={url} type="link">
@@ -77,7 +73,7 @@ export const TeamTable = ({ teams }: TeamTableProps) => {
           description: "Title displayed for the teams table team column.",
         }),
         accessor: (d) => (d?.displayName ? d.displayName[locale] : d.name),
-        Cell: ({ row, value }: ICell) =>
+        Cell: ({ row, value }: Cell) =>
           viewAccessor(paths.teamView(row.original.id), value, intl),
       },
       {
@@ -103,7 +99,7 @@ export const TeamTable = ({ teams }: TeamTableProps) => {
           description: "Title displayed for the teams table email column.",
         }),
         accessor: (d) => d.contactEmail,
-        Cell: ({ value }: ICell) => emailLinkAccessor(value, intl),
+        Cell: ({ value }: Cell) => emailLinkAccessor(value, intl),
       },
     ],
     [paths, intl, locale],

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
@@ -11,14 +11,14 @@ import useRoutes from "~/hooks/useRoutes";
 import Table, {
   ColumnsOf,
   tableActionsAccessor,
-  IndividualCell,
+  Cell,
 } from "~/components/Table/ClientManagedTable";
 
 interface TeamTableProps {
   teams: Array<Team>;
 }
 
-type Cell = IndividualCell<Team>;
+type TeamCell = Cell<Team>;
 
 const viewAccessor = (url: string, label: Maybe<string>, intl: IntlShape) => (
   <Link href={url} type="link">
@@ -73,7 +73,7 @@ export const TeamTable = ({ teams }: TeamTableProps) => {
           description: "Title displayed for the teams table team column.",
         }),
         accessor: (d) => (d?.displayName ? d.displayName[locale] : d.name),
-        Cell: ({ row, value }: Cell) =>
+        Cell: ({ row, value }: TeamCell) =>
           viewAccessor(paths.teamView(row.original.id), value, intl),
       },
       {
@@ -99,7 +99,7 @@ export const TeamTable = ({ teams }: TeamTableProps) => {
           description: "Title displayed for the teams table email column.",
         }),
         accessor: (d) => d.contactEmail,
-        Cell: ({ value }: Cell) => emailLinkAccessor(value, intl),
+        Cell: ({ value }: TeamCell) => emailLinkAccessor(value, intl),
       },
     ],
     [paths, intl, locale],


### PR DESCRIPTION
🤖 Resolves #5600 

## 👋 Introduction

This updates our `ClientManagedTable` components to use the `Cell` attribute instead of `accessor` to render non-primitive values.

## 🕵️ Details

We were using `accessor` to render any value (even JSX). However, the docs state that we should be using `Cell` instead and [make `accessor` a primitive value](https://react-table-v7.tanstack.com/docs/api/useTable#column-options:~:text=The%20data%20returned%20by%20an%20accessor%20should%20be%20primitive%20and%20sortable.).

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build the app `npm run build`
2. Navigate to each table
3. Confirm they still function as expected
    - Search
    - Sort
    - Rendering values


