### PR TITLE
[Debt] Remove outdated colour keys

### DIFF
--- a/packages/ui/src/components/Card/Card.tsx
+++ b/packages/ui/src/components/Card/Card.tsx
@@ -6,11 +6,7 @@ export type Color =
   | "tertiary"
   | "quaternary"
   | "quinary"
-  | "white"
-  | "ts-primary"
-  | "ia-primary"
-  | "ts-secondary"
-  | "ia-secondary";
+  | "white";
 
 export interface CardProps {
   title: string;
@@ -48,22 +44,6 @@ const colorMap = {
   white: {
     "data-h2-background-color": "base(white)",
     "data-h2-color": "base:all(black)",
-  },
-  "ts-primary": {
-    "data-h2-background-color": "base(primary)",
-    "data-h2-color": "base(white)",
-  },
-  "ts-secondary": {
-    "data-h2-background-color": "base(secondary)",
-    "data-h2-color": "base(white)",
-  },
-  "ia-primary": {
-    "data-h2-background-color": "base(primary)",
-    "data-h2-color": "base(white)",
-  },
-  "ia-secondary": {
-    "data-h2-background-color": "base(secondary)",
-    "data-h2-color": "base(white)",
   },
 };
 

--- a/packages/ui/src/components/CardLink/CardLink.stories.tsx
+++ b/packages/ui/src/components/CardLink/CardLink.stories.tsx
@@ -35,7 +35,7 @@ export default {
       },
     },
     color: {
-      options: ["ts-primary", "ia-primary", "ia-secondary"],
+      options: ["primary", "secondary", "tertiary", "quaternary", "quinary"],
     },
   },
 } as Meta;

--- a/packages/ui/src/components/CardLink/CardLink.tsx
+++ b/packages/ui/src/components/CardLink/CardLink.tsx
@@ -11,10 +11,7 @@ export type Color =
   | "secondary"
   | "tertiary"
   | "quaternary"
-  | "quinary"
-  | "ts-primary"
-  | "ia-primary"
-  | "ia-secondary";
+  | "quinary";
 
 export interface CardLinkProps {
   href: string;
@@ -52,19 +49,6 @@ export const colorMap: Record<Color, Record<string, string>> = {
     "data-h2-background-color": "base(quinary) base:dark:iap(quinary.light)",
     "data-h2-color": "base:all(black) base:all:iap(white)",
   },
-  "ts-primary": {
-    "data-h2-background-color": "base(secondary) base:iap(primary)",
-    "data-h2-color": "base(white) base:all:iap(white)",
-  },
-  "ia-primary": {
-    "data-h2-background": "base(secondary) base:iap(primary)",
-    "data-h2-color": "base(white) base:all:iap(white)",
-  },
-  "ia-secondary": {
-    "data-h2-background":
-      "base(primary) base:iap(secondary) base:admin(tertiary)",
-    "data-h2-color": "base(white) base:admin(black)",
-  },
 };
 
 interface LinkProps {
@@ -101,7 +85,7 @@ const Link = ({ href, external, children }: LinkProps) => {
 
 const CardLink = ({
   href,
-  color = "ts-primary",
+  color = "primary",
   external,
   icon,
   label,

--- a/packages/ui/src/components/ToggleGroup/ToggleGroup.stories.tsx
+++ b/packages/ui/src/components/ToggleGroup/ToggleGroup.stories.tsx
@@ -39,7 +39,27 @@ const AllTemplate: StoryFn<typeof ToggleGroup.Root> = (args) => {
         <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
         <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
       </ToggleGroup.Root>
+      <ToggleGroup.Root {...args} color="primary.dark">
+        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
+        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
+        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
+      </ToggleGroup.Root>
       <ToggleGroup.Root {...args} color="secondary">
+        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
+        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
+        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
+      </ToggleGroup.Root>
+      <ToggleGroup.Root {...args} color="tertiary">
+        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
+        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
+        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
+      </ToggleGroup.Root>
+      <ToggleGroup.Root {...args} color="quaternary">
+        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
+        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
+        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
+      </ToggleGroup.Root>
+      <ToggleGroup.Root {...args} color="quinary">
         <ToggleGroup.Item value="one">One</ToggleGroup.Item>
         <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
         <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
@@ -50,31 +70,6 @@ const AllTemplate: StoryFn<typeof ToggleGroup.Root> = (args) => {
         <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
       </ToggleGroup.Root>
       <ToggleGroup.Root {...args} color="white">
-        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
-        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
-        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
-      </ToggleGroup.Root>
-      <ToggleGroup.Root {...args} color="ia-primary">
-        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
-        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
-        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
-      </ToggleGroup.Root>
-      <ToggleGroup.Root {...args} color="ia-secondary">
-        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
-        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
-        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
-      </ToggleGroup.Root>
-      <ToggleGroup.Root {...args} color="yellow">
-        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
-        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
-        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
-      </ToggleGroup.Root>
-      <ToggleGroup.Root {...args} color="blue">
-        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
-        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
-        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
-      </ToggleGroup.Root>
-      <ToggleGroup.Root {...args} color="red">
         <ToggleGroup.Item value="one">One</ToggleGroup.Item>
         <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
         <ToggleGroup.Item value="three">Three</ToggleGroup.Item>

--- a/packages/ui/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/packages/ui/src/components/ToggleGroup/ToggleGroup.tsx
@@ -8,14 +8,11 @@ export type Color =
   | "primary"
   | "primary.dark"
   | "secondary"
-  | "cta"
+  | "tertiary"
+  | "quaternary"
+  | "quinary"
   | "white"
-  | "black"
-  | "ia-primary"
-  | "ia-secondary"
-  | "yellow"
-  | "red"
-  | "blue";
+  | "black";
 
 const colorMap: Record<Color, Record<string, string>> = {
   primary: {
@@ -33,8 +30,18 @@ const colorMap: Record<Color, Record<string, string>> = {
     "data-h2-color":
       "base:children[>*](black) base:dark:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](black)",
   },
-  cta: {
+  tertiary: {
     "data-h2-background-color": "base(tertiary)",
+    "data-h2-color":
+      "base:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
+  },
+  quaternary: {
+    "data-h2-background-color": "base(quaternary)",
+    "data-h2-color":
+      "base:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
+  },
+  quinary: {
+    "data-h2-background-color": "base(quinary)",
     "data-h2-color":
       "base:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
   },
@@ -47,31 +54,6 @@ const colorMap: Record<Color, Record<string, string>> = {
     "data-h2-background-color": "base(black) base:dark(black.lighter)",
     "data-h2-color":
       "base:children[>*](white) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
-  },
-  "ia-primary": {
-    "data-h2-background-color": "base(primary)",
-    "data-h2-color":
-      "base:children[>*](white) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
-  },
-  "ia-secondary": {
-    "data-h2-background-color": "base(secondary)",
-    "data-h2-color":
-      "base:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](black)",
-  },
-  yellow: {
-    "data-h2-background-color": "base(quaternary)",
-    "data-h2-color":
-      "base:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
-  },
-  red: {
-    "data-h2-background-color": "base(tertiary)",
-    "data-h2-color":
-      "base:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
-  },
-  blue: {
-    "data-h2-background-color": "base(secondary)",
-    "data-h2-color":
-      "base:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
   },
 };
 


### PR DESCRIPTION
🤖 Resolves #6397 

## 👋 Introduction

Since hydrogen now supports theming, we no longer need our theme prefixed colour keys. This removes them along with outdated colour keys.

## 🧪 Testing

Valid keys are:

 - Primary
 - Secondary
 - Tertiary
 - Quaternary
 - Quinary
 - White
 - Black
 - Success
 - Warning
 - Error

1. Confirm the only colour keys that exist are the ones listed
2. Confirm app still builds properly
