### PR TITLE
[Accessibility] Remove aria-selected attribute from ToggleSelection

### DIFF
--- a/packages/ui/src/components/ToggleSection/ToggleSection.tsx
+++ b/packages/ui/src/components/ToggleSection/ToggleSection.tsx
@@ -140,12 +140,7 @@ const InitialContent = React.forwardRef<
   const id = composeId(NAME.INITIAL_CONTENT, context?.contentId);
 
   return (
-    <div
-      id={id}
-      ref={forwardedRef}
-      aria-selected={!!context?.open || false}
-      {...props}
-    >
+    <div id={id} ref={forwardedRef} {...props}>
       {context?.open ? null : children}
     </div>
   );
@@ -163,12 +158,7 @@ const OpenContent = React.forwardRef<
   const id = composeId(NAME.OPEN_CONTENT, context?.contentId);
 
   return (
-    <div
-      id={id}
-      ref={forwardedRef}
-      aria-selected={context?.open || false}
-      {...props}
-    >
+    <div id={id} ref={forwardedRef} {...props}>
       {context?.open ? children : null}
     </div>
   );


### PR DESCRIPTION
🤖 Resolves #6764 

## 👋 Introduction

- Removes `aria-selected` attribute from div elements in `<ToggleSelection />, which is only allowed on elements with specific roles (eg. tab, row, etc.)

## 🧪 Testing

1. Use Storybook or go to `http://localhost:8000/en/applications/{applicationId}/profile` (You will need to turn on APPLICATION_REVAMP feature flag)
2. Ensure aria errors do not appear.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/87bf5ffb-cce5-4deb-b797-a01a26863835)
