### PR TITLE
[Feature] Add accessibility addon to storybook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6664,6 +6664,279 @@
         "lodash.values": "^4.3.0"
       }
     },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-7.0.18.tgz",
+      "integrity": "sha512-kftOzFBpg3goWbLBXDLLsJslfrKYbHs1xtFEH5/4J9NFNE8vZKbIBDQa/R3ezWheL+l2y+5qOlWoLl5z96zlWA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addon-highlight": "7.0.18",
+        "@storybook/channels": "7.0.18",
+        "@storybook/client-logger": "7.0.18",
+        "@storybook/components": "7.0.18",
+        "@storybook/core-events": "7.0.18",
+        "@storybook/global": "^5.0.0",
+        "@storybook/manager-api": "7.0.18",
+        "@storybook/preview-api": "7.0.18",
+        "@storybook/theming": "7.0.18",
+        "@storybook/types": "7.0.18",
+        "axe-core": "^4.2.0",
+        "lodash": "^4.17.21",
+        "react-resize-detector": "^7.1.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/addon-highlight": {
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-7.0.18.tgz",
+      "integrity": "sha512-a3nfUhbu6whoDclIZSV/fzLj132tNNjV05ENTpuN3JpLoMd3+obDUWzeQUs9TetK4RBRN3ewM7sIMEI4oBpgmg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "7.0.18",
+        "@storybook/global": "^5.0.0",
+        "@storybook/preview-api": "7.0.18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/channel-postmessage": {
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-7.0.18.tgz",
+      "integrity": "sha512-rpwBH5ANdPnugS6+7xG9qHSoS+aPSEnBxDKsONWFubfMTTXQuFkf/793rBbxGkoINdqh8kSdKOM2rIty6e9cmQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.0.18",
+        "@storybook/client-logger": "7.0.18",
+        "@storybook/core-events": "7.0.18",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.0.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/channels": {
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.0.18.tgz",
+      "integrity": "sha512-rkA7ea0M3+dWS+71iHJdiZ5R2QuIdiVg0CgyLJHDagc1qej7pEVNhMWtppeq+X5Pwp9nkz8ZTQ7aCjTf6th0/A==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/client-logger": {
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.0.18.tgz",
+      "integrity": "sha512-uKgFdVedYoRDZBVrE1IBdWNHDFln1IxWEeI+7ZiNSQwREG9swHpU5Fa8DceclM/oLjJRuzG1jFzv+XZY8894+Q==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/components": {
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-7.0.18.tgz",
+      "integrity": "sha512-Jn1CbF9UAKt8BVaZtuhmthpcZ02VMaCFXR0ISfDXCpiMKnylmpP0+WfXcoKLzz6yS+EW8EW5S9+Qq8xgQY8H7A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.0.18",
+        "@storybook/csf": "^0.1.0",
+        "@storybook/global": "^5.0.0",
+        "@storybook/theming": "7.0.18",
+        "@storybook/types": "7.0.18",
+        "memoizerific": "^1.11.3",
+        "use-resize-observer": "^9.1.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/core-events": {
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.0.18.tgz",
+      "integrity": "sha512-7gxHBQDezdKOeq/u1LL80Bwjfcwsv7XOS3yWQElcgqp+gLaYB6OwwgtkCB2yV6a6l4nep9IdPWE8G3TxIzn9xw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/manager-api": {
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-7.0.18.tgz",
+      "integrity": "sha512-anQkm09twL96YkKGXHa+LI0+yMaY6Jxs1lRaetHdMlIqN4VHBHhizHaMgtGfH6xCTuO3WdrKTN7cZii5RH7PBQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.0.18",
+        "@storybook/client-logger": "7.0.18",
+        "@storybook/core-events": "7.0.18",
+        "@storybook/csf": "^0.1.0",
+        "@storybook/global": "^5.0.0",
+        "@storybook/router": "7.0.18",
+        "@storybook/theming": "7.0.18",
+        "@storybook/types": "7.0.18",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "semver": "^7.3.7",
+        "store2": "^2.14.2",
+        "telejson": "^7.0.3",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/preview-api": {
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.0.18.tgz",
+      "integrity": "sha512-xxtC0gPGMn/DbwvS4ZuJaBwfFNsjUCf0yLYHFrNe6fxncbvcLZ550RuyUwYuIRfsiKrlgfa3QmmCa4JM/JesHQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channel-postmessage": "7.0.18",
+        "@storybook/channels": "7.0.18",
+        "@storybook/client-logger": "7.0.18",
+        "@storybook/core-events": "7.0.18",
+        "@storybook/csf": "^0.1.0",
+        "@storybook/global": "^5.0.0",
+        "@storybook/types": "7.0.18",
+        "@types/qs": "^6.9.5",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "synchronous-promise": "^2.0.15",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/router": {
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-7.0.18.tgz",
+      "integrity": "sha512-Mue4s/BnKgdYcsiW9yuvW3qL9k3AgYn5HIhnkBExAteyiUGdAca4IJFhArmGgFktgeLc4ecBQ7sgaCljApnbgg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.0.18",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/theming": {
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-7.0.18.tgz",
+      "integrity": "sha512-P1gMKa/mKQHIMq0sxBIwTzAcF6v/6hrc62YmkuV62vXu+8zNV2YWbRwywqm3Q6faZEadmb/bL9+z8whaKhCL/g==",
+      "dev": true,
+      "dependencies": {
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@storybook/client-logger": "7.0.18",
+        "@storybook/global": "^5.0.0",
+        "memoizerific": "^1.11.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/types": {
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.0.18.tgz",
+      "integrity": "sha512-qPop2CbvmX42/BX29YT9jIzW2TlMcMjAE+KCpcKLBiD1oT5DJ1fhMzpe6RW9HkMegkBxjWx54iamN4oHM/pwcQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.0.18",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/semver": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/@storybook/addon-actions": {
       "version": "7.0.17",
       "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-7.0.17.tgz",
@@ -24529,6 +24802,19 @@
         }
       }
     },
+    "node_modules/react-resize-detector": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.1.2.tgz",
+      "integrity": "sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-router": {
       "version": "6.11.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.2.tgz",
@@ -29370,6 +29656,7 @@
         "wonka": "^6.3.2"
       },
       "devDependencies": {
+        "@storybook/addon-a11y": "^7.0.18",
         "storybook": "^7.0.6"
       }
     },
@@ -34990,6 +35277,196 @@
         "lodash.transform": "^4.6.0",
         "lodash.union": "^4.6.0",
         "lodash.values": "^4.3.0"
+      }
+    },
+    "@storybook/addon-a11y": {
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-7.0.18.tgz",
+      "integrity": "sha512-kftOzFBpg3goWbLBXDLLsJslfrKYbHs1xtFEH5/4J9NFNE8vZKbIBDQa/R3ezWheL+l2y+5qOlWoLl5z96zlWA==",
+      "dev": true,
+      "requires": {
+        "@storybook/addon-highlight": "7.0.18",
+        "@storybook/channels": "7.0.18",
+        "@storybook/client-logger": "7.0.18",
+        "@storybook/components": "7.0.18",
+        "@storybook/core-events": "7.0.18",
+        "@storybook/global": "^5.0.0",
+        "@storybook/manager-api": "7.0.18",
+        "@storybook/preview-api": "7.0.18",
+        "@storybook/theming": "7.0.18",
+        "@storybook/types": "7.0.18",
+        "axe-core": "^4.2.0",
+        "lodash": "^4.17.21",
+        "react-resize-detector": "^7.1.2"
+      },
+      "dependencies": {
+        "@storybook/addon-highlight": {
+          "version": "7.0.18",
+          "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-7.0.18.tgz",
+          "integrity": "sha512-a3nfUhbu6whoDclIZSV/fzLj132tNNjV05ENTpuN3JpLoMd3+obDUWzeQUs9TetK4RBRN3ewM7sIMEI4oBpgmg==",
+          "dev": true,
+          "requires": {
+            "@storybook/core-events": "7.0.18",
+            "@storybook/global": "^5.0.0",
+            "@storybook/preview-api": "7.0.18"
+          }
+        },
+        "@storybook/channel-postmessage": {
+          "version": "7.0.18",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-7.0.18.tgz",
+          "integrity": "sha512-rpwBH5ANdPnugS6+7xG9qHSoS+aPSEnBxDKsONWFubfMTTXQuFkf/793rBbxGkoINdqh8kSdKOM2rIty6e9cmQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "7.0.18",
+            "@storybook/client-logger": "7.0.18",
+            "@storybook/core-events": "7.0.18",
+            "@storybook/global": "^5.0.0",
+            "qs": "^6.10.0",
+            "telejson": "^7.0.3"
+          }
+        },
+        "@storybook/channels": {
+          "version": "7.0.18",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.0.18.tgz",
+          "integrity": "sha512-rkA7ea0M3+dWS+71iHJdiZ5R2QuIdiVg0CgyLJHDagc1qej7pEVNhMWtppeq+X5Pwp9nkz8ZTQ7aCjTf6th0/A==",
+          "dev": true
+        },
+        "@storybook/client-logger": {
+          "version": "7.0.18",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.0.18.tgz",
+          "integrity": "sha512-uKgFdVedYoRDZBVrE1IBdWNHDFln1IxWEeI+7ZiNSQwREG9swHpU5Fa8DceclM/oLjJRuzG1jFzv+XZY8894+Q==",
+          "dev": true,
+          "requires": {
+            "@storybook/global": "^5.0.0"
+          }
+        },
+        "@storybook/components": {
+          "version": "7.0.18",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-7.0.18.tgz",
+          "integrity": "sha512-Jn1CbF9UAKt8BVaZtuhmthpcZ02VMaCFXR0ISfDXCpiMKnylmpP0+WfXcoKLzz6yS+EW8EW5S9+Qq8xgQY8H7A==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "7.0.18",
+            "@storybook/csf": "^0.1.0",
+            "@storybook/global": "^5.0.0",
+            "@storybook/theming": "7.0.18",
+            "@storybook/types": "7.0.18",
+            "memoizerific": "^1.11.3",
+            "use-resize-observer": "^9.1.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "7.0.18",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.0.18.tgz",
+          "integrity": "sha512-7gxHBQDezdKOeq/u1LL80Bwjfcwsv7XOS3yWQElcgqp+gLaYB6OwwgtkCB2yV6a6l4nep9IdPWE8G3TxIzn9xw==",
+          "dev": true
+        },
+        "@storybook/manager-api": {
+          "version": "7.0.18",
+          "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-7.0.18.tgz",
+          "integrity": "sha512-anQkm09twL96YkKGXHa+LI0+yMaY6Jxs1lRaetHdMlIqN4VHBHhizHaMgtGfH6xCTuO3WdrKTN7cZii5RH7PBQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "7.0.18",
+            "@storybook/client-logger": "7.0.18",
+            "@storybook/core-events": "7.0.18",
+            "@storybook/csf": "^0.1.0",
+            "@storybook/global": "^5.0.0",
+            "@storybook/router": "7.0.18",
+            "@storybook/theming": "7.0.18",
+            "@storybook/types": "7.0.18",
+            "dequal": "^2.0.2",
+            "lodash": "^4.17.21",
+            "memoizerific": "^1.11.3",
+            "semver": "^7.3.7",
+            "store2": "^2.14.2",
+            "telejson": "^7.0.3",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/preview-api": {
+          "version": "7.0.18",
+          "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.0.18.tgz",
+          "integrity": "sha512-xxtC0gPGMn/DbwvS4ZuJaBwfFNsjUCf0yLYHFrNe6fxncbvcLZ550RuyUwYuIRfsiKrlgfa3QmmCa4JM/JesHQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/channel-postmessage": "7.0.18",
+            "@storybook/channels": "7.0.18",
+            "@storybook/client-logger": "7.0.18",
+            "@storybook/core-events": "7.0.18",
+            "@storybook/csf": "^0.1.0",
+            "@storybook/global": "^5.0.0",
+            "@storybook/types": "7.0.18",
+            "@types/qs": "^6.9.5",
+            "dequal": "^2.0.2",
+            "lodash": "^4.17.21",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "synchronous-promise": "^2.0.15",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/router": {
+          "version": "7.0.18",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-7.0.18.tgz",
+          "integrity": "sha512-Mue4s/BnKgdYcsiW9yuvW3qL9k3AgYn5HIhnkBExAteyiUGdAca4IJFhArmGgFktgeLc4ecBQ7sgaCljApnbgg==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "7.0.18",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "7.0.18",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-7.0.18.tgz",
+          "integrity": "sha512-P1gMKa/mKQHIMq0sxBIwTzAcF6v/6hrc62YmkuV62vXu+8zNV2YWbRwywqm3Q6faZEadmb/bL9+z8whaKhCL/g==",
+          "dev": true,
+          "requires": {
+            "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+            "@storybook/client-logger": "7.0.18",
+            "@storybook/global": "^5.0.0",
+            "memoizerific": "^1.11.3"
+          }
+        },
+        "@storybook/types": {
+          "version": "7.0.18",
+          "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.0.18.tgz",
+          "integrity": "sha512-qPop2CbvmX42/BX29YT9jIzW2TlMcMjAE+KCpcKLBiD1oT5DJ1fhMzpe6RW9HkMegkBxjWx54iamN4oHM/pwcQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "7.0.18",
+            "@types/babel__core": "^7.0.0",
+            "@types/express": "^4.7.0",
+            "file-system-cache": "^2.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "@storybook/addon-actions": {
@@ -48151,6 +48628,15 @@
         "tslib": "^2.0.0"
       }
     },
+    "react-resize-detector": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.1.2.tgz",
+      "integrity": "sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21"
+      }
+    },
     "react-router": {
       "version": "6.11.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.2.tgz",
@@ -49259,6 +49745,7 @@
       "version": "file:packages/storybook-helpers",
       "requires": {
         "@gc-digital-talent/theme": "*",
+        "@storybook/addon-a11y": "^7.0.18",
         "@storybook/addon-actions": "^7.0.6",
         "@storybook/addon-essentials": "^7.0.6",
         "@storybook/addon-links": "^7.0.6",

--- a/packages/storybook-helpers/main.ts
+++ b/packages/storybook-helpers/main.ts
@@ -36,8 +36,9 @@ const config: StorybookConfig = {
     "../../../packages/**/src/**/*.stories.@(js|jsx|ts|tsx|mdx)",
   ],
   addons: [
-    "@storybook/addon-links",
+    "@storybook/addon-a11y",
     "@storybook/addon-essentials",
+    "@storybook/addon-links",
     "@storybook/addon-viewport",
     "storybook-addon-intl",
   ],

--- a/packages/storybook-helpers/package.json
+++ b/packages/storybook-helpers/package.json
@@ -27,6 +27,7 @@
     "wonka": "^6.3.2"
   },
   "devDependencies": {
+    "@storybook/addon-a11y": "^7.0.18",
     "storybook": "^7.0.6"
   }
 }

--- a/packages/ui/src/components/Switch/Switch.stories.tsx
+++ b/packages/ui/src/components/Switch/Switch.stories.tsx
@@ -36,7 +36,7 @@ const Template: ComponentStory<typeof Switch.Root> = () => (
       data-h2-display="base(flex)"
       data-h2-gap="base(0, x.25)"
     >
-      <label htmlFor="checked">Default Not Checked</label>
+      <label htmlFor="unchecked">Default Not Checked</label>
       <Switch.Root id="unchecked">
         <Switch.Thumb />
       </Switch.Root>


### PR DESCRIPTION
🤖 Resolves #6280 

## 👋 Introduction

This adds the `@storybook/addon-a11y` to storybook to help surface accessibility issues earlier in development.

## 🕵️ Details

> **Note**
> Something that is a little annoying is that it scans `#storybook-root` which itself has a violation that sometimes shows up 🤦‍♀️ 

This surfaced some issues with not-so-common components and new tickets were created for each one:

- https://github.com/GCTC-NTGC/gc-digital-talent/issues/6766
- https://github.com/GCTC-NTGC/gc-digital-talent/issues/6765
- https://github.com/GCTC-NTGC/gc-digital-talent/issues/6764
- https://github.com/GCTC-NTGC/gc-digital-talent/issues/6763
- https://github.com/GCTC-NTGC/gc-digital-talent/issues/6762
- https://github.com/GCTC-NTGC/gc-digital-talent/issues/6761
- https://github.com/GCTC-NTGC/gc-digital-talent/issues/6760
- https://github.com/GCTC-NTGC/gc-digital-talent/issues/6759

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Install new deps `npm i`
2. Run storybook `npm run storybook`
3. Confirm the addon is in the panel and functioning

## 📸 Screenshot

![Screenshot 2023-05-31 095926](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/84c2c636-af17-45e0-b6d3-e6c82506a779)
