### PR TITLE
[Dependency] Upgrades Cypress to version 12

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   run-cypress:
     # Platform recommended in cypress-io/github-action docs.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       # Use native docker command within docker-compose
       COMPOSE_DOCKER_CLI_BUILD: 1

--- a/apps/e2e/cypress.config.ts
+++ b/apps/e2e/cypress.config.ts
@@ -32,7 +32,6 @@ export default defineConfig({
       on("task", verifyDownloadTasks);
       return require("./cypress/plugins/index.js")(on, config);
     },
-    experimentalSessionAndOrigin: true,
     excludeSpecPattern: "**/examples/*.spec.js",
     baseUrl: "http://localhost:8000",
   },

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -16,7 +16,7 @@
     "@testing-library/cypress": "^8.0.7",
     "axe-core": "^4.7.1",
     "cy-verify-downloads": "^0.1.14",
-    "cypress": "^11.2.0",
+    "cypress": "^12.13.0",
     "cypress-axe": "^1.4.0",
     "cypress-multi-reporters": "^1.6.3",
     "cypress-terminal-report": "^5.1.1",

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -13,7 +13,7 @@
     "@gc-digital-talent/web": "*"
   },
   "devDependencies": {
-    "@testing-library/cypress": "^8.0.7",
+    "@testing-library/cypress": "^9.0.0",
     "axe-core": "^4.7.1",
     "cy-verify-downloads": "^0.1.14",
     "cypress": "^12.13.0",

--- a/maintenance/scripts/setup.sh
+++ b/maintenance/scripts/setup.sh
@@ -23,6 +23,6 @@ cp .env.example .env --preserve=all
 # build projects
 git config --global --add safe.directory /var/www/html
 cd /var/www/html
-npm install
+npm ci
 npm run build:fresh
 chmod -R a+r,a+w node_modules apps/*/.turbo packages/*/.turbo

--- a/maintenance/scripts/setup.sh
+++ b/maintenance/scripts/setup.sh
@@ -23,6 +23,6 @@ cp .env.example .env --preserve=all
 # build projects
 git config --global --add safe.directory /var/www/html
 cd /var/www/html
-npm ci
+npm install
 npm run build:fresh
 chmod -R a+r,a+w node_modules apps/*/.turbo packages/*/.turbo

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,13 +34,196 @@
         "@testing-library/cypress": "^8.0.7",
         "axe-core": "^4.7.1",
         "cy-verify-downloads": "^0.1.14",
-        "cypress": "^11.2.0",
+        "cypress": "^12.13.0",
         "cypress-axe": "^1.4.0",
         "cypress-multi-reporters": "^1.6.3",
         "cypress-terminal-report": "^5.1.1",
         "eslint-plugin-cypress": "^2.13.3",
         "prettier": "^2.8.8",
         "tsconfig": "*"
+      }
+    },
+    "apps/e2e/node_modules/@types/node": {
+      "version": "14.18.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.47.tgz",
+      "integrity": "sha512-OuJi8bIng4wYHHA3YpKauL58dZrPxro3d0tabPHyiNF8rKfGKuVfr83oFlPLmKri1cX+Z3cJP39GXmnqkP11Gw==",
+      "dev": true
+    },
+    "apps/e2e/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "apps/e2e/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "apps/e2e/node_modules/cypress": {
+      "version": "12.13.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.13.0.tgz",
+      "integrity": "sha512-QJlSmdPk+53Zhy69woJMySZQJoWfEWun3X5OOenGsXjRPVfByVTHorxNehbzhZrEzH9RDUDqVcck0ahtlS+N/Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@cypress/request": "^2.88.10",
+        "@cypress/xvfb": "^1.2.4",
+        "@types/node": "^14.14.31",
+        "@types/sinonjs__fake-timers": "8.1.1",
+        "@types/sizzle": "^2.3.2",
+        "arch": "^2.2.0",
+        "blob-util": "^2.0.2",
+        "bluebird": "^3.7.2",
+        "buffer": "^5.6.0",
+        "cachedir": "^2.3.0",
+        "chalk": "^4.1.0",
+        "check-more-types": "^2.24.0",
+        "cli-cursor": "^3.1.0",
+        "cli-table3": "~0.6.1",
+        "commander": "^6.2.1",
+        "common-tags": "^1.8.0",
+        "dayjs": "^1.10.4",
+        "debug": "^4.3.4",
+        "enquirer": "^2.3.6",
+        "eventemitter2": "6.4.7",
+        "execa": "4.1.0",
+        "executable": "^4.1.1",
+        "extract-zip": "2.0.1",
+        "figures": "^3.2.0",
+        "fs-extra": "^9.1.0",
+        "getos": "^3.2.1",
+        "is-ci": "^3.0.0",
+        "is-installed-globally": "~0.4.0",
+        "lazy-ass": "^1.6.0",
+        "listr2": "^3.8.3",
+        "lodash": "^4.17.21",
+        "log-symbols": "^4.0.0",
+        "minimist": "^1.2.8",
+        "ospath": "^1.2.2",
+        "pretty-bytes": "^5.6.0",
+        "proxy-from-env": "1.0.0",
+        "request-progress": "^3.0.0",
+        "semver": "^7.3.2",
+        "supports-color": "^8.1.1",
+        "tmp": "~0.2.1",
+        "untildify": "^4.0.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "cypress": "bin/cypress"
+      },
+      "engines": {
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+      }
+    },
+    "apps/e2e/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "apps/e2e/node_modules/listr2": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
+      "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
+      "dev": true,
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "colorette": "^2.0.16",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rfdc": "^1.3.0",
+        "rxjs": "^7.5.1",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "enquirer": ">= 2.3.0 < 3"
+      },
+      "peerDependenciesMeta": {
+        "enquirer": {
+          "optional": true
+        }
+      }
+    },
+    "apps/e2e/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "apps/e2e/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "apps/e2e/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "apps/e2e/node_modules/tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
+      "dependencies": {
+        "rimraf": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.17.0"
       }
     },
     "apps/web": {
@@ -17982,6 +18165,7 @@
       "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
@@ -18093,12 +18277,14 @@
     "node_modules/cypress/node_modules/@types/node": {
       "version": "14.18.36",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cypress/node_modules/brace-expansion": {
       "version": "1.1.11",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -18108,6 +18294,7 @@
       "version": "5.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -18116,6 +18303,7 @@
       "version": "7.2.3",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -18135,6 +18323,7 @@
       "version": "3.14.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^2.1.0",
         "colorette": "^2.0.16",
@@ -18161,6 +18350,7 @@
       "version": "3.1.2",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -18172,6 +18362,7 @@
       "version": "3.0.2",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -18186,6 +18377,7 @@
       "version": "8.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -18200,6 +18392,7 @@
       "version": "0.2.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "rimraf": "^3.0.0"
       },
@@ -37156,13 +37349,153 @@
         "@testing-library/cypress": "^8.0.7",
         "axe-core": "^4.7.1",
         "cy-verify-downloads": "^0.1.14",
-        "cypress": "^11.2.0",
+        "cypress": "^12.13.0",
         "cypress-axe": "^1.4.0",
         "cypress-multi-reporters": "^1.6.3",
         "cypress-terminal-report": "^5.1.1",
         "eslint-plugin-cypress": "^2.13.3",
         "prettier": "^2.8.8",
         "tsconfig": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.18.47",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.47.tgz",
+          "integrity": "sha512-OuJi8bIng4wYHHA3YpKauL58dZrPxro3d0tabPHyiNF8rKfGKuVfr83oFlPLmKri1cX+Z3cJP39GXmnqkP11Gw==",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        },
+        "cypress": {
+          "version": "12.13.0",
+          "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.13.0.tgz",
+          "integrity": "sha512-QJlSmdPk+53Zhy69woJMySZQJoWfEWun3X5OOenGsXjRPVfByVTHorxNehbzhZrEzH9RDUDqVcck0ahtlS+N/Q==",
+          "dev": true,
+          "requires": {
+            "@cypress/request": "^2.88.10",
+            "@cypress/xvfb": "^1.2.4",
+            "@types/node": "^14.14.31",
+            "@types/sinonjs__fake-timers": "8.1.1",
+            "@types/sizzle": "^2.3.2",
+            "arch": "^2.2.0",
+            "blob-util": "^2.0.2",
+            "bluebird": "^3.7.2",
+            "buffer": "^5.6.0",
+            "cachedir": "^2.3.0",
+            "chalk": "^4.1.0",
+            "check-more-types": "^2.24.0",
+            "cli-cursor": "^3.1.0",
+            "cli-table3": "~0.6.1",
+            "commander": "^6.2.1",
+            "common-tags": "^1.8.0",
+            "dayjs": "^1.10.4",
+            "debug": "^4.3.4",
+            "enquirer": "^2.3.6",
+            "eventemitter2": "6.4.7",
+            "execa": "4.1.0",
+            "executable": "^4.1.1",
+            "extract-zip": "2.0.1",
+            "figures": "^3.2.0",
+            "fs-extra": "^9.1.0",
+            "getos": "^3.2.1",
+            "is-ci": "^3.0.0",
+            "is-installed-globally": "~0.4.0",
+            "lazy-ass": "^1.6.0",
+            "listr2": "^3.8.3",
+            "lodash": "^4.17.21",
+            "log-symbols": "^4.0.0",
+            "minimist": "^1.2.8",
+            "ospath": "^1.2.2",
+            "pretty-bytes": "^5.6.0",
+            "proxy-from-env": "1.0.0",
+            "request-progress": "^3.0.0",
+            "semver": "^7.3.2",
+            "supports-color": "^8.1.1",
+            "tmp": "~0.2.1",
+            "untildify": "^4.0.0",
+            "yauzl": "^2.10.0"
+          }
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "listr2": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
+          "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
+          "dev": true,
+          "requires": {
+            "cli-truncate": "^2.1.0",
+            "colorette": "^2.0.16",
+            "log-update": "^4.0.0",
+            "p-map": "^4.0.0",
+            "rfdc": "^1.3.0",
+            "rxjs": "^7.5.1",
+            "through": "^2.3.8",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tmp": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+          "dev": true,
+          "requires": {
+            "rimraf": "^3.0.0"
+          }
+        }
       }
     },
     "@gc-digital-talent/env": {
@@ -47870,6 +48203,7 @@
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
       "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
@@ -47917,11 +48251,13 @@
       "dependencies": {
         "@types/node": {
           "version": "14.18.36",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "dev": true,
+          "peer": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -47929,11 +48265,13 @@
         },
         "commander": {
           "version": "5.1.0",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "glob": {
           "version": "7.2.3",
           "dev": true,
+          "peer": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -47946,6 +48284,7 @@
         "listr2": {
           "version": "3.14.0",
           "dev": true,
+          "peer": true,
           "requires": {
             "cli-truncate": "^2.1.0",
             "colorette": "^2.0.16",
@@ -47960,6 +48299,7 @@
         "minimatch": {
           "version": "3.1.2",
           "dev": true,
+          "peer": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -47967,6 +48307,7 @@
         "rimraf": {
           "version": "3.0.2",
           "dev": true,
+          "peer": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -47974,6 +48315,7 @@
         "supports-color": {
           "version": "8.1.1",
           "dev": true,
+          "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -47981,6 +48323,7 @@
         "tmp": {
           "version": "0.2.1",
           "dev": true,
+          "peer": true,
           "requires": {
             "rimraf": "^3.0.0"
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@gc-digital-talent/web": "*"
       },
       "devDependencies": {
-        "@testing-library/cypress": "^8.0.7",
+        "@testing-library/cypress": "^9.0.0",
         "axe-core": "^4.7.1",
         "cy-verify-downloads": "^0.1.14",
         "cypress": "^12.13.0",
@@ -41,6 +41,23 @@
         "eslint-plugin-cypress": "^2.13.3",
         "prettier": "^2.8.8",
         "tsconfig": "*"
+      }
+    },
+    "apps/e2e/node_modules/@testing-library/cypress": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-9.0.0.tgz",
+      "integrity": "sha512-c1XiCGeHGGTWn0LAU12sFUfoX3qfId5gcSE2yHode+vsyHDWraxDPALjVnHd4/Fa3j4KBcc5k++Ccy6A9qnkMA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "@testing-library/dom": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "cypress": "^12.0.0"
       }
     },
     "apps/e2e/node_modules/@types/node": {
@@ -11866,22 +11883,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@testing-library/cypress": {
-      "version": "8.0.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.14.6",
-        "@testing-library/dom": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "cypress": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -37346,7 +37347,7 @@
       "requires": {
         "@gc-digital-talent/date-helpers": "*",
         "@gc-digital-talent/web": "*",
-        "@testing-library/cypress": "^8.0.7",
+        "@testing-library/cypress": "^9.0.0",
         "axe-core": "^4.7.1",
         "cy-verify-downloads": "^0.1.14",
         "cypress": "^12.13.0",
@@ -37358,6 +37359,16 @@
         "tsconfig": "*"
       },
       "dependencies": {
+        "@testing-library/cypress": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-9.0.0.tgz",
+          "integrity": "sha512-c1XiCGeHGGTWn0LAU12sFUfoX3qfId5gcSE2yHode+vsyHDWraxDPALjVnHd4/Fa3j4KBcc5k++Ccy6A9qnkMA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.14.6",
+            "@testing-library/dom": "^8.1.0"
+          }
+        },
         "@types/node": {
           "version": "14.18.47",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.47.tgz",
@@ -43979,14 +43990,6 @@
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
       "requires": {
         "defer-to-connect": "^2.0.0"
-      }
-    },
-    "@testing-library/cypress": {
-      "version": "8.0.7",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.14.6",
-        "@testing-library/dom": "^8.1.0"
       }
     },
     "@testing-library/dom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,189 +60,6 @@
         "cypress": "^12.0.0"
       }
     },
-    "apps/e2e/node_modules/@types/node": {
-      "version": "14.18.47",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.47.tgz",
-      "integrity": "sha512-OuJi8bIng4wYHHA3YpKauL58dZrPxro3d0tabPHyiNF8rKfGKuVfr83oFlPLmKri1cX+Z3cJP39GXmnqkP11Gw==",
-      "dev": true
-    },
-    "apps/e2e/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "apps/e2e/node_modules/commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "apps/e2e/node_modules/cypress": {
-      "version": "12.13.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.13.0.tgz",
-      "integrity": "sha512-QJlSmdPk+53Zhy69woJMySZQJoWfEWun3X5OOenGsXjRPVfByVTHorxNehbzhZrEzH9RDUDqVcck0ahtlS+N/Q==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@cypress/request": "^2.88.10",
-        "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^14.14.31",
-        "@types/sinonjs__fake-timers": "8.1.1",
-        "@types/sizzle": "^2.3.2",
-        "arch": "^2.2.0",
-        "blob-util": "^2.0.2",
-        "bluebird": "^3.7.2",
-        "buffer": "^5.6.0",
-        "cachedir": "^2.3.0",
-        "chalk": "^4.1.0",
-        "check-more-types": "^2.24.0",
-        "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.1",
-        "commander": "^6.2.1",
-        "common-tags": "^1.8.0",
-        "dayjs": "^1.10.4",
-        "debug": "^4.3.4",
-        "enquirer": "^2.3.6",
-        "eventemitter2": "6.4.7",
-        "execa": "4.1.0",
-        "executable": "^4.1.1",
-        "extract-zip": "2.0.1",
-        "figures": "^3.2.0",
-        "fs-extra": "^9.1.0",
-        "getos": "^3.2.1",
-        "is-ci": "^3.0.0",
-        "is-installed-globally": "~0.4.0",
-        "lazy-ass": "^1.6.0",
-        "listr2": "^3.8.3",
-        "lodash": "^4.17.21",
-        "log-symbols": "^4.0.0",
-        "minimist": "^1.2.8",
-        "ospath": "^1.2.2",
-        "pretty-bytes": "^5.6.0",
-        "proxy-from-env": "1.0.0",
-        "request-progress": "^3.0.0",
-        "semver": "^7.3.2",
-        "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
-        "untildify": "^4.0.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "cypress": "bin/cypress"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
-      }
-    },
-    "apps/e2e/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "apps/e2e/node_modules/listr2": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
-      "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
-      "dev": true,
-      "dependencies": {
-        "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.16",
-        "log-update": "^4.0.0",
-        "p-map": "^4.0.0",
-        "rfdc": "^1.3.0",
-        "rxjs": "^7.5.1",
-        "through": "^2.3.8",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "enquirer": ">= 2.3.0 < 3"
-      },
-      "peerDependenciesMeta": {
-        "enquirer": {
-          "optional": true
-        }
-      }
-    },
-    "apps/e2e/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "apps/e2e/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "apps/e2e/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "apps/e2e/node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "dev": true,
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.17.0"
-      }
-    },
     "apps/web": {
       "name": "@gc-digital-talent/web",
       "version": "1.0.0",
@@ -18161,12 +17978,11 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.13.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.13.0.tgz",
+      "integrity": "sha512-QJlSmdPk+53Zhy69woJMySZQJoWfEWun3X5OOenGsXjRPVfByVTHorxNehbzhZrEzH9RDUDqVcck0ahtlS+N/Q==",
       "dev": true,
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
@@ -18182,10 +17998,10 @@
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
         "cli-table3": "~0.6.1",
-        "commander": "^5.1.0",
+        "commander": "^6.2.1",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
@@ -18200,7 +18016,7 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
@@ -18215,7 +18031,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/cypress-axe": {
@@ -18278,24 +18094,22 @@
     "node_modules/cypress/node_modules/@types/node": {
       "version": "14.18.36",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cypress/node_modules/brace-expansion": {
       "version": "1.1.11",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/cypress/node_modules/commander": {
-      "version": "5.1.0",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -18304,7 +18118,6 @@
       "version": "7.2.3",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -18324,7 +18137,6 @@
       "version": "3.14.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^2.1.0",
         "colorette": "^2.0.16",
@@ -18351,7 +18163,6 @@
       "version": "3.1.2",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -18363,7 +18174,6 @@
       "version": "3.0.2",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -18378,7 +18188,6 @@
       "version": "8.1.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -18393,7 +18202,6 @@
       "version": "0.2.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "rimraf": "^3.0.0"
       },
@@ -37368,144 +37176,6 @@
             "@babel/runtime": "^7.14.6",
             "@testing-library/dom": "^8.1.0"
           }
-        },
-        "@types/node": {
-          "version": "14.18.47",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.47.tgz",
-          "integrity": "sha512-OuJi8bIng4wYHHA3YpKauL58dZrPxro3d0tabPHyiNF8rKfGKuVfr83oFlPLmKri1cX+Z3cJP39GXmnqkP11Gw==",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "commander": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-          "dev": true
-        },
-        "cypress": {
-          "version": "12.13.0",
-          "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.13.0.tgz",
-          "integrity": "sha512-QJlSmdPk+53Zhy69woJMySZQJoWfEWun3X5OOenGsXjRPVfByVTHorxNehbzhZrEzH9RDUDqVcck0ahtlS+N/Q==",
-          "dev": true,
-          "requires": {
-            "@cypress/request": "^2.88.10",
-            "@cypress/xvfb": "^1.2.4",
-            "@types/node": "^14.14.31",
-            "@types/sinonjs__fake-timers": "8.1.1",
-            "@types/sizzle": "^2.3.2",
-            "arch": "^2.2.0",
-            "blob-util": "^2.0.2",
-            "bluebird": "^3.7.2",
-            "buffer": "^5.6.0",
-            "cachedir": "^2.3.0",
-            "chalk": "^4.1.0",
-            "check-more-types": "^2.24.0",
-            "cli-cursor": "^3.1.0",
-            "cli-table3": "~0.6.1",
-            "commander": "^6.2.1",
-            "common-tags": "^1.8.0",
-            "dayjs": "^1.10.4",
-            "debug": "^4.3.4",
-            "enquirer": "^2.3.6",
-            "eventemitter2": "6.4.7",
-            "execa": "4.1.0",
-            "executable": "^4.1.1",
-            "extract-zip": "2.0.1",
-            "figures": "^3.2.0",
-            "fs-extra": "^9.1.0",
-            "getos": "^3.2.1",
-            "is-ci": "^3.0.0",
-            "is-installed-globally": "~0.4.0",
-            "lazy-ass": "^1.6.0",
-            "listr2": "^3.8.3",
-            "lodash": "^4.17.21",
-            "log-symbols": "^4.0.0",
-            "minimist": "^1.2.8",
-            "ospath": "^1.2.2",
-            "pretty-bytes": "^5.6.0",
-            "proxy-from-env": "1.0.0",
-            "request-progress": "^3.0.0",
-            "semver": "^7.3.2",
-            "supports-color": "^8.1.1",
-            "tmp": "~0.2.1",
-            "untildify": "^4.0.0",
-            "yauzl": "^2.10.0"
-          }
-        },
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "listr2": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
-          "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
-          "dev": true,
-          "requires": {
-            "cli-truncate": "^2.1.0",
-            "colorette": "^2.0.16",
-            "log-update": "^4.0.0",
-            "p-map": "^4.0.0",
-            "rfdc": "^1.3.0",
-            "rxjs": "^7.5.1",
-            "through": "^2.3.8",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "tmp": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-          "dev": true,
-          "requires": {
-            "rimraf": "^3.0.0"
-          }
         }
       }
     },
@@ -48202,11 +47872,10 @@
       "version": "1.0.1"
     },
     "cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.13.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.13.0.tgz",
+      "integrity": "sha512-QJlSmdPk+53Zhy69woJMySZQJoWfEWun3X5OOenGsXjRPVfByVTHorxNehbzhZrEzH9RDUDqVcck0ahtlS+N/Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
@@ -48222,10 +47891,10 @@
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
         "cli-table3": "~0.6.1",
-        "commander": "^5.1.0",
+        "commander": "^6.2.1",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
@@ -48240,7 +47909,7 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
@@ -48254,27 +47923,25 @@
       "dependencies": {
         "@types/node": {
           "version": "14.18.36",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "dev": true,
-          "peer": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "commander": {
-          "version": "5.1.0",
-          "dev": true,
-          "peer": true
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
         },
         "glob": {
           "version": "7.2.3",
           "dev": true,
-          "peer": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -48287,7 +47954,6 @@
         "listr2": {
           "version": "3.14.0",
           "dev": true,
-          "peer": true,
           "requires": {
             "cli-truncate": "^2.1.0",
             "colorette": "^2.0.16",
@@ -48302,7 +47968,6 @@
         "minimatch": {
           "version": "3.1.2",
           "dev": true,
-          "peer": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -48310,7 +47975,6 @@
         "rimraf": {
           "version": "3.0.2",
           "dev": true,
-          "peer": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -48318,7 +47982,6 @@
         "supports-color": {
           "version": "8.1.1",
           "dev": true,
-          "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -48326,7 +47989,6 @@
         "tmp": {
           "version": "0.2.1",
           "dev": true,
-          "peer": true,
           "requires": {
             "rimraf": "^3.0.0"
           }


### PR DESCRIPTION
🤖 Resolves #5095, #6510.

## 👋 Introduction

This PR upgrades Cypress to v12.

## 🕵️ Details

Other related changes:

- Updated the platform recommended in `cypress-io/github-action` docs
- Removed the experimental `experimentalSessionAndOrigin` flag that was incorporated into the version 12 of Cypress
- Update `@testing-library/cypress` to a version compatible with version 12 of Cypress

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm install`
2. `npm run e2e`
3. Ensure Cypress works as it did before locally and in CI
