### PR TITLE
Explore routing simplification with subdomains

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -54,8 +54,8 @@ PUSHER_APP_CLUSTER=mt1
 MIX_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
 MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 
-OAUTH_REDIRECT_URI="http://localhost:8000/auth-callback"
-OAUTH_POST_LOGIN_REDIRECT="http://localhost:8000/talent/profile"
+OAUTH_REDIRECT_URI="http://api.localhost:8000/auth-callback"
+OAUTH_POST_LOGIN_REDIRECT="http://api.localhost:8000/talent/profile"
 
 # Setting this value fakes a login for local development.
 # DEVELOPMENT ONLY. DO NOT ENABLE IN PRODUCTION.

--- a/api/config/cors.php
+++ b/api/config/cors.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'paths' => ['api/*', 'sanctum/csrf-cookie'],
+    'paths' => ['*'],
 
     'allowed_methods' => ['*'],
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,4 +1,4 @@
-API_URI="/graphql"
+API_URI="http://api.localhost:8000/graphql"
 
 OAUTH_POST_LOGOUT_REDIRECT="http://localhost:8000/logged-out"
 

--- a/infrastructure/conf/nginx-conf-local/api
+++ b/infrastructure/conf/nginx-conf-local/api
@@ -1,0 +1,29 @@
+
+# enable rewrite logging for debugging
+error_log /var/log/nginx/error.log notice;
+# rewrite_log on;
+
+server {
+    #proxy_cache cache;
+    #proxy_cache_valid 200 1s;
+
+    # on the servers, the pages are served on 8080 then reverse proxied upstream
+    listen 8080;
+    listen [::]:8080;
+    root /home/site/wwwroot;
+    index index.php;
+
+    server_name api.localhost;
+
+    # api
+    location / {
+        fastcgi_pass 127.0.0.1:9000;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
+        ## TUNE buffers to avoid "upstream sent too big headers" error ##
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
+        fastcgi_busy_buffers_size 64k;
+    }
+}
+

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -8,12 +8,12 @@ server {
     #proxy_cache_valid 200 1s;
 
     # on the servers, the pages are served on 8080 then reverse proxied upstream
-    listen 8080;
-    listen [::]:8080;
+    listen 8080 default_server;
+    listen [::]:8080 default_server;
     root /home/site/wwwroot;
-    index  index.php index.html index.htm;
+    index index.html index.htm;
 
-    #server_name localhost;
+    server_name _;
 
     # redirect server error pages
     error_page   404  /404;
@@ -58,57 +58,6 @@ server {
         proxy_set_header X-Forwarded-Proto http;
         proxy_set_header Host localhost:8000;
         break;
-    }
-
-    # api
-    location = /phpinfo.php {
-        fastcgi_pass 127.0.0.1:9000;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/phpinfo.php;
-    }
-    location = /xdebuginfo.php {
-        fastcgi_pass 127.0.0.1:9000;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/xdebuginfo.php;
-    }
-    location = /graphql {
-        fastcgi_pass 127.0.0.1:9000;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
-    }
-    location = /graphiql {
-        fastcgi_pass 127.0.0.1:9000;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
-    }
-    location = /login {
-        fastcgi_pass 127.0.0.1:9000;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
-    }
-    location = /register {
-        fastcgi_pass 127.0.0.1:9000;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
-    }
-    location = /auth-callback {
-        fastcgi_pass 127.0.0.1:9000;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
-        ## TUNE buffers to avoid "upstream sent too big headers" error ##
-        fastcgi_buffers 16 32k;
-        fastcgi_buffer_size 64k;
-        fastcgi_busy_buffers_size 64k;
-    }
-    location = /refresh {
-        fastcgi_pass 127.0.0.1:9000;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
-    }
-    location ~ "^/api(/(.*))?$" {
-        fastcgi_pass 127.0.0.1:9000;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
     }
 
     # rewrite root-level possible lang prefix to apps/web index.html

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -10,8 +10,8 @@ server {
     # on the servers, the pages are served on 8080 then reverse proxied upstream
     listen 8080 default_server;
     listen [::]:8080 default_server;
-    root /home/site/wwwroot;
-    index index.html index.htm;
+    root /home/site/wwwroot/apps/web/dist;
+    index index.html;
 
     server_name _;
 
@@ -60,117 +60,10 @@ server {
         break;
     }
 
-    # rewrite root-level possible lang prefix to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/?$" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/?$" /apps/web/dist/index.html break;
-    }
-
-    # rewrite tc-report static files to "tc-report/_site"
-    location ~ "^/tc-report/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" {
-        rewrite "^/tc-report/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" /tc-report/_site/$1 break;
-    }
-
-     # rewrite talent static files to "apps/web/dist"
-    location ~ "^(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" {
-        rewrite "^(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" /apps/web/dist/$1 break;
-    }
-
-    # rewrite possible lang prefix then "admin" to admin index.html
-    location ~ "^(?:/[a-z]{2})?/admin(/?.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/admin(/?.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite possible lang prefix then "talent" to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/talent(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/talent(/.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite possible lang prefix then "users" to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/users(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/users(/.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite possible lang prefix then "search" to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/search(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/search(/.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite possible lang prefix then "logged-out" to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/logged-out(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/logged-out(/.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite possible lang prefix then "browse" to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/browse(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/browse(/.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite possible lang prefix then "404" to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/404(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/404(/.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite possible lang prefix then "support" to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/support(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/support(/.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite possible lang prefix then "accessibility-statement" to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/accessibility-statement(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/accessibility-statement(/.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite possible lang prefix then "create-account" to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/create-account(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/create-account(/.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite possible lang prefix then "register-info" to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/register-info(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/register-info(/.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite possible lang prefix then "login-info" to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/login-info(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/login-info(/.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite talent static files to "web/dist"
-    location ~ "^/indigenous-it-apprentice/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" {
-        rewrite "^/indigenous-it-apprentice/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|webmanifest))$" /apps/web/dist/$1 break;
-    }
-
-    # rewrite possible lang prefix then "indigenous-it-apprentice" to web index.html
-    location ~ "^(?:/[a-z]{2})?/indigenous-it-apprentice(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/indigenous-it-apprentice(/.*|$)" /apps/web/dist/index.html break;
+    location / {
+        # First attempt to serve request as file, then
+        # as directory, then fall back to redirecting to index.html
+        try_files $uri $uri/ $uri.html /index.html;
     }
 }
 

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -172,17 +172,5 @@ server {
         expires 0;
         rewrite "^(?:/[a-z]{2})?/indigenous-it-apprentice(/.*|$)" /apps/web/dist/index.html break;
     }
-
-    # fallback any other files to "tc-report/_site"
-    ## Must be second to last of the file!
-    location ~ "^/(.*\.(\w+))$" {
-        rewrite "^/(.*\.(\w+))$" /tc-report/_site/$1 break;
-    }
-
-    # fallback any other path to "tc-report/_site" index.html
-    ## Must be last of the file!
-    location ~ ^/(.*)$ {
-        rewrite ^/(.*)$ /tc-report/_site/$1/index.html break;
-    }
 }
 

--- a/infrastructure/conf/nginx-conf-local/report
+++ b/infrastructure/conf/nginx-conf-local/report
@@ -1,0 +1,28 @@
+
+# enable rewrite logging for debugging
+error_log /var/log/nginx/error.log notice;
+# rewrite_log on;
+
+server {
+    #proxy_cache cache;
+    #proxy_cache_valid 200 1s;
+
+    # on the servers, the pages are served on 8080 then reverse proxied upstream
+    listen 8080;
+    listen [::]:8080;
+    root /home/site/wwwroot/tc-report/_site;
+    index index.html;
+
+    server_name report.localhost;
+
+    # redirect server error pages
+    error_page   404  /404;
+
+    # Disable .git directory
+    location ~ /\.git {
+        deny all;
+        access_log off;
+        log_not_found off;
+    }
+}
+

--- a/packages/auth/src/hooks/useApiRoutes.ts
+++ b/packages/auth/src/hooks/useApiRoutes.ts
@@ -5,7 +5,7 @@ export interface ApiRoutes {
   refreshAccessToken: () => string;
 }
 
-const apiRoot = (): string => "/";
+const apiRoot = (): string => "http://api.localhost:8000/"; // this should be an environment variable
 
 const apiRoutes = {
   login: (from?: string, locale?: string): string => {
@@ -15,7 +15,7 @@ const apiRoutes = {
     const searchString = searchTerms.join("&");
 
     const url =
-      path.join(apiRoot(), "login") + (searchString ? `?${searchString}` : "");
+      new URL("/login", apiRoot()) + (searchString ? `?${searchString}` : "");
 
     return url;
   },


### PR DESCRIPTION
>__Warning__
> This is an exploratory branch for review and evaluation but is incomplete and should not be merged to main.

## 👋 Introduction

This branch explorers how our server-side routing could be simplified and made more manageable with subdomains.

## 🕵️ Details

We have discussed as a team the possibility of using subdomains with our app to simplify our routing but there was doubt about how that might work or look.  This branch demonstrates how our one large config file could be broken down into three much smaller files. It sets up the _api_ and _report_ subdomains for our api and the tc-report.

### Status
- Main site :heavy_check_mark: 
- Graphiql :heavy_check_mark: 
- Login with mock auth :heavy_check_mark: 
- Login with SiC :x: Would need to whitelist the new URL
- Refresh and logout :question: not tested
- tc-report
   - The HTML pages work, but we removed the landing page so you'll need to navigate to a specific page like http://report.localhost:8000/en/talent-cloud/report/
   - The asset paths are broken.  We'd need to recompile the site, I think.
- Deploy conf file :x:    

## 🧪 Testing

1. Manually symlink the new config files for nginx inside the webserver container.  (Or just copy them to sites-enabled.)
![image](https://user-images.githubusercontent.com/8978655/225724015-dbd891fb-b1da-45ea-b3d7-77883bd01547.png)
2. Copy new .env files (or rerun setup)
3. Rebuild the app 

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/8978655/225724843-d47b97c5-9584-4fc3-814f-a55804df1d29.png)


