### PR TITLE
Remove FC from admin pages

### DIFF
--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -22,7 +22,7 @@ interface DashboardPageProps {
   currentUser?: User | null;
 }
 
-const DashboardPage: React.FC<DashboardPageProps> = ({ currentUser }) => {
+const DashboardPage = ({ currentUser }: DashboardPageProps) => {
   const intl = useIntl();
   const adminRoutes = useRoutes();
   const navigationCrumbs = [
@@ -136,7 +136,7 @@ const DashboardPage: React.FC<DashboardPageProps> = ({ currentUser }) => {
   );
 };
 
-const DashboardPageApi: React.FC = () => {
+const DashboardPageApi = () => {
   const [{ data, fetching, error }] = useMeQuery();
 
   return (

--- a/apps/web/src/pages/AdminDashboardPage/components/LatestRequestsTable.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/components/LatestRequestsTable.tsx
@@ -6,7 +6,7 @@ import { notEmpty } from "@gc-digital-talent/helpers";
 import { useLatestRequestsQuery } from "~/api/generated";
 import { SearchRequestTable } from "~/components/SearchRequestTable/SearchRequestTable";
 
-const LatestRequestsTable: React.FC = () => {
+const LatestRequestsTable = () => {
   const [{ data, fetching, error }] = useLatestRequestsQuery();
 
   const poolCandidateSearchRequests =

--- a/apps/web/src/pages/Classifications/CreateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/CreateClassificationPage.tsx
@@ -22,9 +22,9 @@ interface CreateClassificationFormProps {
   handleCreateClassification: (data: FormValues) => Promise<FormValues>;
 }
 
-export const CreateClassificationForm: React.FunctionComponent<
-  CreateClassificationFormProps
-> = ({ handleCreateClassification }) => {
+export const CreateClassificationForm = ({
+  handleCreateClassification,
+}: CreateClassificationFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();
@@ -195,7 +195,7 @@ export const CreateClassificationForm: React.FunctionComponent<
   );
 };
 
-const CreateClassification: React.FunctionComponent = () => {
+const CreateClassification = () => {
   const intl = useIntl();
   const routes = useRoutes();
   const [, executeMutation] = useCreateClassificationMutation();

--- a/apps/web/src/pages/Classifications/IndexClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/IndexClassificationPage.tsx
@@ -9,7 +9,7 @@ import useRoutes from "~/hooks/useRoutes";
 
 import ClassificationTableApi from "./components/ClassificationTable";
 
-export const IndexClassificationPage: React.FC = () => {
+export const IndexClassificationPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
 

--- a/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
@@ -30,9 +30,10 @@ interface UpdateClassificationFormProps {
   ) => Promise<FormValues>;
 }
 
-export const UpdateClassificationForm: React.FunctionComponent<
-  UpdateClassificationFormProps
-> = ({ initialClassification, handleUpdateClassification }) => {
+export const UpdateClassificationForm = ({
+  initialClassification,
+  handleUpdateClassification,
+}: UpdateClassificationFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();

--- a/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
+++ b/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
@@ -137,7 +137,7 @@ const context: Partial<OperationContext> = {
   requestPolicy: "cache-first", // The list of classifications will rarely change, so we override default request policy to avoid unnecessary cache updates.
 };
 
-const ClassificationTableApi: React.FunctionComponent = () => {
+const ClassificationTableApi = () => {
   const [result] = useGetClassificationsQuery({
     context,
   });

--- a/apps/web/src/pages/Departments/CreateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/CreateDepartmentPage.tsx
@@ -25,9 +25,9 @@ interface CreateDepartmentProps {
   ) => Promise<CreateDepartmentMutation["createDepartment"]>;
 }
 
-export const CreateDepartmentForm: React.FunctionComponent<
-  CreateDepartmentProps
-> = ({ handleCreateDepartment }) => {
+export const CreateDepartmentForm = ({
+  handleCreateDepartment,
+}: CreateDepartmentProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();
@@ -124,7 +124,7 @@ export const CreateDepartmentForm: React.FunctionComponent<
   );
 };
 
-const CreateDepartmentPage: React.FunctionComponent = () => {
+const CreateDepartmentPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
   const [, executeMutation] = useCreateDepartmentMutation();

--- a/apps/web/src/pages/Departments/IndexDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/IndexDepartmentPage.tsx
@@ -9,7 +9,7 @@ import useRoutes from "~/hooks/useRoutes";
 
 import DepartmentTableApi from "./components/DepartmentTable";
 
-export const DepartmentPage: React.FC = () => {
+export const DepartmentPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
   const pageTitle = intl.formatMessage({

--- a/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
@@ -31,9 +31,10 @@ interface UpdateDepartmentProps {
   ) => Promise<UpdateDepartmentMutation["updateDepartment"]>;
 }
 
-export const UpdateDepartmentForm: React.FunctionComponent<
-  UpdateDepartmentProps
-> = ({ initialDepartment, handleUpdateDepartment }) => {
+export const UpdateDepartmentForm = ({
+  initialDepartment,
+  handleUpdateDepartment,
+}: UpdateDepartmentProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();

--- a/apps/web/src/pages/Departments/components/DepartmentTable.tsx
+++ b/apps/web/src/pages/Departments/components/DepartmentTable.tsx
@@ -80,7 +80,7 @@ export const DepartmentTable = ({ departments }: DepartmentTableProps) => {
   );
 };
 
-const DepartmentTableApi: React.FunctionComponent = () => {
+const DepartmentTableApi = () => {
   const [result] = useDepartmentsQuery();
   const { data, fetching, error } = result;
 

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
@@ -46,9 +46,7 @@ export interface BrowsePoolsProps {
   poolAdvertisements: PoolAdvertisement[];
 }
 
-export const BrowsePools: React.FC<BrowsePoolsProps> = ({
-  poolAdvertisements,
-}) => {
+export const BrowsePools = ({ poolAdvertisements }: BrowsePoolsProps) => {
   const { mode } = useTheme();
   const intl = useIntl();
   const { loggedIn } = useAuthentication();
@@ -321,7 +319,7 @@ export const BrowsePools: React.FC<BrowsePoolsProps> = ({
   );
 };
 
-const BrowsePoolsApi: React.FC = () => {
+const BrowsePoolsApi = () => {
   const [{ data, fetching, error }] = useBrowsePoolAdvertisementsQuery();
 
   const filteredPoolAdvertisements = data?.publishedPoolAdvertisements.filter(

--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -42,12 +42,12 @@ interface CreatePoolFormProps {
   teamsArray: Team[];
 }
 
-export const CreatePoolForm: React.FunctionComponent<CreatePoolFormProps> = ({
+export const CreatePoolForm = ({
   userId,
   classificationsArray,
   handleCreatePool,
   teamsArray,
-}) => {
+}: CreatePoolFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();

--- a/apps/web/src/pages/Pools/IndexPoolPage/IndexPoolPage.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/IndexPoolPage.tsx
@@ -9,7 +9,7 @@ import SEO from "~/components/SEO/SEO";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import PoolTableApi from "./components/PoolTable";
 
-export const PoolPage: React.FC = () => {
+export const PoolPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
 

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/PoolInfoCard.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/PoolInfoCard.tsx
@@ -19,7 +19,7 @@ export interface PoolInfoCardProps {
   };
 }
 
-const P: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
+const P = ({ children }: { children?: React.ReactNode }) => (
   <p
     data-h2-display="base(flex)"
     data-h2-align-items="base(center)"

--- a/apps/web/src/pages/SearchRequests/IndexSearchRequestPage/IndexSearchRequestPage.tsx
+++ b/apps/web/src/pages/SearchRequests/IndexSearchRequestPage/IndexSearchRequestPage.tsx
@@ -8,7 +8,7 @@ import SearchRequestTableApi from "~/components/SearchRequestTable/SearchRequest
 import useRoutes from "~/hooks/useRoutes";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 
-export const IndexSearchRequestPage: React.FunctionComponent = () => {
+export const IndexSearchRequestPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
 

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -87,7 +87,7 @@ export interface RequestFormProps {
   >;
 }
 
-export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
+export const RequestForm = ({
   departments,
   skills,
   classifications,
@@ -95,7 +95,7 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
   candidateCount,
   selectedClassifications,
   handleCreatePoolCandidateSearchRequest,
-}) => {
+}: RequestFormProps) => {
   const intl = useIntl();
   const paths = useRoutes();
   const navigate = useNavigate();
@@ -450,16 +450,16 @@ export const RequestForm: React.FunctionComponent<RequestFormProps> = ({
   );
 };
 
-const RequestFormApi: React.FunctionComponent<{
-  applicantFilter: Maybe<ApplicantFilterInput>;
-  candidateCount: Maybe<number>;
-  searchFormInitialValues?: SearchFormValues;
-  selectedClassifications?: Maybe<SimpleClassification>[];
-}> = ({
+const RequestFormApi = ({
   applicantFilter,
   candidateCount,
   searchFormInitialValues,
   selectedClassifications,
+}: {
+  applicantFilter: Maybe<ApplicantFilterInput>;
+  candidateCount: Maybe<number>;
+  searchFormInitialValues?: SearchFormValues;
+  selectedClassifications?: Maybe<SimpleClassification>[];
 }) => {
   const intl = useIntl();
   const [lookupResult] = useGetPoolCandidateSearchRequestDataQuery();

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/AddSkillsToFilter.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/AddSkillsToFilter.tsx
@@ -12,10 +12,7 @@ export interface AddSkillsToFilterProps {
   linkId: string;
 }
 
-const AddSkillsToFilter: React.FC<AddSkillsToFilterProps> = ({
-  allSkills,
-  linkId,
-}) => {
+const AddSkillsToFilter = ({ allSkills, linkId }: AddSkillsToFilterProps) => {
   const intl = useIntl();
   const { control, watch } = useFormContext();
   const watchedSkills = watch("skills");

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/CandidateResults.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/CandidateResults.tsx
@@ -8,11 +8,11 @@ import SearchPools, { type SearchPoolsProps } from "./SearchPools";
 
 type CandidateResultsProps = SearchPoolsProps;
 
-const CandidateResults: React.FC<CandidateResultsProps> = ({
+const CandidateResults = ({
   candidateCount,
   pool,
   handleSubmit,
-}) => {
+}: CandidateResultsProps) => {
   const intl = useIntl();
 
   return candidateCount > 0 ? (

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/EstimatedCandidates.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/EstimatedCandidates.tsx
@@ -62,9 +62,10 @@ interface EstimatedCandidatesProps {
   updatePending?: boolean;
 }
 
-const EstimatedCandidates: React.FunctionComponent<
-  EstimatedCandidatesProps
-> = ({ candidateCount, updatePending }) => {
+const EstimatedCandidates = ({
+  candidateCount,
+  updatePending,
+}: EstimatedCandidatesProps) => {
   const intl = useIntl();
 
   return (

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/FilterBlock.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/FilterBlock.tsx
@@ -10,13 +10,13 @@ interface FilterBlockProps {
   headingLevel?: HeadingRank;
 }
 
-const FilterBlock: React.FC<FilterBlockProps> = ({
+const FilterBlock = ({
   id,
   title,
   text,
   children,
   headingLevel = "h3",
-}) => {
+}: FilterBlockProps) => {
   const Heading = headingLevel;
   return (
     <div>

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchContainer.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchContainer.tsx
@@ -217,7 +217,7 @@ const testId = (chunks: React.ReactNode) => (
   <span data-testid="candidateCount">{chunks}</span>
 );
 
-const SearchContainer: React.FC<SearchContainerProps> = ({
+const SearchContainer = ({
   applicantFilter,
   classifications,
   updatePending,
@@ -227,7 +227,7 @@ const SearchContainer: React.FC<SearchContainerProps> = ({
   totalCandidateCount,
   onUpdateApplicantFilter,
   onSubmit,
-}) => {
+}: SearchContainerProps) => {
   const intl = useIntl();
 
   const poolClassificationFilterCount = applicantFilter?.pools?.length ?? 0;

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchFilterAdvice.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchFilterAdvice.tsx
@@ -3,20 +3,20 @@ import { useIntl } from "react-intl";
 
 import { LanguageAbility, Maybe, PositionDuration } from "~/api/generated";
 
-const SearchFilterAdvice: React.FC<{
-  operationalRequirementFilterCount: number;
-  educationSelection: Maybe<boolean>;
-  workingLanguage: Maybe<LanguageAbility>;
-  employmentDuration: Maybe<Maybe<PositionDuration>[]>;
-  equityFiltersActive: number;
-  skillCount: number;
-}> = ({
+const SearchFilterAdvice = ({
   operationalRequirementFilterCount,
   educationSelection,
   workingLanguage,
   employmentDuration,
   equityFiltersActive,
   skillCount,
+}: {
+  operationalRequirementFilterCount: number;
+  educationSelection: Maybe<boolean>;
+  workingLanguage: Maybe<LanguageAbility>;
+  employmentDuration: Maybe<Maybe<PositionDuration>[]>;
+  equityFiltersActive: number;
+  skillCount: number;
 }) => {
   const intl = useIntl();
   if (

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchHeading.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchHeading.tsx
@@ -3,7 +3,7 @@ import { useIntl } from "react-intl";
 
 import Hero from "~/components/Hero/Hero";
 
-const SearchHeading: React.FunctionComponent = () => {
+const SearchHeading = () => {
   const intl = useIntl();
   return (
     <Hero

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchPools.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchPools.tsx
@@ -23,11 +23,11 @@ export interface SearchPoolsProps {
   ) => Promise<void>;
 }
 
-const SearchPools: React.FunctionComponent<SearchPoolsProps> = ({
+const SearchPools = ({
   candidateCount,
   pool,
   handleSubmit,
-}) => {
+}: SearchPoolsProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
   const selectedClassifications =

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -36,11 +36,15 @@ type Data = NonNullable<
 
 type CandidateCell = Cell<PoolCandidate>;
 
-const TableEditButton: React.FC<{
+const TableEditButton = ({
+  poolCandidateId,
+  poolId,
+  label,
+}: {
   poolCandidateId?: string;
   poolId?: string;
   label?: string;
-}> = ({ poolCandidateId, poolId, label }) => {
+}) => {
   const intl = useIntl();
   const paths = useRoutes();
   return (
@@ -201,9 +205,9 @@ const employmentEquityAccessor = (user: Applicant, intl: IntlShape) =>
     .sort()
     .join("-");
 
-export const SingleSearchRequestTable: React.FunctionComponent<
-  SearchPoolCandidatesQuery
-> = ({ searchPoolCandidates }) => {
+export const SingleSearchRequestTable = ({
+  searchPoolCandidates,
+}: SearchPoolCandidatesQuery) => {
   const intl = useIntl();
 
   const columns = useMemo<ColumnsOf<Data>>(
@@ -483,9 +487,11 @@ const transformApplicantFilterToPoolCandidateSearchInput = (
   };
 };
 
-const SingleSearchRequestTableApi: React.FunctionComponent<{
+const SingleSearchRequestTableApi = ({
+  filter,
+}: {
   filter: AbstractFilter;
-}> = ({ filter }) => {
+}) => {
   const isLegacyFilter = isPoolCandidateFilter(filter);
 
   const poolCandidateFilterInput = isLegacyFilter

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/UpdateSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/UpdateSearchRequest.tsx
@@ -26,9 +26,10 @@ interface UpdateSearchRequestFormProps {
   ) => Promise<FormValues>;
 }
 
-export const UpdateSearchRequestForm: React.FunctionComponent<
-  UpdateSearchRequestFormProps
-> = ({ initialSearchRequest, handleUpdateSearchRequest }) => {
+export const UpdateSearchRequestForm = ({
+  initialSearchRequest,
+  handleUpdateSearchRequest,
+}: UpdateSearchRequestFormProps) => {
   const intl = useIntl();
   const [isSaving, setIsSaving] = React.useState<boolean>(false);
   const navigate = useNavigate();
@@ -187,9 +188,11 @@ export const UpdateSearchRequestForm: React.FunctionComponent<
   );
 };
 
-const UpdateSearchRequest: React.FunctionComponent<{
+const UpdateSearchRequest = ({
+  initialSearchRequest,
+}: {
   initialSearchRequest: PoolCandidateSearchRequest;
-}> = ({ initialSearchRequest }) => {
+}) => {
   const [, executeMutation] = useUpdatePoolCandidateSearchRequestMutation();
   const handleUpdateSearchRequest = (
     id: string,

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
@@ -23,9 +23,11 @@ import useRoutes from "~/hooks/useRoutes";
 import SingleSearchRequestTableApi from "./SearchRequestCandidatesTable";
 import UpdateSearchRequest from "./UpdateSearchRequest";
 
-const ManagerInfo: React.FunctionComponent<{
+const ManagerInfo = ({
+  searchRequest,
+}: {
   searchRequest: PoolCandidateSearchRequest;
-}> = ({ searchRequest }) => {
+}) => {
   const intl = useIntl();
   const locale = getLocale(intl);
   const {
@@ -225,9 +227,9 @@ interface SingleSearchRequestProps {
   searchRequest: PoolCandidateSearchRequest;
 }
 
-export const ViewSearchRequest: React.FunctionComponent<
-  SingleSearchRequestProps
-> = ({ searchRequest }) => {
+export const ViewSearchRequest = ({
+  searchRequest,
+}: SingleSearchRequestProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
   const { additionalComments, poolCandidateFilter, applicantFilter, wasEmpty } =
@@ -321,9 +323,11 @@ export const ViewSearchRequest: React.FunctionComponent<
   );
 };
 
-const ViewSearchRequestApi: React.FunctionComponent<{
+const ViewSearchRequestApi = ({
+  searchRequestId,
+}: {
   searchRequestId: string;
-}> = ({ searchRequestId }) => {
+}) => {
   const intl = useIntl();
   const routes = useRoutes();
   const [{ data: searchRequestData, fetching, error }] =

--- a/apps/web/src/pages/SkillFamilies/CreateSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/CreateSkillFamilyPage.tsx
@@ -56,9 +56,10 @@ interface CreateSkillFamilyFormProps {
   ) => Promise<CreateSkillFamilyMutation["createSkillFamily"]>;
 }
 
-export const CreateSkillFamilyForm: React.FunctionComponent<
-  CreateSkillFamilyFormProps
-> = ({ skills, handleCreateSkillFamily }) => {
+export const CreateSkillFamilyForm = ({
+  skills,
+  handleCreateSkillFamily,
+}: CreateSkillFamilyFormProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
   const navigate = useNavigate();

--- a/apps/web/src/pages/SkillFamilies/IndexSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/IndexSkillFamilyPage.tsx
@@ -9,7 +9,7 @@ import useRoutes from "~/hooks/useRoutes";
 
 import SkillFamilyTableApi from "./components/SkillFamilyTable";
 
-const IndexSkillFamilyPage: React.FC = () => {
+const IndexSkillFamilyPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
 

--- a/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
@@ -53,9 +53,11 @@ interface UpdateSkillFamilyFormProps {
   ) => Promise<UpdateSkillFamilyMutation["updateSkillFamily"]>;
 }
 
-export const UpdateSkillFamilyForm: React.FunctionComponent<
-  UpdateSkillFamilyFormProps
-> = ({ initialSkillFamily, skills, handleUpdateSkillFamily }) => {
+export const UpdateSkillFamilyForm = ({
+  initialSkillFamily,
+  skills,
+  handleUpdateSkillFamily,
+}: UpdateSkillFamilyFormProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
   const navigate = useNavigate();

--- a/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
+++ b/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
@@ -109,7 +109,7 @@ export const SkillFamilyTable = ({ skillFamilies }: SkillFamilyTableProps) => {
   );
 };
 
-const SkillFamilyTableApi: React.FunctionComponent = () => {
+const SkillFamilyTableApi = () => {
   const [result] = useAllSkillFamiliesQuery();
   const { data, fetching, error } = result;
 

--- a/apps/web/src/pages/Skills/CreateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/CreateSkillPage.tsx
@@ -52,10 +52,10 @@ interface CreateSkillFormProps {
   ) => Promise<CreateSkillMutation["createSkill"]>;
 }
 
-export const CreateSkillForm: React.FunctionComponent<CreateSkillFormProps> = ({
+export const CreateSkillForm = ({
   families,
   handleCreateSkill,
-}) => {
+}: CreateSkillFormProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
   const navigate = useNavigate();

--- a/apps/web/src/pages/Skills/UpdateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateSkillPage.tsx
@@ -53,11 +53,11 @@ interface UpdateSkillFormProps {
   ) => Promise<UpdateSkillMutation["updateSkill"]>;
 }
 
-export const UpdateSkillForm: React.FunctionComponent<UpdateSkillFormProps> = ({
+export const UpdateSkillForm = ({
   initialSkill,
   families,
   handleUpdateSkill,
-}) => {
+}: UpdateSkillFormProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
   const navigate = useNavigate();

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -142,7 +142,7 @@ const context: Partial<OperationContext> = {
   requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
 };
 
-const SkillTableApi: React.FunctionComponent = () => {
+const SkillTableApi = () => {
   const [result] = useAllSkillsQuery({
     context,
   });

--- a/apps/web/src/pages/SupportPage/SupportPage.tsx
+++ b/apps/web/src/pages/SupportPage/SupportPage.tsx
@@ -21,7 +21,7 @@ const getFlourishStyles = (isTop: boolean) => ({
     : "base(auto, auto, 0, 0)",
 });
 
-export const SupportPage: React.FC = () => {
+export const SupportPage = () => {
   const { mode } = useTheme();
   const intl = useIntl();
   const paths = useRoutes();

--- a/apps/web/src/pages/Users/AdminUserProfilePage/components/UserProfilePrintButton.tsx
+++ b/apps/web/src/pages/Users/AdminUserProfilePage/components/UserProfilePrintButton.tsx
@@ -12,10 +12,13 @@ export interface UserProfilePrintButtonProps {
   applicant: Applicant;
 }
 
-const UserProfilePrintButton: React.FunctionComponent<{
+const UserProfilePrintButton = ({
+  applicant,
+  children,
+}: {
   applicant: Applicant;
   children?: React.ReactNode;
-}> = ({ applicant, children }) => {
+}) => {
   const intl = useIntl();
 
   const componentRef = useRef(null);

--- a/apps/web/src/pages/Users/CreateUserPage/CreateUserPage.tsx
+++ b/apps/web/src/pages/Users/CreateUserPage/CreateUserPage.tsx
@@ -40,9 +40,7 @@ const formValuesToData = (values: FormValues): CreateUserInput => ({
   sub: emptyToUndefined(values.sub),
 });
 
-export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
-  handleCreateUser,
-}) => {
+export const CreateUserForm = ({ handleCreateUser }: CreateUserFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();
@@ -257,7 +255,7 @@ export const CreateUserForm: React.FunctionComponent<CreateUserFormProps> = ({
   );
 };
 
-const CreateUserPage: React.FunctionComponent = () => {
+const CreateUserPage = () => {
   const [, executeMutation] = useCreateUserMutation();
   const handleCreateUser = (data: CreateUserInput) =>
     executeMutation({ user: data }).then((result) => {

--- a/apps/web/src/pages/Users/IndexUserPage/IndexUserPage.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/IndexUserPage.tsx
@@ -9,7 +9,7 @@ import useRoutes from "~/hooks/useRoutes";
 
 import UserTable from "./components/UserTable";
 
-export const IndexUserPage: React.FC = () => {
+export const IndexUserPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
 

--- a/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
@@ -61,10 +61,10 @@ interface UpdateUserFormProps {
   ) => Promise<UpdateUserAsAdminMutation["updateUserAsAdmin"]>;
 }
 
-export const UpdateUserForm: React.FunctionComponent<UpdateUserFormProps> = ({
+export const UpdateUserForm = ({
   initialUser,
   handleUpdateUser,
-}) => {
+}: UpdateUserFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();

--- a/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
@@ -34,7 +34,7 @@ export interface AddToPoolDialogProps {
   pools: Pool[];
 }
 
-const AddToPoolDialog: React.FC<AddToPoolDialogProps> = ({ user, pools }) => {
+const AddToPoolDialog = ({ user, pools }: AddToPoolDialogProps) => {
   const intl = useIntl();
   const [open, setOpen] = React.useState(false);
   const methods = useForm<FormValues>();

--- a/apps/web/src/pages/Users/UserInformationPage/components/ChangeDateDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/ChangeDateDialog.tsx
@@ -26,10 +26,10 @@ export interface ChangeDateDialogProps {
   user: Applicant;
 }
 
-const ChangeDateDialog: React.FC<ChangeDateDialogProps> = ({
+const ChangeDateDialog = ({
   selectedCandidate,
   user,
-}) => {
+}: ChangeDateDialogProps) => {
   const intl = useIntl();
   const [open, setOpen] = React.useState(false);
   const methods = useForm<FormValues>();

--- a/apps/web/src/pages/Users/UserInformationPage/components/ChangeStatusDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/ChangeStatusDialog.tsx
@@ -43,11 +43,11 @@ export interface ChangeStatusDialogProps {
   pools: Pool[];
 }
 
-const ChangeStatusDialog: React.FC<ChangeStatusDialogProps> = ({
+const ChangeStatusDialog = ({
   selectedCandidate,
   user,
   pools,
-}) => {
+}: ChangeStatusDialogProps) => {
   const intl = useIntl();
   const [open, setOpen] = React.useState(false);
   const methods = useForm<FormValues>();


### PR DESCRIPTION
🤖 Related to (but does not close) #5214 

## 👋 Introduction

This branch removes the most of the uses of React.FunctionComponent and React.FC from the admin pages.  Other subsequent PRs will finish removing it from this location and remove it from other locations.

## 🧪 Testing

1. App builds
2. App runs OK and looks normal

> **Note**
> Some of the diffs looks really big but if you review with whitespace changes hidden it will appear more familiar.