### PR TITLE
[Bug] Replaces quotes with guillemets in French string

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7331,7 +7331,7 @@
     "description": "list a number of work experiences"
   },
   "LfhuFi": {
-    "defaultMessage": "Comment j’ai utilisé “{skillName}” dans ce rôle",
+    "defaultMessage": "Comment j’ai utilisé «{skillName}» dans ce rôle",
     "description": "Title for section on how a skill was used in the role"
   },
   "NGEgVN": {


### PR DESCRIPTION
🤖 Resolves #6582.

## 👋 Introduction

This PR replaces quotes with _guillemets_ in a French string.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run intl-compile`
2. `npm run storybook`
3. Navigate to **Experience Accordion** > **Accordion Award** in storybook
4. Switch locale to FR
5. Observe _guillemets_ instead of quotes in **Comment j’ai utilisé** strings

## 📸 Screenshot

![Screen Shot 2023-05-19 at 13 15 04](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/a98bb0f9-efb6-4f1f-b9cf-b05894dd858d)

