### PR TITLE
Bug - 6227 - browse pools route

### DIFF
--- a/apps/web/src/components/Layout/Layout.tsx
+++ b/apps/web/src/components/Layout/Layout.tsx
@@ -71,7 +71,7 @@ const Layout = () => {
         description: "Label displayed on the Search menu item.",
       })}
     </MenuLink>,
-    <MenuLink key="browseOpportunities" to={paths.allPools()}>
+    <MenuLink key="browseOpportunities" to={paths.browsePools()}>
       {intl.formatMessage({
         defaultMessage: "Browse opportunities",
         id: "SXvOXV",

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -151,8 +151,7 @@ const getRoutes = (lang: Locales) => {
     iap: () => path.join(baseUrl, "indigenous-it-apprentice"),
 
     // Pools
-    browse: () => path.join(baseUrl, "browse"),
-    allPools: () => path.join(baseUrl, "browse", "pools"),
+    browsePools: () => path.join(baseUrl, "browse", "pools"),
     pool: (poolId: string) => path.join(baseUrl, "browse", "pools", poolId),
     createApplication: (poolId: string) =>
       path.join(baseUrl, "browse", "pools", poolId, "create-application"),

--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -189,7 +189,7 @@ const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
 
   const crumbs = useBreadcrumbs([
     {
-      url: paths.browse(),
+      url: paths.browsePools(),
       label: intl.formatMessage({
         defaultMessage: "Browse IT Jobs",
         id: "l1fsXC",

--- a/apps/web/src/pages/Applications/MyApplicationsPage/components/ApplicationList/ApplicationList.tsx
+++ b/apps/web/src/pages/Applications/MyApplicationsPage/components/ApplicationList/ApplicationList.tsx
@@ -103,7 +103,10 @@ const ApplicationList = ({ applications }: ApplicationListProps) => {
                   })}
                 </p>
                 <p data-h2-font-weight="base(700)">
-                  <Link data-h2-color="base(primary)" href={paths.browse()}>
+                  <Link
+                    data-h2-color="base(primary)"
+                    href={paths.browsePools()}
+                  >
                     {intl.formatMessage({
                       defaultMessage:
                         "Check our available opportunities to start an application.",

--- a/apps/web/src/pages/Applications/SignAndSubmitPage/SignAndSubmitPage.tsx
+++ b/apps/web/src/pages/Applications/SignAndSubmitPage/SignAndSubmitPage.tsx
@@ -298,7 +298,7 @@ export const SignAndSubmitForm = ({
               id: "kjtiha",
               description: "Breadcrumb for sign and submit page.",
             }),
-            url: paths.allPools(),
+            url: paths.browsePools(),
           },
           {
             label: jobTitle,

--- a/apps/web/src/pages/Auth/LoggedOutPage/LoggedOutPage.tsx
+++ b/apps/web/src/pages/Auth/LoggedOutPage/LoggedOutPage.tsx
@@ -96,7 +96,7 @@ const LoggedOutPage = () => {
               </TileLink>
             </div>
             <div data-h2-flex-item="base(1of1) l-tablet(1of3)">
-              <TileLink href={paths.allPools()} color="primary">
+              <TileLink href={paths.browsePools()} color="primary">
                 {intl.formatMessage({
                   defaultMessage: "View open pools",
                   id: "FtlwFY",

--- a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
+++ b/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
@@ -85,7 +85,7 @@ const CreateApplication = () => {
 
   if (!hasRequiredData) {
     if (!poolId) {
-      redirectPath = paths.allPools();
+      redirectPath = paths.browsePools();
     }
     handleError();
   }

--- a/apps/web/src/pages/Home/HomePage/components/Hero/Hero.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/Hero/Hero.tsx
@@ -92,7 +92,7 @@ const Hero = ({ defaultImage }: HeroProps) => {
           <CallToActionLink
             color="quaternary"
             Icon={JobIcon}
-            href={paths.allPools()}
+            href={paths.browsePools()}
           >
             {intl.formatMessage({
               defaultMessage: "Looking for a job?",

--- a/apps/web/src/pages/Home/HomePage/components/Opportunities/Opportunities.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/Opportunities/Opportunities.tsx
@@ -94,7 +94,7 @@ const Opportunities = () => {
               })}
               links={[
                 {
-                  href: paths.allPools(),
+                  href: paths.browsePools(),
                   label: intl.formatMessage(
                     {
                       defaultMessage:

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
@@ -67,7 +67,7 @@ export const BrowsePools = ({ poolAdvertisements }: BrowsePoolsProps) => {
   const crumbs = useBreadcrumbs([
     {
       label: title,
-      url: paths.allPools(),
+      url: paths.browsePools(),
     },
   ]);
 

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -206,7 +206,7 @@ export const PoolAdvertisementPoster = ({
         id: "NSuNSA",
         description: "Breadcrumb title for the browse pools page.",
       }),
-      url: paths.allPools(),
+      url: paths.browsePools(),
     },
     {
       label: fullTitle,


### PR DESCRIPTION
🤖 Resolves #6227 

## 👋 Introduction

- Fixes dead browse opportunities link on the applicant dashboard page, found in the draft applications accordion empty state.
- Removes old `browse()` route and renames route `allPools()` to `browsePools()`.

## 🧪 Testing

1. Ensure the `browsePools()` route is working correctly.

## 📸 Screenshot

![image.png](https://images.zenhubusercontent.com/5d9df0b9aba55400015a68fe/2bbea1bd-adc9-4858-be93-7f35f864ba39)
