### PR TITLE
Tooling 4461 seeding improvements

### DIFF
--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -59,6 +59,11 @@ class PoolFactory extends Factory
             $pool->classifications()->saveMany($classifications);
             $pool->essentialSkills()->saveMany($skills->slice(0, 5));
             $pool->nonessentialSkills()->saveMany($skills->slice(5, 5));
+
+            if(isset($pool->published_at)) {
+                $pool->stream = $this->faker->randomElement(ApiEnums::poolStreams());
+                $pool->save();
+            }
         });
     }
 }

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -200,6 +200,11 @@ class UserFactory extends Factory
             $user->expectedGenericJobTitles()->saveMany(
                 GenericJobTitle::inRandomOrder()->take(1)->get()
             );
+
+            if($user->looking_for_bilingual == false && $user->looking_for_english == false && $user->looking_for_french == false){
+                $user->looking_for_english = true;
+                $user->save();
+            }
         });
     }
 }

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -243,6 +243,8 @@ class DatabaseSeeder extends Seeder
             ->where('level', '<', 5)
             ->get();
 
+        $testTeamId = Team::where('name', 'test-team')->sole()['id'];
+
         foreach ($classifications as $classification) {
             foreach ($publishingGroups as $publishingGroup) {
                 foreach ($dates as $date) {
@@ -251,7 +253,9 @@ class DatabaseSeeder extends Seeder
                     })->create([
                         'closing_date' => $date,
                         'publishing_group' => $publishingGroup,
-                        'published_at' => $faker->dateTimeBetween('-1 year', 'now')
+                        'published_at' => $faker->dateTimeBetween('-1 year', 'now'),
+                        'stream' => $faker->randomElement(ApiEnums::poolStreams()),
+                        'team_id' => $testTeamId,
                     ]);
                 }
             }

--- a/api/database/seeders/PoolSeeder.php
+++ b/api/database/seeders/PoolSeeder.php
@@ -59,6 +59,7 @@ class PoolSeeder extends Seeder
                     $classificationIT01Id = Classification::where('group', 'ilike', 'IT')->where('level', 1)->sole()['id'];
                     $createdPool->classifications()->sync([$classificationIT01Id]);
                     $createdPool->stream = ApiEnums::POOL_STREAM_BUSINESS_ADVISORY_SERVICES;
+                    $createdPool->advertisement_language = ApiEnums::POOL_ADVERTISEMENT_VARIOUS;
                     $createdPool->save();
                 }
             } else {


### PR DESCRIPTION
🤖 Resolves #4461 

## 👋 Introduction

Improve database seeding for quality of life purposes. 

## 🕵️ Details

- sometimes, users would be looking for neither english nor french nor bilingual, which needed a solution
- published pools now always have a stream
- digital careers pool accepts various, so any, languages
- dcm team would have one pool, test team zero pools, adjusted so the pool table isn't so empty
- applicant@test.com always has an experience that fulfills the essential skills of the digital careers pool

## 🧪 Testing

1. seed, bounce around pools, look at opportunities, apply to DCM pool as applicant@test.com
2. re-seed and and check again to be sure

Seeding should not error, applying as applicant should be quick, and published pools have streams.  


