### PR TITLE
Fix ApplicantFilterTest

### DIFF
--- a/api/database/factories/PoolCandidateSearchRequestFactory.php
+++ b/api/database/factories/PoolCandidateSearchRequestFactory.php
@@ -24,7 +24,6 @@ class PoolCandidateSearchRequestFactory extends Factory
    */
   public function definition()
   {
-    $isOldRequest = $this->faker->boolean(20); // simulate requests created before the addition of new required fields
 
     return [
       'full_name' => $this->faker->name(),
@@ -38,8 +37,23 @@ class PoolCandidateSearchRequestFactory extends Factory
       'was_empty' => $this->faker->boolean(),
       'request_status' => $this->faker->randomElement(ApiEnums::poolCandidateSearchStatuses()),
       'request_status_changed_at' => $this->faker->boolean() ? $this->faker->dateTimeBetween($startDate = '-1 months', $endDate = 'now') : null,
-      'manager_job_title' => $isOldRequest ? null :  $this->faker->jobTitle(),
-      'position_type' => $isOldRequest ? null : $this->faker->randomElement(ApiEnums::poolCandidateSearchPositionTypes()),
+      'manager_job_title' => $this->faker->jobTitle(),
+      'position_type' => $this->faker->randomElement(ApiEnums::poolCandidateSearchPositionTypes()),
     ];
+  }
+
+  /**
+   * Simulate requests created before the addition of new required fields, for convenient testing/seeding or viewing in frontend
+   */
+  public function withOldRequests($chanceOfTrue = 20)
+  {
+    return $this->afterCreating(function (PoolCandidateSearchRequest $request) use ($chanceOfTrue) {
+      $isOldRequest = $this->faker->boolean($chanceOfTrue);
+      if ($isOldRequest) {
+        $request->manager_job_title = null;
+        $request->position_type = null;
+        $request->save();
+      }
+    });
   }
 }


### PR DESCRIPTION
## 👋 Introduction

Oops, I merged in #7312 without realizing that a factory change I made would make tests fail somewhat regularly

## 🕵️ Details

Rather than always generate the simulated old requests, null for new fields, change it to a stateful function you can call in the seeder when you need it. Such as to observe copy changes for null states when you want to. 
The test failures stemmed from needing the fields in question to be non-null but they were generated null. 

## 🧪 Testing

1. Tests pass

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/453a3c74-fcb9-49ce-855a-612c59f8ce7f)
