### PR TITLE
[Copy] Changes résidants to résidents

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5355,7 +5355,7 @@
     "description": "Heading for personal experiences in experience by type listing"
   },
   "aCg/OZ": {
-    "defaultMessage": "La préférence sera accordée aux anciens combattants, aux citoyens canadiens et aux résidants permanents.",
+    "defaultMessage": "La préférence sera accordée aux anciens combattants, aux citoyens canadiens et aux résidents permanents.",
     "description": "First hiring policy for pool advertisement"
   },
   "aDRIDD": {


### PR DESCRIPTION
🤖 Resolves #7361.

## 👋 Introduction

This PR changes the spelling of _résidants_ to _résidents_ for consistency.