### PR TITLE
[A11y] Update education card colour

### DIFF
--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -587,7 +587,7 @@ export const PoolAdvertisementPoster = ({
                 data-h2-align-items="base(center) p-tablet(stretch)"
               >
                 <Card
-                  color="ts-secondary"
+                  color="secondary"
                   style={{ width: "100%" }}
                   title={intl.formatMessage({
                     defaultMessage: "Combination Experience",
@@ -655,7 +655,7 @@ export const PoolAdvertisementPoster = ({
                 </div>
                 <Card
                   style={{ width: "100%" }}
-                  color="ts-secondary"
+                  color="secondary"
                   title={intl.formatMessage({
                     defaultMessage: "2-Year Post-secondary Education",
                     id: "U6IroF",


### PR DESCRIPTION
🤖 Resolves #6251 

## 👋 Introduction

This fixes the experience/education cards colour contrast ratio by using the new `secondary` colour prop instead of the old `ts-secondary`

## 🕵️ Details

We deprecated the old prefixed color pallette in favour of hydrogen themes but have yet to update some components.

https://github.com/GCTC-NTGC/gc-digital-talent/issues/6397

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build:fresh`
2. Navigate to a job poster
3. Run axe dev tools
4. Confirm there are no colour contrast errors

## 📸 Screenshot

![Screenshot 2023-04-25 185509](https://user-images.githubusercontent.com/4127998/234425738-daa61f71-a335-4950-be2d-e697024b4ff6.png)
