### PR TITLE
Feature - 5812 - Removes abbreviation from Home Page Hero Heading

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2013,8 +2013,8 @@
     "defaultMessage": "Erreur : la suppression de la candidature a échoué",
     "description": "Message displayed to user after application fails to get deleted."
   },
-  "eSPoJw": {
-    "defaultMessage": "Talents numériques du <abbreviation>GC</abbreviation>",
+  "MS9dB9": {
+    "defaultMessage": "Talents numériques du GC",
     "description": "Application title"
   },
   "NjHXGh": {

--- a/apps/web/src/pages/Home/HomePage/components/Hero/Hero.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/Hero/Hero.tsx
@@ -52,17 +52,11 @@ const Hero = ({ defaultImage }: HeroProps) => {
           data-h2-text-align="base(center) p-tablet(left)"
         >
           <Heading level="h1" data-h2-margin="base(0, 0, x0.5, 0)">
-            {intl.formatMessage(
-              {
-                defaultMessage:
-                  "<abbreviation>GC</abbreviation> Digital Talent",
-                id: "eSPoJw",
-                description: "Application title",
-              },
-              {
-                abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
-              },
-            )}
+            {intl.formatMessage({
+              defaultMessage: "GC Digital Talent",
+              id: "MS9dB9",
+              description: "Application title",
+            })}
           </Heading>
           <p
             data-h2-font-size="base(h6, 1.4)"


### PR DESCRIPTION
🤖 Resolves #5812.

## 👋 Introduction

This PR removes the abbreviation from the Home Page Hero Heading.

## 🧪 Testing

1. Navigate to Home page `/en/`
2. Verify h1 heading (**GC Digital Talent**) does not have an underline on **GC** and does not show alt text on hover
3. Navigate to Home page `/fr/`
2. Verify h1 heading (**Talents numériques du GC**) does not have an underline on **GC** and does not show alt text on hover

## 📸 Screenshots

![Screen Shot 2023-03-06 at 10 43 35](https://user-images.githubusercontent.com/3046459/223160934-e5838ed2-4d98-4500-832e-1bd6c6ddba38.png)

![Screen Shot 2023-03-06 at 10 43 44](https://user-images.githubusercontent.com/3046459/223160955-405a7175-5db9-4927-a37d-01514b763aaf.png)
