### PR TITLE
[Fix] Hide recruitment flag from accessibility tree

### DIFF
--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/PoolCard/PoolCard.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/PoolCard/PoolCard.tsx
@@ -70,6 +70,7 @@ const PoolCard = ({ pool, headingLevel = "h3" }: PoolCardProps) => {
       data-h2-radius="base(rounded)"
     >
       <div
+        aria-hidden="true"
         data-h2-position="base(absolute)"
         data-h2-location="base(0, auto, auto, x.5) p-tablet(0, auto, auto, x2)"
       >


### PR DESCRIPTION
🤖 Resolves #6952 

## 👋 Introduction

This adds `aria-hidden="true"` to the recruitment flag on the browse jobs page.

## 🕵️ Details

The flag was being read to screen reader users before the heading, causing some users confusion. Since the content of the flag also appears in the title, we have opted to hide it from the accessibility tree since no information is lost in doing so.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/browse/pools`
3. Inspect the flag on pool cards in the accessibility tree
4. Confirm it is ignored
5. Test using a screen reader
6. Confirm the contents of the flag are ignored
