### PR TITLE
[Feature] Archive and un-archive pools

### DIFF
--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -122,6 +122,7 @@ class Pool extends Model
         $publishedDate = $this->published_at;
         $closedDate = $this->closing_date;
         $currentTime = date("Y-m-d H:i:s");
+        $deletedDate = $this->deleted_at;
         if ($closedDate != null) {
             $isClosed = $currentTime >= $closedDate ? true : false;
         } else {
@@ -132,8 +133,15 @@ class Pool extends Model
         } else {
             $isPublished = false;
         }
+        if ($deletedDate != null) {
+            $isDeleted = $currentTime >= $deletedDate ? true : false;
+        } else {
+            $isDeleted = false;
+        }
 
-        if (!$isPublished) {
+        if ($isDeleted) {
+            return ApiEnums::POOL_IS_ARCHIVED;
+        } elseif (!$isPublished) {
             return ApiEnums::POOL_IS_DRAFT;
         } elseif ($isPublished && !$isClosed) {
             return ApiEnums::POOL_IS_PUBLISHED;

--- a/api/app/Policies/PoolPolicy.php
+++ b/api/app/Policies/PoolPolicy.php
@@ -184,12 +184,16 @@ class PoolPolicy
      * @param  \App\Models\Pool  $pool
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function deleteDraft(User $user, Pool $pool)
+    public function delete(User $user, Pool $pool)
     {
         $pool->loadMissing('team');
-        if ($pool->getStatusAttribute() !== ApiEnums::POOL_IS_DRAFT) {
-            return Response::deny("You cannot delete a Pool once it's been published.");
+        $poolStatus = $pool->getStatusAttribute();
+        if ($poolStatus == ApiEnums::POOL_IS_DRAFT) {
+            return $user->isAbleTo("delete-team-draftPool", $pool->team);
+        } else if ($poolStatus == ApiEnums::POOL_IS_CLOSED) {
+            return $user->isAbleTo("delete-team-closedPool", $pool->team);
+        } else {
+            return Response::deny("You cannot delete a pool with this status.");
         }
-        return $user->isAbleTo("delete-team-draftPool", $pool->team);
     }
 }

--- a/api/app/Policies/PoolPolicy.php
+++ b/api/app/Policies/PoolPolicy.php
@@ -196,4 +196,22 @@ class PoolPolicy
             return Response::deny("You cannot delete a pool with this status.");
         }
     }
+
+    /**
+     * Determine whether the user can restore the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Pool  $pool
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function restore(User $user, Pool $pool)
+    {
+        $pool->loadMissing('team');
+        $poolStatus = $pool->getStatusAttribute();
+        if ($poolStatus == ApiEnums::POOL_IS_ARCHIVED) {
+            return $user->isAbleTo("delete-team-closedPool", $pool->team);  // same permission to delete and un-delete
+        } else {
+            return Response::deny("You cannot restore a pool with this status.");
+        }
+    }
 }

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -65,6 +65,7 @@ return [
         'pool' => 'pool',
         'publishedPool' => 'publishedPool',
         'draftPool' => 'draftPool',
+        'closedPool' => 'closedPool',
         'poolClosingDate' => 'poolClosingDate',
         'application' => 'application',
         'submittedApplication' => 'submittedApplication',
@@ -239,6 +240,10 @@ return [
         'delete-team-draftPool' => [
             'en' => 'Delete draft Pools in this Team',
             'fr' => 'Supprimer les pools de brouillons dans cette équipe'
+        ],
+        'delete-team-closedPool' => [
+            'en' => 'Delete closed pools in this team',
+            'fr' => 'Supprimer des bassins fermés dans cette équipe'
         ],
 
         'view-own-application' => [
@@ -561,6 +566,9 @@ return [
             ],
             'draftPool' => [
                 'team' => ['update', 'delete']
+            ],
+            'closedPool' => [
+                'team' => ['delete']
             ],
             'poolClosingDate' => [
                 'team' => ['update']

--- a/api/database/helpers/ApiEnums.php
+++ b/api/database/helpers/ApiEnums.php
@@ -266,12 +266,14 @@ class ApiEnums
     const POOL_IS_DRAFT = 'DRAFT';
     const POOL_IS_PUBLISHED = 'PUBLISHED';
     const POOL_IS_CLOSED = 'CLOSED';
+    const POOL_IS_ARCHIVED = 'ARCHIVED';
     public static function poolStatuses(): array
     {
         return [
             self::POOL_IS_DRAFT,
             self::POOL_IS_PUBLISHED,
             self::POOL_IS_CLOSED,
+            self::POOL_IS_ARCHIVED,
         ];
     }
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -858,7 +858,10 @@ type Query {
     @deprecated(reason: "Removing in favour of users query")
   # countApplicants returns the number of candidates matching its filters, and requires no special permissions.
   countApplicants(where: ApplicantFilterInput): Int! @count(model: "User")
-  pool(id: UUID! @eq): Pool @find @can(ability: "view", query: true)
+  pool(id: UUID! @eq): Pool
+    @find
+    @can(ability: "view", query: true)
+    @softDeletes
   pools: [Pool]! @all @can(ability: "viewAny", model: "Pool")
   publishedPools(
     closingAfter: DateTime @where(key: "closing_date", operator: ">")

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1755,7 +1755,7 @@ type Mutation {
     @delete(globalId: false)
     @guard
     @can(ability: "delete", find: "id")
-
+  restorePool(id: ID!): Pool @restore @can(ability: "restore", find: "id")
   # Application mutations
   archiveApplication(id: ID!): PoolCandidate
     @guard

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1752,10 +1752,6 @@ type Mutation {
     @delete(globalId: false)
     @guard
     @can(ability: "deleteDraft", find: "id")
-  deletePool(id: ID!): Pool
-    @delete(model: "Pool", globalId: false)
-    @guard
-    @can(ability: "deleteDraft", find: "id")
 
   # Application mutations
   archiveApplication(id: ID!): PoolCandidate

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1751,7 +1751,7 @@ type Mutation {
   deletePool(id: ID!): Pool
     @delete(globalId: false)
     @guard
-    @can(ability: "deleteDraft", find: "id")
+    @can(ability: "delete", find: "id")
 
   # Application mutations
   archiveApplication(id: ID!): PoolCandidate

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -952,7 +952,12 @@ type Query {
   applicant(id: UUID!): User @deprecated(reason: "Removing in favour of user query")
   applicants(includeIds: [ID]!): [User]! @deprecated(reason: "Removing in favour of users query")
   countApplicants(where: ApplicantFilterInput): Int!
-  pool(id: UUID!): Pool
+  pool(
+    id: UUID!
+
+    """Allows to filter if trashed elements should be fetched."""
+    trashed: Trashed
+  ): Pool
   pools: [Pool]!
   publishedPools(closingAfter: DateTime, publishingGroup: PublishingGroup): [Pool!]!
   poolByKey(key: String!): Pool

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -566,6 +566,7 @@ type Mutation {
   changePoolClosingDate(id: ID!, newClosingDate: DateTime!): Pool
   closePool(id: ID!): Pool
   deletePool(id: ID!): Pool
+  restorePool(id: ID!): Pool
   archiveApplication(id: ID!): PoolCandidate
   changeApplicationSuspendedAt(id: ID!, isSuspended: Boolean!): PoolCandidate
   createApplication(userId: ID!, poolId: ID!): PoolCandidate

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -615,10 +615,6 @@
     "defaultMessage": "Apprentissage en cours d’emploi",
     "description": "Experience requirement, On the job."
   },
-  "2K8q04": {
-    "defaultMessage": "Avez-vous besoin de mesures d’adaptation, ou avez-vous des questions sur ce processus?",
-    "description": "Opening sentence asking if accommodations are needed"
-  },
   "2KjiDn": {
     "defaultMessage": "Niveau 4 : Gestionnaire",
     "description": "title for IT-04 manager dialog"
@@ -4480,6 +4476,10 @@
     "defaultMessage": "Voici une liste des utilisateurs actifs ainsi que certains de leurs renseignements.",
     "description": "Descriptive text about the list of users in the admin portal."
   },
+  "UwdpPS": {
+    "defaultMessage": "Qui peut formuler une demande?",
+    "description": "Title for the hiring policies section of a pool advertisement"
+  },
   "UxF291": {
     "defaultMessage": "Nom de famille",
     "description": "Label displayed for the last name field in create account form."
@@ -5274,6 +5274,10 @@
     "defaultMessage": "Expériences de travail",
     "description": "Heading for personal experiences in experience by type listing"
   },
+  "aCg/OZ": {
+    "defaultMessage": "La préférence sera accordée aux anciens combattants, aux citoyens canadiens et aux résidants permanents.",
+    "description": "First hiring policy for pool advertisement"
+  },
   "aDRIDD": {
     "defaultMessage": "Éducation actuelle",
     "description": "Label displayed on Education Experience form for current education bounded box"
@@ -5483,6 +5487,10 @@
   "boPmF+": {
     "defaultMessage": "Examen de langue écrit",
     "description": "Legend text for written exam language preference for exams"
+  },
+  "bq1MMd": {
+    "defaultMessage": "Nous n’avons trouvé aucun candidat qui répondait automatiquement à vos critères, mais nous pouvons peut-être encore vous aider.",
+    "description": "Text telling users they can still be helped regardless of search results"
   },
   "bqaNWT": {
     "defaultMessage": "Ajouter l'utilisateur au bassin",
@@ -6055,6 +6063,10 @@
   "fYyK2p": {
     "defaultMessage": "Créer une classification",
     "description": "Page title for the classification creation page"
+  },
+  "faWz84": {
+    "defaultMessage": "Personnes résidant au Canada, et citoyens canadiens et résidents permanents résidant à l’étranger.",
+    "description": "List of criteria needed in order to apply"
   },
   "fdKtYm": {
     "defaultMessage": "Description (anglais)",
@@ -7695,6 +7707,10 @@
     "defaultMessage": "Description (anglais)",
     "description": "Label displayed on the create a skill form description (English) field."
   },
+  "rKUVdL": {
+    "defaultMessage": "Veuillez communiquer avec l’équipe <a>{name} </a> par courriel, si vous avez <strong>des questions</strong> ou <strong>si vous avez besoin de mesures d’adaptation </strong> tout au long de ce processus.",
+    "description": "Opening sentence asking if accommodations are needed"
+  },
   "rNVDaA": {
     "defaultMessage": "Désolé. Une erreur s'est produite. Veuillez envoyer un courriel à <anchorTag>{emailAddress}</anchorTag> et mentionner ce code d’erreur : {errorCode}.",
     "description": "Support form toast message error"
@@ -7922,6 +7938,10 @@
   "ssJxrj": {
     "defaultMessage": "Je suis un membre des Premières Nations.",
     "description": "Text for the option to self-declare as a status first nations"
+  },
+  "swESO/": {
+    "defaultMessage": "À distance, hybride ou sur site",
+    "description": "Location requirement when a pool advertisement is remote"
   },
   "swugkW": {
     "defaultMessage": "Droit de priorité :",
@@ -8457,6 +8477,10 @@
   "x8tCSM": {
     "defaultMessage": "Cette compétence nécessaire doit être jumelée à au moins une expérience figurant dans le CV",
     "description": "Message that appears when a required skill has no experiences linked to it"
+  },
+  "xAfVa9": {
+    "defaultMessage": "Nous pouvons peut-être vous aider!",
+    "description": "Heading for helping user if no candidates matched the filters chosen."
   },
   "xGjm2A": {
     "defaultMessage": "Sélectionnez les compétences qui amélioreront les chances de correspondre aux qualités recherchées par le les gestionnaire. Celles-ci peuvent généralement être appris en cours de travail et ne sont pas nécessaires pour être accepté dans le bassin",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -615,9 +615,9 @@
     "defaultMessage": "Apprentissage en cours d’emploi",
     "description": "Experience requirement, On the job."
   },
-  "2JIgrl": {
-    "defaultMessage": "Souhaitez-vous poursuivre?",
-    "description": "Message displayed to users before removing a member from a team"
+  "2K8q04": {
+    "defaultMessage": "Avez-vous besoin de mesures d’adaptation, ou avez-vous des questions sur ce processus?",
+    "description": "Opening sentence asking if accommodations are needed"
   },
   "2KjiDn": {
     "defaultMessage": "Niveau 4 : Gestionnaire",
@@ -2806,10 +2806,6 @@
     "defaultMessage": "Nom du bassin",
     "description": "Title displayed for the Pool table pool name column."
   },
-  "Hqt/ej": {
-    "defaultMessage": "Archive",
-    "description": "Heading for the archive pool dialog"
-  },
   "HrRgTT": {
     "defaultMessage": "Veuillez sélectionner une compétence pour continuer.",
     "description": "Help text to tell users to select a skill before submitting"
@@ -2825,10 +2821,6 @@
   "HwPuG0": {
     "defaultMessage": "Date d'expiration mise à jour avec succès",
     "description": "Toast for successful expiry date update on view-user page"
-  },
-  "HxTuuy": {
-    "defaultMessage": "Ce bassin n'est plus annoncée.",
-    "description": "Status description of a pool in ARCHIVED status"
   },
   "Hy2UdW": {
     "defaultMessage": "Vous êtes sur le point de retirer un rôle de l’utilisateur suivant : <strong>{userName}</strong>",
@@ -3009,10 +3001,6 @@
   "JamdKo": {
     "defaultMessage": "Premières Nations non inscrites",
     "description": "The indigenous community for non-status First Nations"
-  },
-  "Jc0lds": {
-    "defaultMessage": "Bassin archivé",
-    "description": "Button to archive the pool in the archive pool dialog"
   },
   "Jdlnz6": {
     "defaultMessage": "ᓀᐦᐃᔭᐍᐏᐣ nēhiyawēwin (Cris des Plaines)",
@@ -4492,10 +4480,6 @@
     "defaultMessage": "Voici une liste des utilisateurs actifs ainsi que certains de leurs renseignements.",
     "description": "Descriptive text about the list of users in the admin portal."
   },
-  "UwdpPS": {
-    "defaultMessage": "Qui peut formuler une demande?",
-    "description": "Title for the hiring policies section of a pool advertisement"
-  },
   "UxF291": {
     "defaultMessage": "Nom de famille",
     "description": "Label displayed for the last name field in create account form."
@@ -5290,10 +5274,6 @@
     "defaultMessage": "Expériences de travail",
     "description": "Heading for personal experiences in experience by type listing"
   },
-  "aCg/OZ": {
-    "defaultMessage": "La préférence sera accordée aux anciens combattants, aux citoyens canadiens et aux résidants permanents.",
-    "description": "First hiring policy for pool advertisement"
-  },
   "aDRIDD": {
     "defaultMessage": "Éducation actuelle",
     "description": "Label displayed on Education Experience form for current education bounded box"
@@ -5503,10 +5483,6 @@
   "boPmF+": {
     "defaultMessage": "Examen de langue écrit",
     "description": "Legend text for written exam language preference for exams"
-  },
-  "bq1MMd": {
-    "defaultMessage": "Nous n’avons trouvé aucun candidat qui répondait automatiquement à vos critères, mais nous pouvons peut-être encore vous aider.",
-    "description": "Text telling users they can still be helped regardless of search results"
   },
   "bqaNWT": {
     "defaultMessage": "Ajouter l'utilisateur au bassin",
@@ -6079,10 +6055,6 @@
   "fYyK2p": {
     "defaultMessage": "Créer une classification",
     "description": "Page title for the classification creation page"
-  },
-  "faWz84": {
-    "defaultMessage": "Personnes résidant au Canada, et citoyens canadiens et résidents permanents résidant à l’étranger.",
-    "description": "List of criteria needed in order to apply"
   },
   "fdKtYm": {
     "defaultMessage": "Description (anglais)",
@@ -7723,10 +7695,6 @@
     "defaultMessage": "Description (anglais)",
     "description": "Label displayed on the create a skill form description (English) field."
   },
-  "rKUVdL": {
-    "defaultMessage": "Veuillez communiquer avec l’équipe <a>{name} </a> par courriel, si vous avez <strong>des questions</strong> ou <strong>si vous avez besoin de mesures d’adaptation </strong> tout au long de ce processus.",
-    "description": "Opening sentence asking if accommodations are needed"
-  },
   "rNVDaA": {
     "defaultMessage": "Désolé. Une erreur s'est produite. Veuillez envoyer un courriel à <anchorTag>{emailAddress}</anchorTag> et mentionner ce code d’erreur : {errorCode}.",
     "description": "Support form toast message error"
@@ -7954,10 +7922,6 @@
   "ssJxrj": {
     "defaultMessage": "Je suis un membre des Premières Nations.",
     "description": "Text for the option to self-declare as a status first nations"
-  },
-  "swESO/": {
-    "defaultMessage": "À distance, hybride ou sur site",
-    "description": "Location requirement when a pool advertisement is remote"
   },
   "swugkW": {
     "defaultMessage": "Droit de priorité :",
@@ -8294,10 +8258,6 @@
     "defaultMessage": "Continuer vers CléGC et s'inscrire",
     "description": "GCKey registration link text on the registration page"
   },
-  "vRLrmc": {
-    "defaultMessage": "Voulez-vous continuer?",
-    "description": "Question posed to user before committing a destructive act"
-  },
   "vV0SDz": {
     "defaultMessage": "{title} à {organization}",
     "description": "Title at organization"
@@ -8497,10 +8457,6 @@
   "x8tCSM": {
     "defaultMessage": "Cette compétence nécessaire doit être jumelée à au moins une expérience figurant dans le CV",
     "description": "Message that appears when a required skill has no experiences linked to it"
-  },
-  "xAfVa9": {
-    "defaultMessage": "Nous pouvons peut-être vous aider!",
-    "description": "Heading for helping user if no candidates matched the filters chosen."
   },
   "xGjm2A": {
     "defaultMessage": "Sélectionnez les compétences qui amélioreront les chances de correspondre aux qualités recherchées par le les gestionnaire. Celles-ci peuvent généralement être appris en cours de travail et ne sont pas nécessaires pour être accepté dans le bassin",

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -10,7 +10,6 @@ import {
 } from "@gc-digital-talent/ui";
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import { notEmpty } from "@gc-digital-talent/helpers";
-import { useLogger } from "@gc-digital-talent/logger";
 
 import SEO from "~/components/SEO/SEO";
 import {
@@ -313,7 +312,6 @@ type RouteParams = {
 export const EditPoolPage = () => {
   const intl = useIntl();
   const { poolId } = useParams<RouteParams>();
-  const logger = useLogger();
   const routes = useRoutes();
 
   const notFoundMessage = intl.formatMessage(
@@ -386,7 +384,7 @@ export const EditPoolPage = () => {
               }
               onClose={() => mutations.close(poolId)}
               onExtend={(closingDate) => mutations.extend(poolId, closingDate)}
-              onArchive={() => logger.warning("onArchive not yet implemented")}
+              onArchive={() => mutations.delete(poolId)}
             />
           </EditPoolContext.Provider>
         ) : (

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -72,6 +72,7 @@ export interface EditPoolFormProps {
   onExtend: (closingDate: Scalars["DateTime"]) => Promise<void>;
   onArchive: () => void;
   onDuplicate: () => void;
+  onUnarchive: () => void;
 }
 
 export const EditPoolForm = ({
@@ -85,6 +86,7 @@ export const EditPoolForm = ({
   onClose,
   onExtend,
   onArchive,
+  onUnarchive,
 }: EditPoolFormProps): JSX.Element => {
   const intl = useIntl();
   const paths = useRoutes();
@@ -297,6 +299,7 @@ export const EditPoolForm = ({
               onExtend={onExtend}
               onArchive={onArchive}
               onDuplicate={onDuplicate}
+              onUnarchive={onUnarchive}
             />
           </TableOfContents.Content>
         </TableOfContents.Wrapper>
@@ -384,7 +387,8 @@ export const EditPoolPage = () => {
               }
               onClose={() => mutations.close(poolId)}
               onExtend={(closingDate) => mutations.extend(poolId, closingDate)}
-              onArchive={() => mutations.delete(poolId)}
+              onArchive={() => mutations.archive(poolId)}
+              onUnarchive={() => mutations.unarchive(poolId)}
             />
           </EditPoolContext.Provider>
         ) : (

--- a/apps/web/src/pages/Pools/EditPoolPage/components/ArchiveDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/ArchiveDialog.tsx
@@ -1,46 +1,50 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { Dialog, Button } from "@gc-digital-talent/ui";
+import { Button, Dialog } from "@gc-digital-talent/ui";
+import { Pool } from "@gc-digital-talent/graphql";
+
+import { getFullPoolTitleLabel } from "~/utils/poolUtils";
 
 type ArchiveDialogProps = {
+  pool: Pool;
   onArchive: () => void;
 };
 
-const ArchiveDialog = ({ onArchive }: ArchiveDialogProps): JSX.Element => {
+const ArchiveDialog = ({
+  pool,
+  onArchive,
+}: ArchiveDialogProps): JSX.Element => {
   const intl = useIntl();
   const Footer = React.useMemo(
     () => (
       <>
-        <div style={{ flexGrow: 2 } /* push other div to the right */}>
-          <Dialog.Close>
-            <Button color="secondary">
-              {intl.formatMessage({
-                defaultMessage: "Cancel and go back",
-                id: "tiF/jI",
-                description: "Close dialog button",
-              })}
-            </Button>
-          </Dialog.Close>
-        </div>
-        <div>
-          <Dialog.Close>
-            <Button
-              onClick={() => {
-                onArchive();
-              }}
-              mode="solid"
-              color="secondary"
-            >
-              {intl.formatMessage({
-                defaultMessage: "Archive pool",
-                id: "Jc0lds",
-                description:
-                  "Button to archive the pool in the archive pool dialog",
-              })}
-            </Button>
-          </Dialog.Close>
-        </div>
+        <Dialog.Close>
+          <Button color="secondary" mode="inline">
+            {intl.formatMessage({
+              defaultMessage: "Cancel and go back",
+              id: "tiF/jI",
+              description: "Close dialog button",
+            })}
+          </Button>
+        </Dialog.Close>
+
+        <Dialog.Close>
+          <Button
+            onClick={() => {
+              onArchive();
+            }}
+            mode="solid"
+            color="error"
+          >
+            {intl.formatMessage({
+              defaultMessage: "Archive this pool",
+              id: "Jp0Beg",
+              description:
+                "Button to archive the pool in the archive pool dialog",
+            })}
+          </Button>
+        </Dialog.Close>
       </>
     ),
     [intl, onArchive],
@@ -48,7 +52,7 @@ const ArchiveDialog = ({ onArchive }: ArchiveDialogProps): JSX.Element => {
   return (
     <Dialog.Root>
       <Dialog.Trigger>
-        <Button color="secondary" mode="solid" disabled>
+        <Button color="secondary" mode="solid">
           {intl.formatMessage({
             defaultMessage: "Archive",
             id: "P8NuMo",
@@ -59,13 +63,37 @@ const ArchiveDialog = ({ onArchive }: ArchiveDialogProps): JSX.Element => {
       <Dialog.Content>
         <Dialog.Header>
           {intl.formatMessage({
-            defaultMessage: "Archive",
-            id: "Hqt/ej",
+            defaultMessage: "Archive this pool",
+            id: "7gOyU5",
             description: "Heading for the archive pool dialog",
           })}
         </Dialog.Header>
         <Dialog.Body>
-          {/* todo */}
+          <p data-h2-margin-bottom="base(x0.5)">
+            {intl.formatMessage({
+              defaultMessage: "You're about to archive this pool:",
+              id: "FboyrB",
+              description: "First paragraph for archive pool dialog",
+            })}
+          </p>
+          <p data-h2-font-weight="base(700)" data-h2-margin-bottom="base(x0.5)">
+            {getFullPoolTitleLabel(intl, pool)}
+          </p>
+          <p data-h2-margin-bottom="base(x0.5)">
+            {intl.formatMessage({
+              defaultMessage:
+                "This will hide this pool from all relevant tables and from a user's pool information.",
+              id: "FGedDI",
+              description: "Second paragraph for archive pool dialog",
+            })}
+          </p>
+          <p>
+            {intl.formatMessage({
+              defaultMessage: "Do you wish to continue?",
+              id: "qYr1H8",
+              description: "Third paragraph for archive pool dialog",
+            })}
+          </p>
           <Dialog.Footer>{Footer}</Dialog.Footer>
         </Dialog.Body>
       </Dialog.Content>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/StatusSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/StatusSection.tsx
@@ -16,6 +16,7 @@ import DeleteDialog from "./DeleteDialog";
 import DuplicateDialog from "./DuplicateDialog";
 import ArchiveDialog from "./ArchiveDialog";
 import ExtendDialog from "./ExtendDialog";
+import UnarchiveDialog from "./UnarchiveDialog";
 
 interface StatusSectionProps {
   pool: Pool;
@@ -26,6 +27,7 @@ interface StatusSectionProps {
   onExtend: (submitData: Scalars["DateTime"]) => Promise<void>;
   onArchive: () => void;
   onDuplicate: () => void;
+  onUnarchive: () => void;
 }
 
 const StatusSection = ({
@@ -37,6 +39,7 @@ const StatusSection = ({
   onClose,
   onExtend,
   onArchive,
+  onUnarchive,
 }: StatusSectionProps): JSX.Element => {
   const intl = useIntl();
 
@@ -186,41 +189,45 @@ const StatusSection = ({
 
         {/* Archived status */}
         {pool.status === PoolStatus.Archived ? (
-          <div
-            data-h2-background-color="base(gray.light)"
-            data-h2-padding="base(x.5)"
-            data-h2-radius="base(s)"
-            style={{ flexGrow: 2 }} // to push buttons to the right side
-          >
+          <>
             <div
-              data-h2-display="base(flex)"
-              data-h2-align-items="base(center)"
-              style={{ gap: "0.5rem" }}
+              data-h2-background-color="base(gray.light)"
+              data-h2-padding="base(x.5)"
+              data-h2-radius="base(s)"
+              style={{ flexGrow: 2 }} // to push buttons to the right side
             >
-              <FolderOpenIcon
-                style={{
-                  width: "1rem",
-                  height: "1rem",
-                  marginRight: "0.5rem",
-                }}
-              />
-              <span>
-                {intl.formatMessage({
-                  defaultMessage: "<heavyPrimary>Archived</heavyPrimary>",
-                  id: "+5da+V",
-                  description: "Status name of a pool in ARCHIVED status",
-                })}
-              </span>
-              <span>
-                {intl.formatMessage({
-                  defaultMessage: "This pool is no longer advertised.",
-                  id: "HxTuuy",
-                  description:
-                    "Status description of a pool in ARCHIVED status",
-                })}
-              </span>
+              <div
+                data-h2-display="base(flex)"
+                data-h2-align-items="base(center)"
+                style={{ gap: "0.5rem" }}
+              >
+                <FolderOpenIcon
+                  style={{
+                    width: "1rem",
+                    height: "1rem",
+                    marginRight: "0.5rem",
+                  }}
+                />
+                <span>
+                  {intl.formatMessage({
+                    defaultMessage: "<heavyPrimary>Archived</heavyPrimary>",
+                    id: "+5da+V",
+                    description: "Status name of a pool in ARCHIVED status",
+                  })}
+                </span>
+                <span>
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "This pool is no longer advertised or visible to the public.",
+                    id: "TtX+o7",
+                    description:
+                      "Status description of a pool in ARCHIVED status",
+                  })}
+                </span>
+              </div>
             </div>
-          </div>
+            <UnarchiveDialog pool={pool} onUnarchive={onUnarchive} />
+          </>
         ) : undefined}
       </div>
       <DuplicateDialog onDuplicate={onDuplicate} pool={pool} />

--- a/apps/web/src/pages/Pools/EditPoolPage/components/StatusSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/StatusSection.tsx
@@ -180,7 +180,7 @@ const StatusSection = ({
               </div>
             </div>
             <ExtendDialog closingDate={pool.closingDate} onExtend={onExtend} />
-            <ArchiveDialog onArchive={onArchive} />
+            <ArchiveDialog pool={pool} onArchive={onArchive} />
           </>
         ) : undefined}
 

--- a/apps/web/src/pages/Pools/EditPoolPage/components/UnarchiveDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/UnarchiveDialog.tsx
@@ -3,19 +3,19 @@ import { useIntl } from "react-intl";
 
 import { Button, Dialog } from "@gc-digital-talent/ui";
 import { Pool } from "@gc-digital-talent/graphql";
-import { uiMessages } from "@gc-digital-talent/i18n";
 
 import { getFullPoolTitleLabel } from "~/utils/poolUtils";
+import { uiMessages } from "@gc-digital-talent/i18n";
 
-type ArchiveDialogProps = {
+type UnarchiveDialogProps = {
   pool: Pool;
-  onArchive: () => void;
+  onUnarchive: () => void;
 };
 
-const ArchiveDialog = ({
+const UnarchiveDialog = ({
   pool,
-  onArchive,
-}: ArchiveDialogProps): JSX.Element => {
+  onUnarchive,
+}: UnarchiveDialogProps): JSX.Element => {
   const intl = useIntl();
   const Footer = React.useMemo(
     () => (
@@ -33,48 +33,48 @@ const ArchiveDialog = ({
         <Dialog.Close>
           <Button
             onClick={() => {
-              onArchive();
+              onUnarchive();
             }}
             mode="solid"
             color="error"
           >
             {intl.formatMessage({
-              defaultMessage: "Archive this pool",
-              id: "Jp0Beg",
+              defaultMessage: "Un-archive this pool",
+              id: "Rs50V0",
               description:
-                "Button to archive the pool in the archive pool dialog",
+                "Button to un-archive the pool in the un-archive pool dialog",
             })}
           </Button>
         </Dialog.Close>
       </>
     ),
-    [intl, onArchive],
+    [intl, onUnarchive],
   );
   return (
     <Dialog.Root>
       <Dialog.Trigger>
         <Button color="secondary" mode="solid">
           {intl.formatMessage({
-            defaultMessage: "Archive",
-            id: "P8NuMo",
-            description: "Text on a button to archive the pool",
+            defaultMessage: "Un-archive",
+            id: "U/zhJQ",
+            description: "Text on a button to un-archive the pool",
           })}
         </Button>
       </Dialog.Trigger>
       <Dialog.Content>
         <Dialog.Header>
           {intl.formatMessage({
-            defaultMessage: "Archive this pool",
-            id: "7gOyU5",
-            description: "Heading for the archive pool dialog",
+            defaultMessage: "Un-archive this pool",
+            id: "jdD/iA",
+            description: "Heading for the un-archive pool dialog",
           })}
         </Dialog.Header>
         <Dialog.Body>
           <p data-h2-margin-bottom="base(x0.5)">
             {intl.formatMessage({
-              defaultMessage: "You're about to archive this pool:",
-              id: "FboyrB",
-              description: "First paragraph for archive pool dialog",
+              defaultMessage: "You're about to un-archive this pool:",
+              id: "/42EqQ",
+              description: "First paragraph for un-archive pool dialog",
             })}
           </p>
           <p data-h2-font-weight="base(700)" data-h2-margin-bottom="base(x0.5)">
@@ -83,12 +83,12 @@ const ArchiveDialog = ({
           <p data-h2-margin-bottom="base(x0.5)">
             {intl.formatMessage({
               defaultMessage:
-                "This will hide this pool from all relevant tables and from a user's pool information.",
-              id: "FGedDI",
-              description: "Second paragraph for archive pool dialog",
+                "This will show this pool back to the public.  All users associated with this pool will be able to see it on their profile information.",
+              id: "8Bsa1r",
+              description: "Second paragraph for un-archive pool dialog",
             })}
           </p>
-          <p>{intl.formatMessage(uiMessages.confirmContinue)}</p>
+          {intl.formatMessage(uiMessages.confirmContinue)}
           <Dialog.Footer>{Footer}</Dialog.Footer>
         </Dialog.Body>
       </Dialog.Content>
@@ -96,4 +96,4 @@ const ArchiveDialog = ({
   );
 };
 
-export default ArchiveDialog;
+export default UnarchiveDialog;

--- a/apps/web/src/pages/Pools/EditPoolPage/components/UnarchiveDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/UnarchiveDialog.tsx
@@ -83,8 +83,8 @@ const UnarchiveDialog = ({
           <p data-h2-margin-bottom="base(x0.5)">
             {intl.formatMessage({
               defaultMessage:
-                "This will show this pool back to the public.  All users associated with this pool will be able to see it on their profile information.",
-              id: "8Bsa1r",
+                "This will show this pool back to the public.  All users associated with this pool will be able to see it in their profile information.",
+              id: "Bg1Pga",
               description: "Second paragraph for un-archive pool dialog",
             })}
           </p>

--- a/apps/web/src/pages/Pools/EditPoolPage/editPoolOperations.graphql
+++ b/apps/web/src/pages/Pools/EditPoolPage/editPoolOperations.graphql
@@ -1,7 +1,7 @@
 # query to populated the edit pool page
 query getEditPoolData($poolId: UUID!) {
   # the existing data of the pool to edit
-  pool(id: $poolId) {
+  pool(id: $poolId, trashed: WITH) {
     id
     name {
       en

--- a/apps/web/src/pages/Pools/EditPoolPage/editPoolOperations.graphql
+++ b/apps/web/src/pages/Pools/EditPoolPage/editPoolOperations.graphql
@@ -179,3 +179,9 @@ mutation duplicatePool($id: ID!, $teamId: ID!) {
     id
   }
 }
+
+mutation restorePool($id: ID!) {
+  restorePool(id: $id) {
+    id
+  }
+}

--- a/apps/web/src/pages/Pools/EditPoolPage/hooks/useMutations.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/hooks/useMutations.ts
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { useIntl } from "react-intl";
 
 import { toast } from "@gc-digital-talent/toast";
+import { useRestorePoolMutation } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import {
@@ -158,8 +159,8 @@ const useMutations = () => {
   const deletePool = (id: string) => {
     executeDeleteMutation({ id })
       .then((result) => {
-        navigateBack();
         if (result.data?.deletePool) {
+          navigateBack();
           toast.success(
             intl.formatMessage({
               defaultMessage: "Pool deleted successfully!",
@@ -172,6 +173,36 @@ const useMutations = () => {
         }
       })
       .catch(handleDeleteError);
+  };
+
+  const handleArchiveError = () => {
+    toast.error(
+      intl.formatMessage({
+        defaultMessage: "Error: archiving pool failed",
+        id: "zotZ6j",
+        description:
+          "Message displayed to user after pool fails to get archived.",
+      }),
+    );
+  };
+
+  const archivePool = (id: string) => {
+    executeDeleteMutation({ id })
+      .then((result) => {
+        if (result.data?.deletePool) {
+          navigateBack();
+          toast.success(
+            intl.formatMessage({
+              defaultMessage: "Pool archived successfully!",
+              id: "jft3KM",
+              description: "Message displayed to user after pool is archived",
+            }),
+          );
+        } else {
+          handleArchiveError();
+        }
+      })
+      .catch(handleArchiveError);
   };
 
   const [{ fetching: duplicateFetching }, executeDuplicateMutation] =
@@ -192,7 +223,6 @@ const useMutations = () => {
   const duplicatePool = (id: string, teamId: string) => {
     executeDuplicateMutation({ id, teamId })
       .then((result) => {
-        navigateBack();
         if (result.data?.duplicatePool?.id) {
           toast.success(
             intl.formatMessage({
@@ -210,6 +240,39 @@ const useMutations = () => {
       .catch(handleDuplicateError);
   };
 
+  const [{ fetching: restoreFetching }, executeRestoreMutation] =
+    useRestorePoolMutation();
+
+  const handleUnarchiveError = () => {
+    toast.error(
+      intl.formatMessage({
+        defaultMessage: "Error: un-archiving pool failed",
+        id: "H9fzdi",
+        description:
+          "Message displayed to user after pool fails to get un-archived.",
+      }),
+    );
+  };
+
+  const unarchivePool = (id: string) => {
+    executeRestoreMutation({ id })
+      .then((result) => {
+        if (result.data?.restorePool) {
+          toast.success(
+            intl.formatMessage({
+              defaultMessage: "Pool un-archived successfully!",
+              id: "5it7iX",
+              description:
+                "Message displayed to user after pool is un-archived",
+            }),
+          );
+        } else {
+          handleUnarchiveError();
+        }
+      })
+      .catch(handleUnarchiveError);
+  };
+
   return {
     isFetching:
       updateFetching ||
@@ -217,7 +280,8 @@ const useMutations = () => {
       publishFetching ||
       closeFetching ||
       deleteFetching ||
-      duplicateFetching,
+      duplicateFetching ||
+      restoreFetching,
     mutations: {
       update,
       extend,
@@ -225,6 +289,8 @@ const useMutations = () => {
       close,
       delete: deletePool,
       duplicate: duplicatePool,
+      archive: archivePool,
+      unarchive: unarchivePool,
     },
   };
 };

--- a/apps/web/src/pages/Pools/poolOperations.graphql
+++ b/apps/web/src/pages/Pools/poolOperations.graphql
@@ -37,7 +37,7 @@ fragment pool on Pool {
 }
 
 query GetBasicPoolInfo($poolId: UUID!) {
-  pool(id: $poolId) {
+  pool(id: $poolId, trashed: WITH) {
     id
     name {
       en

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/RemoveTeamMemberDialog.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/RemoveTeamMemberDialog.tsx
@@ -3,7 +3,11 @@ import { useIntl } from "react-intl";
 import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
 
 import { Dialog, Button, Pill } from "@gc-digital-talent/ui";
-import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  getLocalizedName,
+  uiMessages,
+} from "@gc-digital-talent/i18n";
 
 import { Team, useUpdateUserAsAdminMutation } from "~/api/generated";
 import { getFullNameLabel } from "~/utils/nameUtils";
@@ -123,12 +127,7 @@ const RemoveTeamMemberDialog = ({
             </>
           ) : null}
           <p data-h2-margin="base(x1, 0)">
-            {intl.formatMessage({
-              defaultMessage: "Do you wish to continue?",
-              id: "2JIgrl",
-              description:
-                "Message displayed to users before removing a member from a team",
-            })}
+            {intl.formatMessage(uiMessages.confirmContinue)}
           </p>
           <Dialog.Footer>
             <Dialog.Close>

--- a/apps/web/src/pages/Users/UpdateUserPage/components/RemoveIndividualRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/RemoveIndividualRoleDialog.tsx
@@ -3,7 +3,11 @@ import { useIntl } from "react-intl";
 import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
 
 import { Dialog, Button, Pill } from "@gc-digital-talent/ui";
-import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  getLocalizedName,
+  uiMessages,
+} from "@gc-digital-talent/i18n";
 import { toast } from "@gc-digital-talent/toast";
 
 import { Role, User } from "~/api/generated";
@@ -99,12 +103,7 @@ const RemoveIndividualRoleDialog = ({
             </Pill>
           </p>
           <p data-h2-margin="base(x1, 0)">
-            {intl.formatMessage({
-              defaultMessage: "Do you wish to continue?",
-              id: "vRLrmc",
-              description:
-                "Question posed to user before committing a destructive act",
-            })}
+            {intl.formatMessage(uiMessages.confirmContinue)}
           </p>
           <Dialog.Footer>
             <Dialog.Close>

--- a/apps/web/src/pages/Users/UpdateUserPage/components/RemoveTeamRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/RemoveTeamRoleDialog.tsx
@@ -3,7 +3,11 @@ import { useIntl } from "react-intl";
 import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
 
 import { Dialog, Button, Pill } from "@gc-digital-talent/ui";
-import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  getLocalizedName,
+  uiMessages,
+} from "@gc-digital-talent/i18n";
 import { toast } from "@gc-digital-talent/toast";
 
 import {
@@ -135,12 +139,7 @@ const RemoveTeamRoleDialog = ({
             ))}
           </p>
           <p data-h2-margin="base(x1, 0)">
-            {intl.formatMessage({
-              defaultMessage: "Do you wish to continue?",
-              id: "vRLrmc",
-              description:
-                "Question posed to user before committing a destructive act",
-            })}
+            {intl.formatMessage(uiMessages.confirmContinue)}
           </p>
           <Dialog.Footer>
             <Dialog.Close>

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1036,6 +1036,10 @@
     "defaultMessage": "Architecture intégrée de la TI",
     "description": "Pool Stream described as Enterprise Architecture."
   },
+  "ijGl5r": {
+    "defaultMessage": "Souhaitez-vous poursuivre?",
+    "description": "A request to confirm that the user wants to continue"
+  },
   "iqD8qE": {
     "defaultMessage": "Erreur inconnue",
     "description": "Fallback text when an error message is not supplied"

--- a/packages/i18n/src/messages/uiMessages.ts
+++ b/packages/i18n/src/messages/uiMessages.ts
@@ -100,6 +100,11 @@ const uiMessages = defineMessages({
     id: "rnZULP",
     description: "Button text to truncate text to view fewer characters",
   },
+  confirmContinue: {
+    defaultMessage: "Do you wish to continue?",
+    id: "ijGl5r",
+    description: "A request to confirm that the user wants to continue",
+  },
 });
 
 export default uiMessages;


### PR DESCRIPTION
🤖 Resolves #6578 

## 👋 Introduction

This branch adds the ability to delete and restore pools.

## 🕵️ Details

The delete and restore functionality is based on the soft-delete functionality built into Eloquent.  Based on [this comment](https://talent-cloud.slack.com/archives/C0259G6KXJ6/p1689168553019879?thread_ts=1689106800.319769&cid=C0259G6KXJ6), a new permission was added to the matrix to check if the user has the ability to delete a closed pool.  Based on [this comment](https://talent-cloud.slack.com/archives/C0259G6KXJ6/p1689692066451029?thread_ts=1689691611.551129&cid=C0259G6KXJ6), the same permission was used to check when restoring the deleted pool.

Based on [this comment](https://talent-cloud.slack.com/archives/C0259G6KXJ6/p1689168580183789?thread_ts=1689106800.319769&cid=C0259G6KXJ6), an issue (#7306) was opened to convert the draft-delete operation to a hard-delete.

Based on the issue AC and following discussion, archived pools do not show up in the UI anywhere.  However, for ease of testing, I have updated the edit pool page to allow viewing deleted pools if the proper UUID is used in the URL.  The API policies still enforce proper permissions for actually updating the archived pools.

Note on this AC:
> When confirmed, the pool's status should change from "Archived" to "Closed"

Restoring a pool actually restores the previous status, not always CLOSED.  This is the default behaviour of Eloquent and seems sensible.


## 🧪 Testing

1. Rerun the roles and permissions seeder `./artisan db:seed --class=RolePermissionSeeder`
2. Rerun the "Refresh API" task
3. Rebuild the frontend
4. Log into the admin site and navigate to `/en/admin/pools`
5. Work through the AC on the issue

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/50968221-3e5f-4d4b-bd2a-4abb1829984e)

# :truck: Deployment instructions
- Rerun the roles and permissions seeder to get the new rows.