### PR TITLE
[Tooling] Remove obsolete npm from Dependabot check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,14 +7,6 @@ version: 2
 updates:
   # JAVASCRIPT package.json updates
 
-  # TODO: Remove as final step of #5065
-  - package-ecosystem: "npm"
-    directory: "/packages"
-    schedule:
-      interval: "weekly"
-      day: "thursday"
-    open-pull-requests-limit: 15
-
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
🤖 Resolves #5917.

## 👋 Introduction

This PR removes an invalid directory to scan in Dependabot.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. 🤞
2. Once this branch merged into `main`, verify `npm` is no longer listed at https://github.com/GCTC-NTGC/gc-digital-talent/network/updates


