### PR TITLE
[Bug] Fix screening question validation

### DIFF
--- a/api/app/Rules/QuestionsAnswered.php
+++ b/api/app/Rules/QuestionsAnswered.php
@@ -27,6 +27,12 @@ class QuestionsAnswered implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
+        // short-circuit check off feature flag
+        $flagBoolean = config('feature.application_revamp');
+        if (!$flagBoolean) {
+            return;
+        }
+
         $questions = ScreeningQuestion::where('pool_id', $value)
             ->get()
             ->pluck('id');

--- a/api/tests/Feature/PoolApplicationTest.php
+++ b/api/tests/Feature/PoolApplicationTest.php
@@ -784,6 +784,11 @@ class PoolApplicationTest extends TestCase
 
     public function testApplicationSubmitScreeningQuestions(): void
     {
+        $flagBoolean = config('feature.application_revamp');
+        if (!$flagBoolean) {
+            $this->markTestSkipped('application_revamp is OFF');
+        }
+
         $newPool = Pool::factory()->create([
             'closing_date' =>  Carbon::now()->addDays(1),
             'advertisement_language' => ApiEnums::POOL_ADVERTISEMENT_ENGLISH, // avoid language requirements


### PR DESCRIPTION
🤖 Resolves #6644 

## 👋 Introduction

This checks to ensure the application revamp 🧛 feature flag is enabled before validating that screening questions have been answered.

## 🕵️ Details

We have enabled the ability for admins to add screening questions but have yet to display them to users. This is causing issues with our validation since users are unable to answer those questions 😛 . This just exits the validation early if we do not have the flag enabled.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure `api/.env` has `FEATURE_APPLICATION_REVAMP=true` under the feature flag section
2. Start an application with screening questions on it
3. Confirm you **_cannot_** submit with none of the questions being answered
4. Disabled the feature flag in `api/.env`
5. Attempt the submit the application
6. Confirm it will submit
