### PR TITLE
[Bug] Removes placeholder prop from most `Input` and `TextArea` components

### DIFF
--- a/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
@@ -22,11 +22,6 @@ const AwardFields = ({ labels }: SubExperienceFormProps) => {
           <Input
             id="awardTitle"
             label={labels.awardTitle}
-            placeholder={intl.formatMessage({
-              defaultMessage: "Write award title here...",
-              id: "9ttiBB",
-              description: "Placeholder for award title input",
-            })}
             name="awardTitle"
             type="text"
             rules={{ required: intl.formatMessage(errorMessages.required) }}
@@ -76,11 +71,6 @@ const AwardFields = ({ labels }: SubExperienceFormProps) => {
           <Input
             id="issuedBy"
             label={labels.issuedBy}
-            placeholder={intl.formatMessage({
-              defaultMessage: "Write name here...",
-              id: "TSqr8X",
-              description: "Placeholder for issuing organization input",
-            })}
             name="issuedBy"
             type="text"
             rules={{ required: intl.formatMessage(errorMessages.required) }}

--- a/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
@@ -22,12 +22,6 @@ const CommunityFields = ({ labels }: SubExperienceFormProps) => {
           <Input
             id="role"
             label={labels.role}
-            placeholder={intl.formatMessage({
-              defaultMessage: "Write title here...",
-              id: "5ikciS",
-              description:
-                "Placeholder displayed on the Community Experience form for role input",
-            })}
             name="role"
             type="text"
             rules={{ required: intl.formatMessage(errorMessages.required) }}
@@ -53,12 +47,6 @@ const CommunityFields = ({ labels }: SubExperienceFormProps) => {
           <Input
             id="organization"
             label={labels.organization}
-            placeholder={intl.formatMessage({
-              defaultMessage: "Write group name here...",
-              id: "EfR7Rv",
-              description:
-                "Placeholder displayed on the Community Experience form for organization input",
-            })}
             name="organization"
             type="text"
             rules={{ required: intl.formatMessage(errorMessages.required) }}
@@ -114,12 +102,6 @@ const CommunityFields = ({ labels }: SubExperienceFormProps) => {
           <Input
             id="project"
             label={labels.project}
-            placeholder={intl.formatMessage({
-              defaultMessage: "Write project name here...",
-              id: "81ITk+",
-              description:
-                "Placeholder displayed on the Community Experience form for project input",
-            })}
             name="project"
             type="text"
             rules={{ required: intl.formatMessage(errorMessages.required) }}

--- a/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
@@ -77,11 +77,6 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
           <Input
             id="areaOfStudy"
             label={labels.areaOfStudy}
-            placeholder={intl.formatMessage({
-              defaultMessage: "Write area of study here...",
-              id: "Uv9q53",
-              description: "Placeholder for area of study input",
-            })}
             name="areaOfStudy"
             type="text"
             rules={{ required: intl.formatMessage(errorMessages.required) }}
@@ -134,11 +129,6 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
           <Input
             id="institution"
             label={labels.institution}
-            placeholder={intl.formatMessage({
-              defaultMessage: "Write name here...",
-              id: "EHOcOR",
-              description: "Placeholder for institution input",
-            })}
             name="institution"
             type="text"
             rules={{ required: intl.formatMessage(errorMessages.required) }}
@@ -174,11 +164,6 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
           <Input
             id="thesisTitle"
             label={labels.thesisTitle}
-            placeholder={intl.formatMessage({
-              defaultMessage: "Write title here...",
-              id: "8THvSC",
-              description: "Placeholder for thesis title input",
-            })}
             name="thesisTitle"
             type="text"
           />

--- a/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
@@ -20,11 +20,6 @@ const PersonalFields = ({ labels }: SubExperienceFormProps) => {
       <Input
         id="experienceTitle"
         label={labels.experienceTitle}
-        placeholder={intl.formatMessage({
-          defaultMessage: "Write title here...",
-          id: "Q18B0y",
-          description: "Placeholder for experience title input",
-        })}
         name="experienceTitle"
         type="text"
         rules={{ required: intl.formatMessage(errorMessages.required) }}
@@ -32,11 +27,6 @@ const PersonalFields = ({ labels }: SubExperienceFormProps) => {
       <TextArea
         id="experienceDescription"
         label={labels.experienceDescription}
-        placeholder={intl.formatMessage({
-          defaultMessage: "Describe experience details here...",
-          id: "Os+BwT",
-          description: "Placeholder for experience description input",
-        })}
         name="experienceDescription"
         rules={{ required: intl.formatMessage(errorMessages.required) }}
       />

--- a/apps/web/src/components/SkillsInDetail/SkillsInDetail.tsx
+++ b/apps/web/src/components/SkillsInDetail/SkillsInDetail.tsx
@@ -146,12 +146,6 @@ const SkillsInDetail = ({
                     description:
                       "Label for the textarea in the skills in detail section.",
                   })}
-                  placeholder={intl.formatMessage({
-                    defaultMessage: "How I used this skill...",
-                    id: "i99arX",
-                    description:
-                      "Placeholder message for textarea in the skills in detail section.",
-                  })}
                   name={`skills.${index}.details`}
                   rules={{
                     required: required

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -534,17 +534,9 @@
     "defaultMessage": "Formulaire de demande",
     "description": "Heading for request form."
   },
-  "N6+rnM": {
-    "defaultMessage": "example@canada.ca...",
-    "description": "Placeholder for government email input in the request form"
-  },
   "NXzsK4": {
     "defaultMessage": "Recherche dans le bassin de talents numériques",
     "description": "Main heading displayed at the top of request page."
-  },
-  "OjhS6t": {
-    "defaultMessage": "Nom complet...",
-    "description": "Placeholder for full name input in the request form."
   },
   "SZTFJq": {
     "defaultMessage": "Recherche dans le bassin de talents numériques",
@@ -630,10 +622,6 @@
     "defaultMessage": "Si vous avez des exigences plus détaillées concernant le lieu de travail, veuillez nous en faire part dans la section des commentaires du formulaire de soumission.",
     "description": "Message describing the work location filter in the search form."
   },
-  "zz9pwK": {
-    "defaultMessage": "Développeur...",
-    "description": "Placeholder for job title input in the request form."
-  },
   "ky585k": {
     "defaultMessage": "Conditions d’emploi ({operationalRequirementFilterCount})"
   },
@@ -673,21 +661,9 @@
     "defaultMessage": "Date d’attribution",
     "description": "Label displayed on award form for date awarded input"
   },
-  "5ikciS": {
-    "defaultMessage": "Écrire le titre ici...",
-    "description": "Placeholder displayed on the Community Experience form for role input"
-  },
   "7inIW/": {
     "defaultMessage": "Vous avez des titres de compétences? Partagez votre grade, vos certificats, vos cours en ligne, votre programme d’apprentissage du métier, vos licences ou d’autres titres de compétences. Si vous avez eu un apprentissage dans un établissement scolaire reconnu, faites part de votre expérience ici.",
     "description": "Description blurb for Education Details Form"
-  },
-  "81ITk+": {
-    "defaultMessage": "Écrire le nom du projet ici...",
-    "description": "Placeholder displayed on the Community Experience form for project input"
-  },
-  "8THvSC": {
-    "defaultMessage": "Écrire le titre ici...",
-    "description": "Placeholder for thesis title input"
   },
   "8i+lzm": {
     "defaultMessage": "Je suis actuellement actif(-ve) dans ce rôle.",
@@ -701,10 +677,6 @@
     "defaultMessage": "Organisation",
     "description": "Label displayed on Work Experience form for organization input"
   },
-  "9ttiBB": {
-    "defaultMessage": "Écrire le titre accordé ici...",
-    "description": "Placeholder for award title input"
-  },
   "Badvbb": {
     "defaultMessage": "Groupe/Organisation/Collectivité",
     "description": "Label displayed on Community Experience form for organization input"
@@ -712,14 +684,6 @@
   "DyaaHi": {
     "defaultMessage": "Portée du prix",
     "description": "Label displayed on Award form for award scope input"
-  },
-  "EHOcOR": {
-    "defaultMessage": "Écrire le nom ici...",
-    "description": "Placeholder for institution input"
-  },
-  "EfR7Rv": {
-    "defaultMessage": "Écrire le nom du groupe ici...",
-    "description": "Placeholder displayed on the Community Experience form for organization input"
   },
   "N87bC7": {
     "defaultMessage": "Titre de la thèse",
@@ -733,25 +697,9 @@
     "defaultMessage": "1. Détails de l’expérience communautaire",
     "description": "Title for Community Experience form"
   },
-  "Os+BwT": {
-    "defaultMessage": "Décrire les détails de l’expérience ici...",
-    "description": "Placeholder for experience description input"
-  },
-  "Q18B0y": {
-    "defaultMessage": "Écrire le titre ici...",
-    "description": "Placeholder for experience title input"
-  },
-  "TSqr8X": {
-    "defaultMessage": "Écrire le nom ici...",
-    "description": "Placeholder for issuing organization input"
-  },
   "UDpZ1q": {
     "defaultMessage": "1. Détails de l’expérience personnelle",
     "description": "Title for Personal Experience Details form"
-  },
-  "Uv9q53": {
-    "defaultMessage": "Écrire le domaine d’étude ici...",
-    "description": "Placeholder for area of study input"
   },
   "W7LpsW": {
     "defaultMessage": "1. Détails des études",
@@ -1029,10 +977,6 @@
     "defaultMessage": "Il n'y a pas encore de compétences rattachées à cette expérience. Vous pouvez en ajouter quelques-unes à l'étape ci-dessus.",
     "description": "Message to user when no skills have been attached to experience."
   },
-  "H1J8wl": {
-    "defaultMessage": "p. ex., Thomas",
-    "description": "Placeholder displayed for the first name field in create account form."
-  },
   "H3Za3e": {
     "defaultMessage": "Enregistrer et aller sur mon profil",
     "description": "Button label for submit button on create account form."
@@ -1189,10 +1133,6 @@
     "defaultMessage": "Options d'équité en matière d'emploi :",
     "description": "Heading for employment equity categories available to be added to user profile."
   },
-  "UIkTbl": {
-    "defaultMessage": "p. ex. thomas.edison@example.com",
-    "description": "Placeholder displayed for the first name field in create account form."
-  },
   "3vjhOA": {
     "defaultMessage": "Évaluation linguistique du gouvernement du Canada",
     "description": "Message on links to the language evaluation tests"
@@ -1220,10 +1160,6 @@
   "X354at": {
     "defaultMessage": "Évaluation bilingue",
     "description": "Legend bilingual evaluation status in language information form"
-  },
-  "X9IdZQ": {
-    "defaultMessage": "p. ex, Edison",
-    "description": "Placeholder displayed for the first name field in create account form."
   },
   "XBfLOu": {
     "defaultMessage": "Mon statut",
@@ -1356,10 +1292,6 @@
   "i5xxbe": {
     "defaultMessage": "Courriel",
     "description": "Label for email field in About Me form"
-  },
-  "i99arX": {
-    "defaultMessage": "Comment j'ai utilisé cette compétence...",
-    "description": "Placeholder message for textarea in the skills in detail section."
   },
   "jbftvG": {
     "defaultMessage": "<strong>Oui</strong>, je suis un(e) employé(e) du gouvernement du Canada",
@@ -1504,10 +1436,6 @@
   "xDgNfZ": {
     "defaultMessage": "Renseignements du gouvernement",
     "description": "Title for Profile Form Wrapper in Government Information Form"
-  },
-  "xq6TbG": {
-    "defaultMessage": "Commencez à écrire ici...",
-    "description": "Placeholder displayed on the About Me form current city field."
   },
   "Vvb8tu": {
     "defaultMessage": "J'envisagerais d'accepter un emploi qui :",
@@ -1928,10 +1856,6 @@
   "NjHXGh": {
     "defaultMessage": "En savoir plus<hidden> sur le Bureau de la dirigeante principale de l’information</hidden>",
     "description": "Link text for the Office of the Chief Information Officer"
-  },
-  "OH5tTS": {
-    "defaultMessage": "En option, ajoutez une ville ou un village ici...",
-    "description": "Location Exemptions field placeholder for work location preference form"
   },
   "5G+j56": {
     "defaultMessage": "Numéro de priorité accordé par la Commission de la fonction publique du Canada",
@@ -3368,10 +3292,6 @@
     "defaultMessage": "Erreur : échec de la mise à jour de la famille de compétences",
     "description": "Message displayed to user after skillFamily fails to get updated."
   },
-  "/MBeNc": {
-    "defaultMessage": "Commencez à écrire vos notes ici...",
-    "description": "Placeholder text for a pool candidates notes field"
-  },
   "/fv4O0": {
     "defaultMessage": "Aucune information n'a été fournie.",
     "description": "Message on Admin side when user not filled WorkPreferences section."
@@ -3911,10 +3831,6 @@
     "defaultMessage": "Archive",
     "description": "Text on a button to archive the pool"
   },
-  "PCuQMN": {
-    "defaultMessage": "Saisissez les tâches clés pour cette affiche de poste...",
-    "description": "Placeholder message for  the English - Your Work textarea in the edit pool page."
-  },
   "PH+6C9": {
     "defaultMessage": "Emplacement précis (français)",
     "description": "Label for a pool advertisements specific French Location"
@@ -3955,14 +3871,6 @@
     "defaultMessage": "Professionnel",
     "description": "Title for pool advertisement occupational skill list"
   },
-  "XprYVQ": {
-    "defaultMessage": "Rédiger l'introduction de cette offre d'emploi...",
-    "description": "Placeholder message for  the English - Your Impact textarea in the edit pool page."
-  },
-  "Xsxvql": {
-    "defaultMessage": "Saisissez les tâches clés pour cette affiche de poste...",
-    "description": "Placeholder message for the French - Your Work textarea in the edit pool page."
-  },
   "YH6bFU": {
     "defaultMessage": "Colonnes du tableau",
     "description": "Dialog title for the admin tables columns toggle."
@@ -3978,10 +3886,6 @@
   "cEeW3m": {
     "defaultMessage": "Emplacement (français) : {locationFr}",
     "description": "Pool advertisement location requirement, French"
-  },
-  "cQE6qE": {
-    "defaultMessage": "Rédiger l'introduction de cette offre d'emploi...",
-    "description": "Placeholder message for the French - Your Impact textarea in the edit pool page."
   },
   "cy5aj8": {
     "defaultMessage": "État",
@@ -6163,10 +6067,6 @@
   "h486wf": {
     "defaultMessage": "Erreur : La mise à jour de l’équipe a échoué",
     "description": "Messaged displayed after updating team fails"
-  },
-  "hTzoAW": {
-    "defaultMessage": "personne-ressource@courriel.com",
-    "description": "Placeholder email format example for team contact email input"
   },
   "i0IT1I": {
     "defaultMessage": "Annuler et retourner aux équipes",

--- a/apps/web/src/lang/whitelist.yml
+++ b/apps/web/src/lang/whitelist.yml
@@ -1,4 +1,3 @@
-- N6+rnM # 'example@canada.ca...' Placeholder for government email input in the request forms
 - FmN1eN # +123243234 (Placeholder displayed on the About Me form telephone field.)
 - rywI3C # Verbal (Label displayed on the language information form verbal field.)
 - Ledr63 # 'Signature' Toc navigation item on sign and submit page.

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/PersonalInformation/FormFields.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/PersonalInformation/FormFields.tsx
@@ -98,12 +98,6 @@ const FormFields = ({ labels }: FormFieldProps) => {
           name="currentCity"
           type="text"
           label={labels.currentCity}
-          placeholder={intl.formatMessage({
-            defaultMessage: "Start writing here...",
-            id: "xq6TbG",
-            description:
-              "Placeholder displayed on the About Me form current city field.",
-          })}
           rules={{
             required: intl.formatMessage(errorMessages.required),
           }}

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/WorkPreferences/FormFields.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/WorkPreferences/FormFields.tsx
@@ -95,12 +95,6 @@ const FormFields = ({ labels }: FormFieldProps) => {
         label={labels.locationExemptions}
         name="locationExemptions"
         describedBy="location-exemption-description"
-        placeholder={intl.formatMessage({
-          defaultMessage: "Optionally, add a city or village here...",
-          id: "OH5tTS",
-          description:
-            "Location Exemptions field placeholder for work location preference form",
-        })}
       />
       <div
         id="location-exemption-description"

--- a/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
@@ -180,12 +180,6 @@ export const CreateAccountForm = ({
                     name="firstName"
                     type="text"
                     label={labels.firstName}
-                    placeholder={intl.formatMessage({
-                      defaultMessage: "e.g. Thomas",
-                      id: "H1J8wl",
-                      description:
-                        "Placeholder displayed for the first name field in create account form.",
-                    })}
                     rules={{
                       required: intl.formatMessage(errorMessages.required),
                     }}
@@ -197,12 +191,6 @@ export const CreateAccountForm = ({
                     name="lastName"
                     type="text"
                     label={labels.lastName}
-                    placeholder={intl.formatMessage({
-                      defaultMessage: "e.g. Edison",
-                      id: "X9IdZQ",
-                      description:
-                        "Placeholder displayed for the first name field in create account form.",
-                    })}
                     rules={{
                       required: intl.formatMessage(errorMessages.required),
                     }}
@@ -215,12 +203,6 @@ export const CreateAccountForm = ({
                   type="email"
                   name="email"
                   label={labels.email}
-                  placeholder={intl.formatMessage({
-                    defaultMessage: "e.g. thomas.edison@example.com",
-                    id: "UIkTbl",
-                    description:
-                      "Placeholder displayed for the first name field in create account form.",
-                  })}
                   rules={{
                     required: intl.formatMessage(errorMessages.required),
                   }}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/WorkTasksSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/WorkTasksSection.tsx
@@ -109,12 +109,6 @@ const WorkTasksSection = ({
                   description:
                     "Label for the English - Your Work textarea in the edit pool page.",
                 })}
-                placeholder={intl.formatMessage({
-                  defaultMessage: "Write the key tasks for this job poster...",
-                  id: "PCuQMN",
-                  description:
-                    "Placeholder message for  the English - Your Work textarea in the edit pool page.",
-                })}
                 name="YourWorkEn"
                 rules={{
                   validate: {
@@ -146,12 +140,6 @@ const WorkTasksSection = ({
                   id: "8bJgxK",
                   description:
                     "Label for the French - Your Work textarea in the edit pool page.",
-                })}
-                placeholder={intl.formatMessage({
-                  defaultMessage: "Write the key tasks for this job poster...",
-                  id: "Xsxvql",
-                  description:
-                    "Placeholder message for the French - Your Work textarea in the edit pool page.",
                 })}
                 name="YourWorkFr"
                 rules={{

--- a/apps/web/src/pages/Pools/EditPoolPage/components/YourImpactSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/YourImpactSection.tsx
@@ -109,13 +109,6 @@ const YourImpactSection = ({
                   description:
                     "Label for the English - Your Impact textarea in the edit pool page.",
                 })}
-                placeholder={intl.formatMessage({
-                  defaultMessage:
-                    "Write the introduction for this job poster...",
-                  id: "XprYVQ",
-                  description:
-                    "Placeholder message for  the English - Your Impact textarea in the edit pool page.",
-                })}
                 name="yourImpactEn"
                 rules={{
                   validate: {
@@ -147,13 +140,6 @@ const YourImpactSection = ({
                   id: "fPy7Mg",
                   description:
                     "Label for the French - Your Impact textarea in the edit pool page.",
-                })}
-                placeholder={intl.formatMessage({
-                  defaultMessage:
-                    "Write the introduction for this job poster...",
-                  id: "cQE6qE",
-                  description:
-                    "Placeholder message for the French - Your Impact textarea in the edit pool page.",
                 })}
                 name="yourImpactFr"
                 rules={{

--- a/apps/web/src/pages/Profile/AboutMePage/components/AboutMeForm/AboutMeForm.tsx
+++ b/apps/web/src/pages/Profile/AboutMePage/components/AboutMeForm/AboutMeForm.tsx
@@ -356,12 +356,6 @@ const AboutMeForm = ({
               name="currentCity"
               type="text"
               label={labelMap.currentCity}
-              placeholder={intl.formatMessage({
-                defaultMessage: "Start writing here...",
-                id: "xq6TbG",
-                description:
-                  "Placeholder displayed on the About Me form current city field.",
-              })}
               rules={{
                 required: intl.formatMessage(errorMessages.required),
               }}

--- a/apps/web/src/pages/Profile/WorkLocationPage/components/WorkLocationForm/WorkLocationForm.tsx
+++ b/apps/web/src/pages/Profile/WorkLocationPage/components/WorkLocationForm/WorkLocationForm.tsx
@@ -228,12 +228,6 @@ const WorkLocationForm = ({
                 id="location-exemptions"
                 label={labels.locationExemptions}
                 name="locationExemptions"
-                placeholder={intl.formatMessage({
-                  defaultMessage: "Optionally, add a city or village here...",
-                  id: "OH5tTS",
-                  description:
-                    "Location Exemptions field placeholder for work location preference form",
-                })}
               />
             </div>
           </div>

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -269,12 +269,6 @@ export const RequestForm = ({
                   id: "dRnKNR",
                   description: "Label for full name input in the request form",
                 })}
-                placeholder={intl.formatMessage({
-                  defaultMessage: "Full name...",
-                  id: "OjhS6t",
-                  description:
-                    "Placeholder for full name input in the request form.",
-                })}
                 rules={{
                   required: intl.formatMessage(errorMessages.required),
                 }}
@@ -313,12 +307,6 @@ export const RequestForm = ({
                   description:
                     "Label for government email input in the request form",
                 })}
-                placeholder={intl.formatMessage({
-                  defaultMessage: "example@canada.ca...",
-                  id: "N6+rnM",
-                  description:
-                    "Placeholder for government email input in the request form",
-                })}
                 rules={{
                   required: intl.formatMessage(errorMessages.required),
                 }}
@@ -333,12 +321,6 @@ export const RequestForm = ({
                   defaultMessage: "What is the job title for this position?",
                   id: "7lCUIL",
                   description: "Label for job title input in the request form",
-                })}
-                placeholder={intl.formatMessage({
-                  defaultMessage: "Developer...",
-                  id: "zz9pwK",
-                  description:
-                    "Placeholder for job title input in the request form.",
                 })}
                 rules={{
                   required: intl.formatMessage(errorMessages.required),

--- a/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamFormFields.tsx
+++ b/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamFormFields.tsx
@@ -92,12 +92,6 @@ const CreateTeamFormFields = ({ departments }: CreateTeamFormFieldsProps) => {
             id: "PhrOLp",
             description: "Label for the French team display name input",
           })}
-          placeholder={intl.formatMessage({
-            defaultMessage: "contact@email.com",
-            id: "hTzoAW",
-            description:
-              "Placeholder email format example for team contact email input",
-          })}
           rules={{
             required: intl.formatMessage(errorMessages.required),
           }}

--- a/apps/web/src/pages/Users/UserInformationPage/components/NotesSection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/NotesSection.tsx
@@ -123,12 +123,6 @@ const NotesSection = ({ user }: BasicUserInformationProps) => {
                       },
                     )}
                     defaultValue={candidate.notes ? candidate.notes : ""}
-                    placeholder={intl.formatMessage({
-                      defaultMessage: "Start writing your notes here...",
-                      id: "/MBeNc",
-                      description:
-                        "Placeholder text for a pool candidates notes field",
-                    })}
                     rows={4}
                   />
                 </div>


### PR DESCRIPTION
🤖 Resolves #6324.

## 👋 Introduction

This PR removes the `placeholder` prop from most `Input` and `TextArea` components with the exceptions of:

### e.g. Python, JavaScript, etc.
https://github.com/GCTC-NTGC/gc-digital-talent/blob/843a63a0350eac9c8c72c84f3ac2edc8d974c932/apps/web/src/components/SkillPicker/SkillPicker.tsx#L152-L156

### +123243234
https://github.com/GCTC-NTGC/gc-digital-talent/blob/843a63a0350eac9c8c72c84f3ac2edc8d974c932/apps/web/src/pages/Profile/AboutMePage/components/AboutMeForm/AboutMeForm.tsx#L374-L379

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure `placeholder` attribute not used on `input` and `textarea` except for `SkillPicker` and telephone `input`