### PR TITLE
[Copy] Removes term buckets

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4602,8 +4602,8 @@
     "defaultMessage": "Nous voulons en apprendre davantage sur vous et sur votre intérêt ou votre passion dans le domaine de la TI!",
     "description": "How it works, step 2 content sentence 1"
   },
-  "hKKYYL": {
-    "defaultMessage": "Ce lot comprend le travail à temps plein sur des projets importants et formels qui nécessitent le partage et l’application rigoureuse de compétences et de connaissances en matière de gestion de projets de la TI.",
+  "Cq+1U7": {
+    "defaultMessage": "Ce volet comprend le travail à temps plein sur des projets importants et formels qui nécessitent le partage et l’application rigoureuse de compétences et de connaissances en matière de gestion de projets de la TI.",
     "description": "Title for the 'project portfolio management' IT work stream"
   },
   "iA1BBF": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2285,7 +2285,7 @@
     "defaultMessage": "Ce volet comprend la programmation, la conception et le développement de systèmes, l’analyse des activités, la configuration, les tests et la mise en œuvre.",
     "description": "Title for the 'software solutions' IT work stream"
   },
-  "MyDw3F": {
+  "zkdmhU": {
     "defaultMessage": "Nous proposons également des processus de recrutement passif qui nous permettent de trouver rapidement des talents lorsque la demande se fait sentir. Bien qu’il n’y ait aucune garantie qu’un emploi résultera des possibilités ci-dessous, c’est un moyen facile pour que votre nom et votre CV soient trouvés par les gestionnaires le moment venu. N’hésitez pas à soumettre votre nom pour tout poste qui correspond à vos compétences.",
     "description": "instructions for section with ongoing pool advertisements"
   },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2285,8 +2285,8 @@
     "defaultMessage": "Ce volet comprend la programmation, la conception et le développement de systèmes, l’analyse des activités, la configuration, les tests et la mise en œuvre.",
     "description": "Title for the 'software solutions' IT work stream"
   },
-  "uTTxqE": {
-    "defaultMessage": "Nous proposons également des processus de recrutement passif qui nous permettent de trouver rapidement des talents lorsque la demande se fait sentir. Bien qu’il n’y ait aucune garantie qu’un emploi résultera des possibilités ci-dessous, c’est un moyen facile pour que votre nom et votre CV soient trouvés par les gestionnaires le moment venu. N’hésitez pas à soumettre votre nom pour tout poste qui correspond à vos compétences.",
+  "y5/tVk": {
+    "defaultMessage": "Nous proposons également des processus de recrutement passif qui nous permettent de trouver rapidement des talents lorsque la demande se fait sentir. Bien qu’il n’y ait aucune garantie qu’un emploi résultera des possibilités ci-dessous, c’est un moyen facile pour que votre nom et votre CV soient trouvés par les gestionnaires le moment venu. N’hésitez pas à soumettre votre nom pour tout volet qui correspond à vos compétences.",
     "description": "instructions for section with ongoing pool advertisements"
   },
   "BxJSsB": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2285,7 +2285,7 @@
     "defaultMessage": "Ce volet comprend la programmation, la conception et le développement de systèmes, l’analyse des activités, la configuration, les tests et la mise en œuvre.",
     "description": "Title for the 'software solutions' IT work stream"
   },
-  "zkdmhU": {
+  "uTTxqE": {
     "defaultMessage": "Nous proposons également des processus de recrutement passif qui nous permettent de trouver rapidement des talents lorsque la demande se fait sentir. Bien qu’il n’y ait aucune garantie qu’un emploi résultera des possibilités ci-dessous, c’est un moyen facile pour que votre nom et votre CV soient trouvés par les gestionnaires le moment venu. N’hésitez pas à soumettre votre nom pour tout poste qui correspond à vos compétences.",
     "description": "instructions for section with ongoing pool advertisements"
   },

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
@@ -125,7 +125,6 @@ const OngoingRecruitmentSection = ({
   const abbreviation = (text: React.ReactNode) => wrapAbbr(text, intl);
 
   // this great big object is all the data to populate the accordions
-  // this great big object is all the data to populate the accordions
   const streams: StreamViewModel[] = [
     // IT business line advisory services bucket
     {

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
@@ -965,9 +965,9 @@ const OngoingRecruitmentSection = ({
       </p>
       <p>
         {intl.formatMessage({
-          id: "uTTxqE",
+          id: "y5/tVk",
           defaultMessage:
-            "We also offer passive recruitment processes that allow us to find talent fast when the demand arises. While there’s no guarantee a job will result from the opportunities below, it’s an easy way for your name and résumé to be found by managers when the time comes. Feel free to submit your name to any bucket that matches your skills.",
+            "We also offer passive recruitment processes that allow us to find talent fast when the demand arises. While there’s no guarantee a job will result from the opportunities below, it’s an easy way for your name and résumé to be found by managers when the time comes. Feel free to submit your name to any stream that matches your skills.",
           description:
             "instructions for section with ongoing pool advertisements",
         })}

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
@@ -966,9 +966,9 @@ const OngoingRecruitmentSection = ({
       </p>
       <p>
         {intl.formatMessage({
-          id: "zkdmhU",
+          id: "uTTxqE",
           defaultMessage:
-            "We also offer passive recruitment process that allow us to find talent fast when the demand arises. While there’s no guarantee a job will result from the opportunities below, it’s an easy way for your name and résumé to be found by managers when the time comes. Feel free to submit your name to any bucket that matches your skills.",
+            "We also offer passive recruitment processes that allow us to find talent fast when the demand arises. While there’s no guarantee a job will result from the opportunities below, it’s an easy way for your name and résumé to be found by managers when the time comes. Feel free to submit your name to any bucket that matches your skills.",
           description:
             "instructions for section with ongoing pool advertisements",
         })}

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
@@ -126,7 +126,7 @@ const OngoingRecruitmentSection = ({
 
   // this great big object is all the data to populate the accordions
   const streams: StreamViewModel[] = [
-    // IT business line advisory services bucket
+    // IT business line advisory services
     {
       key: PoolStream.BusinessAdvisoryServices,
       title: intl.formatMessage(messages.businessAdvisoryServicesTitle, {

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
@@ -966,9 +966,9 @@ const OngoingRecruitmentSection = ({
       </p>
       <p>
         {intl.formatMessage({
-          id: "MyDw3F",
+          id: "zkdmhU",
           defaultMessage:
-            "We also offer passive recruitment process buckets that allow us to find talent fast when the demand arises. While there’s no guarantee a job will result from the opportunities below, it’s an easy way for your name and résumé to be found by managers when the time comes. Feel free to submit your name to any bucket that matches your skills.",
+            "We also offer passive recruitment process that allow us to find talent fast when the demand arises. While there’s no guarantee a job will result from the opportunities below, it’s an easy way for your name and résumé to be found by managers when the time comes. Feel free to submit your name to any bucket that matches your skills.",
           description:
             "instructions for section with ongoing pool advertisements",
         })}

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/messages.ts
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/messages.ts
@@ -99,8 +99,8 @@ const messages = defineMessages({
   },
   projectPortfolioSummary: {
     defaultMessage:
-      "This bucket includes working full-time on large, formal projects that require the sharing of and application of rigorous application of <abbreviation>IT</abbreviation> project management skills and knowledge.",
-    id: "hKKYYL",
+      "This stream includes working full-time on large, formal projects that require the sharing of and application of rigorous application of <abbreviation>IT</abbreviation> project management skills and knowledge.",
+    id: "Cq+1U7",
     description: "Title for the 'project portfolio management' IT work stream",
   },
   securityTitle: {


### PR DESCRIPTION
🤖 Resolves #6913.

## 👋 Introduction

This PR removes the word buckets from the instructions for section with ongoing pool advertisements.

## 🕵️ Details

The French equivalent copy does not need to be changed. This PR **does not** make changes to tc-report, which does use the term buckets, as it is out of scope.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to`/browse/pools`
2. Observe "passive recruitment processes that allow us"
