### PR TITLE
[Bug] Add compiled schema file to codegen deps

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,11 @@
       "outputs": ["src/assets/css/hydrogen.css"]
     },
     "codegen": {
-      "inputs": ["src/**/*.graphql", "../../packages/**/src/**/*.graphql"],
+      "inputs": [
+        "../../api/storage/app/lighthouse-schema.graphql",
+        "src/**/*.graphql",
+        "../../packages/**/src/**/*.graphql"
+      ],
       "outputs": ["src/api/generated.ts", "src/index.ts"],
       "outputMode": "new-only"
     },
@@ -45,7 +49,12 @@
       "outputMode": "new-only"
     },
     "check-intl": {
-      "inputs": ["src/**/*.ts", "src/**/*.tsx", "src/lang/en.json", "src/lang/fr.json"],
+      "inputs": [
+        "src/**/*.ts",
+        "src/**/*.tsx",
+        "src/lang/en.json",
+        "src/lang/fr.json"
+      ],
       "dependsOn": ["build:intl-cli", "intl-compile"],
       "cache": false,
       "outputMode": "new-only"


### PR DESCRIPTION
🤖 Resolves #6240 

## 👋 Introduction

Configures turbo to re-rerun codegen when the api schema changes.

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run `npm run codegen`. Should run.
2. Run `npm run codegen` again. Should be full turbo.
3. Change something in the schema.graphql file.
4. Run `refresh_api` script or `php artisan lighthouse:print-schema --write` to recompile the schema
5. Run `npm run codegen` again. Should re-run, and the change to the schema should appear in generated.ts