### PR TITLE
[Copy] Change "Duplicate this pool" to "Duplicate job poster"

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8227,9 +8227,9 @@
     "defaultMessage": "Erreur : Une erreur s’est produite. Veuillez essayer de nouveau dans une minute ou communiquez avec votre administrateur.",
     "description": "Message displayed to user after pool fails to get duplicated."
   },
-  "jCS7J4": {
-    "defaultMessage": "Dupliquer ce bassin",
-    "description": "Title to duplicate a pool"
+  "DxvIPq": {
+    "defaultMessage": "Dupliquer l’affiche d’emploi",
+    "description": "Title to duplicate a job poster"
   },
   "oJri9k": {
     "defaultMessage": "Vous êtes sur le point de dupliquer le bassin suivant : {poolName}",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8220,7 +8220,7 @@
     "description": "Text explaining what will happen when duplicating a pool"
   },
   "QmMm7V": {
-    "defaultMessage": "Dupliquer et consulter le nouveau l’affiche d’emploi",
+    "defaultMessage": "Dupliquer et consulter la nouvelle affiche d’emploi",
     "description": "Button text to duplicate a job poster"
   },
   "hHYn/8": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8219,9 +8219,9 @@
     "defaultMessage": "Ceci créera un nouveau basin et copiera toute information qui existe déjà.",
     "description": "Text explaining what will happen when duplicating a pool"
   },
-  "b71NDl": {
-    "defaultMessage": "Dupliquer et consulter le nouveau bassin",
-    "description": "Button text to duplicate a pool"
+  "QmMm7V": {
+    "defaultMessage": "Dupliquer et consulter le nouveau l’affiche d’emploi",
+    "description": "Button text to duplicate a job poster"
   },
   "hHYn/8": {
     "defaultMessage": "Erreur : Une erreur s’est produite. Veuillez essayer de nouveau dans une minute ou communiquez avec votre administrateur.",

--- a/apps/web/src/pages/Pools/EditPoolPage/components/DuplicateDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/DuplicateDialog.tsx
@@ -100,9 +100,9 @@ const DuplicateDialog = ({
                 onClick={onDuplicate}
               >
                 {intl.formatMessage({
-                  defaultMessage: "Duplicate and view new pool",
-                  id: "b71NDl",
-                  description: "Button text to duplicate a pool",
+                  defaultMessage: "Duplicate and view new job poster",
+                  id: "QmMm7V",
+                  description: "Button text to duplicate a job poster",
                 })}
               </Button>
             </Dialog.Footer>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/DuplicateDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/DuplicateDialog.tsx
@@ -30,9 +30,9 @@ const DuplicateDialog = ({
   }
 
   const title = intl.formatMessage({
-    defaultMessage: "Duplicate this pool",
-    id: "jCS7J4",
-    description: "Title to duplicate a pool",
+    defaultMessage: "Duplicate job poster",
+    id: "DxvIPq",
+    description: "Title to duplicate a job poster",
   });
   const poolName = getFullPoolAdvertisementTitleHtml(intl, poolAdvertisement);
 


### PR DESCRIPTION
🤖 Resolves #6794

## 👋 Introduction

- Updates duplicate dialog title to "Duplicate job poster", and action button in dialog.

## 🧪 Testing

1. Go to Pools table and select "Edit" on any pool.
2. Scroll to bottom and ensure copy change is correct.
3. Open dialog by selecting "Duplicate job poster" and view the title and button copy is correct.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/26659f86-e7e0-4410-9599-258741e901be)
![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/dfb13d69-5262-4974-a72f-82fcdf1da862)


