### PR TITLE
Feature - 5782 - Update role policy

### DIFF
--- a/api/app/Policies/RolePolicy.php
+++ b/api/app/Policies/RolePolicy.php
@@ -3,6 +3,7 @@
 namespace App\Policies;
 
 use App\Models\User;
+use App\Models\Role;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class RolePolicy
@@ -15,12 +16,9 @@ class RolePolicy
      * @param  \App\Models\User|null  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function viewAny(User $user = null)
+    public function viewAny(User $user)
     {
-        if ($user) {
-            return $user->isAdmin();
-        }
-        return false;
+        return $user->isAbleTo('view-any-role');
     }
 
     /**
@@ -32,6 +30,30 @@ class RolePolicy
      */
     public function viewAnyRoleAssignments(User $user)
     {
-        return $user->isAdmin();
+        return $user->isAbleTo('view-any-role');
+    }
+
+    /**
+     * Determine whether the user can view a specific role
+     *
+     * @param  \App\Models\User|null  $user
+     * @param  \App\Models\Role|null  $role
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function view(User $user)
+    {
+        return $user->isAbleTo('view-any-role');
+    }
+
+    /**
+     * Determine whether the user can update a specific role
+     *
+     * @param  \App\Models\User|null  $user
+     * @param  \App\Models\Role|null  $role
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function update(User $user)
+    {
+        return $user->isAbleTo('update-any-role');
     }
 }

--- a/api/app/Policies/UserPolicy.php
+++ b/api/app/Policies/UserPolicy.php
@@ -3,7 +3,9 @@
 namespace App\Policies;
 
 use App\Models\User;
+use App\Models\Team;
 use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Support\Facades\Log;
 
 class UserPolicy
 {
@@ -66,8 +68,18 @@ class UserPolicy
      * @param  \App\Models\User  $model
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function update(User $user, User $model)
+    public function update(User $user, User $model, array $injected)
     {
+        /**
+         * If a user is assigning a role here, check all actions
+         * and fail early
+         */
+        if (isset($injected["roles"])) {
+            if (!$user->isAbleTo("assign-any-role")) {
+                return false;
+            }
+        }
+
         return $user->isAdmin() || $user->id === $model->id;
     }
 
@@ -80,8 +92,8 @@ class UserPolicy
      */
     public function delete(User $user, User $model)
     {
-        if($user->isAdmin()){
-            if($user->id !== $model->id){
+        if ($user->isAdmin()) {
+            if ($user->id !== $model->id) {
                 return true;
             } else {
                 return false; // Do not allow user to delete their own model.

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1591,7 +1591,7 @@ type Mutation {
   updateUserAsUser(id: ID!, user: UpdateUserAsUserInput! @spread): User
     @update
     @guard
-    @can(ability: "update", find: "id")
+    @can(ability: "update", find: "id", injectArgs: true)
   updateUserAsAdmin(id: ID!, user: UpdateUserAsAdminInput! @spread): User
     @update
     @guard

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1595,7 +1595,7 @@ type Mutation {
   updateUserAsAdmin(id: ID!, user: UpdateUserAsAdminInput! @spread): User
     @update
     @guard
-    @can(ability: "update", find: "id")
+    @can(ability: "update", find: "id", injectArgs: true)
   deleteUser(id: ID!): User
     @delete(globalId: false)
     @guard

--- a/apps/e2e/cypress/e2e/talentsearch/create-account.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/create-account.cy.js
@@ -1,4 +1,12 @@
+import { aliasMutation } from "../../support/graphql-test-utils";
+
 describe("Create account tests", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/graphql", (req) => {
+      aliasMutation(req, "CreateAccount");
+    });
+  });
+
   it("Logging in as a new user goes to create-account and then to profile", () => {
     const uniqueTestId = (
       Math.floor(Math.random() * Number.MAX_SAFE_INTEGER) + 1
@@ -45,6 +53,7 @@ describe("Create account tests", () => {
     });
     cy.findByRole("button", { name: "Save and go to my profile" }).click();
 
+    cy.wait("@gqlCreateAccountMutation");
     // should go to the profile page
     cy.findByRole("heading", {
       name: `Cypress ${uniqueTestId}'s profile`,


### PR DESCRIPTION
🤖 Resolves #5782

## 👋 Introduction

Updates the `UserPolicy` and `RolePolicy` with the new Laratrust permissions.

## 🕵️ Details

The `assign` permissions were added to the `UserPolicy` if the user is attempting update a user's roles using the [`injectArgs`](https://lighthouse-php.com/5/security/authorization.html#restrict-fields-through-policies:~:text=checks%20with%20the-,injectArgs,-argument%3A) option in lighthouse-php.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run PHPUnit and confirm tests pass for `UserRoleTest`
2. Review the policies to confirm they match [the spreadsheet](https://docs.google.com/spreadsheets/d/1RC7wufxwjLEvaEunHsfZfOzBefg218dvvzkDwKSiQjI/edit#gid=428263758)


