### PR TITLE
[Debt] Makes `nullSelection` prop required on `Select` component

### DIFF
--- a/apps/web/src/components/ExperienceSortAndFilter/ExperienceSortAndFilter.tsx
+++ b/apps/web/src/components/ExperienceSortAndFilter/ExperienceSortAndFilter.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useIntl } from "react-intl";
 import { FormProvider, useForm } from "react-hook-form";
 
-import { formMessages } from "@gc-digital-talent/i18n";
+import { formMessages, uiMessages } from "@gc-digital-talent/i18n";
 import { Select } from "@gc-digital-talent/forms";
 
 import experienceMessages from "~/messages/experienceMessages";
@@ -109,6 +109,7 @@ const ExperienceSortAndFilter = ({
             description: "Label for selector to choose experience sort options",
           })}
           name="sortBy"
+          nullSelection={intl.formatMessage(uiMessages.nullSelectionOption)}
           options={sortOptions}
           trackUnsaved={false}
         />
@@ -123,6 +124,7 @@ const ExperienceSortAndFilter = ({
               "Label for selector to choose experience filter options",
           })}
           name="filterBy"
+          nullSelection={intl.formatMessage(uiMessages.nullSelectionOption)}
           options={filterOptions}
           trackUnsaved={false}
         />

--- a/apps/web/src/components/SkillDialog/SkillDialog.tsx
+++ b/apps/web/src/components/SkillDialog/SkillDialog.tsx
@@ -14,15 +14,15 @@ import { getSkillDialogMessages } from "./utils";
 import { SkillDialogContext } from "./types";
 
 export interface FormValues {
-  category?: SkillCategory | "";
+  category?: SkillCategory | "all" | "";
   family?: Scalars["ID"];
   skill?: Scalars["ID"];
   details?: string;
 }
 
 const defaultFormValues: FormValues = {
-  category: "",
-  family: "",
+  category: "all",
+  family: "all",
   skill: "",
 };
 

--- a/apps/web/src/components/SkillDialog/SkillSelection.tsx
+++ b/apps/web/src/components/SkillDialog/SkillSelection.tsx
@@ -10,7 +10,11 @@ import {
   Well,
 } from "@gc-digital-talent/ui";
 import { Combobox, Select } from "@gc-digital-talent/forms";
-import { errorMessages, getLocalizedName } from "@gc-digital-talent/i18n";
+import {
+  errorMessages,
+  getLocalizedName,
+  uiMessages,
+} from "@gc-digital-talent/i18n";
 
 import { invertSkillSkillFamilyTree } from "~/utils/skillUtils";
 import { Skill, SkillCategory } from "~/api/generated";
@@ -43,7 +47,7 @@ const SkillSelection = ({
   const filteredFamilies = React.useMemo(() => {
     const invertedTree = invertSkillSkillFamilyTree(skills);
 
-    return category
+    return category && category !== "all"
       ? invertedTree.filter((currentFamily) => {
           return currentFamily.category === category;
         })
@@ -51,14 +55,14 @@ const SkillSelection = ({
   }, [skills, category]);
 
   const filteredSkills = React.useMemo(() => {
-    if (family) {
+    if (family && family !== "all") {
       // We only care about family if it is set
       // since we are filtering families by category
       return skills.filter((currentSkill) =>
         currentSkill.families?.some((skillFamily) => skillFamily.id === family),
       );
     }
-    if (category) {
+    if (category && category !== "all") {
       return skills.filter((currentSkill) =>
         currentSkill.families?.some(
           (skillFamily) => skillFamily.category === category,
@@ -108,6 +112,7 @@ const SkillSelection = ({
           <Select
             id="skill-category"
             name="category"
+            nullSelection={intl.formatMessage(uiMessages.nullSelectionOption)}
             trackUnsaved={false}
             label={intl.formatMessage({
               defaultMessage: "Filter skills by category",
@@ -116,7 +121,7 @@ const SkillSelection = ({
             })}
             options={[
               {
-                value: "",
+                value: "all",
                 label: intl.formatMessage({
                   defaultMessage: "All categories",
                   id: "ZtHmo1",
@@ -145,6 +150,7 @@ const SkillSelection = ({
         <Select
           id="skill-family"
           name="family"
+          nullSelection={intl.formatMessage(uiMessages.nullSelectionOption)}
           trackUnsaved={false}
           label={intl.formatMessage({
             defaultMessage: "Filter skills by skill family",
@@ -153,7 +159,7 @@ const SkillSelection = ({
           })}
           options={[
             {
-              value: "",
+              value: "all",
               label: intl.formatMessage({
                 defaultMessage: "All skill families",
                 id: "eLk4bq",

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection.tsx
@@ -4,7 +4,11 @@ import { FormProvider, useForm } from "react-hook-form";
 
 import { TableOfContents } from "@gc-digital-talent/ui";
 import { notEmpty } from "@gc-digital-talent/helpers";
-import { getLocalizedName, getPoolStream } from "@gc-digital-talent/i18n";
+import {
+  getLocalizedName,
+  getPoolStream,
+  uiMessages,
+} from "@gc-digital-talent/i18n";
 import {
   Input,
   Select,
@@ -147,6 +151,7 @@ const PoolNameSection = ({
                   "Label displayed on the pool form classification field.",
               })}
               name="classification"
+              nullSelection={intl.formatMessage(uiMessages.nullSelectionOption)}
               options={classificationOptions}
               disabled={formDisabled}
             />

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/UpdateSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/UpdateSearchRequest.tsx
@@ -13,6 +13,7 @@ import { toast } from "@gc-digital-talent/toast";
 import {
   commonMessages,
   getPoolCandidateSearchStatus,
+  uiMessages,
 } from "@gc-digital-talent/i18n";
 
 import {
@@ -199,6 +200,9 @@ export const UpdateSearchRequestForm = ({
               <Select
                 id="status"
                 name="status"
+                nullSelection={intl.formatMessage(
+                  uiMessages.nullSelectionOption,
+                )}
                 label={intl.formatMessage(commonMessages.status)}
                 options={enumToOptions(PoolCandidateSearchStatus, [
                   PoolCandidateSearchStatus.New,

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/AddTeamMemberDialog.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/AddTeamMemberDialog.tsx
@@ -10,6 +10,7 @@ import {
   commonMessages,
   errorMessages,
   getLocalizedName,
+  uiMessages,
 } from "@gc-digital-talent/i18n";
 
 import {
@@ -43,6 +44,7 @@ AddTeamMemberDialogProps) => {
     defaultValues: {
       user: "",
       team: team.id,
+      teamDisplay: team.id,
       roles: [],
     },
   });
@@ -130,6 +132,9 @@ AddTeamMemberDialogProps) => {
                 <Select
                   id="user"
                   name="user"
+                  nullSelection={intl.formatMessage(
+                    uiMessages.nullSelectionOption,
+                  )}
                   rules={{
                     required: intl.formatMessage(errorMessages.required),
                   }}
@@ -146,6 +151,9 @@ AddTeamMemberDialogProps) => {
                 <Select
                   id="teamDisplay"
                   name="teamDisplay"
+                  nullSelection={intl.formatMessage(
+                    uiMessages.nullSelectionOption,
+                  )}
                   disabled
                   label={intl.formatMessage({
                     defaultMessage: "Team",

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/EditTeamMemberDialog.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/EditTeamMemberDialog.tsx
@@ -11,6 +11,7 @@ import {
   errorMessages,
   formMessages,
   getLocalizedName,
+  uiMessages,
 } from "@gc-digital-talent/i18n";
 
 import { Role, Team, useUpdateUserAsAdminMutation } from "~/api/generated";
@@ -38,7 +39,9 @@ const EditTeamMemberDialog = ({
   const methods = useForm<TeamMemberFormValues>({
     defaultValues: {
       user: user.id,
+      userDisplay: user.id,
       team: team.id,
+      teamDisplay: team.id,
       roles: user.roles.map((role) => role.id),
     },
   });
@@ -129,6 +132,9 @@ const EditTeamMemberDialog = ({
                 <Select
                   id="userDisplay"
                   name="userDisplay"
+                  nullSelection={intl.formatMessage(
+                    uiMessages.nullSelectionOption,
+                  )}
                   disabled
                   label={intl.formatMessage({
                     defaultMessage: "Manager name",
@@ -148,6 +154,9 @@ const EditTeamMemberDialog = ({
                 <Select
                   id="teamDisplay"
                   name="teamDisplay"
+                  nullSelection={intl.formatMessage(
+                    uiMessages.nullSelectionOption,
+                  )}
                   disabled
                   label={intl.formatMessage({
                     defaultMessage: "Team",

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/types.ts
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/types.ts
@@ -2,7 +2,9 @@ import { Scalars, UpdateUserAsAdminInput } from "~/api/generated";
 
 export type TeamMemberFormValues = {
   user: Scalars["UUID"];
+  userDisplay: Scalars["UUID"];
   team: Scalars["UUID"];
+  teamDisplay: Scalars["UUID"];
   roles: Array<Scalars["UUID"]>;
 };
 

--- a/apps/web/src/pages/Users/UpdateUserPage/components/AddTeamRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/AddTeamRoleDialog.tsx
@@ -12,6 +12,7 @@ import {
   errorMessages,
   formMessages,
   getLocalizedName,
+  uiMessages,
 } from "@gc-digital-talent/i18n";
 
 import {
@@ -143,6 +144,9 @@ const AddTeamRoleDialog = ({
                 <Select
                   id="team"
                   name="team"
+                  nullSelection={intl.formatMessage(
+                    uiMessages.nullSelectionOption,
+                  )}
                   label={intl.formatMessage({
                     defaultMessage: "Team",
                     id: "GaMSN8",

--- a/packages/forms/src/components/Select/Select.stories.tsx
+++ b/packages/forms/src/components/Select/Select.stories.tsx
@@ -103,12 +103,6 @@ SelectDefault.args = {
   id: uniqueId(),
   label: "Departments",
   name: "departments",
-  nullSelection: "",
-};
-
-export const SelectWithNullSelection = Template.bind({});
-SelectWithNullSelection.args = {
-  ...SelectDefault.args,
   nullSelection: "Select an option",
 };
 
@@ -117,7 +111,6 @@ SelectWithGroups.args = {
   ...SelectDefault.args,
   label: "Groups",
   name: "groups",
-  nullSelection: "Select an option",
 };
 
 export const SelectRequired = Template.bind({});

--- a/packages/forms/src/components/Select/Select.tsx
+++ b/packages/forms/src/components/Select/Select.tsx
@@ -36,8 +36,8 @@ export type SelectProps = CommonInputProps &
   > & {
     /** List of options and/or optgroups for the select element. */
     options: OptGroupOrOption[];
-    /** Null selection string provides a null value with instructions to user (eg. Select a department...) */
-    nullSelection?: string;
+    /** Null selection string provides a null value with instructions to user (e.g. Select a department) */
+    nullSelection: string;
     /** Determine if it should sort options in alphanumeric ascending order */
     doNotSort?: boolean;
   };
@@ -128,11 +128,9 @@ const Select = ({
         {...register(name, rules)}
         {...rest}
       >
-        {nullSelection && (
-          <option value="" disabled>
-            {nullSelection}
-          </option>
-        )}
+        <option value="" disabled>
+          {nullSelection}
+        </option>
         {optionsModified.map((option) =>
           Object.prototype.hasOwnProperty.call(option, "options") ? (
             <optgroup

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -996,6 +996,10 @@
     "defaultMessage": "Annuler et revenir en arrière",
     "description": "Text to cancel changes to a form"
   },
+  "fUF8rg": {
+    "defaultMessage": "Sélectionnez une option",
+    "description": "Null selection for select input"
+  },
   "g08hvq": {
     "defaultMessage": "Étape 1",
     "description": "Breadcrumb back to review application page."

--- a/packages/i18n/src/messages/uiMessages.ts
+++ b/packages/i18n/src/messages/uiMessages.ts
@@ -100,6 +100,11 @@ const uiMessages = defineMessages({
     id: "rnZULP",
     description: "Button text to truncate text to view fewer characters",
   },
+  nullSelectionOption: {
+    defaultMessage: "Select an option",
+    id: "fUF8rg",
+    description: "Null selection for select input",
+  },
 });
 
 export default uiMessages;


### PR DESCRIPTION
🤖 Resolves #6417.

## 👋 Introduction

This PR makes the `nullSelection` prop required on the `Select` component and adds a null selection for select input message for re-use.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Test all components changed in a04c0288c7fd248e292f999bd3e512a8a888b1ee to make sure they function as they did before but with a `disabled` option.

## 📸 Screenshot

![Screen Shot 2023-07-26 at 10 54 27](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/08d7d207-38dd-4b65-8129-660686767b47)

## 🎩 Gratitude

@esizer, 🙇 