### PR TITLE
[Feature] Filter out the ATIP stream when making stream options for the search page

### DIFF
--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -313,12 +313,14 @@ const SearchForm = React.forwardRef<SearchFormRef, SearchFormProps>(
         })),
       [classifications, getClassificationLabel],
     );
-    const streamOptions: Option<PoolStream>[] = enumToOptions(PoolStream).map(
-      ({ value }) => ({
+    const streamOptions: Option<PoolStream>[] = enumToOptions(PoolStream)
+      .map(({ value }) => ({
         value: value as PoolStream,
         label: intl.formatMessage(getPoolStream(value)),
-      }),
-    );
+      }))
+      // Avoid showing the ATIP stream as an option, since we don't have pools with candidates yet.
+      // TODO: remove this when ATIP pools are ready. See ticket https://github.com/GCTC-NTGC/gc-digital-talent/issues/7601
+      .filter(({ value }) => value !== PoolStream.AccessInformationPrivacy);
 
     return (
       <FormProvider {...methods}>


### PR DESCRIPTION
🤖 Resolves #7600

## 👋 Introduction

Hides the new Access to Information and Privacy stream on the talent search page, until there are pools with candidates to fulfill those requests.

## 🕵️ Details

This is likely temporary

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Go to http://localhost:8000/en/search
2. Ensure you can't select "Access to Information and Privacy" in the streams dropdown

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4313717/ff313f77-1507-4c97-83d2-83a04d759f87)
