### PR TITLE
Fix dashboard status icon size

### DIFF
--- a/apps/web/src/components/InfoItem/BaseInfoItem.tsx
+++ b/apps/web/src/components/InfoItem/BaseInfoItem.tsx
@@ -102,6 +102,7 @@ export const BaseInfoItem = ({
         <Icon
           data-h2-height="base(x.75)"
           data-h2-width="base(x.75)"
+          data-h2-min-width="base(x.75)"
           data-h2-margin-top="base(x.15)"
           data-h2-transition="base(color .2s ease)"
           {...iconColorMap[iconColor]}


### PR DESCRIPTION
🤖 Resolves #5990 

## 👋 Introduction

This branch fixes a small bug where the status icon would get shrunk if the title text wrapped to a second line.

## 🕵️ Details

I think flex box was shrinking the icon item to try to compensate for the longer text item.  I set a min-width on the icon and that seems to have fixed it.

## 🧪 Testing

1. Start Storybook and navigate to the Application Dashboard / Dashboard Heading / Partially Completed Profile story.
2. Narrow the viewport until  some of the profile titles start to wrap.
3. Confirm that the icons are the same size for the wrapped and unwrapped lines.

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/8978655/226430128-744e66ba-fa61-4b5a-9d9c-8d6a64f0919a.png)
![image](https://user-images.githubusercontent.com/8978655/226430180-f004b8c7-ccf3-48e2-b2a3-4e4c2c0c3695.png)



