### PR TITLE
[Bug] Updates Estimated candidates sentence case

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -470,7 +470,7 @@
   ".ellipsis": {
     "defaultMessage": "... "
   },
-  "09x+E7": {
+  "2dkgQe": {
     "defaultMessage": "Nombre approximatif de candidats",
     "description": "Heading for total estimated candidates box next to search form."
   },

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/EstimatedCandidates.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/EstimatedCandidates.tsx
@@ -93,8 +93,8 @@ const EstimatedCandidates = ({
               data-h2-font-weight="base(700)"
             >
               {intl.formatMessage({
-                defaultMessage: "Estimated Candidates",
-                id: "09x+E7",
+                defaultMessage: "Estimated candidates",
+                id: "2dkgQe",
                 description:
                   "Heading for total estimated candidates box next to search form.",
               })}


### PR DESCRIPTION
🤖 Resolves #6482.

## 👋 Introduction

This PR updates a heading, **Estimated Candidates**, to sentence case **Estimated candidates**.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/en/search`
2. Observe **Estimated candidates**
3. Navigate to `/fr/search`
4. Observe **Nombre approximatif de candidats** remains the same

## 📸 Screenshots
![Screen Shot 2023-05-04 at 16 45 24](https://user-images.githubusercontent.com/3046459/236325672-639e162a-b1cc-4386-8918-11951a01efcd.png)

![Screen Shot 2023-05-04 at 16 45 45](https://user-images.githubusercontent.com/3046459/236325684-72db617b-4085-48c2-84fd-82211636a9de.png)


