### PR TITLE
[Bug] Changes all `nullSelection` values to begin with Select

### DIFF
--- a/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
@@ -53,8 +53,8 @@ const AwardFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.awardedTo}
             name="awardedTo"
             nullSelection={intl.formatMessage({
-              defaultMessage: "Choose one",
-              id: "C13NNv",
+              defaultMessage: "Select an option",
+              id: "KWLDYe",
               description:
                 "Null selection for select input in the awarded to form.",
             })}
@@ -92,8 +92,8 @@ const AwardFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.awardedScope}
             name="awardedScope"
             nullSelection={intl.formatMessage({
-              defaultMessage: "Choose one",
-              id: "+QpeDR",
+              defaultMessage: "Select an option",
+              id: "xyHtkt",
               description:
                 "Null selection for select input in the award scope form.",
             })}

--- a/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
@@ -34,8 +34,8 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.educationType}
             name="educationType"
             nullSelection={intl.formatMessage({
-              defaultMessage: "Choose one",
-              id: "jmUyRm",
+              defaultMessage: "Select an option",
+              id: "gIXZ1i",
               description:
                 "Null selection for select education type in the education form.",
             })}
@@ -150,8 +150,8 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.educationStatus}
             name="educationStatus"
             nullSelection={intl.formatMessage({
-              defaultMessage: "Choose one",
-              id: "UouZPP",
+              defaultMessage: "Select an option",
+              id: "0iSfwq",
               description:
                 "Null selection for select status in the education form.",
             })}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1321,8 +1321,8 @@
     "defaultMessage": "Ces renseignements seront communiqués aux gestionnaires d'embauche.",
     "description": "Explanation on how employment equity information will be used, item one"
   },
-  "e/ez/m": {
-    "defaultMessage": "Choisir un niveau",
+  "/ImWz4": {
+    "defaultMessage": "Sélectionnez un niveau",
     "description": "Null selection for form."
   },
   "evxvnW": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1469,8 +1469,8 @@
     "defaultMessage": "Comment ces données seront-elles utilisées?",
     "description": "Heading for how employment equity information will be used."
   },
-  "u4v1RB": {
-    "defaultMessage": "Choisir un groupe",
+  "9Upe1V": {
+    "defaultMessage": "Sélectionnez un groupe",
     "description": "Null selection for form."
   },
   "uG2MuI": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -665,8 +665,8 @@
     "defaultMessage": "Projet/produit",
     "description": "Label displayed on Community Experience form for project input"
   },
-  "jmUyRm": {
-    "defaultMessage": "Choisir un",
+  "gIXZ1i": {
+    "defaultMessage": "Sélectionnez une option",
     "description": "Null selection for select education type in the education form."
   },
   "491LrZ": {
@@ -761,8 +761,8 @@
     "defaultMessage": "1. Détails des études",
     "description": "Title for Education Details Form"
   },
-  "C13NNv": {
-    "defaultMessage": "Choisir un",
+  "KWLDYe": {
+    "defaultMessage": "Sélectionnez une option",
     "description": "Null selection for select input in the awarded to form."
   },
   "YJdsMY": {
@@ -821,16 +821,16 @@
     "defaultMessage": "Titre du prix",
     "description": "Label displayed on award form for award title input"
   },
-  "+QpeDR": {
-    "defaultMessage": "Choisir un",
+  "xyHtkt": {
+    "defaultMessage": "Sélectionnez une option",
     "description": "Null selection for select input in the award scope form."
   },
   "wASF5V": {
     "defaultMessage": "Je suis actuellement actif dans ce rôle.",
     "description": "Label displayed on Community Experience form for current role input"
   },
-  "UouZPP": {
-    "defaultMessage": "Choisir un",
+  "0iSfwq": {
+    "defaultMessage": "Sélectionnez une option",
     "description": "Null selection for select status in the education form."
   },
   "xJulQ4": {

--- a/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.test.tsx
+++ b/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.test.tsx
@@ -107,7 +107,7 @@ describe("GovernmentInfoForm", () => {
 
     expect(
       screen.getByRole("option", {
-        name: /choose group/i,
+        name: /Select a group/i,
       }),
     ).toBeInTheDocument();
     expect(

--- a/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.test.tsx
+++ b/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.test.tsx
@@ -112,7 +112,7 @@ describe("GovernmentInfoForm", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("option", {
-        name: /choose level/i,
+        name: /Select a level/i,
       }),
     ).toBeInTheDocument();
 

--- a/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
+++ b/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
@@ -20,7 +20,7 @@ import {
   objectsToSortedOptions,
   FieldLabels,
 } from "@gc-digital-talent/forms";
-import { empty } from "@gc-digital-talent/helpers";
+import { empty, notEmpty } from "@gc-digital-talent/helpers";
 import { toast } from "@gc-digital-talent/toast";
 import { ExternalLink } from "@gc-digital-talent/ui";
 
@@ -308,7 +308,7 @@ export const GovernmentInfoFormFields = ({
       resetDirtyField("govEmployeeType");
       if (!isPlaced) {
         resetDirtyField("currentClassificationGroup");
-        if (groupSelection === "Choose Department") {
+        if (empty(groupSelection)) {
           resetDirtyField("currentClassificationLevel");
         }
       }
@@ -434,7 +434,7 @@ export const GovernmentInfoFormFields = ({
                 options={groupOptions}
               />
             </div>
-            {groupSelection !== "Choose Department" && (
+            {notEmpty(groupSelection) && (
               <div style={{ width: "100%" }}>
                 <Select
                   id="currentClassificationLevel"

--- a/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
+++ b/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
@@ -424,8 +424,8 @@ export const GovernmentInfoFormFields = ({
                 label={labels.currentClassificationGroup}
                 name="currentClassificationGroup"
                 nullSelection={intl.formatMessage({
-                  defaultMessage: "Choose Group",
-                  id: "u4v1RB",
+                  defaultMessage: "Select a group",
+                  id: "9Upe1V",
                   description: "Null selection for form.",
                 })}
                 rules={{

--- a/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
+++ b/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
@@ -444,8 +444,8 @@ export const GovernmentInfoFormFields = ({
                     required: intl.formatMessage(errorMessages.required),
                   }}
                   nullSelection={intl.formatMessage({
-                    defaultMessage: "Choose Level",
-                    id: "e/ez/m",
+                    defaultMessage: "Select a level",
+                    id: "/ImWz4",
                     description: "Null selection for form.",
                   })}
                   options={levelOptions}


### PR DESCRIPTION
🤖 Resolves #6323.

## 👋 Introduction

This PR change all `nullSelection` values to begin with the word **Select**.

## 🦴 Bonus

h/t @esizer [fix group conditional logic](https://github.com/GCTC-NTGC/gc-digital-talent/pull/6402/commits/23e0774c7eb89af574189f5f9139f13ae01d52ca)

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Search for values within `nullSelect`
2. Ensure all of the strings begin with the word **Select**
3. Navigate to `/users/:userId/profile/government-info/edit`
4. Observe nullSelection option for **Current Classification Group** and **Current Classification Level**
5. Navigate to `/users/:userId/profile/experiences/award/create
6. Observe nullSelection option for **Awarded to** and **Award Scope**
7. Navigate to `/users/:userId/profile/experiences/education/create
8. Observe nullSelection option for **Type of Education** and **Status**

## 📸 Screenshots

![Screen Shot 2023-04-26 at 09 54 20](https://user-images.githubusercontent.com/3046459/234598169-c3db04b2-46f3-4374-98f0-44d1fd3c2f3b.png)
![Screen Shot 2023-04-26 at 09 54 05](https://user-images.githubusercontent.com/3046459/234598180-6e67dab1-a033-4d2d-b7a0-23fc46dcf733.png)
![Screen Shot 2023-04-26 at 09 48 18](https://user-images.githubusercontent.com/3046459/234598185-2cfc1d4a-cc76-4ed6-a4a6-91dd110a1f72.png)
![Screen Shot 2023-04-26 at 09 47 38](https://user-images.githubusercontent.com/3046459/234598186-f590aec2-e8fb-4d59-a57e-0ab9e3181e2a.png)
![Screen Shot 2023-04-26 at 09 44 49](https://user-images.githubusercontent.com/3046459/234598190-bee96a79-0c8d-4e30-a90f-3cc9b578c83e.png)
![Screen Shot 2023-04-26 at 09 43 51](https://user-images.githubusercontent.com/3046459/234598195-7effd966-3ffe-48de-bae9-63f8d6efba68.png)

