### PR TITLE
[Fix] Force delete draft pools

### DIFF
--- a/api/database/migrations/2023_08_02_145650_cascade_pool_delete.php
+++ b/api/database/migrations/2023_08_02_145650_cascade_pool_delete.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('classification_pool', function (Blueprint $table) {
+            $table->dropForeign('classification_pool_pool_id_foreign');
+            $table->foreign('pool_id')->references('id')->on('pools')->cascadeOnDelete(true);
+        });
+        Schema::table('pools_nonessential_skills', function (Blueprint $table) {
+            $table->dropForeign('pools_nonessential_skills_pool_id_foreign');
+            $table->foreign('pool_id')->references('id')->on('pools')->cascadeOnDelete(true);
+        });
+        Schema::table('pools_essential_skills', function (Blueprint $table) {
+            $table->dropForeign('pools_essential_skills_pool_id_foreign');
+            $table->foreign('pool_id')->references('id')->on('pools')->cascadeOnDelete(true);
+        });
+        Schema::table('screening_questions', function (Blueprint $table) {
+            $table->dropForeign('screening_questions_pool_id_foreign');
+            $table->foreign('pool_id')->references('id')->on('pools')->cascadeOnDelete(true);
+        });
+    }
+
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('classification_pool', function (Blueprint $table) {
+            $table->dropForeign('classification_pool_pool_id_foreign');
+            $table->foreign('pool_id')->references('id')->on('pools');
+        });
+        Schema::table('pools_nonessential_skills', function (Blueprint $table) {
+            $table->dropForeign('pools_nonessential_skills_pool_id_foreign');
+            $table->foreign('pool_id')->references('id')->on('pools');
+        });
+        Schema::table('pools_essential_skills', function (Blueprint $table) {
+            $table->dropForeign('pools_essential_skills_pool_id_foreign');
+            $table->foreign('pool_id')->references('id')->on('pools');
+        });
+        Schema::table('screening_questions', function (Blueprint $table) {
+            $table->dropForeign('screening_questions_pool_id_foreign');
+            $table->foreign('pool_id')->references('id')->on('pools');
+        });
+    }
+};

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1781,11 +1781,7 @@ type Mutation {
   ): Pool @guard @can(ability: "changePoolClosingDate", find: "id")
   closePool(id: ID!): Pool @guard @can(ability: "closePool", find: "id")
   deletePool(id: ID! @whereKey): Pool
-    @delete
-    @guard
-    @can(ability: "deleteDraft", find: "id")
-  deletePool(id: ID! @whereKey): Pool
-    @delete(model: "Pool")
+    @forceDelete(model: "Pool")
     @guard
     @can(ability: "deleteDraft", find: "id")
   archivePool(id: ID!): Pool


### PR DESCRIPTION
🤖 Resolves #7306 

## 👋 Introduction

This branch updates the existing pool "delete draft" mutation to perform a force-delete.

## 🕵️ Details

I had to update the foreign keys to cascade deletes to the pivot tables.  I left the pivots for _pool candidate_ and _pool candidate filter_ since they should never be hit for drafts.

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/9e2fe166-7266-45f3-9a61-13e31f9cb646)


## 🧪 Testing

1. Run migrations and update the schema.
2. Delete a draft pool and observe that the row is completely gone from the database.

## 🚚 Deployment

I don't know if we want to remove the existing deleted drafts in production.  If so, it can easily be accomplished by SSH'ing into the server and using Tinker.
1. Did you remember to backup the databaae?  :laughing: 
2. `Pool::withTrashed->count()`
3. `Pool::onlyTrashed()->count()`
4. `Pool::onlyTrashed()->forceDelete()`
5. `Pool::withTrashed->count()`