### PR TITLE
Docs - 5654 - Removes `refresh_admin.sh` reference

### DIFF
--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -36,7 +36,6 @@ To refresh each sub-project after they have been setup run one of the refresh sc
 
 - `docker-compose run --rm maintenance bash refresh_api.sh`
 - `docker-compose run --rm maintenance bash refresh_frontend.sh`
-- `docker-compose run --rm maintenance bash refresh_admin.sh`
 
 Or refresh all of them in order:
 


### PR DESCRIPTION
🤖 Resolves #5654.

## 👋 Introduction

This PR removes an outdated line from the documentation.

## 🧪 Testing

1. Search for `refresh_admin.sh` in codebase
3. Verify it does not appear anywhere

