### PR TITLE
[Bug] Fix storybook component errors

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.stories.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { faker } from "@faker-js/faker";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { fakePoolCandidates } from "@gc-digital-talent/fake-data";
@@ -6,6 +7,20 @@ import { fakePoolCandidates } from "@gc-digital-talent/fake-data";
 import PoolCandidatesTable from "./PoolCandidatesTable";
 
 const poolCandidateData = fakePoolCandidates();
+
+const mockPoolCandidatesWithSkillCount = poolCandidateData.map(
+  (poolCandidate) => {
+    const skillCount = faker.datatype.number({
+      min: 0,
+      max: 10,
+    });
+    return {
+      id: poolCandidate.id,
+      poolCandidate,
+      skillCount: skillCount || null,
+    };
+  },
+);
 
 const mockPaginatorInfo = {
   count: 1,
@@ -27,7 +42,7 @@ export default {
       GetPoolCandidatesPaginated: {
         data: {
           poolCandidatesPaginated: {
-            data: poolCandidateData,
+            data: mockPoolCandidatesWithSkillCount,
             paginatorInfo: mockPaginatorInfo,
           },
         },

--- a/apps/web/src/pages/Applications/ApplicationResumePage/ApplicationResumePage.stories.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumePage/ApplicationResumePage.stories.tsx
@@ -6,13 +6,16 @@ import {
   fakePoolCandidates,
 } from "@gc-digital-talent/fake-data";
 
+import { ExperienceForDate } from "~/types/experience";
+
 import { ApplicationResume } from "./ApplicationResumePage";
-import { ApplicationPageProps } from "../ApplicationApi";
 
 const fakePoolCandidate = fakePoolCandidates(1)[0];
 const fakeUser = fakePoolCandidate.user;
 
-const noExperiencesProps: ApplicationPageProps = {
+type ApplicationResumeStory = ComponentStory<typeof ApplicationResume>;
+
+const noExperiencesProps: ApplicationResumeStory["args"] = {
   application: {
     ...fakePoolCandidate,
     user: {
@@ -20,9 +23,10 @@ const noExperiencesProps: ApplicationPageProps = {
       experiences: [],
     },
   },
+  experiences: [],
 };
 
-const hasExperiencesProps: ApplicationPageProps = {
+const hasExperiencesProps: ApplicationResumeStory["args"] = {
   application: {
     ...fakePoolCandidate,
     user: {
@@ -30,6 +34,7 @@ const hasExperiencesProps: ApplicationPageProps = {
       experiences: fakeExperiences(5),
     },
   },
+  experiences: fakeExperiences(5) as Array<ExperienceForDate>,
 };
 
 export default {
@@ -37,7 +42,7 @@ export default {
   title: "Pages/Application Revamp/Review Resume",
 } as ComponentMeta<typeof ApplicationResume>;
 
-const Template: ComponentStory<typeof ApplicationResume> = (props) => (
+const Template: ApplicationResumeStory = (props) => (
   <ApplicationResume {...props} />
 );
 


### PR DESCRIPTION
🤖 Resolves #6595 

## 👋 Introduction

Updates the shape of args passed into 3 stories to fix errors with the data the components require.

## 🕵️ Details

We updated the shape of `poolCandidatesPaginated` but never updated the story, this fixes that along with adjusting the args for the reivew resume page story.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run storybook `npm run storybook`
2. Confirm the following stories function as expected:
    - Pages / Application Revamp / Review Resume / No Experiences
    - Pages / Application Revamp / Review Resume / Has Experiences
    - Tables / Pool Candidates Table / Default

## 📸 Screenshot
![Screenshot 2023-05-19 154425](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/99bcadbe-d88d-49ad-ac2b-3e3b57e4b412)


