### PR TITLE
[Debt] Deprecate non-paginated queries

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -870,7 +870,7 @@ type Query {
     @all
     @guard
     @can(ability: "viewAny")
-    @deprecated(reason: "Removing in favour of usersPaginated query")
+    @deprecated(reason: "users is deprecated. Use usersPaginated instead.")
   usersPaginated(
     where: UserFilterInput
     orderBy: [OrderByClause!] @orderBy
@@ -883,12 +883,12 @@ type Query {
     @find(model: "User")
     @guard
     @can(ability: "view", query: true, model: "User")
-    @deprecated(reason: "Removing in favour of user query")
+    @deprecated(reason: "applicant is deprecated. Use user instead.")
   applicants(includeIds: [ID]! @in(key: "id")): [User]!
     @all(model: "User")
     @guard
     @can(ability: "viewAny", model: "User")
-    @deprecated(reason: "Removing in favour of users query")
+    @deprecated(reason: "applicants is deprecated. Use usersPaginated instead.")
   # countApplicants returns the number of candidates matching its filters, and requires no special permissions.
   countApplicants(where: ApplicantFilterInput): Int!
     @count(model: "User", scopes: ["inITPublishingGroup"])
@@ -912,7 +912,9 @@ type Query {
     @all(scopes: ["notDraft"])
     @guard
     @can(ability: "view", resolved: true)
-    @deprecated(reason: "Removing in favour of poolCandidatesPaginated query")
+    @deprecated(
+      reason: "poolCandidates is deprecated. Use poolCandidatesPaginated instead."
+    )
   poolCandidatesPaginated(
     where: PoolCandidateSearchInput
     orderBy: _
@@ -990,7 +992,7 @@ type Query {
     @can(ability: "viewAny")
     @orderBy(column: "created_at", direction: DESC)
     @deprecated(
-      reason: "Removing in favour of poolCandidateSearchRequestsPaginated query"
+      reason: "poolCandidateSearchRequests is deprecated. Use poolCandidateSearchRequestsPaginated instead."
     )
   latestPoolCandidateSearchRequests(
     limit: Int @limit

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -55,7 +55,7 @@ type User {
   languageAbility: LanguageAbility
     @rename(attribute: "language_ability")
     @deprecated(
-      reason: "deprecated in favour of relying on lookingFor<Language>"
+      reason: "languageAbility is deprecated. Use lookingFor<Language> instead."
     )
   lookingForEnglish: Boolean @rename(attribute: "looking_for_english")
   lookingForFrench: Boolean @rename(attribute: "looking_for_french")
@@ -82,7 +82,9 @@ type User {
   hasDisability: Boolean @rename(attribute: "has_disability")
   isIndigenous: Boolean
     @rename(attribute: "is_indigenous")
-    @deprecated(reason: "replaced by indigenousCommunities")
+    @deprecated(
+      reason: "isIndigenous is deprecated. Use indigenousCommunities instead."
+    )
   isVisibleMinority: Boolean @rename(attribute: "is_visible_minority")
   indigenousCommunities: [IndigenousCommunity]
     @rename(attribute: "indigenous_communities")
@@ -97,13 +99,19 @@ type User {
     @rename(attribute: "accepted_operational_requirements")
   expectedSalary: [SalaryRange]
     @rename(attribute: "expected_salary")
-    @deprecated(reason: "Expected role and salary removed")
+    @deprecated(
+      reason: "expectedSalary is deprecated. Remove as part of #6226."
+    )
   expectedClassifications: [Classification]
     @belongsToMany
-    @deprecated(reason: "Expected role and salary removed")
+    @deprecated(
+      reason: "expectedClassifications is deprecated. Remove as part of #6226."
+    )
   wouldAcceptTemporary: Boolean
     @rename(attribute: "would_accept_temporary")
-    @deprecated(reason: "replaced with positionDuration")
+    @deprecated(
+      reason: "expectedSalary is deprecated. use positionDuration instead."
+    )
   positionDuration: [PositionDuration] @rename(attribute: "position_duration")
 
   # Pool info
@@ -128,14 +136,14 @@ type User {
   pools: [Pool]
     @hasMany
     @can(ability: "view", resolved: true)
-    @deprecated(
-      reason: "Pools are now associated with a Team more than a single User. Use User.roles.team.pools instead."
-    ) # Pools a user owns
+    @deprecated(reason: "pools is deprecated. User.roles.team.pools instead.") # Pools a user owns
   # Profile Status
   isProfileComplete: Boolean
   expectedGenericJobTitles: [GenericJobTitle]
     @belongsToMany
-    @deprecated(reason: "Expected role and salary removed")
+    @deprecated(
+      reason: "expectedGenericJobTitles is deprecated. Remove in #7645"
+    )
   priorityWeight: Int @rename(attribute: "priority_weight")
   # teams and roles
   roleAssignments: [RoleAssignment!] @hasMany
@@ -563,7 +571,9 @@ type ApplicantFilter {
   locationPreferences: [WorkRegion] @rename(attribute: "location_preferences")
   wouldAcceptTemporary: Boolean
     @rename(attribute: "would_accept_temporary")
-    @deprecated(reason: "replaced with positionDuration")
+    @deprecated(
+      reason: "wouldAcceptTemporary is deprecated. Use positionDuration instead."
+    )
   positionDuration: [PositionDuration] @rename(attribute: "position_duration")
   skills: [Skill] @belongsToMany
   # request creation connects to qualifiedClassifications
@@ -870,7 +880,7 @@ type Query {
     @all
     @guard
     @can(ability: "viewAny")
-    @deprecated(reason: "users is deprecated. Use usersPaginated instead.")
+    @deprecated(reason: "users is deprecated. UsersPaginated instead.")
   usersPaginated(
     where: UserFilterInput
     orderBy: [OrderByClause!] @orderBy
@@ -883,12 +893,12 @@ type Query {
     @find(model: "User")
     @guard
     @can(ability: "view", query: true, model: "User")
-    @deprecated(reason: "applicant is deprecated. Use user instead.")
+    @deprecated(reason: "applicant is deprecated. User instead.")
   applicants(includeIds: [ID]! @in(key: "id")): [User]!
     @all(model: "User")
     @guard
     @can(ability: "viewAny", model: "User")
-    @deprecated(reason: "applicants is deprecated. Use usersPaginated instead.")
+    @deprecated(reason: "applicants is deprecated. UsersPaginated instead.")
   # countApplicants returns the number of candidates matching its filters, and requires no special permissions.
   countApplicants(where: ApplicantFilterInput): Int!
     @count(model: "User", scopes: ["inITPublishingGroup"])
@@ -957,7 +967,7 @@ type Query {
     @guard
     @can(ability: "viewAny", model: "PoolCandidateSearchRequest")
     @deprecated(
-      reason: "This should only be queried as part of a PoolCandidateSearchRequest."
+      reason: "poolCandidateFilter is deprecated. Use positionDuration instead. Use PoolCandidateSearchRequest.poolCandidateFilter instead."
     )
   poolCandidateFilters: [PoolCandidateFilter]!
     @all
@@ -965,14 +975,14 @@ type Query {
     @can(ability: "viewAny", model: "PoolCandidateSearchRequest")
     @throttle(name: "graphql")
     @deprecated(
-      reason: "This should only be queried as part of a PoolCandidateSearchRequest."
+      reason: "poolCandidateFilters is deprecated. Use PoolCandidateSearchRequest.poolCandidateFilter instead."
     )
   applicantFilter(id: ID! @eq): ApplicantFilter
     @find
     @guard
     @can(ability: "viewAny", model: "PoolCandidateSearchRequest")
     @deprecated(
-      reason: "This should only be queried as part of a PoolCandidateSearchRequest."
+      reason: "applicantFilter is deprecated. Use PoolCandidateSearchRequest.applicantFilter instead."
     )
   applicantFilters: [ApplicantFilter]!
     @all
@@ -980,7 +990,7 @@ type Query {
     @can(ability: "viewAny", model: "PoolCandidateSearchRequest")
     @throttle(name: "graphql")
     @deprecated(
-      reason: "This should only be queried as part of a PoolCandidateSearchRequest."
+      reason: "applicantFilters is deprecated. Use PoolCandidateSearchRequest.applicantFilter instead."
     )
   poolCandidateSearchRequest(id: ID! @eq): PoolCandidateSearchRequest
     @find
@@ -1002,7 +1012,7 @@ type Query {
     @guard
     @can(ability: "viewAny")
     @deprecated(
-      reason: "Use poolCandidateSearchRequests instead, with a specified limit"
+      reason: "latestPoolCandidateSearchRequests is deprecated. Use poolCandidateSearchRequestsPaginated instead."
     )
   poolCandidateSearchRequestsPaginated(
     where: PoolCandidateSearchRequestInput

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -866,7 +866,11 @@ type CandidateSearchPoolResult {
 type Query {
   me: User @auth
   user(id: UUID! @eq): User @find @guard @can(ability: "view", query: true)
-  users: [User]! @all @guard @can(ability: "viewAny")
+  users: [User]!
+    @all
+    @guard
+    @can(ability: "viewAny")
+    @deprecated(reason: "Removing in favour of usersPaginated query")
   usersPaginated(
     where: UserFilterInput
     orderBy: [OrderByClause!] @orderBy
@@ -908,6 +912,7 @@ type Query {
     @all(scopes: ["notDraft"])
     @guard
     @can(ability: "view", resolved: true)
+    @deprecated(reason: "Removing in favour of poolCandidatesPaginated query")
   poolCandidatesPaginated(
     where: PoolCandidateSearchInput
     orderBy: _
@@ -984,6 +989,9 @@ type Query {
     @guard
     @can(ability: "viewAny")
     @orderBy(column: "created_at", direction: DESC)
+    @deprecated(
+      reason: "Removing in favour of poolCandidateSearchRequestsPaginated query"
+    )
   latestPoolCandidateSearchRequests(
     limit: Int @limit
   ): [PoolCandidateSearchRequest]!

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1,7 +1,7 @@
 type Query {
   me: User
   user(id: UUID!): User
-  users: [User]!
+  users: [User]! @deprecated(reason: "Removing in favour of usersPaginated query")
   applicant(id: UUID!): User @deprecated(reason: "Removing in favour of user query")
   applicants(includeIds: [ID]!): [User]! @deprecated(reason: "Removing in favour of users query")
   countApplicants(where: ApplicantFilterInput): Int!
@@ -10,7 +10,7 @@ type Query {
   poolByKey(key: String!): Pool
   pools: [Pool]!
   poolCandidate(id: UUID!): PoolCandidate
-  poolCandidates(includeIds: [ID]): [PoolCandidate]!
+  poolCandidates(includeIds: [ID]): [PoolCandidate]! @deprecated(reason: "Removing in favour of poolCandidatesPaginated query")
   countPoolCandidatesByPool(where: ApplicantFilterInput): [CandidateSearchPoolResult!]!
   classification(id: UUID!): Classification
   classifications: [Classification]!
@@ -21,7 +21,7 @@ type Query {
   applicantFilter(id: ID!): ApplicantFilter @deprecated(reason: "This should only be queried as part of a PoolCandidateSearchRequest.")
   applicantFilters: [ApplicantFilter]! @deprecated(reason: "This should only be queried as part of a PoolCandidateSearchRequest.")
   poolCandidateSearchRequest(id: ID!): PoolCandidateSearchRequest
-  poolCandidateSearchRequests(limit: Int): [PoolCandidateSearchRequest]!
+  poolCandidateSearchRequests(limit: Int): [PoolCandidateSearchRequest]! @deprecated(reason: "Removing in favour of poolCandidateSearchRequestsPaginated query")
   latestPoolCandidateSearchRequests(limit: Int): [PoolCandidateSearchRequest]! @deprecated(reason: "Use poolCandidateSearchRequests instead, with a specified limit")
   skillFamily(id: UUID!): SkillFamily
   skillFamilies: [SkillFamily]!

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1,9 +1,9 @@
 type Query {
   me: User
   user(id: UUID!): User
-  users: [User]! @deprecated(reason: "users is deprecated. Use usersPaginated instead.")
-  applicant(id: UUID!): User @deprecated(reason: "applicant is deprecated. Use user instead.")
-  applicants(includeIds: [ID]!): [User]! @deprecated(reason: "applicants is deprecated. Use usersPaginated instead.")
+  users: [User]! @deprecated(reason: "users is deprecated. UsersPaginated instead.")
+  applicant(id: UUID!): User @deprecated(reason: "applicant is deprecated. User instead.")
+  applicants(includeIds: [ID]!): [User]! @deprecated(reason: "applicants is deprecated. UsersPaginated instead.")
   countApplicants(where: ApplicantFilterInput): Int!
   pool(id: UUID!): Pool
   publishedPools(closingAfter: DateTime, publishingGroup: PublishingGroup): [Pool!]!
@@ -16,13 +16,13 @@ type Query {
   classifications: [Classification]!
   department(id: UUID!): Department
   departments: [Department]!
-  poolCandidateFilter(id: UUID!): PoolCandidateFilter @deprecated(reason: "This should only be queried as part of a PoolCandidateSearchRequest.")
-  poolCandidateFilters: [PoolCandidateFilter]! @deprecated(reason: "This should only be queried as part of a PoolCandidateSearchRequest.")
-  applicantFilter(id: ID!): ApplicantFilter @deprecated(reason: "This should only be queried as part of a PoolCandidateSearchRequest.")
-  applicantFilters: [ApplicantFilter]! @deprecated(reason: "This should only be queried as part of a PoolCandidateSearchRequest.")
+  poolCandidateFilter(id: UUID!): PoolCandidateFilter @deprecated(reason: "poolCandidateFilter is deprecated. Use positionDuration instead. Use PoolCandidateSearchRequest.poolCandidateFilter instead.")
+  poolCandidateFilters: [PoolCandidateFilter]! @deprecated(reason: "poolCandidateFilters is deprecated. Use PoolCandidateSearchRequest.poolCandidateFilter instead.")
+  applicantFilter(id: ID!): ApplicantFilter @deprecated(reason: "applicantFilter is deprecated. Use PoolCandidateSearchRequest.applicantFilter instead.")
+  applicantFilters: [ApplicantFilter]! @deprecated(reason: "applicantFilters is deprecated. Use PoolCandidateSearchRequest.applicantFilter instead.")
   poolCandidateSearchRequest(id: ID!): PoolCandidateSearchRequest
   poolCandidateSearchRequests(limit: Int): [PoolCandidateSearchRequest]! @deprecated(reason: "poolCandidateSearchRequests is deprecated. Use poolCandidateSearchRequestsPaginated instead.")
-  latestPoolCandidateSearchRequests(limit: Int): [PoolCandidateSearchRequest]! @deprecated(reason: "Use poolCandidateSearchRequests instead, with a specified limit")
+  latestPoolCandidateSearchRequests(limit: Int): [PoolCandidateSearchRequest]! @deprecated(reason: "latestPoolCandidateSearchRequests is deprecated. Use poolCandidateSearchRequestsPaginated instead.")
   skillFamily(id: UUID!): SkillFamily
   skillFamilies: [SkillFamily]!
   skill(id: UUID!): Skill
@@ -176,7 +176,7 @@ type User {
   currentCity: String
   citizenship: CitizenshipStatus
   armedForcesStatus: ArmedForcesStatus
-  languageAbility: LanguageAbility @deprecated(reason: "deprecated in favour of relying on lookingFor<Language>")
+  languageAbility: LanguageAbility @deprecated(reason: "languageAbility is deprecated. Use lookingFor<Language> instead.")
   lookingForEnglish: Boolean
   lookingForFrench: Boolean
   lookingForBilingual: Boolean
@@ -193,7 +193,7 @@ type User {
   priorityNumber: String
   isWoman: Boolean
   hasDisability: Boolean
-  isIndigenous: Boolean @deprecated(reason: "replaced by indigenousCommunities")
+  isIndigenous: Boolean @deprecated(reason: "isIndigenous is deprecated. Use indigenousCommunities instead.")
   isVisibleMinority: Boolean
   indigenousCommunities: [IndigenousCommunity]
   indigenousDeclarationSignature: String
@@ -201,9 +201,9 @@ type User {
   locationPreferences: [WorkRegion]
   locationExemptions: String
   acceptedOperationalRequirements: [OperationalRequirement]
-  expectedSalary: [SalaryRange] @deprecated(reason: "Expected role and salary removed")
-  expectedClassifications: [Classification] @deprecated(reason: "Expected role and salary removed")
-  wouldAcceptTemporary: Boolean @deprecated(reason: "replaced with positionDuration")
+  expectedSalary: [SalaryRange] @deprecated(reason: "expectedSalary is deprecated. Remove as part of #6226.")
+  expectedClassifications: [Classification] @deprecated(reason: "expectedClassifications is deprecated. Remove as part of #6226.")
+  wouldAcceptTemporary: Boolean @deprecated(reason: "expectedSalary is deprecated. use positionDuration instead.")
   positionDuration: [PositionDuration]
   poolCandidates: [PoolCandidate]
   experiences: [Experience]
@@ -213,9 +213,9 @@ type User {
   personalExperiences: [PersonalExperience]
   workExperiences: [WorkExperience]
   userSkills: [UserSkill!]
-  pools: [Pool] @deprecated(reason: "Pools are now associated with a Team more than a single User. Use User.roles.team.pools instead.")
+  pools: [Pool] @deprecated(reason: "pools is deprecated. User.roles.team.pools instead.")
   isProfileComplete: Boolean
-  expectedGenericJobTitles: [GenericJobTitle] @deprecated(reason: "Expected role and salary removed")
+  expectedGenericJobTitles: [GenericJobTitle] @deprecated(reason: "expectedGenericJobTitles is deprecated. Remove in #7645")
   priorityWeight: Int
   roleAssignments: [RoleAssignment!]
   unreadNotifications: [Notification!]
@@ -609,7 +609,7 @@ type ApplicantFilter {
   languageAbility: LanguageAbility
   operationalRequirements: [OperationalRequirement]
   locationPreferences: [WorkRegion]
-  wouldAcceptTemporary: Boolean @deprecated(reason: "replaced with positionDuration")
+  wouldAcceptTemporary: Boolean @deprecated(reason: "wouldAcceptTemporary is deprecated. Use positionDuration instead.")
   positionDuration: [PositionDuration]
   skills: [Skill]
   qualifiedClassifications: [Classification]

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1,16 +1,16 @@
 type Query {
   me: User
   user(id: UUID!): User
-  users: [User]! @deprecated(reason: "Removing in favour of usersPaginated query")
-  applicant(id: UUID!): User @deprecated(reason: "Removing in favour of user query")
-  applicants(includeIds: [ID]!): [User]! @deprecated(reason: "Removing in favour of users query")
+  users: [User]! @deprecated(reason: "users is deprecated. Use usersPaginated instead.")
+  applicant(id: UUID!): User @deprecated(reason: "applicant is deprecated. Use user instead.")
+  applicants(includeIds: [ID]!): [User]! @deprecated(reason: "applicants is deprecated. Use usersPaginated instead.")
   countApplicants(where: ApplicantFilterInput): Int!
   pool(id: UUID!): Pool
   publishedPools(closingAfter: DateTime, publishingGroup: PublishingGroup): [Pool!]!
   poolByKey(key: String!): Pool
   pools: [Pool]!
   poolCandidate(id: UUID!): PoolCandidate
-  poolCandidates(includeIds: [ID]): [PoolCandidate]! @deprecated(reason: "Removing in favour of poolCandidatesPaginated query")
+  poolCandidates(includeIds: [ID]): [PoolCandidate]! @deprecated(reason: "poolCandidates is deprecated. Use poolCandidatesPaginated instead.")
   countPoolCandidatesByPool(where: ApplicantFilterInput): [CandidateSearchPoolResult!]!
   classification(id: UUID!): Classification
   classifications: [Classification]!
@@ -21,7 +21,7 @@ type Query {
   applicantFilter(id: ID!): ApplicantFilter @deprecated(reason: "This should only be queried as part of a PoolCandidateSearchRequest.")
   applicantFilters: [ApplicantFilter]! @deprecated(reason: "This should only be queried as part of a PoolCandidateSearchRequest.")
   poolCandidateSearchRequest(id: ID!): PoolCandidateSearchRequest
-  poolCandidateSearchRequests(limit: Int): [PoolCandidateSearchRequest]! @deprecated(reason: "Removing in favour of poolCandidateSearchRequestsPaginated query")
+  poolCandidateSearchRequests(limit: Int): [PoolCandidateSearchRequest]! @deprecated(reason: "poolCandidateSearchRequests is deprecated. Use poolCandidateSearchRequestsPaginated instead.")
   latestPoolCandidateSearchRequests(limit: Int): [PoolCandidateSearchRequest]! @deprecated(reason: "Use poolCandidateSearchRequests instead, with a specified limit")
   skillFamily(id: UUID!): SkillFamily
   skillFamilies: [SkillFamily]!


### PR DESCRIPTION
🤖 Resolves #4416 

## 👋 Introduction

Deprectaes some non-paginated queries in favour of their paginated versions.

## 🕵️ Details

We have some queries that contain large datasets that require paginated results. We are deprecating the non-paginated versions to be removed in the near future.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/graphql`
2. Confirm the queries are marked as deprecated
3. Confirm the reason stated is accurate
