### PR TITLE
[Bug] Expand nested language provider

### DIFF
--- a/apps/web/src/components/Layout/IAPLayout.tsx
+++ b/apps/web/src/components/Layout/IAPLayout.tsx
@@ -20,10 +20,49 @@ import * as micMessages from "~/lang/micCompiled.json";
 
 const messages: Map<string, Messages> = new Map([["mic", micMessages]]);
 
-const Layout = () => {
+const IAPNavMenu = () => {
   const intl = useIntl();
-  const location = useLocation();
   const paths = useRoutes();
+
+  return (
+    <NavMenu
+      mainItems={[
+        <MenuLink key="home" to={paths.iap()}>
+          {intl.formatMessage({
+            defaultMessage: "Home",
+            id: "M1JKQs",
+            description:
+              "Link to the homepage for IT Apprenticeship Program for Indigenous Peoples.",
+          })}
+        </MenuLink>,
+      ]}
+    />
+  );
+};
+
+const IAPSeo = () => {
+  const intl = useIntl();
+
+  return (
+    <SEO
+      title={intl.formatMessage({
+        defaultMessage: "IT Apprenticeship Program for Indigenous Peoples",
+        id: "oMpO+C",
+        description:
+          "Title tag for IT Apprenticeship Program for Indigenous Peoples site",
+      })}
+      description={intl.formatMessage({
+        defaultMessage: "Apply now to get started on your IT career journey.",
+        id: "Z9W+O2",
+        description:
+          "Meta tag description for IT Apprenticeship Program for Indigenous Peoples site",
+      })}
+    />
+  );
+};
+
+const Layout = () => {
+  const location = useLocation();
   useLayoutTheme("iap");
 
   const aiConnectionString = getRuntimeVariable(
@@ -45,22 +84,7 @@ const Layout = () => {
       <AnimatePresence>
         <React.Fragment key={location.pathname}>
           <Favicon project="iap" />
-          <SEO
-            title={intl.formatMessage({
-              defaultMessage:
-                "IT Apprenticeship Program for Indigenous Peoples",
-              id: "oMpO+C",
-              description:
-                "Title tag for IT Apprenticeship Program for Indigenous Peoples site",
-            })}
-            description={intl.formatMessage({
-              defaultMessage:
-                "Apply now to get started on your IT career journey.",
-              id: "Z9W+O2",
-              description:
-                "Meta tag description for IT Apprenticeship Program for Indigenous Peoples site",
-            })}
-          />
+          <IAPSeo />
           <SkipLink />
           <div
             className="container"
@@ -71,18 +95,7 @@ const Layout = () => {
           >
             <div>
               <Header />
-              <NavMenu
-                mainItems={[
-                  <MenuLink key="home" to={paths.iap()}>
-                    {intl.formatMessage({
-                      defaultMessage: "Home",
-                      id: "M1JKQs",
-                      description:
-                        "Link to the homepage for IT Apprenticeship Program for Indigenous Peoples.",
-                    })}
-                  </MenuLink>,
-                ]}
-              />
+              <IAPNavMenu />
             </div>
             <main id="main">
               <Outlet />


### PR DESCRIPTION
🤖 Resolves #6612 

## 👋 Introduction

This moves the two strings to child components so they have access to the current nested language provider context.

## 🕵️ Details

We were using the parent language provider context that did not include the nested provider strings (Mi'kmaq)

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build:fresh`
2. Navigate to `/indigenous-it-apprentice?locale=mic`
3. Confirm both the page title and nav menu are using the Mi'kmaq language

## 📸 Screenshot

![Screenshot 2023-05-18 135059](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/988d9c8c-8d74-494a-9627-a3ca915f59bc)

