### PR TITLE
[Bug] Adjust advanced filter styles

### DIFF
--- a/apps/web/src/pages/SearchRequests/SearchPage/components/AdvancedFilters.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/AdvancedFilters.tsx
@@ -5,7 +5,10 @@ import { useFormContext } from "react-hook-form";
 import isArray from "lodash/isArray";
 
 import { Accordion, Heading } from "@gc-digital-talent/ui";
-import { StandardHeader as StandardAccordionHeader } from "@gc-digital-talent/ui/src/components/Accordion/StandardHeader";
+import {
+  StandardHeader as StandardAccordionHeader,
+  StandardHeaderProps,
+} from "@gc-digital-talent/ui/src/components/Accordion/StandardHeader";
 import { Checklist, RadioGroup } from "@gc-digital-talent/forms";
 import {
   getOperationalRequirement,
@@ -160,9 +163,24 @@ const AdvancedFilters = () => {
     }),
   );
 
+  const accordionTitleProps: StandardHeaderProps = {
+    headingAs: "h4",
+    titleProps: {
+      "data-h2-font-size": "base(copy, 1)",
+    },
+    subtitleProps: {
+      "data-h2-font-size": "base(caption, 1)",
+    },
+  };
+
   return (
     <>
-      <Heading level="h3" size="h6" data-h2-font-weight="base(700)">
+      <Heading
+        level="h3"
+        size="h6"
+        data-h2-font-weight="base(700)"
+        data-h2-margin="base(x3, 0, x1, 0)"
+      >
         {intl.formatMessage({
           defaultMessage: "Advanced filters",
           id: "eozWFc",
@@ -179,6 +197,7 @@ const AdvancedFilters = () => {
       >
         <Accordion.Item value="educationRequirement">
           <StandardAccordionHeader
+            {...accordionTitleProps}
             subtitle={getFieldLabel(
               educationRequirement,
               educationRequirementOptions,
@@ -222,6 +241,7 @@ const AdvancedFilters = () => {
         </Accordion.Item>
         <Accordion.Item value="employmentDuration">
           <StandardAccordionHeader
+            {...accordionTitleProps}
             subtitle={getFieldLabel(
               employmentDuration,
               employmentDurationOptions,
@@ -260,6 +280,7 @@ const AdvancedFilters = () => {
         </Accordion.Item>
         <Accordion.Item value="operationalRequirements">
           <StandardAccordionHeader
+            {...accordionTitleProps}
             subtitle={getFieldLabel(
               operationalRequirements,
               operationalRequirementOptionsShort,

--- a/packages/ui/src/components/Accordion/StandardHeader.tsx
+++ b/packages/ui/src/components/Accordion/StandardHeader.tsx
@@ -2,10 +2,15 @@ import React from "react";
 
 import Accordion, { AccordionHeaderProps } from "./Accordion";
 
+type TitleProps = React.HTMLAttributes<HTMLSpanElement> & {
+  [data: string]: string;
+};
 export interface StandardHeaderProps extends AccordionHeaderProps {
   Icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   context?: React.ReactNode;
   subtitle?: React.ReactNode;
+  titleProps?: TitleProps;
+  subtitleProps?: TitleProps;
 }
 
 export const StandardHeader = ({
@@ -13,6 +18,8 @@ export const StandardHeader = ({
   context,
   subtitle,
   children,
+  titleProps,
+  subtitleProps,
   ...rest
 }: StandardHeaderProps) => {
   return (
@@ -28,6 +35,7 @@ export const StandardHeader = ({
             data-h2-display="base(block)"
             data-h2-font-size="base(h6, 1)"
             data-h2-font-weight="base(700)"
+            {...titleProps}
           >
             {children}
           </span>
@@ -37,6 +45,7 @@ export const StandardHeader = ({
               data-h2-display="base(block)"
               data-h2-font-size="base(copy)"
               data-h2-margin="base(x.25, 0, 0, 0)"
+              {...subtitleProps}
             >
               {subtitle}
             </span>


### PR DESCRIPTION
🤖 Resolves #5728 

## 👋 Introduction

This does a few things,

- Increases spacing above advanced filters to match spacing between other sections
- Updates the headings to be the appropriate ranks
- Reduces the size of the headings to be smaller than the lower ranked headings on the pages

## 🕵️ Details

Kind of hacky way of getting the font size reduced on the headers but I do believe we plan on overhauling the accordions to support action links so think of this as a temp fix? 😅 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build:fresh`
2. Navigate to `/search`
3. Confirm advanced filters has similar spacing to other sections
4. Confirm it is using the appropriate heading tanks
5. Confirm the accordion titles are smaller than the lower ranked "Advanced filters" heading

## 📸 Screenshot

![Screenshot 2023-04-28 152327](https://user-images.githubusercontent.com/4127998/235235820-9b5260d2-feac-49c0-bbad-a76436470ea2.png)

