### PR TITLE
[Feature] Update IAP navigation items

### DIFF
--- a/apps/web/src/components/Layout/IAPLayout.tsx
+++ b/apps/web/src/components/Layout/IAPLayout.tsx
@@ -4,41 +4,21 @@ import { useLocation, Outlet, ScrollRestoration } from "react-router-dom";
 import { ApplicationInsights } from "@microsoft/applicationinsights-web";
 import { AnimatePresence } from "framer-motion";
 
-import { MenuLink, SkipLink } from "@gc-digital-talent/ui";
+import { SkipLink } from "@gc-digital-talent/ui";
 import { NestedLanguageProvider, Messages } from "@gc-digital-talent/i18n";
 import { getRuntimeVariable } from "@gc-digital-talent/env";
+import { useAuthentication, useAuthorization } from "@gc-digital-talent/auth";
 
 import SEO, { Favicon } from "~/components/SEO/SEO";
-import NavMenu from "~/components/NavMenu";
 import Header from "~/components/Header";
 import Footer from "~/components/Footer";
+import IAPNavMenu from "~/components/NavMenu/IAPNavMenu";
 
-import useRoutes from "~/hooks/useRoutes";
 import useLayoutTheme from "~/hooks/useLayoutTheme";
 
 import * as micMessages from "~/lang/micCompiled.json";
 
 const messages: Map<string, Messages> = new Map([["mic", micMessages]]);
-
-const IAPNavMenu = () => {
-  const intl = useIntl();
-  const paths = useRoutes();
-
-  return (
-    <NavMenu
-      mainItems={[
-        <MenuLink key="home" to={paths.iap()}>
-          {intl.formatMessage({
-            defaultMessage: "Home",
-            id: "M1JKQs",
-            description:
-              "Link to the homepage for IT Apprenticeship Program for Indigenous Peoples.",
-          })}
-        </MenuLink>,
-      ]}
-    />
-  );
-};
 
 const IAPSeo = () => {
   const intl = useIntl();
@@ -63,6 +43,8 @@ const IAPSeo = () => {
 
 const Layout = () => {
   const location = useLocation();
+  const { user } = useAuthorization();
+  const { loggedIn } = useAuthentication();
   useLayoutTheme("iap");
 
   const aiConnectionString = getRuntimeVariable(
@@ -95,7 +77,7 @@ const Layout = () => {
           >
             <div>
               <Header />
-              <IAPNavMenu />
+              <IAPNavMenu {...{ loggedIn, user }} />
             </div>
             <main id="main">
               <Outlet />

--- a/apps/web/src/components/Layout/Layout.tsx
+++ b/apps/web/src/components/Layout/Layout.tsx
@@ -28,7 +28,7 @@ export const LogoutButton = React.forwardRef<
   LogoutButtonProps
 >(({ children, ...rest }, forwardedRef) => (
   <button
-    data-h2-color="base(black) base:hover(primary)"
+    data-h2-color="base(black) base:hover(primary) base:iap(primary) base:iap:hover(primary.darker)"
     data-h2-font-size="base(normal)"
     data-h2-text-decoration="base(underline)"
     style={{

--- a/apps/web/src/components/NavMenu/IAPNavMenu.tsx
+++ b/apps/web/src/components/NavMenu/IAPNavMenu.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { MenuLink } from "@gc-digital-talent/ui";
+import { Maybe, User } from "@gc-digital-talent/graphql";
+
+import useRoutes from "~/hooks/useRoutes";
+
+import NavMenu from "./NavMenu";
+import LogoutConfirmation from "../LogoutConfirmation";
+import { LogoutButton } from "../Layout/Layout";
+
+interface IAPNavMenuProps {
+  loggedIn?: boolean;
+  user?: Maybe<User>;
+}
+
+const IAPNavMenu = ({ loggedIn, user }: IAPNavMenuProps) => {
+  const intl = useIntl();
+  const paths = useRoutes();
+
+  let authLinks = [
+    <MenuLink key="login-info" to={`${paths.login()}?iap`}>
+      {intl.formatMessage({
+        defaultMessage: "Login",
+        id: "md7Klw",
+        description: "Label displayed on the login link menu item.",
+      })}
+    </MenuLink>,
+    <MenuLink key="register" to={`${paths.register()}?iap`}>
+      {intl.formatMessage({
+        defaultMessage: "Register",
+        id: "LMGaDQ",
+        description: "Label displayed on the register link menu item.",
+      })}
+    </MenuLink>,
+  ];
+
+  if (loggedIn && user) {
+    authLinks = [
+      <LogoutConfirmation key="logout">
+        <LogoutButton>
+          {intl.formatMessage({
+            defaultMessage: "Logout",
+            id: "3vDhoc",
+            description: "Label displayed on the logout link menu item.",
+          })}
+        </LogoutButton>
+      </LogoutConfirmation>,
+    ];
+  }
+
+  return (
+    <NavMenu
+      utilityItems={authLinks}
+      mainItems={[
+        <MenuLink key="home" to={paths.iap()}>
+          {intl.formatMessage({
+            defaultMessage: "IT Apprenticeship Program for Indigenous Peoples",
+            id: "k4Vsh0",
+            description:
+              "Link to the homepage for IT Apprenticeship Program for Indigenous Peoples.",
+          })}
+        </MenuLink>,
+        <MenuLink key="home" to={paths.home()} end>
+          {intl.formatMessage({
+            defaultMessage: "GC Digital Talent",
+            id: "e8a8MB",
+            description: "Link to the homepage for GC Digital Talent..",
+          })}
+        </MenuLink>,
+      ]}
+    />
+  );
+};
+
+export default IAPNavMenu;

--- a/apps/web/src/components/NavMenu/IAPNavMenu.tsx
+++ b/apps/web/src/components/NavMenu/IAPNavMenu.tsx
@@ -54,7 +54,7 @@ const IAPNavMenu = ({ loggedIn, user }: IAPNavMenuProps) => {
     <NavMenu
       utilityItems={authLinks}
       mainItems={[
-        <MenuLink key="home" to={paths.iap()}>
+        <MenuLink key="iap-home" to={paths.iap()}>
           {intl.formatMessage({
             defaultMessage: "IT Apprenticeship Program for Indigenous Peoples",
             id: "k4Vsh0",

--- a/apps/web/src/components/NavMenu/IAPNavMenu.tsx
+++ b/apps/web/src/components/NavMenu/IAPNavMenu.tsx
@@ -65,8 +65,8 @@ const IAPNavMenu = ({ loggedIn, user }: IAPNavMenuProps) => {
         <MenuLink key="home" to={paths.home()} end>
           {intl.formatMessage({
             defaultMessage: "GC Digital Talent",
-            id: "e8a8MB",
-            description: "Link to the homepage for GC Digital Talent..",
+            id: "hfI9v3",
+            description: "Link to the homepage for GC Digital Talent.",
           })}
         </MenuLink>,
       ]}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -131,10 +131,6 @@
     "defaultMessage": "Nous vous inviterons à créer un profil qui sera sauvegardé et présenté comme étant votre demande.",
     "description": "How it works, step 2 content sentence 2"
   },
-  "M1JKQs": {
-    "defaultMessage": "Accueil",
-    "description": "Link to the homepage for IT Apprenticeship Program for Indigenous Peoples."
-  },
   "U8bLT7": {
     "defaultMessage": "Comment cela fonctionnera-t-il?",
     "description": "heading for how the indigenous talent portal will work"
@@ -8310,5 +8306,13 @@
   "ccBhi2": {
     "defaultMessage": "Trouvez des talents",
     "description": "Page title for the search page"
+  },
+  "hfI9v3": {
+    "defaultMessage": "Talents numériques du GC",
+    "description": "Link to the homepage for GC Digital Talent."
+  },
+  "k4Vsh0": {
+    "defaultMessage": "Programme d’apprentissage en TI pour les personnes autochtones",
+    "description": "Link to the homepage for IT Apprenticeship Program for Indigenous Peoples."
   }
 }

--- a/packages/ui/src/components/Link/MenuLink.tsx
+++ b/packages/ui/src/components/Link/MenuLink.tsx
@@ -9,7 +9,7 @@ const MenuLink = ({ children, ...rest }: MenuLinkProps) => {
     <NavLink
       {...rest}
       data-h2-background-color="base(transparent)"
-      data-h2-color="base(black) base:hover(primary)"
+      data-h2-color="base(black) base:hover(primary) base:iap(primary) base:iap:hover(primary.darker)"
       data-h2-border="base(none)"
       data-h2-font-size="base(normal)"
       data-h2-font-weight="base(400) base:selectors[.active](800)"


### PR DESCRIPTION
🤖 Resolves #6886 

## 👋 Introduction

Updates the IAP navigation items.

## 🕵️ Details

Changes "Home" to "IT Apprenticeship Program for Indigenous Peoples" and adds:

- GC Digital Talent
- Login/Logout
- Register

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/indigenous-it-apprentice`
3. Confirm both IAP and GCDT links appear along with login/register
4. Login
5. Navigate back to `/indigenous-it-apprentice`
6. Confirm Login / Register are now Logout

## 📸 Screenshot


![Screenshot 2023-06-15 144506](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/eea6ce05-1c1c-4c53-b2e2-bfe6afac95fd)
![Screenshot 2023-06-15 144524](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/26612a3c-fcbc-4499-a813-3f1c3484e244)
