### PR TITLE
[Bug] English typo in placeholder

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6498,7 +6498,7 @@
     "defaultMessage": "Annuler et retourner aux équipes",
     "description": "Link text to cancel updating a team"
   },
-  "jzax3k": {
+  "IrvQbY": {
     "defaultMessage": "Sélectionnez un ou plusieurs ministères...",
     "description": "Placeholder text for the team departments input"
   },

--- a/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamFormFields.tsx
+++ b/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamFormFields.tsx
@@ -75,8 +75,8 @@ const CreateTeamFormFields = ({ departments }: CreateTeamFormFieldsProps) => {
             description: "Label for the team departments input",
           })}
           placeholder={intl.formatMessage({
-            defaultMessage: "Select on or more departments...",
-            id: "jzax3k",
+            defaultMessage: "Select one or more departments...",
+            id: "IrvQbY",
             description: "Placeholder text for the team departments input",
           })}
           rules={{


### PR DESCRIPTION
🤖 Resolves #5923.

## 👋 Introduction

This PR fixes a typo in the English placeholder text for the team departments input.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/en/admin/teams/create`
2. Make sure **Departments** select placeholder text is correct
3. Navigate to `/fr/admin/teams/create`
4. Make sure **Ministères** select placeholder text is correct

## 📸 Screenshot
![Screen Shot 2023-03-14 at 14 28 36](https://user-images.githubusercontent.com/3046459/225103383-58ef4879-2baa-427d-8496-02ba724f8afb.png)




