### PR TITLE
[Fix] Dropdown menu item colour contrast

### DIFF
--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { ComponentStory, ComponentMeta } from "@storybook/react";
+import type { StoryFn } from "@storybook/react";
 import CheckIcon from "@heroicons/react/24/solid/CheckIcon";
 
 import Button from "../Button";
@@ -15,7 +15,7 @@ export default {
       page: DropdownMenuDocs,
     },
   },
-} as ComponentMeta<typeof DropdownMenu.Root>;
+};
 
 const Check = () => (
   <DropdownMenu.ItemIndicator>
@@ -23,10 +23,11 @@ const Check = () => (
   </DropdownMenu.ItemIndicator>
 );
 
-const Template: ComponentStory<typeof DropdownMenu.Root> = () => {
+const Template: StoryFn<typeof DropdownMenu.Root> = () => {
+  const [isOpen, setIsOpen] = React.useState<boolean>(true);
   const [value, setValue] = React.useState<string>("");
   return (
-    <DropdownMenu.Root>
+    <DropdownMenu.Root open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenu.Trigger>
         <Button>Open Dropdown</Button>
       </DropdownMenu.Trigger>

--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import type { StoryFn } from "@storybook/react";
+import type { StoryFn, Meta } from "@storybook/react";
 import CheckIcon from "@heroicons/react/24/solid/CheckIcon";
+
+import { OverlayOrDialogDecorator } from "storybook-helpers";
 
 import Button from "../Button";
 
@@ -10,12 +12,13 @@ import DropdownMenu from "./DropdownMenu";
 export default {
   component: DropdownMenu.Root,
   title: "Components/Dropdown Menu",
+  decorators: [OverlayOrDialogDecorator],
   parameters: {
     docs: {
       page: DropdownMenuDocs,
     },
   },
-};
+} as Meta;
 
 const Check = () => (
   <DropdownMenu.ItemIndicator>

--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
@@ -87,9 +87,9 @@ const itemStyleProps = {
     fontSize: "0.85rem",
   },
   "data-h2-align-items": "base(center)",
-  "data-h2-background-color": "base(transparent) base:hover(secondary.15)",
-  "data-h2-color":
-    "base(black) base:selectors[[data-disabled]](black.lightest)",
+  "data-h2-background-color":
+    "base(transparent) base:hover(secondary.15) base:selectors[[data-disabled]]:hover(black.lightest.10)",
+  "data-h2-color": "base(black) base:selectors[[data-disabled]](black.light)",
   "data-h2-cursor": "base(pointer)",
   "data-h2-display": "base(flex)",
   "data-h2-padding": "base(x.25, x.5, x.25, x1)",

--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
@@ -88,7 +88,8 @@ const itemStyleProps = {
   },
   "data-h2-align-items": "base(center)",
   "data-h2-background-color": "base(transparent) base:hover(secondary.15)",
-  "data-h2-color": "base(secondary.dark) base:selectors[[data-disabled]](gray)",
+  "data-h2-color":
+    "base(black) base:selectors[[data-disabled]](black.lightest)",
   "data-h2-cursor": "base(pointer)",
   "data-h2-display": "base(flex)",
   "data-h2-padding": "base(x.25, x.5, x.25, x1)",
@@ -134,7 +135,7 @@ const Label = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label>
 >((props, forwardedRef) => (
   <DropdownMenuPrimitive.Label
-    data-h2-color="base(gray)"
+    data-h2-color="base(black)"
     ref={forwardedRef}
     {...props}
   />


### PR DESCRIPTION
🤖 Resolves #7351 

## 👋 Introduction

Updates the colour of dropdown menu items to fix colour contrast issues. Also, makes the story open by default so we can detect errors easier with the storybook a11y addon.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run storybook
2. Navigate to the "Dropdown Menu" story
3. Confirm it is open by default
4. Confirm colours have changed and meet colour contrast ration of 4.5:1

## 📸 Screenshot

![Screenshot 2023-07-21 093402](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/8aac8000-bf8b-4af0-9311-e6223b7226ec)

