### PR TITLE
[Bug] Fixes active recruitments applications filter

### DIFF
--- a/apps/web/src/pages/Applications/ApplicantDashboardPage/components/QualifiedRecruitments/QualifiedRecruitments.tsx
+++ b/apps/web/src/pages/Applications/ApplicantDashboardPage/components/QualifiedRecruitments/QualifiedRecruitments.tsx
@@ -52,10 +52,11 @@ const QualifiedRecruitments = ({
   const intl = useIntl();
 
   const activeRecruitments = applications.filter(
-    ({ status, archivedAt, expiryDate }) => {
+    ({ status, archivedAt, expiryDate, submittedAt }) => {
       const expiry = expiryDate ? parseISO(expiryDate) : null;
       return (
         status !== PoolCandidateStatus.Expired &&
+        submittedAt !== null &&
         archivedAt === null &&
         (expiry ? isFuture(expiry) : true)
       );


### PR DESCRIPTION
🤖 Resolves #6256.

h/t @vd1992.

## 👋 Introduction

This PR adds a condition to filter out draft applications based on the `submittedAt` field (and the assumption that if the application has a `submittedAt` value, it is not a draft) from the active recruitments section of the **My dashboard** page.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/browse/pools`
2. Create a draft application
3. Navigate to `/applicant/dashboard`
4. Ensure cards in **Draft applications** accordion do not also appear in **Active recruitments** accordion

## 📸 Screenshot
![Screen Shot 2023-04-17 at 10 47 21](https://user-images.githubusercontent.com/3046459/232523913-11cdf5f2-25ec-4599-b725-d7e700291595.png)


