### PR TITLE
Seeding - add users with specific roles to local seeder

### DIFF
--- a/api/database/seeders/UserSeederLocal.php
+++ b/api/database/seeders/UserSeederLocal.php
@@ -51,6 +51,36 @@ class UserSeederLocal extends Seeder
             ->syncRoles([$poolOperatorRole], $dcmTeam)
             ->syncRoles([$poolOperatorRole], $testTeam)
             ->syncRoles([$baseUserRole, $applicantRole, $platformAdminRole, $requestResponderRole], null);
+
+        User::factory()->create([
+            'first_name' => 'Platform',
+            'last_name' => 'Admin',
+            'email' => 'platform@test.com',
+            'sub' => 'platform@test.com',
+            'legacy_roles' => [ApiEnums::LEGACY_ROLE_ADMIN, ApiEnums::LEGACY_ROLE_APPLICANT]
+        ])
+            ->syncRoles([$baseUserRole, $platformAdminRole], null);
+
+        User::factory()->create([
+            'first_name' => 'Request',
+            'last_name' => 'Responder',
+            'email' => 'request@test.com',
+            'sub' => 'request@test.com',
+            'legacy_roles' => [ApiEnums::LEGACY_ROLE_ADMIN, ApiEnums::LEGACY_ROLE_APPLICANT]
+        ])
+            ->syncRoles([$baseUserRole, $requestResponderRole], null);
+
+        User::factory()->create([
+            'first_name' => 'Pool',
+            'last_name' => 'Operator',
+            'email' => 'pool@test.com',
+            'sub' => 'pool@test.com',
+            'legacy_roles' => [ApiEnums::LEGACY_ROLE_ADMIN, ApiEnums::LEGACY_ROLE_APPLICANT]
+         ])
+            ->syncRoles([$poolOperatorRole], $dcmTeam)
+            ->syncRoles([$poolOperatorRole], $testTeam)
+            ->syncRoles([$baseUserRole], null);
+
         User::factory()->create([
             'first_name' => 'Applicant',
             'last_name' => 'Test',

--- a/api/database/seeders/UserSeederLocal.php
+++ b/api/database/seeders/UserSeederLocal.php
@@ -59,7 +59,7 @@ class UserSeederLocal extends Seeder
             'sub' => 'platform@test.com',
             'legacy_roles' => [ApiEnums::LEGACY_ROLE_ADMIN, ApiEnums::LEGACY_ROLE_APPLICANT]
         ])
-            ->syncRoles([$baseUserRole, $platformAdminRole], null);
+            ->syncRoles([$baseUserRole, $applicantRole, $platformAdminRole], null);
 
         User::factory()->create([
             'first_name' => 'Request',
@@ -68,7 +68,7 @@ class UserSeederLocal extends Seeder
             'sub' => 'request@test.com',
             'legacy_roles' => [ApiEnums::LEGACY_ROLE_ADMIN, ApiEnums::LEGACY_ROLE_APPLICANT]
         ])
-            ->syncRoles([$baseUserRole, $requestResponderRole], null);
+            ->syncRoles([$baseUserRole, $applicantRole, $requestResponderRole], null);
 
         User::factory()->create([
             'first_name' => 'Pool',
@@ -79,7 +79,7 @@ class UserSeederLocal extends Seeder
          ])
             ->syncRoles([$poolOperatorRole], $dcmTeam)
             ->syncRoles([$poolOperatorRole], $testTeam)
-            ->syncRoles([$baseUserRole], null);
+            ->syncRoles([$baseUserRole, $applicantRole], null);
 
         User::factory()->create([
             'first_name' => 'Applicant',


### PR DESCRIPTION
## 👋 Introduction

Seeding some users for convenience, small and quick addition.

## 🕵️ Details

While testing with roles in mind, it can be a bit slow if you don't immediately have a user with the specific permissions ready to go. And then rather than edit users with permissions in mind, it is easier to create some role specific ones ready to go.

platform@test.com -> platform-admin
request@test.com -> request-responder
pool@test.com -> pool-operator

All share base-user, without the applicant role you can immediately see login directs people to an error page. 

## 🧪 Testing

1. seed and login
2. policies aren't all sorted out yet so things will look off

