### PR TITLE
[Bug] Fix nested `<p>` tags

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/PersonalInformation/Display.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/PersonalInformation/Display.tsx
@@ -116,7 +116,7 @@ const Display = ({
             description: "Contact languages preference label",
           })}
         >
-          <p>
+          <span data-h2-display="base(block)">
             {intl.formatMessage(
               {
                 defaultMessage: "General communication: {language}",
@@ -129,8 +129,8 @@ const Display = ({
                   : notProvided,
               },
             )}
-          </p>
-          <p>
+          </span>
+          <span data-h2-display="base(block)">
             {intl.formatMessage(
               {
                 defaultMessage: "Spoken interviews: {language}",
@@ -145,8 +145,8 @@ const Display = ({
                   : notProvided,
               },
             )}
-          </p>
-          <p>
+          </span>
+          <span data-h2-display="base(block)">
             {intl.formatMessage(
               {
                 defaultMessage: "Written exams: {language}",
@@ -159,7 +159,7 @@ const Display = ({
                   : notProvided,
               },
             )}
-          </p>
+          </span>
         </FieldDisplay>
       </DisplayColumn>
       <DisplayColumn>


### PR DESCRIPTION
🤖 Resolves #6531 

## 👋 Introduction

This converts `<p>` tags on the `ApplicationProfilePage` to `<span>` tags to not have them improperly nested.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run build:fresh`
2. Cereate an application and continute to the profile step
3. Run axe dev tools, confirm no errors
4. Confirm there are no console errors about nested `<p>`
5. Confirm the Language section in Personal information still renders as expected

## 📸 Screenshot

![Screenshot 2023-05-19 091158](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/d35a94c6-392b-4ee7-b6e9-63c760093eeb)

