### PR TITLE
[Bug] Resolved application revamp edit experience bug

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationResumeEditPage/ApplicationResumeEditPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumeEditPage/ApplicationResumeEditPage.tsx
@@ -114,6 +114,7 @@ const ApplicationResumeEditPage = () => {
     variables: {
       id: applicationId || "",
     },
+    requestPolicy: "cache-first",
   });
   const [
     {


### PR DESCRIPTION
🤖 Resolves #6523 

## 👋 Introduction

Resolve the bug that makes it impossible to edit experiences.
A bit of an annoying bug so I am pulling it in early. 

## 🕵️ Details

The issue appears to be with `useGetApplicationQuery` within `ApplicationResumeEditPage`. 
Mimicked request policy of #6473

## 🧪 Testing

1. Navigate to `/en/applications/:id/resume`
2. Click on "edit" for an experience, and confirm the page loads and updating experiences works

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/ae6fe546-7b11-4fda-9928-f92ca5df8a08)
