### PR TITLE
[Bug] Adds i18n for `LanguageSelector` locale strings

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7476,5 +7476,17 @@
   "z+qxaE": {
     "defaultMessage": "Veuillez sélectionner un type afin de poursuivre.",
     "description": "Test displayed on the experience form when a user has not selected an experience type."
+  },
+  "HtllH6": {
+    "defaultMessage": "Ojibwé de l’Ouest",
+    "description": "Name of Western Ojibway language"
+  },
+  "TEt9Ua": {
+    "defaultMessage": "Cris des Plaines",
+    "description": "Name of Plains Cree language"
+  },
+  "qxe/hN": {
+    "defaultMessage": "Mi’kmaq",
+    "description": "Name of Mikmaq language"
   }
 }

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7488,5 +7488,9 @@
   "qxe/hN": {
     "defaultMessage": "Mi’kmaq",
     "description": "Name of Mikmaq language"
+  },
+  "zAl7ZH": {
+    "defaultMessage": "Michif",
+    "description": "Name of Michif language"
   }
 }

--- a/apps/web/src/lang/whitelist.yml
+++ b/apps/web/src/lang/whitelist.yml
@@ -31,3 +31,4 @@
 - kyMlnN # 'Classifications' - Breadcrumb title for the classifications page link.
 - I0VGC0 # 'Placement' - 'User placement breadcrumb text'
 - 9Aa5c0 # 'Notes - {poolName}' Label for the notes field for a specific pool
+- zAl7ZH # 'Michif' Name of Michif language

--- a/apps/web/src/pages/Home/IAPHomePage/components/LanguageSelector.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/LanguageSelector.tsx
@@ -5,17 +5,45 @@ import { CheckIcon, ChevronDownIcon } from "@heroicons/react/24/solid";
 
 import { DropdownMenu, Button, Separator } from "@gc-digital-talent/ui";
 
-const localeMap = new Map([
-  ["crg", "Michif"],
-  ["crk", "Plains Cree"],
-  ["ojw", "Western Ojibway"],
-  ["mic", "Mikmaq"],
-]);
-
 const LanguageSelector = () => {
   const intl = useIntl();
   const [searchParams, setSearchParams] = useSearchParams();
   const locale = searchParams.get("locale");
+
+  const localeMap = new Map([
+    [
+      "crg",
+      intl.formatMessage({
+        id: "zAl7ZH",
+        defaultMessage: "Michif",
+        description: "Name of Michif language",
+      }),
+    ],
+    [
+      "crk",
+      intl.formatMessage({
+        id: "TEt9Ua",
+        defaultMessage: "Plains Cree",
+        description: "Name of Plains Cree language",
+      }),
+    ],
+    [
+      "ojw",
+      intl.formatMessage({
+        id: "HtllH6",
+        defaultMessage: "Western Ojibway",
+        description: "Name of Western Ojibway language",
+      }),
+    ],
+    [
+      "mic",
+      intl.formatMessage({
+        id: "qxe/hN",
+        defaultMessage: "Mikmaq",
+        description: "Name of Mikmaq language",
+      }),
+    ],
+  ]);
 
   const currentLocale = localeMap.get(locale || "");
 


### PR DESCRIPTION
🤖 Resolves #6098.

## 👋 Introduction

This PR adds i18n ability for locale strings used in the `LanguageSelector` component.

## 📓 TODO

- [x]  Get French translations of strings

<details>
<summary>Strings for translation</summary>

```
{
  "HtllH6": {
    "defaultMessage": "Western Ojibway",
    "description": "Name of Western Ojibway language"
  },
  "TEt9Ua": {
    "defaultMessage": "Plains Cree",
    "description": "Name of Plains Cree language"
  },
  "qxe/hN": {
    "defaultMessage": "Mikmaq",
    "description": "Name of Mikmaq language"
  },
  "zAl7ZH": {
    "defaultMessage": "Michif",
    "description": "Name of Michif language"
  }
}
```

</details> 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Uncomment and import the LanguageSelector component from the [IAP Home page](https://github.com/GCTC-NTGC/gc-digital-talent/blob/11990f2cc63d26297db374c4dc9cdfe216162a66/apps/web/src/pages/Home/IAPHomePage/Home.tsx#L67)
2. `npm run build`
3. Navigate to `/fr/indigenous-it-apprentice/`
5. Ensure options in `select` for **Cette page est accessible en langues autochtones** appear in French