### PR TITLE
[Fix] Fix snapshot test

### DIFF
--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -49,18 +49,16 @@ class SnapshotTest extends TestCase
         $pool1 = Pool::factory()->published()->create();
         $pool2 = Pool::factory()->published()->create();
 
-        $poolCandidate = PoolCandidate::factory()
-            ->create([
-                "user_id" => $user->id,
-                "pool_id" => $pool1->id,
-                "pool_candidate_status" => ApiEnums::CANDIDATE_STATUS_DRAFT
-            ]);
-        $poolCandidateUnrelated = PoolCandidate::factory()
-            ->create([
-                "user_id" => $user->id,
-                "pool_id" => $pool2->id,
-                "pool_candidate_status" => ApiEnums::CANDIDATE_STATUS_DRAFT
-            ]);
+        $poolCandidate = PoolCandidate::factory()->create([
+            "user_id" => $user->id,
+            "pool_id" => $pool1->id,
+            "pool_candidate_status" => ApiEnums::CANDIDATE_STATUS_DRAFT
+        ]);
+        $poolCandidateUnrelated = PoolCandidate::factory()->create([
+            "user_id" => $user->id,
+            "pool_id" => $pool2->id,
+            "pool_candidate_status" => ApiEnums::CANDIDATE_STATUS_DRAFT
+        ]);
 
         // get what the snapshot should look like
         $expectedSnapshot = $this->actingAs($user, "api")

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -50,14 +50,12 @@ class SnapshotTest extends TestCase
         $pool2 = Pool::factory()->published()->create();
 
         $poolCandidate = PoolCandidate::factory()
-            ->availableInSearch()
             ->create([
                 "user_id" => $user->id,
                 "pool_id" => $pool1->id,
                 "pool_candidate_status" => ApiEnums::CANDIDATE_STATUS_DRAFT
             ]);
         $poolCandidateUnrelated = PoolCandidate::factory()
-            ->availableInSearch()
             ->create([
                 "user_id" => $user->id,
                 "pool_id" => $pool2->id,

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -94,6 +94,10 @@ class SnapshotTest extends TestCase
         });
         $expectedSnapshot['poolCandidates'] = $filteredPoolCandidates;
 
+        fwrite(STDERR, print_r($expectedSnapshot, true));
+        fwrite(STDERR, print_r($decodedActual, true));
+
+
         assertEquals($expectedSnapshot, $decodedActual);
     }
 

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -46,14 +46,23 @@ class SnapshotTest extends TestCase
             ->asApplicant()
             ->create();
 
-        $poolCandidate = PoolCandidate::factory()->create([
-            "user_id" => $user->id,
-            "pool_candidate_status" => ApiEnums::CANDIDATE_STATUS_DRAFT
-        ]);
-        $poolCandidateUnrelated = PoolCandidate::factory()->create([
-            "user_id" => $user->id,
-            "pool_candidate_status" => ApiEnums::CANDIDATE_STATUS_DRAFT
-        ]);
+        $pool1 = Pool::factory()->published()->create();
+        $pool2 = Pool::factory()->published()->create();
+
+        $poolCandidate = PoolCandidate::factory()
+            ->availableInSearch()
+            ->create([
+                "user_id" => $user->id,
+                "pool_id" => $pool1->id,
+                "pool_candidate_status" => ApiEnums::CANDIDATE_STATUS_DRAFT
+            ]);
+        $poolCandidateUnrelated = PoolCandidate::factory()
+            ->availableInSearch()
+            ->create([
+                "user_id" => $user->id,
+                "pool_id" => $pool2->id,
+                "pool_candidate_status" => ApiEnums::CANDIDATE_STATUS_DRAFT
+            ]);
 
         // get what the snapshot should look like
         $expectedSnapshot = $this->actingAs($user, "api")

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -90,7 +90,7 @@ class SnapshotTest extends TestCase
 
         // there are two pool candidates present, only one should appear in the snapshot, adjust expectedSnapshot to fit this
         $filteredPoolCandidates = array_filter($expectedSnapshot['poolCandidates'], function ($individualPoolCandidate) use ($poolCandidate) {
-            return in_array($poolCandidate['id'], $individualPoolCandidate);
+            return $poolCandidate['id'] === $individualPoolCandidate['id'];
         });
         $expectedSnapshot['poolCandidates'] = $filteredPoolCandidates;
 

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -89,9 +89,10 @@ class SnapshotTest extends TestCase
         $decodedActual = json_decode($actualSnapshot, true);
 
         // there are two pool candidates present, only one should appear in the snapshot, adjust expectedSnapshot to fit this
-        $filteredPoolCandidates = array_filter($expectedSnapshot['poolCandidates'], function ($individualPoolCandidate) use ($poolCandidate) {
+        // array_values reindexes the array from zero https://stackoverflow.com/a/3401863
+        $filteredPoolCandidates = array_values(array_filter($expectedSnapshot['poolCandidates'], function ($individualPoolCandidate) use ($poolCandidate) {
             return $poolCandidate['id'] === $individualPoolCandidate['id'];
-        });
+        }));
         $expectedSnapshot['poolCandidates'] = $filteredPoolCandidates;
 
         fwrite(STDERR, print_r($expectedSnapshot, true));

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -94,11 +94,6 @@ class SnapshotTest extends TestCase
             return $poolCandidate['id'] === $individualPoolCandidate['id'];
         }));
         $expectedSnapshot['poolCandidates'] = $filteredPoolCandidates;
-
-        fwrite(STDERR, print_r($expectedSnapshot, true));
-        fwrite(STDERR, print_r($decodedActual, true));
-
-
         assertEquals($expectedSnapshot, $decodedActual);
     }
 


### PR DESCRIPTION
🤖 Resolves #7204

## 👋 Introduction

This branch (hopefully) fixes the snapshot test that has been failing intermittently.  The solution was to use `array_values` to reindex the array back at zero after removing one of the elements.  I left in the more explicit pool and candidate initialization since I feel it makes the test more clear.  I don't think it actually fixed anything though.

## 🕵️ Details

I'm actually finding it really difficult to replicate this failure locally.  This is solution seems pretty stable.  You can check the previous commit before I removed the logging:
https://github.com/GCTC-NTGC/gc-digital-talent/actions/runs/5546440323
![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/d41d45e8-659c-46c4-9169-502a8752b419)


## 🧪 Testing

1. Review the code
2. Review the CI runs