### PR TITLE
[Feature] Remove pool candidate details section from print

### DIFF
--- a/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
+++ b/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
@@ -16,12 +16,9 @@ import {
   getEmploymentEquityStatement,
   getGenericJobTitles,
   getIndigenousCommunity,
-  getJobLookingStatus,
   getLanguageProficiency,
   getLocale,
   getOperationalRequirement,
-  getPoolCandidatePriorities,
-  getPoolCandidateStatus,
   getSimpleGovEmployeeType,
   getWorkRegion,
   navigationMessages,
@@ -88,11 +85,8 @@ const ProfileDocument = React.forwardRef<HTMLDivElement, ProfileDocumentProps>(
             )}
             {results &&
               results.map((initialResult, index) => {
-                const isPoolCandidate = "user" in initialResult;
                 const result: Applicant =
                   "user" in initialResult ? initialResult.user : initialResult;
-                const resultPoolCandidate: PoolCandidate | null =
-                  isPoolCandidate ? initialResult : null;
 
                 const govEmployeeTypeId =
                   enumToOptions(GovEmployeeType).find(
@@ -185,110 +179,6 @@ const ProfileDocument = React.forwardRef<HTMLDivElement, ProfileDocumentProps>(
                             )}
                         </Heading>
                       </PageSection>
-                      {isPoolCandidate ? (
-                        <PageSection>
-                          <Heading level="h3">
-                            {intl.formatMessage({
-                              defaultMessage: "Pool candidate details",
-                              id: "xD0Vbd",
-                              description:
-                                "Title of the pool candidate details content section",
-                            })}
-                          </Heading>
-                          <p>
-                            {intl.formatMessage({
-                              defaultMessage: "Status",
-                              id: "s2y5eG",
-                              description: "Status label",
-                            })}
-                            {intl.formatMessage(commonMessages.dividingColon)}
-                            {resultPoolCandidate && resultPoolCandidate.status
-                              ? intl.formatMessage(
-                                  getPoolCandidateStatus(
-                                    resultPoolCandidate.status as string,
-                                  ),
-                                )
-                              : ""}
-                          </p>
-                          <p>
-                            {intl.formatMessage({
-                              defaultMessage: "Priority",
-                              id: "qSDM1H",
-                              description: "Priority label",
-                            })}
-                            {intl.formatMessage(commonMessages.dividingColon)}
-                            {result.priorityWeight
-                              ? intl.formatMessage(
-                                  getPoolCandidatePriorities(
-                                    result.priorityWeight,
-                                  ),
-                                )
-                              : ""}
-                          </p>
-                          <p>
-                            {intl.formatMessage({
-                              defaultMessage: "Availability",
-                              id: "mevv+t",
-                              description: "Availability label",
-                            })}
-                            {intl.formatMessage(commonMessages.dividingColon)}
-                            {result.jobLookingStatus
-                              ? intl.formatMessage(
-                                  getJobLookingStatus(
-                                    result.jobLookingStatus as string,
-                                    "short",
-                                  ),
-                                )
-                              : ""}
-                          </p>
-                          <p>
-                            {intl.formatMessage({
-                              defaultMessage: "Notes",
-                              id: "rwNxlI",
-                              description: "Notes label",
-                            })}
-                            {intl.formatMessage(commonMessages.dividingColon)}
-                            {(resultPoolCandidate &&
-                              resultPoolCandidate.notes) ||
-                              ""}
-                          </p>
-                          <p>
-                            {intl.formatMessage({
-                              defaultMessage: "Date received",
-                              id: "DjSiTu",
-                              description: "Date received label",
-                            })}
-                            {intl.formatMessage(commonMessages.dividingColon)}
-                            {(resultPoolCandidate &&
-                              resultPoolCandidate.submittedAt) ||
-                              ""}
-                          </p>
-                          <p>
-                            {intl.formatMessage({
-                              defaultMessage: "Expiry date",
-                              id: "Gthvhd",
-                              description: "Expiry date label",
-                            })}
-                            {intl.formatMessage(commonMessages.dividingColon)}
-                            {(resultPoolCandidate &&
-                              resultPoolCandidate.expiryDate) ||
-                              ""}
-                          </p>
-                          <p>
-                            {intl.formatMessage({
-                              defaultMessage: "Archival date",
-                              id: "bjnh/y",
-                              description: "Archival date label",
-                            })}
-                            {intl.formatMessage(commonMessages.dividingColon)}
-                            {(resultPoolCandidate &&
-                              resultPoolCandidate.archivedAt) ||
-                              ""}
-                          </p>
-                        </PageSection>
-                      ) : (
-                        ""
-                      )}
                       <PageSection>
                         <Heading level="h3">
                           {intl.formatMessage(navigationMessages.myStatus)}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7912,37 +7912,9 @@
     "defaultMessage": "Membre des FAC",
     "description": "Veteran/member label"
   },
-  "DjSiTu": {
-    "defaultMessage": "Date de réception",
-    "description": "Date received label"
-  },
-  "Gthvhd": {
-    "defaultMessage": "Date d'expiration",
-    "description": "Expiry date label"
-  },
-  "bjnh/y": {
-    "defaultMessage": "Date d'archivage",
-    "description": "Archival date label"
-  },
   "mevv+t": {
     "defaultMessage": "Disponibilité",
     "description": "Availability label"
-  },
-  "qSDM1H": {
-    "defaultMessage": "Priorité",
-    "description": "Priority label"
-  },
-  "rwNxlI": {
-    "defaultMessage": "Notes",
-    "description": "Notes label"
-  },
-  "s2y5eG": {
-    "defaultMessage": "Statut",
-    "description": "Status label"
-  },
-  "xD0Vbd": {
-    "defaultMessage": "Détails du candidat du bassin",
-    "description": "Title of the pool candidate details content section"
   },
   "mUiS9q": {
     "defaultMessage": "{resultCount, plural, =1 {Profil du candidat} other {Profils des candidats} }",


### PR DESCRIPTION
🤖 Resolves #6948 

## 👋 Introduction

Removes the section from the download view. 

## 🧪 Testing

1. Navigate to `/en/admin/pools/:id/pool-candidates`
2. Select 1 or more candidates then click "Download Profiles" 
3. Affirm the section is no longer present

## 📸 Screenshot

Before

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/776c6fa9-45cc-49db-8e50-eeb169b53b78)

After

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/f8f70210-56e2-416d-a761-a779152abb2c)
