### PR TITLE
[Bug] Fix user role from removing email

### DIFF
--- a/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
@@ -311,7 +311,9 @@ const UpdateUserPage = () => {
       id,
       user: {
         id,
-        email: emptyToNull(data.email),
+        // Do not include email in the request if it is not part of form data
+        // to prevent accidentally setting it to null
+        email: data.email !== undefined ? emptyToNull(data.email) : undefined,
         ...pick(data, [
           "firstName",
           "lastName",


### PR DESCRIPTION
🤖 Resolves #6103 

## 👋 Introduction

This prevents role updates from overriding the user email to `null`.

## 🕵️ Details

We were setting the users email to `null` when it did not exist (either undefined or empty string) to prevent our validation from seeing `""` as a duplicate email. This unsets the email key in our mutation variables if it is undefined so that it is only nulled when it is an empty string.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build the application `npm run build`
2. Navigate to `/admin/users/{userId}/edit
3. **Add** a role, confirm email is still present
4. **Remove** a role, confirm email is still present
5. **Empty** out the email, confirm it saves as empty
6. Attempt to update to an **existing** email, confirm it fails with nice error message
7. Attempt to update to a **unique** email, confirm it succeeds


