### PR TITLE
[Feature] Add Indigenous communities to CSV

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/usePoolCandidateCsvData.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/usePoolCandidateCsvData.tsx
@@ -27,6 +27,7 @@ import {
   skillKeyAndJustifications,
   getExperienceTitles,
   getScreeningQuestionResponses,
+  getIndigenousCommunities,
 } from "~/utils/csvUtils";
 import { Maybe, PoolCandidate, PositionDuration, Pool } from "~/api/generated";
 import adminMessages from "~/messages/adminMessages";
@@ -353,7 +354,7 @@ const usePoolCandidateCsvData = (
       }),
     },
     {
-      key: "isIndigenous",
+      key: "indigenousCommunities",
       label: intl.formatMessage({
         defaultMessage: "Indigenous",
         id: "83v9YH",
@@ -512,7 +513,10 @@ const usePoolCandidateCsvData = (
             intl,
           ),
           isWoman: yesOrNo(user.isWoman, intl),
-          isIndigenous: yesOrNo(user.isIndigenous, intl),
+          indigenousCommunities: getIndigenousCommunities(
+            user.indigenousCommunities,
+            intl,
+          ),
           isVisibleMinority: yesOrNo(user.isVisibleMinority, intl),
           hasDisability: yesOrNo(user.hasDisability, intl),
           expectedClassification: getExpectedClassifications(

--- a/apps/web/src/pages/Users/IndexUserPage/hooks/useUserCsvData.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/hooks/useUserCsvData.tsx
@@ -14,6 +14,7 @@ import {
   employeeTypeToString,
   flattenExperiencesToSkills,
   getExpectedClassifications,
+  getIndigenousCommunities,
   getLocationPreference,
   getLookingForLanguage,
   getOperationalRequirements,
@@ -197,7 +198,7 @@ const useUserCsvData = (users: User[]) => {
       }),
     },
     {
-      key: "isIndigenous",
+      key: "indigenousCommunities",
       label: intl.formatMessage({
         defaultMessage: "Indigenous",
         id: "83v9YH",
@@ -260,7 +261,7 @@ const useUserCsvData = (users: User[]) => {
         positionDuration,
         acceptedOperationalRequirements,
         isWoman,
-        isIndigenous,
+        indigenousCommunities,
         isVisibleMinority,
         hasDisability,
         expectedGenericJobTitles,
@@ -310,7 +311,10 @@ const useUserCsvData = (users: User[]) => {
           intl,
         ),
         isWoman: yesOrNo(isWoman, intl),
-        isIndigenous: yesOrNo(isIndigenous, intl),
+        indigenousCommunities: getIndigenousCommunities(
+          indigenousCommunities,
+          intl,
+        ),
         isVisibleMinority: yesOrNo(isVisibleMinority, intl),
         hasDisability: yesOrNo(hasDisability, intl),
         expectedClassification: getExpectedClassifications(

--- a/apps/web/src/utils/csvUtils.tsx
+++ b/apps/web/src/utils/csvUtils.tsx
@@ -4,6 +4,7 @@ import {
   User,
   GovEmployeeType,
   Skill,
+  IndigenousCommunity,
   Maybe,
   Experience,
   ScreeningQuestionResponse,
@@ -33,7 +34,6 @@ import {
   getExperienceName,
 } from "~/utils/experienceUtils";
 import experienceMessages from "~/messages/experienceMessages";
-import { IndigenousCommunity } from "../api/generated";
 
 /**
  * Converts a possible boolean

--- a/apps/web/src/utils/csvUtils.tsx
+++ b/apps/web/src/utils/csvUtils.tsx
@@ -11,6 +11,7 @@ import {
 import {
   Locales,
   getGenericJobTitles,
+  getIndigenousCommunity,
   getOperationalRequirement,
   getSimpleGovEmployeeType,
   getWorkRegion,
@@ -32,6 +33,7 @@ import {
   getExperienceName,
 } from "~/utils/experienceUtils";
 import experienceMessages from "~/messages/experienceMessages";
+import { IndigenousCommunity } from "../api/generated";
 
 /**
  * Converts a possible boolean
@@ -418,4 +420,25 @@ export const getScreeningQuestionResponses = (
   });
 
   return data;
+};
+
+/**
+ * Converts Indigenous communities to column data
+ *
+ * Note: Does not support legacy communities
+ *
+ * @param IndigenousCommunity[]
+ */
+export const getIndigenousCommunities = (
+  communities: Maybe<Maybe<IndigenousCommunity>[]>,
+  intl: IntlShape,
+) => {
+  const communityNames = communities
+    ?.filter(notEmpty)
+    ?.filter(
+      (community) => community !== IndigenousCommunity.LegacyIsIndigenous,
+    )
+    .map((community) => intl.formatMessage(getIndigenousCommunity(community)));
+
+  return communityNames?.join(", ") || "";
 };


### PR DESCRIPTION
🤖 Resolves #7213 

## 👋 Introduction

Updates the Indigenous column in CSV downloads to display the communities rather than yes or no.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to the pool candidate and user tables
3. Download CSV of users for each table
4. Confirm both show Indigenous communities in the CSV (empty if none)

##  📁 Files

[users_2023-07-25T13_57_00.072Z.csv](https://github.com/GCTC-NTGC/gc-digital-talent/files/12162001/users_2023-07-25T13_57_00.072Z.csv)
[pool_candidates_2023-07-25T13_47_59.744Z - pool_candidates_2023-07-25T13_47_59.744Z.csv](https://github.com/GCTC-NTGC/gc-digital-talent/files/12162003/pool_candidates_2023-07-25T13_47_59.744Z.-.pool_candidates_2023-07-25T13_47_59.744Z.csv)
