### PR TITLE
Feature - 6645 - Add 100 words to fr text areas on edit pool page

### DIFF
--- a/apps/web/src/pages/Pools/EditPoolPage/components/WorkTasksSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/WorkTasksSection.tsx
@@ -38,7 +38,8 @@ interface WorkTasksSectionProps {
   onSave: (submitData: WorkTasksSubmitData) => void;
 }
 
-const TEXT_AREA_MAX_WORDS = 400;
+const TEXT_AREA_MAX_WORDS_EN = 400;
+const TEXT_AREA_MAX_WORDS_FR = TEXT_AREA_MAX_WORDS_EN + 100;
 const TEXT_AREA_ROWS = 15;
 
 const WorkTasksSection = ({
@@ -118,9 +119,9 @@ const WorkTasksSection = ({
                 rules={{
                   validate: {
                     wordCount: (value: string) =>
-                      countNumberOfWords(value) <= TEXT_AREA_MAX_WORDS ||
+                      countNumberOfWords(value) <= TEXT_AREA_MAX_WORDS_EN ||
                       intl.formatMessage(errorMessages.overWordLimit, {
-                        value: TEXT_AREA_MAX_WORDS,
+                        value: TEXT_AREA_MAX_WORDS_EN,
                       }),
                   },
                 }}
@@ -131,7 +132,7 @@ const WorkTasksSection = ({
                   <div data-h2-align-self="base(flex-end)">
                     <WordCounter
                       text={watchYourWorkEn ?? ""}
-                      wordLimit={TEXT_AREA_MAX_WORDS}
+                      wordLimit={TEXT_AREA_MAX_WORDS_EN}
                     />
                   </div>
                 )}
@@ -156,9 +157,9 @@ const WorkTasksSection = ({
                 rules={{
                   validate: {
                     wordCount: (value: string) =>
-                      countNumberOfWords(value) <= TEXT_AREA_MAX_WORDS ||
+                      countNumberOfWords(value) <= TEXT_AREA_MAX_WORDS_FR ||
                       intl.formatMessage(errorMessages.overWordLimit, {
-                        value: TEXT_AREA_MAX_WORDS,
+                        value: TEXT_AREA_MAX_WORDS_FR,
                       }),
                   },
                 }}
@@ -169,7 +170,7 @@ const WorkTasksSection = ({
                   <div data-h2-align-self="base(flex-end)">
                     <WordCounter
                       text={watchYourWorkFr ?? ""}
-                      wordLimit={TEXT_AREA_MAX_WORDS}
+                      wordLimit={TEXT_AREA_MAX_WORDS_FR}
                     />
                   </div>
                 )}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/YourImpactSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/YourImpactSection.tsx
@@ -38,7 +38,8 @@ interface YourImpactSectionProps {
   onSave: (submitData: YourImpactSubmitData) => void;
 }
 
-const TEXT_AREA_MAX_WORDS = 200;
+const TEXT_AREA_MAX_WORDS_EN = 200;
+const TEXT_AREA_MAX_WORDS_FR = TEXT_AREA_MAX_WORDS_EN + 100;
 const TEXT_AREA_ROWS = 15;
 
 const YourImpactSection = ({
@@ -119,9 +120,9 @@ const YourImpactSection = ({
                 rules={{
                   validate: {
                     wordCount: (value: string) =>
-                      countNumberOfWords(value) <= TEXT_AREA_MAX_WORDS ||
+                      countNumberOfWords(value) <= TEXT_AREA_MAX_WORDS_EN ||
                       intl.formatMessage(errorMessages.overWordLimit, {
-                        value: TEXT_AREA_MAX_WORDS,
+                        value: TEXT_AREA_MAX_WORDS_EN,
                       }),
                   },
                 }}
@@ -132,7 +133,7 @@ const YourImpactSection = ({
                   <div data-h2-align-self="base(flex-end)">
                     <WordCounter
                       text={watchYourImpactEn ?? ""}
-                      wordLimit={TEXT_AREA_MAX_WORDS}
+                      wordLimit={TEXT_AREA_MAX_WORDS_EN}
                     />
                   </div>
                 )}
@@ -158,9 +159,9 @@ const YourImpactSection = ({
                 rules={{
                   validate: {
                     wordCount: (value: string) =>
-                      countNumberOfWords(value) <= TEXT_AREA_MAX_WORDS ||
+                      countNumberOfWords(value) <= TEXT_AREA_MAX_WORDS_FR ||
                       intl.formatMessage(errorMessages.overWordLimit, {
-                        value: TEXT_AREA_MAX_WORDS,
+                        value: TEXT_AREA_MAX_WORDS_FR,
                       }),
                   },
                 }}
@@ -171,7 +172,7 @@ const YourImpactSection = ({
                   <div data-h2-align-self="base(flex-end)">
                     <WordCounter
                       text={watchYourImpactFr ?? ""}
-                      wordLimit={TEXT_AREA_MAX_WORDS}
+                      wordLimit={TEXT_AREA_MAX_WORDS_FR}
                     />
                   </div>
                 )}


### PR DESCRIPTION
🤖 Resolves #6645 

## 👋 Introduction

- Adds 100 words to French text areas on Edit pool page.

## 🧪 Testing

1. Login as admin 
2. Go to pools table and find a pool with DRAFT status.
3. Click on edit and scroll down to Your Impact and Work Tasks section.
4. Ensure the french text areas allow higher word count.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/7ee771bd-2582-4a6b-9150-e28cdd80c8d2)
