### PR TITLE
[Fix] Fix eslint no-unused-modules path for `apps/web`

### DIFF
--- a/apps/web/.eslintrc.js
+++ b/apps/web/.eslintrc.js
@@ -1,9 +1,11 @@
+const path = require('path');
+
 module.exports = {
   root: true,
   extends: ["custom"],
   rules: {
     // Ignore stories for unused modules
-    "import/no-unused-modules": [1, { unusedExports: true, ignoreExports: ["src/**/*.stories.{ts,tsx}"] }],
+    "import/no-unused-modules": [1, { unusedExports: true, ignoreExports: [path.join(__dirname, "./src/**/*.stories.{ts,tsx}")] }],
   },
   settings: {
     "import/resolver": {


### PR DESCRIPTION
🤖 Resolves #7436

## 👋 Introduction

Fixes a bug with the path resolution for vscode eslint server.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run lint, confirm it works
2. Confirm VSCode highlights linting errors and can fix them