### PR TITLE
[Bug] Fix chips padding

### DIFF
--- a/packages/ui/src/components/Chip/Chips.tsx
+++ b/packages/ui/src/components/Chip/Chips.tsx
@@ -12,6 +12,7 @@ const Chips = ({ children }: ChipsProps) => (
     data-h2-flex-wrap="base(wrap)"
     data-h2-gap="base(x.25, x.125)"
     data-h2-list-style="base(none)"
+    data-h2-padding="base(0)"
   >
     {isArray(children) ? (
       children.map((child) => <li key={child.key}>{child}</li>)


### PR DESCRIPTION
🤖 Resolves #6903 

## 👋 Introduction

Removes `ul` padding from the `Chips` component.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run storybook `npm run storybook`
2. Confirm chips are not indented

## 📸 Screenshot
![Screenshot 2023-06-09 120217](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/89fd5d6b-40cb-481a-962c-b659b040a1e1)


