### PR TITLE
[a11y] Fix TOC List Items

### DIFF
--- a/apps/web/src/components/InfoItem/BaseInfoItem.tsx
+++ b/apps/web/src/components/InfoItem/BaseInfoItem.tsx
@@ -63,6 +63,7 @@ export interface BaseInfoItemProps {
   iconColor?: IconColor;
   titleHref?: string;
   hiddenContextPrefix?: string;
+  asListItem?: boolean;
 }
 
 export const BaseInfoItem = ({
@@ -74,8 +75,10 @@ export const BaseInfoItem = ({
   iconColor = "success",
   titleHref,
   hiddenContextPrefix,
+  asListItem = true,
 }: BaseInfoItemProps) => {
   const Icon = icon;
+  const Wrapper = asListItem ? "li" : "span";
 
   // combine the context prefix for a11y if available
   const combinedTitle = (
@@ -90,7 +93,7 @@ export const BaseInfoItem = ({
   );
 
   return (
-    <li
+    <Wrapper
       data-h2-display="base(flex)"
       data-h2-flex-direction="base(row)"
       data-h2-gap="base(x0.5)"
@@ -109,23 +112,23 @@ export const BaseInfoItem = ({
         />
       )}
 
-      <div>
+      <span data-h2-display="base(flex)" data-h2-flex-direction="base(column)">
         {titleHref ? (
           <Link href={titleHref} {...{ ...textColorMap[titleColor] }}>
             {combinedTitle}
           </Link>
         ) : (
-          <p {...{ ...textColorMap[titleColor] }}>{combinedTitle}</p>
+          <span {...{ ...textColorMap[titleColor] }}>{combinedTitle}</span>
         )}
 
-        <p
+        <span
           data-h2-font-size="base(caption)"
           data-h2-text-decoration="base(none)"
           {...{ ...textColorMap[subTitleColor] }}
         >
           {subTitle}
-        </p>
-      </div>
-    </li>
+        </span>
+      </span>
+    </Wrapper>
   );
 };

--- a/apps/web/src/components/InfoItem/StatusItem.tsx
+++ b/apps/web/src/components/InfoItem/StatusItem.tsx
@@ -15,6 +15,7 @@ export interface StatusItemProps {
   subTitle?: string;
   status?: Status;
   titleHref?: string;
+  asListItem?: boolean;
 }
 
 export const StatusItem = ({
@@ -22,6 +23,7 @@ export const StatusItem = ({
   subTitle,
   status = "default",
   titleHref,
+  asListItem = true,
 }: StatusItemProps) => {
   const intl = useIntl();
   switch (status) {
@@ -35,6 +37,7 @@ export const StatusItem = ({
           subTitle={subTitle}
           subTitleColor="error"
           titleHref={titleHref}
+          asListItem={asListItem}
           hiddenContextPrefix={intl.formatMessage(commonMessages.error)}
         />
       );
@@ -46,6 +49,7 @@ export const StatusItem = ({
           subTitle={subTitle}
           subTitleColor="default"
           titleHref={titleHref}
+          asListItem={asListItem}
           hiddenContextPrefix={intl.formatMessage(commonMessages.partial)}
         />
       );
@@ -57,10 +61,17 @@ export const StatusItem = ({
           subTitle={subTitle}
           subTitleColor="success"
           titleHref={titleHref}
+          asListItem={asListItem}
           hiddenContextPrefix={intl.formatMessage(commonMessages.success)}
         />
       );
     default:
-      return <BaseInfoItem title={title} titleHref={titleHref} />;
+      return (
+        <BaseInfoItem
+          title={title}
+          titleHref={titleHref}
+          asListItem={asListItem}
+        />
+      );
   }
 };

--- a/apps/web/src/components/UserProfile/UserProfile.tsx
+++ b/apps/web/src/components/UserProfile/UserProfile.tsx
@@ -174,6 +174,7 @@ const UserProfile = ({
           {showSection("about") && (
             <TableOfContents.AnchorLink id="about-section">
               <StatusItem
+                asListItem={false}
                 title={intl.formatMessage({
                   defaultMessage: "About Me",
                   id: "4sJvia",
@@ -189,6 +190,7 @@ const UserProfile = ({
           {showSection("employmentEquity") && (
             <TableOfContents.AnchorLink id="diversity-equity-inclusion-section">
               <StatusItem
+                asListItem={false}
                 title={intl.formatMessage({
                   defaultMessage: "Diversity, equity and inclusion",
                   id: "e2R6fy",
@@ -205,6 +207,7 @@ const UserProfile = ({
           {showSection("language") && (
             <TableOfContents.AnchorLink id="language-section">
               <StatusItem
+                asListItem={false}
                 title={intl.formatMessage({
                   defaultMessage: "Language Information",
                   id: "B9x0ZV",
@@ -220,6 +223,7 @@ const UserProfile = ({
           {showSection("government") && (
             <TableOfContents.AnchorLink id="government-section">
               <StatusItem
+                asListItem={false}
                 title={intl.formatMessage({
                   defaultMessage: "Government Information",
                   id: "Nc4sjC",
@@ -236,6 +240,7 @@ const UserProfile = ({
           {showSection("workLocation") && (
             <TableOfContents.AnchorLink id="work-location-section">
               <StatusItem
+                asListItem={false}
                 title={intl.formatMessage({
                   defaultMessage: "Work Location",
                   id: "9WxeNz",
@@ -251,6 +256,7 @@ const UserProfile = ({
           {showSection("workPreferences") && (
             <TableOfContents.AnchorLink id="work-preferences-section">
               <StatusItem
+                asListItem={false}
                 title={intl.formatMessage({
                   defaultMessage: "Work Preferences",
                   id: "0DzlCc",
@@ -266,6 +272,7 @@ const UserProfile = ({
           {showSection("roleSalary") && (
             <TableOfContents.AnchorLink id="role-and-salary-section">
               <StatusItem
+                asListItem={false}
                 title={intl.formatMessage({
                   defaultMessage: "Role and salary expectations",
                   id: "95OYVk",

--- a/packages/ui/src/components/TableOfContents/AnchorLink.tsx
+++ b/packages/ui/src/components/TableOfContents/AnchorLink.tsx
@@ -6,9 +6,9 @@ export interface AnchorLinkProps extends HTMLAttributes<HTMLAnchorElement> {
 }
 
 const AnchorLink = ({ id, children }: AnchorLinkProps) => (
-  <ScrollToLink to={id} data-h2-margin="base(0, 0, x.5, 0)">
-    {children}
-  </ScrollToLink>
+  <li data-h2-margin="base(0, 0, x.5, 0)">
+    <ScrollToLink to={id}>{children}</ScrollToLink>
+  </li>
 );
 
 export default AnchorLink;

--- a/packages/ui/src/components/TableOfContents/Navigation.tsx
+++ b/packages/ui/src/components/TableOfContents/Navigation.tsx
@@ -36,13 +36,15 @@ const Navigation = ({ children, ...rest }: { children?: React.ReactNode }) => {
         >
           {intl.formatMessage(uiMessages.onThisPage)}
         </h2>
-        <nav
-          aria-labelledby={`toc-heading-${id}`}
-          data-h2-display="base(flex)"
-          data-h2-flex-direction="base(column)"
-          {...alignItemsStyles}
-        >
-          {children}
+        <nav aria-labelledby={`toc-heading-${id}`} {...alignItemsStyles}>
+          <ul
+            data-h2-display="base(flex)"
+            data-h2-flex-direction="base(column)"
+            data-h2-list-style="base(none)"
+            data-h2-padding="base(0)"
+          >
+            {children}
+          </ul>
         </nav>
       </div>
     </Sidebar>


### PR DESCRIPTION
🤖 Resolves #6254 

## 👋 Introduction

Updates both `TableOfContents` and `StatusItem` to render differently fixing an issue with list descendants. 

## 🕵️ Details

Our `StatusItem` as rendering an `<li />` element wrapping it which was causing issues with the list nesting. As well, the `TableOfContents` as not rendering any `<ul />` even though it is a list. 

This allows us to render a `<span />` instead of `<li />` for our `StatusItem` through the `asListItem?: boolean = true` prop. It also updated the `TableOfContents` to render items as a list by default.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build the app `npm run build:fresh`
2. Navigae to a profile
3. Confirm the table of contents renders as a list with no styling changes
4. Navigate to the dashboard
5. Confirm the status items in the hero still render as expected with no styling changes
6. Run axe on both pages and confirm there are no errors related to list items

## 📸 Screenshot

![Screenshot 2023-04-18 103536](https://user-images.githubusercontent.com/4127998/232811072-cbd8e51f-d52a-47a0-87ba-cfd38e1a921b.png)
