### PR TITLE
[Fix] Fix manager email address

### DIFF
--- a/apps/web/src/pages/Home/ManagerHomePage/ManagerHomePage.tsx
+++ b/apps/web/src/pages/Home/ManagerHomePage/ManagerHomePage.tsx
@@ -144,7 +144,7 @@ const HomePage = () => {
             })}
             links={[
               {
-                href: `mailto:gctalent-talentgc@support-soutien.gc.ca?subject=${encodeURIComponent(
+                href: `mailto:recruitment-recruitementgiti@tbs-sct.gc.ca?subject=${encodeURIComponent(
                   intl.formatMessage({
                     defaultMessage:
                       "I'm interested in running a recruitment process",
@@ -306,7 +306,7 @@ const HomePage = () => {
               ),
               link: {
                 external: true,
-                path: `mailto:gctalent-talentgc@support-soutien.gc.ca?subject=${encodeURIComponent(
+                path: `mailto:recruitment-recruitementgiti@tbs-sct.gc.ca?subject=${encodeURIComponent(
                   intl.formatMessage({
                     defaultMessage:
                       "I'm interested in gaining hiring experience",


### PR DESCRIPTION
🤖 Resolves #7461 

## 👋 Introduction

This branch updates the email address on the manager homepage.

## 🧪 Testing

1. Browse to /manager.
2. Find the two email links and ensure they point to the right place.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/cb32993c-a1b7-4733-9a1b-1734bb77df44)
