### PR TITLE
[Fix] Add validation message and translation for pool closing date

### DIFF
--- a/api/app/GraphQL/Validators/Mutation/PublishPoolValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/PublishPoolValidator.php
@@ -55,6 +55,7 @@ final class PublishPoolValidator extends Validator
         return  [
             'required' => ':attribute required',
             'exists' => ':attribute does not exist.',
+            'closing_date.required' => 'ClosingDateRequired',
             'closing_date.after' => 'Closing date must be after today.',
             'advertisement_location.*.required_if' => 'PoolLocationRequired',
             'advertisement_location.*.required_with' => 'You must enter both french and english fields for the advertisement_location',

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1223,6 +1223,10 @@
     "defaultMessage": "Collectivité",
     "description": "The scope of the award was within the community."
   },
+  "oCrAvX": {
+    "defaultMessage": "Un champ obligatoire est vide : Date de clôture",
+    "description": "Error message that the pool closing date is required."
+  },
   "oGXgxJ": {
     "defaultMessage": "Alerte de fermeture",
     "description": "Text for the close button on alerts"

--- a/packages/i18n/src/messages/apiMessages.ts
+++ b/packages/i18n/src/messages/apiMessages.ts
@@ -63,6 +63,11 @@ export const apiMessages: { [key: string]: MessageDescriptor } = defineMessages(
       description: "Error message that the application cannot be deleted.",
     },
 
+    ClosingDateRequired: {
+      defaultMessage: "You are missing a required field: Closing date",
+      id: "oCrAvX",
+      description: "Error message that the pool closing date is required.",
+    },
     "validator:closing_date.after": {
       defaultMessage: "Closing date must be after today.",
       id: "csLjMi",


### PR DESCRIPTION
🤖 Resolves #6802

## 👋 Introduction

This branch adds a custom validation message in the API for the closing date validation and a matching translation on the client-side.

## 🧪 Testing

1. Log in as admin, switch to French.
2. Create a draft pool and attempt to publish it without a closing date.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/df28379d-2069-42d2-b6ef-715e1f7075d5)
