### PR TITLE
bug/5699-PoolInfoCard-salary-range

### DIFF
--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/poolAdvertisementOperations.graphql
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/poolAdvertisementOperations.graphql
@@ -43,6 +43,8 @@ query getPoolAdvertisement($id: UUID!) {
         en
         fr
       }
+      minSalary
+      maxSalary
       genericJobTitles {
         id
         key


### PR DESCRIPTION
🤖 Resolves #5699 

## 👋 Introduction

Makes `PoolInfoCard` render salary correctly.

## 🕵️ Details

Was just missing salary in the fields requested by the API operation. 

## 🧪 Testing

1. head to `/en/browse/pools/:poolid` and assert salary range is rendered 

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/40485260/218221542-7b4c9561-e8e7-4c1c-aa25-e7d86941d0b6.png)




