### PR TITLE
[Bug] Fix `<ul>` nested in `<p>` on the application résumé page

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationResumePage/ApplicationResumePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumePage/ApplicationResumePage.tsx
@@ -289,20 +289,20 @@ export const ApplicationResume = ({
               id: "Q3yncO",
               description: "Title for list of experiences",
             })}
-            <ul data-h2-margin="base(x0.5, 0)">
-              {Object.keys(experiencesByType).map((experienceType) => {
-                return (
-                  <li data-h2-margin="base(x0.5, 0)" key={experienceType}>
-                    {formatExperienceCount(
-                      intl,
-                      experienceType as ExperienceType,
-                      experiencesByType[experienceType].length,
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
           </p>
+          <ul data-h2-margin="base(x0.5, 0, x1, 0)">
+            {Object.keys(experiencesByType).map((experienceType) => {
+              return (
+                <li data-h2-margin="base(x0.5, 0)" key={experienceType}>
+                  {formatExperienceCount(
+                    intl,
+                    experienceType as ExperienceType,
+                    experiencesByType[experienceType].length,
+                  )}
+                </li>
+              );
+            })}
+          </ul>
         </>
       ) : (
         <>


### PR DESCRIPTION
🤖 Resolves #6670 

## 👋 Introduction

Moves the `<ul>` outside of the wrapping `<p>` tag.


## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build dev mode `npm run dev`
2. Create an application and continue until you land on the résumé page
3. Confirm no console errors about invalid nesting appears
4. Confirm the list of number of experiences occurs outside of the `<p>` for the lead in text 

## 📸 Screenshot
![Screenshot 2023-05-30 150326](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/8c0faf2c-5c24-4ae5-9887-e91bb629f6e2)



