### PR TITLE
[Feature] Update availability status display

### DIFF
--- a/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
+++ b/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import isEmpty from "lodash/isEmpty";
+import isPast from "date-fns/isPast";
 
 import { Link, Well } from "@gc-digital-talent/ui";
 import { getPoolCandidateStatus } from "@gc-digital-talent/i18n";
+import { PoolCandidate } from "@gc-digital-talent/graphql";
+import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 
 import { getFullPoolTitleHtml } from "~/utils/poolUtils";
 import useRoutes from "~/hooks/useRoutes";
@@ -11,6 +14,13 @@ import useRoutes from "~/hooks/useRoutes";
 import { UserInformationProps } from "../../pages/Users/UserInformationPage/types";
 import ChangeStatusDialog from "../../pages/Users/UserInformationPage/components/ChangeStatusDialog";
 import ChangeDateDialog from "../../pages/Users/UserInformationPage/components/ChangeDateDialog";
+
+const isSuspended = (suspendedAt: PoolCandidate["suspendedAt"]): boolean => {
+  if (!suspendedAt) return false;
+
+  const suspendedAtDate = parseDateTimeUtc(suspendedAt);
+  return isPast(suspendedAtDate);
+};
 
 const PoolStatusTable = ({ user, pools }: UserInformationProps) => {
   const intl = useIntl();
@@ -49,6 +59,14 @@ const PoolStatusTable = ({ user, pools }: UserInformationProps) => {
               id: "sUx3ZS",
               description:
                 "Title of the 'Status' column for the table on view-user page",
+            })}
+          </th>
+          <th data-h2-padding="base(x.25, 0)" data-h2-width="base(25%)">
+            {intl.formatMessage({
+              defaultMessage: "Availability",
+              id: "1pPs0u",
+              description:
+                "Title of the 'Availability' column for the table on view-user page",
             })}
           </th>
           <th data-h2-padding="base(x.25, 0)" data-h2-width="base(25%)">
@@ -94,6 +112,24 @@ const PoolStatusTable = ({ user, pools }: UserInformationProps) => {
                     user={user}
                     pools={pools}
                   />
+                </td>
+                <td
+                  data-h2-background-color="base(gray.light)"
+                  data-h2-padding="base(x.25, 0)"
+                >
+                  {isSuspended(candidate.suspendedAt)
+                    ? intl.formatMessage({
+                        defaultMessage: "Inactive",
+                        id: "u5UAJn",
+                        description:
+                          "Status message if the application is suspended",
+                      })
+                    : intl.formatMessage({
+                        defaultMessage: "Active",
+                        id: "4L9rHO",
+                        description:
+                          "Status message if the application is not suspended",
+                      })}
                 </td>
                 <td
                   data-h2-text-decoration="base(underline)"

--- a/apps/web/src/components/Table/ApiManagedTable/useFilterOptions.test.tsx
+++ b/apps/web/src/components/Table/ApiManagedTable/useFilterOptions.test.tsx
@@ -82,12 +82,11 @@ describe("useFilterOptions", () => {
   describe("simple fields", () => {
     it("returns static optionsData of appropriate length for non-async fields", () => {
       const result = renderHookWithProviders({});
-      const [countSimple, countAsync] = [14, 3];
+      const [countSimple, countAsync] = [13, 3];
       const countTotal = countSimple + countAsync;
       expect(Object.keys(result.current.optionsData)).toHaveLength(countTotal);
 
       expect(result.current.optionsData.employmentDuration).toHaveLength(2);
-      expect(result.current.optionsData.jobLookingStatus).toHaveLength(3);
       expect(result.current.optionsData.languageAbility).toHaveLength(3);
       expect(result.current.optionsData.operationalRequirement).toHaveLength(7);
       expect(result.current.optionsData.workRegion).toHaveLength(8);

--- a/apps/web/src/components/Table/ApiManagedTable/useFilterOptions.tsx
+++ b/apps/web/src/components/Table/ApiManagedTable/useFilterOptions.tsx
@@ -8,7 +8,6 @@ import {
   getLanguageAbility,
   getOperationalRequirement,
   getEducationType,
-  getJobLookingStatus,
   EmploymentDuration,
   OperationalRequirementV2,
   getEmploymentEquityGroup,
@@ -28,7 +27,6 @@ import {
   PoolStream,
   WorkRegion,
   EducationType,
-  JobLookingStatus,
   LanguageAbility,
   PoolCandidateStatus,
   useGetFilterDataQuery,
@@ -101,10 +99,6 @@ export default function useFilterOptions(enableEducationType = false) {
     employmentDuration: enumToOptions(EmploymentDuration).map(({ value }) => ({
       value,
       label: intl.formatMessage(getEmploymentDuration(value, "short")),
-    })),
-    jobLookingStatus: enumToOptions(JobLookingStatus).map(({ value }) => ({
-      value,
-      label: intl.formatMessage(getJobLookingStatus(value, "short")),
     })),
     skills: filterRes.data?.skills.filter(notEmpty).map(({ id, name }) => ({
       value: id,

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3172,10 +3172,6 @@
     "defaultMessage": "Ajouter l'utilisateur au bassin",
     "description": "Button to add user to pool on the view-user page"
   },
-  "4N6O+3": {
-    "defaultMessage": "Statut personnel",
-    "description": "Title of the 'Personal status' section of the view-user page"
-  },
   "4Zl/mp": {
     "defaultMessage": "Personne handicapée",
     "description": "Text on view-user page that the user has a disability"
@@ -3430,18 +3426,6 @@
   "ZLDt/c": {
     "defaultMessage": "<strong>{jobTitle}</strong> à <strong>{department}</strong>",
     "description": "Subtitle displayed above the single search request component."
-  },
-  "4pAtT5": {
-    "defaultMessage": "<heavyPrimary>Inactif</heavyPrimary> ‒ Ne souhaite pas être contacté pour des possibilités d'emploi",
-    "description": "Text in view user page saying they currently have the 'Inactive' status"
-  },
-  "BqQrcn": {
-    "defaultMessage": "<heavyPrimary>Ouvert aux possibilités</heavyPrimary> ‒ Ne cherche pas activement, mais souhaite toujours être contacté pour des possibilités d'emploi",
-    "description": "Text in view user page saying they currently have the 'Open to opportunities' status"
-  },
-  "uv0RmD": {
-    "defaultMessage": "<heavyPrimary>Actif</heavyPrimary> ‒ Souhaite être contacté pour des possibilités d'emploi",
-    "description": "Text in view user page saying they currently have the 'Active' status"
   },
   "+5da+V": {
     "defaultMessage": "<heavyPrimary>Archivé</heavyPrimary>",

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -5,7 +5,7 @@ import { useReactToPrint } from "react-to-print";
 import { SubmitHandler } from "react-hook-form";
 
 import { notEmpty } from "@gc-digital-talent/helpers";
-import { getJobLookingStatus, getLanguage } from "@gc-digital-talent/i18n";
+import { getLanguage } from "@gc-digital-talent/i18n";
 import { Link, Pending } from "@gc-digital-talent/ui";
 import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 
@@ -42,7 +42,6 @@ import {
 } from "~/components/Table/ClientManagedTable";
 import {
   durationToEnumPositionDuration,
-  stringToEnumJobLooking,
   stringToEnumLanguage,
   stringToEnumLocation,
   stringToEnumOperational,
@@ -88,9 +87,6 @@ function transformFormValuesToUserFilterInput(
     },
     isGovEmployee: data.govEmployee[0] ? true : undefined,
     isProfileComplete: data.profileComplete[0] ? true : undefined,
-    jobLookingStatus: data.jobLookingStatus.map((status) => {
-      return stringToEnumJobLooking(status);
-    }),
     poolFilters: data.pools.map((pool) => {
       const poolString = pool;
       return { poolId: poolString };
@@ -124,7 +120,6 @@ function transformUserFilterInputToFormValues(
         : [],
     govEmployee: input?.isGovEmployee ? ["true"] : [],
     profileComplete: input?.isProfileComplete ? ["true"] : [],
-    jobLookingStatus: input?.jobLookingStatus?.filter(notEmpty) ?? [],
     pools:
       input?.poolFilters
         ?.filter(notEmpty)
@@ -213,7 +208,6 @@ const defaultState = {
     },
     isGovEmployee: undefined,
     isProfileComplete: undefined,
-    jobLookingStatus: [],
     poolFilters: [],
   },
 };
@@ -261,7 +255,6 @@ const UserTable = ({ title }: { title: string }) => {
       applicantFilter: fancyFilterState?.applicantFilter,
       isGovEmployee: fancyFilterState?.isGovEmployee,
       isProfileComplete: fancyFilterState?.isProfileComplete,
-      jobLookingStatus: fancyFilterState?.jobLookingStatus,
       poolFilters: fancyFilterState?.poolFilters,
     };
   };
@@ -325,21 +318,6 @@ const UserTable = ({ title }: { title: string }) => {
           getFullNameHtml(user.firstName, user.lastName, intl),
         id: "candidateName",
         sortColumnName: "first_name",
-      },
-      {
-        label: intl.formatMessage({
-          defaultMessage: "Status",
-          id: "Ag+0A4",
-          description: "Title displayed for the User table Status column",
-        }),
-        accessor: (user) =>
-          user.jobLookingStatus
-            ? intl.formatMessage(
-                getJobLookingStatus(user.jobLookingStatus as string, "short"),
-              )
-            : "",
-        id: "jobLookingStatus",
-        sortColumnName: "job_looking_status",
       },
       {
         label: intl.formatMessage({

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.test.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.test.tsx
@@ -30,7 +30,6 @@ const emptyFormValues = {
   classifications: [],
   employmentDuration: [],
   govEmployee: [],
-  jobLookingStatus: [],
   languageAbility: [],
   operationalRequirement: [],
   pools: [],
@@ -139,7 +138,6 @@ describe("UserTableFilterDialog", () => {
         await selectFilterOption(/work preferences/i);
         await selectFilterOption(/work locations/i);
         await selectFilterOption(/duration/i);
-        await selectFilterOption(/availability/i);
         await selectFilterOption(/profile complete/i);
         await selectFilterOption(/government employee/i);
         await selectFilterOption(/classifications/i);
@@ -150,7 +148,7 @@ describe("UserTableFilterDialog", () => {
         expect(mockSubmit).toHaveBeenCalledTimes(1);
 
         const activeFilter = mockSubmit.mock.lastCall[0];
-        expect(Object.keys(activeFilter)).toHaveLength(17);
+        expect(Object.keys(activeFilter)).toHaveLength(16);
         // Static filters.
         expect(activeFilter.workRegion).toHaveLength(1);
         expect(activeFilter.employmentDuration).toHaveLength(1);
@@ -225,7 +223,7 @@ describe("UserTableFilterDialog", () => {
 
   it("shows correct filters in modal", () => {
     renderButton({ isOpenDefault: true });
-    expect(screen.getAllByRole("combobox")).toHaveLength(10);
+    expect(screen.getAllByRole("combobox")).toHaveLength(9);
   });
 
   describe("enableEducationType prop", () => {
@@ -241,7 +239,7 @@ describe("UserTableFilterDialog", () => {
         isOpenDefault: true,
         enableEducationType: true,
       });
-      expect(screen.getAllByRole("combobox")).toHaveLength(11);
+      expect(screen.getAllByRole("combobox")).toHaveLength(10);
       expect(
         screen.getByRole("combobox", { name: /education/i }),
       ).toBeVisible();

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.tsx
@@ -27,7 +27,6 @@ export type FormValues = {
   // See: https://www.figma.com/proto/XS4Ag6GWcgdq2dBlLzBkay?node-id=1064:5862#224617157
   educationType?: Option["value"][];
   employmentDuration: Option["value"][];
-  jobLookingStatus: Option["value"][];
   skills: Option["value"][];
   profileComplete: Option["value"][];
   govEmployee: Option["value"][];
@@ -196,17 +195,6 @@ const UserTableFilterDialog = ({
                     id: "hmfQmT",
                   })}
                   options={optionsData.employmentDuration}
-                />
-              </div>
-              <div data-h2-flex-item="base(1of1) p-tablet(1of2) laptop(1of3)">
-                <MultiSelectField
-                  id="jobLookingStatus"
-                  name="jobLookingStatus"
-                  label={formatMessage({
-                    defaultMessage: "Availability",
-                    id: "hOxIeP",
-                  })}
-                  options={optionsData.jobLookingStatus}
                 />
               </div>
               <div data-h2-flex-item="base(1of1) p-tablet(1of2) laptop(1of3)">

--- a/apps/web/src/pages/Users/UserInformationPage/components/CandidateStatusSection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/CandidateStatusSection.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { Heading, Well } from "@gc-digital-talent/ui";
+import { Heading } from "@gc-digital-talent/ui";
 import { ROLE_NAME, useAuthorization } from "@gc-digital-talent/auth";
 
-import { JobLookingStatus } from "~/api/generated";
 import PoolStatusTable from "~/components/PoolStatusTable/PoolStatusTable";
 
 import { UserInformationProps } from "../types";
@@ -21,40 +20,6 @@ const CandidateStatusSection = ({ user, pools }: UserInformationProps) => {
 
   return (
     <>
-      <Heading level="h4" data-h2-margin="base(x2, 0, x1, 0)">
-        {intl.formatMessage({
-          defaultMessage: "Personal status",
-          id: "4N6O+3",
-          description:
-            "Title of the 'Personal status' section of the view-user page",
-        })}
-      </Heading>
-      <Well>
-        {user.jobLookingStatus === JobLookingStatus.ActivelyLooking &&
-          intl.formatMessage({
-            defaultMessage:
-              "<heavyPrimary>Active</heavyPrimary> - Wants to be contacted for job opportunities",
-            id: "uv0RmD",
-            description:
-              "Text in view user page saying they currently have the 'Active' status",
-          })}
-        {user.jobLookingStatus === JobLookingStatus.OpenToOpportunities &&
-          intl.formatMessage({
-            defaultMessage:
-              "<heavyPrimary>Open to opportunities</heavyPrimary> - Not actively looking but still wants to be contacted for job opportunities",
-            id: "BqQrcn",
-            description:
-              "Text in view user page saying they currently have the 'Open to opportunities' status",
-          })}
-        {user.jobLookingStatus === JobLookingStatus.Inactive &&
-          intl.formatMessage({
-            defaultMessage:
-              "<heavyPrimary>Inactive</heavyPrimary> - Does not want to be contacted for job opportunities",
-            id: "4pAtT5",
-            description:
-              "Text in view user page saying they currently have the 'Inactive' status",
-          })}
-      </Well>
       <Heading level="h4" data-h2-margin="base(x2, 0, x1, 0)">
         {intl.formatMessage({
           defaultMessage: "Pool status",

--- a/apps/web/src/pages/Users/userOperations.graphql
+++ b/apps/web/src/pages/Users/userOperations.graphql
@@ -324,6 +324,7 @@ query GetViewUserData($id: UUID!) {
       status
       expiryDate
       notes
+      suspendedAt
       user {
         id
       }


### PR DESCRIPTION
🤖 Resolves #6831 

## 👋 Introduction

This branch updates the application availability status in a few places.

## 🧪 Testing

Rebuild the app then check the two AC:

- [ ] Remove personal status from User Information page
- [ ] Add suspended status column to Pool Candidate mini-table on the snapshot and Profile pages

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/4c420867-4021-4d8b-929e-9c368197873e)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/4b318da2-1102-4fb6-ac32-441467ddde1f)

