### PR TITLE
Bug - 5805 - Removes extra period

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2350,7 +2350,7 @@
     "description": "Text describing upcoming opportunities instructing users to update a profile when logged in"
   },
   "OMDX09": {
-    "defaultMessage": "Préparez-vous en mettant à jour votre profil.",
+    "defaultMessage": "Préparez-vous en mettant à jour votre profil",
     "description": "Link text to update your profile for executive jobs in government"
   },
   "OdjW9z": {


### PR DESCRIPTION
🤖 Resolves #5805.

## 👋 Introduction

This PR removes an inconsistent use of punctuation on button text in French.

## 🧪 Testing

1. Login as a user
2. Navigate to home page
3. View button text under Executives in digital government
4. Switch to French
5. View button text under Les cadres dans le gouvernement numérique
6. Verify there is no period at the end of _Préparez-vous en mettant à jour votre profil_

## 📸 Screenshot
![Screen Shot 2023-03-10 at 10 27 00](https://user-images.githubusercontent.com/3046459/224356005-ad09aa96-4118-4153-8b6c-e89d6f65590d.png)




