### PR TITLE
[Fix] `TrackApplicationsCard` action link alignment

### DIFF
--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplicationsCard.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplicationsCard.tsx
@@ -158,7 +158,8 @@ const TrackApplicationsCard = ({
       >
         <div
           data-h2-display="base(flex)"
-          data-h2-justify-content="base(center) p-tablet(flex-start)"
+          data-h2-flex-direction="base(column) p-tablet(row)"
+          data-h2-justify-content="base(flex-start)"
           data-h2-gap="base(x1)"
         >
           <ApplicationActions.ViewAction
@@ -184,7 +185,7 @@ const TrackApplicationsCard = ({
         </div>
         <div
           data-h2-flex-grow="p-tablet(1)"
-          data-h2-text-align="base(center) p-tablet(right)"
+          data-h2-text-align="base(left) p-tablet(right)"
         >
           <ApplicationActions.CopyApplicationIdAction
             show


### PR DESCRIPTION
🤖 Resolves #7465 

## 👋 Introduction

Updates the action links on the `TrackApplicationsCard` to be left aligned smaller screens.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run storybook `npm run storybook`
2. Navigate to the "Track Applications Card" story
3. Change the viewport to a small screen (preferrable mulple)
4. Confirm the action links appear left aligned in a column layout

## 📸 Screenshot
![Screenshot 2023-08-11 131122](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/7d21eed9-517f-4767-ad13-64b0c26780cb)
