### PR TITLE
Feature - 5903 - Removes instances of `wrapAbbr` from IAP

### DIFF
--- a/apps/web/src/hooks/useQuote.tsx
+++ b/apps/web/src/hooks/useQuote.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { wrapAbbr } from "~/utils/nameUtils";
-
 export interface Quote {
   content: React.ReactNode | string;
   author: string | React.ReactNode;
@@ -13,17 +11,11 @@ const useQuote = (): Quote => {
 
   const quotes: Quote[] = [
     {
-      author: intl.formatMessage(
-        {
-          defaultMessage:
-            "Government of Canada <abbreviation>IT</abbreviation> Apprentice",
-          id: "pRGDLn",
-          description: "author of testimonial number one",
-        },
-        {
-          abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
-        },
-      ),
+      author: intl.formatMessage({
+        defaultMessage: "Government of Canada IT Apprentice",
+        id: "49UIne",
+        description: "author of testimonial number one",
+      }),
       content: intl.formatMessage(
         {
           defaultMessage:

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5308,7 +5308,7 @@
     "description": "Title for the 'software solutions' IT work stream"
   },
   "pWoAv0": {
-    "defaultMessage": "Le Programme d’apprentissage en TI pour les personnes autochtones est une initiative du gouvernement du Canada visant particulièrement les Premières Nations, les Inuits et les Métis. C’est un chemin vers un emploi dans la fonction publique fédérale pour les personnes autochtones qui ont une passion pour la technologie de l’information (<abbreviation>TI</abbreviation>).",
+    "defaultMessage": "Le Programme d’apprentissage en TI pour les personnes autochtones est une initiative du gouvernement du Canada visant particulièrement les Premières Nations, les Inuits et les Métis. C’est un chemin vers un emploi dans la fonction publique fédérale pour les personnes autochtones qui ont une passion pour la technologie de l’information (TI).",
     "description": "First paragraph about the program"
   },
   "DgMIfz": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5159,8 +5159,8 @@
     "defaultMessage": "Parcourir les emplois en <abbreviation>TI</abbreviation>",
     "description": "Link text for IT jobs in government call to action"
   },
-  "2MQK8R": {
-    "defaultMessage": "Nous voulons vous informer qu’entre-temps, des mises à jour sont apportées à ce site qui permettront aux personnes autochtones qui souhaitent se joindre au Programme d’apprentissage en <abbreviation>TI</abbreviation> de présenter une demande en ligne.",
+  "BSSYnh": {
+    "defaultMessage": "Nous voulons vous informer qu’entre-temps, des mises à jour sont apportées à ce site qui permettront aux personnes autochtones qui souhaitent se joindre au Programme d’apprentissage en TI de présenter une demande en ligne.",
     "description": "Second paragraph for apply now dialog"
   },
   "2aBKgf": {
@@ -5187,28 +5187,28 @@
     "defaultMessage": "Architecture intégrée de la <abbreviation>TI</abbreviation>",
     "description": "work stream example"
   },
-  "7Kb+Uh": {
-    "defaultMessage": "Programme d’apprentissage en <abbreviation>TI</abbreviation> pour les peuples autochtones. Postulez dès aujourd’hui pour entamer votre parcours de carrière en TI.",
+  "qZvV7b": {
+    "defaultMessage": "Programme d’apprentissage en TI pour les peuples autochtones. Postulez dès aujourd’hui pour entamer votre parcours de carrière en TI.",
     "description": "Homepage title for Indigenous Apprenticeship Program"
   },
   "7wcfnG": {
     "defaultMessage": "Il y a deux types d'employés du <abbreviation>TI-03</abbreviation> : ceux qui suivent un cheminement en gestion et les contributeurs individuels.",
     "description": "IT-03 description precursor"
   },
-  "9FKjvW": {
-    "defaultMessage": "En collaboration avec le Programme d’apprentissage en <abbreviation>TI</abbreviation> pour les peuples autochtones, le Portail des talents autochtones commencera par mettre l’accent sur les talents en <abbreviation>TI</abbreviation> et en technologie, ce qui permettra :",
+  "Dzyk1q": {
+    "defaultMessage": "En collaboration avec le Programme d’apprentissage en TI pour les peuples autochtones, le Portail des talents autochtones commencera par mettre l’accent sur les talents en TI et en technologie, ce qui permettra :",
     "description": "Description for strategy for the indigenous talent portal"
   },
-  "9Nf78m": {
-    "defaultMessage": "Qui peut présenter une demande pour devenir apprenti dans le cadre du Programme d’apprentissage en <abbreviation>TI</abbreviation> pour les peuples autochtones du gouvernement du Canada?",
+  "p2sBh3": {
+    "defaultMessage": "Qui peut présenter une demande pour devenir apprenti dans le cadre du Programme d’apprentissage en TI pour les peuples autochtones du gouvernement du Canada?",
     "description": "Learn more dialog question one heading"
   },
   "AlRcyu": {
     "defaultMessage": "Gestion de portefeuilles de projets de la <abbreviation>TI</abbreviation>",
     "description": "Title for the 'project portfolio management' IT work stream"
   },
-  "BxAUGH": {
-    "defaultMessage": "Veuillez envoyer votre curriculum vitae et votre lettre de présentation expliquant votre passion pour la <abbreviation>TI</abbreviation> et pourquoi vous souhaitez vous joindre au programme, à : <mailLink>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</mailLink>. Un membre de l’équipe communiquera avec vous dans 3 à 5 jours ouvrables.",
+  "EqVMCE": {
+    "defaultMessage": "Veuillez envoyer votre curriculum vitae et votre lettre de présentation expliquant votre passion pour la TI et pourquoi vous souhaitez vous joindre au programme, à : <mailLink>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</mailLink>. Un membre de l’équipe communiquera avec vous dans 3 à 5 jours ouvrables.",
     "description": "First paragraph for apply now dialog"
   },
   "CIwCa3": {
@@ -5223,8 +5223,8 @@
     "defaultMessage": "Niveau 4 : Gestionnaire (101 000 $ à 126 000 $). <openModal>En savoir plus sur <abbreviation>TI-04</abbreviation></openModal>",
     "description": "Checkbox label for Level IT-04 manager selection, ignore things in <> tags please"
   },
-  "Ea8q/H": {
-    "defaultMessage": "Découvrez-en davantage sur le Programme d’apprentissage en <abbreviation>TI</abbreviation> pour les peuples autochtones du gouvernement du Canada",
+  "L9yjr3": {
+    "defaultMessage": "Découvrez-en davantage sur le Programme d’apprentissage en TI pour les peuples autochtones du gouvernement du Canada",
     "description": "Heading for the Learn more dialog"
   },
   "F5kDhX": {
@@ -5295,8 +5295,8 @@
     "defaultMessage": "<strong>Cheminement en gestion</strong> : Chefs d'équipe de la <abbreviation>TI</abbreviation> (<abbreviation>TI-03</abbreviation>) sont chargés de superviser le travail et les équipes de projet pour les services et les opérations de la <abbreviation>TI</abbreviation> dans leur domaine d'expertise afin de soutenir la prestation de services aux clients et aux intervenants. Les chefs d'équipe de la <abbreviation>TI</abbreviation> se trouvent dans tous les volets de travail.",
     "description": "IT-03 team lead path description, ignore things in <> tags please"
   },
-  "RCV8Us": {
-    "defaultMessage": "Nous reconnaissons l’importance de la voix des autochtones au sein du gouvernement fédéral. L’objectif du programme d’apprentissage en <abbreviation>TI</abbreviation> destiné aux peuples autochtones est de faire entendre la voix des autochtones en créant des occasions pour les membres des Premières Nations, les Inuits et les Métis de faire partie de la fonction publique fédérale.",
+  "J2uivT": {
+    "defaultMessage": "Nous reconnaissons l’importance de la voix des autochtones au sein du gouvernement fédéral. L’objectif du programme d’apprentissage en TI destiné aux peuples autochtones est de faire entendre la voix des autochtones en créant des occasions pour les membres des Premières Nations, les Inuits et les Métis de faire partie de la fonction publique fédérale.",
     "description": "Paragraph one for the self-declaration explanation dialog"
   },
   "S02Y/P": {
@@ -5307,12 +5307,12 @@
     "defaultMessage": "Solutions logicielles de la <abbreviation>TI</abbreviation>",
     "description": "Title for the 'software solutions' IT work stream"
   },
-  "b3v0nI": {
-    "defaultMessage": "Le Programme d’apprentissage en <abbreviation>TI</abbreviation> pour les personnes autochtones est une initiative du gouvernement du Canada visant particulièrement les Premières Nations, les Inuits et les Métis. C’est un chemin vers un emploi dans la fonction publique fédérale pour les personnes autochtones qui ont une passion pour la technologie de l’information (<abbreviation>TI</abbreviation>).",
+  "pWoAv0": {
+    "defaultMessage": "Le Programme d’apprentissage en TI pour les personnes autochtones est une initiative du gouvernement du Canada visant particulièrement les Premières Nations, les Inuits et les Métis. C’est un chemin vers un emploi dans la fonction publique fédérale pour les personnes autochtones qui ont une passion pour la technologie de l’information (<abbreviation>TI</abbreviation>).",
     "description": "First paragraph about the program"
   },
-  "W2G590": {
-    "defaultMessage": "Le Programme d’apprentissage en <abbreviation>TI</abbreviation> vous convient-il?",
+  "DgMIfz": {
+    "defaultMessage": "Le Programme d’apprentissage en TI vous convient-il?",
     "description": "Application box heading part one"
   },
   "WgGDug": {
@@ -5323,16 +5323,16 @@
     "defaultMessage": "Ce volet comprend la gestion de l’infrastructure des réseaux, des ordinateurs centraux, des serveurs et du stockage, la fourniture d’un soutien de la <abbreviation>TI</abbreviation> et les relations avec les clients et fournisseurs.",
     "description": "Title for the 'infrastructure operations' IT work stream"
   },
-  "Zd1x6H": {
-    "defaultMessage": "Programme d’apprentissage en <abbreviation>TI</abbreviation> pour les personnes autochtones + Portail des talents autochtones",
+  "osGGIt": {
+    "defaultMessage": "Programme d’apprentissage en TI pour les personnes autochtones + Portail des talents autochtones",
     "description": "heading for indigenous talent portal section"
   },
   "bNBhvY": {
     "defaultMessage": "Niveau 4 : Conseiller principal (101 000 $ à 126 000 $). <openModal>En savoir plus sur <abbreviation>TI-04</abbreviation></openModal>",
     "description": "Checkbox label for Level IT-04 senior advisor selection, ignore things in <> tags please"
   },
-  "cMDC/P": {
-    "defaultMessage": "Répondre à la forte demande de talents autochtones en <abbreviation>TI</abbreviation>.",
+  "Xhfkfg": {
+    "defaultMessage": "Répondre à la forte demande de talents autochtones en TI.",
     "description": "Talent portal strategy item 1 content"
   },
   "drDPf3": {
@@ -5343,8 +5343,8 @@
     "defaultMessage": "Architecture intégrée de la <abbreviation>TI</abbreviation>",
     "description": "Title for the 'enterprise architecture' IT work stream"
   },
-  "gxOExQ": {
-    "defaultMessage": "Nous voulons en apprendre davantage sur vous et sur votre intérêt ou votre passion dans le domaine de la <abbreviation>TI</abbreviation>!",
+  "yZMQ6j": {
+    "defaultMessage": "Nous voulons en apprendre davantage sur vous et sur votre intérêt ou votre passion dans le domaine de la TI!",
     "description": "How it works, step 2 content sentence 1"
   },
   "hKKYYL": {
@@ -5379,8 +5379,8 @@
     "defaultMessage": "Si vous n’êtes pas sûr de vouloir fournir vos renseignements, ou si vous avez des questions concernant le programme d’apprentissage en <abbreviation>TI</abbreviation> pour les personnes autochtones, veuillez <link>nous contacter</link> nous serons heureux de vous rencontrer.",
     "description": "Text describing where to get help with the self-declaration form"
   },
-  "pRGDLn": {
-    "defaultMessage": "Apprenti en <abbreviation>TI</abbreviation> du Gouvernement du Canada",
+  "49UIne": {
+    "defaultMessage": "Apprenti en TI du Gouvernement du Canada",
     "description": "author of testimonial number one"
   },
   "tM1de5": {

--- a/apps/web/src/pages/Home/IAPHomePage/Home.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.tsx
@@ -5,7 +5,6 @@ import { motion } from "framer-motion";
 import { imageUrl } from "@gc-digital-talent/helpers";
 
 import useQuote from "~/hooks/useQuote";
-import { wrapAbbr } from "~/utils/nameUtils";
 
 import Banner from "./components/Banner";
 import Card from "./components/Card";
@@ -89,18 +88,13 @@ const Home: React.FunctionComponent = () => {
               alt=""
             />
             <span data-h2-visually-hidden="base(invisible)">
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "<abbreviation>IT</abbreviation> Apprenticeship Program for Indigenous Peoples. Apply today to get started on your <abbreviation>IT</abbreviation> career journey.",
-                  id: "7Kb+Uh",
-                  description:
-                    "Homepage title for Indigenous Apprenticeship Program",
-                },
-                {
-                  abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
-                },
-              )}
+              {intl.formatMessage({
+                defaultMessage:
+                  "IT Apprenticeship Program for Indigenous Peoples. Apply today to get started on your IT career journey.",
+                id: "qZvV7b",
+                description:
+                  "Homepage title for Indigenous Apprenticeship Program",
+              })}
             </span>
           </h1>
         </div>
@@ -196,18 +190,12 @@ const Home: React.FunctionComponent = () => {
                     })}
                   </Heading>
                   <p data-h2-margin="base(x2, 0, x1, 0)">
-                    {intl.formatMessage(
-                      {
-                        defaultMessage:
-                          "The <abbreviation>IT</abbreviation> Apprenticeship Program for Indigenous Peoples is a Government of Canada initiative specifically for First Nations, Inuit, and Métis peoples. It is pathway to employment in the federal public service for Indigenous peoples who have a passion for Information Technology (<abbreviation>IT</abbreviation>).",
-                        id: "b3v0nI",
-                        description: "First paragraph about the program",
-                      },
-                      {
-                        abbreviation: (text: React.ReactNode) =>
-                          wrapAbbr(text, intl),
-                      },
-                    )}
+                    {intl.formatMessage({
+                      defaultMessage:
+                        "The IT Apprenticeship Program for Indigenous Peoples is a Government of Canada initiative specifically for First Nations, Inuit, and Métis peoples. It is pathway to employment in the federal public service for Indigenous peoples who have a passion for Information Technology (IT).",
+                      id: "pWoAv0",
+                      description: "First paragraph about the program",
+                    })}
                   </p>
                   <p data-h2-margin="base(x1, 0)">
                     {intl.formatMessage({
@@ -496,18 +484,12 @@ const Home: React.FunctionComponent = () => {
                     data-h2-font-size="base(h3, 1)"
                   >
                     <span data-h2-display="base(block)">
-                      {intl.formatMessage(
-                        {
-                          defaultMessage:
-                            "Is the <abbreviation>IT</abbreviation> Apprenticeship Program right for you?",
-                          id: "W2G590",
-                          description: "Application box heading part one",
-                        },
-                        {
-                          abbreviation: (text: React.ReactNode) =>
-                            wrapAbbr(text, intl),
-                        },
-                      )}
+                      {intl.formatMessage({
+                        defaultMessage:
+                          "Is the IT Apprenticeship Program right for you?",
+                        id: "DgMIfz",
+                        description: "Application box heading part one",
+                      })}
                     </span>
                     <span>
                       {intl.formatMessage({
@@ -581,17 +563,12 @@ const Home: React.FunctionComponent = () => {
               color="white"
               data-h2-margin="base(0, 0, x3, 0) p-tablet(x3, 0)"
             >
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "<abbreviation>IT</abbreviation> Apprenticeship Program for Indigenous Peoples + The Indigenous Talent Portal",
-                  id: "Zd1x6H",
-                  description: "heading for indigenous talent portal section",
-                },
-                {
-                  abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
-                },
-              )}
+              {intl.formatMessage({
+                defaultMessage:
+                  "IT Apprenticeship Program for Indigenous Peoples + The Indigenous Talent Portal",
+                id: "osGGIt",
+                description: "heading for indigenous talent portal section",
+              })}
             </Heading>
             <Heading as="h3" color="white">
               {intl.formatMessage({
@@ -654,18 +631,12 @@ const Home: React.FunctionComponent = () => {
                 })}
               >
                 <p data-h2-margin="base(x1, 0, 0, 0)">
-                  {intl.formatMessage(
-                    {
-                      defaultMessage:
-                        "We want to learn about you and about your interest/passion in the area of <abbreviation>IT</abbreviation>!",
-                      id: "gxOExQ",
-                      description: "How it works, step 2 content sentence 1",
-                    },
-                    {
-                      abbreviation: (text: React.ReactNode) =>
-                        wrapAbbr(text, intl),
-                    },
-                  )}
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "We want to learn about you and about your interest/passion in the area of IT!",
+                    id: "yZMQ6j",
+                    description: "How it works, step 2 content sentence 1",
+                  })}
                 </p>
                 <p data-h2-margin="base(x1, 0, 0, 0)">
                   {intl.formatMessage({
@@ -719,18 +690,13 @@ const Home: React.FunctionComponent = () => {
               data-h2-color="base(white)"
               data-h2-max-width="base(38rem)"
             >
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "In collaboration with the <abbreviation>IT</abbreviation> Apprenticeship Program for Indigenous Peoples, the Indigenous Talent Portal will begin with a focus on <abbreviation>IT</abbreviation> and technology talent, which will:",
-                  id: "9FKjvW",
-                  description:
-                    "Description for strategy for the indigenous talent portal",
-                },
-                {
-                  abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
-                },
-              )}
+              {intl.formatMessage({
+                defaultMessage:
+                  "In collaboration with the IT Apprenticeship Program for Indigenous Peoples, the Indigenous Talent Portal will begin with a focus on IT and technology talent, which will:",
+                id: "Dzyk1q",
+                description:
+                  "Description for strategy for the indigenous talent portal",
+              })}
             </p>
           </div>
           <div data-h2-flex-grid="base(flex-start, x3, x2)">
@@ -744,18 +710,12 @@ const Home: React.FunctionComponent = () => {
                 })}
               >
                 <p>
-                  {intl.formatMessage(
-                    {
-                      defaultMessage:
-                        "Address the great demand for Indigenous talent in <abbreviation>IT</abbreviation>.",
-                      id: "cMDC/P",
-                      description: "Talent portal strategy item 1 content",
-                    },
-                    {
-                      abbreviation: (text: React.ReactNode) =>
-                        wrapAbbr(text, intl),
-                    },
-                  )}
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "Address the great demand for Indigenous talent in IT.",
+                    id: "Xhfkfg",
+                    description: "Talent portal strategy item 1 content",
+                  })}
                 </p>
               </Card>
             </div>

--- a/apps/web/src/pages/Home/IAPHomePage/components/Dialog/ApplyDialog.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Dialog/ApplyDialog.tsx
@@ -3,8 +3,6 @@ import { useIntl } from "react-intl";
 
 import { Button, Dialog } from "@gc-digital-talent/ui";
 
-import { wrapAbbr } from "~/utils/nameUtils";
-
 import CloseButton from "./CloseButton";
 
 import { BasicDialogProps } from "./types";
@@ -44,28 +42,22 @@ const ApplyDialog = ({ btnProps }: BasicDialogProps) => {
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "Please send your resume and cover letter explaining your passion for <abbreviation>IT</abbreviation> and why you're interested in joining the program to: <mailLink>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</mailLink>. A team member will contact you in 3-5 business days",
-                id: "BxAUGH",
+                  "Please send your resume and cover letter explaining your passion for IT and why you're interested in joining the program to: <mailLink>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</mailLink>. A team member will contact you in 3-5 business days",
+                id: "EqVMCE",
                 description: "First paragraph for apply now dialog",
               },
               {
                 mailLink: mailAccessor,
-                abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
               },
             )}
           </p>
           <p data-h2-margin="base(x1, 0, 0, 0)">
-            {intl.formatMessage(
-              {
-                defaultMessage:
-                  "We want to let you know that in the meantime, updates are being made on this site that will allow Indigenous peoples who are interested in joining the <abbreviation>IT</abbreviation> Apprenticeship Program to apply online.",
-                id: "2MQK8R",
-                description: "Second paragraph for apply now dialog",
-              },
-              {
-                abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
-              },
-            )}
+            {intl.formatMessage({
+              defaultMessage:
+                "We want to let you know that in the meantime, updates are being made on this site that will allow Indigenous peoples who are interested in joining the IT Apprenticeship Program to apply online.",
+              id: "BSSYnh",
+              description: "Second paragraph for apply now dialog",
+            })}
           </p>
           <p data-h2-margin="base(x1, 0, 0, 0)">
             {intl.formatMessage({

--- a/apps/web/src/pages/Home/IAPHomePage/components/Dialog/LearnDialog.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Dialog/LearnDialog.tsx
@@ -3,8 +3,6 @@ import { useIntl } from "react-intl";
 
 import { Button, Dialog } from "@gc-digital-talent/ui";
 
-import { wrapAbbr } from "~/utils/nameUtils";
-
 import Heading from "../Heading";
 import CloseButton from "./CloseButton";
 
@@ -26,17 +24,12 @@ const LearnDialog = ({ btnProps }: BasicDialogProps) => {
       </Dialog.Trigger>
       <Dialog.Content>
         <Dialog.Header>
-          {intl.formatMessage(
-            {
-              defaultMessage:
-                "Learn More About the Government of Canada <abbreviation>IT</abbreviation> Apprenticeship Program for Indigenous Peoples",
-              id: "Ea8q/H",
-              description: "Heading for the Learn more dialog",
-            },
-            {
-              abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
-            },
-          )}
+          {intl.formatMessage({
+            defaultMessage:
+              "Learn More About the Government of Canada IT Apprenticeship Program for Indigenous Peoples",
+            id: "L9yjr3",
+            description: "Heading for the Learn more dialog",
+          })}
         </Dialog.Header>
         <Dialog.Body>
           <Heading
@@ -44,17 +37,12 @@ const LearnDialog = ({ btnProps }: BasicDialogProps) => {
             data-h2-font-size="base(h6, 1.3)"
             data-h2-margin="base(0)"
           >
-            {intl.formatMessage(
-              {
-                defaultMessage:
-                  "Who can apply to become an apprentice as part of the Government of Canada <abbreviation>IT</abbreviation> Apprenticeship Program for Indigenous Peoples?",
-                id: "9Nf78m",
-                description: "Learn more dialog question one heading",
-              },
-              {
-                abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
-              },
-            )}
+            {intl.formatMessage({
+              defaultMessage:
+                "Who can apply to become an apprentice as part of the Government of Canada IT Apprenticeship Program for Indigenous Peoples?",
+              id: "p2sBh3",
+              description: "Learn more dialog question one heading",
+            })}
           </Heading>
           <p data-h2-margin="base(x1, 0)">
             {intl.formatMessage({

--- a/apps/web/src/pages/Home/IAPHomePage/components/Dialog/SelfDeclarationDialog.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Dialog/SelfDeclarationDialog.tsx
@@ -3,8 +3,6 @@ import { useIntl } from "react-intl";
 
 import { Button, Dialog } from "@gc-digital-talent/ui";
 
-import { wrapAbbr } from "~/utils/nameUtils";
-
 import CloseButton from "./CloseButton";
 
 import type { BasicDialogProps } from "./types";
@@ -29,18 +27,13 @@ const SelfDeclarationDialog = ({ children, btnProps }: BasicDialogProps) => {
         </Dialog.Header>
         <Dialog.Body>
           <p data-h2-margin="base(x1, 0)">
-            {intl.formatMessage(
-              {
-                defaultMessage:
-                  "We recognize the importance of Indigenous voices in the federal government. The goal of the <abbreviation>IT</abbreviation> Apprenticeship Program for Indigenous Peoples is to amplify Indigenous voices by creating opportunities for First Nations, Inuit, and Métis peoples to join the federal public service.",
-                id: "RCV8Us",
-                description:
-                  "Paragraph one for the self-declaration explanation dialog",
-              },
-              {
-                abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
-              },
-            )}
+            {intl.formatMessage({
+              defaultMessage:
+                "We recognize the importance of Indigenous voices in the federal government. The goal of the IT Apprenticeship Program for Indigenous Peoples is to amplify Indigenous voices by creating opportunities for First Nations, Inuit, and Métis peoples to join the federal public service.",
+              id: "J2uivT",
+              description:
+                "Paragraph one for the self-declaration explanation dialog",
+            })}
           </p>
           <p data-h2-margin="base(x1, 0)">
             {intl.formatMessage({


### PR DESCRIPTION
🤖 Resolves #5903.

## 👋 Introduction

This PR removes instances of `wrapAbbr` from the IAP home page and its dialogs.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/en/indigenous-it-apprentice`
2. Ensure none of text has abbreviations with underline and alt text on hover
3. Navigate to `/fr/indigenous-it-apprentice`
4. Ensure none of text has abbreviations with underline and alt text on hover
5. Ensure none of text has an English fallback


