### PR TITLE
Feature - 5999 - platform admin can view pools table

### DIFF
--- a/apps/e2e/cypress/e2e/admin/pool-candidate.cy.js
+++ b/apps/e2e/cypress/e2e/admin/pool-candidate.cy.js
@@ -18,7 +18,7 @@ describe("Pool Candidates", () => {
     cy.intercept("POST", "/graphql", (req) => {
       aliasQuery(req, "GetPoolCandidateStatus");
       aliasQuery(req, "getPoolCandidateSnapshot");
-      aliasQuery(req, "getMePools");
+      aliasQuery(req, "allPools");
       aliasQuery(req, "GetPoolCandidatesPaginated");
 
       aliasMutation(req, "UpdatePoolCandidateStatus");
@@ -98,7 +98,7 @@ describe("Pool Candidates", () => {
 
     loginAndGoToPoolsPage();
 
-    cy.wait("@gqlgetMePoolsQuery");
+    cy.wait("@gqlallPoolsQuery");
 
     cy.findByRole("textbox", { name: /search/i })
       .clear()
@@ -196,7 +196,7 @@ describe("Pool Candidates", () => {
 
     loginAndGoToPoolsPage();
 
-    cy.wait("@gqlgetMePoolsQuery");
+    cy.wait("@gqlallPoolsQuery");
 
     cy.findByRole("textbox", { name: /search/i })
       .clear()

--- a/apps/web/src/components/AdminSideMenu/AdminSideMenu.tsx
+++ b/apps/web/src/components/AdminSideMenu/AdminSideMenu.tsx
@@ -57,7 +57,7 @@ const AdminSideMenu = ({ isOpen, onToggle, onDismiss }: AdminSideMenuProps) => {
       key: "pools",
       href: paths.poolTable(),
       icon: Squares2X2Icon,
-      roles: [ROLE_NAME.PoolOperator],
+      roles: [ROLE_NAME.PoolOperator, ROLE_NAME.PlatformAdmin],
       text: intl.formatMessage({
         defaultMessage: "Pools",
         id: "wCBE9S",

--- a/apps/web/src/components/AdminSideMenu/AdminSideMenu.tsx
+++ b/apps/web/src/components/AdminSideMenu/AdminSideMenu.tsx
@@ -14,9 +14,9 @@ import {
 
 import { SideMenu, SideMenuItem } from "@gc-digital-talent/ui";
 import { useAuthorization, RoleName, ROLE_NAME } from "@gc-digital-talent/auth";
-import { Maybe, RoleAssignment } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
+import { checkRole } from "~/utils/teamUtils";
 import LoginOrLogout from "./LoginOrLogout";
 
 export interface AdminSideMenuProps {
@@ -24,31 +24,6 @@ export interface AdminSideMenuProps {
   onToggle: () => void;
   onDismiss: () => void;
 }
-
-/**
- * Check to see if user contains one or more roles
- *
- * @param checkRoles              Roles to check for
- * @param userRoleAssignments     Users current role assignments
- * @returns boolean
- */
-const checkRole = (
-  checkRoles: RoleName[] | null,
-  userRoleAssignments: Maybe<RoleAssignment[]>,
-): boolean => {
-  if (!checkRoles) {
-    return true;
-  }
-  const visible = checkRoles.reduce((prev, curr) => {
-    if (userRoleAssignments?.map((a) => a.role?.name)?.includes(curr)) {
-      return true;
-    }
-
-    return prev;
-  }, false);
-
-  return visible;
-};
 
 const AdminSideMenu = ({ isOpen, onToggle, onDismiss }: AdminSideMenuProps) => {
   const intl = useIntl();

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -1127,7 +1127,7 @@ const createRoute = (locale: Locales, loginPath: string) =>
                   index: true,
                   element: (
                     <RequireAuth
-                      roles={[ROLE_NAME.PoolOperator]}
+                      roles={[ROLE_NAME.PoolOperator, ROLE_NAME.PlatformAdmin]}
                       loginPath={loginPath}
                     >
                       <IndexPoolPage />

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -1152,6 +1152,7 @@ const createRoute = (locale: Locales, loginPath: string) =>
                       roles={[
                         ROLE_NAME.PoolOperator,
                         ROLE_NAME.RequestResponder,
+                        ROLE_NAME.PlatformAdmin,
                       ]}
                       loginPath={loginPath}
                     >
@@ -1166,6 +1167,7 @@ const createRoute = (locale: Locales, loginPath: string) =>
                           roles={[
                             ROLE_NAME.PoolOperator,
                             ROLE_NAME.RequestResponder,
+                            ROLE_NAME.PlatformAdmin,
                           ]}
                           loginPath={loginPath}
                         >
@@ -1177,7 +1179,10 @@ const createRoute = (locale: Locales, loginPath: string) =>
                       path: "edit",
                       element: (
                         <RequireAuth
-                          roles={[ROLE_NAME.PoolOperator]}
+                          roles={[
+                            ROLE_NAME.PoolOperator,
+                            ROLE_NAME.PlatformAdmin,
+                          ]}
                           loginPath={loginPath}
                         >
                           <EditPoolPage />

--- a/apps/web/src/pages/Pools/IndexPoolPage/IndexPoolPage.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/IndexPoolPage.tsx
@@ -9,7 +9,10 @@ import SEO from "~/components/SEO/SEO";
 
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import { checkRole } from "~/utils/teamUtils";
-import PoolTableApi from "./components/PoolTable";
+import {
+  PoolOperatorTableApi,
+  PoolAdminTableApi,
+} from "./components/PoolTable";
 
 export const PoolPage = () => {
   const intl = useIntl();
@@ -46,7 +49,7 @@ export const PoolPage = () => {
     <AdminContentWrapper crumbs={navigationCrumbs}>
       <SEO title={pageTitle} />
       <PageHeader icon={Squares2X2Icon}>{pageTitle}</PageHeader>
-      <PoolTableApi />
+      {isAdmin ? <PoolAdminTableApi /> : <PoolOperatorTableApi />}
     </AdminContentWrapper>
   );
 };

--- a/apps/web/src/pages/Pools/IndexPoolPage/IndexPoolPage.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/IndexPoolPage.tsx
@@ -9,6 +9,7 @@ import SEO from "~/components/SEO/SEO";
 
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import { checkRole } from "~/utils/teamUtils";
+import { Pending } from "@gc-digital-talent/ui";
 import {
   PoolOperatorTableApi,
   PoolAdminTableApi,
@@ -17,7 +18,7 @@ import {
 export const PoolPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
-  const { roleAssignments } = useAuthorization();
+  const { roleAssignments, isLoaded } = useAuthorization();
   const isAdmin = checkRole(["platform_admin"], roleAssignments);
 
   const pageTitle = intl.formatMessage({
@@ -49,7 +50,9 @@ export const PoolPage = () => {
     <AdminContentWrapper crumbs={navigationCrumbs}>
       <SEO title={pageTitle} />
       <PageHeader icon={Squares2X2Icon}>{pageTitle}</PageHeader>
-      {isAdmin ? <PoolAdminTableApi /> : <PoolOperatorTableApi />}
+      <Pending fetching={!isLoaded}>
+        {isAdmin ? <PoolAdminTableApi /> : <PoolOperatorTableApi />}
+      </Pending>
     </AdminContentWrapper>
   );
 };

--- a/apps/web/src/pages/Pools/IndexPoolPage/IndexPoolPage.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/IndexPoolPage.tsx
@@ -1,17 +1,21 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { Squares2X2Icon } from "@heroicons/react/24/outline";
+import { useAuthorization } from "@gc-digital-talent/auth/";
 
 import useRoutes from "~/hooks/useRoutes";
 import PageHeader from "~/components/PageHeader";
 import SEO from "~/components/SEO/SEO";
 
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
+import { checkRole } from "~/utils/teamUtils";
 import PoolTableApi from "./components/PoolTable";
 
 export const PoolPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
+  const { roleAssignments } = useAuthorization();
+  const isAdmin = checkRole(["platform_admin"], roleAssignments);
 
   const pageTitle = intl.formatMessage({
     defaultMessage: "Pools",

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -23,6 +23,8 @@ import {
   Scalars,
   GetMePoolsQuery,
   useGetMePoolsQuery,
+  AllPoolsQuery,
+  useAllPoolsQuery,
   RoleAssignment,
 } from "~/api/generated";
 import Table, {
@@ -31,13 +33,17 @@ import Table, {
   Cell,
 } from "~/components/Table/ClientManagedTable";
 
-type Data = NonNullable<
-  FromArray<
-    NonNullable<
-      FromArray<NonNullable<GetMePoolsQuery["me"]>["roleAssignments"]>["team"]
-    >["pools"]
-  >
->;
+type Data =
+  | NonNullable<
+      FromArray<
+        NonNullable<
+          FromArray<
+            NonNullable<GetMePoolsQuery["me"]>["roleAssignments"]
+          >["team"]
+        >["pools"]
+      >
+    >
+  | NonNullable<FromArray<AllPoolsQuery["pools"]>>;
 type PoolCell = Cell<Pool>;
 
 // callbacks extracted to separate function to stabilize memoized component
@@ -383,7 +389,7 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
   );
 };
 
-const PoolTableApi = () => {
+export const PoolOperatorTableApi = () => {
   const [result] = useGetMePoolsQuery();
   const { data, fetching, error } = result;
   const poolsArray = roleAssignmentsToPools(data?.me?.roleAssignments);
@@ -395,4 +401,14 @@ const PoolTableApi = () => {
   );
 };
 
-export default PoolTableApi;
+export const PoolAdminTableApi = () => {
+  const [result] = useAllPoolsQuery();
+  const { data, fetching, error } = result;
+  const poolsArray = unpackMaybes(data?.pools);
+
+  return (
+    <Pending fetching={fetching} error={error}>
+      <PoolTable pools={poolsArray ?? []} />
+    </Pending>
+  );
+};

--- a/apps/web/src/pages/Pools/IndexPoolPage/indexPoolsOperations.graphql
+++ b/apps/web/src/pages/Pools/IndexPoolPage/indexPoolsOperations.graphql
@@ -35,3 +35,32 @@ query getMePools {
     }
   }
 }
+
+query allPools {
+  pools {
+    id
+    owner {
+      id
+      email
+      firstName
+      lastName
+    }
+    name {
+      en
+      fr
+    }
+    description {
+      en
+      fr
+    }
+    classifications {
+      id
+      group
+      level
+    }
+    advertisementStatus
+    stream
+    processNumber
+    createdDate
+  }
+}

--- a/apps/web/src/utils/teamUtils.ts
+++ b/apps/web/src/utils/teamUtils.ts
@@ -1,5 +1,11 @@
+import { RoleName } from "@gc-digital-talent/auth";
 import { notEmpty } from "@gc-digital-talent/helpers";
-import { Role, RoleAssignment, UserPublicProfile } from "~/api/generated";
+import {
+  Maybe,
+  Role,
+  RoleAssignment,
+  UserPublicProfile,
+} from "~/api/generated";
 
 export type TeamMember = {
   roles: Array<Role>;
@@ -36,4 +42,29 @@ export const groupRoleAssignmentsByUser = (
   });
 
   return users;
+};
+
+/**
+ * Check to see if user contains one or more roles
+ *
+ * @param checkRoles              Roles to check for
+ * @param userRoleAssignments     Users current role assignments
+ * @returns boolean
+ */
+export const checkRole = (
+  checkRoles: RoleName[] | null,
+  userRoleAssignments: Maybe<RoleAssignment[]>,
+): boolean => {
+  if (!checkRoles) {
+    return true;
+  }
+  const visible = checkRoles.reduce((prev, curr) => {
+    if (userRoleAssignments?.map((a) => a.role?.name)?.includes(curr)) {
+      return true;
+    }
+
+    return prev;
+  }, false);
+
+  return visible;
 };


### PR DESCRIPTION
🤖 Resolves #5999 

## 👋 Introduction

Enables users with platform admin but not pool operator role to also view the pool table.

## 🕵️ Details

Simpler solution (I think) than the query pause idea. Just two wrapper components with different queries and conditionally render one or the other.
Platform admin can now also view a pool layout, info, and edit pages (need to in order to publish) but not candidates.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. use adminer or whichever tool to keep reference of all pools
2. login as pool operator (pool@test.com), view pools table and note pools displayed
3. login as platform admin (platform@test.com), view pools table and note pools displayed
4. pool operator can only view dcm/test team pools whereas the other can view all so the table has more pools
5. platform admin can also see information for the pools but not view candidates

