### PR TITLE
[Bug] Enable filtering for All in ongoing recruitments

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2729,10 +2729,6 @@
     "defaultMessage": "La liste n’est pas filtrée. ",
     "description": "Announcement that the job stream filter is not active."
   },
-  "8NB+Ay": {
-    "defaultMessage": "Filtre rapide. ",
-    "description": "A label for a quick filter input."
-  },
   "SypvZP": {
     "defaultMessage": "La liste est filtrée vers le {jobStream} volet du travail.",
     "description": "Announcement that the job stream filter is active."

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8068,6 +8068,10 @@
     "defaultMessage": "Exigences pédagogiques",
     "description": "CSV Header, Education Requirement column"
   },
+  "qQtJDw": {
+    "defaultMessage": "Tous",
+    "description": "All statuses"
+  },
   "5nlauT": {
     "defaultMessage": "Question filtre {index} : {question}",
     "description": "CSV Header, Screening question column. "

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8068,9 +8068,9 @@
     "defaultMessage": "Exigences pédagogiques",
     "description": "CSV Header, Education Requirement column"
   },
-  "qQtJDw": {
+  "XnvXtO": {
     "defaultMessage": "Tous",
-    "description": "All statuses"
+    "description": "All"
   },
   "5nlauT": {
     "defaultMessage": "Question filtre {index} : {question}",

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
@@ -1038,28 +1038,29 @@ const OngoingRecruitmentSection = ({
             {" "}
             <div data-h2-padding="base(x.5, x1, x.5, x.5)">
               <DropdownMenu.RadioGroup value={quickFilterStream}>
-                <DropdownMenu.RadioItem
-                  value="ALL"
-                  onSelect={() => {
-                    setQuickFilterStream("ALL");
-                  }}
-                >
-                  <DropdownMenu.ItemIndicator>
-                    <CheckIcon />
-                  </DropdownMenu.ItemIndicator>
-                  <span>
-                    {intl.formatMessage({
-                      defaultMessage: "All",
-                      id: "qQtJDw",
-                      description: "All statuses",
-                    })}
-                  </span>
-                </DropdownMenu.RadioItem>
+                <React.Fragment key="ALL">
+                  <DropdownMenu.RadioItem
+                    value="ALL"
+                    onSelect={() => {
+                      setQuickFilterStream("ALL");
+                    }}
+                  >
+                    <DropdownMenu.ItemIndicator>
+                      <CheckIcon />
+                    </DropdownMenu.ItemIndicator>
+                    <span>
+                      {intl.formatMessage({
+                        defaultMessage: "All",
+                        id: "qQtJDw",
+                        description: "All statuses",
+                      })}
+                    </span>
+                  </DropdownMenu.RadioItem>
+                </React.Fragment>
                 {options.map((option, index) => (
-                  <>
+                  <React.Fragment key={option.value}>
                     <DropdownMenu.RadioItem
                       value={option.value}
-                      key={option.value}
                       onSelect={() => {
                         setQuickFilterStream(option.value);
                       }}
@@ -1071,7 +1072,7 @@ const OngoingRecruitmentSection = ({
                     </DropdownMenu.RadioItem>
 
                     {index + 1 < options.length && <DropdownMenu.Separator />}
-                  </>
+                  </React.Fragment>
                 ))}
               </DropdownMenu.RadioGroup>
             </div>

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
@@ -1023,8 +1023,8 @@ const OngoingRecruitmentSection = ({
                 {quickFilterStream === "ALL"
                   ? intl.formatMessage({
                       defaultMessage: "All",
-                      id: "qQtJDw",
-                      description: "All statuses",
+                      id: "XnvXtO",
+                      description: "All",
                     })
                   : intl.formatMessage(getPoolStream(quickFilterStream))}
               </span>
@@ -1035,7 +1035,6 @@ const OngoingRecruitmentSection = ({
             </Button>
           </DropdownMenu.Trigger>
           <DropdownMenu.Content data-h2-padding="base(0)">
-            {" "}
             <div data-h2-padding="base(x.5, x1, x.5, x.5)">
               <DropdownMenu.RadioGroup value={quickFilterStream}>
                 <React.Fragment key="ALL">
@@ -1051,8 +1050,8 @@ const OngoingRecruitmentSection = ({
                     <span>
                       {intl.formatMessage({
                         defaultMessage: "All",
-                        id: "qQtJDw",
-                        description: "All statuses",
+                        id: "XnvXtO",
+                        description: "All",
                       })}
                     </span>
                   </DropdownMenu.RadioItem>

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1141,9 +1141,9 @@
     "defaultMessage": "Suspendu",
     "description": "Suspended status"
   },
-  "qQtJDw": {
+  "XnvXtO": {
     "defaultMessage": "Tous",
-    "description": "All statuses"
+    "description": "All"
   },
   "nLW9zq": {
     "defaultMessage": "Technologie de l’information"

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -627,8 +627,8 @@ export const candidateExpiryFilterStatuses = defineMessages({
   },
   [CandidateExpiryFilter.All]: {
     defaultMessage: "All",
-    id: "qQtJDw",
-    description: "All statuses",
+    id: "XnvXtO",
+    description: "All",
   },
   [CandidateExpiryFilter.Expired]: {
     defaultMessage: "Expired",
@@ -654,8 +654,8 @@ export const candidateSuspendedFilterStatuses = defineMessages({
   },
   [CandidateSuspendedFilter.All]: {
     defaultMessage: "All",
-    id: "qQtJDw",
-    description: "All statuses",
+    id: "XnvXtO",
+    description: "All",
   },
   [CandidateSuspendedFilter.Suspended]: {
     defaultMessage: "Suspended",


### PR DESCRIPTION
🤖 Resolves #6584 

## 👋 Introduction

Enable reverting to filtering out nothing for the recruitments section. 

## 🕵️ Details

Implemented the suggested `<Dropdown>`
Followed the skill picker implementation as a guide. 

## 🧪 Testing

1. Navigate to `/en/browse/pools` and scroll down to the ongoing recruitments section
2. Play around with filtering

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/e4f403e4-6fd8-4e0b-b3e9-e15e1a73e179)
