### PR TITLE
Remove titles from templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ 🐛-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/ 🐛-bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: "🐛 Bug Report"
 about: Report a bug to fix errors or improve UX
-title: ""
+title: "🐛 "
 labels: bug
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/ 🐛-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/ 🐛-bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: "🐛 Bug Report"
 about: Report a bug to fix errors or improve UX
-title: "🐛 Bug Report"
+title: ""
 labels: bug
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/⌨-accessibility-issue.md
+++ b/.github/ISSUE_TEMPLATE/⌨-accessibility-issue.md
@@ -1,7 +1,7 @@
 ---
 name: "⌨ Accessibility Issue"
 about: An accessibility related issue template.
-title: "⌨ Accessibility Issue"
+title: ""
 labels: accessibility
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/⌨-accessibility-issue.md
+++ b/.github/ISSUE_TEMPLATE/⌨-accessibility-issue.md
@@ -1,7 +1,7 @@
 ---
 name: "⌨ Accessibility Issue"
 about: An accessibility related issue template.
-title: ""
+title: "⌨ "
 labels: accessibility
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/♻️-debt-refactor.md
+++ b/.github/ISSUE_TEMPLATE/♻️-debt-refactor.md
@@ -1,7 +1,7 @@
 ---
 name: "♻️ Debt/Refactor"
 about: Something that needs to be improved or removed (without affecting expected functionality)
-title: "♻️ Debt/Refactor"
+title: ""
 labels: debt
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/♻️-debt-refactor.md
+++ b/.github/ISSUE_TEMPLATE/♻️-debt-refactor.md
@@ -1,7 +1,7 @@
 ---
 name: "♻️ Debt/Refactor"
 about: Something that needs to be improved or removed (without affecting expected functionality)
-title: ""
+title: "♻️ "
 labels: debt
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/⚙️-new-component.md
+++ b/.github/ISSUE_TEMPLATE/⚙️-new-component.md
@@ -1,7 +1,7 @@
 ---
 name: "⚙️ New component"
 about: An issue template for component epics.
-title: ""
+title: "⚙️ "
 labels: design, updates in progress
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/⚙️-new-component.md
+++ b/.github/ISSUE_TEMPLATE/⚙️-new-component.md
@@ -1,7 +1,7 @@
 ---
 name: "⚙️ New component"
 about: An issue template for component epics.
-title: "⚙️ New component"
+title: ""
 labels: design, updates in progress
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/✏️-documentation.md
+++ b/.github/ISSUE_TEMPLATE/✏️-documentation.md
@@ -1,7 +1,7 @@
 ---
 name: "✏️ Documentation"
 about: Updates or addition to the documentation
-title: ""
+title: "✏️ "
 labels: documentation
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/✏️-documentation.md
+++ b/.github/ISSUE_TEMPLATE/✏️-documentation.md
@@ -1,7 +1,7 @@
 ---
 name: "✏️ Documentation"
 about: Updates or addition to the documentation
-title: "✏️ Documentation"
+title: ""
 labels: documentation
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/✨-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/✨-feature-request.md
@@ -1,7 +1,7 @@
 ---
 name: "✨ Feature Request"
 about: A new feature or change to existing functionality
-title: "✨ Feature Request"
+title: ""
 labels: feature
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/✨-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/✨-feature-request.md
@@ -1,7 +1,7 @@
 ---
 name: "✨ Feature Request"
 about: A new feature or change to existing functionality
-title: ""
+title: "✨ "
 labels: feature
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/📐-new-design-issue.md
+++ b/.github/ISSUE_TEMPLATE/📐-new-design-issue.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F4D0 New design issue"
 about: An issue template to help kickstart a design-related task.
-title: ""
+title: "\U0001F4D0 "
 labels: design, updates in progress
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/📐-new-design-issue.md
+++ b/.github/ISSUE_TEMPLATE/📐-new-design-issue.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F4D0 New design issue"
 about: An issue template to help kickstart a design-related task.
-title: "\U0001F4D0 Generic design issue"
+title: ""
 labels: design, updates in progress
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/🛠️-tooling.md
+++ b/.github/ISSUE_TEMPLATE/🛠️-tooling.md
@@ -1,7 +1,7 @@
 ---
 name: "🛠️ Tooling"
 about: Updates to the CI pipeline
-title: "🛠️ Tooling"
+title: ""
 labels: tooling
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/🛠️-tooling.md
+++ b/.github/ISSUE_TEMPLATE/🛠️-tooling.md
@@ -1,7 +1,7 @@
 ---
 name: "🛠️ Tooling"
 about: Updates to the CI pipeline
-title: ""
+title: "🛠️ "
 labels: tooling
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/🧩-new-pattern.md
+++ b/.github/ISSUE_TEMPLATE/🧩-new-pattern.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F9E9 New pattern"
 about: An issue template for UI patterns.
-title: ""
+title: "\U0001F9E9 "
 labels: design, updates in progress
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/🧩-new-pattern.md
+++ b/.github/ISSUE_TEMPLATE/🧩-new-pattern.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F9E9 New pattern"
 about: An issue template for UI patterns.
-title: "\U0001F9E9 New pattern"
+title: ""
 labels: design, updates in progress
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/🧪-tests.md
+++ b/.github/ISSUE_TEMPLATE/🧪-tests.md
@@ -1,7 +1,7 @@
 ---
 name: "🧪 Tests"
 about: Updates/additions to the existing tests (Unit, e2e, etc.)
-title: "🧪 Tests"
+title: ""
 labels: tests
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/🧪-tests.md
+++ b/.github/ISSUE_TEMPLATE/🧪-tests.md
@@ -1,7 +1,7 @@
 ---
 name: "🧪 Tests"
 about: Updates/additions to the existing tests (Unit, e2e, etc.)
-title: ""
+title: "🧪 "
 labels: tests
 assignees: ""
 ---


### PR DESCRIPTION
## 👋 Introduction

This branch removes the placeholder issue titles from the templates.

## 🕵️ Details

We tend to get many issues on our board with very long titles.  For example, many titles start with ":keyboard:  Accessibility Issue - " but it's already clear that it's an issue with the accessibility label. I'm hoping that by removing the placeholder titles, submitters will not use them as prefixes and be encouraged to write short descriptive titles.