### PR TITLE
Fix babel-plugin-formatjs upgrade

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -96,7 +96,7 @@
     "@types/react-dom": "^18.0.11",
     "@types/react-helmet": "^6.1.6",
     "@types/react-table": "^7.7.13",
-    "babel-plugin-formatjs": "^10.3.36",
+    "babel-plugin-formatjs": "^10.4.0",
     "core-js": "^3.29.0",
     "eslint": "^8.34.0",
     "eslint-config-custom": "*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -96,7 +96,7 @@
     "@types/react-dom": "^18.0.11",
     "@types/react-helmet": "^6.1.6",
     "@types/react-table": "^7.7.13",
-    "babel-plugin-formatjs": "^10.4.0",
+    "babel-plugin-formatjs": "^10.3.36",
     "core-js": "^3.29.0",
     "eslint": "^8.34.0",
     "eslint-config-custom": "*",

--- a/apps/web/src/lang/whitelist.yml
+++ b/apps/web/src/lang/whitelist.yml
@@ -1,4 +1,4 @@
-- N6+rnM # 'example@canada.ca...' Placeholder for government email input in the request form
+- N6+rnM # 'example@canada.ca...' Placeholder for government email input in the request forms
 - FmN1eN # +123243234 (Placeholder displayed on the About Me form telephone field.)
 - rywI3C # Verbal (Label displayed on the language information form verbal field.)
 - Ledr63 # 'Signature' Toc navigation item on sign and submit page.

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,7 @@
         "@types/react-dom": "^18.0.11",
         "@types/react-helmet": "^6.1.6",
         "@types/react-table": "^7.7.13",
-        "babel-plugin-formatjs": "^10.3.36",
+        "babel-plugin-formatjs": "^10.4.0",
         "core-js": "^3.29.0",
         "eslint": "^8.34.0",
         "eslint-config-custom": "*",
@@ -132,46 +132,6 @@
         "webpack-config": "*",
         "webpack-merge": "^5.8.0"
       }
-    },
-    "apps/web/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-      "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/icu-skeleton-parser": "1.3.18",
-        "tslib": "^2.4.0"
-      }
-    },
-    "apps/web/node_modules/@formatjs/ts-transformer": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.12.0.tgz",
-      "integrity": "sha512-/jEpXcqA6y/vdijgkxSoKGfkGR5VcClJeI8hnpJ2PBCHfrc4ywFMyoZqRAakKW3IJVttaDo7mGvBAIDxV1F4Qg==",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/icu-messageformat-parser": "2.3.0",
-        "@types/json-stable-stringify": "^1.0.32",
-        "@types/node": "14 || 16 || 17",
-        "chalk": "^4.0.0",
-        "json-stable-stringify": "^1.0.1",
-        "tslib": "^2.4.0",
-        "typescript": "^4.7"
-      },
-      "peerDependencies": {
-        "ts-jest": ">=27"
-      },
-      "peerDependenciesMeta": {
-        "ts-jest": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "dev": true
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.1.0",
@@ -2559,9 +2519,9 @@
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
+      "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.14.3",
         "@formatjs/icu-skeleton-parser": "1.3.18",
@@ -2625,22 +2585,12 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@formatjs/intl/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-      "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/icu-skeleton-parser": "1.3.18",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@formatjs/ts-transformer": {
-      "version": "3.11.6",
-      "dev": true,
-      "license": "MIT",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.12.0.tgz",
+      "integrity": "sha512-/jEpXcqA6y/vdijgkxSoKGfkGR5VcClJeI8hnpJ2PBCHfrc4ywFMyoZqRAakKW3IJVttaDo7mGvBAIDxV1F4Qg==",
       "dependencies": {
-        "@formatjs/icu-messageformat-parser": "2.2.0",
+        "@formatjs/icu-messageformat-parser": "2.3.0",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/node": "14 || 16 || 17",
         "chalk": "^4.0.0",
@@ -2659,8 +2609,8 @@
     },
     "node_modules/@formatjs/ts-transformer/node_modules/@types/node": {
       "version": "17.0.45",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -13961,17 +13911,18 @@
       "license": "MIT"
     },
     "node_modules/babel-plugin-formatjs": {
-      "version": "10.3.36",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-formatjs/-/babel-plugin-formatjs-10.4.0.tgz",
+      "integrity": "sha512-m9heKeKjINsaL20RPrZ7bqvB298WPJOOVRB0AdTtXHs9MOWkXYx89YdJRu/L6dgj7IGg09OG7OZXIvlYGVBPLg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.10.4",
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-jsx": "7",
         "@babel/traverse": "7",
         "@babel/types": "^7.12.11",
-        "@formatjs/icu-messageformat-parser": "2.2.0",
-        "@formatjs/ts-transformer": "3.11.6",
+        "@formatjs/icu-messageformat-parser": "2.3.0",
+        "@formatjs/ts-transformer": "3.12.0",
         "@types/babel__core": "^7.1.7",
         "@types/babel__helper-plugin-utils": "^7.10.0",
         "@types/babel__traverse": "^7.1.7",
@@ -18678,46 +18629,6 @@
         "eslint": "7 || 8"
       }
     },
-    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-      "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/icu-skeleton-parser": "1.3.18",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/ts-transformer": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.12.0.tgz",
-      "integrity": "sha512-/jEpXcqA6y/vdijgkxSoKGfkGR5VcClJeI8hnpJ2PBCHfrc4ywFMyoZqRAakKW3IJVttaDo7mGvBAIDxV1F4Qg==",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/icu-messageformat-parser": "2.3.0",
-        "@types/json-stable-stringify": "^1.0.32",
-        "@types/node": "14 || 16 || 17",
-        "chalk": "^4.0.0",
-        "json-stable-stringify": "^1.0.1",
-        "tslib": "^2.4.0",
-        "typescript": "^4.7"
-      },
-      "peerDependencies": {
-        "ts-jest": ">=27"
-      },
-      "peerDependenciesMeta": {
-        "ts-jest": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-formatjs/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "dev": true
-    },
     "node_modules/eslint-plugin-formatjs/node_modules/@typescript-eslint/types": {
       "version": "5.45.0",
       "dev": true,
@@ -21736,16 +21647,6 @@
         "@formatjs/ecma402-abstract": "1.14.3",
         "@formatjs/fast-memoize": "1.2.8",
         "@formatjs/icu-messageformat-parser": "2.3.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/intl-messageformat/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-      "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/icu-skeleton-parser": "1.3.18",
         "tslib": "^2.4.0"
       }
     },
@@ -28253,16 +28154,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-intl/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-      "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/icu-skeleton-parser": "1.3.18",
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/react-is": {
@@ -34860,40 +34751,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "packages/i18n/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-      "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/icu-skeleton-parser": "1.3.18",
-        "tslib": "^2.4.0"
-      }
-    },
-    "packages/i18n/node_modules/@formatjs/ts-transformer": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.12.0.tgz",
-      "integrity": "sha512-/jEpXcqA6y/vdijgkxSoKGfkGR5VcClJeI8hnpJ2PBCHfrc4ywFMyoZqRAakKW3IJVttaDo7mGvBAIDxV1F4Qg==",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/icu-messageformat-parser": "2.3.0",
-        "@types/json-stable-stringify": "^1.0.32",
-        "@types/node": "14 || 16 || 17",
-        "chalk": "^4.0.0",
-        "json-stable-stringify": "^1.0.1",
-        "tslib": "^2.4.0",
-        "typescript": "^4.7"
-      },
-      "peerDependencies": {
-        "ts-jest": ">=27"
-      },
-      "peerDependenciesMeta": {
-        "ts-jest": {
-          "optional": true
-        }
-      }
-    },
     "packages/i18n/node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
       "dev": true,
@@ -34906,12 +34763,6 @@
       "engines": {
         "node": ">=10.10.0"
       }
-    },
-    "packages/i18n/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "dev": true
     },
     "packages/i18n/node_modules/acorn": {
       "version": "7.4.1",
@@ -36914,43 +36765,6 @@
         "webpack": "^5.75.0",
         "webpack-shell-plugin-next": "^2.3.1"
       }
-    },
-    "packages/webpack-config/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-      "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/icu-skeleton-parser": "1.3.18",
-        "tslib": "^2.4.0"
-      }
-    },
-    "packages/webpack-config/node_modules/@formatjs/ts-transformer": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.12.0.tgz",
-      "integrity": "sha512-/jEpXcqA6y/vdijgkxSoKGfkGR5VcClJeI8hnpJ2PBCHfrc4ywFMyoZqRAakKW3IJVttaDo7mGvBAIDxV1F4Qg==",
-      "dependencies": {
-        "@formatjs/icu-messageformat-parser": "2.3.0",
-        "@types/json-stable-stringify": "^1.0.32",
-        "@types/node": "14 || 16 || 17",
-        "chalk": "^4.0.0",
-        "json-stable-stringify": "^1.0.1",
-        "tslib": "^2.4.0",
-        "typescript": "^4.7"
-      },
-      "peerDependencies": {
-        "ts-jest": ">=27"
-      },
-      "peerDependenciesMeta": {
-        "ts-jest": {
-          "optional": true
-        }
-      }
-    },
-    "packages/webpack-config/node_modules/@formatjs/ts-transformer/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
     }
   },
   "dependencies": {
@@ -38412,8 +38226,9 @@
       }
     },
     "@formatjs/icu-messageformat-parser": {
-      "version": "2.2.0",
-      "dev": true,
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
+      "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
       "requires": {
         "@formatjs/ecma402-abstract": "1.14.3",
         "@formatjs/icu-skeleton-parser": "1.3.18",
@@ -38439,18 +38254,6 @@
         "@formatjs/intl-listformat": "7.1.9",
         "intl-messageformat": "10.3.1",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@formatjs/icu-messageformat-parser": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-          "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-          "requires": {
-            "@formatjs/ecma402-abstract": "1.14.3",
-            "@formatjs/icu-skeleton-parser": "1.3.18",
-            "tslib": "^2.4.0"
-          }
-        }
       }
     },
     "@formatjs/intl-displaynames": {
@@ -38480,10 +38283,11 @@
       }
     },
     "@formatjs/ts-transformer": {
-      "version": "3.11.6",
-      "dev": true,
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.12.0.tgz",
+      "integrity": "sha512-/jEpXcqA6y/vdijgkxSoKGfkGR5VcClJeI8hnpJ2PBCHfrc4ywFMyoZqRAakKW3IJVttaDo7mGvBAIDxV1F4Qg==",
       "requires": {
-        "@formatjs/icu-messageformat-parser": "2.2.0",
+        "@formatjs/icu-messageformat-parser": "2.3.0",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/node": "14 || 16 || 17",
         "chalk": "^4.0.0",
@@ -38494,7 +38298,8 @@
       "dependencies": {
         "@types/node": {
           "version": "17.0.45",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
         }
       }
     },
@@ -39449,32 +39254,6 @@
             "strip-json-comments": "^3.1.1"
           }
         },
-        "@formatjs/icu-messageformat-parser": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-          "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-          "dev": true,
-          "requires": {
-            "@formatjs/ecma402-abstract": "1.14.3",
-            "@formatjs/icu-skeleton-parser": "1.3.18",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@formatjs/ts-transformer": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.12.0.tgz",
-          "integrity": "sha512-/jEpXcqA6y/vdijgkxSoKGfkGR5VcClJeI8hnpJ2PBCHfrc4ywFMyoZqRAakKW3IJVttaDo7mGvBAIDxV1F4Qg==",
-          "dev": true,
-          "requires": {
-            "@formatjs/icu-messageformat-parser": "2.3.0",
-            "@types/json-stable-stringify": "^1.0.32",
-            "@types/node": "14 || 16 || 17",
-            "chalk": "^4.0.0",
-            "json-stable-stringify": "^1.0.1",
-            "tslib": "^2.4.0",
-            "typescript": "^4.7"
-          }
-        },
         "@humanwhocodes/config-array": {
           "version": "0.5.0",
           "dev": true,
@@ -39483,12 +39262,6 @@
             "debug": "^4.1.1",
             "minimatch": "^3.0.4"
           }
-        },
-        "@types/node": {
-          "version": "17.0.45",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-          "dev": true
         },
         "acorn": {
           "version": "7.4.1",
@@ -40892,7 +40665,7 @@
         "@types/react-dom": "^18.0.11",
         "@types/react-helmet": "^6.1.6",
         "@types/react-table": "^7.7.13",
-        "babel-plugin-formatjs": "^10.3.36",
+        "babel-plugin-formatjs": "^10.4.0",
         "core-js": "^3.29.0",
         "date-fns": "^2.29.3",
         "dotenv": "^16.0.3",
@@ -40926,40 +40699,6 @@
         "webpack-cli": "^5.0.0",
         "webpack-config": "*",
         "webpack-merge": "^5.8.0"
-      },
-      "dependencies": {
-        "@formatjs/icu-messageformat-parser": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-          "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-          "dev": true,
-          "requires": {
-            "@formatjs/ecma402-abstract": "1.14.3",
-            "@formatjs/icu-skeleton-parser": "1.3.18",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@formatjs/ts-transformer": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.12.0.tgz",
-          "integrity": "sha512-/jEpXcqA6y/vdijgkxSoKGfkGR5VcClJeI8hnpJ2PBCHfrc4ywFMyoZqRAakKW3IJVttaDo7mGvBAIDxV1F4Qg==",
-          "dev": true,
-          "requires": {
-            "@formatjs/icu-messageformat-parser": "2.3.0",
-            "@types/json-stable-stringify": "^1.0.32",
-            "@types/node": "14 || 16 || 17",
-            "chalk": "^4.0.0",
-            "json-stable-stringify": "^1.0.1",
-            "tslib": "^2.4.0",
-            "typescript": "^4.7"
-          }
-        },
-        "@types/node": {
-          "version": "17.0.45",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-          "dev": true
-        }
       }
     },
     "@gc-digital-talent/webpack-config": {
@@ -40979,39 +40718,6 @@
         "ts-loader": "^9.4.2",
         "webpack": "^5.75.0",
         "webpack-shell-plugin-next": "^2.3.1"
-      },
-      "dependencies": {
-        "@formatjs/icu-messageformat-parser": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-          "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-          "requires": {
-            "@formatjs/ecma402-abstract": "1.14.3",
-            "@formatjs/icu-skeleton-parser": "1.3.18",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@formatjs/ts-transformer": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.12.0.tgz",
-          "integrity": "sha512-/jEpXcqA6y/vdijgkxSoKGfkGR5VcClJeI8hnpJ2PBCHfrc4ywFMyoZqRAakKW3IJVttaDo7mGvBAIDxV1F4Qg==",
-          "requires": {
-            "@formatjs/icu-messageformat-parser": "2.3.0",
-            "@types/json-stable-stringify": "^1.0.32",
-            "@types/node": "14 || 16 || 17",
-            "chalk": "^4.0.0",
-            "json-stable-stringify": "^1.0.1",
-            "tslib": "^2.4.0",
-            "typescript": "^4.7"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "17.0.45",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-              "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
-            }
-          }
-        }
       }
     },
     "@graphql-codegen/add": {
@@ -48624,7 +48330,9 @@
       }
     },
     "babel-plugin-formatjs": {
-      "version": "10.3.36",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-formatjs/-/babel-plugin-formatjs-10.4.0.tgz",
+      "integrity": "sha512-m9heKeKjINsaL20RPrZ7bqvB298WPJOOVRB0AdTtXHs9MOWkXYx89YdJRu/L6dgj7IGg09OG7OZXIvlYGVBPLg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.10.4",
@@ -48632,8 +48340,8 @@
         "@babel/plugin-syntax-jsx": "7",
         "@babel/traverse": "7",
         "@babel/types": "^7.12.11",
-        "@formatjs/icu-messageformat-parser": "2.2.0",
-        "@formatjs/ts-transformer": "3.11.6",
+        "@formatjs/icu-messageformat-parser": "2.3.0",
+        "@formatjs/ts-transformer": "3.12.0",
         "@types/babel__core": "^7.1.7",
         "@types/babel__helper-plugin-utils": "^7.10.0",
         "@types/babel__traverse": "^7.1.7",
@@ -51747,38 +51455,6 @@
         "unicode-emoji-utils": "^1.1.1"
       },
       "dependencies": {
-        "@formatjs/icu-messageformat-parser": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-          "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-          "dev": true,
-          "requires": {
-            "@formatjs/ecma402-abstract": "1.14.3",
-            "@formatjs/icu-skeleton-parser": "1.3.18",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@formatjs/ts-transformer": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.12.0.tgz",
-          "integrity": "sha512-/jEpXcqA6y/vdijgkxSoKGfkGR5VcClJeI8hnpJ2PBCHfrc4ywFMyoZqRAakKW3IJVttaDo7mGvBAIDxV1F4Qg==",
-          "dev": true,
-          "requires": {
-            "@formatjs/icu-messageformat-parser": "2.3.0",
-            "@types/json-stable-stringify": "^1.0.32",
-            "@types/node": "14 || 16 || 17",
-            "chalk": "^4.0.0",
-            "json-stable-stringify": "^1.0.1",
-            "tslib": "^2.4.0",
-            "typescript": "^4.7"
-          }
-        },
-        "@types/node": {
-          "version": "17.0.45",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-          "dev": true
-        },
         "@typescript-eslint/types": {
           "version": "5.45.0",
           "dev": true
@@ -53677,18 +53353,6 @@
         "@formatjs/fast-memoize": "1.2.8",
         "@formatjs/icu-messageformat-parser": "2.3.0",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@formatjs/icu-messageformat-parser": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-          "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-          "requires": {
-            "@formatjs/ecma402-abstract": "1.14.3",
-            "@formatjs/icu-skeleton-parser": "1.3.18",
-            "tslib": "^2.4.0"
-          }
-        }
       }
     },
     "invariant": {
@@ -57978,18 +57642,6 @@
         "hoist-non-react-statics": "^3.3.2",
         "intl-messageformat": "10.3.1",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@formatjs/icu-messageformat-parser": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-          "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-          "requires": {
-            "@formatjs/ecma402-abstract": "1.14.3",
-            "@formatjs/icu-skeleton-parser": "1.3.18",
-            "tslib": "^2.4.0"
-          }
-        }
       }
     },
     "react-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,7 @@
         "@types/react-dom": "^18.0.11",
         "@types/react-helmet": "^6.1.6",
         "@types/react-table": "^7.7.13",
-        "babel-plugin-formatjs": "^10.4.0",
+        "babel-plugin-formatjs": "^10.3.36",
         "core-js": "^3.29.0",
         "eslint": "^8.34.0",
         "eslint-config-custom": "*",
@@ -13961,63 +13961,22 @@
       "license": "MIT"
     },
     "node_modules/babel-plugin-formatjs": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-formatjs/-/babel-plugin-formatjs-10.4.0.tgz",
-      "integrity": "sha512-m9heKeKjINsaL20RPrZ7bqvB298WPJOOVRB0AdTtXHs9MOWkXYx89YdJRu/L6dgj7IGg09OG7OZXIvlYGVBPLg==",
+      "version": "10.3.36",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.10.4",
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-jsx": "7",
         "@babel/traverse": "7",
         "@babel/types": "^7.12.11",
-        "@formatjs/icu-messageformat-parser": "2.3.0",
-        "@formatjs/ts-transformer": "3.12.0",
+        "@formatjs/icu-messageformat-parser": "2.2.0",
+        "@formatjs/ts-transformer": "3.11.6",
         "@types/babel__core": "^7.1.7",
         "@types/babel__helper-plugin-utils": "^7.10.0",
         "@types/babel__traverse": "^7.1.7",
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/babel-plugin-formatjs/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-      "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/icu-skeleton-parser": "1.3.18",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/babel-plugin-formatjs/node_modules/@formatjs/ts-transformer": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.12.0.tgz",
-      "integrity": "sha512-/jEpXcqA6y/vdijgkxSoKGfkGR5VcClJeI8hnpJ2PBCHfrc4ywFMyoZqRAakKW3IJVttaDo7mGvBAIDxV1F4Qg==",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/icu-messageformat-parser": "2.3.0",
-        "@types/json-stable-stringify": "^1.0.32",
-        "@types/node": "14 || 16 || 17",
-        "chalk": "^4.0.0",
-        "json-stable-stringify": "^1.0.1",
-        "tslib": "^2.4.0",
-        "typescript": "^4.7"
-      },
-      "peerDependencies": {
-        "ts-jest": ">=27"
-      },
-      "peerDependenciesMeta": {
-        "ts-jest": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/babel-plugin-formatjs/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "dev": true
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
@@ -40933,7 +40892,7 @@
         "@types/react-dom": "^18.0.11",
         "@types/react-helmet": "^6.1.6",
         "@types/react-table": "^7.7.13",
-        "babel-plugin-formatjs": "^10.4.0",
+        "babel-plugin-formatjs": "^10.3.36",
         "core-js": "^3.29.0",
         "date-fns": "^2.29.3",
         "dotenv": "^16.0.3",
@@ -48665,9 +48624,7 @@
       }
     },
     "babel-plugin-formatjs": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-formatjs/-/babel-plugin-formatjs-10.4.0.tgz",
-      "integrity": "sha512-m9heKeKjINsaL20RPrZ7bqvB298WPJOOVRB0AdTtXHs9MOWkXYx89YdJRu/L6dgj7IGg09OG7OZXIvlYGVBPLg==",
+      "version": "10.3.36",
       "dev": true,
       "requires": {
         "@babel/core": "^7.10.4",
@@ -48675,46 +48632,12 @@
         "@babel/plugin-syntax-jsx": "7",
         "@babel/traverse": "7",
         "@babel/types": "^7.12.11",
-        "@formatjs/icu-messageformat-parser": "2.3.0",
-        "@formatjs/ts-transformer": "3.12.0",
+        "@formatjs/icu-messageformat-parser": "2.2.0",
+        "@formatjs/ts-transformer": "3.11.6",
         "@types/babel__core": "^7.1.7",
         "@types/babel__helper-plugin-utils": "^7.10.0",
         "@types/babel__traverse": "^7.1.7",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@formatjs/icu-messageformat-parser": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-          "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
-          "dev": true,
-          "requires": {
-            "@formatjs/ecma402-abstract": "1.14.3",
-            "@formatjs/icu-skeleton-parser": "1.3.18",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@formatjs/ts-transformer": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.12.0.tgz",
-          "integrity": "sha512-/jEpXcqA6y/vdijgkxSoKGfkGR5VcClJeI8hnpJ2PBCHfrc4ywFMyoZqRAakKW3IJVttaDo7mGvBAIDxV1F4Qg==",
-          "dev": true,
-          "requires": {
-            "@formatjs/icu-messageformat-parser": "2.3.0",
-            "@types/json-stable-stringify": "^1.0.32",
-            "@types/node": "14 || 16 || 17",
-            "chalk": "^4.0.0",
-            "json-stable-stringify": "^1.0.1",
-            "tslib": "^2.4.0",
-            "typescript": "^4.7"
-          }
-        },
-        "@types/node": {
-          "version": "17.0.45",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-          "dev": true
-        }
       }
     },
     "babel-plugin-istanbul": {


### PR DESCRIPTION
## 👋 Introduction

Something went wrong with the dependabot upgrade of babel-plugin-formatjs upgrade (#5834) this morning and broke Jest testing.

## 🕵️ Details

I've backed #5834 and manually upgraded babel-plugin-formatjs upgrade.

(I accidentally named the branch and first commit 5833.  It was actually 5834 that broke.)

## 🧪 Testing

1. Builds OK
2. Jest tests OK
3. Github Actions OK

