### PR TITLE
Bug - 6115 error when attempting team updates

### DIFF
--- a/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.test.tsx
+++ b/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+import "@testing-library/jest-dom";
+import { screen, act, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import { renderWithProviders } from "@gc-digital-talent/jest-helpers";
+import { fakeTeams } from "@gc-digital-talent/fake-data";
+import UpdateTeamForm, { UpdateTeamFormProps } from "./UpdateTeamForm";
+
+// adjust mockTeam to enable testing expected values
+// must ensure name is kebab-ed and that roleAssignments are not passed into the mutation
+const mockTeam = fakeTeams(1)[0];
+if (mockTeam.displayName) {
+  mockTeam.displayName.en = "Uppercase No Kebab";
+}
+mockTeam.roleAssignments = [{ id: "fake assignment" }];
+
+const renderUpdateTeamForm = (props: UpdateTeamFormProps) => {
+  return renderWithProviders(<UpdateTeamForm {...props} />);
+};
+
+describe("UpdateTeamForm", () => {
+  it("should submit correctly", async () => {
+    const mockSave = jest.fn(() => Promise.resolve(mockTeam));
+
+    act(() => {
+      renderUpdateTeamForm({
+        team: mockTeam,
+        onSubmit: mockSave,
+      });
+    });
+
+    const contactEmail = screen.getByRole("textbox", {
+      name: /contact email/i,
+    });
+    fireEvent.change(contactEmail, { target: { value: "test@test.com" } });
+
+    fireEvent.submit(
+      screen.getByRole("button", { name: /save team information/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockSave).toHaveBeenCalledWith(mockTeam.id, {
+        contactEmail: "test@test.com",
+        departments: {
+          sync: mockTeam.departments?.map((department) => department?.id),
+        },
+        description: mockTeam.description,
+        displayName: mockTeam.displayName,
+        name: "uppercase-no-kebab",
+      });
+    });
+  });
+});

--- a/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.tsx
+++ b/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.tsx
@@ -61,7 +61,7 @@ const formValuesToSubmitData = (data: FormValues): UpdateTeamInput => {
   };
 };
 
-interface UpdateTeamFormProps {
+export interface UpdateTeamFormProps {
   team: Team;
   departments?: Maybe<Array<Maybe<Omit<Department, "teams">>>>;
   onSubmit: (

--- a/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.tsx
+++ b/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.tsx
@@ -44,7 +44,7 @@ type FormValues = {
 const dataToFormValues = (data: Team): FormValues => {
   const { departments, displayName, description, ...rest } = data;
   return {
-    ...omit(rest, ["id", "__typename"]),
+    ...omit(rest, ["id", "__typename", "roleAssignments"]),
     displayName: omit(displayName, "__typename"),
     description: omit(description, "__typename"),
     departments: unpackIds(departments),


### PR DESCRIPTION
🤖 Resolves #6115

## 👋 Introduction

Solves the bug and enables updating teams. 

## 🕵️ Details

For some reason, roleAssignments was being sneakily passed along in the ...rest. I removed it with the omit function.
As well, added a simple Jest test to exercise the submit functionality of the form. Maybe we should start Jest testing more 🤔 

## 🧪 Testing

1. Tests pass
2. Head to /admin/teams as platform_admin and successfully update a team

