### PR TITLE
Dependabot re-add limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+    open-pull-requests-limit: 50
 
   # This ignores all updates to tc-report, since it's now served as a static website.
   #


### PR DESCRIPTION
Unlimited, not an option 🤷 
Surely 50 ought to suffice?

