### PR TITLE
[Feature] Hide work duration in IAP application

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/WorkPreferences/Display.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/WorkPreferences/Display.tsx
@@ -13,6 +13,7 @@ import { PositionDuration } from "~/api/generated";
 
 import FieldDisplay from "../FieldDisplay";
 import DisplayColumn from "../DisplayColumn";
+import { useApplicationContext } from "../../../ApplicationContext";
 
 interface DisplayProps {
   user: User;
@@ -27,6 +28,7 @@ const Display = ({
   },
 }: DisplayProps) => {
   const intl = useIntl();
+  const { isIAP } = useApplicationContext();
   const notProvided = intl.formatMessage(commonMessages.notProvided);
   const locations = locationPreferences?.filter(notEmpty);
   const acceptedRequirements =
@@ -54,16 +56,18 @@ const Display = ({
       data-h2-gap="base(x1)"
     >
       <DisplayColumn>
-        <FieldDisplay
-          hasError={empty(positionDuration)}
-          label={intl.formatMessage({
-            defaultMessage: "Job duration",
-            id: "/yOfhq",
-            description: "Job duration label",
-          })}
-        >
-          {positionDuration ? durationMessage : notProvided}
-        </FieldDisplay>
+        {!isIAP && (
+          <FieldDisplay
+            hasError={empty(positionDuration)}
+            label={intl.formatMessage({
+              defaultMessage: "Job duration",
+              id: "/yOfhq",
+              description: "Job duration label",
+            })}
+          >
+            {positionDuration ? durationMessage : notProvided}
+          </FieldDisplay>
+        )}
         <div>
           <FieldDisplay
             label={intl.formatMessage({

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/WorkPreferences/FormFields.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/WorkPreferences/FormFields.tsx
@@ -16,12 +16,16 @@ import {
 
 import { WorkRegion } from "~/api/generated";
 
+import { useFormContext } from "react-hook-form";
 import { FormFieldProps } from "../../types";
 import WithEllipsisPrefix from "./WithEllipsisPrefix";
 import useDirtyFields from "../../hooks/useDirtyFields";
+import { useApplicationContext } from "../../../ApplicationContext";
 
 const FormFields = ({ labels }: FormFieldProps) => {
   const intl = useIntl();
+  const { isIAP } = useApplicationContext();
+  const { register } = useFormContext();
   useDirtyFields("work");
 
   return (
@@ -30,41 +34,49 @@ const FormFields = ({ labels }: FormFieldProps) => {
       data-h2-flex-direction="base(column)"
       data-h2-gap="base(x1 0)"
     >
-      <RadioGroup
-        idPrefix="required-work-preferences"
-        legend={labels.wouldAcceptTemporary}
-        name="wouldAcceptTemporary"
-        id="wouldAcceptTemporary"
-        rules={{
-          required: intl.formatMessage(errorMessages.required),
-        }}
-        items={[
-          {
-            value: "true",
-            label: (
-              <WithEllipsisPrefix>
-                {intl.formatMessage({
-                  defaultMessage:
-                    "any duration. (short term, long term, or indeterminate duration)",
-                  id: "uHx3G7",
-                  description:
-                    "Label displayed on Work Preferences form for any duration option",
-                })}
-              </WithEllipsisPrefix>
-            ),
-          },
-          {
-            value: "false",
-            label: intl.formatMessage({
-              defaultMessage:
-                "...indeterminate duration only. (permanent only)",
-              id: "sYqIp5",
-              description:
-                "Label displayed on Work Preferences form for indeterminate duration option.",
-            }),
-          },
-        ]}
-      />
+      {isIAP ? (
+        <input
+          {...register("wouldAcceptTemporary")}
+          type="hidden"
+          value="true"
+        />
+      ) : (
+        <RadioGroup
+          idPrefix="required-work-preferences"
+          legend={labels.wouldAcceptTemporary}
+          name="wouldAcceptTemporary"
+          id="wouldAcceptTemporary"
+          rules={{
+            required: intl.formatMessage(errorMessages.required),
+          }}
+          items={[
+            {
+              value: "true",
+              label: (
+                <WithEllipsisPrefix>
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "any duration. (short term, long term, or indeterminate duration)",
+                    id: "uHx3G7",
+                    description:
+                      "Label displayed on Work Preferences form for any duration option",
+                  })}
+                </WithEllipsisPrefix>
+              ),
+            },
+            {
+              value: "false",
+              label: intl.formatMessage({
+                defaultMessage:
+                  "...indeterminate duration only. (permanent only)",
+                id: "sYqIp5",
+                description:
+                  "Label displayed on Work Preferences form for indeterminate duration option.",
+              }),
+            },
+          ]}
+        />
+      )}
       <Checklist
         idPrefix="optional-work-preferences"
         legend={labels.acceptedOperationalRequirements}

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/hooks/useDirtyFields.ts
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/hooks/useDirtyFields.ts
@@ -10,6 +10,12 @@ const useDirtyFields = (section: SectionKey): void => {
 
   useEffect(() => {
     toggleDirty(section, isDirty);
+    /**
+     * Note: toggleDirty is updated after toggling causing and infinite
+     * state update loop
+     *
+     * This is necessary to facilitate validating all of the forms at once
+     */
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDirty]);
 };

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/hooks/useDirtyFields.ts
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/hooks/useDirtyFields.ts
@@ -1,18 +1,17 @@
 import { useEffect } from "react";
-import { useFormContext } from "react-hook-form";
+import { useFormState } from "react-hook-form";
 
 import { useProfileFormContext } from "../components/ProfileFormContext";
 import { SectionKey } from "../types";
 
 const useDirtyFields = (section: SectionKey): void => {
   const { toggleDirty } = useProfileFormContext();
-  const {
-    formState: { isDirty },
-  } = useFormContext();
+  const { isDirty } = useFormState();
 
   useEffect(() => {
     toggleDirty(section, isDirty);
-  }, [isDirty, section, toggleDirty]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDirty]);
 };
 
 export default useDirtyFields;


### PR DESCRIPTION
🤖 Resolves #7024 

## 👋 Introduction

Hides work duration, setting it to `true` when within an IAP application.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build npm run dev
2. Navigate to /indigenous-it-apprentice
3. Click "Apply now"
4. Continue to the profile step
5. Confirm work duration does not appear in the work preferences section
6. Click "Edit" on the work preferences section
7. Confirm there is no radio group  for work duration
8. Submit and confirm it submits with the following:

```js
positionDuration: [
    "PERMANENT",
    "TEMPORARY"
]
```

## 📸 Screenshot


![Screenshot 2023-06-23 085111](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/489bf0f1-fcc8-4709-8af2-26d09a10e4c7)
![Screenshot 2023-06-23 085118](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/e9534569-e0ce-478a-b3ce-3cce578626c7)
