### PR TITLE
bug/5842-codegen-turbo overcaching

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,7 @@
         "outputs": ["src/assets/css/hydrogen.css"]
     },
     "codegen": {
+      "inputs": ["src/**/*.graphql", "../../packages/**/src/**/*.graphql"],
       "outputs": ["src/api/generated.ts", "src/index.ts"]
     },
     "dev": {


### PR DESCRIPTION
🤖 Resolves #5842 

## 👋 Introduction

Hopefully patch that graphql caching matter

## 🕵️ Details

Just implementing Peter's suggestion 

## 🧪 Testing

1. npm run build
2. make changes to a graphql file
3. npm run build
4. assert the generated file was fresh

I tested by adding another return field to

![image](https://user-images.githubusercontent.com/40485260/223268051-6b5e805b-a65f-4de7-afb6-2ef67af26648.png)

and ensured the type was updated where the query was used

![image](https://user-images.githubusercontent.com/40485260/223267385-6c5690c0-c4d8-4d67-b89c-459be0150182.png)




