### PR TITLE
[Bug] Add default og tags

### DIFF
--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -6,18 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title><%= htmlWebpackPlugin.options.title %></title>
-  <meta name="description" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
-  <meta property="og:url" content="https://talent.canada.ca/">
-  <meta property="og:type" content="website">
-  <meta property="og:title" content="GC Digital Talent">
-  <meta property="og:description" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
-  <meta property="og:image" content="">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta property="twitter:domain" content="talent.canada.ca">
-  <meta property="twitter:url" content="https://talent.canada.ca/en/">
-  <meta name="twitter:title" content="GC Digital Talent">
-  <meta name="twitter:description" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
-  <meta name="twitter:image" content="">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -6,17 +6,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title><%= htmlWebpackPlugin.options.title %></title>
-  <meta name="description" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
+  <meta name="description" lang="en" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
+  <meta name="description" lang="fr" content="Talent numérique du GC est la nouvelle plateforme de recrutement pour les emplois numériques et technologiques au gouvernement du Canada. Postulez maintenant!">
   <meta property="og:url" content="https://talent.canada.ca/">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="GC Digital Talent">
-  <meta property="og:description" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
+  <meta property="og:title" lang="en" content="GC Digital Talent">
+  <meta property="og:title" lang="fr" content="Talent numérique du GC">
+  <meta property="og:description" lang="en" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
+  <meta property="og:description" lang="fr" content="Talent numérique du GC est la nouvelle plateforme de recrutement pour les emplois numériques et technologiques au gouvernement du Canada. Postulez maintenant!">
   <meta property="og:image" content="">
   <meta name="twitter:card" content="summary_large_image">
   <meta property="twitter:domain" content="talent.canada.ca">
   <meta property="twitter:url" content="https://talent.canada.ca/en/">
-  <meta name="twitter:title" content="GC Digital Talent">
-  <meta name="twitter:description" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
+  <meta name="twitter:title" lang="en" content="GC Digital Talent">
+  <meta name="twitter:title" lang="fr" content="Talent numérique du GC">
+  <meta name="twitter:description" lang="en" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
+  <meta name="twitter:description" lang="fr" content="Talent numérique du GC est la nouvelle plateforme de recrutement pour les emplois numériques et technologiques au gouvernement du Canada. Postulez maintenant!">
   <meta name="twitter:image" content="">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -7,7 +7,7 @@
 
   <title><%= htmlWebpackPlugin.options.title %></title>
   <meta name="description" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
-  <meta property="og:url" content="https://talent.canada.ca/en/">
+  <meta property="og:url" content="https://talent.canada.ca/">
   <meta property="og:type" content="website">
   <meta property="og:title" content="GC Digital Talent">
   <meta property="og:description" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -4,7 +4,21 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
   <title><%= htmlWebpackPlugin.options.title %></title>
+  <meta name="description" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
+  <meta property="og:url" content="https://talent.canada.ca/en/">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="GC Digital Talent">
+  <meta property="og:description" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
+  <meta property="og:image" content="">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta property="twitter:domain" content="talent.canada.ca">
+  <meta property="twitter:url" content="https://talent.canada.ca/en/">
+  <meta name="twitter:title" content="GC Digital Talent">
+  <meta name="twitter:description" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
+  <meta name="twitter:image" content="">
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap" rel="stylesheet">

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -6,22 +6,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title><%= htmlWebpackPlugin.options.title %></title>
-  <meta name="description" lang="en" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
-  <meta name="description" lang="fr" content="Talent numérique du GC est la nouvelle plateforme de recrutement pour les emplois numériques et technologiques au gouvernement du Canada. Postulez maintenant!">
+  <meta name="description" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
   <meta property="og:url" content="https://talent.canada.ca/">
   <meta property="og:type" content="website">
-  <meta property="og:title" lang="en" content="GC Digital Talent">
-  <meta property="og:title" lang="fr" content="Talent numérique du GC">
-  <meta property="og:description" lang="en" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
-  <meta property="og:description" lang="fr" content="Talent numérique du GC est la nouvelle plateforme de recrutement pour les emplois numériques et technologiques au gouvernement du Canada. Postulez maintenant!">
+  <meta property="og:title" content="GC Digital Talent">
+  <meta property="og:description" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
   <meta property="og:image" content="">
   <meta name="twitter:card" content="summary_large_image">
   <meta property="twitter:domain" content="talent.canada.ca">
   <meta property="twitter:url" content="https://talent.canada.ca/en/">
-  <meta name="twitter:title" lang="en" content="GC Digital Talent">
-  <meta name="twitter:title" lang="fr" content="Talent numérique du GC">
-  <meta name="twitter:description" lang="en" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
-  <meta name="twitter:description" lang="fr" content="Talent numérique du GC est la nouvelle plateforme de recrutement pour les emplois numériques et technologiques au gouvernement du Canada. Postulez maintenant!">
+  <meta name="twitter:title" content="GC Digital Talent">
+  <meta name="twitter:description" content="GC Digital Talent is the new recruitment platform for digital and tech jobs in the Government of Canada. Apply now!">
   <meta name="twitter:image" content="">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/packages/webpack-config/webpack.base.js
+++ b/packages/webpack-config/webpack.base.js
@@ -11,7 +11,7 @@ const fs = require("fs");
 
 const meta = {
   title: "GC Digital Talent | Talent numérique du GC",
-  description: "Recruitment platform for digital jobs in the Government of Canada. Recrutement pour les emplois numériques au gouvernement du Canada.",
+  description: "Recruitment platform for digital jobs in the Government of Canada. Plateforme de recrutement pour les emplois numériques au gouvernement du Canada.",
   url: "https://talent.canada.ca/",
   domain: "talent.canada.ca",
   image: "",

--- a/packages/webpack-config/webpack.base.js
+++ b/packages/webpack-config/webpack.base.js
@@ -9,6 +9,15 @@ require('dotenv').config({ path: './.env' });
 const shell = require("shelljs");
 const fs = require("fs");
 
+const meta = {
+  title: "GC Digital Talent | Talent numérique du GC",
+  description: "Recruitment platform for digital jobs in the Government of Canada. Recrutement pour les emplois numériques au gouvernement du Canada.",
+  url: "https://talent.canada.ca/",
+  domain: "talent.canada.ca",
+  image: "",
+  type: "website"
+}
+
 module.exports = (basePath) => {
   return {
     plugins: [
@@ -45,8 +54,20 @@ module.exports = (basePath) => {
 
       // generate an index.html file based on given template
       new HtmlWebpackPlugin({
-        title: "GC Digital Talent",
+        title: meta.title,
         template: "./public/index.html",
+        meta: {
+          description: meta.description,
+          "og:url": meta.url,
+          "og:type": meta.type,
+          "og:title": meta.title,
+          "og:description": meta.description,
+          "og:image": meta.image,
+          "twitter:domain": meta.domain,
+          "twitter:url": meta.url,
+          "twitter:title": meta.title,
+          "twitter:image": meta.image,
+        }
       }),
 
       // generate an config file with the environment variables (not actually HTML but it's handy to reuse the plugin)


### PR DESCRIPTION
🤖 Resolves #5872 

## 👋 Introduction

Adds fallback, default open graph tags to `index.html`

## 🕵️ Details

This only adds English versions to remain under the soft 155 character limit for SEO. Should we tweak the text to shorten in and include French?

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> **Note**
> Hard to test because `react-helmet-async` takes over and replaces the tags.

1. Comment out the `<SEO />` component in `HomePage.tsx` and `Layout.tsx`
2. Build the app `npm run build`
3. Navigate to the homepage `/en`
4. Confirm the open graph tags exist


