### PR TITLE
Add feature flag for application revamp :vampire: 

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -10,6 +10,7 @@ OAUTH_LOGOUT_URI="http://localhost:8000/oxauth/endsession"
 # Feature flags
 FEATURE_ONGOING_RECRUITMENTS=true
 FEATURE_APPLICANT_DASHBOARD=true
+FEATURE_APPLICATION_REVAMP=true
 
 # Logging - enable by setting the logging level.  Eight severity levels from rfc5424.
 LOG_CONSOLE_LEVEL="debug"

--- a/apps/web/public/config.ejs
+++ b/apps/web/public/config.ejs
@@ -15,6 +15,7 @@ const data = new Map([
     // Feature flags
     ["FEATURE_ONGOING_RECRUITMENTS", filterUnusable("$FEATURE_ONGOING_RECRUITMENTS") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_ONGOING_RECRUITMENTS %>"],
     ["FEATURE_APPLICANT_DASHBOARD", filterUnusable("$FEATURE_APPLICANT_DASHBOARD") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_APPLICANT_DASHBOARD %>"],
+    ["FEATURE_APPLICATION_REVAMP", filterUnusable("$FEATURE_APPLICATION_REVAMP") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_APPLICATION_REVAMP %>"],
 
     // Azure application insights not used in dev
     ["APPLICATIONINSIGHTS_CONNECTION_STRING", filterUnusable("$APPLICATIONINSIGHTS_CONNECTION_STRING")],

--- a/packages/env/src/useFeatureFlags.ts
+++ b/packages/env/src/useFeatureFlags.ts
@@ -3,6 +3,7 @@ import { getFeatureFlags } from "./utils";
 export type FeatureFlags = {
   ongoingRecruitments: boolean;
   applicantDashboard: boolean;
+  applicationRevamp: boolean;
 };
 
 const useFeatureFlags = (): FeatureFlags => {

--- a/packages/env/src/utils.ts
+++ b/packages/env/src/utils.ts
@@ -41,4 +41,5 @@ export const checkFeatureFlag = (name: string): boolean => {
 export const getFeatureFlags = () => ({
   ongoingRecruitments: checkFeatureFlag("FEATURE_ONGOING_RECRUITMENTS"),
   applicantDashboard: checkFeatureFlag("FEATURE_APPLICANT_DASHBOARD"),
+  applicationRevamp: checkFeatureFlag("FEATURE_APPLICATION_REVAMP"),
 });


### PR DESCRIPTION
🤖 Resolves #5960 

## 👋 Introduction

This branch adds the feature flag for application revamp. 

## 🧪 Testing

1. Copy a new .env file for apps/web (or rerun setup)
2. Rebuild the app (or rerun setup)
3. Visit the site, open the console, and run  `window.__SERVER_CONFIG__`, observe an entry for FEATURE_APPLICATION_REVAMP

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/8978655/227952876-a24b9a7b-b877-49b5-b1c0-a91528cf0a69.png)


