### PR TITLE
[Fix] Email for contact us on manager home page

### DIFF
--- a/apps/web/src/pages/Home/ManagerHomePage/ManagerHomePage.tsx
+++ b/apps/web/src/pages/Home/ManagerHomePage/ManagerHomePage.tsx
@@ -314,7 +314,7 @@ const HomePage = () => {
                     id: "2OTKDd",
                     description: "Subject for email to gain hiring experience",
                   }),
-                )}}`,
+                )}`,
                 label: intl.formatMessage({
                   defaultMessage:
                     "Contact us<hidden> about hiring experience</hidden>",

--- a/apps/web/src/pages/Home/ManagerHomePage/ManagerHomePage.tsx
+++ b/apps/web/src/pages/Home/ManagerHomePage/ManagerHomePage.tsx
@@ -22,6 +22,7 @@ import managerProfileHero from "~/assets/img/manager-profile-hero.jpg";
 import peopleGatheredAroundLaptop from "~/assets/img/people-gathered-around-laptop.jpg";
 import peopleSittingOnCouch from "~/assets/img/people-sitting-on-couch-discussing-something.jpg";
 import peopleSittingInLine from "~/assets/img/people-sitting-in-a-line-smiling-at-another-person.jpg";
+import { TALENTSEARCH_SUPPORT_EMAIL } from "~/constants/talentSearchConstants";
 
 const HomePage = () => {
   const intl = useIntl();
@@ -144,7 +145,7 @@ const HomePage = () => {
             })}
             links={[
               {
-                href: `mailto:recruitment-recruitementgiti@tbs-sct.gc.ca?subject=${encodeURIComponent(
+                href: `mailto:${TALENTSEARCH_SUPPORT_EMAIL}?subject=${encodeURIComponent(
                   intl.formatMessage({
                     defaultMessage:
                       "I'm interested in running a recruitment process",
@@ -306,7 +307,7 @@ const HomePage = () => {
               ),
               link: {
                 external: true,
-                path: `mailto:recruitment-recruitementgiti@tbs-sct.gc.ca?subject=${encodeURIComponent(
+                path: `mailto:${TALENTSEARCH_SUPPORT_EMAIL}?subject=${encodeURIComponent(
                   intl.formatMessage({
                     defaultMessage:
                       "I'm interested in gaining hiring experience",


### PR DESCRIPTION
🤖 Resolves #7572.

## 👋 Introduction

This PR changes the email address for Contact us on the manager home page to use the `TALENTSEARCH_SUPPORT_EMAIL` constant.

## 🕵️ Details

Also, removes an unintended closing curly bracket from the end of one of the subject lines that is part of the `mailto` link, fe877b89c517a979f009505c041685818966eb78.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/manager`


2. Hover over or select the **Contact us** buttons
3. Observe to address is gctalent-talentgc@support-soutien.gc.ca

## 📸 Screenshots

![Screen Shot 2023-08-11 at 09 53 12](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/1dabc2a2-dae9-4307-953a-6896685432f1)

![Screen Shot 2023-08-11 at 09 53 26](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/d7ad12fd-b1d0-4022-bb7d-a96d389150d0)
