### PR TITLE
[Bug] Snapshots and pool candidate models

### DIFF
--- a/api/app/Listeners/StoreApplicationSnapshot.php
+++ b/api/app/Listeners/StoreApplicationSnapshot.php
@@ -3,7 +3,6 @@
 namespace App\Listeners;
 
 use App\Events\ApplicationSubmitted;
-use App\GraphQL\Util\GraphQLClient;
 use App\Models\User;
 use App\Models\Pool;
 use App\Http\Resources\UserResource;
@@ -64,6 +63,13 @@ class StoreApplicationSnapshot
         $essentialSkillIds = $pool->essentialSkills()->pluck('id')->toArray();
         $nonessentialSkillIds = $pool->nonessentialSkills()->pluck('id')->toArray();
         $poolSkillIds = array_merge($essentialSkillIds, $nonessentialSkillIds);
+
+        // filter out any non-applicable PoolCandidate models attached to User
+        $poolCandidateCollection = $user->poolCandidates;
+        $filteredPoolCandidateCollection = $poolCandidateCollection->filter(function ($individualPoolCandidate) use ($poolCandidate) {
+            return $individualPoolCandidate->id === $poolCandidate->id;
+        });
+        $user->poolCandidates = $filteredPoolCandidateCollection;
 
         $profile = new UserResource($user);
         $profile = $profile->poolSkillIds($poolSkillIds);

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -50,6 +50,10 @@ class SnapshotTest extends TestCase
             "user_id" => $user->id,
             "pool_candidate_status" => ApiEnums::CANDIDATE_STATUS_DRAFT
         ]);
+        $poolCandidateUnrelated = PoolCandidate::factory()->create([
+            "user_id" => $user->id,
+            "pool_candidate_status" => ApiEnums::CANDIDATE_STATUS_DRAFT
+        ]);
 
         // get what the snapshot should look like
         $expectedSnapshot = $this->actingAs($user, "api")
@@ -74,6 +78,12 @@ class SnapshotTest extends TestCase
         )->json("data.poolCandidate.profileSnapshot");
 
         $decodedActual = json_decode($actualSnapshot, true);
+
+        // there are two pool candidates present, only one should appear in the snapshot, adjust expectedSnapshot to fit this
+        $filteredPoolCandidates = array_filter($expectedSnapshot['poolCandidates'], function ($individualPoolCandidate) use ($poolCandidate) {
+            return in_array($poolCandidate['id'], $individualPoolCandidate);
+        });
+        $expectedSnapshot['poolCandidates'] = $filteredPoolCandidates;
 
         assertEquals($expectedSnapshot, $decodedActual);
     }


### PR DESCRIPTION
🤖 Resolves #6946 

## 👋 Introduction

Stop collecting every pool candidate in the snapshot. 

## 🕵️ Details

Just filtering pool candidates first before the main resource collection chain. 
As well, update the snapshot test for this. 

## 🧪 Testing

1. Assert you cannot replicate what was defined in the issue body 
2. Tests pass 

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/268857fe-6820-4539-9c4b-54a036ae6cee)

