### PR TITLE
[a11y] Update right nav landmark name

### DIFF
--- a/apps/web/src/components/NavMenu/NavMenu.tsx
+++ b/apps/web/src/components/NavMenu/NavMenu.tsx
@@ -51,9 +51,9 @@ const NavMenu = ({ mainItems, utilityItems }: NavMenuProps) => {
             <div data-h2-flex-item="base(1of1) p-tablet(1of3)">
               <nav
                 aria-label={intl.formatMessage({
-                  defaultMessage: "Utility",
-                  id: "HkzjEV",
-                  description: "Label for the utility link navigation",
+                  defaultMessage: "Account menu",
+                  id: "LIhwJ+",
+                  description: "Label for the user account navigation menu",
                 })}
               >
                 <ul

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2710,10 +2710,6 @@
     "defaultMessage": "Déconnexion",
     "description": "Title for the modal that appears when an authenticated user lands on /logged-out."
   },
-  "HkzjEV": {
-    "defaultMessage": "Utilitaire",
-    "description": "Label for the utility link navigation"
-  },
   "HocLRh": {
     "defaultMessage": "Nom du bassin",
     "description": "Title displayed for the Pool table pool name column."
@@ -3140,6 +3136,10 @@
   "LGSw+f": {
     "defaultMessage": "Tous les apprentis seront appuyés par des pairs et des mentors soigneusement sélectionnés. Les apprentis seront également invités à se joindre à un Réseau d’apprentissage pour les Autochtones, où ils auront des occasions de communiquer avec d’autres employés autochtones du gouvernement du Canada et avec d’autres apprentis autochtones qui participent à ce programme.",
     "description": "Learn more dialog question two paragraph two"
+  },
+  "LIhwJ+": {
+    "defaultMessage": "Menu du compte",
+    "description": "Label for the user account navigation menu"
   },
   "LMGaDQ": {
     "defaultMessage": "S'inscrire",


### PR DESCRIPTION
🤖 Resolves #7275 

## 👋 Introduction

Updates the name of the navigation landmark that contains account based actions.

## 🕵️ Details

Some users were having issues finding these links easily, we believe that was due to it having a very generic name. This changes the name to hopefully make it easier to locate for AT users.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Inspect the nav menu on the right side
3. Confirm the accessible name is "Account menu"
4. Confirm that name is available in the landmark list for ATs

## 📸 Screenshot

![Screenshot 2023-07-13 141223](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/1b3578ca-ba27-46a0-8200-37c76d6889ff)

