### PR TITLE
[Debt] Reduce initial bundle size

### DIFF
--- a/apps/web/src/components/AdminSideMenu/AdminSideMenu.tsx
+++ b/apps/web/src/components/AdminSideMenu/AdminSideMenu.tsx
@@ -1,16 +1,14 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import {
-  AcademicCapIcon,
-  HomeIcon,
-  BuildingOfficeIcon,
-  BuildingOffice2Icon,
-  TagIcon,
-  TicketIcon,
-  UserGroupIcon,
-  UserIcon,
-  Squares2X2Icon,
-} from "@heroicons/react/24/outline";
+import AcademicCapIcon from "@heroicons/react/24/outline/AcademicCapIcon";
+import HomeIcon from "@heroicons/react/24/outline/HomeIcon";
+import BuildingOfficeIcon from "@heroicons/react/24/outline/BuildingOfficeIcon";
+import BuildingOffice2Icon from "@heroicons/react/24/outline/BuildingOffice2Icon";
+import TagIcon from "@heroicons/react/24/outline/TagIcon";
+import TicketIcon from "@heroicons/react/24/outline/TicketIcon";
+import UserGroupIcon from "@heroicons/react/24/outline/UserGroupIcon";
+import UserIcon from "@heroicons/react/24/outline/UserIcon";
+import Squares2X2Icon from "@heroicons/react/24/outline/Squares2X2Icon";
 
 import { SideMenu, SideMenuItem } from "@gc-digital-talent/ui";
 import { useAuthorization, RoleName, ROLE_NAME } from "@gc-digital-talent/auth";

--- a/apps/web/src/components/AdminSideMenu/LoginOrLogout.tsx
+++ b/apps/web/src/components/AdminSideMenu/LoginOrLogout.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useLocation } from "react-router-dom";
-import {
-  ArrowLeftOnRectangleIcon,
-  ArrowRightOnRectangleIcon,
-} from "@heroicons/react/24/outline";
+import ArrowLeftOnRectangleIcon from "@heroicons/react/24/outline/ArrowLeftOnRectangleIcon";
+import ArrowRightOnRectangleIcon from "@heroicons/react/24/outline/ArrowRightOnRectangleIcon";
 
 import { useApiRoutes, useAuthentication } from "@gc-digital-talent/auth";
 import { ExternalSideMenuItem, SideMenuButton } from "@gc-digital-talent/ui";

--- a/apps/web/src/components/ApplicationPageWrapper/ApplicationPageWrapper.tsx
+++ b/apps/web/src/components/ApplicationPageWrapper/ApplicationPageWrapper.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { CalendarIcon } from "@heroicons/react/24/outline";
+import CalendarIcon from "@heroicons/react/24/outline/CalendarIcon";
 
 import {
   parseDateTimeUtc,

--- a/apps/web/src/components/EmploymentEquity/dialogs/DialogFooter.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/DialogFooter.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { ArrowDownOnSquareIcon } from "@heroicons/react/24/solid";
+import ArrowDownOnSquareIcon from "@heroicons/react/24/solid/ArrowDownOnSquareIcon";
 
 import { Button, Dialog } from "@gc-digital-talent/ui";
 

--- a/apps/web/src/components/InfoItem/StatusItem.tsx
+++ b/apps/web/src/components/InfoItem/StatusItem.tsx
@@ -1,9 +1,7 @@
 import * as React from "react";
 
-import {
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-} from "@heroicons/react/24/solid";
+import CheckCircleIcon from "@heroicons/react/24/solid/CheckCircleIcon";
+import ExclamationCircleIcon from "@heroicons/react/24/solid/ExclamationCircleIcon";
 import { useIntl } from "react-intl";
 import { commonMessages } from "@gc-digital-talent/i18n";
 import { BaseInfoItem } from "./BaseInfoItem";

--- a/apps/web/src/components/Layout/AdminLayout.tsx
+++ b/apps/web/src/components/Layout/AdminLayout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Outlet, ScrollRestoration } from "react-router-dom";
 import { useIntl } from "react-intl";
-import { Bars3Icon } from "@heroicons/react/24/solid";
+import Bars3Icon from "@heroicons/react/24/solid/Bars3Icon";
 
 import { useIsSmallScreen } from "@gc-digital-talent/helpers";
 import { useLocalStorage } from "@gc-digital-talent/storage";

--- a/apps/web/src/components/MissingLanguageRequirements/MissingLanguageRequirements.tsx
+++ b/apps/web/src/components/MissingLanguageRequirements/MissingLanguageRequirements.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
+import ExclamationTriangleIcon from "@heroicons/react/24/solid/ExclamationTriangleIcon";
 
 import {
   Chip,

--- a/apps/web/src/components/MissingSkills/MissingSkills.tsx
+++ b/apps/web/src/components/MissingSkills/MissingSkills.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import {
-  ExclamationTriangleIcon,
-  InformationCircleIcon,
-  LightBulbIcon,
-} from "@heroicons/react/24/solid";
+import ExclamationTriangleIcon from "@heroicons/react/24/solid/ExclamationTriangleIcon";
+import InformationCircleIcon from "@heroicons/react/24/solid/InformationCircleIcon";
+import LightBulbIcon from "@heroicons/react/24/solid/LightBulbIcon";
 
 import {
   Chip,

--- a/apps/web/src/components/Pagination/Pagination.tsx
+++ b/apps/web/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,5 @@
-import { ArrowLeftIcon, ArrowRightIcon } from "@heroicons/react/24/solid";
+import ArrowLeftIcon from "@heroicons/react/24/solid/ArrowLeftIcon";
+import ArrowRightIcon from "@heroicons/react/24/solid/ArrowRightIcon";
 import * as React from "react";
 import { useIntl } from "react-intl";
 

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateDocument.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateDocument.tsx
@@ -1,14 +1,13 @@
 import React, { HTMLAttributes } from "react";
-import {
-  ChatBubbleLeftRightIcon,
-  CurrencyDollarIcon,
-  InformationCircleIcon,
-  BuildingLibraryIcon,
-  LightBulbIcon,
-  BoltIcon,
-  MapPinIcon,
-  HandThumbUpIcon,
-} from "@heroicons/react/24/outline";
+import ChatBubbleLeftRightIcon from "@heroicons/react/24/outline/ChatBubbleLeftRightIcon";
+import CurrencyDollarIcon from "@heroicons/react/24/outline/CurrencyDollarIcon";
+import InformationCircleIcon from "@heroicons/react/24/outline/InformationCircleIcon";
+import BuildingLibraryIcon from "@heroicons/react/24/outline/BuildingLibraryIcon";
+import LightBulbIcon from "@heroicons/react/24/outline/LightBulbIcon";
+import BoltIcon from "@heroicons/react/24/outline/BoltIcon";
+import MapPinIcon from "@heroicons/react/24/outline/MapPinIcon";
+import HandThumbUpIcon from "@heroicons/react/24/outline/HandThumbUpIcon";
+
 import { useIntl } from "react-intl";
 
 import { notEmpty } from "@gc-digital-talent/helpers";

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateTableFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateTableFilterDialog.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useIntl } from "react-intl";
 import { useFormContext, SubmitHandler } from "react-hook-form";
-import { AdjustmentsVerticalIcon } from "@heroicons/react/24/outline";
+import AdjustmentsVerticalIcon from "@heroicons/react/24/outline/AdjustmentsVerticalIcon";
 
 import { Button, Dialog } from "@gc-digital-talent/ui";
 import {

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { IntlShape, useIntl } from "react-intl";
-import { LockClosedIcon } from "@heroicons/react/24/solid";
+import LockClosedIcon from "@heroicons/react/24/solid/LockClosedIcon";
 import { useReactToPrint } from "react-to-print";
 import { SubmitHandler } from "react-hook-form";
 

--- a/apps/web/src/components/ProfileFormWrapper/CancelButton.tsx
+++ b/apps/web/src/components/ProfileFormWrapper/CancelButton.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
-import { ArrowLeftCircleIcon } from "@heroicons/react/24/outline";
+import ArrowLeftCircleIcon from "@heroicons/react/24/outline/ArrowLeftCircleIcon";
 
 import { Link } from "@gc-digital-talent/ui";
 

--- a/apps/web/src/components/ProfileFormWrapper/SaveButton.tsx
+++ b/apps/web/src/components/ProfileFormWrapper/SaveButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ArrowDownOnSquareIcon } from "@heroicons/react/24/solid";
+import ArrowDownOnSquareIcon from "@heroicons/react/24/solid/ArrowDownOnSquareIcon";
 import { useIntl } from "react-intl";
 
 import { Submit } from "@gc-digital-talent/forms";

--- a/apps/web/src/components/SkillPicker/FamilyPicker.tsx
+++ b/apps/web/src/components/SkillPicker/FamilyPicker.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { CheckIcon, ChevronDownIcon } from "@heroicons/react/24/solid";
+import CheckIcon from "@heroicons/react/24/solid/CheckIcon";
+import ChevronDownIcon from "@heroicons/react/24/solid/ChevronDownIcon";
 
 import { Button, DropdownMenu, ScrollArea } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";

--- a/apps/web/src/components/SkillPicker/SkillBlock.tsx
+++ b/apps/web/src/components/SkillPicker/SkillBlock.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { CheckCircleIcon } from "@heroicons/react/24/outline";
+import CheckCircleIcon from "@heroicons/react/24/outline/CheckCircleIcon";
 
 import { Button, Collapsible } from "@gc-digital-talent/ui";
 import { useLocale, getLocalizedName } from "@gc-digital-talent/i18n";

--- a/apps/web/src/components/SkillsInDetail/SkillsInDetail.tsx
+++ b/apps/web/src/components/SkillsInDetail/SkillsInDetail.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
 import { useForm, useWatch } from "react-hook-form";
-import { TrashIcon } from "@heroicons/react/24/solid";
+import TrashIcon from "@heroicons/react/24/solid/TrashIcon";
 
 import { Button, Well } from "@gc-digital-talent/ui";
 import {

--- a/apps/web/src/components/Table/ApiManagedTable/SearchForm.tsx
+++ b/apps/web/src/components/Table/ApiManagedTable/SearchForm.tsx
@@ -1,7 +1,8 @@
 import React, { useRef } from "react";
 import debounce from "lodash/debounce";
 import { useIntl } from "react-intl";
-import { CheckIcon, ChevronDownIcon } from "@heroicons/react/24/solid";
+import CheckIcon from "@heroicons/react/24/solid/CheckIcon";
+import ChevronDownIcon from "@heroicons/react/24/solid/ChevronDownIcon";
 
 import { Button, DropdownMenu } from "@gc-digital-talent/ui";
 

--- a/apps/web/src/components/Table/ApiManagedTable/TableHeader.tsx
+++ b/apps/web/src/components/Table/ApiManagedTable/TableHeader.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from "react";
 import { useIntl } from "react-intl";
-import { PlusIcon, TableCellsIcon } from "@heroicons/react/24/outline";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import TableCellsIcon from "@heroicons/react/24/outline/TableCellsIcon";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { Button, Link, Dialog } from "@gc-digital-talent/ui";

--- a/apps/web/src/components/Table/ClientManagedTable/SortIcon.tsx
+++ b/apps/web/src/components/Table/ClientManagedTable/SortIcon.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { BarsArrowUpIcon, BarsArrowDownIcon } from "@heroicons/react/24/solid";
+import BarsArrowUpIcon from "@heroicons/react/24/solid/BarsArrowUpIcon";
+import BarsArrowDownIcon from "@heroicons/react/24/solid/BarsArrowDownIcon";
 
 interface SortIconProps {
   isSortedDesc?: boolean;

--- a/apps/web/src/components/Table/ClientManagedTable/Table.tsx
+++ b/apps/web/src/components/Table/ClientManagedTable/Table.tsx
@@ -5,7 +5,8 @@ import isEqual from "lodash/isEqual";
 import { useIntl } from "react-intl";
 import { useSearchParams } from "react-router-dom";
 import { FormProvider, useForm } from "react-hook-form";
-import { PlusIcon, TableCellsIcon } from "@heroicons/react/24/outline";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
+import TableCellsIcon from "@heroicons/react/24/outline/TableCellsIcon";
 import {
   useTable,
   useGlobalFilter,

--- a/apps/web/src/components/Table/ClientManagedTable/TableActionButtons.tsx
+++ b/apps/web/src/components/Table/ClientManagedTable/TableActionButtons.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { PencilIcon, TrashIcon } from "@heroicons/react/24/outline";
+import PencilIcon from "@heroicons/react/24/outline/PencilIcon";
+import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
 
 import { Link, Button } from "@gc-digital-talent/ui";
 

--- a/apps/web/src/components/Table/ResetButton.tsx
+++ b/apps/web/src/components/Table/ResetButton.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { XMarkIcon } from "@heroicons/react/24/solid";
+import XMarkIcon from "@heroicons/react/24/solid/XMarkIcon";
 
 const ResetButton = (
   props: Omit<React.HTMLProps<HTMLButtonElement>, "children">,

--- a/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import {
-  ComputerDesktopIcon,
-  SunIcon,
-  MoonIcon,
-} from "@heroicons/react/24/solid";
+import ComputerDesktopIcon from "@heroicons/react/24/solid/ComputerDesktopIcon";
+import SunIcon from "@heroicons/react/24/solid/SunIcon";
+import MoonIcon from "@heroicons/react/24/solid/MoonIcon";
 
 import { ToggleGroup } from "@gc-digital-talent/ui";
 import { useTheme, ThemeMode } from "@gc-digital-talent/theme";

--- a/apps/web/src/components/UserProfile/ExperienceByTypeListing.tsx
+++ b/apps/web/src/components/UserProfile/ExperienceByTypeListing.tsx
@@ -1,11 +1,9 @@
 import * as React from "react";
-import {
-  BookOpenIcon,
-  BriefcaseIcon,
-  LightBulbIcon,
-  StarIcon,
-  UserGroupIcon,
-} from "@heroicons/react/24/solid";
+import BookOpenIcon from "@heroicons/react/24/solid/BookOpenIcon";
+import BriefcaseIcon from "@heroicons/react/24/solid/BriefcaseIcon";
+import LightBulbIcon from "@heroicons/react/24/solid/LightBulbIcon";
+import StarIcon from "@heroicons/react/24/solid/StarIcon";
+import UserGroupIcon from "@heroicons/react/24/solid/UserGroupIcon";
 import { useIntl } from "react-intl";
 
 import { Accordion, HeadingRank } from "@gc-digital-talent/ui";

--- a/apps/web/src/components/UserProfile/PrintExperienceByType/PrintExperienceByType.tsx
+++ b/apps/web/src/components/UserProfile/PrintExperienceByType/PrintExperienceByType.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import {
-  BookOpenIcon,
-  BriefcaseIcon,
-  LightBulbIcon,
-  StarIcon,
-  UserGroupIcon,
-} from "@heroicons/react/24/solid";
+import BookOpenIcon from "@heroicons/react/24/solid/BookOpenIcon";
+import BriefcaseIcon from "@heroicons/react/24/solid/BriefcaseIcon";
+import LightBulbIcon from "@heroicons/react/24/solid/LightBulbIcon";
+import StarIcon from "@heroicons/react/24/solid/StarIcon";
+import UserGroupIcon from "@heroicons/react/24/solid/UserGroupIcon";
 
 import { AwardExperience, Experience } from "~/api/generated";
 import {

--- a/apps/web/src/components/UserProfile/UserProfile.tsx
+++ b/apps/web/src/components/UserProfile/UserProfile.tsx
@@ -1,16 +1,14 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import {
-  ChatBubbleLeftRightIcon,
-  CurrencyDollarIcon,
-  BuildingLibraryIcon,
-  LightBulbIcon,
-  BoltIcon,
-  MapPinIcon,
-  HandThumbUpIcon,
-  UserIcon,
-} from "@heroicons/react/24/outline";
-import { UserCircleIcon } from "@heroicons/react/24/solid";
+import ChatBubbleLeftRightIcon from "@heroicons/react/24/outline/ChatBubbleLeftRightIcon";
+import CurrencyDollarIcon from "@heroicons/react/24/outline/CurrencyDollarIcon";
+import BuildingLibraryIcon from "@heroicons/react/24/outline/BuildingLibraryIcon";
+import LightBulbIcon from "@heroicons/react/24/outline/LightBulbIcon";
+import BoltIcon from "@heroicons/react/24/outline/BoltIcon";
+import MapPinIcon from "@heroicons/react/24/outline/MapPinIcon";
+import HandThumbUpIcon from "@heroicons/react/24/outline/HandThumbUpIcon";
+import UserIcon from "@heroicons/react/24/outline/UserIcon";
+import UserCircleIcon from "@heroicons/react/24/solid/UserCircleIcon";
 
 import { notEmpty } from "@gc-digital-talent/helpers";
 import { TableOfContents, HeadingRank, Link } from "@gc-digital-talent/ui";

--- a/apps/web/src/components/UserProfileDocument/UserProfileDocument.tsx
+++ b/apps/web/src/components/UserProfileDocument/UserProfileDocument.tsx
@@ -1,14 +1,12 @@
 import React, { HTMLAttributes } from "react";
-import {
-  ChatBubbleLeftRightIcon,
-  CurrencyDollarIcon,
-  InformationCircleIcon,
-  BuildingLibraryIcon,
-  LightBulbIcon,
-  BoltIcon,
-  MapPinIcon,
-  HandThumbUpIcon,
-} from "@heroicons/react/24/outline";
+import ChatBubbleLeftRightIcon from "@heroicons/react/24/outline/ChatBubbleLeftRightIcon";
+import CurrencyDollarIcon from "@heroicons/react/24/outline/CurrencyDollarIcon";
+import InformationCircleIcon from "@heroicons/react/24/outline/InformationCircleIcon";
+import BuildingLibraryIcon from "@heroicons/react/24/outline/BuildingLibraryIcon";
+import LightBulbIcon from "@heroicons/react/24/outline/LightBulbIcon";
+import BoltIcon from "@heroicons/react/24/outline/BoltIcon";
+import MapPinIcon from "@heroicons/react/24/outline/MapPinIcon";
+import HandThumbUpIcon from "@heroicons/react/24/outline/HandThumbUpIcon";
 import { useIntl } from "react-intl";
 
 import { notEmpty } from "@gc-digital-talent/helpers";

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -1,16 +1,14 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import {
-  BoltIcon,
-  HomeIcon,
-  BuildingOfficeIcon,
-  BuildingOffice2Icon,
-  TicketIcon,
-  UserGroupIcon,
-  UserIcon,
-  Squares2X2Icon,
-  PuzzlePieceIcon,
-} from "@heroicons/react/24/outline";
+import BoltIcon from "@heroicons/react/24/outline/BoltIcon";
+import HomeIcon from "@heroicons/react/24/outline/HomeIcon";
+import BuildingOfficeIcon from "@heroicons/react/24/outline/BuildingOfficeIcon";
+import BuildingOffice2Icon from "@heroicons/react/24/outline/BuildingOffice2Icon";
+import TicketIcon from "@heroicons/react/24/outline/TicketIcon";
+import UserGroupIcon from "@heroicons/react/24/outline/UserGroupIcon";
+import UserIcon from "@heroicons/react/24/outline/UserIcon";
+import Squares2X2Icon from "@heroicons/react/24/outline/Squares2X2Icon";
+import PuzzlePieceIcon from "@heroicons/react/24/outline/PuzzlePieceIcon";
 
 import { Heading, Pending } from "@gc-digital-talent/ui";
 import { useAuthorization, hasRole } from "@gc-digital-talent/auth";

--- a/apps/web/src/pages/Applications/ApplicantDashboardPage/components/DashboardHeading.tsx
+++ b/apps/web/src/pages/Applications/ApplicantDashboardPage/components/DashboardHeading.tsx
@@ -1,12 +1,10 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
-import {
-  BriefcaseIcon,
-  BookOpenIcon,
-  UsersIcon,
-  LightBulbIcon,
-  StarIcon,
-} from "@heroicons/react/24/solid";
+import BriefcaseIcon from "@heroicons/react/24/solid/BriefcaseIcon";
+import BookOpenIcon from "@heroicons/react/24/solid/BookOpenIcon";
+import UsersIcon from "@heroicons/react/24/solid/UsersIcon";
+import LightBulbIcon from "@heroicons/react/24/solid/LightBulbIcon";
+import StarIcon from "@heroicons/react/24/solid/StarIcon";
 
 import Hero from "~/components/Hero/Hero";
 import useRoutes from "~/hooks/useRoutes";

--- a/apps/web/src/pages/Applications/ApplicantDashboardPage/components/HeroCard.tsx
+++ b/apps/web/src/pages/Applications/ApplicantDashboardPage/components/HeroCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@gc-digital-talent/ui";
-import { ChevronDoubleRightIcon } from "@heroicons/react/24/solid";
+import ChevronDoubleRightIcon from "@heroicons/react/24/solid/ChevronDoubleRightIcon";
 import * as React from "react";
 
 export type Color =

--- a/apps/web/src/pages/Applications/ApplicantDashboardPage/components/QualifiedRecruitments/QualifiedRecruitmentStatus.tsx
+++ b/apps/web/src/pages/Applications/ApplicantDashboardPage/components/QualifiedRecruitments/QualifiedRecruitmentStatus.tsx
@@ -1,9 +1,7 @@
 import * as React from "react";
-import {
-  ExclamationCircleIcon,
-  CheckCircleIcon,
-  LockClosedIcon,
-} from "@heroicons/react/24/solid";
+import ExclamationCircleIcon from "@heroicons/react/24/solid/ExclamationCircleIcon";
+import CheckCircleIcon from "@heroicons/react/24/solid/CheckCircleIcon";
+import LockClosedIcon from "@heroicons/react/24/solid/LockClosedIcon";
 import { useIntl } from "react-intl";
 import { PoolCandidate } from "~/api/generated";
 import {

--- a/apps/web/src/pages/Applications/ApplicantDashboardPage/components/QualifiedRecruitments/QualifiedRecruitments.tsx
+++ b/apps/web/src/pages/Applications/ApplicantDashboardPage/components/QualifiedRecruitments/QualifiedRecruitments.tsx
@@ -1,7 +1,11 @@
+/* eslint-disable import/no-duplicates */
+// known issue with date-fns and eslint https://github.com/date-fns/date-fns/issues/1756#issuecomment-624803874
 import * as React from "react";
 import { motion } from "framer-motion";
 import { useIntl } from "react-intl";
-import { isFuture, isPast, parseISO } from "date-fns";
+import isFuture from "date-fns/isFuture";
+import isPast from "date-fns/isPast";
+import parseISO from "date-fns/parseISO";
 
 import { Accordion, Heading, Well } from "@gc-digital-talent/ui";
 import { StandardHeader as StandardAccordionHeader } from "@gc-digital-talent/ui/src/components/Accordion/StandardHeader";

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { PresentationChartBarIcon } from "@heroicons/react/20/solid";
+import PresentationChartBarIcon from "@heroicons/react/20/solid/PresentationChartBarIcon";
 
 import { Heading } from "@gc-digital-talent/ui";
 import { ApplicationStep } from "@gc-digital-talent/graphql";

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useParams } from "react-router";
 import { useIntl } from "react-intl";
-import { UserCircleIcon } from "@heroicons/react/20/solid";
+import UserCircleIcon from "@heroicons/react/20/solid/UserCircleIcon";
 
 import {
   Heading,

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/DiversityEquityInclusion/DiversityEquityInclusion.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/DiversityEquityInclusion/DiversityEquityInclusion.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { UserCircleIcon } from "@heroicons/react/24/outline";
+import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
 import { useIntl } from "react-intl";
 
 import { Heading, ToggleSection, Well } from "@gc-digital-talent/ui";

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/GovernmentInformation/GovernmentInformation.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/GovernmentInformation/GovernmentInformation.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { SubmitHandler } from "react-hook-form";
-import { BuildingLibraryIcon } from "@heroicons/react/24/outline";
+import BuildingLibraryIcon from "@heroicons/react/24/outline/BuildingLibraryIcon";
 
 import { ToggleSection, Well } from "@gc-digital-talent/ui";
 import { BasicForm } from "@gc-digital-talent/forms";

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/LanguageProfile/LanguageProfile.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/LanguageProfile/LanguageProfile.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { SubmitHandler } from "react-hook-form";
-import { LanguageIcon } from "@heroicons/react/24/outline";
+import LanguageIcon from "@heroicons/react/24/outline/LanguageIcon";
 
 import { ToggleSection, Well } from "@gc-digital-talent/ui";
 import { BasicForm } from "@gc-digital-talent/forms";

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/PersonalInformation/PersonalInformation.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/PersonalInformation/PersonalInformation.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { SubmitHandler } from "react-hook-form";
-import { UserIcon } from "@heroicons/react/24/outline";
+import UserIcon from "@heroicons/react/24/outline/UserIcon";
 
 import { ToggleSection, Well } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/WorkPreferences/WorkPreferences.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/WorkPreferences/WorkPreferences.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { HandThumbUpIcon } from "@heroicons/react/24/outline";
+import HandThumbUpIcon from "@heroicons/react/24/outline/HandThumbUpIcon";
 import { useIntl } from "react-intl";
 import { SubmitHandler } from "react-hook-form";
 

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/utils.ts
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/utils.ts
@@ -1,10 +1,8 @@
 import { IntlShape, MessageDescriptor, defineMessage } from "react-intl";
-import {
-  PencilSquareIcon,
-  ExclamationCircleIcon,
-  CheckCircleIcon,
-  InformationCircleIcon,
-} from "@heroicons/react/24/outline";
+import PencilSquareIcon from "@heroicons/react/24/outline/PencilSquareIcon";
+import ExclamationCircleIcon from "@heroicons/react/24/outline/ExclamationCircleIcon";
+import CheckCircleIcon from "@heroicons/react/24/outline/CheckCircleIcon";
+import InformationCircleIcon from "@heroicons/react/24/outline/InformationCircleIcon";
 import { HeadingProps } from "@gc-digital-talent/ui";
 import { FieldLabels } from "@gc-digital-talent/forms";
 import { commonMessages } from "@gc-digital-talent/i18n";

--- a/apps/web/src/pages/Applications/ApplicationQuestionsIntroductionPage/ApplicationQuestionsIntroductionPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsIntroductionPage/ApplicationQuestionsIntroductionPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { PencilSquareIcon } from "@heroicons/react/20/solid";
+import PencilSquareIcon from "@heroicons/react/20/solid/PencilSquareIcon";
 
 import { Heading, Link, Separator } from "@gc-digital-talent/ui";
 import { ApplicationStep } from "@gc-digital-talent/graphql";

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { PencilSquareIcon } from "@heroicons/react/20/solid";
+import PencilSquareIcon from "@heroicons/react/20/solid/PencilSquareIcon";
 
 import { Heading } from "@gc-digital-talent/ui";
 import {

--- a/apps/web/src/pages/Applications/ApplicationResumeAddPage/ApplicationResumeAddPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumeAddPage/ApplicationResumeAddPage.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import {
-  StarIcon,
-  BriefcaseIcon,
-  BookOpenIcon,
-  UserGroupIcon,
-  LightBulbIcon,
-} from "@heroicons/react/20/solid";
+import StarIcon from "@heroicons/react/20/solid/StarIcon";
+import BriefcaseIcon from "@heroicons/react/20/solid/BriefcaseIcon";
+import BookOpenIcon from "@heroicons/react/20/solid/BookOpenIcon";
+import UserGroupIcon from "@heroicons/react/20/solid/UserGroupIcon";
+import LightBulbIcon from "@heroicons/react/20/solid/LightBulbIcon";
 
 import { Accordion, DefinitionList, Heading } from "@gc-digital-talent/ui";
 import { StandardHeader as StandardAccordionHeader } from "@gc-digital-talent/ui/src/components/Accordion/StandardHeader";

--- a/apps/web/src/pages/Applications/ApplicationResumeEditPage/ApplicationResumeEditPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumeEditPage/ApplicationResumeEditPage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useParams } from "react-router-dom";
-import { StarIcon } from "@heroicons/react/20/solid";
+import StarIcon from "@heroicons/react/20/solid/StarIcon";
 
 import { Heading, Pending, ThrowNotFound } from "@gc-digital-talent/ui";
 import { ApplicationStep } from "@gc-digital-talent/graphql";

--- a/apps/web/src/pages/Applications/ApplicationResumeIntroductionPage/ApplicationResumeIntroductionPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumeIntroductionPage/ApplicationResumeIntroductionPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { StarIcon } from "@heroicons/react/20/solid";
+import StarIcon from "@heroicons/react/20/solid/StarIcon";
 
 import { Heading, Link, Separator } from "@gc-digital-talent/ui";
 import { ApplicationStep } from "@gc-digital-talent/graphql";

--- a/apps/web/src/pages/Applications/ApplicationResumePage/ApplicationResumePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumePage/ApplicationResumePage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { IntlShape, useIntl } from "react-intl";
-import { StarIcon } from "@heroicons/react/20/solid";
+import StarIcon from "@heroicons/react/20/solid/StarIcon";
 import groupBy from "lodash/groupBy";
 import { FormProvider, useForm } from "react-hook-form";
 

--- a/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { RocketLaunchIcon } from "@heroicons/react/20/solid";
+import RocketLaunchIcon from "@heroicons/react/20/solid/RocketLaunchIcon";
 
 import { Heading } from "@gc-digital-talent/ui";
 import { ApplicationStep } from "@gc-digital-talent/graphql";

--- a/apps/web/src/pages/Applications/ApplicationSkillsIntroductionPage/ApplicationSkillsIntroductionPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsIntroductionPage/ApplicationSkillsIntroductionPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { SparklesIcon } from "@heroicons/react/20/solid";
+import SparklesIcon from "@heroicons/react/20/solid/SparklesIcon";
 
 import { Heading, Link, Separator } from "@gc-digital-talent/ui";
 import { ApplicationStep } from "@gc-digital-talent/graphql";

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { SparklesIcon } from "@heroicons/react/20/solid";
+import SparklesIcon from "@heroicons/react/20/solid/SparklesIcon";
 
 import { Heading } from "@gc-digital-talent/ui";
 import {

--- a/apps/web/src/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { RocketLaunchIcon } from "@heroicons/react/20/solid";
+import RocketLaunchIcon from "@heroicons/react/20/solid/RocketLaunchIcon";
 
 import { Alert, ExternalLink, Link } from "@gc-digital-talent/ui";
 import { ApplicationStep } from "@gc-digital-talent/graphql";

--- a/apps/web/src/pages/Applications/ApplicationWelcomePage/ApplicationWelcomePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationWelcomePage/ApplicationWelcomePage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { HeartIcon } from "@heroicons/react/24/solid";
+import HeartIcon from "@heroicons/react/24/solid/HeartIcon";
 import { useNavigate } from "react-router-dom";
 
 import { Button, Heading, Link, Separator } from "@gc-digital-talent/ui";

--- a/apps/web/src/pages/Applications/MyApplicationsPage/components/ApplicationCard/utils.ts
+++ b/apps/web/src/pages/Applications/MyApplicationsPage/components/ApplicationCard/utils.ts
@@ -1,4 +1,4 @@
-import { isPast } from "date-fns";
+import isPast from "date-fns/isPast";
 import { IntlShape } from "react-intl";
 
 import {

--- a/apps/web/src/pages/Applications/ReviewApplicationPage/ReviewApplicationPage.tsx
+++ b/apps/web/src/pages/Applications/ReviewApplicationPage/ReviewApplicationPage.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
 import { useParams } from "react-router-dom";
-import { ArrowSmallRightIcon } from "@heroicons/react/24/solid";
+import ArrowSmallRightIcon from "@heroicons/react/24/solid/ArrowSmallRightIcon";
 
 import { Pending, ThrowNotFound, Well, Link } from "@gc-digital-talent/ui";
 import { navigationMessages } from "@gc-digital-talent/i18n";

--- a/apps/web/src/pages/Applications/SignAndSubmitPage/SignAndSubmitPage.tsx
+++ b/apps/web/src/pages/Applications/SignAndSubmitPage/SignAndSubmitPage.tsx
@@ -3,11 +3,9 @@ import { useNavigate, useParams } from "react-router-dom";
 import uniqueId from "lodash/uniqueId";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
-import { ArrowSmallRightIcon } from "@heroicons/react/24/outline";
-import {
-  ClipboardDocumentCheckIcon,
-  UserIcon,
-} from "@heroicons/react/24/solid";
+import ArrowSmallRightIcon from "@heroicons/react/24/outline/ArrowSmallRightIcon";
+import ClipboardDocumentCheckIcon from "@heroicons/react/24/solid/ClipboardDocumentCheckIcon";
+import UserIcon from "@heroicons/react/24/solid/UserIcon";
 
 import { toast } from "@gc-digital-talent/toast";
 import {

--- a/apps/web/src/pages/Classifications/IndexClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/IndexClassificationPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { TagIcon } from "@heroicons/react/24/outline";
+import TagIcon from "@heroicons/react/24/outline/TagIcon";
 
 import PageHeader from "~/components/PageHeader";
 import SEO from "~/components/SEO/SEO";

--- a/apps/web/src/pages/Departments/IndexDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/IndexDepartmentPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { BuildingOfficeIcon } from "@heroicons/react/24/outline";
+import BuildingOfficeIcon from "@heroicons/react/24/outline/BuildingOfficeIcon";
 
 import PageHeader from "~/components/PageHeader";
 import SEO from "~/components/SEO/SEO";

--- a/apps/web/src/pages/DirectivePage/DirectivePage.tsx
+++ b/apps/web/src/pages/DirectivePage/DirectivePage.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import {
-  MapIcon,
-  ChartPieIcon,
-  NewspaperIcon,
-  MagnifyingGlassCircleIcon,
-  BookmarkSquareIcon,
-} from "@heroicons/react/24/outline";
+import MapIcon from "@heroicons/react/24/outline/MapIcon";
+import ChartPieIcon from "@heroicons/react/24/outline/ChartPieIcon";
+import NewspaperIcon from "@heroicons/react/24/outline/NewspaperIcon";
+import MagnifyingGlassCircleIcon from "@heroicons/react/24/outline/MagnifyingGlassCircleIcon";
+import BookmarkSquareIcon from "@heroicons/react/24/outline/BookmarkSquareIcon";
 
 import {
   Heading,

--- a/apps/web/src/pages/Home/AdminHomePage/AdminHomePage.tsx
+++ b/apps/web/src/pages/Home/AdminHomePage/AdminHomePage.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useLocation, useNavigate } from "react-router-dom";
-import {
-  HomeIcon,
-  ArrowRightOnRectangleIcon,
-} from "@heroicons/react/24/outline";
+import HomeIcon from "@heroicons/react/24/outline/HomeIcon";
+import ArrowRightOnRectangleIcon from "@heroicons/react/24/outline/ArrowRightOnRectangleIcon";
 
 import { CardLink, Loading } from "@gc-digital-talent/ui";
 import { getLocale } from "@gc-digital-talent/i18n";

--- a/apps/web/src/pages/Home/HomePage/components/About/About.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/About/About.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { NewspaperIcon } from "@heroicons/react/24/outline";
+import NewspaperIcon from "@heroicons/react/24/outline/NewspaperIcon";
 
 import { CardFlat, Heading } from "@gc-digital-talent/ui";
 import { useLocale } from "@gc-digital-talent/i18n";

--- a/apps/web/src/pages/Home/HomePage/components/Opportunities/Opportunities.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/Opportunities/Opportunities.tsx
@@ -1,7 +1,7 @@
 // Vendor dependencies
 import React from "react";
 import { useIntl } from "react-intl";
-import { MagnifyingGlassCircleIcon } from "@heroicons/react/24/outline";
+import MagnifyingGlassCircleIcon from "@heroicons/react/24/outline/MagnifyingGlassCircleIcon";
 
 // Local assets
 import { Heading, CardFlat } from "@gc-digital-talent/ui";

--- a/apps/web/src/pages/Home/IAPHomePage/components/LanguageSelector.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/LanguageSelector.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useSearchParams } from "react-router-dom";
-import { CheckIcon, ChevronDownIcon } from "@heroicons/react/24/solid";
+import CheckIcon from "@heroicons/react/24/solid/CheckIcon";
+import ChevronDownIcon from "@heroicons/react/24/solid/ChevronDownIcon";
 
 import { DropdownMenu, Button, Separator } from "@gc-digital-talent/ui";
 

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
 import { useParams } from "react-router-dom";
-import { UserCircleIcon } from "@heroicons/react/24/outline";
-import { ArrowLeftCircleIcon } from "@heroicons/react/24/solid";
+import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
+import ArrowLeftCircleIcon from "@heroicons/react/24/solid/ArrowLeftCircleIcon";
 
 import {
   NotFound,

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
-import { CalendarIcon, PencilSquareIcon } from "@heroicons/react/24/outline";
+import CalendarIcon from "@heroicons/react/24/outline/CalendarIcon";
+import PencilSquareIcon from "@heroicons/react/24/outline/PencilSquareIcon";
 
 import { toast } from "@gc-digital-talent/toast";
 import {

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/ActiveRecruitmentSection/ActiveRecruitmentSection.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/ActiveRecruitmentSection/ActiveRecruitmentSection.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { RocketLaunchIcon } from "@heroicons/react/24/outline";
+import RocketLaunchIcon from "@heroicons/react/24/outline/RocketLaunchIcon";
 import { useIntl } from "react-intl";
 
 import { Heading } from "@gc-digital-talent/ui";

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CpuChipIcon } from "@heroicons/react/24/outline";
+import CpuChipIcon from "@heroicons/react/24/outline/CpuChipIcon";
 import { useIntl } from "react-intl";
 import { useLocation } from "react-router-dom";
 import { FormProvider, useForm } from "react-hook-form";

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/PoolCard/PoolCard.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/PoolCard/PoolCard.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import {
-  CurrencyDollarIcon,
-  BoltIcon,
-  CalendarDaysIcon,
-} from "@heroicons/react/24/outline";
+import CurrencyDollarIcon from "@heroicons/react/24/outline/CurrencyDollarIcon";
+import BoltIcon from "@heroicons/react/24/outline/BoltIcon";
+import CalendarDaysIcon from "@heroicons/react/24/outline/CalendarDaysIcon";
 
 import { Heading, HeadingRank, Link, Chip, Chips } from "@gc-digital-talent/ui";
 import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";

--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useNavigate } from "react-router-dom";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
-import { Squares2X2Icon } from "@heroicons/react/24/outline";
+import Squares2X2Icon from "@heroicons/react/24/outline/Squares2X2Icon";
 
 import { toast } from "@gc-digital-talent/toast";
 import { Select, Submit, unpackMaybes } from "@gc-digital-talent/forms";

--- a/apps/web/src/pages/Pools/EditPoolPage/components/StatusSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/StatusSection.tsx
@@ -1,11 +1,9 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
-import {
-  FolderOpenIcon,
-  LockClosedIcon,
-  PencilIcon,
-  MegaphoneIcon,
-} from "@heroicons/react/24/outline";
+import FolderOpenIcon from "@heroicons/react/24/outline/FolderOpenIcon";
+import LockClosedIcon from "@heroicons/react/24/outline/LockClosedIcon";
+import PencilIcon from "@heroicons/react/24/outline/PencilIcon";
+import MegaphoneIcon from "@heroicons/react/24/outline/MegaphoneIcon";
 
 import { TableOfContents, Well } from "@gc-digital-talent/ui";
 

--- a/apps/web/src/pages/Pools/IndexPoolPage/IndexPoolPage.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/IndexPoolPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Squares2X2Icon } from "@heroicons/react/24/outline";
+import Squares2X2Icon from "@heroicons/react/24/outline/Squares2X2Icon";
 import { useAuthorization } from "@gc-digital-talent/auth/";
 
 import useRoutes from "~/hooks/useRoutes";

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -1,16 +1,14 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useParams } from "react-router-dom";
-import {
-  BoltIcon,
-  BriefcaseIcon as BriefcaseIconOutline,
-  ClipboardDocumentCheckIcon,
-  CheckCircleIcon,
-  CloudIcon,
-  CpuChipIcon,
-  LightBulbIcon,
-  PhoneIcon,
-} from "@heroicons/react/24/outline";
+import BoltIcon from "@heroicons/react/24/outline/BoltIcon";
+import BriefcaseIconOutline from "@heroicons/react/24/outline/BriefcaseIcon";
+import ClipboardDocumentCheckIcon from "@heroicons/react/24/outline/ClipboardDocumentCheckIcon";
+import CheckCircleIcon from "@heroicons/react/24/outline/CheckCircleIcon";
+import CloudIcon from "@heroicons/react/24/outline/CloudIcon";
+import CpuChipIcon from "@heroicons/react/24/outline/CpuChipIcon";
+import LightBulbIcon from "@heroicons/react/24/outline/LightBulbIcon";
+import PhoneIcon from "@heroicons/react/24/outline/PhoneIcon";
 
 import {
   Button,

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/PoolInfoCard.test.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/PoolInfoCard.test.tsx
@@ -3,7 +3,7 @@
  */
 import React from "react";
 import "@testing-library/jest-dom";
-import { format } from "date-fns";
+import format from "date-fns/format";
 
 import { renderWithProviders } from "@gc-digital-talent/jest-helpers";
 import { DATE_FORMAT_STRING } from "@gc-digital-talent/date-helpers";

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/PoolInfoCard.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/PoolInfoCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { CalendarIcon, CurrencyDollarIcon } from "@heroicons/react/24/solid";
+import CalendarIcon from "@heroicons/react/24/solid/CalendarIcon";
+import CurrencyDollarIcon from "@heroicons/react/24/solid/CurrencyDollarIcon";
 
 import { getLocale, localizeSalaryRange } from "@gc-digital-talent/i18n";
 import {

--- a/apps/web/src/pages/Pools/PoolLayout.tsx
+++ b/apps/web/src/pages/Pools/PoolLayout.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useParams, Outlet } from "react-router-dom";
-import {
-  ClipboardDocumentIcon,
-  Cog8ToothIcon,
-  UserGroupIcon,
-} from "@heroicons/react/24/outline";
+import ClipboardDocumentIcon from "@heroicons/react/24/outline/ClipboardDocumentIcon";
+import Cog8ToothIcon from "@heroicons/react/24/outline/Cog8ToothIcon";
+import UserGroupIcon from "@heroicons/react/24/outline/UserGroupIcon";
 
 import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
 

--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -2,12 +2,9 @@ import * as React from "react";
 import { useIntl } from "react-intl";
 import { useParams } from "react-router-dom";
 import { FormProvider, useForm } from "react-hook-form";
-import {
-  CheckIcon,
-  ClipboardIcon,
-  ArrowTopRightOnSquareIcon,
-} from "@heroicons/react/24/outline";
-
+import CheckIcon from "@heroicons/react/24/outline/CheckIcon";
+import ClipboardIcon from "@heroicons/react/24/outline/ClipboardIcon";
+import ArrowTopRightOnSquareIcon from "@heroicons/react/24/outline/ArrowTopRightOnSquareIcon";
 import {
   Pending,
   Chip,

--- a/apps/web/src/pages/Profile/ExperienceAndSkillsPage/components/AddExperienceDialog.tsx
+++ b/apps/web/src/pages/Profile/ExperienceAndSkillsPage/components/AddExperienceDialog.tsx
@@ -1,14 +1,13 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useSearchParams } from "react-router-dom";
-import {
-  BookOpenIcon,
-  BriefcaseIcon,
-  LightBulbIcon,
-  StarIcon,
-  UserGroupIcon,
-} from "@heroicons/react/24/outline";
-import { PlusIcon, ArrowLeftIcon } from "@heroicons/react/24/solid";
+import BookOpenIcon from "@heroicons/react/24/outline/BookOpenIcon";
+import BriefcaseIcon from "@heroicons/react/24/outline/BriefcaseIcon";
+import LightBulbIcon from "@heroicons/react/24/outline/LightBulbIcon";
+import StarIcon from "@heroicons/react/24/outline/StarIcon";
+import UserGroupIcon from "@heroicons/react/24/outline/UserGroupIcon";
+import PlusIcon from "@heroicons/react/24/solid/PlusIcon";
+import ArrowLeftIcon from "@heroicons/react/24/solid/ArrowLeftIcon";
 
 import { Dialog, IconButton, Link } from "@gc-digital-talent/ui";
 

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useIntl } from "react-intl";
 import { SubmitHandler } from "react-hook-form";
 import { OperationContext } from "urql";
-import { TrashIcon } from "@heroicons/react/24/solid";
+import TrashIcon from "@heroicons/react/24/solid/TrashIcon";
 
 import { toast } from "@gc-digital-talent/toast";
 import {

--- a/apps/web/src/pages/Profile/RoleSalaryPage/components/RoleSalaryForm/RoleSalaryForm.tsx
+++ b/apps/web/src/pages/Profile/RoleSalaryPage/components/RoleSalaryForm/RoleSalaryForm.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useNavigate } from "react-router-dom";
-import { InformationCircleIcon } from "@heroicons/react/24/solid";
+import InformationCircleIcon from "@heroicons/react/24/solid/InformationCircleIcon";
 
 import { BasicForm, Checklist, unpackMaybes } from "@gc-digital-talent/forms";
 import { errorMessages, navigationMessages } from "@gc-digital-talent/i18n";

--- a/apps/web/src/pages/SearchRequests/IndexSearchRequestPage/IndexSearchRequestPage.tsx
+++ b/apps/web/src/pages/SearchRequests/IndexSearchRequestPage/IndexSearchRequestPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TicketIcon } from "@heroicons/react/24/outline";
+import TicketIcon from "@heroicons/react/24/outline/TicketIcon";
 import { useIntl } from "react-intl";
 
 import PageHeader from "~/components/PageHeader";

--- a/apps/web/src/pages/SkillFamilies/IndexSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/IndexSkillFamilyPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { UserGroupIcon } from "@heroicons/react/24/outline";
+import UserGroupIcon from "@heroicons/react/24/outline/UserGroupIcon";
 
 import PageHeader from "~/components/PageHeader";
 import SEO from "~/components/SEO/SEO";

--- a/apps/web/src/pages/Skills/IndexSkillPage.tsx
+++ b/apps/web/src/pages/Skills/IndexSkillPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { AcademicCapIcon } from "@heroicons/react/24/outline";
+import AcademicCapIcon from "@heroicons/react/24/outline/AcademicCapIcon";
 
 import PageHeader from "~/components/PageHeader";
 import SEO from "~/components/SEO/SEO";

--- a/apps/web/src/pages/Teams/CreateTeamPage/CreateTeamPage.tsx
+++ b/apps/web/src/pages/Teams/CreateTeamPage/CreateTeamPage.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
-import { BuildingOffice2Icon } from "@heroicons/react/24/outline";
+import BuildingOffice2Icon from "@heroicons/react/24/outline/BuildingOffice2Icon";
 
 import { Pending } from "@gc-digital-talent/ui";
 import { notEmpty } from "@gc-digital-talent/helpers";

--- a/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamForm.tsx
+++ b/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamForm.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { SubmitHandler } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import { useIntl } from "react-intl";
-import { kebabCase } from "lodash";
+import kebabCase from "lodash/kebabCase";
 
 import { Link } from "@gc-digital-talent/ui";
 import { BasicForm, Submit } from "@gc-digital-talent/forms";

--- a/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamFormFields.tsx
+++ b/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamFormFields.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useFormContext } from "react-hook-form";
-import { kebabCase } from "lodash";
+import kebabCase from "lodash/kebabCase";
 
 import { Input, MultiSelectField } from "@gc-digital-talent/forms";
 import { errorMessages, getLocalizedName } from "@gc-digital-talent/i18n";

--- a/apps/web/src/pages/Teams/IndexTeamPage/IndexTeamPage.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/IndexTeamPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { BuildingOffice2Icon } from "@heroicons/react/24/outline";
+import BuildingOffice2Icon from "@heroicons/react/24/outline/BuildingOffice2Icon";
 
 import useRoutes from "~/hooks/useRoutes";
 import SEO from "~/components/SEO/SEO";

--- a/apps/web/src/pages/Teams/TeamLayout.tsx
+++ b/apps/web/src/pages/Teams/TeamLayout.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useParams, Outlet } from "react-router-dom";
-import {
-  UserGroupIcon,
-  Cog8ToothIcon,
-  ClipboardDocumentListIcon,
-} from "@heroicons/react/24/outline";
+import UserGroupIcon from "@heroicons/react/24/outline/UserGroupIcon";
+import Cog8ToothIcon from "@heroicons/react/24/outline/Cog8ToothIcon";
+import ClipboardDocumentListIcon from "@heroicons/react/24/outline/ClipboardDocumentListIcon";
 
 import { ThrowNotFound, Pending } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/AddTeamMemberDialog.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/AddTeamMemberDialog.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
-import { PlusIcon } from "@heroicons/react/24/outline";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
 
 import { Dialog, Button, IconButton } from "@gc-digital-talent/ui";
 import { MultiSelectField, Select } from "@gc-digital-talent/forms";

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/EditTeamMemberDialog.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/EditTeamMemberDialog.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
-import { PencilIcon } from "@heroicons/react/24/outline";
+import PencilIcon from "@heroicons/react/24/outline/PencilIcon";
 
 import { Dialog, Button } from "@gc-digital-talent/ui";
 import { MultiSelectField, Select } from "@gc-digital-talent/forms";

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/RemoveTeamMemberDialog.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/RemoveTeamMemberDialog.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { TrashIcon } from "@heroicons/react/24/outline";
+import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
 
 import { Dialog, Button, Pill } from "@gc-digital-talent/ui";
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";

--- a/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.tsx
+++ b/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { useNavigate } from "react-router-dom";
 import { SubmitHandler } from "react-hook-form";
 import omit from "lodash/omit";
+import kebabCase from "lodash/kebabCase";
 
 import {
   BasicForm,
@@ -26,7 +27,6 @@ import {
 } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
 
-import { kebabCase } from "lodash";
 import CreateTeamFormFields from "../../CreateTeamPage/components/CreateTeamFormFields";
 import DescriptionWordCounter, {
   TEXT_AREA_MAX_WORDS,

--- a/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
+++ b/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useParams } from "react-router-dom";
-import { PrinterIcon } from "@heroicons/react/24/outline";
+import PrinterIcon from "@heroicons/react/24/outline/PrinterIcon";
 
 import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
 

--- a/apps/web/src/pages/Users/IndexUserPage/IndexUserPage.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/IndexUserPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { UserIcon } from "@heroicons/react/24/outline";
+import UserIcon from "@heroicons/react/24/outline/UserIcon";
 
 import SEO from "~/components/SEO/SEO";
 import PageHeader from "~/components/PageHeader";

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useIntl } from "react-intl";
 import { useFormContext, SubmitHandler } from "react-hook-form";
-import { AdjustmentsVerticalIcon } from "@heroicons/react/24/outline";
+import AdjustmentsVerticalIcon from "@heroicons/react/24/outline/AdjustmentsVerticalIcon";
 
 import { Dialog, Button } from "@gc-digital-talent/ui";
 import {

--- a/apps/web/src/pages/Users/UpdateUserPage/components/AddIndividualRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/AddIndividualRoleDialog.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
-import { PlusIcon } from "@heroicons/react/24/outline";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
 
 import { Dialog, Button, IconButton } from "@gc-digital-talent/ui";
 import { MultiSelectField } from "@gc-digital-talent/forms";

--- a/apps/web/src/pages/Users/UpdateUserPage/components/AddTeamRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/AddTeamRoleDialog.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
-import { PlusIcon } from "@heroicons/react/24/outline";
+import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
 
 import { Dialog, Button, IconButton } from "@gc-digital-talent/ui";
 import { MultiSelectField, Select } from "@gc-digital-talent/forms";

--- a/apps/web/src/pages/Users/UpdateUserPage/components/EditTeamRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/EditTeamRoleDialog.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
-import { PencilIcon } from "@heroicons/react/24/outline";
+import PencilIcon from "@heroicons/react/24/outline/PencilIcon";
 
 import { Dialog, Button } from "@gc-digital-talent/ui";
 import { MultiSelectField } from "@gc-digital-talent/forms";

--- a/apps/web/src/pages/Users/UpdateUserPage/components/RemoveIndividualRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/RemoveIndividualRoleDialog.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { TrashIcon } from "@heroicons/react/24/outline";
+import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
 
 import { Dialog, Button, Pill } from "@gc-digital-talent/ui";
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";

--- a/apps/web/src/pages/Users/UpdateUserPage/components/RemoveTeamRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/RemoveTeamRoleDialog.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { TrashIcon } from "@heroicons/react/24/outline";
+import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
 
 import { Dialog, Button, Pill } from "@gc-digital-talent/ui";
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";

--- a/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useParams } from "react-router-dom";
-import {
-  CalculatorIcon,
-  InformationCircleIcon,
-  PencilSquareIcon,
-  UserIcon,
-} from "@heroicons/react/24/outline";
+import CalculatorIcon from "@heroicons/react/24/outline/CalculatorIcon";
+import InformationCircleIcon from "@heroicons/react/24/outline/InformationCircleIcon";
+import PencilSquareIcon from "@heroicons/react/24/outline/PencilSquareIcon";
+import UserIcon from "@heroicons/react/24/outline/UserIcon";
 
 import { Pending, TableOfContents, ThrowNotFound } from "@gc-digital-talent/ui";
 import { notEmpty } from "@gc-digital-talent/helpers";

--- a/apps/web/src/pages/Users/UserInformationPage/components/EmploymentEquitySection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/EmploymentEquitySection.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { CheckIcon } from "@heroicons/react/24/outline";
+import CheckIcon from "@heroicons/react/24/outline/CheckIcon";
 
 import { Well } from "@gc-digital-talent/ui";
 

--- a/apps/web/src/pages/Users/UserLayout.tsx
+++ b/apps/web/src/pages/Users/UserLayout.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useParams, Outlet } from "react-router-dom";
-import {
-  UserIcon,
-  UserCircleIcon,
-  Cog8ToothIcon,
-} from "@heroicons/react/24/outline";
+import UserIcon from "@heroicons/react/24/outline/UserIcon";
+import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
+import Cog8ToothIcon from "@heroicons/react/24/outline/Cog8ToothIcon";
 
 import { ThrowNotFound, Pending } from "@gc-digital-talent/ui";
 

--- a/apps/web/src/pages/Users/UserPlacementPage/UserPlacementPage.tsx
+++ b/apps/web/src/pages/Users/UserPlacementPage/UserPlacementPage.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useIntl } from "react-intl";
 import { useParams } from "react-router";
 import { OperationContext } from "urql";
-import { UserIcon } from "@heroicons/react/24/outline";
+import UserIcon from "@heroicons/react/24/outline/UserIcon";
 import { Scalars, useUserQuery } from "@gc-digital-talent/graphql";
 
 import PageHeader from "~/components/PageHeader";

--- a/packages/date-helpers/src/date.test.ts
+++ b/packages/date-helpers/src/date.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { toDate } from "date-fns-tz";
+import toDate from "date-fns-tz/toDate";
 import { createIntl, createIntlCache } from "react-intl";
 
 import {

--- a/packages/date-helpers/src/index.ts
+++ b/packages/date-helpers/src/index.ts
@@ -1,10 +1,13 @@
+/* eslint-disable import/no-duplicates */
+// known issue with date-fns and eslint https://github.com/date-fns/date-fns/issues/1756#issuecomment-624803874
 import type { IntlShape } from "react-intl";
-// Note: ignore to stop merging date-fns imports
-// eslint-disable-next-line import/no-duplicates
-import { add, format, parse, parseISO } from "date-fns";
-// eslint-disable-next-line import/no-duplicates
-import { fr } from "date-fns/locale";
-import { formatInTimeZone, toDate } from "date-fns-tz";
+import add from "date-fns/add";
+import format from "date-fns/format";
+import parse from "date-fns/parse";
+import parseISO from "date-fns/parseISO";
+import fr from "date-fns/locale/fr";
+import formatInTimeZone from "date-fns-tz/formatInTimeZone";
+import toDate from "date-fns-tz/toDate";
 
 import { Scalars } from "@gc-digital-talent/graphql";
 import { getLocale } from "@gc-digital-talent/i18n";

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -132,6 +132,30 @@ module.exports = {
     "no-shadow": "off",
     "@typescript-eslint/no-shadow": "error",
     "react/function-component-definition": "off",
+    "no-restricted-imports": [
+      "error",
+      {
+        name: "lodash",
+        message:
+          "Please import the individual function, not the entire library.",
+      },
+      {
+        name: "@heroicons/react/24/outline",
+        message: "Please import the individual icons, not the entire set.",
+      },
+      {
+        name: "@heroicons/react/24/solid",
+        message: "Please import the individual icons, not the entire set.",
+      },
+      {
+        name: "@heroicons/react/20/outline",
+        message: "Please import the individual icons, not the entire set.",
+      },
+      {
+        name: "@heroicons/react/20/solid",
+        message: "Please import the individual icons, not the entire set.",
+      },
+    ],
   },
   settings: {
     "import/extensions": [".ts", ".tsx"],

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -140,6 +140,16 @@ module.exports = {
           "Please import the individual function, not the entire library.",
       },
       {
+        name: "date-fns",
+        message:
+          "Please import the individual function, not the entire library.",
+      },
+      {
+        name: "date-fns-tz",
+        message:
+          "Please import the individual function, not the entire library.",
+      },
+      {
         name: "@heroicons/react/24/outline",
         message: "Please import the individual icons, not the entire set.",
       },

--- a/packages/forms/src/components/CheckButton/CheckButton.tsx
+++ b/packages/forms/src/components/CheckButton/CheckButton.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { CheckIcon, MinusIcon } from "@heroicons/react/24/outline";
+import CheckIcon from "@heroicons/react/24/outline/CheckIcon";
+import MinusIcon from "@heroicons/react/24/outline/MinusIcon";
 
 import { formMessages } from "@gc-digital-talent/i18n";
 

--- a/packages/forms/src/components/Combobox/Actions.tsx
+++ b/packages/forms/src/components/Combobox/Actions.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { Combobox as ComboboxPrimitive } from "@headlessui/react";
-import {
-  XMarkIcon,
-  ChevronDownIcon,
-  ArrowPathIcon,
-} from "@heroicons/react/24/solid";
+import XMarkIcon from "@heroicons/react/24/solid/XMarkIcon";
+import ChevronDownIcon from "@heroicons/react/24/solid/ChevronDownIcon";
+import ArrowPathIcon from "@heroicons/react/24/solid/ArrowPathIcon";
 import { useIntl } from "react-intl";
 
 import { uiMessages } from "@gc-digital-talent/i18n";

--- a/packages/forms/src/components/Combobox/NoOptions.tsx
+++ b/packages/forms/src/components/Combobox/NoOptions.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { ArrowPathIcon } from "@heroicons/react/24/solid";
+import ArrowPathIcon from "@heroicons/react/24/solid/ArrowPathIcon";
 
 import { formMessages } from "@gc-digital-talent/i18n";
 

--- a/packages/forms/src/components/DateInput/DateInput.stories.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.stories.tsx
@@ -1,9 +1,12 @@
+/* eslint-disable import/no-duplicates */
+// known issue with date-fns and eslint https://github.com/date-fns/date-fns/issues/1756#issuecomment-624803874
 import React from "react";
 import { useIntl } from "react-intl";
 import { useFormContext } from "react-hook-form";
 import { ComponentMeta, ComponentStory, Story } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import { isAfter, parseISO } from "date-fns";
+import isAfter from "date-fns/isAfter";
+import parseISO from "date-fns/parseISO";
 
 import {
   formatDate,

--- a/packages/forms/src/components/DateInput/DateInput.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.tsx
@@ -1,8 +1,12 @@
+/* eslint-disable import/no-duplicates */
+// known issue with date-fns and eslint https://github.com/date-fns/date-fns/issues/1756#issuecomment-624803874
 import React from "react";
 import { useIntl } from "react-intl";
 import get from "lodash/get";
 import omit from "lodash/omit";
-import { isAfter, isBefore, isValid } from "date-fns";
+import isAfter from "date-fns/isAfter";
+import isBefore from "date-fns/isBefore";
+import isValid from "date-fns/isValid";
 import { FieldError, useFormContext, Controller } from "react-hook-form";
 
 import { errorMessages } from "@gc-digital-talent/i18n";

--- a/packages/forms/src/components/DateInput/utils.ts
+++ b/packages/forms/src/components/DateInput/utils.ts
@@ -1,4 +1,4 @@
-import { format } from "date-fns";
+import format from "date-fns/format";
 import { IntlShape } from "react-intl";
 
 import { dateMessages } from "@gc-digital-talent/i18n";

--- a/packages/forms/src/components/Fieldset/Fieldset.tsx
+++ b/packages/forms/src/components/Fieldset/Fieldset.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useIntl } from "react-intl";
-import { QuestionMarkCircleIcon, XCircleIcon } from "@heroicons/react/24/solid";
+import QuestionMarkCircleIcon from "@heroicons/react/24/solid/QuestionMarkCircleIcon";
+import XCircleIcon from "@heroicons/react/24/solid/XCircleIcon";
 
 import { commonMessages, formMessages } from "@gc-digital-talent/i18n";
 

--- a/packages/forms/src/components/InputLabel/InputLabel.tsx
+++ b/packages/forms/src/components/InputLabel/InputLabel.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import { QuestionMarkCircleIcon, XCircleIcon } from "@heroicons/react/24/solid";
+import QuestionMarkCircleIcon from "@heroicons/react/24/solid/QuestionMarkCircleIcon";
+import XCircleIcon from "@heroicons/react/24/solid/XCircleIcon";
 import { useIntl } from "react-intl";
 
 import { commonMessages } from "@gc-digital-talent/i18n";

--- a/packages/forms/src/components/Repeater/Repeater.tsx
+++ b/packages/forms/src/components/Repeater/Repeater.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import {
-  ChevronUpIcon,
-  ChevronDownIcon,
-  TrashIcon,
-} from "@heroicons/react/24/solid";
+import ChevronUpIcon from "@heroicons/react/24/solid/ChevronUpIcon";
+import ChevronDownIcon from "@heroicons/react/24/solid/ChevronDownIcon";
+import TrashIcon from "@heroicons/react/24/solid/TrashIcon";
 
 import { Button, useAnnouncer } from "@gc-digital-talent/ui";
 import { formMessages } from "@gc-digital-talent/i18n";

--- a/packages/toast/src/components/Toast/Toast.tsx
+++ b/packages/toast/src/components/Toast/Toast.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ToastContainer, Slide, CloseButtonProps } from "react-toastify";
 
-import { XCircleIcon } from "@heroicons/react/24/solid";
+import XCircleIcon from "@heroicons/react/24/solid/XCircleIcon";
 
 import closeButtonStyles from "./styles";
 

--- a/packages/toast/src/toast.tsx
+++ b/packages/toast/src/toast.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import {
-  CheckCircleIcon,
-  EyeIcon,
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-} from "@heroicons/react/24/outline";
+import CheckCircleIcon from "@heroicons/react/24/outline/CheckCircleIcon";
+import EyeIcon from "@heroicons/react/24/outline/EyeIcon";
+import ExclamationCircleIcon from "@heroicons/react/24/outline/ExclamationCircleIcon";
+import ExclamationTriangleIcon from "@heroicons/react/24/outline/ExclamationTriangleIcon";
 import { toast as toastify, ToastOptions } from "react-toastify";
 
 import ToastMessage from "./components/ToastMessage/ToastMessage";

--- a/packages/ui/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
-import { AcademicCapIcon, Cog8ToothIcon } from "@heroicons/react/24/solid";
+import AcademicCapIcon from "@heroicons/react/24/solid/AcademicCapIcon";
+import Cog8ToothIcon from "@heroicons/react/24/solid/Cog8ToothIcon";
 import { faker } from "@faker-js/faker";
 
 import AccordionDocs from "./Accordion.docs.mdx";

--- a/packages/ui/src/components/Accordion/Accordion.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.tsx
@@ -2,7 +2,7 @@
  * Documentation: https://www.radix-ui.com/docs/primitives/components/accordion
  */
 import React from "react";
-import { ChevronDownIcon } from "@heroicons/react/24/solid";
+import ChevronDownIcon from "@heroicons/react/24/solid/ChevronDownIcon";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 
 import type { HeadingRank } from "../../types";

--- a/packages/ui/src/components/Alert/Alert.stories.tsx
+++ b/packages/ui/src/components/Alert/Alert.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BellIcon } from "@heroicons/react/24/outline";
+import BellIcon from "@heroicons/react/24/outline/BellIcon";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { faker } from "@faker-js/faker";

--- a/packages/ui/src/components/Alert/Alert.tsx
+++ b/packages/ui/src/components/Alert/Alert.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { XCircleIcon } from "@heroicons/react/24/solid";
+import XCircleIcon from "@heroicons/react/24/solid/XCircleIcon";
 import { useIntl } from "react-intl";
 
 import { uiMessages } from "@gc-digital-talent/i18n";

--- a/packages/ui/src/components/Alert/utils.ts
+++ b/packages/ui/src/components/Alert/utils.ts
@@ -1,11 +1,9 @@
 import React from "react";
 import { IntlShape } from "react-intl";
-import {
-  CheckCircleIcon,
-  EyeIcon,
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-} from "@heroicons/react/24/outline";
+import CheckCircleIcon from "@heroicons/react/24/outline/CheckCircleIcon";
+import EyeIcon from "@heroicons/react/24/outline/EyeIcon";
+import ExclamationCircleIcon from "@heroicons/react/24/outline/ExclamationCircleIcon";
+import ExclamationTriangleIcon from "@heroicons/react/24/outline/ExclamationTriangleIcon";
 
 import { uiMessages } from "@gc-digital-talent/i18n";
 

--- a/packages/ui/src/components/Breadcrumbs/Crumb.tsx
+++ b/packages/ui/src/components/Breadcrumbs/Crumb.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { ChevronRightIcon } from "@heroicons/react/24/solid";
+import ChevronRightIcon from "@heroicons/react/24/solid/ChevronRightIcon";
 
 interface CrumbProps {
   children: React.ReactNode;

--- a/packages/ui/src/components/Chip/Chip.tsx
+++ b/packages/ui/src/components/Chip/Chip.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { XCircleIcon } from "@heroicons/react/24/outline";
+import XCircleIcon from "@heroicons/react/24/outline/XCircleIcon";
 import { useIntl } from "react-intl";
 
 import { uiMessages } from "@gc-digital-talent/i18n";

--- a/packages/ui/src/components/DefinitionList/DefinitionList.stories.tsx
+++ b/packages/ui/src/components/DefinitionList/DefinitionList.stories.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
-import {
-  AcademicCapIcon,
-  BackspaceIcon,
-  CakeIcon,
-  DevicePhoneMobileIcon,
-  EnvelopeIcon,
-} from "@heroicons/react/24/solid";
+import AcademicCapIcon from "@heroicons/react/24/solid/AcademicCapIcon";
+import BackspaceIcon from "@heroicons/react/24/solid/BackspaceIcon";
+import CakeIcon from "@heroicons/react/24/solid/CakeIcon";
+import DevicePhoneMobileIcon from "@heroicons/react/24/solid/DevicePhoneMobileIcon";
+import EnvelopeIcon from "@heroicons/react/24/solid/EnvelopeIcon";
 import { faker } from "@faker-js/faker";
 
 import DefinitionList from "./DefinitionList";

--- a/packages/ui/src/components/Dialog/Dialog.test.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.test.tsx
@@ -4,7 +4,7 @@
 import "@testing-library/jest-dom";
 import { fireEvent, screen } from "@testing-library/react";
 import React from "react";
-import { PlusIcon } from "@heroicons/react/24/solid";
+import PlusIcon from "@heroicons/react/24/solid/PlusIcon";
 import { faker } from "@faker-js/faker";
 
 import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -3,7 +3,7 @@
  */
 import React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { XMarkIcon } from "@heroicons/react/24/outline";
+import XMarkIcon from "@heroicons/react/24/outline/XMarkIcon";
 import { useIntl } from "react-intl";
 
 import { uiMessages } from "@gc-digital-talent/i18n";

--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
-import { CheckIcon } from "@heroicons/react/24/solid";
+import CheckIcon from "@heroicons/react/24/solid/CheckIcon";
 
 import Button from "../Button";
 

--- a/packages/ui/src/components/Link/ExternalLink.tsx
+++ b/packages/ui/src/components/Link/ExternalLink.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
+import ArrowTopRightOnSquareIcon from "@heroicons/react/24/outline/ArrowTopRightOnSquareIcon";
 import { useIntl } from "react-intl";
 
 import { uiMessages } from "@gc-digital-talent/i18n";

--- a/packages/ui/src/components/SideMenu/SideMenu.stories.tsx
+++ b/packages/ui/src/components/SideMenu/SideMenu.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
-import { HomeIcon } from "@heroicons/react/24/outline";
-import { ArrowRightOnRectangleIcon } from "@heroicons/react/24/solid";
+import HomeIcon from "@heroicons/react/24/outline/HomeIcon";
+import ArrowRightOnRectangleIcon from "@heroicons/react/24/solid/ArrowRightOnRectangleIcon";
 
 import SideMenuComponent from "./SideMenu";
 import { SideMenuButton } from "./SideMenuItem";

--- a/packages/ui/src/components/SideMenu/SideMenu.test.tsx
+++ b/packages/ui/src/components/SideMenu/SideMenu.test.tsx
@@ -5,7 +5,7 @@ import "@testing-library/jest-dom";
 import React from "react";
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@gc-digital-talent/jest-helpers";
-import { MagnifyingGlassIcon } from "@heroicons/react/24/solid";
+import MagnifyingGlassIcon from "@heroicons/react/24/solid/MagnifyingGlassIcon";
 import SideMenu from "./SideMenu";
 import type { SideMenuProps } from "./SideMenu";
 import SideMenuItem from "./SideMenuItem";

--- a/packages/ui/src/components/SideMenu/SideMenu.tsx
+++ b/packages/ui/src/components/SideMenu/SideMenu.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import FocusLock from "react-focus-lock";
 import { RemoveScroll } from "react-remove-scroll";
-import { Bars3Icon } from "@heroicons/react/24/outline";
+import Bars3Icon from "@heroicons/react/24/outline/Bars3Icon";
 import { useIntl } from "react-intl";
 
 import { uiMessages } from "@gc-digital-talent/i18n";

--- a/packages/ui/src/components/Stepper/testUtils.ts
+++ b/packages/ui/src/components/Stepper/testUtils.ts
@@ -1,10 +1,8 @@
-import {
-  AcademicCapIcon,
-  BanknotesIcon,
-  CakeIcon,
-  DevicePhoneMobileIcon,
-  EnvelopeIcon,
-} from "@heroicons/react/20/solid";
+import AcademicCapIcon from "@heroicons/react/20/solid/AcademicCapIcon";
+import BanknotesIcon from "@heroicons/react/20/solid/BanknotesIcon";
+import CakeIcon from "@heroicons/react/20/solid/CakeIcon";
+import DevicePhoneMobileIcon from "@heroicons/react/20/solid/DevicePhoneMobileIcon";
+import EnvelopeIcon from "@heroicons/react/20/solid/EnvelopeIcon";
 
 import { StepType } from "./types";
 

--- a/packages/ui/src/components/Stepper/utils.ts
+++ b/packages/ui/src/components/Stepper/utils.ts
@@ -1,4 +1,6 @@
-import { CheckIcon, FlagIcon, MapPinIcon } from "@heroicons/react/20/solid";
+import CheckIcon from "@heroicons/react/20/solid/CheckIcon";
+import FlagIcon from "@heroicons/react/20/solid/FlagIcon";
+import MapPinIcon from "@heroicons/react/20/solid/MapPinIcon";
 import { MessageDescriptor } from "react-intl";
 
 import { uiMessages } from "@gc-digital-talent/i18n";

--- a/packages/ui/src/components/TileLink/TileLink.tsx
+++ b/packages/ui/src/components/TileLink/TileLink.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link as RouterLink } from "react-router-dom";
-import { ChevronDoubleRightIcon } from "@heroicons/react/24/solid";
+import ChevronDoubleRightIcon from "@heroicons/react/24/solid/ChevronDoubleRightIcon";
 
 import { sanitizeUrl } from "@gc-digital-talent/helpers";
 

--- a/packages/ui/src/components/ToggleGroup/ToggleGroup.stories.tsx
+++ b/packages/ui/src/components/ToggleGroup/ToggleGroup.stories.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import { defineMessages, useIntl } from "react-intl";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
-import {
-  AcademicCapIcon,
-  BanknotesIcon,
-  UserIcon,
-} from "@heroicons/react/24/outline";
+import AcademicCapIcon from "@heroicons/react/24/outline/AcademicCapIcon";
+import BanknotesIcon from "@heroicons/react/24/outline/BanknotesIcon";
+import UserIcon from "@heroicons/react/24/outline/UserIcon";
 
 import ToggleGroupDocs from "./ToggleGroup.docs.mdx";
 import ToggleGroup from "./ToggleGroup";

--- a/packages/ui/src/components/ToggleSection/ToggleSection.stories.tsx
+++ b/packages/ui/src/components/ToggleSection/ToggleSection.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
-import { AcademicCapIcon } from "@heroicons/react/24/solid";
+import AcademicCapIcon from "@heroicons/react/24/solid/AcademicCapIcon";
 
 import { action } from "@storybook/addon-actions";
 import ToggleSection from "./ToggleSection";


### PR DESCRIPTION
🤖 Resolves #6161 

## 👋 Introduction

This branch aims to reduce the initial bundle size to improve performance.  I reduced overall size 20% and the app.js file by 24%!

## 🕵️ Details

- Import individual heroicon files to allow tree-shaking
- Import individual date-fns files to allow tree-shaking
- Eslint rule to enforce the above

## :question: Questions

- Application Insights is a [big,](https://bundlephobia.com/package/@microsoft/applicationinsights-web@3.0.1)  [big](https://bundlephobia.com/package/@microsoft/applicationinsights-react-js@3.4.2) library in our initial bundle.  How badly do we want it?
- Why doesn't it get moved to a separate chunk?  Is it because it's coupled in the context component used everywhere?
- Are we starting it up twice in https://github.com/GCTC-NTGC/gc-digital-talent/blob/3848f92dbaaaa699c5d6f875572a4bde90ab9d17/apps/web/src/components/Layout/IAPLayout.tsx#L4

## 🧪 Testing

> __Note__
It's probably easier to review this one commit-by-commit.

1. Rebuild app
2. Ensure it loads and runs correctly
3. Observe a smaller file-size

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/8978655/236008971-8761dd81-b85c-4c65-8aa9-db0324e83f88.png)
