### PR TITLE
[Fix] Sidebar mobile spacing

### DIFF
--- a/packages/ui/src/components/TableOfContents/Sidebar.tsx
+++ b/packages/ui/src/components/TableOfContents/Sidebar.tsx
@@ -6,7 +6,11 @@ export interface SidebarProps extends React.HTMLProps<HTMLElement> {
 
 const Sidebar = ({ children, ...rest }: SidebarProps) => (
   <aside data-h2-flex-item="base(1of1) l-tablet(1of4)" {...rest}>
-    <div data-h2-height="base(100%)" data-h2-position="base(relative)">
+    <div
+      data-h2-height="base(100%)"
+      data-h2-position="base(relative)"
+      data-h2-margin-bottom="base(x1)"
+    >
       <div
         data-h2-position="base(sticky)"
         data-h2-location="base(x3, auto, auto, auto)"


### PR DESCRIPTION
🤖 Resolves #7587 

## 👋 Introduction

Adds margin bottom to the sidebar to improve mobile spacing in safari.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to the success page of an application
3. Reduce screen width
4. Confirm stepper is spaced from alert on mobile screens

## 📸 Screenshot

<img width="573" alt="image" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/6b6032ca-f5e0-4f73-9a7c-22f2e07ac20a">
