### PR TITLE
[Feature] Update recruitment cards

### DIFF
--- a/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.stories.tsx
+++ b/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.stories.tsx
@@ -19,7 +19,6 @@ const mockTeams = fakeTeams(1, mockDepartments);
 const mockCandidates = fakePoolCandidates(1);
 const mockCandidate = {
   ...mockCandidates[0],
-  status: PoolCandidateStatus.QualifiedAvailable,
   pool: {
     ...mockCandidates[0].pool,
     team: mockTeams[0],
@@ -28,57 +27,43 @@ const mockCandidate = {
   },
 };
 
+const poolCandidateStatuses = Object.values(PoolCandidateStatus);
+type Availability = "Available" | "Unavailable";
+const availabilities: Availability[] = ["Available", "Unavailable"];
+
 export default {
   component: QualifiedRecruitmentCard,
   title: "Components/Qualified Recruitment Card",
-  args: {
-    headingLevel: "h2",
-  },
 };
 
-const Template: StoryFn<typeof QualifiedRecruitmentCard> = (args) => (
-  <QualifiedRecruitmentCard {...args} />
-);
-
-export const Available = Template.bind({});
-Available.args = {
-  candidate: {
-    ...mockCandidate,
-    suspendedAt: null,
-  },
+const Template: StoryFn<typeof QualifiedRecruitmentCard> = () => {
+  return (
+    <div data-h2-display="base(flex)">
+      <div data-h2-padding="base(x1)" data-h2-background="base(white)">
+        {poolCandidateStatuses.map((poolCandidateStatus) =>
+          availabilities.map((availability) => (
+            <div
+              data-h2-margin="base(0, 0, x.5, 0)"
+              key={`${poolCandidateStatus} - ${availability}`}
+            >
+              <span>{`${poolCandidateStatus}  ${availability}`}</span>
+              <QualifiedRecruitmentCard
+                candidate={{
+                  ...mockCandidate,
+                  status: poolCandidateStatus,
+                  suspendedAt:
+                    availability === "Available"
+                      ? null
+                      : faker.date.past().toISOString(),
+                }}
+                headingLevel="h2"
+              />
+            </div>
+          )),
+        )}
+      </div>
+    </div>
+  );
 };
 
-export const Suspended = Template.bind({});
-Suspended.args = {
-  candidate: {
-    ...mockCandidate,
-    suspendedAt: faker.date.past().toISOString(),
-  },
-};
-
-export const Ongoing = Template.bind({});
-Ongoing.args = {
-  candidate: {
-    ...mockCandidate,
-    pool: {
-      ...mockCandidate.pool,
-      publishingGroup: PublishingGroup.ItJobsOngoing,
-    },
-  },
-};
-
-export const Expired = Template.bind({});
-Expired.args = {
-  candidate: {
-    ...mockCandidate,
-    status: PoolCandidateStatus.Expired,
-  },
-};
-
-export const Placed = Template.bind({});
-Placed.args = {
-  candidate: {
-    ...mockCandidate,
-    status: PoolCandidateStatus.PlacedCasual,
-  },
-};
+export const AllCards = Template.bind({});

--- a/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.tsx
+++ b/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.tsx
@@ -275,12 +275,14 @@ const QualifiedRecruitmentCard = ({
             data-h2-line-height="base(1)"
             data-h2-flex-grow="base(0)"
           >
-            <AvailabilityIcon
-              data-h2-height="base(auto)"
-              data-h2-width="base(1em)"
-              data-h2-flex-shrink="base(0)"
-              {...availability.color}
-            />
+            {AvailabilityIcon ? (
+              <AvailabilityIcon
+                data-h2-height="base(auto)"
+                data-h2-width="base(1em)"
+                data-h2-flex-shrink="base(0)"
+                {...availability.color}
+              />
+            ) : null}
             <span>{availability.text}</span>
           </p>
           {availability.showDialog && (

--- a/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.tsx
+++ b/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import ShieldCheckIcon from "@heroicons/react/20/solid/ShieldCheckIcon";
 import ChevronRightIcon from "@heroicons/react/20/solid/ChevronRightIcon";
 import GlobeAmericasIcon from "@heroicons/react/20/solid/GlobeAmericasIcon";
 import CpuChipIcon from "@heroicons/react/20/solid/CpuChipIcon";
@@ -41,7 +40,6 @@ const QualifiedRecruitmentCard = ({
   const contentHeadingLevel = incrementHeadingRank(headingLevel);
   const {
     title,
-    isQualified,
     statusPill,
     availability: { icon: AvailabilityIcon, ...availability },
   } = getQualifiedRecruitmentInfo(candidate, intl);
@@ -65,6 +63,8 @@ const QualifiedRecruitmentCard = ({
     }
   }, [linkCopied, setLinkCopied]);
 
+  const PillIcon = statusPill.icon;
+
   return (
     <div
       data-h2-border-left="base(x.5 solid secondary)"
@@ -83,13 +83,13 @@ const QualifiedRecruitmentCard = ({
           {title.html}
         </Heading>
         <Pill bold mode="outline" color={statusPill.color}>
-          {isQualified ? (
+          {PillIcon ? (
             <span
               data-h2-display="base(flex)"
               data-h2-align-items="base(center)"
               data-h2-gap="base(0 x.25)"
             >
-              <ShieldCheckIcon
+              <PillIcon
                 data-h2-width="base(1rem)"
                 data-h2-height="base(auto)"
               />
@@ -214,7 +214,7 @@ const QualifiedRecruitmentCard = ({
                 data-h2-grid-template-columns="p-tablet(repeat(2, 1fr))"
                 data-h2-gap="base(x.125 x.5)"
               >
-                {categorizedSkills[SkillCategory.Behavioural].map((skill) => (
+                {categorizedSkills[SkillCategory.Behavioural]?.map((skill) => (
                   <li key={skill.id}>{getLocalizedName(skill.name, intl)}</li>
                 ))}
               </ul>
@@ -237,7 +237,7 @@ const QualifiedRecruitmentCard = ({
                 data-h2-grid-template-columns="p-tablet(repeat(2, 1fr))"
                 data-h2-gap="base(x.125 x.5)"
               >
-                {categorizedSkills[SkillCategory.Technical].map((skill) => (
+                {categorizedSkills[SkillCategory.Technical]?.map((skill) => (
                   <li key={skill.id}>{getLocalizedName(skill.name, intl)}</li>
                 ))}
               </ul>

--- a/apps/web/src/components/QualifiedRecruitmentCard/utils.ts
+++ b/apps/web/src/components/QualifiedRecruitmentCard/utils.ts
@@ -18,14 +18,14 @@ import {
 } from "~/utils/poolCandidate";
 import { Application } from "~/utils/applicationUtils";
 import {
-  deriveStatusLabelKey as derivePoolCandidateStatusLabelKey,
-  getStatusLabel as getPoolCandidateStatusLabel,
-  isHiredStatus,
-  isReadyToHireStatus,
-  isExpiredStatus,
-  isInactiveStatus,
-  isErrorStatus,
-} from "~/utils/poolCandidateMessages";
+  deriveCombinedStatus,
+  getCombinedStatusLabel,
+  isHiredCombinedStatus,
+  isReadyToHireCombinedStatus,
+  isExpiredCombinedStatus,
+  isInactiveCombinedStatus,
+  isErrorCombinedStatus,
+} from "~/utils/poolCandidateCombinedStatus";
 import { PoolCandidate } from "@gc-digital-talent/graphql";
 import ShieldCheckIcon from "@heroicons/react/20/solid/ShieldCheckIcon";
 
@@ -51,44 +51,49 @@ export const getStatusPillInfo = (
   suspendedAt: PoolCandidate["suspendedAt"],
   intl: IntlShape,
 ): StatusPillInfo => {
-  const labelKey = derivePoolCandidateStatusLabelKey(status, suspendedAt);
-  const label = labelKey ? getPoolCandidateStatusLabel(labelKey) : null;
+  const combinedStatus = deriveCombinedStatus(status, suspendedAt);
+  const combinedStatusLabel = combinedStatus
+    ? getCombinedStatusLabel(combinedStatus)
+    : null;
+  const text = combinedStatusLabel
+    ? intl.formatMessage(combinedStatusLabel)
+    : "";
 
-  if (isReadyToHireStatus(labelKey)) {
+  if (isReadyToHireCombinedStatus(combinedStatus)) {
     return {
       color: "success",
-      text: label ? intl.formatMessage(label) : "",
+      text,
       icon: ShieldCheckIcon,
     };
   }
-  if (isHiredStatus(labelKey)) {
+  if (isHiredCombinedStatus(combinedStatus)) {
     return {
       color: "secondary",
-      text: label ? intl.formatMessage(label) : "",
+      text,
     };
   }
-  if (isExpiredStatus(labelKey)) {
+  if (isExpiredCombinedStatus(combinedStatus)) {
     return {
       color: "black",
-      text: label ? intl.formatMessage(label) : "",
+      text,
     };
   }
-  if (isInactiveStatus(labelKey)) {
+  if (isInactiveCombinedStatus(combinedStatus)) {
     return {
       color: "warning",
-      text: label ? intl.formatMessage(label) : "",
+      text,
     };
   }
-  if (isErrorStatus(labelKey)) {
+  if (isErrorCombinedStatus(combinedStatus)) {
     return {
       color: "error",
-      text: label ? intl.formatMessage(label) : "",
+      text,
     };
   }
 
   return {
     color: "primary",
-    text: label ? intl.formatMessage(label) : "",
+    text,
   };
 };
 type AvailabilityInfo = {

--- a/apps/web/src/components/QualifiedRecruitmentCard/utils.ts
+++ b/apps/web/src/components/QualifiedRecruitmentCard/utils.ts
@@ -107,9 +107,7 @@ const getAvailabilityInfo = (
   if (isExpiredCombinedStatus(combinedStatus)) {
     return {
       icon: null,
-      color: {
-        "data-h2-color": "base(gray.darker)",
-      },
+      color: {},
       text: null,
       showDialog: false,
     };
@@ -118,9 +116,7 @@ const getAvailabilityInfo = (
   if (isHiredLongTermCombinedStatus(combinedStatus)) {
     return {
       icon: null,
-      color: {
-        "data-h2-color": "base(quaternary.dark)",
-      },
+      color: {},
       text: null,
       showDialog: false,
     };
@@ -140,9 +136,7 @@ const getAvailabilityInfo = (
   if (isInactiveCombinedStatus(combinedStatus)) {
     return {
       icon: null,
-      color: {
-        "data-h2-color": "base(quaternary.dark)",
-      },
+      color: {},
       text: null,
       showDialog: false,
     };

--- a/apps/web/src/components/QualifiedRecruitmentCard/utils.ts
+++ b/apps/web/src/components/QualifiedRecruitmentCard/utils.ts
@@ -1,21 +1,14 @@
 import React from "react";
 import { IntlShape } from "react-intl";
-import LockClosedIcon from "@heroicons/react/20/solid/LockClosedIcon";
 import NoSymbolIcon from "@heroicons/react/20/solid/NoSymbolIcon";
 import CheckCircleIcon from "@heroicons/react/20/solid/CheckCircleIcon";
-import StarIcon from "@heroicons/react/20/solid/StarIcon";
 
 import { Color, IconType } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 
 import { Department, Maybe, PoolCandidateStatus } from "~/api/generated";
 import poolCandidateMessages from "~/messages/poolCandidateMessages";
-import { fullPoolTitle, isOngoingPublishingGroup } from "~/utils/poolUtils";
-import {
-  isPlacedStatus,
-  isQualifiedStatus,
-  isExpiredStatus as isExpiredPoolCandidateStatus,
-} from "~/utils/poolCandidate";
+import { fullPoolTitle } from "~/utils/poolUtils";
 import { Application } from "~/utils/applicationUtils";
 import {
   deriveCombinedStatus,
@@ -25,6 +18,8 @@ import {
   isExpiredCombinedStatus,
   isInactiveCombinedStatus,
   isErrorCombinedStatus,
+  isHiredLongTermCombinedStatus,
+  isSuspendedCombinedStatus,
 } from "~/utils/poolCandidateCombinedStatus";
 import { PoolCandidate } from "@gc-digital-talent/graphql";
 import ShieldCheckIcon from "@heroicons/react/20/solid/ShieldCheckIcon";
@@ -97,7 +92,7 @@ export const getStatusPillInfo = (
   };
 };
 type AvailabilityInfo = {
-  icon: IconType;
+  icon: IconType | null;
   color: Record<string, string>;
   text: React.ReactNode;
   showDialog: boolean;
@@ -107,52 +102,65 @@ const getAvailabilityInfo = (
   { status, suspendedAt }: Application,
   intl: IntlShape,
 ): AvailabilityInfo => {
-  if (isExpiredPoolCandidateStatus(status)) {
+  const combinedStatus = deriveCombinedStatus(status, suspendedAt);
+
+  if (isExpiredCombinedStatus(combinedStatus)) {
     return {
-      icon: LockClosedIcon,
+      icon: null,
       color: {
         "data-h2-color": "base(gray.darker)",
       },
-      text: intl.formatMessage(poolCandidateMessages.expiredAvailability),
+      text: null,
       showDialog: false,
     };
   }
 
-  if (isPlacedStatus(status)) {
+  if (isHiredLongTermCombinedStatus(combinedStatus)) {
     return {
-      icon: StarIcon,
+      icon: null,
       color: {
         "data-h2-color": "base(quaternary.dark)",
       },
-      text: intl.formatMessage(poolCandidateMessages.placedAvailability),
+      text: null,
       showDialog: false,
     };
   }
 
-  return suspendedAt
-    ? {
-        icon: NoSymbolIcon,
-        color: {
-          "data-h2-color": "base(error)",
-        },
-        text: intl.formatMessage(poolCandidateMessages.suspendedAvailability),
-        showDialog: true,
-      }
-    : {
-        icon: CheckCircleIcon,
-        color: {
-          "data-h2-color": "base(success)",
-        },
-        text: intl.formatMessage(poolCandidateMessages.openAvailability),
-        showDialog: true,
-      };
+  if (isSuspendedCombinedStatus(combinedStatus)) {
+    return {
+      icon: NoSymbolIcon,
+      color: {
+        "data-h2-color": "base(error)",
+      },
+      text: intl.formatMessage(poolCandidateMessages.suspendedAvailability),
+      showDialog: true,
+    };
+  }
+
+  if (isInactiveCombinedStatus(combinedStatus)) {
+    return {
+      icon: null,
+      color: {
+        "data-h2-color": "base(quaternary.dark)",
+      },
+      text: null,
+      showDialog: false,
+    };
+  }
+
+  return {
+    icon: CheckCircleIcon,
+    color: {
+      "data-h2-color": "base(success)",
+    },
+    text: intl.formatMessage(poolCandidateMessages.openAvailability),
+    showDialog: true,
+  };
 };
 
 type QualifiedRecruitmentInfo = {
   statusPill: StatusPillInfo;
   availability: AvailabilityInfo;
-  isQualified: boolean;
-  isOngoing: boolean;
   title: {
     html: React.ReactNode;
     label: string;
@@ -170,8 +178,6 @@ export const getQualifiedRecruitmentInfo = (
       intl,
     ),
     availability: getAvailabilityInfo(candidate, intl),
-    isQualified: isQualifiedStatus(candidate.status),
-    isOngoing: isOngoingPublishingGroup(candidate.pool.publishingGroup),
     title: fullPoolTitle(intl, candidate.pool),
   };
 };

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -468,6 +468,10 @@
     "defaultMessage": "Préférences de lieux",
     "description": "CSV Header, Location Preferences column"
   },
+  "13fSK+": {
+    "defaultMessage": "La date de soumission est dépassée",
+    "description": "Status for an application that where the recruitment has expired"
+  },
   "159+n7": {
     "defaultMessage": "Compétences sélectionnées ({numOfSkills})",
     "description": "Title for skills section on summary of filters section"
@@ -933,6 +937,10 @@
   "4SNVtn": {
     "defaultMessage": "{poolCandidateName} possède 0 des 0 compétences",
     "description": "Aria-label for the title displayed on the candidate skill count column."
+  },
+  "4TmwRU": {
+    "defaultMessage": "Candidature reçue",
+    "description": "Status for an application that has been submitted"
   },
   "4V/DsD": {
     "defaultMessage": "En savoir plus<hidden> à propos de la collectivité des gestionnaires</hidden>",
@@ -1677,6 +1685,10 @@
   "9OBHdP": {
     "defaultMessage": "{date} - Aujourd’hui",
     "description": "A date range that goes to the present day"
+  },
+  "9Pxjw5": {
+    "defaultMessage": "En attente d’évaluation des compétences",
+    "description": "Status for an application that where applicant is being assessed"
   },
   "9QxHnD": {
     "defaultMessage": "Créer<hidden> une compétence</hidden>",
@@ -2656,6 +2668,10 @@
   "GHvRHc": {
     "defaultMessage": "Pour soumettre une demande, veuillez fournir les renseignements suivants afin que nous puissions communiquer avec vous.",
     "description": "Explanation message for request form."
+  },
+  "GIC6EK": {
+    "defaultMessage": "Expiré",
+    "description": "Expired status"
   },
   "GIN69n": {
     "defaultMessage": "Date de clôture :",
@@ -4528,6 +4544,10 @@
     "defaultMessage": "<strong>Nota :</strong> Les résultats tiendront compte de tout candidat qui correspond à <strong>l’un ou plusieurs</strong> des groupes d’équité en matière d’emploi ayant été sélectionnés",
     "description": "Context for employment equity filter in search form."
   },
+  "UZWLKn": {
+    "defaultMessage": "En attente d’évaluation des compétences",
+    "description": "Status for an application that is having skills reviewed"
+  },
   "Ua/X9Q": {
     "defaultMessage": "Flux",
     "description": "Title for stream on summary of filters section"
@@ -5405,6 +5425,10 @@
     "defaultMessage": "bassin_candidats_{date}.csv",
     "description": "Filename for pool candidate CSV file download"
   },
+  "aagbij": {
+    "defaultMessage": "En cours de révision",
+    "description": "Status for an application that is being reviewed"
+  },
   "adM1fA": {
     "defaultMessage": "Si vous soumettez un formulaire qui n’avait aucun candidat d’évalué, veuillez nous en parler davantage dans les commentaires.",
     "description": "Instructions to provide additional details when submitting a request with no candidates"
@@ -5659,10 +5683,6 @@
   "cTCdw5": {
     "defaultMessage": "Nous tenons à vous remercier de votre intérêt à devenir un(e) apprenti(e) de la TI au sein du gouvernement du Canada. Votre expérience vécue, votre passion et vos intérêts sont chaleureusement accueillis et reconnus. Un membre de l’équipe du Bureau des initiatives autochtones communiquera avec vous au cours des trois à cinq prochains jours ouvrables pour discuter votre demande.",
     "description": "Description of review process and next steps for the IAP applicant."
-  },
-  "cVWREE": {
-    "defaultMessage": "Félicitations! Étant donné que l’on vous a embauché à la suite de ce recrutement, vous ne recevrez plus de possibilités qui y sont liées.",
-    "description": "Message displayed when an applicant has been placed as a result of a recruitment"
   },
   "cVszq/": {
     "defaultMessage": "En apposant votre signature (en tapant votre nom au complet), vous contribuez à un espace honnête et sûr où les personnes autochtones peuvent accéder à ces possibilités.",
@@ -6949,10 +6969,6 @@
     "defaultMessage": "Débutant",
     "description": "Label for the beginner skill level"
   },
-  "kekvz1": {
-    "defaultMessage": "Ce recrutement a expiré et n’est plus disponible pour des possibilités d’embauche.",
-    "description": "Message displayed when an applicant application to a recruitment has expired and no longer available"
-  },
   "kf5Td+": {
     "defaultMessage": "Assurez-vous de sauvegarder ou de fermer tout formulaire ouvert avant de continuer.",
     "description": "Message displayed to users when they attempt to quit the profile form with unsaved changes"
@@ -7384,6 +7400,10 @@
     "defaultMessage": "Vous devez indiquer dans cette section en quoi consistent vos préférences en matière d’offres d’emploi et de lieux de travail",
     "description": "Descriptive text explaining the work preferences section of the application profile"
   },
+  "njJCTd": {
+    "defaultMessage": "Sélectionné",
+    "description": "Status for an application that has been screened out of eligibility"
+  },
   "nmImtK": {
     "defaultMessage": "Se déconnecter",
     "description": "Message displayed to users to sign out of the application"
@@ -7635,6 +7655,10 @@
   "peTSHR": {
     "defaultMessage": "Notes sur cette demande",
     "description": "Heading for the notes about this request section of the single search request view."
+  },
+  "pf3KKo": {
+    "defaultMessage": "Poursuivre l’ébauche",
+    "description": "Link text to continue a application draft"
   },
   "pg1S01": {
     "defaultMessage": "Sauter la liste des compétences.",
@@ -8369,6 +8393,10 @@
   "vPPz4w": {
     "defaultMessage": "EXposition",
     "description": "Subject line for contact email for EXposition"
+  },
+  "vTyr7O": {
+    "defaultMessage": "Retiré",
+    "description": "Status for an application that has been removed from the recruitment"
   },
   "vV0SDz": {
     "defaultMessage": "{title} à {organization}",

--- a/apps/web/src/messages/poolCandidateMessages.ts
+++ b/apps/web/src/messages/poolCandidateMessages.ts
@@ -11,20 +11,6 @@ const messages = defineMessages({
     id: "LYCaEd",
     description: "Simplified status label for expired recruitments",
   },
-  placedAvailability: {
-    defaultMessage:
-      "Congrats! As you were hired from this recruitment, you will no longer receive opportunities related to it.",
-    id: "cVWREE",
-    description:
-      "Message displayed when an applicant has been placed as a result of a recruitment",
-  },
-  expiredAvailability: {
-    defaultMessage:
-      "This recruitment has expired and it is no longer available for hiring opportunities.",
-    id: "kekvz1",
-    description:
-      "Message displayed when an applicant application to a recruitment has expired and no longer available",
-  },
   suspendedAvailability: {
     defaultMessage:
       "You are not receiving opportunities from this recruitment.",

--- a/apps/web/src/pages/Applications/MyApplicationsPage/components/ApplicationCard/ApplicationCard.tsx
+++ b/apps/web/src/pages/Applications/MyApplicationsPage/components/ApplicationCard/ApplicationCard.tsx
@@ -3,9 +3,12 @@ import { useIntl } from "react-intl";
 
 import { Heading, HeadingProps, Pill } from "@gc-digital-talent/ui";
 import { notEmpty } from "@gc-digital-talent/helpers";
-import { getPoolCandidateStatusLabel } from "@gc-digital-talent/i18n";
 
 import { getFullPoolTitleHtml } from "~/utils/poolUtils";
+import {
+  deriveStatusLabelKey as derivePoolCandidateStatusLabelKey,
+  getStatusLabel as getPoolCandidateStatusLabel,
+} from "~/utils/poolCandidateMessages";
 import { type PoolCandidate } from "~/api/generated";
 
 import ApplicationActions from "./ApplicationActions";
@@ -54,7 +57,13 @@ const ApplicationCard = ({
   );
   const submittedAt = formatSubmittedAt(application.submittedAt, intl);
   const closingDate = formatClosingDate(application.pool.closingDate, intl);
-  const status = getPoolCandidateStatusLabel(application.status);
+  const statusLabelKey = derivePoolCandidateStatusLabelKey(
+    application.status,
+    application.suspendedAt,
+  );
+  const status = statusLabelKey
+    ? getPoolCandidateStatusLabel(statusLabelKey)
+    : null;
 
   return (
     <div

--- a/apps/web/src/pages/Applications/MyApplicationsPage/components/ApplicationCard/ApplicationCard.tsx
+++ b/apps/web/src/pages/Applications/MyApplicationsPage/components/ApplicationCard/ApplicationCard.tsx
@@ -6,9 +6,9 @@ import { notEmpty } from "@gc-digital-talent/helpers";
 
 import { getFullPoolTitleHtml } from "~/utils/poolUtils";
 import {
-  deriveStatusLabelKey as derivePoolCandidateStatusLabelKey,
-  getStatusLabel as getPoolCandidateStatusLabel,
-} from "~/utils/poolCandidateMessages";
+  deriveCombinedStatus,
+  getCombinedStatusLabel,
+} from "~/utils/poolCandidateCombinedStatus";
 import { type PoolCandidate } from "~/api/generated";
 
 import ApplicationActions from "./ApplicationActions";
@@ -57,12 +57,12 @@ const ApplicationCard = ({
   );
   const submittedAt = formatSubmittedAt(application.submittedAt, intl);
   const closingDate = formatClosingDate(application.pool.closingDate, intl);
-  const statusLabelKey = derivePoolCandidateStatusLabelKey(
+  const combinedStatus = deriveCombinedStatus(
     application.status,
     application.suspendedAt,
   );
-  const status = statusLabelKey
-    ? getPoolCandidateStatusLabel(statusLabelKey)
+  const combinedStatusLabel = combinedStatus
+    ? getCombinedStatusLabel(combinedStatus)
     : null;
 
   return (
@@ -160,9 +160,9 @@ const ApplicationCard = ({
           show={applicationIsDraft && !recruitmentIsExpired}
           application={application}
         />
-        {!applicationIsDraft && status ? (
+        {!applicationIsDraft && combinedStatusLabel ? (
           <Pill color="secondary" mode="outline">
-            {intl.formatMessage(status)}
+            {intl.formatMessage(combinedStatusLabel)}
           </Pill>
         ) : null}
       </div>

--- a/apps/web/src/pages/Home/HomePage/HomePage.tsx
+++ b/apps/web/src/pages/Home/HomePage/HomePage.tsx
@@ -1,5 +1,16 @@
+import { faker } from "@faker-js/faker";
+import {
+  fakeDepartments,
+  fakePoolCandidates,
+  fakeTeams,
+} from "@gc-digital-talent/fake-data";
+import {
+  PoolCandidateStatus,
+  PublishingGroup,
+} from "@gc-digital-talent/graphql";
 import React from "react";
 import { useIntl } from "react-intl";
+import QualifiedRecruitmentCard from "~/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard";
 
 import SEO from "~/components/SEO/SEO";
 
@@ -8,8 +19,50 @@ import type { HeroProps } from "./components/Hero/Hero";
 
 const HomePage = ({ defaultImage }: HeroProps) => {
   const intl = useIntl();
+
+  const mockDepartments = fakeDepartments();
+  const mockTeams = fakeTeams(1, mockDepartments);
+  const mockCandidates = fakePoolCandidates(1);
+  const mockCandidate = {
+    ...mockCandidates[0],
+    pool: {
+      ...mockCandidates[0].pool,
+      team: mockTeams[0],
+      publishingGroup: PublishingGroup.ItJobs,
+      publishedAt: faker.date.past().toISOString(),
+    },
+  };
+
+  const poolCandidateStatuses = Object.values(PoolCandidateStatus);
+  const isAvailablePossibilities = [true, false];
+
   return (
     <>
+      <div data-h2-display="base(flex)">
+        <div data-h2-padding="base(x1)" data-h2-background="base(white)">
+          {poolCandidateStatuses.map((poolCandidateStatus) =>
+            isAvailablePossibilities.map((isAvailable) => (
+              <div
+                data-h2-margin="base(0, 0, x.5, 0)"
+                key={`${poolCandidateStatus} - ${isAvailable}`}
+              >
+                <span>{`${poolCandidateStatus}, ${
+                  isAvailable ? "Available" : "Unavailable"
+                }`}</span>
+                <QualifiedRecruitmentCard
+                  candidate={{
+                    ...mockCandidate,
+                    status: poolCandidateStatus,
+                    suspendedAt: isAvailable
+                      ? null
+                      : faker.date.past().toISOString(),
+                  }}
+                />
+              </div>
+            )),
+          )}
+        </div>
+      </div>
       <SEO
         title={intl.formatMessage({
           defaultMessage: "Welcome",

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplicationsCard.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplicationsCard.tsx
@@ -49,8 +49,12 @@ const TrackApplicationsCard = ({
 
   // We don't get DraftExpired status from the API, so we need to check if the draft is expired ourselves
   const statusPill = isDraftExpired
-    ? getStatusPillInfo(PoolCandidateStatus.DraftExpired, intl)
-    : getStatusPillInfo(application.status, intl);
+    ? getStatusPillInfo(
+        PoolCandidateStatus.DraftExpired,
+        application.suspendedAt,
+        intl,
+      )
+    : getStatusPillInfo(application.status, application.suspendedAt, intl);
 
   const applicationDateInfo = getApplicationDateInfo(application, intl);
   const { user } = useAuthorization();

--- a/apps/web/src/utils/poolCandidateCombinedStatus.tsx
+++ b/apps/web/src/utils/poolCandidateCombinedStatus.tsx
@@ -37,6 +37,10 @@ const READY_TO_HIRE_STATUSES: CombinedStatus[] = ["READY_TO_HIRE"];
 export const isReadyToHireCombinedStatus = (
   status: Maybe<CombinedStatus>,
 ): boolean => (status ? READY_TO_HIRE_STATUSES.includes(status) : false);
+const SUSPENDED_STATUSES: CombinedStatus[] = ["NOT_INTERESTED"];
+export const isSuspendedCombinedStatus = (
+  status: Maybe<CombinedStatus>,
+): boolean => (status ? SUSPENDED_STATUSES.includes(status) : false);
 const EXPIRED_STATUSES: CombinedStatus[] = ["EXPIRED"];
 export const isExpiredCombinedStatus = (
   status: Maybe<CombinedStatus>,
@@ -52,6 +56,13 @@ export const isInactiveCombinedStatus = (
 const ERROR_STATUSES: CombinedStatus[] = ["REMOVED"];
 export const isErrorCombinedStatus = (status: Maybe<CombinedStatus>): boolean =>
   status ? ERROR_STATUSES.includes(status) : false;
+const HIRED_LONGE_TERM_STATUSES: CombinedStatus[] = [
+  "HIRED_INDETERMINATE",
+  "HIRED_TERM",
+];
+export const isHiredLongTermCombinedStatus = (
+  status: Maybe<CombinedStatus>,
+): boolean => (status ? HIRED_LONGE_TERM_STATUSES.includes(status) : false);
 
 // Map combined statuses to their labels
 const combinedStatusLabels = defineMessages<CombinedStatus>({

--- a/apps/web/src/utils/poolCandidateCombinedStatus.tsx
+++ b/apps/web/src/utils/poolCandidateCombinedStatus.tsx
@@ -8,7 +8,7 @@ import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 import getOrThrowError from "@gc-digital-talent/i18n/src/utils/error";
 
 // Custom status keys used to consolidate labels
-type StatusLabelKey =
+type CombinedStatus =
   | "DRAFT"
   | "RECEIVED"
   | "UNDER_REVIEW"
@@ -26,32 +26,35 @@ type StatusLabelKey =
   | "PAUSED"
   | "WITHDREW";
 
-const HIRED_STATUSES: StatusLabelKey[] = [
+const HIRED_STATUSES: CombinedStatus[] = [
   "HIRED_CASUAL",
   "HIRED_TERM",
   "HIRED_INDETERMINATE",
 ];
-export const isHiredStatus = (status: Maybe<StatusLabelKey>): boolean =>
+export const isHiredCombinedStatus = (status: Maybe<CombinedStatus>): boolean =>
   status ? HIRED_STATUSES.includes(status) : false;
-const READY_TO_HIRE_STATUSES: StatusLabelKey[] = ["READY_TO_HIRE"];
-export const isReadyToHireStatus = (status: Maybe<StatusLabelKey>): boolean =>
-  status ? READY_TO_HIRE_STATUSES.includes(status) : false;
-const EXPIRED_STATUSES: StatusLabelKey[] = ["EXPIRED"];
-export const isExpiredStatus = (status: Maybe<StatusLabelKey>): boolean =>
-  status ? EXPIRED_STATUSES.includes(status) : false;
-const INACTIVE_STATUSES: StatusLabelKey[] = [
+const READY_TO_HIRE_STATUSES: CombinedStatus[] = ["READY_TO_HIRE"];
+export const isReadyToHireCombinedStatus = (
+  status: Maybe<CombinedStatus>,
+): boolean => (status ? READY_TO_HIRE_STATUSES.includes(status) : false);
+const EXPIRED_STATUSES: CombinedStatus[] = ["EXPIRED"];
+export const isExpiredCombinedStatus = (
+  status: Maybe<CombinedStatus>,
+): boolean => (status ? EXPIRED_STATUSES.includes(status) : false);
+const INACTIVE_STATUSES: CombinedStatus[] = [
   "NOT_INTERESTED",
   "PAUSED",
   "WITHDREW",
 ];
-export const isInactiveStatus = (status: Maybe<StatusLabelKey>): boolean =>
-  status ? INACTIVE_STATUSES.includes(status) : false;
-const ERROR_STATUSES: StatusLabelKey[] = ["REMOVED"];
-export const isErrorStatus = (status: Maybe<StatusLabelKey>): boolean =>
+export const isInactiveCombinedStatus = (
+  status: Maybe<CombinedStatus>,
+): boolean => (status ? INACTIVE_STATUSES.includes(status) : false);
+const ERROR_STATUSES: CombinedStatus[] = ["REMOVED"];
+export const isErrorCombinedStatus = (status: Maybe<CombinedStatus>): boolean =>
   status ? ERROR_STATUSES.includes(status) : false;
 
-// Map new, consolidated keys to their labels
-const statusLabels = defineMessages<StatusLabelKey>({
+// Map combined statuses to their labels
+const combinedStatusLabels = defineMessages<CombinedStatus>({
   DRAFT: defineMessage({
     defaultMessage: "Continue draft",
     id: "pf3KKo",
@@ -143,8 +146,8 @@ const statusLabels = defineMessages<StatusLabelKey>({
   }),
 });
 
-// Map existing statuses to their new, consolidated keys
-const statusLabelMap = new Map<PoolCandidateStatus, StatusLabelKey>([
+// Map pool candidate statuses to their regular combined statuses
+const statusMap = new Map<PoolCandidateStatus, CombinedStatus>([
   [PoolCandidateStatus.Draft, "DRAFT"],
   [PoolCandidateStatus.NewApplication, "RECEIVED"],
   [PoolCandidateStatus.ApplicationReview, "UNDER_REVIEW"],
@@ -165,39 +168,39 @@ const statusLabelMap = new Map<PoolCandidateStatus, StatusLabelKey>([
   [PoolCandidateStatus.Removed, "REMOVED"],
 ]);
 
-// Map existing statuses to their new, consolidated keys when the status is suspended
-const suspendedStatusLabelMap = new Map<PoolCandidateStatus, StatusLabelKey>([
+// Map pool candidate statuses to their suspended combined statuses
+const suspendedStatusMap = new Map<PoolCandidateStatus, CombinedStatus>([
   [PoolCandidateStatus.PlacedCasual, "NOT_INTERESTED"],
   [PoolCandidateStatus.QualifiedAvailable, "NOT_INTERESTED"],
 ]);
 
 /**
- * Get the label for a status
+ * Derived a combined status from the pool candidate status and the suspendedAt timestamp
  *
- * @param status  Database status
+ * @param status  pool candidate status
  * @param suspendedAt  The timestamp for the user to suspend the pool candidate.  If suspended the label may be different.
- * @returns Maybe<MessageDescriptor>    Returns the message or null
+ * @returns Maybe<CombinedStatus>    Returns the combined status or null
  */
-export const deriveStatusLabelKey = (
+export const deriveCombinedStatus = (
   status: Maybe<PoolCandidateStatus>,
   suspendedAt: PoolCandidate["suspendedAt"],
-): StatusLabelKey | null | undefined => {
+): Maybe<CombinedStatus> => {
   if (!status) return null;
   const isSuspended = suspendedAt && new Date() > parseDateTimeUtc(suspendedAt);
 
-  const statusLabelKey =
-    isSuspended && suspendedStatusLabelMap.has(status)
-      ? suspendedStatusLabelMap.get(status) // special suspended label
-      : statusLabelMap.get(status); // regular label
+  const combinedStatus =
+    isSuspended && suspendedStatusMap.has(status)
+      ? suspendedStatusMap.get(status) // special suspended label
+      : statusMap.get(status); // regular label
 
-  return statusLabelKey;
+  return combinedStatus;
 };
 
-export const getStatusLabel = (
-  statusLabelKey: keyof typeof statusLabels,
+export const getCombinedStatusLabel = (
+  statusLabelKey: keyof typeof combinedStatusLabels,
 ): MessageDescriptor =>
   getOrThrowError(
-    statusLabels,
+    combinedStatusLabels,
     statusLabelKey,
     `Invalid statusLabelKey '${statusLabelKey}'`,
   );

--- a/apps/web/src/utils/poolCandidateCombinedStatus.tsx
+++ b/apps/web/src/utils/poolCandidateCombinedStatus.tsx
@@ -7,7 +7,7 @@ import {
 import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 import getOrThrowError from "@gc-digital-talent/i18n/src/utils/error";
 
-// Custom status keys used to consolidate labels
+// Status that represent the combination of pool candidate status and the suspendedAt timestamp
 type CombinedStatus =
   | "DRAFT"
   | "RECEIVED"

--- a/apps/web/src/utils/poolCandidateMessages.tsx
+++ b/apps/web/src/utils/poolCandidateMessages.tsx
@@ -1,0 +1,203 @@
+import { defineMessage, defineMessages, MessageDescriptor } from "react-intl";
+import {
+  PoolCandidateStatus,
+  Maybe,
+  PoolCandidate,
+} from "@gc-digital-talent/graphql";
+import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
+import getOrThrowError from "@gc-digital-talent/i18n/src/utils/error";
+
+// Custom status keys used to consolidate labels
+type StatusLabelKey =
+  | "DRAFT"
+  | "RECEIVED"
+  | "UNDER_REVIEW"
+  | "PENDING_SKILLS"
+  | "ASSESSMENT"
+  | "DATE_PASSED"
+  | "SCREENED_OUT"
+  | "EXPIRED"
+  | "REMOVED"
+  | "HIRED_CASUAL"
+  | "NOT_INTERESTED"
+  | "HIRED_INDETERMINATE"
+  | "HIRED_TERM"
+  | "READY_TO_HIRE"
+  | "PAUSED"
+  | "WITHDREW";
+
+const HIRED_STATUSES: StatusLabelKey[] = [
+  "HIRED_CASUAL",
+  "HIRED_TERM",
+  "HIRED_INDETERMINATE",
+];
+export const isHiredStatus = (status: Maybe<StatusLabelKey>): boolean =>
+  status ? HIRED_STATUSES.includes(status) : false;
+const READY_TO_HIRE_STATUSES: StatusLabelKey[] = ["READY_TO_HIRE"];
+export const isReadyToHireStatus = (status: Maybe<StatusLabelKey>): boolean =>
+  status ? READY_TO_HIRE_STATUSES.includes(status) : false;
+const EXPIRED_STATUSES: StatusLabelKey[] = ["EXPIRED"];
+export const isExpiredStatus = (status: Maybe<StatusLabelKey>): boolean =>
+  status ? EXPIRED_STATUSES.includes(status) : false;
+const INACTIVE_STATUSES: StatusLabelKey[] = [
+  "NOT_INTERESTED",
+  "PAUSED",
+  "WITHDREW",
+];
+export const isInactiveStatus = (status: Maybe<StatusLabelKey>): boolean =>
+  status ? INACTIVE_STATUSES.includes(status) : false;
+const ERROR_STATUSES: StatusLabelKey[] = ["REMOVED"];
+export const isErrorStatus = (status: Maybe<StatusLabelKey>): boolean =>
+  status ? ERROR_STATUSES.includes(status) : false;
+
+// Map new, consolidated keys to their labels
+const statusLabels = defineMessages<StatusLabelKey>({
+  DRAFT: defineMessage({
+    defaultMessage: "Continue draft",
+    id: "pf3KKo",
+    description: "Link text to continue a application draft",
+  }),
+  RECEIVED: defineMessage({
+    defaultMessage: "Application received",
+    id: "4TmwRU",
+    description: "Status for an application that has been submitted",
+  }),
+  UNDER_REVIEW: defineMessage({
+    defaultMessage: "Application under review",
+    id: "aagbij",
+    description: "Status for an application that is being reviewed",
+  }),
+  PENDING_SKILLS: defineMessage({
+    defaultMessage: "Application pending assessment",
+    id: "UZWLKn",
+    description: "Status for an application that is having skills reviewed",
+  }),
+  ASSESSMENT: defineMessage({
+    defaultMessage: "Application pending assessment",
+    id: "9Pxjw5",
+    description:
+      "Status for an application that where applicant is being assessed",
+  }),
+  DATE_PASSED: defineMessage({
+    defaultMessage: "Submission date passed",
+    id: "13fSK+",
+    description:
+      "Status for an application that where the recruitment has expired",
+  }),
+  SCREENED_OUT: defineMessage({
+    defaultMessage: "Screened out",
+    id: "njJCTd",
+    description:
+      "Status for an application that has been screened out of eligibility",
+  }),
+  EXPIRED: defineMessage({
+    defaultMessage: "Expired",
+    id: "GIC6EK",
+    description: "Expired status",
+  }),
+
+  REMOVED: defineMessage({
+    defaultMessage: "Removed",
+    id: "vTyr7O",
+    description:
+      "Status for an application that has been removed from the recruitment",
+  }),
+  HIRED_CASUAL: defineMessage({
+    defaultMessage: "Hired (Casual)",
+    id: "0YZeO0",
+    description:
+      "Status for an application that has been hired with a casual contract",
+  }),
+  NOT_INTERESTED: defineMessage({
+    defaultMessage: "Not interested",
+    id: "c+6rQB",
+    description: "Status for when the user has suspended an application",
+  }),
+  HIRED_INDETERMINATE: defineMessage({
+    defaultMessage: "Hired (Indeterminate)",
+    id: "/Sobod",
+    description:
+      "Status for an application that has been hired with an indeterminate contract",
+  }),
+  HIRED_TERM: defineMessage({
+    defaultMessage: "Hired (Term)",
+    id: "VplMpm",
+    description:
+      "Status for an application that has been hired with a term contract",
+  }),
+  READY_TO_HIRE: defineMessage({
+    defaultMessage: "Ready to hire",
+    id: "9gpVCX",
+    description: "Status for an application where user user is ready to hire",
+  }),
+  PAUSED: defineMessage({
+    defaultMessage: "Paused",
+    id: "KA/hfo",
+    description:
+      "Status for an application to an advertisement that is unavailable",
+  }),
+  WITHDREW: defineMessage({
+    defaultMessage: "Withdrew",
+    id: "C+hP/v",
+    description: "Status for an application that has been withdrawn",
+  }),
+});
+
+// Map existing statuses to their new, consolidated keys
+const statusLabelMap = new Map<PoolCandidateStatus, StatusLabelKey>([
+  [PoolCandidateStatus.Draft, "DRAFT"],
+  [PoolCandidateStatus.NewApplication, "RECEIVED"],
+  [PoolCandidateStatus.ApplicationReview, "UNDER_REVIEW"],
+  [PoolCandidateStatus.ScreenedIn, "PENDING_SKILLS"],
+  [PoolCandidateStatus.UnderAssessment, "ASSESSMENT"],
+  [PoolCandidateStatus.DraftExpired, "DATE_PASSED"],
+  [PoolCandidateStatus.ScreenedOutApplication, "SCREENED_OUT"],
+  [PoolCandidateStatus.ScreenedOutAssessment, "SCREENED_OUT"],
+  [PoolCandidateStatus.ScreenedOutNotInterested, "SCREENED_OUT"],
+  [PoolCandidateStatus.ScreenedOutNotResponsive, "SCREENED_OUT"],
+  [PoolCandidateStatus.QualifiedAvailable, "READY_TO_HIRE"],
+  [PoolCandidateStatus.QualifiedUnavailable, "PAUSED"],
+  [PoolCandidateStatus.QualifiedWithdrew, "WITHDREW"],
+  [PoolCandidateStatus.PlacedCasual, "HIRED_CASUAL"],
+  [PoolCandidateStatus.PlacedTerm, "HIRED_TERM"],
+  [PoolCandidateStatus.PlacedIndeterminate, "HIRED_INDETERMINATE"],
+  [PoolCandidateStatus.Expired, "EXPIRED"],
+  [PoolCandidateStatus.Removed, "REMOVED"],
+]);
+
+// Map existing statuses to their new, consolidated keys when the status is suspended
+const suspendedStatusLabelMap = new Map<PoolCandidateStatus, StatusLabelKey>([
+  [PoolCandidateStatus.PlacedCasual, "NOT_INTERESTED"],
+  [PoolCandidateStatus.QualifiedAvailable, "NOT_INTERESTED"],
+]);
+
+/**
+ * Get the label for a status
+ *
+ * @param status  Database status
+ * @param suspendedAt  The timestamp for the user to suspend the pool candidate.  If suspended the label may be different.
+ * @returns Maybe<MessageDescriptor>    Returns the message or null
+ */
+export const deriveStatusLabelKey = (
+  status: Maybe<PoolCandidateStatus>,
+  suspendedAt: PoolCandidate["suspendedAt"],
+): StatusLabelKey | null | undefined => {
+  if (!status) return null;
+  const isSuspended = suspendedAt && new Date() > parseDateTimeUtc(suspendedAt);
+
+  const statusLabelKey =
+    isSuspended && suspendedStatusLabelMap.has(status)
+      ? suspendedStatusLabelMap.get(status) // special suspended label
+      : statusLabelMap.get(status); // regular label
+
+  return statusLabelKey;
+};
+
+export const getStatusLabel = (
+  statusLabelKey: keyof typeof statusLabels,
+): MessageDescriptor =>
+  getOrThrowError(
+    statusLabels,
+    statusLabelKey,
+    `Invalid statusLabelKey '${statusLabelKey}'`,
+  );

--- a/packages/i18n/src/index.tsx
+++ b/packages/i18n/src/index.tsx
@@ -76,7 +76,6 @@ import {
   poolCandidatePriorities,
   getCandidateExpiryFilterStatus,
   getCandidateSuspendedFilterStatus,
-  getPoolCandidateStatusLabel,
 } from "./messages/localizedConstants";
 
 import { STORED_LOCALE } from "./const";
@@ -155,7 +154,6 @@ export {
   getAbbreviations,
   getCandidateExpiryFilterStatus,
   getCandidateSuspendedFilterStatus,
-  getPoolCandidateStatusLabel,
 };
 
 export type { Locales, Messages };

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -67,10 +67,6 @@
     "defaultMessage": "Fils d’Ariane",
     "description": "Label for the links to page ancestors"
   },
-  "13fSK+": {
-    "defaultMessage": "La date de soumission est dépassée",
-    "description": "Status for an application that where the recruitment has expired"
-  },
   "14Cv7d": {
     "defaultMessage": "Retrait en cours...",
     "description": "Submitting text for delete button."
@@ -162,10 +158,6 @@
   "4S30lt": {
     "defaultMessage": "Expérience de travail appliquée",
     "description": "Option for education requirement, applied work experience"
-  },
-  "4TmwRU": {
-    "defaultMessage": "Candidature reçue",
-    "description": "Status for an application that has been submitted"
   },
   "4dD2mf": {
     "defaultMessage": "cela m'oblige à faire <strong>des heures supplémentaires habituelles.</strong>",
@@ -288,10 +280,6 @@
   "9EnPf0": {
     "defaultMessage": "Accès à l’information et protection des renseignements personnels",
     "description": "Pool Stream described as Access to Information and Privacy."
-  },
-  "9Pxjw5": {
-    "defaultMessage": "Évaluation en cours",
-    "description": "Status for an application that where applicant is being assessed"
   },
   "9ZyJZq": {
     "defaultMessage": "cela m'oblige à me déplacer.",
@@ -752,14 +740,6 @@
     "defaultMessage": "S.O.",
     "description": "displayed when localized string not available"
   },
-  "UZWLKn": {
-    "defaultMessage": "En attente d’évaluation des compétences",
-    "description": "Status for an application that ie having skills reviewed"
-  },
-  "UayO6H": {
-    "defaultMessage": "Qualifié",
-    "description": "Status for an application where the applicant has qualified"
-  },
   "Uk0WG0": {
     "defaultMessage": "Organisationnel",
     "description": "The scope of the award was organizational."
@@ -891,10 +871,6 @@
   "aMkZ80": {
     "defaultMessage": "Vous devez indiquer le lieu précis en anglais et en français si l’annonce ne vise pas un poste à distance.",
     "description": "Error message that advertisement locations must be filled in English and French."
-  },
-  "aagbij": {
-    "defaultMessage": "En cours de révision",
-    "description": "Status for an application that is being reviewed"
   },
   "ad4CnG": {
     "defaultMessage": "Ébauche expirée",
@@ -1167,10 +1143,6 @@
     "defaultMessage": "Un champ obligatoire est vide : Groupe des publications",
     "description": "Error message that the pool advertisement must have publishing group filled."
   },
-  "njJCTd": {
-    "defaultMessage": "Sélectionné",
-    "description": "Status for an application that has been screened out of eligibility"
-  },
   "nnMYWr": {
     "defaultMessage": "Préférences de travail",
     "description": "Name of Work preferences page"
@@ -1234,10 +1206,6 @@
   "pPPm5b": {
     "defaultMessage": "Moi",
     "description": "The award was given to me."
-  },
-  "pf3KKo": {
-    "defaultMessage": "Poursuivre l’ébauche",
-    "description": "Link text to continue a application draft"
   },
   "plwOsC": {
     "defaultMessage": "Sélectionnez",
@@ -1405,10 +1373,6 @@
   "vPDtGU": {
     "defaultMessage": "e ne suis pas membre des Forces armées canadiennes.",
     "description": "declare self to not be in the CAF without bolding"
-  },
-  "vTyr7O": {
-    "defaultMessage": "Retiré",
-    "description": "Status for an application that has been removed from the recruitment"
   },
   "vgxxk0": {
     "defaultMessage": "Vétéran",

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -1,4 +1,4 @@
-import { defineMessage, defineMessages, MessageDescriptor } from "react-intl";
+import { defineMessages, MessageDescriptor } from "react-intl";
 import {
   Language,
   LanguageAbility,
@@ -26,7 +26,6 @@ import {
   IndigenousCommunity,
   CandidateExpiryFilter,
   CandidateSuspendedFilter,
-  Maybe,
   EducationRequirementOption,
   PoolCandidateSearchPositionType,
 } from "@gc-digital-talent/graphql";
@@ -1764,144 +1763,3 @@ export const getIndigenousCommunity = (
     indigenousCommunity,
     `Invalid indigenous community '${indigenousCommunity}'`,
   );
-
-// Custom status keys used to consolidate labels
-type StatusLabelKey =
-  | "DRAFT"
-  | "RECEIVED"
-  | "UNDER_REVIEW"
-  | "PENDING_SKILLS"
-  | "ASSESSMENT"
-  | "DATE_PASSED"
-  | "SCREENED_OUT"
-  | "QUALIFIED"
-  | "EXPIRED"
-  | "REMOVED";
-
-// Map new, consolidated keys to their labels
-const statusLabels = new Map<StatusLabelKey, MessageDescriptor | null>([
-  [
-    "DRAFT",
-    defineMessage({
-      defaultMessage: "Continue draft",
-      id: "pf3KKo",
-      description: "Link text to continue a application draft",
-    }),
-  ],
-  [
-    "RECEIVED",
-    defineMessage({
-      defaultMessage: "Application received",
-      id: "4TmwRU",
-      description: "Status for an application that has been submitted",
-    }),
-  ],
-  [
-    "UNDER_REVIEW",
-    defineMessage({
-      defaultMessage: "Application under review",
-      id: "aagbij",
-      description: "Status for an application that is being reviewed",
-    }),
-  ],
-  [
-    "PENDING_SKILLS",
-    defineMessage({
-      defaultMessage: "Application pending assessment",
-      id: "UZWLKn",
-      description: "Status for an application that is having skills reviewed",
-    }),
-  ],
-  [
-    "ASSESSMENT",
-    defineMessage({
-      defaultMessage: "Application pending assessment",
-      id: "9Pxjw5",
-      description:
-        "Status for an application that where applicant is being assessed",
-    }),
-  ],
-  [
-    "DATE_PASSED",
-    defineMessage({
-      defaultMessage: "Submission date passed",
-      id: "13fSK+",
-      description:
-        "Status for an application that where the recruitment has expired",
-    }),
-  ],
-  [
-    "SCREENED_OUT",
-    defineMessage({
-      defaultMessage: "Screened out",
-      id: "njJCTd",
-      description:
-        "Status for an application that has been screened out of eligibility",
-    }),
-  ],
-  [
-    "QUALIFIED",
-    defineMessage({
-      defaultMessage: "Qualified",
-      id: "UayO6H",
-      description:
-        "Status for an application where the applicant has qualified",
-    }),
-  ],
-  [
-    "EXPIRED",
-    defineMessage({
-      defaultMessage: "Expired",
-      id: "GIC6EK",
-      description: "Expired status",
-    }),
-  ],
-  [
-    "REMOVED",
-    defineMessage({
-      defaultMessage: "Removed",
-      id: "vTyr7O",
-      description:
-        "Status for an application that has been removed from the recruitment",
-    }),
-  ],
-]);
-
-// Map existing statuses to their new, consolidated keys
-const statusLabelMap = new Map<PoolCandidateStatus, StatusLabelKey>([
-  [PoolCandidateStatus.Draft, "DRAFT"],
-  [PoolCandidateStatus.NewApplication, "RECEIVED"],
-  [PoolCandidateStatus.ApplicationReview, "UNDER_REVIEW"],
-  [PoolCandidateStatus.ScreenedIn, "PENDING_SKILLS"],
-  [PoolCandidateStatus.UnderAssessment, "ASSESSMENT"],
-  [PoolCandidateStatus.DraftExpired, "DATE_PASSED"],
-  [PoolCandidateStatus.ScreenedOutApplication, "SCREENED_OUT"],
-  [PoolCandidateStatus.ScreenedOutAssessment, "SCREENED_OUT"],
-  [PoolCandidateStatus.ScreenedOutNotInterested, "SCREENED_OUT"],
-  [PoolCandidateStatus.ScreenedOutNotResponsive, "SCREENED_OUT"],
-  [PoolCandidateStatus.QualifiedAvailable, "QUALIFIED"],
-  [PoolCandidateStatus.QualifiedUnavailable, "QUALIFIED"],
-  [PoolCandidateStatus.QualifiedWithdrew, "QUALIFIED"],
-  [PoolCandidateStatus.PlacedCasual, "QUALIFIED"],
-  [PoolCandidateStatus.PlacedTerm, "QUALIFIED"],
-  [PoolCandidateStatus.PlacedIndeterminate, "QUALIFIED"],
-  [PoolCandidateStatus.Expired, "EXPIRED"],
-  [PoolCandidateStatus.Removed, "REMOVED"],
-]);
-
-/**
- * Get the label for a status
- *
- * Note: This is different than other helpers
- * in this file since it is mapping old statuses
- * that do not match the database ENUM
- *
- * @param status  Database status
- * @returns Maybe<MessageDescriptor>    Returns the message or null
- */
-export const getPoolCandidateStatusLabel = (
-  status: Maybe<PoolCandidateStatus>,
-) => {
-  const key = status ? statusLabelMap.get(status) : null;
-  return key ? statusLabels.get(key) : null;
-};


### PR DESCRIPTION
🤖 Resolves #7432 

## 👋 Introduction

This branch updates the status chip, links, and status message on the recruitment cards.

## 🕵️ Details

At a high level, this branch extends the idea of a status map that was started in the i18n package and formalizes it into "CombinedStatus" which is derived from the pool candidate status and suspendedAt timestamp, together.

It also updates the Storybook story to list all possible status combinations, even if some should never appear as a qualified recruitment.

## 🧪 Testing

1. Check that the cards appear as intended in storybook
2. Check that the cards appear as intended in the application

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/dc2c3688-9be4-40ca-ab5e-b86f070ae653)