### PR TITLE
[Bug] Application skills page validation

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -12,7 +12,6 @@ import {
   Separator,
   ThrowNotFound,
 } from "@gc-digital-talent/ui";
-import { notEmpty } from "@gc-digital-talent/helpers";
 import { toast } from "@gc-digital-talent/toast";
 import { Input } from "@gc-digital-talent/forms";
 import { useFeatureFlags } from "@gc-digital-talent/env";
@@ -30,6 +29,7 @@ import {
 } from "~/api/generated";
 import { AnyExperience } from "~/types/experience";
 
+import { isIncomplete } from "~/validators/profile/skillRequirements";
 import SkillTree from "./components/SkillTree";
 import { ApplicationPageProps } from "../ApplicationApi";
 import SkillDescriptionAccordion from "./components/SkillDescriptionAccordion";
@@ -111,17 +111,10 @@ export const ApplicationSkills = ({
   const nextStep =
     followingPageUrl ?? paths.applicationQuestionsIntro(application.id);
 
-  const skillsMissingExperiences = categorizedEssentialSkills[
-    SkillCategory.Technical
-  ]
-    ?.filter((essentialSkill) => {
-      return !application.user.experiences?.some((experience) => {
-        return experience?.skills?.some(
-          (skill) => skill.id === essentialSkill.id,
-        );
-      });
-    })
-    .filter(notEmpty);
+  const isSkillsExperiencesIncomplete = isIncomplete(
+    application.user,
+    application.pool,
+  );
 
   const methods = useForm<FormValues>();
   const { setValue } = methods;
@@ -327,7 +320,7 @@ export const ApplicationSkills = ({
               onClick={() => {
                 setValue(
                   "skillsMissingExperiences",
-                  skillsMissingExperiences?.length || 0,
+                  isSkillsExperiencesIncomplete ? 1 : 0,
                 );
               }}
             >


### PR DESCRIPTION
🤖 Resolves #7168

## 👋 Introduction

Resolving the validation quirk present on `/en/applications/:id/skills`

## 🕵️ Details

The validation done was different from the one used by the stepper, I changed the page to use that validator instead. 
That one ensured skill details was also filled. 

## 🧪 Testing

1. I managed to replicate the issue by doing the steps in the picture
2. Attempt to replicate the bug by doing that, it should not let you proceed until you update all the skills to have details. 

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/82830b36-5051-4b41-96c5-b6fd51466c6d)


