### PR TITLE
[Bug] Updates breadcrumb copy on Work location form page

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1289,9 +1289,9 @@
     "defaultMessage": "Quel était votre niveau de responsabilité dans ce rôle?",
     "description": "Question for user in skills in detail section of experience form."
   },
-  "c/Qp8R": {
-    "defaultMessage": "Préférence pour le lieu de travail",
-    "description": "Display Text for the current page in Work Location Preference Form Page"
+  "5fF50z": {
+    "defaultMessage": "Lieu de travail",
+    "description": "Display Text for the current page in Work location Form Page"
   },
   "5KRzTl": {
     "defaultMessage": "Vous pouvez vous connecter à votre profil Talent numérique à l'aide de votre CléGC existante, même si vous n'avez jamais utilisé cette plateforme auparavant.",

--- a/apps/web/src/pages/Profile/WorkLocationPage/components/WorkLocationForm/WorkLocationForm.tsx
+++ b/apps/web/src/pages/Profile/WorkLocationPage/components/WorkLocationForm/WorkLocationForm.tsx
@@ -121,10 +121,10 @@ const WorkLocationForm = ({
         },
         {
           label: intl.formatMessage({
-            defaultMessage: "Work Location Preference",
-            id: "c/Qp8R",
+            defaultMessage: "Work location",
+            id: "5fF50z",
             description:
-              "Display Text for the current page in Work Location Preference Form Page",
+              "Display Text for the current page in Work location Form Page",
           }),
           url: `${paths.workLocation(initialData.id)}${
             applicationId ? `?applicationId=${applicationId}` : ``
@@ -154,10 +154,10 @@ const WorkLocationForm = ({
           : [
               {
                 label: intl.formatMessage({
-                  defaultMessage: "Work Location Preference",
-                  id: "c/Qp8R",
+                  defaultMessage: "Work location",
+                  id: "5fF50z",
                   description:
-                    "Display Text for the current page in Work Location Preference Form Page",
+                    "Display Text for the current page in Work location Form Page",
                 }),
                 url: paths.workLocation(initialData.id),
               },


### PR DESCRIPTION
🤖 Resolves #5610.

## 👋 Introduction

This PR updates some English and French copy used in the breadcrumbs on the Work location form to make it consistent with the heading level 1 copy.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate to Work location form `/fr/users/:userId/profile/work-location/edit`
3. Verify last breadcrumb item (Lieu de travail) matches heading level 1 (Lieu de travail)
4. Switch to English
5. Verify last breadcrumb item (Work location) matches heading level 1 (Work location)
6. Navigate to Work location form within an application `/fr/users/:userId/profile/work-location/edit?applicationId=:applicationId`
7. Verify last breadcrumb item (Lieu de travail) matches heading level 1 (Lieu de travail)
8. Switch to English
9. Verify last breadcrumb item (Work location) matches heading level 1 (Work location)



## 📸 Screenshots
![Screen Shot 2023-04-05 at 10 46 02](https://user-images.githubusercontent.com/3046459/230117873-7527c4d4-9679-4601-a643-6a935333c446.png)
![Screen Shot 2023-04-05 at 10 45 54](https://user-images.githubusercontent.com/3046459/230117876-bdbc6356-f9e9-4e53-bfb9-4fe796890efb.png)
![Screen Shot 2023-04-05 at 10 45 41](https://user-images.githubusercontent.com/3046459/230117881-93eb84c3-6bf2-41f6-ab5c-e18fa64d1492.png)
![Screen Shot 2023-04-05 at 10 45 33](https://user-images.githubusercontent.com/3046459/230117884-a603b3db-a6c4-4ffe-84be-20f259c2cb05.png)


