### PR TITLE
Tooling - 4569 - Adds preset `stats` errors-warnings

### DIFF
--- a/apps/web/webpack.base.js
+++ b/apps/web/webpack.base.js
@@ -23,6 +23,7 @@ module.exports = merge(base(basePath), {
       "~": path.resolve(basePath, "./src/"),
     }
   },
+  stats: "errors-warnings",
   // TO DO: We should be able to remove this after merging all apps
   output: {
     publicPath: "/", // final path for routing

--- a/apps/web/webpack.base.js
+++ b/apps/web/webpack.base.js
@@ -24,7 +24,6 @@ module.exports = merge(base(basePath), {
     }
   },
   stats: "errors-warnings",
-  // TO DO: We should be able to remove this after merging all apps
   output: {
     publicPath: "/", // final path for routing
     filename: "[name].[contenthash].js", // file hashing for cache busting


### PR DESCRIPTION
🤖 Resolves #4569.

## 👋 Introduction

This PR limits webpack's output to errors and warnings.

## 🧪 Testing

1. `npm run build`
2. Observe only output errors and warnings

## 📸 Screenshots

### Before
![Screen Shot 2023-03-07 at 10 46 01](https://user-images.githubusercontent.com/3046459/223474562-4cc94f9d-f207-45d9-8409-a2ff06aceee0.png)

### Now
![Screen Shot 2023-03-07 at 10 46 46](https://user-images.githubusercontent.com/3046459/223474576-271358c2-fab4-4a3a-9142-5cea9919f12e.png)