### PR TITLE
[Bug] Removes ellipses from `nullSelection`

### DIFF
--- a/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
@@ -53,8 +53,8 @@ const AwardFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.awardedTo}
             name="awardedTo"
             nullSelection={intl.formatMessage({
-              defaultMessage: "Choose one...",
-              id: "WjssQc",
+              defaultMessage: "Choose one",
+              id: "C13NNv",
               description:
                 "Null selection for select input in the awarded to form.",
             })}
@@ -92,8 +92,8 @@ const AwardFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.awardedScope}
             name="awardedScope"
             nullSelection={intl.formatMessage({
-              defaultMessage: "Choose one...",
-              id: "sIM1t+",
+              defaultMessage: "Choose one",
+              id: "+QpeDR",
               description:
                 "Null selection for select input in the award scope form.",
             })}

--- a/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
@@ -34,8 +34,8 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.educationType}
             name="educationType"
             nullSelection={intl.formatMessage({
-              defaultMessage: "Choose one...",
-              id: "3YyYDt",
+              defaultMessage: "Choose one",
+              id: "jmUyRm",
               description:
                 "Null selection for select education type in the education form.",
             })}
@@ -150,8 +150,8 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.educationStatus}
             name="educationStatus"
             nullSelection={intl.formatMessage({
-              defaultMessage: "Choose one...",
-              id: "wwiDm1",
+              defaultMessage: "Choose one",
+              id: "UouZPP",
               description:
                 "Null selection for select status in the education form.",
             })}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -570,8 +570,8 @@
     "defaultMessage": "Filtre de classification",
     "description": "Label for classification filter in search form."
   },
-  "WE/Nu+": {
-    "defaultMessage": "Sélectionnez un ministère...",
+  "y827h2": {
+    "defaultMessage": "Sélectionnez un ministère",
     "description": "Null selection for department select input in the request form."
   },
   "XSxaGk": {
@@ -586,8 +586,8 @@
     "defaultMessage": "Dans ce champ, veuillez inclure tous les détails et qualifications supplémentaires que vous recherchez auprès des candidats, comme les langages de programmation, les certifications, les connaissances ou un lieu de travail particulier.",
     "description": "Blurb before additional comments textarea in the request form."
   },
-  "asqSAJ": {
-    "defaultMessage": "Sélectionnez un lieu...",
+  "bo+d/M": {
+    "defaultMessage": "Sélectionnez un lieu",
     "description": "Placeholder for work location filter in search form."
   },
   "dRnKNR": {
@@ -665,8 +665,8 @@
     "defaultMessage": "Projet/produit",
     "description": "Label displayed on Community Experience form for project input"
   },
-  "3YyYDt": {
-    "defaultMessage": "Choisir un...",
+  "jmUyRm": {
+    "defaultMessage": "Choisir un",
     "description": "Null selection for select education type in the education form."
   },
   "491LrZ": {
@@ -761,8 +761,8 @@
     "defaultMessage": "1. Détails des études",
     "description": "Title for Education Details Form"
   },
-  "WjssQc": {
-    "defaultMessage": "Choisir un...",
+  "C13NNv": {
+    "defaultMessage": "Choisir un",
     "description": "Null selection for select input in the awarded to form."
   },
   "YJdsMY": {
@@ -821,16 +821,16 @@
     "defaultMessage": "Titre du prix",
     "description": "Label displayed on award form for award title input"
   },
-  "sIM1t+": {
-    "defaultMessage": "Choisir un...",
+  "+QpeDR": {
+    "defaultMessage": "Choisir un",
     "description": "Null selection for select input in the award scope form."
   },
   "wASF5V": {
     "defaultMessage": "Je suis actuellement actif dans ce rôle.",
     "description": "Label displayed on Community Experience form for current role input"
   },
-  "wwiDm1": {
-    "defaultMessage": "Choisir un...",
+  "UouZPP": {
+    "defaultMessage": "Choisir un",
     "description": "Null selection for select status in the education form."
   },
   "xJulQ4": {
@@ -949,8 +949,8 @@
     "defaultMessage": "Indiquez tous les emplacements où vous êtes prêt à travailler, y compris votre emplacement actuel (si vous souhaitez y travailler).",
     "description": "Description text for Profile Form wrapper in Work Location Preferences Form"
   },
-  "8QN6ZC": {
-    "defaultMessage": "Sélectionnez un niveau...",
+  "mX4+Dq": {
+    "defaultMessage": "Sélectionnez un niveau",
     "description": "Placeholder displayed on the language information form comprehension field."
   },
   "vNvh0G": {
@@ -1093,8 +1093,8 @@
     "defaultMessage": "Annuler",
     "description": "Button text to close employment equity form."
   },
-  "M6PbPI": {
-    "defaultMessage": "Sélectionner une province ou un territoire...",
+  "H1wLfA": {
+    "defaultMessage": "Sélectionner une province ou un territoire",
     "description": "Placeholder displayed on the About Me form province or territory field."
   },
   "MTwQ3S": {
@@ -1241,8 +1241,8 @@
     "defaultMessage": "Nous aimerions savoir ci-dessous si vous êtes déjà un(e) employé(e) du gouvernement du Canada. Nous recueillons ces renseignements parce qu'ils nous aident à comprendre, au niveau global, comment les compétences numériques sont réparties entre les ministères.",
     "description": "First message before is a government of canada radio group in create account form."
   },
-  "Y7jEXr": {
-    "defaultMessage": "Sélectionnez un niveau...",
+  "tl7bV2": {
+    "defaultMessage": "Sélectionnez un niveau",
     "description": "Placeholder displayed on the language information form verbal field."
   },
   "Y7l4/n": {
@@ -1281,8 +1281,8 @@
     "defaultMessage": "Éducation actuelle",
     "description": "Label displayed on Education Experience form for current education bounded box"
   },
-  "aQJOd0": {
-    "defaultMessage": "Sélectionnez un niveau...",
+  "4JS9Yp": {
+    "defaultMessage": "Sélectionnez un niveau",
     "description": "Placeholder displayed on the language information form written field."
   },
   "b9/MXQ": {
@@ -2717,8 +2717,8 @@
     "defaultMessage": "Les analystes fournissent des services techniques, des conseils, des analyses et des recherches dans leur domaine d’expertise, afin de soutenir la prestation de services aux clients et aux intervenants.",
     "description": "Description for the 'IT-02 Analyst' classification"
   },
-  "cmFeXj": {
-    "defaultMessage": "Sélectionnez un volet...",
+  "dJXjhw": {
+    "defaultMessage": "Sélectionnez un volet",
     "description": "Placeholder for stream filter in browse opportunities form."
   },
   "0lDq3P": {
@@ -2781,8 +2781,8 @@
     "defaultMessage": "J'aimerais être recommandé(e) à des emplois aux niveaux suivants :",
     "description": "Legend for role and salary checklist form"
   },
-  "JCyvcW": {
-    "defaultMessage": "Sélectionnez une langue...",
+  "ViNcRW": {
+    "defaultMessage": "Sélectionnez une langue",
     "description": "Placeholder displayed on the About Me form preferred interview language"
   },
   "KT3jUW": {
@@ -2797,8 +2797,8 @@
     "defaultMessage": "Sélectionnez votre langue de communication préférée",
     "description": "Legend text for required communication language preference in About Me form"
   },
-  "PBl2Rj": {
-    "defaultMessage": "Sélectionnez une langue...",
+  "cYw8hN": {
+    "defaultMessage": "Sélectionnez une langue",
     "description": "Placeholder displayed on the About Me form preferred exam language"
   },
   "WE0OGe": {
@@ -2837,8 +2837,8 @@
     "defaultMessage": "Les classifications gouvernementales sont des étiquettes que le gouvernement du Canada utilise pour regrouper des types de travail similaires. Dans le gouvernement du Canada, le salaire est lié à la façon dont les postes sont classés.",
     "description": "Description for the role and salary expectation form"
   },
-  "wRxZQV": {
-    "defaultMessage": "Sélectionnez une langue...",
+  "/Y/n1N": {
+    "defaultMessage": "Sélectionnez une langue",
     "description": "Placeholder displayed on the About Me form preferred communication language"
   },
   "dYS0MA": {
@@ -3025,8 +3025,8 @@
     "defaultMessage": "Groupe et niveau",
     "description": "Title displayed on the single search request table classifications column."
   },
-  "OqGhl+": {
-    "defaultMessage": "Sélectionner un niveau...",
+  "Le4EQq": {
+    "defaultMessage": "Sélectionner un niveau",
     "description": "Placeholder displayed on the classification form level field."
   },
   "QOvS1b": {
@@ -3304,16 +3304,16 @@
     "defaultMessage": "Connexion",
     "description": "Label displayed on the Login menu item."
   },
-  "7Cx7lp": {
-    "defaultMessage": "Sélectionner une compétence ou plus...",
+  "GhszAa": {
+    "defaultMessage": "Sélectionner une compétence ou plus",
     "description": "Placeholder displayed on the skill family form skills field."
   },
   "953EAy": {
     "defaultMessage": "Compétence {skillId} non trouvée.",
     "description": "Message displayed for skill not found."
   },
-  "9bz9jA": {
-    "defaultMessage": " Sélectionner une famille ou plus...",
+  "wORNl0": {
+    "defaultMessage": " Sélectionner une famille ou plus",
     "description": "Placeholder displayed on the skill form families field."
   },
   "9yGJ6k": {
@@ -3324,8 +3324,8 @@
     "defaultMessage": "Nom",
     "description": "Title displayed for the skill table Name column."
   },
-  "Cw8pyL": {
-    "defaultMessage": " Sélectionner zéro rôle ou plus...",
+  "SQqD4j": {
+    "defaultMessage": " Sélectionner zéro rôle ou plus",
     "description": "Placeholder displayed on the user form roles field."
   },
   "Dbqtm6": {
@@ -3424,8 +3424,8 @@
     "defaultMessage": "Création réussie de la compétence!",
     "description": "Message displayed to user after skill is created successfully."
   },
-  "brucUP": {
-    "defaultMessage": "Sélectionner une famille de compétences ou plus...",
+  "GNhFh2": {
+    "defaultMessage": "Sélectionner une famille de compétences ou plus",
     "description": "Placeholder displayed on the skill form skill families field."
   },
   "d8CQJr": {
@@ -3492,8 +3492,8 @@
     "defaultMessage": " Erreur : échec de la création de la compétence ",
     "description": "Message displayed to user after skill family fails to get created."
   },
-  "rna1rM": {
-    "defaultMessage": "Sélectionner une catégorie...",
+  "+hRCVl": {
+    "defaultMessage": "Sélectionner une catégorie",
     "description": "Placeholder displayed on the skill family form category field."
   },
   "xx8yaE": {
@@ -3700,8 +3700,8 @@
     "defaultMessage": "Date d'expiration",
     "description": "Label displayed on the date field of the change candidate expiry date dialog"
   },
-  "X198m3": {
-    "defaultMessage": "Sélectionner un bassin...",
+  "Rm4SuQ": {
+    "defaultMessage": "Sélectionner un bassin",
     "description": "Placeholder displayed on the pool field of the add user to pool dialog."
   },
   "ZDmkKD": {
@@ -3835,8 +3835,8 @@
     "defaultMessage": "Rôle et salaire escomptés",
     "description": "Title of the Role and salary expectations section"
   },
-  "usNShh": {
-    "defaultMessage": "Sélectionner un statut de bassin...",
+  "Bkxf6p": {
+    "defaultMessage": "Sélectionner un statut de bassin",
     "description": "Placeholder displayed on the status field of the change candidate status dialog."
   },
   "uutH18": {
@@ -3927,8 +3927,8 @@
     "defaultMessage": "Enregistrer les autres exigences",
     "description": "Text on a button to save the pool other requirements"
   },
-  "7aG86f": {
-    "defaultMessage": "Sélectionnez une classification...",
+  "tD99Wf": {
+    "defaultMessage": "Sélectionnez une classification",
     "description": "Placeholder displayed on the pool form classification field."
   },
   "7k27sT": {
@@ -4795,8 +4795,8 @@
     "defaultMessage": "Prénom",
     "description": "CSV Header, First Name column"
   },
-  "vgOfaa": {
-    "defaultMessage": "Sélectionnez un volet/un titre de poste...",
+  "fR6xVv": {
+    "defaultMessage": "Sélectionnez un volet/un titre de poste",
     "description": "Placeholder displayed on the pool form classification field."
   },
   "w/v77x": {
@@ -4995,8 +4995,8 @@
     "defaultMessage": "Bassins additionnels",
     "description": "Label displayed on the additional pools field of the change candidate status dialog"
   },
-  "vtXnOQ": {
-    "defaultMessage": "Sélectionnez d’autres bassins additionnels...",
+  "xjZO11": {
+    "defaultMessage": "Sélectionnez d’autres bassins additionnels",
     "description": "Placeholder displayed on the additional pools field of the change candidate status dialog."
   },
   "wiUfZL": {
@@ -5011,16 +5011,16 @@
     "defaultMessage": "Nom du propriétaire",
     "description": "Title displayed for the Pool table Owner Name column"
   },
-  "0UY4v5": {
-    "defaultMessage": "Sélectionnez une langue...",
+  "uup5F2": {
+    "defaultMessage": "Sélectionnez une langue",
     "description": "Placeholder displayed on the user form preferred communication language field."
   },
   "CfXIqC": {
     "defaultMessage": "Langue de communication préférée",
     "description": "Title displayed for the User table Preferred Communication Language column."
   },
-  "F4Flho": {
-    "defaultMessage": "Sélectionnez une langue...",
+  "98lXOH": {
+    "defaultMessage": "Sélectionnez une langue",
     "description": "Placeholder displayed on the user form preferred written exam language  field."
   },
   "K7fcQT": {
@@ -5039,8 +5039,8 @@
     "defaultMessage": "Langue parlée préférée pour l'entretien",
     "description": "Label displayed on the user form preferred spoken interview language field."
   },
-  "RYW3AP": {
-    "defaultMessage": "Sélectionnez une langue...",
+  "D45cvR": {
+    "defaultMessage": "Sélectionnez une langue",
     "description": "Placeholder displayed on the user form preferred written exam language field."
   },
   "SxP9zE": {
@@ -5063,8 +5063,8 @@
     "defaultMessage": "Langue de communication préférée",
     "description": "Title displayed on the Pool Candidates table Preferred Communication Language column."
   },
-  "fGAMy/": {
-    "defaultMessage": "Sélectionnez une langue...",
+  "0SEvhI": {
+    "defaultMessage": "Sélectionnez une langue",
     "description": "Placeholder displayed on the user form preferred spoken interview language field."
   },
   "zzwPOR": {
@@ -6414,8 +6414,8 @@
     "defaultMessage": "Annuler et retourner aux équipes",
     "description": "Link text to cancel updating a team"
   },
-  "IrvQbY": {
-    "defaultMessage": "Sélectionnez un ou plusieurs ministères...",
+  "F7nP5o": {
+    "defaultMessage": "Sélectionnez un ou plusieurs ministères",
     "description": "Placeholder text for the team departments input"
   },
   "ytHvhD": {
@@ -6566,8 +6566,8 @@
     "defaultMessage": "Rôles individuels",
     "description": "Heading for updating a users individual roles"
   },
-  "eW7I5E": {
-    "defaultMessage": "Sélectionner les rôles...",
+  "Cn73yN": {
+    "defaultMessage": "Sélectionner les rôles",
     "description": "Placeholder text for role selection input"
   },
   "fyidgo": {
@@ -6722,8 +6722,8 @@
     "defaultMessage": "Nom de l’équipe (Anglais)",
     "description": "Name of an organization/team in English field."
   },
-  "hr/i9h": {
-    "defaultMessage": "Sélectionnez une équipe...",
+  "COJ3St": {
+    "defaultMessage": "Sélectionnez une équipe",
     "description": "Placeholder displayed for team selection input."
   },
   "mOS8rj": {
@@ -6846,16 +6846,16 @@
     "defaultMessage": "Ajouter une nouvelle adhésion",
     "description": "Label for the form to add a team membership to a user"
   },
-  "ZdOvlC": {
-    "defaultMessage": "Sélectionnez une équipe...",
+  "5C8xs4": {
+    "defaultMessage": "Sélectionnez une équipe",
     "description": "Placeholder text for team selection input"
   },
   "sSnNWm": {
     "defaultMessage": "Supprimer l’adhésion<hidden> dans {team}</hidden>",
     "description": "Label for the form to remove a team role from a user"
   },
-  "x7vMC8": {
-    "defaultMessage": "Sélectionnez un rôle...",
+  "mTsq+x": {
+    "defaultMessage": "Sélectionnez un rôle",
     "description": "Placeholder text for role selection input"
   },
   "12rbnA": {

--- a/apps/web/src/pages/Classifications/CreateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/CreateClassificationPage.tsx
@@ -127,8 +127,8 @@ export const CreateClassificationForm = ({
                   "Label displayed on the classification form level field.",
               })}
               nullSelection={intl.formatMessage({
-                defaultMessage: "Select a level...",
-                id: "OqGhl+",
+                defaultMessage: "Select a level",
+                id: "Le4EQq",
                 description:
                   "Placeholder displayed on the classification form level field.",
               })}

--- a/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
@@ -140,8 +140,8 @@ export const UpdateClassificationForm = ({
                   "Label displayed on the classification form level field.",
               })}
               nullSelection={intl.formatMessage({
-                defaultMessage: "Select a level...",
-                id: "OqGhl+",
+                defaultMessage: "Select a level",
+                id: "Le4EQq",
                 description:
                   "Placeholder displayed on the classification form level field.",
               })}

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
@@ -975,8 +975,8 @@ const OngoingRecruitmentSection = ({
               description: "A label for a quick filter input.",
             })}
             nullSelection={intl.formatMessage({
-              defaultMessage: "Select a job stream...",
-              id: "cmFeXj",
+              defaultMessage: "Select a job stream",
+              id: "dJXjhw",
               description:
                 "Placeholder for stream filter in browse opportunities form.",
             })}

--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -140,8 +140,8 @@ export const CreatePoolForm = ({
               })}
               name="classification"
               nullSelection={intl.formatMessage({
-                defaultMessage: "Select a classification...",
-                id: "7aG86f",
+                defaultMessage: "Select a classification",
+                id: "tD99Wf",
                 description:
                   "Placeholder displayed on the pool form classification field.",
               })}
@@ -160,8 +160,8 @@ export const CreatePoolForm = ({
               })}
               name="team"
               nullSelection={intl.formatMessage({
-                defaultMessage: "Select a team...",
-                id: "hr/i9h",
+                defaultMessage: "Select a team",
+                id: "COJ3St",
                 description: "Placeholder displayed for team selection input.",
               })}
               options={teamOptions}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection.tsx
@@ -160,8 +160,8 @@ const PoolNameSection = ({
                 })}
                 name="stream"
                 nullSelection={intl.formatMessage({
-                  defaultMessage: "Select a stream/job title...",
-                  id: "vgOfaa",
+                  defaultMessage: "Select a stream/job title",
+                  id: "fR6xVv",
                   description:
                     "Placeholder displayed on the pool form classification field.",
                 })}

--- a/apps/web/src/pages/Profile/AboutMePage/components/AboutMeForm/AboutMeForm.tsx
+++ b/apps/web/src/pages/Profile/AboutMePage/components/AboutMeForm/AboutMeForm.tsx
@@ -289,8 +289,8 @@ const AboutMeForm = ({
               name="preferredLang"
               rules={{ required: intl.formatMessage(errorMessages.required) }}
               nullSelection={intl.formatMessage({
-                defaultMessage: "Select a language...",
-                id: "wRxZQV",
+                defaultMessage: "Select a language",
+                id: "/Y/n1N",
                 description:
                   "Placeholder displayed on the About Me form preferred communication language",
               })}
@@ -306,8 +306,8 @@ const AboutMeForm = ({
               name="preferredLanguageForInterview"
               rules={{ required: intl.formatMessage(errorMessages.required) }}
               nullSelection={intl.formatMessage({
-                defaultMessage: "Select a language...",
-                id: "JCyvcW",
+                defaultMessage: "Select a language",
+                id: "ViNcRW",
                 description:
                   "Placeholder displayed on the About Me form preferred interview language",
               })}
@@ -323,8 +323,8 @@ const AboutMeForm = ({
               name="preferredLanguageForExam"
               rules={{ required: intl.formatMessage(errorMessages.required) }}
               nullSelection={intl.formatMessage({
-                defaultMessage: "Select a language...",
-                id: "PBl2Rj",
+                defaultMessage: "Select a language",
+                id: "cYw8hN",
                 description:
                   "Placeholder displayed on the About Me form preferred exam language",
               })}
@@ -338,8 +338,8 @@ const AboutMeForm = ({
               name="currentProvince"
               label={labelMap.currentProvince}
               nullSelection={intl.formatMessage({
-                defaultMessage: "Select a province or territory...",
-                id: "M6PbPI",
+                defaultMessage: "Select a province or territory",
+                id: "H1wLfA",
                 description:
                   "Placeholder displayed on the About Me form province or territory field.",
               })}

--- a/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
+++ b/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
@@ -369,8 +369,8 @@ export const GovernmentInfoFormFields = ({
               name="department"
               label={labels.department}
               nullSelection={intl.formatMessage({
-                defaultMessage: "Select a department...",
-                id: "WE/Nu+",
+                defaultMessage: "Select a department",
+                id: "y827h2",
                 description:
                   "Null selection for department select input in the request form.",
               })}

--- a/apps/web/src/pages/Profile/LanguageInfoPage/components/ConsideredLanguages.tsx
+++ b/apps/web/src/pages/Profile/LanguageInfoPage/components/ConsideredLanguages.tsx
@@ -232,8 +232,8 @@ const ConsideredLanguages = ({ labels }: ConsideredLanguagesProps) => {
                 name="comprehensionLevel"
                 label={labels.comprehensionLevel}
                 nullSelection={intl.formatMessage({
-                  defaultMessage: "Select a level...",
-                  id: "8QN6ZC",
+                  defaultMessage: "Select a level",
+                  id: "mX4+Dq",
                   description:
                     "Placeholder displayed on the language information form comprehension field.",
                 })}
@@ -249,8 +249,8 @@ const ConsideredLanguages = ({ labels }: ConsideredLanguagesProps) => {
                 name="writtenLevel"
                 label={labels.writtenLevel}
                 nullSelection={intl.formatMessage({
-                  defaultMessage: "Select a level...",
-                  id: "aQJOd0",
+                  defaultMessage: "Select a level",
+                  id: "4JS9Yp",
                   description:
                     "Placeholder displayed on the language information form written field.",
                 })}
@@ -266,8 +266,8 @@ const ConsideredLanguages = ({ labels }: ConsideredLanguagesProps) => {
                 name="verbalLevel"
                 label={labels.verbalLevel}
                 nullSelection={intl.formatMessage({
-                  defaultMessage: "Select a level...",
-                  id: "Y7jEXr",
+                  defaultMessage: "Select a level",
+                  id: "tl7bV2",
                   description:
                     "Placeholder displayed on the language information form verbal field.",
                 })}

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -280,8 +280,8 @@ export const RequestForm = ({
                     "Label for department select input in the request form",
                 })}
                 nullSelection={intl.formatMessage({
-                  defaultMessage: "Select a department...",
-                  id: "WE/Nu+",
+                  defaultMessage: "Select a department",
+                  id: "y827h2",
                   description:
                     "Null selection for department select input in the request form.",
                 })}

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -516,8 +516,8 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                 description: "Label for work location filter in search form.",
               })}
               placeholder={intl.formatMessage({
-                defaultMessage: "Select a location...",
-                id: "asqSAJ",
+                defaultMessage: "Select a location",
+                id: "bo+d/M",
                 description:
                   "Placeholder for work location filter in search form.",
               })}

--- a/apps/web/src/pages/SkillFamilies/CreateSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/CreateSkillFamilyPage.tsx
@@ -213,8 +213,8 @@ export const CreateSkillFamilyForm = ({
                   "Label displayed on the skill family form category field.",
               })}
               nullSelection={intl.formatMessage({
-                defaultMessage: "Select a category...",
-                id: "rna1rM",
+                defaultMessage: "Select a category",
+                id: "+hRCVl",
                 description:
                   "Placeholder displayed on the skill family form category field.",
               })}
@@ -237,8 +237,8 @@ export const CreateSkillFamilyForm = ({
                     "Label displayed on the skill family form skills field.",
                 })}
                 placeholder={intl.formatMessage({
-                  defaultMessage: "Select one or more skills...",
-                  id: "7Cx7lp",
+                  defaultMessage: "Select one or more skills",
+                  id: "GhszAa",
                   description:
                     "Placeholder displayed on the skill family form skills field.",
                 })}

--- a/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
@@ -202,8 +202,8 @@ export const UpdateSkillFamilyForm = ({
                   "Label displayed on the skill family form category field.",
               })}
               nullSelection={intl.formatMessage({
-                defaultMessage: "Select a category...",
-                id: "rna1rM",
+                defaultMessage: "Select a category",
+                id: "+hRCVl",
                 description:
                   "Placeholder displayed on the skill family form category field.",
               })}
@@ -226,8 +226,8 @@ export const UpdateSkillFamilyForm = ({
                     "Label displayed on the skill family form skills field.",
                 })}
                 placeholder={intl.formatMessage({
-                  defaultMessage: "Select one or more skills...",
-                  id: "7Cx7lp",
+                  defaultMessage: "Select one or more skills",
+                  id: "GhszAa",
                   description:
                     "Placeholder displayed on the skill family form skills field.",
                 })}

--- a/apps/web/src/pages/Skills/CreateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/CreateSkillPage.tsx
@@ -262,8 +262,8 @@ export const CreateSkillForm = ({
                     "Label displayed on the skill form skill families field.",
                 })}
                 placeholder={intl.formatMessage({
-                  defaultMessage: "Select one or more skill families...",
-                  id: "brucUP",
+                  defaultMessage: "Select one or more skill families",
+                  id: "GNhFh2",
                   description:
                     "Placeholder displayed on the skill form skill families field.",
                 })}

--- a/apps/web/src/pages/Skills/UpdateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateSkillPage.tsx
@@ -256,8 +256,8 @@ export const UpdateSkillForm = ({
                     "Label displayed on the skill form families field.",
                 })}
                 placeholder={intl.formatMessage({
-                  defaultMessage: "Select one or more families...",
-                  id: "9bz9jA",
+                  defaultMessage: "Select one or more families",
+                  id: "wORNl0",
                   description:
                     "Placeholder displayed on the skill form families field.",
                 })}

--- a/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamFormFields.tsx
+++ b/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamFormFields.tsx
@@ -75,8 +75,8 @@ const CreateTeamFormFields = ({ departments }: CreateTeamFormFieldsProps) => {
             description: "Label for the team departments input",
           })}
           placeholder={intl.formatMessage({
-            defaultMessage: "Select one or more departments...",
-            id: "IrvQbY",
+            defaultMessage: "Select one or more departments",
+            id: "F7nP5o",
             description: "Placeholder text for the team departments input",
           })}
           rules={{

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/AddTeamMemberDialog.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/AddTeamMemberDialog.tsx
@@ -165,8 +165,8 @@ AddTeamMemberDialogProps) => {
                 })}
                 rules={{ required: intl.formatMessage(errorMessages.required) }}
                 placeholder={intl.formatMessage({
-                  defaultMessage: "Select roles...",
-                  id: "eW7I5E",
+                  defaultMessage: "Select roles",
+                  id: "Cn73yN",
                   description: "Placeholder text for role selection input",
                 })}
                 options={roleOptions}

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/EditTeamMemberDialog.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/EditTeamMemberDialog.tsx
@@ -170,8 +170,8 @@ const EditTeamMemberDialog = ({
                 })}
                 rules={{ required: intl.formatMessage(errorMessages.required) }}
                 placeholder={intl.formatMessage({
-                  defaultMessage: "Select roles...",
-                  id: "eW7I5E",
+                  defaultMessage: "Select roles",
+                  id: "Cn73yN",
                   description: "Placeholder text for role selection input",
                 })}
                 options={roleOptions}

--- a/apps/web/src/pages/Users/CreateUserPage/CreateUserPage.tsx
+++ b/apps/web/src/pages/Users/CreateUserPage/CreateUserPage.tsx
@@ -143,8 +143,8 @@ export const CreateUserForm = ({ handleCreateUser }: CreateUserFormProps) => {
               })}
               name="preferredLang"
               nullSelection={intl.formatMessage({
-                defaultMessage: "Select a language...",
-                id: "0UY4v5",
+                defaultMessage: "Select a language",
+                id: "uup5F2",
                 description:
                   "Placeholder displayed on the user form preferred communication language field.",
               })}
@@ -166,8 +166,8 @@ export const CreateUserForm = ({ handleCreateUser }: CreateUserFormProps) => {
               })}
               name="preferredLanguageForInterview"
               nullSelection={intl.formatMessage({
-                defaultMessage: "Select a language...",
-                id: "fGAMy/",
+                defaultMessage: "Select a language",
+                id: "0SEvhI",
                 description:
                   "Placeholder displayed on the user form preferred spoken interview language field.",
               })}
@@ -189,8 +189,8 @@ export const CreateUserForm = ({ handleCreateUser }: CreateUserFormProps) => {
               })}
               name="preferredLanguageForExam"
               nullSelection={intl.formatMessage({
-                defaultMessage: "Select a language...",
-                id: "RYW3AP",
+                defaultMessage: "Select a language",
+                id: "D45cvR",
                 description:
                   "Placeholder displayed on the user form preferred written exam language field.",
               })}
@@ -229,8 +229,8 @@ export const CreateUserForm = ({ handleCreateUser }: CreateUserFormProps) => {
                   description: "Label displayed on the user form roles field.",
                 })}
                 placeholder={intl.formatMessage({
-                  defaultMessage: "Select zero or more roles...",
-                  id: "Cw8pyL",
+                  defaultMessage: "Select zero or more roles",
+                  id: "SQqD4j",
                   description:
                     "Placeholder displayed on the user form roles field.",
                 })}

--- a/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
@@ -172,8 +172,8 @@ export const UpdateUserForm = ({
             })}
             name="preferredLang"
             nullSelection={intl.formatMessage({
-              defaultMessage: "Select a language...",
-              id: "0UY4v5",
+              defaultMessage: "Select a language",
+              id: "uup5F2",
               description:
                 "Placeholder displayed on the user form preferred communication language field.",
             })}
@@ -195,8 +195,8 @@ export const UpdateUserForm = ({
             })}
             name="preferredLanguageForInterview"
             nullSelection={intl.formatMessage({
-              defaultMessage: "Select a language...",
-              id: "fGAMy/",
+              defaultMessage: "Select a language",
+              id: "0SEvhI",
               description:
                 "Placeholder displayed on the user form preferred spoken interview language field.",
             })}
@@ -218,8 +218,8 @@ export const UpdateUserForm = ({
             })}
             name="preferredLanguageForExam"
             nullSelection={intl.formatMessage({
-              defaultMessage: "Select a language...",
-              id: "F4Flho",
+              defaultMessage: "Select a language",
+              id: "98lXOH",
               description:
                 "Placeholder displayed on the user form preferred written exam language  field.",
             })}
@@ -258,8 +258,8 @@ export const UpdateUserForm = ({
                 description: "Label displayed on the user form roles field.",
               })}
               placeholder={intl.formatMessage({
-                defaultMessage: "Select zero or more roles...",
-                id: "Cw8pyL",
+                defaultMessage: "Select zero or more roles",
+                id: "SQqD4j",
                 description:
                   "Placeholder displayed on the user form roles field.",
               })}

--- a/apps/web/src/pages/Users/UpdateUserPage/components/AddIndividualRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/AddIndividualRoleDialog.tsx
@@ -128,8 +128,8 @@ const AddIndividualRoleDialog = ({
                 })}
                 rules={{ required: intl.formatMessage(errorMessages.required) }}
                 placeholder={intl.formatMessage({
-                  defaultMessage: "Select roles...",
-                  id: "eW7I5E",
+                  defaultMessage: "Select roles",
+                  id: "Cn73yN",
                   description: "Placeholder text for role selection input",
                 })}
                 options={roleOptions}

--- a/apps/web/src/pages/Users/UpdateUserPage/components/AddTeamRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/AddTeamRoleDialog.tsx
@@ -148,8 +148,8 @@ const AddTeamRoleDialog = ({
                   required: intl.formatMessage(errorMessages.required),
                 }}
                 placeholder={intl.formatMessage({
-                  defaultMessage: "Select team...",
-                  id: "ZdOvlC",
+                  defaultMessage: "Select team",
+                  id: "5C8xs4",
                   description: "Placeholder text for team selection input",
                 })}
                 options={teamOptions ?? []}
@@ -165,8 +165,8 @@ const AddTeamRoleDialog = ({
                 })}
                 rules={{ required: intl.formatMessage(errorMessages.required) }}
                 placeholder={intl.formatMessage({
-                  defaultMessage: "Select role...",
-                  id: "x7vMC8",
+                  defaultMessage: "Select role",
+                  id: "mTsq+x",
                   description: "Placeholder text for role selection input",
                 })}
                 options={roleOptions}

--- a/apps/web/src/pages/Users/UpdateUserPage/components/EditTeamRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/EditTeamRoleDialog.tsx
@@ -156,8 +156,8 @@ const EditTeamRoleDialog = ({
                 })}
                 rules={{ required: intl.formatMessage(errorMessages.required) }}
                 placeholder={intl.formatMessage({
-                  defaultMessage: "Select role...",
-                  id: "x7vMC8",
+                  defaultMessage: "Select role",
+                  id: "mTsq+x",
                   description: "Placeholder text for role selection input",
                 })}
                 options={roleOptions}

--- a/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
@@ -207,8 +207,8 @@ const AddToPoolDialog = ({ user, pools }: AddToPoolDialogProps) => {
                       "Label displayed on the pools field of the add user to pool dialog",
                   })}
                   placeholder={intl.formatMessage({
-                    defaultMessage: "Select a pool...",
-                    id: "X198m3",
+                    defaultMessage: "Select a pool",
+                    id: "Rm4SuQ",
                     description:
                       "Placeholder displayed on the pool field of the add user to pool dialog.",
                   })}

--- a/apps/web/src/pages/Users/UserInformationPage/components/ChangeStatusDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/ChangeStatusDialog.tsx
@@ -237,8 +237,8 @@ const ChangeStatusDialog = ({
                       "Label displayed on the status field of the change candidate status dialog",
                   })}
                   nullSelection={intl.formatMessage({
-                    defaultMessage: "Select a pool status...",
-                    id: "usNShh",
+                    defaultMessage: "Select a pool status",
+                    id: "Bkxf6p",
                     description:
                       "Placeholder displayed on the status field of the change candidate status dialog.",
                   })}
@@ -273,8 +273,8 @@ const ChangeStatusDialog = ({
                       "Label displayed on the additional pools field of the change candidate status dialog",
                   })}
                   placeholder={intl.formatMessage({
-                    defaultMessage: "Select additional pools...",
-                    id: "vtXnOQ",
+                    defaultMessage: "Select additional pools",
+                    id: "xjZO11",
                     description:
                       "Placeholder displayed on the additional pools field of the change candidate status dialog.",
                   })}

--- a/packages/forms/src/components/Select/Select.stories.tsx
+++ b/packages/forms/src/components/Select/Select.stories.tsx
@@ -109,7 +109,7 @@ SelectDefault.args = {
 export const SelectWithNullSelection = Template.bind({});
 SelectWithNullSelection.args = {
   ...SelectDefault.args,
-  nullSelection: "Select an option...",
+  nullSelection: "Select an option",
 };
 
 export const SelectWithGroups = TemplateGroups.bind({});
@@ -117,7 +117,7 @@ SelectWithGroups.args = {
   ...SelectDefault.args,
   label: "Groups",
   name: "groups",
-  nullSelection: "Select an option...",
+  nullSelection: "Select an option",
 };
 
 export const SelectRequired = Template.bind({});

--- a/packages/forms/src/components/Select/SelectFieldV2.test.tsx
+++ b/packages/forms/src/components/Select/SelectFieldV2.test.tsx
@@ -304,18 +304,18 @@ describe("SelectFieldV2", () => {
     const placeholderText = document.querySelector(
       `.${CLASS_PREFIX}__control`,
     )?.textContent;
-    expect(placeholderText).toBe("Select...");
+    expect(placeholderText).toBe("Select");
   });
 
   it("should have custom placeholder when specified", () => {
     renderWithProviders(
-      <SelectFieldV2 label="Foo Bar" placeholder="Select thing..." />,
+      <SelectFieldV2 label="Foo Bar" placeholder="Select thing" />,
     );
 
     const placeholderText = document.querySelector(
       `.${CLASS_PREFIX}__control`,
     )?.textContent;
-    expect(placeholderText).toBe("Select thing...");
+    expect(placeholderText).toBe("Select thing");
   });
 
   it("should show loading indicator when isLoading", () => {

--- a/packages/forms/src/components/Select/SelectFieldV2.tsx
+++ b/packages/forms/src/components/Select/SelectFieldV2.tsx
@@ -14,7 +14,7 @@ import flatMap from "lodash/flatMap";
 import orderBy from "lodash/orderBy";
 import { useIntl } from "react-intl";
 
-import { errorMessages } from "@gc-digital-talent/i18n";
+import { errorMessages, formMessages } from "@gc-digital-talent/i18n";
 
 import useFieldState from "../../hooks/useFieldState";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
@@ -115,12 +115,7 @@ const LocalizedLoadingMessage = <
 
   return (
     <components.LoadingMessage {...props}>
-      {formatMessage({
-        defaultMessage: "Loading...",
-        id: "ylHC90",
-        description:
-          "Message shown in options dropdown when Select field is loading options.",
-      })}
+      {formatMessage(formMessages.loading)}
     </components.LoadingMessage>
   );
 };
@@ -137,12 +132,7 @@ const LocalizedNoOptionsMessage = <
 
   return (
     <components.NoOptionsMessage {...props}>
-      {formatMessage({
-        defaultMessage: "No options",
-        id: "lsFH+y",
-        description:
-          "Message shown in options dropdown when Select field has no options.",
-      })}
+      {formatMessage(formMessages.noOptions)}
     </components.NoOptionsMessage>
   );
 };
@@ -216,12 +206,7 @@ const SelectFieldV2 = ({
   const { formatMessage } = useIntl();
   const [isContextVisible, setContextVisible] = React.useState<boolean>(false);
 
-  const defaultPlaceholder = formatMessage({
-    defaultMessage: "Select",
-    id: "plwOsC",
-    description:
-      "Default placeholder shown when Select field has nothing actively selected.",
-  });
+  const defaultPlaceholder = formatMessage(formMessages.defaultPlaceholder);
 
   // Defaults from minimal attributes.
   id ??= camelCase(label); // eslint-disable-line no-param-reassign

--- a/packages/forms/src/components/Select/SelectFieldV2.tsx
+++ b/packages/forms/src/components/Select/SelectFieldV2.tsx
@@ -217,8 +217,8 @@ const SelectFieldV2 = ({
   const [isContextVisible, setContextVisible] = React.useState<boolean>(false);
 
   const defaultPlaceholder = formatMessage({
-    defaultMessage: "Select...",
-    id: "rQwIDB",
+    defaultMessage: "Select",
+    id: "plwOsC",
     description:
       "Default placeholder shown when Select field has nothing actively selected.",
   });

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1345,5 +1345,17 @@
   "T/97gk": {
     "defaultMessage": "Supprimer l’article {index}",
     "description": "Button text to remove an item from repeatable fields"
+  },
+  "lsFH+y": {
+    "defaultMessage": "Aucune option",
+    "description": "Message shown in options dropdown when Select field has no options."
+  },
+  "plwOsC": {
+    "defaultMessage": "Sélectionnez",
+    "description": "Default placeholder shown when Select field has nothing actively selected."
+  },
+  "ylHC90": {
+    "defaultMessage": "Chargement...",
+    "description": "Message shown in options dropdown when Select field is loading options."
   }
 }

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1234,8 +1234,8 @@
     "defaultMessage": "Jour",
     "description": "Label for a day of the month input field"
   },
-  "cbKlUG": {
-    "defaultMessage": "Sélectionnez un mois...",
+  "5hXz/z": {
+    "defaultMessage": "Sélectionnez un mois",
     "description": "Placeholder for a month select field"
   },
   "fAj9+G": {

--- a/packages/i18n/src/messages/dateMessages.ts
+++ b/packages/i18n/src/messages/dateMessages.ts
@@ -17,8 +17,8 @@ const dateMessages = defineMessages({
     description: "Label for a day of the month input field",
   },
   selectAMonth: {
-    defaultMessage: "Select a month...",
-    id: "cbKlUG",
+    defaultMessage: "Select a month",
+    id: "5hXz/z",
     description: "Placeholder for a month select field",
   },
   january: {

--- a/packages/i18n/src/messages/formMessages.ts
+++ b/packages/i18n/src/messages/formMessages.ts
@@ -98,6 +98,24 @@ const formMessages = defineMessages({
     description:
       "Message announced to assistive technology when a repeatable field has been removed",
   },
+  defaultPlaceholder: {
+    defaultMessage: "Select",
+    id: "plwOsC",
+    description:
+      "Default placeholder shown when Select field has nothing actively selected.",
+  },
+  loading: {
+    defaultMessage: "Loading...",
+    id: "ylHC90",
+    description:
+      "Message shown in options dropdown when Select field is loading options.",
+  },
+  noOptions: {
+    defaultMessage: "No options",
+    id: "lsFH+y",
+    description:
+      "Message shown in options dropdown when Select field has no options.",
+  },
 });
 
 export default formMessages;


### PR DESCRIPTION
🤖 Resolves #6153.

## 👋 Introduction

This PR removes ellipses from `nullSelection`.

## 🕵️ Details

Because of how react-select works, the `placeholder` prop is essentially the null selection and so those values have had their ellipses removed as well.

## 🦴 Bonus

It also fixes some strings in the `SelectFieldV2 `component that had been missing translations.

### Screenshots

<details><summary>Before</summary>

![Screen Shot 2023-04-18 at 11 57 17](https://user-images.githubusercontent.com/3046459/232846454-ba6c8848-f831-4029-b1db-6392b3943063.png)</details>

<details><summary>After</summary>

![Screen Shot 2023-04-18 at 12 36 57](https://user-images.githubusercontent.com/3046459/232846467-6e812146-6fab-4beb-88af-d8ab30b38c08.png)</details>

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Look far and wide for ellipses used in `Select`, `MultiSelectField` components
2. Ensure English and French versions still work
