### PR TITLE
[Bug] Adds i18n for salary range

### DIFF
--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1,4 +1,8 @@
 {
+  "+5tH6F": {
+    "defaultMessage": "90 000 $ - 99 000 $",
+    "description": "Salary category for between 90,000 and 99,000"
+  },
   "+6TuVe": {
     "defaultMessage": "Désélectionner {label}",
     "description": "Text to uncheck checkbox button"
@@ -289,6 +293,10 @@
     "defaultMessage": "Évaluation en cours",
     "description": "Status for an application that where applicant is being assessed"
   },
+  "9V/aG1": {
+    "defaultMessage": "80 000 $ - 89 000 $",
+    "description": "Salary category for between 80,000 and 89,000"
+  },
   "9ZyJZq": {
     "defaultMessage": "cela m'oblige à me déplacer.",
     "description": "The operational requirement described as travel as required."
@@ -332,6 +340,10 @@
   "AvBSV+": {
     "defaultMessage": "Oh non... ",
     "description": "Title displayed for a table error loading state."
+  },
+  "B33R8u": {
+    "defaultMessage": "70 000 $ - 79 000 $",
+    "description": "Salary category for between 70,000 and 79,000"
   },
   "BnnVAv": {
     "defaultMessage": "Permis de conduire",
@@ -392,6 +404,10 @@
   "FvV+QW": {
     "defaultMessage": "Renseignements gouvernementaux",
     "description": "Name of Government information page"
+  },
+  "GHgubE": {
+    "defaultMessage": "100 000 $ +",
+    "description": "Salary category for 100,000 or more"
   },
   "GIC6EK": {
     "defaultMessage": "Expiré",
@@ -603,6 +619,10 @@
   "PMwqcS": {
     "defaultMessage": "La date doit être avant ou égale au {date}",
     "description": "Error message when a date was entered that is greater than the maximum required"
+  },
+  "PWGNQ2": {
+    "defaultMessage": "50 000 $ - 59 000 $",
+    "description": "Salary category for between 50,000 and 59,000"
   },
   "PxUSSH": {
     "defaultMessage": "Mon statut",
@@ -1151,6 +1171,10 @@
   "mDOWWQ": {
     "defaultMessage": "Soumission",
     "description": "Default text for submitting button."
+  },
+  "mHdQ1A": {
+    "defaultMessage": "60 000 $ - 69 000 $",
+    "description": "Salary category for between 60,000 and 69,000"
   },
   "mLwm2+": {
     "defaultMessage": "Yukon",

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -128,16 +128,40 @@ export const getLanguageProficiency = (
     `Invalid skill level '${languageProf}'`,
   );
 
-const salaryRanges = {
-  [SalaryRange["50_59K"]]: "$50,000 - $59,000",
-  [SalaryRange["60_69K"]]: "$60,000 - $69,000",
-  [SalaryRange["70_79K"]]: "$70,000 - $79,000",
-  [SalaryRange["80_89K"]]: "$80,000 - $89,000",
-  [SalaryRange["90_99K"]]: "$90,000 - $99,000",
-  [SalaryRange["100KPlus"]]: "$100,000 - plus",
-};
+const salaryRanges = defineMessages({
+  [SalaryRange["50_59K"]]: {
+    defaultMessage: "$50,000 - $59,000",
+    id: "PWGNQ2",
+    description: "Salary category for between 50,000 and 59,000",
+  },
+  [SalaryRange["60_69K"]]: {
+    defaultMessage: "$60,000 - $69,000",
+    id: "mHdQ1A",
+    description: "Salary category for between 60,000 and 69,000",
+  },
+  [SalaryRange["70_79K"]]: {
+    defaultMessage: "$70,000 - $79,000",
+    id: "B33R8u",
+    description: "Salary category for between 70,000 and 79,000",
+  },
+  [SalaryRange["80_89K"]]: {
+    defaultMessage: "$80,000 - $89,000",
+    id: "9V/aG1",
+    description: "Salary category for between 80,000 and 89,000",
+  },
+  [SalaryRange["90_99K"]]: {
+    defaultMessage: "$90,000 - $99,000",
+    id: "+5tH6F",
+    description: "Salary category for between 90,000 and 99,000",
+  },
+  [SalaryRange["100KPlus"]]: {
+    defaultMessage: "$100,000 +",
+    id: "GHgubE",
+    description: "Salary category for 100,000 or more",
+  },
+});
 
-export const getSalaryRange = (salaryId: string | number): string =>
+export const getSalaryRange = (salaryId: string | number): MessageDescriptor =>
   getOrThrowError(salaryRanges, salaryId, `Invalid Salary Range '${salaryId}'`);
 
 const languages = defineMessages({


### PR DESCRIPTION
🤖 Resolves #7396.

## 👋 Introduction

This PR adds i18n for salary range strings.

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run intl-compile`
2. `npm run storybook`
3. Navigate to `IndividualPoolCard`
4. Observe second card **Salary range**
5. Switch locale to FR
6. Observe second card **Échelle salariale** is different than English

## 📸 Screen recording

https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/fc8c71b7-9e77-4e36-9130-2bc9d3882ee9
