### PR TITLE
[Feature] Refactor and add new columns to requests table

### DIFF
--- a/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.test.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.test.tsx
@@ -61,8 +61,9 @@ describe("SearchRequestsTable", () => {
     });
 
     // Assert table filled with values and the result of requests[0] is present
-    expect(screen.getAllByText(requestOne.fullName ?? "")).toBeTruthy();
-    expect(screen.getAllByText(requestOne.jobTitle ?? "")).toBeTruthy();
+    expect(
+      screen.getAllByText(`View ${requestOne.jobTitle ?? ""}`),
+    ).toBeTruthy();
     expect(
       screen.getAllByText(requestOne.department?.name.en ?? ""),
     ).toBeTruthy();

--- a/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
@@ -17,6 +17,7 @@ import {
 import {
   getLocalizedName,
   getPoolCandidateSearchStatus,
+  getPoolStream,
 } from "@gc-digital-talent/i18n";
 import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 
@@ -43,6 +44,8 @@ import adminMessages from "~/messages/adminMessages";
 import SearchRequestsTableFilter, {
   FormValues,
 } from "./components/SearchRequestsTableFilterDialog";
+import tableClassificationPills from "../Table/ClientManagedTable/tableClassificationPills";
+import tableCommaList from "../Table/ClientManagedTable/tableCommaList";
 
 type Data = NonNullable<FromArray<PoolCandidateSearchRequestPaginator["data"]>>;
 
@@ -216,16 +219,6 @@ const SearchRequestsTableApi = ({
   const requestsData = data?.poolCandidateSearchRequestsPaginated?.data ?? [];
   const filteredData = requestsData.filter(notEmpty);
 
-  /*
-    - [x] Combine "Job title" and "Action" and set as first column. New name is "Request Job title".
-    - [x] Ensure sorting still works on new request job title column
-    - [x] Reorder all columns (not including group and stream):
-          ID (hidden) | Request job title | GLS | Manager (hidden) | Department | Status | Date Received
-    - [ ] Add group-level and streams of request to api response.
-    - [ ] Add new columns for group and level, and stream.
-    - [ ] Add it to group-level and stream to filtering.
-  */
-
   const columns = useMemo<ColumnsOf<Data>>(
     () => [
       {
@@ -241,9 +234,9 @@ const SearchRequestsTableApi = ({
       {
         label: intl.formatMessage({
           defaultMessage: "Request job title",
-          id: "oc7cTw",
+          id: "6AhLsc",
           description:
-            "Title displayed for the search request table edit column.",
+            "Title displayed for the search request table request job title column.",
         }),
         id: "job_title",
         accessor: (d) =>
@@ -252,6 +245,37 @@ const SearchRequestsTableApi = ({
             d.jobTitle || "",
             "", // TODO: What should I use here incase of a duplicate job title?
           ),
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Group and level",
+          id: "y+r+ej",
+          description:
+            "Title displayed on the search request table group and level column.",
+        }),
+        id: "group_and_level",
+        accessor: (d) =>
+          tableClassificationPills({
+            classifications:
+              d.applicantFilter?.qualifiedClassifications?.filter(notEmpty),
+          }),
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Stream",
+          id: "LoKxJe",
+          description:
+            "Title displayed on the search request table stream column.",
+        }),
+        id: "stream",
+        accessor: (d) =>
+          tableCommaList({
+            list:
+              d.applicantFilter?.qualifiedStreams
+                ?.filter(notEmpty)
+                .map((stream) => intl.formatMessage(getPoolStream(stream))) ??
+              [],
+          }),
       },
       {
         label: intl.formatMessage({

--- a/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
@@ -97,7 +97,7 @@ function dateCell(date: Maybe<Scalars["DateTime"]>, intl: IntlShape) {
 
 const defaultState = {
   ...TABLE_DEFAULTS,
-  hiddenColumnIds: ["id", "email"],
+  hiddenColumnIds: ["id", "manager", "email"],
   filters: {},
 };
 
@@ -216,28 +216,18 @@ const SearchRequestsTableApi = ({
   const requestsData = data?.poolCandidateSearchRequestsPaginated?.data ?? [];
   const filteredData = requestsData.filter(notEmpty);
 
+  /*
+    - [x] Combine "Job title" and "Action" and set as first column. New name is "Request Job title".
+    - [x] Ensure sorting still works on new request job title column
+    - [x] Reorder all columns (not including group and stream):
+          ID (hidden) | Request job title | GLS | Manager (hidden) | Department | Status | Date Received
+    - [ ] Add group-level and streams of request to api response.
+    - [ ] Add new columns for group and level, and stream.
+    - [ ] Add it to group-level and stream to filtering.
+  */
+
   const columns = useMemo<ColumnsOf<Data>>(
     () => [
-      {
-        label: intl.formatMessage({
-          defaultMessage: "Action",
-          id: "TDTE1c",
-          description:
-            "Title displayed for the search request table edit column.",
-        }),
-        id: "action",
-        accessor: (d) =>
-          tableViewItemButtonAccessor(
-            paths.searchRequestView(d.id),
-            intl.formatMessage({
-              defaultMessage: "request",
-              id: "gLtTaW",
-              description:
-                "Text displayed after View text for Search Request table view action",
-            }),
-            d.fullName || "",
-          ),
-      },
       {
         label: intl.formatMessage({
           defaultMessage: "ID",
@@ -250,25 +240,18 @@ const SearchRequestsTableApi = ({
       },
       {
         label: intl.formatMessage({
-          defaultMessage: "Date Received",
-          id: "r2gD/4",
+          defaultMessage: "Request job title",
+          id: "oc7cTw",
           description:
-            "Title displayed on the search request table requested date column.",
+            "Title displayed for the search request table edit column.",
         }),
-        id: "requestedDate",
-        sortColumnName: "created_at",
-        accessor: (d) => dateCell(d.requestedDate, intl),
-      },
-      {
-        label: intl.formatMessage({
-          defaultMessage: "Status",
-          id: "t3sEc+",
-          description:
-            "Title displayed on the search request table status column.",
-        }),
-        id: "status",
-        sortColumnName: "done_at",
-        accessor: (d) => statusAccessor(d.status, intl),
+        id: "job_title",
+        accessor: (d) =>
+          tableViewItemButtonAccessor(
+            paths.searchRequestView(d.id),
+            d.jobTitle || "",
+            "", // TODO: What should I use here incase of a duplicate job title?
+          ),
       },
       {
         label: intl.formatMessage({
@@ -304,14 +287,25 @@ const SearchRequestsTableApi = ({
       },
       {
         label: intl.formatMessage({
-          defaultMessage: "Job Title",
-          id: "8hee5d",
+          defaultMessage: "Status",
+          id: "t3sEc+",
           description:
-            "Title displayed on the search request table job title column.",
+            "Title displayed on the search request table status column.",
         }),
-        id: "jobTitle",
-        sortColumnName: "job_title",
-        accessor: (d) => d.jobTitle,
+        id: "status",
+        sortColumnName: "done_at",
+        accessor: (d) => statusAccessor(d.status, intl),
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Date Received",
+          id: "r2gD/4",
+          description:
+            "Title displayed on the search request table requested date column.",
+        }),
+        id: "requestedDate",
+        sortColumnName: "created_at",
+        accessor: (d) => dateCell(d.requestedDate, intl),
       },
     ],
     [intl, paths],

--- a/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
@@ -243,7 +243,7 @@ const SearchRequestsTableApi = ({
           tableViewItemButtonAccessor(
             paths.searchRequestView(d.id),
             d.jobTitle || "",
-            "", // TODO: What should I use here incase of a duplicate job title?
+            "",
           ),
       },
       {

--- a/apps/web/src/components/Table/ClientManagedTable/tableClassificationPills.tsx
+++ b/apps/web/src/components/Table/ClientManagedTable/tableClassificationPills.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { notEmpty } from "@gc-digital-talent/helpers";
+import { Pill } from "@gc-digital-talent/ui";
+import { Maybe } from "@gc-digital-talent/graphql";
+import { Classification } from "~/api/generated";
+import uniqueId from "lodash/uniqueId";
+
+interface TableClassificationPillsProps {
+  classifications: Maybe<Maybe<Classification>[]>;
+}
+
+const TableClassificationPills = ({
+  classifications,
+}: TableClassificationPillsProps) => {
+  const filteredClassifications = classifications
+    ? classifications.filter(notEmpty)
+    : [];
+  const pillsArray = filteredClassifications.map((classification, index) => {
+    return (
+      <span
+        key={uniqueId()}
+        {...(index + 1 !== filteredClassifications.length && {
+          "data-h2-padding-right": "base(x1)",
+        })}
+      >
+        <Pill color="primary" mode="outline">
+          {`${classification.group}-0${classification.level}`}
+        </Pill>
+      </span>
+    );
+  });
+  return pillsArray.length > 0 ? (
+    <div data-h2-display="base(flex)">{pillsArray}</div>
+  ) : null;
+};
+
+const tableClassificationPills = (props: TableClassificationPillsProps) => (
+  <TableClassificationPills {...props} />
+);
+
+export default tableClassificationPills;

--- a/apps/web/src/components/Table/ClientManagedTable/tableCommaList.tsx
+++ b/apps/web/src/components/Table/ClientManagedTable/tableCommaList.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+interface TableCommaListProps {
+  list: string[];
+}
+
+const TableCommaList = ({ list }: TableCommaListProps) => {
+  return list.length > 0 ? (
+    <p>
+      {list.map((item, index) => {
+        if (index + 1 === list.length) return item;
+
+        return `${item}, `;
+      })}
+    </p>
+  ) : null;
+};
+
+const tableCommaList = (props: TableCommaListProps) => (
+  <TableCommaList {...props} />
+);
+
+export default tableCommaList;

--- a/apps/web/src/pages/SearchRequests/poolCandidateSearchRequestOperations.graphql
+++ b/apps/web/src/pages/SearchRequests/poolCandidateSearchRequestOperations.graphql
@@ -134,6 +134,15 @@ query getPoolCandidateSearchRequestsPaginated(
     data {
       additionalComments
       adminNotes
+      applicantFilter {
+        id
+        qualifiedClassifications {
+          id
+          group
+          level
+        }
+        qualifiedStreams
+      }
       department {
         id
         departmentNumber


### PR DESCRIPTION
🤖 Resolves #6603 

## 👋 Introduction

- Adds Group and level(s) column to Request table.
- Adds Stream(s) column to Request table.
- Combines the "Action" column (View column) with the "Job title" column. Making the job title the "view request" link.
- Rearranges the columns in a new order:
  - ID (hidden)
  - Request job title
  - Group and level
  - Stream
  - Manager (hidden)
  - Email (hidden)
  - Status
  - Date received

## 🕵️ Details

I believe some of the seeded data does not have a classification or stream after the new changes to `ApplicantFilter` type, which included the new `qualifiedClassifications` and `qualifiedStreams`.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. login as admin and go to admin app.
2. Go to Requests table and view new changes.
3. Ensure all changes are correct.
4. Ensure all sorting works as expected.
5. Ensure all filtering works as expected.
