### PR TITLE
Create a `@self` directive to help organize schema

### DIFF
--- a/api/app/GraphQL/Directives/SelfDirective.php
+++ b/api/app/GraphQL/Directives/SelfDirective.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\GraphQL\Directives;
+
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Support\Contracts\FieldResolver;
+
+final class SelfDirective extends BaseDirective implements FieldResolver
+{
+    // TODO implement the directive https://lighthouse-php.com/master/custom-directives/getting-started.html
+
+    public static function definition(): string
+    {
+        return /** @lang GraphQL */ <<<'GRAPHQL'
+"""
+The field will be resolved to the same value as its parent.
+For example, useful in the following situation:
+type User {
+    profile: Applicant @self
+}
+"""
+directive @self on FIELD_DEFINITION
+GRAPHQL;
+    }
+
+    /**
+     * Set a field resolver on the FieldValue.
+     *
+     * This must call $fieldValue->setResolver() before returning
+     * the FieldValue.
+     *
+     * @param  \Nuwave\Lighthouse\Schema\Values\FieldValue  $fieldValue
+     * @return \Nuwave\Lighthouse\Schema\Values\FieldValue
+     */
+    public function resolveField(FieldValue $fieldValue)
+    {
+        $fieldValue->setResolver(function ($root, array $args) {
+            return $root;
+        });
+
+        return $fieldValue;
+    }
+}

--- a/api/composer.json
+++ b/api/composer.json
@@ -66,7 +66,7 @@
     "post-root-package-install": [
       "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
     ],
-    "post-update-cmd": [
+    "post-install-cmd": [
       "php artisan lighthouse:ide-helper"
     ]
   }

--- a/api/composer.json
+++ b/api/composer.json
@@ -66,7 +66,7 @@
     "post-root-package-install": [
       "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
     ],
-    "post-install-cmd": [
+    "post-update-cmd": [
       "php artisan lighthouse:ide-helper"
     ]
   }

--- a/api/schema-directives.graphql
+++ b/api/schema-directives.graphql
@@ -66,6 +66,16 @@ directive @pluck(
     key: String!
 ) on INPUT_FIELD_DEFINITION
 
+# Directive class: App\GraphQL\Directives\SelfDirective
+"""
+The field will be resolved to the same value as its parent.
+For example, useful in the following situation:
+type User {
+    profile: Applicant @self
+}
+"""
+directive @self on FIELD_DEFINITION
+
 # Directive class: Nuwave\Lighthouse\Testing\MockDirective
 """
 Allows you to easily hook up a resolver for an endpoint.
@@ -1307,26 +1317,6 @@ directive @in(
   """
   key: String
 ) repeatable on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
-
-# Directive class: Nuwave\Lighthouse\Schema\Directives\InjectDirective
-"""
-Inject a value from the context object into the arguments.
-"""
-directive @inject(
-  """
-  A path to the property of the context that will be injected.
-  If the value is nested within the context, you may use dot notation
-  to get it, e.g. "user.id".
-  """
-  context: String!
-
-  """
-  The target name of the argument into which the value is injected.
-  You can use dot notation to set the value at arbitrary depth
-  within the incoming argument.
-  """
-  name: String!
-) repeatable on FIELD_DEFINITION
 
 # Directive class: Nuwave\Lighthouse\Schema\Directives\InterfaceDirective
 """


### PR DESCRIPTION
🤖 Resolves #6527 

## 👋 Introduction

Adds the `@self` custom lighthouse directive.

## 🕵️ Details

I wanted to write some php unit tests for this directive, but I can't figure out how to do so. A proper unit test wouldn't be dependent on the schema or models in the app. I tried using a [test schema](https://lighthouse-php.com/6/testing/extensions.html#mock-resolvers), but couldn't figure out how to set it up in a way that properly made use of the directive.

NOTE: you will need to restart VS Code for IDE tools to recognize the `@self` directive.

## 🧪 Testing

1. Temporarily modify the schema: add `applicant: Applicant @self` to the `User` type.
2. Add `AUTH_DEFAULT_USER='admin@test.com'` to api/.env
3. go to http://localhost:8000/graphiql and run the following query:
```
query {
  me {
    applicant {
      email
    }
  }
}
```
4. You should get the email admin@test.com
5. Undo your changes to the schema
