### PR TITLE
[Bug] Fix `<TreeView />` story faker seed

### DIFF
--- a/packages/ui/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/ui/src/components/TreeView/TreeView.stories.tsx
@@ -8,6 +8,8 @@ import Card from "../Card";
 import Alert from "../Alert";
 import { StandardHeader } from "../Accordion/StandardHeader";
 
+faker.seed(0);
+
 export default {
   component: TreeView.Root,
   title: "Components/TreeView",


### PR DESCRIPTION
🤖 Resolves #6768 
## 👋 Introduction

Adds `faker.seed(0)` to the `<TreeView />` story to stabilize the copy during chromatic snapshots.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> **Note**
> Actually not certain how to test this 🤔 Maybe restart storybook a few times and confirm the copy does not change with each run? 🤷‍♀️ 
