### PR TITLE
Feature - 5997 - add My Roles to teams table

### DIFF
--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.stories.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.stories.tsx
@@ -3,9 +3,26 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { fakeTeams } from "@gc-digital-talent/fake-data";
 
-import { TeamTable } from "./TeamTable";
+import { TeamTable, MyRoleTeam } from "./TeamTable";
 
 const mockTeams = fakeTeams();
+
+const mockRolesAndTeams: MyRoleTeam[] = [
+  {
+    teamId: mockTeams[0].id,
+    roleName: {
+      en: "Role 1 EN",
+      fr: "Role 1 FR",
+    },
+  },
+  {
+    teamId: mockTeams[0].id,
+    roleName: {
+      en: "Role 2 EN",
+      fr: "Role 2 FR",
+    },
+  },
+];
 
 export default {
   component: TeamTable,
@@ -16,11 +33,12 @@ export default {
 } as ComponentMeta<typeof TeamTable>;
 
 const Template: ComponentStory<typeof TeamTable> = (args) => {
-  const { teams } = args;
-  return <TeamTable teams={teams} />;
+  const { teams, myRolesAndTeams } = args;
+  return <TeamTable teams={teams} myRolesAndTeams={myRolesAndTeams} />;
 };
 
 export const Default = Template.bind({});
 Default.args = {
   teams: mockTeams,
+  myRolesAndTeams: mockRolesAndTeams,
 };

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.test.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.test.tsx
@@ -98,11 +98,21 @@ describe("TeamTable", () => {
       myRolesAndTeams: transformedRoleAssignment,
     });
 
-    // role 1 pill should appear twice, role 2 pill appear once
-    const grabRole1 = screen.queryAllByText("Role 1");
-    expect(grabRole1).toHaveLength(2);
+    // find an expected team name in the table
+    // find an expected link for that team
+    const teamName = mockTeams[0]?.displayName?.en
+      ? mockTeams[0].displayName.en
+      : "";
+    const teamId = mockTeams[0].id;
 
-    const grabRole2 = screen.queryAllByText("Role 2");
-    expect(grabRole2).toHaveLength(1);
+    expect(screen.getByText(teamName)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: teamName })).toHaveAttribute(
+      "href",
+      `/en/admin/teams/${teamId}`,
+    );
+
+    // role 1 pill should appear twice, role 2 pill appear once
+    expect(screen.queryAllByText("Role 1")).toHaveLength(2);
+    expect(screen.queryAllByText("Role 2")).toHaveLength(1);
   });
 });

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.test.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+import "@testing-library/jest-dom";
+import { screen } from "@testing-library/react";
+import React from "react";
+import { renderWithProviders } from "@gc-digital-talent/jest-helpers";
+import { fakeTeams } from "@gc-digital-talent/fake-data";
+import { RoleAssignment } from "~/api/generated";
+
+import {
+  roleAssignmentsToRoleTeamArray,
+  TeamTable,
+  TeamTableProps,
+} from "./TeamTable";
+
+const mockTeams = fakeTeams(5);
+const mockRoleAssignments: RoleAssignment[] = [
+  {
+    id: "roleAssign1",
+    team: mockTeams[0],
+    role: {
+      id: "role1",
+      name: "role1",
+      displayName: {
+        en: "Role 1",
+        fr: "Role 1",
+      },
+      isTeamBased: true,
+    },
+  },
+  {
+    id: "roleAssign2",
+    team: mockTeams[0],
+    role: {
+      id: "role2",
+      name: "role2",
+      displayName: {
+        en: "Role 2",
+        fr: "Role 2",
+      },
+      isTeamBased: true,
+    },
+  },
+  {
+    id: "roleAssign3",
+    team: mockTeams[1],
+    role: {
+      id: "role1",
+      name: "role1",
+      displayName: {
+        en: "Role 1",
+        fr: "Role 1",
+      },
+      isTeamBased: true,
+    },
+  },
+  {
+    id: "roleAssign4",
+    team: null,
+    role: {
+      id: "role3",
+      name: "role3",
+      displayName: {
+        en: "Individual",
+        fr: "Individual",
+      },
+      isTeamBased: false,
+    },
+  },
+];
+
+const renderTeamsTable = (props: TeamTableProps) =>
+  renderWithProviders(<TeamTable {...props} />);
+
+describe("TeamTable", () => {
+  it("should render correctly", () => {
+    // use function that operates in the API wrapper layer to transform mock roleAssignments
+    // then pass props into TeamTable
+    const transformedRoleAssignment =
+      roleAssignmentsToRoleTeamArray(mockRoleAssignments);
+
+    // mockRoleAssignments has 4 entries, but 1 isn't team based
+    expect(mockRoleAssignments).toHaveLength(4);
+    expect(transformedRoleAssignment).toHaveLength(3);
+
+    // check that the transformed array contains an expected object
+    expect(transformedRoleAssignment).toContainEqual({
+      teamId: mockTeams[0].id,
+      roleName: {
+        en: "Role 1",
+        fr: "Role 1",
+      },
+    });
+
+    renderTeamsTable({
+      teams: mockTeams,
+      myRolesAndTeams: transformedRoleAssignment,
+    });
+
+    // role 1 pill should appear twice, role 2 pill appear once
+    const grabRole1 = screen.queryAllByText("Role 1");
+    expect(grabRole1).toHaveLength(2);
+
+    const grabRole2 = screen.queryAllByText("Role 2");
+    expect(grabRole2).toHaveLength(1);
+  });
+});

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
@@ -5,7 +5,12 @@ import { Pending, Link } from "@gc-digital-talent/ui";
 import { useLocale } from "@gc-digital-talent/i18n";
 import { notEmpty } from "@gc-digital-talent/helpers";
 
-import { Maybe, Team, useListTeamsQuery } from "~/api/generated";
+import {
+  Maybe,
+  Team,
+  useListTeamsQuery,
+  useMeRoleAssignmentsQuery,
+} from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
 import Table, {
   ColumnsOf,
@@ -135,12 +140,24 @@ export const TeamTable = ({ teams }: TeamTableProps) => {
 };
 
 const TeamTableApi = () => {
-  const [{ data, fetching, error }] = useListTeamsQuery();
+  const [{ data: dataTeam, fetching: fetchingTeam, error: errorTeam }] =
+    useListTeamsQuery();
+  const [{ data: dataMe, fetching: fetchingMe, error: errorMe }] =
+    useMeRoleAssignmentsQuery();
 
-  const teams = data?.teams.filter(notEmpty);
+  const isFetching = fetchingTeam === true || fetchingMe === true;
+
+  const teams = dataTeam?.teams.filter(notEmpty);
+
+  const roleAssignments =
+    dataMe?.me && dataMe.me?.roleAssignments ? dataMe.me.roleAssignments : null;
+
+  if (roleAssignments && roleAssignments.length > 0) {
+    //
+  }
 
   return (
-    <Pending fetching={fetching} error={error}>
+    <Pending fetching={isFetching} error={errorTeam || errorMe}>
       <TeamTable teams={teams || []} />
     </Pending>
   );

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
@@ -117,7 +117,11 @@ const myRolesCell = (
   );
 
   const rolesPillsArray = teamFiltered.map((roleTeam) => (
-    <Pill color="primary" mode="outline" key={teamId}>
+    <Pill
+      color="primary"
+      mode="outline"
+      key={`${teamId}-${roleTeam.roleName.en}`}
+    >
       {roleTeam.roleName[locale]}
     </Pill>
   ));

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
@@ -201,8 +201,8 @@ export const TeamTable = ({ teams, myRolesAndTeams }: TeamTableProps) => {
     return {
       initialSortBy: [
         {
-          id: "teamName",
-          desc: false,
+          id: "myRoles",
+          desc: true,
         },
       ],
     };

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
@@ -20,7 +20,7 @@ import Table, {
 } from "~/components/Table/ClientManagedTable";
 import { RoleAssignment } from "@gc-digital-talent/graphql";
 
-interface TeamTableProps {
+export interface TeamTableProps {
   teams: Array<Team>;
   myRolesAndTeams: Array<MyRoleTeam>;
 }
@@ -35,7 +35,7 @@ export type MyRoleTeam = {
 // given an array of RoleAssignments
 // generate an array of MyRoleTeam objects for team-based roles, filtering out individual roles and empty
 // the returned array functions like a map
-const roleAssignmentsToRoleTeamArray = (
+export const roleAssignmentsToRoleTeamArray = (
   roleAssignments: RoleAssignment[],
 ): MyRoleTeam[] => {
   let collection: Array<MyRoleTeam> = [];

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
@@ -163,8 +163,9 @@ export const TeamTable = ({ teams, myRolesAndTeams }: TeamTableProps) => {
       {
         Header: intl.formatMessage({
           defaultMessage: "My Roles",
-          id: "aBNNL3",
-          description: "Title displayed for the teams table my roles column.",
+          id: "+agJAH",
+          description:
+            "Label displayed for the table's My Roles column header.",
         }),
         accessor: (d) => myRolesAccessor(d.id, myRolesAndTeams, locale),
         Cell: ({ row }: TeamCell) =>

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
@@ -27,7 +27,7 @@ interface TeamTableProps {
 
 type TeamCell = Cell<Team>;
 
-type MyRoleTeam = {
+export type MyRoleTeam = {
   teamId: string;
   roleName: LocalizedString;
 };
@@ -158,6 +158,17 @@ export const TeamTable = ({ teams, myRolesAndTeams }: TeamTableProps) => {
       },
       {
         Header: intl.formatMessage({
+          defaultMessage: "My Roles",
+          id: "aBNNL3",
+          description: "Title displayed for the teams table my roles column.",
+        }),
+        accessor: (d) => myRolesAccessor(d.id, myRolesAndTeams, locale),
+        Cell: ({ row }: TeamCell) =>
+          myRolesCell(row.original.id, myRolesAndTeams, locale),
+        id: "myRoles",
+      },
+      {
+        Header: intl.formatMessage({
           defaultMessage: "Department",
           id: "BDo1aH",
           description: "Title displayed for the teams table department column.",
@@ -180,17 +191,6 @@ export const TeamTable = ({ teams, myRolesAndTeams }: TeamTableProps) => {
         }),
         accessor: (d) => d.contactEmail,
         Cell: ({ value }: TeamCell) => emailLinkAccessor(value, intl),
-      },
-      {
-        Header: intl.formatMessage({
-          defaultMessage: "My Roles",
-          id: "aBNNL3",
-          description: "Title displayed for the teams table my roles column.",
-        }),
-        accessor: (d) => myRolesAccessor(d.id, myRolesAndTeams, locale),
-        Cell: ({ row }: TeamCell) =>
-          myRolesCell(row.original.id, myRolesAndTeams, locale),
-        id: "myRoles",
       },
     ],
     [paths, intl, locale, myRolesAndTeams],

--- a/apps/web/src/pages/Teams/teamsOperations.graphql
+++ b/apps/web/src/pages/Teams/teamsOperations.graphql
@@ -62,6 +62,27 @@ query ListTeams {
   }
 }
 
+query MeRoleAssignments {
+  me {
+    roleAssignments {
+      id
+      role {
+        id
+        name
+        displayName {
+          en
+          fr
+        }
+        isTeamBased
+      }
+      team {
+        id
+        name
+      }
+    }
+  }
+}
+
 query ListRoles {
   roles {
     id


### PR DESCRIPTION
🤖 Resolves #5997

## 👋 Introduction

Adds a column called "My Roles", this outputs the users roles (if any) associated with a team in the table row.

## 🕵️ Details

Went along with the proposed implementation idea.
Assembling a collection of objects consisting of team id and role name. Then you can generate the UI element from it. 
Updated storybook to render this, as well as added a jest test file. 

## 🧪 Testing

1. login as admin and observe the teams table
2. code readthrough

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/40485260/228325117-95548061-6279-4e98-b5f3-8cb648eca760.png)




