### PR TITLE
[Bug] Fix `PoolCandidatePolicyTest`

### DIFF
--- a/api/tests/Unit/PoolCandidatePolicyTest.php
+++ b/api/tests/Unit/PoolCandidatePolicyTest.php
@@ -196,6 +196,10 @@ class PoolCandidatePolicyTest extends TestCase
      */
     public function testUpdate()
     {
+        // Ensure candidate is not draft
+        $this->poolCandidate->submitted_at = config('constants.past_date');
+        $this->poolCandidate->save();
+
         $this->assertTrue($this->poolOperatorUser->can('update', $this->poolCandidate));
 
         $this->assertFalse($this->guestUser->can('update', $this->poolCandidate));


### PR DESCRIPTION
🤖 Resolves #5914 

## 👋 Introduction

This fixes the `testUpdate` on `PoolCandidatePolicyTest`.

## 🕵️ Details

There was a chance that `$this->poolCandidate` was a draft which would return `false` for the `assertTrue` on `poolOperatorUser`. This updates `$this->poolCandidate` to be submitted before testing assertions.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run `php artisan test tests/Unit/PoolCandidatePolicyTest.php` 10+ times locally
2. Confirm it always passes



