### PR TITLE
[Feature] ExperienceSkill pivots should soft-delete

### DIFF
--- a/api/app/Models/Experience.php
+++ b/api/app/Models/Experience.php
@@ -130,31 +130,6 @@ abstract class Experience extends Model
                 $this->userSkills()->attach($userSkillId, $detailsArray);
             }
         }
-
-        // ExperienceSkill::onlyTrashed()
-        //     ->where('experience_id', $this->id)
-        //     ->whereHas('userSkill', function ($query) use ($skillIds) {
-        //         $query->whereIn('skill_id', $skillIds);
-        //     })
-        //     ->restore();
-
-        // // I wanted to use syncWithoutDetaching, but it doesn't allow for updating pivot values like sync does.
-        // $skillsAlreadyAttachedToExperience = $this->userSkills()->pluck('skill_id');
-        // foreach($skills as $newSkill) {
-        //     $newSkill = collect($newSkill);
-        //     $userSkillId = $this->user->userSkills->firstWhere('skill_id', $newSkill->get('id'))->id;
-        //     $detailsArray = $newSkill->only('details')->toArray();
-        //     // If experienceSkill already exists
-        //     if ($skillsAlreadyAttachedToExperience->contains($newSkill->get('id'))) {
-        //         // And details is defined, then update details
-        //         if ($newSkill->has('details')) {
-        //             $this->userSkills()->updateExistingPivot($userSkillId, $detailsArray);
-        //         }
-        //     // Otherwise experienceSkill doesn't exist, so add it now
-        //     } else {
-        //         $this->userSkills()->attach($userSkillId, $detailsArray);
-        //     }
-        // }
         // If this experience instance continues to be used, ensure the in-memory instance is updated.
         $this->refresh();
     }

--- a/api/app/Models/Experience.php
+++ b/api/app/Models/Experience.php
@@ -96,7 +96,7 @@ abstract class Experience extends Model
         $skillIds = collect($skills)->pluck('id');
         $this->user->addSkills($skillIds);
 
-        $userSkills = UserSkill::where('user_id', $this->user_id); // Get this users UserSkills once, to avoid repeated db calls.
+        $userSkills = UserSkill::where('user_id', $this->user_id)->get(); // Get this users UserSkills once, to avoid repeated db calls.
 
         // Restore soft-deleted experience-skills which need to be connected.
          ExperienceSkill::onlyTrashed()
@@ -125,7 +125,7 @@ abstract class Experience extends Model
                     $existingPivot->save();
                 }
             } else { // If pivot doesn't exist yet, create it
-                $userSkillId = UserSkill::where('user_id', $this->user_id)->where('skill_id', $newSkill->get('id'))->first()->id;
+                $userSkillId = $userSkills->where('skill_id', $newSkill->get('id'))->first()->id;
                 $detailsArray = $newSkill->only('details')->toArray();
                 $this->userSkills()->attach($userSkillId, $detailsArray);
             }

--- a/api/app/Models/ExperienceSkill.php
+++ b/api/app/Models/ExperienceSkill.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Staudenmeir\EloquentHasManyDeep\HasRelationships;
+
+/**
+ * Class ExperienceSkill
+ *
+ * @property string $id
+ * @property string $experience_id
+ * @property string $experience_type
+ * @property string $user_skill_id
+ * @property string $details
+ * @property Illuminate\Support\Carbon $created_at
+ * @property Illuminate\Support\Carbon $updated_at
+ * @property Illuminate\Support\Carbon $deleted_at
+ */
+
+class ExperienceSkill extends Model
+{
+    use SoftDeletes;
+    use HasRelationships;
+
+
+    protected $keyType = 'string';
+    protected $table = 'experience_skill';
+
+    public function experience(): MorphTo
+    {
+        return $this->morphTo('experience');
+    }
+
+    public function userSkill(): BelongsTo
+    {
+        return $this->belongsTo(UserSkill::class);
+    }
+
+    public function skill()
+    {
+        return $this->hasOneDeepFromRelations($this->userSkill(), (new UserSkill())->skill());
+    }
+}

--- a/api/app/Models/Skill.php
+++ b/api/app/Models/Skill.php
@@ -59,31 +59,31 @@ class Skill extends Model
 
     public function awardExperiences()
     {
-        return $this->hasOneDeepFromRelations($this->userSkills(), (new UserSkill())->awardExperiences())
+        return $this->hasManyDeepFromRelations($this->userSkills(), (new UserSkill())->awardExperiences())
             ->withPivot('experience_skill', ['created_at', 'updated_at', 'details'])
             ->whereNull('experience_skill.deleted_at');
     }
     public function communityExperiences()
     {
-        return $this->hasOneDeepFromRelations($this->userSkills(), (new UserSkill())->communityExperiences())
+        return $this->hasManyDeepFromRelations($this->userSkills(), (new UserSkill())->communityExperiences())
             ->withPivot('experience_skill', ['created_at', 'updated_at', 'details'])
             ->whereNull('experience_skill.deleted_at');
     }
     public function educationExperiences()
     {
-        return $this->hasOneDeepFromRelations($this->userSkills(), (new UserSkill())->educationExperiences())
+        return $this->hasManyDeepFromRelations($this->userSkills(), (new UserSkill())->educationExperiences())
             ->withPivot('experience_skill', ['created_at', 'updated_at', 'details'])
             ->whereNull('experience_skill.deleted_at');
     }
     public function personalExperiences()
     {
-        return $this->hasOneDeepFromRelations($this->userSkills(), (new UserSkill())->personalExperiences())
+        return $this->hasManyDeepFromRelations($this->userSkills(), (new UserSkill())->personalExperiences())
             ->withPivot('experience_skill', ['created_at', 'updated_at', 'details'])
             ->whereNull('experience_skill.deleted_at');
     }
     public function workExperiences()
     {
-        return $this->hasOneDeepFromRelations($this->userSkills(), (new UserSkill())->workExperiences())
+        return $this->hasManyDeepFromRelations($this->userSkills(), (new UserSkill())->workExperiences())
             ->withPivot('experience_skill', ['created_at', 'updated_at', 'details'])
             ->whereNull('experience_skill.deleted_at');
     }

--- a/api/app/Models/Skill.php
+++ b/api/app/Models/Skill.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Staudenmeir\EloquentHasManyDeep\HasRelationships;
 
 /**
  * Class Skill
@@ -24,6 +25,7 @@ class Skill extends Model
 {
     use HasFactory;
     use SoftDeletes;
+    use HasRelationships;
 
     protected $keyType = 'string';
 
@@ -57,23 +59,33 @@ class Skill extends Model
 
     public function awardExperiences()
     {
-        return $this->hasManyThrough(AwardExperience::class, UserSkill::class);
+        return $this->hasOneDeepFromRelations($this->userSkills(), (new UserSkill())->awardExperiences())
+            ->withPivot('experience_skill', ['created_at', 'updated_at', 'details'])
+            ->whereNull('experience_skill.deleted_at');
     }
     public function communityExperiences()
     {
-        return $this->hasManyThrough(CommunityExperience::class, UserSkill::class);
+        return $this->hasOneDeepFromRelations($this->userSkills(), (new UserSkill())->communityExperiences())
+            ->withPivot('experience_skill', ['created_at', 'updated_at', 'details'])
+            ->whereNull('experience_skill.deleted_at');
     }
     public function educationExperiences()
     {
-        return $this->hasManyThrough(EducationExperience::class, UserSkill::class);
+        return $this->hasOneDeepFromRelations($this->userSkills(), (new UserSkill())->educationExperiences())
+            ->withPivot('experience_skill', ['created_at', 'updated_at', 'details'])
+            ->whereNull('experience_skill.deleted_at');
     }
     public function personalExperiences()
     {
-        return $this->hasManyThrough(PersonalExperience::class, UserSkill::class);
+        return $this->hasOneDeepFromRelations($this->userSkills(), (new UserSkill())->personalExperiences())
+            ->withPivot('experience_skill', ['created_at', 'updated_at', 'details'])
+            ->whereNull('experience_skill.deleted_at');
     }
     public function workExperiences()
     {
-        return $this->hasManyThrough(WorkExperience::class, UserSkill::class);
+        return $this->hasOneDeepFromRelations($this->userSkills(), (new UserSkill())->workExperiences())
+            ->withPivot('experience_skill', ['created_at', 'updated_at', 'details'])
+            ->whereNull('experience_skill.deleted_at');
     }
     public function getExperiencesAttribute()
     {

--- a/api/app/Models/UserSkill.php
+++ b/api/app/Models/UserSkill.php
@@ -38,7 +38,8 @@ class UserSkill extends Model
             'experience_skill'
         )
             ->withTimestamps()
-            ->withPivot('details')
+            ->withPivot(['details', 'deleted_at'])
+            ->wherePivotNull('deleted_at')
             ->as('experience_skill');
     }
     public function communityExperiences()
@@ -49,7 +50,8 @@ class UserSkill extends Model
             'experience_skill'
         )
             ->withTimestamps()
-            ->withPivot('details')
+            ->withPivot(['details', 'deleted_at'])
+            ->wherePivotNull('deleted_at')
             ->as('experience_skill');
     }
     public function educationExperiences()
@@ -60,7 +62,8 @@ class UserSkill extends Model
             'experience_skill'
         )
             ->withTimestamps()
-            ->withPivot('details')
+            ->withPivot(['details', 'deleted_at'])
+            ->wherePivotNull('deleted_at')
             ->as('experience_skill');
     }
     public function personalExperiences()
@@ -71,7 +74,8 @@ class UserSkill extends Model
             'experience_skill'
         )
             ->withTimestamps()
-            ->withPivot('details')
+            ->withPivot(['details', 'deleted_at'])
+            ->wherePivotNull('deleted_at')
             ->as('experience_skill');
     }
     public function workExperiences()
@@ -82,7 +86,8 @@ class UserSkill extends Model
             'experience_skill'
         )
             ->withTimestamps()
-            ->withPivot('details')
+            ->withPivot(['details', 'deleted_at'])
+            ->wherePivotNull('deleted_at')
             ->as('experience_skill_pivot');
     }
 }

--- a/api/app/Traits/ExperienceFactoryWithSkills.php
+++ b/api/app/Traits/ExperienceFactoryWithSkills.php
@@ -7,13 +7,14 @@ use App\Models\Skill;
 trait ExperienceFactoryWithSkills
 {
     /**
-     * Add skills to an experience
+     * Add skills to an experience.
+     * NOTE: does not create Skills. Skills must already be seeded!!!
      */
     public function withSkills(Int $count = 3)
     {
         return $this->afterCreating(function ($model) use ($count) {
             $skills = Skill::inRandomOrder()->limit($count)->get();
-            $model->syncSkills($skills->only(['id']));
+            $model->syncSkills($skills);
         });
     }
 }

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -195,7 +195,7 @@ class UserFactory extends Factory
             // Take $count random skills and assign each to a random experience of this user.
             $skills = Skill::inRandomOrder()->take($count)->get();
             $experience = $this->faker->randomElement($user->experiences);
-            $experience->syncSkills($skills->only(['id']));
+            $experience->syncSkills($skills);
         });
     }
 

--- a/api/database/migrations/2023_07_31_160346_update_experience_skill_with_soft_delete.php
+++ b/api/database/migrations/2023_07_31_160346_update_experience_skill_with_soft_delete.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('experience_skill', function (Blueprint $table) {
+            $table->date('deleted_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('experience_skill', function (Blueprint $table) {
+            $table->dropColumn('deleted_at');
+        });
+    }
+};

--- a/api/tests/Feature/ExperienceTest.php
+++ b/api/tests/Feature/ExperienceTest.php
@@ -319,7 +319,7 @@ class ExperienceTest extends TestCase
         $this->assertCount(2, $this->platformAdmin->userSkills);
     }
 
-    public function testUserSkillRelationshipIgnoresSoftDeletedPivots(): void {
+    public function testUserSkillRelationshipSkipsSoftDeletedPivots(): void {
         Skill::factory()->count(3)->create();
         $experience = AwardExperience::factory()->withSkills(3)->create();
         // sanity check
@@ -332,7 +332,7 @@ class ExperienceTest extends TestCase
         $this->assertCount(2, $experience->fresh()->userSkills);
     }
 
-    public function tesSkillRelationshipIgnoresSoftDeletedPivots(): void {
+    public function tesSkillRelationshipSkipsSoftDeletedPivots(): void {
         Skill::factory()->count(3)->create();
         $experience = AwardExperience::factory()->withSkills(3)->create();
         // sanity check

--- a/api/tests/Feature/ExperienceTest.php
+++ b/api/tests/Feature/ExperienceTest.php
@@ -1,10 +1,12 @@
 <?php
 
 use App\Models\AwardExperience;
+use App\Models\ExperienceSkill;
 use App\Models\Skill;
 use App\Models\User;
 use App\Models\UserSkill;
 use App\Models\WorkExperience;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithExceptionHandling;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Testing\Fluent\AssertableJson;
@@ -317,4 +319,29 @@ class ExperienceTest extends TestCase
         $this->assertCount(2, $this->platformAdmin->userSkills);
     }
 
+    public function testUserSkillRelationshipIgnoresSoftDeletedPivots(): void {
+        Skill::factory()->count(3)->create();
+        $experience = AwardExperience::factory()->withSkills(3)->create();
+        // sanity check
+        $this->assertCount(3, $experience->fresh()->userSkills);
+        // soft-delete one ExperienceSkill
+        $pivot = ExperienceSkill::first();
+        $pivot->deleted_at = Carbon::now();
+        $pivot->save();
+        // assert that the soft-deleted relationship is ignored
+        $this->assertCount(2, $experience->fresh()->userSkills);
+    }
+
+    public function tesSkillRelationshipIgnoresSoftDeletedPivots(): void {
+        Skill::factory()->count(3)->create();
+        $experience = AwardExperience::factory()->withSkills(3)->create();
+        // sanity check
+        $this->assertCount(3, $experience->fresh()->skills);
+        // soft-delete one ExperienceSkill
+        $pivot = ExperienceSkill::first();
+        $pivot->deleted_at = Carbon::now();
+        $pivot->save();
+        // assert that the soft-deleted relationship is ignored
+        $this->assertCount(2, $experience->fresh()->skills);
+    }
 }

--- a/api/tests/Feature/ExperienceTest.php
+++ b/api/tests/Feature/ExperienceTest.php
@@ -216,6 +216,36 @@ class ExperienceTest extends TestCase
         $this->assertCount(2, $experience->skills);
         $this->assertCount(2, $experience2->skills);
     }
+    public function checkMethodRestoresSoftDeletedPivots($method): void {
+        $userSkill = UserSkill::factory()->create([
+            'user_id' => $this->platformAdmin->id
+        ]);
+        $experience = WorkExperience::factory()->create([
+            'user_id' => $this->platformAdmin->id
+        ]);
+        $experienceSkill = new ExperienceSkill();
+        $experienceSkill->experience_id = $experience->id;
+        $experienceSkill->experience_type = 'workExperience';
+        $experienceSkill->user_skill_id = $userSkill->id;
+        $experienceSkill->details = "some details";
+        $experienceSkill->save();
+
+        // sanity check
+        $this->assertCount(1, $experience->fresh()->userSkills);
+
+        // now manually soft-delete the experienceSkill
+        $experienceSkill->deleted_at = Carbon::now();
+        $experienceSkill->save();
+
+        // now connect the same skill again
+        $experience->refresh()->$method([
+            ['id' => $userSkill->skill_id]
+        ]);
+
+        // now check that the experienceSkill is no longer soft-deleted, and the pivot details is same as before.
+        $this->assertNull($experienceSkill->fresh()->deleted_at);
+        $this->assertEquals('some details', $experience->userSkills->first()->experience_skill->details);
+    }
 
     // syncSkills tests
 
@@ -267,6 +297,35 @@ class ExperienceTest extends TestCase
     public function testSyncSkillsUndefinedDetailsDoesNotUpdateDetails(): void {
         $this->checkUndefinedDetailsDoesNotUpdateDetails('syncSkills');
     }
+    public function testSyncSkillsOnlySoftDeletesPivots(): void {
+        $userSkills = UserSkill::factory(2)->create([
+            'user_id' => $this->platformAdmin->id
+        ]);
+        $experience = WorkExperience::factory()->create([
+            'user_id' => $this->platformAdmin->id
+        ]);
+        $experience->userSkills()->sync([
+            $userSkills[0]->id => ['details' => 'first skill'],
+            $userSkills[1]->id => ['details' => 'second skill'],
+        ]);
+        // Sanity check
+        $this->assertCount(2, ExperienceSkill::all());
+
+        $experience->syncSkills([
+            ['id' => $userSkills[0]->skill_id],
+        ]);
+        // After syncing with just one skill, the other experienceSkill should be soft-deleted but otherwise unchanged.
+        $experienceSkill = ExperienceSkill::withTrashed()
+            ->where('user_skill_id', $userSkills[1]->id)
+            ->where('experience_id', $experience->id)
+            ->first();
+        $this->assertNotNull($experienceSkill);
+        $this->assertTrue($experienceSkill->trashed());
+        $this->assertEquals('second skill', $experienceSkill->details);
+    }
+    public function testSyncSkillsRestoresSoftDeletedPivots(): void {
+        $this->checkMethodRestoresSoftDeletedPivots('syncSkills');
+    }
 
     // connectSkills tests
 
@@ -291,6 +350,9 @@ class ExperienceTest extends TestCase
     }
     public function testConnectSkillsUndefinedDetailsDoesNotUpdateDetails(): void {
         $this->checkUndefinedDetailsDoesNotUpdateDetails('connectSkills');
+    }
+    public function testConnectSkillsRestoresSoftDeletedPivots(): void {
+        $this->checkMethodRestoresSoftDeletedPivots('connectSkills');
     }
 
     // disconnectSkills tests
@@ -319,6 +381,34 @@ class ExperienceTest extends TestCase
         $this->assertCount(2, $this->platformAdmin->userSkills);
     }
 
+    public function testDisconnectSkillsOnlySoftDeletesPivots(): void {
+        $userSkill = UserSkill::factory()->create([
+            'user_id' => $this->platformAdmin->id
+        ]);
+        $experience = WorkExperience::factory()->create([
+            'user_id' => $this->platformAdmin->id
+        ]);
+        $experience->userSkills()->sync([
+            $userSkill->id => ['details' => 'some details'],
+        ]);
+        // sanity check
+        $experienceSkill = ExperienceSkill::where('user_skill_id', $userSkill->id)
+            ->where('experience_id', $experience->id)
+            ->first();
+        $this->assertNotNull($experienceSkill);
+
+        // After disconnecting, the ExperienceSkill should still exist but soft-deleted but otherwise unchanged.
+        $experience->disconnectSkills([
+            $userSkill->skill_id,
+        ]);
+        $freshExperienceSkill =  ExperienceSkill::withTrashed()
+            ->where('user_skill_id', $userSkill->id)
+            ->where('experience_id', $experience->id)
+            ->first();
+        $this->assertTrue($freshExperienceSkill->trashed());
+        $this->assertEquals('some details', $freshExperienceSkill->details);
+    }
+
     public function testUserSkillRelationshipSkipsSoftDeletedPivots(): void {
         Skill::factory()->count(3)->create();
         $experience = AwardExperience::factory()->withSkills(3)->create();
@@ -332,7 +422,7 @@ class ExperienceTest extends TestCase
         $this->assertCount(2, $experience->fresh()->userSkills);
     }
 
-    public function tesSkillRelationshipSkipsSoftDeletedPivots(): void {
+    public function testSkillRelationshipSkipsSoftDeletedPivots(): void {
         Skill::factory()->count(3)->create();
         $experience = AwardExperience::factory()->withSkills(3)->create();
         // sanity check

--- a/api/tests/Feature/SkillTest.php
+++ b/api/tests/Feature/SkillTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use App\Models\CommunityExperience;
+use App\Models\ExperienceSkill;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
@@ -9,6 +11,7 @@ use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 use App\Models\Skill;
 use App\Models\User;
+use Carbon\Carbon;
 use Database\Helpers\ApiEnums;
 use Database\Seeders\RolePermissionSeeder;
 
@@ -97,7 +100,6 @@ class SkillTest extends TestCase
      */
     public function test_update_skill()
     {
-
         $variables = [
             'id' => $this->uuid,
             'skill' => [
@@ -169,5 +171,19 @@ class SkillTest extends TestCase
         $this->actingAs($this->adminUser, 'api')
             ->graphQL($mutation, $variables)
             ->assertJsonFragment(['name' => $variables['skill']['name']]);
+    }
+
+    public function testExperienceRelationshipsSkipSoftDeletedPivots(): void {
+        Skill::factory()->count(1)->create();
+        $experience = CommunityExperience::factory()->withSkills(1)->create();
+        $skill = $experience->skills->first();
+        // sanity check
+        $this->assertCount(1, $skill->fresh()->communityExperiences);
+        // soft-delete one ExperienceSkill
+        $pivot = ExperienceSkill::first();
+        $pivot->deleted_at = Carbon::now();
+        $pivot->save();
+        // assert that the soft-deleted relationship is ignored
+        $this->assertCount(0, $skill->fresh()->communityExperiences);
     }
 }

--- a/api/tests/Feature/UserSkillTest.php
+++ b/api/tests/Feature/UserSkillTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Models\ExperienceSkill;
+use App\Models\Skill;
+use App\Models\WorkExperience;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserSkillTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $platformAdmin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Run necessary seeders
+        $this->seed(RolePermissionSeeder::class);
+    }
+
+    public function testExperienceRelationshipSkipsSoftDeletedPivots(): void {
+        Skill::factory()->count(3)->create();
+        $experience = WorkExperience::factory()->withSkills(1)->create();
+        $userSkill = $experience->userSkills->first();
+        // sanity check
+        $this->assertCount(1, $userSkill->fresh()->workExperiences);
+        // soft-delete one ExperienceSkill
+        $pivot = ExperienceSkill::first();
+        $pivot->deleted_at = Carbon::now();
+        $pivot->save();
+        // assert that the soft-deleted relationship is ignored
+        $this->assertCount(0, $userSkill->fresh()->workExperiences);
+    }
+}


### PR DESCRIPTION
🤖 Resolves #7363.

## 👋 Introduction

This makes ExperienceSkills soft-deleted. That means that if you link an experience to a skill, add details, remove it, and re-link the skill, your previous details text will be restored.

## 🕵️ Details

This required some finagling to "simulate" soft-delete functionality, because [pivot models may not use the SoftDeletes trait](https://laravel.com/docs/10.x/eloquent-relationships#defining-custom-intermediate-table-models). In fact, I created an ExperienceSkill model which _can_ use the SoftDeletes trait and used that to make things a bit easier. But I can't use that model in the experience->skill relationships, because our API is currently designed around the `withPivot` functionality.

> Sidebar: Using withPivot is actually something I'd like to deprecate. Not only has it made this issue and #7218 **wayyyy** more complicated, I've also come to dislike how context-sensitive it makes the API. The value of something like `skill.experienceSkillRecord` for a given skill is entirely dependent on how you got to that skill. But that's an issue for another day. Especially since it's tied into our existing applicant snapshots. 😩

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Create or go to an experience
2. Link that experience to a skill
3. Write details for how you used this skill
4. Remove the skill from the experience
5. Re-add the same skill
6. Check that the details you originally wrote are back.