### PR TITLE
[Debt] Hide admin table Id columns

### DIFF
--- a/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
+++ b/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
@@ -120,7 +120,7 @@ export const ClassificationTable = ({
     <Table
       data={memoizedData}
       columns={columns}
-      hiddenCols={["minSalary", "maxSalary"]}
+      hiddenCols={["id", "minSalary", "maxSalary"]}
       addBtn={{
         path: paths.classificationCreate(),
         label: intl.formatMessage({

--- a/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
+++ b/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
@@ -101,6 +101,7 @@ export const SkillFamilyTable = ({
     <Table
       data={data}
       columns={columns}
+      hiddenCols={["id"]}
       addBtn={{
         path: paths.skillFamilyCreate(),
         label: intl.formatMessage({

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -122,6 +122,7 @@ export const SkillTable = ({ skills, title }: SkillTableProps) => {
     <Table
       data={data}
       columns={columns}
+      hiddenCols={["id"]}
       addBtn={{
         path: paths.skillCreate(),
         label: intl.formatMessage({


### PR DESCRIPTION
🤖 Resolves #4154 

## 👋 Introduction

Hides the ID column by default for tables that included them.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to the index pages in `/admin`
3. Confirm that ID columns do not appear by default but can still be turned on

## 📸 Screenshot

![Screenshot 2023-07-24 101722](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/2075c22c-787a-470f-aaaa-e1cbe26a2bdb)
![Screenshot 2023-07-24 101725](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/d103142c-69f1-4234-bfb2-5cf27556c700)
![Screenshot 2023-07-24 101729](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/62071e0d-05ac-4952-b597-2895c49ece21)

