### PR TITLE
[Feature] Application entry redirect

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -7,7 +7,6 @@ import {
   Stepper,
   Pending,
   ThrowNotFound,
-  StepType,
 } from "@gc-digital-talent/ui";
 
 import SEO from "~/components/SEO/SEO";
@@ -17,149 +16,30 @@ import useRoutes from "~/hooks/useRoutes";
 import useCurrentPage from "~/hooks/useCurrentPage";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
-import { ApplicationPageInfo } from "~/types/poolCandidate";
 import {
   getFullPoolAdvertisementTitleHtml,
   getFullPoolAdvertisementTitleLabel,
 } from "~/utils/poolUtils";
+import { useGetApplicationQuery } from "~/api/generated";
 import {
-  Applicant,
-  ApplicationStep,
-  Maybe,
-  PoolAdvertisement,
-  useGetApplicationQuery,
-} from "~/api/generated";
+  checkForDisabledPage,
+  deriveSteps,
+  getApplicationPages,
+} from "~/utils/applicationUtils";
 
 import { ApplicationPageProps } from "./ApplicationApi";
-import { getPageInfo as welcomePageInfo } from "./ApplicationWelcomePage/ApplicationWelcomePage";
-import { getPageInfo as profilePageInfo } from "./ApplicationProfilePage/ApplicationProfilePage";
-import { getPageInfo as resumeIntroductionPageInfo } from "./ApplicationResumeIntroductionPage/ApplicationResumeIntroductionPage";
-import { getPageInfo as resumeAddPageInfo } from "./ApplicationResumeAddPage/ApplicationResumeAddPage";
-import { getPageInfo as resumeEditPageInfo } from "./ApplicationResumeEditPage/ApplicationResumeEditPage";
-import { getPageInfo as resumePageInfo } from "./ApplicationResumePage/ApplicationResumePage";
-import { getPageInfo as educationPageInfo } from "./ApplicationEducationPage/ApplicationEducationPage";
-import { getPageInfo as skillsIntroductionPageInfo } from "./ApplicationSkillsIntroductionPage/ApplicationSkillsIntroductionPage";
-import { getPageInfo as skillsPageInfo } from "./ApplicationSkillsPage/ApplicationSkillsPage";
-import { getPageInfo as questionsIntroductionPageInfo } from "./ApplicationQuestionsIntroductionPage/ApplicationQuestionsIntroductionPage";
-import { getPageInfo as questionsPageInfo } from "./ApplicationQuestionsPage/ApplicationQuestionsPage";
-import { getPageInfo as reviewPageInfo } from "./ApplicationReviewPage/ApplicationReviewPage";
-import { getPageInfo as successPageInfo } from "./ApplicationSuccessPage/ApplicationSuccessPage";
 import { StepDisabledPage } from "./StepDisabledPage/StepDisabledPage";
-
-type PageNavKey =
-  | "welcome"
-  | "profile"
-  | "resume-intro"
-  | "resume-add"
-  | "resume-edit"
-  | "resume"
-  | "education"
-  | "skills-intro"
-  | "skills"
-  | "questions-intro"
-  | "questions"
-  | "review"
-  | "success";
-
-const missingPrerequisites = (
-  prerequisiteSteps: Maybe<Array<ApplicationStep>>,
-  submittedSteps: Maybe<Array<ApplicationStep>>,
-): Maybe<Array<ApplicationStep>> => {
-  return prerequisiteSteps?.filter(
-    (currentPagePrerequisite) =>
-      !submittedSteps?.includes(currentPagePrerequisite),
-  );
-};
-
-const deriveSteps = (
-  pages: Map<PageNavKey, ApplicationPageInfo>,
-  submittedSteps: Maybe<Array<ApplicationStep>>,
-  applicant: Applicant,
-  poolAdvertisement: Maybe<PoolAdvertisement>,
-): Maybe<Array<StepType>> => {
-  const steps = Array.from(pages.values())
-    .filter((page) => !page.omitFromStepper) // Hide some pages from stepper
-    .map((page) => ({
-      label: page.link.label || page.title,
-      href: page.link.url,
-      icon: page.icon,
-      completed:
-        page.stepSubmitted && submittedSteps?.includes(page.stepSubmitted),
-      disabled: !!missingPrerequisites(page.prerequisites, submittedSteps)
-        ?.length,
-      error: poolAdvertisement
-        ? page?.hasError?.(applicant, poolAdvertisement)
-        : false,
-    }));
-
-  steps.pop(); // We do not want to show final step in the stepper
-
-  return steps;
-};
-
-// check if the current page should be disabled and figure out where to return the user to
-function checkForDisabledPage(
-  currentPageUrl: string | undefined,
-  pages: Map<PageNavKey, ApplicationPageInfo>,
-  submittedSteps: Maybe<ApplicationStep[]>,
-): { isOnDisabledPage: boolean; urlToReturnTo?: string } {
-  // copied from useCurrentPage, but I need the full ApplicationPageInfo
-  const pagesArray = Array.from(pages.values());
-  const currentPageInfo = pagesArray.find(
-    (page) => page.link.url === currentPageUrl,
-  );
-  const pageMissingPrerequisites = missingPrerequisites(
-    currentPageInfo?.prerequisites,
-    submittedSteps,
-  );
-
-  if (pageMissingPrerequisites && pageMissingPrerequisites.length > 0) {
-    // go back to the first missing page
-    const firstMissingPrerequisite = pageMissingPrerequisites[0];
-    const pageForFirstMissingPrerequisite = pagesArray.find((p) => {
-      return p.stepSubmitted === firstMissingPrerequisite;
-    });
-    return {
-      isOnDisabledPage: true,
-      urlToReturnTo: pageForFirstMissingPrerequisite?.link.url,
-    };
-  }
-
-  // yay, nothing missing!
-  return { isOnDisabledPage: false };
-}
 
 const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
   const intl = useIntl();
   const paths = useRoutes();
   const { experienceId } = useParams();
-
-  const pages = new Map<PageNavKey, ApplicationPageInfo>([
-    ["welcome", welcomePageInfo({ paths, intl, application })],
-    ["profile", profilePageInfo({ paths, intl, application })],
-    ["resume", resumePageInfo({ paths, intl, application })],
-    ["resume-intro", resumeIntroductionPageInfo({ paths, intl, application })],
-    ["resume-add", resumeAddPageInfo({ paths, intl, application })],
-    [
-      "resume-edit",
-      resumeEditPageInfo({
-        paths,
-        intl,
-        application,
-        resourceId: experienceId,
-      }),
-    ],
-    ["education", educationPageInfo({ paths, intl, application })],
-    ["skills", skillsPageInfo({ paths, intl, application })],
-    ["skills-intro", skillsIntroductionPageInfo({ paths, intl, application })],
-    ["questions", questionsPageInfo({ paths, intl, application })],
-    [
-      "questions-intro",
-      questionsIntroductionPageInfo({ paths, intl, application }),
-    ],
-    ["review", reviewPageInfo({ paths, intl, application })],
-    ["success", successPageInfo({ paths, intl, application })],
-  ]);
+  const pages = getApplicationPages({
+    intl,
+    paths,
+    application,
+    experienceId,
+  });
 
   const poolNameHtml = getFullPoolAdvertisementTitleHtml(
     intl,

--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl, defineMessage } from "react-intl";
-import { Outlet, useParams } from "react-router-dom";
+import { Outlet, useParams, useNavigate } from "react-router-dom";
 
 import {
   TableOfContents,
@@ -8,6 +8,7 @@ import {
   Pending,
   ThrowNotFound,
 } from "@gc-digital-talent/ui";
+import { empty } from "@gc-digital-talent/helpers";
 
 import SEO from "~/components/SEO/SEO";
 import Hero from "~/components/Hero/Hero";
@@ -25,6 +26,7 @@ import {
   checkForDisabledPage,
   deriveSteps,
   getApplicationPages,
+  getNextNonSubmittedStep,
 } from "~/utils/applicationUtils";
 
 import { ApplicationPageProps } from "./ApplicationApi";
@@ -33,6 +35,7 @@ import { StepDisabledPage } from "./StepDisabledPage/StepDisabledPage";
 const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
   const intl = useIntl();
   const paths = useRoutes();
+  const navigate = useNavigate();
   const { experienceId } = useParams();
   const pages = getApplicationPages({
     intl,
@@ -93,6 +96,21 @@ const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
     pages,
     application.submittedSteps,
   );
+
+  const nextStepUrl = getNextNonSubmittedStep(
+    pages,
+    application.submittedSteps,
+  );
+
+  // If we cannot find the current page, redirect to the first step
+  // that has not been submitted yet, or the last step
+  React.useEffect(() => {
+    if (empty(currentPage)) {
+      navigate(nextStepUrl, {
+        replace: true,
+      });
+    }
+  }, [currentPage, navigate, nextStepUrl]);
 
   return (
     <>

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
@@ -53,6 +53,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       ApplicationStep.EducationRequirements,
       ApplicationStep.SkillRequirements,
     ],
+    introUrl: paths.applicationQuestionsIntro(application.id),
     stepSubmitted: ApplicationStep.ScreeningQuestions,
     hasError: (applicant: Applicant, poolAdvertisement: PoolAdvertisement) => {
       return screeningQuestionsSectionHasMissingResponses(

--- a/apps/web/src/pages/Applications/ApplicationResumePage/ApplicationResumePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumePage/ApplicationResumePage.tsx
@@ -42,6 +42,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       url: path,
     },
     prerequisites: [ApplicationStep.Welcome, ApplicationStep.ReviewYourProfile],
+    introUrl: paths.applicationResumeIntro(application.id),
     stepSubmitted: ApplicationStep.ReviewYourResume,
     hasError: (applicant: Applicant) => {
       const isIncomplete = resumeIsIncomplete(applicant);

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -52,6 +52,7 @@ export const getPageInfo: GetApplicationPageInfo = ({
       ApplicationStep.ReviewYourResume,
       ApplicationStep.EducationRequirements,
     ],
+    introUrl: paths.applicationSkillsIntro(application.id),
     stepSubmitted: ApplicationStep.SkillRequirements,
     hasError: (applicant: Applicant, poolAdvertisement: PoolAdvertisement) => {
       return skillRequirementsIsIncomplete(applicant, poolAdvertisement);

--- a/apps/web/src/types/poolCandidate.ts
+++ b/apps/web/src/types/poolCandidate.ts
@@ -21,6 +21,8 @@ export type ApplicationPageInfo = PageNavInfo & {
   omitFromStepper?: boolean;
   // Which application steps should be submitted before you can use this page?
   prerequisites: Array<ApplicationStep>;
+  // Introduction page URL, if it exists
+  introUrl?: string;
   // Which application step does this page submit?
   stepSubmitted: ApplicationStep | null;
   // Is the applicant valid as far as this page is concerned?

--- a/apps/web/src/types/poolCandidate.ts
+++ b/apps/web/src/types/poolCandidate.ts
@@ -32,3 +32,18 @@ export type ApplicationPageInfo = PageNavInfo & {
 export type GetApplicationPageInfo = (
   args: GetApplicationPageInfoArgs,
 ) => ApplicationPageInfo;
+
+export type ApplicationPageNavKey =
+  | "welcome"
+  | "profile"
+  | "resume-intro"
+  | "resume-add"
+  | "resume-edit"
+  | "resume"
+  | "education"
+  | "skills-intro"
+  | "skills"
+  | "questions-intro"
+  | "questions"
+  | "review"
+  | "success";

--- a/apps/web/src/utils/applicationUtils.ts
+++ b/apps/web/src/utils/applicationUtils.ts
@@ -1,5 +1,7 @@
 import { IntlShape } from "react-intl";
 
+import { StepType } from "@gc-digital-talent/ui";
+
 import useRoutes from "~/hooks/useRoutes";
 import {
   Applicant,
@@ -26,7 +28,6 @@ import { getPageInfo as questionsIntroductionPageInfo } from "~/pages/Applicatio
 import { getPageInfo as questionsPageInfo } from "~/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage";
 import { getPageInfo as reviewPageInfo } from "~/pages/Applications/ApplicationReviewPage/ApplicationReviewPage";
 import { getPageInfo as successPageInfo } from "~/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage";
-import { StepType } from "@gc-digital-talent/ui";
 
 type GetApplicationPagesArgs = {
   paths: ReturnType<typeof useRoutes>;

--- a/apps/web/src/utils/applicationUtils.ts
+++ b/apps/web/src/utils/applicationUtils.ts
@@ -125,7 +125,7 @@ export function getNextNonSubmittedStep(
     nextStep = nonSubmittedStep || pagesArray[pagesArray.length - 1];
   }
 
-  return nextStep.link.url;
+  return nextStep.introUrl || nextStep.link.url;
 }
 
 // check if the current page should be disabled and figure out where to return the user to

--- a/apps/web/src/utils/applicationUtils.ts
+++ b/apps/web/src/utils/applicationUtils.ts
@@ -1,0 +1,143 @@
+import { IntlShape } from "react-intl";
+
+import useRoutes from "~/hooks/useRoutes";
+import {
+  Applicant,
+  ApplicationStep,
+  Maybe,
+  PoolAdvertisement,
+  PoolCandidate,
+} from "~/api/generated";
+import {
+  ApplicationPageInfo,
+  ApplicationPageNavKey,
+} from "~/types/poolCandidate";
+
+import { getPageInfo as welcomePageInfo } from "~/pages/Applications/ApplicationWelcomePage/ApplicationWelcomePage";
+import { getPageInfo as profilePageInfo } from "~/pages/Applications/ApplicationProfilePage/ApplicationProfilePage";
+import { getPageInfo as resumeIntroductionPageInfo } from "~/pages/Applications/ApplicationResumeIntroductionPage/ApplicationResumeIntroductionPage";
+import { getPageInfo as resumeAddPageInfo } from "~/pages/Applications/ApplicationResumeAddPage/ApplicationResumeAddPage";
+import { getPageInfo as resumeEditPageInfo } from "~/pages/Applications/ApplicationResumeEditPage/ApplicationResumeEditPage";
+import { getPageInfo as resumePageInfo } from "~/pages/Applications/ApplicationResumePage/ApplicationResumePage";
+import { getPageInfo as educationPageInfo } from "~/pages/Applications/ApplicationEducationPage/ApplicationEducationPage";
+import { getPageInfo as skillsIntroductionPageInfo } from "~/pages/Applications/ApplicationSkillsIntroductionPage/ApplicationSkillsIntroductionPage";
+import { getPageInfo as skillsPageInfo } from "~/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage";
+import { getPageInfo as questionsIntroductionPageInfo } from "~/pages/Applications/ApplicationQuestionsIntroductionPage/ApplicationQuestionsIntroductionPage";
+import { getPageInfo as questionsPageInfo } from "~/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage";
+import { getPageInfo as reviewPageInfo } from "~/pages/Applications/ApplicationReviewPage/ApplicationReviewPage";
+import { getPageInfo as successPageInfo } from "~/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage";
+import { StepType } from "@gc-digital-talent/ui";
+
+type GetApplicationPagesArgs = {
+  paths: ReturnType<typeof useRoutes>;
+  intl: IntlShape;
+  application: Omit<PoolCandidate, "pool">;
+  experienceId?: string;
+};
+
+// NOTE: Expected to grow
+// eslint-disable-next-line import/prefer-default-export
+export const getApplicationPages = ({
+  paths,
+  intl,
+  application,
+  experienceId,
+}: GetApplicationPagesArgs): Map<
+  ApplicationPageNavKey,
+  ApplicationPageInfo
+> => {
+  return new Map<ApplicationPageNavKey, ApplicationPageInfo>([
+    ["welcome", welcomePageInfo({ paths, intl, application })],
+    ["profile", profilePageInfo({ paths, intl, application })],
+    ["resume", resumePageInfo({ paths, intl, application })],
+    ["resume-intro", resumeIntroductionPageInfo({ paths, intl, application })],
+    ["resume-add", resumeAddPageInfo({ paths, intl, application })],
+    [
+      "resume-edit",
+      resumeEditPageInfo({
+        paths,
+        intl,
+        application,
+        resourceId: experienceId,
+      }),
+    ],
+    ["education", educationPageInfo({ paths, intl, application })],
+    ["skills", skillsPageInfo({ paths, intl, application })],
+    ["skills-intro", skillsIntroductionPageInfo({ paths, intl, application })],
+    ["questions", questionsPageInfo({ paths, intl, application })],
+    [
+      "questions-intro",
+      questionsIntroductionPageInfo({ paths, intl, application }),
+    ],
+    ["review", reviewPageInfo({ paths, intl, application })],
+    ["success", successPageInfo({ paths, intl, application })],
+  ]);
+};
+
+const missingPrerequisites = (
+  prerequisiteSteps: Maybe<Array<ApplicationStep>>,
+  submittedSteps: Maybe<Array<ApplicationStep>>,
+): Maybe<Array<ApplicationStep>> => {
+  return prerequisiteSteps?.filter(
+    (currentPagePrerequisite) =>
+      !submittedSteps?.includes(currentPagePrerequisite),
+  );
+};
+
+export const deriveSteps = (
+  pages: Map<ApplicationPageNavKey, ApplicationPageInfo>,
+  submittedSteps: Maybe<Array<ApplicationStep>>,
+  applicant: Applicant,
+  poolAdvertisement: Maybe<PoolAdvertisement>,
+): Maybe<Array<StepType>> => {
+  const steps = Array.from(pages.values())
+    .filter((page) => !page.omitFromStepper) // Hide some pages from stepper
+    .map((page) => ({
+      label: page.link.label || page.title,
+      href: page.link.url,
+      icon: page.icon,
+      completed:
+        page.stepSubmitted && submittedSteps?.includes(page.stepSubmitted),
+      disabled: !!missingPrerequisites(page.prerequisites, submittedSteps)
+        ?.length,
+      error: poolAdvertisement
+        ? page?.hasError?.(applicant, poolAdvertisement)
+        : false,
+    }));
+
+  steps.pop(); // We do not want to show final step in the stepper
+
+  return steps;
+};
+
+// check if the current page should be disabled and figure out where to return the user to
+export function checkForDisabledPage(
+  currentPageUrl: string | undefined,
+  pages: Map<ApplicationPageNavKey, ApplicationPageInfo>,
+  submittedSteps: Maybe<ApplicationStep[]>,
+): { isOnDisabledPage: boolean; urlToReturnTo?: string } {
+  // copied from useCurrentPage, but I need the full ApplicationPageInfo
+  const pagesArray = Array.from(pages.values());
+  const currentPageInfo = pagesArray.find(
+    (page) => page.link.url === currentPageUrl,
+  );
+  const pageMissingPrerequisites = missingPrerequisites(
+    currentPageInfo?.prerequisites,
+    submittedSteps,
+  );
+
+  if (pageMissingPrerequisites && pageMissingPrerequisites.length > 0) {
+    // go back to the first missing page
+    const firstMissingPrerequisite = pageMissingPrerequisites[0];
+    const pageForFirstMissingPrerequisite = pagesArray.find((p) => {
+      return p.stepSubmitted === firstMissingPrerequisite;
+    });
+    return {
+      isOnDisabledPage: true,
+      urlToReturnTo: pageForFirstMissingPrerequisite?.link.url,
+    };
+  }
+
+  // yay, nothing missing!
+  return { isOnDisabledPage: false };
+}

--- a/apps/web/src/utils/applicationUtils.ts
+++ b/apps/web/src/utils/applicationUtils.ts
@@ -110,6 +110,24 @@ export const deriveSteps = (
   return steps;
 };
 
+export function getNextNonSubmittedStep(
+  pages: Map<ApplicationPageNavKey, ApplicationPageInfo>,
+  submittedSteps: Maybe<ApplicationStep[]>,
+): string {
+  const pagesArray = Array.from(pages.values());
+  let nextStep = pagesArray[0];
+
+  if (submittedSteps && submittedSteps.length > 0) {
+    const nonSubmittedStep = pagesArray.find((p) => {
+      return p.stepSubmitted && !submittedSteps?.includes(p.stepSubmitted);
+    });
+
+    nextStep = nonSubmittedStep || pagesArray[pagesArray.length - 1];
+  }
+
+  return nextStep.link.url;
+}
+
 // check if the current page should be disabled and figure out where to return the user to
 export function checkForDisabledPage(
   currentPageUrl: string | undefined,


### PR DESCRIPTION
🤖 Resolves #6320 

## 👋 Introduction

Adds a redirect if you land on a page in the application process when navigating to it with the base path (`/applications/{applicationId}`)

## 🕵️ Details

This is sort of janky and I believe it would be smoother in a [loader](https://reactrouter.com/en/main/route/loader) but we have yet to start implementing the refactor required for that. 😢 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build the app `npm run build:fresh`
2. Start and application
3. Navigate to `/applications/{applicationId}`
4. Confirm you are are redirected to the welcome page
5. Manually update the `submittedSteps`
6. Confirm entering `/applications/{applicationId}` into the address bar redirects to either:
    1. The first page for the step that has not been submitted yet or,
    2. The introduction page for the first step that has not been submitted yet
