### PR TITLE
[Bug] Fixes obscured text

### DIFF
--- a/apps/web/src/pages/Home/IAPHomePage/Home.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.tsx
@@ -225,6 +225,7 @@ export const Home = ({ latestPool }: HomeProps) => {
                     data-h2-font-size="base(h3, 1)"
                     data-h2-margin="base(x6, 0, x2, 0) p-tablet(x1, 0, x2, 0)"
                     data-h2-text-align="base(center) p-tablet(left)"
+                    data-h2-layer="base(1, relative)"
                   >
                     {intl.formatMessage({
                       defaultMessage: "About the Program",


### PR DESCRIPTION
🤖 Resolves #7078.

## 👋 Introduction

This PR fixes an image of feathers that were overlapping text to make it less legible.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/indigenous-it-apprentice`
2. Reduce the page width until the first copy heading appears below the image
3. Confirm the feathers do not obscure the heading in any of the five languages

## 📸 Screenshots

![Screen Shot 2023-06-27 at 15 24 08](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/27c62672-7eca-465c-89e7-f96d61d7dfda)
![Screen Shot 2023-06-27 at 15 27 19](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/8586cb39-fa1a-4e0a-8fb4-ae066f1bafef)
![Screen Shot 2023-06-27 at 15 28 41](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/85b8a06d-3c04-4a72-898a-2aeb204c91c9)
![Screen Shot 2023-06-27 at 15 29 17](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/576cb074-44ce-4c37-81d4-763f2fc65815)
![Screen Shot 2023-06-27 at 15 29 58](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/e5cf3274-0376-474c-a911-a31b0b998b29)