### PR TITLE
Remove FC from packages/forms

### DIFF
--- a/packages/forms/src/components/CheckButton/CheckButton.tsx
+++ b/packages/forms/src/components/CheckButton/CheckButton.tsx
@@ -47,7 +47,9 @@ const CheckButton = ({
     onToggle();
   };
 
-  let Icon: string | React.FC<React.SVGProps<SVGSVGElement>> = "span";
+  let Icon:
+    | string
+    | React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement>> = "span";
   if (indeterminate) {
     Icon = MinusIcon;
   }

--- a/packages/forms/src/components/Checkbox/Checkbox.tsx
+++ b/packages/forms/src/components/Checkbox/Checkbox.tsx
@@ -31,7 +31,7 @@ export interface CheckboxProps
   isUnsaved?: boolean;
 }
 
-const Checkbox: React.FunctionComponent<CheckboxProps> = ({
+const Checkbox = ({
   id,
   label,
   name,
@@ -42,7 +42,7 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
   boundingBoxLabel = label,
   trackUnsaved = true,
   ...rest
-}) => {
+}: CheckboxProps) => {
   const [isContextVisible, setContextVisible] = React.useState<boolean>(false);
   const {
     register,

--- a/packages/forms/src/components/Checklist/Checklist.tsx
+++ b/packages/forms/src/components/Checklist/Checklist.tsx
@@ -40,7 +40,7 @@ export interface ChecklistProps extends React.HTMLProps<HTMLFieldSetElement> {
  * Must be part of a form controlled by react-hook-form.
  * The form will represent the data at `name` as an array, containing the values of the checked boxes.
  */
-const Checklist: React.FunctionComponent<ChecklistProps> = ({
+const Checklist = ({
   idPrefix,
   legend,
   name,
@@ -51,7 +51,7 @@ const Checklist: React.FunctionComponent<ChecklistProps> = ({
   hideOptional,
   trackUnsaved = true,
   ...rest
-}) => {
+}: ChecklistProps) => {
   const {
     register,
     formState: { errors },

--- a/packages/forms/src/components/DateInput/DateInput.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.tsx
@@ -40,7 +40,7 @@ export interface DateInputProps extends React.HTMLProps<HTMLFieldSetElement> {
  * Must be part of a form controlled by react-hook-form.
  * The form will represent the data at `name` as an array, containing the values of the checked boxes.
  */
-const DateInput: React.FunctionComponent<DateInputProps> = ({
+const DateInput = ({
   legend,
   name,
   rules = {},
@@ -51,7 +51,7 @@ const DateInput: React.FunctionComponent<DateInputProps> = ({
   show = [DATE_SEGMENT.Year, DATE_SEGMENT.Month, DATE_SEGMENT.Day],
   trackUnsaved = true,
   ...rest
-}) => {
+}: DateInputProps) => {
   const intl = useIntl();
   const {
     control,

--- a/packages/forms/src/components/Fieldset/Fieldset.tsx
+++ b/packages/forms/src/components/Fieldset/Fieldset.tsx
@@ -36,7 +36,7 @@ export interface FieldsetProps extends React.HTMLProps<HTMLFieldSetElement> {
   flat?: boolean;
 }
 
-const Fieldset: React.FC<FieldsetProps> = ({
+const Fieldset = ({
   legend,
   name,
   required,
@@ -50,7 +50,7 @@ const Fieldset: React.FC<FieldsetProps> = ({
   flat = false,
   trackUnsaved = true,
   ...rest
-}) => {
+}: FieldsetProps) => {
   const [contextIsActive, setContextIsActive] = useState(false);
   const intl = useIntl();
   const fieldState = useFieldState(name ?? "");

--- a/packages/forms/src/components/Input/Input.tsx
+++ b/packages/forms/src/components/Input/Input.tsx
@@ -33,7 +33,7 @@ export interface InputProps
   trackUnsaved?: boolean;
 }
 
-const Input: React.FunctionComponent<InputProps> = ({
+const Input = ({
   id,
   context,
   label,
@@ -46,7 +46,7 @@ const Input: React.FunctionComponent<InputProps> = ({
   whitespaceTrim = true,
   trackUnsaved = true,
   ...rest
-}) => {
+}: InputProps) => {
   const [isContextVisible, setContextVisible] = React.useState<boolean>(false);
   const {
     register,

--- a/packages/forms/src/components/InputContext/InputContext.tsx
+++ b/packages/forms/src/components/InputContext/InputContext.tsx
@@ -5,7 +5,7 @@ export interface InputContextProps {
   context: string | React.ReactNode;
 }
 
-const InputContext: React.FC<InputContextProps> = ({ context, isVisible }) => {
+const InputContext = ({ context, isVisible }: InputContextProps) => {
   return isVisible ? (
     <span
       data-h2-display="base(block)"

--- a/packages/forms/src/components/InputLabel/InputLabel.tsx
+++ b/packages/forms/src/components/InputLabel/InputLabel.tsx
@@ -18,7 +18,7 @@ export interface InputLabelProps {
   fillLabel?: boolean;
 }
 
-const InputLabel: React.FC<InputLabelProps> = ({
+const InputLabel = ({
   inputId,
   label,
   labelSize,
@@ -30,7 +30,7 @@ const InputLabel: React.FC<InputLabelProps> = ({
   contextIsVisible = false,
   hideOptional = false,
   hideBottomMargin = false,
-}): React.ReactElement => {
+}: InputLabelProps): React.ReactElement => {
   const [contextIsActive, setContextIsActive] = useState(false);
   const clickHandler = () => {
     contextToggleHandler(!contextIsActive);

--- a/packages/forms/src/components/InputWrapper/InputWrapper.tsx
+++ b/packages/forms/src/components/InputWrapper/InputWrapper.tsx
@@ -27,7 +27,7 @@ export interface InputWrapperProps {
   onContextToggle?: (visible: boolean) => void;
 }
 
-const InputWrapper: React.FC<InputWrapperProps> = ({
+const InputWrapper = ({
   inputId,
   inputName,
   label,
@@ -44,7 +44,7 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
   fillLabel = false,
   trackUnsaved = true,
   ...rest
-}) => {
+}: InputWrapperProps) => {
   const [contextVisible, setContextVisible] = useState(false);
   const fieldState = useFieldState(inputName || "", !trackUnsaved);
   const isUnsaved = fieldState === "dirty" && trackUnsaved;

--- a/packages/forms/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/forms/src/components/RadioGroup/RadioGroup.tsx
@@ -41,7 +41,7 @@ export interface RadioGroupProps extends React.HTMLProps<HTMLFieldSetElement> {
  * Must be part of a form controlled by react-hook-form.
  * The form will represent the data at `name` as an array, containing the values of the checked boxes.
  */
-const RadioGroup: React.FunctionComponent<RadioGroupProps> = ({
+const RadioGroup = ({
   idPrefix,
   legend,
   name,
@@ -55,7 +55,7 @@ const RadioGroup: React.FunctionComponent<RadioGroupProps> = ({
   hideLegend,
   trackUnsaved = true,
   ...rest
-}) => {
+}: RadioGroupProps) => {
   const {
     register,
     formState: { errors },

--- a/packages/forms/src/components/Select/Select.tsx
+++ b/packages/forms/src/components/Select/Select.tsx
@@ -83,7 +83,7 @@ function sortOptions(options: OptGroupOrOption[]) {
   );
 }
 
-const Select: React.FunctionComponent<SelectProps> = ({
+const Select = ({
   id,
   label,
   name,
@@ -95,7 +95,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
   trackUnsaved = true,
   doNotSort = false,
   ...rest
-}) => {
+}: SelectProps) => {
   const [isContextVisible, setContextVisible] = React.useState<boolean>(false);
   const {
     register,

--- a/packages/forms/src/components/Submit/Submit.tsx
+++ b/packages/forms/src/components/Submit/Submit.tsx
@@ -15,7 +15,7 @@ export interface SubmitProps extends Omit<ButtonProps, "ref" | "type"> {
   disabled?: boolean;
 }
 
-const Submit: React.FunctionComponent<SubmitProps> = ({
+const Submit = ({
   text,
   submittedText,
   isSubmittingText,
@@ -24,7 +24,7 @@ const Submit: React.FunctionComponent<SubmitProps> = ({
   isSubmitting: overrideSubmitting,
   disabled,
   ...rest
-}) => {
+}: SubmitProps) => {
   const intl = useIntl();
   const defaultText = intl.formatMessage(formMessages.submit);
   const defaultSubmittedText = intl.formatMessage(formMessages.submitted);

--- a/packages/forms/src/components/TextArea/TextArea.tsx
+++ b/packages/forms/src/components/TextArea/TextArea.tsx
@@ -26,7 +26,7 @@ export interface TextAreaProps
   hideOptional?: boolean;
 }
 
-const TextArea: React.FunctionComponent<TextAreaProps> = ({
+const TextArea = ({
   id,
   context,
   label,
@@ -37,7 +37,7 @@ const TextArea: React.FunctionComponent<TextAreaProps> = ({
   whitespaceTrim = true,
   hideOptional,
   ...rest
-}) => {
+}: TextAreaProps) => {
   const [isContextVisible, setContextVisible] = React.useState<boolean>(false);
   const {
     register,

--- a/packages/forms/src/components/WordCounter/WordCounter.tsx
+++ b/packages/forms/src/components/WordCounter/WordCounter.tsx
@@ -12,11 +12,11 @@ export interface WordCounterProps {
   wordLimit: number;
 }
 
-const WordCounter: React.FunctionComponent<WordCounterProps> = ({
+const WordCounter = ({
   text,
   wordLimit,
   ...rest
-}): React.ReactElement => {
+}: WordCounterProps): React.ReactElement => {
   const intl = useIntl();
   const numOfWords = countNumberOfWords(text);
   const wordsLeft = wordLimit - numOfWords;


### PR DESCRIPTION
🤖 Related to (but does not close) #5214 

## 👋 Introduction

This branch removes the use of React.FunctionComponent and React.FC from packages/forms.  Other subsequent PRs will remove it from other locations.

## 🧪 Testing

1. App builds
2. App runs OK (especially form components)
3. There are no more instances of FunctionComponent or FC in packages/forms.
