### PR TITLE
[Fix] Fixes typo for button `font-size`

### DIFF
--- a/packages/ui/src/hooks/useCommonButtonLinkStyles.ts
+++ b/packages/ui/src/hooks/useCommonButtonLinkStyles.ts
@@ -787,7 +787,7 @@ const getDisplay = (block?: boolean): StyleRecord => {
 const getFontSize = (mode: ButtonLinkMode): StyleRecord => {
   return styleExclusions.fontSize.includes(mode)
     ? {}
-    : { "data-h2-font-font-ize": "base(copy)" };
+    : { "data-h2-font-size": "base(copy)" };
 };
 
 /**


### PR DESCRIPTION
🤖 Resolves #6943

## 👋 Introduction

Fixes a typo introduced by the button and link refactor.

## 🕵️ Details

I'm just bad at typing and never noticed hydrogen yelling at me in the console 🤦‍♀️ 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build the app `npm run dev`
2. Confirm no hydrogen errors
3. Confirm buttons have the `copy` font-size unless the mode is set to `text`