### PR TITLE
[Accessibility] Accordion subtitle colour

### DIFF
--- a/packages/ui/src/components/Accordion/styles.ts
+++ b/packages/ui/src/components/Accordion/styles.ts
@@ -29,7 +29,7 @@ const simpleStyles: AccordionStyles = {
   "data-h2-color": `
     base:selectors[>.Accordion__Item > .Accordion__Content > .Accordion__Separator](secondary.dark)
     base:selectors[>.Accordion__Item > .Accordion__Header > .Accordion__Trigger > .Accordion__Chevron](secondary.dark)
-    base:selectors[>.Accordion__Item > .Accordion__Header > .Accordion__Trigger .Accordion__Subtitle](secondary.dark)
+    base:selectors[>.Accordion__Item > .Accordion__Header > .Accordion__Trigger .Accordion__Subtitle](black.light)
   `,
   "data-h2-display":
     "base:selectors[>.Accordion__Item .Accordion__Separator](none)",


### PR DESCRIPTION
🤖 Resolves #6898 

## 👋 Introduction

Swap the subtitle colour to the requested `black.light` 

## 🧪 Testing

1. Navigate to the search page
2. No colour contrast issues should be left on the page

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/5b91bfd0-08ab-4aee-ac09-75fb72b32f25)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/39a8ace4-85e7-4b63-b32b-75d18d64dd26)
