### PR TITLE
Cache statics

### DIFF
--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -21,7 +21,7 @@
       data-h2-background="base(background)"
       data-h2-font-family="base(sans)"
     ></div>
-    <script src="<%= htmlWebpackPlugin.files.publicPath %>config.js?cache-bust=1"></script>
+    <script src="<%= htmlWebpackPlugin.files.publicPath %>config.js"></script>
     <noscript
       >It looks like JavaScript is disabled in your browser settings or
       unsupported by the browser itself. JavaScript is required to view this

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -91,146 +91,129 @@ server {
 
     # rewrite root-level possible lang prefix to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/?$" {
-        add_header Cache-Control no-cache;
-        expires 0;
+        add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         rewrite "^(?:/[a-z]{2})?/?$" /apps/web/dist/index.html break;
     }
 
-    # find the web config in the writable home root, limit cache
+    # find the web config in the writable home root - run time variables
     location = /config.js {
+        add_header Cache-Control "public, max-age=60"; # 1 minute - to distrubute variable changes
         alias /home/site/config-web.js;
-        add_header Cache-Control "public, max-age=60";
     }
 
     # rewrite tc-report static files to "tc-report/_site"
-    location ~ "^/tc-report/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|doc|docx|map|webmanifest))$" {
-        rewrite "^/tc-report/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|doc|docx|map|webmanifest))$" /tc-report/_site/$1 break;
+    location ~ "^/tc-report/(.*\.(?:png|ico|gif|jpg|jpeg|svg|css|js|pdf|doc|docx|map|webmanifest))$" {
+        add_header Cache-Control "public, max-age=604800"; # 1 week
+        rewrite "^/tc-report/(.*\.(:?png|ico|gif|jpg|jpeg|svg|css|js|pdf|doc|docx|map|webmanifest))$" /tc-report/_site/$1 break;
     }
 
-    # rewrite talent static files to "apps/web/dist"
-    location ~ "^(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|doc|docx|map|webmanifest))$" {
-        rewrite "^(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|doc|docx|map|webmanifest))$" /apps/web/dist/$1 break;
+    # rewrite talent static contenthashed files to "apps/web/dist"
+    location ~ "^(/(?:.*\.)?[a-z0-9]{20}\.(?:png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest))$" {
+        add_header Cache-Control "public, max-age=31536000"; # 1 year
+        rewrite "^(/(?:.*\.)?[a-z0-9]{20}\.(?:png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest))$" /apps/web/dist/$1 break;
     }
 
-    # rewrite possible lang prefix then "talent" to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/talent(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/talent(/.*|$)" /apps/web/dist/index.html break;
+     # rewrite talent static unhashed files to "apps/web/dist"
+    location ~ "^(/.*\.(?:png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest))$" {
+        add_header Cache-Control "public, max-age=3600"; # 1 hour
+        rewrite "^(/.*\.(?:png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest))$" /apps/web/dist/$1 break;
     }
 
     # rewrite possible lang prefix then "admin" to admin index.html
     location ~ "^(?:/[a-z]{2})?/admin(/?.*|$)" {
-      add_header Cache-Control no-cache;
-      expires 0;
-      rewrite "^(?:/[a-z]{2})?/admin(/?.*|$)" /apps/web/dist/index.html break;
+        add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
+        rewrite "^(?:/[a-z]{2})?/admin(/?.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "users" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/users(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
+          add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         rewrite "^(?:/[a-z]{2})?/users(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "search" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/search(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
+          add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         rewrite "^(?:/[a-z]{2})?/search(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "logged-out" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/logged-out(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
+          add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         rewrite "^(?:/[a-z]{2})?/logged-out(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "browse" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/browse(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
+      add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         rewrite "^(?:/[a-z]{2})?/browse(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "404" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/404(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
+          add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         rewrite "^(?:/[a-z]{2})?/404(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "support" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/support(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
+          add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         rewrite "^(?:/[a-z]{2})?/support(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "accessibility-statement" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/accessibility-statement(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
+          add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         rewrite "^(?:/[a-z]{2})?/accessibility-statement(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "directive-on-digital-talent" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/directive-on-digital-talent(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
+          add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         rewrite "^(?:/[a-z]{2})?/directive-on-digital-talent(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "applications" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/applications(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
+          add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         rewrite "^(?:/[a-z]{2})?/applications(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "create-account" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/create-account(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
+          add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         rewrite "^(?:/[a-z]{2})?/create-account(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "register-info" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/register-info(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
+      add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         rewrite "^(?:/[a-z]{2})?/register-info(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "login-info" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/login-info(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
+          add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         rewrite "^(?:/[a-z]{2})?/login-info(/.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite talent static files to "web/dist"
-    location ~ "^/indigenous-it-apprentice/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|doc|docx|map|webmanifest))$" {
-        rewrite "^/indigenous-it-apprentice/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|doc|docx|map|webmanifest))$" /apps/web/dist/$1 break;
     }
 
     # rewrite possible lang prefix then "indigenous-it-apprentice" to web index.html
     location ~ "^(?:/[a-z]{2})?/indigenous-it-apprentice(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
+          add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         rewrite "^(?:/[a-z]{2})?/indigenous-it-apprentice(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # fallback any other files to "tc-report/_site"
     ## Must be second to last of the file!
     location ~ "^/(.*\.(\w+))$" {
+        add_header Cache-Control "public, max-age=604800"; # 1 week
         rewrite "^/(.*\.(\w+))$" /tc-report/_site/$1 break;
     }
 
     # fallback any other path to "tc-report/_site" index.html
     ## Must be last of the file!
     location ~ ^/(.*)$ {
+        add_header Cache-Control "public, max-age=604800"; # 1 week
         rewrite ^/(.*)$ /tc-report/_site/$1/index.html break;
     }
 }

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -179,6 +179,12 @@ server {
         rewrite "^(?:/[a-z]{2})?/applications(/.*|$)" /apps/web/dist/index.html break;
     }
 
+    # rewrite possible lang prefix then "applicant" to apps/web index.html
+    location ~ "^(?:/[a-z]{2})?/applicant(/.*|$)" {
+          add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
+        rewrite "^(?:/[a-z]{2})?/applicant(/.*|$)" /apps/web/dist/index.html break;
+    }
+
     # rewrite possible lang prefix then "create-account" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/create-account(/.*|$)" {
           add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -119,6 +119,12 @@ server {
         rewrite "^(/.*\.(?:png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest))$" /apps/web/dist/$1 break;
     }
 
+    # rewrite possible lang prefix then "talent" to apps/web index.html
+    location ~ "^(?:/[a-z]{2})?/talent(/.*|$)" {
+        add_header Cache-Control "public, max-age=0"; # 1 hour
+        rewrite "^(?:/[a-z]{2})?/talent(/.*|$)" /apps/web/dist/index.html break;
+    }
+
     # rewrite possible lang prefix then "admin" to admin index.html
     location ~ "^(?:/[a-z]{2})?/admin(/?.*|$)" {
         add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -12,7 +12,6 @@ server {
     listen [::]:8080;
     root /home/site/wwwroot;
     index  index.php index.html index.htm;
-
     #server_name localhost;
 
     # redirect server error pages
@@ -25,14 +24,18 @@ server {
         log_not_found off;
     }
 
+    # never cache locally
+    add_header Cache-Control "no-cache, max-age=0";
+
     location = /robots.txt {
         alias /home/site/wwwroot/infrastructure/conf/dev.robots.txt;
     }
+
     # Permanent redirects to avoid dead links
     location = /en/communities/digital-talent { return 301 https://www.canada.ca/en/government/system/digital-government/gcdigital-community.html; }
     location = /fr/communities/digital-talent { return 301 https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/collectivite-gcnumerique.html; }
 
-    # permanent redirect within the same domain with relative path
+    # Permanent redirect within the same domain with relative path
     location = /en/talent/search {
         absolute_redirect off;
         return 301 /en/search;
@@ -116,134 +119,96 @@ server {
 
     # rewrite root-level possible lang prefix to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/?$" {
-        add_header Cache-Control no-cache;
-        expires 0;
         rewrite "^(?:/[a-z]{2})?/?$" /apps/web/dist/index.html break;
     }
 
-    # limit cache
+    # run time variables
     location = /config.js {
         alias /home/site/wwwroot/apps/web/dist/config.js;
-        add_header Cache-Control "public, max-age=60";
     }
 
     # rewrite tc-report static files to "tc-report/_site"
-    location ~ "^/tc-report/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|doc|docx|map|webmanifest))$" {
-        rewrite "^/tc-report/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|doc|docx|map|webmanifest))$" /tc-report/_site/$1 break;
+    location ~ "^/tc-report/(.*\.(?:png|ico|gif|jpg|jpeg|svg|css|js|pdf|doc|docx|map|webmanifest))$" {
+        rewrite "^/tc-report/(.*\.(:?png|ico|gif|jpg|jpeg|svg|css|js|pdf|doc|docx|map|webmanifest))$" /tc-report/_site/$1 break;
     }
 
-     # rewrite talent static files to "apps/web/dist"
-    location ~ "^(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest))$" {
-        rewrite "^(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest))$" /apps/web/dist/$1 break;
+    # rewrite talent static contenthashed files to "apps/web/dist"
+    location ~ "^(/(?:.*\.)?[a-z0-9]{20}\.(?:png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest))$" {
+        rewrite "^(/(?:.*\.)?[a-z0-9]{20}\.(?:png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest))$" /apps/web/dist/$1 break;
+    }
+
+     # rewrite talent static unhashed files to "apps/web/dist"
+    location ~ "^(/.*\.(?:png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest))$" {
+        rewrite "^(/.*\.(?:png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest))$" /apps/web/dist/$1 break;
     }
 
     # rewrite possible lang prefix then "admin" to admin index.html
     location ~ "^(?:/[a-z]{2})?/admin(/?.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
         rewrite "^(?:/[a-z]{2})?/admin(/?.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite possible lang prefix then "talent" to apps/web index.html
-    location ~ "^(?:/[a-z]{2})?/talent(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
-        rewrite "^(?:/[a-z]{2})?/talent(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "users" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/users(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
         rewrite "^(?:/[a-z]{2})?/users(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "search" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/search(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
         rewrite "^(?:/[a-z]{2})?/search(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "logged-out" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/logged-out(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
         rewrite "^(?:/[a-z]{2})?/logged-out(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "browse" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/browse(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
         rewrite "^(?:/[a-z]{2})?/browse(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "404" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/404(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
         rewrite "^(?:/[a-z]{2})?/404(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "support" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/support(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
         rewrite "^(?:/[a-z]{2})?/support(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "accessibility-statement" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/accessibility-statement(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
         rewrite "^(?:/[a-z]{2})?/accessibility-statement(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "directive-on-digital-talent" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/directive-on-digital-talent(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
         rewrite "^(?:/[a-z]{2})?/directive-on-digital-talent(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "applications" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/applications(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
         rewrite "^(?:/[a-z]{2})?/applications(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "create-account" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/create-account(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
         rewrite "^(?:/[a-z]{2})?/create-account(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "register-info" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/register-info(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
         rewrite "^(?:/[a-z]{2})?/register-info(/.*|$)" /apps/web/dist/index.html break;
     }
 
     # rewrite possible lang prefix then "login-info" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/login-info(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
         rewrite "^(?:/[a-z]{2})?/login-info(/.*|$)" /apps/web/dist/index.html break;
-    }
-
-    # rewrite talent static files to "web/dist"
-    location ~ "^/indigenous-it-apprentice/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest))$" {
-        rewrite "^/indigenous-it-apprentice/(.*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest))$" /apps/web/dist/$1 break;
     }
 
     # rewrite possible lang prefix then "indigenous-it-apprentice" to web index.html
     location ~ "^(?:/[a-z]{2})?/indigenous-it-apprentice(/.*|$)" {
-        add_header Cache-Control no-cache;
-        expires 0;
         rewrite "^(?:/[a-z]{2})?/indigenous-it-apprentice(/.*|$)" /apps/web/dist/index.html break;
     }
 
@@ -259,4 +224,3 @@ server {
         rewrite ^/(.*)$ /tc-report/_site/$1/index.html break;
     }
 }
-

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -149,6 +149,11 @@ server {
         rewrite "^(/.*\.(?:png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest))$" /apps/web/dist/$1 break;
     }
 
+    # rewrite possible lang prefix then "talent" to apps/web index.html
+    location ~ "^(?:/[a-z]{2})?/talent(/.*|$)" {
+        rewrite "^(?:/[a-z]{2})?/talent(/.*|$)" /apps/web/dist/index.html break;
+    }
+
     # rewrite possible lang prefix then "admin" to admin index.html
     location ~ "^(?:/[a-z]{2})?/admin(/?.*|$)" {
         rewrite "^(?:/[a-z]{2})?/admin(/?.*|$)" /apps/web/dist/index.html break;

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -3,6 +3,13 @@
 error_log /var/log/nginx/error.log notice;
 # rewrite_log on;
 
+# never cache locally
+# Set default $hdr_cache_control if Cache-Control does not exist
+# https://www.axllent.org/docs/add-nginx-headers-if-not-set/
+map $upstream_http_cache_control $hdr_cache_control {
+    '' "no-store";
+}
+
 server {
     #proxy_cache cache;
     #proxy_cache_valid 200 1s;
@@ -24,8 +31,8 @@ server {
         log_not_found off;
     }
 
-    # never cache locally
-    add_header Cache-Control "no-cache, max-age=0";
+    # The following are only added if they do not already exist.  Avoid overwriting headers from PHP.
+    add_header Cache-Control $hdr_cache_control;
 
     location = /robots.txt {
         alias /home/site/wwwroot/infrastructure/conf/dev.robots.txt;

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -199,6 +199,11 @@ server {
         rewrite "^(?:/[a-z]{2})?/applications(/.*|$)" /apps/web/dist/index.html break;
     }
 
+    # rewrite possible lang prefix then "applicant" to apps/web index.html
+    location ~ "^(?:/[a-z]{2})?/applicant(/.*|$)" {
+        rewrite "^(?:/[a-z]{2})?/applicant(/.*|$)" /apps/web/dist/index.html break;
+    }
+
     # rewrite possible lang prefix then "create-account" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/create-account(/.*|$)" {
         rewrite "^(?:/[a-z]{2})?/create-account(/.*|$)" /apps/web/dist/index.html break;


### PR DESCRIPTION
🤖 Resolves #6164 

## 👋 Introduction

This branch improves the caching policies for static content

## 🕵️ Details

 - Disables all caching for local serving
 - Sets long cache lives for hashed files
 - Sets short cache lives for unhashed files
 - Disables caching for index.html
 - Adds a missing route rule
 - Removes temporary cache-busting extension

## 🧪 Testing

> **Note**
To refresh Nginx rules, shell into the webserver container and rule `nginx -s reload`.

> **Note**
To test deployed, I have deployed this branch to DEV.  Contact me if you want to confirm it's still there.

1. Locally:
    1.  All responses come back as "no-store".
    2. GraphQL responses are also identified as "private".
2. Deployed:
      1. Index.html comes back as no-cache, max-age=0
      2. Hashed files come back as public, max-age=31536000
      3. Unhashed files come back with public, a short max-age
      4. GraphQL responses come back as "private".

- [ ] Homepage looks good
- [ ] IAP looks good
- [ ] TC-report looks good
- [ ] Admin looks good

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/8978655/231534688-5c19ba5b-d0cf-473e-8050-1efbc831ab59.png)
