### PR TITLE
[Debt] Removes My status section

### DIFF
--- a/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
+++ b/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
@@ -175,7 +175,7 @@ const ProfileDocument = React.forwardRef<HTMLDivElement, ProfileDocumentProps>(
                       </PageSection>
                       <PageSection>
                         <Heading level="h3">
-                          {intl.formatMessage(navigationMessages.myStatus)}
+                          {intl.formatMessage(commonMessages.status)}
                         </Heading>
                         {result.armedForcesStatus !== null &&
                           result.armedForcesStatus !== undefined && (

--- a/apps/web/src/components/UserProfile/UserProfile.tsx
+++ b/apps/web/src/components/UserProfile/UserProfile.tsx
@@ -53,7 +53,6 @@ interface UserProfileProps {
     government?: SectionControl;
     hiringPools?: SectionControl;
     language?: SectionControl;
-    myStatus?: SectionControl;
     careerTimelineAndRecruitment?: SectionControl;
     workLocation?: SectionControl;
     workPreferences?: SectionControl;
@@ -153,13 +152,6 @@ const UserProfile = ({
       {isNavigationVisible && (
         <TableOfContents.Navigation>
           <TableOfContents.List>
-            {showSection("myStatus") && (
-              <TableOfContents.ListItem>
-                <TableOfContents.AnchorLink id={PAGE_SECTION_ID.STATUS}>
-                  {intl.formatMessage(navigationMessages.myStatus)}
-                </TableOfContents.AnchorLink>
-              </TableOfContents.ListItem>
-            )}
             {showSection("about") && (
               <TableOfContents.ListItem>
                 <TableOfContents.AnchorLink id={PAGE_SECTION_ID.ABOUT}>
@@ -276,36 +268,6 @@ const UserProfile = ({
       )}
       <TableOfContents.Content>
         {subTitle}
-        {showSection("myStatus") && (
-          <TableOfContents.Section id={PAGE_SECTION_ID.STATUS}>
-            <HeadingWrapper show={!!sections.myStatus?.editUrl}>
-              <div
-                data-h2-flex-item="base(1of1) p-tablet(fill)"
-                data-h2-text-align="base(center) p-tablet(left)"
-              >
-                <TableOfContents.Heading as={headingLevel} icon={LightBulbIcon}>
-                  {intl.formatMessage(navigationMessages.myStatus)}
-                </TableOfContents.Heading>
-              </div>
-              {sections.myStatus?.editUrl && (
-                <EditUrlLink
-                  link={sections.myStatus.editUrl}
-                  text={intl.formatMessage(
-                    {
-                      defaultMessage: "Edit {title}",
-                      id: "3R3jKp",
-                      description: "Link to edit object",
-                    },
-                    {
-                      title: intl.formatMessage(navigationMessages.myStatus),
-                    },
-                  )}
-                />
-              )}
-            </HeadingWrapper>
-            {sections.myStatus?.override ? sections.myStatus.override : null}
-          </TableOfContents.Section>
-        )}
         {showSection("about") && (
           <TableOfContents.Section id={PAGE_SECTION_ID.ABOUT}>
             <HeadingWrapper show={!!sections.about?.editUrl}>

--- a/apps/web/src/components/UserProfile/constants.ts
+++ b/apps/web/src/components/UserProfile/constants.ts
@@ -1,5 +1,4 @@
 export const PAGE_SECTION_ID = {
-  STATUS: "status-section",
   ABOUT: "about-section",
   DEI: "diversity-equity-inclusion-section",
   LANGUAGE: "language-section",

--- a/apps/web/src/pages/Profile/ProfilePage/ProfilePage.stories.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/ProfilePage.stories.tsx
@@ -12,17 +12,6 @@ export default {
   component: ProfilePage,
   title: "Pages/Profile Page",
   args: {},
-  parameters: {
-    apiResponses: {
-      getMyStatus: {
-        data: {
-          me: {
-            isProfileComplete: true,
-          },
-        },
-      },
-    },
-  },
 } as Meta;
 
 const Template: StoryFn<ProfilePageProps["user"]> = (args) => {
@@ -38,14 +27,7 @@ CompletedWithExperiences.args = {
   ...fakeUserData,
   experiences: fakeExperienceArray,
 };
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const nullUserData: any = {};
-Object.keys(fakeUserData).forEach((key) => {
-  nullUserData[key] = null;
-});
 EmptyAllNull.args = {
-  ...nullUserData,
   id: "test ID", // this page can only be loaded by a logged in user
   email: undefined,
 };

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -588,10 +588,6 @@
     "defaultMessage": "La date doit être avant ou égale au {date}",
     "description": "Error message when a date was entered that is greater than the maximum required"
   },
-  "PxUSSH": {
-    "defaultMessage": "Mon statut",
-    "description": "Name of My status page"
-  },
   "QCcpJr": {
     "defaultMessage": "Éliminé à la présélection – non réactif",
     "description": "The pool candidate's status is Screened Out because no longer responding"

--- a/packages/i18n/src/messages/navigationMessages.ts
+++ b/packages/i18n/src/messages/navigationMessages.ts
@@ -26,11 +26,6 @@ const navigationMessages = defineMessages({
     id: "Gx8qCK",
     description: "Name of About me page",
   },
-  myStatus: {
-    defaultMessage: "My status",
-    id: "PxUSSH",
-    description: "Name of My status page",
-  },
   diversityEquityInclusion: {
     defaultMessage: "Diversity, equity and inclusion",
     id: "ad4mTC",


### PR DESCRIPTION
🤖 Resolves #6804.

## 👋 Introduction

This PR removes the **My status** section no longer used in the user profile.

## 🕵️ Details

- Removes **My status** section from `apps/web/src/components/UserProfile/UserProfile.tsx`
- Replaces the **My status** string with **Status** in `ProfileDocument` (h/t @Jerryescandon).
- Removes some unused strings related to the section and some unused code related to how the profile page used to work in ` apps/web/src/pages/Profile/ProfilePage/ProfilePage.stories.tsx`.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run storybook`
2. Ensure **Profile Page** stories continue to work as before
3. Navigate to profile page
4. Ensure that the profile continue to work as before