### PR TITLE
[A11y] Hide icons on IAP to ATs

### DIFF
--- a/apps/web/src/pages/Home/IAPHomePage/components/Card.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Card.tsx
@@ -10,7 +10,7 @@ interface CardProps {
 
 const Card = ({ title, Icon, children }: CardProps) => (
   <div data-h2-text-align="base(center)">
-    {Icon && <Icon data-h2-width="base(x4)" />}
+    {Icon && <Icon data-h2-width="base(x4)" aria-hidden="true" />}
     <Heading
       as="h4"
       color="white"


### PR DESCRIPTION
🤖 Resolves #6249 

## 👋 Introduction

Thinks adds the `aria-hidden` attribute to the icons on the IAP homepage so they are not identified by assistive technologies.


## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build:fresh`
2. Navigate to `/indigenous-it-apprentice`
3. Scroll down to the "Strategy" section
4. Confirm the icons have `aria-hidden=true`
5. Confirm an AT does not identify them
