### PR TITLE
[Debt] Remove unused prop from filter dialogs

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateTableFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateTableFilterDialog.tsx
@@ -35,17 +35,13 @@ export type FormValues = {
   publishingGroups: Option["value"][];
 };
 
-type FooterProps = Pick<
-  PoolCandidateTableFilterDialogProps,
-  "enableEducationType"
->;
-const Footer = ({ enableEducationType }: FooterProps): JSX.Element => {
+const Footer = () => {
   const { formatMessage } = useIntl();
   const {
     reset,
     formState: { isSubmitting },
   } = useFormContext();
-  const { emptyFormValues } = useFilterOptions(enableEducationType);
+  const { emptyFormValues } = useFilterOptions();
   const handleClear = () => {
     reset(emptyFormValues);
   };
@@ -75,7 +71,6 @@ interface PoolCandidateTableFilterDialogProps {
   onOpenChange: (open: boolean) => void;
   onSubmit: SubmitHandler<FormValues>;
   activeFilters: FormValues;
-  enableEducationType?: boolean;
 }
 
 const PoolCandidateTableFilterDialog = ({
@@ -83,11 +78,9 @@ const PoolCandidateTableFilterDialog = ({
   onOpenChange,
   onSubmit,
   activeFilters,
-  enableEducationType = false,
 }: PoolCandidateTableFilterDialogProps): JSX.Element => {
   const { formatMessage, locale } = useIntl();
-  const { optionsData, rawGraphqlResults } =
-    useFilterOptions(enableEducationType);
+  const { optionsData, rawGraphqlResults } = useFilterOptions();
 
   return (
     <Dialog.Root open={isOpen} onOpenChange={onOpenChange}>
@@ -301,7 +294,7 @@ const PoolCandidateTableFilterDialog = ({
 
 type PoolCandidateTableFiltersProps = Pick<
   PoolCandidateTableFilterDialogProps,
-  "onSubmit" | "enableEducationType"
+  "onSubmit"
 > & {
   isOpenDefault?: boolean;
   initialFilters?: FormValues;
@@ -310,11 +303,10 @@ type PoolCandidateTableFiltersProps = Pick<
 const PoolCandidateTableFilters = ({
   onSubmit,
   isOpenDefault = false,
-  enableEducationType,
   initialFilters,
   ...rest
 }: PoolCandidateTableFiltersProps) => {
-  const { emptyFormValues } = useFilterOptions(enableEducationType);
+  const { emptyFormValues } = useFilterOptions();
   const initialStateActiveFilters = initialFilters ?? emptyFormValues;
   const [activeFilters, setActiveFilters] = useState<FormValues>(
     initialStateActiveFilters,
@@ -329,7 +321,7 @@ const PoolCandidateTableFilters = ({
 
   return (
     <PoolCandidateTableFilterDialog
-      {...{ isOpen, isOpenDefault, activeFilters, enableEducationType }}
+      {...{ isOpen, isOpenDefault, activeFilters }}
       {...rest}
       onOpenChange={setIsOpen}
       onSubmit={handleSubmit}

--- a/apps/web/src/components/Table/ApiManagedTable/useFilterOptions.test.tsx
+++ b/apps/web/src/components/Table/ApiManagedTable/useFilterOptions.test.tsx
@@ -18,11 +18,9 @@ import useFilterOptions from "./useFilterOptions";
 
 describe("useFilterOptions", () => {
   function renderHookWithProviders({
-    enableEducationSelect,
     msDelay = 0,
     responseData = {},
   }: {
-    enableEducationSelect?: boolean;
     msDelay?: number;
     responseData?: object;
   }) {
@@ -40,34 +38,12 @@ describe("useFilterOptions", () => {
         <GraphqlProvider value={mockClient}>{children}</GraphqlProvider>
       </IntlProvider>
     );
-    const { result } = renderHook(
-      () => useFilterOptions(enableEducationSelect),
-      {
-        wrapper,
-      },
-    );
+    const { result } = renderHook(() => useFilterOptions(), {
+      wrapper,
+    });
 
     return result;
   }
-  describe("enableEducationSelect toggle", () => {
-    it("has key educationType when enabled and appropriate number of options", () => {
-      const result = renderHookWithProviders({ enableEducationSelect: true });
-      expect(result.current.emptyFormValues.educationType).toStrictEqual([]);
-      expect(result.current.optionsData.educationType).toHaveLength(8);
-    });
-
-    it("does not have key educationType when disabled", () => {
-      const result = renderHookWithProviders({ enableEducationSelect: false });
-      expect(result.current.emptyFormValues.educationType).toBeUndefined();
-      expect(result.current.optionsData.educationType).toBeUndefined();
-    });
-
-    it("does not have key educationType when unset", () => {
-      const result = renderHookWithProviders({});
-      expect(result.current.emptyFormValues.educationType).toBeUndefined();
-      expect(result.current.optionsData.educationType).toBeUndefined();
-    });
-  });
 
   describe("rawGraphqlResults", () => {
     it("shows as fetching before response arrives", () => {

--- a/apps/web/src/components/Table/ApiManagedTable/useFilterOptions.tsx
+++ b/apps/web/src/components/Table/ApiManagedTable/useFilterOptions.tsx
@@ -47,7 +47,7 @@ const context: Partial<OperationContext> = {
 
 // TODO: Remove this toggle after data model settles.
 // See: https://www.figma.com/proto/XS4Ag6GWcgdq2dBlLzBkay?node-id=1064:5862#224617157
-export default function useFilterOptions(enableEducationType = false) {
+export default function useFilterOptions() {
   const intl = useIntl();
   const { locale } = useLocale();
   const [filterRes] = useGetFilterDataQuery({
@@ -103,14 +103,6 @@ export default function useFilterOptions(enableEducationType = false) {
       value,
       label: intl.formatMessage(getWorkRegion(value)),
     })),
-    ...(enableEducationType
-      ? {
-          educationType: enumToOptions(EducationType).map(({ value }) => ({
-            value,
-            label: intl.formatMessage(getEducationType(value)),
-          })),
-        }
-      : {}),
     // Not really an enum, but works fine.
     employmentDuration: enumToOptions(EmploymentDuration).map(({ value }) => ({
       value,

--- a/apps/web/src/components/Table/ApiManagedTable/useFilterOptions.tsx
+++ b/apps/web/src/components/Table/ApiManagedTable/useFilterOptions.tsx
@@ -7,7 +7,6 @@ import {
   getEmploymentDuration,
   getLanguageAbility,
   getOperationalRequirement,
-  getEducationType,
   EmploymentDuration,
   OperationalRequirementV2,
   getEmploymentEquityGroup,
@@ -32,7 +31,6 @@ import {
   PoolStream,
   PublishingGroup,
   WorkRegion,
-  EducationType,
   LanguageAbility,
   PoolCandidateStatus,
   useGetFilterDataQuery,
@@ -45,8 +43,6 @@ const context: Partial<OperationContext> = {
   requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
 };
 
-// TODO: Remove this toggle after data model settles.
-// See: https://www.figma.com/proto/XS4Ag6GWcgdq2dBlLzBkay?node-id=1064:5862#224617157
 export default function useFilterOptions() {
   const intl = useIntl();
   const { locale } = useLocale();

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6755,9 +6755,6 @@
     "defaultMessage": "Sauvegarder la date de clôture",
     "description": "Text on a button to save the pool closing date"
   },
-  "jtygmI": {
-    "defaultMessage": "Éducation"
-  },
   "jw6Umr": {
     "defaultMessage": "Veuillez sélectionner un type d’expérience",
     "description": "Heading for the experience type section fo the experience form"

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.stories.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.stories.tsx
@@ -56,8 +56,3 @@ RandomLatency.parameters = {
   },
   chromatic: { disableSnapshot: true },
 };
-
-export const WithEducationSelect = Template.bind({});
-WithEducationSelect.args = {
-  enableEducationType: true,
-};

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.test.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.test.tsx
@@ -237,49 +237,4 @@ describe("UserTableFilterDialog", () => {
     renderButton({ isOpenDefault: true });
     expect(screen.getAllByRole("combobox")).toHaveLength(10);
   });
-
-  describe("enableEducationType prop", () => {
-    it("hides education filter when not enabled", () => {
-      renderButton({ isOpenDefault: true });
-      expect(
-        screen.queryByRole("combobox", { name: /education/i }),
-      ).not.toBeInTheDocument();
-    });
-
-    it("shows education filter when enabled", () => {
-      renderButton({
-        isOpenDefault: true,
-        enableEducationType: true,
-      });
-      expect(screen.getAllByRole("combobox")).toHaveLength(11);
-      expect(
-        screen.getByRole("combobox", { name: /education/i }),
-      ).toBeVisible();
-    });
-
-    it("submits empty education data when empty", async () => {
-      renderButton({
-        isOpenDefault: true,
-        enableEducationType: true,
-      });
-      await submitFilters();
-
-      const activeFilter = mockSubmit.mock.lastCall[0];
-      expect(activeFilter.educationType).toBeDefined();
-      expect(activeFilter.educationType).toHaveLength(0);
-    });
-
-    it("submits education data when populated", async () => {
-      renderButton({
-        isOpenDefault: true,
-        enableEducationType: true,
-      });
-      await selectFilterOption(/education/i);
-      await selectFilterOption(/education/i);
-      await submitFilters();
-
-      const activeFilter = mockSubmit.mock.lastCall[0];
-      expect(activeFilter.educationType).toHaveLength(2);
-    });
-  });
 });

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.tsx
@@ -22,9 +22,6 @@ export type FormValues = {
   languageAbility: Option["value"][];
   operationalRequirement: Option["value"][];
   workRegion: Option["value"][];
-  // TODO: Make mandatory once data model settles.
-  // See: https://www.figma.com/proto/XS4Ag6GWcgdq2dBlLzBkay?node-id=1064:5862#224617157
-  educationType?: Option["value"][];
   employmentDuration: Option["value"][];
   skills: Option["value"][];
   profileComplete: Option["value"][];
@@ -32,14 +29,13 @@ export type FormValues = {
   roles: Option["value"][];
 };
 
-type FooterProps = Pick<UserTableFilterDialogProps, "enableEducationType">;
-const Footer = ({ enableEducationType }: FooterProps): JSX.Element => {
+const Footer = () => {
   const { formatMessage } = useIntl();
   const {
     reset,
     formState: { isSubmitting },
   } = useFormContext();
-  const { emptyFormValues } = useFilterOptions(enableEducationType);
+  const { emptyFormValues } = useFilterOptions();
   const handleClear = () => {
     reset(emptyFormValues);
   };
@@ -74,7 +70,6 @@ interface UserTableFilterDialogProps {
   onOpenChange: (open: boolean) => void;
   onSubmit: SubmitHandler<FormValues>;
   activeFilters: FormValues;
-  enableEducationType?: boolean;
 }
 
 const UserTableFilterDialog = ({
@@ -82,11 +77,9 @@ const UserTableFilterDialog = ({
   activeFilters,
   isOpen,
   onOpenChange,
-  enableEducationType = false,
 }: UserTableFilterDialogProps): JSX.Element => {
   const { formatMessage } = useIntl();
-  const { optionsData, rawGraphqlResults } =
-    useFilterOptions(enableEducationType);
+  const { optionsData, rawGraphqlResults } = useFilterOptions();
 
   return (
     <Dialog.Root open={isOpen} onOpenChange={onOpenChange}>
@@ -176,19 +169,6 @@ const UserTableFilterDialog = ({
                   doNotSort
                 />
               </div>
-              {enableEducationType && (
-                <div data-h2-flex-item="base(1of1)">
-                  <MultiSelectField
-                    id="educationType"
-                    name="educationType"
-                    label={formatMessage({
-                      defaultMessage: "Education",
-                      id: "jtygmI",
-                    })}
-                    options={optionsData.educationType}
-                  />
-                </div>
-              )}
               <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
                 <MultiSelectFieldBase
                   forceArrayFormValue
@@ -259,7 +239,7 @@ const UserTableFilterDialog = ({
 
 export type UserTableFiltersProps = Pick<
   UserTableFilterDialogProps,
-  "onSubmit" | "enableEducationType"
+  "onSubmit"
 > & {
   isOpenDefault?: boolean;
   initialFilters?: FormValues;
@@ -268,12 +248,11 @@ export type UserTableFiltersProps = Pick<
 const UserTableFilters = ({
   onSubmit,
   isOpenDefault = false,
-  enableEducationType,
   initialFilters,
   ...rest
 }: UserTableFiltersProps) => {
   const [isOpen, setOpen] = React.useState<boolean>(isOpenDefault);
-  const { emptyFormValues } = useFilterOptions(enableEducationType);
+  const { emptyFormValues } = useFilterOptions();
   const initialStateActiveFilters = initialFilters ?? emptyFormValues;
   const [activeFilters, setActiveFilters] = useState<FormValues>(
     initialStateActiveFilters,
@@ -287,7 +266,7 @@ const UserTableFilters = ({
 
   return (
     <UserTableFilterDialog
-      {...{ activeFilters, isOpenDefault, enableEducationType, isOpen }}
+      {...{ activeFilters, isOpenDefault, isOpen }}
       {...rest}
       onOpenChange={setOpen}
       onSubmit={handleSubmit}


### PR DESCRIPTION
🤖 Resolves #4638 

## 👋 Introduction

This removes an unused prop from the admin table filter dialogs.

## 🕵️ Details

We have no plan to ever enable the education type filter so we can safely remove it.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/admin/users`
3. Confirm the filter dialog still functions
4. Navigate to `/admin/pools/{poolId}/pool-candidates`
5. Confirm the filter dialog still functions