### PR TITLE
[Debt] Removes `classNames` prop from Button component

### DIFF
--- a/apps/web/src/assets/css/app.css
+++ b/apps/web/src/assets/css/app.css
@@ -28,17 +28,6 @@ button {
   padding: 0;
 }
 
-.button {
-  border: none;
-  cursor: pointer;
-  overflow-wrap: break-word;
-}
-
-.disabled {
-  cursor: not-allowed;
-  opacity: 50%;
-}
-
 p {
   white-space: pre-wrap;
 }

--- a/apps/web/src/assets/css/app.css
+++ b/apps/web/src/assets/css/app.css
@@ -23,11 +23,6 @@ button {
   border: none;
 }
 
-.reset-ul {
-  list-style: none;
-  padding: 0;
-}
-
 p {
   white-space: pre-wrap;
 }

--- a/apps/web/src/components/Pagination/Pagination.tsx
+++ b/apps/web/src/components/Pagination/Pagination.tsx
@@ -88,9 +88,6 @@ const Pagination = ({
               {/* left navigation arrow */}
               <li data-h2-display="base(inline-block)">
                 <Button
-                  classNames={
-                    isLeftArrowDisabled || lessThanTwoItems ? "disabled" : ""
-                  }
                   color={color}
                   mode={mode}
                   type="button"
@@ -144,7 +141,6 @@ const Pagination = ({
                     data-h2-display="base(inline-block)"
                   >
                     <Button
-                      classNames={lessThanTwoItems ? "disabled" : ""}
                       data-testid="pagination"
                       color={color}
                       mode={`${current ? "solid" : mode}`}
@@ -178,9 +174,6 @@ const Pagination = ({
               {/* right navigation arrow */}
               <li data-h2-display="base(inline-block)">
                 <Button
-                  classNames={
-                    isRightArrowDisabled || lessThanTwoItems ? "disabled" : ""
-                  }
                   color={color}
                   mode={mode}
                   type="button"

--- a/apps/web/src/components/Pagination/Pagination.tsx
+++ b/apps/web/src/components/Pagination/Pagination.tsx
@@ -82,7 +82,8 @@ const Pagination = ({
             <ul
               data-h2-display="base(flex)"
               data-h2-gap="base(x.25)"
-              className="reset-ul"
+              data-h2-list-style="base(none)"
+              data-h2-padding="base(0)"
               {...rest}
             >
               {/* left navigation arrow */}

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -462,7 +462,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <button
         ref={ref}
-        className={`button ${classNames}`}
+        className={classNames ? `button ${classNames}` : "button"}
         // eslint-disable-next-line react/button-has-type
         type={type || "button"}
         disabled={disabled}

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -29,7 +29,6 @@ export interface ButtonProps extends React.HTMLProps<HTMLButtonElement> {
   /** Determines whether the element should be block level and 100% width. */
   block?: boolean;
   type?: "button" | "submit" | "reset";
-  classNames?: string;
 }
 
 export const h2ButtonColors = {
@@ -444,7 +443,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       mode = "solid",
       disabled,
       block = false,
-      classNames,
       ...rest
     },
     ref,
@@ -462,7 +460,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <button
         ref={ref}
-        className={classNames ? `button ${classNames}` : "button"}
         // eslint-disable-next-line react/button-has-type
         type={type || "button"}
         disabled={disabled}
@@ -471,6 +468,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         data-h2-font-weight="base(700)"
         data-h2-transition="base:hover(background .2s ease 0s)"
         data-h2-cursor="base(pointer)"
+        data-h2-overflow-wrap="base(break-word)"
         {...(block
           ? { "data-h2-display": "base(block)" }
           : { "data-h2-display": "base(inline-block)" })}


### PR DESCRIPTION
🤖 Resolves #5804.

## 👋 Introduction

This PR removes `classNames` prop from Button component that was little used and ultimately, was able to be removed.

## ➕ Bonus

https://github.com/GCTC-NTGC/gc-digital-talent/commit/a1ab41ab0942306c0229647e19d9e4902827834d - Removes the `.reset-ul` css class that was being referenced in only one place (outside of tc-report) and was replaced with Hydrogen data attributes

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure `button` or `disabled` css class are not being used (outside of tc-report)
2. Ensure `classNames` prop not called anywhere on Button component references