### PR TITLE
[Bug] Prevent matchStringCaseDiacriticInsensitive() from crashing for enormous strings

### DIFF
--- a/packages/forms/src/utils.ts
+++ b/packages/forms/src/utils.ts
@@ -99,6 +99,10 @@ export function matchStringCaseDiacriticInsensitive(
   needle: string,
   compareString: string,
 ) {
+  if (needle.length > 1000) {
+    // short-circuit for very long needle cases, prevents RegExp crashing
+    return false;
+  }
   const escapedNeedle = escapeAString(needle); // escape certain characters for Regex purposes
   return (
     compareString

--- a/packages/forms/src/utils.ts
+++ b/packages/forms/src/utils.ts
@@ -3,6 +3,7 @@ import { IntlShape } from "react-intl";
 import { LocalizedString, Maybe, Scalars } from "@gc-digital-talent/graphql";
 import { getLocale } from "@gc-digital-talent/i18n";
 import { getId, notEmpty } from "@gc-digital-talent/helpers";
+import { defaultLogger } from "@gc-digital-talent/logger";
 
 /**
  * Filters out empty data from data response.
@@ -101,6 +102,9 @@ export function matchStringCaseDiacriticInsensitive(
 ) {
   if (needle.length > 1000) {
     // short-circuit for very long needle cases, prevents RegExp crashing
+    defaultLogger.warning(
+      "Short-circuit function matchStringCaseDiacriticInsensitive",
+    );
     return false;
   }
   const escapedNeedle = escapeAString(needle); // escape certain characters for Regex purposes


### PR DESCRIPTION
🤖 Resolves #6031 

## 👋 Introduction

Prevent crashing of the function, and subsequently the page if a very, very long string is input. 

## 🕵️ Details

The function is only used in one place, the `Skillpicker`, and it is a rather edge case since it requires someone to go out of their way to intentionally crash their browser. 
Since the input doesn't actually submit anything, rather, just searches through a skills array in the frontend. I decided against adding restrictions to inputs, there was only one place where this function applied anyway. The input in question doesn't have a rules prop either. 

So I elected for the simple cap to short-circuit the function in cases where the string is 1000 characters or more. 

## 🧪 Testing

1. Navigate to `/en/search`
2. Head to the skills selection section
3. Paste a very massive string into the search, page should not crash

## 📸 Screenshot

Only used in one component. 
There is another function that uses it, matchString**_s_**CaseDiacriticInsensitive(), that isn't used anywhere. 

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/f634bcc3-11ee-4046-a3c8-c7ef605befbc)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/17e6f0c8-9d0a-4cfe-9627-40a7077a5b92)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/499afae2-cbd2-4f1e-a67c-598381f03f51)
