### PR TITLE
[Feature] Add null state for priority number

### DIFF
--- a/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
+++ b/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
@@ -419,19 +419,20 @@ const ProfileDocument = React.forwardRef<HTMLDivElement, ProfileDocumentProps>(
                             ? intl.formatMessage(commonMessages.yes)
                             : intl.formatMessage(commonMessages.no)}
                         </p>
-                        {result.hasPriorityEntitlement &&
-                          result.priorityNumber && (
-                            <p>
-                              {intl.formatMessage({
-                                defaultMessage: "Priority number",
-                                id: "mGGj/i",
-                                description:
-                                  "Label for applicant's priority number value",
-                              })}
-                              {intl.formatMessage(commonMessages.dividingColon)}
-                              {result.priorityNumber}
-                            </p>
-                          )}
+                        {result.hasPriorityEntitlement && (
+                          <p>
+                            {intl.formatMessage({
+                              defaultMessage: "Priority number",
+                              id: "mGGj/i",
+                              description:
+                                "Label for applicant's priority number value",
+                            })}
+                            {intl.formatMessage(commonMessages.dividingColon)}
+                            {result.priorityNumber
+                              ? result.priorityNumber
+                              : intl.formatMessage(commonMessages.notProvided)}
+                          </p>
+                        )}
                       </PageSection>
                       <PageSection>
                         <Heading level="h3">

--- a/apps/web/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
+++ b/apps/web/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
@@ -170,7 +170,7 @@ const GovernmentInformationSection = ({
               </span>
             </p>
           </div>
-          {applicant.priorityNumber && (
+          {applicant.hasPriorityEntitlement && (
             <div data-h2-flex-item="base(1of1)">
               <p>
                 <span data-h2-display="base(block)">
@@ -181,7 +181,9 @@ const GovernmentInformationSection = ({
                   })}
                 </span>
                 <span data-h2-font-weight="base(700)">
-                  {applicant.priorityNumber}
+                  {applicant.priorityNumber
+                    ? applicant.priorityNumber
+                    : intl.formatMessage(commonMessages.notProvided)}
                 </span>
               </p>
             </div>


### PR DESCRIPTION
🤖 Resolves #7103 

## 👋 Introduction

This branch adds a null state for the priority number.

## 🕵️ Details

I ended up going with "Not provided" instead of "(Number not provided)" for consistency.  The former was already in use for the new inline forms.

## 🧪 Testing

1. Build the app
2. Create or edit a user with priority entitlement but no priority number
3. Submit an application
4. Check
    - Profile page
    - Application _Review your profile_ page
    - Admin _View user_ page
    - Admin _View application_ page
    - Admin "printed" user page
    - NOT the CSV - I figured the tabular form is clear enough
    - Any spots missed?

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/450324ac-5fac-4f4c-a7be-d3696f85a189)

