### PR TITLE
[Feature] IAP publishing group, application theme

### DIFF
--- a/api/database/helpers/ApiEnums.php
+++ b/api/database/helpers/ApiEnums.php
@@ -387,6 +387,7 @@ class ApiEnums
     /**
      * Publishing Groups
      */
+    const PUBLISHING_GROUP_IAP = 'IAP';
     const PUBLISHING_GROUP_IT_JOBS = 'IT_JOBS';
     const PUBLISHING_GROUP_IT_JOBS_ONGOING = 'IT_JOBS_ONGOING';
     const PUBLISHING_GROUP_EXECUTIVE_JOBS = 'EXECUTIVE_JOBS';
@@ -395,6 +396,7 @@ class ApiEnums
     public static function publishingGroups(): array
     {
         return [
+            self::PUBLISHING_GROUP_IAP,
             self::PUBLISHING_GROUP_IT_JOBS,
             self::PUBLISHING_GROUP_IT_JOBS_ONGOING,
             self::PUBLISHING_GROUP_EXECUTIVE_JOBS,

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -436,6 +436,7 @@ enum PoolAdvertisementLanguage {
 }
 
 enum PublishingGroup {
+  IAP
   IT_JOBS
   IT_JOBS_ONGOING
   EXECUTIVE_JOBS

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -24,7 +24,10 @@ type Applicant {
   department: Department
   hasPriorityEntitlement: Boolean
   priorityNumber: String
-  languageAbility: LanguageAbility @deprecated(reason: "deprecated in favour of relying on lookingFor<Language>")
+  languageAbility: LanguageAbility
+    @deprecated(
+      reason: "deprecated in favour of relying on lookingFor<Language>"
+    )
   lookingForEnglish: Boolean
   lookingForFrench: Boolean
   lookingForBilingual: Boolean
@@ -39,7 +42,8 @@ type Applicant {
   isVisibleMinority: Boolean
   indigenousCommunities: [IndigenousCommunity]
   indigenousDeclarationSignature: String
-  jobLookingStatus: JobLookingStatus @deprecated(reason: "Removing with applicantDashboard feature flag")
+  jobLookingStatus: JobLookingStatus
+    @deprecated(reason: "Removing with applicantDashboard feature flag")
   poolCandidates: [PoolCandidate]
   hasDiploma: Boolean
   locationPreferences: [WorkRegion]
@@ -47,7 +51,8 @@ type Applicant {
   acceptedOperationalRequirements: [OperationalRequirement]
   expectedSalary: [SalaryRange]
   expectedClassifications: [Classification]
-  wouldAcceptTemporary: Boolean @deprecated(reason: "replaced with positionDuration")
+  wouldAcceptTemporary: Boolean
+    @deprecated(reason: "replaced with positionDuration")
   positionDuration: [PositionDuration]
   experiences: [Experience]
   awardExperiences: [AwardExperience]
@@ -67,7 +72,8 @@ type ApplicantFilter {
   languageAbility: LanguageAbility
   operationalRequirements: [OperationalRequirement]
   locationPreferences: [WorkRegion]
-  wouldAcceptTemporary: Boolean @deprecated(reason: "replaced with positionDuration")
+  wouldAcceptTemporary: Boolean
+    @deprecated(reason: "replaced with positionDuration")
   positionDuration: [PositionDuration]
   expectedClassifications: [Classification]
   skills: [Skill]
@@ -350,7 +356,9 @@ input CreateTeamInput {
   contactEmail: Email
 }
 
-"""When creating a User, name is required."""
+"""
+When creating a User, name is required.
+"""
 input CreateUserInput {
   sub: String
   legacyRoles: [LegacyRole] = []
@@ -400,7 +408,9 @@ input CreateUserInput {
   awardExperiences: AwardExperienceHasMany
 }
 
-"""A date string with format `Y-m-d`, e.g. `2011-05-23`."""
+"""
+A date string with format `Y-m-d`, e.g. `2011-05-23`.
+"""
 scalar Date
 
 """
@@ -478,7 +488,9 @@ enum EducationType {
   OTHER
 }
 
-"""A RFC 5321 compliant email."""
+"""
+A RFC 5321 compliant email.
+"""
 scalar Email
 
 type EquitySelections {
@@ -577,7 +589,9 @@ input KeyFilterInput {
   key: KeyString!
 }
 
-"""A human readable ID"""
+"""
+A human readable ID
+"""
 scalar KeyString
 
 enum Language {
@@ -592,10 +606,14 @@ enum LanguageAbility {
 }
 
 enum LegacyRole {
-  """A user who has administrator privileges"""
+  """
+  A user who has administrator privileges
+  """
   ADMIN
 
-  """A user who has a profile to apply to hiring pools"""
+  """
+  A user who has a profile to apply to hiring pools
+  """
   APPLICANT
 }
 
@@ -617,45 +635,101 @@ dealing with really large numbers to be on the safe side.
 scalar Mixed
 
 type Mutation {
-  createUser(user: CreateUserInput!): User @deprecated(reason: "The ability of admins to create new users will soon be removed.")
+  createUser(user: CreateUserInput!): User
+    @deprecated(
+      reason: "The ability of admins to create new users will soon be removed."
+    )
   updateUserAsUser(id: ID!, user: UpdateUserAsUserInput!): User
   updateUserAsAdmin(id: ID!, user: UpdateUserAsAdminInput!): User
   deleteUser(id: ID!): User
-  createPoolCandidateAsAdmin(poolCandidate: CreatePoolCandidateAsAdminInput!): PoolCandidate
-  updatePoolCandidateAsAdmin(id: ID!, poolCandidate: UpdatePoolCandidateAsAdminInput!): PoolCandidate
+  createPoolCandidateAsAdmin(
+    poolCandidate: CreatePoolCandidateAsAdminInput!
+  ): PoolCandidate
+  updatePoolCandidateAsAdmin(
+    id: ID!
+    poolCandidate: UpdatePoolCandidateAsAdminInput!
+  ): PoolCandidate
   deletePoolCandidate(id: ID!): PoolCandidate
-  createClassification(classification: CreateClassificationInput!): Classification
-  updateClassification(id: ID!, classification: UpdateClassificationInput!): Classification
+  createClassification(
+    classification: CreateClassificationInput!
+  ): Classification
+  updateClassification(
+    id: ID!
+    classification: UpdateClassificationInput!
+  ): Classification
   deleteClassification(id: ID!): Classification
   createDepartment(department: CreateDepartmentInput!): Department
   updateDepartment(id: ID!, department: UpdateDepartmentInput!): Department
   deleteDepartment(id: ID!): Department
-  createPoolCandidateSearchRequest(poolCandidateSearchRequest: CreatePoolCandidateSearchRequestInput!): PoolCandidateSearchRequest
-  updatePoolCandidateSearchRequest(id: ID!, poolCandidateSearchRequest: UpdatePoolCandidateSearchRequestInput!): PoolCandidateSearchRequest
+  createPoolCandidateSearchRequest(
+    poolCandidateSearchRequest: CreatePoolCandidateSearchRequestInput!
+  ): PoolCandidateSearchRequest
+  updatePoolCandidateSearchRequest(
+    id: ID!
+    poolCandidateSearchRequest: UpdatePoolCandidateSearchRequestInput!
+  ): PoolCandidateSearchRequest
   deletePoolCandidateSearchRequest(id: ID!): PoolCandidateSearchRequest
   createSkillFamily(skillFamily: CreateSkillFamilyInput!): SkillFamily
   updateSkillFamily(id: ID!, skillFamily: UpdateSkillFamilyInput!): SkillFamily
   createSkill(skill: CreateSkillInput!): Skill
   updateSkill(id: ID!, skill: UpdateSkillInput!): Skill
-  createWorkExperience(userId: ID!, workExperience: WorkExperienceInput!): WorkExperience
-  createPersonalExperience(userId: ID!, personalExperience: PersonalExperienceInput!): PersonalExperience
-  createCommunityExperience(userId: ID!, communityExperience: CommunityExperienceInput!): CommunityExperience
-  createEducationExperience(userId: ID!, educationExperience: EducationExperienceInput!): EducationExperience
-  createAwardExperience(userId: ID!, awardExperience: AwardExperienceInput!): AwardExperience
-  updateWorkExperience(id: ID!, workExperience: WorkExperienceInput!): WorkExperience
-  updatePersonalExperience(id: ID!, personalExperience: PersonalExperienceInput!): PersonalExperience
-  updateCommunityExperience(id: ID!, communityExperience: CommunityExperienceInput!): CommunityExperience
-  updateEducationExperience(id: ID!, educationExperience: EducationExperienceInput!): EducationExperience
-  updateAwardExperience(id: ID!, awardExperience: AwardExperienceInput!): AwardExperience
+  createWorkExperience(
+    userId: ID!
+    workExperience: WorkExperienceInput!
+  ): WorkExperience
+  createPersonalExperience(
+    userId: ID!
+    personalExperience: PersonalExperienceInput!
+  ): PersonalExperience
+  createCommunityExperience(
+    userId: ID!
+    communityExperience: CommunityExperienceInput!
+  ): CommunityExperience
+  createEducationExperience(
+    userId: ID!
+    educationExperience: EducationExperienceInput!
+  ): EducationExperience
+  createAwardExperience(
+    userId: ID!
+    awardExperience: AwardExperienceInput!
+  ): AwardExperience
+  updateWorkExperience(
+    id: ID!
+    workExperience: WorkExperienceInput!
+  ): WorkExperience
+  updatePersonalExperience(
+    id: ID!
+    personalExperience: PersonalExperienceInput!
+  ): PersonalExperience
+  updateCommunityExperience(
+    id: ID!
+    communityExperience: CommunityExperienceInput!
+  ): CommunityExperience
+  updateEducationExperience(
+    id: ID!
+    educationExperience: EducationExperienceInput!
+  ): EducationExperience
+  updateAwardExperience(
+    id: ID!
+    awardExperience: AwardExperienceInput!
+  ): AwardExperience
   deleteWorkExperience(id: ID!): WorkExperience
   deletePersonalExperience(id: ID!): PersonalExperience
   deleteCommunityExperience(id: ID!): CommunityExperience
   deleteEducationExperience(id: ID!): EducationExperience
   deleteAwardExperience(id: ID!): AwardExperience
   createPool(pool: CreatePoolInput!): Pool
-  createPoolAdvertisement(userId: ID!, teamId: ID!, poolAdvertisement: CreatePoolAdvertisementInput!): PoolAdvertisement
-  updatePool(id: ID!, pool: UpdatePoolInput!): Pool @deprecated(reason: "Should use updatePoolAdvertisement instead.")
-  updatePoolAdvertisement(id: ID!, poolAdvertisement: UpdatePoolAdvertisementInput!): PoolAdvertisement
+  createPoolAdvertisement(
+    userId: ID!
+    teamId: ID!
+    poolAdvertisement: CreatePoolAdvertisementInput!
+  ): PoolAdvertisement
+  updatePool(id: ID!, pool: UpdatePoolInput!): Pool
+    @deprecated(reason: "Should use updatePoolAdvertisement instead.")
+  updatePoolAdvertisement(
+    id: ID!
+    poolAdvertisement: UpdatePoolAdvertisementInput!
+  ): PoolAdvertisement
   publishPoolAdvertisement(id: ID!): PoolAdvertisement
   changePoolClosingDate(id: ID!, newClosingDate: DateTime!): PoolAdvertisement
   closePoolAdvertisement(id: ID!): PoolAdvertisement
@@ -666,13 +740,18 @@ type Mutation {
   createApplication(userId: ID!, poolId: ID!): PoolCandidate
   deleteApplication(id: ID!): Boolean
   submitApplication(id: ID!, signature: String!): PoolCandidate
-  updateApplication(id: ID!, application: UpdateApplicationInput!): PoolCandidate
+  updateApplication(
+    id: ID!
+    application: UpdateApplicationInput!
+  ): PoolCandidate
   createTeam(team: CreateTeamInput!): Team
   updateTeam(id: UUID!, team: UpdateTeamInput!): Team
   deleteTeam(id: UUID!): Team
 }
 
-"""e.g. Overtime as Required, Shift Work, Travel as Required, etc."""
+"""
+e.g. Overtime as Required, Shift Work, Travel as Required, etc.
+"""
 enum OperationalRequirement {
   SHIFT_WORK
   ON_CALL
@@ -686,12 +765,18 @@ enum OperationalRequirement {
   OVERTIME_REGULAR
 }
 
-"""Allows ordering a list of records."""
+"""
+Allows ordering a list of records.
+"""
 input OrderByClause {
-  """The column that is used for ordering."""
+  """
+  The column that is used for ordering.
+  """
   column: String!
 
-  """The direction that is used for ordering."""
+  """
+  The direction that is used for ordering.
+  """
   order: SortOrder!
 }
 
@@ -699,7 +784,9 @@ input OrderByClause {
 Aggregate functions when ordering by a relation without specifying a column.
 """
 enum OrderByRelationAggregateFunction {
-  """Amount of items."""
+  """
+  Amount of items.
+  """
   COUNT
 }
 
@@ -707,73 +794,119 @@ enum OrderByRelationAggregateFunction {
 Aggregate functions when ordering by a relation that may specify a column.
 """
 enum OrderByRelationWithColumnAggregateFunction {
-  """Average."""
+  """
+  Average.
+  """
   AVG
 
-  """Minimum."""
+  """
+  Minimum.
+  """
   MIN
 
-  """Maximum."""
+  """
+  Maximum.
+  """
   MAX
 
-  """Sum."""
+  """
+  Sum.
+  """
   SUM
 
-  """Amount of items."""
+  """
+  Amount of items.
+  """
   COUNT
 }
 
-"""Information about pagination using a Relay style cursor connection."""
+"""
+Information about pagination using a Relay style cursor connection.
+"""
 type PageInfo {
-  """When paginating forwards, are there more items?"""
+  """
+  When paginating forwards, are there more items?
+  """
   hasNextPage: Boolean!
 
-  """When paginating backwards, are there more items?"""
+  """
+  When paginating backwards, are there more items?
+  """
   hasPreviousPage: Boolean!
 
-  """The cursor to continue paginating backwards."""
+  """
+  The cursor to continue paginating backwards.
+  """
   startCursor: String
 
-  """The cursor to continue paginating forwards."""
+  """
+  The cursor to continue paginating forwards.
+  """
   endCursor: String
 
-  """Total number of nodes in the paginated connection."""
+  """
+  Total number of nodes in the paginated connection.
+  """
   total: Int!
 
-  """Number of nodes in the current page."""
+  """
+  Number of nodes in the current page.
+  """
   count: Int!
 
-  """Index of the current page."""
+  """
+  Index of the current page.
+  """
   currentPage: Int!
 
-  """Index of the last available page."""
+  """
+  Index of the last available page.
+  """
   lastPage: Int!
 }
 
-"""Information about pagination using a fully featured paginator."""
+"""
+Information about pagination using a fully featured paginator.
+"""
 type PaginatorInfo {
-  """Number of items in the current page."""
+  """
+  Number of items in the current page.
+  """
   count: Int!
 
-  """Index of the current page."""
+  """
+  Index of the current page.
+  """
   currentPage: Int!
 
-  """Index of the first item in the current page."""
+  """
+  Index of the first item in the current page.
+  """
   firstItem: Int
 
-  """Are there more pages after this one?"""
+  """
+  Are there more pages after this one?
+  """
   hasMorePages: Boolean!
 
-  """Index of the last item in the current page."""
+  """
+  Index of the last item in the current page.
+  """
   lastItem: Int
 
-  """Index of the last available page."""
+  """
+  Index of the last available page.
+  """
   lastPage: Int!
 
-  """Number of items per page."""
+  """
+  Number of items per page.
+  """
   perPage: Int!
 
-  """Number of total available items."""
+  """
+  Number of total available items.
+  """
   total: Int!
 }
 
@@ -802,7 +935,9 @@ input PersonalExperienceInput {
   skills: UpdateExperienceSkills
 }
 
-"""A phone number string, accepts any string"""
+"""
+A phone number string, accepts any string
+"""
 scalar PhoneNumber
 
 type Pool {
@@ -917,12 +1052,18 @@ input PoolCandidateFilterInput {
   poolCandidateStatus: [PoolCandidateStatus]
 }
 
-"""A paginated list of PoolCandidate items."""
+"""
+A paginated list of PoolCandidate items.
+"""
 type PoolCandidatePaginator {
-  """Pagination information about the list of items."""
+  """
+  Pagination information about the list of items.
+  """
   paginatorInfo: PaginatorInfo!
 
-  """A list of PoolCandidate items."""
+  """
+  A list of PoolCandidate items.
+  """
   data: [PoolCandidate!]!
 }
 
@@ -1015,6 +1156,7 @@ enum ProvinceOrTerritory {
 }
 
 enum PublishingGroup {
+  IAP
   IT_JOBS
   IT_JOBS_ONGOING
   EXECUTIVE_JOBS
@@ -1036,20 +1178,42 @@ type Query {
   pools: [Pool]!
   poolCandidate(id: UUID!): PoolCandidate
   poolCandidates(includeIds: [ID]): [PoolCandidate]!
-  countPoolCandidates(where: PoolCandidateFilterInput): Int! @deprecated(reason: "Replaced by countApplicants")
-  searchPoolCandidates(where: PoolCandidateFilterInput, orderBy: [OrderByClause!], expiryStatus: CandidateExpiryFilter): [PoolCandidate]!
-  countPoolCandidatesByPool(where: ApplicantFilterInput): [CandidateSearchPoolResult!]!
+  countPoolCandidates(where: PoolCandidateFilterInput): Int!
+    @deprecated(reason: "Replaced by countApplicants")
+  searchPoolCandidates(
+    where: PoolCandidateFilterInput
+    orderBy: [OrderByClause!]
+    expiryStatus: CandidateExpiryFilter
+  ): [PoolCandidate]!
+  countPoolCandidatesByPool(
+    where: ApplicantFilterInput
+  ): [CandidateSearchPoolResult!]!
   classification(id: UUID!): Classification
   classifications: [Classification]!
   department(id: UUID!): Department
   departments: [Department]!
-  poolCandidateFilter(id: UUID!): PoolCandidateFilter @deprecated(reason: "This should only be queried as part of a PoolCandidateSearchRequest.")
-  poolCandidateFilters: [PoolCandidateFilter]! @deprecated(reason: "This should only be queried as part of a PoolCandidateSearchRequest.")
-  applicantFilter(id: ID!): ApplicantFilter @deprecated(reason: "This should only be queried as part of a PoolCandidateSearchRequest.")
-  applicantFilters: [ApplicantFilter]! @deprecated(reason: "This should only be queried as part of a PoolCandidateSearchRequest.")
+  poolCandidateFilter(id: UUID!): PoolCandidateFilter
+    @deprecated(
+      reason: "This should only be queried as part of a PoolCandidateSearchRequest."
+    )
+  poolCandidateFilters: [PoolCandidateFilter]!
+    @deprecated(
+      reason: "This should only be queried as part of a PoolCandidateSearchRequest."
+    )
+  applicantFilter(id: ID!): ApplicantFilter
+    @deprecated(
+      reason: "This should only be queried as part of a PoolCandidateSearchRequest."
+    )
+  applicantFilters: [ApplicantFilter]!
+    @deprecated(
+      reason: "This should only be queried as part of a PoolCandidateSearchRequest."
+    )
   poolCandidateSearchRequest(id: ID!): PoolCandidateSearchRequest
   poolCandidateSearchRequests(limit: Int): [PoolCandidateSearchRequest]!
-  latestPoolCandidateSearchRequests(limit: Int): [PoolCandidateSearchRequest]! @deprecated(reason: "Use poolCandidateSearchRequests instead, with a specified limit")
+  latestPoolCandidateSearchRequests(limit: Int): [PoolCandidateSearchRequest]!
+    @deprecated(
+      reason: "Use poolCandidateSearchRequests instead, with a specified limit"
+    )
   skillFamily(id: UUID!): SkillFamily
   skillFamilies: [SkillFamily]!
   skill(id: UUID!): Skill
@@ -1063,33 +1227,49 @@ type Query {
     where: UserFilterInput
     orderBy: [OrderByClause!]
 
-    """Limits number of fetched items. Maximum allowed value: 1000."""
+    """
+    Limits number of fetched items. Maximum allowed value: 1000.
+    """
     first: Int = 10
 
-    """The offset from which items are returned."""
+    """
+    The offset from which items are returned.
+    """
     page: Int
   ): UserPaginator
   poolCandidatesPaginated(
     where: PoolCandidateSearchInput
     orderBy: [QueryPoolCandidatesPaginatedOrderByRelationOrderByClause!]
 
-    """Limits number of fetched items. Maximum allowed value: 1000."""
+    """
+    Limits number of fetched items. Maximum allowed value: 1000.
+    """
     first: Int = 10
 
-    """The offset from which items are returned."""
+    """
+    The offset from which items are returned.
+    """
     page: Int
   ): PoolCandidatePaginator
 }
 
-"""Order by clause for Query.poolCandidatesPaginated.orderBy."""
+"""
+Order by clause for Query.poolCandidatesPaginated.orderBy.
+"""
 input QueryPoolCandidatesPaginatedOrderByRelationOrderByClause {
-  """The column that is used for ordering."""
+  """
+  The column that is used for ordering.
+  """
   column: String
 
-  """The direction that is used for ordering."""
+  """
+  The direction that is used for ordering.
+  """
   order: SortOrder!
 
-  """Aggregate specification."""
+  """
+  Aggregate specification.
+  """
   user: QueryPoolCandidatesPaginatedOrderByUser
 }
 
@@ -1097,14 +1277,20 @@ input QueryPoolCandidatesPaginatedOrderByRelationOrderByClause {
 Aggregate specification for Query.poolCandidatesPaginated.orderBy.user.
 """
 input QueryPoolCandidatesPaginatedOrderByUser {
-  """The aggregate function to apply to the column."""
+  """
+  The aggregate function to apply to the column.
+  """
   aggregate: OrderByRelationWithColumnAggregateFunction!
 
-  """Name of the column to use."""
+  """
+  Name of the column to use.
+  """
   column: QueryPoolCandidatesPaginatedOrderByUserColumn
 }
 
-"""Allowed column names for Query.poolCandidatesPaginated.orderBy."""
+"""
+Allowed column names for Query.poolCandidatesPaginated.orderBy.
+"""
 enum QueryPoolCandidatesPaginatedOrderByUserColumn {
   PRIORITY_WEIGHT
   JOB_LOOKING_STATUS
@@ -1143,51 +1329,83 @@ input RolesInput {
   team: ID
 }
 
-"""The available SQL operators that are used to filter query results."""
+"""
+The available SQL operators that are used to filter query results.
+"""
 enum SQLOperator {
-  """Equal operator (`=`)"""
+  """
+  Equal operator (`=`)
+  """
   EQ
 
-  """Not equal operator (`!=`)"""
+  """
+  Not equal operator (`!=`)
+  """
   NEQ
 
-  """Greater than operator (`>`)"""
+  """
+  Greater than operator (`>`)
+  """
   GT
 
-  """Greater than or equal operator (`>=`)"""
+  """
+  Greater than or equal operator (`>=`)
+  """
   GTE
 
-  """Less than operator (`<`)"""
+  """
+  Less than operator (`<`)
+  """
   LT
 
-  """Less than or equal operator (`<=`)"""
+  """
+  Less than or equal operator (`<=`)
+  """
   LTE
 
-  """Simple pattern matching (`LIKE`)"""
+  """
+  Simple pattern matching (`LIKE`)
+  """
   LIKE
 
-  """Negation of simple pattern matching (`NOT LIKE`)"""
+  """
+  Negation of simple pattern matching (`NOT LIKE`)
+  """
   NOT_LIKE
 
-  """Whether a value is within a set of values (`IN`)"""
+  """
+  Whether a value is within a set of values (`IN`)
+  """
   IN
 
-  """Whether a value is not within a set of values (`NOT IN`)"""
+  """
+  Whether a value is not within a set of values (`NOT IN`)
+  """
   NOT_IN
 
-  """Whether a value is within a range of values (`BETWEEN`)"""
+  """
+  Whether a value is within a range of values (`BETWEEN`)
+  """
   BETWEEN
 
-  """Whether a value is not within a range of values (`NOT BETWEEN`)"""
+  """
+  Whether a value is not within a range of values (`NOT BETWEEN`)
+  """
   NOT_BETWEEN
 
-  """Whether a value is null (`IS NULL`)"""
+  """
+  Whether a value is null (`IS NULL`)
+  """
   IS_NULL
 
-  """Whether a value is not null (`IS NOT NULL`)"""
+  """
+  Whether a value is not null (`IS NOT NULL`)
+  """
   IS_NOT_NULL
 
-  """Whether a set of values contains a value (`@>`)"""
+  """
+  Whether a set of values contains a value (`@>`)
+  """
   CONTAINS
 }
 
@@ -1225,24 +1443,38 @@ enum SecurityStatus {
   TOP_SECRET
 }
 
-"""Information about pagination using a simple paginator."""
+"""
+Information about pagination using a simple paginator.
+"""
 type SimplePaginatorInfo {
-  """Number of items in the current page."""
+  """
+  Number of items in the current page.
+  """
   count: Int!
 
-  """Index of the current page."""
+  """
+  Index of the current page.
+  """
   currentPage: Int!
 
-  """Index of the first item in the current page."""
+  """
+  Index of the first item in the current page.
+  """
   firstItem: Int
 
-  """Index of the last item in the current page."""
+  """
+  Index of the last item in the current page.
+  """
   lastItem: Int
 
-  """Number of items per page."""
+  """
+  Number of items per page.
+  """
   perPage: Int!
 
-  """Are there more pages after this one?"""
+  """
+  Are there more pages after this one?
+  """
   hasMorePages: Boolean!
 }
 
@@ -1294,12 +1526,18 @@ input SkillKeywordsInput {
   fr: [String!]
 }
 
-"""Directions for ordering a list of records."""
+"""
+Directions for ordering a list of records.
+"""
 enum SortOrder {
-  """Sort records in ascending order."""
+  """
+  Sort records in ascending order.
+  """
   ASC
 
-  """Sort records in descending order."""
+  """
+  Sort records in descending order.
+  """
   DESC
 }
 
@@ -1322,17 +1560,25 @@ input TeamBelongsTo {
 Specify if you want to include or exclude trashed results from a query.
 """
 enum Trashed {
-  """Only return trashed results."""
+  """
+  Only return trashed results.
+  """
   ONLY
 
-  """Return both trashed and non-trashed results."""
+  """
+  Return both trashed and non-trashed results.
+  """
   WITH
 
-  """Only return non-trashed results."""
+  """
+  Only return non-trashed results.
+  """
   WITHOUT
 }
 
-"""128 bit universally unique identifier (UUID)"""
+"""
+128 bit universally unique identifier (UUID)
+"""
 scalar UUID
 
 input UpdateApplicationInput {
@@ -1455,7 +1701,9 @@ input UpdateTeamInput {
   contactEmail: Email
 }
 
-"""When updating a User, all fields are optional"""
+"""
+When updating a User, all fields are optional
+"""
 input UpdateUserAsAdminInput {
   id: ID
   sub: String
@@ -1572,7 +1820,10 @@ type User {
   currentCity: String
   citizenship: CitizenshipStatus
   armedForcesStatus: ArmedForcesStatus
-  languageAbility: LanguageAbility @deprecated(reason: "deprecated in favour of relying on lookingFor<Language>")
+  languageAbility: LanguageAbility
+    @deprecated(
+      reason: "deprecated in favour of relying on lookingFor<Language>"
+    )
   lookingForEnglish: Boolean
   lookingForFrench: Boolean
   lookingForBilingual: Boolean
@@ -1593,14 +1844,16 @@ type User {
   isVisibleMinority: Boolean
   indigenousCommunities: [IndigenousCommunity]
   indigenousDeclarationSignature: String
-  jobLookingStatus: JobLookingStatus @deprecated(reason: "Removing with applicantDashboard feature flag")
+  jobLookingStatus: JobLookingStatus
+    @deprecated(reason: "Removing with applicantDashboard feature flag")
   hasDiploma: Boolean
   locationPreferences: [WorkRegion]
   locationExemptions: String
   acceptedOperationalRequirements: [OperationalRequirement]
   expectedSalary: [SalaryRange]
   expectedClassifications: [Classification]
-  wouldAcceptTemporary: Boolean @deprecated(reason: "replaced with positionDuration")
+  wouldAcceptTemporary: Boolean
+    @deprecated(reason: "replaced with positionDuration")
   positionDuration: [PositionDuration]
   poolCandidates: [PoolCandidate]
   experiences: [Experience]
@@ -1609,7 +1862,10 @@ type User {
   educationExperiences: [EducationExperience]
   personalExperiences: [PersonalExperience]
   workExperiences: [WorkExperience]
-  pools: [Pool] @deprecated(reason: "Pools are now associated with a Team more than a single User. Use User.roles.team.pools instead.")
+  pools: [Pool]
+    @deprecated(
+      reason: "Pools are now associated with a Team more than a single User. Use User.roles.team.pools instead."
+    )
   isProfileComplete: Boolean
   expectedGenericJobTitles: [GenericJobTitle]
   priorityWeight: Int
@@ -1632,12 +1888,18 @@ input UserFilterInput {
   generalSearch: String
 }
 
-"""A paginated list of User items."""
+"""
+A paginated list of User items.
+"""
 type UserPaginator {
-  """Pagination information about the list of items."""
+  """
+  Pagination information about the list of items.
+  """
   paginatorInfo: PaginatorInfo!
 
-  """A list of User items."""
+  """
+  A list of User items.
+  """
   data: [User!]!
 }
 
@@ -1655,21 +1917,33 @@ type UserPublicProfile {
   lastName: String
 }
 
-"""Dynamic WHERE conditions for queries."""
+"""
+Dynamic WHERE conditions for queries.
+"""
 input WhereConditions {
-  """The column that is used for the condition."""
+  """
+  The column that is used for the condition.
+  """
   column: String
 
-  """The operator that is used for the condition."""
+  """
+  The operator that is used for the condition.
+  """
   operator: SQLOperator = EQ
 
-  """The value that is used for the condition."""
+  """
+  The value that is used for the condition.
+  """
   value: Mixed
 
-  """A set of conditions that requires all conditions to match."""
+  """
+  A set of conditions that requires all conditions to match.
+  """
   AND: [WhereConditions!]
 
-  """A set of conditions that requires at least one condition to match."""
+  """
+  A set of conditions that requires at least one condition to match.
+  """
   OR: [WhereConditions!]
 
   """
@@ -1678,18 +1952,28 @@ input WhereConditions {
   HAS: WhereConditionsRelation
 }
 
-"""Dynamic HAS conditions for WHERE condition queries."""
+"""
+Dynamic HAS conditions for WHERE condition queries.
+"""
 input WhereConditionsRelation {
-  """The relation that is checked."""
+  """
+  The relation that is checked.
+  """
   relation: String!
 
-  """The comparison operator to test against the amount."""
+  """
+  The comparison operator to test against the amount.
+  """
   operator: SQLOperator = GTE
 
-  """The amount to test."""
+  """
+  The amount to test.
+  """
   amount: Int = 1
 
-  """Additional condition logic."""
+  """
+  Additional condition logic.
+  """
   condition: WhereConditions
 }
 

--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -8,6 +8,7 @@ import {
   Pending,
   ThrowNotFound,
 } from "@gc-digital-talent/ui";
+import { useTheme } from "@gc-digital-talent/theme";
 import { empty } from "@gc-digital-talent/helpers";
 
 import SEO from "~/components/SEO/SEO";
@@ -21,7 +22,7 @@ import {
   getFullPoolAdvertisementTitleHtml,
   getFullPoolAdvertisementTitleLabel,
 } from "~/utils/poolUtils";
-import { useGetApplicationQuery } from "~/api/generated";
+import { PublishingGroup, useGetApplicationQuery } from "~/api/generated";
 import {
   checkForDisabledPage,
   deriveSteps,
@@ -37,6 +38,7 @@ const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
   const paths = useRoutes();
   const navigate = useNavigate();
   const { experienceId } = useParams();
+  const { setTheme, mode } = useTheme();
   const pages = getApplicationPages({
     intl,
     paths,
@@ -102,6 +104,8 @@ const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
     application.submittedSteps,
   );
 
+  const publishingGroup = application.poolAdvertisement?.publishingGroup;
+
   // If we cannot find the current page, redirect to the first step
   // that has not been submitted yet, or the last step
   React.useEffect(() => {
@@ -111,6 +115,12 @@ const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
       });
     }
   }, [currentPage, navigate, nextStepUrl]);
+
+  React.useEffect(() => {
+    if (publishingGroup === PublishingGroup.Iap) {
+      setTheme("iap", mode);
+    }
+  }, [setTheme, publishingGroup, mode]);
 
   return (
     <>

--- a/apps/web/src/pages/Applications/applicationOperations.graphql
+++ b/apps/web/src/pages/Applications/applicationOperations.graphql
@@ -170,6 +170,7 @@ query GetApplication($id: UUID!) {
       }
       stream
       closingDate
+      publishingGroup
       advertisementLanguage
       classifications {
         id

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -1576,6 +1576,11 @@ export const publishingGroups = defineMessages({
     id: "Mixlw/",
     description: "The publishing group called Executive Jobs",
   },
+  [PublishingGroup.Iap]: {
+    defaultMessage: "IAP",
+    id: "7ObbNV",
+    description: "The publishing group called IAP",
+  },
   [PublishingGroup.ItJobs]: {
     defaultMessage: "IT Jobs",
     id: "C8nrGM",


### PR DESCRIPTION
🤖 Resolves #6461 

## 👋 Introduction

This adds the IAP publishing group and sets the theme to IAP on application pages for the new publishing group.

## 🕵️ Details

Something to note, the loading spinner may hop themes since it will fallback to the current theme until we know the publishing group.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> **Note**
> We currently only show IT pools so you will need to navigate directly to the job poster. The URL can be found on the admin "pool information" page

1. Build `npm run build:fresh`
2. Create a pool, note the new IAP publishing group (use this)
3. Start an application for an IT pool
4. Confirm the new application pages use the digital talent theme
5. Start an application for an IAP pool
6. Confirm the new application pages use the IAP theme

## 📸 Screenshot

![localhost_8000_en_applications_96a99aae-7b10-4e9f-a25e-ad34be43003d_welcome](https://user-images.githubusercontent.com/4127998/236470977-f02a9c07-81bd-47c8-8007-e1d7957e4ac8.png)

