### PR TITLE
[Bug] Fixes name of IAP

### DIFF
--- a/apps/web/src/components/Dialog/IapContactDialog.tsx
+++ b/apps/web/src/components/Dialog/IapContactDialog.tsx
@@ -15,9 +15,9 @@ const IapContactDialog = () => {
 
   const title = intl.formatMessage({
     defaultMessage: "Contact us",
-    id: "o4tj77",
+    id: "k1rUj5",
     description:
-      "Title for the contact dialog for the Indigenous Apprenticeship Program application process",
+      "Title for the contact dialog for the IT Apprenticeship Program for Indigenous Peoples application process",
   });
 
   return (

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8228,12 +8228,12 @@
     "defaultMessage": "<strong>Préavis!</strong> Avant de vous demander d’aller établir vos justificatifs CléGC, nous vous demandons d’examiner de nouveau les critères d’admissibilité du programme afin de veiller à ce que vous répondiez aux exigences.",
     "description": "A request for the user to review the IAP eligibility criteria"
   },
-  "LVPNZ3": {
-    "defaultMessage": "Afin d’entamer la réalisation de votre profil auprès du Programme d’apprentissage destiné aux Autochtones, vous <strong>devez tout d’abord vous inscrire à la plateforme à l’aide de votre CléGC.</strong>.",
+  "epqFro": {
+    "defaultMessage": "Afin d’entamer la réalisation de votre profil auprès du Programme d’apprentissage en TI pour les personnes autochtones, vous <strong>devez tout d’abord vous inscrire à la plateforme à l’aide de votre CléGC.</strong>.",
     "description": "Instructions on how to register with GCKey - IAP variant"
   },
   "ZOeVCm": {
-    "defaultMessage": "Vous pouvez accéder à votre profil du Programme d’apprentissage destiné aux Autochtones en vous servant de votre CléGC existante, même si vous n’avez jamais utilisé cette plateforme.",
+    "defaultMessage": "Vous pouvez accéder à votre profil du Programme d’apprentissage en TI pour les personnes autochtones en vous servant de votre CléGC existante, même si vous n’avez jamais utilisé cette plateforme.",
     "description": "Instructions on how to login with GCKey - IAP variant"
   },
   "cPgH94": {
@@ -8318,7 +8318,7 @@
   },
   "o4tj77": {
     "defaultMessage": "Pour nous joindre",
-    "description": "Title for the contact dialog for the Indigenous Apprenticeship Program application process"
+    "description": "Title for the contact dialog for the IT Apprenticeship Program for Indigenous Peoples application process"
   },
   "58x4fO": {
     "defaultMessage": "Indiquez s'il y a une ville que vous souhaitez exclure d'une région.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7261,9 +7261,9 @@
     "defaultMessage": "Ces compétences essentielles ont été évaluées dans le cadre du processus :",
     "description": "Text showing the essentials skills assessed during the process"
   },
-  "AnIVCJ": {
+  "cTCdw5": {
     "defaultMessage": "Nous tenons à vous remercier de votre intérêt à devenir un(e) apprenti(e) de la TI au sein du gouvernement du Canada. Votre expérience vécue, votre passion et vos intérêts sont chaleureusement accueillis et reconnus. Un membre de l’équipe du Bureau des initiatives autochtones communiquera avec vous au cours des trois à cinq prochains jours ouvrables pour discuter votre demande.",
-    "description": "Description of review process and next steps for the indigenous apprenticeship applicant."
+    "description": "Description of review process and next steps for the IAP applicant."
   },
   "VldclB": {
     "defaultMessage": "Expériences relatives aux exigences pédagogiques",
@@ -7728,9 +7728,9 @@
     "defaultMessage": "Merci d’avoir postulé dans le cadre du Programme d’apprentissage en TI pour les peuples autochtones!",
     "description": "Title for notification that a an IAP application was submitted"
   },
-  "tfzO5t": {
+  "nIJlba": {
     "defaultMessage": "Obtention réussie d’un diplôme d’études secondaires ou un équivalent du GED.",
-    "description": "Message under radio button in Indigenous apprenticeship application education page."
+    "description": "Message under radio button in IAP application education page."
   },
   "nWZiWr": {
     "defaultMessage": "Obtention réussie d’un diplôme d’études secondaires ou un équivalent du GED.",
@@ -7912,8 +7912,8 @@
     "defaultMessage": "Profil linguistique",
     "description": "Title of the Language Information link section"
   },
-  "gNyD/H": {
-    "defaultMessage": "Désormais, lorsque vous vous connecterez à votre compte, vous vous retrouverez sur cette page. Vous pouvez utiliser la section <strong><a>Suivi de vos candidatures</a></strong> sur cette page pour examiner votre candidature au programme d’apprentissage destiné aux Autochtones et faire le suivi de votre position dans le programme.",
+  "Z9wBwT": {
+    "defaultMessage": "Désormais, lorsque vous vous connecterez à votre compte, vous vous retrouverez sur cette page. Vous pouvez utiliser la section <strong><a>Suivi de vos candidatures</a></strong> sur cette page pour examiner votre candidature au Programme d’apprentissage en TI pour les personnes autochtones et faire le suivi de votre position dans le programme.",
     "description": "Third paragraph for profile and applications notification welcoming an IAP user"
   },
   "LOmX3T": {
@@ -7932,8 +7932,8 @@
     "defaultMessage": "Préférences de travail",
     "description": "Title of the Work Location link section"
   },
-  "DeWP/3": {
-    "defaultMessage": "Désormais, lorsque vous vous connecterez à votre compte, vous vous retrouverez sur cette page. Vous pouvez utiliser la section <strong><a>Suivi de vos candidatures</a></strong> sur cette page pour examiner votre candidature au programme d’apprentissage destiné aux Autochtones et faire le suivi de votre statut dans le programme.",
+  "vYvmxq": {
+    "defaultMessage": "Désormais, lorsque vous vous connecterez à votre compte, vous vous retrouverez sur cette page. Vous pouvez utiliser la section <strong><a>Suivi de vos candidatures</a></strong> sur cette page pour examiner votre candidature au Programme d’apprentissage en TI pour les personnes autochtones et faire le suivi de votre statut dans le programme.",
     "description": "Third paragraph for profile and applications notification welcoming an IAP user"
   },
   "U0qb7j": {
@@ -8356,9 +8356,9 @@
     "defaultMessage": "Veuillez sélectionner les options qui reflètent le mieux vos qualifications",
     "description": "Legend for the radio group in the application education page - IAP variant."
   },
-  "GZSvWZ": {
+  "8IIIER": {
     "defaultMessage": "<strong>Je possède un diplôme d’études secondaires ou l’équivalent (p. ex., formation Générale). </strong>",
-    "description": "Radio group option for education requirement filter in Indigenous apprenticeship application education form."
+    "description": "Radio group option for education requirement filter in IAP application education form."
   },
   "kukr/B": {
     "defaultMessage": "<strong>Je respecte l’option d’expérience appliquée</strong>",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8232,7 +8232,7 @@
     "defaultMessage": "Afin d’entamer la réalisation de votre profil auprès du Programme d’apprentissage en TI pour les personnes autochtones, vous <strong>devez tout d’abord vous inscrire à la plateforme à l’aide de votre CléGC.</strong>.",
     "description": "Instructions on how to register with GCKey - IAP variant"
   },
-  "ZOeVCm": {
+  "ySpJ2L": {
     "defaultMessage": "Vous pouvez accéder à votre profil du Programme d’apprentissage en TI pour les personnes autochtones en vous servant de votre CléGC existante, même si vous n’avez jamais utilisé cette plateforme.",
     "description": "Instructions on how to login with GCKey - IAP variant"
   },
@@ -8316,7 +8316,7 @@
     "defaultMessage": "CV et recrutement",
     "description": "Name of Résumé and recruitment page"
   },
-  "o4tj77": {
+  "k1rUj5": {
     "defaultMessage": "Pour nous joindre",
     "description": "Title for the contact dialog for the IT Apprenticeship Program for Indigenous Peoples application process"
   },

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
@@ -355,9 +355,9 @@ const ApplicationEducation = ({
         ? intl.formatMessage({
             defaultMessage:
               "<strong>I have a high school diploma or equivalent (e.g. GED)</strong>",
-            id: "GZSvWZ",
+            id: "8IIIER",
             description:
-              "Radio group option for education requirement filter in Indigenous apprenticeship application education form.",
+              "Radio group option for education requirement filter in IAP application education form.",
           })
         : intl.formatMessage({
             defaultMessage:
@@ -373,9 +373,9 @@ const ApplicationEducation = ({
               ? intl.formatMessage({
                   defaultMessage:
                     "Successful completion of a standard high school diploma or GED equivalent.",
-                  id: "tfzO5t",
+                  id: "nIJlba",
                   description:
-                    "Message under radio button in Indigenous apprenticeship application education page.",
+                    "Message under radio button in IAP application education page.",
                 })
               : intl.formatMessage(applicationMessages.postSecondaryEducation, {
                   link: qualityStandardsLink,

--- a/apps/web/src/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage.tsx
@@ -76,9 +76,9 @@ const ApplicationSuccess = ({ application }: ApplicationPageProps) => {
           ? intl.formatMessage({
               defaultMessage:
                 "Thank you for your interest in becoming an IT apprentice with the Government of Canada. Your lived experience, skills, passion and interests are warmly received and acknowledged. A member of the Office of Indigenous Initiatives team will contact you within the next three to five business days to discuss your application.",
-              id: "AnIVCJ",
+              id: "cTCdw5",
               description:
-                "Description of review process and next steps for the indigenous apprenticeship applicant.",
+                "Description of review process and next steps for the IAP applicant.",
             })
           : intl.formatMessage({
               defaultMessage:

--- a/apps/web/src/pages/Auth/LoginPage/LoginPage.tsx
+++ b/apps/web/src/pages/Auth/LoginPage/LoginPage.tsx
@@ -107,8 +107,8 @@ const LoginPage = () => {
               <p>
                 {intl.formatMessage({
                   defaultMessage:
-                    "You can log into your IT Indigenous Apprenticeship Program profile using your existing GCKey, even if you’ve never used this platform before.",
-                  id: "ZOeVCm",
+                    "You can log into your IT Apprenticeship Program for Indigenous Peoples profile using your existing GCKey, even if you’ve never used this platform before.",
+                  id: "ySpJ2L",
                   description:
                     "Instructions on how to login with GCKey - IAP variant",
                 })}

--- a/apps/web/src/pages/Auth/RegisterPage/RegisterPage.tsx
+++ b/apps/web/src/pages/Auth/RegisterPage/RegisterPage.tsx
@@ -108,8 +108,8 @@ const RegisterPage = () => {
               <p>
                 {intl.formatMessage({
                   defaultMessage:
-                    "In order to get started on your profile with the IT Indigenous Apprenticeship Program, you <strong>first have to register for the platform using GCKey</strong>.",
-                  id: "LVPNZ3",
+                    "In order to get started on your profile with the IT Apprenticeship Program for Indigenous Peoples, you <strong>first have to register for the platform using GCKey</strong>.",
+                  id: "epqFro",
                   description:
                     "Instructions on how to register with GCKey - IAP variant",
                 })}

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
@@ -194,8 +194,8 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "When you log into your account, you'll start on this page from now on. You can use the <strong><a>Track your applications</a></strong> section on this page to review your Indigenous apprenticeship application and track your position in the program.",
-                id: "gNyD/H",
+                  "When you log into your account, you'll start on this page from now on. You can use the <strong><a>Track your applications</a></strong> section on this page to review your application to the IT Apprenticeship Program for Indigenous Peoples and track your position in the program.",
+                id: "Z9wBwT",
                 description:
                   "Third paragraph for profile and applications notification welcoming an IAP user",
               },
@@ -248,8 +248,8 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "When you log into your account, you'll start on this page from now on. You can use the <strong><a>Track your applications</a></strong> section on this page to review your Indigenous apprenticeship application and track your status in the program.",
-                id: "DeWP/3",
+                  "When you log into your account, you'll start on this page from now on. You can use the <strong><a>Track your applications</a></strong> section on this page to review your application to the IT Apprenticeship Program for Indigenous Peoples and track your status in the program.",
+                id: "vYvmxq",
                 description:
                   "Third paragraph for profile and applications notification welcoming an IAP user",
               },

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -167,6 +167,14 @@ module.exports = {
       },
     ],
     "react/forbid-elements": [1, { forbid: ["a"] }],
+    "no-restricted-syntax": [
+      "error",
+      {
+        selector: "Literal[value=/Indigenous Apprenticeship Program/i]",
+        message:
+          "The name of the program is IT Apprenticeship Program for Indigenous Peoples.",
+      },
+    ],
   },
   settings: {
     "import/extensions": [".ts", ".tsx"],


### PR DESCRIPTION
🤖 Resolves #7113.

## 👋 Introduction

This PR replaces instances of "IT Indigenous Apprenticeship Program" with "IT Apprenticeship Program for Indigenous Peoples" as well as the French equivalent translations. It also adds an eslint rule that forces "Indigenous Apprenticeship Program" copy to error (h/t @petertgiles).

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/en/login-info?from=/en/indigenous-it-apprentice&personality=iap`
2. Observe **IT Apprenticeship Program for Indigenous Peoples** text in first paragraph
3. Navigate to `/en/register-info?from=/en/indigenous-it-apprentice&personality=iap`
4. Observe **IT Apprenticeship Program for Indigenous Peoples** text in first paragraph
5. Ensure no instances of **Indigenous Apprenticeship Program** appear in codebase
