### PR TITLE
[Feature] Changes Pool Candidates Preferred Communication Language column order and visibility

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -273,7 +273,7 @@ const provinceAccessor = (
 
 const defaultState = {
   ...TABLE_DEFAULTS,
-  hiddenColumnIds: ["preferredLang", "candidacyStatus"],
+  hiddenColumnIds: ["candidacyStatus"],
   filters: {
     applicantFilter: {
       operationalRequirements: [],

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -589,17 +589,6 @@ const PoolCandidatesTable = ({
       },
       {
         label: intl.formatMessage({
-          defaultMessage: "Email",
-          id: "BSVnmg",
-          description:
-            "Title displayed for the Pool Candidates table Email column.",
-        }),
-        id: "email",
-        accessor: ({ user }) => user?.email,
-        sortColumnName: "EMAIL",
-      },
-      {
-        label: intl.formatMessage({
           defaultMessage: "Preferred Communication Language",
           id: "eN8J/9",
           description:
@@ -609,6 +598,17 @@ const PoolCandidatesTable = ({
         accessor: ({ user }) =>
           preferredLanguageAccessor(user?.preferredLang, intl),
         sortColumnName: "PREFERRED_LANG",
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Email",
+          id: "BSVnmg",
+          description:
+            "Title displayed for the Pool Candidates table Email column.",
+        }),
+        id: "email",
+        accessor: ({ user }) => user?.email,
+        sortColumnName: "EMAIL",
       },
       {
         label: intl.formatMessage({


### PR DESCRIPTION
🤖 Resolves #6315.

## 👋 Introduction

This PR makes the Pool Candidates table **Preferred Communication Language** column visible by default and displays the **Preferred Communication Language** directly after the **Candidate Name** column.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/admin/pools/:poolId/pool-candidates`
2. Observe **Preferred Communication Language** renders by default
3. Observe **Preferred Communication Language** displays directly after the **Candidate Name** column

## 📸 Screenshots

![Screen Shot 2023-04-27 at 11 36 58](https://user-images.githubusercontent.com/3046459/234914225-15470d56-4cd2-49a9-9d47-d9ced9196f82.png)
![Screen Shot 2023-04-27 at 11 38 12](https://user-images.githubusercontent.com/3046459/234914219-f1d26977-38fc-4caf-9c46-e0b1eadee6b9.png)
![Screen Shot 2023-04-27 at 11 37 10](https://user-images.githubusercontent.com/3046459/234914223-0ffb5f88-d987-45b4-ad7c-95119a3cf4ac.png)

