### PR TITLE
[Feature] New date picker

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -63,6 +63,7 @@ recrutementgiti
 résumé
 rolepermission
 skillset
+spinbutton
 subcomponents
 subquery
 TALENTSEARCH

--- a/apps/e2e/cypress/e2e/admin/pool-candidate.cy.js
+++ b/apps/e2e/cypress/e2e/admin/pool-candidate.cy.js
@@ -121,7 +121,13 @@ describe("Pool Candidates", () => {
       cy.get("option:selected").should("have.text", "Screened In");
     });
 
-    cy.findByLabelText(/Candidate expiry date/i).type("2023-12-01");
+    cy.findByRole("group", { name: /candidate expiry date/i }).within(() => {
+      cy.findAllByRole("spinbutton", { name: /year/i }).clear()
+      cy.findAllByRole("spinbutton", { name: /year/i }).type("2023");
+      cy.findAllByRole("combobox", { name: /month/i }).select("12");
+      cy.findAllByRole("spinbutton", { name: /day/i }).clear();
+      cy.findAllByRole("spinbutton", { name: /day/i }).type("01");
+    });
 
     cy.findByRole("textbox", { name: /notes/i }).type("New Notes");
 
@@ -218,7 +224,11 @@ describe("Pool Candidates", () => {
       cy.get("option:selected").should("have.text", "Screened In");
     });
 
-    cy.findByLabelText(/Candidate expiry date/i).clear();
+    cy.findByRole("group", { name: /candidate expiry date/i }).within(() => {
+      cy.findAllByRole("spinbutton", { name: /year/i }).clear()
+      cy.findAllByRole("combobox", { name: /month/i }).select("");
+      cy.findAllByRole("spinbutton", { name: /day/i }).clear();
+    });
 
     cy.findByRole("textbox", { name: /notes/i }).clear();
 

--- a/apps/e2e/cypress/e2e/admin/pools.cy.js
+++ b/apps/e2e/cypress/e2e/admin/pools.cy.js
@@ -175,8 +175,13 @@ describe("Pools", () => {
     expectUpdate();
 
     // Update expiry date to some arbitrary date in the future
-    cy.findByLabelText(/end date/i).clear();
-    cy.findByLabelText(/end date/i).type("2030-01-01");
+    cy.findByRole("group", { name: /end date/i }).within(() => {
+      cy.findAllByRole("spinbutton", { name: /year/i }).clear()
+      cy.findAllByRole("spinbutton", { name: /year/i }).type("2030");
+      cy.findAllByRole("combobox", { name: /month/i }).select("01");
+      cy.findAllByRole("spinbutton", { name: /day/i }).clear();
+      cy.findAllByRole("spinbutton", { name: /day/i }).type("01");
+    });
 
     cy.findByRole("button", { name: /save closing date/i }).click();
     expectUpdate();

--- a/apps/e2e/cypress/e2e/talentsearch/submit-application.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/submit-application.cy.js
@@ -234,12 +234,10 @@ describe("Submit Application Workflow Tests", () => {
     cy.findByRole("group", { name: /start date/i }).within(() => {
       cy.findAllByRole("spinbutton", { name: /year/i }).type("2001");
       cy.findAllByRole("combobox", { name: /month/i }).select("01");
-      cy.findAllByRole("spinbutton", { name: /day/i }).type("01");
     });
     cy.findByRole("group", { name: /end date/i }).within(() => {
       cy.findAllByRole("spinbutton", { name: /year/i }).type("2001");
       cy.findAllByRole("combobox", { name: /month/i }).select("01");
-      cy.findAllByRole("spinbutton", { name: /day/i }).type("02");
     });
     cy.findByRole("combobox", { name: /Status/i }).select(
       "Successful Completion (Credential Awarded)",

--- a/apps/e2e/cypress/e2e/talentsearch/submit-application.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/submit-application.cy.js
@@ -237,7 +237,7 @@ describe("Submit Application Workflow Tests", () => {
     });
     cy.findByRole("group", { name: /end date/i }).within(() => {
       cy.findAllByRole("spinbutton", { name: /year/i }).type("2001");
-      cy.findAllByRole("combobox", { name: /month/i }).select("01");
+      cy.findAllByRole("combobox", { name: /month/i }).select("02");
     });
     cy.findByRole("combobox", { name: /Status/i }).select(
       "Successful Completion (Credential Awarded)",

--- a/apps/e2e/cypress/e2e/talentsearch/submit-application.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/submit-application.cy.js
@@ -231,8 +231,16 @@ describe("Submit Application Workflow Tests", () => {
     cy.findByRole("textbox", { name: /Institution/i }).type(
       "Cypress University",
     );
-    cy.findByLabelText(/Start Date/i).type("2001-01-01");
-    cy.findByLabelText(/End Date/i).type("2001-02-01");
+    cy.findByRole("group", { name: /start date/i }).within(() => {
+      cy.findAllByRole("spinbutton", { name: /year/i }).type("2001");
+      cy.findAllByRole("combobox", { name: /month/i }).select("01");
+      cy.findAllByRole("spinbutton", { name: /day/i }).type("01");
+    });
+    cy.findByRole("group", { name: /end date/i }).within(() => {
+      cy.findAllByRole("spinbutton", { name: /year/i }).type("2001");
+      cy.findAllByRole("combobox", { name: /month/i }).select("01");
+      cy.findAllByRole("spinbutton", { name: /day/i }).type("02");
+    });
     cy.findByRole("combobox", { name: /Status/i }).select(
       "Successful Completion (Credential Awarded)",
     );

--- a/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
@@ -38,21 +38,6 @@ const AwardFields = ({ labels }: SubExperienceFormProps) => {
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-          <DateInput
-            id="awardedDate"
-            legend={labels.awardedDate}
-            name="awardedDate"
-            show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
-            rules={{
-              required: intl.formatMessage(errorMessages.required),
-              max: {
-                value: strToFormDate(todayDate.toISOString()),
-                message: intl.formatMessage(errorMessages.mustNotBeFuture),
-              },
-            }}
-          />
-        </div>
-        <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
           <Select
             id="awardedTo"
             label={labels.awardedTo}
@@ -86,7 +71,7 @@ const AwardFields = ({ labels }: SubExperienceFormProps) => {
             rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
         </div>
-        <div data-h2-flex-item="base(1of1)">
+        <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
           <Select
             id="awardedScope"
             label={labels.awardedScope}
@@ -112,6 +97,21 @@ const AwardFields = ({ labels }: SubExperienceFormProps) => {
               value,
               label: intl.formatMessage(getAwardedScope(value)),
             }))}
+          />
+        </div>
+        <div data-h2-flex-item="base(1of1)">
+          <DateInput
+            id="awardedDate"
+            legend={labels.awardedDate}
+            name="awardedDate"
+            show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+              max: {
+                value: strToFormDate(todayDate.toISOString()),
+                message: intl.formatMessage(errorMessages.mustNotBeFuture),
+              },
+            }}
           />
         </div>
       </div>

--- a/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
@@ -1,24 +1,34 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { Input, Select, enumToOptions } from "@gc-digital-talent/forms";
+import {
+  DateInput,
+  Input,
+  Select,
+  enumToOptions,
+  DATE_SEGMENT,
+} from "@gc-digital-talent/forms";
 import {
   errorMessages,
   getAwardedScope,
   getAwardedTo,
 } from "@gc-digital-talent/i18n";
+import { strToFormDate } from "@gc-digital-talent/date-helpers";
 
 import { SubExperienceFormProps } from "~/types/experience";
 import { AwardedScope, AwardedTo } from "~/api/generated";
 
 const AwardFields = ({ labels }: SubExperienceFormProps) => {
   const intl = useIntl();
-  const todayDate = Date();
+  const todayDate = new Date();
 
   return (
     <div data-h2-margin="base(x.5, 0, 0, 0)" data-h2-max-width="base(50rem)">
       <div data-h2-flex-grid="base(flex-start, x2, x1)">
-        <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
+        <div
+          data-h2-flex-item="base(1of1) p-tablet(1of2)"
+          data-h2-align-self="base(flex-end)"
+        >
           <Input
             id="awardTitle"
             label={labels.awardTitle}
@@ -28,15 +38,15 @@ const AwardFields = ({ labels }: SubExperienceFormProps) => {
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-          <Input
+          <DateInput
             id="awardedDate"
-            label={labels.awardedDate}
+            legend={labels.awardedDate}
             name="awardedDate"
-            type="date"
+            show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
             rules={{
               required: intl.formatMessage(errorMessages.required),
               max: {
-                value: todayDate,
+                value: strToFormDate(todayDate.toISOString()),
                 message: intl.formatMessage(errorMessages.mustNotBeFuture),
               },
             }}

--- a/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
@@ -2,14 +2,20 @@ import React from "react";
 import { useIntl } from "react-intl";
 import { useWatch } from "react-hook-form";
 
-import { Checkbox, Input } from "@gc-digital-talent/forms";
+import {
+  Checkbox,
+  DATE_SEGMENT,
+  DateInput,
+  Input,
+} from "@gc-digital-talent/forms";
 import { errorMessages } from "@gc-digital-talent/i18n";
+import { strToFormDate } from "@gc-digital-talent/date-helpers";
 
 import { SubExperienceFormProps } from "~/types/experience";
 
 const CommunityFields = ({ labels }: SubExperienceFormProps) => {
   const intl = useIntl();
-  const todayDate = Date();
+  const todayDate = new Date();
   // to toggle whether endDate is required, the state of the current-role checkbox must be monitored and have to adjust the form accordingly
   const isCurrent = useWatch({ name: "currentRole" });
   // ensuring endDate isn't before startDate, using this as a minimum value
@@ -51,52 +57,6 @@ const CommunityFields = ({ labels }: SubExperienceFormProps) => {
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-          <div data-h2-flex-grid="base(flex-start, x2, 0)">
-            <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-              <Input
-                id="startDate"
-                label={labels.startDate}
-                name="startDate"
-                type="date"
-                rules={{
-                  required: intl.formatMessage(errorMessages.required),
-                  max: {
-                    value: todayDate,
-                    message: intl.formatMessage(errorMessages.mustNotBeFuture),
-                  },
-                }}
-              />
-            </div>
-            <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-              {/* conditionally render the endDate based off the state attached to the checkbox input */}
-              {!isCurrent && (
-                <Input
-                  id="endDate"
-                  label={labels.endDate}
-                  name="endDate"
-                  type="date"
-                  rules={
-                    isCurrent
-                      ? {}
-                      : {
-                          required: intl.formatMessage(errorMessages.required),
-                          min: {
-                            value: startDate,
-                            message: intl.formatMessage(
-                              errorMessages.mustBeGreater,
-                              {
-                                value: startDate,
-                              },
-                            ),
-                          },
-                        }
-                  }
-                />
-              )}
-            </div>
-          </div>
-        </div>
-        <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
           <Input
             id="project"
             label={labels.project}
@@ -104,6 +64,48 @@ const CommunityFields = ({ labels }: SubExperienceFormProps) => {
             type="text"
             rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
+        </div>
+        <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
+          <DateInput
+            id="startDate"
+            legend={labels.startDate}
+            name="startDate"
+            show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+              max: {
+                value: strToFormDate(todayDate.toISOString()),
+                message: intl.formatMessage(errorMessages.mustNotBeFuture),
+              },
+            }}
+          />
+        </div>
+        <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
+          {/* conditionally render the endDate based off the state attached to the checkbox input */}
+          {!isCurrent && (
+            <DateInput
+              id="endDate"
+              legend={labels.endDate}
+              name="endDate"
+              show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+              rules={
+                isCurrent
+                  ? {}
+                  : {
+                      required: intl.formatMessage(errorMessages.required),
+                      min: {
+                        value: startDate,
+                        message: intl.formatMessage(
+                          errorMessages.mustBeGreater,
+                          {
+                            value: startDate,
+                          },
+                        ),
+                      },
+                    }
+              }
+            />
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
@@ -4,6 +4,8 @@ import { useWatch } from "react-hook-form";
 
 import {
   Checkbox,
+  DATE_SEGMENT,
+  DateInput,
   Input,
   Select,
   enumToOptions,
@@ -13,13 +15,14 @@ import {
   getEducationStatus,
   getEducationType,
 } from "@gc-digital-talent/i18n";
+import { strToFormDate } from "@gc-digital-talent/date-helpers";
 
 import { SubExperienceFormProps } from "~/types/experience";
 import { EducationStatus, EducationType } from "~/api/generated";
 
 const EducationFields = ({ labels }: SubExperienceFormProps) => {
   const intl = useIntl();
-  const todayDate = Date();
+  const todayDate = new Date();
   // to toggle whether End Date is required, the state of the Current Role checkbox must be monitored and have to adjust the form accordingly
   const isCurrent = useWatch({ name: "currentRole" });
   // ensuring end date isn't before the start date, using this as a minimum value
@@ -81,49 +84,6 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-          <div data-h2-flex-grid="base(flex-start, x2, 0)">
-            <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-              <Input
-                id="startDate"
-                label={labels.startDate}
-                name="startDate"
-                type="date"
-                rules={{
-                  required: intl.formatMessage(errorMessages.required),
-                  max: {
-                    value: todayDate,
-                    message: intl.formatMessage(errorMessages.mustNotBeFuture),
-                  },
-                }}
-              />
-            </div>
-            <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-              {!isCurrent && (
-                <Input
-                  id="endDate"
-                  label={labels.endDate}
-                  name="endDate"
-                  type="date"
-                  rules={
-                    isCurrent
-                      ? {}
-                      : {
-                          required: intl.formatMessage(errorMessages.required),
-                          min: {
-                            value: watchStartDate,
-                            message: intl.formatMessage(
-                              errorMessages.dateMustFollow,
-                              { value: watchStartDate },
-                            ),
-                          },
-                        }
-                  }
-                />
-              )}
-            </div>
-          </div>
-        </div>
-        <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
           <Input
             id="institution"
             label={labels.institution}
@@ -158,13 +118,52 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
             }))}
           />
         </div>
-        <div data-h2-flex-item="base(1of1)">
+        <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
           <Input
             id="thesisTitle"
             label={labels.thesisTitle}
             name="thesisTitle"
             type="text"
           />
+        </div>
+        <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
+          <DateInput
+            id="startDate"
+            legend={labels.startDate}
+            name="startDate"
+            show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+              max: {
+                value: strToFormDate(todayDate.toISOString()),
+                message: intl.formatMessage(errorMessages.mustNotBeFuture),
+              },
+            }}
+          />
+        </div>
+        <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
+          {!isCurrent && (
+            <DateInput
+              id="endDate"
+              legend={labels.endDate}
+              name="endDate"
+              show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+              rules={
+                isCurrent
+                  ? {}
+                  : {
+                      required: intl.formatMessage(errorMessages.required),
+                      min: {
+                        value: watchStartDate,
+                        message: intl.formatMessage(
+                          errorMessages.dateMustFollow,
+                          { value: watchStartDate },
+                        ),
+                      },
+                    }
+              }
+            />
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
@@ -2,14 +2,21 @@ import React from "react";
 import { useIntl } from "react-intl";
 import { useWatch } from "react-hook-form";
 
-import { Checkbox, Input, TextArea } from "@gc-digital-talent/forms";
+import {
+  Checkbox,
+  DATE_SEGMENT,
+  DateInput,
+  Input,
+  TextArea,
+} from "@gc-digital-talent/forms";
 import { errorMessages } from "@gc-digital-talent/i18n";
+import { strToFormDate } from "@gc-digital-talent/date-helpers";
 
 import { SubExperienceFormProps } from "~/types/experience";
 
 const PersonalFields = ({ labels }: SubExperienceFormProps) => {
   const intl = useIntl();
-  const todayDate = Date();
+  const todayDate = new Date();
   // to toggle whether End Date is required, the state of the Current Role checkbox must be monitored and have to adjust the form accordingly
   const isCurrent = useWatch({ name: "currentRole" });
   // ensuring end date isn't before the start date, using this as a minimum value
@@ -61,32 +68,29 @@ const PersonalFields = ({ labels }: SubExperienceFormProps) => {
         })}
         name="currentRole"
       />
-      <div
-        data-h2-display="base(flex)"
-        data-h2-flex-direction="base(column) p-tablet(row)"
-      >
-        <div data-h2-padding="base(0) p-tablet(0, x2, 0, 0)">
-          <Input
+      <div data-h2-flex-grid="base(flex-start, x2, x1)">
+        <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
+          <DateInput
             id="startDate"
-            label={labels.startDate}
+            legend={labels.startDate}
             name="startDate"
-            type="date"
+            show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
             rules={{
               required: intl.formatMessage(errorMessages.required),
               max: {
-                value: todayDate,
+                value: strToFormDate(todayDate.toISOString()),
                 message: intl.formatMessage(errorMessages.mustNotBeFuture),
               },
             }}
           />
         </div>
-        <div>
+        <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
           {!isCurrent && (
-            <Input
+            <DateInput
               id="endDate"
-              label={labels.endDate}
+              legend={labels.endDate}
               name="endDate"
-              type="date"
+              show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
               rules={
                 isCurrent
                   ? {}

--- a/apps/web/src/components/ExperienceFormFields/WorkFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields.tsx
@@ -2,14 +2,20 @@ import React from "react";
 import { useIntl } from "react-intl";
 import { useWatch } from "react-hook-form";
 
-import { Checkbox, Input } from "@gc-digital-talent/forms";
+import {
+  Checkbox,
+  DATE_SEGMENT,
+  DateInput,
+  Input,
+} from "@gc-digital-talent/forms";
 import { errorMessages } from "@gc-digital-talent/i18n";
+import { strToFormDate } from "@gc-digital-talent/date-helpers";
 
 import { SubExperienceFormProps } from "~/types/experience";
 
 const WorkFields = ({ labels }: SubExperienceFormProps) => {
   const intl = useIntl();
-  const todayDate = Date();
+  const todayDate = new Date();
   // to toggle whether End Date is required, the state of the Current Role checkbox must be monitored and have to adjust the form accordingly
   const isCurrent = useWatch({ name: "currentRole" });
   // ensuring end date isn't before the start date, using this as a minimum value
@@ -51,50 +57,44 @@ const WorkFields = ({ labels }: SubExperienceFormProps) => {
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-          <div data-h2-flex-grid="base(flex-start, x2, 0)">
-            <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-              <Input
-                id="startDate"
-                label={labels.startDate}
-                name="startDate"
-                type="date"
-                rules={{
-                  required: intl.formatMessage(errorMessages.required),
-                  max: {
-                    value: todayDate,
-                    message: intl.formatMessage(errorMessages.mustNotBeFuture),
-                  },
-                }}
-              />
-            </div>
-            <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-              {/* conditionally render the end-date based off the state attached to the checkbox input */}
-              {!isCurrent && (
-                <Input
-                  id="endDate"
-                  label={labels.endDate}
-                  name="endDate"
-                  type="date"
-                  rules={
-                    isCurrent
-                      ? {}
-                      : {
-                          required: intl.formatMessage(errorMessages.required),
-                          min: {
-                            value: startDate,
-                            message: intl.formatMessage(
-                              errorMessages.futureDate,
-                            ),
-                          },
-                        }
-                  }
-                />
-              )}
-            </div>
-          </div>
+          <Input id="team" label={labels.team} name="team" type="text" />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-          <Input id="team" label={labels.team} name="team" type="text" />
+          <DateInput
+            id="startDate"
+            legend={labels.startDate}
+            name="startDate"
+            show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+              max: {
+                value: strToFormDate(todayDate.toISOString()),
+                message: intl.formatMessage(errorMessages.mustNotBeFuture),
+              },
+            }}
+          />
+        </div>
+        <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
+          {/* conditionally render the end-date based off the state attached to the checkbox input */}
+          {!isCurrent && (
+            <DateInput
+              id="endDate"
+              legend={labels.endDate}
+              name="endDate"
+              show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+              rules={
+                isCurrent
+                  ? {}
+                  : {
+                      required: intl.formatMessage(errorMessages.required),
+                      min: {
+                        value: startDate,
+                        message: intl.formatMessage(errorMessages.futureDate),
+                      },
+                    }
+              }
+            />
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.test.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.test.tsx
@@ -45,7 +45,9 @@ describe("ApplicationStatusForm", () => {
       screen.getByRole("combobox", { name: /candidate pool status/i }),
     ).toBeInTheDocument();
 
-    expect(screen.getByLabelText(/candidate expiry date/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: /candidate expiry date/i }),
+    ).toBeInTheDocument();
 
     expect(screen.getByRole("textbox", { name: /notes/i })).toBeInTheDocument();
 

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.tsx
@@ -6,7 +6,7 @@ import PencilSquareIcon from "@heroicons/react/24/outline/PencilSquareIcon";
 
 import { toast } from "@gc-digital-talent/toast";
 import {
-  Input,
+  DateInput,
   Select,
   Submit,
   TextArea,
@@ -152,16 +152,15 @@ export const ApplicationStatusForm = ({
                       label: intl.formatMessage(getPoolCandidateStatus(value)),
                     }))}
                   />
-                  <Input
+                  <DateInput
                     id="expiryDate"
                     name="expiryDate"
-                    label={intl.formatMessage({
+                    legend={intl.formatMessage({
                       defaultMessage: "Candidate expiry date",
                       id: "SoKPAb",
                       description:
                         "Label displayed on the pool candidate application form expiry date field.",
                     })}
-                    type="date"
                   />
                 </div>
               </div>

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.test.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.test.tsx
@@ -4,8 +4,10 @@
 import "@testing-library/jest-dom";
 import React from "react";
 import { act, fireEvent, screen, within } from "@testing-library/react";
-import { currentDate } from "@gc-digital-talent/date-helpers";
-import { renderWithProviders } from "@gc-digital-talent/jest-helpers";
+import {
+  renderWithProviders,
+  updateDate,
+} from "@gc-digital-talent/jest-helpers";
 import { EditPoolForm, EditPoolFormProps } from "./EditPoolPage";
 import EditPoolStory, {
   DraftPool,
@@ -297,15 +299,25 @@ describe("Edit Pool tests", () => {
     });
 
     // find the modal
-    const dialog = screen.getByRole("dialog");
+    const dialog = await screen.getByRole("dialog", {
+      name: /extend closing date/i,
+    });
 
     // interact with the modal
     await act(async () => {
-      fireEvent.change(within(dialog).getByLabelText(/end date/i), {
-        target: { value: currentDate() },
+      const dateInput = within(dialog).getByRole("group", {
+        name: /end date/i,
       });
+      updateDate(dateInput, {
+        day: "01",
+        month: "01",
+        year: "3000",
+      });
+
       fireEvent.click(
-        within(dialog).getByRole("button", { name: /extend closing date/i }),
+        within(dialog).getByRole("button", {
+          name: /extend closing date/i,
+        }),
       );
     });
 

--- a/apps/web/src/pages/Pools/EditPoolPage/components/ClosingDateSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/ClosingDateSection.tsx
@@ -3,7 +3,7 @@ import { useIntl } from "react-intl";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { TableOfContents } from "@gc-digital-talent/ui";
-import { Input, Submit } from "@gc-digital-talent/forms";
+import { DateInput, Submit } from "@gc-digital-talent/forms";
 import {
   convertDateTimeToDate,
   convertDateTimeZone,
@@ -91,21 +91,15 @@ const ClosingDateSection = ({
       </p>
       <FormProvider {...methods}>
         <form onSubmit={handleSubmit(handleSave)}>
-          <div
-            data-h2-display="base(grid)"
-            data-h2-gap="base(x1)"
-            data-h2-grid-template-columns="l-tablet(repeat(2, 1fr))"
-            data-h2-margin="base(x1 0)"
-          >
-            <Input
+          <div data-h2-margin="base(x1 0)">
+            <DateInput
               id="endDate"
-              label={intl.formatMessage({
+              legend={intl.formatMessage({
                 defaultMessage: "End Date",
                 id: "80DOGy",
                 description:
                   "Label displayed on the pool candidate form end date field.",
               })}
-              type="date"
               name="endDate"
               disabled={formDisabled}
             />

--- a/apps/web/src/pages/Pools/EditPoolPage/components/ExtendDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/ExtendDialog.tsx
@@ -3,11 +3,11 @@ import { useIntl } from "react-intl";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { Dialog, Button } from "@gc-digital-talent/ui";
-import { Input } from "@gc-digital-talent/forms";
+import { DateInput } from "@gc-digital-talent/forms";
 import { commonMessages, errorMessages } from "@gc-digital-talent/i18n";
 import {
   convertDateTimeZone,
-  currentDate,
+  strToFormDate,
 } from "@gc-digital-talent/date-helpers";
 
 import { Pool, Scalars } from "~/api/generated";
@@ -27,6 +27,7 @@ const ExtendDialog = ({
 }: ExtendDialogProps): JSX.Element => {
   const intl = useIntl();
   const [open, setOpen] = React.useState(false);
+  const todayDate = new Date();
 
   const handleExtend = useCallback(
     async (formValues: FormValues) => {
@@ -84,7 +85,7 @@ const ExtendDialog = ({
               description: "Helper message for changing the pool closing date",
             })}
           </p>
-          <p data-h2-margin="base(x.25 0)">
+          <p data-h2-margin="base(x.5 0)">
             {intl.formatMessage({
               defaultMessage: "Write a new closing date:",
               id: "BQsJSG",
@@ -94,20 +95,19 @@ const ExtendDialog = ({
           </p>
           <FormProvider {...methods}>
             <form onSubmit={handleSubmit(handleExtend)}>
-              <Input
+              <DateInput
                 id="extendDialog-endDate"
-                label={intl.formatMessage({
+                legend={intl.formatMessage({
                   defaultMessage: "End Date",
                   id: "80DOGy",
                   description:
                     "Label displayed on the pool candidate form end date field.",
                 })}
-                type="date"
                 name="endDate"
                 rules={{
                   required: intl.formatMessage(errorMessages.required),
                   min: {
-                    value: currentDate(),
+                    value: strToFormDate(todayDate.toISOString()),
                     message: intl.formatMessage(errorMessages.futureDate),
                   },
                 }}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/ExtendDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/ExtendDialog.tsx
@@ -13,7 +13,7 @@ import {
 import { Pool, Scalars } from "~/api/generated";
 
 type FormValues = {
-  endDate?: Pool["closingDate"];
+  expiryEndDate?: Pool["closingDate"];
 };
 
 type ExtendDialogProps = {
@@ -31,9 +31,9 @@ const ExtendDialog = ({
 
   const handleExtend = useCallback(
     async (formValues: FormValues) => {
-      const closingDateInUtc = formValues.endDate
+      const closingDateInUtc = formValues.expiryEndDate
         ? convertDateTimeZone(
-            `${formValues.endDate} 23:59:59`,
+            `${formValues.expiryEndDate} 23:59:59`,
             "Canada/Pacific",
             "UTC",
           )
@@ -46,7 +46,7 @@ const ExtendDialog = ({
 
   const methods = useForm<FormValues>({
     defaultValues: {
-      endDate: closingDate
+      expiryEndDate: closingDate
         ? new Date(closingDate).toISOString().split("T")[0]
         : "",
     },
@@ -96,14 +96,14 @@ const ExtendDialog = ({
           <FormProvider {...methods}>
             <form onSubmit={handleSubmit(handleExtend)}>
               <DateInput
-                id="extendDialog-endDate"
+                id="expiryEndDate"
                 legend={intl.formatMessage({
                   defaultMessage: "End Date",
                   id: "80DOGy",
                   description:
                     "Label displayed on the pool candidate form end date field.",
                 })}
-                name="endDate"
+                name="expiryEndDate"
                 rules={{
                   required: intl.formatMessage(errorMessages.required),
                   min: {

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceForm.test.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceForm.test.tsx
@@ -2,13 +2,7 @@
  * @jest-environment jsdom
  */
 import "@testing-library/jest-dom";
-import {
-  screen,
-  fireEvent,
-  act,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { screen, fireEvent, act, waitFor } from "@testing-library/react";
 import React from "react";
 import { fakeSkills } from "@gc-digital-talent/fake-data";
 import {

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceForm.test.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceForm.test.tsx
@@ -2,10 +2,20 @@
  * @jest-environment jsdom
  */
 import "@testing-library/jest-dom";
-import { screen, fireEvent, act, waitFor } from "@testing-library/react";
+import {
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import React from "react";
 import { fakeSkills } from "@gc-digital-talent/fake-data";
-import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
+import {
+  axeTest,
+  renderWithProviders,
+  updateDate,
+} from "@gc-digital-talent/jest-helpers";
 import type { ExperienceType } from "~/types/experience";
 import { ExperienceForm, ExperienceFormProps } from "./ExperienceFormPage";
 
@@ -102,7 +112,9 @@ describe("ExperienceForm", () => {
       screen.getByRole("combobox", { name: /award scope/i }),
     ).toBeInTheDocument();
     // Note: Date inputs have no role by default
-    expect(screen.getByLabelText(/date awarded/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: /date awarded/i }),
+    ).toBeInTheDocument();
   });
 
   it("should render community fields", async () => {
@@ -124,8 +136,12 @@ describe("ExperienceForm", () => {
       screen.getByRole("textbox", { name: /project/i }),
     ).toBeInTheDocument();
 
-    expect(screen.getByLabelText(/start date/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/end date/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: /start date/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: /end date/i }),
+    ).toBeInTheDocument();
   });
 
   it("should render education fields", async () => {
@@ -155,8 +171,12 @@ describe("ExperienceForm", () => {
       screen.getByRole("textbox", { name: /thesis title/i }),
     ).toBeInTheDocument();
 
-    expect(screen.getByLabelText(/start date/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/end date/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: /start date/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: /end date/i }),
+    ).toBeInTheDocument();
   });
 
   it("should render personal fields", async () => {
@@ -183,8 +203,12 @@ describe("ExperienceForm", () => {
       screen.getByRole("group", { name: /current experience/i }),
     ).toBeInTheDocument();
 
-    expect(screen.getByLabelText(/start date/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/end date/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: /start date/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: /end date/i }),
+    ).toBeInTheDocument();
   });
 
   it("should render work fields", async () => {
@@ -209,8 +233,12 @@ describe("ExperienceForm", () => {
       screen.getByRole("group", { name: /current role/i }),
     ).toBeInTheDocument();
 
-    expect(screen.getByLabelText(/start date/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/end date/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: /start date/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: /end date/i }),
+    ).toBeInTheDocument();
   });
 
   it("should render work fields", async () => {
@@ -275,8 +303,11 @@ describe("ExperienceForm", () => {
     const awardTitle = screen.getByRole("textbox", { name: /award title/i });
     fireEvent.change(awardTitle, { target: { value: "AwardTitle" } });
 
-    const dateAwarded = screen.getByLabelText(/date awarded/i);
-    fireEvent.change(dateAwarded, { target: { value: "1111-11-11" } });
+    const dateAwarded = screen.getByRole("group", { name: /date awarded/i });
+    updateDate(dateAwarded, {
+      year: "1111",
+      month: "11",
+    });
 
     const awardedTo = screen.getByRole("combobox", {
       name: /awarded to/i,

--- a/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
@@ -5,7 +5,7 @@ import zipWith from "lodash/zipWith";
 
 import { Dialog, Button } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
-import { Input, MultiSelectField } from "@gc-digital-talent/forms";
+import { DateInput, MultiSelectField } from "@gc-digital-talent/forms";
 import { commonMessages, errorMessages } from "@gc-digital-talent/i18n";
 import { currentDate } from "@gc-digital-talent/date-helpers";
 import { notEmpty } from "@gc-digital-talent/helpers";
@@ -221,15 +221,14 @@ const AddToPoolDialog = ({ user, pools }: AddToPoolDialogProps) => {
                 })}
               </p>
               <div data-h2-margin="base(x.5, 0, x.125, 0)">
-                <Input
+                <DateInput
                   id="addToPoolDialog-expiryDate"
-                  label={intl.formatMessage({
+                  legend={intl.formatMessage({
                     defaultMessage: "Expiry date",
                     id: "sICXeM",
                     description:
                       "Label displayed on the date field of the add user to pool dialog",
                   })}
-                  type="date"
                   name="expiryDate"
                   rules={{
                     required: intl.formatMessage(errorMessages.required),

--- a/apps/web/src/pages/Users/UserInformationPage/components/ChangeDateDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/ChangeDateDialog.tsx
@@ -4,7 +4,7 @@ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 
 import { Dialog, Button } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
-import { Input } from "@gc-digital-talent/forms";
+import { DateInput } from "@gc-digital-talent/forms";
 import { commonMessages, errorMessages } from "@gc-digital-talent/i18n";
 import { currentDate } from "@gc-digital-talent/date-helpers";
 
@@ -131,15 +131,14 @@ const ChangeDateDialog = ({
                 })}
               </p>
               <div data-h2-margin="base(x.5, 0, x.125, 0)">
-                <Input
+                <DateInput
                   id="changeDateDialog-expiryDate"
-                  label={intl.formatMessage({
+                  legend={intl.formatMessage({
                     defaultMessage: "Expiry date",
                     id: "WAO4vD",
                     description:
                       "Label displayed on the date field of the change candidate expiry date dialog",
                   })}
-                  type="date"
                   name="expiryDate"
                   rules={{
                     required: intl.formatMessage(errorMessages.required),

--- a/packages/forms/src/components/DateInput/ControlledInput.tsx
+++ b/packages/forms/src/components/DateInput/ControlledInput.tsx
@@ -89,6 +89,7 @@ const ControlledInput = ({
             defaultValue={year}
             placeholder={intl.formatMessage(dateMessages.yearPlaceholder)}
             data-h2-width="base(100%)"
+            min={1900}
             {...inputStyles}
           />
         </div>
@@ -129,6 +130,7 @@ const ControlledInput = ({
             onChange={handleDayChange}
             defaultValue={day}
             max={31}
+            min={0}
             placeholder={intl.formatMessage(dateMessages.dayPlaceholder)}
             data-h2-width="base(100%)"
             {...inputStyles}

--- a/packages/forms/src/components/DateInput/ControlledInput.tsx
+++ b/packages/forms/src/components/DateInput/ControlledInput.tsx
@@ -50,8 +50,6 @@ const ControlledInput = ({
       show,
     });
 
-    console.log(newValue);
-
     onChange(newValue);
   };
 

--- a/packages/forms/src/components/DateInput/ControlledInput.tsx
+++ b/packages/forms/src/components/DateInput/ControlledInput.tsx
@@ -130,7 +130,7 @@ const ControlledInput = ({
             onChange={handleDayChange}
             defaultValue={day}
             max={31}
-            min={0}
+            min={1}
             placeholder={intl.formatMessage(dateMessages.dayPlaceholder)}
             data-h2-width="base(100%)"
             {...inputStyles}

--- a/packages/forms/src/components/DateInput/ControlledInput.tsx
+++ b/packages/forms/src/components/DateInput/ControlledInput.tsx
@@ -50,21 +50,24 @@ const ControlledInput = ({
       show,
     });
 
-    if (newValue) {
-      onChange(newValue);
-    }
+    console.log(newValue);
+
+    onChange(newValue);
   };
 
   const handleYearChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    handleChange(e.target.value.padStart(4, "0"), DATE_SEGMENT.Year);
+    const { value: newYear } = e.target;
+    handleChange(newYear ? newYear.padStart(4, "0") : "", DATE_SEGMENT.Year);
   };
 
   const handleMonthChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    handleChange(e.target.value.padStart(2, "0"), DATE_SEGMENT.Month);
+    const { value: newMonth } = e.target;
+    handleChange(newMonth ? newMonth.padStart(2, "0") : "", DATE_SEGMENT.Month);
   };
 
   const handleDayChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    handleChange(e.target.value.padStart(2, "0"), DATE_SEGMENT.Day);
+    const { value: newDay } = e.target;
+    handleChange(newDay ? newDay.padStart(2, "0") : "", DATE_SEGMENT.Day);
   };
 
   const months = getMonthOptions(intl);

--- a/packages/forms/src/components/DateInput/ControlledInput.tsx
+++ b/packages/forms/src/components/DateInput/ControlledInput.tsx
@@ -105,7 +105,7 @@ const ControlledInput = ({
             data-h2-width="base(100%)"
             {...inputStyles}
           >
-            <option disabled value="">
+            <option value="">
               {intl.formatMessage(dateMessages.selectAMonth)}
             </option>
             {months.map((monthName, index) => (

--- a/packages/forms/src/components/DateInput/DateInput.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.tsx
@@ -72,13 +72,6 @@ const DateInput = ({
     const { year, month, day } = splitSegments(value);
     const isOptionalAndEmpty = !rules.required && !year && !month && !day;
 
-    console.log({
-      required: !rules.required,
-      year,
-      month,
-      day,
-    });
-
     return (
       isOptionalAndEmpty ||
       isValid(formDateStringToDate(value)) ||

--- a/packages/forms/src/components/DateInput/DateInput.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.tsx
@@ -103,6 +103,8 @@ const DateInput = ({
       <Field.Fieldset aria-describedby={ariaDescribedBy} flat {...rest}>
         <Field.Legend
           required={required}
+          data-h2-font-size="base(copy)"
+          data-h2-font-weight="base(700)"
           {...(hideLegend && {
             "data-h2-visually-hidden": "base(invisible)",
           })}

--- a/packages/forms/src/components/DateInput/DateInput.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.tsx
@@ -12,7 +12,6 @@ import { FieldError, useFormContext, Controller } from "react-hook-form";
 import { errorMessages } from "@gc-digital-talent/i18n";
 import { formDateStringToDate } from "@gc-digital-talent/date-helpers";
 
-import { is } from "date-fns/locale";
 import Field from "../Field";
 import { CommonInputProps, HTMLFieldsetProps } from "../../types";
 import useFieldState from "../../hooks/useFieldState";

--- a/packages/forms/src/components/DateInput/DateInput.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.tsx
@@ -12,6 +12,7 @@ import { FieldError, useFormContext, Controller } from "react-hook-form";
 import { errorMessages } from "@gc-digital-talent/i18n";
 import { formDateStringToDate } from "@gc-digital-talent/date-helpers";
 
+import { is } from "date-fns/locale";
 import Field from "../Field";
 import { CommonInputProps, HTMLFieldsetProps } from "../../types";
 import useFieldState from "../../hooks/useFieldState";
@@ -69,8 +70,15 @@ const DateInput = ({
 
   const isValidDate = (value: string) => {
     const { year, month, day } = splitSegments(value);
-    const isOptionalAndEmpty =
-      Boolean(rules.required) && !year && !month && !day;
+    const isOptionalAndEmpty = !rules.required && !year && !month && !day;
+
+    console.log({
+      required: !rules.required,
+      year,
+      month,
+      day,
+    });
+
     return (
       isOptionalAndEmpty ||
       isValid(formDateStringToDate(value)) ||

--- a/packages/forms/src/components/DateInput/utils.ts
+++ b/packages/forms/src/components/DateInput/utils.ts
@@ -56,7 +56,7 @@ type GetComputedSegmentValue = (args: GetComputedSegmentValueArgs) => string;
  * @returns string
  */
 const getComputedSegmentValue: GetComputedSegmentValue = ({ values, show }) => {
-  if (values.new) {
+  if (values.new !== null) {
     return values.new;
   }
 
@@ -72,7 +72,7 @@ type SetComputedValueArgs = {
   initialValue?: string;
   show: Array<DateSegment>;
   segment: DateSegment;
-  value: string;
+  value: string | null;
 };
 
 type SetComputedValueFunc = (args: SetComputedValueArgs) => string | undefined;
@@ -117,6 +117,10 @@ export const setComputedValue: SetComputedValueFunc = ({
     },
     show: show.includes(DATE_SEGMENT.Day),
   });
+
+  if (!newYear && !newMonth && !newDay) {
+    return "";
+  }
 
   return [newYear, newMonth, newDay].join("-");
 };

--- a/packages/forms/src/components/Field/Fieldset.tsx
+++ b/packages/forms/src/components/Field/Fieldset.tsx
@@ -15,16 +15,19 @@ const Fieldset = ({ flat, boundingBox, ...rest }: FieldsetProps) => {
   return (
     <fieldset
       {...(boundingBox && styles)}
-      data-h2-background="base(white) base:dark(black.light)"
       data-h2-display="base(flex)"
       data-h2-flex-direction="base(column)"
       data-h2-gap="base(x.25 0)"
       data-h2-position="base(relative)"
       data-h2-margin-top="base(x1.25)"
-      {...(flat && {
-        "data-h2-border": "base(none)",
-        "data-h2-padding": "base(0)",
-      })}
+      {...(flat
+        ? {
+            "data-h2-border": "base(none)",
+            "data-h2-padding": "base(0)",
+          }
+        : {
+            "data-h2-background": "base(white) base:dark(black.light)",
+          })}
       {...rest}
     />
   );

--- a/packages/forms/src/components/Field/Legend.tsx
+++ b/packages/forms/src/components/Field/Legend.tsx
@@ -14,8 +14,7 @@ const Legend = ({ required, children, ...props }: LegendProps) => (
     data-h2-position="base(absolute)"
     data-h2-left="base(0)"
     data-h2-top="base(-x1.25)"
-    data-h2-font-size="base(copy)"
-    data-h2-font-weight="base(700)"
+    data-h2-font-size="base(caption)"
     {...props}
   >
     {children}

--- a/packages/forms/src/components/Field/Legend.tsx
+++ b/packages/forms/src/components/Field/Legend.tsx
@@ -14,7 +14,8 @@ const Legend = ({ required, children, ...props }: LegendProps) => (
     data-h2-position="base(absolute)"
     data-h2-left="base(0)"
     data-h2-top="base(-x1.25)"
-    data-h2-font-size="base(caption)"
+    data-h2-font-size="base(copy)"
+    data-h2-font-weight="base(700)"
     {...props}
   >
     {children}

--- a/packages/forms/src/components/Input/Input.tsx
+++ b/packages/forms/src/components/Input/Input.tsx
@@ -12,7 +12,7 @@ import useCommonInputStyles from "../../hooks/useCommonInputStyles";
 export type InputProps = HTMLInputProps &
   CommonInputProps & {
     /** Set the type of the input. */
-    type: "text" | "number" | "email" | "tel" | "password" | "date" | "search";
+    type: "text" | "number" | "email" | "tel" | "password" | "search";
     // Whether to trim leading/ending whitespace upon blurring of an input, default on
     whitespaceTrim?: boolean;
   };

--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -6,6 +6,7 @@ import Checklist, {
 } from "./components/Checklist";
 import Combobox, { ComboboxProps } from "./components/Combobox";
 import DateInput, { DateInputProps } from "./components/DateInput/DateInput";
+import { DateSegment, DATE_SEGMENT } from "./components/DateInput/types";
 import Field, {
   ContextProps,
   DescriptionsProps,
@@ -50,6 +51,7 @@ import {
 import useCommonInputStyles from "./hooks/useCommonInputStyles";
 
 export {
+  DATE_SEGMENT,
   DateInput,
   Checkbox,
   CheckButton,
@@ -72,6 +74,7 @@ export {
 
 export type {
   DateInputProps,
+  DateSegment,
   CheckboxProps,
   CheckboxOption,
   CheckButtonProps,

--- a/packages/jest-helpers/src/index.ts
+++ b/packages/jest-helpers/src/index.ts
@@ -3,6 +3,7 @@ import "./mocks/matchMeta";
 import Providers from "./components/Providers";
 
 import axeTest from "./utils/axe";
+import updateDate from "./utils/date";
 import renderWithProviders from "./utils/render";
 
-export { Providers, axeTest, renderWithProviders };
+export { Providers, axeTest, updateDate, renderWithProviders };

--- a/packages/jest-helpers/src/utils/date.ts
+++ b/packages/jest-helpers/src/utils/date.ts
@@ -1,0 +1,27 @@
+import { fireEvent, within } from "@testing-library/react";
+
+const changeDate = (
+  container: HTMLElement,
+  update: {
+    year?: string;
+    month?: string;
+    day?: string;
+  },
+) => {
+  if (update.year) {
+    const year = within(container).getByRole("spinbutton", { name: /year/i });
+    fireEvent.change(year, { target: { value: update.year } });
+  }
+
+  if (update.month) {
+    const month = within(container).getByRole("combobox", { name: /month/i });
+    fireEvent.change(month, { target: { value: update.month } });
+  }
+
+  if (update.day) {
+    const day = within(container).getByRole("spinbutton", { name: /day/i });
+    fireEvent.change(day, { target: { value: update.day } });
+  }
+};
+
+export default changeDate;


### PR DESCRIPTION
🤖 Resolves #6352 

## 👋 Introduction

Replaces the default `input[type=date]` with our custom date input and prevents using `input[type=date]` in the future.

## 🕵️ Details

Some layouts were slightly adjusted to accommodate the larger inputs.

## 🐛 August Bug

While testing this, I noticed a bug with our date formatting. If you select August 1st, it is formatted as July 31st. The date stores in the database correctly but rendered incorrectly. If you are testing and notice this, it does seem to be a bug with formatting and not the date input itself.

![Screenshot 2023-06-16 102400](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/a9d162ad-de07-418f-b9eb-d5a4e9459cd0)

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to every experience form and test the date inputs, confirming they only allow month and year
3. Navigate to a pool edit page in the admin and test the following:
    - Closing Date
    - Extend Date
4. Navigate to a pool candidate and test the following:
    - Application status expiry date
    - Pool status form, both adding and changing the expiry date

## 📸 Screenshot

### Default
![Screenshot 2023-06-16 103604](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/070ac443-e00f-4ba4-9845-366df6b10095)

### Experience
![Screenshot 2023-06-16 103551](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/553465d3-a741-4417-9f52-72bce3f9d20b)
