### PR TITLE
[Bug] Adds dashboard experiences count

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6591,7 +6591,7 @@
     "description": "Question posed to user before committing a destructive act"
   },
   "aRTIWM": {
-    "defaultMessage": "{itemCount, plural, =0 {0 items} =1 {1 item} other {# items} } ajouté",
+    "defaultMessage": "{itemCount, plural, =0 {0 articles ajoutés} =1 {1 article ajouté} other {# articles ajoutés} }",
     "description": "context message to describe number of experience items added"
   },
   "JMe3n2": {

--- a/apps/web/src/pages/Applications/ApplicantDashboardPage/components/DashboardHeading.tsx
+++ b/apps/web/src/pages/Applications/ApplicantDashboardPage/components/DashboardHeading.tsx
@@ -26,7 +26,17 @@ import {
   workPreferencesSectionHasEmptyRequiredFields,
   workPreferencesSectionHasEmptyOptionalFields,
 } from "~/validators/profile";
+import {
+  compareByDate,
+  isAwardExperience,
+  isCommunityExperience,
+  isEducationExperience,
+  isPersonalExperience,
+  isWorkExperience,
+} from "~/utils/experienceUtils";
 
+import { AwardExperience } from "~/api/generated";
+import { notEmpty } from "@gc-digital-talent/helpers";
 import {
   HeroCardExperienceItem,
   HeroCardProfileItem,
@@ -52,6 +62,31 @@ export interface DashboardHeadingProps {
 const DashboardHeading = ({ user }: DashboardHeadingProps) => {
   const intl = useIntl();
   const paths = useRoutes();
+
+  const notEmptyExperiences = user.experiences?.filter(notEmpty);
+
+  const awardExperiences =
+    notEmptyExperiences
+      ?.filter(isAwardExperience)
+      .map(
+        (award: AwardExperience) =>
+          ({
+            ...award,
+            startDate: award.awardedDate,
+            endDate: award.awardedDate,
+          } as AwardExperience & { startDate: string; endDate: string }),
+      )
+      .sort(compareByDate) || [];
+  const communityExperiences =
+    notEmptyExperiences?.filter(isCommunityExperience).sort(compareByDate) ||
+    [];
+  const educationExperiences =
+    notEmptyExperiences?.filter(isEducationExperience).sort(compareByDate) ||
+    [];
+  const personalExperiences =
+    notEmptyExperiences?.filter(isPersonalExperience).sort(compareByDate) || [];
+  const workExperiences =
+    notEmptyExperiences?.filter(isWorkExperience).sort(compareByDate) || [];
 
   return (
     <Hero
@@ -195,7 +230,7 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
               id: "giUfys",
               description: "Title for work experience section",
             })}
-            itemCount={user.workExperiences?.length}
+            itemCount={workExperiences?.length}
             icon={BriefcaseIcon}
             color="primary"
           />
@@ -205,7 +240,7 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
               id: "u6LIbY",
               description: "Title for education experience section",
             })}
-            itemCount={user.educationExperiences?.length}
+            itemCount={educationExperiences?.length}
             icon={BookOpenIcon}
             color="secondary"
           />
@@ -215,7 +250,7 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
               id: "Rz7WtH",
               description: "Title for community experience section",
             })}
-            itemCount={user.communityExperiences?.length}
+            itemCount={communityExperiences?.length}
             icon={UsersIcon}
             color="tertiary"
           />
@@ -225,7 +260,7 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
               id: "wTFUPE",
               description: "Title for personal experience section",
             })}
-            itemCount={user.personalExperiences?.length}
+            itemCount={personalExperiences?.length}
             icon={LightBulbIcon}
             color="quaternary"
           />
@@ -235,7 +270,7 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
               id: "+ikQY0",
               description: "Title for award section",
             })}
-            itemCount={user.awardExperiences?.length}
+            itemCount={awardExperiences?.length}
             icon={StarIcon}
             color="quinary"
           />

--- a/apps/web/src/pages/Applications/ApplicantDashboardPage/components/DashboardHeading.tsx
+++ b/apps/web/src/pages/Applications/ApplicantDashboardPage/components/DashboardHeading.tsx
@@ -27,7 +27,6 @@ import {
   workPreferencesSectionHasEmptyOptionalFields,
 } from "~/validators/profile";
 import {
-  compareByDate,
   isAwardExperience,
   isCommunityExperience,
   isEducationExperience,

--- a/apps/web/src/pages/Applications/ApplicantDashboardPage/components/DashboardHeading.tsx
+++ b/apps/web/src/pages/Applications/ApplicantDashboardPage/components/DashboardHeading.tsx
@@ -66,27 +66,21 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
   const notEmptyExperiences = user.experiences?.filter(notEmpty);
 
   const awardExperiences =
-    notEmptyExperiences
-      ?.filter(isAwardExperience)
-      .map(
-        (award: AwardExperience) =>
-          ({
-            ...award,
-            startDate: award.awardedDate,
-            endDate: award.awardedDate,
-          } as AwardExperience & { startDate: string; endDate: string }),
-      )
-      .sort(compareByDate) || [];
+    notEmptyExperiences?.filter(isAwardExperience).map(
+      (award: AwardExperience) =>
+        ({
+          ...award,
+          startDate: award.awardedDate,
+          endDate: award.awardedDate,
+        } as AwardExperience & { startDate: string; endDate: string }),
+    ) || [];
   const communityExperiences =
-    notEmptyExperiences?.filter(isCommunityExperience).sort(compareByDate) ||
-    [];
+    notEmptyExperiences?.filter(isCommunityExperience) || [];
   const educationExperiences =
-    notEmptyExperiences?.filter(isEducationExperience).sort(compareByDate) ||
-    [];
+    notEmptyExperiences?.filter(isEducationExperience) || [];
   const personalExperiences =
-    notEmptyExperiences?.filter(isPersonalExperience).sort(compareByDate) || [];
-  const workExperiences =
-    notEmptyExperiences?.filter(isWorkExperience).sort(compareByDate) || [];
+    notEmptyExperiences?.filter(isPersonalExperience) || [];
+  const workExperiences = notEmptyExperiences?.filter(isWorkExperience) || [];
 
   return (
     <Hero


### PR DESCRIPTION
🤖 Resolves #6258.

## 👋 Introduction

This PR adds dashboard experiences count that had not been hooked up.

## 🦴 Bonus

[Fixes French context message to describe number of experience items added](https://github.com/GCTC-NTGC/gc-digital-talent/commit/8a8b37e95c93463aeac3e54f366b620f3fb1a798). This string likely got confused when translating as the translator likely did not know what to translate.

### Screenshot
![Screen Shot 2023-04-24 at 09 51 33](https://user-images.githubusercontent.com/3046459/234038636-f7d2d53d-1d05-4e15-824c-fc84a54a331d.png)

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to **My dashboard** page `/applicant/dashboard`
2. Ensure experiences have counts
3. Switch to French
4. Ensure experiences have counts in French (_article_ not _item_)

## 📸 Screenshots

![Screen Shot 2023-04-24 at 11 09 53](https://user-images.githubusercontent.com/3046459/234038873-9413d725-6dbe-4929-a471-ae16393eb56c.png)

![Screen Shot 2023-04-24 at 11 12 51](https://user-images.githubusercontent.com/3046459/234039659-e1fab518-3efc-4b56-ad87-5b784852c2cf.png)

