### PR TITLE
[Bug] Add charset to restricted page

### DIFF
--- a/apps/web/public/restricted.html
+++ b/apps/web/public/restricted.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8" />
     <title>Unauthorized | Non autorisé</title>
   </head>
   <body>
@@ -11,4 +12,3 @@
     </p>
   </body>
 </html>
-


### PR DESCRIPTION
🤖 Resolves #6705 

## 👋 Introduction

This branch adds the charset to the head of the restricted page so that the accented characters are rendered properly.

## 🧪 Testing

1. Build the app or just manually copy the page from public to dist
2. Visit /restricted.html

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/9a4158d7-65c7-4751-9f46-310aa19d4ded)

