### PR TITLE
[Accessibility] External link color contrast

### DIFF
--- a/apps/web/src/pages/Auth/RegisterPage/RegisterPage.tsx
+++ b/apps/web/src/pages/Auth/RegisterPage/RegisterPage.tsx
@@ -98,7 +98,7 @@ const RegisterPage = () => {
               <ExternalLink
                 href={loginPath}
                 mode="inline"
-                type="link"
+                type="button"
                 color="secondary"
               >
                 {intl.formatMessage({

--- a/packages/ui/src/components/Link/ExternalLink.tsx
+++ b/packages/ui/src/components/Link/ExternalLink.tsx
@@ -20,10 +20,10 @@ const ExternalLink = ({
   newTab,
   children,
   color,
-  mode,
-  block,
+  mode = "solid",
+  block = false,
   disabled,
-  type,
+  type = "link",
   weight,
   ...rest
 }: ExternalLinkProps) => {

--- a/packages/ui/src/components/Link/useCommonLinkStyles.ts
+++ b/packages/ui/src/components/Link/useCommonLinkStyles.ts
@@ -11,7 +11,7 @@ const linkColorMap: Record<Color, Record<string, string>> = {
     "data-h2-color": "base(primary) base:hover(primary.darker)",
   },
   secondary: {
-    "data-h2-color": "base(secondary) base:hover(secondary.darker)",
+    "data-h2-color": "base(secondary.darker) base:hover(secondary.darkest)",
   },
   tertiary: {
     "data-h2-color": "base(tertiary) base:hover(tertiary.darker)",


### PR DESCRIPTION
🤖 Resolves #6766 

## 👋 Introduction

- Updates the `linkColorMap.secondary` colour and hover colour to fix colour contrast issues on white backgrounds.
- Changes the "Login in instead" link on the Register page to `type=button` to match Login page styling.

## 🧪 Testing

1. Go to Register page and ensure the link has sufficient colour contrast. Simple way is to running the axe DevTools extension. 

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/a06290fb-d02c-4250-a57b-dff35d566ffb)
