### PR TITLE
Remove remaining FC from apps/web

### DIFF
--- a/apps/web/src/components/InfoItem/BaseInfoItem.tsx
+++ b/apps/web/src/components/InfoItem/BaseInfoItem.tsx
@@ -59,7 +59,7 @@ export interface BaseInfoItemProps {
   titleColor?: TextColor;
   subTitle?: string;
   subTitleColor?: TextColor;
-  icon?: React.FC<React.SVGProps<SVGSVGElement>>;
+  icon?: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement>>;
   iconColor?: IconColor;
   titleHref?: string;
   hiddenContextPrefix?: string;

--- a/apps/web/src/components/PageHeader/PageHeader.stories.tsx
+++ b/apps/web/src/components/PageHeader/PageHeader.stories.tsx
@@ -3,7 +3,7 @@ import { Story, Meta } from "@storybook/react";
 
 import PageHeaderComponent from "./PageHeader";
 
-const HomeIcon: React.FC = (props) => (
+const HomeIcon = (props: React.HTMLAttributes<HTMLOrSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 20 20"

--- a/apps/web/src/components/PageHeader/types.ts
+++ b/apps/web/src/components/PageHeader/types.ts
@@ -1,6 +1,8 @@
 import React from "react";
 
-export type IconType = React.FC<React.SVGProps<SVGSVGElement>>;
+export type IconType = React.ForwardRefExoticComponent<
+  React.SVGProps<SVGSVGElement>
+>;
 
 type PageNavLink = {
   label?: React.ReactNode;
@@ -8,7 +10,7 @@ type PageNavLink = {
 };
 
 export type PageNavInfo = {
-  icon: React.FC<React.SVGProps<SVGSVGElement>>;
+  icon: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement>>;
   title: string;
   link: PageNavLink;
 };

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateDocument.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateDocument.tsx
@@ -33,15 +33,15 @@ const HeadingWrapper = ({ children }: { children?: React.ReactNode }) => {
 
 export interface HeadingProps {
   as?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
-  icon?: React.FC<React.SVGProps<SVGSVGElement>>;
+  icon?: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement>>;
 }
 
-const Heading: React.FC<HeadingProps & HTMLAttributes<HTMLHeadingElement>> = ({
+const Heading = ({
   icon,
   children,
   as = "h2",
   ...rest
-}) => {
+}: HeadingProps & HTMLAttributes<HTMLHeadingElement>) => {
   const El = as;
   const Icon = icon || null;
 

--- a/apps/web/src/components/Table/ClientManagedTable/Table.tsx
+++ b/apps/web/src/components/Table/ClientManagedTable/Table.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-key */
 import "regenerator-runtime/runtime"; // Hack: Needed for react-table?
-import React, { HTMLAttributes, ReactElement } from "react";
+import React, { ReactElement } from "react";
 import isEqual from "lodash/isEqual";
 import { useIntl } from "react-intl";
 import { useSearchParams } from "react-router-dom";
@@ -75,9 +75,11 @@ const IndeterminateCheckbox = ({
   );
 };
 
-const ButtonIcon: React.FC<{
-  icon: React.FC<HTMLAttributes<HTMLOrSVGElement>>;
-}> = ({ icon }) => {
+const ButtonIcon = ({
+  icon,
+}: {
+  icon: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement>>;
+}) => {
   const Icon = icon;
 
   return (

--- a/apps/web/src/components/Table/ClientManagedTable/tableComponents.tsx
+++ b/apps/web/src/components/Table/ClientManagedTable/tableComponents.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes } from "react";
+import React from "react";
 import { useIntl } from "react-intl";
 
 export const IndeterminateCheckbox = ({
@@ -36,17 +36,17 @@ export const IndeterminateCheckbox = ({
   );
 };
 
-export const Spacer: React.FC<{ children?: React.ReactNode }> = ({
-  children,
-}) => (
+export const Spacer = ({ children }: { children?: React.ReactNode }) => (
   <div data-h2-margin="base(0, 0, 0, x.5)" style={{ flexShrink: 0 }}>
     {children}
   </div>
 );
 
-export const ButtonIcon: React.FC<{
-  icon: React.FC<HTMLAttributes<HTMLOrSVGElement>>;
-}> = ({ icon }) => {
+export const ButtonIcon = ({
+  icon,
+}: {
+  icon: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement>>;
+}) => {
   const Icon = icon;
 
   return (

--- a/apps/web/src/components/UserProfileDocument/UserProfileDocument.tsx
+++ b/apps/web/src/components/UserProfileDocument/UserProfileDocument.tsx
@@ -32,7 +32,7 @@ const HeadingWrapper = ({ children }: { children?: React.ReactNode }) => {
 
 export interface HeadingProps {
   as?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
-  icon?: React.FC<React.SVGProps<SVGSVGElement>>;
+  icon?: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement>>;
 }
 
 const Heading = ({

--- a/apps/web/src/pages/ApplicantDashboardPage/components/HeroCardItem.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/HeroCardItem.tsx
@@ -74,7 +74,7 @@ export const HeroCardProfileItem = ({
 export interface HeroCardExperienceItemProps {
   sectionName: string;
   itemCount?: number;
-  icon?: React.FC<React.SVGProps<SVGSVGElement>>;
+  icon?: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement>>;
   color?: BaseInfoItemIconColor;
 }
 

--- a/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
@@ -292,7 +292,7 @@ export const CreateAccountForm = ({
   );
 };
 
-const CreateAccount: React.FunctionComponent = () => {
+const CreateAccount = () => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();

--- a/apps/web/src/pages/Home/IAPHomePage/components/Card.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Card.tsx
@@ -4,7 +4,7 @@ import Heading from "./Heading";
 
 interface CardProps {
   title: string;
-  Icon?: React.FC<React.HTMLAttributes<HTMLOrSVGElement>>;
+  Icon?: (props: React.HTMLAttributes<HTMLOrSVGElement>) => React.ReactElement;
   children?: React.ReactNode;
 }
 

--- a/apps/web/src/pages/Home/IAPHomePage/components/Svg/CloseQuote.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Svg/CloseQuote.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const CloseQuote: React.FC = (props) => (
+const CloseQuote = (props: React.HTMLAttributes<HTMLOrSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/apps/web/src/pages/Home/IAPHomePage/components/Svg/OpenQuote.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Svg/OpenQuote.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const OpenQuote: React.FC = (props) => (
+const OpenQuote = (props: React.HTMLAttributes<HTMLOrSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/PoolCard/IconLabel.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/PoolCard/IconLabel.tsx
@@ -2,9 +2,7 @@ import React from "react";
 
 interface IconLabelProps {
   label: React.ReactNode;
-  icon:
-    | ((props: React.HTMLAttributes<HTMLOrSVGElement>) => React.ReactElement)
-    | React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement>>;
+  icon: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement>>;
   children?: React.ReactNode;
 }
 

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/PoolCard/IconLabel.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/PoolCard/IconLabel.tsx
@@ -1,8 +1,10 @@
-import React, { SVGAttributes } from "react";
+import React from "react";
 
 interface IconLabelProps {
   label: React.ReactNode;
-  icon: React.FC<SVGAttributes<SVGSVGElement>>;
+  icon:
+    | ((props: React.HTMLAttributes<HTMLOrSVGElement>) => React.ReactElement)
+    | React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement>>;
   children?: React.ReactNode;
 }
 

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -117,7 +117,7 @@ const Text = ({ children }: { children: React.ReactNode }) => (
 );
 interface IconTitleProps {
   children: React.ReactNode;
-  icon: React.FC<React.SVGProps<SVGSVGElement>>;
+  icon: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement>>;
 }
 
 const IconTitle = ({ children, icon }: IconTitleProps) => {

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/ClassificationDefinition.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/ClassificationDefinition.tsx
@@ -190,7 +190,7 @@ interface ClassificationDefinitionProps {
   name: string;
 }
 
-const definitionMap: Record<string, React.FC> = {
+const definitionMap: Record<string, () => JSX.Element> = {
   [GenericJobTitleKey.TechnicianIt01]: LevelOne,
   [GenericJobTitleKey.AnalystIt02]: LevelTwo,
   [GenericJobTitleKey.TeamLeaderIt03]: LevelThreeLead,

--- a/apps/web/src/pages/Profile/EmploymentEquityPage/components/EmploymentEquityForm/EquityOption.tsx
+++ b/apps/web/src/pages/Profile/EmploymentEquityPage/components/EmploymentEquityForm/EquityOption.tsx
@@ -21,7 +21,10 @@ interface EquityOptionProps {
   title: React.ReactNode;
 }
 
-const dialogMap: Record<EquityGroup, React.FC<EquityDialogProps>> = {
+const dialogMap: Record<
+  EquityGroup,
+  (props: EquityDialogProps) => JSX.Element
+> = {
   disability: DisabilityDialog,
   minority: VisibleMinorityDialog,
   woman: WomanDialog,

--- a/apps/web/src/pages/Profile/EmploymentEquityPage/components/IndigenousEquityOption.tsx
+++ b/apps/web/src/pages/Profile/EmploymentEquityPage/components/IndigenousEquityOption.tsx
@@ -18,7 +18,10 @@ interface EquityOptionProps {
   title: React.ReactNode;
 }
 
-const dialogMap: Record<EquityGroup, React.FC<IndigenousDialogProps>> = {
+const dialogMap: Record<
+  EquityGroup,
+  (props: IndigenousDialogProps) => JSX.Element
+> = {
   indigenous: IndigenousDialog,
 };
 

--- a/apps/web/src/pages/Profile/ExperienceAndSkillsPage/components/AddExperienceDialog.tsx
+++ b/apps/web/src/pages/Profile/ExperienceAndSkillsPage/components/AddExperienceDialog.tsx
@@ -21,7 +21,7 @@ type AddExperienceDialogProps = {
 };
 
 interface ExperienceSection {
-  icon: React.FC<React.SVGProps<SVGSVGElement>>;
+  icon: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement>>;
   title: string;
   description: string;
   buttonText: string;

--- a/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
+++ b/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
@@ -523,13 +523,13 @@ export interface GovernmentInfoFormProps {
   submitHandler: (data: UpdateUserAsUserInput) => Promise<void>;
 }
 
-const GovernmentInfoForm: React.FunctionComponent<GovernmentInfoFormProps> = ({
+const GovernmentInfoForm = ({
   departments,
   classifications,
   initialData,
   application,
   submitHandler,
-}) => {
+}: GovernmentInfoFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();

--- a/apps/web/src/pages/Skills/CreateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/CreateSkillPage.tsx
@@ -278,7 +278,7 @@ export const CreateSkillForm = ({
   );
 };
 
-const CreateSkillPage: React.FunctionComponent = () => {
+const CreateSkillPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
   const [lookupResult] = useAllSkillFamiliesQuery();

--- a/apps/web/src/types/pages.ts
+++ b/apps/web/src/types/pages.ts
@@ -6,7 +6,7 @@ type PageNavLink = {
 };
 
 export type PageNavInfo = {
-  icon: React.FC<React.SVGProps<SVGSVGElement>>;
+  icon: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement>>;
   title: string;
   link: PageNavLink;
 };


### PR DESCRIPTION
🤖 Related to (but does not close) #5214 

## 👋 Introduction

This branch removes the remainder of the uses of React.FunctionComponent and React.FC from the apps/web project.  Other subsequent PRs will finish removing it from other locations.  This includes some trickier changes that may need closer inspection.

One more PR is incoming with the remainder of replacements (mostly `packages/ui`) and the linting rule.

## 🧪 Testing

1. App builds
2. App runs OK and looks normal
3. No more instances of FC or FunctionComponent remain in apps/web

> **Note**
> If any diffs look really big, review with whitespace changes hidden it will appear more familiar.