### PR TITLE
[Copy] Update skill hero card

### DIFF
--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -318,6 +318,11 @@ const getRoutes = (lang: Locales) => {
       );
     },
 
+    skillLibrary: () =>
+      path.join(applicantUrl, "profile-and-applications", "skills"),
+    skillShowcase: () =>
+      path.join(applicantUrl, "profile-and-applications", "skills", "showcase"),
+
     /**
      * Deprecated
      *

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -611,6 +611,10 @@
     "defaultMessage": "Gestion d’un processus de recrutement",
     "description": "Heading for pool operator dashboard links"
   },
+  "2A1UT9": {
+    "defaultMessage": "Compétence à améliorer",
+    "description": "Title for skills to improve showcase section"
+  },
   "2Ckihd": {
     "defaultMessage": "Trouvé <primary>{skillCount}</primary> compétences.",
     "description": "The number of skills found within the skill picker."
@@ -777,10 +781,6 @@
   "3IZ3mN": {
     "defaultMessage": "Équipe",
     "description": "Title displayed for the role table display team column"
-  },
-  "3Ix4Rz": {
-    "defaultMessage": "Types de travail d’intérêt",
-    "description": "Title for types of work of interest section"
   },
   "3JL02L": {
     "defaultMessage": "Décerné à :",
@@ -3169,10 +3169,6 @@
   "KS1jGw": {
     "defaultMessage": "Bâtissez votre carrière numérique",
     "description": "Heading for the recruitment opportunities"
-  },
-  "KSH0Di": {
-    "defaultMessage": "Justificatifs sur les compétences",
-    "description": "Title for skill credentials section"
   },
   "KSNNgE": {
     "defaultMessage": "Mettre à jour un ministère",
@@ -5844,6 +5840,10 @@
     "defaultMessage": "Annonce du bassin",
     "description": "Label for pool advertisement url field"
   },
+  "deiylo": {
+    "defaultMessage": "Meilleures compétences",
+    "description": "Title for top skills showcase section"
+  },
   "dfkNm9": {
     "defaultMessage": "Mise à jour réussie de votre parcours professionnel!",
     "description": "Message displayed to users when saving career timeline is successful."
@@ -7755,10 +7755,6 @@
     "defaultMessage": "Cadre de conformité et d’application de la loi proactives",
     "description": "Title for the compliance enforcement section."
   },
-  "qxRpIs": {
-    "defaultMessage": "Mise en valeur des compétences comportementales",
-    "description": "Title for behavioural skill showcase section"
-  },
   "r2gD/4": {
     "defaultMessage": "Date de réception",
     "description": "Title displayed on the search request table requested date column."
@@ -8126,10 +8122,6 @@
   "taxkCS": {
     "defaultMessage": "Enregistrer et ajouter une compétence",
     "description": "Button text to save a specific skill to a users profile"
-  },
-  "tgG8VK": {
-    "defaultMessage": "Mise en valeur des compétences techniques",
-    "description": "Title for technical skill showcase section"
   },
   "tiF/jI": {
     "defaultMessage": "Annuler et revenir en arrière",

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
@@ -10,7 +10,6 @@ import StarIcon from "@heroicons/react/20/solid/StarIcon";
 import UserGroupIcon from "@heroicons/react/20/solid/UserGroupIcon";
 import LockClosedIcon from "@heroicons/react/20/solid/LockClosedIcon";
 import ShieldCheckIcon from "@heroicons/react/20/solid/ShieldCheckIcon";
-import BeakerIcon from "@heroicons/react/20/solid/BeakerIcon";
 
 import { notEmpty } from "@gc-digital-talent/helpers";
 import {

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
@@ -101,25 +101,18 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
     notEmptyExperiences?.filter(isPersonalExperience) || [];
   const workExperiences = notEmptyExperiences?.filter(isWorkExperience) || [];
 
-  // TODO - complete these
-  const skillShowcaseUrl = "#";
-  const behaviouralSkillLibraryUrl = "#"; // Behavioural skill library links to the page_with_curl Create the "Skill library" page #6936 and scrolls the user to the relevant page section title
-  const technicalSkillLibraryUrl = "#"; // Technical skill library links to the page_with_curl Create the "Skill library" page #6936 and scrolls the user to the relevant page section title
-  const behaviouralSkillShowcaseUrl = "#"; // Behavioural skill showcase links to the eventual Skill showcase page and scrolls the user to the relevant page section title
-  const technicalSkillShowcaseUrl = "#"; // Technical skill showcase links to the eventual Skill showcase page and scrolls the user to the relevant page section title
-  const typesOfWorkInterestUrl = "#"; // Types of work of interest links to the eventual Skill showcase page and scrolls the user to the relevant page section title
-  const skillCredentialsUrl = "#"; // Skill credentials links to the eventual Skill showcase page and scrolls the user to the relevant page section title
+  const skillShowcaseUrl = paths.skillShowcase();
+  const skillLibraryUrl = paths.skillLibrary();
+
   const behaviouralSkillLibraryCount = 0;
   const technicalSkillLibraryCount = 0;
-  const typesOfWorkInterestCount = 0;
-  const skillCredentialsCount = 0;
   // The completion states are determined by the following rules:
   //   The skill library items need to have at least 1 skill
   //   The showcase items need to have at least 1 skill added to each of the 4 showcases
   const behaviouralSkillLibraryStatus = "success";
   const technicalSkillLibraryStatus = "success";
-  const behaviouralSkillShowcaseStatus = "success";
-  const technicalSkillShowcaseStatus = "success";
+  const topSkillsStatus = "success";
+  const skillsToImproveStatus = "success";
 
   return (
     <Hero
@@ -465,7 +458,7 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
               })}
               itemCount={behaviouralSkillLibraryCount}
               status={behaviouralSkillLibraryStatus}
-              href={behaviouralSkillLibraryUrl}
+              href={`${skillLibraryUrl}#behavioural`}
             />
             <StatusItem
               title={intl.formatMessage({
@@ -475,45 +468,25 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
               })}
               itemCount={technicalSkillLibraryCount}
               status={technicalSkillLibraryStatus}
-              href={technicalSkillLibraryUrl}
+              href={`${skillLibraryUrl}#technical`}
             />
             <StatusItem
               title={intl.formatMessage({
-                defaultMessage: "Behavioural skill showcase",
-                id: "qxRpIs",
-                description: "Title for behavioural skill showcase section",
+                defaultMessage: "Top skills",
+                id: "deiylo",
+                description: "Title for top skills showcase section",
               })}
-              status={behaviouralSkillShowcaseStatus}
-              href={behaviouralSkillShowcaseUrl}
+              status={topSkillsStatus}
+              href={`${skillShowcaseUrl}#top-skills`}
             />
             <StatusItem
               title={intl.formatMessage({
-                defaultMessage: "Technical skill showcase",
-                id: "tgG8VK",
-                description: "Title for technical skill showcase section",
+                defaultMessage: "Skill to improve",
+                id: "2A1UT9",
+                description: "Title for skills to improve showcase section",
               })}
-              status={technicalSkillShowcaseStatus}
-              href={technicalSkillShowcaseUrl}
-            />
-            <StatusItem
-              title={intl.formatMessage({
-                defaultMessage: "Types of work of interest",
-                id: "3Ix4Rz",
-                description: "Title for types of work of interest section",
-              })}
-              itemCount={typesOfWorkInterestCount}
-              icon={BeakerIcon}
-              href={typesOfWorkInterestUrl}
-            />
-            <StatusItem
-              title={intl.formatMessage({
-                defaultMessage: "Skill credentials",
-                id: "KSH0Di",
-                description: "Title for skill credentials section",
-              })}
-              itemCount={skillCredentialsCount}
-              icon={ShieldCheckIcon}
-              href={skillCredentialsUrl}
+              status={skillsToImproveStatus}
+              href={`${skillShowcaseUrl}#skills-to-improve`}
             />
           </HeroCard>
         ) : null}


### PR DESCRIPTION
🤖 Resolves #7392 

## 👋 Introduction

Updates the skill showcase hero card on the "Profile and applications" page.

## 🕵️ Details

We have added new paths for the upcoming pages in `useRoutes` and used those for the skill showcase card.

> **Note**
> This does not create the pages, so interacting with the links takes you to a 404.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login and navigaqte to `/applicant/profile-and-application`
3. Confirm the "Skill showcase" card link labels and urls match [the mockup](https://github.com/GCTC-NTGC/gc-digital-talent/issues/7392)

## 📸 Screenshot

![Screenshot 2023-08-01 091027](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/7f2133fc-2646-4d20-8e27-5e8132e13969)

