### PR TITLE
[Accessibility] Fix color contrast on pool candidate table status column

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -136,7 +136,10 @@ const statusAccessor = (
 ) => {
   if (status === PoolCandidateStatus.NewApplication) {
     return (
-      <span data-h2-color="base(tertiary)" data-h2-font-weight="base(700)">
+      <span
+        data-h2-color="base(tertiary.darker)"
+        data-h2-font-weight="base(700)"
+      >
         {status
           ? intl.formatMessage(getPoolCandidateStatus(status as string))
           : ""}


### PR DESCRIPTION
🤖 Resolves #6765 

## 👋 Introduction

- Uses `tertiary.darker` shade color for new application status on Pool Candidate table.

## 🧪 Testing

1. Go to Pool Candidate table and view candidates of a pool (you might need to create a new/ update an application if the table doesn't have any candidates with a new application status).
2. Ensure "New Application" status colour contrast is sufficient.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/04507d57-f5e3-4f2e-8f08-d3f5d69a7c4d)
