### PR TITLE
[A11y] Focus section on TOC link click

### DIFF
--- a/packages/ui/src/components/Link/ScrollToLink.tsx
+++ b/packages/ui/src/components/Link/ScrollToLink.tsx
@@ -1,8 +1,12 @@
 import React from "react";
 import { useLocation, Link, LinkProps } from "react-router-dom";
 
+type ClickEvent =
+  | React.MouseEvent<HTMLAnchorElement | undefined>
+  | React.KeyboardEvent<HTMLAnchorElement | undefined>;
+
 export type ScrollLinkClickFunc = (
-  e: React.MouseEvent<HTMLAnchorElement | undefined>,
+  e: ClickEvent,
   section: HTMLElement | null,
 ) => void;
 
@@ -44,7 +48,7 @@ const ScrollToLink = ({
     setTargetSection(section);
   }, [to]);
 
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement | undefined>) => {
+  const handleClick = (e: ClickEvent) => {
     scrollToSection(targetSection);
     if (onScrollTo) {
       onScrollTo(e, targetSection);

--- a/packages/ui/src/components/TableOfContents/AnchorLink.tsx
+++ b/packages/ui/src/components/TableOfContents/AnchorLink.tsx
@@ -1,14 +1,24 @@
 import React, { HTMLAttributes } from "react";
-import { ScrollToLink } from "../Link";
+import { ScrollLinkClickFunc, ScrollToLink } from "../Link";
 
 export interface AnchorLinkProps extends HTMLAttributes<HTMLAnchorElement> {
   id: string;
 }
 
-const AnchorLink = ({ id, children }: AnchorLinkProps) => (
-  <li data-h2-margin="base(0, 0, x.5, 0)">
-    <ScrollToLink to={id}>{children}</ScrollToLink>
-  </li>
-);
+const AnchorLink = ({ id, children }: AnchorLinkProps) => {
+  const handleScrollTo: ScrollLinkClickFunc = (_, section) => {
+    if (section) {
+      section.focus();
+    }
+  };
+
+  return (
+    <li data-h2-margin="base(0, 0, x.5, 0)">
+      <ScrollToLink to={id} onScrollTo={handleScrollTo}>
+        {children}
+      </ScrollToLink>
+    </li>
+  );
+};
 
 export default AnchorLink;

--- a/packages/ui/src/components/TableOfContents/Section.tsx
+++ b/packages/ui/src/components/TableOfContents/Section.tsx
@@ -9,7 +9,7 @@ const Section = ({
   children,
   ...rest
 }: SectionProps & HTMLAttributes<HTMLDivElement>) => (
-  <div id={id} {...rest}>
+  <div id={id} tabIndex={-1} data-h2-outline="base(none)" {...rest}>
     {children}
   </div>
 );


### PR DESCRIPTION
🤖 Resolves #5540 

## 👋 Introduction

Updates the `TableOfContents` links so that they set the focus on target section when invoked.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> **Bonus**
> Test this with an AT enabled to hear what is announced at the same time

1. `npm run build`
2. Navigate to a profile
3. Tab to a TOC link and invoke it (with `enter` or `space`)
4. Hit tab
5. Confirm the next focused element is the link in that section
