### PR TITLE
[Feature] Add notes to pool candidates table

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -299,7 +299,7 @@ class PoolCandidate extends Model
 
         $query->whereHas('user', function ($query) use ($search) {
             User::scopeGeneralSearch($query, $search);
-        });
+        })->orWhere('notes', 'ilike', "%{$search}%");
 
         return $query;
     }

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -330,6 +330,16 @@ class PoolCandidate extends Model
         return $query;
     }
 
+    public static function scopeNotes(Builder $query, ?string $notes): Builder
+    {
+
+        if (!empty($notes)) {
+            $query->where('notes', 'ilike', "%{$notes}%");
+        }
+
+        return $query;
+    }
+
 
     public function scopePoolCandidateStatuses(Builder $query, ?array $poolCandidateStatuses): Builder
     {

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -297,9 +297,13 @@ class PoolCandidate extends Model
             return $query;
         }
 
-        $query->whereHas('user', function ($query) use ($search) {
-            User::scopeGeneralSearch($query, $search);
-        })->orWhere('notes', 'ilike', "%{$search}%");
+        $query->where(function ($query) use ($search) {
+            $query->whereHas('user', function ($query) use ($search) {
+                User::scopeGeneralSearch($query, $search);
+            })->orWhere(function ($query) use ($search) {
+                self::scopeNotes($query, $search);
+            });
+        });
 
         return $query;
     }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -897,7 +897,6 @@ input PoolCandidateSearchRequestInput {
   streams: [PoolStream] @scope
   fullName: String @scope
   email: String @scope
-  adminNotes: String @scope
   jobTitle: String @scope
   additionalComments: String @scope
   adminNotes: String @scope

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -882,6 +882,7 @@ input PoolCandidateSearchInput {
   email: String @scope
   generalSearch: String @scope
   name: String @scope
+  notes: String @scope
   priorityWeight: [Int] @scope(name: "priorityWeight")
   poolCandidateStatus: [PoolCandidateStatus]
     @scope(name: "poolCandidateStatuses")
@@ -896,6 +897,7 @@ input PoolCandidateSearchRequestInput {
   streams: [PoolStream] @scope
   fullName: String @scope
   email: String @scope
+  adminNotes: String @scope
   jobTitle: String @scope
   additionalComments: String @scope
   adminNotes: String @scope

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -844,6 +844,7 @@ input PoolCandidateSearchInput {
   email: String
   generalSearch: String
   name: String
+  notes: String
   priorityWeight: [Int]
   poolCandidateStatus: [PoolCandidateStatus]
   expiryStatus: CandidateExpiryFilter

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -64,6 +64,7 @@ import {
 } from "~/utils/userUtils";
 import { getFullNameLabel } from "~/utils/nameUtils";
 import ProfileDocument from "~/components/ProfileDocument/ProfileDocument";
+import adminMessages from "~/messages/adminMessages";
 
 import usePoolCandidateCsvData from "./usePoolCandidateCsvData";
 
@@ -671,12 +672,7 @@ const PoolCandidatesTable = ({
         sortColumnName: "FIRST_NAME",
       },
       {
-        label: intl.formatMessage({
-          defaultMessage: "Notes",
-          id: "caSdGd",
-          description:
-            "Title displayed on the Pool Candidates table notes column.",
-        }),
+        label: intl.formatMessage(adminMessages.notes),
         id: "notes",
         accessor: ({ poolCandidate }) => notesAccessor(poolCandidate, intl),
       },

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -65,7 +65,6 @@ import {
 import { getFullNameLabel } from "~/utils/nameUtils";
 import ProfileDocument from "~/components/ProfileDocument/ProfileDocument";
 
-import { User } from "@gc-digital-talent/graphql";
 import usePoolCandidateCsvData from "./usePoolCandidateCsvData";
 
 import PoolCandidateTableFilterDialog, {

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -474,6 +474,7 @@ const PoolCandidatesTable = ({
       generalSearch: searchBarTerm && !searchType ? searchBarTerm : undefined,
       email: searchType === "email" ? searchBarTerm : undefined,
       name: searchType === "name" ? searchBarTerm : undefined,
+      notes: searchType === "notes" ? searchBarTerm : undefined,
 
       // from fancy filter
       applicantFilter: fancyFilterState?.applicantFilter,
@@ -868,6 +869,10 @@ const PoolCandidatesTable = ({
               description: "Label for user table search dropdown (email).",
             }),
             value: "email",
+          },
+          {
+            label: intl.formatMessage(adminMessages.notes),
+            value: "notes",
           },
         ]}
         onColumnHiddenChange={(event) => {

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -6,7 +6,7 @@ import { SubmitHandler } from "react-hook-form";
 
 import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 import { notEmpty } from "@gc-digital-talent/helpers";
-import { Pending } from "@gc-digital-talent/ui";
+import { Pending, Spoiler } from "@gc-digital-talent/ui";
 import {
   getCandidateSuspendedFilterStatus,
   getLanguage,
@@ -65,6 +65,7 @@ import {
 import { getFullNameLabel } from "~/utils/nameUtils";
 import ProfileDocument from "~/components/ProfileDocument/ProfileDocument";
 
+import { User } from "@gc-digital-talent/graphql";
 import usePoolCandidateCsvData from "./usePoolCandidateCsvData";
 
 import PoolCandidateTableFilterDialog, {
@@ -308,9 +309,31 @@ const provinceAccessor = (
     ? intl.formatMessage(getProvinceOrTerritory(province as string))
     : "";
 
+const notesAccessor = (candidate: PoolCandidate, intl: IntlShape) =>
+  candidate?.notes ? (
+    <Spoiler
+      text={candidate.notes}
+      linkSuffix={intl.formatMessage(
+        {
+          defaultMessage: "notes for {name}",
+          id: "CZbb7c",
+          description:
+            "Link text suffix to read more notes for a pool candidate",
+        },
+        {
+          name: getFullNameLabel(
+            candidate.user.firstName,
+            candidate.user.lastName,
+            intl,
+          ),
+        },
+      )}
+    />
+  ) : null;
+
 const defaultState = {
   ...TABLE_DEFAULTS,
-  hiddenColumnIds: ["candidacyStatus"],
+  hiddenColumnIds: ["candidacyStatus", "notes"],
   filters: {
     applicantFilter: {
       operationalRequirements: [],
@@ -647,6 +670,16 @@ const PoolCandidatesTable = ({
         accessor: ({ poolCandidate: { user } }) =>
           `${user?.firstName} ${user?.lastName}`,
         sortColumnName: "FIRST_NAME",
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Notes",
+          id: "caSdGd",
+          description:
+            "Title displayed on the Pool Candidates table notes column.",
+        }),
+        id: "notes",
+        accessor: ({ poolCandidate }) => notesAccessor(poolCandidate, intl),
       },
       {
         label: intl.formatMessage({

--- a/apps/web/src/components/PoolCandidatesTable/usePoolCandidateCsvData.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/usePoolCandidateCsvData.tsx
@@ -118,11 +118,7 @@ const usePoolCandidateCsvData = (
     },
     {
       key: "notes",
-      label: intl.formatMessage({
-        defaultMessage: "Notes",
-        id: "ev6HnY",
-        description: "CSV Header, Notes column",
-      }),
+      label: intl.formatMessage(adminMessages.notes),
     },
     {
       key: "currentProvince",

--- a/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
@@ -114,7 +114,7 @@ const notesAccessor = (
             "Link text suffix to read more notes for a search request",
         },
         {
-          name: searchRequest.fullName,
+          name: searchRequest.jobTitle,
         },
       )}
     />

--- a/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
@@ -3,7 +3,7 @@ import { IntlShape, useIntl } from "react-intl";
 import { SubmitHandler } from "react-hook-form";
 
 import { notEmpty } from "@gc-digital-talent/helpers";
-import { Pending } from "@gc-digital-talent/ui";
+import { Pending, Spoiler } from "@gc-digital-talent/ui";
 import {
   InputMaybe,
   Maybe,
@@ -43,6 +43,7 @@ import adminMessages from "~/messages/adminMessages";
 import SearchRequestsTableFilter, {
   FormValues,
 } from "./components/SearchRequestsTableFilterDialog";
+import { PoolCandidateSearchRequest } from "../../api/generated";
 
 type Data = NonNullable<FromArray<PoolCandidateSearchRequestPaginator["data"]>>;
 
@@ -95,9 +96,30 @@ function dateCell(date: Maybe<Scalars["DateTime"]>, intl: IntlShape) {
   ) : null;
 }
 
+const notesAccessor = (
+  searchRequest: PoolCandidateSearchRequest,
+  intl: IntlShape,
+) =>
+  searchRequest?.adminNotes ? (
+    <Spoiler
+      text={searchRequest.adminNotes}
+      linkSuffix={intl.formatMessage(
+        {
+          defaultMessage: "notes for {name}",
+          id: "I73/lv",
+          description:
+            "Link text suffix to read more notes for a pool searchRequest",
+        },
+        {
+          name: searchRequest.fullName,
+        },
+      )}
+    />
+  ) : null;
+
 const defaultState = {
   ...TABLE_DEFAULTS,
-  hiddenColumnIds: ["id", "email"],
+  hiddenColumnIds: ["id", "email", "adminNotes"],
   filters: {},
 };
 
@@ -312,6 +334,11 @@ const SearchRequestsTableApi = ({
         id: "jobTitle",
         sortColumnName: "job_title",
         accessor: (d) => d.jobTitle,
+      },
+      {
+        label: intl.formatMessage(adminMessages.notes),
+        id: "adminNotes",
+        accessor: (d) => notesAccessor(d, intl),
       },
     ],
     [intl, paths],

--- a/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
@@ -108,7 +108,7 @@ const notesAccessor = (
           defaultMessage: "notes for {name}",
           id: "I73/lv",
           description:
-            "Link text suffix to read more notes for a pool searchRequest",
+            "Link text suffix to read more notes for a search request",
         },
         {
           name: searchRequest.fullName,

--- a/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
@@ -106,7 +106,7 @@ const notesAccessor = (
       linkSuffix={intl.formatMessage(
         {
           defaultMessage: "notes for {name}",
-          id: "I73/lv",
+          id: "6eih3b",
           description:
             "Link text suffix to read more notes for a search request",
         },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -854,10 +854,6 @@
     "defaultMessage": "Apprenti en TI du Gouvernement du Canada",
     "description": "author of testimonial number one"
   },
-  "4AubyK": {
-    "defaultMessage": "Notes",
-    "description": "Title of the 'Notes' section of the view-user page"
-  },
   "4BpFoX": {
     "defaultMessage": "{title} émis par {issuedBy}",
     "description": "The award title is issued by some group"
@@ -5406,10 +5402,6 @@
     "defaultMessage": "À la prochaine fois!",
     "description": "Title for the page users land on after successful logout."
   },
-  "caSdGd": {
-    "defaultMessage": "Notes",
-    "description": "Title displayed on the Pool Candidates table notes column."
-  },
   "cag7TH": {
     "defaultMessage": "Question {number} (FR)",
     "description": "Heading for displaying a screening question French"
@@ -5745,10 +5737,6 @@
   "eqVWC6": {
     "defaultMessage": "Appliquée par : <strong><red>{closingDate}</red></strong>",
     "description": "Text notifying user of closing date for an application"
-  },
-  "ev6HnY": {
-    "defaultMessage": "Notes",
-    "description": "CSV Header, Notes column"
   },
   "evxvnW": {
     "defaultMessage": "L'utilisateur a été mis à jour avec succès!",
@@ -7057,10 +7045,6 @@
   "nok2sR": {
     "defaultMessage": "Nom :",
     "description": "Display text for the name field on users"
-  },
-  "npC3bT": {
-    "defaultMessage": "Notes",
-    "description": "Title for admin editing a pool candidates notes"
   },
   "nsm/uC": {
     "defaultMessage": "{skillName} (Essentielles)",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2012,6 +2012,10 @@
     "defaultMessage": "Y a-t-il des frais pour participer au programme?",
     "description": "Learn more dialog question ten heading"
   },
+  "CZbb7c": {
+    "defaultMessage": "notes pour {name}",
+    "description": "Link text suffix to read more notes for a pool candidate"
+  },
   "CfNtWn": {
     "defaultMessage": "Ce processus ne comporte pas de questions filtres. Vous pouvez passer à l’étape suivante.",
     "description": "Message displayed to users when there are no screening questions for a process"
@@ -5401,6 +5405,10 @@
   "cZmuts": {
     "defaultMessage": "À la prochaine fois!",
     "description": "Title for the page users land on after successful logout."
+  },
+  "caSdGd": {
+    "defaultMessage": "Notes",
+    "description": "Title displayed on the Pool Candidates table notes column."
   },
   "cag7TH": {
     "defaultMessage": "Question {number} (FR)",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1190,6 +1190,10 @@
     "defaultMessage": "Postes bilingues (français et anglais)",
     "description": "Bilingual Positions message"
   },
+  "6eih3b": {
+    "defaultMessage": "notes pour {name}",
+    "description": "Link text suffix to read more notes for a search request"
+  },
   "6esMaA": {
     "defaultMessage": "Expérience ou formation minimale",
     "description": "Page title for the application education page"
@@ -2743,10 +2747,6 @@
   "I0VGC0": {
     "defaultMessage": "Placement",
     "description": "User placement breadcrumb text"
-  },
-  "6eih3b": {
-    "defaultMessage": "notes pour {name}",
-    "description": "Link text suffix to read more notes for a search request"
   },
   "I7rxxQ": {
     "defaultMessage": "Mots-clés",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2744,6 +2744,10 @@
     "defaultMessage": "Placement",
     "description": "User placement breadcrumb text"
   },
+  "I73/lv": {
+    "defaultMessage": "notes pour {name}",
+    "description": "Link text suffix to read more notes for a search request"
+  },
   "I7rxxQ": {
     "defaultMessage": "Mots-clés",
     "description": "Title displayed for the skill table Keywords column."

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2744,7 +2744,7 @@
     "defaultMessage": "Placement",
     "description": "User placement breadcrumb text"
   },
-  "I73/lv": {
+  "6eih3b": {
     "defaultMessage": "notes pour {name}",
     "description": "Link text suffix to read more notes for a search request"
   },

--- a/apps/web/src/lang/whitelist.yml
+++ b/apps/web/src/lang/whitelist.yml
@@ -9,12 +9,9 @@
 - 9yGJ6k # 'Description' Title displayed for the skill table Description column.
 - XSo129 # 'Description' Title displayed for the Skill Family table Description column.
 - hlcd+5 # 'Résultats du tableau'
-- 4AubyK # Notes (Title of the 'Notes' section of the view-user page)
 - Hqt/ej # 'Archive' 'Heading for the archive pool dialog'
 - P8NuMo # 'Archive' 'Text on a button to archive the pool'
 - TDTE1c # 'Action' Title displayed for the search request table edit column.
-- ev6HnY # 'Notes' CSV Header, Notes column
-- npC3bT # 'Notes' Title for admin editing a pool candidates notes
 - m0JFE/ # 'Code' Title for the application's profile snapshot
 - w/qZsH # 'Classification' Label displayed on the pool form classification field.
 - wHX/8C # 'Admin' Title tag for Admin site
@@ -30,6 +27,4 @@
 - cag7TH # 'Question {number} (FR)'
 - /sBGov # 'Question {number}' - Question is same, number is untranslated
 - kvpRgN # 'Classifications' - Title for classifications
-- rwNxlI # 'Notes' - Notes label
 - EK+25s # 'Notes' - Notes in adminMessages constant
-- caSdGd # 'Notes' - Pool Candidate table column

--- a/apps/web/src/lang/whitelist.yml
+++ b/apps/web/src/lang/whitelist.yml
@@ -32,3 +32,4 @@
 - kvpRgN # 'Classifications' - Title for classifications
 - rwNxlI # 'Notes' - Notes label
 - EK+25s # 'Notes' - Notes in adminMessages constant
+- caSdGd # 'Notes' - Pool Candidate table column

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.tsx
@@ -22,6 +22,7 @@ import { strToFormDate } from "@gc-digital-talent/date-helpers";
 import { emptyToNull } from "@gc-digital-talent/helpers";
 
 import { getFullPoolTitleHtml } from "~/utils/poolUtils";
+import adminMessages from "~/messages/adminMessages";
 import {
   PoolCandidateStatus,
   Scalars,
@@ -179,14 +180,7 @@ export const ApplicationStatusForm = ({
                     data-h2-height="base(0.75em)"
                     data-h2-margin="base(0, x0.25, 0, 0)"
                   />
-                  <span>
-                    {intl.formatMessage({
-                      defaultMessage: "Notes",
-                      id: "npC3bT",
-                      description:
-                        "Title for admin editing a pool candidates notes",
-                    })}
-                  </span>
+                  <span>{intl.formatMessage(adminMessages.notes)}</span>
                 </Heading>
                 <p data-h2-margin="base(x0.25 0)">
                   {intl.formatMessage({

--- a/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
@@ -49,11 +49,7 @@ const UserInformation = ({ user, pools }: UserInformationProps) => {
     },
     {
       id: "notes",
-      title: intl.formatMessage({
-        defaultMessage: "Notes",
-        id: "4AubyK",
-        description: "Title of the 'Notes' section of the view-user page",
-      }),
+      title: intl.formatMessage(adminMessages.notes),
       titleIcon: PencilSquareIcon,
       content: <NotesSection user={user} />,
     },

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -876,6 +876,10 @@
     "defaultMessage": "Terminé avec succès (aucun titre de compétence)",
     "description": "Successful Completion with no credentials for education status input"
   },
+  "cCWdDX": {
+    "defaultMessage": "Lire davantage <hidden> {context}</hidden>",
+    "description": "Button text to expand truncated text to view all contents"
+  },
   "cEB0aW": {
     "defaultMessage": "exige des <strong>heures supplémentaires régulièrement</strong>.",
     "description": "The operational requirement described as regular overtime."
@@ -1218,6 +1222,10 @@
   "rlq4uZ": {
     "defaultMessage": "Compétences techniques",
     "description": "The skill is considered technical."
+  },
+  "rnZULP": {
+    "defaultMessage": "Lire moins <hidden> {context}</hidden>",
+    "description": "Button text to truncate text to view fewer characters"
   },
   "rsxrMs": {
     "defaultMessage": "Retirer {label}",

--- a/packages/i18n/src/messages/uiMessages.ts
+++ b/packages/i18n/src/messages/uiMessages.ts
@@ -90,6 +90,16 @@ const uiMessages = defineMessages({
     id: "0bcof1",
     description: "Prefix when a step is the currently active one.",
   },
+  readMore: {
+    defaultMessage: "Read more<hidden> {context}</hidden>",
+    id: "cCWdDX",
+    description: "Button text to expand truncated text to view all contents",
+  },
+  readLess: {
+    defaultMessage: "Read less<hidden> {context}</hidden>",
+    id: "rnZULP",
+    description: "Button text to truncate text to view fewer characters",
+  },
 });
 
 export default uiMessages;

--- a/packages/ui/src/components/Spoiler/Spoiler.stories.tsx
+++ b/packages/ui/src/components/Spoiler/Spoiler.stories.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { StoryFn } from "@storybook/react";
+import { faker } from "@faker-js/faker";
+
+import Spoiler from "./Spoiler";
+
+faker.seed(0);
+
+export default {
+  component: Spoiler,
+  title: "Components/Spoiler",
+};
+
+const Template: StoryFn<typeof Spoiler> = (args) => <Spoiler {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  linkSuffix: "of the spoiler",
+  text: faker.lorem.sentences(3),
+};

--- a/packages/ui/src/components/Spoiler/Spoiler.tsx
+++ b/packages/ui/src/components/Spoiler/Spoiler.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { uiMessages } from "@gc-digital-talent/i18n";
+
+import Button from "../Button";
+import Collapsible from "../Collapsible";
+
+export interface SpoilerProps {
+  // Accessible name for the "read more" button
+  linkSuffix: string;
+  // Text to be truncated to read more
+  text: string;
+  // Character count before cutoff
+  characterCount?: number;
+}
+
+const Spoiler = ({ linkSuffix, text, characterCount = 32 }: SpoilerProps) => {
+  const intl = useIntl();
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const truncated = text.slice(0, characterCount);
+
+  return (
+    <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
+      <div
+        data-h2-display="base(flex)"
+        data-h2-align-items="base(center)"
+        data-h2-gap="base(0 x.25)"
+      >
+        <div>{truncated}&hellip;</div>
+        <Collapsible.Trigger asChild>
+          <Button mode="inline" color="black" data-h2-flex-shrink="base(0)">
+            {!isOpen
+              ? intl.formatMessage(uiMessages.readMore, {
+                  context: linkSuffix,
+                })
+              : intl.formatMessage(uiMessages.readLess, {
+                  context: linkSuffix,
+                })}
+          </Button>
+        </Collapsible.Trigger>
+      </div>
+      <Collapsible.Content>{text}</Collapsible.Content>
+    </Collapsible.Root>
+  );
+};
+
+export default Spoiler;

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -62,6 +62,7 @@ import SideMenu, {
   type SideMenuProps,
   type SideMenuItemProps,
 } from "./components/SideMenu";
+import Spoiler, { SpoilerProps } from "./components/Spoiler/Spoiler";
 import Stepper, { StepperProps } from "./components/Stepper/Stepper";
 import { StepType } from "./components/Stepper/types";
 import Switch from "./components/Switch";
@@ -108,6 +109,7 @@ export type {
   PillSize,
   SideMenuProps,
   SideMenuItemProps,
+  SpoilerProps,
   StepperProps,
   StepType,
   TocAnchorLinkProps,
@@ -154,6 +156,7 @@ export {
   SideMenuButton,
   SideMenuItem,
   SideMenuContentWrapper,
+  Spoiler,
   Stepper,
   Switch,
   TableOfContents,


### PR DESCRIPTION
🤖 Resolves #6818 

## 👋 Introduction

Adds a notes column to the pool candidates table, in a new `<Spoiler />` component, allowing users to search by it.

## 🕵️ Details

### `<Spoiler />`

Added a new component to show partial content with a "read more" button to show the full text.

```tsx
export interface SpoilerProps {
  // Accessible name for the "read more" button
  linkSuffix: string;
  // Text to be truncated to read more
  text: string;
  // Character count before cutoff
  characterCount?: number;
}
```

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to the pool candidate table `/admin/pools/{poolID}/pool-candidates
3. Confirm "Notes" is hidden by default
4. Confirm you can show it using the columns dialog
5. Confirm you can open the notes field to read the full text
6. Confirm you can search for notes and results are accurate

## 📸 Screenshot

![Screenshot 2023-07-07 095142](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/76147aac-d77b-4098-affa-2ed3c4747a4a)
