### PR TITLE
[Bug] Rename Foreign Affairs and department update issue

### DIFF
--- a/api/database/seeders/DepartmentSeeder.php
+++ b/api/database/seeders/DepartmentSeeder.php
@@ -39,8 +39,8 @@ class DepartmentSeeder extends Seeder
       [
         'department_number' => 5,
         'name' => [
-          'en' => 'Foreign Affairs, Trade and Development (Department of)',
-          'fr' => 'Affaires étrangères, du Commerce et du Développement (Ministère des)',
+          'en' => 'Global Affairs Canada',
+          'fr' => 'Affaires mondiales Canada',
         ],
       ],
       [

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1356,12 +1356,7 @@ input CreateDepartmentInput {
 }
 
 input UpdateDepartmentInput {
-  departmentNumber: Int
-    @rename(attribute: "department_number")
-    @rules(
-      apply: ["unique:departments,department_number"]
-      messages: [{ rule: "unique", message: "DepartmentNumberInUse" }]
-    )
+  departmentNumber: Int @rename(attribute: "department_number")
   name: LocalizedStringInput
 }
 


### PR DESCRIPTION
🤖 Resolves #6642

## 👋 Introduction

Renames the department in the seeder. The rest of the work is updating through the admin dashboard. 

## 🕵️ Details

Updating a department was broken, validation would fail due to the `department_number` constraint even if all you were changing was the name. Normally this is resolved by adding ignoring in validation classes.
However, creating a department has the full validation message that informs you of what you did wrong, and the constraint on `department_number` in table of uniqueness will prevent updating to a number in use.

Given that updating a department number is unlikely to happen much if at all. And that the validation of department number doesn't just involve adding the validation class, but also updating the mutation and form to pass in an id at `UpdateDepartmentInput.id` for the validator to see. I figured that the default error toast would handle things. And we don't always have a validator on graphql to validate stuff for uniqueness that has a database constraint so there isn't a pattern to maintain. 

Summary:
Database stops you from reusing department numbers and the mutation fails with a toast. Probably don't have a lot of people trying to update departments with existing department numbers so changing the department mutation and form to pass in `UpdateDepartmentInput.id` for a new validator seems overkill.  

## 🧪 Testing

1. "Foreign Affairs" is gone
2. Updating departments works

## 💻 Deployment

After this is live and updating departments works, update the name in the admin dashboard. 


