### PR TITLE
[Feature] Allow experiences to break in print view

### DIFF
--- a/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
+++ b/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
@@ -52,6 +52,13 @@ const PageSection = ({ children }: { children: React.ReactNode }) => (
   </div>
 );
 
+// If a section is too big, use this instead of PageSection to allow it to break
+const BreakingPageSection = ({ children }: { children: React.ReactNode }) => (
+  <div data-h2-margin-bottom="base(2rem)" data-h2-display="base(block)">
+    {children}
+  </div>
+);
+
 const ProfileDocument = React.forwardRef<HTMLDivElement, ProfileDocumentProps>(
   ({ results }, ref) => {
     const intl = useIntl();
@@ -680,7 +687,7 @@ const ProfileDocument = React.forwardRef<HTMLDivElement, ProfileDocumentProps>(
                           </div>
                         )}
                       </PageSection>
-                      <PageSection>
+                      <BreakingPageSection>
                         <Heading level="h3">
                           {intl.formatMessage(
                             navigationMessages.careerTimelineAndRecruitment,
@@ -689,7 +696,7 @@ const ProfileDocument = React.forwardRef<HTMLDivElement, ProfileDocumentProps>(
                         <PrintExperienceByType
                           experiences={result.experiences?.filter(notEmpty)}
                         />
-                      </PageSection>
+                      </BreakingPageSection>
                     </div>
                     {index + 1 !== results.length && (
                       <div style={{ breakAfter: "page" }} />

--- a/apps/web/src/components/UserProfile/PrintExperienceByType/ExperienceItem.tsx
+++ b/apps/web/src/components/UserProfile/PrintExperienceByType/ExperienceItem.tsx
@@ -231,7 +231,7 @@ const ExperienceItem = ({ experience }: ExperienceItemProps) => {
   }
 
   return (
-    <div>
+    <div data-h2-break-inside="base(avoid) base:print(avoid)">
       {title && <Heading level="h5">{title}</Heading>}
       {dateRange && <p>{dateRange}</p>}
       {content && content}


### PR DESCRIPTION
🤖 Resolves #6947 

## 👋 Introduction

This branch allows the experiences section of the print view to page break within it.  This avoids a big gap between the _Role and salary_ and the inevitable page break before _Career timeline_.  I also added the styles to avoid breaking within an experience.

## 🧪 Testing

1. Log in as admin
2. Print a profile, observe there is no page break between _Role and salary_ and _Career timeline_.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/866b210d-a227-4a81-9e57-f39d2e096a87)