### PR TITLE
[Bug] Add TOC/Breadcrumb hover states

### DIFF
--- a/apps/web/src/components/InfoItem/BaseInfoItem.tsx
+++ b/apps/web/src/components/InfoItem/BaseInfoItem.tsx
@@ -4,13 +4,13 @@ import Link from "@gc-digital-talent/ui/src/components/Link";
 export type TextColor = "default" | "error" | "success";
 const textColorMap: Record<TextColor, Record<string, string>> = {
   default: {
-    "data-h2-color": "base:all(black)",
+    "data-h2-color": "base(black) base:hover(primary)",
   },
   error: {
-    "data-h2-color": "base:all(error.darker)",
+    "data-h2-color": "base(error.darker) base:hover(error.darkest)",
   },
   success: {
-    "data-h2-color": "base:all(success)",
+    "data-h2-color": "base(success) base:hover(success.darker)",
   },
 };
 

--- a/packages/ui/src/components/Breadcrumbs/Crumb.tsx
+++ b/packages/ui/src/components/Breadcrumbs/Crumb.tsx
@@ -15,10 +15,12 @@ const Crumb = ({ children, isCurrent, url }: CrumbProps) => (
       {...(isCurrent
         ? {
             "data-h2-font-weight": "base(700)",
-            "data-h2-text-decoration": "base(none)",
+            "data-h2-text-decoration": "base(none) base:hover(underline)",
             "aria-current": "page",
           }
-        : {})}
+        : {
+            "data-h2-text-decoration": "base:hover(none)",
+          })}
     >
       {children}
     </Link>

--- a/packages/ui/src/components/Link/useCommonLinkStyles.ts
+++ b/packages/ui/src/components/Link/useCommonLinkStyles.ts
@@ -1,10 +1,64 @@
 import type { LinkProps } from "./Link";
-import { colorMap } from "../Button/Button";
+import { colorMap, Color } from "../Button/Button";
 
 interface CommonLinkStyleArgs
   extends Pick<LinkProps, "color" | "mode" | "block" | "type" | "weight"> {
   disabled?: boolean;
 }
+
+const linkColorMap: Record<Color, Record<string, string>> = {
+  primary: {
+    "data-h2-color": "base(primary) base:hover(primary.darker)",
+  },
+  secondary: {
+    "data-h2-color": "base(secondary) base:hover(secondary.darker)",
+  },
+  tertiary: {
+    "data-h2-color": "base(tertiary) base:hover(tertiary.darker)",
+  },
+  quaternary: {
+    "data-h2-color": "base(quaternary) base:hover(quaternary.darker)",
+  },
+  quinary: {
+    "data-h2-color": "base(quinary) base:hover(quinary.darker)",
+  },
+  success: {
+    "data-h2-color": "base(success) base:hover(success.darker)",
+  },
+  warning: {
+    "data-h2-color": "base(warning) base:hover(warning.darker)",
+  },
+  error: {
+    "data-h2-color": "base(error) base:hover(error.darker)",
+  },
+  black: {
+    "data-h2-color": "base(black) base:hover(primary)",
+  },
+  white: {
+    "data-h2-color": "base(white) base:hover(primary)",
+  },
+  "ia-primary": {
+    "data-h2-color": "base(primary) base:hover(primary.darker)",
+  },
+  "ia-secondary": {
+    "data-h2-color": "base(secondary) base:hover(secondary.darker)",
+  },
+  purple: {
+    "data-h2-color": "base(primary) base:hover(primary.darker)",
+  },
+  blue: {
+    "data-h2-color": "base(secondary) base:hover(secondary.darker)",
+  },
+  red: {
+    "data-h2-color": "base(tertiary) base:hover(tertiary.darker)",
+  },
+  yellow: {
+    "data-h2-color": "base(quaternary) base:hover(quaternary.darker)",
+  },
+  cta: {
+    "data-h2-color": "base(tertiary) base:hover(tertiary.darker)",
+  },
+};
 
 const useCommonLinkStyles = ({
   color,
@@ -28,7 +82,9 @@ const useCommonLinkStyles = ({
         ...padding,
         "data-h2-font-size": "base(copy)",
         ...weightStyle,
-        ...(disabled && { style: { opacity: 0.6, pointerEvents: "none" } }),
+        ...(disabled && {
+          style: { opacity: 0.6, pointerEvents: "none" } as React.CSSProperties,
+        }),
         ...(color && mode ? { ...colorMap[color][mode] } : {}),
         ...(block
           ? {
@@ -37,7 +93,12 @@ const useCommonLinkStyles = ({
             }
           : { "data-h2-display": "base(inline-block)" }),
       }
-    : {};
+    : {
+        ...(color
+          ? { ...linkColorMap[color] }
+          : { "data-h2-color": "base:hover(primary)" }),
+        "data-h2-text-decoration": "base(underline) base:hover(none)",
+      };
 };
 
 export default useCommonLinkStyles;

--- a/packages/ui/src/components/TableOfContents/AnchorLink.tsx
+++ b/packages/ui/src/components/TableOfContents/AnchorLink.tsx
@@ -7,7 +7,13 @@ export interface AnchorLinkProps extends HTMLAttributes<HTMLAnchorElement> {
 
 const AnchorLink = ({ id, children }: AnchorLinkProps) => (
   <li data-h2-margin="base(0, 0, x.5, 0)">
-    <ScrollToLink to={id}>{children}</ScrollToLink>
+    <ScrollToLink
+      data-h2-color="base(black) base:hover(primary)"
+      data-h2-text-decoration="base(underline) base:hover(none)"
+      to={id}
+    >
+      {children}
+    </ScrollToLink>
   </li>
 );
 


### PR DESCRIPTION
🤖 Resolves #6253 

## 👋 Introduction

This adds styles to indicate hover state for TOC and Breadcrumb links.

## 🕵️ Details

This also updates the `useCommonLinkStyles` hook to set hover state for links that do not have `type=button`.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run build:fresh`
2. Navigate to a pool advertisement
3. Confirm both "On this page" and breadcrumb links change style when hovered
4. Navigate to a user profile
5. Confirm "On this page" links change style when hovered

## 📸 Screenshot
![Screenshot 2023-04-26 082240](https://user-images.githubusercontent.com/4127998/234573832-1c0ee3fe-0fba-48d7-965a-a1abcfb84553.png)


