### PR TITLE
[Chore] Fix turbo `.env` cache

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["package.json"],
+  "globalDependencies": ["package.json", "**/.env"],
   "pipeline": {
     "build": {
       "dependsOn": ["^build", "build:css", "intl-compile", "codegen"],


### PR DESCRIPTION
🤖 Resolves #6176 

## 👋 Introduction

This busts the turbo cache when changing our `.env` files.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run `npm run build` x3 (cache is not full after a `turbo.json` change)
2. Confirm you still get full turbo
3. Flip one of our env variables in the `.env` file
4. Re-run `npm run build`
5. Confirm it is a fresh build

