### PR TITLE
[Bug] Fixes equity section copy

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -579,7 +579,7 @@
     "description": "Content displayed in the About area of the hero section of the Search page."
   },
   "dlRmxI": {
-    "defaultMessage": "Les gestionnaires peuvent demander des candidats par groupe d’équité en matière d’emploi pour combler les écarts actuels et futurs de représentation au sein de l’effectif. (Les catégories reflètent les données sur l’équité en matière d’emploi définies en vertu de la Loi sur l’emploi dans la fonction publique et recueillies dans le cadre du processus de demande de la CFP. Par souci d’uniformité, cette plateforme reflète la terminologie des catégories de la CFP.)",
+    "defaultMessage": "Les gestionnaires peuvent demander à consulter des candidats selon leur groupe d’équité en matière d’emploi afin de traiter de certaines lacunes actuelles ou futures par rapport à leur représentation dans le cadre des effectifs. Les catégories reflètent les données sur l’équité en matière d’emploi telles qu’elles sont définies par la Loi sur l’emploi dans la fonction publique, et qui sont recueillies par l’entremise du processus de dotation de la Commission de la fonction publique (CFP). À des fins d’uniformité, la présente plateforme reflète la terminologie de la CFP par rapport aux catégories.",
     "description": "Message describing the employment equity filter in the search form."
   },
   "Zzd/sJ": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -578,7 +578,7 @@
     "defaultMessage": "Ce bassin est ouvert à la plupart des ministères et organismes. Les candidats dans le bassin sont à la fois des professionnels en début de carrière et des professionnels chevronnés ayant plusieurs années d’expérience de travail. Il s’agit d’un bassin de recrutement continu, ce qui signifie que de nouveaux candidats sont ajoutés chaque semaine.",
     "description": "Content displayed in the About area of the hero section of the Search page."
   },
-  "Za/qCZ": {
+  "dlRmxI": {
     "defaultMessage": "Les gestionnaires peuvent demander des candidats par groupe d’équité en matière d’emploi pour combler les écarts actuels et futurs de représentation au sein de l’effectif. (Les catégories reflètent les données sur l’équité en matière d’emploi définies en vertu de la Loi sur l’emploi dans la fonction publique et recueillies dans le cadre du processus de demande de la CFP. Par souci d’uniformité, cette plateforme reflète la terminologie des catégories de la CFP.)",
     "description": "Message describing the employment equity filter in the search form."
   },

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -444,8 +444,8 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
             })}
             text={intl.formatMessage({
               defaultMessage:
-                "Managers can request candidates by employment equity group(s) to address current of future representation gaps in the workforce. (Categories reflect EE data defined under the Public Service Employment Act and collected through the PSC application process. For consistency, this platform reflects the PSC's category terminology.)",
-              id: "Za/qCZ",
+                "Managers can request candidates by employment equity group to address current and future representation gaps in the workforce. Categories reflect employment equity data defined under the Public Service Employment Act and collected through the Public Service Commission of Canada's (PSC) application process. For consistency, this platform reflects the PSC's category terminology.",
+              id: "dlRmxI",
               description:
                 "Message describing the employment equity filter in the search form.",
             })}

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -625,7 +625,7 @@
     "defaultMessage": "Disponibilité, volonté et capacité à faire des heures supplémentaires (planifiées)",
     "description": "The operational requirement described as scheduled overtime."
   },
-  "mFKg18": {
+  "ghhKNZ": {
     "defaultMessage": "Identité autochtone",
     "description": "Group for when someone indicates they are indigenous"
   },

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -41,8 +41,8 @@ export const employmentEquityGroups = defineMessages({
     description: "Group for when someone indicates they are a woman",
   },
   indigenous: {
-    defaultMessage: "Indigenous Identity",
-    id: "mFKg18",
+    defaultMessage: "Indigenous identity",
+    id: "ghhKNZ",
     description: "Group for when someone indicates they are indigenous",
   },
   minority: {


### PR DESCRIPTION
🤖 Resolves #6480.

## 👋 Introduction

This PR fixes the copy for the equity section paragraph in English and French and changes the string **Indigenous identity** to use sentence case.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/en/search`
2. Observe **Employment equity** paragraph
3. Observe **Indigenous identity** label for checkbox
4. Navigate to `/fr/search`
2. Observe **Équité en matière d'emploi** paragraph

## 📸 Screenshots

![Screen Shot 2023-05-09 at 11 48 29](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/14fb69d9-5bf2-4278-8384-6cc35ead5abb)

![Screen Shot 2023-05-09 at 11 48 47](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/44c5f520-cb09-4d89-8070-3c0fcb09266b)
