### PR TITLE
[Accessibility] Fix color contrast errors on all toggle group buttons

### DIFF
--- a/packages/ui/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/packages/ui/src/components/ToggleGroup/ToggleGroup.tsx
@@ -31,7 +31,7 @@ const colorMap: Record<Color, Record<string, string>> = {
   secondary: {
     "data-h2-background-color": "base(secondary) base:dark(secondary.lighter)",
     "data-h2-color":
-      "base:children[>*](white) base:dark:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
+      "base:children[>*](black) base:dark:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](black)",
   },
   cta: {
     "data-h2-background-color": "base(tertiary)",
@@ -56,7 +56,7 @@ const colorMap: Record<Color, Record<string, string>> = {
   "ia-secondary": {
     "data-h2-background-color": "base(secondary)",
     "data-h2-color":
-      "base:children[>*](white) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
+      "base:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](black)",
   },
   yellow: {
     "data-h2-background-color": "base(quaternary)",


### PR DESCRIPTION
🤖 Resolves 6763

## 👋 Introduction

- Fixes all color contrast errors on ToggleGroup buttons.
- Note: The `primary` color needed black font to pass. Otherwise, all saturated colors have black font.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Go to storybook and view ToggleGroup story and ensure there are no violations.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/74a341c0-adaf-48f9-ba46-dbaef7acfb5b)
