### PR TITLE
[Debt] Prevent `undefined` window storage

### DIFF
--- a/packages/storage/src/local.ts
+++ b/packages/storage/src/local.ts
@@ -13,15 +13,15 @@ import {
  * @returns
  */
 export function getFromLocalStorage<T>(key: string, defaultValue: T): T {
-  return getFromStorage(window?.localStorage, key, defaultValue);
+  return getFromStorage(window.localStorage, key, defaultValue);
 }
 
 export function setInLocalStorage<T>(key: string, value: T): void {
-  return setInStorage(window?.localStorage, key, value);
+  return setInStorage(window.localStorage, key, value);
 }
 
 export function removeFromLocalStorage(key: string): void {
-  return removeFromStorage(window?.localStorage, key);
+  return removeFromStorage(window.localStorage, key);
 }
 
 /** Sync state to local storage so that it persists through a page refresh. Usage is similar to useState except we pass in a local storage key so that we can default to that value on page load instead of the specified initial value.
@@ -30,5 +30,5 @@ export function removeFromLocalStorage(key: string): void {
  * @param  {T} initialValue
  */
 export function useLocalStorage<T>(key: string, initialValue: T) {
-  return useStorage(window?.localStorage, key, initialValue);
+  return useStorage(window.localStorage, key, initialValue);
 }

--- a/packages/storage/src/session.ts
+++ b/packages/storage/src/session.ts
@@ -13,15 +13,15 @@ import {
  * @returns
  */
 export function getFromSessionStorage<T>(key: string, defaultValue: T): T {
-  return getFromStorage(window?.sessionStorage, key, defaultValue);
+  return getFromStorage(window.sessionStorage, key, defaultValue);
 }
 
 export function setInSessionStorage<T>(key: string, value: T): void {
-  return setInStorage(window?.sessionStorage, key, value);
+  return setInStorage(window.sessionStorage, key, value);
 }
 
 export function removeFromSessionStorage(key: string): void {
-  return removeFromStorage(window?.sessionStorage, key);
+  return removeFromStorage(window.sessionStorage, key);
 }
 
 /** Sync state to session storage so that it persists through a page refresh. Usage is similar to useState except we pass in a local storage key so that we can default to that value on page load instead of the specified initial value.
@@ -30,5 +30,5 @@ export function removeFromSessionStorage(key: string): void {
  * @param  {T} initialValue
  */
 export function useSessionStorage<T>(key: string, initialValue: T) {
-  return useStorage(window?.sessionStorage, key, initialValue);
+  return useStorage(window.sessionStorage, key, initialValue);
 }

--- a/packages/storage/src/utils.ts
+++ b/packages/storage/src/utils.ts
@@ -5,7 +5,6 @@ export function getFromStorage<T>(
   key: string,
   defaultValue: T,
 ): T {
-  // TODO: Is it worth allowing store to be undefined? And why catch and hide errors here?
   if (store === undefined) {
     return defaultValue;
   }
@@ -21,23 +20,12 @@ export function getFromStorage<T>(
   }
 }
 
-export function setInStorage<T>(
-  store: Storage | undefined,
-  key: string,
-  value: T,
-): void {
-  if (store) {
-    store.setItem(key, JSON.stringify(value));
-  }
+export function setInStorage<T>(store: Storage, key: string, value: T): void {
+  store.setItem(key, JSON.stringify(value));
 }
 
-export function removeFromStorage(
-  store: Storage | undefined,
-  key: string,
-): void {
-  if (store) {
-    store.removeItem(key);
-  }
+export function removeFromStorage(store: Storage, key: string): void {
+  store.removeItem(key);
 }
 
 /** Sync state to local storage so that it persists through a page refresh. Usage is similar to useState except we pass in a local storage key so that we can default to that value on page load instead of the specified initial value.


### PR DESCRIPTION
🤖 Resolves #4648 

## 👋 Introduction

Updates the storage argument type to no longer accept `undefined`

## 🕵️ Details

It appears in the typescript `lib.dom.d.ts` that both local and session storage are never allowed to be undefined so it should be as simple as removing the `undefined` in the arg types.

```tsx
interface WindowLocalStorage {
    readonly localStorage: Storage;
}

interface WindowSessionStorage {
    readonly sessionStorage: Storage;
}

interface Window extends ... WindowLocalStorage, WindowSessionStorage { ... }
```

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate to `/admin`
3. open/close the menu
4. Refresh page
5. Confirm menu remains in state you left it in and the local storage is set as expected
6. Navigate to a profile form
7. Make a change
8. Refresh the page
9. Confirm the unsaved changes appear and session storage is set as expected
