### PR TITLE
[Bug] Removes `ConsideredLanguages` repeated copy

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1253,7 +1253,7 @@
     "defaultMessage": "Lieu de travail",
     "description": "Title for Profile Form wrapper  in Work Location Preferences Form"
   },
-  "1F7at9": {
+  "4faEVw": {
     "defaultMessage": "Vous pouvez découvrir vos niveaux à l’aide d’une <selfAssessmentLink>auto-évaluation des aptitudes linguistiques</selfAssessmentLink>.",
     "description": "Text including link to language proficiency evaluation in language information form"
   },

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/LanguageProfile/ConsideredLanguages.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/LanguageProfile/ConsideredLanguages.tsx
@@ -214,8 +214,8 @@ const ConsideredLanguages = ({ labels }: ConsideredLanguagesProps) => {
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "You can find out find out your levels with a <selfAssessmentLink>language proficiency self-assessment</selfAssessmentLink>.",
-                id: "1F7at9",
+                  "You can find out your levels with a <selfAssessmentLink>language proficiency self-assessment</selfAssessmentLink>.",
+                id: "4faEVw",
                 description:
                   "Text including link to language proficiency evaluation in language information form",
               },

--- a/apps/web/src/pages/Profile/LanguageInfoPage/components/ConsideredLanguages.tsx
+++ b/apps/web/src/pages/Profile/LanguageInfoPage/components/ConsideredLanguages.tsx
@@ -287,8 +287,8 @@ const ConsideredLanguages = ({ labels }: ConsideredLanguagesProps) => {
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "You can find out find out your levels with a <selfAssessmentLink>language proficiency self-assessment</selfAssessmentLink>.",
-                id: "1F7at9",
+                  "You can find out your levels with a <selfAssessmentLink>language proficiency self-assessment</selfAssessmentLink>.",
+                id: "4faEVw",
                 description:
                   "Text including link to language proficiency evaluation in language information form",
               },


### PR DESCRIPTION
🤖 Resolves #7104.

## 👋 Introduction

This PR removes repeated copy from the `ConsideredLanguages` components.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `users/:userId/profile/language-info/edit`
2. Observe "You can find out your levels" copy
3. Navigate to `/applications/:applicationId/profile`
4. Click **Edit language profile**
5. Observe "You can find out your levels" copy

## 📸 Screenshot
![Screen Shot 2023-06-27 at 12 06 14](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/d6c77956-2309-4776-aae5-6b353e572a14)
![Screen Shot 2023-06-27 at 12 06 58](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/945cf31d-db48-4ad4-bf36-d77cb05709da)


