### PR TITLE
[Bug] Fix sorting of Award Experiences

### DIFF
--- a/api/database/factories/CommunityExperienceFactory.php
+++ b/api/database/factories/CommunityExperienceFactory.php
@@ -21,12 +21,14 @@ class CommunityExperienceFactory extends Factory
      */
     public function definition()
     {
+        $startDate = $this->faker->date();
+
         return [
             'title' => $this->faker->jobTitle(),
             'organization' => $this->faker->company(),
             'project' => $this->faker->bs(),
-            'start_date' => $this->faker->date(),
-            'end_date' => $this->faker->boolean() ? $this->faker->date() : null,
+            'start_date' => $startDate,
+            'end_date' => $this->faker->boolean() ? $this->faker->dateTimeBetween($startDate) : null,
             'details' => $this->faker->text(),
         ];
     }

--- a/api/database/factories/EducationExperienceFactory.php
+++ b/api/database/factories/EducationExperienceFactory.php
@@ -21,12 +21,14 @@ class EducationExperienceFactory extends Factory
      */
     public function definition()
     {
+        $startDate = $this->faker->date();
+
         return [
             'institution' => $this->faker->company(),
             'area_of_study' => $this->faker->jobTitle(),
             'thesis_title' => $this->faker->bs(),
-            'start_date' => $this->faker->date(),
-            'end_date' => $this->faker->boolean() ? $this->faker->date() : null,
+            'start_date' => $startDate,
+            'end_date' => $this->faker->boolean() ? $this->faker->dateTimeBetween($startDate) : null,
             'type' => $this->faker->randomElement(
                 [
                     'DIPLOMA',

--- a/api/database/factories/PersonalExperienceFactory.php
+++ b/api/database/factories/PersonalExperienceFactory.php
@@ -21,11 +21,13 @@ class PersonalExperienceFactory extends Factory
      */
     public function definition()
     {
+        $startDate = $this->faker->date();
+
         return [
             'title' => $this->faker->jobTitle(),
             'description' => $this->faker->text(),
-            'start_date' => $this->faker->date(),
-            'end_date' => $this->faker->boolean() ? $this->faker->date() : null,
+            'start_date' => $startDate,
+            'end_date' => $this->faker->boolean() ? $this->faker->dateTimeBetween($startDate) : null,
             'details' => $this->faker->text(),
         ];
     }

--- a/api/database/factories/WorkExperienceFactory.php
+++ b/api/database/factories/WorkExperienceFactory.php
@@ -21,12 +21,14 @@ class WorkExperienceFactory extends Factory
      */
     public function definition()
     {
+        $startDate = $this->faker->date();
+
         return [
             'role' => $this->faker->jobTitle(),
             'organization' => $this->faker->company(),
             'division' => $this->faker->bs(),
-            'start_date' => $this->faker->date(),
-            'end_date' => $this->faker->boolean() ? $this->faker->date() : null,
+            'start_date' => $startDate,
+            'end_date' => $this->faker->boolean() ? $this->faker->dateTimeBetween($startDate) : null,
             'details' => $this->faker->text(),
         ];
     }

--- a/apps/web/src/pages/Applications/ApplicationResumePage/ApplicationResumePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumePage/ApplicationResumePage.tsx
@@ -187,7 +187,7 @@ export const ApplicationResume = ({
 
   const methods = useForm<FormValues>();
   const { watch, register, setValue } = methods;
-  const watchSortExperiencesBy = watch("sortExperiencesBy");
+  const watchSortExperiencesBy = watch("sortExperiencesBy", "date_desc"); // default first option in the <Select>
   const actionProps = register("action");
 
   const nonEmptyExperiences = experiences?.filter(notEmpty) ?? [];
@@ -383,7 +383,7 @@ export const ApplicationResume = ({
           </div>
           {hasSomeExperience ? (
             <Accordion.Root type="multiple">
-              {experiences.map((experience) => {
+              {nonEmptyExperiences.map((experience) => {
                 return (
                   <ExperienceAccordion
                     key={experience.id}

--- a/apps/web/src/pages/Profile/ExperienceAndSkillsPage/ExperienceAndSkillsPage.test.tsx
+++ b/apps/web/src/pages/Profile/ExperienceAndSkillsPage/ExperienceAndSkillsPage.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { compareByDate } from "~/types/experience";
+import { compareByDate } from "~/utils/experienceUtils";
 import { Applicant, Experience } from "~/api/generated";
 import { ExperienceForDate } from "./components/ExperienceAndSkills";
 

--- a/apps/web/src/types/experience.ts
+++ b/apps/web/src/types/experience.ts
@@ -51,29 +51,6 @@ export type ExperienceForDate =
   | PersonalExperience
   | WorkExperience;
 
-export const compareByDate = (e1: ExperienceForDate, e2: ExperienceForDate) => {
-  const e1EndDate = e1.endDate ? new Date(e1.endDate).getTime() : null;
-  const e2EndDate = e2.endDate ? new Date(e2.endDate).getTime() : null;
-  const e1StartDate = e1.startDate ? new Date(e1.startDate).getTime() : -1;
-  const e2StartDate = e2.startDate ? new Date(e2.startDate).getTime() : -1;
-
-  // All items with no end date should be at the top and sorted by most recent start date.
-  if (!e1EndDate && !e2EndDate) {
-    return e2StartDate - e1StartDate;
-  }
-
-  if (!e1EndDate) {
-    return -1;
-  }
-
-  if (!e2EndDate) {
-    return 1;
-  }
-
-  // Items with end date should be sorted by most recent end date at top.
-  return e2EndDate - e1EndDate;
-};
-
 type MergedExperiences = Array<
   | AwardExperience
   | CommunityExperience

--- a/apps/web/src/utils/experienceUtils.ts
+++ b/apps/web/src/utils/experienceUtils.ts
@@ -320,10 +320,30 @@ export const isWorkExperience = (e: AnyExperience): e is WorkExperience =>
   e.__typename === "WorkExperience";
 
 export const compareByDate = (e1: ExperienceForDate, e2: ExperienceForDate) => {
-  const e1EndDate = e1.endDate ? new Date(e1.endDate).getTime() : null;
-  const e2EndDate = e2.endDate ? new Date(e2.endDate).getTime() : null;
-  const e1StartDate = e1.startDate ? new Date(e1.startDate).getTime() : -1;
-  const e2StartDate = e2.startDate ? new Date(e2.startDate).getTime() : -1;
+  // fit AwardExperience to startDate - endDate format
+  const e1Adjusted = e1;
+  const e2Adjusted = e2;
+  if (e1.__typename === "AwardExperience") {
+    e1Adjusted.startDate = e1.awardedDate;
+    e1Adjusted.endDate = e1.awardedDate;
+  }
+  if (e2.__typename === "AwardExperience") {
+    e2Adjusted.startDate = e2.awardedDate;
+    e2Adjusted.endDate = e2.awardedDate;
+  }
+
+  const e1EndDate = e1Adjusted.endDate
+    ? new Date(e1Adjusted.endDate).getTime()
+    : null;
+  const e2EndDate = e2Adjusted.endDate
+    ? new Date(e2Adjusted.endDate).getTime()
+    : null;
+  const e1StartDate = e1Adjusted.startDate
+    ? new Date(e1Adjusted.startDate).getTime()
+    : -1;
+  const e2StartDate = e2Adjusted.startDate
+    ? new Date(e2Adjusted.startDate).getTime()
+    : -1;
 
   // All items with no end date should be at the top and sorted by most recent start date.
   if (!e1EndDate && !e2EndDate) {


### PR DESCRIPTION
🤖 Resolves #6456 

## 👋 Introduction

Make sorting experiences work with Award Experiences and removed the duplicate sort.  

## 🕵️ Details

Solved by treating them as the same as the other experience types with the special state that award_date = start_date = end_date

As well, resolved some sorting bugs I noticed:
`nonEmptyExperiences` was introduced in #6574, but needs to be passed into what is rendered for the sort to happen
`watchSortExperiencesBy` starts off as undefined, which makes the sort initially disconnected from the select, resolved with a default
Seeding allows for end dates before start dates for experiences, changed that

## 🧪 Testing

1. head to `/en/applications/:id/resume`
2. observe sorting
3. create more experiences and see sorting

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/2f6fafa7-4dd4-4b26-be26-53b4c4847a91)
