### PR TITLE
[Feature] Snapshot test

### DIFF
--- a/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
@@ -95,8 +95,15 @@ query getProfile($userId: UUID!) {
       status
       expiryDate
       signature
+      archivedAt
+      submittedAt
+      suspendedAt
+      user {
+        id
+      }
       pool {
         id
+        closingDate
         name {
           en
           fr
@@ -106,6 +113,20 @@ query getProfile($userId: UUID!) {
           id
           group
           level
+          name {
+            en
+            fr
+          }
+          genericJobTitles {
+            id
+            key
+            name {
+              en
+              fr
+            }
+          }
+          minSalary
+          maxSalary
         }
       }
       educationRequirementOption
@@ -131,11 +152,23 @@ query getProfile($userId: UUID!) {
 fragment experience on Experience {
   id
   __typename
+  user {
+    id
+    email
+  }
   details
   skills {
     id
     key
     name {
+      en
+      fr
+    }
+    description {
+      en
+      fr
+    }
+    keywords {
       en
       fr
     }

--- a/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
@@ -87,7 +87,7 @@ query getProfile($userId: UUID!) {
       }
     }
     experiences {
-      ...experience
+      ...profileExperience
     }
     isProfileComplete
     poolCandidates {
@@ -131,7 +131,7 @@ query getProfile($userId: UUID!) {
       }
       educationRequirementOption
       educationRequirementExperiences {
-        ...experience
+        ...profileExperience
       }
       screeningQuestionResponses {
         id
@@ -149,7 +149,7 @@ query getProfile($userId: UUID!) {
   }
 }
 
-fragment experience on Experience {
+fragment profileExperience on Experience {
   id
   __typename
   user {

--- a/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
@@ -98,9 +98,6 @@ query getProfile($userId: UUID!) {
       archivedAt
       submittedAt
       suspendedAt
-      user {
-        id
-      }
       pool {
         id
         closingDate
@@ -152,10 +149,6 @@ query getProfile($userId: UUID!) {
 fragment profileExperience on Experience {
   id
   __typename
-  user {
-    id
-    email
-  }
   details
   skills {
     id

--- a/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
@@ -9,9 +9,9 @@ query getProfile($userId: UUID!) {
     email
     telephone
     preferredLang
-    currentProvince
     preferredLanguageForInterview
     preferredLanguageForExam
+    currentProvince
     currentCity
     citizenship
     armedForcesStatus
@@ -75,9 +75,6 @@ query getProfile($userId: UUID!) {
       level
     }
     positionDuration
-    experiences {
-      ...experience
-    }
     userSkills {
       id
       skill {
@@ -89,7 +86,12 @@ query getProfile($userId: UUID!) {
         }
       }
     }
+    experiences {
+      ...experience
+    }
+    isProfileComplete
     poolCandidates {
+      id
       status
       expiryDate
       signature
@@ -106,7 +108,6 @@ query getProfile($userId: UUID!) {
           level
         }
       }
-      id
       educationRequirementOption
       educationRequirementExperiences {
         ...experience
@@ -124,13 +125,12 @@ query getProfile($userId: UUID!) {
         }
       }
     }
-    isProfileComplete
   }
 }
 
 fragment experience on Experience {
-  __typename
   id
+  __typename
   details
   skills {
     id

--- a/api/app/Http/Resources/PoolCandidateResource.php
+++ b/api/app/Http/Resources/PoolCandidateResource.php
@@ -35,7 +35,10 @@ class PoolCandidateResource extends JsonResource
             'educationRequirementOption' => $this->education_requirement_option,
             'educationRequirementExperiences' => $collection,
             'signature' => $this->signature,
-            'screeningQuestionResponses' => ScreeningQuestionResponseResource::collection($this->screeningQuestionResponses)
+            'screeningQuestionResponses' => ScreeningQuestionResponseResource::collection($this->screeningQuestionResponses),
+            'archivedAt' => $this->archived_at,
+            'submittedAt' => $this->submitted_at,
+            'suspendedAt' => $this->suspended_at,
         ];
     }
 }

--- a/api/app/Http/Resources/PoolResource.php
+++ b/api/app/Http/Resources/PoolResource.php
@@ -18,7 +18,8 @@ class PoolResource extends JsonResource
             'id' => $this->id,
             'name' => $this->name,
             'stream' => $this->stream,
-            'classifications' => ClassificationResource::collection($this->classifications)
+            'classifications' => ClassificationResource::collection($this->classifications),
+            'closingDate' => $this->closing_date,
         ];
     }
 }

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -181,7 +181,7 @@ class SnapshotTest extends TestCase
         $backendQueryNormalized = SnapshotTest::normalizeQueryLines($backendQuery);
         $frontendQueryNormalized = SnapshotTest::normalizeQueryLines($frontendQuery);
 
-        for ($i = 0; $i < min([count($backendQueryNormalized), count($frontendQueryNormalized)]) + 1; $i++) {
+        for ($i = 0; $i < min([count($backendQueryNormalized), count($frontendQueryNormalized)]); $i++) {
             $backendLine = $backendQueryNormalized[$i];
             $frontendLine = $frontendQueryNormalized[$i];
 

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -18,6 +18,9 @@ use Illuminate\Foundation\Testing\WithFaker;
 
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertNotNull;
+use function PHPUnit\Framework\assertSame;
+use function PHPUnit\Framework\assertSameSize;
+
 use Faker;
 
 class SnapshotTest extends TestCase
@@ -149,5 +152,48 @@ class SnapshotTest extends TestCase
         $intersectedArray = array_intersect($unusedSkillIds, $snapshotSkillIds);
         $intersectedArrayLength = count($intersectedArray);
         assertEquals($intersectedArrayLength, 0);
+    }
+
+    // a cleanup routine to make the lines of query easier to diff
+    private static function normalizeQueryLines(array $lines)
+    {
+        foreach ($lines as &$line) {
+            // remove comments
+            $pos = strpos($line, '#');
+            if ($pos !== false) {
+                $line = substr($line, 0, $pos);
+            }
+            // trim whitespace
+            $line = trim($line);
+        }
+
+        // remove empty lines
+        $arrayWithoutEmptyLines = array_filter($lines, fn ($line) => !empty($line));
+
+        return array_values($arrayWithoutEmptyLines);
+    }
+
+    public function testSnapshotQueryInSync()
+    {
+        $backendQuery = file(base_path('app/GraphQL/Mutations/PoolCandidateSnapshot.graphql'), FILE_IGNORE_NEW_LINES);
+        $frontendQuery = file(base_path('../apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql'), FILE_IGNORE_NEW_LINES);
+
+        $backendQueryNormalized = SnapshotTest::normalizeQueryLines($backendQuery);
+        $frontendQueryNormalized = SnapshotTest::normalizeQueryLines($frontendQuery);
+
+        for ($i = 0; $i < min([count($backendQueryNormalized), count($frontendQueryNormalized)]) + 1; $i++) {
+            $backendLine = $backendQueryNormalized[$i];
+            $frontendLine = $frontendQueryNormalized[$i];
+
+            // some expected diffs
+            if ($i == 0 && $backendLine == 'query getProfile($userId: UUID!) {' && $frontendLine == 'query getMe {')
+                continue;
+            if ($i == 1 && $backendLine == 'user(id: $userId) {' && $frontendLine == 'me {')
+                continue;
+
+            assertSame($backendLine, $frontendLine, 'Mismatch on line ' . $i + 1 . '.');
+        }
+
+        assertSameSize($backendQueryNormalized, $frontendQueryNormalized, 'The queries should have the same number of lines.');
     }
 }

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -154,7 +154,7 @@ class SnapshotTest extends TestCase
         assertEquals($intersectedArrayLength, 0);
     }
 
-    // a cleanup routine to make the lines of query easier to diff
+    // a cleanup routine to make the lines of a query easier to diff
     private static function normalizeQueryLines(array $lines)
     {
         foreach ($lines as &$line) {
@@ -172,7 +172,16 @@ class SnapshotTest extends TestCase
 
         return array_values($arrayWithoutEmptyLines);
     }
-
+    /**
+     * A test to ensure that that the query used in PHP to make profile snapshots matches the query
+     * used to display live snapshots.  The two queries need to stay in sync to ensure the snapshots
+     * remain accurate.
+     *
+     * It's unusual for a PHPUnit test to touch files outside of the project directory but I think
+     * it makes sense for this test.
+     *
+     * @return void
+     */
     public function testSnapshotQueryInSync()
     {
         $backendQuery = file(base_path('app/GraphQL/Mutations/PoolCandidateSnapshot.graphql'), FILE_IGNORE_NEW_LINES);

--- a/apps/web/src/pages/Profile/ProfilePage/ProfilePage.stories.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/ProfilePage.stories.tsx
@@ -2,13 +2,12 @@ import React from "react";
 import { Meta, StoryFn } from "@storybook/react";
 
 import { fakeUsers, fakeExperiences } from "@gc-digital-talent/fake-data";
-import { GetMeQuery } from "@gc-digital-talent/graphql";
 
 import { JobLookingStatus } from "~/api/generated";
 
 import ProfilePage, { ProfileForm, ProfilePageProps } from "./ProfilePage";
 
-const fakeUserData: ProfilePageProps["user"] = fakeUsers(1)[0];
+const fakeUserData = fakeUsers(1)[0];
 const fakeExperienceArray = fakeExperiences(3);
 
 export default {

--- a/apps/web/src/pages/Profile/ProfilePage/ProfilePage.stories.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/ProfilePage.stories.tsx
@@ -2,12 +2,13 @@ import React from "react";
 import { Meta, StoryFn } from "@storybook/react";
 
 import { fakeUsers, fakeExperiences } from "@gc-digital-talent/fake-data";
+import { GetMeQuery } from "@gc-digital-talent/graphql";
 
 import { JobLookingStatus } from "~/api/generated";
 
 import ProfilePage, { ProfileForm, ProfilePageProps } from "./ProfilePage";
 
-const fakeUserData = fakeUsers(1)[0];
+const fakeUserData: ProfilePageProps["user"] = fakeUsers(1)[0];
 const fakeExperienceArray = fakeExperiences(3);
 
 export default {

--- a/apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql
+++ b/apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql
@@ -87,68 +87,7 @@ query getMe {
       }
     }
     experiences {
-      id
-      __typename
-      user {
-        id
-        email
-      }
-      details
-      skills {
-        id
-        key
-        name {
-          en
-          fr
-        }
-        description {
-          en
-          fr
-        }
-        keywords {
-          en
-          fr
-        }
-        experienceSkillRecord {
-          details
-        }
-      }
-      ... on AwardExperience {
-        title
-        issuedBy
-        awardedDate
-        awardedTo
-        awardedScope
-      }
-      ... on CommunityExperience {
-        title
-        organization
-        project
-        startDate
-        endDate
-      }
-      ... on EducationExperience {
-        institution
-        areaOfStudy
-        thesisTitle
-        startDate
-        endDate
-        type
-        status
-      }
-      ... on PersonalExperience {
-        title
-        description
-        startDate
-        endDate
-      }
-      ... on WorkExperience {
-        role
-        organization
-        division
-        startDate
-        endDate
-      }
+      ...experience
     }
     isProfileComplete
     poolCandidates {
@@ -189,5 +128,70 @@ query getMe {
         }
       }
     }
+  }
+}
+
+fragment experience on Experience {
+  id
+  __typename
+  user {
+    id
+    email
+  }
+  details
+  skills {
+    id
+    key
+    name {
+      en
+      fr
+    }
+    description {
+      en
+      fr
+    }
+    keywords {
+      en
+      fr
+    }
+    experienceSkillRecord {
+      details
+    }
+  }
+  ... on AwardExperience {
+    title
+    issuedBy
+    awardedDate
+    awardedTo
+    awardedScope
+  }
+  ... on CommunityExperience {
+    title
+    organization
+    project
+    startDate
+    endDate
+  }
+  ... on EducationExperience {
+    institution
+    areaOfStudy
+    thesisTitle
+    startDate
+    endDate
+    type
+    status
+  }
+  ... on PersonalExperience {
+    title
+    description
+    startDate
+    endDate
+  }
+  ... on WorkExperience {
+    role
+    organization
+    division
+    startDate
+    endDate
   }
 }

--- a/apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql
+++ b/apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql
@@ -93,6 +93,8 @@ query getMe {
     poolCandidates {
       id
       status
+      expiryDate
+      signature
       archivedAt
       submittedAt
       suspendedAt
@@ -125,6 +127,22 @@ query getMe {
           }
           minSalary
           maxSalary
+        }
+      }
+      educationRequirementOption
+      educationRequirementExperiences {
+        ...experience
+      }
+      screeningQuestionResponses {
+        id
+        answer
+        screeningQuestion {
+          id
+          sortOrder
+          question {
+            en
+            fr
+          }
         }
       }
     }

--- a/apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql
+++ b/apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql
@@ -87,7 +87,7 @@ query getMe {
       }
     }
     experiences {
-      ...experience
+      ...profileExperience
     }
     isProfileComplete
     poolCandidates {
@@ -131,7 +131,7 @@ query getMe {
       }
       educationRequirementOption
       educationRequirementExperiences {
-        ...experience
+        ...profileExperience
       }
       screeningQuestionResponses {
         id
@@ -149,7 +149,7 @@ query getMe {
   }
 }
 
-fragment experience on Experience {
+fragment profileExperience on Experience {
   id
   __typename
   user {

--- a/apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql
+++ b/apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql
@@ -98,9 +98,6 @@ query getMe {
       archivedAt
       submittedAt
       suspendedAt
-      user {
-        id
-      }
       pool {
         id
         closingDate
@@ -152,10 +149,6 @@ query getMe {
 fragment profileExperience on Experience {
   id
   __typename
-  user {
-    id
-    email
-  }
   details
   skills {
     id

--- a/apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql
+++ b/apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql
@@ -1,3 +1,5 @@
+# Comes from apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql
+# Should match the getMe query from that file to take accurate snapshots
 query getMe {
   me {
     id

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplicationsCard.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplicationsCard.tsx
@@ -20,7 +20,10 @@ import { useAuthorization } from "@gc-digital-talent/auth";
 import { commonMessages } from "@gc-digital-talent/i18n";
 import { getApplicationDateInfo } from "./utils";
 
-type Application = Omit<PoolCandidate, "user">;
+type Application = Omit<
+  PoolCandidate,
+  "user" | "educationRequirementExperiences"
+>;
 
 export interface TrackApplicationsCardProps {
   application: Application;

--- a/packages/fake-data/src/fakePoolCandidateTypes.ts
+++ b/packages/fake-data/src/fakePoolCandidateTypes.ts
@@ -1,0 +1,19 @@
+import { PoolCandidate } from "@gc-digital-talent/graphql";
+import {
+  GeneratedAwardExperience,
+  GeneratedCommunityExperience,
+  GeneratedEducationExperience,
+  GeneratedPersonalExperience,
+  GeneratedWorkExperience,
+} from "./fakeExperiences";
+
+export type GeneratedPoolCandidate = PoolCandidate & {
+  __typename: "PoolCandidate";
+  educationRequirementExperiences: Array<
+    | GeneratedAwardExperience
+    | GeneratedCommunityExperience
+    | GeneratedEducationExperience
+    | GeneratedPersonalExperience
+    | GeneratedWorkExperience
+  >;
+};

--- a/packages/fake-data/src/fakePoolCandidates.ts
+++ b/packages/fake-data/src/fakePoolCandidates.ts
@@ -10,9 +10,26 @@ import {
   Pool,
   User,
 } from "@gc-digital-talent/graphql";
-
+import {
+  GeneratedAwardExperience,
+  GeneratedCommunityExperience,
+  GeneratedEducationExperience,
+  GeneratedPersonalExperience,
+  GeneratedWorkExperience,
+} from "./fakeExperiences";
 import fakePools from "./fakePools";
 import fakeUsers from "./fakeUsers";
+
+export type GeneratedPoolCandidate = PoolCandidate & {
+  __typename: "PoolCandidate";
+  educationRequirementExperiences: Array<
+    | GeneratedAwardExperience
+    | GeneratedCommunityExperience
+    | GeneratedEducationExperience
+    | GeneratedPersonalExperience
+    | GeneratedWorkExperience
+  >;
+};
 
 const generatePoolCandidate = (pools: Pool[], users: User[]): PoolCandidate => {
   faker.setLocale("en");

--- a/packages/fake-data/src/fakePoolCandidates.ts
+++ b/packages/fake-data/src/fakePoolCandidates.ts
@@ -10,26 +10,8 @@ import {
   Pool,
   User,
 } from "@gc-digital-talent/graphql";
-import {
-  GeneratedAwardExperience,
-  GeneratedCommunityExperience,
-  GeneratedEducationExperience,
-  GeneratedPersonalExperience,
-  GeneratedWorkExperience,
-} from "./fakeExperiences";
 import fakePools from "./fakePools";
 import fakeUsers from "./fakeUsers";
-
-export type GeneratedPoolCandidate = PoolCandidate & {
-  __typename: "PoolCandidate";
-  educationRequirementExperiences: Array<
-    | GeneratedAwardExperience
-    | GeneratedCommunityExperience
-    | GeneratedEducationExperience
-    | GeneratedPersonalExperience
-    | GeneratedWorkExperience
-  >;
-};
 
 const generatePoolCandidate = (pools: Pool[], users: User[]): PoolCandidate => {
   faker.setLocale("en");

--- a/packages/fake-data/src/fakeUsers.ts
+++ b/packages/fake-data/src/fakeUsers.ts
@@ -12,7 +12,6 @@ import {
   OperationalRequirement,
   JobLookingStatus,
   Pool,
-  PoolCandidate,
   WorkRegion,
   SalaryRange,
   GovEmployeeType,
@@ -35,7 +34,7 @@ import {
 import fakeClassifications from "./fakeClassifications";
 import fakeDepartments from "./fakeDepartments";
 import fakeGenericJobTitles from "./fakeGenericJobTitles";
-import { GeneratedPoolCandidate } from "./fakePoolCandidates";
+import { GeneratedPoolCandidate } from "./fakePoolCandidateTypes";
 
 type GeneratedUser = User & {
   __typename: "User";

--- a/packages/fake-data/src/fakeUsers.ts
+++ b/packages/fake-data/src/fakeUsers.ts
@@ -35,6 +35,7 @@ import {
 import fakeClassifications from "./fakeClassifications";
 import fakeDepartments from "./fakeDepartments";
 import fakeGenericJobTitles from "./fakeGenericJobTitles";
+import { GeneratedPoolCandidate } from "./fakePoolCandidates";
 
 type GeneratedUser = User & {
   __typename: "User";
@@ -47,6 +48,7 @@ type GeneratedUser = User & {
       | GeneratedWorkExperience
     >[]
   >;
+  poolCandidates?: Maybe<Array<Maybe<GeneratedPoolCandidate>>>;
 };
 
 const generateUser = (
@@ -60,7 +62,7 @@ const generateUser = (
   personalExperiences: GeneratedPersonalExperience[], // Experiences belonging to this user
   workExperiences: GeneratedWorkExperience[], // Experiences belonging to this user
 
-  poolCandidates: PoolCandidate[] = [], // poolCandidates associating this user with a pool
+  poolCandidates: GeneratedPoolCandidate[] = [], // poolCandidates associating this user with a pool
   pools: Pool[] = [], // pools owned by this user
 ): GeneratedUser => {
   faker.setLocale("en");


### PR DESCRIPTION
🤖 Resolves #7323 

## 👋 Introduction

This branch adds a PHPUnit test to ensure the that the query that makes the profile snapshots stays in sync with the regular query for displaying the profile.  It also syncs up the existing drift between the two queries by reordering fields and adding any missing between the two.  

I'm doubtful that _everything_ in the queries is necessary ~but I figured removing anything was out of scope for this PR~.  I needed to remove some extra user fields in [remove redundant user fields](https://github.com/GCTC-NTGC/gc-digital-talent/pull/7447/commits/dca71623946f0366ebf2ba6cd40730a695817338) or the JSON would have a loop in it.  I'm not clear when those fields were added or why since it's older than the file history can retrieve.  They seem redundant since `User` is the top-level model of the query.  Nothing seems broken as far as I can see.

There was some gnarly type stuff needed to make Storybook happy.  I _think_ I fixed it correctly.  :crossed_fingers: 

## 🧪 Testing

Rebuild the app before beginning.

- [ ] Nothing removed from either query
- [ ] PHPUnit tests pass
- [ ] Applicant can submit an application which makes a new snapshot
- [ ] Admin can view the snapshot
- [ ] Nothing missing from the snapshot and it matches the user's profile