### PR TITLE
[Spike] Laravel notifications

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -834,4 +834,6 @@ RAWSQL2;
             $this->callRolesFunction($roleAssignmentHasMany['sync'], 'syncRoles');
         }
     }
+
+    // TODO: https://laravel.com/docs/10.x/notifications#marking-notifications-as-read
 }

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Facades\DB;
 use Laratrust\Contracts\LaratrustUser;
 use Laratrust\Traits\HasRolesAndPermissions;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Log;
+use Illuminate\Notifications\Notifiable;
 
 /**
  * Class User
@@ -75,6 +75,7 @@ class User extends Model implements Authenticatable, LaratrustUser
     use HasFactory;
     use SoftDeletes;
     use AuthenticatableTrait;
+    use Notifiable;
 
     protected $keyType = 'string';
 

--- a/api/app/Notifications/GcNotifyEmailChannel.php
+++ b/api/app/Notifications/GcNotifyEmailChannel.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Notifications\Notification;
+use App\Facades\Notify;
+
+class GcNotifyEmailChannel
+{
+    /**
+     * Send the given notification.
+     */
+    public function send(object $notifiable, Notification $notification): void
+    {
+        $emailDefinition = $notification->toGcNotifyEmail($notifiable);
+
+        $response = Notify::sendEmail(
+            $emailDefinition["email_address"],
+            $emailDefinition["template_id"],
+            $emailDefinition["message_variables"],
+        );
+
+        throw_if(!$response->successful(), 'Notification failed to send');
+    }
+}

--- a/api/app/Notifications/PoolStatusChanged.php
+++ b/api/app/Notifications/PoolStatusChanged.php
@@ -32,6 +32,7 @@ class PoolStatusChanged extends Notification
 
     /**
      * Get the array representation of the notification.
+     * https://laravel.com/docs/10.x/notifications#formatting-database-notifications
      *
      * @return array<string, mixed>
      */

--- a/api/app/Notifications/PoolStatusChanged.php
+++ b/api/app/Notifications/PoolStatusChanged.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -15,8 +16,9 @@ class PoolStatusChanged extends Notification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $pool_id,
-        public string $new_status
+        public string $new_status,
+        public string $pool_name,
+
     ) {
     }
 
@@ -27,7 +29,7 @@ class PoolStatusChanged extends Notification
      */
     public function via(object $notifiable): array
     {
-        return ['database'];
+        return ['database', GcNotifyEmailChannel::class];
     }
 
     /**
@@ -39,8 +41,28 @@ class PoolStatusChanged extends Notification
     public function toArray(object $notifiable): array
     {
         return [
-            'pool_id' => $this->pool_id,
-            'new_status' => $this->new_status
+            'user_name' => trim($notifiable->first_name . " " . $notifiable->last_name),
+            'new_status' => $this->new_status,
+            'pool_name' => $this->pool_name,
+        ];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     * https://laravel.com/docs/10.x/notifications#formatting-database-notifications
+     *
+     * @return array<string, mixed>
+     */
+    public function toGcNotifyEmail(object $notifiable): array
+    {
+        return [
+            'template_id' => '959f6a2a-1e02-47c9-b4c9-9680b49accf7',
+            'email_address' => $notifiable->email,
+            'message_variables' => [
+                'user_name' => trim($notifiable->first_name . " " . $notifiable->last_name),
+                'new_status' => $this->new_status,
+                'pool_name' => $this->pool_name,
+            ]
         ];
     }
 }

--- a/api/app/Notifications/PoolStatusChanged.php
+++ b/api/app/Notifications/PoolStatusChanged.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class PoolStatusChanged extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public string $pool_id,
+        public string $new_status
+    ) {
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'pool_id' => $this->pool_id,
+            'new_status' => $this->new_status
+        ];
+    }
+}

--- a/api/database/migrations/2023_06_07_143802_create_notifications_table.php
+++ b/api/database/migrations/2023_06_07_143802_create_notifications_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->uuidMorphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -140,6 +140,9 @@ type User {
   priorityWeight: Int @rename(attribute: "priority_weight")
   # teams and roles
   roleAssignments: [RoleAssignment!] @hasMany
+
+  unreadNotifications: [String!]
+  notifications: [String!]
 }
 
 enum ProvinceOrTerritory {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1543,6 +1543,8 @@ type User {
   expectedGenericJobTitles: [GenericJobTitle]
   priorityWeight: Int
   roleAssignments: [RoleAssignment!]
+  unreadNotifications: [String!]
+  notifications: [String!]
 }
 
 input UserBelongsTo {


### PR DESCRIPTION
> __Note__
This branch probably won't be merged but it could be useful as a reference for production code in a future branch.

🤖 Resolves #6795 

## 👋 Introduction

The branch explores how the Laravel notification system can be used to send notifications through the GraphQL API and the GC Notify email system.

## 🕵️ Details

### GraphQL API

Laravel recommends using the _database_ channel for displaying notifications in the user interface.  I added the fields to the GraphQL schema to make those notifications visible as well.  We would also need to decide on a method for marking the notifications as read - probably on query or on dismiss.

Ref: https://laravel.com/docs/10.x/notifications#database-notifications

### GC Notify

Eric already did the heavy lifting on this integration.  I just added a notification channel to send the notifications through.

Ref: https://laravel.com/docs/10.x/notifications#custom-channels

### Further research

I didn't look into queuing notifications although it does seem possible.  This would probably be more important with external tools like FreshDesk or GC Notify to avoid tying up API connections.  It could be considered an optimization for down the road, though.

Ref: https://laravel.com/docs/10.x/notifications#queueing-notifications

I didn't demo triggering these notifications on events.  I think the `ApplicationSubmitted` event and the `StoreApplicationSnapshot` listener are a pretty good model for this.

## 🧪 Testing

### Prep

Using GC Notify is a bit painful.  You can ask me for my test API key if you want.  I safe-listed the email address for devrobotfam so that you can see the results.  Or you can sign up and test it out yourself.

  - If you want to make your own account
    1. Navigate to notifications.canada.ca and sign up.
    2. Safe-list your preferred email address
    3. Add your email message template with the variables `((user_name))`, `((new_status))`, and `((pool_name))`.
    4. Update the message template ID at api/app/Notifications/PoolStatusChanged.phpL59

Here's the email template I'm using:
  > Hello ((user_name)),
Your status has changed to ((new_status)) in the pool ((pool_name)).

### Try it out

1. Add your value for GCNOTIFY_API_KEY to the API .env file.
2. Run the database migrations.
3. Refresh the GraphQL schema
4. Start up Tinker with `php artisan tinker`
5. Create your user with ` $user = User::factory()->create(['first_name'=>'first', 'last_name'=>'last', 'email'=>'ADD YOUR EMAIL ADDRESS HERE'])`
  - Or `$user = User::where('email', 'ADD YOUR EMAIL ADDRESS HERE')->get()->sole()`  for an existing user
6. Send your notifications with `Notification::send($user, new App\Notifications\PoolStatusChanged("test_status", "test_pool"));`
7. Check GraphiQL for the notifications (update AUTH_DEFAULT_USER as needed)
```graphql
query {
  me {
    firstName
    unreadNotifications
    notifications
  }
}
```
8. Check devrobotfam for the emails

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/74b09ac0-580b-4602-ab1f-59c587ea8cb8)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/3478b1ce-4d55-41c5-bb62-533722fcc8c2)

