### PR TITLE
[Bug] Fixes incorrect icon

### DIFF
--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -4,11 +4,12 @@ import { useParams } from "react-router-dom";
 import {
   BoltIcon,
   BriefcaseIcon as BriefcaseIconOutline,
-  PhoneIcon,
-  LightBulbIcon,
+  ClipboardDocumentCheckIcon,
   CheckCircleIcon,
-  CpuChipIcon,
   CloudIcon,
+  CpuChipIcon,
+  LightBulbIcon,
+  PhoneIcon,
 } from "@heroicons/react/24/outline";
 
 import {
@@ -780,7 +781,7 @@ export const PoolAdvertisementPoster = ({
                   },
                 )}
               </Text>
-              <IconTitle icon={PhoneIcon}>
+              <IconTitle icon={ClipboardDocumentCheckIcon}>
                 {intl.formatMessage({
                   defaultMessage: "Hiring Policies",
                   id: "isfAkZ",


### PR DESCRIPTION
🤖 Resolves #6085.

## 👋 Introduction

This PR fixes an incorrect icon.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to browse pool `/browse/pools/:poolId/#details-section`
2. Observe icon beside **Hiring policies** heading

## 📸 Screenshot

![Screen Shot 2023-04-25 at 12 21 57](https://user-images.githubusercontent.com/3046459/234351634-4e47f37c-2056-40d5-aacc-786d7907249c.png)

