### PR TITLE
[Fix] Disable `no-unused-modules` rule

### DIFF
--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -62,7 +62,8 @@ module.exports = {
     "consistent-return": "warn",
     "import/no-extraneous-dependencies": "off",
     "import/extensions": ["warn", "never", { json: "always" }],
-    "import/no-unused-modules": [1, { unusedExports: true, ignoreExports: ["src/index.{ts,tsx}"] }],
+    // Note: Re-enable with #7453
+    //"import/no-unused-modules": [1, { unusedExports: true, ignoreExports: ["src/index.{ts,tsx}"] }],
     "react/display-name": "off",
     "react/prop-types": "off",
     "react/jsx-filename-extension": [

--- a/packages/forms/.eslintrc.js
+++ b/packages/forms/.eslintrc.js
@@ -5,7 +5,5 @@ module.exports = {
   rules: {
     // this package does not have a translation script
     "formatjs/blocklist-elements": ["error", ["literal"]],
-    // Ignore stories for unused modules
-    "import/no-unused-modules": [1, { unusedExports: true, ignoreExports: ["src/index.{ts,tsx}", "src/**/*.stories.{ts,tsx}"] }],
   },
 };

--- a/packages/toast/.eslintrc.js
+++ b/packages/toast/.eslintrc.js
@@ -5,7 +5,5 @@ module.exports = {
   rules: {
     // this package does not have a translation script
     "formatjs/blocklist-elements": ["error", ["literal"]],
-    // Ignore stories for unused modules
-    "import/no-unused-modules": [1, { unusedExports: true, ignoreExports: ["src/index.{ts,tsx}", "src/**/*.stories.{ts,tsx}"] }],
   },
 };

--- a/packages/tooling/.eslintrc.js
+++ b/packages/tooling/.eslintrc.js
@@ -5,7 +5,5 @@ module.exports = {
   rules: {
     // this package does not have a translation script
     "formatjs/blocklist-elements": ["error", ["literal"]],
-    // No ignore patterns
-    "import/no-unused-modules": [1, { unusedExports: true }],
   },
 };

--- a/packages/ui/.eslintrc.js
+++ b/packages/ui/.eslintrc.js
@@ -5,7 +5,5 @@ module.exports = {
   rules: {
     // this package does not have a translation script
     "formatjs/blocklist-elements": ["error", ["literal"]],
-    // Ignore stories for unused modules
-    "import/no-unused-modules": [1, { unusedExports: true, ignoreExports: ["src/index.{ts,tsx}", "src/**/*.stories.{ts,tsx}"] }],
   },
 };


### PR DESCRIPTION
🤖 Resolves #7452 

## 👋 Introduction

This disabled the `no-unused-modules` eslint rule in `packages/*`.

## 🕵️ Details

Since we extend a non-conventional rule filename (`index.js`), the rule has an issue with `ignoreExports` config. We have decided to disable this rule temporary until we can fix or work around that breaking issue.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Open a `.tsx` file in `packages/*`
2. Force an eslint error
3. Confirm VSCode flags the error and can fix it (if it is a fixable error)
