### PR TITLE
[Fix] Remove invalid attributes from column visibility checkboxes

### DIFF
--- a/apps/web/src/components/Table/ClientManagedTable/Table.tsx
+++ b/apps/web/src/components/Table/ClientManagedTable/Table.tsx
@@ -308,7 +308,9 @@ function Table<T extends Record<string, unknown>>({
                               </Field.Legend>
                               <div data-h2-margin="base(x.125, 0)">
                                 <IndeterminateCheckbox
-                                  {...(getToggleHideAllColumnsProps() as React.ComponentProps<
+                                  {...(getToggleHideAllColumnsProps({
+                                    title: undefined,
+                                  }) as React.ComponentProps<
                                     typeof IndeterminateCheckbox
                                   >)}
                                 />
@@ -318,11 +320,12 @@ function Table<T extends Record<string, unknown>>({
                                   key={column.id}
                                   data-h2-margin="base(x.125, 0)"
                                 >
-                                  <label htmlFor={column.Header?.toString()}>
+                                  <label>
                                     <input
-                                      id={column.Header?.toString()}
                                       type="checkbox"
-                                      {...column.getToggleHiddenProps()}
+                                      {...column.getToggleHiddenProps({
+                                        title: undefined,
+                                      })}
                                     />
                                     {` ${column.Header}`}
                                   </label>


### PR DESCRIPTION
🤖 Resolves #7274 

## 👋 Introduction

Removes the `for`, `id` and `title` attributes from the client tables column visibly checkboxes.

## 🕵️ Details

These attributes were causing issues for AT users since:
 - `for` and `id` were invalid since they contained spaces which indicates multiple values
 - `title` attribute is discouraged and causes issues with ATs

Since the input is wrapped in a label, `for` and `id` were doing nothing but confusing the ATs. Since they were confused by multiple values in these attributes it started falling back eventually landing on the `title` attribute. Since the `title` was "Toggle Column Visibility" for all, the users had no idea what column they were toggling and never heard their current state.

All attributes were removed as unnecessary since wrapping an `input` with a `label` automatically associates them with each other also making the `title` attribute redundant.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to a table
3. Open the columns dialog
4. Confirm the checkboxes have the proper accessible name
5. Confirm state is announced to screen readers

