### PR TITLE
[Fix] Fixes typo on education page of application

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8052,9 +8052,9 @@
     "defaultMessage": "Le passage réussi de deux années d’éducation postsecondaire en sciences informatiques, en technologie de l’information, en gestion de l’information ou dans un autre domaine spécialisé pertinent à ce poste.",
     "description": "post secondary education experience for pool advertisement"
   },
-  "3O0s49": {
+  "TBsQMo": {
     "defaultMessage": "Choisissez l’option qui s’applique à votre situation",
-    "description": "Legend for the  radio group in the application education page."
+    "description": "Legend for the radio group in the application education page."
   },
   "6Q1N7Z": {
     "defaultMessage": "Veuillez sélectionner les expériences dans :",

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
@@ -400,10 +400,10 @@ const ApplicationEducation = ({
           <RadioGroup
             idPrefix="education_requirement"
             legend={intl.formatMessage({
-              defaultMessage: "Select the option the applies to you",
-              id: "3O0s49",
+              defaultMessage: "Select the option that applies to you",
+              id: "TBsQMo",
               description:
-                "Legend for the  radio group in the application education page.",
+                "Legend for the radio group in the application education page.",
             })}
             name="educationRequirement"
             items={educationRequirementOptions}


### PR DESCRIPTION
🤖 Resolves #6673.

## 👋 Introduction

This PR fixes a typo on the education page of the application process.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate to a pool advertisement
3. Apply to the pool
4. Continue to the education requirement step
5. Confirm the education requirement copy is accurate

## 📸 Screenshot

![Screen Shot 2023-05-23 at 15 00 33](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/1163343c-40f1-4f28-be16-25ddb4384bad)

