### PR TITLE
[Feature] Request table view [group+level] [stream] link

### DIFF
--- a/api/database/factories/ApplicantFilterFactory.php
+++ b/api/database/factories/ApplicantFilterFactory.php
@@ -81,9 +81,7 @@ class ApplicantFilterFactory extends Factory
             )->get();
             $filter->skills()->saveMany($skills);
 
-            $pools = Pool::whereNotNull("published_at")->inRandomOrder()->limit(
-                $this->faker->numberBetween($minCount, 1)
-            )->get();
+            $pools = Pool::whereNotNull("published_at")->inRandomOrder()->limit(1)->get();
             $filter->pools()->saveMany($pools);
             $filter->qualifiedClassifications()->saveMany($pools->flatMap(fn ($pool) => $pool->classifications));
             $stream = (empty($pools) || count($pools) === 0) ? $this->faker->randomElements(

--- a/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
@@ -3,7 +3,7 @@ import { IntlShape, useIntl } from "react-intl";
 import { SubmitHandler } from "react-hook-form";
 
 import { notEmpty } from "@gc-digital-talent/helpers";
-import { Pending, Spoiler } from "@gc-digital-talent/ui";
+import { Link, Pending, Spoiler } from "@gc-digital-talent/ui";
 import {
   InputMaybe,
   Maybe,
@@ -33,14 +33,17 @@ import {
   TABLE_DEFAULTS,
 } from "~/components/Table/ApiManagedTable/helpers";
 import useTableState from "~/components/Table/ApiManagedTable/useTableState";
-import tableViewItemButtonAccessor from "~/components/Table/ClientManagedTable/TableViewItemButton";
 import useRoutes from "~/hooks/useRoutes";
 import {
   stringToEnumRequestStatus,
   stringToEnumStream,
 } from "~/utils/requestUtils";
 import adminMessages from "~/messages/adminMessages";
-import { PoolCandidateSearchRequest } from "~/api/generated";
+import {
+  Classification,
+  PoolCandidateSearchRequest,
+  PoolStream,
+} from "~/api/generated";
 
 import SearchRequestsTableFilter, {
   FormValues,
@@ -120,9 +123,38 @@ const notesAccessor = (
     />
   ) : null;
 
+const viewRequestAccessor = (
+  viewUrl: string,
+  classification: Classification | undefined,
+  stream: PoolStream | undefined,
+  intl: IntlShape,
+) => (
+  <Link href={viewUrl}>
+    {intl.formatMessage(
+      {
+        defaultMessage: "View {groupLevel} {stream} request",
+        id: "Wm/eBb",
+        description:
+          "Label for view request link, on the view column of search request table.",
+      },
+      {
+        groupLevel: `${classification?.group}-0${classification?.level}`,
+        stream: intl.formatMessage(getPoolStream(stream || "")),
+      },
+    )}
+  </Link>
+);
+
 const defaultState = {
   ...TABLE_DEFAULTS,
-  hiddenColumnIds: ["id", "manager", "email", "adminNotes"],
+  hiddenColumnIds: [
+    "id",
+    "group_and_level",
+    "stream",
+    "manager",
+    "email",
+    "adminNotes",
+  ],
   filters: {},
 };
 
@@ -255,18 +287,19 @@ const SearchRequestsTableApi = ({
       },
       {
         label: intl.formatMessage({
-          defaultMessage: "Request job title",
-          id: "6AhLsc",
+          defaultMessage: "View Request",
+          id: "kZGKwO",
           description:
-            "Title displayed for the search request table request job title column.",
+            "Title displayed for the search request table view column.",
         }),
-        id: "job_title",
-        sortColumnName: "job_title",
+        id: "view_request",
+        sortColumnName: "view_request",
         accessor: (d) =>
-          tableViewItemButtonAccessor(
+          viewRequestAccessor(
             paths.searchRequestView(d.id),
-            d.jobTitle || "",
-            "",
+            d.applicantFilter?.qualifiedClassifications?.filter(notEmpty)[0], // TODO: What if there are more than one?
+            d.applicantFilter?.qualifiedStreams?.filter(notEmpty)[0], // TODO: What if there are more than one?
+            intl,
           ),
       },
       {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1194,10 +1194,6 @@
     "defaultMessage": "Les techniciens en <abbreviation>TI</abbreviation> se retrouvent principalement dans trois filières de travail :",
     "description": "Preceding list description"
   },
-  "6AhLsc": {
-    "defaultMessage": "Demander le titre du poste",
-    "description": "Title displayed for the search request table request job title column."
-  },
   "6B7e8/": {
     "defaultMessage": "Archiver<hidden> la candidature{name}</hidden>",
     "description": "Link text to continue a specific application"
@@ -4888,6 +4884,10 @@
     "defaultMessage": "En apprendre davantage sur les cotes de sécurité",
     "description": "Link text for security clearance information"
   },
+  "Wm/eBb": {
+    "defaultMessage": "Voir la demande pour {groupLevel} {stream}",
+    "description": "Label for view request link, on the view column of search request table."
+  },
   "Wmuizf": {
     "defaultMessage": "Langue préférée pour l'entretien parlé :",
     "description": "Display text for the preferred spoken interview language field on users"
@@ -6956,6 +6956,10 @@
   "kXAnJt": {
     "defaultMessage": "Échec de la mise à jour des notes pour le candidat dans le {poolName}",
     "description": "Toast notification for failed update of candidates notes in specified pool"
+  },
+  "kZGKwO": {
+    "defaultMessage": "Voir la demande",
+    "description": "Title displayed for the search request table view column."
   },
   "karCOz": {
     "defaultMessage": "Débutant",


### PR DESCRIPTION
🤖 Resolves #7349 

## 👋 Introduction

- Changes column header changed back to "View request"
- View request link uses the text format "View [ classification-level] [stream] request" (FR: Voir la demande pour [group-level] [stream])
- Hides the "Stream" and "Group & Level" columns on the request table by default
-  Removes the Job title column

## 🕵️ Details

- What should the link text format look like when there can be multiple classifications or multiple streams or both? Currently, a user can only select one on the Search page, so I set the link to display the first item in the array.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Login as admin@test.com
2. Go to Requests table`http://localhost:8000/en/admin/talent-requests` 
3. Ensure all criteria was met on the table view

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/6627504e-ffb9-4d83-9edb-ae81adfb1ad0)
