### PR TITLE
[A11y] Improve Pool Candidate View Link Context

### DIFF
--- a/apps/e2e/cypress/e2e/admin/pool-candidate.cy.js
+++ b/apps/e2e/cypress/e2e/admin/pool-candidate.cy.js
@@ -107,7 +107,7 @@ describe("Pool Candidates", () => {
       .click();
     cy.wait("@gqlGetPoolCandidatesPaginatedQuery");
 
-    cy.findAllByRole("link", { name: /view application/i })
+    cy.findAllByRole("link", { name: /view(.+)application/i })
       .eq(0)
       .click();
 

--- a/apps/e2e/cypress/e2e/admin/pool-candidate.cy.js
+++ b/apps/e2e/cypress/e2e/admin/pool-candidate.cy.js
@@ -210,7 +210,7 @@ describe("Pool Candidates", () => {
       .click();
     cy.wait("@gqlGetPoolCandidatesPaginatedQuery");
 
-    cy.findAllByRole("link", { name: /view application/i })
+    cy.findAllByRole("link", { name: /view(.+)application/i })
       .eq(0)
       .click();
 

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -61,8 +61,9 @@ import {
   stringToEnumOperational,
   stringToEnumPoolCandidateStatus,
 } from "~/utils/userUtils";
-
+import { getFullNameLabel } from "~/utils/nameUtils";
 import ProfileDocument from "~/components/ProfileDocument/ProfileDocument";
+
 import usePoolCandidateCsvData from "./usePoolCandidateCsvData";
 
 import PoolCandidateTableFilterDialog, {
@@ -239,7 +240,11 @@ const viewAccessor = (
     candidate.status !== PoolCandidateStatus.ScreenedOutApplication &&
     candidate.status !== PoolCandidateStatus.UnderAssessment &&
     candidate.status !== PoolCandidateStatus.ScreenedOutAssessment;
-
+  const candidateName = getFullNameLabel(
+    candidate.user.firstName,
+    candidate.user.lastName,
+    intl,
+  );
   if (isQualified) {
     return (
       <span data-h2-font-weight="base(700)">
@@ -251,6 +256,18 @@ const viewAccessor = (
             description:
               "Title displayed for the Pool Candidates table View Profile link.",
           }),
+          undefined,
+          intl.formatMessage(
+            {
+              defaultMessage: "View {name}'s profile",
+              id: "bWTzRy",
+              description:
+                "Link text to view a candidates profile for assistive technologies",
+            },
+            {
+              name: candidateName,
+            },
+          ),
         )}
       </span>
     );
@@ -265,6 +282,18 @@ const viewAccessor = (
           description:
             "Title displayed for the Pool Candidates table View Application link.",
         }),
+        undefined,
+        intl.formatMessage(
+          {
+            defaultMessage: "View {name}'s application",
+            id: "mzGMZC",
+            description:
+              "Link text to view a candidates application for assistive technologies",
+          },
+          {
+            name: candidateName,
+          },
+        ),
       )}
     </span>
   );

--- a/apps/web/src/components/Table/ClientManagedTable/TableViewItemButton.tsx
+++ b/apps/web/src/components/Table/ClientManagedTable/TableViewItemButton.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React, { AriaAttributes, HTMLAttributes } from "react";
 import { useIntl } from "react-intl";
 
-import { Link } from "@gc-digital-talent/ui";
+import { Link, LinkProps } from "@gc-digital-talent/ui";
 
-export interface TableViewItemButtonProps {
+export interface TableViewItemButtonProps extends LinkProps {
   /** The destination url. */
   viewUrl: string;
   /** Name of the type of object */
@@ -16,10 +16,11 @@ function TableViewItemButton({
   viewUrl,
   name,
   hiddenLabel,
+  ...rest
 }: TableViewItemButtonProps): React.ReactElement {
   const intl = useIntl();
   return (
-    <Link href={viewUrl}>
+    <Link href={viewUrl} {...rest}>
       {intl.formatMessage(
         {
           defaultMessage: "View {name} <hidden>{hiddenLabel}</hidden>",
@@ -38,9 +39,11 @@ export function tableViewItemButtonAccessor(
   viewUrl: string,
   name: string,
   hiddenLabel?: string,
+  ariaLabel?: AriaAttributes["aria-label"],
 ) {
   return (
     <TableViewItemButton
+      aria-label={ariaLabel}
       viewUrl={viewUrl}
       name={name}
       hiddenLabel={hiddenLabel}

--- a/apps/web/src/components/Table/ClientManagedTable/TableViewItemButton.tsx
+++ b/apps/web/src/components/Table/ClientManagedTable/TableViewItemButton.tsx
@@ -1,4 +1,4 @@
-import React, { AriaAttributes, HTMLAttributes } from "react";
+import React, { AriaAttributes } from "react";
 import { useIntl } from "react-intl";
 
 import { Link, LinkProps } from "@gc-digital-talent/ui";

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8531,5 +8531,13 @@
   "dwe1M+": {
     "defaultMessage": "{count} candidats répondent à vos critères.",
     "description": "Message announced to assistive technology users when the estimated candidate count changes."
+  },
+  "bWTzRy": {
+    "defaultMessage": "Consulter le profil de {name}",
+    "description": "Link text to view a candidates profile for assistive technologies"
+  },
+  "mzGMZC": {
+    "defaultMessage": "Consulter la demande de {name}",
+    "description": "Link text to view a candidates application for assistive technologies"
   }
 }


### PR DESCRIPTION
🤖 Resolves #7105 

## 👋 Introduction

This adds the candidate's name as an `aria-label` to improve the context of the link when viewed in isolation.

## 🕵️ Details

We had hidden text (which has known issues) so we needed to add an `aria-label` arg to the view accessor helper to support this.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> **Note**
> You may need to clear the filters to get both a "View profile" and "View application" link to appear to fully test this implementation.

1. Build `npm run dev`
2. Navigate to the pool candidates table `/admin/pools/{poolId}/pool-candidates
3. Inspect both the "View application" and "View profile" links within the accessibility tree
4. Confirm they are unique and include the candidates name

## 📸 Screenshot

![Screenshot 2023-06-29 125248](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/e70baf78-ba10-4cba-84da-b076e1e8c56c)
![Screenshot 2023-06-29 125303](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/2f6d97ec-cc8b-4ba3-9710-6c0d20dc4aa5)

