### PR TITLE
[A11y] Replace Multiselect with Checklist for Region input

### DIFF
--- a/apps/e2e/cypress/e2e/talentsearch/search-workflows.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/search-workflows.cy.js
@@ -176,20 +176,19 @@ describe("Talent Search Workflow Tests", () => {
     cy.wait("@gqlCountApplicantsAndCountPoolCandidatesByPoolQuery");
     searchFindsMySingleCandidate();
 
-    // work location combobox
-    cy.findByRole("combobox", { name: /Region/i }).then((combobox) => {
-      // fail
-      cy.wrap(combobox).type("Atlantic{enter}");
-      cy.wait("@gqlCountApplicantsAndCountPoolCandidatesByPoolQuery");
-      searchRejectsMySingleCandidate();
-      // reset
-      cy.wrap(combobox).type("{backspace}");
-      searchFindsMySingleCandidate();
-      // pass
-      cy.wrap(combobox).type("Ontario{enter}");
-      cy.wait("@gqlCountApplicantsAndCountPoolCandidatesByPoolQuery");
-      searchFindsMySingleCandidate();
-    });
+    // work location - fail
+    cy.findByRole("checkbox", {
+      name: /Atlantic/i,
+    }).click();
+    cy.wait("@gqlCountApplicantsAndCountPoolCandidatesByPoolQuery");
+    searchRejectsMySingleCandidate();
+
+    // work location - pass
+    cy.findByRole("checkbox", {
+      name: /Ontario/i,
+    }).click();
+    cy.wait("@gqlCountApplicantsAndCountPoolCandidatesByPoolQuery");
+    searchFindsMySingleCandidate();
 
     // working language ability - fail
     cy.findByRole("radio", {

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -8,7 +8,6 @@ import {
   Checklist,
   RadioGroup,
   Select,
-  MultiSelectField,
   enumToOptions,
   unpackMaybes,
 } from "@gc-digital-talent/forms";
@@ -508,7 +507,8 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                 "Message describing the work location filter in the search form.",
             })}
           >
-            <MultiSelectField
+            <Checklist
+              idPrefix="locationPreferences"
               id="locationPreferences"
               name="locationPreferences"
               context={intl.formatMessage({
@@ -518,7 +518,7 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                 description:
                   "Context for the work region/location preferences filter in the search form.",
               })}
-              label={intl.formatMessage({
+              legend={intl.formatMessage({
                 defaultMessage: "Region",
                 id: "F+WFWB",
                 description: "Label for work location filter in search form.",
@@ -529,7 +529,7 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
                 description:
                   "Placeholder for work location filter in search form.",
               })}
-              options={enumToOptions(WorkRegion).map(({ value }) => ({
+              items={enumToOptions(WorkRegion).map(({ value }) => ({
                 value,
                 label: intl.formatMessage(getWorkRegion(value)),
               }))}


### PR DESCRIPTION
🤖 Resolves #7073 

## 👋 Introduction

This replaces the region `Multiselect` field with a `Checklist` field to improve accessibility.

## 🕵️ Details

Assistive technologies were having trouble using our multiselect field so we are replacing it with checklists for now.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/search`
3. Confirm work location's regions input is a checklist
4. Confirm it matches [the provided mockup](https://github.com/GCTC-NTGC/gc-digital-talent/issues/7073#issuecomment-1609616741)
5. Confirm it still functions as expected

## 📸 Screenshot

![Screenshot 2023-06-29 130821](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/6adc62be-f576-41f1-9da5-9f3fb0a1f465)
