### PR TITLE
bug/5837-cypress-test

### DIFF
--- a/apps/e2e/cypress/e2e/admin/pool-candidate.cy.js
+++ b/apps/e2e/cypress/e2e/admin/pool-candidate.cy.js
@@ -96,7 +96,12 @@ describe("Pool Candidates", () => {
 
     cy.wait("@gqlgetPoolsQuery");
 
+    cy.findByRole("textbox", { name: /search/i })
+      .clear()
+      .type("cypress");
+
     cy.findByRole("link", {name: new RegExp(`View Candidates for Cypress Test Pool EN ${uniqueTestId}`, "i")})
+      .should("exist")
       .click();
     cy.wait("@gqlGetPoolCandidatesPaginatedQuery");
 
@@ -190,7 +195,12 @@ describe("Pool Candidates", () => {
 
     cy.wait("@gqlgetPoolsQuery");
 
+    cy.findByRole("textbox", { name: /search/i })
+      .clear()
+      .type("cypress");
+
     cy.findByRole("link", {name: new RegExp(`View Candidates for Cypress Test Pool EN ${uniqueTestId}`, "i")})
+      .should("exist")
       .click();
     cy.wait("@gqlGetPoolCandidatesPaginatedQuery");
 


### PR DESCRIPTION
🤖 Resolves #5837 

## 👋 Introduction

That bug seems annoying, so lets get rid of it.
Hopefully resolves the pool-candidate spec issue.

## 🕵️ Details

It appears that the test pool isn't always on the first page of pools, which causes the test to fail due to not finding it.
So searching for it, along with the should("exist") to make the search run. 

## 🧪 Testing

1. cypress keeps passing

![image](https://user-images.githubusercontent.com/40485260/222541642-0a9a7bc8-7298-4c0d-913d-110120ecf8bb.png)


