### PR TITLE
[Fix] Switch FieldDisplay to div

### DIFF
--- a/apps/web/src/components/Profile/components/FieldDisplay.tsx
+++ b/apps/web/src/components/Profile/components/FieldDisplay.tsx
@@ -12,12 +12,12 @@ const FieldDisplay = ({
   hasError,
   ...rest
 }: FieldDisplayProps) => (
-  <p {...(hasError && { "data-h2-color": "base(error)" })} {...rest}>
+  <div {...(hasError && { "data-h2-color": "base(error)" })} {...rest}>
     <span data-h2-display="base(block)" data-h2-font-weight="base(700)">
       {label}
     </span>
     {children && <span>{children}</span>}
-  </p>
+  </div>
 );
 
 export default FieldDisplay;


### PR DESCRIPTION
🤖 Resolves #7390 

## 👋 Introduction

This branch switches the FieldDisplay component to use a div instead of a p.  This fixes the "ul cannot descend from p" warning.

## 🧪 Testing

1. Rebuild the app in dev mode.
2. Open your browser console.
3. Navigate to the _Profile information_ page and observe no warnings.
4. Navigate to the _Review your profile_ step in an application and observe no warnings.