### PR TITLE
[Fix] Focus error summary on experience forms

### DIFF
--- a/apps/web/src/components/ExperienceFormFields/ErrorSummary.tsx
+++ b/apps/web/src/components/ExperienceFormFields/ErrorSummary.tsx
@@ -8,7 +8,7 @@ import { getExperienceFormLabels } from "~/utils/experienceUtils";
 import { ExperienceType } from "~/types/experience";
 
 interface ErrorSummaryProps {
-  experienceType?: ExperienceType;
+  experienceType?: ExperienceType | "";
 }
 
 const ErrorSummary = ({ experienceType }: ErrorSummaryProps) => {

--- a/apps/web/src/pages/Applications/ApplicationResumeAddPage/components/AddExperienceForm.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumeAddPage/components/AddExperienceForm.tsx
@@ -20,6 +20,7 @@ import {
 } from "~/types/experience";
 import TasksAndResponsibilities from "~/components/ExperienceFormFields/TasksAndResponsibilities";
 import ExperienceDetails from "~/components/ExperienceFormFields/ExperienceDetails";
+import ErrorSummary from "~/components/ExperienceFormFields/ErrorSummary";
 
 import { experienceTypeTitles } from "../messages";
 
@@ -38,7 +39,9 @@ const AddExperienceForm = ({ applicationId }: AddExperienceFormProps) => {
   const navigate = useNavigate();
   const paths = useRoutes();
   const { user } = useAuthorization();
-  const methods = useForm<ExperienceExperienceFormValues>();
+  const methods = useForm<ExperienceExperienceFormValues>({
+    shouldFocusError: false,
+  });
   const {
     watch,
     register,
@@ -100,6 +103,7 @@ const AddExperienceForm = ({ applicationId }: AddExperienceFormProps) => {
   return (
     <FormProvider {...methods}>
       <form onSubmit={methods.handleSubmit(handleSubmit)}>
+        <ErrorSummary experienceType={type} />
         <Heading level="h3">
           {intl.formatMessage({
             defaultMessage: "Select a type of experience",

--- a/apps/web/src/pages/Applications/ApplicationResumeEditPage/components/ExperienceEditForm.tsx
+++ b/apps/web/src/pages/Applications/ApplicationResumeEditPage/components/ExperienceEditForm.tsx
@@ -54,6 +54,7 @@ const EditExperienceForm = ({
   );
   const methods = useForm<ExperienceExperienceFormValues>({
     defaultValues,
+    shouldFocusError: false,
   });
   const executeDeletionMutation = useDeleteExperienceMutation(experienceType);
   const { executeMutation, getMutationArgs } = useExperienceMutations(

--- a/packages/forms/src/components/ErrorSummary.tsx
+++ b/packages/forms/src/components/ErrorSummary.tsx
@@ -72,7 +72,7 @@ const ErrorSummary = React.forwardRef<
   };
 
   return invalidFields.length > 0 ? (
-    <Alert.Root type="error" ref={forwardedRef} tabIndex={0}>
+    <Alert.Root type="error" ref={forwardedRef} tabIndex={-1}>
       <Alert.Title>
         {intl.formatMessage(errorMessages.summaryTitle)}
       </Alert.Title>


### PR DESCRIPTION
🤖 Resolves #6950 

## 👋 Introduction

This fixes a bug where the error summary was not being focused on the application experience forms.

## 🕵️ Details

This changes 3 distinct things:

- Removes the summary from the natural tab order only allowing us to focus programmatically
- Prevents the experience forms from focusing the first invalid input on submission
- Adds the missing error summary to the add experience form

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Start an application and continue to the resume step
3. add an exerience
4. Submit form with errors
5. confirm error summary appears and focus is brought to it
6. Repeat steps 3-5 on the edit form

## 📸 Screenshot

<img width="883" alt="Screenshot 2023-06-20 at 10 40 17 AM" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/8ce9d9f4-aa3a-4d08-be89-f703774cf994">
