### PR TITLE
Bug 5993 experience application return path

### DIFF
--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceForm.stories.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceForm.stories.tsx
@@ -45,6 +45,7 @@ const TemplateExperienceFormForm: Story<ExperienceFormStoryArgs> = ({
     deleteExperience={() => {
       /* do nothing */
     }}
+    returnPath=""
   />
 );
 

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceForm.test.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceForm.test.tsx
@@ -12,6 +12,7 @@ import type { ExperienceQueryData, ExperienceType } from "./types";
 const mockUserId = "user-id";
 const mockSkills = fakeSkills(50);
 const mockExperiences = fakeExperiences(5);
+const returnPath = "";
 const mockCallback = jest.fn();
 
 const renderExperienceForm = (props: ExperienceFormProps) =>
@@ -26,6 +27,7 @@ describe("ExperienceForm", () => {
       onUpdateExperience: mockCallback,
       deleteExperience: mockCallback,
       skills: mockSkills,
+      returnPath,
     });
 
     await axeTest(container);
@@ -38,6 +40,7 @@ describe("ExperienceForm", () => {
       onUpdateExperience: mockCallback,
       deleteExperience: mockCallback,
       skills: mockSkills,
+      returnPath,
     });
 
     await axeTest(container);
@@ -50,6 +53,7 @@ describe("ExperienceForm", () => {
       onUpdateExperience: mockCallback,
       deleteExperience: mockCallback,
       skills: mockSkills,
+      returnPath,
     });
 
     await axeTest(container);
@@ -62,6 +66,7 @@ describe("ExperienceForm", () => {
       onUpdateExperience: mockCallback,
       deleteExperience: mockCallback,
       skills: mockSkills,
+      returnPath,
     });
 
     await axeTest(container);
@@ -74,6 +79,7 @@ describe("ExperienceForm", () => {
       onUpdateExperience: mockCallback,
       deleteExperience: mockCallback,
       skills: mockSkills,
+      returnPath,
     });
 
     await axeTest(container);
@@ -88,6 +94,7 @@ describe("ExperienceForm", () => {
       onUpdateExperience: mockSave,
       deleteExperience: mockDelete,
       skills: mockSkills,
+      returnPath,
     });
 
     expect(
@@ -115,6 +122,7 @@ describe("ExperienceForm", () => {
       onUpdateExperience: mockSave,
       deleteExperience: mockDelete,
       skills: mockSkills,
+      returnPath,
     });
 
     expect(
@@ -138,6 +146,7 @@ describe("ExperienceForm", () => {
       onUpdateExperience: mockSave,
       deleteExperience: mockDelete,
       skills: mockSkills,
+      returnPath,
     });
 
     expect(
@@ -169,6 +178,7 @@ describe("ExperienceForm", () => {
       onUpdateExperience: mockSave,
       deleteExperience: mockDelete,
       skills: mockSkills,
+      returnPath,
     });
 
     expect(
@@ -197,6 +207,7 @@ describe("ExperienceForm", () => {
       onUpdateExperience: mockSave,
       deleteExperience: mockDelete,
       skills: mockSkills,
+      returnPath,
     });
 
     expect(
@@ -223,6 +234,7 @@ describe("ExperienceForm", () => {
       onUpdateExperience: mockSave,
       deleteExperience: mockDelete,
       skills: mockSkills,
+      returnPath,
     });
 
     expect(
@@ -239,6 +251,7 @@ describe("ExperienceForm", () => {
       onUpdateExperience: mockSave,
       deleteExperience: mockDelete,
       skills: mockSkills,
+      returnPath,
     });
   });
 
@@ -251,6 +264,7 @@ describe("ExperienceForm", () => {
       onUpdateExperience: mockSave,
       deleteExperience: mockDelete,
       skills: mockSkills,
+      returnPath,
     });
 
     await act(() => {
@@ -280,6 +294,7 @@ describe("ExperienceForm", () => {
       deleteExperience: mockDelete,
       skills: mockSkills,
       experience: experience as ExperienceQueryData,
+      returnPath,
     });
 
     await act(() => {
@@ -298,6 +313,7 @@ describe("ExperienceForm", () => {
       onUpdateExperience: mockSave,
       deleteExperience: mockDelete,
       skills: mockSkills,
+      returnPath,
     });
 
     await act(() => {
@@ -320,6 +336,7 @@ it("delete should not render when edit is false", async () => {
     deleteExperience: mockDelete,
     skills: mockSkills,
     edit: false,
+    returnPath,
   });
 
   expect(screen.queryByText("Delete experience from My Profile")).toBeFalsy();
@@ -335,6 +352,7 @@ it("delete should render when edit is true and be called properly", async () => 
     deleteExperience: mockDelete,
     skills: mockSkills,
     edit: true,
+    returnPath,
   });
 
   // get and open Dialog Component

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -70,6 +70,7 @@ export interface ExperienceFormProps {
   deleteExperience: () => void;
   cacheKey?: string;
   edit?: boolean;
+  returnPath: string;
 }
 
 export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
@@ -82,14 +83,10 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
   cacheKey,
   edit,
   poolAdvertisement,
+  returnPath,
 }) => {
   const intl = useIntl();
-  const { id: applicationId } = useApplicationInfo(userId);
   const paths = useRoutes();
-
-  const returnPath = `${paths.skillsAndExperiences(userId)}${
-    applicationId ? `?${applicationId}` : ``
-  }`;
 
   let crumbs: { label: string | React.ReactNode; url: string }[] = [
     {
@@ -358,7 +355,7 @@ const ExperienceFormContainer = ({ edit }: ExperienceFormContainerProps) => {
   const paths = useRoutes();
   const cacheKey = `ts-createExperience-${experienceId || experienceType}`;
   const returnPath = `${paths.skillsAndExperiences(userId || "")}${
-    applicationId ? `?${applicationId}` : ``
+    applicationId ? `/?applicationId=${applicationId}` : ``
   }`;
 
   const [
@@ -507,6 +504,7 @@ const ExperienceFormContainer = ({ edit }: ExperienceFormContainerProps) => {
           deleteExperience={handleDeleteExperience}
           cacheKey={cacheKey}
           edit={edit}
+          returnPath={returnPath}
         />
       ) : (
         <ThrowNotFound


### PR DESCRIPTION
🤖 Resolves #5993 

## 👋 Introduction

Enable returning to the correct place after updating an experience in the application workflow. 

## 🕵️ Details

URL was slightly mangled.
`returnPath` was defined in two places, elected to define it in just the container and pass it in as props to the form component. 

## 🧪 Testing

1. apply to an opportunity 
2. update various experiences and create them, ensure you stay in the application workflow
3. links work as expected

