### PR TITLE
[Bug] Suspended filtering fix

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -382,11 +382,11 @@ class PoolCandidate extends Model
         $suspendedStatus = isset($suspendedStatus) ? $suspendedStatus : ApiEnums::CANDIDATE_SUSPENDED_FILTER_ACTIVE;
         if ($suspendedStatus == ApiEnums::CANDIDATE_SUSPENDED_FILTER_ACTIVE) {
             $query->where(function ($query) {
-                $query->whereDate('suspended_at', '>=', Carbon::now())
+                $query->where('suspended_at', '>=', Carbon::now())
                     ->orWhereNull('suspended_at');
             });
         } else if ($suspendedStatus == ApiEnums::CANDIDATE_SUSPENDED_FILTER_SUSPENDED) {
-            $query->whereDate('suspended_at', '<', Carbon::now());
+            $query->where('suspended_at', '<', Carbon::now());
         }
         return $query;
     }

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -158,7 +158,7 @@ class PoolCandidate extends Model
         })
             ->whereIn('pool_candidates.pool_candidate_status', [ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE, ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL]) // Where the PoolCandidate is accepted into the pool and not already placed.
             ->where(function ($query) {
-                $query->whereDate('suspended_at', '>=', Carbon::now())->orWhereNull('suspended_at'); // Where the candidate has not suspended their candidacy in the pool
+                $query->where('suspended_at', '>=', Carbon::now())->orWhereNull('suspended_at'); // Where the candidate has not suspended their candidacy in the pool
             })
             // Now scope for valid pools, according to streams
             ->whereHas('pool', function ($query) use ($streams) {
@@ -187,7 +187,7 @@ class PoolCandidate extends Model
         })
             ->whereIn('pool_candidates.pool_candidate_status', [ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE, ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL]) // Where the PoolCandidate is accepted into the pool and not already placed.
             ->where(function ($query) {
-                $query->whereDate('suspended_at', '>=', Carbon::now())->orWhereNull('suspended_at'); // Where the candidate has not suspended their candidacy in the pool
+                $query->where('suspended_at', '>=', Carbon::now())->orWhereNull('suspended_at'); // Where the candidate has not suspended their candidacy in the pool
             })
             // Now ensure the PoolCandidate is in a pool with the right classification
             ->whereHas('pool', function ($query) use ($classifications) {
@@ -345,7 +345,7 @@ class PoolCandidate extends Model
     {
         $query->whereIn('pool_candidate_status', [ApiEnums::CANDIDATE_STATUS_QUALIFIED_AVAILABLE, ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL])
             ->where(function ($query) {
-                $query->whereDate('suspended_at', '>=', Carbon::now())
+                $query->where('suspended_at', '>=', Carbon::now())
                     ->orWhereNull('suspended_at');
             });
         return $query;

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -264,10 +264,10 @@ class User extends Model implements Authenticatable, LaratrustUser
                             }
                             $query->where(function ($query) use ($filter) {
                                 if (array_key_exists('suspendedStatus', $filter) && $filter['suspendedStatus'] == ApiEnums::CANDIDATE_SUSPENDED_FILTER_ACTIVE) {
-                                    $query->whereDate('suspended_at', '>=', Carbon::now())
+                                    $query->where('suspended_at', '>=', Carbon::now())
                                         ->orWhereNull('suspended_at');
                                 } else if (array_key_exists('suspendedStatus', $filter) && $filter['suspendedStatus'] == ApiEnums::CANDIDATE_SUSPENDED_FILTER_SUSPENDED) {
-                                    $query->whereDate('suspended_at', '<', Carbon::now());
+                                    $query->where('suspended_at', '<', Carbon::now());
                                 }
                             });
                             return $query;

--- a/api/config/constants.php
+++ b/api/config/constants.php
@@ -1,6 +1,6 @@
 <?php
 
-    return [
+return [
     /*
     |--------------------------------------------------------------------------
     | Far Future Date
@@ -9,9 +9,10 @@
     | This value is used for unit testing.
     |
     */
-        'far_future_date' => '2050-01-01',
-        /* PAST DATE
+    'far_future_date' => '2050-01-01',
+    /* PAST DATE
         | value is used for testing
         */
-        'past_date' => '2020-01-01',
-    ];
+    'past_date' => '2020-01-01',
+    'far_past_datetime' => '2000-01-01 01:23:45'
+];

--- a/api/tests/Feature/PoolCandidateSearchTest.php
+++ b/api/tests/Feature/PoolCandidateSearchTest.php
@@ -9,6 +9,7 @@ use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 use Database\Helpers\ApiEnums;
+use Carbon\Carbon;
 
 class PoolCandidateSearchTest extends TestCase
 {
@@ -284,6 +285,123 @@ class PoolCandidateSearchTest extends TestCase
                 "poolCandidatesPaginated" => [
                     "paginatorInfo" => [
                         'count' => 4,
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    public function testPoolCandidatesSearchSuspendedFilter(): void
+    {
+        PoolCandidate::factory()->count(5)->create([
+            'pool_id' => $this->pool->id,
+            'expiry_date' => config('constants.far_future_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL,
+            'suspended_at' => null,
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $this->pool->id,
+            'expiry_date' => config('constants.far_future_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL,
+            'suspended_at' => config('constants.far_past_datetime'),
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $this->pool->id,
+            'expiry_date' => config('constants.far_future_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL,
+            'suspended_at' => Carbon::now()->subMinutes(1)
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $this->pool->id,
+            'expiry_date' => config('constants.far_future_date'),
+            'pool_candidate_status' => ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL,
+            'suspended_at' => Carbon::now()->addMinutes(1)
+        ]);
+
+        $query =
+            /** @lang GraphQL */
+            '
+            query poolCandidatesPaginated ($where: PoolCandidateSearchInput) {
+                poolCandidatesPaginated (
+                  where: $where
+                  orderBy: [
+                  { column: "status_weight", order: ASC }
+                  { user: { aggregate: MAX, column: PRIORITY_WEIGHT }, order: ASC }
+                ]) {
+                    paginatorInfo {
+                        count
+                    }
+                }
+            }
+        ';
+
+        // assert active 6 returned
+        $this->actingAs($this->teamUser, "api")->graphQL(
+            $query,
+            [
+                'where' => [
+                    'suspendedStatus' => null, // default active for the scope
+                ]
+            ]
+        )->assertJson([
+            "data" => [
+                "poolCandidatesPaginated" => [
+                    "paginatorInfo" => [
+                        'count' => 6,
+                    ]
+                ]
+            ]
+        ]);
+
+        // assert active 6 returned
+        $this->actingAs($this->teamUser, "api")->graphQL(
+            $query,
+            [
+                'where' => [
+                    'suspendedStatus' => ApiEnums::CANDIDATE_SUSPENDED_FILTER_ACTIVE,
+                ]
+            ]
+        )->assertJson([
+            "data" => [
+                "poolCandidatesPaginated" => [
+                    "paginatorInfo" => [
+                        'count' => 6,
+                    ]
+                ]
+            ]
+        ]);
+
+        // assert suspended 2 returned
+        $this->actingAs($this->teamUser, "api")->graphQL(
+            $query,
+            [
+                'where' => [
+                    'suspendedStatus' => ApiEnums::CANDIDATE_SUSPENDED_FILTER_SUSPENDED,
+                ]
+            ]
+        )->assertJson([
+            "data" => [
+                "poolCandidatesPaginated" => [
+                    "paginatorInfo" => [
+                        'count' => 2,
+                    ]
+                ]
+            ]
+        ]);
+
+        // assert all 8 returned
+        $this->actingAs($this->teamUser, "api")->graphQL(
+            $query,
+            [
+                'where' => [
+                    'suspendedStatus' => ApiEnums::CANDIDATE_SUSPENDED_FILTER_ALL,
+                ]
+            ]
+        )->assertJson([
+            "data" => [
+                "poolCandidatesPaginated" => [
+                    "paginatorInfo" => [
+                        'count' => 8,
                     ]
                 ]
             ]


### PR DESCRIPTION
🤖 Resolves #6986 

## 👋 Introduction

Resolves the issue with filtering by suspended selection. 

## 🕵️ Details

Read the issue comments for details starting here https://github.com/GCTC-NTGC/gc-digital-talent/issues/6986#issuecomment-1593742001
But yeah, appears `whereDate()` does not work for this and I followed how draft was scoped by just using `where()`

I also adjusted other instances of filtering for suspended from `whereDate` to `where` since it seems like it'd obviously be not working well there either and it seems straightforward a fix. 

## 🧪 Testing

1. You cannot replicate the issue Brinda
2. Suspended candidates filtering works not just for the pool candidate table, but elsewhere with availability scopes like the search page. 
3. And tests pass


