### PR TITLE
[Fix] Fix linter warning in notifications

### DIFF
--- a/api/app/GraphQL/Mutations/MarkNotificationAsRead.php
+++ b/api/app/GraphQL/Mutations/MarkNotificationAsRead.php
@@ -16,7 +16,8 @@ final class MarkNotificationAsRead
     public function __invoke($_, array $args)
     {
         $notificationId = $args['id'];
-        $notification = Auth::user()
+        $user = User::find(Auth::id());
+        $notification = $user
             ->notifications()
             ->firstWhere('id', $notificationId);
 


### PR DESCRIPTION
🤖 Resolves #7240 

## 👋 Introduction

I missed a linter warning in #7233.  This branch updates the dismiss notification mutation to be a little safer.

## 🧪 Testing

1. Review code
2. Run phpunit tests
3. (optional) - review AC in  #7233
