### PR TITLE
[Bug] Platform admin applicant permission added

### DIFF
--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -621,6 +621,9 @@ return [
             'skillFamily' => [
                 'any' => ['create', 'update', 'delete']
             ],
+            'applicantProfile' => [
+                'any' => ['view'],
+            ],
             'user' => [
                 'any' => ['view', 'update', 'delete']
             ],

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -211,6 +211,7 @@ class RolePermissionTest extends TestCase
             'create-any-skillFamily',
             'update-any-skillFamily',
             'delete-any-skillFamily',
+            'view-any-applicantProfile',
             'view-any-user',
             'view-any-userBasicInfo',
             'update-any-user',


### PR DESCRIPTION
🤖 
Resolves #6404
Resolves #6406

## 👋 Introduction

Updates permissions to solve the error on the users page. 

## 🕵️ Details

Given user and applicant models overlap heavily, if you can view any user, you should be able to view any applicant model. 

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/0c5877da-6ffb-4982-a865-cfcaa45d8de5)

Checked in 

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/d1e721da-a5c8-4c33-ae93-9fda43a2ab61)

Needed for the query 

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/a7dc1823-1169-43f2-882e-e6f075f5764a)


## 🧪 Testing

1. Navigate to `en/admin/users` as `platform@test.com`
2. Observe select ability functions
3. Click on edit for a user
4. No error toast about authorization should appear

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/d64f0bdd-9e72-4c8e-96fc-47c79b2a160c)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/16c2ea02-3544-4cb8-a8ef-0512a054f1ad)

## 🖥️ Deployment

Run `php artisan db:seed --class=RolePermissionSeeder` 

