### PR TITLE
[Bug] Fixes pool candidates skill count

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -604,10 +604,12 @@ class PoolCandidate extends Model
     public function scopeWithSkillCount(Builder $query)
     {
         // Checks if the query already has a skill_count select and if it does, it skips adding it again
-        $currentSql = $query->getQuery()->toSql();
+        $currentSql = strtolower($query->getQuery()->toSql());
         $skillCountAppearances = substr_count($currentSql, 'skill_count');
-        $orderedBySkillCount = str_contains($currentSql, 'order by "skill_count"');
-        if ($orderedBySkillCount && $skillCountAppearances === 2) {
+        $orderedBySkillCountAsc = str_contains($currentSql, '"skill_count" asc');
+        $orderedBySkillCountDesc = str_contains($currentSql, '"skill_count" desc');
+        $orderedBySkillCount = $orderedBySkillCountAsc || $orderedBySkillCountDesc;
+        if ((($orderedBySkillCount) && $skillCountAppearances === 2) || !($orderedBySkillCount && $skillCountAppearances === 1)) {
             return $query;
         }
 

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -14,6 +14,9 @@ use Illuminate\Database\Eloquent\Builder;
 use App\Http\Resources\UserResource;
 use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 /**
  * Class PoolCandidate
@@ -604,12 +607,17 @@ class PoolCandidate extends Model
     public function scopeWithSkillCount(Builder $query)
     {
         // Checks if the query already has a skill_count select and if it does, it skips adding it again
-        $currentSql = strtolower($query->getQuery()->toSql());
-        $skillCountAppearances = substr_count($currentSql, 'skill_count');
-        $orderedBySkillCountAsc = str_contains($currentSql, '"skill_count" asc');
-        $orderedBySkillCountDesc = str_contains($currentSql, '"skill_count" desc');
-        $orderedBySkillCount = $orderedBySkillCountAsc || $orderedBySkillCountDesc;
-        if ((($orderedBySkillCount) && $skillCountAppearances === 2) || !($orderedBySkillCount && $skillCountAppearances === 1)) {
+        $columns = $query->getQuery()->columns;
+        $normalizedColumns = array_map(function ($column) {
+            // Massage the column name to be a string and only return the column name
+            return $column instanceof Expression
+                ? Str::afterLast($column->getValue(DB::getQueryGrammar()), 'as ')
+                : Str::afterLast($column, 'as ');
+        }, $columns ?? []);
+
+        // Check if our array of columns contains the skill_count column
+        // If it does, we do not need to add it again
+        if (in_array('"skill_count"', $normalizedColumns)) {
             return $query;
         }
 

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -15,7 +15,6 @@ use App\Http\Resources\UserResource;
 use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
 use Illuminate\Database\Query\Expression;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 /**


### PR DESCRIPTION
🤖 Resolves #6594.

h/t @esizer.

## 👋 Introduction

This PR fix the pool candidates **number of skills matched** column that was not working correctly and strengthens the tests associated with it.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run `docker-compose exec -w /home/site/wwwroot/api webserver sh -c "./vendor/bin/phpunit ./tests/Feature/PoolCandidateTest.php"`
2. Ensure tests passed 10 times