### PR TITLE
Debt - 5171 - Fix TS Cypress Warning

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           spec: "**/*.cy.js"
           browser: chrome
-          config-file: cypress.config.js
+          config-file: cypress.config.ts
           project: ./apps/e2e
           # See: https://github.com/cypress-io/github-action/issues/489#issuecomment-1021379037
           command-prefix: "--"

--- a/apps/e2e/cypress.config.ts
+++ b/apps/e2e/cypress.config.ts
@@ -1,8 +1,8 @@
-const { defineConfig } = require('cypress')
+import { defineConfig } from "cypress"
 
 const extendedTimeout = 60000;
 
-module.exports = defineConfig({
+export default defineConfig({
   defaultCommandTimeout: process.env.CYPRESS_EXTEND_TIMEOUTS ? extendedTimeout : 8000,
   pageLoadTimeout: process.env.CYPRESS_EXTEND_TIMEOUTS ? extendedTimeout : 60000,
   requestTimeout: process.env.CYPRESS_EXTEND_TIMEOUTS ? extendedTimeout : 5000,
@@ -18,7 +18,6 @@ module.exports = defineConfig({
   viewportHeight: 1080,
   videoCompression: 15,
   chromeWebSecurity: true,
-  authServerRoot: 'http://localhost:8000/oxauth',
   e2e: {
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.

--- a/apps/e2e/cypress/e2e/admin/auth.cy.js
+++ b/apps/e2e/cypress/e2e/admin/auth.cy.js
@@ -1,8 +1,11 @@
 import { aliasQuery } from "../../support/graphql-test-utils";
+
+const AUTH_SERVER_ROOT = 'http://localhost:8000/oxauth';
+
 describe('Auth flows (development)', () => {
   // Helpers
   const onAuthLoginPage = () => {
-    cy.url().should('contain', Cypress.config().authServerRoot + '/authorize')
+    cy.url().should('contain', AUTH_SERVER_ROOT + '/authorize')
   }
   const onLoginInfoPage = () => {
       cy.url().should('contain', '/en/login-info')
@@ -46,7 +49,7 @@ describe('Auth flows (development)', () => {
     it('redirects app login page to auth login page', () => {
       cy.request({ url: '/login', followRedirect: false }).then((req) => {
         expect(req.redirectedToUrl)
-          .to.include(Cypress.config().authServerRoot + '/authorize')
+          .to.include(AUTH_SERVER_ROOT + '/authorize')
       })
     })
 

--- a/apps/e2e/cypress/tsconfg.json
+++ b/apps/e2e/cypress/tsconfg.json
@@ -1,8 +1,0 @@
-{
-  "compilerOptions": {
-    "target": "es5",
-    "lib": ["es5", "dom"],
-    "types": ["cypress", "node"]
-  },
-  "include": ["**/*.ts"]
-}

--- a/apps/e2e/tsconfig.json
+++ b/apps/e2e/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "baseUrl": "."
   },
-  "include": [],
+  "include": ["."],
   "exclude": []
 }

--- a/apps/e2e/tsconfig.json
+++ b/apps/e2e/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "tsconfig/e2e.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "."
+  },
+  "include": [],
+  "exclude": []
 }

--- a/apps/e2e/tsconfig.json
+++ b/apps/e2e/tsconfig.json
@@ -1,3 +1,6 @@
 {
   "extends": "tsconfig/e2e.json",
+  "compilerOptions": {
+    "baseUrl": "./"
+  }
 }


### PR DESCRIPTION
🤖 Resolves #5171 

## 👋 Introduction

This solves the `tsconfig.json` warning that shows up in the console while running cypress tests.

## 🕵️ Details

Turns out it was fairly simple, not sure I feel great merging this with a 13 story point estimation 😅 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run `npm run e2e:run:all`
2. Confirm the warning does not appear
3. Confirm tests are still passing

## 📸 Screenshot

<img width="681" alt="Screenshot 2023-02-21 at 3 04 14 PM" src="https://user-images.githubusercontent.com/4127998/220446920-27bb2261-db19-4951-905e-995f22b10397.png">



