### PR TITLE
feature/4240-admin-header-link

### DIFF
--- a/apps/web/src/components/Layout/Layout.tsx
+++ b/apps/web/src/components/Layout/Layout.tsx
@@ -94,16 +94,16 @@ const Layout = () => {
       loggedInUser.legacyRoles.length > 0 &&
       loggedInUser.legacyRoles.includes(LegacyRole.Admin)
     ) {
-      const adminLink = (
+      menuItems = [
+        ...menuItems,
         <MenuLink key="adminDashboard" to={paths.adminDashboard()}>
           {intl.formatMessage({
             defaultMessage: "Admin",
             id: "wHX/8C",
             description: "Title tag for Admin site",
           })}
-        </MenuLink>
-      );
-      menuItems.push(adminLink);
+        </MenuLink>,
+      ];
     }
   }
 

--- a/apps/web/src/components/Layout/Layout.tsx
+++ b/apps/web/src/components/Layout/Layout.tsx
@@ -15,6 +15,7 @@ import NavMenu from "@common/components/NavMenu";
 import Header from "@common/components/Header";
 
 import useRoutes from "~/hooks/useRoutes";
+import { LegacyRole } from "~/api/generated";
 
 interface LogoutButtonProps extends React.HTMLProps<HTMLButtonElement> {
   children: React.ReactNode;
@@ -88,6 +89,22 @@ const Layout = () => {
         })}
       </MenuLink>,
     ];
+    if (
+      loggedInUser?.legacyRoles &&
+      loggedInUser.legacyRoles.length > 0 &&
+      loggedInUser.legacyRoles.includes(LegacyRole.Admin)
+    ) {
+      const adminLink = (
+        <MenuLink key="adminDashboard" to={paths.adminDashboard()}>
+          {intl.formatMessage({
+            defaultMessage: "Admin",
+            id: "wHX/8C",
+            description: "Title tag for Admin site",
+          })}
+        </MenuLink>
+      );
+      menuItems.push(adminLink);
+    }
   }
 
   let authLinks = [


### PR DESCRIPTION
🤖 Resolves #4240 

## 👋 Introduction

If logged in as an admin, display a link to the admin dashboard in the navigation menu. 

## 🕵️ Details

Adding to the menu was straightforward, the complicating factor is the red text.
I realized the issue is with some things that will need to be refactored. 

The links are `<MenuLink>` components and there styling is run here
https://github.com/GCTC-NTGC/gc-digital-talent/blob/eb1abe5786e14b934d484a079bc1aa32af4842dc/frontend/common/src/components/Link/MenuLink.tsx#L9-L19

Note the `type`. 

The styling function is this one, and it only returns styling for buttons, meaning something needs to be made to style link types.

https://github.com/GCTC-NTGC/gc-digital-talent/blob/eb1abe5786e14b934d484a079bc1aa32af4842dc/frontend/common/src/components/Link/useCommonLinkStyles.ts#L21-L36

Will make an issue for this...

## 🧪 Testing

1. head to `http://localhost:8000/en/`
2. as a guest, ensure you don't see the admin link
3. as an applicant, ensure you don't see the admin link
4. as an admin, ensure you DO see the admin link and it links you to `/admin`

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/40485260/218567542-091f5739-746a-4d65-b1a3-28d3c0ba27e9.png)

