### PR TITLE
[Bug] Make department number update-able 

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1412,7 +1412,12 @@ input UpdatePoolInput {
 }
 
 input CreateDepartmentInput {
-  departmentNumber: Int! @rename(attribute: "department_number")
+  departmentNumber: Int!
+    @rename(attribute: "department_number")
+    @rules(
+      apply: ["unique:departments,department_number"]
+      messages: [{ rule: "unique", message: "DepartmentNumberInUse" }]
+    )
   name: LocalizedStringInput
 }
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1417,7 +1417,12 @@ input CreateDepartmentInput {
 }
 
 input UpdateDepartmentInput {
-  departmentNumber: Int @rename(attribute: "department_number")
+  departmentNumber: Int
+    @rename(attribute: "department_number")
+    @rules(
+      apply: ["unique:departments,department_number"]
+      messages: [{ rule: "unique", message: "DepartmentNumberInUse" }]
+    )
   name: LocalizedStringInput
 }
 

--- a/apps/web/src/pages/Departments/CreateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/CreateDepartmentPage.tsx
@@ -88,6 +88,7 @@ export const CreateDepartmentForm = ({
               rules={{
                 required: intl.formatMessage(errorMessages.required),
               }}
+              min="0"
             />
             <Input
               id="name_en"

--- a/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
@@ -152,7 +152,12 @@ const UpdateDepartmentPage = () => {
   const handleUpdateDepartment = (id: string, data: UpdateDepartmentInput) =>
     executeMutation({
       id,
-      department: pick(data, ["departmentName", "name.en", "name.fr"]),
+      department: pick(data, [
+        "departmentName",
+        "name.en",
+        "name.fr",
+        "departmentNumber",
+      ]),
     }).then((result) => {
       if (result.data?.updateDepartment) {
         return result.data?.updateDepartment;

--- a/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
@@ -100,6 +100,7 @@ export const UpdateDepartmentForm = ({
               rules={{
                 required: intl.formatMessage(errorMessages.required),
               }}
+              min="0"
             />
             <Input
               id="name_en"

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -781,6 +781,10 @@
     "defaultMessage": "Cette chaîne de clés de famille de compétences est déjà utilisée",
     "description": "Error message that the given skill family key is already in use."
   },
+  "xH10Pp": {
+    "defaultMessage": "Ce numéro de ministère est déjà utilisé",
+    "description": "Error message that the input department number is already in use."
+  },
   "XerShr": {
     "defaultMessage": "Recherche active",
     "description": "Job Looking Status described as Actively looking."

--- a/packages/i18n/src/messages/apiMessages.ts
+++ b/packages/i18n/src/messages/apiMessages.ts
@@ -42,6 +42,14 @@ export const apiMessages: { [key: string]: MessageDescriptor } = defineMessages(
         "Error message that the given skill family key is already in use.",
     },
 
+    // department validation
+    DepartmentNumberInUse: {
+      defaultMessage: "This department number is already in use",
+      id: "xH10Pp",
+      description:
+        "Error message that the input department number is already in use.",
+    },
+
     // application validation
     AlreadyArchived: {
       defaultMessage: "Application is already archived.",


### PR DESCRIPTION
🤖 Resolves #6409

## 👋 Introduction

Make it possible to update department number. 

## 🕵️ Details

Needed to ensure `departmentNumber` was passed into the mutation. 

Given `department_number` must be unique in the database, added a validation rule with error message to the input for a nicer experience. To avoid it being forgotten about, I also copied the rule to create department as well. 

I also slapped a min = 0 for department number to prevent having negative department numbers accidentally or even intentionally. Can be reverted if desired. 

## ~TRANSLATION: TODO~

## 🧪 Testing

1. Head to `/en/admin/settings/departments`
2. Ensure updating a department's number works and the error toast appears if you attempt to reuse numbers

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/06d30e80-a078-4b4d-ba53-61ec0ab529ce)

Error message that is returned without the validation

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/a6499ebe-a0bf-4f2d-92a2-f2677e126a0d)
