### PR TITLE
[Feature] Changes Pool Candidates table Priority to Category column label

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateTableFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateTableFilterDialog.tsx
@@ -247,8 +247,10 @@ const PoolCandidateTableFilterDialog = ({
                   id="priorityWeight"
                   name="priorityWeight"
                   label={formatMessage({
-                    defaultMessage: "Priority",
-                    id: "8lCjAM",
+                    defaultMessage: "Category",
+                    id: "qrDCTV",
+                    description:
+                      "Title displayed for the Pool Candidates table Priority column.",
                   })}
                   options={optionsData.priorityWeight}
                 />

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -613,16 +613,16 @@ const PoolCandidatesTable = ({
       },
       {
         label: intl.formatMessage({
-          defaultMessage: "Priority",
-          id: "EZQ9Dj",
+          defaultMessage: "Category",
+          id: "qrDCTV",
           description:
             "Title displayed for the Pool Candidates table Priority column.",
         }),
         header: (
           <span>
             {intl.formatMessage({
-              defaultMessage: "Priority",
-              id: "EZQ9Dj",
+              defaultMessage: "Category",
+              id: "qrDCTV",
               description:
                 "Title displayed for the Pool Candidates table Priority column.",
             })}

--- a/apps/web/src/components/PoolCandidatesTable/usePoolCandidateCsvData.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/usePoolCandidateCsvData.tsx
@@ -103,8 +103,8 @@ const usePoolCandidateCsvData = (
     {
       key: "priority",
       label: intl.formatMessage({
-        defaultMessage: "Priority",
-        id: "w9RqOI",
+        defaultMessage: "Category",
+        id: "o9B983",
         description: "CSV Header, Priority column",
       }),
     },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1517,9 +1517,6 @@
     "defaultMessage": "Récipiendaire(s) du prix",
     "description": "Label for the person or group that received an award"
   },
-  "8lCjAM": {
-    "defaultMessage": "Priorité"
-  },
   "8mt/5/": {
     "defaultMessage": "Exemptions de lieux",
     "description": "CSV Header, Location Exemptions column"
@@ -2271,10 +2268,6 @@
   "EWzkQb": {
     "defaultMessage": "Une fois que vous avez mis votre CV à jour et que vous êtes satisfait des expériences que vous avez ajoutées, vous les utiliserez dans d’autres étapes pour nous aider à mieux comprendre comment vous répondez aux exigences de compétences pour cette occasion.",
     "description": "Application step to begin working on résumé, paragraph three"
-  },
-  "EZQ9Dj": {
-    "defaultMessage": "Priorité",
-    "description": "Title displayed for the Pool Candidates table Priority column."
   },
   "EZX/44": {
     "defaultMessage": "Examens écrits : {language}",
@@ -7102,6 +7095,10 @@
     "defaultMessage": "Créer<hidden> des équipes</hidden>",
     "description": "Breadcrumb title for the create team page link."
   },
+  "o9B983": {
+    "defaultMessage": "Catégorie",
+    "description": "CSV Header, Priority column"
+  },
   "oC/GRF": {
     "defaultMessage": "Vous n'avez aucune expérience liée à cette compétence",
     "description": "The skill is not attached to any experience"
@@ -7404,6 +7401,10 @@
   "qnaIOA": {
     "defaultMessage": "P. ex. : Vous voulez postuler pour la région du Québec, mais pas pour Montréal.",
     "description": "Example for Work location exceptions field in work location preference form"
+  },
+  "qrDCTV": {
+    "defaultMessage": "Catégorie",
+    "description": "Title displayed for the Pool Candidates table Priority column."
   },
   "qrdJ13": {
     "defaultMessage": "Date de la remise du prix",
@@ -8103,10 +8104,6 @@
   "w9FYqi": {
     "defaultMessage": "Annonce du bassin",
     "description": "Sub title for admin view pool page"
-  },
-  "w9RqOI": {
-    "defaultMessage": "Priorité",
-    "description": "CSV Header, Priority column"
   },
   "wASF5V": {
     "defaultMessage": "Je suis actuellement actif dans ce rôle.",


### PR DESCRIPTION
🤖 Resolves #6354.

## 👋 Introduction

This PR changes the column label for `priority` on the Pool Candidates table from **Priority** to **Category**.

## 🕵️ Details

Although it was not in the acceptance criteria, I also changed the column label for the CSV in `usePoolCandidateCsvData` since this is a corresponding value.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. View a pool candidates table page: `/admin/pools/:poolId/pool-candidates`
2. Observe rendered column is **Category** and not **Priority**
3. Open Filters dialog
4. Observe rendered column is **Category** and not **Priority**
5. Open Columns dialog
6. Observe rendered column is **Category** and not **Priority**

## 📸 Screenshots

### English

![Screen Shot 2023-07-11 at 12 37 45](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/22fa547e-5e62-455a-92eb-f9fc0e764360)
![Screen Shot 2023-07-11 at 12 37 59](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/9e66845b-494e-498b-a16c-347a81f7e993)
![Screen Shot 2023-07-11 at 12 38 33](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/ed0842a0-a773-48a8-b893-380b31db7ec1)

### French

![Screen Shot 2023-07-11 at 12 38 50](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/55643251-be62-4ab1-b019-be98f338d3c0)
![Screen Shot 2023-07-11 at 12 38 59](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/490020ab-7883-4864-89fe-82a5b5f1a667)
![Screen Shot 2023-07-11 at 12 39 05](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/1adf7dc8-2f71-4825-9d06-a83688f22e73)