### PR TITLE
[Bug] Add consistent styles for `abbr` tags

### DIFF
--- a/apps/web/src/assets/css/app.css
+++ b/apps/web/src/assets/css/app.css
@@ -20,7 +20,8 @@ button:not(disabled) {
 }
 
 abbr {
-  text-decoration: underline inherit dotted;
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
 }
 
 abbr:hover {

--- a/apps/web/src/assets/css/app.css
+++ b/apps/web/src/assets/css/app.css
@@ -19,6 +19,14 @@ button:not(disabled) {
   cursor: pointer;
 }
 
+abbr {
+  text-decoration: underline inherit dotted;
+}
+
+abbr:hover {
+  cursor: help;
+}
+
 [data-h2] table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
🤖 Resolves #5785 

## 👋 Introduction

Adds some default styles to the `abbr` tag so they appear consistently across browsers

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate the homepage
3. Confirm the GC wrapped in `abbr` shows consistently in all major browsers (Chrome, Firefox, Safari)

>**Note**
> Dotted underline appears slightly differently in each browser, but at least it is there! 😛 

## 📸 Screenshot

### Chrome

![chrome](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/0611f97c-3911-49c6-b219-5be36ff18a10)

### Firefox
![firefox](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/9bf98e2d-3567-49bc-9a7d-7ab46d3513a7)

### Safari
<img width="566" alt="Screenshot 2023-05-18 at 2 05 15 PM" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/096d080f-68bf-464b-a774-c37a7afa0b53">

