### PR TITLE
[Bug] Fix inconsistent skill accordion colours

### DIFF
--- a/apps/web/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
+++ b/apps/web/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
@@ -74,13 +74,13 @@ const SkillAccordion = ({
 
     return (
       <>
-        <p data-h2-color="base(primary)">{title}</p>
+        <p data-h2-color="base(primary.darker)">{title}</p>
         <p data-h2-margin="base(0, 0, x.5, 0)">
           {getDateRange({ endDate, startDate, intl })}
         </p>
-        <p> {description} </p>
+        <p>{description}</p>
         <p>{justification}</p>
-        <p> {details} </p>
+        <p>{details}</p>
       </>
     );
   };
@@ -103,7 +103,7 @@ const SkillAccordion = ({
     return (
       <div>
         <p>
-          <span data-h2-color="base(primary)"> {areaOfStudy} </span>
+          <span data-h2-color="base(primary.darker)">{areaOfStudy}</span>{" "}
           {intl.formatMessage(
             {
               defaultMessage: " at {institution}",
@@ -118,7 +118,10 @@ const SkillAccordion = ({
         </p>
         <p>
           {type ? intl.formatMessage(getEducationType(type)) : ""}{" "}
-          <span data-h2-color="base(primary)" data-h2-font-style="base(italic)">
+          <span
+            data-h2-color="base(primary.darker)"
+            data-h2-font-style="base(italic)"
+          >
             {status ? intl.formatMessage(getEducationStatus(status)) : ""}{" "}
           </span>
         </p>
@@ -134,7 +137,7 @@ const SkillAccordion = ({
               )
             : ""}
         </p>
-        <p> {details} </p>
+        <p>{details}</p>
         <p>{justification}</p>
       </div>
     );
@@ -188,7 +191,7 @@ const SkillAccordion = ({
         </p>
         <p>{justification}</p>
         <p
-          data-h2-color="base(primary)"
+          data-h2-color="base(primary.darker)"
           data-h2-font-weight="base(700)"
           data-h2-margin="base(x1, 0, x.25, 0)"
         >
@@ -244,7 +247,7 @@ const SkillAccordion = ({
         </p>
         <p>{justification}</p>
         <p
-          data-h2-color="base(primary)"
+          data-h2-color="base(primary.darker)"
           data-h2-font-weight="base(700)"
           data-h2-margin="base(x1, 0, x.25, 0)"
         >
@@ -291,7 +294,7 @@ const SkillAccordion = ({
         <p>{division}</p>
         <p>{justification}</p>
         <p
-          data-h2-color="base(primary)"
+          data-h2-color="base(primary.darker)"
           data-h2-font-weight="base(700)"
           data-h2-margin="base(x1, 0, x.25, 0)"
         >

--- a/packages/i18n/src/components/richTextElements.tsx
+++ b/packages/i18n/src/components/richTextElements.tsx
@@ -40,7 +40,7 @@ export const heavyPrimary = (text: React.ReactNode) => (
  * @param text text to wrap.
  */
 export const primary = (text: React.ReactNode) => (
-  <span data-h2-color="base(primary.dark)">{text}</span>
+  <span data-h2-color="base(primary.darker)">{text}</span>
 );
 
 /**


### PR DESCRIPTION
🤖 Resolves #6577 

## 👋 Introduction

Updates primary text in the `SkillAccordion` component to be `primary.darker`

## 🕵️ Details

Kind of hard to see since `primary.darker` is so close to the black colour 😬 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run build`
2. Navigate to `/users/{userId}/profile/experiences`
3. Add the same skill to each experience type
4. Select the "By skills" tab
5. Open the accordion for the skill you added to each experience type
6. Confirm all primary text is using `primary.darker`

## 📸 Screenshot

![Screenshot 2023-05-19 104946](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/4922d774-0427-4eb8-abfb-db6a9bf849db)
