### PR TITLE
Feature/5752 constrain pools table by teams

### DIFF
--- a/apps/e2e/cypress/e2e/admin/pool-candidate.cy.js
+++ b/apps/e2e/cypress/e2e/admin/pool-candidate.cy.js
@@ -18,7 +18,7 @@ describe("Pool Candidates", () => {
     cy.intercept("POST", "/graphql", (req) => {
       aliasQuery(req, "GetPoolCandidateStatus");
       aliasQuery(req, "getPoolCandidateSnapshot");
-      aliasQuery(req, "getPools");
+      aliasQuery(req, "getMePools");
       aliasQuery(req, "GetPoolCandidatesPaginated");
 
       aliasMutation(req, "UpdatePoolCandidateStatus");
@@ -94,7 +94,7 @@ describe("Pool Candidates", () => {
 
     loginAndGoToPoolsPage();
 
-    cy.wait("@gqlgetPoolsQuery");
+    cy.wait("@gqlgetMePoolsQuery");
 
     cy.findByRole("textbox", { name: /search/i })
       .clear()
@@ -193,7 +193,7 @@ describe("Pool Candidates", () => {
 
     loginAndGoToPoolsPage();
 
-    cy.wait("@gqlgetPoolsQuery");
+    cy.wait("@gqlgetMePoolsQuery");
 
     cy.findByRole("textbox", { name: /search/i })
       .clear()

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -134,6 +134,40 @@ const emailLinkAccessor = (value: Maybe<string>, intl: IntlShape) => {
   );
 };
 
+// data manipulation functions
+// roles assignments array to teams array
+const createTeamsArray = (
+  roleAssignmentArray: Maybe<RoleAssignment[]>,
+): Team[] | null => {
+  if (roleAssignmentArray) {
+    let teamsArray: Team[] = [];
+    roleAssignmentArray.forEach((roleAssignmentInstance) => {
+      if (roleAssignmentInstance.team) {
+        teamsArray = [...teamsArray, roleAssignmentInstance.team];
+      }
+    });
+    return teamsArray;
+  }
+  return null;
+};
+// teams array to pools array
+const createPoolsArray = (teamsArray: Maybe<Team[]>): Pool[] | null => {
+  if (teamsArray) {
+    let poolsArray: Pool[] = [];
+    teamsArray.forEach((team) => {
+      if (team.pools) {
+        team.pools.forEach((pool) => {
+          if (pool) {
+            poolsArray = [...poolsArray, pool];
+          }
+        });
+      }
+    });
+    return poolsArray;
+  }
+  return null;
+};
+
 interface PoolTableProps {
   pools: Pool[];
 }
@@ -365,40 +399,6 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
 };
 
 const PoolTableApi = () => {
-  // data manipulation functions
-  // roles assignments to team collection
-  const createTeamsArray = (
-    roleAssignmentArray: Maybe<RoleAssignment[]>,
-  ): Team[] | null => {
-    if (roleAssignmentArray) {
-      let teamsArray: Team[] = [];
-      roleAssignmentArray.forEach((roleAssignmentInstance) => {
-        if (roleAssignmentInstance.team) {
-          teamsArray = [...teamsArray, roleAssignmentInstance.team];
-        }
-      });
-      return teamsArray;
-    }
-    return null;
-  };
-  // teams to pool collection
-  const createPoolsArray = (teamsArray: Maybe<Team[]>): Pool[] | null => {
-    if (teamsArray) {
-      let poolsArray: Pool[] = [];
-      teamsArray.forEach((team) => {
-        if (team.pools) {
-          team.pools.forEach((pool) => {
-            if (pool) {
-              poolsArray = [...poolsArray, pool];
-            }
-          });
-        }
-      });
-      return poolsArray;
-    }
-    return null;
-  };
-
   const [result] = useGetMePoolsQuery();
   const { data, fetching, error } = result;
   const teamsArray = createTeamsArray(data?.me?.roleAssignments);

--- a/apps/web/src/pages/Pools/IndexPoolPage/indexPoolsOperations.graphql
+++ b/apps/web/src/pages/Pools/IndexPoolPage/indexPoolsOperations.graphql
@@ -1,28 +1,37 @@
-query getPools {
-  pools {
-    id
-    owner {
+query getMePools {
+  me {
+    roleAssignments {
       id
-      email
-      firstName
-      lastName
+      team {
+        id
+        name
+        pools {
+          id
+          owner {
+            id
+            email
+            firstName
+            lastName
+          }
+          name {
+            en
+            fr
+          }
+          description {
+            en
+            fr
+          }
+          classifications {
+            id
+            group
+            level
+          }
+          advertisementStatus
+          stream
+          processNumber
+          createdDate
+        }
+      }
     }
-    name {
-      en
-      fr
-    }
-    description {
-      en
-      fr
-    }
-    classifications {
-      id
-      group
-      level
-    }
-    advertisementStatus
-    stream
-    processNumber
-    createdDate
   }
 }


### PR DESCRIPTION
🤖 Resolves #5752 

## 👋 Introduction

Rather than fetch all pools for the table, only pass in what the user is able to view.

## 🕵️ Details

Swapping queries and some type wrangling 😖 

## 🧪 Testing

1. go to /pools and affirm you can only see the pools you ought to see
2. run this query in playground to see what pools you have access to
```

query getMyPools {
  me {
    roleAssignments {
      team {
        id 
        name
        pools {
          id 
          name {
            en
          }
        }
      }
    }
  }
}
```

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/40485260/223591528-a172b47d-f45a-47f9-9167-a2828e67d406.png)



![image](https://user-images.githubusercontent.com/40485260/223591455-6bc607e0-c21b-42aa-8c9a-45508744eca6.png)

