### PR TITLE
[Fix] Fix flex grid margin

### DIFF
--- a/apps/web/src/pages/Profile/ResumeAndRecruitmentPage/components/AddExperienceDialog.tsx
+++ b/apps/web/src/pages/Profile/ResumeAndRecruitmentPage/components/AddExperienceDialog.tsx
@@ -183,10 +183,7 @@ const AddExperienceDialog = ({
               description: "Instructions for the Add Experience dialog",
             })}
           </div>
-          <div
-            data-h2-margin="base(0, x0.5)"
-            data-h2-flex-grid="base(stretch, x2, x1)"
-          >
+          <div data-h2-flex-grid="base(stretch, x2, x1)">
             {experienceSections.map(({ icon: Icon, ...section }) => (
               <div
                 key={section.title}


### PR DESCRIPTION
🤖 Resolves #7158 

## 👋 Introduction

This branch updates the margin for the grid in the _Add experience_ dialog.

## 🕵️ Details

This was a regression picked up during the Hydrogen 2.0.2 upgrade.  It seems the built-in flex grid margins changed and the explicit margin in the same element overrode them.  I just removed the explicit margin.

https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/85818a0d-5116-4271-a339-c87bacc23d72

## 🧪 Testing

1. Build the app, log in, navigate to the _Résumé and recruitment_ page (or open the _Résumé and recruitment_ story)
2. Click the _Add experience_ button to open the dialog

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/081730e5-19fa-425d-a738-a9d4882e216e)

