### PR TITLE
[Bug] GovernmentInfoForm disconnect BelongsTo relations 

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1411,6 +1411,7 @@ input PoolBelongsToMany {
 
 input DepartmentBelongsTo {
   connect: ID!
+  disconnect: Boolean
 }
 
 input DepartmentBelongsToMany {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1410,7 +1410,7 @@ input PoolBelongsToMany {
 }
 
 input DepartmentBelongsTo {
-  connect: ID!
+  connect: ID
   disconnect: Boolean
 }
 

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -417,6 +417,7 @@ type Department {
 
 input DepartmentBelongsTo {
   connect: ID!
+  disconnect: Boolean
 }
 
 input DepartmentBelongsToMany {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -416,7 +416,7 @@ type Department {
 }
 
 input DepartmentBelongsTo {
-  connect: ID!
+  connect: ID
   disconnect: Boolean
 }
 

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/GovernmentInformation/utils.ts
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/GovernmentInformation/utils.ts
@@ -50,9 +50,9 @@ export const formValuesToSubmitData = (
     return {
       isGovEmployee: false,
       govEmployeeType: null,
-      department: null,
+      department: { disconnect: true },
       currentClassification: {
-        connect: null,
+        disconnect: true,
       },
       hasPriorityEntitlement: values.priorityEntitlementYesNo === "yes",
       priorityNumber:

--- a/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
+++ b/apps/web/src/pages/Profile/GovernmentInfoPage/components/GovernmentInfoForm/GovernmentInfoForm.tsx
@@ -94,9 +94,9 @@ export const formValuesToSubmitData = (
     return {
       isGovEmployee: false,
       govEmployeeType: null,
-      department: null,
+      department: { disconnect: true },
       currentClassification: {
-        connect: null,
+        disconnect: true,
       },
       hasPriorityEntitlement: values.priorityEntitlementYesNo === "yes",
       priorityNumber:


### PR DESCRIPTION
🤖 Resolves #6413 

## 👋 Introduction

The removal of `BelongsTo` relation classification and department wasn't written how it should be used. Written to use `disconnect`. 

## 🧪 Testing

Update the government info section with user info as a government employee then update it as not an employee. 
Keep an eye on the network tab and ensure requests/responses are what they should be for the operation. 

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/40485260/236918008-88291baa-1cc4-42ac-a643-47e633ab7450.png)

