### PR TITLE
[Bug] Fix applicant pool candidates query

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -273,7 +273,7 @@ type Applicant {
   jobLookingStatus: JobLookingStatus
     @rename(attribute: "job_looking_status")
     @deprecated(reason: "Removing with applicantDashboard feature flag")
-  poolCandidates: [PoolCandidate] @hasMany @can(ability: "view", resolved: true)
+  poolCandidates: [PoolCandidate] @hasMany(scopes: ["notDraft"]) @can(ability: "view", resolved: true)
 
   hasDiploma: Boolean @rename(attribute: "has_diploma")
   locationPreferences: [WorkRegion] @rename(attribute: "location_preferences")


### PR DESCRIPTION
🤖 Resolves #6005 

## 👋 Introduction

Adds the `notDraft` scope to `Query.applicant.poolCandidates`.

## 🕵️ Details

No one but the owner of a draft may view draft pool candidates. This was causing a problem with `Query.applicant.poolCandidates` since it was exposing draft applications. This adds the scope to filter out draft applications.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Login as applicant
2. Submit an application and start another on as a draft
3. Login as an admin
4. View the user information page for the applicant user
5. Confirm there are no GraphQL errors
6. Confirm you only see the submitted application

## 📸 Screenshot

![Screenshot 2023-03-20 113822](https://user-images.githubusercontent.com/4127998/226391188-eac5d354-359e-44f9-a1cc-0587db4783ba.png)


