### PR TITLE
[Feature] Requested pool labelling for requests

### DIFF
--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -15,6 +15,7 @@ import {
   getPoolStream,
 } from "@gc-digital-talent/i18n";
 
+import { getFullPoolAdvertisementTitleHtml } from "~/utils/poolUtils";
 import { wrapAbbr } from "~/utils/nameUtils";
 import {
   ApplicantFilter,
@@ -255,6 +256,21 @@ const ApplicantFilters = ({
     <section data-h2-flex-grid="base(flex-start, x2, x.5)">
       <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
         <div>
+          <FilterBlock
+            title={intl.formatMessage({
+              defaultMessage: "Pool Requested",
+              id: "rz8uPO",
+              description:
+                "Title for the pool block in the manager info section of the single search request view.",
+            })}
+            content={
+              applicantFilter
+                ? applicantFilter?.pools?.map((pool) =>
+                    getFullPoolAdvertisementTitleHtml(intl, pool),
+                  )
+                : null
+            }
+          />
           <FilterBlock
             title={intl.formatMessage({
               defaultMessage: "Group and level",

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -526,6 +526,21 @@ const SearchRequestFilters = ({
           <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
             <FilterBlock
               title={intl.formatMessage({
+                defaultMessage: "Pool Requested",
+                id: "rz8uPO",
+                description:
+                  "Title for the pool block in the manager info section of the single search request view.",
+              })}
+              content={
+                pools
+                  ? pools.map((pool) =>
+                      getFullPoolAdvertisementTitleHtml(intl, pool),
+                    )
+                  : null
+              }
+            />
+            <FilterBlock
+              title={intl.formatMessage({
                 defaultMessage: "Group and level",
                 id: "Rn5e/i",
                 description:

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.stories.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.stories.tsx
@@ -1,60 +1,34 @@
 import React from "react";
 import { Meta, Story } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import { fakeDepartments } from "@gc-digital-talent/fake-data";
 import {
-  CreatePoolCandidateSearchRequestInput,
-  OperationalRequirement,
-  PoolCandidateFilter,
-  WorkRegion,
-} from "~/api/generated";
+  fakeApplicantFilters,
+  fakeClassifications,
+  fakeDepartments,
+  fakePools,
+  fakeSkills,
+} from "@gc-digital-talent/fake-data";
+import { CreatePoolCandidateSearchRequestInput } from "~/api/generated";
 import { RequestForm, RequestFormProps } from "./RequestForm";
 
-const poolCandidateFilter: PoolCandidateFilter = {
-  id: "9ef184ad-1752-411e-a022-7f7989f6bf27",
-  classifications: [
-    {
-      id: "90689420-553d-4a3b-999a-fb94b1baaa69",
-      group: "IT",
-      level: 4,
-    },
-    {
-      id: "bcfa88b3-ed22-4879-8642-e7dd003e91b4",
-      group: "IT",
-      level: 5,
-    },
-    {
-      id: "7b0d9293-e811-413c-b0df-346e55f3fdd0",
-      group: "EC",
-      level: 1,
-    },
-  ],
-  hasDiploma: false,
-  equity: {
-    hasDisability: false,
-    isIndigenous: false,
-    isVisibleMinority: false,
-    isWoman: false,
-  },
-  languageAbility: null,
-  operationalRequirements: [
-    OperationalRequirement.DriversLicense,
-    OperationalRequirement.OnCall,
-  ],
-  workRegions: [WorkRegion.Ontario, WorkRegion.Quebec],
-  pools: [
-    {
-      id: "acf045c9-6daf-4a59-aeb3-ab62acb0418e",
-    },
-  ],
-};
+const classifications = fakeClassifications();
+const pools = fakePools();
+const skills = fakeSkills();
+
+const applicantFilter = fakeApplicantFilters()[0];
+applicantFilter.skills = [skills[0], skills[1]];
+applicantFilter.pools = [pools[0]];
+applicantFilter.qualifiedClassifications = [classifications[0]];
 
 export default {
   component: RequestForm,
   title: "Forms/Request Form",
   args: {
     departments: fakeDepartments(),
-    poolCandidateFilter,
+    applicantFilter,
+    classifications,
+    pools,
+    skills,
     candidateCount: 10,
     handleCreatePoolCandidateSearchRequest: async (
       data: CreatePoolCandidateSearchRequestInput,

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -77,6 +77,7 @@ export interface RequestFormProps {
   departments: Department[];
   skills: Skill[];
   classifications: Classification[];
+  pools: Pool[];
   applicantFilter: Maybe<ApplicantFilterInput>;
   candidateCount: Maybe<number>;
   searchFormInitialValues?: SearchFormValues;
@@ -92,6 +93,7 @@ export const RequestForm = ({
   departments,
   skills,
   classifications,
+  pools,
   applicantFilter,
   candidateCount,
   selectedClassifications,
@@ -226,6 +228,11 @@ export const RequestForm = ({
           return skill && skillId && skill.id === skillId.id;
         });
       }) ?? [],
+    pools: applicantFilter?.pools?.map((poolId) => {
+      return pools.find((pool) => {
+        return pool && poolId && pool.id === poolId.id;
+      });
+    }),
   };
 
   return (
@@ -474,6 +481,7 @@ const RequestFormApi = ({
   const departments: Department[] =
     lookupData?.departments.filter(notEmpty) ?? [];
   const skills: Skill[] = lookupData?.skills.filter(notEmpty) ?? [];
+  const pools: Pool[] = lookupData?.pools.filter(notEmpty) ?? [];
 
   const [, executeMutation] = useCreatePoolCandidateSearchRequestMutation();
   const handleCreatePoolCandidateSearchRequest = (
@@ -500,6 +508,7 @@ const RequestFormApi = ({
           classifications={classifications}
           departments={departments}
           skills={skills}
+          pools={pools}
           applicantFilter={applicantFilter}
           candidateCount={candidateCount}
           searchFormInitialValues={searchFormInitialValues}

--- a/apps/web/src/pages/SearchRequests/RequestPage/requestOperations.graphql
+++ b/apps/web/src/pages/SearchRequests/RequestPage/requestOperations.graphql
@@ -20,6 +20,19 @@ query getPoolCandidateSearchRequestData {
     group
     level
   }
+  pools {
+    id
+    name {
+      en
+      fr
+    }
+    classifications {
+      id
+      group
+      level
+    }
+    stream
+  }
 }
 
 mutation createPoolCandidateSearchRequest(

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
@@ -10,7 +10,6 @@ import {
 import { Pending, NotFound, Heading } from "@gc-digital-talent/ui";
 import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 
-import { getFullPoolAdvertisementTitleHtml } from "~/utils/poolUtils";
 import SearchRequestFilters from "~/components/SearchRequestFilters/SearchRequestFilters";
 import { FilterBlock } from "~/components/SearchRequestFilters/deprecated/SearchRequestFilters";
 import {
@@ -38,15 +37,7 @@ const ManagerInfo = ({
     status,
     requestedDate,
     doneDate,
-    poolCandidateFilter,
-    applicantFilter,
   } = searchRequest;
-
-  const nonApplicableMessage = intl.formatMessage({
-    defaultMessage: "N/A",
-    id: "i9AjuX",
-    description: "Text shown when the filter was not selected",
-  });
 
   return (
     <>
@@ -128,28 +119,6 @@ const ManagerInfo = ({
                 data-h2-padding="base(0, x1, 0, 0)"
                 data-h2-height="base(100%)"
               >
-                <FilterBlock
-                  title={intl.formatMessage({
-                    defaultMessage: "Pool Requested",
-                    id: "rz8uPO",
-                    description:
-                      "Title for the pool block in the manager info section of the single search request view.",
-                  })}
-                  content={
-                    applicantFilter
-                      ? applicantFilter?.pools?.map((pool) =>
-                          getFullPoolAdvertisementTitleHtml(intl, pool, {
-                            defaultTitle: nonApplicableMessage,
-                          }),
-                        )
-                      : poolCandidateFilter?.pools?.map((pool) =>
-                          getFullPoolAdvertisementTitleHtml(intl, pool, {
-                            defaultTitle: nonApplicableMessage,
-                          }),
-                        )
-                  }
-                />
-
                 <FilterBlock
                   title={intl.formatMessage({
                     defaultMessage: "Status",

--- a/packages/fake-data/src/fakeApplicantFilters.ts
+++ b/packages/fake-data/src/fakeApplicantFilters.ts
@@ -9,6 +9,7 @@ import {
   LanguageAbility,
   PositionDuration,
   Skill,
+  PoolStream,
 } from "@gc-digital-talent/graphql";
 
 import fakeSkills from "./fakeSkills";
@@ -48,6 +49,10 @@ const generateApplicantFilters = (
       Object.values(PositionDuration),
     ),
     skills,
+    qualifiedStreams: faker.helpers.arrayElements<PoolStream>(
+      Object.values(PoolStream),
+      1,
+    ),
   };
 };
 

--- a/packages/fake-data/src/fakeApplicantFilters.ts
+++ b/packages/fake-data/src/fakeApplicantFilters.ts
@@ -1,0 +1,72 @@
+import { faker } from "@faker-js/faker";
+
+import {
+  Classification,
+  ApplicantFilter,
+  OperationalRequirement,
+  Pool,
+  WorkRegion,
+  LanguageAbility,
+  PositionDuration,
+  Skill,
+} from "@gc-digital-talent/graphql";
+
+import fakeSkills from "./fakeSkills";
+import fakeClassifications from "./fakeClassifications";
+import fakePools from "./fakePools";
+
+const generateApplicantFilters = (
+  classifications: Classification[],
+  operationalRequirements: OperationalRequirement[],
+  pools: Pool[],
+  skills: Skill[],
+): ApplicantFilter => {
+  faker.setLocale("en");
+
+  return {
+    id: faker.datatype.uuid(),
+    pools: faker.helpers.arrayElements(pools),
+    expectedClassifications: faker.helpers.arrayElements(classifications),
+    equity: {
+      isIndigenous: faker.datatype.boolean(),
+      isVisibleMinority: faker.datatype.boolean(),
+      isWoman: faker.datatype.boolean(),
+      hasDisability: faker.datatype.boolean(),
+    },
+    hasDiploma: faker.datatype.boolean(),
+    languageAbility: faker.helpers.arrayElement<LanguageAbility>(
+      Object.values(LanguageAbility),
+    ),
+    locationPreferences: faker.helpers.arrayElements<WorkRegion>(
+      Object.values(WorkRegion),
+    ),
+    operationalRequirements:
+      faker.helpers.arrayElements<OperationalRequirement>(
+        operationalRequirements,
+      ),
+    positionDuration: faker.helpers.arrayElements<PositionDuration>(
+      Object.values(PositionDuration),
+    ),
+    skills,
+  };
+};
+
+export default (): ApplicantFilter[] => {
+  const classifications = fakeClassifications();
+  const operationalRequirements =
+    faker.helpers.arrayElements<OperationalRequirement>(
+      Object.values(OperationalRequirement),
+    );
+  const pools = fakePools();
+  const skills = fakeSkills(5);
+
+  faker.seed(0); // repeatable results
+  return [...Array(20)].map(() =>
+    generateApplicantFilters(
+      classifications,
+      operationalRequirements,
+      pools,
+      skills,
+    ),
+  );
+};

--- a/packages/fake-data/src/index.ts
+++ b/packages/fake-data/src/index.ts
@@ -3,6 +3,7 @@ import fakeDepartments from "./fakeDepartments";
 import fakeExperiences, { experienceGenerators } from "./fakeExperiences";
 import fakePoolAdvertisements from "./fakePoolAdvertisements";
 import fakePoolCandidateFilters from "./fakePoolCandidateFilters";
+import fakeApplicantFilters from "./fakeApplicantFilters";
 import fakePoolCandidates from "./fakePoolCandidates";
 import fakePools from "./fakePools";
 import fakeRoles from "./fakeRoles";
@@ -24,6 +25,7 @@ export {
   fakePoolCandidates,
   fakeSearchRequests,
   fakePoolCandidateFilters,
+  fakeApplicantFilters,
   fakeSkillFamilies,
   fakeSkills,
   fakeTeams,


### PR DESCRIPTION
🤖 Resolves #6366 

## 👋 Introduction

Adds a filter block for "Pool requested" to the filter summary component, as well as removes it from the manager info component. 

## 🕵️ Details

Nothing too fancy. I mimicked how classifications/skills were done to add pool naming to the request page.

On that note.
This feels sub-optimal and the query will get rather slow with more pools and any other new additions. Something to look at for refactoring search.
Is it possible to save to local storage the selected classification object, array of skills selected, and pool object rather than fetch all classifications + skills + pools on the following page to re-assemble the state on the page prior?

Like
```
objectStore = {
    classification : {group ...},
    skills: [Skill},
    pool: {name ...}
}
```

Then on the request form page, `{ group,  level } = { objectStore.classification }`  and so on. 

And then wipe it on request submit. 

The query in question. Departments definitely needs to stay but the other three are fetched on the prior page.

![image](https://user-images.githubusercontent.com/40485260/236575075-4a612d0c-d73b-4e18-888c-5dd460d07e2d.png)

Search page -> fetch classifications, pools, skills -> carry-over ids of selected classification, pool. and skills -> Request page -> fetch classifications, pools, skills again -> re-assemble state of search page

Re-assembling example, using fetched all skills and array of skill ids to reproduce search page
![image](https://user-images.githubusercontent.com/40485260/236576445-789722ed-e7d3-4c7e-b8ce-2c32d04c77a3.png)


## 🧪 Testing

1. Go through the search page, submitting a request, and viewing said request
2. Affirm things updated

## 📸 Screenshot

Observe

![image](https://user-images.githubusercontent.com/40485260/236574251-bf039744-97c2-4f23-b5e3-dd03a8f119c4.png)
