### PR TITLE
[Bug] Fix loading alert interrupting toasts

### DIFF
--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -3,8 +3,8 @@
     "defaultMessage": "Oh non... ",
     "description": "Title displayed for a table error loading state."
   },
-  "B7fcr5": {
-    "defaultMessage": "Chargement...",
+  "o/6zAs": {
+    "defaultMessage": "Chargement",
     "description": "Title displayed for a table initial loading state."
   },
   "KC/sxi": {

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -2,8 +2,8 @@ import { defineMessages } from "react-intl";
 
 const commonMessages = defineMessages({
   loadingTitle: {
-    defaultMessage: "Loading...",
-    id: "B7fcr5",
+    defaultMessage: "Loading",
+    id: "o/6zAs",
     description: "Title displayed for a table initial loading state.",
   },
   saving: {

--- a/packages/ui/src/components/Loading/Loading.tsx
+++ b/packages/ui/src/components/Loading/Loading.tsx
@@ -47,7 +47,6 @@ const Loading = ({
 
   return (
     <div
-      role="alert"
       aria-busy="true"
       {...typeMap[inline ? "inline" : "full"]}
       {...(live && {

--- a/packages/ui/src/components/Pending/Pending.tsx
+++ b/packages/ui/src/components/Pending/Pending.tsx
@@ -20,7 +20,7 @@ export interface PendingProps extends LoadingProps {
 const Pending = ({
   fetching,
   error,
-  live = "assertive",
+  live = "polite",
   inline = false,
   children,
 }: PendingProps): JSX.Element => {


### PR DESCRIPTION
🤖 Resolves #6951 

## 👋 Introduction

This makes the loading indicator use `aria-live=polite` since the value of `assertive` was causing it to interrupt the toasts.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build the app `npm run build`
2. Turn on your choice of AT (preferably multiple)
3. Navigate to a form and save it
4. Confirm the toast is announced without being interrupted 
