### PR TITLE
[Chore] Remove `TIMING` from lint

### DIFF
--- a/packages/app-insights/package.json
+++ b/packages/app-insights/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsup",
     "watch": "tsup --watch",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "tsc": "tsc --project tsconfig.json --noEmit",
     "test": "jest --detectOpenHandles --forceExit --passWithNoTests"
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsup",
     "watch": "tsup --watch",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "tsc": "tsc --project tsconfig.json --noEmit",
     "test": "jest --detectOpenHandles --forceExit --passWithNoTests"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsup",
     "watch": "tsup --watch",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "tsc": "tsc --project tsconfig.json --noEmit",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --detectOpenHandles --forceExit --passWithNoTests"
   },

--- a/packages/date-helpers/package.json
+++ b/packages/date-helpers/package.json
@@ -11,7 +11,7 @@
     "build": "tsc --declaration",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsc --declaration",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "test": "jest --detectOpenHandles --forceExit --passWithNoTests"
   },
   "jest": {

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsup",
     "watch": "tsup --watch",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\""
+    "lint": "eslint \"src/**/*.ts*\""
   },
   "devDependencies": {
     "eslint-config-custom": "*",

--- a/packages/fake-data/package.json
+++ b/packages/fake-data/package.json
@@ -11,7 +11,7 @@
     "build": "tsc --declaration",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsc --declaration",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\""
+    "lint": "eslint \"src/**/*.ts*\""
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsup",
     "watch": "tsup --watch",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "tsc": "tsc --project tsconfig.json --noEmit",
     "test": "jest --detectOpenHandles --forceExit"
   },

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -12,7 +12,7 @@
     "build": "tsup src/index.tsx  --dts --external react --minify",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "watch": "tsup src/index.tsx  --watch --dts --external react --minify",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "test": "jest --detectOpenHandles --forceExit --passWithNoTests"
   },
   "dependencies": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsup",
     "watch": "tsup --watch",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "tsc": "tsc --project tsconfig.json --noEmit",
     "test": "jest --detectOpenHandles --forceExit",
     "check-intl": "node ./dist/cli.js",

--- a/packages/jest-helpers/package.json
+++ b/packages/jest-helpers/package.json
@@ -11,7 +11,7 @@
     "build": "tsup src/index.ts  --dts --external react --minify",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "watch": "tsup src/index.ts  --watch --dts --external react --minify",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\""
+    "lint": "eslint \"src/**/*.ts*\""
   },
   "jest": {
     "preset": "jest-presets/jest/node"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -11,7 +11,7 @@
     "build": "tsup src/index.ts  --dts --external react --minify",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "watch": "tsup src/index.ts  --watch --dts --external react --minify",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\""
+    "lint": "eslint \"src/**/*.ts*\""
   },
   "dependencies": {
     "@gc-digital-talent/app-insights": "*"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -11,7 +11,7 @@
     "build": "tsc --declaration",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsc --declaration",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\""
+    "lint": "eslint \"src/**/*.ts*\""
   },
   "devDependencies": {
     "eslint-config-custom": "*",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsup",
     "watch": "tsup --watch",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "tsc": "tsc --project tsconfig.json --noEmit",
     "test": "jest --detectOpenHandles --forceExit --passWithNoTests"
   },

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsup",
     "watch": "tsup --watch",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "tsc": "tsc --project tsconfig.json --noEmit",
     "test": "jest --detectOpenHandles --forceExit --passWithNoTests"
   },

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "watch": "tsup src/checkIntegrity.ts  --watch --dts --external react --minify",
     "check-integrity": "node ./dist/checkIntegrity.js",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\""
+    "lint": "eslint \"src/**/*.ts*\""
   },
   "devDependencies": {
     "@swc/core": "^1.3.56",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsup",
     "watch": "tsup --watch",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "tsc": "tsc --project tsconfig.json --noEmit",
     "test": "jest --detectOpenHandles --forceExit"
   },


### PR DESCRIPTION
🤖 Resolves #6679 

## 👋 Introduction

Removed the `TIIMING` from eslint to reduce noise in output.


## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run `npm run lint`
2. Confirm they still function and timing table does not show in output