### PR TITLE
[Bug] Fix draft pool advertisement visibility

### DIFF
--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -14,7 +14,8 @@ import {
 } from "~/api/generated";
 
 import { RoleAssignment } from "@gc-digital-talent/graphql";
-import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { ROLE_NAME, RoleName } from "@gc-digital-talent/auth";
+import { notEmpty } from "@gc-digital-talent/helpers";
 import { wrapAbbr } from "./nameUtils";
 
 /**
@@ -50,15 +51,21 @@ export const isAdvertisementVisible = (
   roleAssignments: Maybe<RoleAssignment>[],
   status?: Maybe<AdvertisementStatus>,
 ) => {
-  let visible =
-    roleAssignments
-      .map((a) => a?.role?.name)
-      .includes(ROLE_NAME.PlatformAdmin) ?? false;
   if (status !== AdvertisementStatus.Draft) {
-    visible = true;
+    return true;
   }
-
-  return visible;
+  const allowedRoles: RoleName[] = [
+    ROLE_NAME.PlatformAdmin,
+    ROLE_NAME.PoolOperator,
+  ];
+  return (
+    roleAssignments.filter(notEmpty).some((assignment) => {
+      return (
+        assignment.role?.name &&
+        allowedRoles.includes(assignment.role.name as RoleName)
+      );
+    }) ?? false
+  );
 };
 
 /**


### PR DESCRIPTION
🤖 Resolves #6360
 
## 👋 Introduction

Updates the pool advertisement to allow pool operators to preview draft advertisements.

## 🕵️ Details

This also bumps the draft check to exit early if the advertisement is not a draft avoiding the permissions check entirely since all roles can view non-draft pools.

> **Note**
> This does not care if the pool is part of your team as a pool operator since we do that [check on the backend](https://github.com/GCTC-NTGC/gc-digital-talent/blob/a3068e473c155e21fc5eb4516653f890c6d25ca9/api/app/Policies/PoolPolicy.php#L44) and it should error out anyway.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Login as `pool@test.com`
2. Create a draft pool
3. Navigate to `/browse/pools/{poolId}`
4. Confirm you can see the draft pool
5. Attempt to view a draft pool from a different team
6. Confirm the page errors
7. Login as `applicant@test.com`
8. Reload the pool advertisement
9. Confirm the page errors
