### PR TITLE
[Fix] Spacing for personal information form

### DIFF
--- a/apps/web/src/components/Profile/components/PersonalInformation/FormFields.tsx
+++ b/apps/web/src/components/Profile/components/PersonalInformation/FormFields.tsx
@@ -30,9 +30,9 @@ const FormFields = ({ labels }: FormFieldProps) => {
     <>
       <div
         data-h2-display="base(grid)"
-        data-h2-grid-template-columns="base(1fr 1fr)"
-        data-h2-gap="base(0 x1)"
-        data-h2-margin-top="base(-x1)"
+        data-h2-grid-template-columns="l-tablet(1fr 1fr)"
+        data-h2-gap="base(x1)"
+        data-h2-margin-bottom="base(x1)"
       >
         <Input
           id="firstName"
@@ -101,7 +101,7 @@ const FormFields = ({ labels }: FormFieldProps) => {
       </div>
       <div
         data-h2-display="base(grid)"
-        data-h2-gap="l-tablet(0 x1)"
+        data-h2-gap="base(x1)"
         data-h2-grid-template-columns="l-tablet(1fr 1fr 1fr)"
         data-h2-margin-bottom="base(x1)"
       >


### PR DESCRIPTION
🤖 Resolves #7595 

## 👋 Introduction

Fixes the vertical spacing in the personal information form on the profile.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to your profile `/users/{userId}/profile`
3. Open the personal information form
4. Confirm it is consistently spaced on desktop and mobile

## 📸 Screenshot

![Screenshot 2023-08-16 130024](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/3ab6dc42-9c82-4c12-a260-6270d4da830e)
