### PR TITLE
Add h2-build to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "clean": "turbo run clean",
     "intl-extract": "turbo run intl-extract",
     "intl-compile": "turbo run intl-compile",
-    "dev": "turbo run dev --filter='./apps/*' --filter='!@gc-digital-talent/e2e'",
+    "dev": "h2-build && turbo run dev --filter='./apps/*' --filter='!@gc-digital-talent/e2e'",
     "dev:project": "turbo run dev",
     "lint": "turbo run lint",
     "storybook:project": "npm run storybook",


### PR DESCRIPTION
🤖 Resolves #5994

## 👋 Introduction

This branch adds h2-build to dev

## 🕵️ Details

Hydrogen gets left out of the dev build sometimes

## 🧪 Testing

I'm not sure how to replicate the issue. :cry: 

1. `npm run dev`
2. Confirm you see hydrogen output in the output

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/8978655/225970590-1053d26f-8f2b-4eed-962f-af988c90144f.png)


