### PR TITLE
[Bug] Add missing null states to view pool page

### DIFF
--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -49,6 +49,7 @@ export const ViewPool = ({ pool }: ViewPoolProps): JSX.Element => {
   const paths = useRoutes();
   const form = useForm();
   const [linkCopied, setLinkCopied] = React.useState<boolean>(false);
+  const notProvided = intl.formatMessage(commonMessages.notProvided);
 
   /** Reset link copied after 3 seconds */
   React.useEffect(() => {
@@ -91,11 +92,11 @@ export const ViewPool = ({ pool }: ViewPoolProps): JSX.Element => {
 
   const languageRequirement = pool.advertisementLanguage
     ? intl.formatMessage(getLanguageRequirement(pool.advertisementLanguage))
-    : "";
+    : notProvided;
 
   const securityClearance = pool.securityClearance
     ? intl.formatMessage(getSecurityClearance(pool.securityClearance))
-    : "";
+    : notProvided;
 
   const screeningQuestions = pool?.screeningQuestions?.filter(notEmpty) || [];
 
@@ -385,7 +386,7 @@ export const ViewPool = ({ pool }: ViewPoolProps): JSX.Element => {
                 })}
               </p>
               <p data-h2-margin="base(x.5, 0, 0, 0)">
-                {pool.yourImpact?.en || ""}
+                {pool.yourImpact?.en || notProvided}
               </p>
             </div>
             <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
@@ -401,7 +402,7 @@ export const ViewPool = ({ pool }: ViewPoolProps): JSX.Element => {
                 })}
               </p>
               <p data-h2-margin="base(x.5, 0, 0, 0)">
-                {pool.yourImpact?.fr || ""}
+                {pool.yourImpact?.fr || notProvided}
               </p>
             </div>
             <div data-h2-flex-item="base(1of1)">
@@ -429,7 +430,7 @@ export const ViewPool = ({ pool }: ViewPoolProps): JSX.Element => {
                 })}
               </p>
               <p data-h2-margin="base(x.5, 0, 0, 0)">
-                {pool.keyTasks?.en || ""}
+                {pool.keyTasks?.en || notProvided}
               </p>
             </div>
             <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
@@ -445,7 +446,7 @@ export const ViewPool = ({ pool }: ViewPoolProps): JSX.Element => {
                 })}
               </p>
               <p data-h2-margin="base(x.5, 0, 0, 0)">
-                {pool.keyTasks?.fr || ""}
+                {pool.keyTasks?.fr || notProvided}
               </p>
             </div>
           </div>
@@ -456,58 +457,58 @@ export const ViewPool = ({ pool }: ViewPoolProps): JSX.Element => {
               description: "Title required skills for a pool advertisement",
             })}
           </h2>
+          <h3
+            data-h2-font-size="base(h6)"
+            data-h2-font-weight="base(700)"
+            data-h2-margin="base(x1, 0, x.5, 0)"
+          >
+            {intl.formatMessage({
+              defaultMessage: "Occupational",
+              id: "Vpk+nl",
+              description:
+                "Title for pool advertisement occupational skill list",
+            })}
+          </h3>
           {essentialOccupationalSkills?.length ? (
-            <>
-              <h3
-                data-h2-font-size="base(h6)"
-                data-h2-font-weight="base(700)"
-                data-h2-margin="base(x1, 0, x.5, 0)"
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Occupational",
-                  id: "Vpk+nl",
-                  description:
-                    "Title for pool advertisement occupational skill list",
-                })}
-              </h3>
-              <Chips>
-                {essentialOccupationalSkills.map((skill) => (
-                  <Chip
-                    key={`occupationalSkill-${skill.id}`}
-                    mode="outline"
-                    color="primary"
-                    label={getLocalizedName(skill.name, intl)}
-                  />
-                ))}
-              </Chips>
-            </>
-          ) : null}
+            <Chips>
+              {essentialOccupationalSkills.map((skill) => (
+                <Chip
+                  key={`occupationalSkill-${skill.id}`}
+                  mode="outline"
+                  color="primary"
+                  label={getLocalizedName(skill.name, intl)}
+                />
+              ))}
+            </Chips>
+          ) : (
+            <p>{notProvided}</p>
+          )}
+          <h3
+            data-h2-font-size="base(h6)"
+            data-h2-font-weight="base(700)"
+            data-h2-margin="base(x1, 0, x.5, 0)"
+          >
+            {intl.formatMessage({
+              defaultMessage: "Transferable",
+              id: "eGEusj",
+              description:
+                "Title for pool advertisement transferable skill list",
+            })}
+          </h3>
           {essentialTransferableSkills?.length ? (
-            <>
-              <h3
-                data-h2-font-size="base(h6)"
-                data-h2-font-weight="base(700)"
-                data-h2-margin="base(x1, 0, x.5, 0)"
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Transferable",
-                  id: "eGEusj",
-                  description:
-                    "Title for pool advertisement transferable skill list",
-                })}
-              </h3>
-              <Chips>
-                {essentialTransferableSkills.map((skill) => (
-                  <Chip
-                    key={`occupationalSkill-${skill.id}`}
-                    mode="outline"
-                    color="primary"
-                    label={getLocalizedName(skill.name, intl)}
-                  />
-                ))}
-              </Chips>
-            </>
-          ) : null}
+            <Chips>
+              {essentialTransferableSkills.map((skill) => (
+                <Chip
+                  key={`occupationalSkill-${skill.id}`}
+                  mode="outline"
+                  color="primary"
+                  label={getLocalizedName(skill.name, intl)}
+                />
+              ))}
+            </Chips>
+          ) : (
+            <p>{notProvided}</p>
+          )}
           <h2 data-h2-margin="base(x2, 0, 0, 0)" data-h2-font-size="base(h3)">
             {intl.formatMessage({
               defaultMessage: "Nice to have skills",
@@ -515,58 +516,58 @@ export const ViewPool = ({ pool }: ViewPoolProps): JSX.Element => {
               description: "Title optional skills for a pool advertisement",
             })}
           </h2>
+          <h3
+            data-h2-font-size="base(h6)"
+            data-h2-font-weight="base(700)"
+            data-h2-margin="base(x1, 0, x.5, 0)"
+          >
+            {intl.formatMessage({
+              defaultMessage: "Occupational",
+              id: "Vpk+nl",
+              description:
+                "Title for pool advertisement occupational skill list",
+            })}
+          </h3>
           {nonEssentialOccupationalSkills?.length ? (
-            <>
-              <h3
-                data-h2-font-size="base(h6)"
-                data-h2-font-weight="base(700)"
-                data-h2-margin="base(x1, 0, x.5, 0)"
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Occupational",
-                  id: "Vpk+nl",
-                  description:
-                    "Title for pool advertisement occupational skill list",
-                })}
-              </h3>
-              <Chips>
-                {nonEssentialOccupationalSkills.map((skill) => (
-                  <Chip
-                    key={`occupationalSkill-${skill.id}`}
-                    mode="outline"
-                    color="primary"
-                    label={getLocalizedName(skill.name, intl)}
-                  />
-                ))}
-              </Chips>
-            </>
-          ) : null}
+            <Chips>
+              {nonEssentialOccupationalSkills.map((skill) => (
+                <Chip
+                  key={`occupationalSkill-${skill.id}`}
+                  mode="outline"
+                  color="primary"
+                  label={getLocalizedName(skill.name, intl)}
+                />
+              ))}
+            </Chips>
+          ) : (
+            <p>{notProvided}</p>
+          )}
+          <h3
+            data-h2-font-size="base(h6)"
+            data-h2-font-weight="base(700)"
+            data-h2-margin="base(x1, 0, x.5, 0)"
+          >
+            {intl.formatMessage({
+              defaultMessage: "Transferable",
+              id: "eGEusj",
+              description:
+                "Title for pool advertisement transferable skill list",
+            })}
+          </h3>
           {nonEssentialTransferableSkills?.length ? (
-            <>
-              <h3
-                data-h2-font-size="base(h6)"
-                data-h2-font-weight="base(700)"
-                data-h2-margin="base(x1, 0, x.5, 0)"
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Transferable",
-                  id: "eGEusj",
-                  description:
-                    "Title for pool advertisement transferable skill list",
-                })}
-              </h3>
-              <Chips>
-                {nonEssentialTransferableSkills.map((skill) => (
-                  <Chip
-                    key={`occupationalSkill-${skill.id}`}
-                    mode="outline"
-                    color="primary"
-                    label={getLocalizedName(skill.name, intl)}
-                  />
-                ))}
-              </Chips>
-            </>
-          ) : null}
+            <Chips>
+              {nonEssentialTransferableSkills.map((skill) => (
+                <Chip
+                  key={`occupationalSkill-${skill.id}`}
+                  mode="outline"
+                  color="primary"
+                  label={getLocalizedName(skill.name, intl)}
+                />
+              ))}
+            </Chips>
+          ) : (
+            <p>{notProvided}</p>
+          )}
           <h2 data-h2-margin="base(x2, 0, x1, 0)" data-h2-font-size="base(h3)">
             {intl.formatMessage({
               defaultMessage: "Requirements",
@@ -620,7 +621,7 @@ export const ViewPool = ({ pool }: ViewPoolProps): JSX.Element => {
                         "Pool advertisement location requirement, English",
                     },
                     {
-                      locationEn: pool.advertisementLocation?.en ?? "",
+                      locationEn: pool.advertisementLocation?.en ?? notProvided,
                     },
                   )}
                 </li>
@@ -633,7 +634,7 @@ export const ViewPool = ({ pool }: ViewPoolProps): JSX.Element => {
                         "Pool advertisement location requirement, French",
                     },
                     {
-                      locationFr: pool.advertisementLocation?.fr ?? "",
+                      locationFr: pool.advertisementLocation?.fr ?? notProvided,
                     },
                   )}
                 </li>
@@ -729,7 +730,9 @@ export const ViewPool = ({ pool }: ViewPoolProps): JSX.Element => {
                 </div>
               ))}
             </div>
-          ) : null}
+          ) : (
+            <p>{notProvided}</p>
+          )}
         </FormProvider>
         <p data-h2-margin="base(x2, 0, 0, 0)">
           <Link


### PR DESCRIPTION
🤖 Resolves #6306 

## 👋 Introduction

Adds missing null states to the admin view pool page.

## 🕵️ Details

This currently uses the `commonMessages.notProvided` message in favour of introducing a new string that says a similar thing. Currently, I am waiting to hear if this is acceptable from designers.

>**Note**
> This also lifts the skill family headings outside of the skill check to always display them so we can tell admins that they have no added them instead of hiding it completely.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run build`
2. Login as admin and create an empty pool
3. Navigate to the the pool information page for that new pool
4. Confirm there are no empty null states but instead it says "Not provided"

## 📸 Screenshot
![localhost_8000_en_admin_pools_7c5f8c1f-d215-4094-b348-f73a69aa9016](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/bd8fbd25-9ace-49b7-b96a-53130ce4cc18)


