### PR TITLE
[Copy] Update language evaluation labels

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/usePoolCandidateCsvData.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/usePoolCandidateCsvData.tsx
@@ -236,25 +236,25 @@ const usePoolCandidateCsvData = (
     {
       key: "comprehensionLevel",
       label: intl.formatMessage({
-        defaultMessage: "Comprehension Level",
-        id: "QIh0q7",
-        description: "CSV Header, Comprehension Level column",
+        defaultMessage: "Reading level",
+        id: "CEFnPm",
+        description: "CSV Header, Reading (comprehension) Level column",
       }),
     },
     {
       key: "writtenLevel",
       label: intl.formatMessage({
-        defaultMessage: "Written Level",
-        id: "w/v77x",
-        description: "CSV Header, Written Level column",
+        defaultMessage: "Writing level",
+        id: "8ea9ne",
+        description: "CSV Header, Writing Level column",
       }),
     },
     {
       key: "verbalLevel",
       label: intl.formatMessage({
-        defaultMessage: "Verbal Level",
-        id: "5R2iR2",
-        description: "CSV Header, Verbal Level column",
+        defaultMessage: "Oral interaction level",
+        id: "5nrkKw",
+        description: "CSV Header, Oral interaction Level column",
       }),
     },
     {

--- a/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
@@ -103,10 +103,10 @@ const Display = ({
         <FieldDisplay
           label={intl.formatMessage({
             defaultMessage:
-              "Second language level (Comprehension, Written, Verbal)",
-            id: "zF0F6w",
+              "Second language level (Reading, Writing, Oral interaction)",
+            id: "PZCSiW",
             description:
-              "Second language level (Comprehension, Written, Verbal) label",
+              "Second language level (Reading, Writing, Oral interaction) label",
           })}
         >
           {comprehensionLevel || writtenLevel || verbalLevel

--- a/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
@@ -103,10 +103,10 @@ const Display = ({
         <FieldDisplay
           label={intl.formatMessage({
             defaultMessage:
-              "Second language level (Reading, Writing, Oral interaction)",
-            id: "PZCSiW",
+              "Second language level (reading, writing, oral interaction)",
+            id: "qOi2J0",
             description:
-              "Second language level (Reading, Writing, Oral interaction) label",
+              "Second language level (reading, writing, oral interaction) label",
           })}
         >
           {comprehensionLevel || writtenLevel || verbalLevel

--- a/apps/web/src/components/Profile/components/LanguageProfile/utils.ts
+++ b/apps/web/src/components/Profile/components/LanguageProfile/utils.ts
@@ -69,22 +69,22 @@ export const getLabels = (intl: IntlShape) => ({
       "Legend bilingual evaluation status in language information form",
   }),
   comprehensionLevel: intl.formatMessage({
-    defaultMessage: "Comprehension",
-    id: "W4Svkd",
+    defaultMessage: "Reading",
+    id: "g8Xd4a",
     description:
-      "Label displayed on the language information form comprehension field.",
+      "Label displayed on the language information form reading comprehension field.",
   }),
   writtenLevel: intl.formatMessage({
-    defaultMessage: "Written",
-    id: "x5C9Ab",
+    defaultMessage: "Writing",
+    id: "mBnz9m",
     description:
       "Label displayed on the language information form written field.",
   }),
   verbalLevel: intl.formatMessage({
-    defaultMessage: "Verbal",
-    id: "rywI3C",
+    defaultMessage: "Oral interaction",
+    id: "mvYSmp",
     description:
-      "Label displayed on the language information form verbal field.",
+      "Label displayed on the language information form oral interaction field.",
   }),
   estimatedLanguageAbility: intl.formatMessage({
     defaultMessage: "Second language proficiency level",

--- a/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
+++ b/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
@@ -313,10 +313,10 @@ const ProfileDocument = React.forwardRef<HTMLDivElement, ProfileDocumentProps>(
                           <p>
                             {intl.formatMessage({
                               defaultMessage:
-                                "Second language level (Comprehension, Written, Verbal)",
-                              id: "M9x5zm",
+                                "Second language level (reading, writing, oral interaction)",
+                              id: "qOi2J0",
                               description:
-                                "Evaluation results for second language, results in that order",
+                                "Second language level (reading, writing, oral interaction) label",
                             })}
                             {intl.formatMessage(commonMessages.dividingColon)}
                             {insertBetween(", ", [

--- a/apps/web/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
+++ b/apps/web/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
@@ -143,11 +143,12 @@ const LanguageInformationSection = ({
               <span data-h2-display="base(block)">
                 {intl.formatMessage({
                   defaultMessage:
-                    "Second language level (Reading, Writing, Oral interaction):",
-                  id: "dTOh1/",
+                    "Second language level (reading, writing, oral interaction)",
+                  id: "qOi2J0",
                   description:
-                    "Evaluation results for second language, results in that order followed by a colon",
+                    "Second language level (reading, writing, oral interaction) label",
                 })}
+                {intl.formatMessage(commonMessages.dividingColon)}
               </span>
               <span data-h2-font-weight="base(700)">
                 {comprehensionLevel}, {writtenLevel}, {verbalLevel}

--- a/apps/web/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
+++ b/apps/web/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
@@ -143,8 +143,8 @@ const LanguageInformationSection = ({
               <span data-h2-display="base(block)">
                 {intl.formatMessage({
                   defaultMessage:
-                    "Second language level (Comprehension, Written, Verbal):",
-                  id: "D7Qb41",
+                    "Second language level (Reading, Writing, Oral interaction):",
+                  id: "dTOh1/",
                   description:
                     "Evaluation results for second language, results in that order followed by a colon",
                 })}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8562,7 +8562,7 @@
     "defaultMessage": "Afficher les évaluations des compétences de {title}",
     "description": "Button text to show a specific qualified recruitment cards's skill assessments"
   },
-  "x5C9Ab": {
+  "mBnz9m": {
     "defaultMessage": "Écriture",
     "description": "Label displayed on the language information form written field."
   },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3880,9 +3880,9 @@
     "defaultMessage": "Compétences essentielles",
     "description": "Title text for group of need-to-have skills for pool advertisement on experience forms"
   },
-  "PZCSiW": {
-    "defaultMessage": "Niveau de connaissance de la langue seconde (Lecture, Écriture, Expression orale)",
-    "description": "Second language level (Reading, Writing, Oral interaction) label"
+  "qOi2J0": {
+    "defaultMessage": "Niveau de connaissance de la langue seconde (lecture, écriture, expression orale)",
+    "description": "Second language level (reading, writing, oral interaction) label"
   },
   "Pasf+O": {
     "defaultMessage": "Les mises à jour de votre profil après l’envoi de votre candidature ne se refléteront pas dans votre dossier de candidature.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3880,10 +3880,6 @@
     "defaultMessage": "Compétences essentielles",
     "description": "Title text for group of need-to-have skills for pool advertisement on experience forms"
   },
-  "qOi2J0": {
-    "defaultMessage": "Niveau de connaissance de la langue seconde (lecture, écriture, expression orale)",
-    "description": "Second language level (reading, writing, oral interaction) label"
-  },
   "Pasf+O": {
     "defaultMessage": "Les mises à jour de votre profil après l’envoi de votre candidature ne se refléteront pas dans votre dossier de candidature.",
     "description": "List item note 2 for the application review page."
@@ -5808,10 +5804,6 @@
     "defaultMessage": "Après avoir ajouté quelques compétences, veuillez expliquer comment vous les avez utilisées, essayez de répondre à une ou plusieurs de ces questions :",
     "description": "Description for skills in detail section of experience form."
   },
-  "dTOh1/": {
-    "defaultMessage": "Niveau de la langue seconde (Lecture, Écriture, Expression orale) :",
-    "description": "Evaluation results for second language, results in that order followed by a colon"
-  },
   "dVc2uY": {
     "defaultMessage": "Les renseignements gouvernementaux ont été mis à jour avec succès!",
     "description": "Message displayed when a user successfully updates their government employee information."
@@ -7691,6 +7683,10 @@
   "qGyD4w": {
     "defaultMessage": "Questions de sélection",
     "description": "Heading for screening questions section of the application review page."
+  },
+  "qOi2J0": {
+    "defaultMessage": "Niveau de connaissance de la langue seconde (lecture, écriture, expression orale)",
+    "description": "Second language level (reading, writing, oral interaction) label"
   },
   "qPxrKm": {
     "defaultMessage": "Modifier ou retirer les permissions d’adhésion.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1082,10 +1082,6 @@
     "defaultMessage": "Sélectionnez un type",
     "description": "Default selection for the experience type field"
   },
-  "5R2iR2": {
-    "defaultMessage": "Niveau verbal",
-    "description": "CSV Header, Verbal Level column"
-  },
   "5SKmte": {
     "defaultMessage": "Modifier<hidden> le regroupement des compétences</hidden>",
     "description": "Breadcrumb title for the edit skill family page link."
@@ -1145,6 +1141,10 @@
   "5nlauT": {
     "defaultMessage": "Question filtre {index} : {question}",
     "description": "CSV Header, Screening question column. "
+  },
+  "5nrkKw": {
+    "defaultMessage": "Niveau d’expression orale",
+    "description": "CSV Header, Oral interaction Level column"
   },
   "5pQfyv": {
     "defaultMessage": "Postes en français",
@@ -1597,6 +1597,10 @@
   "8diKHR": {
     "defaultMessage": "Si vous n’êtes pas sûr(e) d’avoir un compte CléGC existant, rendez-vous sur le site Web et essayez de vous connecter. Si vous ne vous souvenez pas de votre mot de passe, vous pouvez également le réinitialiser à cet endroit.",
     "description": "Instructions on what to do if user doesn't know if they have a GCKey"
+  },
+  "8ea9ne": {
+    "defaultMessage": "Niveau d’écriture",
+    "description": "CSV Header, Writing Level column"
   },
   "8fQWTc": {
     "defaultMessage": "Toute durée (court terme, long terme ou indéterminée) (recommandé)",
@@ -2089,6 +2093,10 @@
   "CDV1Cw": {
     "defaultMessage": "Modifier {experienceName}",
     "description": "Link text to edit a specific experience"
+  },
+  "CEFnPm": {
+    "defaultMessage": "Niveau de lecture",
+    "description": "CSV Header, Reading (comprehension) Level column"
   },
   "CH6FQA": {
     "defaultMessage": "Supprimer la demande<hidden> ({name})</hidden>",
@@ -3975,10 +3983,6 @@
   "QHR5ay": {
     "defaultMessage": "Vous n'avez pas actuellement de bassins de talents dans votre profil.",
     "description": "Message displayed in recruitment availability when the user is not in any valid pools"
-  },
-  "QIh0q7": {
-    "defaultMessage": "Niveau de compréhension",
-    "description": "CSV Header, Comprehension Level column"
   },
   "QJ5uDV": {
     "defaultMessage": "Sélectionnez un volet",
@@ -8401,10 +8405,6 @@
   "w/qZsH": {
     "defaultMessage": "Classification",
     "description": "Label displayed on the pool form classification field."
-  },
-  "w/v77x": {
-    "defaultMessage": "Niveau d’écriture",
-    "description": "CSV Header, Written Level column"
   },
   "w1/0Cd": {
     "defaultMessage": "Diplôme exigé",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4780,9 +4780,9 @@
     "defaultMessage": "Erreur : Échec de la création du bassin",
     "description": "Message displayed to pool after pool fails to get created."
   },
-  "W4Svkd": {
-    "defaultMessage": "Compréhension",
-    "description": "Label displayed on the language information form comprehension field."
+  "g8Xd4a": {
+    "defaultMessage": "Lecture",
+    "description": "Label displayed on the language information form reading comprehension field."
   },
   "W58QTT": {
     "defaultMessage": "Cet utilisateur n'est encore dans aucun bassin",
@@ -7879,9 +7879,9 @@
     "defaultMessage": "Toutes les compétences suivantes sont facultativement avantageuses pour le poste, et le fait de les démontrer pourrait vous être utile lorsque vous êtes pris en considération.",
     "description": "Descriptive text about how optional technical skills are used in the application process"
   },
-  "rywI3C": {
-    "defaultMessage": "Verbal",
-    "description": "Label displayed on the language information form verbal field."
+  "mvYSmp": {
+    "defaultMessage": "Expression orale",
+    "description": "Label displayed on the language information form oral interaction field."
   },
   "rz21yp": {
     "defaultMessage": "Les apprentis auront-ils droit à des prestations?",
@@ -8563,7 +8563,7 @@
     "description": "Button text to show a specific qualified recruitment cards's skill assessments"
   },
   "x5C9Ab": {
-    "defaultMessage": "Écrit",
+    "defaultMessage": "Écriture",
     "description": "Label displayed on the language information form written field."
   },
   "x6saT3": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7412,6 +7412,10 @@
     "defaultMessage": "{skillName} (Essentielles)",
     "description": "CSV Header, Essential skill column."
   },
+  "ntUOoz": {
+    "defaultMessage": "Sélectionnez les postes pour lesquels vous souhaitez postuler",
+    "description": "Legend for considered position languages check list in language information form"
+  },
   "nueuS8": {
     "defaultMessage": "Lieu de travail",
     "description": "Legend for optional work preferences check list in work preferences form"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4780,10 +4780,6 @@
     "defaultMessage": "Erreur : Échec de la création du bassin",
     "description": "Message displayed to pool after pool fails to get created."
   },
-  "g8Xd4a": {
-    "defaultMessage": "Lecture",
-    "description": "Label displayed on the language information form reading comprehension field."
-  },
   "W58QTT": {
     "defaultMessage": "Cet utilisateur n'est encore dans aucun bassin",
     "description": "Message on view-user page that the user is not in any pools"
@@ -6252,6 +6248,10 @@
     "defaultMessage": "Collectivité des gestionnaires.",
     "description": "Heading for the Managers community page"
   },
+  "g8Xd4a": {
+    "defaultMessage": "Lecture",
+    "description": "Label displayed on the language information form reading comprehension field."
+  },
   "gBAz/G": {
     "defaultMessage": "Identification de la demande copiée",
     "description": "Button text to indicate that a specific application’s ID has been copied"
@@ -7144,6 +7144,10 @@
     "defaultMessage": "Apprendre quoi faire si vous ne trouvez pas une compétence",
     "description": "Button text to show help information about skills"
   },
+  "mBnz9m": {
+    "defaultMessage": "Écriture",
+    "description": "Label displayed on the language information form written field."
+  },
   "mDowK/": {
     "defaultMessage": "Représentée par les expériences suivantes :",
     "description": "Lead in text for experiences that represent the users skills"
@@ -7284,6 +7288,10 @@
     "defaultMessage": "Vous avez acquis de l’expérience en faisant partie d’une communauté ou en lui donnant en retour? Les gens acquièrent des compétences à partir d’un large éventail d’expériences, comme le bénévolat ou la participation à des organisations sans but lucratif, à des communautés autochtones ou à des collaborations virtuelles. Il peut s’agir d’aider lors d’événements et de cérémonies, de faire le disc-jockey au mariage d’un ami, de jouer et de faire de la diffusion en continu.",
     "description": "Description for community experience section"
   },
+  "mvYSmp": {
+    "defaultMessage": "Expression orale",
+    "description": "Label displayed on the language information form oral interaction field."
+  },
   "mxOuYK": {
     "defaultMessage": "Télécharger CSV",
     "description": "Text label for button to download a csv file of items in a table."
@@ -7399,10 +7407,6 @@
   "nsm/uC": {
     "defaultMessage": "{skillName} (Essentielles)",
     "description": "CSV Header, Essential skill column."
-  },
-  "ntUOoz": {
-    "defaultMessage": "Sélectionnez les postes pour lesquels vous souhaitez postuler",
-    "description": "Legend for considered position languages check list in language information form"
   },
   "nueuS8": {
     "defaultMessage": "Lieu de travail",
@@ -7878,10 +7882,6 @@
   "ry5NUs": {
     "defaultMessage": "Toutes les compétences suivantes sont facultativement avantageuses pour le poste, et le fait de les démontrer pourrait vous être utile lorsque vous êtes pris en considération.",
     "description": "Descriptive text about how optional technical skills are used in the application process"
-  },
-  "mvYSmp": {
-    "defaultMessage": "Expression orale",
-    "description": "Label displayed on the language information form oral interaction field."
   },
   "rz21yp": {
     "defaultMessage": "Les apprentis auront-ils droit à des prestations?",
@@ -8561,10 +8561,6 @@
   "x2/qvf": {
     "defaultMessage": "Afficher les évaluations des compétences de {title}",
     "description": "Button text to show a specific qualified recruitment cards's skill assessments"
-  },
-  "mBnz9m": {
-    "defaultMessage": "Écriture",
-    "description": "Label displayed on the language information form written field."
   },
   "x6saT3": {
     "defaultMessage": "Avant de vous amener à votre profil, nous devons recueillir les renseignements nécessaires pour compléter la configuration de votre compte.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3409,10 +3409,6 @@
     "defaultMessage": "Évaluation bilingue",
     "description": "CSV Header, Bilingual Evaluation column"
   },
-  "M9x5zm": {
-    "defaultMessage": "Niveau de la langue seconde (compréhension, écrite, verbale)",
-    "description": "Evaluation results for second language, results in that order"
-  },
   "MCFcrj": {
     "defaultMessage": "Un groupe diversifié de personnes, représentant toutes les races, tous les genres et toutes les origines, réunies dans l'unité. Tout le monde est le bienvenu ici!",
     "description": "Hero image alt text."

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2226,10 +2226,6 @@
     "defaultMessage": "Modifier",
     "description": "Title displayed for the Classification table Edit column."
   },
-  "D7Qb41": {
-    "defaultMessage": "Niveau de la langue seconde (compréhension, écrite, verbale) :",
-    "description": "Evaluation results for second language, results in that order followed by a colon"
-  },
   "D8Pgbs": {
     "defaultMessage": "Créer une classification",
     "description": "Title displayed on the create a classification form."
@@ -3883,6 +3879,10 @@
   "PXlO7h": {
     "defaultMessage": "Compétences essentielles",
     "description": "Title text for group of need-to-have skills for pool advertisement on experience forms"
+  },
+  "PZCSiW": {
+    "defaultMessage": "Niveau de connaissance de la langue seconde (Lecture, Écriture, Expression orale)",
+    "description": "Second language level (Reading, Writing, Oral interaction) label"
   },
   "Pasf+O": {
     "defaultMessage": "Les mises à jour de votre profil après l’envoi de votre candidature ne se refléteront pas dans votre dossier de candidature.",
@@ -5807,6 +5807,10 @@
   "dTMBj9": {
     "defaultMessage": "Après avoir ajouté quelques compétences, veuillez expliquer comment vous les avez utilisées, essayez de répondre à une ou plusieurs de ces questions :",
     "description": "Description for skills in detail section of experience form."
+  },
+  "dTOh1/": {
+    "defaultMessage": "Niveau de la langue seconde (Lecture, Écriture, Expression orale) :",
+    "description": "Evaluation results for second language, results in that order followed by a colon"
   },
   "dVc2uY": {
     "defaultMessage": "Les renseignements gouvernementaux ont été mis à jour avec succès!",
@@ -8829,10 +8833,6 @@
   "zEmPCS": {
     "defaultMessage": "Modifier les renseignements sur l’équipe",
     "description": "Page title for the edit team page"
-  },
-  "zF0F6w": {
-    "defaultMessage": "Niveau de connaissance de la langue seconde (compréhension, écrit, oral.)",
-    "description": "Second language level (Comprehension, Written, Verbal) label"
   },
   "zJKngJ": {
     "defaultMessage": "Gérer votre expérience et les processus de recrutement pour lesquels vous êtes qualifié(e).",

--- a/apps/web/src/lang/whitelist.yml
+++ b/apps/web/src/lang/whitelist.yml
@@ -1,4 +1,3 @@
-- rywI3C # Verbal (Label displayed on the language information form verbal field.)
 - 3oW16P # 'Signature' label for the signature input on the self-declaration form
 - 1ZZgbi # 'Signature' Heading for application snapshot signature
 - BIgaKT # 'Métis' Trigger text for Métis tab

--- a/apps/web/src/pages/Profile/LanguageInfoPage/components/LanguageInformationForm/LanguageInformationForm.tsx
+++ b/apps/web/src/pages/Profile/LanguageInfoPage/components/LanguageInformationForm/LanguageInformationForm.tsx
@@ -26,6 +26,7 @@ import ProfileFormWrapper, {
 } from "~/components/ProfileFormWrapper/ProfileFormWrapper";
 import { getMissingLanguageRequirements } from "~/utils/languageUtils";
 import MissingLanguageRequirements from "~/components/MissingLanguageRequirements";
+import { getLabels as getLanguageProfileLabels } from "~/components/Profile/components/LanguageProfile/utils";
 
 import ConsideredLanguages from "../ConsideredLanguages";
 
@@ -110,45 +111,7 @@ const LanguageInformationForm = ({
   const paths = useRoutes();
   const { id: applicationId, returnRoute } = useApplicationInfo(initialData.id);
 
-  const labels = {
-    consideredPositionLanguages: intl.formatMessage({
-      defaultMessage:
-        "Select the positions you would like to be considered for",
-      id: "ntUOoz",
-      description:
-        "Legend for considered position languages check list in language information form",
-    }),
-    bilingualEvaluation: intl.formatMessage({
-      defaultMessage: "Bilingual evaluation",
-      id: "X354at",
-      description:
-        "Legend bilingual evaluation status in language information form",
-    }),
-    comprehensionLevel: intl.formatMessage({
-      defaultMessage: "Comprehension",
-      id: "W4Svkd",
-      description:
-        "Label displayed on the language information form comprehension field.",
-    }),
-    writtenLevel: intl.formatMessage({
-      defaultMessage: "Written",
-      id: "x5C9Ab",
-      description:
-        "Label displayed on the language information form written field.",
-    }),
-    verbalLevel: intl.formatMessage({
-      defaultMessage: "Verbal",
-      id: "rywI3C",
-      description:
-        "Label displayed on the language information form verbal field.",
-    }),
-    estimatedLanguageAbility: intl.formatMessage({
-      defaultMessage: "Second language proficiency level",
-      id: "T1TKNL",
-      description:
-        "Legend for second language proficiency level in language information form",
-    }),
-  };
+  const labels = getLanguageProfileLabels(intl);
 
   const handleSubmit: SubmitHandler<FormValues> = async (formValues) => {
     return submitHandler(initialData.id, formValuesToSubmitData(formValues))

--- a/apps/web/src/pages/Profile/LanguageInfoPage/components/LanguageInformationForm/LanguageInformationForm.tsx
+++ b/apps/web/src/pages/Profile/LanguageInfoPage/components/LanguageInformationForm/LanguageInformationForm.tsx
@@ -112,6 +112,13 @@ const LanguageInformationForm = ({
   const { id: applicationId, returnRoute } = useApplicationInfo(initialData.id);
 
   const labels = getLanguageProfileLabels(intl);
+  // of the group, one message is slightly different in this component's context
+  labels.consideredPositionLanguages = intl.formatMessage({
+    defaultMessage: "Select the positions you would like to be considered for",
+    id: "ntUOoz",
+    description:
+      "Legend for considered position languages check list in language information form",
+  });
 
   const handleSubmit: SubmitHandler<FormValues> = async (formValues) => {
     return submitHandler(initialData.id, formValuesToSubmitData(formValues))

--- a/apps/web/src/pages/Users/IndexUserPage/hooks/useUserCsvData.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/hooks/useUserCsvData.tsx
@@ -80,25 +80,25 @@ const useUserCsvData = (users: User[]) => {
     {
       key: "comprehensionLevel",
       label: intl.formatMessage({
-        defaultMessage: "Comprehension Level",
-        id: "QIh0q7",
-        description: "CSV Header, Comprehension Level column",
+        defaultMessage: "Reading level",
+        id: "CEFnPm",
+        description: "CSV Header, Reading (comprehension) Level column",
       }),
     },
     {
       key: "writtenLevel",
       label: intl.formatMessage({
-        defaultMessage: "Written Level",
-        id: "w/v77x",
-        description: "CSV Header, Written Level column",
+        defaultMessage: "Writing level",
+        id: "8ea9ne",
+        description: "CSV Header, Writing Level column",
       }),
     },
     {
       key: "verbalLevel",
       label: intl.formatMessage({
-        defaultMessage: "Verbal Level",
-        id: "5R2iR2",
-        description: "CSV Header, Verbal Level column",
+        defaultMessage: "Oral interaction level",
+        id: "5nrkKw",
+        description: "CSV Header, Oral interaction Level column",
       }),
     },
     {


### PR DESCRIPTION
🤖 Resolves #7385

## 👋 Introduction

Updates the labels as requested. 

## 🕵️ Details

Changed the label that also lists the three as I thought that was straightforward and should be in sync with the inputs. 
Also changed one place to reuse the labels from the utils file. 

## 🧪 Testing

1. Navigate to `/en/users/:id/profile#language-section`
2. Play with updating the language levels, observe the copy, and switch to French to check as well

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/a4010366-c9e6-4022-88df-957601f41494)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/ccf6461b-e0c6-4714-bf28-39c4f514c4e3)

`/fr/admin/users/:id/profile#language-section`

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/fd631409-8c4a-4a9a-9a81-70764b5a4c52)


