### PR TITLE
[Fix] Change in hook order

### DIFF
--- a/apps/web/src/components/ExperienceSortAndFilter/sortAndFilterUtil.ts
+++ b/apps/web/src/components/ExperienceSortAndFilter/sortAndFilterUtil.ts
@@ -1,7 +1,8 @@
 /* eslint-disable import/prefer-default-export */
+import { IntlShape } from "react-intl";
+
 import { Experience } from "@gc-digital-talent/graphql";
 import { notEmpty } from "@gc-digital-talent/helpers";
-import { ExperienceForDate } from "~/types/experience";
 import { PAST_DATE } from "@gc-digital-talent/date-helpers";
 
 import {
@@ -12,10 +13,9 @@ import {
   isEducationExperience,
   isPersonalExperience,
   isWorkExperience,
-  useExperienceInfo,
 } from "~/utils/experienceUtils";
+import { ExperienceForDate } from "~/types/experience";
 
-import { IntlShape } from "react-intl";
 import { FormValues as SortAndFilterValues } from "./ExperienceSortAndFilter";
 
 export function sortAndFilterExperiences(

--- a/apps/web/src/components/ExperienceSortAndFilter/sortAndFilterUtil.ts
+++ b/apps/web/src/components/ExperienceSortAndFilter/sortAndFilterUtil.ts
@@ -6,6 +6,7 @@ import { PAST_DATE } from "@gc-digital-talent/date-helpers";
 
 import {
   compareByDate,
+  getExperienceName,
   isAwardExperience,
   isCommunityExperience,
   isEducationExperience,
@@ -14,11 +15,13 @@ import {
   useExperienceInfo,
 } from "~/utils/experienceUtils";
 
+import { IntlShape } from "react-intl";
 import { FormValues as SortAndFilterValues } from "./ExperienceSortAndFilter";
 
 export function sortAndFilterExperiences(
   experiences: Experience[] | undefined,
   sortAndFilterValues: SortAndFilterValues,
+  intl: IntlShape,
 ): Experience[] {
   const experiencesNotNull = experiences?.filter(notEmpty) ?? [];
 
@@ -66,9 +69,9 @@ export function sortAndFilterExperiences(
   switch (sortAndFilterValues?.sortBy) {
     case "title_asc":
       experiencesSorted.sort((e1, e2) => {
-        const { title: t1 } = useExperienceInfo(e1);
-        const { title: t2 } = useExperienceInfo(e2);
-        return t1.localeCompare(t2);
+        const t1 = getExperienceName(e1, intl)?.toString();
+        const t2 = getExperienceName(e2, intl)?.toString();
+        return t1 && t2 ? t1?.localeCompare(t2) : 0;
       });
       break;
     case "date_desc":

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
@@ -202,6 +202,7 @@ export const ApplicationCareerTimeline = ({
   const experienceList = sortAndFilterExperiences(
     nonEmptyExperiences,
     sortAndFilterValues,
+    intl,
   );
   const experiencesByType = groupBy(nonEmptyExperiences, (e) => {
     return deriveExperienceType(e);

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CareerTimelineSection/CareerTimelineSection.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CareerTimelineSection/CareerTimelineSection.tsx
@@ -24,6 +24,7 @@ const CareerTimelineSection = ({ experiences }: CareerTimelineSectionProps) => {
   const experienceList = sortAndFilterExperiences(
     nonEmptyExperiences,
     sortAndFilterValues,
+    intl,
   );
 
   const hasSomeExperience = !!experiences.length;

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineSection.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineSection.tsx
@@ -35,6 +35,7 @@ const CareerTimelineSection = ({
   const experienceList = sortAndFilterExperiences(
     experiences,
     sortAndFilterValues,
+    intl,
   );
 
   const hasExperiences = experiences && experiences.length >= 1;


### PR DESCRIPTION
🤖 Resolves #7397 

## 👋 Introduction

Fixes an issue with sorting experiences calling hooks in the incorrect order.

## 🕵️ Details

This was caused by using a hook `useExperienceInfo` in a non-hook `sortAndFilterExperiences`. The hook was calling `useIntl` at different times because it was not being handled properly due to `useExperienceInfo` (which also contains `useIntl`) being used in a non-hook.

We were just deconstructing it for the title so it was replaced with `getExperienceName` which is what `useExperienceInfo` is using to get the title.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build in dev mode `npm run dev`
2. Navigate to your career timeline (ensuring there are experiences there)
3. Sort the experiences in different ways
4. Confirm there are no errors in the javascript console
5. Confirm sorting still functions as expected