### PR TITLE
[Debt] Remove expectedGenericJobTitles from profile completeness

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -181,8 +181,7 @@ class User extends Model implements Authenticatable, LaratrustUser
             empty($this->attributes['location_preferences']) or
             empty($this->attributes['position_duration'])  or
             is_null($this->attributes['citizenship']) or
-            is_null($this->attributes['armed_forces_status']) or
-            $this->expectedGenericJobTitles->isEmpty()
+            is_null($this->attributes['armed_forces_status'])
         ) {
             return false;
         } else {


### PR DESCRIPTION
🤖 Resolves #6638 

## 👋 Introduction

Remove the deprecated field from being checked in profile completeness. 

## 🕵️ Details

Small change. 

## 🧪 Testing

1. Create application
2. Ensure your role & salary is incomplete, use Adminer to delete the entry from the `generic_job_title_user` pivot
3. Skip to submit page by changing URL
4. Ensure application submits successfully

May need to switch revamp feature flag off to get around education requirement check. 

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/f9e6e1b5-aa75-4123-b6ed-1f95530ac4a8)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/dbbe3c2f-1c73-45dc-8abe-efaea74da2dd)

