### PR TITLE
[a11y] Replace select component on support form

### DIFF
--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
@@ -3,13 +3,12 @@ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
 
 import { toast } from "@gc-digital-talent/toast";
+import { Input, Submit, TextArea, Select } from "@gc-digital-talent/forms";
 import {
-  Input,
-  Submit,
-  TextArea,
-  MultiSelectFieldBase,
-} from "@gc-digital-talent/forms";
-import { errorMessages, apiMessages } from "@gc-digital-talent/i18n";
+  errorMessages,
+  apiMessages,
+  uiMessages,
+} from "@gc-digital-talent/i18n";
 import { Pending, Button, Link } from "@gc-digital-talent/ui";
 
 import { getFullNameLabel } from "~/utils/nameUtils";
@@ -170,9 +169,10 @@ const SupportForm = ({
               }}
               trackUnsaved={false}
             />
-            <MultiSelectFieldBase
+            <Select
               id="subject"
               name="subject"
+              nullSelection={intl.formatMessage(uiMessages.nullSelectionOption)}
               rules={{
                 required: intl.formatMessage(errorMessages.required),
               }}


### PR DESCRIPTION
🤖 Resolves #7355 

## 👋 Introduction

This replaces the component based on `react-select` with one based on the native `select` element on the support form.

## 🕵️ Details

The component based on `react-select` has a multitude of accessibility issues and does not provide much benefit here.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/support`
3. Confirm the select input works as intended
4. Confirm form still submits with proper information

## 📸 Screenshot
![Screenshot 2023-08-01 100425](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/0773778b-7c49-4722-99c9-82a300a567d1)

