### PR TITLE
[Bug] Fix storybook theme selection

### DIFF
--- a/packages/theme/src/components/ThemeProvider.tsx
+++ b/packages/theme/src/components/ThemeProvider.tsx
@@ -112,25 +112,25 @@ const ThemeProvider = ({
     });
   }, [key, mode, themeSelector]);
 
-  React.useEffect(() => {
-    function testDark() {
-      const isSet = key || (mode && mode !== "pref");
-      const prefersDark = window.matchMedia(
-        "(prefers-color-scheme: dark)",
-      ).matches;
-      const isSetDark = localStorage.theme === "dark";
-      const isSetLight = localStorage.theme === "light";
+  const testDark = React.useCallback(() => {
+    const isSet = key || (mode && mode !== "pref");
+    const prefersDark = window.matchMedia(
+      "(prefers-color-scheme: dark)",
+    ).matches;
+    const isSetDark = localStorage.theme === "dark";
+    const isSetLight = localStorage.theme === "light";
 
-      const isDark =
-        (prefersDark && (!isSet || !isSetLight)) || (isSet && isSetDark);
-      if (isDark) {
-        setTheme({
-          key,
-          mode: "dark",
-        });
-      }
+    const isDark =
+      (prefersDark && (!isSet || !isSetLight)) || (isSet && isSetDark);
+    if (isDark) {
+      setTheme({
+        key,
+        mode: "dark",
+      });
     }
+  }, [key, mode, setTheme]);
 
+  React.useEffect(() => {
     window.addEventListener("load", testDark);
     const darkMatcher = window.matchMedia("(prefers-color-scheme: dark)");
     const lightMatcher = window.matchMedia("(prefers-color-scheme: light)");
@@ -143,16 +143,15 @@ const ThemeProvider = ({
       lightMatcher.removeEventListener("change", testDark);
       window.removeEventListener("load", testDark);
     };
-  }, [key, mode, setTheme]);
+  }, [key, mode, setTheme, testDark]);
 
   React.useEffect(() => {
     if (
-      override?.key &&
-      override.key !== key &&
-      override?.mode &&
-      override.mode !== mode
+      (override?.key && override.key !== key) ||
+      (override?.mode && override.mode !== mode)
     ) {
-      setTheme(getDefaultTheme(override));
+      const newTheme = getDefaultTheme(override);
+      setTheme(newTheme);
     }
   }, [setTheme, override, mode, key]);
 


### PR DESCRIPTION
🤖 Resolves #6590 

## 👋 Introduction

Fixes theme selector in storybook.

## 🕵️ Details

Theme selection was updated to only change when both theme override key and mode changed. This updates it to update when either changes.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run storybook `npm run storybook`
2. Change theme and mode
3. Confirm the theme key and mode update along with the colour palette
