### PR TITLE
Allow IconButton to accept a ref

### DIFF
--- a/frontend/common/src/components/Button/IconButton.tsx
+++ b/frontend/common/src/components/Button/IconButton.tsx
@@ -1,16 +1,17 @@
 import React from "react";
 import Button from "./Button";
-import type { ButtonProps } from "./Button";
 
-// NOTE: We should find a way to not need to omit ref
-export interface IconButtonProps extends Omit<ButtonProps, "ref"> {
+export type IconButtonProps = React.ComponentPropsWithoutRef<typeof Button> & {
   icon?: React.FC<React.SVGProps<SVGSVGElement>>;
-}
+};
 
-const IconButton: React.FC<IconButtonProps> = ({ icon, children, ...rest }) => {
+const IconButton = React.forwardRef<
+  React.ElementRef<typeof Button>,
+  IconButtonProps
+>(({ icon, children, ...rest }, ref) => {
   const Icon = icon || null;
   return (
-    <Button {...rest}>
+    <Button ref={ref} {...rest}>
       <span data-h2-display="base(flex)" data-h2-align-items="base(center)">
         {Icon && (
           <Icon
@@ -22,6 +23,6 @@ const IconButton: React.FC<IconButtonProps> = ({ icon, children, ...rest }) => {
       </span>
     </Button>
   );
-};
+});
 
 export default IconButton;

--- a/frontend/common/src/components/Dialog/Dialog.test.tsx
+++ b/frontend/common/src/components/Dialog/Dialog.test.tsx
@@ -6,10 +6,11 @@ import { fireEvent, screen } from "@testing-library/react";
 import React from "react";
 
 import { faker } from "@faker-js/faker";
+import { PlusIcon } from "@heroicons/react/24/outline";
 import { render, axeTest } from "../../helpers/testUtils";
 
 import Dialog from ".";
-import Button from "../Button";
+import Button, { IconButton } from "../Button";
 
 type DialogRootPrimitivePropsWithoutRef = React.ComponentPropsWithoutRef<
   typeof Dialog.Root
@@ -91,5 +92,34 @@ describe("Dialog", () => {
     expect(
       screen.queryByRole("dialog", { name: /dialog title/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("should work with an IconButton", async () => {
+    renderDialog({
+      children: (
+        <>
+          <Dialog.Trigger>
+            <IconButton icon={PlusIcon}>Open Dialog</IconButton>
+          </Dialog.Trigger>
+          <Dialog.Content>
+            <Dialog.Header color="ia-primary" subtitle="Dialog Subtitle">
+              Dialog Title
+            </Dialog.Header>
+            <p>{faker.lorem.sentences(3)}</p>
+            <Dialog.Footer>
+              <Dialog.Close>
+                <Button color="cta">Close Action</Button>
+              </Dialog.Close>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </>
+      ),
+    });
+
+    fireEvent.click(await screen.getByRole("button", { name: /open dialog/i }));
+
+    expect(
+      screen.queryByRole("dialog", { name: /dialog title/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9511,16 +9511,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.1.14",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/icu-skeleton-parser": "1.3.18",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@formatjs/icu-skeleton-parser": {
       "version": "1.3.18",
       "license": "MIT",
@@ -42580,15 +42570,6 @@
       "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.8.tgz",
       "integrity": "sha512-PemNUObyoIZcqdQ1ixTPugzAzhEj7j6AHIyrq/qR6x5BFTvOQeXHYsVZUqBEFduAIscUaDfou+U+xTqOiunJ3Q==",
       "requires": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "@formatjs/icu-messageformat-parser": {
-      "version": "2.1.14",
-      "dev": true,
-      "requires": {
-        "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/icu-skeleton-parser": "1.3.18",
         "tslib": "^2.4.0"
       }
     },


### PR DESCRIPTION
🤖 Resolves #4656 

## 👋 Introduction

This adds the ability to forward a ref to underlying Button component for IconButton.

## 🕵️ Details

This turned out to be a blocker for #4389 so I pulled it in here.  I guess the Dialog component relies on passing a ref to the trigger button so it was emitting warnings when I tried to use an IconButton as the trigger.

Read more here: https://beta.reactjs.org/learn/manipulating-the-dom-with-refs#accessing-another-components-dom-nodes

## 🧪 Testing

1. Review the new test
2. Observe that the test passes
3. Feel good that I pulled this commit into my PR for #4389 and confirmed that it fixed the problem :smile: 


