### PR TITLE
[Fix] Fix language evaluation abbreviation

### DIFF
--- a/apps/web/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
+++ b/apps/web/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
@@ -13,6 +13,7 @@ import {
   hasAllEmptyFields,
   hasEmptyRequiredFields,
 } from "~/validators/profile/languageInformation";
+import { wrapAbbr } from "~/utils/nameUtils";
 
 const LanguageInformationSection = ({
   user,
@@ -121,12 +122,19 @@ const LanguageInformationSection = ({
           <div data-h2-flex-item="base(1of1)">
             <p>
               <span data-h2-display="base(block)">
-                {intl.formatMessage({
-                  defaultMessage: "Completed an official GoC evaluation:",
-                  id: "shPV27",
-                  description:
-                    "Completed a government of canada abbreviation evaluation label and colon",
-                })}
+                {intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "Completed an official <abbreviation>GC</abbreviation> evaluation:",
+                    id: "3E5Xx0",
+                    description:
+                      "Completed a government of canada abbreviation evaluation label and colon",
+                  },
+                  {
+                    abbreviation: (text: React.ReactNode) =>
+                      wrapAbbr(text, intl),
+                  },
+                )}
               </span>
               <span data-h2-font-weight="base(700)">
                 {intl.formatMessage(

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -762,6 +762,10 @@
     "defaultMessage": "Création de la classification réussie!",
     "description": "Message displayed to user after classification is created successfully."
   },
+  "3E5Xx0": {
+    "defaultMessage": "A achevé une évaluation officielle du <abbreviation>GC</abbreviation> :",
+    "description": "Completed a government of canada abbreviation evaluation label and colon"
+  },
   "3GOVZI": {
     "defaultMessage": "Développez des connaissances sur les données",
     "description": "Heading for the direct on digital talent section"
@@ -8010,10 +8014,6 @@
   "sfyaOe": {
     "defaultMessage": "De nouvelles possibilités d’emploi sont publiées tout au long de l’année. En créant votre profil dès maintenant, vous serez mieux préparé pour présenter une candidature solide le moment venu.",
     "description": "Message displayed when there are no executive opportunities available"
-  },
-  "shPV27": {
-    "defaultMessage": "A achevé une évaluation officielle du <abbreviation>GC</abbreviation> :",
-    "description": "Completed a government of canada abbreviation evaluation label and colon"
   },
   "shwFSK": {
     "defaultMessage": "Je suis bilingue (anglais et français) et <strong>j'ai</strong> complété une <languageEvaluationPageLink></languageEvaluationPageLink> officielle en <strong>FRANÇAIS</strong>.",


### PR DESCRIPTION
🤖 Resolves #7467 

## 👋 Introduction

This branch fixes a string where the translators correctly added an abbreviation tag but the original was missing it.  I adjusted "GoC" to the more traditional "GC" in the string as well since that's the abbreviation we have already translated.

## 🧪 Testing

1. Log in as admin and open a user profile.
2. Switch to French and confirm the string changes as expected.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/59d24a59-b663-477b-8f05-5e79095bd487)
