### PR TITLE
Bug - 6030 - notes label not rendered correctly

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4669,9 +4669,9 @@
   "YojrdC": {
     "defaultMessage": "Employé du gouvernement"
   },
-  "Yr4DW5": {
+  "9Aa5c0": {
     "defaultMessage": "Notes - {poolName}",
-    "description": "Label for the notes field on the pool candidate application"
+    "description": "Label for the notes field for a specific pool"
   },
   "Z2KhWS": {
     "defaultMessage": "Retourner à tous les candidats",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3600,10 +3600,6 @@
     "defaultMessage": "Gérer les demandes",
     "description": "Text label for link to requests page on admin dashboard"
   },
-  "CSDdh/": {
-    "defaultMessage": "Notes",
-    "description": "Title for a pool candidates notes field"
-  },
   "bqaNWT": {
     "defaultMessage": "Ajouter l'utilisateur au bassin",
     "description": "title for add to pool dialog on view-user page"

--- a/apps/web/src/lang/whitelist.yml
+++ b/apps/web/src/lang/whitelist.yml
@@ -30,3 +30,4 @@
 - S8ra2P # Actions
 - kyMlnN # 'Classifications' - Breadcrumb title for the classifications page link.
 - I0VGC0 # 'Placement' - 'User placement breadcrumb text'
+- 9Aa5c0 # 'Notes - {poolName}' Label for the notes field for a specific pool

--- a/apps/web/src/lang/whitelist.yml
+++ b/apps/web/src/lang/whitelist.yml
@@ -12,7 +12,6 @@
 - XSo129 # 'Description' Title displayed for the Skill Family table Description column.
 - hlcd+5 # 'Résultats du tableau'
 - 4AubyK # Notes (Title of the 'Notes' section of the view-user page)
-- CSDdh/ # Notes (Title for a pool candidates notes field)
 - gk7uJQ # Classifications (Label displayed on the classifications menu item.)
 - Hqt/ej # 'Archive' 'Heading for the archive pool dialog'
 - P8NuMo # 'Archive' 'Text on a button to archive the pool'
@@ -20,7 +19,6 @@
 - 5TVKj1 # Classifications
 - xJm72U # 'Classifications' title tag
 - TDTE1c # 'Action' Title displayed for the search request table edit column.
-- Yr4DW5 # 'Notes - {poolName}' Label for the notes field on the pool candidate application
 - ev6HnY # 'Notes' CSV Header, Notes column
 - npC3bT # 'Notes' Title for admin editing a pool candidates notes
 - m0JFE/ # 'Code' Title for the application's profile snapshot

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.tsx
@@ -197,9 +197,8 @@ export const ApplicationStatusForm = ({
               label={intl.formatMessage(
                 {
                   defaultMessage: "Notes - {poolName}",
-                  id: "Yr4DW5",
-                  description:
-                    "Label for the notes field on the pool candidate application",
+                  id: "9Aa5c0",
+                  description: "Label for the notes field for a specific pool",
                 },
                 {
                   poolName: getFullPoolAdvertisementTitleHtml(

--- a/apps/web/src/pages/Users/UserInformationPage/components/NotesSection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/NotesSection.tsx
@@ -6,7 +6,10 @@ import { Button, Well } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
 import { BasicForm, TextArea } from "@gc-digital-talent/forms";
 
-import { getFullPoolAdvertisementTitleHtml } from "~/utils/poolUtils";
+import {
+  getFullPoolAdvertisementTitleHtml,
+  getFullPoolAdvertisementTitleLabel,
+} from "~/utils/poolUtils";
 
 import {
   UpdatePoolCandidateAsAdminInput,
@@ -112,7 +115,7 @@ const NotesSection = ({ user }: BasicUserInformationProps) => {
                       defaultMessage: "Notes",
                       id: "CSDdh/",
                       description: "Title for a pool candidates notes field",
-                    })} - ${getFullPoolAdvertisementTitleHtml(
+                    })} - ${getFullPoolAdvertisementTitleLabel(
                       intl,
                       candidate.pool,
                     )}`}

--- a/apps/web/src/pages/Users/UserInformationPage/components/NotesSection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/NotesSection.tsx
@@ -6,10 +6,7 @@ import { Button, Well } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
 import { BasicForm, TextArea } from "@gc-digital-talent/forms";
 
-import {
-  getFullPoolAdvertisementTitleHtml,
-  getFullPoolAdvertisementTitleLabel,
-} from "~/utils/poolUtils";
+import { getFullPoolAdvertisementTitleHtml } from "~/utils/poolUtils";
 
 import {
   UpdatePoolCandidateAsAdminInput,
@@ -111,14 +108,20 @@ const NotesSection = ({ user }: BasicUserInformationProps) => {
                   <TextArea
                     id={candidate.id}
                     name={candidate.id}
-                    label={`${intl.formatMessage({
-                      defaultMessage: "Notes",
-                      id: "CSDdh/",
-                      description: "Title for a pool candidates notes field",
-                    })} - ${getFullPoolAdvertisementTitleLabel(
-                      intl,
-                      candidate.pool,
-                    )}`}
+                    label={intl.formatMessage(
+                      {
+                        defaultMessage: "Notes - {poolName}",
+                        id: "Yr4DW5",
+                        description:
+                          "Label for the notes field on the pool candidate application",
+                      },
+                      {
+                        poolName: getFullPoolAdvertisementTitleHtml(
+                          intl,
+                          candidate.pool,
+                        ),
+                      },
+                    )}
                     defaultValue={candidate.notes ? candidate.notes : ""}
                     placeholder={intl.formatMessage({
                       defaultMessage: "Start writing your notes here...",

--- a/apps/web/src/pages/Users/UserInformationPage/components/NotesSection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/NotesSection.tsx
@@ -111,9 +111,9 @@ const NotesSection = ({ user }: BasicUserInformationProps) => {
                     label={intl.formatMessage(
                       {
                         defaultMessage: "Notes - {poolName}",
-                        id: "Yr4DW5",
+                        id: "9Aa5c0",
                         description:
-                          "Label for the notes field on the pool candidate application",
+                          "Label for the notes field for a specific pool",
                       },
                       {
                         poolName: getFullPoolAdvertisementTitleHtml(


### PR DESCRIPTION
🤖 Resolves #6030 

## 👋 Introduction

Label not rendered correctly. 

## 🕵️ Details

Need the label function rather than the html one for it. 

## 🧪 Testing

1. head to view user for a pool candidates table
2. observe label is fixed for the notes section

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/40485260/226994087-226efc7a-c34e-4e26-a261-d9c4e43c6484.png)



