### PR TITLE
[Fix] Remove Pool keys, which weren't used and could be invalid

### DIFF
--- a/api/app/GraphQL/Mutations/DuplicatePool.php
+++ b/api/app/GraphQL/Mutations/DuplicatePool.php
@@ -22,7 +22,6 @@ final class DuplicatePool
                 'en' => $pool->name['en'] . ' (copy)',
                 'fr' => $pool->name['fr'] . ' (copie)',
             ],
-            'key' => $pool->key ? $pool->key . '_' . time() : null, // If duplicating a pool with a non-null key, ensure the new key is unique.
             'closing_date' => null,
             'published_at' => null,
         ]);

--- a/api/app/GraphQL/Mutations/DuplicatePool.php
+++ b/api/app/GraphQL/Mutations/DuplicatePool.php
@@ -3,7 +3,6 @@
 namespace App\GraphQL\Mutations;
 
 use App\Models\Pool;
-use Database\Helpers\KeyStringHelpers;
 
 final class DuplicatePool
 {

--- a/api/app/GraphQL/Mutations/DuplicatePool.php
+++ b/api/app/GraphQL/Mutations/DuplicatePool.php
@@ -3,6 +3,7 @@
 namespace App\GraphQL\Mutations;
 
 use App\Models\Pool;
+use Database\Helpers\KeyStringHelpers;
 
 final class DuplicatePool
 {
@@ -21,7 +22,7 @@ final class DuplicatePool
                 'en' => $pool->name['en'] . ' (copy)',
                 'fr' => $pool->name['fr'] . ' (copie)',
             ],
-            'key' => $pool->key . '_' . time(), // Ensure unique key
+            'key' => $pool->key ? $pool->key . '_' . time() : null, // If duplicating a pool with a non-null key, ensure the new key is unique.
             'closing_date' => null,
             'published_at' => null,
         ]);

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -18,7 +18,6 @@ use Illuminate\Support\Facades\Auth;
  *
  * @property string $id
  * @property array $name
- * @property string $key
  * @property int $user_id
  * @property array $operational_requirements
  * @property array $key_tasks
@@ -69,7 +68,6 @@ class Pool extends Model
         'closing_date',
         'published_at',
         'name',
-        'key',
         'key_tasks',
         'stream',
         'security_clearance',

--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -10,7 +10,6 @@ use App\Models\Team;
 use App\Models\ScreeningQuestion;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Database\Helpers\KeyStringHelpers;
 use Database\Helpers\ApiEnums;
 
 class PoolFactory extends Factory
@@ -48,7 +47,6 @@ class PoolFactory extends Factory
         // this is essentially the draft state
         return [
             'name' => ['en' => $name, 'fr' => $name],
-            'key' => KeyStringHelpers::toKeyString($name),
             'user_id' => $adminUserId,
             'team_id' => $teamId,
         ];

--- a/api/database/migrations/2023_06_22_205656_drop_pool_key_column.php
+++ b/api/database/migrations/2023_06_22_205656_drop_pool_key_column.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pools', function (Blueprint $table) {
+            $table->dropColumn('key');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pools', function (Blueprint $table) {
+            $table->string('key', 255)->nullable(true);
+        });
+    }
+};

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -59,7 +59,7 @@ class DatabaseSeeder extends Seeder
         // Seed some expected values
         $this->seedPools();
 
-        $digitalTalentPool = Pool::where('key', "digital_careers")->sole();
+        $digitalTalentPool = Pool::where('name->en', 'CMO Digital Careers')->sole();
 
         User::factory([
             'legacy_roles' => [ApiEnums::LEGACY_ROLE_APPLICANT]

--- a/api/database/seeders/PoolSeeder.php
+++ b/api/database/seeders/PoolSeeder.php
@@ -24,7 +24,6 @@ class PoolSeeder extends Seeder
                     'en' => 'CMO Digital Careers',
                     'fr' => 'CMO Carrières Numériques'
                 ],
-                'key' => 'digital_careers',
                 'user_id' => User::where('email', 'admin@test.com')->first()->id,
                 'team_id' => Team::where('name', 'digital-community-management')->first()->id,
                 'published_at' => config('constants.past_date'),
@@ -36,7 +35,6 @@ class PoolSeeder extends Seeder
                     'en' => 'IT Apprenticeship Program for Indigenous Peoples',
                     'fr' => 'Programme d’apprentissage en TI pour les personnes autochtones'
                 ],
-                'key' => 'indigenous_apprenticeship',
                 'user_id' => User::where('email', 'admin@test.com')->first()->id,
                 'team_id' => Team::where('name', 'digital-community-management')->first()->id,
                 'published_at' => config('constants.past_date'),
@@ -47,14 +45,14 @@ class PoolSeeder extends Seeder
 
         foreach ($pools as $poolData) {
             $identifier = [
-                'key' => $poolData['key'],
+                'name->en' => $poolData['name']['en'],
             ];
             $poolModel = Pool::where($identifier)->first();
             if (!$poolModel) {
                 $createdPool = Pool::factory()->published()->create($poolData);
                 // constrain CMO Digital Careers pool to predictable values
-                if ($identifier['key'] == 'digital_careers') {
-                    $classificationIT01Id = Classification::where('group', 'ilike', 'IT')->where('level', 1)->sole()['id'];
+                if ($identifier['name->en'] == 'CMO Digital Careers') {
+                    $classificationIT01Id = Classification::where('group', 'ilike', 'IT')->where('level', 1)->first()['id'];
                     $createdPool->classifications()->sync([$classificationIT01Id]);
                     $createdPool->stream = ApiEnums::POOL_STREAM_BUSINESS_ADVISORY_SERVICES;
                     $createdPool->advertisement_language = ApiEnums::POOL_VARIOUS;

--- a/api/database/seeders/PoolSeederUat.php
+++ b/api/database/seeders/PoolSeederUat.php
@@ -20,7 +20,7 @@ class PoolSeederUat extends Seeder
         $defaultOwner = User::where('email', 'tristan-orourke@talent.test')->first();
 
         $digitalCareers = Pool::updateOrCreate(
-            ['key' => 'digital_careers'],
+            ['name->en' => 'Digital Careers'],
             [
                 'name' => [
                     'en' => 'Digital Careers',

--- a/api/database/seeders/TeamSeeder.php
+++ b/api/database/seeders/TeamSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Department;
 use App\Models\Team;
 use Illuminate\Database\Seeder;
 
@@ -21,7 +22,25 @@ class TeamSeeder extends Seeder
                     'en' => 'Digital Community Management',
                     'fr' => 'Gestion de la collectivité numérique',
                 ],
+                'contact_email' => 'dcm@test.test',
             ],
+            [
+                'name' => 'office-of-indigenous-initiatives',
+                'display_name' => [
+                    'en' => 'Office of Indigenous Initiatives',
+                    'fr' => 'Bureau initiatives autochtones',
+                ],
+                'contact_email' => 'oit@test.test',
+            ]
+        ];
+
+        $teamDepartments = [
+            'digital-community-management' => [
+                ['department_number' => 56] // Treasury Board Secretariat
+            ],
+            'office-of-indigenous-initiatives' => [
+                ['department_number' => 14] // Employment and Social Development (Department of)
+            ]
         ];
 
         foreach ($teams as $team) {
@@ -29,6 +48,16 @@ class TeamSeeder extends Seeder
                 'name' => $team['name'],
             ];
             Team::updateOrCreate($identifier, $team);
+        }
+
+        foreach ($teamDepartments as $teamName => $departments) {
+            $team = Team::where('name', $teamName)->first();
+            foreach ($departments as $departmentIdentifier) {
+                $department = Department::where($departmentIdentifier)->first();
+                if ($team && $department) {
+                    $team->departments()->attach($department);
+                }
+            }
         }
     }
 }

--- a/api/database/seeders/TeamSeederLocal.php
+++ b/api/database/seeders/TeamSeederLocal.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Department;
 use App\Models\Team;
 use Illuminate\Database\Seeder;
 
@@ -21,6 +22,13 @@ class TeamSeederLocal extends Seeder
                     'en' => 'Test Team',
                     'fr' => 'Équipe de test',
                 ],
+                'contact_email' => 'test.team@test.test'
+            ],
+        ];
+
+        $teamDepartments = [
+            'test-team' => [
+                ['department_number' => 56] // Treasury Board Secretariat
             ],
         ];
 
@@ -29,6 +37,16 @@ class TeamSeederLocal extends Seeder
                 'name' => $team['name'],
             ];
             Team::updateOrCreate($identifier, $team);
+        }
+
+        foreach ($teamDepartments as $teamName => $departments) {
+            $team = Team::where('name', $teamName)->first();
+            foreach ($departments as $departmentIdentifier) {
+                $department = Department::where($departmentIdentifier)->first();
+                if ($team && $department) {
+                    $team->departments()->attach($department);
+                }
+            }
         }
     }
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -332,7 +332,6 @@ type Pool {
   owner: UserPublicProfile @belongsTo(relation: "user")
   team: Team @belongsTo @can(ability: "viewAny")
   name: LocalizedString
-  key: KeyString
   classifications: [Classification] @belongsToMany
   operationalRequirements: [OperationalRequirement]
     @rename(attribute: "operational_requirements")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -778,7 +778,6 @@ type Pool {
   owner: UserPublicProfile
   team: Team
   name: LocalizedString
-  key: KeyString
   classifications: [Classification]
   operationalRequirements: [OperationalRequirement]
   poolCandidates: [PoolCandidate]

--- a/api/tests/Feature/ApplicantFilterTest.php
+++ b/api/tests/Feature/ApplicantFilterTest.php
@@ -288,7 +288,6 @@ class ApplicantFilterTest extends TestCase
                             en
                             fr
                         }
-                        key
                     }
                     qualifiedStreams
                     qualifiedClassifications {
@@ -339,7 +338,6 @@ class ApplicantFilterTest extends TestCase
                             [
                                 'id' => $firstFilterModel->pools->first()->id,
                                 'name' => $firstFilterModel->pools->first()->name,
-                                'key' => $firstFilterModel->pools->first()->key,
                             ],
                         ],
                     ],

--- a/apps/web/src/pages/SearchRequests/SearchPage/searchPageOperations.graphql
+++ b/apps/web/src/pages/SearchRequests/SearchPage/searchPageOperations.graphql
@@ -52,7 +52,6 @@ query CountApplicantsAndCountPoolCandidatesByPool(
 query getSearchFormDataAcrossAllPools {
   publishedPools {
     id
-    key
     owner {
       email
       firstName


### PR DESCRIPTION
🤖 Resolves #7077

## 👋 Introduction

The issue was caused by the DuplicatePool mutation, which appended a timestamp to the end of the original pool's key to keep it unique. However, it did this even when the original key was null (which is bascally always), creating a key which starts with underscore. That isn't a valid KeyString, so GraphQL crashed if you requested the key value for Pools (which we did on the Talent Search page).

## 🕵️ Details

I initially fixed the bug in DuplicatePool.php. However... we're not using Pool.key at all. For most of our pools (in production and UAT) it's null anyway. We have no intention of making use of it - publishing group has replaced its original purpose.

So I've removed Pool.key entirely. Good riddance!

## 🧪 Testing

To be thorough, we want to test that the pool interactions still work without keys.

1. Create a pool on the admin side. Fill out the details.
2. Duplicate the pool. Publish the duplicate.
3. Apply to the duplicate pool.
4. On the admin side, qualifiy the application.
5. Go to Talent Search, do a search which you can be sure includes your application.
6. Make sure you never see any graphql errors through this process.

## 📸 Screenshot

Add a screenshot (if possible).
