### PR TITLE
Bug - 6300 - skill descriptions missing in query

### DIFF
--- a/apps/web/src/pages/Applications/SignAndSubmitPage/signAndSubmitOperations.graphql
+++ b/apps/web/src/pages/Applications/SignAndSubmitPage/signAndSubmitOperations.graphql
@@ -5,6 +5,10 @@ fragment poolAdvertisementSkills on Skill {
     en
     fr
   }
+  description {
+    en
+    fr
+  }
   families {
     id
     key

--- a/apps/web/src/pages/Applications/applicationOperations.graphql
+++ b/apps/web/src/pages/Applications/applicationOperations.graphql
@@ -198,6 +198,10 @@ fragment poolAdvertisementSkills on Skill {
     en
     fr
   }
+  description {
+    en
+    fr
+  }
   families {
     id
     key

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/poolAdvertisementOperations.graphql
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/poolAdvertisementOperations.graphql
@@ -69,6 +69,10 @@ query getPoolAdvertisement($id: UUID!) {
         en
         fr
       }
+      description {
+        en
+        fr
+      }
       families {
         id
         key
@@ -87,6 +91,10 @@ query getPoolAdvertisement($id: UUID!) {
       id
       key
       name {
+        en
+        fr
+      }
+      description {
         en
         fr
       }

--- a/apps/web/src/pages/Profile/ExperienceAndSkillsPage/experienceAndSkillsOperations.graphql
+++ b/apps/web/src/pages/Profile/ExperienceAndSkillsPage/experienceAndSkillsOperations.graphql
@@ -72,6 +72,10 @@ fragment poolAdvertisementSkills on Skill {
     en
     fr
   }
+  description {
+    en
+    fr
+  }
   families {
     id
     key


### PR DESCRIPTION
🤖 Resolves #6300 

## 👋 Introduction

Solves the case of the missing skill descriptions. 

## 🕵️ Details

Just a case of missing fields from graphql files it appears.
Thing of concern is, we've had a few bugs like this already, really should think of a good way to mitigate this? Or may be something to keep in mind when reviewing. 

## 🧪 Testing

1. Find skill picker components and check for descriptions
2. ...

## 📸 Screenshot

Edit Pool

![image](https://user-images.githubusercontent.com/40485260/232155740-abc32707-e387-425e-9acd-0e4a5e318b26.png)

Edit Application

![image](https://user-images.githubusercontent.com/40485260/232155841-2618125e-7471-4482-8c2b-d5227eec6eac.png)

Browse Opportunities 

![image](https://user-images.githubusercontent.com/40485260/232155910-916f372e-f479-4ec1-9736-005c9df9faf3.png)

Search Page

![image](https://user-images.githubusercontent.com/40485260/232155953-7b5a3365-6092-48ed-9808-731721022a95.png)


