### PR TITLE
[Bugfix] Truncate Pools and Teams tables to avoid errors when seeding again

### DIFF
--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -203,6 +203,8 @@ class DatabaseSeeder extends Seeder
         PoolCandidateFilter::truncate();
         PoolCandidateSearchRequest::truncate();
         User::truncate();
+        Pool::truncate();
+        Team::truncate();
     }
 
     private function seedPoolCandidate(User $user, Pool $pool)


### PR DESCRIPTION
🤖 Resolves #6403

## 👋 Introduction

Allows you to run Database seeder more than once without errors.

## 🕵️ Details

Resets the Pools and Teams tables before seeding.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run `docker-compose exec -w /home/site/wwwroot/api webserver php artisan db:seed`
2. Run `docker-compose exec -w /home/site/wwwroot/api webserver php artisan db:seed` again
3. It should work now!
