### PR TITLE
[a11y] Hide hero svg for ATs

### DIFF
--- a/apps/web/src/components/Hero/Hero.tsx
+++ b/apps/web/src/components/Hero/Hero.tsx
@@ -176,6 +176,7 @@ const Hero = ({
           />
         ) : (
           <BackgroundGraphic
+            aria-hidden="true"
             data-h2-display="base(block) base:iap(none)"
             data-h2-position="base(absolute)"
             data-h2-location="base(0, 0, auto, auto)"


### PR DESCRIPTION
🤖 Resolves #6234 

## 👋 Introduction

This adds `aria-hidden=true` to the SVG in the hero to avoid ATs announcing it.

## 🕵️ Details

This image is purely decorative so does not need to be announced.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> **Note**
> I could only reliable reproduce the issue in VoiceOver so please check with that screen reader to be certain (JAWS and NVDA were ignoring it regardless of the `aria-hidden` attribute)

1. `npm run build`
2. Navigate to a page with the SVG in the hero (pool advertisements is one)
3. Step through the page with your arrows keys and screen reader on
4. Confirm no image is announced (this was happening between the `h1` and breadcrumbs.
