### PR TITLE
[Bug] All basic forms `mode` to on submit

### DIFF
--- a/apps/web/src/components/SkillPicker/SkillPicker.tsx
+++ b/apps/web/src/components/SkillPicker/SkillPicker.tsx
@@ -53,7 +53,7 @@ const SkillPicker = ({
   const Heading = headingLevel;
   const [validData, setValidData] = React.useState<FormValues>(defaultValues);
   const methods = useForm<FormValues>({
-    mode: "onChange",
+    mode: "onSubmit",
     defaultValues,
   });
   const {

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/PersonalInformation/PersonalInformation.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/PersonalInformation/PersonalInformation.tsx
@@ -98,7 +98,6 @@ const PersonalInformation = ({ user, onUpdate, isUpdating }: SectionProps) => {
             labels={labels}
             onSubmit={handleSubmit}
             options={{
-              mode: "onChange",
               defaultValues: dataToFormValues(user),
             }}
           >

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/components/WorkPreferences/WorkPreferences.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/components/WorkPreferences/WorkPreferences.tsx
@@ -103,7 +103,6 @@ const WorkPreferences = ({ user, onUpdate, isUpdating }: SectionProps) => {
             labels={labels}
             onSubmit={handleSubmit}
             options={{
-              mode: "onChange",
               defaultValues: dataToFormValues(user),
             }}
           >

--- a/apps/web/src/pages/Profile/AboutMePage/components/AboutMeForm/AboutMeForm.tsx
+++ b/apps/web/src/pages/Profile/AboutMePage/components/AboutMeForm/AboutMeForm.tsx
@@ -242,7 +242,6 @@ const AboutMeForm = ({
         cacheKey="about-me-form"
         onSubmit={handleSubmit}
         options={{
-          mode: "onChange",
           defaultValues: initialDataToFormValues(initialUser),
         }}
       >

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -201,8 +201,8 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
         state?.selectedClassifications,
         pools,
       ),
-      mode: "onChange",
-      reValidateMode: "onChange",
+      mode: "onSubmit",
+      reValidateMode: "onSubmit",
     });
     const { watch, trigger } = methods;
 

--- a/packages/forms/src/components/BasicForm.tsx
+++ b/packages/forms/src/components/BasicForm.tsx
@@ -50,7 +50,7 @@ function BasicForm<TFieldValues extends FieldValues>({
   const [showUnsavedChanges, setShowUnsavedChanges] =
     React.useState<boolean>(false);
   const methods = useForm({
-    mode: "onChange",
+    mode: "onSubmit",
     shouldFocusError: false,
     ...options,
     defaultValues: options?.defaultValues,


### PR DESCRIPTION
🤖 Resolves #7009 

## 👋 Introduction

- Sets all form modes within the application to `onSubmit` and only validate on or after submission.

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

> Background: this is to keep the new DateInput component from triggering a validation error before the user has entered their values into all three inputs to form a complete date.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure all `useForm` mode overrides are using onSubmit
2. Ensure validation happens on or after submission but **not** before
3. Ensure error summary still functions as expected
4. Ensure form caching still functions as expected
