### PR TITLE
Feature - 5878 - pool creation team selection

### DIFF
--- a/apps/e2e/cypress/e2e/admin/pools.cy.js
+++ b/apps/e2e/cypress/e2e/admin/pools.cy.js
@@ -56,6 +56,14 @@ describe("Pools", () => {
           .should('have.text', "IT-01 (Information Technology)");
       });
 
+    // Set team
+    cy.findByRole("combobox", { name: /the team that the pool belongs to/i})
+      .select("Digital Community Management")
+      .within(() => {
+        cy.get("option:selected")
+          .should('have.text', "Digital Community Management");
+      });
+
     // Submit form
     cy.findByRole("button", { name: /create new pool/i })
       .click();

--- a/apps/e2e/cypress/e2e/admin/pools.cy.js
+++ b/apps/e2e/cypress/e2e/admin/pools.cy.js
@@ -57,7 +57,7 @@ describe("Pools", () => {
       });
 
     // Set team
-    cy.findByRole("combobox", { name: /the team that the pool belongs to/i})
+    cy.findByRole("combobox", { name: /parent team/i})
       .select("Digital Community Management")
       .within(() => {
         cy.get("option:selected")

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6786,10 +6786,6 @@
     "defaultMessage": "Rôles des membres",
     "description": "Label for the input to add roles to a user's team membership"
   },
-  "eW7I5E": {
-    "defaultMessage": "Sélectionner les rôles...",
-    "description": "Placeholder text for role selection input"
-  },
   "guzGyX": {
     "defaultMessage": "Le membre a été retiré de l’équipe avec succès",
     "description": "Alert displayed to user when a team member is removed"
@@ -6809,5 +6805,13 @@
   "1BEtoY": {
     "defaultMessage": "Nom du gestionnaire",
     "description": "Label for the user select field on team membership form"
+  },
+  "hr/i9h": {
+    "defaultMessage": "Sélectionnez une équipe...",
+    "description": "Placeholder displayed for team selection input."
+  },
+  "mOS8rj": {
+    "defaultMessage": "Équipe principale",
+    "description": "Label displayed for selecting what team a new pool belongs to."
   }
 }

--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -6,12 +6,7 @@ import { Squares2X2Icon } from "@heroicons/react/24/outline";
 
 import { toast } from "@gc-digital-talent/toast";
 import { Select, Submit, unpackMaybes } from "@gc-digital-talent/forms";
-import {
-  errorMessages,
-  commonMessages,
-  getGenericJobTitlesWithClassification,
-  getLocalizedName,
-} from "@gc-digital-talent/i18n";
+import { errorMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import { Pending, AdminBreadcrumbs, Link } from "@gc-digital-talent/ui";
 
 import PageHeader from "~/components/PageHeader/PageHeader";
@@ -22,9 +17,11 @@ import {
   useCreatePoolAdvertisementMutation,
   CreatePoolAdvertisementMutation,
   useGetMePoolCreationQuery,
-  GenericJobTitleKey,
   Classification,
+  Maybe,
+  Team,
 } from "~/api/generated";
+import { RoleAssignment } from "@gc-digital-talent/graphql";
 
 type Option<V> = { value: V; label: string };
 
@@ -32,15 +29,8 @@ type FormValues = {
   classification: string[];
 };
 
-interface GenericJobTitle {
-  key: GenericJobTitleKey;
-  id: string;
-  classificationId: string;
-}
-
 interface CreatePoolFormProps {
   userId: string;
-  genericJobTitles: GenericJobTitle[];
   classificationsArray: Classification[];
   handleCreatePool: (
     userId: string,
@@ -52,7 +42,6 @@ interface CreatePoolFormProps {
 
 export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
   userId,
-  genericJobTitles,
   classificationsArray,
   handleCreatePool,
   teamId,
@@ -116,22 +105,6 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
       url: paths.poolCreate(),
     },
   ];
-
-  // NOTICE NOTICE NOTICE NOTICE NOTICE
-  // how the CreatePool will function, in example, Generic Job Classifications vs regular Classifications is undecided so code segments are left in despite being unused
-  // TODO RESOLVE THIS
-
-  // create the options for the select input, and ensure classification Ids are attached to each option
-  // take care not to try and attach generic job title Id instead, wrong Id throws confusing sql errors
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const jobTitleOptions: Option<string>[] = genericJobTitles.map(
-    ({ key, classificationId }) => ({
-      value: classificationId,
-      label:
-        intl.formatMessage(getGenericJobTitlesWithClassification(key)) ??
-        intl.formatMessage(commonMessages.nameNotLoaded),
-    }),
-  );
 
   // recycled from EditPool
   const classificationOptions: Option<string>[] = classificationsArray
@@ -219,45 +192,35 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
   );
 };
 
+const roleAssignmentsToTeams = (
+  roleAssignmentArray: Maybe<RoleAssignment[]>,
+): Team[] => {
+  const flattenedTeams = roleAssignmentArray?.flatMap(
+    (roleAssign) => roleAssign.team,
+  );
+  const filteredFlattenedTeams = unpackMaybes(flattenedTeams);
+
+  // clear out any duplicate teams that could arise from multiple team-based roles per team
+  // https://stackoverflow.com/a/56757215
+  const teamsArray = filteredFlattenedTeams.filter(
+    (v, i, a) => a.findIndex((v2) => v2.id === v.id) === i,
+  );
+  return teamsArray;
+};
+
 const CreatePoolPage = () => {
   const intl = useIntl();
   const [lookupResult] = useGetMePoolCreationQuery();
   const { data: lookupData, fetching, error } = lookupResult;
 
-  // current user -> type change to only string
+  // current user
   const userIdQueryUntyped = lookupData?.me?.id;
-  const restrictUserType = (user: string | undefined): string => {
-    if (user) {
-      return user;
-    }
-    return "";
-  };
-  const userIdQuery = restrictUserType(userIdQueryUntyped);
+  const userIdQuery = userIdQueryUntyped || "";
 
-  // get rid of all those annoying Maybes, make sure classifications isn't a maybe either
-  const jobTitlesData = unpackMaybes(lookupData?.genericJobTitles);
-  const jobTitlesMapped = jobTitlesData
-    ? jobTitlesData.map((jobTitle) => {
-        return {
-          key: jobTitle.key,
-          id: jobTitle.id,
-          classificationId: jobTitle.classification
-            ? jobTitle.classification.id
-            : "",
-        };
-      })
-    : [];
-
-  // fetched all classifications
   const classificationsData = unpackMaybes(lookupData?.classifications);
+  const teamsArray = roleAssignmentsToTeams(lookupData?.me?.roleAssignments);
 
-  // find the dcm team in order to pass it into the pool creation component
-  // this will be changed later when pool creation is updated to incorporate team selection
-  const teamsData = unpackMaybes(lookupData?.teams);
-  const dcmTeam = teamsData.filter(
-    (team) => team.name === "digital-community-management",
-  );
-  const dcmTeamId = dcmTeam && dcmTeam.length > 0 ? dcmTeam[0].id : "";
+  const dcmTeamId = "";
 
   const [, executeMutation] = useCreatePoolAdvertisementMutation();
   const handleCreatePool = (
@@ -286,7 +249,6 @@ const CreatePoolPage = () => {
       <Pending fetching={fetching} error={error}>
         <CreatePoolForm
           userId={userIdQuery}
-          genericJobTitles={jobTitlesMapped}
           classificationsArray={classificationsData}
           handleCreatePool={handleCreatePool}
           teamId={dcmTeamId}

--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -172,8 +172,8 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
             <Select
               id="team"
               label={intl.formatMessage({
-                defaultMessage: "The team that the pool belongs to",
-                id: "DuTk5E",
+                defaultMessage: "Parent team",
+                id: "mOS8rj",
                 description:
                   "Label displayed for selecting what team a new pool belongs to.",
               })}

--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -27,6 +27,7 @@ type Option<V> = { value: V; label: string };
 
 type FormValues = {
   classification: string[];
+  team: string;
 };
 
 interface CreatePoolFormProps {
@@ -37,14 +38,14 @@ interface CreatePoolFormProps {
     teamId: string,
     data: CreatePoolAdvertisementInput,
   ) => Promise<CreatePoolAdvertisementMutation["createPoolAdvertisement"]>;
-  teamId: string; // currently API wrapper feeds in the dcm team by default
+  teamsArray: Team[];
 }
 
 export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
   userId,
   classificationsArray,
   handleCreatePool,
-  teamId,
+  teamsArray,
 }) => {
   const intl = useIntl();
   const navigate = useNavigate();
@@ -61,7 +62,7 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
     },
   });
   const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
-    await handleCreatePool(userId, teamId, formValuesToSubmitData(data))
+    await handleCreatePool(userId, data.team, formValuesToSubmitData(data))
       .then((result) => {
         if (result) {
           navigate(paths.poolUpdate(result.id));
@@ -114,6 +115,13 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
     }))
     .sort((a, b) => (a.label >= b.label ? 1 : -1));
 
+  const teamOptions: Option<string>[] = teamsArray
+    .map(({ id, displayName }) => ({
+      value: id,
+      label: getLocalizedName(displayName, intl),
+    }))
+    .sort((a, b) => (a.label >= b.label ? 1 : -1));
+
   return (
     <section data-h2-container="base(left, small, 0)">
       <PageHeader icon={Squares2X2Icon}>
@@ -157,6 +165,25 @@ export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
                   "Placeholder displayed on the pool form classification field.",
               })}
               options={classificationOptions}
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <Select
+              id="team"
+              label={intl.formatMessage({
+                defaultMessage: "The team that the pool belongs to",
+                id: "DuTk5E",
+                description:
+                  "Label displayed for selecting what team a new pool belongs to.",
+              })}
+              name="team"
+              nullSelection={intl.formatMessage({
+                defaultMessage: "Select a team...",
+                id: "hr/i9h",
+                description: "Placeholder displayed for team selection input.",
+              })}
+              options={teamOptions}
               rules={{
                 required: intl.formatMessage(errorMessages.required),
               }}
@@ -220,8 +247,6 @@ const CreatePoolPage = () => {
   const classificationsData = unpackMaybes(lookupData?.classifications);
   const teamsArray = roleAssignmentsToTeams(lookupData?.me?.roleAssignments);
 
-  const dcmTeamId = "";
-
   const [, executeMutation] = useCreatePoolAdvertisementMutation();
   const handleCreatePool = (
     userId: string,
@@ -251,7 +276,7 @@ const CreatePoolPage = () => {
           userId={userIdQuery}
           classificationsArray={classificationsData}
           handleCreatePool={handleCreatePool}
-          teamId={dcmTeamId}
+          teamsArray={teamsArray}
         />
       </Pending>
     </>

--- a/apps/web/src/pages/Pools/poolOperations.graphql
+++ b/apps/web/src/pages/Pools/poolOperations.graphql
@@ -129,23 +129,17 @@ query getMePoolCreation {
   me {
     legacyRoles
     id
-  }
-  genericJobTitles {
-    name {
-      en
-      fr
-    }
-    key
-    classification {
-      name {
-        en
-        fr
-      }
-      group
-      level
+    roleAssignments {
       id
+      team {
+        id
+        name
+        displayName {
+          en
+          fr
+        }
+      }
     }
-    id
   }
   classifications {
     name {
@@ -154,10 +148,6 @@ query getMePoolCreation {
     }
     level
     group
-    id
-  }
-  teams {
-    name
     id
   }
 }


### PR DESCRIPTION
🤖 Resolves #5878 

## 👋 Introduction

Incorporates team selection in the pool creation process. 

## 🕵️ Details

Just a matter of updating queries and passing in a teams array to the form. 
Overhauled a few things too, like the unused genericJobTitles collection. 

## 🧪 Testing

1. play around with pool creation, try to think of edge cases
2. confirm you can create pools and they attach to teams, and your teams are appearing correctly

a query to check your teams and their associated pools

```
query getMyPools {
  me {
    roleAssignments {
      team {
        id 
        name
        pools {
          id 
          name {
            en
          }
        }
      }
    }
  }
}
```

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/40485260/224164509-a28cecc6-8de9-4c1d-8d6c-b1c0b65285b2.png)


