### PR TITLE
[Fix] Adjust DateInput min and max validation

### DIFF
--- a/packages/forms/src/components/DateInput/DateInput.test.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.test.tsx
@@ -226,6 +226,32 @@ describe("DateInput", () => {
     });
   });
 
+  it("doesn't fail min validation on null", async () => {
+    const submitFn = jest.fn();
+
+    renderDateInput({
+      formProps: {
+        ...defaultProps.formProps,
+        onSubmit: submitFn,
+      },
+      inputProps: {
+        ...defaultProps.inputProps,
+        rules: {
+          min: {
+            value: "2023-02-01",
+            message: "must be after",
+          },
+        },
+      },
+    });
+
+    user.click(await screen.getByRole("button", { name: /submit/i }));
+
+    await waitFor(async () => {
+      expect(submitFn).toHaveBeenCalled();
+    });
+  });
+
   it("not submit after max range", async () => {
     const submitFn = jest.fn();
 
@@ -276,6 +302,32 @@ describe("DateInput", () => {
 
     await waitFor(async () => {
       expect(submitFn).not.toHaveBeenCalled();
+    });
+  });
+
+  it("doesn't fail max validation on null", async () => {
+    const submitFn = jest.fn();
+
+    renderDateInput({
+      formProps: {
+        ...defaultProps.formProps,
+        onSubmit: submitFn,
+      },
+      inputProps: {
+        ...defaultProps.inputProps,
+        rules: {
+          max: {
+            value: "2023-02-01",
+            message: "Must be before",
+          },
+        },
+      },
+    });
+
+    user.click(await screen.getByRole("button", { name: /submit/i }));
+
+    await waitFor(async () => {
+      expect(submitFn).toHaveBeenCalled();
     });
   });
 

--- a/packages/forms/src/components/DateInput/DateInput.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.tsx
@@ -82,6 +82,9 @@ const DateInput = ({
     if (!rules.min) {
       return true;
     }
+    if (!value) {
+      return true;
+    }
 
     const currentDate = formDateStringToDate(value);
     const minDate = formDateStringToDate(rules.min.value);
@@ -90,6 +93,9 @@ const DateInput = ({
 
   const isBeforeMax = (value: string) => {
     if (!rules.max) {
+      return true;
+    }
+    if (!value) {
       return true;
     }
 


### PR DESCRIPTION
🤖 Resolves #7137 

## 👋 Introduction

This branch updates the min and max validation of the DateInput component to not fail on null inputs.

## 🕵️ Details

#7079 hasn't been merged yet so I can't complete the last AC.  Whichever PR gets merged first, I'll update the second one to match.

## 🧪 Testing

1. Run the new jest tests