### PR TITLE
Debt - 5854 - Removes `intl.formatMessage` description instructions

### DIFF
--- a/apps/web/src/components/UserProfile/ProfileSections/DiversityEquityInclusionSection.tsx
+++ b/apps/web/src/components/UserProfile/ProfileSections/DiversityEquityInclusionSection.tsx
@@ -74,9 +74,9 @@ const DiversityEquityInclusionSection: React.FunctionComponent<{
               {intl.formatMessage({
                 defaultMessage:
                   "You have not identified as a member of any employment equity groups.",
-                id: "vpAafL",
+                id: "G3K1/H",
                 description:
-                  "Message indicating the user has not been marked as part of an equity group, Ignore things in <> please.",
+                  "Message indicating the user has not been marked as part of an equity group",
               })}
             </p>
             <p data-h2-margin="base(x.5, 0, 0, 0)">
@@ -251,9 +251,9 @@ const DiversityEquityInclusionSection: React.FunctionComponent<{
               {intl.formatMessage({
                 defaultMessage:
                   "You have identified as a member of an employment equity group.<strong> You can add additional employment equity groups to your profile by editing this section if they apply to you.</strong>",
-                id: "f8ZHHW",
+                id: "K4O5hP",
                 description:
-                  "Final paragraph in the employment equity profile section, ignore things in <> please",
+                  "Final paragraph in the employment equity profile section",
               })}
             </p>
           </div>

--- a/apps/web/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
+++ b/apps/web/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
@@ -190,9 +190,8 @@ const WorkPreferencesSection: React.FunctionComponent<{
               {intl.formatMessage({
                 defaultMessage:
                   "I would <strong>not consider</strong> accepting a job that:",
-                id: "GThNuu",
-                description:
-                  "would not accept job line before a list, ignore things in <> please",
+                id: "TwSvmH",
+                description: "would not accept job line before a list",
               })}
             </p>
             <ul data-h2-padding="base(0, 0, 0, x1)">
@@ -223,9 +222,8 @@ const WorkPreferencesSection: React.FunctionComponent<{
               {intl.formatMessage({
                 defaultMessage:
                   "I would <strong>not consider</strong> accepting a job that:",
-                id: "GThNuu",
-                description:
-                  "would not accept job line before a list, ignore things in <> please",
+                id: "TwSvmH",
+                description: "would not accept job line before a list",
               })}
             </p>
             <ul data-h2-padding="base(0, 0, 0, x1)">

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5211,25 +5211,25 @@
     "defaultMessage": "Veuillez envoyer votre curriculum vitae et votre lettre de présentation expliquant votre passion pour la TI et pourquoi vous souhaitez vous joindre au programme, à : <mailLink>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</mailLink>. Un membre de l’équipe communiquera avec vous dans 3 à 5 jours ouvrables.",
     "description": "First paragraph for apply now dialog"
   },
-  "CIwCa3": {
+  "7xDPj5": {
     "defaultMessage": "<strong>Contributeur individuel</strong> : Les conseillers techniques en <abbreviation>TI</abbreviation> (<abbreviation>TI-03</abbreviation>) fournissent des conseils techniques spécialisés, des recommandations et du soutien sur les solutions et les services dans leur domaine d'expertise pour appuyer la prestation de services aux clients et aux intervenants. Les conseillers techniques en <abbreviation>TI</abbreviation> se trouvent dans tous les volets de travail.",
-    "description": "IT-03 advisor description, ignore things in <> tags please"
+    "description": "IT-03 advisor description"
   },
   "E3loNV": {
     "defaultMessage": "Planification et établissement de rapports en matière de <abbreviation>TI</abbreviation>",
     "description": "Title for the 'planning and reporting' IT work stream"
   },
-  "EGXG1j": {
+  "O8m3JS": {
     "defaultMessage": "Niveau 4 : Gestionnaire (101 000 $ à 126 000 $). <openModal>En savoir plus sur <abbreviation>TI-04</abbreviation></openModal>",
-    "description": "Checkbox label for Level IT-04 manager selection, ignore things in <> tags please"
+    "description": "Checkbox label for Level IT-04 manager selection"
   },
   "L9yjr3": {
     "defaultMessage": "Découvrez-en davantage sur le Programme d’apprentissage en TI pour les peuples autochtones du gouvernement du Canada",
     "description": "Heading for the Learn more dialog"
   },
-  "F5kDhX": {
+  "SPECr8": {
     "defaultMessage": "<strong>Contributeur individuel</strong> : Les conseillers principaux en <abbreviation>TI</abbreviation> (<abbreviation>TI-04</abbreviation>) fournissent des conseils techniques et une orientation stratégique d'experts dans leur domaine d'expertise en matière de fourniture de solutions et de services à des clients internes ou externes et à des intervenants.",
-    "description": "IT-04 senior advisor description precursor to work stream list, ignore things in <> tags please"
+    "description": "IT-04 senior advisor description precursor to work stream list"
   },
   "FtJRWS": {
     "defaultMessage": "Conçu par la communauté autochtone pour la communauté autochtone, ce programme recrute des candidats pour des postes de niveau d'entrée pour des possibilités d’apprentissage et de développement des <abbreviation>TI</abbreviation> dans l’ensemble du gouvernement.",
@@ -5259,9 +5259,9 @@
     "defaultMessage": "Voici où vous pouvez ajouter des expériences et des compétences à votre profil. Cela pourrait aller d'aider les membres de la communauté à résoudre leurs problèmes d'ordinateur au travail à temps plein dans une organisme de TI.",
     "description": "Description for the experience and skills page in applicant profile."
   },
-  "L6sIvM": {
+  "FEEa2S": {
     "defaultMessage": "Niveau 3 : Chef d'équipe (88 000 $ à 110 000 $). <openModal>En savoir plus sur <abbreviation>TI-03</abbreviation></openModal>",
-    "description": "Checkbox label for Level IT-03 leader selection, ignore things in <> tags please"
+    "description": "Checkbox label for Level IT-03 leader selection"
   },
   "LOvD2e": {
     "defaultMessage": "Vous recherchez des talents en <abbreviation>TI</abbreviation> de niveau débutant et vous désirez soutenir la diversité, l’inclusion et la réconciliation? Communiquez avec le programme d’apprentissage en <abbreviation>TI</abbreviation> pour les personnes autochtones et lancez le processus d’embauche de stagiaires autochtones dès aujourd’hui!",
@@ -5279,9 +5279,9 @@
     "defaultMessage": "Gestion de la base de données de la <abbreviation>TI</abbreviation>",
     "description": "work stream example"
   },
-  "OheHgg": {
+  "NeR+6V": {
     "defaultMessage": "<strong>Contributeur individuel</strong> : Les conseillers principaux en <abbreviation>TI</abbreviation> (<abbreviation>TI-04</abbreviation>) fournissent des conseils techniques et une orientation stratégique d'experts dans leur domaine d'expertise en matière de fourniture de solutions et de services à des clients internes ou externes et à des intervenants.",
-    "description": "IT-04 senior advisor description precursor to work stream list, ignore things in <> tags please"
+    "description": "IT-04 senior advisor description precursor to work stream list"
   },
   "OqglGZ": {
     "defaultMessage": "Ce volet comprend le travail avec la direction de l’architecture <abbreviation>TI</abbreviation> du ministère, la collaboration avec d’autres volets de <abbreviation>TI</abbreviation> et la recherche sur les technologies émergentes.",
@@ -5291,9 +5291,9 @@
     "defaultMessage": "Conçu par la communauté autochtone, avec elle et pour elle, le programme recrute des candidats des Premières Nations, inuits et métis qui se passionnent pour les TI, pour des emplois de niveau débutant, ainsi que pour des possibilités d’apprentissage et de perfectionnement.",
     "description": "Summary for Indigenous community job opportunities on Browse IT jobs page"
   },
-  "QdYrqI": {
+  "t+WUYM": {
     "defaultMessage": "<strong>Cheminement en gestion</strong> : Chefs d'équipe de la <abbreviation>TI</abbreviation> (<abbreviation>TI-03</abbreviation>) sont chargés de superviser le travail et les équipes de projet pour les services et les opérations de la <abbreviation>TI</abbreviation> dans leur domaine d'expertise afin de soutenir la prestation de services aux clients et aux intervenants. Les chefs d'équipe de la <abbreviation>TI</abbreviation> se trouvent dans tous les volets de travail.",
-    "description": "IT-03 team lead path description, ignore things in <> tags please"
+    "description": "IT-03 team lead path description"
   },
   "J2uivT": {
     "defaultMessage": "Nous reconnaissons l’importance de la voix des autochtones au sein du gouvernement fédéral. L’objectif du programme d’apprentissage en TI destiné aux peuples autochtones est de faire entendre la voix des autochtones en créant des occasions pour les membres des Premières Nations, les Inuits et les Métis de faire partie de la fonction publique fédérale.",
@@ -5327,9 +5327,9 @@
     "defaultMessage": "Programme d’apprentissage en TI pour les personnes autochtones + Portail des talents autochtones",
     "description": "heading for indigenous talent portal section"
   },
-  "bNBhvY": {
+  "dofE/5": {
     "defaultMessage": "Niveau 4 : Conseiller principal (101 000 $ à 126 000 $). <openModal>En savoir plus sur <abbreviation>TI-04</abbreviation></openModal>",
-    "description": "Checkbox label for Level IT-04 senior advisor selection, ignore things in <> tags please"
+    "description": "Checkbox label for Level IT-04 senior advisor selection"
   },
   "Xhfkfg": {
     "defaultMessage": "Répondre à la forte demande de talents autochtones en TI.",
@@ -5363,13 +5363,13 @@
     "defaultMessage": "Explorer les occasions en matière de <abbreviation>TI</abbreviation> au sein du gouvernement fédéral",
     "description": "Button text to submit the Indigenous self-declaration form when not Indigenous."
   },
-  "jZDflg": {
+  "WTdmxR": {
     "defaultMessage": "Niveau 3 : Conseiller technique (88 000 $ à 110 000 $). <openModal>En savoir plus sur <abbreviation>TI-03</abbreviation></openModal>",
-    "description": "Checkbox label for Level IT-03 advisor selection, ignore things in <> tags please"
+    "description": "Checkbox label for Level IT-03 advisor selection"
   },
-  "oUDpNl": {
+  "YVuyjO": {
     "defaultMessage": "<strong>Cheminement en gestion</strong> : les gestionnaires de la <abbreviation>TI</abbreviation> (<abbreviation>TI-04</abbreviation>) sont responsables de la gestion du développement et de la prestation des services et des activités de <abbreviation>TI</abbreviation> par l'entremise de chefs d'équipe subalternes, de conseillers techniques et d'équipes de projet, pour la prestation des services aux clients et aux intervenants. Les gestionnaires de la <abbreviation>TI</abbreviation> se trouvent dans tous les volets de travail.",
-    "description": "IT-04 manager path description, ignore things in <> tags please"
+    "description": "IT-04 manager path description"
   },
   "oZ03/b": {
     "defaultMessage": "Cette plateforme met l'accent sur l'embauche de talents numériques pour travailler dans des postes classifiés comme <abbreviation>TI</abbreviation> (technologie de l'information). Examinez les niveaux suivants dans la classification <abbreviation>TI</abbreviation> et <strong>sélectionnez uniquement</strong> ceux qui représentent le travail que vous voulez faire.",
@@ -5391,9 +5391,9 @@
     "defaultMessage": "Il appartient aux gestionnaires de gérer l’élaboration et la prestation de services et (ou) d’opérations de <abbreviation>TI</abbreviation> par l’entremise de chefs d’équipe subalternes, de conseillers techniques et d’équipes de projet.",
     "description": "Description for the 'IT-04 Manager' classification, paragraph 1"
   },
-  "uT/A3r": {
+  "SngY7e": {
     "defaultMessage": "Niveau 2 : Analyste (de 75 000 $ à 91 000 $). <openModal>En savoir plus sur <abbreviation>TI-02</abbreviation></openModal>",
-    "description": "Checkbox label for Level IT-02 selection, ignore things in <> tags please"
+    "description": "Checkbox label for Level IT-02 selection"
   },
   "vbEXnp": {
     "defaultMessage": "Gestion de bases de données de la <abbreviation>TI</abbreviation>",
@@ -5403,9 +5403,9 @@
     "defaultMessage": "Sécurité de la <abbreviation>TI</abbreviation>",
     "description": "Title for the 'security' IT work stream"
   },
-  "xIwrND": {
+  "X+Y+qq": {
     "defaultMessage": "Niveau 1 : Technicien(ne) (de 60 000 $ à 78 000 $). <openModal>En savoir plus sur <abbreviation>TI-01</abbreviation></openModal>",
-    "description": "Checkbox label for Level IT-01 selection, ignore things in <> tags please"
+    "description": "Checkbox label for Level IT-01 selection"
   },
   "y+HB+k": {
     "defaultMessage": "Gestion de la base de données de la <abbreviation>TI</abbreviation>",
@@ -6070,9 +6070,9 @@
     "defaultMessage": "{title} à {organization}",
     "description": "Title at organization"
   },
-  "vpAafL": {
+  "G3K1/H": {
     "defaultMessage": "Vous n'avez pas été identifié comme membre de groupes visés par l'équité en matière d'emploi.",
-    "description": "Message indicating the user has not been marked as part of an equity group, Ignore things in <> please."
+    "description": "Message indicating the user has not been marked as part of an equity group"
   },
   "w+L6oa": {
     "defaultMessage": "Par date",
@@ -6174,9 +6174,9 @@
     "defaultMessage": "Modifiez vos options de compétences et d'expérience.",
     "description": "Link text for editing skills and experiences on profile."
   },
-  "GThNuu": {
+  "TwSvmH": {
     "defaultMessage": "Je <strong>n'envisagerais pas</strong> d'accepter un emploi qui :",
-    "description": "would not accept job line before a list, ignore things in <> please"
+    "description": "would not accept job line before a list"
   },
   "VOheZB": {
     "defaultMessage": "<primary>{role}</primary> à {organization}",
@@ -6394,9 +6394,9 @@
     "defaultMessage": "Langue préférée de l'examen écrit :",
     "description": "Preferred Language for exams label and colon"
   },
-  "f8ZHHW": {
+  "K4O5hP": {
     "defaultMessage": "Vous vous êtes identifié(e) en tant que membre d’un groupe d’équité en matière d’emploi.<strong> Vous pouvez ajouter d’autres groupes d’équité en matière d’emploi à votre profil en modifiant la présente section, s’ils s’appliquent à vous.</strong>",
-    "description": "Final paragraph in the employment equity profile section, ignore things in <> please"
+    "description": "Final paragraph in the employment equity profile section"
   },
   "1GWQal": {
     "defaultMessage": "Vous n’avez toujours pas indiqué votre collectivité! <pledgeLink>Veuillez l’entrer ici.</pledgeLink>",

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/ClassificationDefinition.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/ClassificationDefinition.tsx
@@ -68,9 +68,8 @@ const LevelThreeLead = () => {
           {
             defaultMessage:
               "<strong>Management Path</strong>: <abbreviation>IT</abbreviation> Team Leads (<abbreviation>IT-03</abbreviation>) are responsible for supervising work and project teams for <abbreviation>IT</abbreviation> services and operations in their field of expertise to support service delivery to clients and stakeholders. <abbreviation>IT</abbreviation> Team Leads are found in all work streams.",
-            id: "QdYrqI",
-            description:
-              "IT-03 team lead path description, ignore things in <> tags please",
+            id: "t+WUYM",
+            description: "IT-03 team lead path description",
           },
           {
             abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
@@ -104,9 +103,8 @@ const LevelThreeAdvisor = () => {
           {
             defaultMessage:
               "<strong>Individual Contributor</strong>: <abbreviation>IT</abbreviation> Technical Advisors (<abbreviation>IT-03</abbreviation>) provide specialized technical advice, recommendations and support on solutions and services in their field of expertise in support of service delivery to clients and stakeholders. <abbreviation>IT</abbreviation> Technical Advisors are found in all work streams.",
-            id: "CIwCa3",
-            description:
-              "IT-03 advisor description, ignore things in <> tags please",
+            id: "7xDPj5",
+            description: "IT-03 advisor description",
           },
           {
             abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
@@ -140,9 +138,8 @@ const LevelFourManager = () => {
           {
             defaultMessage:
               "<strong>Management Path</strong>: <abbreviation>IT</abbreviation> Managers (<abbreviation>IT-04</abbreviation>) are responsible for managing the development and delivery of <abbreviation>IT</abbreviation> services and/or operations through subordinate team leaders, technical advisors, and project teams, for service delivery to clients and stakeholders. <abbreviation>IT</abbreviation> Managers are found in all work streams.",
-            id: "oUDpNl",
-            description:
-              "IT-04 manager path description, ignore things in <> tags please",
+            id: "YVuyjO",
+            description: "IT-04 manager path description",
           },
           {
             abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
@@ -176,9 +173,9 @@ const LevelFourAdvisor = (): JSX.Element => {
           {
             defaultMessage:
               "<strong>Individual Contributor</strong>: <abbreviation>IT</abbreviation> Senior Advisors (<abbreviation>IT-04</abbreviation>) provide expert technical advice and strategic direction in their field of expertise in the provision of solutions and services to internal or external clients, and stakeholders.",
-            id: "OheHgg",
+            id: "NeR+6V",
             description:
-              "IT-04 senior advisor description precursor to work stream list, ignore things in <> tags please",
+              "IT-04 senior advisor description precursor to work stream list",
           },
           {
             abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),

--- a/apps/web/src/pages/Profile/RoleSalaryPage/components/RoleSalaryForm/RoleSalaryForm.tsx
+++ b/apps/web/src/pages/Profile/RoleSalaryPage/components/RoleSalaryForm/RoleSalaryForm.tsx
@@ -231,9 +231,8 @@ const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
                 {
                   defaultMessage:
                     "Level 1: Technician ($60,000 to $78,000). <openModal>Learn about <abbreviation>IT-01</abbreviation></openModal>",
-                  id: "xIwrND",
-                  description:
-                    "Checkbox label for Level IT-01 selection, ignore things in <> tags please",
+                  id: "X+Y+qq",
+                  description: "Checkbox label for Level IT-01 selection",
                 },
                 {
                   openModal: (msg: React.ReactNode) =>
@@ -248,9 +247,8 @@ const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
                 {
                   defaultMessage:
                     "Level 2: Analyst ($75,000 to $91,000). <openModal>Learn about <abbreviation>IT-02</abbreviation></openModal>",
-                  id: "uT/A3r",
-                  description:
-                    "Checkbox label for Level IT-02 selection, ignore things in <> tags please",
+                  id: "SngY7e",
+                  description: "Checkbox label for Level IT-02 selection",
                 },
                 {
                   openModal: (msg: React.ReactNode) =>
@@ -265,9 +263,9 @@ const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
                 {
                   defaultMessage:
                     "Level 3: Team Leader ($88,000 to $110,000). <openModal>Learn about <abbreviation>IT-03</abbreviation></openModal>",
-                  id: "L6sIvM",
+                  id: "FEEa2S",
                   description:
-                    "Checkbox label for Level IT-03 leader selection, ignore things in <> tags please",
+                    "Checkbox label for Level IT-03 leader selection",
                 },
                 {
                   openModal: (msg: React.ReactNode) =>
@@ -282,9 +280,9 @@ const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
                 {
                   defaultMessage:
                     "Level 3: Technical Advisor ($88,000 to $110,000). <openModal>Learn about <abbreviation>IT-03</abbreviation></openModal>",
-                  id: "jZDflg",
+                  id: "WTdmxR",
                   description:
-                    "Checkbox label for Level IT-03 advisor selection, ignore things in <> tags please",
+                    "Checkbox label for Level IT-03 advisor selection",
                 },
                 {
                   openModal: (msg: React.ReactNode) =>
@@ -299,9 +297,9 @@ const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
                 {
                   defaultMessage:
                     "Level 4: Senior Advisor ($101,000 to $126,000). <openModal>Learn about <abbreviation>IT-04</abbreviation></openModal>",
-                  id: "bNBhvY",
+                  id: "dofE/5",
                   description:
-                    "Checkbox label for Level IT-04 senior advisor selection, ignore things in <> tags please",
+                    "Checkbox label for Level IT-04 senior advisor selection",
                 },
                 {
                   openModal: (msg: React.ReactNode) =>
@@ -316,9 +314,9 @@ const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
                 {
                   defaultMessage:
                     "Level 4: Manager ($101,000 to $126,000). <openModal>Learn about <abbreviation>IT-04</abbreviation></openModal>",
-                  id: "EGXG1j",
+                  id: "O8m3JS",
                   description:
-                    "Checkbox label for Level IT-04 manager selection, ignore things in <> tags please",
+                    "Checkbox label for Level IT-04 manager selection",
                 },
                 {
                   openModal: (msg: React.ReactNode) =>

--- a/apps/web/src/pages/Profile/RoleSalaryPage/components/dialogs.tsx
+++ b/apps/web/src/pages/Profile/RoleSalaryPage/components/dialogs.tsx
@@ -226,9 +226,8 @@ export const DialogLevelThreeLead = ({ children }: DialogLevelsProps) => {
               {
                 defaultMessage:
                   "<strong>Management Path</strong>: <abbreviation>IT</abbreviation> Team Leads (<abbreviation>IT-03</abbreviation>) are responsible for supervising work and project teams for <abbreviation>IT</abbreviation> services and operations in their field of expertise to support service delivery to clients and stakeholders. <abbreviation>IT</abbreviation> Team Leads are found in all work streams.",
-                id: "QdYrqI",
-                description:
-                  "IT-03 team lead path description, ignore things in <> tags please",
+                id: "t+WUYM",
+                description: "IT-03 team lead path description",
               },
               {
                 abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
@@ -287,9 +286,8 @@ export const DialogLevelThreeAdvisor = ({ children }: DialogLevelsProps) => {
               {
                 defaultMessage:
                   "<strong>Individual Contributor</strong>: <abbreviation>IT</abbreviation> Technical Advisors (<abbreviation>IT-03</abbreviation>) provide specialized technical advice, recommendations and support on solutions and services in their field of expertise in support of service delivery to clients and stakeholders. <abbreviation>IT</abbreviation> Technical Advisors are found in all work streams.",
-                id: "CIwCa3",
-                description:
-                  "IT-03 advisor description, ignore things in <> tags please",
+                id: "7xDPj5",
+                description: "IT-03 advisor description",
               },
               {
                 abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
@@ -348,9 +346,8 @@ export const DialogLevelFourLead = ({ children }: DialogLevelsProps) => {
               {
                 defaultMessage:
                   "<strong>Management Path</strong>: <abbreviation>IT</abbreviation> Managers (<abbreviation>IT-04</abbreviation>) are responsible for managing the development and delivery of <abbreviation>IT</abbreviation> services and/or operations through subordinate team leaders, technical advisors, and project teams, for service delivery to clients and stakeholders. <abbreviation>IT</abbreviation> Managers are found in all work streams.",
-                id: "oUDpNl",
-                description:
-                  "IT-04 manager path description, ignore things in <> tags please",
+                id: "YVuyjO",
+                description: "IT-04 manager path description",
               },
               {
                 abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
@@ -409,9 +406,9 @@ export const DialogLevelFourAdvisor = ({ children }: DialogLevelsProps) => {
               {
                 defaultMessage:
                   "<strong>Individual Contributor</strong>: <abbreviation>IT</abbreviation> Senior Advisors (<abbreviation>IT-04</abbreviation>) provide expert technical advice and strategic direction in their field of expertise in the provision of solutions and services to internal or external clients, and stakeholders. <abbreviation>IT</abbreviation> Senior Advisors are primarily found in six work streams:",
-                id: "F5kDhX",
+                id: "SPECr8",
                 description:
-                  "IT-04 senior advisor description precursor to work stream list, ignore things in <> tags please",
+                  "IT-04 senior advisor description precursor to work stream list",
               },
               {
                 abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -457,9 +457,9 @@
     "defaultMessage": "m'exige de <strong>voyager</strong>.",
     "description": "The operational requirement described as travel as required."
   },
-  "ZcvDAo": {
+  "EdAaI7": {
     "defaultMessage": "Il manque des champs <red>obligatoires</red>.",
-    "description": "Message that there are required fields missing. Please ignore things in <> tags."
+    "description": "Message that there are required fields missing"
   },
   "9rn/MG": {
     "defaultMessage": "exige <strong>des quarts de travail</strong>.",

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -50,9 +50,8 @@ const commonMessages = defineMessages({
   },
   requiredFieldsMissing: {
     defaultMessage: "There are <red>required</red> fields missing.",
-    id: "ZcvDAo",
-    description:
-      "Message that there are required fields missing. Please ignore things in <> tags.",
+    id: "EdAaI7",
+    description: "Message that there are required fields missing",
   },
   nameNotLoaded: {
     defaultMessage: "Error: name not loaded",


### PR DESCRIPTION
🤖 Resolves #5854.

## 👋 Introduction

This PR removes `intl.formatMessage` description instructions that should be sent as general [translation instructions](https://github.com/GCTC-NTGC/gc-digital-talent/blob/main/documentation/translation.md#requesting-translation-services).

## 🧪 Testing

1. Ensure all strings still appear correctly in English and French


