### PR TITLE
[Feature] Pool candidate skill count

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -150,13 +150,22 @@ class PoolCandidate extends Model
      */
     public function getSkillCountAttribute()
     {
+        $this->load([
+            'pool.essentialSkills',
+            'pool.nonessentialSkills',
+            'user.awardExperiences.skills',
+            'user.communityExperiences.skills',
+            'user.educationExperiences.skills',
+            'user.personalExperiences.skills',
+            'user.workExperiences.skills',
+        ]);
         $skillIds = collect();
-        $skillIds = $skillIds->merge($this->pool->essentialSkills()->get()->pluck('id'));
-        $skillIds = $skillIds->merge($this->pool->nonessentialSkills()->get()->pluck('id'));
+        $skillIds = $skillIds->merge($this->pool->essentialSkills->pluck('id'));
+        $skillIds = $skillIds->merge($this->pool->nonessentialSkills->pluck('id'));
 
         $count = 0;
         foreach ($this->user->experiences as $experience) {
-            $skillCount = $experience->skills->whereIn('experience_skill_pivot.skill_id', $skillIds)->count();
+            $skillCount = $experience->skills()->whereIn('skill_id', $skillIds)->count();
             if ($skillCount) {
                 $count += $skillCount;
             }

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -549,33 +549,11 @@ class PoolCandidate extends Model
     public function scopeSkillsAdditive(Builder $query, ?array $skills): Builder
     {
 
-        // Added as temporary example
-        $query->addSelect([
-            'skill_count' => Skill::whereIn('skills.id', $skills)
-                ->join('users', 'users.id', '=', 'pool_candidates.user_id')
-                ->select(DB::raw('count(*) as skill_count'))
-                ->where(function (Builder $query) {
-                    $query->orWhereHas('awardExperiences', function (Builder $query) {
-                        $query->whereColumn('user_id', 'users.id');
-                    })
-                        ->orWhereHas('educationExperiences', function (Builder $query) {
-                            $query->whereColumn('user_id', 'users.id');
-                        })
-                        ->orWhereHas('communityExperiences', function (Builder $query) {
-                            $query->whereColumn('user_id', 'users.id');
-                        })
-                        ->orWhereHas('personalExperiences', function (Builder $query) {
-                            $query->whereColumn('user_id', 'users.id');
-                        })
-                        ->orWhereHas('workExperiences', function (Builder $query) {
-                            $query->whereColumn('user_id', 'users.id');
-                        });
-                })
-        ]);
-
         if (empty($skills)) {
             return $query;
         }
+
+        $query = $this->addSkillCountSelect($query, $skills);
 
         // call the skillFilter off connected user
         $query->whereHas('user', function (Builder $userQuery) use ($skills) {
@@ -590,6 +568,8 @@ class PoolCandidate extends Model
         if (empty($skills)) {
             return $query;
         }
+
+        $query = $this->addSkillCountSelect($query, $skills);
 
         // call the skillFilter off connected user
         $query->whereHas('user', function (Builder $userQuery) use ($skills) {
@@ -648,5 +628,32 @@ class PoolCandidate extends Model
         $submittedSteps = collect([$this->submitted_steps, $applicationStep])->flatten()->unique();
 
         $this->submitted_steps = $submittedSteps->values()->all();
+    }
+
+    private function addSkillCountSelect(Builder $query, ?array $skills): Builder
+    {
+        return $query->addSelect([
+            'skill_count' => Skill::whereIn('skills.id', $skills)
+                ->join('users', 'users.id', '=', 'pool_candidates.user_id')
+                ->select(DB::raw('count(*) as skill_count'))
+                ->where(function (Builder $query) {
+                    $query->orWhereHas('awardExperiences', function (Builder $query) {
+                        $query->whereColumn('user_id', 'users.id');
+                    })
+                        ->orWhereHas('educationExperiences', function (Builder $query) {
+                            $query->whereColumn('user_id', 'users.id');
+                        })
+                        ->orWhereHas('communityExperiences', function (Builder $query) {
+                            $query->whereColumn('user_id', 'users.id');
+                        })
+                        ->orWhereHas('personalExperiences', function (Builder $query) {
+                            $query->whereColumn('user_id', 'users.id');
+                        })
+                        ->orWhereHas('workExperiences', function (Builder $query) {
+                            $query->whereColumn('user_id', 'users.id');
+                        });
+                })
+
+        ]);
     }
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -476,6 +476,7 @@ type PoolCandidate {
   cmoIdentifier: ID @rename(attribute: "cmo_identifier")
   # Expiry date for this candidate being in the pool.
   expiryDate: Date @rename(attribute: "expiry_date")
+  skillCount: Int @rename(attribute: "skill_count")
 
   status: PoolCandidateStatus @rename(attribute: "pool_candidate_status")
   statusWeight: Int @rename(attribute: "status_weight")

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -471,12 +471,12 @@ type PoolCandidate {
     @belongsTo(relation: "pool")
     @can(ability: "viewAdvertisement", resolved: true)
   user: Applicant! @belongsTo(relation: "user")
+  skillCount: Int @rename(attribute: "skill_count")
 
   # cmoIdentifier can be an arbitrary string used to relate this candidate to an external database.
   cmoIdentifier: ID @rename(attribute: "cmo_identifier")
   # Expiry date for this candidate being in the pool.
   expiryDate: Date @rename(attribute: "expiry_date")
-  skillCount: Int @rename(attribute: "skill_count")
 
   status: PoolCandidateStatus @rename(attribute: "pool_candidate_status")
   statusWeight: Int @rename(attribute: "status_weight")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -873,6 +873,7 @@ type PoolCandidate {
   user: Applicant!
   cmoIdentifier: ID
   expiryDate: Date
+  skillCount: Int
   status: PoolCandidateStatus
   statusWeight: Int
   notes: String

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -871,9 +871,9 @@ type PoolCandidate {
   pool: Pool!
   poolAdvertisement: PoolAdvertisement
   user: Applicant!
+  skillCount: Int
   cmoIdentifier: ID
   expiryDate: Date
-  skillCount: Int
   status: PoolCandidateStatus
   statusWeight: Int
   notes: String

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -373,6 +373,13 @@ const PoolCandidatesTable = ({
         },
       };
     }
+    if (sortingRule?.column.sortColumnName === "SKILL_COUNT") {
+      return {
+        column: "skill_count",
+        order: sortingRule.desc ? SortOrder.Desc : SortOrder.Asc,
+        user: undefined,
+      };
+    }
     // input cannot be optional for QueryPoolCandidatesPaginatedOrderByRelationOrderByClause
     // default tertiary sort is submitted_at,
     return {
@@ -606,6 +613,7 @@ const PoolCandidatesTable = ({
           description: "Title displayed on the candidate skill count column.",
         }),
         id: "skillCount",
+        sortColumnName: "SKILL_COUNT",
         accessor: ({ skillCount }) => skillCount,
       },
       {

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -373,7 +373,11 @@ const PoolCandidatesTable = ({
         },
       };
     }
-    if (sortingRule?.column.sortColumnName === "SKILL_COUNT") {
+    if (
+      sortingRule?.column.sortColumnName === "SKILL_COUNT" &&
+      applicantFilterInput?.applicantFilter?.skills &&
+      applicantFilterInput.applicantFilter.skills.length > 0
+    ) {
       return {
         column: "skill_count",
         order: sortingRule.desc ? SortOrder.Desc : SortOrder.Asc,
@@ -387,7 +391,7 @@ const PoolCandidatesTable = ({
       order: SortOrder.Asc,
       user: undefined,
     };
-  }, [sortingRule]);
+  }, [sortingRule, applicantFilterInput]);
 
   // merge search bar input with fancy filter state
   const addSearchToPoolCandidateFilterInput = (

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -601,6 +601,15 @@ const PoolCandidatesTable = ({
       },
       {
         label: intl.formatMessage({
+          defaultMessage: "Number of skills matched",
+          id: "0dQ62G",
+          description: "Title displayed on the candidate skill count column.",
+        }),
+        id: "skillCount",
+        accessor: ({ skillCount }) => skillCount,
+      },
+      {
+        label: intl.formatMessage({
           defaultMessage: "Email",
           id: "BSVnmg",
           description:

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/poolCandidatesOperations.graphql
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/poolCandidatesOperations.graphql
@@ -78,6 +78,7 @@ fragment poolCandidateTable on PoolCandidate {
     positionDuration
     priorityWeight
   }
+  skillCount
   cmoIdentifier
   expiryDate
   status

--- a/apps/web/src/pages/SearchRequests/IndexSearchRequestPage/searchRequestOperations.graphql
+++ b/apps/web/src/pages/SearchRequests/IndexSearchRequestPage/searchRequestOperations.graphql
@@ -1,6 +1,7 @@
 query searchPoolCandidates($poolCandidateFilter: PoolCandidateFilterInput) {
   searchPoolCandidates(where: $poolCandidateFilter) {
     id
+    skillCount
     user {
       id
       email

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -232,6 +232,15 @@ export const SingleSearchRequestTable = ({
       },
       {
         Header: intl.formatMessage({
+          defaultMessage: "Number of skills matched",
+          id: "GnaY0Y",
+          description:
+            "Title displayed on the single search request table candidate skill count column",
+        }),
+        accessor: "skillCount",
+      },
+      {
+        Header: intl.formatMessage({
           defaultMessage: "Group and Level",
           id: "MmFgbF",
           description:


### PR DESCRIPTION
🤖 Resolves #6395 

## 👋 Introduction

Adds a virtual `skillCount` column to `poolCandidatesPaginated` paginated query.

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 📋 TO DO

- [ ] Update with wrapping type
- [ ] Add translations

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build:fresh`
2. Navigate to a request `/admin/talent-requests/{requestId}`
3. Clear filters
4. Add a lot of skills
5. Confirm the "Number of skills column" updates with matching skills
6. Confirm they sort (kinda weird since status and priority) are locked.

## 📸 Screenshot

![Screenshot 2023-05-08 150519](https://user-images.githubusercontent.com/4127998/236911173-df5aff70-17a8-436c-8fb9-32f0d55fda3a.png)

