### PR TITLE
Debug PHP

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     "recommendations": [
         "streetsidesoftware.code-spell-checker",
         "dbaeumer.vscode-eslint",
-        "esbenp.prettier-vscode"
+        "esbenp.prettier-vscode",
+        "xdebug.php-debug"
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,15 @@
 {
     "configurations": [
         {
+            "name": "Listen for PHP Xdebug from Docker",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "pathMappings": {
+                "/home/site/wwwroot/": "${workspaceFolder}"
+            }
+        },
+        {
             "type": "node",
             "name": "jest-common",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,12 @@
             }
         },
         {
+            "name": "Listen for PHP Xdebug locally",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+        },
+        {
             "type": "node",
             "name": "jest-common",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,7 @@
 {
     "configurations": [
         {
-            "name": "Listen for PHP Xdebug from Docker",
+            "name": "Listen for PHP Xdebug from webserver",
             "type": "php",
             "request": "launch",
             "port": 9003,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
             "pathMappings": {
                 "/home/site/wwwroot/": "${workspaceFolder}"
             }
+            // For configuration, see the infrastructure/conf/xdebug.ini file.
         },
         {
             "name": "Listen for PHP Xdebug locally",

--- a/api/xdebuginfo.php
+++ b/api/xdebuginfo.php
@@ -1,0 +1,3 @@
+<?php
+
+xdebug_info();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     volumes:
       - ./:/home/site/wwwroot
       - ./infrastructure/conf/nginx-conf-local:/etc/nginx/sites-available/
+      - ./infrastructure/conf/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
     ports:
       - 8000:8080
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - ROBOTS_FILENAME=dev.robots.txt
     # Uncomment to test out post deployment script
     # command: ./infrastructure/bin/post_deployment.sh .
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   maintenance:
     build: ./infrastructure/maintenance-container

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -59,6 +59,11 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/phpinfo.php;
     }
+    location = /xdebuginfo.php {
+        fastcgi_pass 127.0.0.1:9000;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/xdebuginfo.php;
+    }
     location = /graphql {
         fastcgi_pass 127.0.0.1:9000;
         include fastcgi_params;

--- a/infrastructure/conf/xdebug.ini
+++ b/infrastructure/conf/xdebug.ini
@@ -1,8 +1,7 @@
 xdebug.mode=develop,debug
+xdebug.client_port=9003
+xdebug.client_host=host.docker.internal
 
 ; "trigger" is meant to be used with a browser extension.
-; "yes" if you want to start the debugger every request.  Slow but good for graphql-playground.
+; "yes" if you want to start the debugger every request.  Slower but good for graphql-playground and CLI.
 xdebug.start_with_request=trigger
-
-xdebug.client_port=9003
-xdebug.discover_client_host=1

--- a/infrastructure/conf/xdebug.ini
+++ b/infrastructure/conf/xdebug.ini
@@ -2,6 +2,6 @@ xdebug.mode=develop,debug
 xdebug.client_port=9003
 xdebug.client_host=host.docker.internal
 
-; "trigger" is meant to be used with a browser extension.
+; "trigger" is meant to be used with a browser extension or by setting the environment variable XDEBUG_SESSION=1 on demand.
 ; "yes" if you want to start the debugger every request.  Slower but good for graphql-playground and CLI.
 xdebug.start_with_request=trigger

--- a/infrastructure/conf/xdebug.ini
+++ b/infrastructure/conf/xdebug.ini
@@ -1,0 +1,8 @@
+xdebug.mode=develop,debug
+
+; "trigger" is meant to be used with a browser extension.
+; "yes" if you want to start the debugger every request.  Slow but good for graphql-playground.
+xdebug.start_with_request=trigger
+
+xdebug.client_port=9003
+xdebug.discover_client_host=1

--- a/infrastructure/conf/xdebug.ini
+++ b/infrastructure/conf/xdebug.ini
@@ -1,5 +1,8 @@
 xdebug.mode=develop,debug
 xdebug.client_port=9003
+; To find the IP address of your WSL2 instance to put in here run:
+; - on Windows: `wsl.exe hostname -I`
+; - insde WSL2: `ip a s eth0 | awk '/inet / {print$2}'`
 xdebug.client_host=host.docker.internal
 
 ; "trigger" is meant to be used with a browser extension or by setting the environment variable XDEBUG_SESSION=1 on demand.


### PR DESCRIPTION
🤖 Resolves #1359 

## 👋 Introduction

This branch makes it easier to debug PHP code.

## 🕵️ Details

The container we use for our webserver already has Xdebug installed to help debug PHP code but our environment needs a bit extra glue to help out:
- A helper page at /xdebuginfo.php to review settings and logs (only locally)
- A configuration file mounted in the container to help xdebug look for a debugging client on the docker host machine
- A VSCode debugging extension and a pair of debugging profiles

Xdebug can be set to start on every request but I found it was significantly slower than without it.  I set it to start on a trigger by default, like by a browser extension.  The browser extension is interesting but it doesn't work when running things from the CLI (phpunit, seeders, etc) and it doesn't seem to trigger on graphql-playground requests.  I prefer the environment variable or simply changing the xdebug setting manually on demand.

## 🧪 Testing

### One-time Prep

1. Install the VSCode "xdebug.php-debug" extension for debugging
2. Install the browser extension for your browser and set it to debug mode
    -  https://xdebug.org/docs/step_debug#browser-extensions
3. Tear down the webserver container and re-up it

### Test debugging web requests with the browser extension

1. Start the VSCode debugger with the "listen from webserver" profile
2. Set a breakpoint somewhere
    - The boot function in the `AppServiceProvider` should be safely hit on every web request
3. Load a page from the app
    - The browser extension doesn't seem to properly activate the debugger for playground requests :cry: 
5. Step through the code!

## Test debugging every request by changing the settings

1. Start the VSCode debugger with the "listen from webserver" profile
2. Set a breakpoint somewhere
    - The boot function in the `AppServiceProvider` should be safely hit on every web request
3. Update the `xdebug.start_with_request` variable to `yes` in the `infrastructure/conf/xdebug.ini` file and restart the webserver container
4. Load the graphql-playground and send some requests
4. Step through the code!

## Test debugging CLI commands in the webserver container with the env variable

1. Start the VSCode debugger with the "listen from webserver" profile
2. Set a breakpoint somewhere
    - You could pick the UserTest test file and set a breakpoint in a test
3. Open a terminal in the webserver container
4. Run `export XDEBUG_SESSION=1` to enable the debugger on every request
    - Alternatively you could edit the `xdebug.start_with_request` setting as in the section above
5. Run a CLI command
    - `cd /var/www/html/wwwroot/api`
    - `vendor/bin/phpunit ./tests/Feature/UserTest.php` 
4. Step through the code!

## Test debugging CLI commands locally

It works the same way, except that you won't have to set the `client_host` setting to the docker host.  :smile:   Oh, and use the "listen for Xdebug locally" debug profile.

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/8978655/221208820-0c78daff-dd8a-4a79-8938-e46e05e8299b.png)

![image](https://user-images.githubusercontent.com/8978655/221217274-690791fe-45f4-4f24-89bd-6303cca7c30f.png)
