### PR TITLE
[Debt] Renames `SelectFieldV2` to `MultiSelectFieldBase`

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateTableFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateTableFilterDialog.tsx
@@ -6,7 +6,7 @@ import AdjustmentsVerticalIcon from "@heroicons/react/24/outline/AdjustmentsVert
 import { Button, Dialog } from "@gc-digital-talent/ui";
 import {
   BasicForm,
-  SelectFieldV2,
+  MultiSelectFieldBase,
   MultiSelectField,
 } from "@gc-digital-talent/forms";
 
@@ -129,7 +129,7 @@ const PoolCandidateTableFilterDialog = ({
                 />
               </div>
               <div data-h2-flex-item="base(1of1) p-tablet(1of2) laptop(2of5)">
-                <SelectFieldV2
+                <MultiSelectFieldBase
                   forceArrayFormValue
                   id="languageAbility"
                   name="languageAbility"
@@ -183,7 +183,7 @@ const PoolCandidateTableFilterDialog = ({
                 />
               </div>
               <div data-h2-flex-item="base(1of1) p-tablet(1of2) laptop(1of3)">
-                <SelectFieldV2
+                <MultiSelectFieldBase
                   forceArrayFormValue
                   id="hasDiploma"
                   name="hasDiploma"
@@ -195,7 +195,7 @@ const PoolCandidateTableFilterDialog = ({
                 />
               </div>
               <div data-h2-flex-item="base(1of1) p-tablet(1of2) laptop(1of3)">
-                <SelectFieldV2
+                <MultiSelectFieldBase
                   forceArrayFormValue
                   id="expiryStatus"
                   name="expiryStatus"
@@ -208,7 +208,7 @@ const PoolCandidateTableFilterDialog = ({
                 />
               </div>
               <div data-h2-flex-item="base(1of1) p-tablet(1of2) laptop(1of3)">
-                <SelectFieldV2
+                <MultiSelectFieldBase
                   forceArrayFormValue
                   id="suspendedStatus"
                   name="suspendedStatus"

--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
@@ -7,7 +7,7 @@ import {
   Input,
   Submit,
   TextArea,
-  SelectFieldV2,
+  MultiSelectFieldBase,
 } from "@gc-digital-talent/forms";
 import { errorMessages, apiMessages } from "@gc-digital-talent/i18n";
 import { Pending, Button, Link } from "@gc-digital-talent/ui";
@@ -170,7 +170,7 @@ const SupportForm = ({
               }}
               trackUnsaved={false}
             />
-            <SelectFieldV2
+            <MultiSelectFieldBase
               id="subject"
               name="subject"
               rules={{

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.tsx
@@ -6,7 +6,7 @@ import AdjustmentsVerticalIcon from "@heroicons/react/24/outline/AdjustmentsVert
 import { Dialog, Button } from "@gc-digital-talent/ui";
 import {
   BasicForm,
-  SelectFieldV2,
+  MultiSelectFieldBase,
   MultiSelectField,
 } from "@gc-digital-talent/forms";
 
@@ -130,7 +130,7 @@ const UserTableFilterDialog = ({
                 />
               </div>
               <div data-h2-flex-item="base(1of1) p-tablet(1of2) laptop(2of5)">
-                <SelectFieldV2
+                <MultiSelectFieldBase
                   forceArrayFormValue
                   id="languageAbility"
                   name="languageAbility"
@@ -186,7 +186,7 @@ const UserTableFilterDialog = ({
                 </div>
               )}
               <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-                <SelectFieldV2
+                <MultiSelectFieldBase
                   forceArrayFormValue
                   id="employmentDuration"
                   name="employmentDuration"
@@ -198,7 +198,7 @@ const UserTableFilterDialog = ({
                 />
               </div>
               <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-                <SelectFieldV2
+                <MultiSelectFieldBase
                   forceArrayFormValue
                   id="profileComplete"
                   name="profileComplete"
@@ -222,7 +222,7 @@ const UserTableFilterDialog = ({
                 />
               </div>
               <div data-h2-flex-item="base(1of1) p-tablet(1of2) laptop(2of5)">
-                <SelectFieldV2
+                <MultiSelectFieldBase
                   forceArrayFormValue
                   id="govEmployee"
                   name="govEmployee"

--- a/packages/forms/src/components/MultiSelect/MultiSelectField.test.tsx
+++ b/packages/forms/src/components/MultiSelect/MultiSelectField.test.tsx
@@ -38,7 +38,7 @@ const Providers = ({
   );
 };
 
-// In SelectFieldV2, we hardcode the classNamePrefix prop into react-select's
+// In MultiSelectFieldBase, we hardcode the classNamePrefix prop into react-select's
 // Select component to making styling/testing simpler.
 const CLASS_PREFIX = "react-select";
 const FIELD_NAME = "select-input";

--- a/packages/forms/src/components/MultiSelect/MultiSelectField.tsx
+++ b/packages/forms/src/components/MultiSelect/MultiSelectField.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 
-import SelectFieldV2, {
-  type SelectFieldV2Props,
-} from "../Select/SelectFieldV2";
+import MultiSelectFieldBase, {
+  type MultiSelectFieldBaseProps,
+} from "../Select/MultiSelectFieldBase";
 
 export type MultiSelectFieldProps = Omit<
-  SelectFieldV2Props,
+  MultiSelectFieldBaseProps,
   "isMulti" | "forceArrayFormValue"
 >;
 
 const MultiSelectField = (props: MultiSelectFieldProps) => (
-  <SelectFieldV2 isMulti {...props} />
+  <MultiSelectFieldBase isMulti {...props} />
 );
 
 export default MultiSelectField;

--- a/packages/forms/src/components/Select/MultiSelectFieldBase.stories.tsx
+++ b/packages/forms/src/components/Select/MultiSelectFieldBase.stories.tsx
@@ -14,11 +14,11 @@ import {
 
 import BasicForm from "../BasicForm";
 import Submit from "../Submit";
-import SelectFieldV2, { Option } from "./SelectFieldV2";
+import MultiSelectFieldBase, { Option } from "./MultiSelectFieldBase";
 
 export default {
-  component: SelectFieldV2,
-  title: "Form/SelectFieldV2",
+  component: MultiSelectFieldBase,
+  title: "Form/MultiSelectFieldBase",
   decorators: [
     (Story) => {
       return (
@@ -35,9 +35,9 @@ export default {
       );
     },
   ],
-} as ComponentMeta<typeof SelectFieldV2>;
+} as ComponentMeta<typeof MultiSelectFieldBase>;
 
-const Template: ComponentStory<typeof SelectFieldV2> = (args) => {
+const Template: ComponentStory<typeof MultiSelectFieldBase> = (args) => {
   const intl = useIntl();
   const skillFamilies = fakeSkillFamilies(10, fakeSkills(2));
   const fakeOptions: Option[] = skillFamilies.map(({ id, name }) => ({
@@ -45,10 +45,10 @@ const Template: ComponentStory<typeof SelectFieldV2> = (args) => {
     label: getLocalizedName(name, intl),
   }));
 
-  return <SelectFieldV2 {...args} options={fakeOptions} />;
+  return <MultiSelectFieldBase {...args} options={fakeOptions} />;
 };
 
-const TemplateGroup: ComponentStory<typeof SelectFieldV2> = (args) => {
+const TemplateGroup: ComponentStory<typeof MultiSelectFieldBase> = (args) => {
   const intl = useIntl();
   const departments = fakeDepartments();
   const pools = fakePools();
@@ -89,7 +89,7 @@ const TemplateGroup: ComponentStory<typeof SelectFieldV2> = (args) => {
     options: group.options,
   }));
 
-  return <SelectFieldV2 {...args} options={groupOptions} />;
+  return <MultiSelectFieldBase {...args} options={groupOptions} />;
 };
 
 export const Default = Template.bind({});

--- a/packages/forms/src/components/Select/MultiSelectFieldBase.test.tsx
+++ b/packages/forms/src/components/Select/MultiSelectFieldBase.test.tsx
@@ -14,7 +14,9 @@ import {
 import { FormProvider, useForm, RegisterOptions } from "react-hook-form";
 import type { FieldValues, SubmitHandler } from "react-hook-form";
 import IntlProvider from "react-intl/src/components/provider";
-import SelectFieldV2, { useRulesWithDefaultMessages } from "./SelectFieldV2";
+import MultiSelectFieldBase, {
+  useRulesWithDefaultMessages,
+} from "./MultiSelectFieldBase";
 
 const Providers = ({
   children,
@@ -39,7 +41,7 @@ const Providers = ({
   );
 };
 
-// In SelectFieldV2, we hardcode the classNamePrefix prop into react-select's
+// In MultiSelectFieldBase, we hardcode the classNamePrefix prop into react-select's
 // Select component to making styling/testing simpler.
 const CLASS_PREFIX = "react-select";
 const FIELD_NAME = "select-input";
@@ -124,9 +126,9 @@ describe("useRulesWithDefaultMessages", () => {
   });
 });
 
-describe("SelectFieldV2", () => {
+describe("MultiSelectFieldBase", () => {
   it("should render properly with only label prop", () => {
-    renderWithProviders(<SelectFieldV2 {...defaultProps} />);
+    renderWithProviders(<MultiSelectFieldBase {...defaultProps} />);
     expect(
       screen.getByRole("combobox", { name: /foo bar/i }),
     ).toBeInTheDocument();
@@ -139,7 +141,7 @@ describe("SelectFieldV2", () => {
 
   it("should use `name` when `id` and `label` also provided", () => {
     renderWithProviders(
-      <SelectFieldV2 {...defaultProps} id="foo" name="bar" />,
+      <MultiSelectFieldBase {...defaultProps} id="foo" name="bar" />,
     );
     expect(
       document.querySelector('input[type="hidden"]')?.getAttribute("name"),
@@ -147,7 +149,9 @@ describe("SelectFieldV2", () => {
   });
 
   it("should write proper text in options menu when none provided", () => {
-    renderWithProviders(<SelectFieldV2 {...defaultProps} options={[]} />);
+    renderWithProviders(
+      <MultiSelectFieldBase {...defaultProps} options={[]} />,
+    );
     toggleMenuOpen(document.body);
     const noticeText = document.querySelector(
       `.${CLASS_PREFIX}__menu-notice`,
@@ -157,11 +161,14 @@ describe("SelectFieldV2", () => {
 
   it("should submit undefined when no selection (no validation rules)", async () => {
     const mockSubmit = jest.fn();
-    renderWithProviders(<SelectFieldV2 {...defaultProps} options={[]} />, {
-      wrapperProps: {
-        onSubmit: mockSubmit,
+    renderWithProviders(
+      <MultiSelectFieldBase {...defaultProps} options={[]} />,
+      {
+        wrapperProps: {
+          onSubmit: mockSubmit,
+        },
       },
-    });
+    );
 
     await act(async () => {
       fireEvent.submit(screen.getByRole("button"));
@@ -172,14 +179,17 @@ describe("SelectFieldV2", () => {
 
   it("should submit default when set and no selection (no validation rules)", async () => {
     const mockSubmit = jest.fn();
-    renderWithProviders(<SelectFieldV2 {...defaultProps} options={[]} />, {
-      wrapperProps: {
-        onSubmit: mockSubmit,
-        defaultValues: {
-          fooBar: "",
+    renderWithProviders(
+      <MultiSelectFieldBase {...defaultProps} options={[]} />,
+      {
+        wrapperProps: {
+          onSubmit: mockSubmit,
+          defaultValues: {
+            fooBar: "",
+          },
         },
       },
-    });
+    );
 
     await act(async () => {
       fireEvent.submit(screen.getByRole("button"));
@@ -191,7 +201,7 @@ describe("SelectFieldV2", () => {
   it("should prevent submit when required and throw custom error message", async () => {
     const mockSubmit = jest.fn();
     renderWithProviders(
-      <SelectFieldV2
+      <MultiSelectFieldBase
         {...defaultProps}
         options={[]}
         rules={{ required: "Required!" }}
@@ -211,7 +221,7 @@ describe("SelectFieldV2", () => {
   it("should prevent submit when required and throw default error message", async () => {
     const mockSubmit = jest.fn();
     renderWithProviders(
-      <SelectFieldV2
+      <MultiSelectFieldBase
         {...defaultProps}
         options={[]}
         rules={{ required: "required" }}
@@ -235,14 +245,14 @@ describe("SelectFieldV2", () => {
 
   it("should show 'required' text when required", () => {
     renderWithProviders(
-      <SelectFieldV2 {...defaultProps} rules={{ required: true }} />,
+      <MultiSelectFieldBase {...defaultProps} rules={{ required: true }} />,
     );
     expect(screen.getByText("*")).toBeInTheDocument();
   });
 
   it("should be clearable when not required", () => {
     renderWithProviders(
-      <SelectFieldV2
+      <MultiSelectFieldBase
         {...defaultProps}
         options={[{ value: "BAZ", label: "Baz" }]}
       />,
@@ -277,7 +287,10 @@ describe("SelectFieldV2", () => {
 
   it("should not be clearable when required", () => {
     renderWithProviders(
-      <SelectFieldV2 {...defaultProps} rules={{ required: "Required!" }} />,
+      <MultiSelectFieldBase
+        {...defaultProps}
+        rules={{ required: "Required!" }}
+      />,
     );
     toggleMenuOpen(document.body);
     selectFirstOption(document.body);
@@ -288,7 +301,7 @@ describe("SelectFieldV2", () => {
   });
 
   it("should have default placeholder when not specified", () => {
-    renderWithProviders(<SelectFieldV2 {...defaultProps} />);
+    renderWithProviders(<MultiSelectFieldBase {...defaultProps} />);
 
     const placeholderText = document.querySelector(
       `.${CLASS_PREFIX}__control`,
@@ -298,7 +311,7 @@ describe("SelectFieldV2", () => {
 
   it("should have custom placeholder when specified", () => {
     renderWithProviders(
-      <SelectFieldV2 {...defaultProps} placeholder="Select thing" />,
+      <MultiSelectFieldBase {...defaultProps} placeholder="Select thing" />,
     );
 
     const placeholderText = document.querySelector(
@@ -308,7 +321,7 @@ describe("SelectFieldV2", () => {
   });
 
   it("should show loading indicator when isLoading", () => {
-    renderWithProviders(<SelectFieldV2 {...defaultProps} isLoading />);
+    renderWithProviders(<MultiSelectFieldBase {...defaultProps} isLoading />);
 
     const loadingIndicator = document.querySelector(
       `.${CLASS_PREFIX}__loading-indicator`,
@@ -317,7 +330,7 @@ describe("SelectFieldV2", () => {
   });
 
   it("should write proper text in options menu when isLoading", () => {
-    renderWithProviders(<SelectFieldV2 {...defaultProps} isLoading />);
+    renderWithProviders(<MultiSelectFieldBase {...defaultProps} isLoading />);
     toggleMenuOpen(document.body);
 
     const loadingText = document.querySelector(
@@ -329,7 +342,7 @@ describe("SelectFieldV2", () => {
   it("should submit selected value as string by default", async () => {
     const mockSubmit = jest.fn();
     renderWithProviders(
-      <SelectFieldV2
+      <MultiSelectFieldBase
         {...defaultProps}
         options={[{ value: "BAZ", label: "Baz" }]}
       />,
@@ -348,7 +361,7 @@ describe("SelectFieldV2", () => {
   it("should submit a selected value as array when specified", async () => {
     const mockSubmit = jest.fn();
     renderWithProviders(
-      <SelectFieldV2
+      <MultiSelectFieldBase
         forceArrayFormValue
         {...defaultProps}
         options={[{ value: "BAZ", label: "Baz" }]}

--- a/packages/forms/src/components/Select/MultiSelectFieldBase.tsx
+++ b/packages/forms/src/components/Select/MultiSelectFieldBase.tsx
@@ -44,7 +44,7 @@ declare module "react-select/dist/declarations/src/Select" {
 }
 
 // TODO: Eventually extend react-select's Select Props, so that anything extra is passed through.
-export type SelectFieldV2Props = CommonInputProps & {
+export type MultiSelectFieldBaseProps = CommonInputProps & {
   /** List of options for the select element. */
   options?: Options;
   /** Default message shown on select input. */
@@ -184,7 +184,7 @@ export const useRulesWithDefaultMessages = (
   return rulesWithDefaults;
 };
 
-const SelectFieldV2 = ({
+const MultiSelectFieldBase = ({
   id,
   context,
   label,
@@ -198,7 +198,7 @@ const SelectFieldV2 = ({
   isLoading = false,
   trackUnsaved = true,
   doNotSort = false,
-}: SelectFieldV2Props): JSX.Element => {
+}: MultiSelectFieldBaseProps): JSX.Element => {
   const { formatMessage } = useIntl();
   const defaultPlaceholder = formatMessage(formMessages.defaultPlaceholder);
   const {
@@ -365,4 +365,4 @@ const SelectFieldV2 = ({
   );
 };
 
-export default SelectFieldV2;
+export default MultiSelectFieldBase;

--- a/packages/forms/src/components/Select/MultiSelectFieldBase.tsx
+++ b/packages/forms/src/components/Select/MultiSelectFieldBase.tsx
@@ -43,7 +43,6 @@ declare module "react-select/dist/declarations/src/Select" {
   }
 }
 
-// TODO: Eventually extend react-select's Select Props, so that anything extra is passed through.
 export type MultiSelectFieldBaseProps = CommonInputProps & {
   /** List of options for the select element. */
   options?: Options;
@@ -203,7 +202,6 @@ const MultiSelectFieldBase = ({
   const defaultPlaceholder = formatMessage(formMessages.defaultPlaceholder);
   const {
     formState: { errors },
-    // TODO: Set explicit TFieldValues. Defaults to Record<string, any>
   } = useFormContext();
   const baseStyles = useCommonInputStyles();
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);

--- a/packages/forms/src/components/Select/MultiSelectFieldBase.tsx
+++ b/packages/forms/src/components/Select/MultiSelectFieldBase.tsx
@@ -183,6 +183,9 @@ export const useRulesWithDefaultMessages = (
   return rulesWithDefaults;
 };
 
+/**
+ * MultiSelectFieldBase should not be used on its own. MultiSelectField should be used instead.
+ */
 const MultiSelectFieldBase = ({
   id,
   context,

--- a/packages/forms/src/components/Select/index.ts
+++ b/packages/forms/src/components/Select/index.ts
@@ -1,8 +1,10 @@
 import Select from "./Select";
-import SelectFieldV2, { type SelectFieldV2Props } from "./SelectFieldV2";
+import MultiSelectFieldBase, {
+  type MultiSelectFieldBaseProps,
+} from "./MultiSelectFieldBase";
 import type { SelectProps } from "./Select";
 
 export default Select;
-export { SelectFieldV2 };
-export type { SelectProps, SelectFieldV2Props };
+export { MultiSelectFieldBase };
+export type { SelectProps, MultiSelectFieldBaseProps };
 export type { Option } from "./Select";

--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -20,8 +20,8 @@ import MultiSelectField from "./components/MultiSelect/MultiSelectField";
 import RadioGroup, { type RadioGroupProps } from "./components/RadioGroup";
 import Repeater from "./components/Repeater/Repeater";
 import Select, {
-  SelectFieldV2,
-  type SelectFieldV2Props,
+  MultiSelectFieldBase,
+  type MultiSelectFieldBaseProps,
   type SelectProps,
   type Option,
 } from "./components/Select";
@@ -63,7 +63,7 @@ export {
   Repeater,
   RadioGroup,
   Select,
-  SelectFieldV2,
+  MultiSelectFieldBase,
   Submit,
   TextArea,
   WordCounter,
@@ -83,7 +83,7 @@ export type {
   InputProps,
   RadioGroupProps,
   SelectProps,
-  SelectFieldV2Props,
+  MultiSelectFieldBaseProps,
   Option,
   SubmitProps,
   TextAreaProps,


### PR DESCRIPTION
🤖 Resolves #5360.

## 👋 Introduction

This PR renames `SelectFieldV2` to `MultiSelectFieldBase` and adds a comment to not use it.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure no instances of `SelectFieldV2` exist in the codebase.
2. Ensure instances of `MultiSelectFieldBase` build in the app and work as they did before renaming.