### PR TITLE
Application skip ahead page

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7380,5 +7380,9 @@
   "EPF4Ac": {
     "defaultMessage": "Le processus de demande repose sur la collecte et l’examen des renseignements de manière linéaire. Par conséquent, il n’est pas encore possible de passer à cette étape. La dernière étape sur laquelle vous travailliez est mise en surbrillance dans la zone des étapes de la page, ou vous pouvez utiliser le bouton fourni pour y accéder directement.",
     "description": "Application step skipped page details"
+  },
+  "88dH+F": {
+    "defaultMessage": "Revenir à la dernière étape sur laquelle je travaillais",
+    "description": "Button text to return back to the last step"
   }
 }

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7372,5 +7372,13 @@
   "wMp4x6": {
     "defaultMessage": "Télécharger le guide (EN)",
     "description": "Link text for English guidance resource download"
+  },
+  "9vQj8o": {
+    "defaultMessage": "Oh! on dirait que vous avez été trop vite!",
+    "description": "Application step skipped page title"
+  },
+  "EPF4Ac": {
+    "defaultMessage": "Le processus de demande repose sur la collecte et l’examen des renseignements de manière linéaire. Par conséquent, il n’est pas encore possible de passer à cette étape. La dernière étape sur laquelle vous travailliez est mise en surbrillance dans la zone des étapes de la page, ou vous pouvez utiliser le bouton fourni pour y accéder directement.",
+    "description": "Application step skipped page details"
   }
 }

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
@@ -52,6 +52,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       ApplicationStep.ReviewYourProfile,
       ApplicationStep.ReviewYourResume,
     ],
+    stepSubmitted: ApplicationStep.EducationRequirements,
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { PresentationChartBarIcon } from "@heroicons/react/20/solid";
 
 import { Heading } from "@gc-digital-talent/ui";
+import { ApplicationStep } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetApplicationPageInfo } from "~/types/poolCandidate";
@@ -46,6 +47,11 @@ export const getPageInfo: GetApplicationPageInfo = ({
         description: "Link text for the application education page",
       }),
     },
+    prerequisites: [
+      ApplicationStep.Welcome,
+      ApplicationStep.ReviewYourProfile,
+      ApplicationStep.ReviewYourResume,
+    ],
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -69,13 +69,19 @@ const submittedStepNav = new Map<ApplicationStep, PageNavKey>([
   [ApplicationStep.ReviewAndSubmit, "review"],
 ]);
 
-const deriveStepsFromPages = (pages: Map<PageNavKey, ApplicationPageInfo>) => {
+const deriveSteps = (
+  pages: Map<PageNavKey, ApplicationPageInfo>,
+  submittedSteps: Maybe<Array<ApplicationStep>>,
+) => {
   const steps = Array.from(pages.values())
     .filter((page) => !page.omitFromStepper) // Hide some pages from stepper
     .map((page) => ({
       label: page.link.label || page.title,
       href: page.link.url,
       icon: page.icon,
+      completed:
+        (page.stepSubmitted && submittedSteps?.includes(page.stepSubmitted)) ??
+        false,
     }));
 
   steps.pop(); // We do not want to show final step in the stepper
@@ -158,7 +164,7 @@ const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
 
   const currentPage = useCurrentPage(pages);
   const currentCrumbs = currentPage?.crumbs || [];
-  const steps = deriveStepsFromPages(pages);
+  const steps = deriveSteps(pages, application.submittedSteps);
   const currentStep = steps.findIndex((step) =>
     currentPage?.link.url.includes(step.href),
   );

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { UserCircleIcon } from "@heroicons/react/20/solid";
 
 import { Heading } from "@gc-digital-talent/ui";
+import { ApplicationStep } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetApplicationPageInfo } from "~/types/poolCandidate";
@@ -40,6 +41,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
     link: {
       url: path,
     },
+    prerequisites: [ApplicationStep.Welcome],
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
@@ -42,6 +42,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       url: path,
     },
     prerequisites: [ApplicationStep.Welcome],
+    stepSubmitted: ApplicationStep.ReviewYourProfile,
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationQuestionsIntroductionPage/ApplicationQuestionsIntroductionPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsIntroductionPage/ApplicationQuestionsIntroductionPage.tsx
@@ -50,6 +50,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       ApplicationStep.EducationRequirements,
       ApplicationStep.SkillRequirements,
     ],
+    stepSubmitted: null,
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationQuestionsIntroductionPage/ApplicationQuestionsIntroductionPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsIntroductionPage/ApplicationQuestionsIntroductionPage.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { PencilSquareIcon } from "@heroicons/react/20/solid";
 
 import { Heading } from "@gc-digital-talent/ui";
+import { ApplicationStep } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetApplicationPageInfo } from "~/types/poolCandidate";
@@ -42,6 +43,13 @@ export const getPageInfo: GetApplicationPageInfo = ({
     link: {
       url: path,
     },
+    prerequisites: [
+      ApplicationStep.Welcome,
+      ApplicationStep.ReviewYourProfile,
+      ApplicationStep.ReviewYourResume,
+      ApplicationStep.EducationRequirements,
+      ApplicationStep.SkillRequirements,
+    ],
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { PencilSquareIcon } from "@heroicons/react/20/solid";
 
 import { Heading } from "@gc-digital-talent/ui";
+import { ApplicationStep } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetApplicationPageInfo } from "~/types/poolCandidate";
@@ -40,6 +41,13 @@ export const getPageInfo: GetApplicationPageInfo = ({
     link: {
       url: path,
     },
+    prerequisites: [
+      ApplicationStep.Welcome,
+      ApplicationStep.ReviewYourProfile,
+      ApplicationStep.ReviewYourResume,
+      ApplicationStep.EducationRequirements,
+      ApplicationStep.SkillRequirements,
+    ],
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
@@ -48,6 +48,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       ApplicationStep.EducationRequirements,
       ApplicationStep.SkillRequirements,
     ],
+    stepSubmitted: ApplicationStep.ScreeningQuestions,
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationResumeAddPage/ApplicationResumeAddPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumeAddPage/ApplicationResumeAddPage.tsx
@@ -46,6 +46,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       url: path,
     },
     prerequisites: [ApplicationStep.Welcome, ApplicationStep.ReviewYourProfile],
+    stepSubmitted: null,
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationResumeAddPage/ApplicationResumeAddPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumeAddPage/ApplicationResumeAddPage.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { StarIcon } from "@heroicons/react/20/solid";
 
 import { Heading } from "@gc-digital-talent/ui";
+import { ApplicationStep } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetApplicationPageInfo } from "~/types/poolCandidate";
@@ -44,6 +45,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
     link: {
       url: path,
     },
+    prerequisites: [ApplicationStep.Welcome, ApplicationStep.ReviewYourProfile],
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationResumeEditPage/ApplicationResumeEditPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumeEditPage/ApplicationResumeEditPage.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { StarIcon } from "@heroicons/react/20/solid";
 
 import { Heading } from "@gc-digital-talent/ui";
+import { ApplicationStep } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetApplicationPageInfo } from "~/types/poolCandidate";
@@ -46,6 +47,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
     link: {
       url: path,
     },
+    prerequisites: [ApplicationStep.Welcome, ApplicationStep.ReviewYourProfile],
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationResumeEditPage/ApplicationResumeEditPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumeEditPage/ApplicationResumeEditPage.tsx
@@ -48,6 +48,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       url: path,
     },
     prerequisites: [ApplicationStep.Welcome, ApplicationStep.ReviewYourProfile],
+    stepSubmitted: null,
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationResumeIntroductionPage/ApplicationResumeIntroductionPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumeIntroductionPage/ApplicationResumeIntroductionPage.tsx
@@ -43,6 +43,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       url: path,
     },
     prerequisites: [ApplicationStep.Welcome, ApplicationStep.ReviewYourProfile],
+    stepSubmitted: null,
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationResumeIntroductionPage/ApplicationResumeIntroductionPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumeIntroductionPage/ApplicationResumeIntroductionPage.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { StarIcon } from "@heroicons/react/20/solid";
 
 import { Heading } from "@gc-digital-talent/ui";
+import { ApplicationStep } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetApplicationPageInfo } from "~/types/poolCandidate";
@@ -41,6 +42,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
     link: {
       url: path,
     },
+    prerequisites: [ApplicationStep.Welcome, ApplicationStep.ReviewYourProfile],
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationResumePage/ApplicationResumePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumePage/ApplicationResumePage.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { StarIcon } from "@heroicons/react/20/solid";
 
 import { Heading } from "@gc-digital-talent/ui";
+import { ApplicationStep } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetApplicationPageInfo } from "~/types/poolCandidate";
@@ -39,6 +40,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
     link: {
       url: path,
     },
+    prerequisites: [ApplicationStep.Welcome, ApplicationStep.ReviewYourProfile],
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationResumePage/ApplicationResumePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumePage/ApplicationResumePage.tsx
@@ -41,6 +41,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       url: path,
     },
     prerequisites: [ApplicationStep.Welcome, ApplicationStep.ReviewYourProfile],
+    stepSubmitted: ApplicationStep.ReviewYourResume,
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
@@ -53,6 +53,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       ApplicationStep.SkillRequirements,
       ApplicationStep.ScreeningQuestions,
     ],
+    stepSubmitted: ApplicationStep.ReviewAndSubmit,
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { RocketLaunchIcon } from "@heroicons/react/20/solid";
 
 import { Heading } from "@gc-digital-talent/ui";
+import { ApplicationStep } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetApplicationPageInfo } from "~/types/poolCandidate";
@@ -44,6 +45,14 @@ export const getPageInfo: GetApplicationPageInfo = ({
         description: "Link text for the application review page",
       }),
     },
+    prerequisites: [
+      ApplicationStep.Welcome,
+      ApplicationStep.ReviewYourProfile,
+      ApplicationStep.ReviewYourResume,
+      ApplicationStep.EducationRequirements,
+      ApplicationStep.SkillRequirements,
+      ApplicationStep.ScreeningQuestions,
+    ],
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationSkillsIntroductionPage/ApplicationSkillsIntroductionPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsIntroductionPage/ApplicationSkillsIntroductionPage.tsx
@@ -49,6 +49,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       ApplicationStep.ReviewYourResume,
       ApplicationStep.EducationRequirements,
     ],
+    stepSubmitted: null,
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationSkillsIntroductionPage/ApplicationSkillsIntroductionPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsIntroductionPage/ApplicationSkillsIntroductionPage.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { SparklesIcon } from "@heroicons/react/20/solid";
 
 import { Heading } from "@gc-digital-talent/ui";
+import { ApplicationStep } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetApplicationPageInfo } from "~/types/poolCandidate";
@@ -42,6 +43,12 @@ export const getPageInfo: GetApplicationPageInfo = ({
     link: {
       url: path,
     },
+    prerequisites: [
+      ApplicationStep.Welcome,
+      ApplicationStep.ReviewYourProfile,
+      ApplicationStep.ReviewYourResume,
+      ApplicationStep.EducationRequirements,
+    ],
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { SparklesIcon } from "@heroicons/react/20/solid";
 
 import { Heading } from "@gc-digital-talent/ui";
+import { ApplicationStep } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetApplicationPageInfo } from "~/types/poolCandidate";
@@ -40,6 +41,12 @@ export const getPageInfo: GetApplicationPageInfo = ({
     link: {
       url: path,
     },
+    prerequisites: [
+      ApplicationStep.Welcome,
+      ApplicationStep.ReviewYourProfile,
+      ApplicationStep.ReviewYourResume,
+      ApplicationStep.EducationRequirements,
+    ],
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -47,6 +47,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       ApplicationStep.ReviewYourResume,
       ApplicationStep.EducationRequirements,
     ],
+    stepSubmitted: ApplicationStep.SkillRequirements,
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { RocketLaunchIcon } from "@heroicons/react/20/solid";
 
 import { Heading } from "@gc-digital-talent/ui";
+import { ApplicationStep } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetApplicationPageInfo } from "~/types/poolCandidate";
@@ -40,6 +41,15 @@ export const getPageInfo: GetApplicationPageInfo = ({
     link: {
       url: path,
     },
+    prerequisites: [
+      ApplicationStep.Welcome,
+      ApplicationStep.ReviewYourProfile,
+      ApplicationStep.ReviewYourResume,
+      ApplicationStep.EducationRequirements,
+      ApplicationStep.SkillRequirements,
+      ApplicationStep.ScreeningQuestions,
+      ApplicationStep.ReviewAndSubmit,
+    ],
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage.tsx
@@ -50,6 +50,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       ApplicationStep.ScreeningQuestions,
       ApplicationStep.ReviewAndSubmit,
     ],
+    stepSubmitted: null,
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationWelcomePage/ApplicationWelcomePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationWelcomePage/ApplicationWelcomePage.tsx
@@ -6,6 +6,7 @@ import { Heading } from "@gc-digital-talent/ui";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetApplicationPageInfo } from "~/types/poolCandidate";
+import { ApplicationStep } from "@gc-digital-talent/graphql";
 import ApplicationApi, { ApplicationPageProps } from "../ApplicationApi";
 
 export const getPageInfo: GetApplicationPageInfo = ({
@@ -50,6 +51,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       }),
     },
     prerequisites: [],
+    stepSubmitted: ApplicationStep.Welcome,
   };
 };
 

--- a/apps/web/src/pages/Applications/ApplicationWelcomePage/ApplicationWelcomePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationWelcomePage/ApplicationWelcomePage.tsx
@@ -49,6 +49,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
         description: "Link text for the application welcome page",
       }),
     },
+    prerequisites: [],
   };
 };
 

--- a/apps/web/src/pages/Applications/StepDisabledPage/StepDisabledPage.tsx
+++ b/apps/web/src/pages/Applications/StepDisabledPage/StepDisabledPage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { Heading, Link } from "@gc-digital-talent/ui";
+import { Heading, Link, Separator } from "@gc-digital-talent/ui";
 
 export const StepDisabledPage = ({
   returnUrl,
@@ -27,12 +27,11 @@ export const StepDisabledPage = ({
           description: "Application step skipped page details",
         })}
       </p>
-      <hr
+      <Separator
+        orientation="horizontal"
         data-h2-background-color="base(gray.lighter)"
-        data-h2-height="base(1px)"
-        data-h2-width="base(100%)"
-        data-h2-border="base(none)"
         data-h2-margin="base(x2, 0)"
+        decorative
       />
       {returnUrl ? (
         <Link href={returnUrl} color="primary" mode="solid" type="button">

--- a/apps/web/src/pages/Applications/StepDisabledPage/StepDisabledPage.tsx
+++ b/apps/web/src/pages/Applications/StepDisabledPage/StepDisabledPage.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { Heading, Link } from "@gc-digital-talent/ui";
+
+export const StepDisabledPage = ({
+  returnUrl,
+}: {
+  returnUrl: string | undefined;
+}) => {
+  const intl = useIntl();
+
+  return (
+    <>
+      <Heading data-h2-margin-top="base(0)">
+        {intl.formatMessage({
+          id: "9vQj8o",
+          defaultMessage: "Uh oh, it looks like you jumped ahead!",
+          description: "Application step skipped page title",
+        })}
+      </Heading>
+      <p>
+        {intl.formatMessage({
+          id: "EPF4Ac",
+          defaultMessage:
+            "The application process relies on collecting and reviewing information in a linear fashion. As a result, it’s not possible to complete this step just yet. The last step you were working on is highlighted in the steps area of the page, or you can use the button provided to go there directly.",
+          description: "Application step skipped page details",
+        })}
+      </p>
+      <hr
+        data-h2-background-color="base(gray.lighter)"
+        data-h2-height="base(1px)"
+        data-h2-width="base(100%)"
+        data-h2-border="base(none)"
+        data-h2-margin="base(x2, 0)"
+      />
+      {returnUrl ? (
+        <Link href={returnUrl} color="primary" mode="solid" type="button">
+          {intl.formatMessage({
+            id: "88dH+F",
+            defaultMessage: "Return to the last step I was working on",
+            description: "Button text to return back to the last step",
+          })}
+        </Link>
+      ) : null}
+    </>
+  );
+};
+
+export default StepDisabledPage;

--- a/apps/web/src/pages/Applications/applicationOperations.graphql
+++ b/apps/web/src/pages/Applications/applicationOperations.graphql
@@ -31,6 +31,7 @@ query GetBasicApplicationInfo($id: UUID!) {
         }
       }
     }
+    submittedSteps
   }
 }
 

--- a/apps/web/src/types/poolCandidate.ts
+++ b/apps/web/src/types/poolCandidate.ts
@@ -16,6 +16,7 @@ export type GetApplicationPageInfoArgs = {
 export type ApplicationPageInfo = PageNavInfo & {
   omitFromStepper?: boolean;
   prerequisites: Array<ApplicationStep>;
+  stepSubmitted: ApplicationStep | null;
 };
 
 export type GetApplicationPageInfo = (

--- a/apps/web/src/types/poolCandidate.ts
+++ b/apps/web/src/types/poolCandidate.ts
@@ -1,3 +1,4 @@
+import { ApplicationStep } from "@gc-digital-talent/graphql";
 import { IntlShape } from "react-intl";
 
 import { PoolCandidate, Scalars } from "~/api/generated";
@@ -14,6 +15,7 @@ export type GetApplicationPageInfoArgs = {
 
 export type ApplicationPageInfo = PageNavInfo & {
   omitFromStepper?: boolean;
+  prerequisites: Array<ApplicationStep>;
 };
 
 export type GetApplicationPageInfo = (

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -195,13 +195,6 @@ server {
         rewrite "^(?:/[a-z]{2})?/register-info(/.*|$)" /apps/web/dist/index.html break;
     }
 
-    # rewrite possible lang prefix then "applications" to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/applications(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/applications(/.*|$)" /apps/web/dist/index.html break;
-    }
-
     # rewrite possible lang prefix then "login-info" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/login-info(/.*|$)" {
         add_header Cache-Control no-cache;

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -195,6 +195,13 @@ server {
         rewrite "^(?:/[a-z]{2})?/register-info(/.*|$)" /apps/web/dist/index.html break;
     }
 
+    # rewrite possible lang prefix then "applications" to apps/web index.html
+    location ~ "^(?:/[a-z]{2})?/applications(/.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
+        rewrite "^(?:/[a-z]{2})?/applications(/.*|$)" /apps/web/dist/index.html break;
+    }
+
     # rewrite possible lang prefix then "login-info" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/login-info(/.*|$)" {
         add_header Cache-Control no-cache;

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -215,6 +215,13 @@ server {
         rewrite "^(?:/[a-z]{2})?/register-info(/.*|$)" /apps/web/dist/index.html break;
     }
 
+    # rewrite possible lang prefix then "applications" to apps/web index.html
+    location ~ "^(?:/[a-z]{2})?/applications(/.*|$)" {
+        add_header Cache-Control no-cache;
+        expires 0;
+        rewrite "^(?:/[a-z]{2})?/applications(/.*|$)" /apps/web/dist/index.html break;
+    }
+
     # rewrite possible lang prefix then "login-info" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/login-info(/.*|$)" {
         add_header Cache-Control no-cache;

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -215,13 +215,6 @@ server {
         rewrite "^(?:/[a-z]{2})?/register-info(/.*|$)" /apps/web/dist/index.html break;
     }
 
-    # rewrite possible lang prefix then "applications" to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/applications(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/applications(/.*|$)" /apps/web/dist/index.html break;
-    }
-
     # rewrite possible lang prefix then "login-info" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/login-info(/.*|$)" {
         add_header Cache-Control no-cache;

--- a/packages/ui/src/components/Stepper/Stepper.stories.tsx
+++ b/packages/ui/src/components/Stepper/Stepper.stories.tsx
@@ -47,16 +47,11 @@ export default {
 } as ComponentMeta<typeof Stepper>;
 
 const Template: ComponentStory<typeof Stepper> = (args) => {
-  const { label, steps, currentIndex, preventDisable } = args;
+  const { label, steps, currentIndex } = args;
 
   return (
     <div data-h2-max-width="base(18rem)">
-      <Stepper
-        preventDisable={preventDisable}
-        steps={steps}
-        label={label}
-        currentIndex={currentIndex}
-      />
+      <Stepper steps={steps} label={label} currentIndex={currentIndex} />
     </div>
   );
 };
@@ -66,7 +61,6 @@ Default.args = {
   label: "Default Stepper",
   steps: defaultSteps,
   currentIndex: 2,
-  preventDisable: true,
 };
 
 export const WithLongLabel = Template.bind({});
@@ -74,5 +68,4 @@ WithLongLabel.args = {
   label: "Default Stepper",
   steps: longLabelSteps,
   currentIndex: 2,
-  preventDisable: true,
 };

--- a/packages/ui/src/components/Stepper/Stepper.tsx
+++ b/packages/ui/src/components/Stepper/Stepper.tsx
@@ -57,7 +57,6 @@ const Stepper = ({
 
   return (
     <nav aria-label={label}>
-      {JSON.stringify(index)}
       {steps && index !== undefined ? (
         <Heading level={headingLevel} size="h6" data-h2-font-weight="base(700)">
           {intl.formatMessage(uiMessages.stepTitle, {

--- a/packages/ui/src/components/Stepper/Stepper.tsx
+++ b/packages/ui/src/components/Stepper/Stepper.tsx
@@ -11,7 +11,7 @@ import { StepState, StepType } from "./types";
 const deriveStepState = (
   stepIndex: number,
   currentIndex: number,
-  completed = false,
+  completed: boolean,
   error = false,
 ): StepState => {
   if (currentIndex === stepIndex) {

--- a/packages/ui/src/components/Stepper/Stepper.tsx
+++ b/packages/ui/src/components/Stepper/Stepper.tsx
@@ -47,8 +47,7 @@ const Stepper = ({
 }: StepperProps) => {
   const intl = useIntl();
   const maxIndex = steps.length - 1;
-  let index = currentIndex > maxIndex ? maxIndex : currentIndex;
-  index = index < 0 ? 0 : index;
+  const index = currentIndex > maxIndex ? maxIndex : currentIndex;
 
   return (
     <nav aria-label={label}>

--- a/packages/ui/src/components/Stepper/testUtils.ts
+++ b/packages/ui/src/components/Stepper/testUtils.ts
@@ -26,15 +26,18 @@ export const defaultSteps: Array<StepType> = [
     href: "/step-three",
     label: "Step Three",
     icon: CakeIcon,
+    disabled: true,
   },
   {
     href: "/step-four",
     label: "Step Four",
     icon: DevicePhoneMobileIcon,
+    disabled: true,
   },
   {
     href: "/step-five",
     label: "Step Five",
     icon: EnvelopeIcon,
+    disabled: true,
   },
 ];

--- a/packages/ui/src/components/Stepper/types.ts
+++ b/packages/ui/src/components/Stepper/types.ts
@@ -10,6 +10,6 @@ export type StepType = {
   href: string;
   icon: IconType;
   label: React.ReactNode;
-  completed?: boolean;
+  completed: boolean;
   error?: boolean;
 };

--- a/packages/ui/src/components/Stepper/types.ts
+++ b/packages/ui/src/components/Stepper/types.ts
@@ -1,6 +1,11 @@
 import React from "react";
 
-export type StepState = "active" | "completed" | "disabled" | "error";
+export type StepState =
+  | "active"
+  | "completed"
+  | "disabled"
+  | "error"
+  | "default";
 
 export type IconType = React.ForwardRefExoticComponent<
   React.SVGProps<SVGSVGElement>
@@ -10,6 +15,7 @@ export type StepType = {
   href: string;
   icon: IconType;
   label: React.ReactNode;
-  completed: boolean;
+  completed?: boolean;
+  disabled?: boolean;
   error?: boolean;
 };

--- a/packages/ui/src/components/Stepper/utils.ts
+++ b/packages/ui/src/components/Stepper/utils.ts
@@ -10,6 +10,7 @@ export const getIconFromState = (state: StepState, defaultIcon: IconType) => {
     ["active", MapPinIcon],
     ["completed", CheckIcon],
     ["disabled", defaultIcon],
+    ["default", defaultIcon],
     ["error", FlagIcon],
   ]);
 
@@ -64,6 +65,20 @@ export const linkStyleMap = new Map<StepState, Record<string, string>>([
   ],
   [
     "disabled",
+    {
+      "data-h2-background-color": `
+        base:children[.Step__Flair](gray.light)
+        base:focus-visible:children[.Step__Flair](focus)
+      `,
+      "data-h2-color": `
+        base(black)
+        base:hover:children[.Step__Text](primary)
+      `,
+      "data-h2-text-decoration": "base(none) base:focus-visible(underline)",
+    },
+  ],
+  [
+    "default",
     {
       "data-h2-background-color": `
         base:children[.Step__Flair](gray.light)

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -57,6 +57,7 @@ import SideMenu, {
   type SideMenuItemProps,
 } from "./components/SideMenu";
 import Stepper, { StepperProps } from "./components/Stepper/Stepper";
+import { StepType } from "./components/Stepper/types";
 import Switch from "./components/Switch";
 import TableOfContents, {
   type TocAnchorLinkProps,
@@ -98,6 +99,7 @@ export type {
   SideMenuProps,
   SideMenuItemProps,
   StepperProps,
+  StepType,
   TocAnchorLinkProps,
   TocHeadingProps,
   TocSectionProps,


### PR DESCRIPTION
🤖 Resolves #6063 

## 👋 Introduction

This branch adds a "skip ahead" page if you manually navigate to a disabled step in the flow and updates the stepper status to reflect submitted steps.

~Bonus: it adds the missing nginx config for the new application pages.~ I'll let #6171 handle this.

## 🕵️ Details

I had to do a bit of refactoring of the stepper component to make this work.  Specifically, I removed the ability of the stepper to disable its own steps and instead rely on the parent component.  This was needed because only the parent component knows the submitted steps and which ones to unlock.  I also added a "default" step state for steps that are not completed, not current, but need to be clickable for the user to go back to if they jumped ahead.  It also fixes a bug where the success page highlighted the "Welcome" step as current.

## 🧪 Testing

New page routing at: https://github.com/GCTC-NTGC/gc-digital-talent/blob/4301e14957ce079fcc5cc6844015ba4d71bf2371/apps/web/src/components/Router.tsx#L1056 

1. Rebuild the app
2. Start a new application or find one already started. Note the value of `submitted_steps` for that application.
3. Manually navigate to the new application pages and manually update the submitted_steps for the application.
4. Confirm it works properly:
    - Already submitted pages should show normally (currently blank with no content)
    - Not submitted pages show the "oh no" page
    - The "oh no" page has a link back to the right spot 
    - Stepper shows submitted steps (error state is #6145)
    - Stepper component disables unsubmitted steps unless it is the next one to complete

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/8978655/230115325-e30b9f62-091c-4298-84d6-7c26e6baa810.png)
