### PR TITLE
[Fix] Override linguist for `tc-report`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-admin/src/hydrogen/**/* linguist-documentation
+tc-report/**/* linguist-vendored
 
 # Declare files that must keep LF endings, even on Windows.
 *.sh text eol=lf


### PR DESCRIPTION
🤖 Resolves #5751 

## 👋 Introduction

Changes our linguist override to mark `tc-report` folder as a vendor.

## 🕵️ Details

I know it is technically not a vendored folder but it seems more appropriate than documentation and improves the project language breakdown.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Guess we just merge and
2. 🤞 

