### PR TITLE
[Bug] Fix pool classification sort

### DIFF
--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -289,7 +289,7 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
         Cell: ({ row }: PoolCell) => {
           return classificationsCell(row.original.classifications);
         },
-        sortType: (rowA, rowB, id, desc) => {
+        sortType: (rowA, rowB) => {
           // passing in sortType to override default sort
           const rowAGroup =
             rowA.original.classifications && rowA.original.classifications[0]

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -317,10 +317,10 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
           // if groups identical then sort by level
           // level sorting adjusted to always be ascending regardless of whether group sort is A-Z or Z-A
           if (rowALevel > rowBLevel) {
-            return desc ? -1 : 1;
+            return 1;
           }
           if (rowALevel < rowBLevel) {
-            return desc ? 1 : -1;
+            return -1;
           }
           return 0;
         },

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -315,7 +315,6 @@ export const PoolTable = ({ pools }: PoolTableProps) => {
             return -1;
           }
           // if groups identical then sort by level
-          // level sorting adjusted to always be ascending regardless of whether group sort is A-Z or Z-A
           if (rowALevel > rowBLevel) {
             return 1;
           }


### PR DESCRIPTION
🤖 Resolves #6374 

## 👋 Introduction

This updates the classification sort on the `PoolTable` to no longer sort differently when the sort order is set to `DESC`

## 🕵️ Details

Thanks to @vd1992 who pointed directly to the change that needed to be made 🥇 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run build:fresh`
2. Navigate to `/admin/pools`
3. Sort the "Group and level" column
4. Confirm it sorts as expected in both `ASC` and `DESC` order.

## 📸 Screenshot


![Screenshot 2023-04-28 142936](https://user-images.githubusercontent.com/4127998/235226252-aa3d590c-fc46-4478-b781-58ccac359273.png)
