### PR TITLE
[Bug] Fix theme override

### DIFF
--- a/packages/theme/src/components/ThemeProvider.tsx
+++ b/packages/theme/src/components/ThemeProvider.tsx
@@ -157,14 +157,14 @@ const ThemeProvider = ({
 
   const state = React.useMemo(
     () => ({
-      mode,
-      key,
+      mode: override?.mode || mode,
+      key: override?.key || key,
       setTheme,
       setMode,
       setKey,
       isPref: !mode || mode === "pref",
     }),
-    [mode, key, setTheme, setMode, setKey],
+    [mode, key, setTheme, setMode, setKey, override],
   );
 
   return (


### PR DESCRIPTION
🤖 Resolves #6012 

## 👋 Introduction

This updates the `ThemeProvider` to supply override to the state.

## 🕵️ Details

We were relying on default `useState` to compute the theme which was sort of unstable. This also updates the `useMemo` to supply override and use it if no default theme has been provided. This should make the override a little more stable 🤷‍♀️ 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run chromatic
2. Confirm no diff

## 📸 Screenshot
![Screenshot 2023-05-17 110828](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/df9cfdc9-13e1-44ab-8f29-085d030056fd)


