### PR TITLE
[Bug] Stabilize chromatic themes

### DIFF
--- a/apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.stories.tsx
+++ b/apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.stories.tsx
@@ -23,4 +23,5 @@ const VIEWPORTS = [
 export const Default = Template.bind({});
 Default.parameters = {
   chromatic: { viewports: VIEWPORTS },
+  themeKey: "default",
 };

--- a/apps/web/src/pages/Errors/ErrorPage/ErrorPage.stories.tsx
+++ b/apps/web/src/pages/Errors/ErrorPage/ErrorPage.stories.tsx
@@ -22,4 +22,6 @@ const VIEWPORTS = [
 export const Default = Template.bind({});
 Default.parameters = {
   chromatic: { viewports: VIEWPORTS },
+  hasDarkMode: true,
+  themeKey: "default",
 };

--- a/apps/web/src/pages/Errors/ErrorPage/ErrorPage.stories.tsx
+++ b/apps/web/src/pages/Errors/ErrorPage/ErrorPage.stories.tsx
@@ -22,6 +22,5 @@ const VIEWPORTS = [
 export const Default = Template.bind({});
 Default.parameters = {
   chromatic: { viewports: VIEWPORTS },
-  hasDarkMode: true,
   themeKey: "default",
 };

--- a/apps/web/src/pages/Home/HomePage/HomePage.stories.tsx
+++ b/apps/web/src/pages/Home/HomePage/HomePage.stories.tsx
@@ -27,4 +27,5 @@ export const Default = Template.bind({});
 Default.parameters = {
   chromatic: { viewports: VIEWPORTS },
   hasDarkMode: true,
+  themeKey: "default",
 };

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.stories.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.stories.tsx
@@ -36,4 +36,5 @@ export const Default = Template.bind({});
 Default.parameters = {
   chromatic: { viewports: VIEWPORTS },
   hasDarkMode: true,
+  themeKey: "default",
 };

--- a/packages/storybook-helpers/decorators/ThemeDecorator.tsx
+++ b/packages/storybook-helpers/decorators/ThemeDecorator.tsx
@@ -90,6 +90,7 @@ const ThemeDecorator = (
       <div id="override-theme-light" data-h2>
         <ThemeProvider
           override={{
+            key,
             mode: "light",
           }}
           themeSelector="#override-theme-light[data-h2]"
@@ -102,6 +103,7 @@ const ThemeDecorator = (
       <div id="override-theme-dark" data-h2>
         <ThemeProvider
           override={{
+            key,
             mode: "dark",
           }}
           themeSelector="#override-theme-dark[data-h2]"


### PR DESCRIPTION
🤖 Resolves #5871 

## 👋 Introduction

This should stabilize the themes in chromatic.

## 🕵️ Details

It seemed to only be pages that defined `parameters.chromatic.viewports`  that were causing problems. I'm still not sure why they were but, adding `parameters.themeKey` instead of relying on the fallback seems to have worked from my limited testing 🤷‍♀️ 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run storybook locally a few times and make sure the pages changed always show up as the expected theme
2. Check chromatic for no diff

## 📸 Screenshot

![Screenshot 2023-03-10 141654](https://user-images.githubusercontent.com/4127998/224406212-725437ca-9c49-45f7-b922-9fbbb37985f3.png)
