### PR TITLE
Bug 6035 address errors with manual candidate addition

### DIFF
--- a/api/app/Console/Commands/SubmittedAtApplicationDates.php
+++ b/api/app/Console/Commands/SubmittedAtApplicationDates.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\PoolCandidate;
+use Illuminate\Console\Command;
+use Carbon\Carbon;
+use Database\Helpers\ApiEnums;
+
+class SubmittedAtApplicationDates extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'update-submitted-at';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'For pool candidates that should have submitted dates, submit them';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $dateNow = Carbon::now();
+        $candidatesToSubmit = PoolCandidate::where('pool_candidate_status', ApiEnums::CANDIDATE_STATUS_NEW_APPLICATION)
+            ->where('submitted_at', null);
+
+        foreach ($candidatesToSubmit as $candidate) {
+            $candidate->update(['submitted_at' => $dateNow]);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/api/app/Console/Commands/SubmittedAtApplicationDates.php
+++ b/api/app/Console/Commands/SubmittedAtApplicationDates.php
@@ -32,7 +32,7 @@ class SubmittedAtApplicationDates extends Command
     {
         $dateNow = Carbon::now();
         $candidatesToSubmit = PoolCandidate::where('pool_candidate_status', ApiEnums::CANDIDATE_STATUS_NEW_APPLICATION)
-            ->where('submitted_at', null);
+            ->where('submitted_at', null)->get();
 
         foreach ($candidatesToSubmit as $candidate) {
             $candidate->update(['submitted_at' => $dateNow]);

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -131,7 +131,9 @@ type User {
   pools: [Pool]
     @hasMany
     @can(ability: "view", resolved: true)
-    @deprecated(reason: "Pools are now associated with a Team more than a single User. Use User.roles.team.pools instead.") # Pools a user owns
+    @deprecated(
+      reason: "Pools are now associated with a Team more than a single User. Use User.roles.team.pools instead."
+    ) # Pools a user owns
   # Profile Status
   isProfileComplete: Boolean
   expectedGenericJobTitles: [GenericJobTitle] @belongsToMany
@@ -276,7 +278,9 @@ type Applicant {
   jobLookingStatus: JobLookingStatus
     @rename(attribute: "job_looking_status")
     @deprecated(reason: "Removing with applicantDashboard feature flag")
-  poolCandidates: [PoolCandidate] @hasMany(scopes: ["notDraft"]) @can(ability: "view", resolved: true)
+  poolCandidates: [PoolCandidate]
+    @hasMany(scopes: ["notDraft"])
+    @can(ability: "view", resolved: true)
 
   hasDiploma: Boolean @rename(attribute: "has_diploma")
   locationPreferences: [WorkRegion] @rename(attribute: "location_preferences")
@@ -434,7 +438,9 @@ enum PublishingGroup {
 type PoolCandidate {
   id: ID!
   pool: Pool! @belongsTo @can(ability: "view", resolved: true)
-  poolAdvertisement: PoolAdvertisement @belongsTo(relation: "pool") @can(ability: "viewAdvertisement", resolved: true)
+  poolAdvertisement: PoolAdvertisement
+    @belongsTo(relation: "pool")
+    @can(ability: "viewAdvertisement", resolved: true)
   user: Applicant! @belongsTo(relation: "user")
 
   # cmoIdentifier can be an arbitrary string used to relate this candidate to an external database.
@@ -899,8 +905,7 @@ type Query {
     @guard
     @can(ability: "viewAnyApplicants", model: "User")
   # countApplicants returns the number of candidates matching its filters, and requires no special permissions.
-  countApplicants(where: ApplicantFilterInput): Int!
-    @count(model: "User")
+  countApplicants(where: ApplicantFilterInput): Int! @count(model: "User")
   pool(id: UUID! @eq): Pool @find @can(ability: "view", query: true)
   poolAdvertisement(id: UUID! @eq): PoolAdvertisement
     @find(model: "Pool")
@@ -942,11 +947,7 @@ type Query {
         ]
       )
   ): [PoolCandidate]!
-    @paginate(
-      defaultCount: 10
-      maxCount: 1000
-      scopes: ["notDraft"]
-    )
+    @paginate(defaultCount: 10, maxCount: 1000, scopes: ["notDraft"])
     @guard
     @can(ability: "view", resolved: true)
   # countPoolCandidates returns the number of candidates matching its filters, and requires no special permissions.
@@ -1307,6 +1308,7 @@ input CreatePoolCandidateAsAdminInput {
   status: PoolCandidateStatus = NEW_APPLICATION
     @rename(attribute: "pool_candidate_status")
   notes: String
+  submittedAt: DateTime @rename(attribute: "submitted_at")
 }
 
 input CreatePoolInput {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -268,6 +268,7 @@ input CreatePoolCandidateAsAdminInput {
   expiryDate: Date
   status: PoolCandidateStatus = NEW_APPLICATION
   notes: String
+  submittedAt: DateTime
 }
 
 input CreatePoolCandidateFilterInput {

--- a/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
@@ -2,12 +2,16 @@ import React from "react";
 import { useIntl } from "react-intl";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import zipWith from "lodash/zipWith";
+import { formatInTimeZone } from "date-fns-tz";
 
 import { Dialog, Button } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
 import { Input, MultiSelectField } from "@gc-digital-talent/forms";
 import { commonMessages, errorMessages } from "@gc-digital-talent/i18n";
-import { currentDate } from "@gc-digital-talent/date-helpers";
+import {
+  currentDate,
+  DATETIME_FORMAT_STRING,
+} from "@gc-digital-talent/date-helpers";
 import { notEmpty } from "@gc-digital-talent/helpers";
 
 import {
@@ -66,6 +70,13 @@ const AddToPoolDialog = ({ user, pools }: AddToPoolDialogProps) => {
       .map((poolId) => poolMap.get(poolId))
       .filter(notEmpty);
 
+    const currentTime = new Date();
+    const formattedToUTC = formatInTimeZone(
+      currentTime,
+      "UTC",
+      DATETIME_FORMAT_STRING,
+    );
+
     const promises = poolsToUpdate.map((pool) => {
       return requestMutation({
         pool: {
@@ -75,6 +86,7 @@ const AddToPoolDialog = ({ user, pools }: AddToPoolDialogProps) => {
           connect: user.id,
         },
         expiryDate: formValues.expiryDate,
+        submittedAt: formattedToUTC,
       }).catch((err) => {
         throw err;
       });


### PR DESCRIPTION
🤖 Resolves #6035 

## 👋 Introduction

Twofold, correct the bug and update the database with an artisan command.

## 🕵️ Details

Corrected the bug by updating the input type to also take `submittedAt`, this is filled during the submission handler.

Update the database with a simple command to fill in dates for candidates with the specific status and null dates. Manual submission automatically sets the status to new application, which makes it easier to pull out the right ones to update. 

## 🧪 Testing

Two parts to check

Bug

1. proceed to view user page for some user
2. attempt to add them to pools
3. this should be successful and the table updates

Database

1. build off main and then head to view user for some user
2. add that user to multiple pools successfully, you will not see the table populate
3. switch branches to this one, run the command below
4. refresh page, the table should now be filled out

```
php artisan update-submitted-at
```


