### PR TITLE
Bug - 6186 - application suspension bug

### DIFF
--- a/apps/web/src/pages/Applications/ApplicantDashboardPage/applicantOperations.graphql
+++ b/apps/web/src/pages/Applications/ApplicantDashboardPage/applicantOperations.graphql
@@ -3,6 +3,7 @@ fragment application on PoolCandidate {
   status
   archivedAt
   submittedAt
+  suspendedAt
   poolAdvertisement {
     id
     closingDate


### PR DESCRIPTION
🤖 Resolves #6186 

## 👋 Introduction

Resolves the application suspension bug, makes suspending work. 

## 🕵️ Details

Turned out to be a microscopic issue of a missing field in the API operations file 😆 
To do a little more work, I decided to test the suspension mutation thoroughly. Testing to ensure suspended candidates didn't appear in searches appeared to have been added. I added testing to exercise the mutation itself. 

## 🧪 Testing

1. Submit an application and head to My dashboard
2. Ensure you can suspend/un-suspend an application

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/40485260/231292603-4b54f35b-749a-4fdb-a3c9-90417d9d019f.png)
