### PR TITLE
[Copy] Updates Work location exceptions copy

### DIFF
--- a/apps/e2e/cypress/e2e/talentsearch/profile-workflows.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/profile-workflows.cy.js
@@ -36,7 +36,7 @@ describe("User Profile Workflow Tests", () => {
 
     // work location
     cy.findByRole("link", { name: /Edit Work location/i }).click();
-    cy.findByRole("textbox", { name: /Location exemptions/i })
+    cy.findByRole("textbox", { name: /Work location exceptions/i })
       .clear()
       .type("Test Locations");
     cy.findByRole("button", { name: /Save and go back/i }).click();

--- a/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
+++ b/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
@@ -451,9 +451,9 @@ const ProfileDocument = React.forwardRef<HTMLDivElement, ProfileDocumentProps>(
                         {!!result.locationExemptions && (
                           <p>
                             {intl.formatMessage({
-                              defaultMessage: "Location exemptions",
-                              id: "ruD4vK",
-                              description: "Location exemptions label",
+                              defaultMessage: "Work location exceptions",
+                              id: "OpKC2i",
+                              description: "Work location exceptions label",
                             })}
                             {intl.formatMessage(commonMessages.dividingColon)}
                             {result.locationExemptions}

--- a/apps/web/src/components/UserProfile/ProfileSections/WorkLocationSection.tsx
+++ b/apps/web/src/components/UserProfile/ProfileSections/WorkLocationSection.tsx
@@ -50,10 +50,11 @@ const WorkLocationSection = ({
             <p>
               <span data-h2-display="base(block)">
                 {intl.formatMessage({
-                  defaultMessage: "Location exemptions:",
-                  id: "MoWNS4",
-                  description: "Location Exemptions label, followed by colon",
+                  defaultMessage: "Work location exceptions",
+                  id: "OpKC2i",
+                  description: "Work location exceptions label",
                 })}
+                {intl.formatMessage(commonMessages.dividingColon)}
               </span>
               <span data-h2-font-weight="base(700)">
                 {applicant.locationExemptions}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1613,10 +1613,6 @@
     "defaultMessage": "Annuler",
     "description": "Link text to cancel deleting application."
   },
-  "0qNkIp": {
-    "defaultMessage": "Exemptions de lieux",
-    "description": "Location Exemptions field label for work location preference form"
-  },
   "1q/MmU": {
     "defaultMessage": "À vous de découvrir",
     "description": "Heading for featured items on the homepage"
@@ -5097,10 +5093,6 @@
     "defaultMessage": "Par compétences",
     "description": "Tab title for experiences sorted by skills in applicant profile."
   },
-  "MoWNS4": {
-    "defaultMessage": "Exemptions à l'emplacement :",
-    "description": "Location Exemptions label, followed by colon"
-  },
   "MuyuAu": {
     "defaultMessage": "Groupe et classification actuels :",
     "description": "Field label before government employment group and level, followed by colon"
@@ -6943,10 +6935,6 @@
     "defaultMessage": "Commencez <hidden> à remplir la section sur la diversité, l’équité et l’inclusion </hidden> ",
     "description": "Call to action to begin editing work preferences"
   },
-  "oEioz2": {
-    "defaultMessage": "Détails au sujet du lieu de travail",
-    "description": "Location specifics label"
-  },
   "u1N0nT": {
     "defaultMessage": "Diversité, équité et inclusion.",
     "description": "Heading for the diversity, equity, and inclusion section on the application profile"
@@ -7888,10 +7876,6 @@
     "defaultMessage": "Envisagerait d'accepter un emploi qui :",
     "description": "Label for what conditions a user will accept, followed by a colon"
   },
-  "ruD4vK": {
-    "defaultMessage": "Exemptions de lieux",
-    "description": "Location exemptions label"
-  },
   "sYuMO8": {
     "defaultMessage": "Aimerait être référé à des emplois aux niveaux suivants :",
     "description": "Label for Role and salary expectations sections"
@@ -8347,5 +8331,13 @@
   "o4tj77": {
     "defaultMessage": "Pour nous joindre",
     "description": "Title for the contact dialog for the Indigenous Apprenticeship Program application process"
+  },
+  "58x4fO": {
+    "defaultMessage": "Indiquez s'il y a une ville que vous souhaitez exclure d'une région.",
+    "description": "Explanation text for Work location exceptions field in work location preference form"
+  },
+  "qnaIOA": {
+    "defaultMessage": "P. ex. : Vous voulez postuler pour la région du Québec, mais pas pour Montréal.",
+    "description": "Example for Work location exceptions field in work location preference form"
   }
 }

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8339,5 +8339,9 @@
   "qnaIOA": {
     "defaultMessage": "P. ex. : Vous voulez postuler pour la région du Québec, mais pas pour Montréal.",
     "description": "Example for Work location exceptions field in work location preference form"
+  },
+  "OpKC2i": {
+    "defaultMessage": "Exceptions relatives au lieu de travail",
+    "description": "Work location exceptions label"
   }
 }

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/WorkPreferences/Display.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/WorkPreferences/Display.tsx
@@ -112,9 +112,9 @@ const Display = ({
         </div>
         <FieldDisplay
           label={intl.formatMessage({
-            defaultMessage: "Location specifics",
-            id: "oEioz2",
-            description: "Location specifics label",
+            defaultMessage: "Work location exceptions",
+            id: "OpKC2i",
+            description: "Work location exceptions label",
           })}
         >
           {locationExemptions || notProvided}

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/WorkPreferences/utils.ts
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/WorkPreferences/utils.ts
@@ -24,10 +24,9 @@ export const getLabels = (intl: IntlShape) => ({
       "Legend for optional work preferences check list in work preferences form",
   }),
   locationExemptions: intl.formatMessage({
-    defaultMessage: "Location exemptions",
-    id: "0qNkIp",
-    description:
-      "Location Exemptions field label for work location preference form",
+    defaultMessage: "Work location exceptions",
+    id: "OpKC2i",
+    description: "Work location exceptions label",
   }),
 });
 

--- a/apps/web/src/pages/Profile/WorkLocationPage/components/WorkLocationForm/WorkLocationForm.test.tsx
+++ b/apps/web/src/pages/Profile/WorkLocationPage/components/WorkLocationForm/WorkLocationForm.test.tsx
@@ -97,7 +97,7 @@ describe("WorkLocationForm", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      await screen.getByLabelText(/Location exemptions/i),
+      await screen.getByLabelText(/Work location exceptions/i),
     ).toBeInTheDocument();
   });
   it("Can't submit unless form is valid (at least one location selected)", async () => {

--- a/apps/web/src/pages/Profile/WorkLocationPage/components/WorkLocationForm/WorkLocationForm.tsx
+++ b/apps/web/src/pages/Profile/WorkLocationPage/components/WorkLocationForm/WorkLocationForm.tsx
@@ -64,10 +64,9 @@ const WorkLocationForm = ({
         "Legend for optional work preferences check list in work preferences form",
     }),
     locationExemptions: intl.formatMessage({
-      defaultMessage: "Location exemptions",
-      id: "0qNkIp",
-      description:
-        "Location Exemptions field label for work location preference form",
+      defaultMessage: "Work location exceptions",
+      id: "OpKC2i",
+      description: "Work location exceptions label",
     }),
   };
 
@@ -200,18 +199,18 @@ const WorkLocationForm = ({
                 {intl.formatMessage({
                   defaultMessage:
                     "Indicate if there is a city that you would like to exclude from a region.",
-                  id: "1CuGS6",
+                  id: "58x4fO",
                   description:
-                    "Explanation text for Location exemptions field in work location preference form",
+                    "Explanation text for Work location exceptions field in work location preference form",
                 })}
               </p>
               <p data-h2-color="base(gray.dark)">
                 {intl.formatMessage({
                   defaultMessage:
                     "E.g.: You want to be considered for the Quebec region, but not for Montréal.",
-                  id: "2K7dVp",
+                  id: "qnaIOA",
                   description:
-                    "Example for Location exemptions field in work location preference form",
+                    "Example for Work location exceptions field in work location preference form",
                 })}
               </p>
             </div>


### PR DESCRIPTION
🤖 Resolves #6829.

## 👋 Introduction

This PR replaces the terms **Location specifics** and **Location exemptions** with **Work location exceptions** on the application and profile.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/users/:userId/profile#work-location-section`
2. Observe **Work location exceptions** copy
3. Switch to French
4. Observe **Exceptions relatives au lieu de travail** copy
5. Navigate to `/users/:userId/profile/work-location/edit`
6. Observe **Work location exceptions* label
7. Switch to French
8. Observe **Exceptions relatives au lieu de travail** label
9. Navigate to `/applications/:applicationId/profile`
10. Observe **Work location exceptions** label
11. Switch to French
12. Observe **Exceptions relatives au lieu de travail** label

## 📸 Screenshots

![Screen Shot 2023-06-26 at 15 55 02](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/589a5cf6-9173-4d22-8f16-2ee566a72a84)
![Screen Shot 2023-06-26 at 15 55 17](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/75b87d96-54d7-4820-88e0-6571e1a23c58)
![Screen Shot 2023-06-26 at 15 56 38](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/5958f8b1-8a38-4c49-aeff-e8156dd64054)

