### PR TITLE
[Fix] Fix experience error with no message

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/components/AddExperienceForm.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/components/AddExperienceForm.tsx
@@ -23,6 +23,7 @@ import ExperienceDetails from "~/components/ExperienceFormFields/ExperienceDetai
 import ErrorSummary from "~/components/ExperienceFormFields/ErrorSummary";
 
 import { experienceTypeTitles } from "../messages";
+import { isSuccessfulCreate } from "./addExperienceUtils";
 
 type FormAction = "return" | "add-another";
 type ExperienceExperienceFormValues =
@@ -63,6 +64,17 @@ const AddExperienceForm = ({ applicationId }: AddExperienceFormProps) => {
     if (executeMutation) {
       executeMutation(args)
         .then((res) => {
+          if (!isSuccessfulCreate(res)) {
+            toast.error(
+              intl.formatMessage({
+                defaultMessage: "Error: adding experience failed",
+                id: "moKAQP",
+                description:
+                  "Message displayed to user after experience fails to be created.",
+              }),
+            );
+            return;
+          }
           if (res.data) {
             toast.success(
               intl.formatMessage({

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/components/addExperienceUtils.ts
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/components/addExperienceUtils.ts
@@ -1,0 +1,68 @@
+/* eslint-disable import/prefer-default-export */
+import {
+  CreateAwardExperienceMutation,
+  CreatePersonalExperienceMutation,
+  CreateCommunityExperienceMutation,
+  CreateEducationExperienceMutation,
+  CreateWorkExperienceMutation,
+} from "~/api/generated";
+
+type CreateExperienceMutation =
+  | CreateAwardExperienceMutation
+  | CreateCommunityExperienceMutation
+  | CreateEducationExperienceMutation
+  | CreatePersonalExperienceMutation
+  | CreateWorkExperienceMutation;
+
+// typesafe field descriminators
+const awardDiscriminator: keyof CreateAwardExperienceMutation =
+  "createAwardExperience";
+const communityDiscriminator: keyof CreateCommunityExperienceMutation =
+  "createCommunityExperience";
+const eductionDiscriminator: keyof CreateEducationExperienceMutation =
+  "createEducationExperience";
+const personalDiscriminator: keyof CreatePersonalExperienceMutation =
+  "createPersonalExperience";
+const workDiscriminator: keyof CreateWorkExperienceMutation =
+  "createWorkExperience";
+
+// type guards based on discriminators
+const isAwardExperience = (
+  mut: CreateExperienceMutation,
+): mut is CreateAwardExperienceMutation => awardDiscriminator in mut;
+const isCommunityExperience = (
+  mut: CreateExperienceMutation,
+): mut is CreateCommunityExperienceMutation => communityDiscriminator in mut;
+const isEducationExperience = (
+  mut: CreateExperienceMutation,
+): mut is CreateEducationExperienceMutation => eductionDiscriminator in mut;
+const isPersonalExperience = (
+  mut: CreateExperienceMutation,
+): mut is CreatePersonalExperienceMutation => personalDiscriminator in mut;
+const isWorkExperience = (
+  mut: CreateExperienceMutation,
+): mut is CreateWorkExperienceMutation => workDiscriminator in mut;
+
+export function isSuccessfulCreate(response: {
+  data?: CreateExperienceMutation;
+}): boolean {
+  if (response.data) {
+    if (isAwardExperience(response.data)) {
+      return !!response.data.createAwardExperience?.id;
+    }
+    if (isCommunityExperience(response.data)) {
+      return !!response.data.createCommunityExperience?.id;
+    }
+    if (isEducationExperience(response.data)) {
+      return !!response.data.createEducationExperience?.id;
+    }
+    if (isPersonalExperience(response.data)) {
+      return !!response.data.createPersonalExperience?.id;
+    }
+    if (isWorkExperience(response.data)) {
+      return !!response.data.createWorkExperience?.id;
+    }
+  }
+
+  return false;
+}

--- a/packages/i18n/src/messages/apiMessages.ts
+++ b/packages/i18n/src/messages/apiMessages.ts
@@ -1,5 +1,4 @@
 import { defineMessages, MessageDescriptor } from "react-intl";
-import errorMessages from "./errorMessages";
 
 // The messages in this object correspond to error messages emitted by the API.
 // Ideally, this could be automatically extracted from the schema but for now we do it manually.
@@ -7,7 +6,11 @@ import errorMessages from "./errorMessages";
 
 export const apiMessages: { [key: string]: MessageDescriptor } = defineMessages(
   {
-    "Internal server error": errorMessages.unknown,
+    "Internal server error": {
+      defaultMessage: "Unknown error",
+      id: "iqD8qE",
+      description: "Fallback text when an error message is not supplied",
+    },
 
     // users validation
     SubInUse: {

--- a/packages/i18n/src/messages/apiMessages.ts
+++ b/packages/i18n/src/messages/apiMessages.ts
@@ -1,4 +1,5 @@
 import { defineMessages, MessageDescriptor } from "react-intl";
+import errorMessages from "./errorMessages";
 
 // The messages in this object correspond to error messages emitted by the API.
 // Ideally, this could be automatically extracted from the schema but for now we do it manually.
@@ -6,6 +7,8 @@ import { defineMessages, MessageDescriptor } from "react-intl";
 
 export const apiMessages: { [key: string]: MessageDescriptor } = defineMessages(
   {
+    "Internal server error": errorMessages.unknown,
+
     // users validation
     SubInUse: {
       defaultMessage:


### PR DESCRIPTION
🤖 Resolves #7207 

## 👋 Introduction

This branch fixes a scenario where it is possible to add an experience and an error occurs but no error message is displayed.

## 🧪 Testing

I found it tricky to figure out a scenario that returns a null object without fully HTTP500'ing.  A good one is to change one of the database columns in the experience table to an incompatible type.

1. Log in as applicant and start an application.
2. On the career timeline step, try to add an experience of the type that you broke.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/5f096d15-1dac-4e6e-8f5a-5e6c0efbea6a)
