### PR TITLE
[Fix] Bad set state call in application career timeline

### DIFF
--- a/apps/e2e/cypress/e2e/talentsearch/submit-application-iap.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/submit-application-iap.cy.js
@@ -15,6 +15,10 @@ import { aliasMutation, aliasQuery } from "../../support/graphql-test-utils";
 
 describe("Submit Application for IAP Workflow Tests", () => {
   beforeEach(() => {
+    cy.intercept("POST", "/graphql", function (req) {
+      aliasQuery(req, "getMyExperiences");
+    });
+
     cy.getSkills().then((allSkills) => {
       cy.wrap([allSkills[0].id]).as("testSkillIds"); // take the first ID for testing
     });
@@ -228,6 +232,7 @@ describe("Submit Application for IAP Workflow Tests", () => {
     );
     cy.findByRole("button", { name: /Save and go back/i }).click();
     cy.expectToast(/Successfully added experience!/i);
+    cy.wait("@gqlgetMyExperiencesQuery");
     // returned to main career timeline review page
     cy.contains(/1 education and certificate experience/i)
       .should("exist")

--- a/apps/e2e/cypress/e2e/talentsearch/submit-application.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/submit-application.cy.js
@@ -22,6 +22,7 @@ describe("Submit Application Workflow Tests", () => {
       aliasQuery(req, "GetApplication");
       aliasQuery(req, "getApplicationData");
       aliasQuery(req, "MyApplications");
+      aliasQuery(req, "getMyExperiences");
 
       aliasMutation(req, "createApplication");
       aliasMutation(req, "UpdateApplication");
@@ -248,6 +249,7 @@ describe("Submit Application Workflow Tests", () => {
     cy.wait("@gqlCreateEducationExperienceMutation");
     cy.expectToast(/Successfully added experience!/i);
     // returned to main career timeline review page
+    cy.wait("@gqlgetMyExperiencesQuery");
     cy.contains(/1 education and certificate experience/i)
       .should("exist")
       .and("be.visible");

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
@@ -124,7 +124,9 @@ const ApplicationCareerTimelineEditPage = () => {
       fetching: experienceFetching,
       error: experienceError,
     },
-  ] = useGetMyExperiencesQuery();
+  ] = useGetMyExperiencesQuery({
+    requestPolicy: "cache-first",
+  });
 
   const application = applicationData?.poolCandidate;
   const experience = experienceData?.me?.experiences?.find(

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
@@ -452,7 +452,9 @@ const ApplicationCareerTimelinePage = () => {
       fetching: experienceFetching,
       error: experienceError,
     },
-  ] = useGetMyExperiencesQuery();
+  ] = useGetMyExperiencesQuery({
+    requestPolicy: "cache-first",
+  });
 
   const application = applicationData?.poolCandidate;
   const experiences = experienceData?.me?.experiences as ExperienceForDate[];

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
@@ -35,6 +35,7 @@ import ExperienceSortAndFilter, {
 } from "~/components/ExperienceSortAndFilter/ExperienceSortAndFilter";
 import { sortAndFilterExperiences } from "~/components/ExperienceSortAndFilter/sortAndFilterUtil";
 
+import { OperationContext } from "urql";
 import { ApplicationPageProps } from "../ApplicationApi";
 import { useApplicationContext } from "../ApplicationContext";
 
@@ -432,6 +433,17 @@ export const ApplicationCareerTimeline = ({
   );
 };
 
+const context: Partial<OperationContext> = {
+  additionalTypenames: [
+    "AwardExperience",
+    "CommunityExperience",
+    "EducationExperience",
+    "PersonalExperience",
+    "WorkExperience",
+  ], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
+  requestPolicy: "cache-first",
+};
+
 const ApplicationCareerTimelinePage = () => {
   const { applicationId } = useParams();
   const [
@@ -453,7 +465,7 @@ const ApplicationCareerTimelinePage = () => {
       error: experienceError,
     },
   ] = useGetMyExperiencesQuery({
-    requestPolicy: "cache-first",
+    context,
   });
 
   const application = applicationData?.poolCandidate;


### PR DESCRIPTION
🤖 Resolves #7391 

## 👋 Introduction

Updates the application career timeline step to prefer cache when querying existing experiences.

## 🕵️ Details

We are calling a top level query on all these pages and queries in nested components seem to cause some issues when querying for similar data. We handle this by preferring cache (set in the parent components).

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build in dev mode `npm run dev`
2. Create and application
3. Continue to the career timeline step
4. "Edit" an experience
5. Confirm no console error appears
6. Complete creating the experience and return to the career timeline page
7. Confirm no console error appears
8. Confirm new experience appears