### PR TITLE
[Bug] Corrects spelling of the word résumé in English

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2665,7 +2665,7 @@
     "defaultMessage": "Ce volet comprend la programmation, la conception et le développement de systèmes, l’analyse des activités, la configuration, les tests et la mise en œuvre.",
     "description": "Title for the 'software solutions' IT work stream"
   },
-  "BWvfeG": {
+  "45mj+u": {
     "defaultMessage": "Nous proposons également des lots de recrutement passif qui nous permettent de trouver rapidement des talents lorsque la demande se fait sentir. Bien qu’il n’y ait aucune garantie qu’un emploi résultera des possibilités ci-dessous, c’est un moyen facile pour que votre nom et votre CV soient trouvés par les gestionnaires le moment venu. N’hésitez pas à soumettre votre nom pour tout poste qui correspond à vos compétences.",
     "description": "instructions for section with ongoing pool advertisements"
   },
@@ -5135,7 +5135,7 @@
     "defaultMessage": "Gestion de portefeuilles de projets de la <abbreviation>TI</abbreviation>",
     "description": "Title for the 'project portfolio management' IT work stream"
   },
-  "EqVMCE": {
+  "iKpxPY": {
     "defaultMessage": "Veuillez envoyer votre curriculum vitae et votre lettre de présentation expliquant votre passion pour la TI et pourquoi vous souhaitez vous joindre au programme, à : <mailLink>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</mailLink>. Un membre de l’équipe communiquera avec vous dans 3 à 5 jours ouvrables.",
     "description": "First paragraph for apply now dialog"
   },
@@ -5627,7 +5627,7 @@
     "defaultMessage": "Expérience personnelle",
     "description": "Title for personal experience section"
   },
-  "yI5DFC": {
+  "aFVp5f": {
     "defaultMessage": "Ajoutez une nouvelle expérience à votre CV",
     "description": "Heading for the Add Experience dialog"
   },
@@ -6614,11 +6614,11 @@
     "defaultMessage": "Toutes les sections sont remplies",
     "description": "Context message that all sections are complete"
   },
-  "9ePTF1": {
+  "naaQ+q": {
     "defaultMessage": "Mon cv et mon expérience",
     "description": "applicant dashboard card title for résumé card"
   },
-  "HvBs2+": {
+  "pqrVnW": {
     "defaultMessage": "Trouvez de nouvelles occasions, faites la mise à jour de votre cv ou effectuez le suivi de demandes.",
     "description": "Subtitle for applicant dashboard hero"
   },
@@ -7537,7 +7537,7 @@
     "defaultMessage": "Plus précisément, non seulement nous voulons connaître votre <strong>parcours professionnel</strong>, mais également votre <strong>expérience communautaire</strong>, vos <strong>récompenses</strong>, vos <strong>initiatives personnelles</strong> et votre <strong>éducation</strong>!",
     "description": "Application step to begin working on résumé, paragraph two"
   },
-  "iK/Vqe": {
+  "EWzkQb": {
     "defaultMessage": "Une fois que vous avez mis votre CV à jour et que vous êtes satisfait des expériences que vous avez ajoutées, vous les utiliserez dans d’autres étapes pour nous aider à mieux comprendre comment vous répondez aux exigences de compétences pour cette occasion.",
     "description": "Application step to begin working on résumé, paragraph three"
   },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -23,7 +23,7 @@
     "defaultMessage": "S’engager à apprendre tout au long du programme, tant au travail qu’en suivant un programme de formation en ligne",
     "description": "IAP Requirement list item five"
   },
-  "1M3LT6": {
+  "v9mTgX": {
     "defaultMessage": "Un processus de demande en ligne sera bientôt disponible afin de permettre aux gens d’exprimer leur intérêt. Entre-temps, nous vous encourageons à envoyer votre curriculum vitae et votre lettre de présentation par courriel, à edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca.",
     "description": "Learn more dialog question eleven paragraph one"
   },

--- a/apps/web/src/pages/Applications/ApplicantDashboardPage/components/DashboardHeading.tsx
+++ b/apps/web/src/pages/Applications/ApplicantDashboardPage/components/DashboardHeading.tsx
@@ -69,8 +69,8 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
       )}
       subtitle={intl.formatMessage({
         defaultMessage:
-          "Find new opportunities, update your resume experience, or track applications.",
-        id: "HvBs2+",
+          "Find new opportunities, update your résumé experience, or track applications.",
+        id: "pqrVnW",
         description: "Subtitle for applicant dashboard hero",
       })}
     >
@@ -183,9 +183,9 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
         <HeroCard
           color="tertiary"
           title={intl.formatMessage({
-            defaultMessage: "My resume and experience",
-            id: "9ePTF1",
-            description: "applicant dashboard card title for resume card",
+            defaultMessage: "My résumé and experience",
+            id: "naaQ+q",
+            description: "applicant dashboard card title for résumé card",
           })}
           href={paths.skillsAndExperiences(user.id)}
         >

--- a/apps/web/src/pages/Applications/ApplicationResumeIntroductionPage/ApplicationResumeIntroductionPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumeIntroductionPage/ApplicationResumeIntroductionPage.tsx
@@ -82,8 +82,8 @@ const ApplicationResumeIntroduction = ({
       <p data-h2-margin="base(x1, 0)">
         {intl.formatMessage({
           defaultMessage:
-            "Once you’ve completed your resume and are happy with the experiences you’ve added, you’ll use them in further steps to help us better understand how you meet the skill requirements for this opportunity.",
-          id: "iK/Vqe",
+            "Once you’ve completed your résumé and are happy with the experiences you’ve added, you’ll use them in further steps to help us better understand how you meet the skill requirements for this opportunity.",
+          id: "EWzkQb",
           description:
             "Application step to begin working on résumé, paragraph three",
         })}

--- a/apps/web/src/pages/Home/IAPHomePage/components/Dialog/ApplyDialog.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Dialog/ApplyDialog.tsx
@@ -42,8 +42,8 @@ const ApplyDialog = ({ btnProps }: BasicDialogProps) => {
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "Please send your resume and cover letter explaining your passion for IT and why you're interested in joining the program to: <mailLink>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</mailLink>. A team member will contact you in 3-5 business days",
-                id: "EqVMCE",
+                  "Please send your résumé and cover letter explaining your passion for IT and why you're interested in joining the program to: <mailLink>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</mailLink>. A team member will contact you in 3-5 business days",
+                id: "iKpxPY",
                 description: "First paragraph for apply now dialog",
               },
               {

--- a/apps/web/src/pages/Home/IAPHomePage/components/Dialog/LearnDialog.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Dialog/LearnDialog.tsx
@@ -249,8 +249,8 @@ const LearnDialog = ({ btnProps }: BasicDialogProps) => {
           <p data-h2-margin="base(x1, 0)">
             {intl.formatMessage({
               defaultMessage:
-                "Soon, an online application process will be available for people to express their interest. In the meantime, we encourage you to send your resumé and cover letter to: edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca",
-              id: "1M3LT6",
+                "Soon, an online application process will be available for people to express their interest. In the meantime, we encourage you to send your résumé and cover letter to: edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca",
+              id: "v9mTgX",
               description: "Learn more dialog question eleven paragraph one",
             })}
           </p>

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
@@ -957,9 +957,9 @@ const OngoingRecruitmentSection = ({
       </p>
       <p>
         {intl.formatMessage({
-          id: "BWvfeG",
+          id: "45mj+u",
           defaultMessage:
-            "We also offer passive recruitment buckets that allow us to find talent fast when the demand arises. While there’s no guarantee a job will result from the opportunities below, it’s an easy way for your name and resume to be found by managers when the time comes. Feel free to submit your name to any bucket that matches your skills.",
+            "We also offer passive recruitment buckets that allow us to find talent fast when the demand arises. While there’s no guarantee a job will result from the opportunities below, it’s an easy way for your name and résumé to be found by managers when the time comes. Feel free to submit your name to any bucket that matches your skills.",
           description:
             "instructions for section with ongoing pool advertisements",
         })}

--- a/apps/web/src/pages/Profile/ExperienceAndSkillsPage/components/AddExperienceDialog.tsx
+++ b/apps/web/src/pages/Profile/ExperienceAndSkillsPage/components/AddExperienceDialog.tsx
@@ -170,8 +170,8 @@ const AddExperienceDialog = ({
           })}
         >
           {intl.formatMessage({
-            defaultMessage: "Add a new experience to your resume",
-            id: "yI5DFC",
+            defaultMessage: "Add a new experience to your résumé",
+            id: "aFVp5f",
             description: "Heading for the Add Experience dialog",
           })}
         </Dialog.Header>


### PR DESCRIPTION
🤖 Resolves #6288.

## 👋 Introduction

This PR corrects spelling of the word résumé in English, excluding the tc-report.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Search for instances of the string **résume**, **resumé**, or **resume** in the codebase
2. Ensure no instances found of **résume** or **resumé**
3. Ensure any existing instances of **resume** do not refer to the word that also means curriculum vitae
