### PR TITLE
[Fix] Remove stream and classification from IAP pool title

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationContext.tsx
+++ b/apps/web/src/pages/Applications/ApplicationContext.tsx
@@ -1,15 +1,9 @@
 import React from "react";
 import { useTheme } from "@gc-digital-talent/theme";
-import {
-  Maybe,
-  Pool,
-  PoolCandidate,
-  PublishingGroup,
-} from "../../api/generated";
 
-export function isIAPPool(pool: Maybe<Pool>): boolean {
-  return pool?.publishingGroup === PublishingGroup.Iap;
-}
+import { isIAPPool } from "~/utils/poolUtils";
+import { PoolCandidate } from "~/api/generated";
+
 interface ApplicationContextState {
   isIAP: boolean;
   followingPageUrl?: string;

--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -29,7 +29,7 @@ import {
 
 import { ApplicationPageProps } from "./ApplicationApi";
 import { StepDisabledPage } from "./StepDisabledPage/StepDisabledPage";
-import ApplicationContextProvider, { isIAPPool } from "./ApplicationContext";
+import ApplicationContextProvider from "./ApplicationContext";
 
 const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
   const intl = useIntl();
@@ -42,9 +42,7 @@ const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
     application,
     experienceId,
   });
-  const title = fullPoolTitle(intl, application.pool, {
-    isIap: isIAPPool(application.pool),
-  });
+  const title = fullPoolTitle(intl, application.pool);
 
   const pageTitle = defineMessage({
     defaultMessage: "Apply to {poolName}",

--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -18,7 +18,7 @@ import useRoutes from "~/hooks/useRoutes";
 import useCurrentPage from "~/hooks/useCurrentPage";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
-import { getFullPoolTitleHtml, getFullPoolTitleLabel } from "~/utils/poolUtils";
+import { fullPoolTitle } from "~/utils/poolUtils";
 import { useGetApplicationQuery } from "~/api/generated";
 import {
   applicationStepsToStepperArgs,
@@ -29,7 +29,7 @@ import {
 
 import { ApplicationPageProps } from "./ApplicationApi";
 import { StepDisabledPage } from "./StepDisabledPage/StepDisabledPage";
-import ApplicationContextProvider from "./ApplicationContext";
+import ApplicationContextProvider, { isIAPPool } from "./ApplicationContext";
 
 const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
   const intl = useIntl();
@@ -42,9 +42,10 @@ const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
     application,
     experienceId,
   });
+  const title = fullPoolTitle(intl, application.pool, {
+    isIap: isIAPPool(application.pool),
+  });
 
-  const poolNameHtml = getFullPoolTitleHtml(intl, application.pool);
-  const poolName = getFullPoolTitleLabel(intl, application.pool);
   const pageTitle = defineMessage({
     defaultMessage: "Apply to {poolName}",
     id: "K8CPir",
@@ -86,7 +87,7 @@ const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
     },
     {
       url: paths.pool(application.pool.id),
-      label: getFullPoolTitleHtml(intl, application.pool),
+      label: title.html,
     },
     ...currentCrumbs,
   ]);
@@ -116,9 +117,9 @@ const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
       }
       currentStepOrdinal={currentStepIndex + 1}
     >
-      <SEO title={intl.formatMessage(pageTitle, { poolName })} />
+      <SEO title={intl.formatMessage(pageTitle, { poolName: title.label })} />
       <Hero
-        title={intl.formatMessage(pageTitle, { poolName: poolNameHtml })}
+        title={intl.formatMessage(pageTitle, { poolName: title.html })}
         crumbs={crumbs}
         subtitle={currentPage?.subtitle}
       />

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -42,7 +42,7 @@ type PoolCell = Cell<Pool>;
 function poolCandidatesLinkAccessor(
   poolCandidatesTableUrl: string,
   intl: IntlShape,
-  pool: Maybe<Pick<Pool, "name" | "classifications" | "stream">>,
+  pool: Maybe<Pool>,
 ) {
   return (
     <Link href={poolCandidatesTableUrl} color="black" data-h2-padding="base(0)">

--- a/apps/web/src/utils/applicationUtils.ts
+++ b/apps/web/src/utils/applicationUtils.ts
@@ -14,7 +14,7 @@ import educationStepInfo from "~/pages/Applications/educationStep/educationStepI
 import profileStepInfo from "~/pages/Applications/profileStep/profileStepInfo";
 import successPageInfo from "~/pages/Applications/successStep/successStepInfo";
 import skillsStepInfo from "~/pages/Applications/skillsStep/skillsStepInfo";
-import { isIAPPool } from "~/pages/Applications/ApplicationContext";
+import { isIAPPool } from "~/utils/poolUtils";
 
 type GetApplicationPagesArgs = {
   paths: ReturnType<typeof useRoutes>;

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -5,12 +5,9 @@ import Cog8ToothIcon from "@heroicons/react/24/outline/Cog8ToothIcon";
 import UserGroupIcon from "@heroicons/react/24/outline/UserGroupIcon";
 
 import { getLocalizedName, getPoolStream } from "@gc-digital-talent/i18n";
-import { RoleAssignment } from "@gc-digital-talent/graphql";
-import { ROLE_NAME, RoleName } from "@gc-digital-talent/auth";
-import { notEmpty } from "@gc-digital-talent/helpers";
-
-import { PageNavKeys, SimpleClassification, SimplePool } from "~/types/pool";
 import {
+  PublishingGroup,
+  RoleAssignment,
   PoolStatus,
   Maybe,
   PoolCandidate,
@@ -18,7 +15,11 @@ import {
   PoolStream,
   Classification,
   Pool,
-} from "~/api/generated";
+} from "@gc-digital-talent/graphql";
+import { ROLE_NAME, RoleName } from "@gc-digital-talent/auth";
+import { notEmpty } from "@gc-digital-talent/helpers";
+
+import { PageNavKeys, SimpleClassification, SimplePool } from "~/types/pool";
 
 import { wrapAbbr } from "./nameUtils";
 import { PageNavInfo } from "../types/pages";
@@ -94,6 +95,10 @@ export const hasUserApplied = (
   return hasApplied;
 };
 
+export function isIAPPool(pool: Maybe<Pool>): boolean {
+  return pool?.publishingGroup === PublishingGroup.Iap;
+}
+
 export interface formatClassificationStringProps {
   group: string;
   level: number;
@@ -146,12 +151,11 @@ export const formattedPoolPosterTitle = ({
 
 interface FullPoolTitleOptions {
   defaultTitle?: React.ReactNode;
-  isIap?: boolean;
 }
 
 export const fullPoolTitle = (
   intl: IntlShape,
-  pool: Maybe<Pick<Pool, "name" | "classifications" | "stream">>,
+  pool: Maybe<Pool>,
   options?: FullPoolTitleOptions,
 ): { html: React.ReactNode; label: string } => {
   const fallbackTitle =
@@ -171,7 +175,7 @@ export const fullPoolTitle = (
 
   const specificTitle = getLocalizedName(pool.name, intl);
 
-  if (options?.isIap) {
+  if (isIAPPool(pool)) {
     return {
       html: specificTitle,
       label: specificTitle,
@@ -193,13 +197,13 @@ export const fullPoolTitle = (
 
 export const getFullPoolTitleHtml = (
   intl: IntlShape,
-  pool: Maybe<Pick<Pool, "name" | "classifications" | "stream">>,
+  pool: Maybe<Pool>,
   options?: { defaultTitle?: string },
 ): React.ReactNode => fullPoolTitle(intl, pool, options).html;
 
 export const getFullPoolTitleLabel = (
   intl: IntlShape,
-  pool: Maybe<Pick<Pool, "name" | "classifications" | "stream">>,
+  pool: Maybe<Pool>,
   options?: { defaultTitle?: string },
 ): string => fullPoolTitle(intl, pool, options).label;
 

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -144,10 +144,15 @@ export const formattedPoolPosterTitle = ({
   };
 };
 
+interface FullPoolTitleOptions {
+  defaultTitle?: React.ReactNode;
+  isIap?: boolean;
+}
+
 export const fullPoolTitle = (
   intl: IntlShape,
   pool: Maybe<Pick<Pool, "name" | "classifications" | "stream">>,
-  options?: { defaultTitle?: string },
+  options?: FullPoolTitleOptions,
 ): { html: React.ReactNode; label: string } => {
   const fallbackTitle =
     options?.defaultTitle ??
@@ -161,10 +166,17 @@ export const fullPoolTitle = (
   if (pool === null || pool === undefined)
     return {
       html: fallbackTitle,
-      label: fallbackTitle,
+      label: fallbackTitle.toString(),
     };
 
   const specificTitle = getLocalizedName(pool.name, intl);
+
+  if (options?.isIap) {
+    return {
+      html: specificTitle,
+      label: specificTitle,
+    };
+  }
 
   const formattedTitle = formattedPoolPosterTitle({
     title: specificTitle,


### PR DESCRIPTION
🤖 Resolves #6977 

## 👋 Introduction

Updates the formatted pool title to not longer include stream and classification when in an application and publishing group is set to IAP.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build app `npm run dev`
2. Navigate to an application for any pool that **_does not_** have IAP publishing group
3. Confirm title **_does_** include stream and classification
4. Navigate to a pool **_within_** the IAP publishing group
5. Confirm the title **_no longer_** contains stream and classification

## 📸 Screenshot

![Screenshot 2023-06-15 141655](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/7f59dd12-0916-4dcb-9870-953a7528702b)
![Screenshot 2023-06-15 141706](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/81afa831-15c8-447c-a45c-5073ec6c337d)

