### PR TITLE
[Bug] Accounts for plural on `ExperienceCard` skill count

### DIFF
--- a/apps/web/src/components/ExperienceCard/ExperienceCard.tsx
+++ b/apps/web/src/components/ExperienceCard/ExperienceCard.tsx
@@ -147,8 +147,9 @@ const ExperienceCard = ({
             <span data-h2-color="base(black.light)">
               {intl.formatMessage(
                 {
-                  defaultMessage: "{skillCount} featured skills",
-                  id: "8LPNbf",
+                  defaultMessage:
+                    "{skillCount, plural, =0 {0 featured skills} =1 {1 featured skill} other {# featured skills}}",
+                  id: "276x9r",
                   description:
                     "Number of skills attached to a specific experience",
                 },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -567,6 +567,10 @@
     "defaultMessage": "Visitez votre profil et la page de candidature",
     "description": "Link text to navigate to the profile and applications page"
   },
+  "276x9r": {
+    "defaultMessage": "{skillCount, plural, =0 {0 compétence mise en évidence} =1 {1 compétence mise en évidence} other {# compétences mises en évidence}}",
+    "description": "Number of skills attached to a specific experience"
+  },
   "27FjxB": {
     "defaultMessage": "Avoir une passion ou un intérêt pour la technologie de l’information (TI), avec cette passion ou cet intérêt démontrés par une expérience personnelle, bénévole, communautaire ou professionnelle.",
     "description": "IAP Requirement list item four"
@@ -1452,10 +1456,6 @@
   "8L5kDc": {
     "defaultMessage": "Téléphone",
     "description": "Label displayed on the user form telephone field."
-  },
-  "8LPNbf": {
-    "defaultMessage": "{skillCount} compétences mises en évidence",
-    "description": "Number of skills attached to a specific experience"
   },
   "8M2Tbu": {
     "defaultMessage": "<strong>Service de relais vidéo :</strong>La CCDP accepte les appels utilisant le service de relais vidéo effectués par l’intermédiaire de <relayServiceLink>SRV Canada</relayServiceLink>.",


### PR DESCRIPTION
🤖 Resolves #7170.

## 👋 Introduction

This PR updates the skill count on the `ExperienceCard` for plural cases in English and French.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. npm run intl-compile
2. npm run storybook
3. View *Award Experience Card* story
4. Open storybook controls
5. Open `experience` > `skills`
6. Remove skills one at a time
7. Observe string *2 featured skills*
8. Observe string *1 featured skill*
9. Observe string *0 featured skills*
10. Refresh window
11. Switch locale to FR
12. Open `experience.skills` array
13. Remove skills one at a time
14. Observe string *2 compétences mises en évidence*
15. Observe string *1 compétence mise en évidence*
16. Observe string *0 compétence mise en évidence*

## 📸 Screen recording

https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/e6399607-8748-4e23-ae90-f8fb7c2b802e
