### PR TITLE
[Feature] Adjust setup script for CI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -51,7 +51,7 @@ jobs:
         run: docker-compose up --detach --build
 
       - name: "Run: setup.sh"
-        run: docker-compose run --rm maintenance bash setup.sh
+        run: docker-compose run --rm maintenance bash setup.sh -c
 
       - uses: actions/setup-node@v3
         with:

--- a/api/database/seeders/CiSeeder.php
+++ b/api/database/seeders/CiSeeder.php
@@ -15,6 +15,9 @@ class CiSeeder extends Seeder
         $this->call(RolePermissionSeeder::class);
         $this->call(ClassificationSeeder::class);
         $this->call(DepartmentSeeder::class);
+        $this->call(GenericJobTitleSeeder::class);
+        $this->call(SkillFamilySeeder::class);
+        $this->call(SkillSeeder::class);
         $this->call(TeamSeederLocal::class);
         $this->call(UserSeederLocal::class);
     }

--- a/api/database/seeders/CiSeeder.php
+++ b/api/database/seeders/CiSeeder.php
@@ -15,6 +15,7 @@ class CiSeeder extends Seeder
         $this->call(RolePermissionSeeder::class);
         $this->call(ClassificationSeeder::class);
         $this->call(DepartmentSeeder::class);
-        $this->call(TeamSeeder::class);
+        $this->call(TeamSeederLocal::class);
+        $this->call(UserSeederLocal::class);
     }
 }

--- a/api/database/seeders/CiSeeder.php
+++ b/api/database/seeders/CiSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class CiSeeder extends Seeder

--- a/api/database/seeders/CiSeeder.php
+++ b/api/database/seeders/CiSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class CiSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $this->call(RolePermissionSeeder::class);
+        $this->call(ClassificationSeeder::class);
+        $this->call(DepartmentSeeder::class);
+        $this->call(TeamSeeder::class);
+    }
+}

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -39,13 +39,6 @@ class DatabaseSeeder extends Seeder
         $this->truncateTables();
 
         // seed a test team and random teams
-        Team::factory()->create([
-            'name' => 'test-team',
-            'display_name' => [
-                'en' => 'Test Team',
-                'fr' => 'Équipe de test',
-            ],
-        ]);
         Team::factory()->count(9)->create();
 
         $this->call(RolePermissionSeeder::class);
@@ -54,6 +47,7 @@ class DatabaseSeeder extends Seeder
         $this->call(GenericJobTitleSeeder::class);
         $this->call(SkillFamilySeeder::class);
         $this->call(SkillSeeder::class);
+        $this->call(TeamSeederLocal::class);
         $this->call(TeamSeeder::class);
         $this->call(UserSeederLocal::class);
         $this->call(PoolSeeder::class);

--- a/api/database/seeders/TeamSeederLocal.php
+++ b/api/database/seeders/TeamSeederLocal.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Team;
+use Illuminate\Database\Seeder;
+
+class TeamSeederLocal extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $teams = [
+            [
+                'name' => 'test-team',
+                'display_name' => [
+                    'en' => 'Test Team',
+                    'fr' => 'Équipe de test',
+                ],
+            ],
+        ];
+
+        foreach ($teams as $team) {
+            $identifier = [
+                'name' => $team['name'],
+            ];
+            Team::updateOrCreate($identifier, $team);
+        }
+    }
+}

--- a/maintenance/scripts/setup.sh
+++ b/maintenance/scripts/setup.sh
@@ -10,7 +10,7 @@ Help()
   echo
 }
 
-CI=false
+GCDT_CI=false
 
 while getopts ":hc" option; do
   case $option in
@@ -18,7 +18,7 @@ while getopts ":hc" option; do
       Help
       exit;;
     c | ci)
-      CI=true;;
+      GCDT_CI=true;;
     \?) # incorrect option
       echo "Error: Invalid option"
       exit;;
@@ -36,7 +36,7 @@ touch ./storage/logs/laravel.log
 rm ./bootstrap/cache/*.php --force
 composer install --prefer-dist
 php artisan key:generate
-if [ "$CI" = true ]; then
+if [ "$GCDT_CI" = true ]; then
   php artisan migrate:fresh
   php artisan db:seed --class=CiSeeder
 else
@@ -54,7 +54,7 @@ cp .env.example .env --preserve=all
 git config --global --add safe.directory /var/www/html
 cd /var/www/html
 npm install
-if [ "$CI" = true ]; then
+if [ "$GCDT_CI" = true ]; then
   npm run build:fresh
 else
   npm run dev:fresh

--- a/maintenance/scripts/setup.sh
+++ b/maintenance/scripts/setup.sh
@@ -36,7 +36,12 @@ touch ./storage/logs/laravel.log
 rm ./bootstrap/cache/*.php --force
 composer install --prefer-dist
 php artisan key:generate
-php artisan migrate:fresh --seed
+if [ "$CI" = true ]; then
+  php artisan migrate:fresh
+  php artisan db:seed --class=CiSeeder
+else
+  php artisan migrate:fresh --seed
+fi
 php artisan lighthouse:print-schema --write
 php artisan config:clear
 chown -R www-data ./storage ./vendor
@@ -49,5 +54,9 @@ cp .env.example .env --preserve=all
 git config --global --add safe.directory /var/www/html
 cd /var/www/html
 npm install
-npm run build:fresh
+if [ "$CI" = true ]; then
+  npm run build:fresh
+else
+  npm run dev:fresh
+fi
 chmod -R a+r,a+w node_modules apps/*/.turbo packages/*/.turbo

--- a/maintenance/scripts/setup.sh
+++ b/maintenance/scripts/setup.sh
@@ -14,10 +14,10 @@ GCDT_CI=false
 
 while getopts ":hc" option; do
   case $option in
-    h | help) # display Help
+    h) # display Help
       Help
       exit;;
-    c | ci)
+    c) # setup for CI
       GCDT_CI=true;;
     \?) # incorrect option
       echo "Error: Invalid option"

--- a/maintenance/scripts/setup.sh
+++ b/maintenance/scripts/setup.sh
@@ -1,5 +1,30 @@
 #! /bin/bash
 
+Help()
+{
+  echo "Setup the project and your environment."
+  echo
+  echo "Syntax: setup.sh [-h|c]"
+  echo "   -h   Show this help message."
+  echo "   -c   Setup the environment for CI."
+  echo
+}
+
+CI=false
+
+while getopts ":hc" option; do
+  case $option in
+    h | help) # display Help
+      Help
+      exit;;
+    c | ci)
+      CI=true;;
+    \?) # incorrect option
+      echo "Error: Invalid option"
+      exit;;
+  esac
+done
+
 parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 source ${parent_path}/lib/common.sh
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "intl-extract": "turbo run intl-extract",
     "intl-compile": "turbo run intl-compile",
     "dev": "h2-build && turbo run dev --filter='./apps/*' --filter='!@gc-digital-talent/e2e'",
+    "dev:fresh": "h2-build && turbo run dev --filter='./apps/*' --filter='!@gc-digital-talent/e2e' --force",
     "dev:project": "turbo run dev",
     "lint": "turbo run lint",
     "storybook:project": "npm run storybook",


### PR DESCRIPTION
🤖 Resolves #5592 

## 👋 Introduction

Adds an option to the `setup.sh` script to run different scripts in CI.

## 🕵️ Details

### Usage

You can no pass options to the command, you cna 

```sh
$ docker-compose run --rm maintenance bash setup.sh -h

Setup the project and your environment.

Syntax: setup.sh [-h|c]
   -h   Show this help message.
   -c   Setup the environment for CI.
```

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run `docker-compose run --rm maintenance bash setup.sh`
2. Confirm it setups the env as usual but in dev mode
3. Run `docker-compose run --rm maintenance bash setup.sh -c`
4. Confirm minimal seeders are run (`CiSeeder.php`) and app is build in prod mode
