### PR TITLE
[Feature] IAP Contact Dialog

### DIFF
--- a/apps/web/src/components/Dialog/IapContactDialog.tsx
+++ b/apps/web/src/components/Dialog/IapContactDialog.tsx
@@ -33,11 +33,11 @@ const IapContactDialog = () => {
               {
                 defaultMessage:
                   "If you have questions concerning this step, or if you are unsure about how to proceed, please feel free to reach out to our support team at <a>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</a>.",
-                id: "NB+kBj",
+                id: "ltzA7w",
                 description:
-                  "How to get help with from the support team - IAP variant",
+                  "How to get help from the support team - IAP variant",
               },
-              { mailLink },
+              { a: mailLink },
             )}
           </p>
         </Dialog.Body>

--- a/apps/web/src/components/Dialog/IapContactDialog.tsx
+++ b/apps/web/src/components/Dialog/IapContactDialog.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import ChatBubbleLeftRightIcon from "@heroicons/react/20/solid/ChatBubbleLeftRightIcon";
+
+import { Button, Dialog, Link } from "@gc-digital-talent/ui";
+
+const mailLink = (chunks: React.ReactNode) => (
+  <Link external href="mailto:edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca">
+    {chunks}
+  </Link>
+);
+
+const IapContactDialog = () => {
+  const intl = useIntl();
+
+  const title = intl.formatMessage({
+    defaultMessage: "Contact us",
+    id: "o4tj77",
+    description:
+      "Title for the contact dialog for the Indigenous Apprenticeship Program application process",
+  });
+
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger>
+        <Button icon={ChatBubbleLeftRightIcon}>{title}</Button>
+      </Dialog.Trigger>
+      <Dialog.Content>
+        <Dialog.Header>{title}</Dialog.Header>
+        <Dialog.Body>
+          <p>
+            {intl.formatMessage(
+              {
+                defaultMessage:
+                  "If you have questions concerning this step, or if you are unsure about how to proceed, please feel free to reach out to our support team at <mailLink>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</mailLink>",
+                id: "TxyOcb",
+                description:
+                  "Text for contacting the support team within the Indigenous Apprenticeship Program application process",
+              },
+              { mailLink },
+            )}
+          </p>
+        </Dialog.Body>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};
+
+export default IapContactDialog;

--- a/apps/web/src/components/Dialog/IapContactDialog.tsx
+++ b/apps/web/src/components/Dialog/IapContactDialog.tsx
@@ -32,10 +32,10 @@ const IapContactDialog = () => {
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "If you have questions concerning this step, or if you are unsure about how to proceed, please feel free to reach out to our support team at <mailLink>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</mailLink>",
-                id: "TxyOcb",
+                  "If you have questions concerning this step, or if you are unsure about how to proceed, please feel free to reach out to our support team at <a>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</a>.",
+                id: "NB+kBj",
                 description:
-                  "Text for contacting the support team within the Indigenous Apprenticeship Program application process",
+                  "How to get help with from the support team - IAP variant",
               },
               { mailLink },
             )}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8304,9 +8304,9 @@
     "defaultMessage": "La CléGC est un service qui vous permet d’accéder à <a>plusieurs services gouvernementaux variés </a> à l’aide d’un seul nom d’utilisateur et mot de passe. Le bouton qui figure ci-dessous vous mènera au site Web CléGC, à partir duquel vous pourrez créer un compte si vous n’en avez toujours pas un. Une fois inscrit(e) à CléGC, vous reviendrez ici pour compléter votre profil.",
     "description": "Instructions on how to register with GCKey paragraph 2- IAP variant"
   },
-  "NB+kBj": {
+  "ltzA7w": {
     "defaultMessage": "Si vous avez des questions concernant cette étape, ou si vous ne savez pas trop comment procéder, veuillez communiquer avec notre équipe de soutien, à <a>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</a>.",
-    "description": "How to get help with logging in - IAP variant"
+    "description": "How to get help from the support team - IAP variant"
   },
   "oPUU6o": {
     "defaultMessage": "Si vous n’êtes pas certain(e) d’avoir un compte CléGC, veuillez continuer au site Web et tentez d’y accéder. Si vous ne pouvez pas vous rappeler de votre mot de passe, vous pourrez également le rétablir.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8304,7 +8304,7 @@
     "defaultMessage": "La CléGC est un service qui vous permet d’accéder à <a>plusieurs services gouvernementaux variés </a> à l’aide d’un seul nom d’utilisateur et mot de passe. Le bouton qui figure ci-dessous vous mènera au site Web CléGC, à partir duquel vous pourrez créer un compte si vous n’en avez toujours pas un. Une fois inscrit(e) à CléGC, vous reviendrez ici pour compléter votre profil.",
     "description": "Instructions on how to register with GCKey paragraph 2- IAP variant"
   },
-  "lRUGPY": {
+  "NB+kBj": {
     "defaultMessage": "Si vous avez des questions concernant cette étape, ou si vous ne savez pas trop comment procéder, veuillez communiquer avec notre équipe de soutien, à <a>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</a>.",
     "description": "How to get help with logging in - IAP variant"
   },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8367,5 +8367,9 @@
   "SyJkc/": {
     "defaultMessage": "Curriculum vitæ et recrutements",
     "description": "Name of Résumé and recruitments page"
+  },
+  "o4tj77": {
+    "defaultMessage": "Pour nous joindre",
+    "description": "Title for the contact dialog for the Indigenous Apprenticeship Program application process"
   }
 }

--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -13,12 +13,13 @@ import { empty, notEmpty } from "@gc-digital-talent/helpers";
 
 import SEO from "~/components/SEO/SEO";
 import Hero from "~/components/Hero/Hero";
+import IapContactDialog from "~/components/Dialog/IapContactDialog";
 
 import useRoutes from "~/hooks/useRoutes";
 import useCurrentPage from "~/hooks/useCurrentPage";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
-import { fullPoolTitle } from "~/utils/poolUtils";
+import { fullPoolTitle, isIAPPool } from "~/utils/poolUtils";
 import { useGetApplicationQuery } from "~/api/generated";
 import {
   applicationStepsToStepperArgs,
@@ -43,6 +44,7 @@ const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
     experienceId,
   });
   const title = fullPoolTitle(intl, application.pool);
+  const isIAP = isIAPPool(application.pool);
 
   const pageTitle = defineMessage({
     defaultMessage: "Apply to {poolName}",
@@ -136,6 +138,11 @@ const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
               currentIndex={currentStepIndex}
               steps={applicationStepsToStepperArgs(steps, application)}
             />
+            {isIAP && (
+              <div data-h2-margin="base(x1 0)">
+                <IapContactDialog />
+              </div>
+            )}
           </TableOfContents.Sidebar>
           <TableOfContents.Content>
             {userIsOnDisabledPage ? (

--- a/apps/web/src/pages/Auth/LoginPage/LoginPage.tsx
+++ b/apps/web/src/pages/Auth/LoginPage/LoginPage.tsx
@@ -151,9 +151,9 @@ const LoginPage = () => {
                   {
                     defaultMessage:
                       "If you have questions concerning this step, or if you are unsure about how to proceed, please feel free to reach out to our support team at <a>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</a>.",
-                    id: "lRUGPY",
+                    id: "NB+kBj",
                     description:
-                      "How to get help with logging in - IAP variant",
+                      "How to get help with from the support team - IAP variant",
                   },
                   {
                     a: (chunks: React.ReactNode) =>

--- a/apps/web/src/pages/Auth/LoginPage/LoginPage.tsx
+++ b/apps/web/src/pages/Auth/LoginPage/LoginPage.tsx
@@ -151,9 +151,9 @@ const LoginPage = () => {
                   {
                     defaultMessage:
                       "If you have questions concerning this step, or if you are unsure about how to proceed, please feel free to reach out to our support team at <a>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</a>.",
-                    id: "NB+kBj",
+                    id: "ltzA7w",
                     description:
-                      "How to get help with from the support team - IAP variant",
+                      "How to get help from the support team - IAP variant",
                   },
                   {
                     a: (chunks: React.ReactNode) =>

--- a/apps/web/src/pages/Auth/RegisterPage/RegisterPage.tsx
+++ b/apps/web/src/pages/Auth/RegisterPage/RegisterPage.tsx
@@ -163,9 +163,9 @@ const RegisterPage = () => {
                   {
                     defaultMessage:
                       "If you have questions concerning this step, or if you are unsure about how to proceed, please feel free to reach out to our support team at <a>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</a>.",
-                    id: "NB+kBj",
+                    id: "ltzA7w",
                     description:
-                      "How to get help with from the support team - IAP variant",
+                      "How to get help from the support team - IAP variant",
                   },
                   {
                     a: (chunks: React.ReactNode) =>

--- a/apps/web/src/pages/Auth/RegisterPage/RegisterPage.tsx
+++ b/apps/web/src/pages/Auth/RegisterPage/RegisterPage.tsx
@@ -163,9 +163,9 @@ const RegisterPage = () => {
                   {
                     defaultMessage:
                       "If you have questions concerning this step, or if you are unsure about how to proceed, please feel free to reach out to our support team at <a>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</a>.",
-                    id: "lRUGPY",
+                    id: "NB+kBj",
                     description:
-                      "How to get help with logging in - IAP variant",
+                      "How to get help with from the support team - IAP variant",
                   },
                   {
                     a: (chunks: React.ReactNode) =>


### PR DESCRIPTION
🤖 Resolves #7023 

## 👋 Introduction

This adds a dialog with contact information to the IAP application process

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/indigenous-it-apprentice`
3. Click "Apply now"
4. Confirm the "Contact us" button appears below the stepper and opens a dialog with the appropriate content
5. Navigate to `/browse/pools`
6. Start an application for any pool other than the IAP pool
7. Confirm the button does not appear

## 📸 Screenshot

![Screenshot 2023-06-23 084157](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/f3af457b-7dfa-4049-92ca-c3802b493be9)
![Screenshot 2023-06-23 084201](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/63bc74a3-e47d-4960-8d89-857bba353ec8)

