### PR TITLE
[Copy] Updates request response time period

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5105,8 +5105,8 @@
     "defaultMessage": "Nous avons reçu votre demande et la réviserons le plus tôt possible.",
     "description": "Paragraph one, message to user the request was received"
   },
-  "ltn4Er": {
-    "defaultMessage": "Vous recevrez un suivi sur votre demande dans 2 à 4 jours ouvrables.",
+  "3rbRfI": {
+    "defaultMessage": "Vous recevrez un suivi sur votre demande dans 5 à 10 jours ouvrables.",
     "description": "Description of when the user should expect a response to their request"
   },
   "rVgBGi": {

--- a/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
@@ -112,8 +112,8 @@ const RequestConfirmationPage = () => {
         <Text>
           {intl.formatMessage({
             defaultMessage:
-              "You will receive a follow up on your request within the next 2 to 4 business days.",
-            id: "ltn4Er",
+              "You will receive a follow up on your request within the next 5 to 10 business days.",
+            id: "3rbRfI",
             description:
               "Description of when the user should expect a response to their request",
           })}


### PR DESCRIPTION
🤖 Resolves #6742.

## 👋 Introduction

This PR updates request response time period in English and French.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate to `/search/request/test`
3. Ensure copy reads: You will receive a follow up on your request within the next 5 to 10 business days. 
4. Switch to French
5. Ensure copy reads: Vous recevrez un suivi sur votre demande dans 5 à 10 jours ouvrables.

## 📸 Screenshot

![Screen Shot 2023-05-29 at 13 50 41](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/15ea7bfd-11d8-4878-9a36-12ecff22726f)

