### PR TITLE
[Feature] Add reset button to table search

### DIFF
--- a/apps/web/src/components/Table/ApiManagedTable/SearchForm.tsx
+++ b/apps/web/src/components/Table/ApiManagedTable/SearchForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import debounce from "lodash/debounce";
 import { useIntl } from "react-intl";
 import { CheckIcon, ChevronDownIcon } from "@heroicons/react/24/solid";
@@ -6,6 +6,7 @@ import { CheckIcon, ChevronDownIcon } from "@heroicons/react/24/solid";
 import { Button, DropdownMenu } from "@gc-digital-talent/ui";
 
 import type { SearchColumn, SearchState } from "./helpers";
+import ResetButton from "../ResetButton";
 
 export interface SearchFormProps {
   onChange: (val: string | undefined, col: string | undefined) => void;
@@ -15,6 +16,7 @@ export interface SearchFormProps {
 
 const SearchForm = ({ onChange, searchBy, initialData }: SearchFormProps) => {
   const intl = useIntl();
+  const searchRef = useRef<HTMLInputElement | null>(null);
 
   const initialColumn =
     initialData?.type && searchBy
@@ -37,6 +39,15 @@ const SearchForm = ({ onChange, searchBy, initialData }: SearchFormProps) => {
     },
     [column, onChange],
   );
+
+  const handleReset = () => {
+    setSearchTerm("");
+    onChange("", column?.value);
+    if (searchRef.current) {
+      searchRef.current.value = "";
+      searchRef.current.focus();
+    }
+  };
 
   const debouncedChangeHandler = React.useMemo(
     () => debounce(handleChange, 300),
@@ -97,35 +108,48 @@ const SearchForm = ({ onChange, searchBy, initialData }: SearchFormProps) => {
           </DropdownMenu.Content>
         </DropdownMenu.Root>
       ) : null}
-      <input
-        name="search"
-        id="tableSearch"
-        type="text"
-        onChange={debouncedChangeHandler}
-        defaultValue={initialData?.term}
-        aria-label={intl.formatMessage({
-          defaultMessage: "Search Table",
-          id: "chFoB8",
-          description: "Label for search field on admin tables.",
-        })}
-        placeholder={intl.formatMessage({
-          defaultMessage: "Start writing here...",
-          id: "3F6QqF",
-          description:
-            "Placeholder displayed on the Global Filter form Search field.",
-        })}
-        data-h2-border="base(1px solid secondary)"
-        data-h2-background-color="base(white)"
-        data-h2-padding="base(x.25, x.5)"
-        data-h2-margin-left="base(0)"
-        {...(showDropdown
-          ? {
-              "data-h2-radius": "base(0, s, s, 0)",
-            }
-          : {
-              "data-h2-radius": "base(s)",
-            })}
-      />
+      <div data-h2-position="base(relative)" data-h2-display="base(flex)">
+        <input
+          name="search"
+          id="tableSearch"
+          type="text"
+          ref={searchRef}
+          onChange={debouncedChangeHandler}
+          defaultValue={initialData?.term}
+          aria-label={intl.formatMessage({
+            defaultMessage: "Search Table",
+            id: "chFoB8",
+            description: "Label for search field on admin tables.",
+          })}
+          placeholder={intl.formatMessage({
+            defaultMessage: "Start writing here...",
+            id: "3F6QqF",
+            description:
+              "Placeholder displayed on the Global Filter form Search field.",
+          })}
+          data-h2-border="base(1px solid secondary)"
+          data-h2-background-color="base(white)"
+          data-h2-padding="base(x.25, x.5)"
+          data-h2-margin-left="base(0)"
+          {...(showDropdown
+            ? {
+                "data-h2-radius": "base(0, s, s, 0)",
+              }
+            : {
+                "data-h2-radius": "base(s)",
+              })}
+        />
+        {searchTerm && (
+          <div
+            data-h2-position="base(absolute)"
+            data-h2-location="base(x.25, x.25, x.25, auto)"
+            data-h2-display="base(flex)"
+            data-h2-align-items="base(stretch)"
+          >
+            <ResetButton onClick={handleReset} />
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/apps/web/src/components/Table/ClientManagedTable/SearchForm.tsx
+++ b/apps/web/src/components/Table/ClientManagedTable/SearchForm.tsx
@@ -1,27 +1,40 @@
-import React from "react";
+import React, { useRef } from "react";
 import { useIntl } from "react-intl";
 import { useAsyncDebounce } from "react-table";
 
+import ResetButton from "../ResetButton";
+
 export interface SearchFormProps {
   onChange: (val: string | undefined) => void;
+  value: string;
 }
 
-const SearchForm = ({ onChange }: SearchFormProps) => {
+const SearchForm = ({ onChange, value }: SearchFormProps) => {
   const intl = useIntl();
+  const searchRef = useRef<HTMLInputElement | null>(null);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.preventDefault();
     onChange(e.target.value);
   };
 
+  const handleReset = () => {
+    onChange("");
+    if (searchRef.current) {
+      searchRef.current.value = "";
+      searchRef.current.focus();
+    }
+  };
+
   const debouncedHandleChange = useAsyncDebounce(handleChange, 200);
 
   return (
-    <div data-h2-display="base(flex)">
+    <div data-h2-position="base(relative)" data-h2-display="base(flex)">
       <input
         name="search"
         id="tableSearch"
         type="text"
+        ref={searchRef}
         onChange={debouncedHandleChange}
         aria-label={intl.formatMessage({
           defaultMessage: "Search Table",
@@ -39,6 +52,16 @@ const SearchForm = ({ onChange }: SearchFormProps) => {
         data-h2-padding="base(x.5, x1)"
         data-h2-radius="base(s)"
       />
+      {value && (
+        <div
+          data-h2-position="base(absolute)"
+          data-h2-location="base(x.25, x.25, x.25, auto)"
+          data-h2-display="base(flex)"
+          data-h2-align-items="base(stretch)"
+        >
+          <ResetButton onClick={handleReset} />
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/web/src/components/Table/ClientManagedTable/Table.tsx
+++ b/apps/web/src/components/Table/ClientManagedTable/Table.tsx
@@ -166,7 +166,7 @@ function Table<T extends Record<string, unknown>>({
     getToggleHideAllColumnsProps,
     rows,
     setGlobalFilter,
-    state: { pageIndex, pageSize, hiddenColumns, sortBy },
+    state: { pageIndex, pageSize, hiddenColumns, sortBy, globalFilter },
     gotoPage,
     setPageSize,
     page,
@@ -255,7 +255,10 @@ function Table<T extends Record<string, unknown>>({
               <div data-h2-flex-grid="base(center, x.5)">
                 {search && (
                   <div data-h2-flex-item="base(content)">
-                    <SearchForm onChange={setGlobalFilter} />
+                    <SearchForm
+                      onChange={setGlobalFilter}
+                      value={globalFilter}
+                    />
                   </div>
                 )}
                 {filterColumns && (

--- a/apps/web/src/components/Table/ResetButton.tsx
+++ b/apps/web/src/components/Table/ResetButton.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import { XMarkIcon } from "@heroicons/react/24/solid";
+
+const ResetButton = (
+  props: Omit<React.HTMLProps<HTMLButtonElement>, "children">,
+) => {
+  const intl = useIntl();
+  return (
+    <button
+      data-h2-background-color="base(transparent) base:hover(gray.lightest)"
+      data-h2-border="base(2px solid transparent) base:focus-visible(2px solid secondary)"
+      data-h2-radius="base(input)"
+      data-h2-cursor="base(pointer)"
+      data-h2-outline="base(none)"
+      data-h2-display="base(flex)"
+      data-h2-align-items="base(center)"
+      data-h2-flex-shrink="base(0)"
+      data-h2-padding="base(x.25)"
+      aria-label={intl.formatMessage({
+        defaultMessage: "Reset search",
+        id: "Yh/4po",
+        description: "Button text to reset search field on tables",
+      })}
+      {...props}
+      type="button"
+    >
+      <XMarkIcon
+        data-h2-height="base(1em)"
+        data-h2-width="base(1em)"
+        data-h2-color="base(gray)"
+      />
+    </button>
+  );
+};
+
+export default ResetButton;

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7591,5 +7591,9 @@
   "6q29tj": {
     "defaultMessage": "En cas d'interruption du travail, les services de référence de cette plateforme seront touchés. Veuillez noter que votre demande sera traitée lorsque les services reprendront. Merci de votre patience.",
     "description": "Content for the PSAC strike notice."
+  },
+  "Yh/4po": {
+    "defaultMessage": "Rétablir la recherche",
+    "description": "Button text to reset search field on tables"
   }
 }


### PR DESCRIPTION
🤖 Resolves #6368 

## 👋 Introduction

Adds a basic reset button to the search input for tables.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build:fresh`
2. Navigate to a client table `/admin/pools/`
3. Type in the search
4. Confirm reset button appears
5. Confirm clicking it clears out the search and sets focus on the search input
6. Navigate to an API table `/admin/users`
7. Repeat steps 3-5

## 📸 Screenshot
![Screenshot 2023-04-27 155235](https://user-images.githubusercontent.com/4127998/234976441-ff5237c8-db19-48cb-957e-cb9b0e4cdb7a.png)

