### PR TITLE
[Feature] Adds Strike Notice

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -54,6 +54,7 @@ OCIO
 Ojibway
 personalisation
 pgsql
+psac
 Queueable
 recruitmentimit
 recruitments

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,5 +71,8 @@
   ],
   "[php]": {
     "editor.defaultFormatter": "bmewburn.vscode-intelephense-client"
+  },
+  "files.associations": {
+    "**/public/config.ejs": "plaintext"
   }
 }

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -11,6 +11,7 @@ OAUTH_LOGOUT_URI="http://localhost:8000/oxauth/endsession"
 FEATURE_ONGOING_RECRUITMENTS=true
 FEATURE_APPLICANT_DASHBOARD=true
 FEATURE_APPLICATION_REVAMP=true
+FEATURE_PSAC_STRIKE=true
 
 # Logging - enable by setting the logging level.  Eight severity levels from rfc5424.
 LOG_CONSOLE_LEVEL="debug"

--- a/apps/web/public/config.ejs
+++ b/apps/web/public/config.ejs
@@ -16,6 +16,7 @@ const data = new Map([
     ["FEATURE_ONGOING_RECRUITMENTS", filterUnusable("$FEATURE_ONGOING_RECRUITMENTS") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_ONGOING_RECRUITMENTS %>"],
     ["FEATURE_APPLICANT_DASHBOARD", filterUnusable("$FEATURE_APPLICANT_DASHBOARD") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_APPLICANT_DASHBOARD %>"],
     ["FEATURE_APPLICATION_REVAMP", filterUnusable("$FEATURE_APPLICATION_REVAMP") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_APPLICATION_REVAMP %>"],
+    ["FEATURE_PSAC_STRIKE", filterUnusable("$FEATURE_PSAC_STRIKE") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_PSAC_STRIKE %>"],
 
     // Azure application insights not used in dev
     ["APPLICATIONINSIGHTS_CONNECTION_STRING", filterUnusable("$APPLICATIONINSIGHTS_CONNECTION_STRING")],

--- a/apps/web/src/components/Hero/Hero.tsx
+++ b/apps/web/src/components/Hero/Hero.tsx
@@ -190,7 +190,7 @@ const Hero = ({
         <>
           <Flourish />
           <div
-            data-h2-container="base(center, large, x1) p-tablet(center, large, x2)"
+            data-h2-container="base(center, large, x1) p-tablet(center, medium, x2)"
             data-h2-position="base(relative)"
             data-h2-margin="base(-x5, auto, 0, auto)"
             data-h2-z-index="base(4)"

--- a/apps/web/src/components/StrikeNotice/StrikeNotice.tsx
+++ b/apps/web/src/components/StrikeNotice/StrikeNotice.tsx
@@ -23,8 +23,8 @@ const StrikeNotice = () => {
       <p>
         {intl.formatMessage({
           defaultMessage:
-            "In the event of a labour disruption, referral services from this platform will be affected. Please note that your request will be responded when services resume. Thank you for your patience.",
-          id: "xyPGzO",
+            "In the event of a labour disruption, referral services from this platform will be affected. Please note that your request will be responded to when services resume. Thank you for your patience.",
+          id: "6q29tj",
           description: "Content for the PSAC strike notice.",
         })}
       </p>

--- a/apps/web/src/components/StrikeNotice/StrikeNotice.tsx
+++ b/apps/web/src/components/StrikeNotice/StrikeNotice.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { Alert } from "@gc-digital-talent/ui";
+
+const StrikeNotice = () => {
+  const intl = useIntl();
+
+  return (
+    <Alert.Root type="warning">
+      <Alert.Title>
+        {intl.formatMessage({
+          defaultMessage:
+            "The Government of Canada and the Public Service Alliance of Canada (PSAC) are currently negotiating collective agreements.",
+          id: "oF8h5+",
+          description: "Heading for the PSAC strike notice.",
+        })}
+      </Alert.Title>
+      <p>
+        {intl.formatMessage({
+          defaultMessage:
+            "In the event of a labour disruption, referral services from this platform will be affected. Please note that your request will be responded when services resume. Thank you for your patience.",
+          id: "xyPGzO",
+          description: "Content for the PSAC strike notice.",
+        })}
+      </p>
+    </Alert.Root>
+  );
+};
+
+export default StrikeNotice;

--- a/apps/web/src/components/StrikeNotice/StrikeNotice.tsx
+++ b/apps/web/src/components/StrikeNotice/StrikeNotice.tsx
@@ -2,9 +2,13 @@ import React from "react";
 import { useIntl } from "react-intl";
 
 import { Alert } from "@gc-digital-talent/ui";
+import { useFeatureFlags } from "@gc-digital-talent/env";
 
 const StrikeNotice = () => {
   const intl = useIntl();
+  const { psacStrike } = useFeatureFlags();
+
+  if (!psacStrike) return null;
 
   return (
     <Alert.Root type="warning">

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7581,7 +7581,7 @@
     "defaultMessage": "Le gouvernement du Canada et l'Alliance de la Fonction publique du Canada (AFPC) sont en pourparlers actuellement pour les conventions collectives.",
     "description": "Heading for the PSAC strike notice."
   },
-  "xyPGzO": {
+  "6q29tj": {
     "defaultMessage": "En cas d'interruption du travail, les services de référence de cette plateforme seront touchés. Veuillez noter que votre demande sera traitée lorsque les services reprendront. Merci de votre patience.",
     "description": "Content for the PSAC strike notice."
   }

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7576,5 +7576,13 @@
   "egLb65": {
     "defaultMessage": "Je suis prêt!",
     "description": "An action button to proceed"
+  },
+  "oF8h5+": {
+    "defaultMessage": "Le gouvernement du Canada et l'Alliance de la Fonction publique du Canada (AFPC) sont en pourparlers actuellement pour les conventions collectives.",
+    "description": "Heading for the PSAC strike notice."
+  },
+  "xyPGzO": {
+    "defaultMessage": "En cas d'interruption du travail, les services de référence de cette plateforme seront touchés. Veuillez noter que votre demande sera traitée lorsque les services reprendront. Merci de votre patience.",
+    "description": "Content for the PSAC strike notice."
   }
 }

--- a/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
@@ -6,6 +6,7 @@ import { Heading, ThrowNotFound, Button, Link } from "@gc-digital-talent/ui";
 
 import Hero from "~/components/Hero";
 import SEO from "~/components/SEO/SEO";
+import StrikeNotice from "~/components/StrikeNotice/StrikeNotice";
 
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import useRoutes from "~/hooks/useRoutes";
@@ -70,6 +71,9 @@ const RequestConfirmationPage = () => {
         crumbs={crumbs}
       />
       <div data-h2-container="base(center, large, x1) p-tablet(center, large, x2)">
+        <div data-h2-container="base(center, large, 0) p-tablet(left, small, 0)">
+          <StrikeNotice />
+        </div>
         <Text data-h2-font-size="base(3rem)">
           {intl.formatMessage({
             defaultMessage: "We got it!",

--- a/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
@@ -71,9 +71,7 @@ const RequestConfirmationPage = () => {
         crumbs={crumbs}
       />
       <div data-h2-container="base(center, large, x1) p-tablet(center, large, x2)">
-        <div data-h2-container="base(center, large, 0) p-tablet(left, small, 0)">
-          <StrikeNotice />
-        </div>
+        <StrikeNotice />
         <Text data-h2-font-size="base(3rem)">
           {intl.formatMessage({
             defaultMessage: "We got it!",

--- a/apps/web/src/pages/SearchRequests/RequestPage/RequestPage.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/RequestPage.tsx
@@ -4,6 +4,7 @@ import { useIntl } from "react-intl";
 import { useLocation } from "react-router-dom";
 
 import Hero from "~/components/Hero/Hero";
+import StrikeNotice from "~/components/StrikeNotice/StrikeNotice";
 import { ApplicantFilterInput } from "~/api/generated";
 import { SimpleClassification } from "~/types/pool";
 import { FormValues as SearchFormValues } from "~/types/searchRequest";
@@ -37,6 +38,7 @@ const RequestPage = () => {
           description: "Main heading displayed at the top of request page.",
         })}
       >
+        <StrikeNotice />
         <div
           data-h2-background-color="base(white)"
           data-h2-radius="base(rounded)"

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchHeading.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchHeading.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { useIntl } from "react-intl";
 
 import Hero from "~/components/Hero/Hero";
+import StrikeNotice from "~/components/StrikeNotice/StrikeNotice";
 
 const SearchHeading = () => {
   const intl = useIntl();
@@ -14,6 +15,7 @@ const SearchHeading = () => {
         description: "Title displayed in the hero section of the Search page.",
       })}
     >
+      <StrikeNotice />
       <div
         data-h2-background-color="base(white)"
         data-h2-radius="base(rounded)"

--- a/packages/env/src/useFeatureFlags.ts
+++ b/packages/env/src/useFeatureFlags.ts
@@ -4,6 +4,7 @@ export type FeatureFlags = {
   ongoingRecruitments: boolean;
   applicantDashboard: boolean;
   applicationRevamp: boolean;
+  psacStrike: boolean;
 };
 
 const useFeatureFlags = (): FeatureFlags => {

--- a/packages/env/src/utils.ts
+++ b/packages/env/src/utils.ts
@@ -42,4 +42,5 @@ export const getFeatureFlags = () => ({
   ongoingRecruitments: checkFeatureFlag("FEATURE_ONGOING_RECRUITMENTS"),
   applicantDashboard: checkFeatureFlag("FEATURE_APPLICANT_DASHBOARD"),
   applicationRevamp: checkFeatureFlag("FEATURE_APPLICATION_REVAMP"),
+  psacStrike: checkFeatureFlag("FEATURE_PSAC_STRIKE"),
 });

--- a/packages/ui/src/components/Alert/Alert.tsx
+++ b/packages/ui/src/components/Alert/Alert.tsx
@@ -160,7 +160,7 @@ const Title = ({ as = "h2", children, ...rest }: AlertTitleProps) => {
 
   return (
     <Heading
-      data-h2-font-size="base(h6, 1)"
+      data-h2-font-size="base(h6)"
       data-h2-font-weight="base(700)"
       data-h2-margin="base(0, 0, x.5, 0)"
       {...rest}


### PR DESCRIPTION
🤖 Resolves #6317

## :truck: Deployment
- new feature flag

## 👋 Introduction

Adds a strike notice to users to explain slower response times on search requests.

## 🕵️ Details

This also reduces the hero container to be slightly smaller and fixes alert title line height.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Copy `FEATURE_PSAC_STRIKE=true` to your `.env` file
2. Rebuild docker `docker-compose down` `docker-compose up --build --detach`
3. Build the application `npm run build:fresh`
4. Navigate to `/search` to confirm alert appears in both French and English
5. Start a request and confirm alert appears in both French and English on request form page
6. Submit request and confirm alert appears in both French and English on confirmation page 

## 📸 Screenshot
![Screenshot 2023-04-18 144232](https://user-images.githubusercontent.com/4127998/232873870-183e4967-1020-458e-aed3-3eacb3198fd4.png)
![Screenshot 2023-04-18 144246](https://user-images.githubusercontent.com/4127998/232873871-039167d4-1a23-4741-8bd3-c9b12ccce2df.png)
![Screenshot 2023-04-18 144255](https://user-images.githubusercontent.com/4127998/232873873-421c437a-4508-4041-b96d-4259415f2c60.png)

