### PR TITLE
[a11y] Changes primary to primary.dark

### DIFF
--- a/apps/web/src/components/UserProfile/ProfileSections/DiversityEquityInclusionSection.tsx
+++ b/apps/web/src/components/UserProfile/ProfileSections/DiversityEquityInclusionSection.tsx
@@ -119,7 +119,7 @@ const DiversityEquityInclusionSection = ({
                         <li>
                           <span
                             data-h2-font-weight="base(700)"
-                            data-h2-color="base(primary)"
+                            data-h2-color="base(primary.dark)"
                           >
                             {intl.formatMessage(
                               {


### PR DESCRIPTION
🤖 Resolves #6760.

## 👋 Introduction

This PR changes text colour from `primary` to `primary.dark` on an element that had insufficient contrast.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run storybook
2. Open the "User profile story 5" story
3. Confirm the text in DEI is not at the minimum contrast requirement (4.5:1)

## 📸 Screenshot

![Screen Shot 2023-06-06 at 11 04 09](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/37e7abc4-1f75-48aa-8d22-2d4a1c5df546)

