### PR TITLE
[Bug] Update name for apprenticeship program

### DIFF
--- a/api/database/seeders/PoolSeeder.php
+++ b/api/database/seeders/PoolSeeder.php
@@ -37,8 +37,8 @@ class PoolSeeder extends Seeder
             ],
             [
                 'name' => [
-                    'en' => 'Indigenous Apprenticeship Program',
-                    'fr' => 'Indigenous Apprenticeship Program FR'
+                    'en' => 'IT Apprenticeship Program for Indigenous Peoples',
+                    'fr' => 'Programme d’apprentissage en TI pour les peuples autochtones'
                 ],
                 'key' => 'indigenous_apprenticeship',
                 'user_id' => User::where('email', 'admin@test.com')->first()->id,

--- a/api/database/seeders/PoolSeeder.php
+++ b/api/database/seeders/PoolSeeder.php
@@ -38,7 +38,7 @@ class PoolSeeder extends Seeder
             [
                 'name' => [
                     'en' => 'IT Apprenticeship Program for Indigenous Peoples',
-                    'fr' => 'Programme d’apprentissage en TI pour les peuples autochtones'
+                    'fr' => 'Programme d’apprentissage en TI pour les personnes autochtones'
                 ],
                 'key' => 'indigenous_apprenticeship',
                 'user_id' => User::where('email', 'admin@test.com')->first()->id,

--- a/apps/web/public/iap.webmanifest
+++ b/apps/web/public/iap.webmanifest
@@ -1,5 +1,5 @@
 {
-  "name": "Indigenous Apprenticeship Program",
+  "name": "IT Apprenticeship Program for Indigenous Peoples",
   "short_name": "IAP",
   "icons": [
     {

--- a/apps/web/src/components/Layout/IAPLayout.tsx
+++ b/apps/web/src/components/Layout/IAPLayout.tsx
@@ -47,17 +47,18 @@ const Layout = () => {
           <Favicon project="iap" />
           <SEO
             title={intl.formatMessage({
-              defaultMessage: "Indigenous Apprenticeship Program",
-              id: "C5tUG2",
+              defaultMessage:
+                "IT Apprenticeship Program for Indigenous Peoples",
+              id: "oMpO+C",
               description:
-                "Title tag for Indigenous Apprenticeship Program site",
+                "Title tag for IT Apprenticeship Program for Indigenous Peoples site",
             })}
             description={intl.formatMessage({
               defaultMessage:
                 "Apply now to get started on your IT career journey.",
-              id: "Oh1/Gc",
+              id: "Z9W+O2",
               description:
-                "Meta tag description for Indigenous Apprenticeship Program site",
+                "Meta tag description for IT Apprenticeship Program for Indigenous Peoples site",
             })}
           />
           <SkipLink />
@@ -75,9 +76,9 @@ const Layout = () => {
                   <MenuLink key="home" to={paths.iap()}>
                     {intl.formatMessage({
                       defaultMessage: "Home",
-                      id: "TFeQL2",
+                      id: "M1JKQs",
                       description:
-                        "Link to the homepage for indigenous apprenticeship program.",
+                        "Link to the homepage for IT Apprenticeship Program for Indigenous Peoples.",
                     })}
                   </MenuLink>,
                 ]}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -300,7 +300,7 @@
     "description": "Meta tag description for IT Apprenticeship Program for Indigenous Peoples site"
   },
   "oMpO+C": {
-    "defaultMessage": "Programme d’apprentissage en TI pour les peuples autochtones",
+    "defaultMessage": "Programme d’apprentissage en TI pour les personnes autochtones",
     "description": "Title tag for IT Apprenticeship Program for Indigenous Peoples site"
   },
   "t2Q+IG": {
@@ -2066,7 +2066,7 @@
     "description": "Instruction on when to fill out equity information, item two"
   },
   "4N/PxH": {
-    "defaultMessage": "Programme d’apprentissage en TI pour les peuples autochtones",
+    "defaultMessage": "Programme d’apprentissage en TI pour les personnes autochtones",
     "description": "Heading for the IT Apprenticeship Program for Indigenous Peoples on home page"
   },
   "YZyNUJ": {
@@ -2194,7 +2194,7 @@
     "description": "Sentence asking whether the user possesses priority entitlement"
   },
   "Ew/GPP": {
-    "defaultMessage": "Inscrivez-vous<hidden> au programme d’apprentissage en TI pour les peuples autochtones</hidden> maintenant",
+    "defaultMessage": "Inscrivez-vous<hidden> au programme d’apprentissage en TI pour les personnes autochtones</hidden> maintenant",
     "description": "Link text to apply for the IT Apprenticeship Program for Indigenous Peoples"
   },
   "bKRX6C": {
@@ -2366,7 +2366,7 @@
     "description": "Title for the current jobs recruiting candidates"
   },
   "02aheT": {
-    "defaultMessage": "J’ai découvert le programme d’apprentissage en TI pour les peuples autochtones sur talent.canada.ca et j’aimerais en savoir davantage sur la façon dont je peux embaucher des stagiaires pour mon équipe.",
+    "defaultMessage": "J’ai découvert le programme d’apprentissage en TI pour les personnes autochtones sur talent.canada.ca et j’aimerais en savoir davantage sur la façon dont je peux embaucher des stagiaires pour mon équipe.",
     "description": "Body of email for info on IT Apprenticeship Program for Indigenous Peoples"
   },
   "fVAMSw": {
@@ -2462,7 +2462,7 @@
     "description": "Skills selected and then a number in parentheses"
   },
   "NSHPIJ": {
-    "defaultMessage": "Inscrivez-vous<hidden> au programme d’apprentissage en TI pour les peuples autochtones</hidden> maintenant",
+    "defaultMessage": "Inscrivez-vous<hidden> au programme d’apprentissage en TI pour les personnes autochtones</hidden> maintenant",
     "description": "Link text to go to IAP homepage on Browse IT jobs page"
   },
   "1UYQaC": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2194,7 +2194,7 @@
     "description": "Sentence asking whether the user possesses priority entitlement"
   },
   "Ew/GPP": {
-    "defaultMessage": "Inscrivez-vous<hidden> au programme d’apprentissage en TI pour les personnes autochtones</hidden> maintenant",
+    "defaultMessage": "Inscrivez-vous<hidden> au Programme d’apprentissage en TI pour les personnes autochtones</hidden> maintenant",
     "description": "Link text to apply for the IT Apprenticeship Program for Indigenous Peoples"
   },
   "bKRX6C": {
@@ -2462,7 +2462,7 @@
     "description": "Skills selected and then a number in parentheses"
   },
   "NSHPIJ": {
-    "defaultMessage": "Inscrivez-vous<hidden> au programme d’apprentissage en TI pour les personnes autochtones</hidden> maintenant",
+    "defaultMessage": "Inscrivez-vous<hidden> au Programme d’apprentissage en TI pour les personnes autochtones</hidden> maintenant",
     "description": "Link text to go to IAP homepage on Browse IT jobs page"
   },
   "1UYQaC": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2366,7 +2366,7 @@
     "description": "Title for the current jobs recruiting candidates"
   },
   "02aheT": {
-    "defaultMessage": "J’ai découvert le programme d’apprentissage en TI pour les personnes autochtones sur talent.canada.ca et j’aimerais en savoir davantage sur la façon dont je peux embaucher des stagiaires pour mon équipe.",
+    "defaultMessage": "J’ai découvert le Programme d’apprentissage en TI pour les personnes autochtones sur talent.canada.ca et j’aimerais en savoir davantage sur la façon dont je peux embaucher des stagiaires pour mon équipe.",
     "description": "Body of email for info on IT Apprenticeship Program for Indigenous Peoples"
   },
   "fVAMSw": {
@@ -5014,7 +5014,7 @@
     "description": "work stream example"
   },
   "gj0bQO": {
-    "defaultMessage": "Programme d’apprentissage en TI pour les peuples autochtones",
+    "defaultMessage": "Programme d’apprentissage en TI pour les personnes autochtones",
     "description": "Homepage title for IT Apprenticeship Program for Indigenous Peoples"
   },
   "nn9B4R": {
@@ -5026,11 +5026,11 @@
     "description": "IT-03 description precursor"
   },
   "Dzyk1q": {
-    "defaultMessage": "En collaboration avec le Programme d’apprentissage en TI pour les peuples autochtones, le Portail des talents autochtones commencera par mettre l’accent sur les talents en TI et en technologie, ce qui permettra :",
+    "defaultMessage": "En collaboration avec le Programme d’apprentissage en TI pour les personnes autochtones, le Portail des talents autochtones commencera par mettre l’accent sur les talents en TI et en technologie, ce qui permettra :",
     "description": "Description for strategy for the indigenous talent portal"
   },
   "p2sBh3": {
-    "defaultMessage": "Qui peut présenter une demande pour devenir apprenti dans le cadre du Programme d’apprentissage en TI pour les peuples autochtones du gouvernement du Canada?",
+    "defaultMessage": "Qui peut présenter une demande pour devenir apprenti dans le cadre du Programme d’apprentissage en TI pour les personnes autochtones du gouvernement du Canada?",
     "description": "Learn more dialog question one heading"
   },
   "AlRcyu": {
@@ -5054,7 +5054,7 @@
     "description": "Checkbox label for Level IT-04 manager selection"
   },
   "L9yjr3": {
-    "defaultMessage": "Découvrez-en davantage sur le Programme d’apprentissage en TI pour les peuples autochtones du gouvernement du Canada",
+    "defaultMessage": "Découvrez-en davantage sur le Programme d’apprentissage en TI pour les personnes autochtones du gouvernement du Canada",
     "description": "Heading for the Learn more dialog"
   },
   "SPECr8": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -131,9 +131,9 @@
     "defaultMessage": "Nous vous inviterons à créer un profil qui sera sauvegardé et présenté comme étant votre demande.",
     "description": "How it works, step 2 content sentence 2"
   },
-  "TFeQL2": {
+  "M1JKQs": {
     "defaultMessage": "Accueil",
-    "description": "Link to the homepage for indigenous apprenticeship program."
+    "description": "Link to the homepage for IT Apprenticeship Program for Indigenous Peoples."
   },
   "U8bLT7": {
     "defaultMessage": "Comment cela fonctionnera-t-il?",
@@ -295,13 +295,13 @@
     "defaultMessage": "Vise à lancer le programme au début de 2023.",
     "description": "Talent portal strategy item 4 content"
   },
-  "Oh1/Gc": {
+  "Z9W+O2": {
     "defaultMessage": "Postulez dès aujourd'hui pour entamer votre parcours de carrière en TI.",
-    "description": "Meta tag description for Indigenous Apprenticeship Program site"
+    "description": "Meta tag description for IT Apprenticeship Program for Indigenous Peoples site"
   },
-  "C5tUG2": {
-    "defaultMessage": "Programme d’apprentissage destiné aux Autochtones",
-    "description": "Title tag for Indigenous Apprenticeship Program site"
+  "oMpO+C": {
+    "defaultMessage": "Programme d’apprentissage en TI pour les peuples autochtones",
+    "description": "Title tag for IT Apprenticeship Program for Indigenous Peoples site"
   },
   "t2Q+IG": {
     "defaultMessage": "Retourner au Français",
@@ -2065,9 +2065,9 @@
     "defaultMessage": "Vous souhaitez être pris en considération pour les perspectives d’emploi adressées aux groupes sous-représentés.",
     "description": "Instruction on when to fill out equity information, item two"
   },
-  "XR37x0": {
-    "defaultMessage": "Programme d’apprentissage destiné aux Autochtones",
-    "description": "Heading for the Indigenous Apprenticeship Program on home page"
+  "4N/PxH": {
+    "defaultMessage": "Programme d’apprentissage en TI pour les peuples autochtones",
+    "description": "Heading for the IT Apprenticeship Program for Indigenous Peoples on home page"
   },
   "YZyNUJ": {
     "defaultMessage": "Signature",
@@ -2193,9 +2193,9 @@
     "defaultMessage": "Avez-vous un droit de priorité pour les candidatures du gouvernement du Canada? Ce statut est accordé par la Commission de la fonction publique du Canada. Pour en savoir plus, <priorityEntitlementLink>visitez le site de l'information sur les droits de priorité</priorityEntitlementLink>.",
     "description": "Sentence asking whether the user possesses priority entitlement"
   },
-  "w3Kkk2": {
-    "defaultMessage": "Inscrivez-vous<hidden> au programme d’apprentissage destiné aux Autochtones</hidden> maintenant",
-    "description": "Link text to apply for the Indigenous Apprenticeship Program"
+  "Ew/GPP": {
+    "defaultMessage": "Inscrivez-vous<hidden> au programme d’apprentissage en TI pour les peuples autochtones</hidden> maintenant",
+    "description": "Link text to apply for the IT Apprenticeship Program for Indigenous Peoples"
   },
   "bKRX6C": {
     "defaultMessage": "Curieux de savoir comment la plateforme Talents numériques du <abbreviation>GC</abbreviation> a été développée? Vous voulez en savoir plus sur les idées, les conceptions et la philosophie de celle-ci? Découvrez le chemin parcouru depuis le pilote expérimental du Nuage de talents du <abbreviation>GC</abbreviation> jusqu’à la plateforme d’aujourd’hui.",
@@ -2365,9 +2365,9 @@
     "defaultMessage": "Processus actifs de recrutement de talents",
     "description": "Title for the current jobs recruiting candidates"
   },
-  "dIIccA": {
-    "defaultMessage": "J’ai découvert le Programme d’apprentissage pour les peuples autochtones sur talent.canada.ca et j’aimerais en savoir davantage sur la façon dont je peux embaucher des stagiaires pour mon équipe.",
-    "description": "Body of email for info on Indigenous Apprenticeship Program"
+  "02aheT": {
+    "defaultMessage": "J’ai découvert le programme d’apprentissage en TI pour les peuples autochtones sur talent.canada.ca et j’aimerais en savoir davantage sur la façon dont je peux embaucher des stagiaires pour mon équipe.",
+    "description": "Body of email for info on IT Apprenticeship Program for Indigenous Peoples"
   },
   "fVAMSw": {
     "defaultMessage": "Soumettez des commentaires",
@@ -2377,9 +2377,9 @@
     "defaultMessage": "D’autres offres seront bientôt affichées!",
     "description": "Heading for message about upcoming opportunities"
   },
-  "gG5eAt": {
+  "71f/uH": {
     "defaultMessage": "Communiquez avec le Programme d’apprentissage",
-    "description": "Link text to email about the Indigenous Apprenticeship Program"
+    "description": "Link text to email about the IT Apprenticeship Program for Indigenous Peoples"
   },
   "C7sYnb": {
     "defaultMessage": "Cette plateforme vous permet de postuler à des processus de recrutement qui permettront aux gestionnaires qui embauchent de vous trouver facilement. Cette page donne un aperçu de nos processus de recrutement ouverts. Revenez-y et consultez cette page fréquemment!",
@@ -2417,9 +2417,9 @@
     "defaultMessage": "Communiquez avec nous",
     "description": "Support form title"
   },
-  "p/dXxz": {
+  "E4PMGL": {
     "defaultMessage": "Je souhaite embaucher des stagiaires autochtones en TI pour mon équipe",
-    "description": "Subject of email for info on Indigenous Apprenticeship Program"
+    "description": "Subject of email for info on IT Apprenticeship Program for Indigenous Peoples"
   },
   "qLYONf": {
     "defaultMessage": "Préparez-vous en créant un profil",
@@ -2461,8 +2461,8 @@
     "defaultMessage": "Compétences sélectionnées ({skillCount})",
     "description": "Skills selected and then a number in parentheses"
   },
-  "07BM9O": {
-    "defaultMessage": "Inscrivez-vous<hidden> au programme d’apprentissage destiné aux Autochtones</hidden> maintenant",
+  "NSHPIJ": {
+    "defaultMessage": "Inscrivez-vous<hidden> au programme d’apprentissage en TI pour les peuples autochtones</hidden> maintenant",
     "description": "Link text to go to IAP homepage on Browse IT jobs page"
   },
   "1UYQaC": {
@@ -5013,13 +5013,13 @@
     "defaultMessage": "Architecture intégrée de la <abbreviation>TI</abbreviation>",
     "description": "work stream example"
   },
-  "Hu04cP": {
+  "gj0bQO": {
     "defaultMessage": "Programme d’apprentissage en TI pour les peuples autochtones",
-    "description": "Homepage title for Indigenous Apprenticeship Program"
+    "description": "Homepage title for IT Apprenticeship Program for Indigenous Peoples"
   },
-  "z5Gcsn": {
+  "nn9B4R": {
     "defaultMessage": "Postulez dès aujourd’hui pour entamer votre parcours de carrière en TI.",
-    "description": "Homepage subtitle for Indigenous Apprenticeship Program"
+    "description": "Homepage subtitle for IT Apprenticeship Program for Indigenous Peoples"
   },
   "7wcfnG": {
     "defaultMessage": "Il y a deux types d'employés du <abbreviation>TI-03</abbreviation> : ceux qui suivent un cheminement en gestion et les contributeurs individuels.",
@@ -5061,9 +5061,9 @@
     "defaultMessage": "<strong>Contributeur individuel</strong> : Les conseillers principaux de la <abbreviation>TI</abbreviation> (<abbreviation>TI-04</abbreviation>) fournissent des conseils techniques d'experts et une orientation stratégique à leur domaine d'expertise, dans la prestation de solutions et de services aux clients internes ou externes, de même qu'aux intervenants. Les conseillers principaux de la <abbreviation>TI</abbreviation> se trouvent surtout dans six volets de travail :",
     "description": "IT-04 senior advisor description precursor to work stream list"
   },
-  "FtJRWS": {
+  "szt3yx": {
     "defaultMessage": "Conçu par la communauté autochtone pour la communauté autochtone, ce programme recrute des candidats pour des postes de niveau d'entrée pour des possibilités d’apprentissage et de développement des <abbreviation>TI</abbreviation> dans l’ensemble du gouvernement.",
-    "description": "Description for the Indigenous Apprenticeship Program on home page"
+    "description": "Description for the IT Apprenticeship Program for Indigenous Peoples on home page"
   },
   "GtZyhK": {
     "defaultMessage": "Technicien (<abbreviation>TI-01</abbreviation>)",
@@ -5093,9 +5093,9 @@
     "defaultMessage": "Niveau 3 : Chef d'équipe (88 000 $ à 110 000 $). <openModal>En savoir plus sur <abbreviation>TI-03</abbreviation></openModal>",
     "description": "Checkbox label for Level IT-03 leader selection"
   },
-  "LOvD2e": {
+  "Q0G/5L": {
     "defaultMessage": "Vous recherchez des talents en <abbreviation>TI</abbreviation> de niveau débutant et vous désirez soutenir la diversité, l’inclusion et la réconciliation? Communiquez avec le programme d’apprentissage en <abbreviation>TI</abbreviation> pour les personnes autochtones et lancez le processus d’embauche de stagiaires autochtones dès aujourd’hui!",
-    "description": "Summary of the Indigenous Apprenticeship Program for the homepage"
+    "description": "Summary of the IT Apprenticeship Program for Indigenous Peoples for the homepage"
   },
   "LlgRM8": {
     "defaultMessage": "Lorsque les responsables du recrutement ont des besoins en personnel informatique et que des postes se libèrent, les candidats qui répondent aux qualifications de ce processus peuvent être contactés pour une évaluation plus approfondie. Cela signifie que divers responsables peuvent vous contacter au sujet d'occasions précises dans le domaine du développement d'applications.",

--- a/apps/web/src/lang/mic.json
+++ b/apps/web/src/lang/mic.json
@@ -327,13 +327,13 @@
     "defaultMessage": "Jinu'kwalsi kisi tuwa'tn wula program ta'n poqjiaq 2023.",
     "description": "Talent portal strategy item 4 content"
   },
-  "Hu04cP": {
+  "gj0bQO": {
     "defaultMessage": "IT Apprenticeship Program wjit L’nu’k",
-    "description": "Homepage title for Indigenous Apprenticeship Program"
+    "description": "Homepage title for IT Apprenticeship Program for Indigenous Peoples"
   },
-  "z5Gcsn": {
+  "nn9B4R": {
     "defaultMessage": "Suwa’te’n kiskuk wjit poqjilukwatn ki’l IT career wutawti.",
-    "description": "Homepage subtitle for Indigenous Apprenticeship Program"
+    "description": "Homepage subtitle for IT Apprenticeship Program for Indigenous Peoples"
   },
   "pBJzgi": {
     "defaultMessage": "Meskeyi, mu we’jituwek ta’n teluwek wi’katikn ninen kwilmek wjit koqowey.",
@@ -351,9 +351,9 @@
     "defaultMessage": "Ikanteske’n wjit elien ikant",
     "description": "Assistive technology skip link"
   },
-  "TFeQL2": {
+  "M1JKQs": {
     "defaultMessage": "Wikuwow",
-    "description": "Link to the homepage for indigenous apprenticeship program."
+    "description": "Link to the homepage for IT Apprenticeship Program for Indigenous Peoples."
   },
   "gKyog2": {
     "defaultMessage": "Oops, teltek kutey  ki’l kisi ika’tu’n wula wi’katikn ki’l ewikasik ta’n teluwek mu sama’tasin tujiw ankaptasin.",
@@ -367,12 +367,12 @@
     "defaultMessage": "Ta’n tujiw mu kisita’suwun wjit wula program tepaqtek wjit ki’l, <mailLink>ke tliwula’tike</mailLink> aqq pipanimitisnen aqq na’tuwan wl’ta’sitew kisis apoqmask ta’n koqowey keut’ pipanikesin.",
     "description": "Second paragraph about who the program is for"
   },
-  "Oh1/Gc": {
+  "Z9W+O2": {
     "defaultMessage": " Suwa’te’n nike’ wjit poqjilukwatn ki’l IT career wutawti.",
-    "description": "Meta tag description for Indigenous Apprenticeship Program site"
+    "description": "Meta tag description for IT Apprenticeship Program for Indigenous Peoples site"
   },
-  "C5tUG2": {
-    "defaultMessage": "L’nu’k Apprenticeship Program ewikasik",
-    "description": "Title tag for Indigenous Apprenticeship Program site"
+  "oMpO+C": {
+    "defaultMessage": "IT Apprenticeship Program wjit L’nu’k",
+    "description": "Title tag for IT Apprenticeship Program for Indigenous Peoples site"
   }
 }

--- a/apps/web/src/pages/Home/HomePage/components/Featured/Featured.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/Featured/Featured.tsx
@@ -25,18 +25,18 @@ const Featured = () => {
       intl.formatMessage({
         defaultMessage:
           "I'm interested in hiring Indigenous IT apprentices for my team",
-        id: "p/dXxz",
+        id: "E4PMGL",
         description:
-          "Subject of email for info on Indigenous Apprenticeship Program",
+          "Subject of email for info on IT Apprenticeship Program for Indigenous Peoples",
       }),
     ),
     body: encodeURIComponent(
       intl.formatMessage({
         defaultMessage:
-          "I discovered the Indigenous Apprenticeship Program on talent.canada.ca and I'd like to learn more about how I can hire apprentices to my team.",
-        id: "dIIccA",
+          "I discovered the IT Apprenticeship Program for Indigenous Peoples on talent.canada.ca and I'd like to learn more about how I can hire apprentices to my team.",
+        id: "02aheT",
         description:
-          "Body of email for info on Indigenous Apprenticeship Program",
+          "Body of email for info on IT Apprenticeship Program for Indigenous Peoples",
       }),
     ),
   };
@@ -105,9 +105,9 @@ const Featured = () => {
         {
           defaultMessage:
             "Are you looking for entry-level <abbreviation>IT</abbreviation> talent and want to support diversity, inclusion, and reconciliation? Connect with the <abbreviation>IT</abbreviation> Apprenticeship Program for Indigenous Peoples and start the process to hire Indigenous apprentices today!",
-          id: "LOvD2e",
+          id: "Q0G/5L",
           description:
-            "Summary of the Indigenous Apprenticeship Program for the homepage",
+            "Summary of the IT Apprenticeship Program for Indigenous Peoples for the homepage",
         },
         {
           abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
@@ -119,9 +119,9 @@ const Featured = () => {
         path: `mailto:edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca?subject=${iapEmail.subject}&body=${iapEmail.body}`,
         label: intl.formatMessage({
           defaultMessage: "Contact the Apprenticeship Program",
-          id: "gG5eAt",
+          id: "71f/uH",
           description:
-            "Link text to email about the Indigenous Apprenticeship Program",
+            "Link text to email about the IT Apprenticeship Program for Indigenous Peoples",
         }),
       },
     },

--- a/apps/web/src/pages/Home/HomePage/components/Opportunities/Opportunities.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/Opportunities/Opportunities.tsx
@@ -129,20 +129,21 @@ const Opportunities = () => {
             <CardFlat
               color="secondary"
               title={intl.formatMessage({
-                defaultMessage: "Indigenous Apprenticeship Program",
-                id: "XR37x0",
+                defaultMessage:
+                  "IT Apprenticeship Program for Indigenous Peoples",
+                id: "4N/PxH",
                 description:
-                  "Heading for the Indigenous Apprenticeship Program on home page",
+                  "Heading for the IT Apprenticeship Program for Indigenous Peoples on home page",
               })}
               links={[
                 {
                   href: `/${locale}/indigenous-it-apprentice`,
                   label: intl.formatMessage({
                     defaultMessage:
-                      "Apply<hidden> to the Indigenous Apprenticeship Program</hidden> now",
+                      "Apply<hidden> to the IT Apprenticeship Program for Indigenous Peoples</hidden> now",
                     description:
-                      "Link text to apply for the Indigenous Apprenticeship Program",
-                    id: "w3Kkk2",
+                      "Link text to apply for the IT Apprenticeship Program for Indigenous Peoples",
+                    id: "Ew/GPP",
                   }),
                 },
               ]}
@@ -152,9 +153,9 @@ const Opportunities = () => {
                   {
                     defaultMessage:
                       "Designed by the Indigenous community for the Indigenous community, this program recruits entry-level applicants for learning and development <abbreviation>IT</abbreviation> opportunities across government.",
-                    id: "FtJRWS",
+                    id: "szt3yx",
                     description:
-                      "Description for the Indigenous Apprenticeship Program on home page",
+                      "Description for the IT Apprenticeship Program for Indigenous Peoples on home page",
                   },
                   {
                     abbreviation: (text: React.ReactNode) =>

--- a/apps/web/src/pages/Home/IAPHomePage/Home.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.tsx
@@ -107,9 +107,9 @@ const Home = () => {
                 {intl.formatMessage({
                   defaultMessage:
                     "IT Apprenticeship Program for Indigenous Peoples",
-                  id: "Hu04cP",
+                  id: "gj0bQO",
                   description:
-                    "Homepage title for Indigenous Apprenticeship Program",
+                    "Homepage title for IT Apprenticeship Program for Indigenous Peoples",
                 })}
               </h1>
               <p
@@ -120,9 +120,9 @@ const Home = () => {
                 {intl.formatMessage({
                   defaultMessage:
                     "Apply today to get started on your IT career journey.",
-                  id: "z5Gcsn",
+                  id: "nn9B4R",
                   description:
-                    "Homepage subtitle for Indigenous Apprenticeship Program",
+                    "Homepage subtitle for IT Apprenticeship Program for Indigenous Peoples",
                 })}
               </p>
             </div>

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
@@ -250,10 +250,10 @@ export const BrowsePools = ({ poolAdvertisements }: BrowsePoolsProps) => {
                   external: true,
                   label: intl.formatMessage({
                     defaultMessage:
-                      "Apply<hidden> to the Indigenous Apprenticeship Program</hidden> now",
+                      "Apply<hidden> to the IT Apprenticeship Program for Indigenous Peoples</hidden> now",
                     description:
                       "Link text to go to IAP homepage on Browse IT jobs page",
-                    id: "07BM9O",
+                    id: "NSHPIJ",
                   }),
                 },
               ]}

--- a/documentation/h2-upgrade-guide.md
+++ b/documentation/h2-upgrade-guide.md
@@ -70,7 +70,7 @@ You can choose to ignore these additions, but they might be nice for you to know
 - I've consolidated the color configurations, but this means that the colors have been renamed for consistency and reuse
   - all colors now use generic functional names (e.g. `primary`, `secondary`, `black`, `white`, `gray`, etc.)
   - Digital Talent brand colors are now prefixed with `dt-`, e.g. `dt-primary`
-  - Indigenous Apprenticeship Program colors are now prefixed with `ia-`, e.g. `ia-primary`
+  - IT Apprenticeship Program for Indigenous Peoples colors are now prefixed with `ia-`, e.g. `ia-primary`
   - if you need to access a light or dark version of a particular color, you can now use the modifier syntax to do so
     - for example, `light-purple` would now be `primary.light`
     - this also means you can set your own modifiers in `hydrogen.config.json` if new color variations are added

--- a/packages/fake-data/src/fakePools.ts
+++ b/packages/fake-data/src/fakePools.ts
@@ -62,7 +62,7 @@ export default (): Pool[] => {
     generatePool("CMO", "CMO", users, classifications),
     generatePool(
       "IT Apprenticeship Program for Indigenous Peoples",
-      "Programme d’apprentissage en TI pour les peuples autochtones",
+      "Programme d’apprentissage en TI pour les personnes autochtones",
       users,
       classifications,
     ),

--- a/packages/fake-data/src/fakePools.ts
+++ b/packages/fake-data/src/fakePools.ts
@@ -61,8 +61,8 @@ export default (): Pool[] => {
   return [
     generatePool("CMO", "CMO", users, classifications),
     generatePool(
-      "Indigenous Apprenticeship Program",
-      "Indigenous Apprenticeship Program FR",
+      "IT Apprenticeship Program for Indigenous Peoples",
+      "Programme d’apprentissage en TI pour les peuples autochtones",
       users,
       classifications,
     ),

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1362,9 +1362,9 @@
     "defaultMessage": "Renseignements manquants",
     "description": "Message displayed when a user has not provided some form of information"
   },
-  "LWsmvv": {
+  "I6gM/P": {
     "defaultMessage": "PAPA",
-    "description": "The publishing group called Indigenous Apprenticeship Program"
+    "description": "The publishing group called IT Apprenticeship Program for Indigenous Peoples"
   },
   "4S30lt": {
     "defaultMessage": "Expérience de travail appliquée",

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -1601,9 +1601,9 @@ export const publishingGroups = defineMessages({
   },
   [PublishingGroup.Iap]: {
     defaultMessage: "IAP",
-    id: "LWsmvv",
+    id: "I6gM/P",
     description:
-      "The publishing group called Indigenous Apprenticeship Program",
+      "The publishing group called IT Apprenticeship Program for Indigenous Peoples",
   },
   [PublishingGroup.ItJobs]: {
     defaultMessage: "IT Jobs",


### PR DESCRIPTION
🤖 Resolves #6593

## 👋 Introduction

This branch replaces all occurrences of the apprenticeship program's name to _IT Apprenticeship Program for Indigenous Peoples_.  Additionally, Brooke confirmed that the French name should use the word _personnes_ not _peuples_ so I updated that, too.  I didn't update the acronym IAP anywhere since it's still reasonably accurate and I haven't heard an updated one used.

## 🧪 Testing

1. _Indigenous Apprenticeship Program_ does not appear in the codebase.
2. _Programme d’apprentissage en TI pour les peuples autochtones_ does not appear in the codebase.
3. No missing translations.
4. No mangled translations.

## 📸 Screenshot
![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/36931981-df71-4ff9-9665-32b71a7bfaab)