### PR TITLE
[Bug] Adds period to end of sentence

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1561,8 +1561,8 @@
     "defaultMessage": "{totalCandidateCount, plural, =0 {Résultats : <testId>{totalCandidateCount}</testId> candidats correspondants à vos critères} =1 {Résultats : <testId>{totalCandidateCount}</testId> candidat correspondant à vos critères} other {Résultats : <testId>{totalCandidateCount}</testId> candidats correspondants à vos critères}}",
     "description": "Heading for total matching candidates in results section of search page."
   },
-  "bbso+7": {
-    "defaultMessage": "{candidateCount, plural, one {Il y a <strong><testId>{candidateCount}</testId></strong> candidat qui répond à vos critères dans ce bassin} other {Il y a <strong><testId>{candidateCount}</testId></strong> candidats qui répondent à vos critères dans ce bassin}}",
+  "oyFGYC": {
+    "defaultMessage": "{candidateCount, plural, one {Il y a <strong><testId>{candidateCount}</testId></strong> candidat qui répond à vos critères dans ce bassin.} other {Il y a <strong><testId>{candidateCount}</testId></strong> candidats qui répondent à vos critères dans ce bassin.}}",
     "description": "Message for total estimated matching candidates in pool"
   },
   "shwFSK": {

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchPools.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchPools.tsx
@@ -45,10 +45,10 @@ const SearchPools = ({
         {intl.formatMessage(
           {
             defaultMessage: `{candidateCount, plural,
-              one {There is <strong><testId>{candidateCount}</testId></strong> matching candidate in this pool}
-              other {There are <strong><testId>{candidateCount}</testId></strong> matching candidates in this pool}
+              one {There is <strong><testId>{candidateCount}</testId></strong> matching candidate in this pool.}
+              other {There are <strong><testId>{candidateCount}</testId></strong> matching candidates in this pool.}
             }`,
-            id: "bbso+7",
+            id: "oyFGYC",
             description:
               "Message for total estimated matching candidates in pool",
           },


### PR DESCRIPTION
🤖 Resolves #6481.

## 👋 Introduction

This PR adds a period to the end of sentence for the **Message for total estimated matching candidates in pool**.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/en/search`
2. Observe period within results cards
3. Navigate to `/fr/search`
4. Observe period within results cards

## 📸 Screenshots

![Screen Shot 2023-05-04 at 14 31 53](https://user-images.githubusercontent.com/3046459/236296730-350a7470-a0a2-40f4-a7c0-f903edcf897d.png)
![Screen Shot 2023-05-04 at 14 31 28](https://user-images.githubusercontent.com/3046459/236296738-d230f716-8bfb-43ca-9092-5b8c1699b4d3.png)

