### PR TITLE
[Fix] Make priority number required

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -178,6 +178,7 @@ class User extends Model implements Authenticatable, LaratrustUser
             ) or
             is_null($this->attributes['is_gov_employee']) or
             is_null($this->attributes['has_priority_entitlement']) or
+            ($this->attributes['has_priority_entitlement'] && is_null($this->attributes["priority_number"])) or
             is_null($this->attributes['location_preferences']) or
             empty($this->attributes['location_preferences']) or
             empty($this->attributes['position_duration'])  or

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -208,7 +208,13 @@ class User extends Model implements Authenticatable, LaratrustUser
                 $query->orWhereNotNull('looking_for_bilingual');
             });
             $query->whereNotNull('is_gov_employee');
-            $query->whereNotNull('has_priority_entitlement');
+            $query->where(function (Builder $query) {
+                $query->whereNotNull('has_priority_entitlement')
+                    ->orWhere(function (Builder $query) {
+                        $query->where('has_priority_entitlement', true)
+                            ->whereNotNull('priority_number');
+                    });
+            });
             $query->whereNotNull('location_preferences');
             $query->whereJsonLength('location_preferences', '>', 0);
             $query->whereJsonLength('position_duration', '>', 0);

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -209,7 +209,7 @@ class User extends Model implements Authenticatable, LaratrustUser
             });
             $query->whereNotNull('is_gov_employee');
             $query->where(function (Builder $query) {
-                $query->whereNotNull('has_priority_entitlement')
+                $query->where('has_priority_entitlement', false)
                     ->orWhere(function (Builder $query) {
                         $query->where('has_priority_entitlement', true)
                             ->whereNotNull('priority_number');

--- a/apps/web/src/components/Profile/components/GovernmentInformation/FormFields.tsx
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/FormFields.tsx
@@ -280,6 +280,7 @@ const FormFields = ({
           type="text"
           label={labels.priorityEntitlementNumber}
           name="priorityEntitlementNumber"
+          rules={{ required: intl.formatMessage(errorMessages.required) }}
         />
       )}
     </div>

--- a/apps/web/src/validators/profile/governmentInformation.ts
+++ b/apps/web/src/validators/profile/governmentInformation.ts
@@ -1,5 +1,5 @@
 import { User } from "@gc-digital-talent/graphql";
-import { empty } from "@gc-digital-talent/helpers";
+import { empty, notEmpty } from "@gc-digital-talent/helpers";
 
 type PartialUser = Pick<
   User,
@@ -21,8 +21,13 @@ export function hasAllEmptyFields({
 export function hasEmptyRequiredFields({
   isGovEmployee,
   hasPriorityEntitlement,
+  priorityNumber,
 }: PartialUser): boolean {
-  return empty(isGovEmployee) || empty(hasPriorityEntitlement);
+  return (
+    empty(isGovEmployee) ||
+    empty(hasPriorityEntitlement) ||
+    (hasPriorityEntitlement && empty(priorityNumber))
+  );
 }
 
 export function hasEmptyOptionalFields({

--- a/apps/web/src/validators/profile/governmentInformation.ts
+++ b/apps/web/src/validators/profile/governmentInformation.ts
@@ -1,5 +1,5 @@
 import { User } from "@gc-digital-talent/graphql";
-import { empty, notEmpty } from "@gc-digital-talent/helpers";
+import { empty } from "@gc-digital-talent/helpers";
 
 type PartialUser = Pick<
   User,


### PR DESCRIPTION
🤖 Resolves #7220 

## 👋 Introduction

This makes the priority number required when the user has selected "Yes" to priority entitlement.

## 🕵️ Details

This change occurs in the application and profile pages but **_not_** create account.

## 🧪 Testing

1. Build `npm run build`
2. Login with a new account
3. Confirm priority number is not required when selected "yes" to priority entitlement
4. Navigate to your profile page
5. Confirm Confirm priority number is required when selected "yes" to priority entitlement 
6. Start and application and continue to the profile step
7. Confirm priority number is required when selected "yes" to priority entitlement 

## 📸 Screenshot

### Create Account
![Screenshot 2023-07-19 083934](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/e7ea5969-4515-4211-98c0-1b754233cf31)

### Profile / Application
![Screenshot 2023-07-19 083957](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/23981c41-32e4-4659-ab22-5a290e755198)

