### PR TITLE
[Bug] Make teams and classifications on Pool Table more searchable

### DIFF
--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -272,21 +272,8 @@ export const PoolTable = ({ pools, title }: PoolTableProps) => {
           description:
             "Title displayed for the Pool table Group and Level column.",
         }),
-        accessor: (d) => {
-          let classificationsString = "";
-          if (d.classifications && d.classifications.length > 0) {
-            d.classifications.forEach((classification) => {
-              if (classification) {
-                const groupLevelString = wrapAbbr(
-                  `${classification?.group}-0${classification?.level}`,
-                  intl,
-                );
-                classificationsString += groupLevelString;
-              }
-            });
-          }
-          return classificationsString;
-        },
+        accessor: ({ classifications }) =>
+          classifications?.map((c) => `${c?.group}-0${c?.level}`)?.join(", "),
         Cell: ({ row }: PoolCell) => {
           return classificationsCell(row.original.classifications);
         },
@@ -331,7 +318,7 @@ export const PoolTable = ({ pools, title }: PoolTableProps) => {
           id: "fCXZ4R",
           description: "Title displayed for the Pool table Team column",
         }),
-        accessor: (d) => `Team ${d.team?.id ? d.team.id : ""}`,
+        accessor: (d) => getLocalizedName(d.team?.displayName, intl),
         Cell: ({ row }: PoolCell) =>
           viewTeamLinkAccessor(
             paths.teamView(row.original.team?.id ? row.original.team?.id : ""),

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -123,11 +123,11 @@ const classificationsCell = (
     ? filteredClassifications.map((classification) => {
         return (
           <Pill
-            key={`${classification?.group}-${classification?.level}`}
+            key={`${classification?.group}-0${classification?.level}`}
             color="primary"
             mode="outline"
           >
-            {classification?.group}&#8209;{classification?.level}
+            {`${classification?.group}-0${classification?.level}`}
           </Pill>
         );
       })

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -117,25 +117,20 @@ const classificationsCell = (
   classifications: Maybe<Maybe<Classification>[]>,
 ): JSX.Element | null => {
   const filteredClassifications = classifications
-    ? classifications.filter((classification) => !!classification)
-    : null;
-  const pillsArray = filteredClassifications
-    ? filteredClassifications.map((classification) => {
-        return (
-          <Pill
-            key={`${classification?.group}-0${classification?.level}`}
-            color="primary"
-            mode="outline"
-          >
-            {`${classification?.group}-0${classification?.level}`}
-          </Pill>
-        );
-      })
-    : null;
-  if (pillsArray) {
-    return <span>{pillsArray}</span>;
-  }
-  return null;
+    ? classifications.filter(notEmpty)
+    : [];
+  const pillsArray = filteredClassifications.map((classification) => {
+    return (
+      <Pill
+        key={`${classification.group}-0${classification.level}`}
+        color="primary"
+        mode="outline"
+      >
+        {`${classification.group}-0${classification.level}`}
+      </Pill>
+    );
+  });
+  return pillsArray.length > 0 ? <span>{pillsArray}</span> : null;
 };
 
 const emailLinkAccessor = (value: Maybe<string>, intl: IntlShape) => {
@@ -273,7 +268,10 @@ export const PoolTable = ({ pools, title }: PoolTableProps) => {
             "Title displayed for the Pool table Group and Level column.",
         }),
         accessor: ({ classifications }) =>
-          classifications?.map((c) => `${c?.group}-0${c?.level}`)?.join(", "),
+          classifications
+            ?.filter(notEmpty)
+            ?.map((c) => `${c.group}-0${c.level}`)
+            ?.join(", "),
         Cell: ({ row }: PoolCell) => {
           return classificationsCell(row.original.classifications);
         },

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -15,7 +15,7 @@ import {
 import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 import { unpackMaybes } from "@gc-digital-talent/forms";
 
-import { getFullNameHtml, wrapAbbr } from "~/utils/nameUtils";
+import { getFullNameHtml } from "~/utils/nameUtils";
 import { getFullPoolAdvertisementTitleHtml } from "~/utils/poolUtils";
 import useRoutes from "~/hooks/useRoutes";
 import {


### PR DESCRIPTION
🤖 Resolves #6605

## 👋 Introduction

I discovered and fixed this bug in the course of investigating something else, so I might as well push up a PR.

## 🕵️ Details

Allows you to use the search bar to filter pools by classification or by team.

## 🧪 Testing

0. Run seeders
1. Log in as admin@test.com
2. Go to http://localhost:8000/en/admin/pools
3. Type "Digital" in search bar and confirm that non DCM team pools are filtered out
4. Type "IT-02" in search bar and confirm that you only see IT-02 pools

