### PR TITLE
[Feature] Search page OR filtering changes

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1565,6 +1565,18 @@
     "defaultMessage": "{candidateCount, plural, one {Il y a <strong><testId>{candidateCount}</testId></strong> candidat qui répond à vos critères dans ce bassin.} other {Il y a <strong><testId>{candidateCount}</testId></strong> candidats qui répondent à vos critères dans ce bassin.}}",
     "description": "Message for total estimated matching candidates in pool"
   },
+  "7mb9oA": {
+    "defaultMessage": "<strong>Nota :</strong> Les résultats tiendront compte de tout candidat qui correspond à <strong>l’une ou plusieurs</strong> des régions sélectionnées",
+    "description": "Context for the work region/location preferences filter in the search form."
+  },
+  "UXsUvN": {
+    "defaultMessage": "<strong>Nota :</strong> Les résultats tiendront compte de tout candidat qui correspond à <strong>l’un ou plusieurs</strong> des groupes d’équité en matière d’emploi ayant été sélectionnés",
+    "description": "Context for employment equity filter in search form."
+  },
+  "kLGIuJ": {
+    "defaultMessage": "<strong>Nota :</strong> Les résultats tiendront compte de tout candidat qui correspond à <strong>l’une ou plusieurs</strong> des compétences ayant été sélectionnées",
+    "description": "Context for skills selection filter in search form."
+  },
   "shwFSK": {
     "defaultMessage": "Je suis bilingue (anglais et français) et <strong>j'ai</strong> complété une <languageEvaluationPageLink></languageEvaluationPageLink> officielle en <strong>FRANÇAIS</strong>.",
     "description": "Message for the completed french bilingual evaluation option"
@@ -1592,10 +1604,6 @@
   "3quMA8": {
     "defaultMessage": "<strong>Pourquoi ne puis-je pas modifier mon statut?</strong>",
     "description": "Message in My Status Form."
-  },
-  "GIPciq": {
-    "defaultMessage": "<strong>Remarque :</strong> Si vous sélectionnez plus d'un groupe visé par l'équité en matière d'emploi, TOUS les candidats qui se sont déclarés membres de N'IMPORTE LEQUEL des groupes visés par l'équité en matière d'emploi sélectionnés seront recommandés. Si vous avez des exigences plus détaillées concernant l'équité en matière d'emploi, veuillez nous en faire part dans la section des commentaires du formulaire de soumission.",
-    "description": "Context for employment equity filter in search form."
   },
   "U6IroF": {
     "defaultMessage": "Études postsecondaires de deux ans",

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/AddSkillsToFilter.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/AddSkillsToFilter.tsx
@@ -68,29 +68,28 @@ const AddSkillsToFilter = ({ allSkills, linkId }: AddSkillsToFilterProps) => {
             "Describing the purpose of the skill filters on the Search page.",
         })}
       </p>
-      {/* <p>
-        {intl.formatMessage({
-          defaultMessage:
-            "Find candidates with the right skills for the job. Use the following tabs to find skills that are necessary for the job and select them to use them as filters for matching candidates.",
-          id: "+cy2GO",
-          description:
-            "Describing how to use the skill filters on search page, paragraph one.",
-        })}
-      </p>
-      <p data-h2-margin="base(x.5, 0, x1, 0)">
-        {intl.formatMessage({
-          defaultMessage:
-            " Why are there a limited number of skills? It’s important that applicants and managers are pulling from the same list of skills in order to create matches.",
-          id: "BQ7cf/",
-          description:
-            "Describing how to use the skill filters on search page, paragraph two.",
-        })}
-      </p> */}
       <SkillPicker
         skills={allSkills || []}
         onUpdateSelectedSkills={handleChange}
         selectedSkills={addedSkills}
       />
+      <span
+        data-h2-display="base(block)"
+        data-h2-margin="base(x.5, 0, 0, 0)"
+        data-h2-border="base(1px solid primary.darker)"
+        data-h2-radius="base(input)"
+        data-h2-background-color="base(primary.lightest)"
+        data-h2-padding="base(x.75)"
+        data-h2-color="base(primary.darker)"
+        data-h2-font-size="base(caption)"
+      >
+        {intl.formatMessage({
+          defaultMessage:
+            "<strong>Note:</strong> Results will include any candidate that matches <strong>1 or more</strong> of the selected skills",
+          id: "kLGIuJ",
+          description: "Context for skills selection filter in search form.",
+        })}
+      </span>
     </div>
   );
 };

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/AddSkillsToFilter.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/AddSkillsToFilter.tsx
@@ -73,23 +73,25 @@ const AddSkillsToFilter = ({ allSkills, linkId }: AddSkillsToFilterProps) => {
         onUpdateSelectedSkills={handleChange}
         selectedSkills={addedSkills}
       />
-      <span
-        data-h2-display="base(block)"
-        data-h2-margin="base(x.5, 0, 0, 0)"
-        data-h2-border="base(1px solid primary.darker)"
-        data-h2-radius="base(input)"
-        data-h2-background-color="base(primary.lightest)"
-        data-h2-padding="base(x.75)"
-        data-h2-color="base(primary.darker)"
-        data-h2-font-size="base(caption)"
-      >
-        {intl.formatMessage({
-          defaultMessage:
-            "<strong>Note:</strong> Results will include any candidate that matches <strong>1 or more</strong> of the selected skills",
-          id: "kLGIuJ",
-          description: "Context for skills selection filter in search form.",
-        })}
-      </span>
+      {addedSkills && addedSkills.length > 0 && (
+        <span
+          data-h2-display="base(block)"
+          data-h2-margin="base(x.5, 0, 0, 0)"
+          data-h2-border="base(1px solid primary.darker)"
+          data-h2-radius="base(input)"
+          data-h2-background-color="base(primary.lightest)"
+          data-h2-padding="base(x.75)"
+          data-h2-color="base(primary.darker)"
+          data-h2-font-size="base(caption)"
+        >
+          {intl.formatMessage({
+            defaultMessage:
+              "<strong>Note:</strong> Results will include any candidate that matches <strong>1 or more</strong> of the selected skills",
+            id: "kLGIuJ",
+            description: "Context for skills selection filter in search form.",
+          })}
+        </span>
+      )}
     </div>
   );
 };

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchContainer.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchContainer.tsx
@@ -57,10 +57,7 @@ const applicantFilterToQueryArgs = (
         qualifiedClassifications: filter?.qualifiedClassifications
           ? pickMap(filter.qualifiedClassifications, ["group", "level"])
           : undefined,
-        // TODO: pickMap the skills array as well?
-        // For now, while most candidates in production do not have skills populated, we want to ignore skill filters when showing a count to managers.
-        // TODO: Add skills back in when most candidates in production have populated skills.
-        skills: undefined,
+        skills: filter?.skills ? pickMap(filter.skills, "id") : undefined,
 
         // Override the filter's pool if one is provided separately.
         pools: poolId ? [{ id: poolId }] : pickMap(filter?.pools, "id"),

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -460,8 +460,8 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
               name="employmentEquity"
               context={intl.formatMessage({
                 defaultMessage:
-                  "<strong>Note:</strong> If you select more than one employment equity group, ALL candidates who have self-declared as being members of ANY of the selected EE groups will be referred. If you have more detailed EE requirements, let us know in the comment section of the submission form.",
-                id: "GIPciq",
+                  "<strong>Note:</strong> Results will include any candidate that matches <strong>1 or more</strong> of the selected EE groups",
+                id: "UXsUvN",
                 description:
                   "Context for employment equity filter in search form.",
               })}
@@ -511,6 +511,13 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             <MultiSelectField
               id="locationPreferences"
               name="locationPreferences"
+              context={intl.formatMessage({
+                defaultMessage:
+                  "<strong>Note:</strong> Results will include any candidate that matches <strong>1 or more</strong> of the selected regions",
+                id: "7mb9oA",
+                description:
+                  "Context for the work region/location preferences filter in the search form.",
+              })}
               label={intl.formatMessage({
                 defaultMessage: "Region",
                 id: "F+WFWB",


### PR DESCRIPTION
🤖 Resolves #6416 

## 👋 Introduction

Re-connects skills filtering on the search page.
Updates some copy. 

## 🕵️ Details

Skills filtering was quick to re-enable. Context was straightforward for location and EE.

Skills was trickier, it is a complex component used in multiple areas. I did not want to muddle with it, so I added the note below the component. I also made it so it can be conditionally rendered based off whether any skills were selected. 

## 🧪 Testing

1. Head to search page
2. Fill out a request, note the added notes are present
3. Note skills filtering returns more candidates with more skills selected
4. Submit request, check in the admin dashboard that the request matches and has the correct candidate count

## TODO

Translations
