### PR TITLE
Feature - 5619 - Updates description blurb for Work, Community Experience forms

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -849,7 +849,7 @@
     "defaultMessage": "Expérience acquise en faisant partie d’une collectivité ou en lui rendant la pareille? Les personnes apprennent des compétences à partir d’un vaste éventail d’expériences comme le bénévolat et celles acquises dans des organismes sans but lucratif, des communautés autochtones ou des collaborations virtuelles.",
     "description": "Description blurb for Community Experience form"
   },
-  "i17oNt": {
+  "qjMTk9": {
     "defaultMessage": "Faites part de vos expériences acquises dans le cadre d’un emploi à temps plein, d’un emploi à temps partiel, d’un travail indépendant, de bourses de recherche ou de stages.",
     "description": "Description blurb for Work Experience form"
   },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -845,7 +845,7 @@
     "defaultMessage": "Type d’études",
     "description": "Label displayed on Education form for education type input"
   },
-  "gDQZIQ": {
+  "6XVNkV": {
     "defaultMessage": "Expérience acquise en faisant partie d’une collectivité ou en lui rendant la pareille? Les personnes apprennent des compétences à partir d’un vaste éventail d’expériences comme le bénévolat et celles acquises dans des organismes sans but lucratif, des communautés autochtones ou des collaborations virtuelles.",
     "description": "Description blurb for Community Experience form"
   },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -850,7 +850,7 @@
     "description": "Description blurb for Community Experience form"
   },
   "qjMTk9": {
-    "defaultMessage": "Faites part de vos expériences acquises dans le cadre d’un emploi à temps plein, d’un emploi à temps partiel, d’un travail indépendant, de bourses de recherche ou de stages.",
+    "defaultMessage": "Partagez les expériences que vous avez acquises dans des postes à temps plein, à temps partiel, du travail autonome, des bourses de recherche, et des stages. Vous n’avez pas nécessairement besoin de tout partager. Misez plutôt sur les expériences qui ont trait à la possibilité qui vous intéresse.",
     "description": "Description blurb for Work Experience form"
   },
   "i55f5L": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -846,7 +846,7 @@
     "description": "Label displayed on Education form for education type input"
   },
   "6XVNkV": {
-    "defaultMessage": "Expérience acquise en faisant partie d’une collectivité ou en lui rendant la pareille? Les personnes apprennent des compétences à partir d’un vaste éventail d’expériences comme le bénévolat et celles acquises dans des organismes sans but lucratif, des communautés autochtones ou des collaborations virtuelles.",
+    "defaultMessage": "Les gens acquièrent des compétences à partir d’une vaste gamme d’expériences, comme le bénévolat ou le fait de faire partie d’un organisme à but non-lucratif, de communautés autochtones ou de collaborations virtuelles. Il pourrait s’agir de n’importe quoi dont, notamment : le fait d’aider dans le cadre d’événements ou de cérémonies, faire le troc, servir de DJ aux noces d’un ami, jouer des jeux et diffuser en temps réel.",
     "description": "Description blurb for Community Experience form"
   },
   "qjMTk9": {

--- a/apps/web/src/pages/Profile/ExperienceFormPage/components/CommunityFormFields/CommunityFormFields.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/components/CommunityFormFields/CommunityFormFields.tsx
@@ -29,8 +29,8 @@ export const CommunityExperienceForm = ({ labels }: SubExperienceFormProps) => {
       <p>
         {intl.formatMessage({
           defaultMessage:
-            "Gained experience by being part of or giving back to a community? People learn skills from a wide range of experiences like volunteering or being part of non-profit organizations, indigenous communities, or virtual collaborations.",
-          id: "gDQZIQ",
+            "People learn skills from a wide range of experiences like volunteering or being part of non-profit organizations, Indigenous communities, or virtual collaborations. Have you gained experience by being part of or giving back to a community? This could be anything from: helping during events and ceremonies, bartering, DJing at a friend's wedding, to gaming and streaming.",
+          id: "6XVNkV",
           description: "Description blurb for Community Experience form",
         })}
       </p>

--- a/apps/web/src/pages/Profile/ExperienceFormPage/components/WorkFormFields/WorkFormFields.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/components/WorkFormFields/WorkFormFields.tsx
@@ -29,8 +29,8 @@ export const WorkExperienceForm = ({ labels }: SubExperienceFormProps) => {
       <p>
         {intl.formatMessage({
           defaultMessage:
-            "Share your experiences gained from full-time, part-time, self-employment, fellowships or internships.",
-          id: "i17oNt",
+            "Share your experiences gained from full-time positions, part-time positions, self-employment, fellowships, and internships. You don't necessarily need to share everything. Instead, focus on experiences related to the opportunity that you are interested in.",
+          id: "qjMTk9",
           description: "Description blurb for Work Experience form",
         })}
       </p>


### PR DESCRIPTION
🤖 Resolves #5619.

## 👋 Introduction

This PR updates English and French copy for the "Description blurb for Work Experience form" and the "Description blurb for Community Experience form".

## 🧪 Testing

1. `npm run build`
2. Navigate to `/users/:id/profile/experiences/community/create`
3. Verify paragraph under **1. Community Experience Details** matches issue copy
4. Switch to French
5. Verify paragraph under **1. Détails de l’expérience communautaire** is in French and matches corresponding copy in fr.json
6. Navigate to `/users/:id/profile/experiences/work/create`
7. Verify paragraph under **1. Work Experience Details** matches issue copy
8. Switch to French
9. Verify paragraph under **1. Détails de l’expérience de travail** is in French and matches corresponding copy in fr.json

## 📸 Screenshots

![Screen Shot 2023-02-10 at 13 31 44](https://user-images.githubusercontent.com/3046459/218170102-2d69e432-f660-4de1-a31e-2924ebc26a33.png)
![Screen Shot 2023-02-10 at 13 31 29](https://user-images.githubusercontent.com/3046459/218170103-955effcc-6db6-4e34-943d-c9d29905e93d.png)