### PR TITLE
[Fix] Remove FF workaround for nested items

### DIFF
--- a/packages/ui/src/components/TableOfContents/List.tsx
+++ b/packages/ui/src/components/TableOfContents/List.tsx
@@ -4,12 +4,7 @@ export type ListItemProps = React.HTMLProps<HTMLLIElement>;
 
 export const ListItem = ({ children, ...rest }: ListItemProps) => (
   <li data-h2-margin-bottom="base(x.25)" {...rest}>
-    <span
-      data-h2-display="base(inline-flex)"
-      data-h2-align-items="base(flex-start)"
-    >
-      {children}
-    </span>
+    {children}
   </li>
 );
 


### PR DESCRIPTION
🤖 Resolves #7604 

## 👋 Introduction

This branch removes an old FF workaround that is breaking the layout of nested nav items.

## 🧪 Testing

1. Review Chromatic diff, especially the Table of Contents story.

## 📸 Screenshot

Add a screenshot (if possible).
