### PR TITLE
[Debt] Removes `withLocalizedQuotes` function

### DIFF
--- a/apps/web/src/components/EmploymentEquity/EquityOptions.tsx
+++ b/apps/web/src/components/EmploymentEquity/EquityOptions.tsx
@@ -12,7 +12,6 @@ import {
 import {
   getEmploymentEquityGroup,
   getEmploymentEquityStatement,
-  withLocalizedQuotes,
 } from "@gc-digital-talent/i18n";
 import { notEmpty } from "@gc-digital-talent/helpers";
 
@@ -270,16 +269,13 @@ const EquityOptions = ({
                     title={intl.formatMessage(
                       getEmploymentEquityGroup("indigenous"),
                     )}
-                    description={withLocalizedQuotes(
-                      intl.formatMessage({
-                        defaultMessage:
-                          "Indigenous identity refers to whether the person identified with the Indigenous peoples of Canada. This includes those who identify as First Nations (North American Indian), Métis and/or Inuk (Inuit), and/or those who report being Registered or Treaty Indians (that is, registered under the Indian Act of Canada), and/or those who have membership in a First Nation or Indian band. Aboriginal peoples of Canada (referred to here as Indigenous peoples) are defined in the Constitution Act, 1982, Section 35 (2) as including the Indian, Inuit and Métis peoples of Canada.",
-                        id: "YDeXEW",
-                        description:
-                          "Definition of Indigenous identity from the StatsCan 'Indigenous identity of person' page.",
-                      }),
-                      intl,
-                    )}
+                    description={intl.formatMessage({
+                      defaultMessage:
+                        '"Indigenous identity refers to whether the person identified with the Indigenous peoples of Canada. This includes those who identify as First Nations (North American Indian), Métis and/or Inuk (Inuit), and/or those who report being Registered or Treaty Indians (that is, registered under the Indian Act of Canada), and/or those who have membership in a First Nation or Indian band. Aboriginal peoples of Canada (referred to here as Indigenous peoples) are defined in the Constitution Act, 1982, Section 35 (2) as including the Indian, Inuit and Métis peoples of Canada."',
+                      id: "Is1RHA",
+                      description:
+                        "Definition of Indigenous identity from the StatsCan 'Indigenous identity of person' page.",
+                    })}
                   />
                 ) : null}
                 {!resolvedDisability && (
@@ -293,16 +289,13 @@ const EquityOptions = ({
                     title={intl.formatMessage(
                       getEmploymentEquityGroup("disability"),
                     )}
-                    description={withLocalizedQuotes(
-                      intl.formatMessage({
-                        defaultMessage:
-                          "Refers to a person whose daily activities are limited as a result of an impairment or difficulty with particular tasks. The only exception to this is for developmental disabilities where a person is considered to be disabled if the respondent has been diagnosed with this condition.",
-                        id: "y5Z2Li",
-                        description:
-                          "Definition of Person with a disability from the StatsCan 'Classification of Status of Disability' page.",
-                      }),
-                      intl,
-                    )}
+                    description={intl.formatMessage({
+                      defaultMessage:
+                        '"Refers to a person whose daily activities are limited as a result of an impairment or difficulty with particular tasks. The only exception to this is for developmental disabilities where a person is considered to be disabled if the respondent has been diagnosed with this condition."',
+                      id: "aK5Oop",
+                      description:
+                        "Definition of Person with a disability from the StatsCan 'Classification of Status of Disability' page.",
+                    })}
                   />
                 )}
                 {!resolvedMinority && (
@@ -316,16 +309,13 @@ const EquityOptions = ({
                     title={intl.formatMessage(
                       getEmploymentEquityGroup("minority"),
                     )}
-                    description={withLocalizedQuotes(
-                      intl.formatMessage({
-                        defaultMessage:
-                          'Visible minority refers to whether a person is a visible minority or not, as defined by the Employment Equity Act. The Employment Equity Act defines visible minorities as "persons, other than Aboriginal peoples, who are non-Caucasian in race or non-white in colour". The visible minority population consists mainly of the following groups: South Asian, Chinese, Black, Filipino, Arab, Latin American, Southeast Asian, West Asian, Korean and Japanese.',
-                        id: "F4K5RB",
-                        description:
-                          "Definition of Visible minority from the StatsCan 'Visible minority of person' page.",
-                      }),
-                      intl,
-                    )}
+                    description={intl.formatMessage({
+                      defaultMessage:
+                        '"Visible minority refers to whether a person is a visible minority or not, as defined by the Employment Equity Act. The Employment Equity Act defines visible minorities as "persons, other than Aboriginal peoples, who are non-Caucasian in race or non-white in colour". The visible minority population consists mainly of the following groups: South Asian, Chinese, Black, Filipino, Arab, Latin American, Southeast Asian, West Asian, Korean and Japanese."',
+                      id: "BDrP1l",
+                      description:
+                        "Definition of Visible minority from the StatsCan 'Visible minority of person' page.",
+                    })}
                   />
                 )}
                 {!resolvedWoman && (
@@ -339,16 +329,13 @@ const EquityOptions = ({
                     title={intl.formatMessage(
                       getEmploymentEquityGroup("woman"),
                     )}
-                    description={withLocalizedQuotes(
-                      intl.formatMessage({
-                        defaultMessage:
-                          "This category includes persons whose reported gender is female. It includes cisgender (cis) and transgender (trans) women.",
-                        id: "6danS7",
-                        description:
-                          "Definition of the Woman category from the StatsCan 'Classification of gender' page.",
-                      }),
-                      intl,
-                    )}
+                    description={intl.formatMessage({
+                      defaultMessage:
+                        '"This category includes persons whose reported gender is female. It includes cisgender (cis) and transgender (trans) women."',
+                      id: "4rI0Yj",
+                      description:
+                        "Definition of the Woman category from the StatsCan 'Classification of gender' page.",
+                    })}
                   />
                 )}
               </>

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -999,6 +999,10 @@
     "defaultMessage": "Lorsque vous postulez à un processus de recrutement et que vous réussissez l’évaluation, vous êtes admis(e) et vous pouvez commencer à être pris en considération pour les possibilités correspondantes. Cette section présente tous les processus actifs et expirés auxquels vous participez actuellement et vous permet de gérer le fait que vous apparaissiez ou non dans les recherches de talents.",
     "description": "Descriptive paragraph for the Qualified recruitment processes section of the career timeline and recruitment page."
   },
+  "4rI0Yj": {
+    "defaultMessage": "« Cette catégorie comprend les personnes dont le genre déclaré est féminin. Elle comprend les femmes cisgenres (cis) et les femmes transgenres (trans). »",
+    "description": "Definition of the Woman category from the StatsCan 'Classification of gender' page."
+  },
   "4sLCWZ": {
     "defaultMessage": "Continuez vers CléGC et connectez-vous",
     "description": "GCKey sign in link text on the sign in page"
@@ -1250,10 +1254,6 @@
   "6bvAQ+": {
     "defaultMessage": "Rétroaction et coordonnées",
     "description": "Title for the accessibility feedback section"
-  },
-  "6danS7": {
-    "defaultMessage": "Cette catégorie comprend les personnes dont le genre déclaré est féminin. Elle comprend les femmes cisgenres (cis) et les femmes transgenres (trans).",
-    "description": "Definition of the Woman category from the StatsCan 'Classification of gender' page."
   },
   "6eA/CF": {
     "defaultMessage": "Langue :",
@@ -1899,6 +1899,10 @@
     "defaultMessage": "Ministère",
     "description": "Title displayed for the teams table department column."
   },
+  "BDrP1l": {
+    "defaultMessage": "« Minorité visible réfère au fait qu'une personne est ou non une minorité visible, tel que défini dans la Loi sur l'équité en matière d'emploi. Dans le cadre de la Loi sur l'équité en matière d'emploi, les minorités visibles sont définies comme « les personnes, autres que les Autochtones, qui ne sont pas de race blanche ou qui n'ont pas la peau blanche ». La population des minorités visibles est principalement composée des groupes suivants : Sud-Asiatique, Chinois, Noir, Philippin, Arabe, Latino-Américain, Asiatique du Sud-Est, Asiatique occidental, Coréen et Japonais. »",
+    "description": "Definition of Visible minority from the StatsCan 'Visible minority of person' page."
+  },
   "BFewIk": {
     "defaultMessage": "Afficher les évaluations des compétences de ce recrutement",
     "description": "Button text to show a miscellaneous qualified recruitment's skill assessments"
@@ -2435,10 +2439,6 @@
     "defaultMessage": "Modifier les options de votre lieu de travail.",
     "description": "Link text to edit work location on profile"
   },
-  "F4K5RB": {
-    "defaultMessage": "Minorité visible réfère au fait qu'une personne est ou non une minorité visible, tel que défini dans la Loi sur l'équité en matière d'emploi. Dans le cadre de la Loi sur l'équité en matière d'emploi, les minorités visibles sont définies comme « les personnes, autres que les Autochtones, qui ne sont pas de race blanche ou qui n'ont pas la peau blanche ». La population des minorités visibles est principalement composée des groupes suivants : Sud-Asiatique, Chinois, Noir, Philippin, Arabe, Latino-Américain, Asiatique du Sud-Est, Asiatique occidental, Coréen et Japonais.",
-    "description": "Definition of Visible minority from the StatsCan 'Visible minority of person' page."
-  },
   "F4RHJu": {
     "defaultMessage": "Il manque des renseignements obligatoires sur la langue",
     "description": "Error message displayed when a users language information is incomplete"
@@ -2950,6 +2950,10 @@
   "Iodi0/": {
     "defaultMessage": "Nos concepteurs prêtent une attention particulière aux éléments suivants : ",
     "description": "Intro to list of items designers consider for accessibility"
+  },
+  "Is1RHA": {
+    "defaultMessage": "« Identité autochtone désigne les personnes s'identifiant aux peuples autochtones du Canada. Cela comprend les personnes qui s'identifient à titre de membres des Premières Nations (Indiens de l'Amérique du Nord), Métis et/ou Inuits, et/ou les personnes qui déclarent être des Indiens inscrits ou des Indiens des traités (aux termes de la Loi sur les Indiens du Canada), et/ou les personnes qui sont membres d'une Première Nation ou d'une bande indienne. Le paragraphe 35 (2) de la Loi constitutionnelle de 1982 précise que l'expression « peuples autochtones du Canada » s'entend notamment des Indiens, des Inuits et des Métis du Canada. »",
+    "description": "Definition of Indigenous identity from the StatsCan 'Indigenous identity of person' page."
   },
   "Ix0KgU": {
     "defaultMessage": "Conseiller principal ou Gestionnaire I T 4 (101 000 $ à 126 000 $)",
@@ -4941,10 +4945,6 @@
     "defaultMessage": "Télécharger le formulaire<hidden>{formName} </hidden> (EN)",
     "description": "Link text for an English form download"
   },
-  "YDeXEW": {
-    "defaultMessage": "Identité autochtone désigne les personnes s'identifiant aux peuples autochtones du Canada. Cela comprend les personnes qui s'identifient à titre de membres des Premières Nations (Indiens de l'Amérique du Nord), Métis et/ou Inuits, et/ou les personnes qui déclarent être des Indiens inscrits ou des Indiens des traités (aux termes de la Loi sur les Indiens du Canada), et/ou les personnes qui sont membres d'une Première Nation ou d'une bande indienne. Le paragraphe 35 (2) de la Loi constitutionnelle de 1982 précise que l'expression « peuples autochtones du Canada » s'entend notamment des Indiens, des Inuits et des Métis du Canada.",
-    "description": "Definition of Indigenous identity from the StatsCan 'Indigenous identity of person' page."
-  },
   "YGM/D5": {
     "defaultMessage": "Le programme dure 24 mois et les apprentis ont accès à un soutien pendant leur période de participation au programme.",
     "description": "Learn more dialog question two paragraph one"
@@ -5250,6 +5250,10 @@
   "aGaaPi": {
     "defaultMessage": "Femme",
     "description": "CSV Header, Woman column"
+  },
+  "aK5Oop": {
+    "defaultMessage": "« Réfère à une personne dont les activités quotidiennes sont limitées en raison d'un trouble ou d'une difficulté à accomplir certaines tâches. La seule exception à cet égard concerne les troubles du développement, le répondant qui a reçu un tel diagnostic étant considéré comme ayant une incapacité. »",
+    "description": "Definition of Person with a disability from the StatsCan 'Classification of Status of Disability' page."
   },
   "aMhznA": {
     "defaultMessage": "Le programme d’apprentissage fait partie d’une initiative élargie sur les talents du numérique au sein du gouvernement du Canada dont le but consiste à recruter d’incroyables talents du numérique comme vous. Ce profil donne accès à d’autres possibilités et recrutements dans le secteur numérique autres que le programme d’apprentissage, si vous souhaitez y présenter votre candidature. Vous pouvez aussi vous en tenir au programme d’apprentissage si vous préférez!",
@@ -8482,10 +8486,6 @@
   "y2Rl/m": {
     "defaultMessage": "Étapes relatives à l’application",
     "description": "Label for the application stepper navigation"
-  },
-  "y5Z2Li": {
-    "defaultMessage": "Réfère à une personne dont les activités quotidiennes sont limitées en raison d'un trouble ou d'une difficulté à accomplir certaines tâches. La seule exception à cet égard concerne les troubles du développement, le répondant qui a reçu un tel diagnostic étant considéré comme ayant une incapacité.",
-    "description": "Definition of Person with a disability from the StatsCan 'Classification of Status of Disability' page."
   },
   "y827h2": {
     "defaultMessage": "Sélectionnez un ministère",

--- a/packages/i18n/src/index.tsx
+++ b/packages/i18n/src/index.tsx
@@ -17,7 +17,6 @@ import {
   getLocalizedName,
   localizeCurrency,
   localizeSalaryRange,
-  withLocalizedQuotes,
 } from "./utils/localize";
 
 import {
@@ -93,7 +92,6 @@ export {
   getLocalizedName,
   localizeCurrency,
   localizeSalaryRange,
-  withLocalizedQuotes,
   STORED_LOCALE,
   apiMessages,
   commonMessages,

--- a/packages/i18n/src/utils/localize.ts
+++ b/packages/i18n/src/utils/localize.ts
@@ -114,9 +114,3 @@ export const localizeSalaryRange = (
 
   return salaryRange;
 };
-
-export const withLocalizedQuotes = (text: string, intl: IntlShape): string => {
-  const locale = getLocale(intl);
-
-  return locale === "fr" ? `« ${text} »` : `"${text}"`;
-};


### PR DESCRIPTION
🤖 Resolves #7537.

## 👋 Introduction

This PR removes the `withLocalizedQuotes` function and includes quotes within the i18n string itself instead.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to profile
2. Observe Diversity, equity and inclusion section
3. Ensure definition strings appear correctly in both English and French (as before)
