### PR TITLE
Updates Hydrogen, removes unsupported config syntax

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -77,7 +77,7 @@
     "@graphql-codegen/typescript": "^3.0.1",
     "@graphql-codegen/typescript-operations": "^2.5.13",
     "@graphql-codegen/typescript-urql": "^3.7.3",
-    "@hydrogen-css/hydrogen": "2.0.0",
+    "@hydrogen-css/hydrogen": "2.0.1",
     "@mdx-js/react": "^2.3.0",
     "@storybook/addon-actions": "^6.5.14",
     "@storybook/addon-essentials": "^6.5.16",

--- a/hydrogen.config.json
+++ b/hydrogen.config.json
@@ -384,57 +384,49 @@
         {
           "key": "tm-linear-divider",
           "default": {
-            "gradient": "linear-gradient(to right, #FFAD31, #52C765, #27C9BC, #FF5958)",
-            "fallback": "#FFAD31"
+            "gradient": "linear-gradient(to right, #FFAD31, #52C765, #27C9BC, #FF5958)"
           }
         },
         {
           "key": "tm-linear-text",
           "default": {
-            "gradient": "linear-gradient(to right, rgba(0, 0, 0, 1) 33%, rgba(0, 0, 0, 0))",
-            "fallback": "transparent"
+            "gradient": "linear-gradient(to right, rgba(0, 0, 0, 1) 33%, rgba(0, 0, 0, 0))"
           }
         },
         {
           "key": "tm-linear-footer",
           "default": {
-            "gradient": "linear-gradient(135deg, #27C9BC, #52C765, #FFAD31 110%)",
-            "fallback": "transparent"
+            "gradient": "linear-gradient(135deg, #27C9BC, #52C765, #FFAD31 110%)"
           }
         },
         {
           "key": "dt-linear",
           "default": {
-            "gradient": "linear-gradient(#674C90, #1D2C4C)",
-            "fallback": "#674C90"
+            "gradient": "linear-gradient(#674C90, #1D2C4C)"
           }
         },
         {
           "key": "ia-linear-primary",
           "default": {
-            "gradient": "linear-gradient(#272F6B, #0F1037)",
-            "fallback": "#272F6B"
+            "gradient": "linear-gradient(#272F6B, #0F1037)"
           }
         },
         {
           "key": "ia-linear-secondary",
           "default": {
-            "gradient": "linear-gradient(#C01E5A, #781443)",
-            "fallback": "#C01E5A"
+            "gradient": "linear-gradient(#C01E5A, #781443)"
           }
         },
         {
           "key": "ia-secondary-to-transparent",
           "default": {
-            "gradient": "linear-gradient(RGB(39, 47, 107), RGB(39, 47, 107, 0))",
-            "fallback": "transparent"
+            "gradient": "linear-gradient(RGB(39, 47, 107), RGB(39, 47, 107, 0))"
           }
         },
         {
           "key": "ia-primary-dark-to-transparent",
           "default": {
-            "gradient": "linear-gradient(rgb(71, 6, 46), rgba(71, 6, 46, 0))",
-            "fallback": "transparent"
+            "gradient": "linear-gradient(rgb(71, 6, 46), rgba(71, 6, 46, 0))"
           }
         }
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "devDependencies": {
         "@graphql-codegen/cli": "3.2.0",
-        "@hydrogen-css/hydrogen": "2.0.0",
+        "@hydrogen-css/hydrogen": "2.0.1",
         "eslint-config-custom": "*",
         "prettier": "^2.8.4",
         "turbo": "^1.8.2"
@@ -93,7 +93,7 @@
         "@graphql-codegen/typescript": "^3.0.1",
         "@graphql-codegen/typescript-operations": "^2.5.13",
         "@graphql-codegen/typescript-urql": "^3.7.3",
-        "@hydrogen-css/hydrogen": "2.0.0",
+        "@hydrogen-css/hydrogen": "2.0.1",
         "@mdx-js/react": "^2.3.0",
         "@storybook/addon-actions": "^6.5.14",
         "@storybook/addon-essentials": "^6.5.16",
@@ -3563,8 +3563,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@hydrogen-css/hydrogen": {
-      "version": "2.0.0",
-      "license": "MIT",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hydrogen-css/hydrogen/-/hydrogen-2.0.1.tgz",
+      "integrity": "sha512-iK74MMhsLQQBfF3njhWkAG8zDZRbl6/nDf67MbowAEj9PpDk/0uuueh+wunjLF3goi/yB2bttrGrt/+Tszbx3g==",
       "dependencies": {
         "autoprefixer": "^10.4.13",
         "browserlist": "^1.0.1",
@@ -41646,7 +41647,7 @@
         "@graphql-codegen/typescript-operations": "^2.5.13",
         "@graphql-codegen/typescript-urql": "^3.7.3",
         "@heroicons/react": "^2.0.15",
-        "@hydrogen-css/hydrogen": "2.0.0",
+        "@hydrogen-css/hydrogen": "2.0.1",
         "@mdx-js/react": "^2.3.0",
         "@microsoft/applicationinsights-react-js": "^3.4.1",
         "@microsoft/applicationinsights-web": "^2.8.10",
@@ -42413,7 +42414,9 @@
       "devOptional": true
     },
     "@hydrogen-css/hydrogen": {
-      "version": "2.0.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hydrogen-css/hydrogen/-/hydrogen-2.0.1.tgz",
+      "integrity": "sha512-iK74MMhsLQQBfF3njhWkAG8zDZRbl6/nDf67MbowAEj9PpDk/0uuueh+wunjLF3goi/yB2bttrGrt/+Tszbx3g==",
       "requires": {
         "autoprefixer": "^10.4.13",
         "browserlist": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@graphql-codegen/cli": "3.2.0",
-    "@hydrogen-css/hydrogen": "2.0.0",
+    "@hydrogen-css/hydrogen": "2.0.1",
     "eslint-config-custom": "*",
     "prettier": "^2.8.4",
     "turbo": "^1.8.2"


### PR DESCRIPTION
## 👋 Introduction

Updates Hydrogen to [`2.0.1`](https://github.com/hydrogen-css/hydrogen/pull/224)

## 🕵️ Details

Specifically:
- Fixes a bug with gradient configurations
- Reduces console output to three lines when `verbose` is disabled

![image](https://user-images.githubusercontent.com/6960386/221879878-0163a17f-a4c4-4649-aaed-1da3a93895df.png)

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Clear your node module and turbo caches
2. Run Storybook


