### PR TITLE
[Bug] Fixes GCKey spelling

### DIFF
--- a/apps/e2e/cypress/e2e/admin/auth.cy.js
+++ b/apps/e2e/cypress/e2e/admin/auth.cy.js
@@ -108,7 +108,7 @@ describe("Auth flows (development)", () => {
       const initialPath = "/en/admin/users";
       cy.visit(initialPath);
       onLoginInfoPage();
-      cy.findByRole("link", { name: /Continue to G C Key and Login/i }).click();
+      cy.findByRole("link", { name: /Continue to GCKey and Login/i }).click();
       onAuthLoginPage();
       loginViaUI("admin");
 

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -861,9 +861,9 @@
     "defaultMessage": "Expérience supprimée",
     "description": "Message displayed to user after experience deleted."
   },
-  "8+PCdN": {
-    "defaultMessage": "Bienvenue sur la plateforme Talent numérique. À l'avenir, vous pouvez vous connecter à votre profil en utilisant le même nom d'utilisateur et le même mot de passe que cléGC.",
-    "description": "Message for successful login alert in create account page."
+  "qHVR2p": {
+    "defaultMessage": "Bienvenue sur la plateforme Talent numérique. À l'avenir, vous pouvez vous connecter à votre profil en utilisant le même nom d'utilisateur et le même mot de passe que CléGC.",
+    "description": "Message for successful login alert in create account page"
   },
   "0ScnOT": {
     "defaultMessage": "Quelle est votre langue de contact préférée?",
@@ -917,9 +917,9 @@
     "defaultMessage": "Postes en français",
     "description": "Message for the french positions option"
   },
-  "ocCSfi": {
+  "A6H4EY": {
     "defaultMessage": "N'oubliez pas que, pour vous reconnecter, vous devez utiliser votre nom d'utilisateur et votre mot de passe de la CléGC. Nous espérons vous voir bientôt!",
-    "description": "Message displayed to a user after logging out."
+    "description": "Message displayed to a user after logging out"
   },
   "6cYs7i": {
     "defaultMessage": "Vous êtes membre d'un ou de plusieurs de ces groupes d'équité en matière d'emploi.",
@@ -953,9 +953,9 @@
     "defaultMessage": "Sélectionnez un niveau...",
     "description": "Placeholder displayed on the language information form comprehension field."
   },
-  "ATDtfb": {
+  "vNvh0G": {
     "defaultMessage": "Continuer vers CléGC et s'inscrire",
-    "description": "GC Key registration link text on the registration page."
+    "description": "GCKey registration link text on the registration page"
   },
   "sYqIp5": {
     "defaultMessage": "... d'une durée indéterminée seulement. (permanent seulement)",
@@ -989,9 +989,9 @@
     "defaultMessage": "ID :",
     "description": "The ID and colon"
   },
-  "78J7jF": {
+  "eYcQ6h": {
     "defaultMessage": "Continuer vers CléGC et se connecter",
-    "description": "GC Key login link text on the login page."
+    "description": "GCKey login link text on the login page."
   },
   "CuHYqt": {
     "defaultMessage": "Sauvegarder et revenir en arrière",
@@ -1065,9 +1065,9 @@
     "defaultMessage": "Ces renseignements personnels supplémentaires ne seront utilisés qu'à des fins de communication.",
     "description": "Description for Personal Information section of the About Me form"
   },
-  "lgsXDg": {
+  "SSSNwI": {
     "defaultMessage": "Vous pouvez vous connecter à votre profil Talent numérique à l'aide de votre CléGC existante, même si vous n'avez jamais utilisé cette plateforme auparavant.",
-    "description": "Instructions on how to login with GC Key."
+    "description": "Instructions on how to login with GCKey"
   },
   "KE49r9": {
     "defaultMessage": "Mon expérience et mes compétences",
@@ -1153,9 +1153,9 @@
     "defaultMessage": "Faites-nous savoir si vous voulez être contacté(e) pour de nouveaux emplois. Veuillez mettre à jour ce statut si votre situation change.",
     "description": "Description for My Status Form"
   },
-  "kJdLk3": {
+  "ypVSZh": {
     "defaultMessage": "Si vous n'êtes pas sûr(e) d'avoir un compte CléGC existant, continuez vers le site Web et essayez de vous connecter. Si vous ne pouvez pas vous souvenir de votre mot de passe, vous pouvez également le réinitialiser là.",
-    "description": "Instructions on what to do if user doesn't know if they have a GC Key"
+    "description": "Instructions on what to do if user doesn't know if they have a GCKey"
   },
   "Q96xMb": {
     "defaultMessage": "Mes renseignements sur l'équité en matière d'emploi :",
@@ -1261,13 +1261,13 @@
     "defaultMessage": "Toute langue (anglais ou français)",
     "description": "No preference for language ability - will accept English or French"
   },
-  "4RXJ4p": {
+  "VWU6bj": {
     "defaultMessage": "Connexion à l'aide de la CléGC",
-    "description": "Seo title for the login page for applicant profiles."
+    "description": "SEO title for the login page for applicant profiles."
   },
-  "iNFweP": {
+  "LVSun4": {
     "defaultMessage": "Connexion à l'aide de la CléGC",
-    "description": "Page title for the login page for applicant profiles."
+    "description": "Page title for the login page for applicant profiles"
   },
   "ZSAzrR": {
     "defaultMessage": "Date d'expiration :",
@@ -1293,9 +1293,9 @@
     "defaultMessage": "Lieu de travail",
     "description": "Display Text for the current page in Work location Form Page"
   },
-  "5KRzTl": {
+  "Ec1Hn9": {
     "defaultMessage": "Vous pouvez vous connecter à votre profil Talent numérique à l'aide de votre CléGC existante, même si vous n'avez jamais utilisé cette plateforme auparavant.",
-    "description": "Instructions on how to login with GC Key."
+    "description": "Instructions on how to login with GCKey"
   },
   "cZmuts": {
     "defaultMessage": "À la prochaine fois!",
@@ -1421,9 +1421,9 @@
     "defaultMessage": "2. Compétences affichées pendant cette expérience",
     "description": "Title for skills on Experience form"
   },
-  "5uOWv0": {
+  "NuGNEF": {
     "defaultMessage": "Si vous n'êtes pas sûr(e) d'avoir un compte CléGC existant, continuez vers le site Web et essayez de vous connecter. Si vous ne pouvez pas vous souvenir de votre mot de passe, vous pouvez également le réinitialiser là.",
-    "description": "Instructions on what to do if user doesn't know if they have a GC Key"
+    "description": "Instructions on what to do if user doesn't know if they have a GCKey"
   },
   "px7yu1": {
     "defaultMessage": "Il n'y a pas d'options d'équité en matière d'emploi.",
@@ -1517,13 +1517,13 @@
     "defaultMessage": "J'envisagerais d'accepter un emploi qui :",
     "description": "Legend for optional work preferences check list in work preferences form"
   },
-  "H4ug6o": {
+  "yxx7np": {
     "defaultMessage": "S'inscrire à l'aide de la CléGC",
-    "description": "Seo title for the registration page for applicant profiles."
+    "description": "SEO title for the registration page for applicant profiles"
   },
-  "YXs6l6": {
+  "vZntuH": {
     "defaultMessage": "S'inscrire à l'aide de la CléGC",
-    "description": "Page title for the registration page for applicant profiles."
+    "description": "Page title for the registration page for applicant profiles"
   },
   "/JQ6DD": {
     "defaultMessage": "Filtre des exigences en matière d'études",
@@ -1581,9 +1581,9 @@
     "defaultMessage": "Je suis bilingue (anglais et français) et <strong>j'ai</strong> complété une <languageEvaluationPageLink></languageEvaluationPageLink> officielle en <strong>ANGLAIS</strong>.",
     "description": "Message for the completed english bilingual evaluation option"
   },
-  "veXICB": {
-    "defaultMessage": "<strong>Vous n'avez pas de compte de CléGC?</strong> <a>Inscrivez-vous.</a>",
-    "description": "Instruction on what to do if user does not have a GC Key."
+  "q53yRm": {
+    "defaultMessage": "<strong>Vous n'avez pas de compte de CléGC?</strong> <a>Inscrivez-vous</a>.",
+    "description": "Instruction on what to do if user does not have a GCKey"
   },
   "t5G3Fz": {
     "defaultMessage": "Intermédiaire <gray>– J'ai des compétences robustes en lecture, écriture et communication verbale.</gray>",

--- a/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
@@ -34,7 +34,6 @@ import {
   getGovernmentInfoLabels,
   GovernmentInfoFormFields,
 } from "~/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm";
-import { wrapAbbr } from "~/utils/nameUtils";
 
 type FormValues = Pick<
   UpdateUserAsUserInput,
@@ -140,18 +139,13 @@ export const CreateAccountForm = ({
               })}
             </Alert.Title>
             <p>
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "Welcome to the Digital Talent platform. Moving forward, you can log into your profile using the same <abbreviation>GC</abbreviation> Key username and password.",
-                  id: "8+PCdN",
-                  description:
-                    "Message for successful login alert in create account page.",
-                },
-                {
-                  abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
-                },
-              )}
+              {intl.formatMessage({
+                defaultMessage:
+                  "Welcome to the Digital Talent platform. Moving forward, you can log into your profile using the same GCKey username and password.",
+                id: "qHVR2p",
+                description:
+                  "Message for successful login alert in create account page",
+              })}
             </p>
           </Alert.Root>
           <BasicForm

--- a/apps/web/src/pages/Auth/LoggedOutPage/LoggedOutPage.tsx
+++ b/apps/web/src/pages/Auth/LoggedOutPage/LoggedOutPage.tsx
@@ -17,7 +17,6 @@ import SEO from "~/components/SEO/SEO";
 
 import useRoutes from "~/hooks/useRoutes";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
-import { wrapAbbr } from "~/utils/nameUtils";
 
 const LoggedOutPage = () => {
   const intl = useIntl();
@@ -57,17 +56,12 @@ const LoggedOutPage = () => {
             })}
           </Alert.Title>
           <p>
-            {intl.formatMessage(
-              {
-                defaultMessage:
-                  "Remember, to sign back in, you'll need to use your <abbreviation>GC</abbreviation> Key username and password. We hope to see you soon!",
-                id: "ocCSfi",
-                description: "Message displayed to a user after logging out.",
-              },
-              {
-                abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
-              },
-            )}
+            {intl.formatMessage({
+              defaultMessage:
+                "Remember, to sign back in, you'll need to use your GCKey username and password. We hope to see you soon!",
+              id: "A6H4EY",
+              description: "Message displayed to a user after logging out",
+            })}
           </p>
         </Alert.Root>
         <h2 data-h2-margin="base(x3, 0, x1, 0)">

--- a/apps/web/src/pages/Auth/LoginPage/LoginPage.tsx
+++ b/apps/web/src/pages/Auth/LoginPage/LoginPage.tsx
@@ -11,7 +11,6 @@ import Hero from "~/components/Hero/Hero";
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
-import { wrapAbbr } from "~/utils/nameUtils";
 
 const keyRegistrationLink = (path: string, chunks: React.ReactNode) => (
   <a href={path}>{chunks}</a>
@@ -31,24 +30,17 @@ const LoginPage = () => {
     getLocale(intl),
   );
 
-  const abbreviation = (text: React.ReactNode) => wrapAbbr(text, intl);
-
   const seoTitle = intl.formatMessage({
-    defaultMessage: "Login using GC Key",
-    id: "4RXJ4p",
-    description: "Seo title for the login page for applicant profiles.",
+    defaultMessage: "Login using GCKey",
+    id: "VWU6bj",
+    description: "SEO title for the login page for applicant profiles.",
   });
 
-  const pageTitle = intl.formatMessage(
-    {
-      defaultMessage: "Login using <abbreviation>GC</abbreviation> Key",
-      id: "iNFweP",
-      description: "Page title for the login page for applicant profiles.",
-    },
-    {
-      abbreviation,
-    },
-  );
+  const pageTitle = intl.formatMessage({
+    defaultMessage: "Login using GCKey",
+    id: "LVSun4",
+    description: "Page title for the login page for applicant profiles",
+  });
 
   const crumbs = useBreadcrumbs([
     {
@@ -64,45 +56,34 @@ const LoginPage = () => {
       <div data-h2-padding="base(x3, 0)">
         <div data-h2-container="base(center, small, x1) p-tablet(center, small, x2)">
           <p>
-            {intl.formatMessage(
-              {
-                defaultMessage:
-                  "You can log into your Digital Talent profile using your existing <abbreviation>GC</abbreviation> Key, even if you’ve never used this platform before.",
-                id: "lgsXDg",
-                description: "Instructions on how to login with GC Key.",
-              },
-              {
-                abbreviation,
-              },
-            )}
+            {intl.formatMessage({
+              defaultMessage:
+                "You can log into your Digital Talent profile using your existing GCKey, even if you’ve never used this platform before.",
+              id: "SSSNwI",
+              description: "Instructions on how to login with GCKey",
+            })}
+          </p>
+          <p data-h2-margin="base(x.5, 0, 0, 0)">
+            {intl.formatMessage({
+              defaultMessage:
+                "If you’re unsure whether you have an existing GCKey account, continue to the website and try logging in. If you can’t remember your password, you can also reset it there.",
+              id: "ypVSZh",
+              description:
+                "Instructions on what to do if user doesn't know if they have a GCKey",
+            })}
           </p>
           <p data-h2-margin="base(x.5, 0, 0, 0)">
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "If you’re unsure whether you have an existing <abbreviation>GC</abbreviation> Key account, continue to the website and try logging in. If you can’t remember your password, you can also reset it there.",
-                id: "kJdLk3",
+                  "<strong>Don't have a GCKey account?</strong> <a>Register for one</a>.",
+                id: "q53yRm",
                 description:
-                  "Instructions on what to do if user doesn't know if they have a GC Key",
-              },
-              {
-                abbreviation,
-              },
-            )}
-          </p>
-          <p data-h2-margin="base(x.5, 0, 0, 0)">
-            {intl.formatMessage(
-              {
-                defaultMessage:
-                  "<strong>Don't have a <abbreviation>GC</abbreviation> Key account?</strong> <a>Register for one.</a>",
-                id: "veXICB",
-                description:
-                  "Instruction on what to do if user does not have a GC Key.",
+                  "Instruction on what to do if user does not have a GCKey",
               },
               {
                 a: (chunks: React.ReactNode) =>
                   keyRegistrationLink(loginPath, chunks),
-                abbreviation,
               },
             )}
           </p>
@@ -135,17 +116,11 @@ const LoginPage = () => {
                 type="button"
                 color="primary"
               >
-                {intl.formatMessage(
-                  {
-                    defaultMessage:
-                      "Continue to <abbreviation>GC</abbreviation> Key and Login",
-                    id: "78J7jF",
-                    description: "GC Key login link text on the login page.",
-                  },
-                  {
-                    abbreviation,
-                  },
-                )}
+                {intl.formatMessage({
+                  defaultMessage: "Continue to GCKey and Login",
+                  id: "eYcQ6h",
+                  description: "GCKey login link text on the login page",
+                })}
               </ExternalLink>
             </p>
           </div>

--- a/apps/web/src/pages/Auth/RegisterPage/RegisterPage.tsx
+++ b/apps/web/src/pages/Auth/RegisterPage/RegisterPage.tsx
@@ -11,7 +11,6 @@ import useRoutes from "~/hooks/useRoutes";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import SEO from "~/components/SEO/SEO";
 import Hero from "~/components/Hero/Hero";
-import { wrapAbbr } from "~/utils/nameUtils";
 
 const keyRegistrationLink = (path: string, chunks: React.ReactNode) => (
   <a href={path}>{chunks}</a>
@@ -31,25 +30,17 @@ const RegisterPage = () => {
     getLocale(intl),
   );
 
-  const abbreviation = (text: React.ReactNode) => wrapAbbr(text, intl);
-
   const seoTitle = intl.formatMessage({
-    defaultMessage: "Register using GC Key",
-    id: "H4ug6o",
-    description: "Seo title for the registration page for applicant profiles.",
+    defaultMessage: "Register using GCKey",
+    id: "yxx7np",
+    description: "SEO title for the registration page for applicant profiles",
   });
 
-  const pageTitle = intl.formatMessage(
-    {
-      defaultMessage: "Register using <abbreviation>GC</abbreviation> Key",
-      id: "YXs6l6",
-      description:
-        "Page title for the registration page for applicant profiles.",
-    },
-    {
-      abbreviation,
-    },
-  );
+  const pageTitle = intl.formatMessage({
+    defaultMessage: "Register using GCKey",
+    id: "vZntuH",
+    description: "Page title for the registration page for applicant profiles",
+  });
 
   const crumbs = useBreadcrumbs([
     {
@@ -65,45 +56,34 @@ const RegisterPage = () => {
       <div data-h2-padding="base(x3, 0)">
         <div data-h2-container="base(center, small, x1) p-tablet(center, small, x2)">
           <p>
-            {intl.formatMessage(
-              {
-                defaultMessage:
-                  "You can log into your Digital Talent profile using your existing <abbreviation>GC</abbreviation> Key, even if you've never used this platform before.",
-                id: "5KRzTl",
-                description: "Instructions on how to login with GC Key.",
-              },
-              {
-                abbreviation,
-              },
-            )}
+            {intl.formatMessage({
+              defaultMessage:
+                "You can log into your Digital Talent profile using your existing GCKey, even if you've never used this platform before.",
+              id: "Ec1Hn9",
+              description: "Instructions on how to login with GCKey",
+            })}
+          </p>
+          <p data-h2-margin="base(x.5, 0, 0, 0)">
+            {intl.formatMessage({
+              defaultMessage:
+                "If you're unsure whether you have an existing GCKey account, continue to the website and try logging in. If you can't remember your password, you can also reset it there.",
+              id: "NuGNEF",
+              description:
+                "Instructions on what to do if user doesn't know if they have a GCKey",
+            })}
           </p>
           <p data-h2-margin="base(x.5, 0, 0, 0)">
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "If you're unsure whether you have an existing <abbreviation>GC</abbreviation> Key account, continue to the website and try logging in. If you can't remember your password, you can also reset it there.",
-                id: "5uOWv0",
+                  "<strong>Don't have a GCKey account?</strong> <a>Register for one</a>.",
+                id: "q53yRm",
                 description:
-                  "Instructions on what to do if user doesn't know if they have a GC Key",
-              },
-              {
-                abbreviation,
-              },
-            )}
-          </p>
-          <p data-h2-margin="base(x.5, 0, 0, 0)">
-            {intl.formatMessage(
-              {
-                defaultMessage:
-                  "<strong>Don't have a <abbreviation>GC</abbreviation> Key account?</strong> <a>Register for one.</a>",
-                id: "veXICB",
-                description:
-                  "Instruction on what to do if user does not have a GC Key.",
+                  "Instruction on what to do if user does not have a GCKey",
               },
               {
                 a: (chunks: React.ReactNode) =>
                   keyRegistrationLink(loginPath, chunks),
-                abbreviation,
               },
             )}
           </p>
@@ -135,18 +115,12 @@ const RegisterPage = () => {
                 type="button"
                 color="primary"
               >
-                {intl.formatMessage(
-                  {
-                    defaultMessage:
-                      "Continue to <abbreviation>GC</abbreviation> Key and Register",
-                    id: "ATDtfb",
-                    description:
-                      "GC Key registration link text on the registration page.",
-                  },
-                  {
-                    abbreviation,
-                  },
-                )}
+                {intl.formatMessage({
+                  defaultMessage: "Continue to GCKey and Register",
+                  id: "vNvh0G",
+                  description:
+                    "GCKey registration link text on the registration page",
+                })}
               </ExternalLink>
             </p>
           </div>

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -26,7 +26,7 @@ To set up a local development environment, run these commands from anywhere in r
      3. Navigate to http://localhost:8000/admin/dashboard
    - For testing applicant accounts:
      1. Navigate to http://localhost:8000/en/login-info
-     2. Click on "Continue to GC Key and login"
+     2. Click on "Continue to GCKey and Login"
      3. Enter `applicant@test.com` as the "User/subject" (the "Claims" input can be left blank, and there is no password)
      4. Navigate to http://localhost:8000/en/talent/profile
 


### PR DESCRIPTION
🤖 Resolves #6284.

## 👋 Introduction

This PR updates the name of the service GCKey to be rendered with the proper spelling of its name: without the space between **GC** and **Key**.

## 🕵️ Details

Any **GC** abbreviation markup on strings that were part of the former **GC Key** have been removed since GCKey is not an abbreviation.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Browse `/logged-out`, `login-info`, `/register-info`, `/create-account`
2. Search for instances of **GC Key**
3. Ensure there are no instances of **GC Key**
4. Search codebase for instances of **GC Key**
5. Ensure there are no instances of **GC Key** or **Clé GC**

## 📸 Screenshots
![Screen Shot 2023-04-17 at 13 16 15](https://user-images.githubusercontent.com/3046459/232560839-54130afa-d872-4b90-a574-43d4be4c0fff.png)
![Screen Shot 2023-04-17 at 13 16 01](https://user-images.githubusercontent.com/3046459/232560842-e9bdf95c-0724-453d-b37c-ae01a9b5e409.png)
![Screen Shot 2023-04-17 at 13 15 45](https://user-images.githubusercontent.com/3046459/232560844-3602267a-fe46-4f7c-9df2-0334d0f46d7f.png)
![Screen Shot 2023-04-17 at 13 14 11](https://user-images.githubusercontent.com/3046459/232560847-66122c72-0a49-4d21-bcc9-2b290b7ca3ef.png)



