### PR TITLE
[Debt] increase maxAssetSize for webpack prod

### DIFF
--- a/apps/web/webpack.prod.js
+++ b/apps/web/webpack.prod.js
@@ -7,6 +7,7 @@ module.exports = merge(base, {
   devtool: "source-map", // Recommended choice for production builds with high quality SourceMaps.
   performance: {
     maxAssetSize: 500000,
+    maxEntrypointSize: 500000,
   },
   plugins: [
     // compress files with gzip

--- a/apps/web/webpack.prod.js
+++ b/apps/web/webpack.prod.js
@@ -5,6 +5,9 @@ const CompressionPlugin = require("compression-webpack-plugin");
 module.exports = merge(base, {
   mode: "production",
   devtool: "source-map", // Recommended choice for production builds with high quality SourceMaps.
+  performance: {
+    maxAssetSize: 500000,
+  },
   plugins: [
     // compress files with gzip
     new CompressionPlugin({


### PR DESCRIPTION
🤖 Resolves #4570 

## 👋 Introduction

Increases the max size to `500000`. 
For asset size, and entrypoint size. I adjusted the latter too because it didn't make sense for it to be less than asset max. 

## 🧪 Testing

1. `npm run build:fresh`

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/40485260/234720876-9e0badc4-d767-4faa-8ef2-4fe71801db3d.png)

