### PR TITLE
add logging for platform admin

### DIFF
--- a/api/app/Http/Middleware/AuditQueryMiddleware.php
+++ b/api/app/Http/Middleware/AuditQueryMiddleware.php
@@ -30,7 +30,7 @@ class AuditQueryMiddleware
     public function handle(Request $request, Closure $next)
     {
         $user = $request->user();
-        if (!is_null($user) && $user->isAdmin())
+        if (!is_null($user) && ( $user->isAdmin() || $user->isPlatformAdmin() ))
         {
             $message = 'GraphQL request from admin user ['.$user['email'].']';
             $this->logger->info(

--- a/api/app/Http/Middleware/AuditQueryMiddleware.php
+++ b/api/app/Http/Middleware/AuditQueryMiddleware.php
@@ -30,9 +30,9 @@ class AuditQueryMiddleware
     public function handle(Request $request, Closure $next)
     {
         $user = $request->user();
-        if (!is_null($user) && ( $user->isAdmin() || $user->isPlatformAdmin() ))
+        if (!is_null($user) && $user->isPlatformAdmin())
         {
-            $message = 'GraphQL request from admin user ['.$user['email'].']';
+            $message = 'GraphQL request from platform admin user ['.$user['email'].']';
             $this->logger->info(
                 $message,
                 $request->json()->all()

--- a/api/app/Http/Middleware/AuditQueryMiddleware.php
+++ b/api/app/Http/Middleware/AuditQueryMiddleware.php
@@ -30,7 +30,7 @@ class AuditQueryMiddleware
     public function handle(Request $request, Closure $next)
     {
         $user = $request->user();
-        if (!is_null($user) && $user->isPlatformAdmin())
+        if (!is_null($user) && $user->hasRole('platform_admin'))
         {
             $message = 'GraphQL request from platform admin user ['.$user['email'].']';
             $this->logger->info(

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -115,7 +115,10 @@ class User extends Model implements Authenticatable
     {
         return is_array($this->legacy_roles) && in_array('ADMIN', $this->legacy_roles);
     }
-
+    public function isPlatformAdmin(): bool
+    {
+        return is_array($this->roles) && in_array('platform_admin', $this->roles);
+    }
     // All the relationships for experiences
     public function awardExperiences(): HasMany
     {

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -115,10 +115,6 @@ class User extends Model implements Authenticatable
     {
         return is_array($this->legacy_roles) && in_array('ADMIN', $this->legacy_roles);
     }
-    public function isPlatformAdmin(): bool
-    {
-        return is_array($this->roles) && in_array('platform_admin', $this->roles);
-    }
     // All the relationships for experiences
     public function awardExperiences(): HasMany
     {


### PR DESCRIPTION
🤖 Resolves #5794

## 👋 Introduction

Adds logging for platform admin 

## 🕵️ Details

In the logger removed isAdmin() check and added  hasRole('platform_admin')
## 🧪 Testing

- Login as admin ( currently all admins are having platform_admin role using the `syncRoles` )
- Do some admin related changes like adding and editing user 
- Check the laravel logs in local and verify the actions are still being logged

## 📸 Screenshot

Add a screenshot (if possible).


