### PR TITLE
[Bug] Fix suspended application test

### DIFF
--- a/api/database/factories/PoolCandidateFactory.php
+++ b/api/database/factories/PoolCandidateFactory.php
@@ -107,7 +107,7 @@ class PoolCandidateFactory extends Factory
             return [
                 'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE,
                 'expiry_date' => $this->faker->dateTimeBetween('1 years', '3 years'),
-                'suspended_at' => $this->faker->dateTimeBetween('-3 months', 'now'),
+                'suspended_at' => $this->faker->dateTimeBetween('-3 months', '-1 minute'),
                 'submitted_steps' => ApiEnums::applicationSteps(),
             ];
         });

--- a/api/tests/Feature/ApplicantTest.php
+++ b/api/tests/Feature/ApplicantTest.php
@@ -978,12 +978,14 @@ class ApplicantTest extends TestCase
         ]);
         PoolCandidate::factory()->count(5)->availableInSearch()->create([
             'pool_id' => $pool1,
+            'suspended_at' => null,
             'user_id' => User::factory([
                 'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
             ])
         ]);
         PoolCandidate::factory()->count(4)->suspended()->create([
             'pool_id' => $pool1,
+            'suspended_at' => config('constants.past_date'),
             'user_id' => User::factory([
                 'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
             ])
@@ -1044,16 +1046,18 @@ class ApplicantTest extends TestCase
         // Assert candidate one returns 10
         $this->actingAs($this->adminUser, "api")
             ->graphQL(
-            /** @lang GraphQL */
-            '
+                /** @lang GraphQL */
+                '
             query applicant($id: UUID!) {
                 applicant(id: $id) {
                     priorityWeight
                 }
             }
-            ', [
-                'id' => $candidateOne->id,
-            ])->assertJson([
+            ',
+                [
+                    'id' => $candidateOne->id,
+                ]
+            )->assertJson([
                 "data" => [
                     "applicant" => [
                         "priorityWeight" => 10,
@@ -1064,16 +1068,18 @@ class ApplicantTest extends TestCase
         // Assert candidate two returns 20
         $this->actingAs($this->adminUser, "api")
             ->graphQL(
-            /** @lang GraphQL */
-            '
+                /** @lang GraphQL */
+                '
             query applicant($id: UUID!) {
                 applicant(id: $id) {
                     priorityWeight
                 }
             }
-            ', [
-                'id' => $candidateTwo->id,
-            ])->assertJson([
+            ',
+                [
+                    'id' => $candidateTwo->id,
+                ]
+            )->assertJson([
                 "data" => [
                     "applicant" => [
                         "priorityWeight" => 20,
@@ -1084,16 +1090,18 @@ class ApplicantTest extends TestCase
         // Assert candidate three returns 30
         $this->actingAs($this->adminUser, "api")
             ->graphQL(
-            /** @lang GraphQL */
-            '
+                /** @lang GraphQL */
+                '
             query applicant($id: UUID!) {
                 applicant(id: $id) {
                     priorityWeight
                 }
             }
-            ', [
-                'id' => $candidateThree->id,
-            ])->assertJson([
+            ',
+                [
+                    'id' => $candidateThree->id,
+                ]
+            )->assertJson([
                 "data" => [
                     "applicant" => [
                         "priorityWeight" => 30,
@@ -1104,16 +1112,18 @@ class ApplicantTest extends TestCase
         // Assert candidate four returns 40
         $this->actingAs($this->adminUser, "api")
             ->graphQL(
-            /** @lang GraphQL */
-            '
+                /** @lang GraphQL */
+                '
             query applicant($id: UUID!) {
                 applicant(id: $id) {
                     priorityWeight
                 }
             }
-            ', [
-                'id' => $candidateFour->id,
-            ])->assertJson([
+            ',
+                [
+                    'id' => $candidateFour->id,
+                ]
+            )->assertJson([
                 "data" => [
                     "applicant" => [
                         "priorityWeight" => 40,
@@ -1463,8 +1473,8 @@ class ApplicantTest extends TestCase
         // Assert the order is correct
         $this->actingAs($this->adminUser, "api")
             ->graphQL(
-            /** @lang GraphQL */
-            '
+                /** @lang GraphQL */
+                '
             query poolCandidatesPaginated {
                 poolCandidatesPaginated (orderBy: [
                     { column: "status_weight", order: ASC }
@@ -1477,7 +1487,8 @@ class ApplicantTest extends TestCase
                     }
                 }
             }
-            ')->assertJson([
+            '
+            )->assertJson([
                 "data" => [
                     "poolCandidatesPaginated" => [
                         "data" => [
@@ -1493,8 +1504,8 @@ class ApplicantTest extends TestCase
         // Assert that DRAFT is not retrieved
         $this->actingAs($this->adminUser, "api")
             ->graphQL(
-            /** @lang GraphQL */
-            '
+                /** @lang GraphQL */
+                '
             query poolCandidatesPaginated {
                 poolCandidatesPaginated (orderBy: [
                     { column: "status_weight", order: ASC }
@@ -1507,7 +1518,8 @@ class ApplicantTest extends TestCase
                     }
                 }
             }
-            ')->assertDontSeeText(ApiEnums::CANDIDATE_STATUS_DRAFT);
+            '
+            )->assertDontSeeText(ApiEnums::CANDIDATE_STATUS_DRAFT);
     }
 
     public function testNullFilterEqualsUndefinedPoolCandidate()

--- a/api/tests/Feature/ApplicantTest.php
+++ b/api/tests/Feature/ApplicantTest.php
@@ -978,14 +978,12 @@ class ApplicantTest extends TestCase
         ]);
         PoolCandidate::factory()->count(5)->availableInSearch()->create([
             'pool_id' => $pool1,
-            'suspended_at' => null,
             'user_id' => User::factory([
                 'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
             ])
         ]);
         PoolCandidate::factory()->count(4)->suspended()->create([
             'pool_id' => $pool1,
-            'suspended_at' => config('constants.past_date'),
             'user_id' => User::factory([
                 'job_looking_status' => ApiEnums::USER_STATUS_ACTIVELY_LOOKING,
             ])


### PR DESCRIPTION
🤖 Resolves #6381 

## 👋 Introduction

Fixes the `ApplicantTest::testCountApplicantsQuerySuspended` making it pass consistently.

## 🕵️ Details

We introduced a new `suspended_at` column on the `PoolCandidate` model to determine if users are available instead of the deprecated `job_looking_status` on the `User` model but never updated the test to reflect that change.

> **Note**
> There are some formatting changes as a result of the new format on save. Sorry if it complicates the diff 😬 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run `for i in {1..20}; do docker-compose exec -w /home/site/wwwroot/api webserver sh -c "./vendor/bin/phpunit ./tests/Feature/ApplicantTest.php"; done`
2. Go make a ☕ or 🍵 
3. Come back and ensure there were no failures

## 📸 Screenshot
![Screenshot 2023-04-26 133547](https://user-images.githubusercontent.com/4127998/234658009-6214cb04-5b2a-450f-8c66-47ae30e42f91.png)


