### PR TITLE
[Bug] AwardContent date displayed fix

### DIFF
--- a/apps/web/src/components/ExperienceCard/AwardContent.tsx
+++ b/apps/web/src/components/ExperienceCard/AwardContent.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 import {
   commonMessages,
   getAwardedScope,
@@ -9,6 +8,7 @@ import {
 } from "@gc-digital-talent/i18n";
 
 import { AwardExperience } from "~/api/generated";
+import { formattedDate } from "~/utils/dateUtils";
 import ContentSection from "./ContentSection";
 import { ContentProps } from "./types";
 
@@ -36,11 +36,7 @@ const AwardContent = ({
       >
         <p>
           {awardedDate
-            ? formatDate({
-                date: parseDateTimeUtc(awardedDate),
-                intl,
-                formatString: "PPP",
-              })
+            ? formattedDate(awardedDate, intl)
             : intl.formatMessage(commonMessages.notProvided)}
         </p>
       </ContentSection>


### PR DESCRIPTION
🤖 Resolves #7000 

## 👋 Introduction

Resolve the date inconsistency for award experiences. 

## 🕵️ Details

I just mimicked how dates were rendered for the other experiences on the same page, plus, since you couldn't pick the day itself the card shouldn't display a day. 
It also seems like we already had all the needed functions present. 

Used `formattedDate()` to align with other experiences

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/0d587934-fa2c-4b38-816e-7edbb4e79def)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/0914b0a7-a65c-40b9-981a-54b25edf4d3f)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/b1b7ded9-53d5-4c76-bba6-33b9284b861c)

## 🧪 Testing

1. Navigate to `/resume-and-recruitments`
2. Create an award experience and assert the date displayed is correct 

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/08113d15-c42b-4f23-afbc-93d7e04560f9)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/32866189-f680-4c06-bf95-8f7498a94239)
