### PR TITLE
[Bug] Fixes over translated variable

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2891,7 +2891,7 @@
     "description": "list a number of work experiences"
   },
   "Io6+0T": {
-    "defaultMessage": "Si vous estimez que vos compétences et votre expérience correspondent au poste de <strong>{titre}</strong>, nous aimerions vous entendre! Cette plateforme vous permet de soumettre une demande en utilisant les renseignements existants dans votre profil et vous pourrez mettre à jour ces renseignements à l’étape suivante.",
+    "defaultMessage": "Si vous estimez que vos compétences et votre expérience correspondent au poste de <strong>{title}</strong>, nous aimerions vous entendre! Cette plateforme vous permet de soumettre une demande en utilisant les renseignements existants dans votre profil et vous pourrez mettre à jour ces renseignements à l’étape suivante.",
     "description": "Lead-in text to the apply call to action at the end of a pool advertisement"
   },
   "Iodi0/": {


### PR DESCRIPTION
🤖 Resolves #7291.

## 👋 Introduction

This PR fixes an i18n string which contained a variable that had been translated into French by mistake.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate to a pool poster `/fr/browse/pools/:pool-id`
3. Go to _Postulez maintenant_ heading
5. Ensure paragraph following heading is in French

## 📸 Screenshots

<img width="1139" alt="Screen Shot 2023-07-17 at 08 44 39" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/1dc52c58-2fbf-4452-b28c-a869ae77cce2">
<img width="1136" alt="Screen Shot 2023-07-17 at 08 44 51" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/4cf40396-a459-4870-9330-a1ab913a67a3">
