### PR TITLE
Added FEATURE_APPLICANT_DASHBOARD boilerplate

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -9,6 +9,7 @@ OAUTH_LOGOUT_URI="http://localhost:8000/oxauth/endsession"
 
 # Feature flags
 FEATURE_ONGOING_RECRUITMENTS=true
+FEATURE_APPLICANT_DASHBOARD=true
 
 # Logging - enable by setting the logging level.  Eight severity levels from rfc5424.
 LOG_CONSOLE_LEVEL="debug"

--- a/apps/web/public/config.ejs
+++ b/apps/web/public/config.ejs
@@ -14,6 +14,7 @@ const data = new Map([
 
     // Feature flags
     ["FEATURE_ONGOING_RECRUITMENTS", filterUnusable("$FEATURE_ONGOING_RECRUITMENTS") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_ONGOING_RECRUITMENTS %>"],
+    ["FEATURE_APPLICANT_DASHBOARD", filterUnusable("$FEATURE_APPLICANT_DASHBOARD") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_APPLICANT_DASHBOARD %>"],
 
     // Azure application insights not used in dev
     ["APPLICATIONINSIGHTS_CONNECTION_STRING", filterUnusable("$APPLICATIONINSIGHTS_CONNECTION_STRING")],

--- a/packages/env/src/useFeatureFlags.ts
+++ b/packages/env/src/useFeatureFlags.ts
@@ -2,6 +2,7 @@ import { getFeatureFlags } from "./utils";
 
 export type FeatureFlags = {
   ongoingRecruitments: boolean;
+  applicantDashboard: boolean;
 };
 
 const useFeatureFlags = (): FeatureFlags => {

--- a/packages/env/src/utils.ts
+++ b/packages/env/src/utils.ts
@@ -40,4 +40,5 @@ export const checkFeatureFlag = (name: string): boolean => {
  */
 export const getFeatureFlags = () => ({
   ongoingRecruitments: checkFeatureFlag("FEATURE_ONGOING_RECRUITMENTS"),
+  applicantDashboard: checkFeatureFlag("FEATURE_APPLICANT_DASHBOARD"),
 });


### PR DESCRIPTION
🤖 Resolves #5736 

## 👋 Introduction

This adds a `FEATURE_APPLICANT_DASHBOARD` feature flag

## 🕵️ Details

This just makes it available for use, defaulting to enabled, with no visible indication of it being on/off.

## 🧪 Testing

As recommended by team, there is no front-facing test, just inspecting PR code.

## 🚀 Deployment Notes
Add the `FEATURE_APPLICANT_DASHBOARD` environment variable and set it to `false`.

## 📸 Screenshot

None.


