### PR TITLE
[Fix] Don't apply more than once

### DIFF
--- a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
+++ b/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
@@ -45,14 +45,9 @@ const CreateApplication = () => {
     },
     executeMutation,
   ] = useCreateApplicationMutation();
-  const [
-    {
-      fetching: fetchingExistingApplications,
-      data: existingApplicationsData,
-      operation: existingApplicationsOperation,
-    },
-  ] = useMyApplicationsQuery();
+  const [{ data: existingApplicationsData }] = useMyApplicationsQuery();
 
+  // Path to display application (new or existing).
   const applicationPath = React.useCallback(
     (applicationId: string) =>
       applicationRevamp
@@ -95,8 +90,7 @@ const CreateApplication = () => {
 
   // If a "me" object came back then we've checked.
   const checkedForExistingApplications = notEmpty(existingApplicationsData?.me);
-
-  // Build a map of existing applications.
+  // Build an array of existing applications.
   const existingApplications =
     existingApplicationsData?.me?.poolCandidates?.map((application) => {
       return {
@@ -104,12 +98,11 @@ const CreateApplication = () => {
         poolId: application?.pool.id,
       };
     });
-
   // Find the pool candidate ID if we've already applied to this pool.
   const existingApplicationIdToThisPool = existingApplications?.find(
     (a) => a.poolId === poolId,
   )?.applicationId;
-
+  // An existing application was found for this pool.  No need to create a new one - let's go.
   if (existingApplicationIdToThisPool) {
     navigate(applicationPath(existingApplicationIdToThisPool), {
       replace: true,

--- a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
+++ b/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useNavigate, useParams } from "react-router-dom";
-import { Id, toast as toastify } from "react-toastify";
 
 import { Loading } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
@@ -32,7 +31,6 @@ type RouteParams = {
 const CreateApplication = () => {
   const { poolId } = useParams<RouteParams>();
   const intl = useIntl();
-  const errorToastId = React.useRef<Id>("");
   const paths = useRoutes();
   const navigate = useNavigate();
   const { applicationRevamp } = useFeatureFlags();
@@ -64,22 +62,14 @@ const CreateApplication = () => {
   const handleError = React.useCallback(
     (msg?: React.ReactNode, path?: string) => {
       navigate(path || redirectPath, { replace: true });
-      /**
-       * This is supposed to prevent the toast
-       * from firing twice, but it does not appear to
-       * work. Leaving it in, in the hopes
-       * it finally does 🤷‍♀️
-       */
-      if (!toastify.isActive(errorToastId.current)) {
-        errorToastId.current = toast.error(
-          msg ||
-            intl.formatMessage({
-              defaultMessage: "Error application creation failed",
-              id: "tlAiJm",
-              description: "Application creation failed",
-            }),
-        );
-      }
+      toast.error(
+        msg ||
+          intl.formatMessage({
+            defaultMessage: "Error application creation failed",
+            id: "tlAiJm",
+            description: "Application creation failed",
+          }),
+      );
       return null;
     },
     [intl, redirectPath, navigate],


### PR DESCRIPTION
🤖 Resolves #6751 

## 👋 Introduction

This branch fixes the issues of the user accidentally applying more than once because of:
- Being logged out while already having an application
- useEffect running more than once on the page

## 🕵️ Details

For the first issue, I just added a query for existing applications and didn't try applying until we have confirmed that an application doesn't already exist.

For the second issue, I added a ref to count how many times we had applied and just didn't fire the mutation if it was greater than zero.  This worked well and it occurred to me we didn't need the useEffect and useCallback functions at all if we relied on that.

## 🧪 Testing

1. Rebuild the app

- [ ] When logged out, try starting an application to a pool with an already existing application.  Confirm that you are sent to the existing application after log in.  Confirm no errors.
- [ ] When logged in, try starting a new application.  Confirm no errors.
- [ ] When logged in, try manually navigating to the `create-application` URL of a pool with an already existing application. Confirm that you are sent to the existing application.  Confirm no errors