### PR TITLE
[Feature] Adds `mailto` link to government email value

### DIFF
--- a/apps/web/src/components/SearchRequestFilters/FilterBlock.tsx
+++ b/apps/web/src/components/SearchRequestFilters/FilterBlock.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import uniqueId from "lodash/uniqueId";
+import isEmpty from "lodash/isEmpty";
+
+import { Maybe } from "@gc-digital-talent/graphql";
+
+interface FilterBlockProps {
+  title: string;
+  content?: Maybe<string | React.ReactNode> | Maybe<string[]>;
+  children?: React.ReactNode;
+}
+
+const FilterBlock = ({ title, content, children }: FilterBlockProps) => {
+  const intl = useIntl();
+
+  const emptyArrayOutput = (
+    input: string | React.ReactNode | string[] | null | undefined,
+  ) => {
+    return input && !isEmpty(input) ? (
+      <p data-h2-display="base(inline)" data-h2-color="base(black)">
+        {input}
+      </p>
+    ) : (
+      <ul data-h2-color="base(black)">
+        <li>
+          {intl.formatMessage({
+            defaultMessage: "(None selected)",
+            id: "+O6J4u",
+            description: "Text shown when the filter was not selected",
+          })}
+        </li>
+      </ul>
+    );
+  };
+
+  return (
+    <div data-h2-padding="base(0, 0, x1, 0)">
+      <div data-h2-visually-hidden="base(visible) p-tablet(hidden)">
+        <p
+          data-h2-display="base(inline)"
+          data-h2-padding="base(0, x.125, 0, 0)"
+          data-h2-font-weight="base(600)"
+        >
+          {title}:
+        </p>
+        {content !== undefined && (
+          <span>
+            {content instanceof Array && content.length > 0 ? (
+              <p data-h2-display="base(inline)" data-h2-color="base(black)">
+                {content.map((text): string => text).join(", ")}
+              </p>
+            ) : (
+              <p data-h2-display="base(inline)" data-h2-color="base(black)">
+                {content && !isEmpty(content)
+                  ? content
+                  : intl.formatMessage({
+                      defaultMessage: "N/A",
+                      id: "i9AjuX",
+                      description:
+                        "Text shown when the filter was not selected",
+                    })}
+              </p>
+            )}
+          </span>
+        )}
+        {children && children}
+      </div>
+      <div data-h2-visually-hidden="base(hidden) p-tablet(visible)">
+        <p
+          data-h2-display="base(block)"
+          data-h2-padding="base(0, x.125, 0, 0)"
+          data-h2-font-weight="base(600)"
+        >
+          {title}
+        </p>
+        {content !== undefined && (
+          <span>
+            {content instanceof Array && content.length > 0 ? (
+              <ul data-h2-color="base(black)">
+                {content.map((text) => (
+                  <li key={uniqueId()}>{text}</li>
+                ))}
+              </ul>
+            ) : (
+              emptyArrayOutput(content)
+            )}
+          </span>
+        )}
+        {children && children}
+      </div>
+    </div>
+  );
+};
+
+export default FilterBlock;

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -1,5 +1,3 @@
-import uniqueId from "lodash/uniqueId";
-import isEmpty from "lodash/isEmpty";
 import * as React from "react";
 import { useIntl } from "react-intl";
 
@@ -25,96 +23,9 @@ import {
   PoolCandidateFilter,
   PositionDuration,
 } from "~/api/generated";
+import FilterBlock from "./FilterBlock";
 
 export type SimpleClassification = Pick<Classification, "group" | "level">;
-
-export interface FilterBlockProps {
-  title: string;
-  content?: Maybe<string | React.ReactNode> | Maybe<string[]>;
-  children?: React.ReactNode;
-}
-
-const FilterBlock = ({ title, content, children }: FilterBlockProps) => {
-  const intl = useIntl();
-
-  const emptyArrayOutput = (
-    input: string | React.ReactNode | string[] | null | undefined,
-  ) => {
-    return input && !isEmpty(input) ? (
-      <p data-h2-display="base(inline)" data-h2-color="base(black)">
-        {input}
-      </p>
-    ) : (
-      <ul data-h2-color="base(black)">
-        <li>
-          {intl.formatMessage({
-            defaultMessage: "(None selected)",
-            id: "+O6J4u",
-            description: "Text shown when the filter was not selected",
-          })}
-        </li>
-      </ul>
-    );
-  };
-
-  return (
-    <div data-h2-padding="base(0, 0, x1, 0)">
-      <div data-h2-visually-hidden="base(visible) p-tablet(hidden)">
-        <p
-          data-h2-display="base(inline)"
-          data-h2-padding="base(0, x.125, 0, 0)"
-          data-h2-font-weight="base(600)"
-        >
-          {title}:
-        </p>
-        {content !== undefined && (
-          <span>
-            {content instanceof Array && content.length > 0 ? (
-              <p data-h2-display="base(inline)" data-h2-color="base(black)">
-                {content.map((text): string => text).join(", ")}
-              </p>
-            ) : (
-              <p data-h2-display="base(inline)" data-h2-color="base(black)">
-                {content && !isEmpty(content)
-                  ? content
-                  : intl.formatMessage({
-                      defaultMessage: "N/A",
-                      id: "i9AjuX",
-                      description:
-                        "Text shown when the filter was not selected",
-                    })}
-              </p>
-            )}
-          </span>
-        )}
-        {children && children}
-      </div>
-      <div data-h2-visually-hidden="base(hidden) p-tablet(visible)">
-        <p
-          data-h2-display="base(block)"
-          data-h2-padding="base(0, x.125, 0, 0)"
-          data-h2-font-weight="base(600)"
-        >
-          {title}
-        </p>
-        {content !== undefined && (
-          <span>
-            {content instanceof Array && content.length > 0 ? (
-              <ul data-h2-color="base(black)">
-                {content.map((text) => (
-                  <li key={uniqueId()}>{text}</li>
-                ))}
-              </ul>
-            ) : (
-              emptyArrayOutput(content)
-            )}
-          </span>
-        )}
-        {children && children}
-      </div>
-    </div>
-  );
-};
 
 const ApplicantFilters = ({
   applicantFilter,

--- a/apps/web/src/components/SearchRequestFilters/index.ts
+++ b/apps/web/src/components/SearchRequestFilters/index.ts
@@ -1,3 +1,4 @@
-import SearchRequestFilters, { FilterBlock } from "./SearchRequestFilters";
+import SearchRequestFilters from "./SearchRequestFilters";
+import FilterBlock from "./FilterBlock";
 
 export { SearchRequestFilters, FilterBlock };

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
@@ -7,7 +7,7 @@ import {
   getPoolCandidateSearchStatus,
   getLocalizedName,
 } from "@gc-digital-talent/i18n";
-import { Pending, NotFound, Heading } from "@gc-digital-talent/ui";
+import { Pending, NotFound, Heading, Link } from "@gc-digital-talent/ui";
 import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 
 import SearchRequestFilters from "~/components/SearchRequestFilters/SearchRequestFilters";
@@ -80,7 +80,13 @@ const ManagerInfo = ({
                     description:
                       "Title for the government email block in the manager info section of the single search request view.",
                   })}
-                  content={email}
+                  content={
+                    email ? (
+                      <Link external href={`mailto:${email}`}>
+                        {email}
+                      </Link>
+                    ) : null
+                  }
                 />
               </div>
             </div>

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
@@ -11,7 +11,6 @@ import { Pending, NotFound, Heading } from "@gc-digital-talent/ui";
 import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 
 import SearchRequestFilters from "~/components/SearchRequestFilters/SearchRequestFilters";
-import { FilterBlock } from "~/components/SearchRequestFilters/deprecated/SearchRequestFilters";
 import {
   PoolCandidateSearchRequest,
   useGetPoolCandidateSearchRequestQuery,
@@ -20,6 +19,7 @@ import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWr
 import useRoutes from "~/hooks/useRoutes";
 
 import adminMessages from "~/messages/adminMessages";
+import FilterBlock from "~/components/SearchRequestFilters/FilterBlock";
 import SingleSearchRequestTableApi from "./SearchRequestCandidatesTable";
 import UpdateSearchRequest from "./UpdateSearchRequest";
 


### PR DESCRIPTION
🤖 Resolves #7235.

## 👋 Introduction

This PR wraps the **government email** value in a `mailto` link on the admin view of a request.

## 🕵️ Details

The `FilterBlock` component being used was deprecated, so I referenced a nearly identical non-deprecated one instead. I also moved the non-deprecated `FilterBlock` component into its own file so it could be reused and referenced cleanly.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/admin/talent-requests/:requestId`
2. Observe clickable mailto link following **Government Email**

## 📸 Screenshot
![Screen Shot 2023-07-12 at 12 26 35](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/f4597397-a90b-4598-980a-4911aa787a92)