### PR TITLE
Remove FC from IAP and Profile pages

### DIFF
--- a/apps/web/src/pages/Applications/ReviewApplicationPage/ReviewApplicationPage.tsx
+++ b/apps/web/src/pages/Applications/ReviewApplicationPage/ReviewApplicationPage.tsx
@@ -34,9 +34,12 @@ interface ReviewApplicationProps {
   closingDate: PoolAdvertisement["closingDate"];
 }
 
-export const ReviewApplication: React.FunctionComponent<
-  ReviewApplicationProps
-> = ({ applicant, poolAdvertisement, applicationId, closingDate }) => {
+export const ReviewApplication = ({
+  applicant,
+  poolAdvertisement,
+  applicationId,
+  closingDate,
+}: ReviewApplicationProps) => {
   const intl = useIntl();
   const paths = useRoutes();
   const experiences =

--- a/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
@@ -56,9 +56,12 @@ export interface CreateAccountFormProps {
   handleCreateAccount: (data: UpdateUserAsUserInput) => Promise<void>;
 }
 
-export const CreateAccountForm: React.FunctionComponent<
-  CreateAccountFormProps
-> = ({ cacheKey, departments, classifications, handleCreateAccount }) => {
+export const CreateAccountForm = ({
+  cacheKey,
+  departments,
+  classifications,
+  handleCreateAccount,
+}: CreateAccountFormProps) => {
   const intl = useIntl();
   const govInfoLabels = getGovernmentInfoLabels(intl);
 

--- a/apps/web/src/pages/Auth/LoggedOutPage/LoggedOutPage.tsx
+++ b/apps/web/src/pages/Auth/LoggedOutPage/LoggedOutPage.tsx
@@ -18,7 +18,7 @@ import useRoutes from "~/hooks/useRoutes";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import { wrapAbbr } from "~/utils/nameUtils";
 
-const LoggedOutPage: React.FC = () => {
+const LoggedOutPage = () => {
   const intl = useIntl();
   const locale = getLocale(intl);
   const { loggedIn, logout } = useAuthentication();

--- a/apps/web/src/pages/Auth/LoginPage/LoginPage.tsx
+++ b/apps/web/src/pages/Auth/LoginPage/LoginPage.tsx
@@ -16,7 +16,7 @@ const keyRegistrationLink = (path: string, chunks: React.ReactNode) => (
   <a href={path}>{chunks}</a>
 );
 
-const LoginPage: React.FC = () => {
+const LoginPage = () => {
   const intl = useIntl();
   const paths = useRoutes();
   const apiPaths = useApiRoutes();

--- a/apps/web/src/pages/Auth/RegisterPage/RegisterPage.tsx
+++ b/apps/web/src/pages/Auth/RegisterPage/RegisterPage.tsx
@@ -15,7 +15,7 @@ const keyRegistrationLink = (path: string, chunks: React.ReactNode) => (
   <a href={path}>{chunks}</a>
 );
 
-const RegisterPage: React.FC = () => {
+const RegisterPage = () => {
   const intl = useIntl();
   const paths = useRoutes();
   const apiPaths = useApiRoutes();

--- a/apps/web/src/pages/Home/IAPHomePage/Home.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.tsx
@@ -31,7 +31,7 @@ const mailLink = (chunks: React.ReactNode) => (
   <a href="mailto:edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca">{chunks}</a>
 );
 
-const Home: React.FunctionComponent = () => {
+const Home = () => {
   const intl = useIntl();
   const quote = useQuote();
   /**

--- a/apps/web/src/pages/Home/IAPHomePage/components/Card.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Card.tsx
@@ -8,7 +8,7 @@ interface CardProps {
   children?: React.ReactNode;
 }
 
-const Card: React.FC<CardProps> = ({ title, Icon, children }) => (
+const Card = ({ title, Icon, children }: CardProps) => (
   <div data-h2-text-align="base(center)">
     {Icon && <Icon data-h2-width="base(x4)" />}
     <Heading

--- a/apps/web/src/pages/Home/IAPHomePage/components/Heading.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Heading.tsx
@@ -8,13 +8,13 @@ interface HeadingProps {
   children?: React.ReactNode;
 }
 
-const Heading: React.FC<HeadingProps> = ({
+const Heading = ({
   as = "h2",
   color = "pink",
   light,
   children,
   ...rest
-}) => {
+}: HeadingProps) => {
   const El = as;
 
   return (

--- a/apps/web/src/pages/Home/IAPHomePage/components/Quote.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Quote.tsx
@@ -4,7 +4,7 @@ import type { Quote as QuoteProps } from "~/hooks/useQuote";
 
 import { CloseQuote, OpenQuote } from "./Svg";
 
-const Quote: React.FC<QuoteProps> = ({ content, author }) => (
+const Quote = ({ content, author }: QuoteProps) => (
   <figure data-h2-padding="base(x2, 0, x1, 0) p-tablet(x3, 0)">
     <blockquote data-h2-position="base(relative)" data-h2-color="base(white)">
       <div data-h2-text-align="base(left)">

--- a/apps/web/src/pages/Home/IAPHomePage/components/Step.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Step.tsx
@@ -8,7 +8,7 @@ interface StepProps {
   children?: React.ReactNode;
 }
 
-const Step: React.FC<StepProps> = ({ position, title, children }) => (
+const Step = ({ position, title, children }: StepProps) => (
   <div data-h2-text-align="base(center)">
     <Heading as="h4" data-h2-font-size="base(h3, 1)" color="white">
       <span

--- a/apps/web/src/pages/Home/IAPHomePage/components/Svg/BarChart.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Svg/BarChart.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const BarChart: React.FC<React.HTMLAttributes<HTMLOrSVGElement>> = (props) => (
+const BarChart = (props: React.HTMLAttributes<HTMLOrSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/apps/web/src/pages/Home/IAPHomePage/components/Svg/Calendar.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Svg/Calendar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const Calendar: React.FC<React.HTMLAttributes<HTMLOrSVGElement>> = (props) => (
+const Calendar = (props: React.HTMLAttributes<HTMLOrSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/apps/web/src/pages/Home/IAPHomePage/components/Svg/People.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Svg/People.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const People: React.FC<React.HTMLAttributes<HTMLOrSVGElement>> = (props) => (
+const People = (props: React.HTMLAttributes<HTMLOrSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/apps/web/src/pages/Home/IAPHomePage/components/Svg/RadiatingCircles.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Svg/RadiatingCircles.tsx
@@ -4,7 +4,7 @@ interface RadiatingCircleProps {
   className: string; // Note: Not sure why we need this, but here it is
 }
 
-const RadiatingCircle: React.FC<RadiatingCircleProps> = (props) => (
+const RadiatingCircle = (props: RadiatingCircleProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/apps/web/src/pages/Home/IAPHomePage/components/Svg/ThickCircle.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Svg/ThickCircle.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 
-const ThickCircle: React.FC<React.HTMLAttributes<HTMLOrSVGElement>> = (
-  props,
-) => (
+const ThickCircle = (props: React.HTMLAttributes<HTMLOrSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/apps/web/src/pages/Home/IAPHomePage/components/Svg/TrendingUp.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Svg/TrendingUp.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 
-const TrendingUp: React.FC<React.HTMLAttributes<HTMLOrSVGElement>> = (
-  props,
-) => (
+const TrendingUp = (props: React.HTMLAttributes<HTMLOrSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/apps/web/src/pages/Home/IAPHomePage/components/Svg/Triangle.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Svg/Triangle.tsx
@@ -4,7 +4,7 @@ interface TriangleProps {
   className: string;
 }
 
-const Triangle: React.FC<TriangleProps> = (props) => (
+const Triangle = (props: TriangleProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/apps/web/src/pages/Profile/AboutMePage/AboutMePage.tsx
+++ b/apps/web/src/pages/Profile/AboutMePage/AboutMePage.tsx
@@ -28,11 +28,11 @@ interface AboutMeFormApiProps {
   onUpdateAboutMe: AboutMeUpdateHandler;
 }
 
-const AboutMeFormApi: React.FunctionComponent<AboutMeFormApiProps> = ({
+const AboutMeFormApi = ({
   applicationId,
   initialUser,
   onUpdateAboutMe,
-}) => {
+}: AboutMeFormApiProps) => {
   const [result] = useGetApplicationQuery({ variables: { id: applicationId } });
   const { data, fetching } = result;
 

--- a/apps/web/src/pages/Profile/AboutMePage/components/AboutMeForm/AboutMeForm.tsx
+++ b/apps/web/src/pages/Profile/AboutMePage/components/AboutMeForm/AboutMeForm.tsx
@@ -66,11 +66,11 @@ export interface AboutMeFormProps {
   onUpdateAboutMe: AboutMeUpdateHandler;
 }
 
-const AboutMeForm: React.FunctionComponent<AboutMeFormProps> = ({
+const AboutMeForm = ({
   initialUser,
   application,
   onUpdateAboutMe,
-}) => {
+}: AboutMeFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();

--- a/apps/web/src/pages/Profile/EmploymentEquityPage/EmploymentEquityPage.tsx
+++ b/apps/web/src/pages/Profile/EmploymentEquityPage/EmploymentEquityPage.tsx
@@ -23,9 +23,12 @@ interface EmploymentEquityFormApiProps {
   onUpdate: EmploymentEquityUpdateHandler;
 }
 
-const EmploymentEquityFormApi: React.FunctionComponent<
-  EmploymentEquityFormApiProps
-> = ({ applicationId, user, isMutating, onUpdate }) => {
+const EmploymentEquityFormApi = ({
+  applicationId,
+  user,
+  isMutating,
+  onUpdate,
+}: EmploymentEquityFormApiProps) => {
   const [result] = useGetApplicationQuery({ variables: { id: applicationId } });
   const { data, fetching } = result;
 
@@ -76,7 +79,7 @@ const ApiOrContent = ({
     />
   );
 
-const EmploymentEquityFormPage: React.FC = () => {
+const EmploymentEquityFormPage = () => {
   const intl = useIntl();
   const [searchParams] = useSearchParams();
   const applicationId = searchParams.get("applicationId");

--- a/apps/web/src/pages/Profile/EmploymentEquityPage/components/EmploymentEquityForm/EmploymentEquityForm.tsx
+++ b/apps/web/src/pages/Profile/EmploymentEquityPage/components/EmploymentEquityForm/EmploymentEquityForm.tsx
@@ -23,12 +23,12 @@ export interface EmploymentEquityFormProps {
   onUpdate: EmploymentEquityUpdateHandler;
 }
 
-const EmploymentEquityForm: React.FC<EmploymentEquityFormProps> = ({
+const EmploymentEquityForm = ({
   user,
   application,
   onUpdate,
   isMutating,
-}) => {
+}: EmploymentEquityFormProps) => {
   const intl = useIntl();
   const paths = useRoutes();
   const { id: applicationId, returnRoute } = useApplicationInfo(user.id);

--- a/apps/web/src/pages/Profile/EmploymentEquityPage/components/EmploymentEquityForm/EquityOptions.tsx
+++ b/apps/web/src/pages/Profile/EmploymentEquityPage/components/EmploymentEquityForm/EquityOptions.tsx
@@ -33,7 +33,7 @@ const resolveMaybeArray = <T,>(value: Maybe<Array<Maybe<T>>>): Array<T> => {
   return value?.filter(notEmpty) ?? [];
 };
 
-const EquityOptions: React.FC<EquityOptionsProps> = ({
+const EquityOptions = ({
   hasDisability,
   indigenousCommunities,
   isVisibleMinority,
@@ -42,7 +42,7 @@ const EquityOptions: React.FC<EquityOptionsProps> = ({
   onRemove,
   onUpdate,
   isDisabled,
-}) => {
+}: EquityOptionsProps) => {
   const intl = useIntl();
 
   const resolvedDisability = resolveMaybe(hasDisability);

--- a/apps/web/src/pages/Profile/EmploymentEquityPage/components/dialogs/AddToProfile.tsx
+++ b/apps/web/src/pages/Profile/EmploymentEquityPage/components/dialogs/AddToProfile.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-const AddToProfile: React.FC = () => {
+const AddToProfile = () => {
   const intl = useIntl();
 
   return (

--- a/apps/web/src/pages/Profile/EmploymentEquityPage/components/dialogs/Definition.tsx
+++ b/apps/web/src/pages/Profile/EmploymentEquityPage/components/dialogs/Definition.tsx
@@ -13,7 +13,7 @@ interface DefinitionProps {
   url: string;
 }
 
-const Definition: React.FC<DefinitionProps> = ({ url }) => {
+const Definition = ({ url }: DefinitionProps) => {
   const intl = useIntl();
 
   return (

--- a/apps/web/src/pages/Profile/EmploymentEquityPage/components/dialogs/DialogFooter.tsx
+++ b/apps/web/src/pages/Profile/EmploymentEquityPage/components/dialogs/DialogFooter.tsx
@@ -4,7 +4,7 @@ import { ArrowDownOnSquareIcon } from "@heroicons/react/24/solid";
 
 import { Button, Dialog } from "@gc-digital-talent/ui";
 
-const DialogFooter: React.FC = () => {
+const DialogFooter = () => {
   const intl = useIntl();
   return (
     <div data-h2-flex-grid="base(center, x1)">

--- a/apps/web/src/pages/Profile/EmploymentEquityPage/components/dialogs/UnderReview.tsx
+++ b/apps/web/src/pages/Profile/EmploymentEquityPage/components/dialogs/UnderReview.tsx
@@ -27,7 +27,7 @@ const reviewLink = (locale: string, chunks: React.ReactNode) => {
   );
 };
 
-const UnderReview: React.FC = () => {
+const UnderReview = () => {
   const intl = useIntl();
   const locale = getLocale(intl);
 

--- a/apps/web/src/pages/Profile/ExperienceAndSkillsPage/components/ExperienceAndSkills.tsx
+++ b/apps/web/src/pages/Profile/ExperienceAndSkillsPage/components/ExperienceAndSkills.tsx
@@ -51,9 +51,12 @@ export interface ExperienceAndSkillsProps {
   };
 }
 
-export const ExperienceAndSkills: React.FunctionComponent<
-  ExperienceAndSkillsProps
-> = ({ experiences, missingSkills, applicantId, poolAdvertisement }) => {
+export const ExperienceAndSkills = ({
+  experiences,
+  missingSkills,
+  applicantId,
+  poolAdvertisement,
+}: ExperienceAndSkillsProps) => {
   const intl = useIntl();
   const paths = useRoutes();
   const [searchParams] = useSearchParams();

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -74,7 +74,7 @@ export interface ExperienceFormProps {
   edit?: boolean;
 }
 
-export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
+export const ExperienceForm = ({
   userId,
   experienceId,
   applicationId,
@@ -86,7 +86,7 @@ export const ExperienceForm: React.FunctionComponent<ExperienceFormProps> = ({
   cacheKey,
   edit,
   poolAdvertisement,
-}) => {
+}: ExperienceFormProps) => {
   const intl = useIntl();
   const paths = useRoutes();
 

--- a/apps/web/src/pages/Profile/ExperienceFormPage/components/ExperienceSkills.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/components/ExperienceSkills.tsx
@@ -18,10 +18,10 @@ export interface ExperienceSkillsProps {
   poolAdvertisement?: PoolAdvertisement;
 }
 
-const ExperienceSkills: React.FC<ExperienceSkillsProps> = ({
+const ExperienceSkills = ({
   skills,
   poolAdvertisement,
-}) => {
+}: ExperienceSkillsProps) => {
   const intl = useIntl();
   const { control, watch } = useFormContext();
   const [addedSkills, setAddedSkills] = React.useState<Skill[]>([]);

--- a/apps/web/src/pages/Profile/GovernmentInfoPage/GovernmentInfoPage.tsx
+++ b/apps/web/src/pages/Profile/GovernmentInfoPage/GovernmentInfoPage.tsx
@@ -29,15 +29,13 @@ interface GovernmentInfoFormApiProps {
   submitHandler: (data: UpdateUserAsUserInput) => Promise<void>;
 }
 
-const GovernmentInfoFormApi: React.FunctionComponent<
-  GovernmentInfoFormApiProps
-> = ({
+const GovernmentInfoFormApi = ({
   applicationId,
   departments,
   classifications,
   initialData,
   submitHandler,
-}) => {
+}: GovernmentInfoFormApiProps) => {
   const [result] = useGetApplicationQuery({ variables: { id: applicationId } });
   const { data, fetching } = result;
 

--- a/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
+++ b/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
@@ -231,9 +231,11 @@ export interface GovernmentInfoFormFieldsProps {
 }
 
 // inner component
-export const GovernmentInfoFormFields: React.FunctionComponent<
-  GovernmentInfoFormFieldsProps
-> = ({ departments, classifications, labels }) => {
+export const GovernmentInfoFormFields = ({
+  departments,
+  classifications,
+  labels,
+}: GovernmentInfoFormFieldsProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
   const { watch, resetField } = useFormContext();

--- a/apps/web/src/pages/Profile/LanguageInfoPage/LanguageInfoPage.tsx
+++ b/apps/web/src/pages/Profile/LanguageInfoPage/LanguageInfoPage.tsx
@@ -25,9 +25,11 @@ interface LanguageInformationFormApiProps {
   submitHandler: LanguageInformationUpdateHandler;
 }
 
-const LanguageInformationFormApi: React.FunctionComponent<
-  LanguageInformationFormApiProps
-> = ({ applicationId, initialData, submitHandler }) => {
+const LanguageInformationFormApi = ({
+  applicationId,
+  initialData,
+  submitHandler,
+}: LanguageInformationFormApiProps) => {
   const [result] = useGetApplicationQuery({ variables: { id: applicationId } });
   const { data, fetching } = result;
 
@@ -72,7 +74,7 @@ const ApiOrContent = ({
     />
   );
 
-const LanguageInformationFormPage: React.FunctionComponent = () => {
+const LanguageInformationFormPage = () => {
   const intl = useIntl();
   const [searchParams] = useSearchParams();
   const applicationId = searchParams.get("applicationId");

--- a/apps/web/src/pages/Profile/LanguageInfoPage/components/LanguageInformationForm/LanguageInformationForm.tsx
+++ b/apps/web/src/pages/Profile/LanguageInfoPage/components/LanguageInformationForm/LanguageInformationForm.tsx
@@ -97,11 +97,15 @@ export type LanguageInformationUpdateHandler = (
   data: UpdateUserAsUserInput,
 ) => Promise<UpdateUserAsUserMutation["updateUserAsUser"]>;
 
-const LanguageInformationForm: React.FunctionComponent<{
+const LanguageInformationForm = ({
+  initialData,
+  application,
+  submitHandler,
+}: {
   initialData: User;
   application?: PoolCandidate;
   submitHandler: LanguageInformationUpdateHandler;
-}> = ({ initialData, application, submitHandler }) => {
+}) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();

--- a/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
@@ -21,9 +21,7 @@ export interface ProfilePageProps {
   profileDataInput: User;
 }
 
-export const ProfileForm: React.FC<ProfilePageProps> = ({
-  profileDataInput,
-}) => {
+export const ProfileForm = ({ profileDataInput }: ProfilePageProps) => {
   const { id: userId, experiences } = profileDataInput;
   const paths = useRoutes();
 
@@ -122,7 +120,7 @@ export const ProfileForm: React.FC<ProfilePageProps> = ({
   );
 };
 
-const ProfilePage: React.FunctionComponent = () => {
+const ProfilePage = () => {
   const intl = useIntl();
   const [result] = useGetMeQuery();
   const { data, fetching, error } = result;

--- a/apps/web/src/pages/Profile/ProfilePage/components/CandidatePoolsSection.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/components/CandidatePoolsSection.tsx
@@ -6,9 +6,11 @@ import { Well } from "@gc-digital-talent/ui";
 import { PoolCandidate } from "~/api/generated";
 import { getFullPoolAdvertisementTitleHtml } from "~/utils/poolUtils";
 
-const CandidatePoolsSection: React.FunctionComponent<{
+const CandidatePoolsSection = ({
+  poolCandidates,
+}: {
   poolCandidates: PoolCandidate[];
-}> = ({ poolCandidates }) => {
+}) => {
   const intl = useIntl();
 
   return (

--- a/apps/web/src/pages/Profile/ProfilePage/components/MyStatusForm/MyStatusForm.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/components/MyStatusForm/MyStatusForm.tsx
@@ -29,10 +29,7 @@ export interface MyStatusFormProps {
   ) => Promise<UpdateMyStatusMutation["updateUserAsUser"]>;
 }
 
-const MyStatusForm: React.FC<MyStatusFormProps> = ({
-  initialData,
-  handleMyStatus,
-}) => {
+const MyStatusForm = ({ initialData, handleMyStatus }: MyStatusFormProps) => {
   const intl = useIntl();
 
   const isFormActive = initialData?.me?.isProfileComplete;
@@ -146,7 +143,7 @@ const MyStatusForm: React.FC<MyStatusFormProps> = ({
   );
 };
 
-const MyStatusApi: React.FunctionComponent = () => {
+const MyStatusApi = () => {
   const intl = useIntl();
   const paths = useRoutes();
   const navigate = useNavigate();

--- a/apps/web/src/pages/Profile/RoleSalaryPage/RoleSalaryPage.tsx
+++ b/apps/web/src/pages/Profile/RoleSalaryPage/RoleSalaryPage.tsx
@@ -24,11 +24,11 @@ interface RoleSalaryFormApiProps {
   updateRoleSalary: RoleSalaryUpdateHandler;
 }
 
-const RoleSalaryFormApi: React.FunctionComponent<RoleSalaryFormApiProps> = ({
+const RoleSalaryFormApi = ({
   applicationId,
   initialData,
   updateRoleSalary,
-}) => {
+}: RoleSalaryFormApiProps) => {
   const [result] = useGetApplicationQuery({ variables: { id: applicationId } });
   const { data, fetching } = result;
 
@@ -73,7 +73,7 @@ const ApiOrContent = ({
     />
   );
 
-const RoleSalaryFormPage: React.FunctionComponent = () => {
+const RoleSalaryFormPage = () => {
   const intl = useIntl();
   const [searchParams] = useSearchParams();
   const applicationId = searchParams.get("applicationId");

--- a/apps/web/src/pages/Profile/RoleSalaryPage/components/RoleSalaryForm/RoleSalaryForm.tsx
+++ b/apps/web/src/pages/Profile/RoleSalaryPage/components/RoleSalaryForm/RoleSalaryForm.tsx
@@ -76,11 +76,11 @@ export interface RoleSalaryFormProps {
   updateRoleSalary: RoleSalaryUpdateHandler;
 }
 
-const RoleSalaryForm: React.FunctionComponent<RoleSalaryFormProps> = ({
+const RoleSalaryForm = ({
   initialData,
   application,
   updateRoleSalary,
-}) => {
+}: RoleSalaryFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();

--- a/apps/web/src/pages/Profile/WorkLocationPage/WorkLocationPage.tsx
+++ b/apps/web/src/pages/Profile/WorkLocationPage/WorkLocationPage.tsx
@@ -27,11 +27,11 @@ interface WorkLocationApiProps {
   ) => Promise<CreateWorkLocationMutation["updateUserAsUser"]>;
 }
 
-const WorkLocationApi: React.FunctionComponent<WorkLocationApiProps> = ({
+const WorkLocationApi = ({
   applicationId,
   initialData,
   handleWorkLocation,
-}) => {
+}: WorkLocationApiProps) => {
   const [result] = useGetApplicationQuery({ variables: { id: applicationId } });
   const { data, fetching } = result;
 

--- a/apps/web/src/pages/Profile/WorkLocationPage/components/WorkLocationForm/WorkLocationForm.tsx
+++ b/apps/web/src/pages/Profile/WorkLocationPage/components/WorkLocationForm/WorkLocationForm.tsx
@@ -46,11 +46,11 @@ export interface WorkLocationFormProps {
   ) => Promise<CreateWorkLocationMutation["updateUserAsUser"]>;
 }
 
-const WorkLocationForm: React.FC<WorkLocationFormProps> = ({
+const WorkLocationForm = ({
   initialData,
   application,
   handleWorkLocationPreference,
-}) => {
+}: WorkLocationFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();

--- a/apps/web/src/pages/Profile/WorkPreferencesPage/WorkPreferencesPage.tsx
+++ b/apps/web/src/pages/Profile/WorkPreferencesPage/WorkPreferencesPage.tsx
@@ -27,9 +27,11 @@ interface WorkPreferencesFormApiProps {
   ) => Promise<UpdateWorkPreferencesMutation["updateUserAsUser"]>;
 }
 
-const WorkPreferencesFormApi: React.FunctionComponent<
-  WorkPreferencesFormApiProps
-> = ({ applicationId, initialData, handleWorkPreferences }) => {
+const WorkPreferencesFormApi = ({
+  applicationId,
+  initialData,
+  handleWorkPreferences,
+}: WorkPreferencesFormApiProps) => {
   const [result] = useGetApplicationQuery({ variables: { id: applicationId } });
   const { data, fetching } = result;
 
@@ -78,7 +80,7 @@ const ApiOrContent = ({
     />
   );
 
-export const WorkPreferencesPage: React.FunctionComponent = () => {
+export const WorkPreferencesPage = () => {
   const intl = useIntl();
   const [searchParams] = useSearchParams();
   const applicationId = searchParams.get("applicationId");

--- a/apps/web/src/pages/Profile/WorkPreferencesPage/components/WorkPreferencesForm/WorkPreferencesForm.tsx
+++ b/apps/web/src/pages/Profile/WorkPreferencesPage/components/WorkPreferencesForm/WorkPreferencesForm.tsx
@@ -67,11 +67,11 @@ const WithEllipsisPrefix = ({ children }: WithEllipsisPrefixProps) => {
   );
 };
 
-const WorkPreferencesForm: React.FC<WorkPreferencesFormProps> = ({
+const WorkPreferencesForm = ({
   initialData,
   application,
   handleWorkPreferences,
-}) => {
+}: WorkPreferencesFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();


### PR DESCRIPTION
🤖 Related to (but does not close) #5214 

## 👋 Introduction

This branch removes the most (but not all!) of the uses of React.FunctionComponent and React.FC from the IAP and profile pages  Other subsequent PRs will finish removing it from this location and remove it from other locations.

## 🧪 Testing

1. App builds
2. App runs OK and looks normal

> **Note**
> If any diffs looks really big, review with whitespace changes hidden it will appear more familiar.