### PR TITLE
Simplify deployment migration logging

### DIFF
--- a/infrastructure/bin/post_deployment.sh
+++ b/infrastructure/bin/post_deployment.sh
@@ -39,20 +39,13 @@ else
 fi
 
 # Laravel database migrations
-# Unfortunately, no useful exit codes from artisan :-(
 MIGRATION_STDOUT=$(php artisan migrate --no-interaction --force --no-ansi)
-# https://unix.stackexchange.com/a/649781
-OCCURRENCES_WORD_MIGRATING=$(printf '%s' "$MIGRATION_STDOUT" | grep -o 'Migrating:' | wc -l)
-OCCURRENCES_WORD_MIGRATED=$(printf '%s' "$MIGRATION_STDOUT" | grep -o 'Migrated:' | wc -l)
+MIGRATION_STATUS=$?
 
-if echo "$MIGRATION_STDOUT"| grep -q 'Exception' ; then
-    BLOCKS="$BLOCKS, { \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \":X: Database migration probably *failed* with an exception. $MENTION\" } }"
-elif [ "$MIGRATION_STDOUT" == 'Nothing to migrate.' ] ; then
-    BLOCKS="$BLOCKS, { \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \":white_check_mark: Database migration *successful* with the _nothing to migrate_ message.\" } }"
-elif [ "$OCCURRENCES_WORD_MIGRATING" == "$OCCURRENCES_WORD_MIGRATED" ] ; then
-    BLOCKS="$BLOCKS, { \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \":white_check_mark: Database migration appeared *successful* for $OCCURRENCES_WORD_MIGRATING migrations.\" } }"
+if [ $MIGRATION_STATUS -eq 0 ]; then
+    BLOCKS="$BLOCKS, { \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \":white_check_mark: Database migration *successful*.\" } }"
 else
-    BLOCKS="$BLOCKS, { \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \":X: Database migration *unknown* status. $MENTION\" } }"
+    BLOCKS="$BLOCKS, { \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \":X: Database migration *failed*. $MENTION\" } }"
 fi
 
 # Include the stdout from the migration as its own block, cleaned to make Slack happy


### PR DESCRIPTION
🤖 Resolves #4987

## 👋 Introduction

This branch fixes the migration logging for deployment.  h/t @vd1992 for reminding me of this one.  :smiling_imp: 

## 🕵️ Details

When we upgraded to Laravel 10 the deployment logging got a bit broken.  However, since the upgrade we actually get a useful exit code from the command so we can simplify the script at the same time.

## 🧪 Testing

### Setup
1. Rebuild the app
2. Uncomment docker-compose.ymlL41 and restart the _webserver_ container
3. cd to `/home/site/wwwroot` and run `./infrastructure/bin/post_deployment.sh . {webhook} tester`
    - you can find the webhook URL here: https://talent-cloud.slack.com/archives/C0259G6KXJ6/p1659981584613159
4. Check devrobotfam for the results 

### Notes
- To roll back a migration run `php artisan migrate:rollback --step=1` from the api directory
- To force a migration to fail you can add this to it: `Schema::drop('this_table_doesnt_exist');`

### Checklist
- [ ] Running with no migrations gives you the successful message
- [ ] Running with all good migrations gives you the successful message
- [ ] Running with a failed migration gives you the failure message

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/8978655/236221375-cd70c9dc-1675-422b-8e01-1bf834954ac4.png)