### PR TITLE
[Bug] Fix language switcher history

### DIFF
--- a/apps/web/src/components/Header/Header.tsx
+++ b/apps/web/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 import {
   localizePath,
@@ -16,8 +16,7 @@ export interface HeaderProps {
 
 const Header = ({ width }: HeaderProps) => {
   const intl = useIntl();
-  const navigate = useNavigate();
-  const { locale, setLocale } = useLocale();
+  const { locale } = useLocale();
 
   const location = useLocation();
   const changeToLang = oppositeLocale(locale);
@@ -97,11 +96,6 @@ const Header = ({ width }: HeaderProps) => {
                 data-h2-outline="base(none)"
                 data-h2-color="base:hover(secondary.darker) base:focus-visible(black)"
                 href={languageTogglePath}
-                onClick={(e) => {
-                  e.preventDefault();
-                  setLocale(changeToLang);
-                  navigate(languageTogglePath);
-                }}
                 lang={changeToLang === "en" ? "en" : "fr"}
               >
                 {intl.formatMessage({


### PR DESCRIPTION
🤖 Resolves #6611 

## 👋 Introduction

Removed the `onClick` handler in the language switcher link.

## 🕵️ Details

Since our `LocaleProvider` is smart enough to determine locale from the url, I do not believe we needed the `onClick` which prevented the default functionality of the link so we could `setLocale` at the same time. Removing that click handler seemed to fix the browser history bug while keeping the functionality intact 🤷‍♀️ 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate to `/en`
3. Switch to French
4. Confirm language changes
5. Click the browser back button
6. Confirm you can go back
7. Repeat steps 2-6 but with the opposite locale
