### PR TITLE
[Bug] Fix edit pool skill submit button state

### DIFF
--- a/apps/web/src/components/SkillPicker/SkillPicker.tsx
+++ b/apps/web/src/components/SkillPicker/SkillPicker.tsx
@@ -9,7 +9,7 @@ import {
   Separator,
   ScrollArea,
 } from "@gc-digital-talent/ui";
-import { InputLabel, Submit } from "@gc-digital-talent/forms";
+import { InputLabel } from "@gc-digital-talent/forms";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 
 import { Scalars, Skill, SkillFamily } from "~/api/generated";
@@ -37,9 +37,6 @@ export interface SkillPickerProps {
   selectedSkills?: Skills;
   onUpdateSelectedSkills?: (newSkills: Skills) => void;
   headingLevel?: HeadingRank;
-  handleSave?: () => void;
-  submitButtonText?: string;
-  isSubmitting?: boolean;
   skillType?: string;
 }
 
@@ -48,9 +45,6 @@ const SkillPicker = ({
   onUpdateSelectedSkills,
   selectedSkills = [],
   headingLevel = "h4",
-  handleSave,
-  submitButtonText,
-  isSubmitting,
   skillType,
 }: SkillPickerProps) => {
   const intl = useIntl();
@@ -60,7 +54,7 @@ const SkillPicker = ({
     mode: "onChange",
     defaultValues,
   });
-  const { watch, handleSubmit } = methods;
+  const { watch } = methods;
   const staticId = useId();
   const skipToHeadingId = `selected-skills-heading-${skillType || staticId}`;
   const queryInputId = `query-${skillType || staticId}`;
@@ -281,17 +275,6 @@ const SkillPicker = ({
             description:
               "Text that appears after skill picker when no skills are selected",
           })}
-        </p>
-      )}
-      {submitButtonText && handleSave && (
-        <p data-h2-margin="base(x1, 0)">
-          <Submit
-            text={submitButtonText}
-            color="cta"
-            mode="solid"
-            isSubmitting={isSubmitting}
-            onClick={handleSubmit(handleSave)}
-          />
         </p>
       )}
     </FormProvider>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/AssetSkillsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/AssetSkillsSection.tsx
@@ -1,13 +1,16 @@
 import * as React from "react";
 import { useState } from "react";
 import { useIntl } from "react-intl";
+import { FormProvider, useFieldArray, useForm } from "react-hook-form";
 
 import { TableOfContents, Chip, Chips } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
+import { Submit } from "@gc-digital-talent/forms";
 
 import {
   AdvertisementStatus,
   PoolAdvertisement,
+  Scalars,
   Skill,
   UpdatePoolAdvertisementInput,
 } from "~/api/generated";
@@ -20,6 +23,12 @@ export type AssetSkillsSubmitData = Pick<
   UpdatePoolAdvertisementInput,
   "nonessentialSkills"
 >;
+
+type FormValues = {
+  currentAssetSkills: {
+    id: Scalars["ID"];
+  }[];
+};
 
 interface AssetSkillsSectionProps {
   poolAdvertisement: PoolAdvertisement;
@@ -36,15 +45,30 @@ const AssetSkillsSection = ({
 }: AssetSkillsSectionProps): JSX.Element => {
   const intl = useIntl();
   const { isSubmitting } = useEditPoolContext();
+  const defaultSkills = poolAdvertisement.nonessentialSkills
+    ? poolAdvertisement.nonessentialSkills
+    : [];
+  const methods = useForm<FormValues>({
+    defaultValues: {
+      currentAssetSkills: defaultSkills.map(({ id }) => ({ id })),
+    },
+  });
+  const { fields } = useFieldArray({
+    name: "currentAssetSkills",
+    control: methods.control,
+  });
 
-  const [selectedSkills, setSelectedSkills] = useState<Array<Skill>>(
-    poolAdvertisement.nonessentialSkills
-      ? poolAdvertisement.nonessentialSkills
-      : [],
-  );
+  const [selectedSkills, setSelectedSkills] =
+    useState<Array<Skill>>(defaultSkills);
 
-  const handleChangeSelectedSkills = (changedSelectedSkills: Array<Skill>) =>
+  const handleChangeSelectedSkills = (changedSelectedSkills: Array<Skill>) => {
+    methods.setValue(
+      "currentAssetSkills",
+      changedSelectedSkills.map(({ id }) => ({ id })),
+      { shouldDirty: true, shouldTouch: true },
+    );
     setSelectedSkills(changedSelectedSkills);
+  };
 
   const handleSave = () => {
     onSave({
@@ -65,7 +89,6 @@ const AssetSkillsSection = ({
       </TableOfContents.Heading>
       {!formDisabled ? (
         <>
-          {" "}
           <p data-h2-margin="base(x1, 0)">
             {intl.formatMessage({
               defaultMessage:
@@ -79,16 +102,31 @@ const AssetSkillsSection = ({
             selectedSkills={selectedSkills}
             skills={skills}
             onUpdateSelectedSkills={handleChangeSelectedSkills}
-            handleSave={handleSave}
             headingLevel="h3"
-            submitButtonText={intl.formatMessage({
-              defaultMessage: "Save asset skills",
-              id: "j4G/wv",
-              description: "Text on a button to save the pool asset skills",
-            })}
-            isSubmitting={isSubmitting}
             skillType="asset"
           />
+          <FormProvider {...methods}>
+            {fields.map((field, index) => (
+              <input
+                key={field.id}
+                type="hidden"
+                {...methods.register(`currentAssetSkills.${index}.id`)}
+              />
+            ))}
+            <p data-h2-margin="base(x1, 0)">
+              <Submit
+                text={intl.formatMessage({
+                  defaultMessage: "Save asset skills",
+                  id: "j4G/wv",
+                  description: "Text on a button to save the pool asset skills",
+                })}
+                color="cta"
+                mode="solid"
+                isSubmitting={isSubmitting}
+                onClick={methods.handleSubmit(handleSave)}
+              />
+            </p>
+          </FormProvider>
         </>
       ) : (
         <Chips>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/AssetSkillsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/AssetSkillsSection.tsx
@@ -76,6 +76,12 @@ const AssetSkillsSection = ({
         sync: selectedSkills.map((skill) => skill.id),
       },
     });
+    methods.reset(
+      { currentAssetSkills: selectedSkills.map(({ id }) => ({ id })) },
+      {
+        keepDirty: false,
+      },
+    );
   };
 
   // disabled unless status is draft

--- a/apps/web/src/pages/Pools/EditPoolPage/components/EssentialSkillsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/EssentialSkillsSection.tsx
@@ -117,9 +117,10 @@ const EssentialSkillsSection = ({
             <p data-h2-margin="base(x1, 0)">
               <Submit
                 text={intl.formatMessage({
-                  defaultMessage: "Save asset skills",
-                  id: "j4G/wv",
-                  description: "Text on a button to save the pool asset skills",
+                  defaultMessage: "Save essential skills",
+                  id: "2asU3k",
+                  description:
+                    "Text on a button to save the pool essential skills",
                 })}
                 color="cta"
                 mode="solid"

--- a/apps/web/src/pages/Pools/EditPoolPage/components/EssentialSkillsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/EssentialSkillsSection.tsx
@@ -1,14 +1,17 @@
 import * as React from "react";
 import { useState } from "react";
 import { useIntl } from "react-intl";
+import { FormProvider, useFieldArray, useForm } from "react-hook-form";
 
 import { TableOfContents, Chip, Chips } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
+import { Submit } from "@gc-digital-talent/forms";
 
 import SkillPicker from "~/components/SkillPicker";
 import {
   AdvertisementStatus,
   PoolAdvertisement,
+  Scalars,
   Skill,
   UpdatePoolAdvertisementInput,
 } from "~/api/generated";
@@ -20,6 +23,12 @@ export type EssentialSkillsSubmitData = Pick<
   UpdatePoolAdvertisementInput,
   "essentialSkills"
 >;
+
+type FormValues = {
+  currentEssentialSkills: {
+    id: Scalars["ID"];
+  }[];
+};
 
 interface EssentialSkillsSectionProps {
   poolAdvertisement: PoolAdvertisement;
@@ -36,12 +45,28 @@ const EssentialSkillsSection = ({
 }: EssentialSkillsSectionProps): JSX.Element => {
   const intl = useIntl();
   const { isSubmitting } = useEditPoolContext();
+  const defaultSkills = poolAdvertisement.essentialSkills
+    ? poolAdvertisement.essentialSkills
+    : [];
+  const methods = useForm<FormValues>({
+    defaultValues: {
+      currentEssentialSkills: defaultSkills.map(({ id }) => ({ id })),
+    },
+  });
+  const { fields } = useFieldArray({
+    name: "currentEssentialSkills",
+    control: methods.control,
+  });
 
-  const [selectedSkills, setSelectedSkills] = useState<Array<Skill>>(
-    poolAdvertisement.essentialSkills ? poolAdvertisement.essentialSkills : [],
-  );
+  const [selectedSkills, setSelectedSkills] =
+    useState<Array<Skill>>(defaultSkills);
 
   const handleChangeSelectedSkills = (changedSelectedSkills: Array<Skill>) => {
+    methods.setValue(
+      "currentEssentialSkills",
+      changedSelectedSkills.map(({ id }) => ({ id })),
+      { shouldDirty: true, shouldTouch: true },
+    );
     setSelectedSkills(changedSelectedSkills);
   };
 
@@ -78,16 +103,31 @@ const EssentialSkillsSection = ({
             selectedSkills={selectedSkills}
             skills={skills}
             onUpdateSelectedSkills={handleChangeSelectedSkills}
-            handleSave={handleSave}
             headingLevel="h3"
-            submitButtonText={intl.formatMessage({
-              defaultMessage: "Save essential skills",
-              id: "2asU3k",
-              description: "Text on a button to save the pool essential skills",
-            })}
-            isSubmitting={isSubmitting}
             skillType="essential"
           />
+          <FormProvider {...methods}>
+            {fields.map((field, index) => (
+              <input
+                key={field.id}
+                type="hidden"
+                {...methods.register(`currentEssentialSkills.${index}.id`)}
+              />
+            ))}
+            <p data-h2-margin="base(x1, 0)">
+              <Submit
+                text={intl.formatMessage({
+                  defaultMessage: "Save asset skills",
+                  id: "j4G/wv",
+                  description: "Text on a button to save the pool asset skills",
+                })}
+                color="cta"
+                mode="solid"
+                isSubmitting={isSubmitting}
+                onClick={methods.handleSubmit(handleSave)}
+              />
+            </p>
+          </FormProvider>
         </>
       ) : (
         <Chips>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/EssentialSkillsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/EssentialSkillsSection.tsx
@@ -76,6 +76,12 @@ const EssentialSkillsSection = ({
         sync: selectedSkills.map((skill) => skill.id),
       },
     });
+    methods.reset(
+      { currentEssentialSkills: selectedSkills.map(({ id }) => ({ id })) },
+      {
+        keepDirty: false,
+      },
+    );
   };
 
   // disabled unless status is draft


### PR DESCRIPTION
🤖 Resolves #6369 

## 👋 Introduction

This moves the `<Submit />` button outside of the `<SkillPicker />` to stabilize it's submitting/submitted/idle state.

## 🕵️ Details

The `<Submit />` button was part of the `<SkillPicker />` form and was not aware of the changing skills. This caused two issues:

1. Changes to the dropdown/search bar were erroneously setting the form state to dirty
2. Skill picker is re-rendered on change so it was reset to clean after every re-render

Moving this out allows us to cleanly track dirty skills and should stabilize the button state.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build the app `npm run build:fresh`
4. Login as `admin@test.com`
5. Create a pool
6. Add a skill and click the submit button
7. Confirm it changes from default message to "Submitting" then, finally "Submitted"
8. Confirm interacting with the search in the skill picker does not change the state of the submit button
9. Add a skill
10. Confirm the state of the submit button changes back to the default
11. Save the form
12. Confirm it changes from default message to "Submitting" then, finally "Submitted"
13. Remove the added skill
14. Confirm the state of the submit button changes back to the default