### PR TITLE
[Fix] Update `StatusItem` to left align text.

### DIFF
--- a/apps/web/src/components/StatusItem/StatusItem.tsx
+++ b/apps/web/src/components/StatusItem/StatusItem.tsx
@@ -141,6 +141,7 @@ const StatusItem = ({
         <StatusItemTitle
           href={href}
           scrollTo={scrollTo}
+          data-h2-text-align="base(left)"
           {...textColorMap[effectiveTitleColor]}
         >
           {combinedTitle}


### PR DESCRIPTION
🤖 Resolves #7454 

## 👋 Introduction

Adds `text-align: left;` to the `StatusItem` component.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/fr/applicant/profile-and-applications` (more noticeable in French)
3. Confirm text in the cards is all left aligned

## 📸 Screenshot

![Screenshot 2023-08-02 130450](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/1015b07a-0ee9-4ffe-801b-f37716f9fdc1)
