### PR TITLE
Feature - 5437 - Assign new user roles

### DIFF
--- a/api/app/Console/Commands/RoleSync.php
+++ b/api/app/Console/Commands/RoleSync.php
@@ -46,6 +46,8 @@ class RoleSync extends Command
             // Everyone gets the base roles :)
             $rolesToSync = [$baseUserRole, $applicantRole];
 
+            $user->syncRoles($rolesToSync);
+
             // Add admin roles if user has the legacy admin role
             if (in_array(ApiEnums::ROLE_ADMIN, $user->legacy_roles)) {
                 array_push($rolesToSync, $requestResponderRole, $superAdminRole);
@@ -53,8 +55,6 @@ class RoleSync extends Command
                 // Attach the pool_operator role to DCM team
                 $user->attachRole($poolOperatorRole, $DCMTeam);
             }
-
-            $user->syncRoles($rolesToSync);
         }
 
         return Command::SUCCESS;

--- a/api/app/Console/Commands/RoleSync.php
+++ b/api/app/Console/Commands/RoleSync.php
@@ -47,13 +47,13 @@ class RoleSync extends Command
             $rolesToSync = [$baseUserRole, $applicantRole];
             $attachTeamRole = false;
 
-            $user->syncRoles($rolesToSync);
-
             // Add admin roles if user has the legacy admin role
             if (in_array(ApiEnums::ROLE_ADMIN, $user->legacy_roles)) {
                 array_push($rolesToSync, $requestResponderRole, $superAdminRole);
                 $attachTeamRole = true;
             }
+
+            $user->syncRoles($rolesToSync);
 
             if ($attachTeamRole) {
                 // Attach the pool_operator role to DCM team

--- a/api/app/Console/Commands/RoleSync.php
+++ b/api/app/Console/Commands/RoleSync.php
@@ -42,22 +42,19 @@ class RoleSync extends Command
 
         $users = User::all();
 
-        foreach($users as $user) {
-            // Only sync roles if they have none assigned
-            if(!$user->roles()->exists()) {
-                // Everyone gets the base roles :)
-                $rolesToSync = [$baseUserRole, $applicantRole];
+        foreach ($users as $user) {
+            // Everyone gets the base roles :)
+            $rolesToSync = [$baseUserRole, $applicantRole];
 
-                // Add admin roles if user has the legacy admin role
-                if(in_array(ApiEnums::ROLE_ADMIN, $user->legacy_roles)) {
-                    array_push($rolesToSync, $requestResponderRole, $superAdminRole);
+            // Add admin roles if user has the legacy admin role
+            if (in_array(ApiEnums::ROLE_ADMIN, $user->legacy_roles)) {
+                array_push($rolesToSync, $requestResponderRole, $superAdminRole);
 
-                    // Attach the pool_operator role to DCM team
-                    $user->attachRole($poolOperatorRole, $DCMTeam);
-                }
-
-                $user->attachRoles($rolesToSync);
+                // Attach the pool_operator role to DCM team
+                $user->attachRole($poolOperatorRole, $DCMTeam);
             }
+
+            $user->syncRoles($rolesToSync);
         }
 
         return Command::SUCCESS;

--- a/api/app/Console/Commands/RoleSync.php
+++ b/api/app/Console/Commands/RoleSync.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Role;
+use App\Models\Team;
+use App\Models\User;
+use Database\Helpers\ApiEnums;
+
+class RoleSync extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'role:sync';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sync Laratrust roles to existing users.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $baseUserRole = Role::where('name', 'base_user')->sole();
+        $applicantRole = Role::where('name', 'applicant')->sole();
+        $poolOperatorRole = Role::where('name', 'pool_operator')->sole();
+        $requestResponderRole = Role::where('name', 'request_responder')->sole();
+        $superAdminRole = Role::where('name', 'platform_admin')->sole();
+
+        $DCMTeam = Team::where('name', 'digital-community-management')
+            ->sole();
+
+        $users = User::all();
+
+        foreach($users as $user) {
+            // Only sync roles if they have none assigned
+            if(!$user->roles()->exists()) {
+                // Everyone gets the base roles :)
+                $rolesToSync = [$baseUserRole, $applicantRole];
+
+                // Add admin roles if user has the legacy admin role
+                if(in_array(ApiEnums::ROLE_ADMIN, $user->legacy_roles)) {
+                    array_push($rolesToSync, $requestResponderRole, $superAdminRole);
+
+                    // Attach the pool_operator role to DCM team
+                    $user->attachRole($poolOperatorRole, $DCMTeam);
+                }
+
+                $user->attachRoles($rolesToSync);
+            }
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/api/app/Console/Commands/RoleSync.php
+++ b/api/app/Console/Commands/RoleSync.php
@@ -45,13 +45,17 @@ class RoleSync extends Command
         foreach ($users as $user) {
             // Everyone gets the base roles :)
             $rolesToSync = [$baseUserRole, $applicantRole];
+            $attachTeamRole = false;
 
             $user->syncRoles($rolesToSync);
 
             // Add admin roles if user has the legacy admin role
             if (in_array(ApiEnums::ROLE_ADMIN, $user->legacy_roles)) {
                 array_push($rolesToSync, $requestResponderRole, $superAdminRole);
+                $attachTeamRole = true;
+            }
 
+            if ($attachTeamRole) {
                 // Attach the pool_operator role to DCM team
                 $user->attachRole($poolOperatorRole, $DCMTeam);
             }


### PR DESCRIPTION
🤖 Resolves #5437 

## 👋 Introduction

This creates the `php artisan role:sync` command to assign new user roles to users.

## 🕵️ Details

This only assigns roles only if the user has no existing roles.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run `docker-compose exec -w /home/site/wwwroot/api webserver sh -c "php artisan role:sync"`
2. Confirm the appropriate roles are assigned.
3. Confirm `legacy_roles` are untouched
4. Re-run command a few times and confirm no errors

You can check with the following:

>**Note**
> ~~I suck at SQL, so if you know a better way let me know 😅~~

h/t @petertgiles for improving the SQL! 🎉 

```sql
SELECT
    u.legacy_roles,
    count(*),
    string_agg(distinct r.name||coalesce('-'||t.name, ''), ', ')    
FROM users u
    LEFT JOIN role_user ON role_user.user_id = u.id
    LEFT JOIN roles r ON role_user.role_id = r.id
    LEFT JOIN teams t ON role_user.team_id = t.id
group by u.legacy_roles
ORDER by u.legacy_roles
```

### Expectations

- `APPLICANT` / empty - base_user, applicant
- `ADMIN` - `pool_operator` (with dcm team), `request_responder`, `platform_admin`

## 🚀 Deployment Instructions

1. Run seeders
  - `./artisan db:seed --class=TeamSeeder`
  - `./artisan db:seed --class=RolePermissionSeeder`
2. Run command
  - `./artisan role:sync`

## 📸 Screenshot

![Screenshot 2023-02-23 141941](https://user-images.githubusercontent.com/4127998/221008677-0e7822fb-48f1-4aa9-81fc-8b07ad1e2205.png)


