### PR TITLE
[Copy] Changes message for total estimated matching candidates in pool

### DIFF
--- a/apps/e2e/cypress/e2e/talentsearch/search-workflows.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/search-workflows.cy.js
@@ -42,7 +42,7 @@ describe("Talent Search Workflow Tests", () => {
       cy.findByRole("article", {
         name: `Cypress Test Pool EN 1 ${uniqueTestId} (I T 1 Business Line Advisory Services)`,
       }).within(() => {
-        cy.contains("There is 1 matching candidate in this pool");
+        cy.contains("There is approximately 1 matching candidate in this pool");
 
         cy.findByRole("button", { name: /Request candidates/i })
           .should("exist")

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2898,6 +2898,10 @@
     "defaultMessage": "Le bureau de gestion de la collectivité du numérique souhaite vous aider à trouver le bon talent.",
     "description": "Text telling users that Digital Community Management can still help them"
   },
+  "JZk4NZ": {
+    "defaultMessage": "{candidateCount, plural, one {Il y a environ <strong><testId>{candidateCount}</testId></strong> candidat qui répond à vos critères dans ce bassin.} other {Il y a environ <strong><testId>{candidateCount}</testId></strong> candidats qui répondent à vos critères dans ce bassin.}}",
+    "description": "Message for total estimated matching candidates in pool"
+  },
   "Jc0lds": {
     "defaultMessage": "Bassin archivé",
     "description": "Button to archive the pool in the archive pool dialog"
@@ -7219,10 +7223,6 @@
   "ow71P8": {
     "defaultMessage": "<strong>Préavis!</strong> Avant de vous demander d’aller établir vos justificatifs CléGC, nous vous demandons d’examiner de nouveau les critères d’admissibilité du programme afin de veiller à ce que vous répondiez aux exigences.",
     "description": "A request for the user to review the IAP eligibility criteria"
-  },
-  "oyFGYC": {
-    "defaultMessage": "{candidateCount, plural, one {Il y a <strong><testId>{candidateCount}</testId></strong> candidat qui répond à vos critères dans ce bassin.} other {Il y a <strong><testId>{candidateCount}</testId></strong> candidats qui répondent à vos critères dans ce bassin.}}",
-    "description": "Message for total estimated matching candidates in pool"
   },
   "p+YRN1": {
     "defaultMessage": "Vous êtes sur le point de modifier le statut de cet utilisateur :",

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
@@ -55,10 +55,10 @@ const SearchResultCard = ({
         {intl.formatMessage(
           {
             defaultMessage: `{candidateCount, plural,
-              one {There is <strong><testId>{candidateCount}</testId></strong> matching candidate in this pool.}
-              other {There are <strong><testId>{candidateCount}</testId></strong> matching candidates in this pool.}
+              one {There is approximately <strong><testId>{candidateCount}</testId></strong> matching candidate in this pool.}
+              other {There are approximately <strong><testId>{candidateCount}</testId></strong> matching candidates in this pool.}
             }`,
-            id: "oyFGYC",
+            id: "JZk4NZ",
             description:
               "Message for total estimated matching candidates in pool",
           },


### PR DESCRIPTION
🤖 Resolves #6174.

## 👋 Introduction

This PR changes the message for total estimated matching candidates in pool to include the word **approximately**.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/search`
2. Observe cards under **Results: X matching candidates** heading
3. Ensure card renders **There is approximately 1** (for one result) or **There are approximately 2** (for greater than one result)
4. Switch to French
5. Ensure card renders **Il y a environ 1** (for one result) or **Il y a environ 2** (for greater than one result)

## 📸 Screenshots

### English
![Screen Shot 2023-07-13 at 15 35 09](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/2c2670c8-9606-4be0-8891-35e134f56a73)

### French
![Screen Shot 2023-07-13 at 15 36 28](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/09eda466-1f33-4753-8d8c-bad6e10485c5)