### PR TITLE
[Fix] Adds missing `userId` prop to story

### DIFF
--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplications.stories.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplications.stories.tsx
@@ -38,6 +38,7 @@ export default {
   title: "Pages/Profile and Applications/Track Applications",
   args: {
     applications: [...activeRecruitments, ...expiredRecruitments],
+    userId: mockApplications[0].id,
   },
 } as Meta;
 


### PR DESCRIPTION
🤖 Resolves #7591.

## 👋 Introduction

This PR adds a missing `userId` prop to a its storybook story that was required for an `intl` string.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run storybook`
2. Navigate to `TrackApplications`
3. Switch locale to FR
4. Observe **Lorsqu'une candidature a été évaluée ave succès,** string in French

## 📸 Screenshot

![Screen Shot 2023-08-15 at 11 43 27](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/50d27b5a-b900-4390-8ca8-9ce5f7446ff0)
