### PR TITLE
New placeholder admin pages

### DIFF
--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -321,7 +321,12 @@ const ViewUserPageV2 = React.lazy(() =>
   ),
 );
 const UserPlacementPage = React.lazy(() =>
-  lazyRetry(() => import("../pages/Users/UserPlacementPage/UserPlacementPage")),
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminUserPlacementPage" */ "../pages/Users/UserPlacementPage/UserPlacementPage"
+      ),
+  ),
 );
 
 /** Teams */
@@ -330,6 +335,38 @@ const IndexTeamPage = React.lazy(() =>
     () =>
       import(
         /* webpackChunkName: "adminIndexTeamPage" */ "../pages/Teams/IndexTeamPage/IndexTeamPage"
+      ),
+  ),
+);
+const CreateTeamPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminCreateTeamPage" */ "../pages/Teams/CreateTeamPage/CreateTeamPage"
+      ),
+  ),
+);
+const ViewTeamPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminViewTeamPage" */ "../pages/Teams/ViewTeamPage/ViewTeamPage"
+      ),
+  ),
+);
+const UpdateTeamPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminUpdateTeamPage" */ "../pages/Teams/UpdateTeamPage/UpdateTeamPage"
+      ),
+  ),
+);
+const TeamMembersPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminTeamMembersPage" */ "../pages/Teams/TeamMembersPage/TeamMembersPage"
       ),
   ),
 );
@@ -969,35 +1006,55 @@ const createRoute = (locale: Locales, loginPath: string) =>
                     </RequireAuth>
                   ),
                 },
-                // {
-                //   path: "create",
-                //   element: (
-                //     <RequireAuth roles={[LegacyRole.Admin]} loginPath={loginPath}>
-                //       <CreateTeamPage />
-                //     </RequireAuth>
-                //   ),
-                // },
-                // {
-                //   path: ":teamId",
-                //   children: [
-                //     {
-                //       index: true,
-                //       element: (
-                //         <RequireAuth roles={[LegacyRole.Admin]} loginPath={loginPath}>
-                //           <ViewTeamPage />
-                //         </RequireAuth>
-                //       ),
-                //     },
-                //     {
-                //       path: "edit",
-                //       element: (
-                //         <RequireAuth roles={[LegacyRole.Admin]} loginPath={loginPath}>
-                //           <UpdateTeamPage />
-                //         </RequireAuth>
-                //       ),
-                //     },
-                //   ],
-                // },
+                {
+                  path: "create",
+                  element: (
+                    <RequireAuth
+                      roles={[LegacyRole.Admin]}
+                      loginPath={loginPath}
+                    >
+                      <CreateTeamPage />
+                    </RequireAuth>
+                  ),
+                },
+                {
+                  path: ":teamId",
+                  children: [
+                    {
+                      index: true,
+                      element: (
+                        <RequireAuth
+                          roles={[LegacyRole.Admin]}
+                          loginPath={loginPath}
+                        >
+                          <ViewTeamPage />
+                        </RequireAuth>
+                      ),
+                    },
+                    {
+                      path: "edit",
+                      element: (
+                        <RequireAuth
+                          roles={[LegacyRole.Admin]}
+                          loginPath={loginPath}
+                        >
+                          <UpdateTeamPage />
+                        </RequireAuth>
+                      ),
+                    },
+                    {
+                      path: "members",
+                      element: (
+                        <RequireAuth
+                          roles={[LegacyRole.Admin]}
+                          loginPath={loginPath}
+                        >
+                          <TeamMembersPage />
+                        </RequireAuth>
+                      ),
+                    },
+                  ],
+                },
               ],
             },
             {

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -312,6 +312,17 @@ const ViewUserPage = React.lazy(() =>
       ),
   ),
 );
+const ViewUserPageV2 = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminViewUserPage" */ "../pages/Users/ViewUserPageV2/ViewUserPage"
+      ),
+  ),
+);
+const UserPlacementPage = React.lazy(() =>
+  lazyRetry(() => import("../pages/Users/UserPlacementPage/UserPlacementPage")),
+);
 
 /** Teams */
 const IndexTeamPage = React.lazy(() =>
@@ -904,6 +915,28 @@ const createRoute = (locale: Locales, loginPath: string) =>
                           loginPath={loginPath}
                         >
                           <ViewUserPage />
+                        </RequireAuth>
+                      ),
+                    },
+                    {
+                      path: "profile",
+                      element: (
+                        <RequireAuth
+                          roles={[LegacyRole.Admin]}
+                          loginPath={loginPath}
+                        >
+                          <ViewUserPageV2 />
+                        </RequireAuth>
+                      ),
+                    },
+                    {
+                      path: "placement",
+                      element: (
+                        <RequireAuth
+                          roles={[LegacyRole.Admin]}
+                          loginPath={loginPath}
+                        >
+                          <UserPlacementPage />
                         </RequireAuth>
                       ),
                     },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5618,5 +5618,29 @@
   "s7QD5B": {
     "defaultMessage": "Modifier <hidden>{title}</hidden>",
     "description": "Text label for button to edit employment equity category from profile."
+  },
+  "BkH0qC": {
+    "defaultMessage": "Profil d’utilisateur",
+    "description": "Page title for the view user profile page"
+  },
+  "/WvEvL": {
+    "defaultMessage": "Information relative au stage",
+    "description": "Page title for the user placement information page"
+  },
+  "vyyfX6": {
+    "defaultMessage": "Créer une nouvelle équipe",
+    "description": "Page title for the create team page"
+  },
+  "SXoCma": {
+    "defaultMessage": "Renseignements sur l’équipe",
+    "description": "Page title for the view team page"
+  },
+  "zEmPCS": {
+    "defaultMessage": "Modifier les renseignements sur l’équipe",
+    "description": "Page title for the edit team page"
+  },
+  "6rb9mg": {
+    "defaultMessage": "Membres de l’équipe",
+    "description": "Page title for the view team members page"
   }
 }

--- a/apps/web/src/pages/Teams/CreateTeamPage/CreateTeamPage.tsx
+++ b/apps/web/src/pages/Teams/CreateTeamPage/CreateTeamPage.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { useIntl } from "react-intl";
+import { BuildingOffice2Icon } from "@heroicons/react/24/outline";
+
+import PageHeader from "@common/components/PageHeader";
+import SEO from "@common/components/SEO/SEO";
+
+const CreateTeamPage = () => {
+  const intl = useIntl();
+
+  const pageTitle = intl.formatMessage({
+    defaultMessage: "Create a new team",
+    id: "vyyfX6",
+    description: "Page title for the create team page",
+  });
+
+  return (
+    <>
+      <SEO title={pageTitle} />
+      <PageHeader icon={BuildingOffice2Icon}>{pageTitle}</PageHeader>
+    </>
+  );
+};
+
+export default CreateTeamPage;

--- a/apps/web/src/pages/Teams/TeamMembersPage/TeamMembersPage.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/TeamMembersPage.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { useIntl } from "react-intl";
+import { BuildingOffice2Icon } from "@heroicons/react/24/outline";
+
+import PageHeader from "@common/components/PageHeader";
+import SEO from "@common/components/SEO/SEO";
+
+const TeamMembersPage = () => {
+  const intl = useIntl();
+
+  const pageTitle = intl.formatMessage({
+    defaultMessage: "Team members",
+    id: "6rb9mg",
+    description: "Page title for the view team members page",
+  });
+
+  return (
+    <>
+      <SEO title={pageTitle} />
+      <PageHeader icon={BuildingOffice2Icon}>{pageTitle}</PageHeader>
+    </>
+  );
+};
+
+export default TeamMembersPage;

--- a/apps/web/src/pages/Teams/UpdateTeamPage/UpdateTeamPage.tsx
+++ b/apps/web/src/pages/Teams/UpdateTeamPage/UpdateTeamPage.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { useIntl } from "react-intl";
+import { BuildingOffice2Icon } from "@heroicons/react/24/outline";
+
+import PageHeader from "@common/components/PageHeader";
+import SEO from "@common/components/SEO/SEO";
+
+const EditTeamPage = () => {
+  const intl = useIntl();
+
+  const pageTitle = intl.formatMessage({
+    defaultMessage: "Edit team information",
+    id: "zEmPCS",
+    description: "Page title for the edit team page",
+  });
+
+  return (
+    <>
+      <SEO title={pageTitle} />
+      <PageHeader icon={BuildingOffice2Icon}>{pageTitle}</PageHeader>
+    </>
+  );
+};
+
+export default EditTeamPage;

--- a/apps/web/src/pages/Teams/ViewTeamPage/ViewTeamPage.tsx
+++ b/apps/web/src/pages/Teams/ViewTeamPage/ViewTeamPage.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { useIntl } from "react-intl";
+import { BuildingOffice2Icon } from "@heroicons/react/24/outline";
+
+import PageHeader from "@common/components/PageHeader";
+import SEO from "@common/components/SEO/SEO";
+
+const ViewTeamPage = () => {
+  const intl = useIntl();
+
+  const pageTitle = intl.formatMessage({
+    defaultMessage: "Team information",
+    id: "SXoCma",
+    description: "Page title for the view team page",
+  });
+
+  return (
+    <>
+      <SEO title={pageTitle} />
+      <PageHeader icon={BuildingOffice2Icon}>{pageTitle}</PageHeader>
+    </>
+  );
+};
+
+export default ViewTeamPage;

--- a/apps/web/src/pages/Users/UserPlacementPage/UserPlacementPage.tsx
+++ b/apps/web/src/pages/Users/UserPlacementPage/UserPlacementPage.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { useIntl } from "react-intl";
+import { UserIcon } from "@heroicons/react/24/outline";
+
+import PageHeader from "@common/components/PageHeader";
+import SEO from "@common/components/SEO/SEO";
+
+const UserPlacementPage = () => {
+  const intl = useIntl();
+
+  const pageTitle = intl.formatMessage({
+    defaultMessage: "Placement information",
+    id: "/WvEvL",
+    description: "Page title for the user placement information page",
+  });
+
+  return (
+    <>
+      <SEO title={pageTitle} />
+      <PageHeader icon={UserIcon}>{pageTitle}</PageHeader>
+    </>
+  );
+};
+
+export default UserPlacementPage;

--- a/apps/web/src/pages/Users/ViewUserPageV2/ViewUserPage.tsx
+++ b/apps/web/src/pages/Users/ViewUserPageV2/ViewUserPage.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { useIntl } from "react-intl";
+import { UserIcon } from "@heroicons/react/24/outline";
+
+import PageHeader from "@common/components/PageHeader";
+import SEO from "@common/components/SEO/SEO";
+
+const ViewUserPage = () => {
+  const intl = useIntl();
+
+  const pageTitle = intl.formatMessage({
+    defaultMessage: "User profile",
+    id: "BkH0qC",
+    description: "Page title for the view user profile page",
+  });
+
+  return (
+    <>
+      <SEO title={pageTitle} />
+      <PageHeader icon={UserIcon}>{pageTitle}</PageHeader>
+    </>
+  );
+};
+
+export default ViewUserPage;


### PR DESCRIPTION
🤖 Resolves #5656 

## 👋 Introduction

Adds placeholder routes for some new admin pages.

## 🕵️ Details

We already have a ViewUserPage but at a different route (`/admin/users/{id}` vs `/admin/users/{id}/profile`) so the new page is referred to as ViewUserPageV2 a couple times.

## 🧪 Testing

Navigate to each of the following routes confirming there is a placeholder page with just a title at each of them:

- `/admin/users/{id}/profile`
- `/admin/users/{id}/placement`
- `/admin/teams/create`
- `/admin/teams/{id}`
- `/admin/teams/{id}/edit`
- `/admin/teams/{id}/members`

