### PR TITLE
[Chore] Bump `eslint-plugin-import` and fix

### DIFF
--- a/apps/web/.eslintrc.js
+++ b/apps/web/.eslintrc.js
@@ -3,10 +3,6 @@ const path = require('path');
 module.exports = {
   root: true,
   extends: ["custom"],
-  rules: {
-    // Ignore stories for unused modules
-    "import/no-unused-modules": [1, { unusedExports: true, ignoreExports: [path.join(__dirname, "./src/**/*.stories.{ts,tsx}")] }],
-  },
   settings: {
     "import/resolver": {
       typescript: {

--- a/apps/web/src/components/AdminContentWrapper/AdminContentWrapper.tsx
+++ b/apps/web/src/components/AdminContentWrapper/AdminContentWrapper.tsx
@@ -1,5 +1,6 @@
-import { Breadcrumbs, BreadcrumbsProps } from "@gc-digital-talent/ui";
 import React from "react";
+
+import { Breadcrumbs, BreadcrumbsProps } from "@gc-digital-talent/ui";
 
 interface AdminContentWrapperProps {
   crumbs: BreadcrumbsProps["crumbs"];

--- a/apps/web/src/components/Context/ContextProvider.tsx
+++ b/apps/web/src/components/Context/ContextProvider.tsx
@@ -13,8 +13,6 @@ import {
   Messages,
 } from "@gc-digital-talent/i18n";
 import { Announcer } from "@gc-digital-talent/ui";
-
-// Note: Commented out until we have dark mode styles properly implemented
 import { ThemeProvider } from "@gc-digital-talent/theme";
 
 interface ContextContainerProps {

--- a/apps/web/src/components/EmploymentEquity/EquityOption.tsx
+++ b/apps/web/src/components/EmploymentEquity/EquityOption.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { useIntl } from "react-intl";
+import PlusCircleIcon from "@heroicons/react/24/solid/PlusCircleIcon";
 
 import { Button } from "@gc-digital-talent/ui";
 
-import PlusCircleIcon from "@heroicons/react/24/solid/PlusCircleIcon";
 import {
   DisabilityDialog,
   VisibleMinorityDialog,

--- a/apps/web/src/components/EmploymentEquity/IndigenousEquityOption.tsx
+++ b/apps/web/src/components/EmploymentEquity/IndigenousEquityOption.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
+import PlusCircleIcon from "@heroicons/react/24/solid/PlusCircleIcon";
 
 import { Button } from "@gc-digital-talent/ui";
 import { getIndigenousCommunity } from "@gc-digital-talent/i18n";
@@ -7,7 +8,6 @@ import { getIndigenousCommunity } from "@gc-digital-talent/i18n";
 import { IndigenousCommunity } from "~/api/generated";
 import CommunityIcon from "~/components/Profile/components/DiversityEquityInclusion/CommunityIcon";
 
-import PlusCircleIcon from "@heroicons/react/24/solid/PlusCircleIcon";
 import { IndigenousDialog } from "./dialogs";
 import { IndigenousDialogProps, IndigenousUpdateProps } from "./types";
 

--- a/apps/web/src/components/EmploymentEquity/dialogs/DisabilityDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/DisabilityDialog.tsx
@@ -4,14 +4,12 @@ import { FormProvider, useForm, type SubmitHandler } from "react-hook-form";
 
 import { Dialog } from "@gc-digital-talent/ui";
 import { Checklist } from "@gc-digital-talent/forms";
-
 import {
   getEmploymentEquityGroup,
   getEmploymentEquityStatement,
 } from "@gc-digital-talent/i18n";
 
 import type { EquityDialogProps } from "../types";
-
 import Definition from "./Definition";
 import DialogFooter from "./DialogFooter";
 import UnderReview from "./UnderReview";

--- a/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
@@ -18,7 +18,6 @@ import {
 } from "~/utils/indigenousDeclaration";
 
 import { IndigenousDialogProps } from "../types";
-
 import Definition from "./Definition";
 import DialogFooter from "./DialogFooter";
 import UnderReview from "./UnderReview";

--- a/apps/web/src/components/EmploymentEquity/dialogs/VisibleMinorityDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/VisibleMinorityDialog.tsx
@@ -10,7 +10,6 @@ import {
 } from "@gc-digital-talent/i18n";
 
 import type { EquityDialogProps } from "../types";
-
 import Definition from "./Definition";
 import DialogFooter from "./DialogFooter";
 import UnderReview from "./UnderReview";

--- a/apps/web/src/components/EmploymentEquity/dialogs/WomanDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/WomanDialog.tsx
@@ -10,7 +10,6 @@ import {
 } from "@gc-digital-talent/i18n";
 
 import type { EquityDialogProps } from "../types";
-
 import Definition from "./Definition";
 import DialogFooter from "./DialogFooter";
 import UnderReview from "./UnderReview";

--- a/apps/web/src/components/ExperienceCard/AwardContent.tsx
+++ b/apps/web/src/components/ExperienceCard/AwardContent.tsx
@@ -9,6 +9,7 @@ import {
 
 import { AwardExperience } from "~/api/generated";
 import { formattedDate } from "~/utils/dateUtils";
+
 import ContentSection from "./ContentSection";
 import { ContentProps } from "./types";
 

--- a/apps/web/src/components/ExperienceCard/ContentSection.tsx
+++ b/apps/web/src/components/ExperienceCard/ContentSection.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { HeadingRank } from "@gc-digital-talent/ui";
 
 interface ContentSectionProps extends React.HTMLProps<HTMLDivElement> {

--- a/apps/web/src/components/ExperienceFormFields/AdditionalDetails.tsx
+++ b/apps/web/src/components/ExperienceFormFields/AdditionalDetails.tsx
@@ -7,8 +7,8 @@ import { TextArea } from "@gc-digital-talent/forms";
 import { Heading } from "@gc-digital-talent/ui";
 
 import { ExperienceType } from "~/types/experience";
-
 import { getExperienceFormLabels } from "~/utils/experienceUtils";
+
 import NullExperienceType from "./NullExperienceType";
 
 const TEXT_AREA_ROWS = 3;

--- a/apps/web/src/components/ExperienceFormFields/ExperienceHeading.tsx
+++ b/apps/web/src/components/ExperienceFormFields/ExperienceHeading.tsx
@@ -1,12 +1,5 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
-import {
-  Accordion,
-  DefinitionList,
-  Heading,
-  StandardAccordionHeader,
-} from "@gc-digital-talent/ui";
-
 import BookOpenIcon from "@heroicons/react/20/solid/BookOpenIcon";
 import BriefcaseIcon from "@heroicons/react/20/solid/BriefcaseIcon";
 import LightBulbIcon from "@heroicons/react/20/solid/LightBulbIcon";
@@ -14,6 +7,14 @@ import StarIcon from "@heroicons/react/20/solid/StarIcon";
 import UserGroupIcon from "@heroicons/react/20/solid/UserGroupIcon";
 import PencilSquareIcon from "@heroicons/react/24/outline/PencilSquareIcon";
 import PlusCircleIcon from "@heroicons/react/24/outline/PlusCircleIcon";
+
+import {
+  Accordion,
+  DefinitionList,
+  Heading,
+  StandardAccordionHeader,
+} from "@gc-digital-talent/ui";
+
 import { experienceTypeTitles } from "~/pages/Applications/ApplicationCareerTimelineAddPage/messages";
 
 type AccordionStates = "learn-more" | "";

--- a/apps/web/src/components/ExperienceFormFields/SelectExperience.tsx
+++ b/apps/web/src/components/ExperienceFormFields/SelectExperience.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-
 import { useIntl } from "react-intl";
 
 import { Heading } from "@gc-digital-talent/ui";
 import { Select } from "@gc-digital-talent/forms";
 import { errorMessages } from "@gc-digital-talent/i18n";
+
 import { experienceTypeTitles } from "~/pages/Applications/ApplicationCareerTimelineAddPage/messages";
 
 const SelectExperience = () => {

--- a/apps/web/src/components/ExperienceTreeView/ExperienceTreeView.stories.tsx
+++ b/apps/web/src/components/ExperienceTreeView/ExperienceTreeView.stories.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { Meta, ComponentStory } from "@storybook/react";
+
 import { fakeExperiences, fakeSkills } from "@gc-digital-talent/fake-data";
+
 import { Experience } from "~/api/generated";
+
 import ExperienceTreeView from "./ExperienceTreeView";
 
 const skills = fakeSkills(2);

--- a/apps/web/src/components/Footer/Footer.stories.tsx
+++ b/apps/web/src/components/Footer/Footer.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
+
 import FooterComponent from "./Footer";
 
 export default {

--- a/apps/web/src/components/Header/Header.stories.tsx
+++ b/apps/web/src/components/Header/Header.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
+
 import HeaderComponent from "./Header";
 
 export default {

--- a/apps/web/src/components/Hero/BackgroundPattern.tsx
+++ b/apps/web/src/components/Hero/BackgroundPattern.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import Svg, { type SVGProps } from "../Svg/Svg";
 
 const BackgroundGraphic = (props: SVGProps) => (

--- a/apps/web/src/components/Hero/Hero.stories.tsx
+++ b/apps/web/src/components/Hero/Hero.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+
 import Hero from "./Hero";
 
 export default {

--- a/apps/web/src/components/Hero/Hero.tsx
+++ b/apps/web/src/components/Hero/Hero.tsx
@@ -7,6 +7,7 @@ import {
   type BreadcrumbsProps,
   Flourish,
 } from "@gc-digital-talent/ui";
+
 import BackgroundGraphic from "./BackgroundPattern";
 
 import "./hero.css";

--- a/apps/web/src/components/Layout/IAPLayout.tsx
+++ b/apps/web/src/components/Layout/IAPLayout.tsx
@@ -13,9 +13,7 @@ import SEO, { Favicon } from "~/components/SEO/SEO";
 import Header from "~/components/Header/Header";
 import Footer from "~/components/Footer/Footer";
 import IAPNavMenu from "~/components/NavMenu/IAPNavMenu";
-
 import useLayoutTheme from "~/hooks/useLayoutTheme";
-
 import * as crgMessages from "~/lang/crgCompiled.json";
 import * as crkMessages from "~/lang/crkCompiled.json";
 import * as ojwMessages from "~/lang/ojwCompiled.json";

--- a/apps/web/src/components/Layout/Layout.tsx
+++ b/apps/web/src/components/Layout/Layout.tsx
@@ -15,7 +15,6 @@ import NavMenu from "~/components/NavMenu/NavMenu";
 import Header from "~/components/Header/Header";
 import Footer from "~/components/Footer/Footer";
 import SignOutConfirmation from "~/components/SignOutConfirmation/SignOutConfirmation";
-
 import useRoutes from "~/hooks/useRoutes";
 import useLayoutTheme from "~/hooks/useLayoutTheme";
 import authMessages from "~/messages/authMessages";

--- a/apps/web/src/components/MissingLanguageRequirements/MissingLanguageRequirements.stories.tsx
+++ b/apps/web/src/components/MissingLanguageRequirements/MissingLanguageRequirements.stories.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
+
 import { fakePools, fakeUsers } from "@gc-digital-talent/fake-data";
 
 import { User, Pool, PoolLanguage } from "~/api/generated";
+
 import MissingLanguageRequirements from "./MissingLanguageRequirements";
 
 type MissingLanguageRequirementsComponent = typeof MissingLanguageRequirements;

--- a/apps/web/src/components/MissingLanguageRequirements/MissingLanguageRequirements.test.tsx
+++ b/apps/web/src/components/MissingLanguageRequirements/MissingLanguageRequirements.test.tsx
@@ -3,11 +3,11 @@
  */
 
 import React from "react";
+
 import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
+import { fakeUsers, fakePools } from "@gc-digital-talent/fake-data";
 
 import { Pool, PoolLanguage, User } from "~/api/generated";
-
-import { fakeUsers, fakePools } from "@gc-digital-talent/fake-data";
 
 import MissingLanguageRequirements, {
   type MissingLanguageRequirementsProps,

--- a/apps/web/src/components/MissingSkills/MissingSkills.test.tsx
+++ b/apps/web/src/components/MissingSkills/MissingSkills.test.tsx
@@ -4,6 +4,7 @@
 
 import React from "react";
 import { within, screen } from "@testing-library/react";
+
 import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
 import { fakeSkillFamilies, fakeSkills } from "@gc-digital-talent/fake-data";
 import { SkillCategory } from "@gc-digital-talent/graphql";

--- a/apps/web/src/components/NavMenu/IAPNavMenu.tsx
+++ b/apps/web/src/components/NavMenu/IAPNavMenu.tsx
@@ -7,9 +7,9 @@ import { Maybe, User } from "@gc-digital-talent/graphql";
 import useRoutes from "~/hooks/useRoutes";
 import authMessages from "~/messages/authMessages";
 
-import NavMenu from "./NavMenu";
 import SignOutConfirmation from "../SignOutConfirmation/SignOutConfirmation";
 import LogoutButton from "../Layout/LogoutButton";
+import NavMenu from "./NavMenu";
 
 interface IAPNavMenuProps {
   loggedIn?: boolean;

--- a/apps/web/src/components/Pagination/Pagination.stories.tsx
+++ b/apps/web/src/components/Pagination/Pagination.stories.tsx
@@ -3,11 +3,13 @@ import { Meta, Story } from "@storybook/react";
 import React from "react";
 
 import { fakeSkills } from "@gc-digital-talent/fake-data";
+
 import { Skill } from "~/api/generated";
 
-import { usePaginationVars } from ".";
 import Pagination from "./Pagination";
 import type { PaginationProps } from "./Pagination";
+
+import { usePaginationVars } from ".";
 
 export default {
   component: Pagination,

--- a/apps/web/src/components/Pagination/Pagination.tsx
+++ b/apps/web/src/components/Pagination/Pagination.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { useIntl } from "react-intl";
 
 import { Button, Color } from "@gc-digital-talent/ui";
+
 import { DOTS, usePagination } from "./usePagination";
 
 export interface PaginationProps {

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateTableFilterDialog.stories.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateTableFilterDialog.stories.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import type { SubmitHandler } from "react-hook-form";
-
 import { OverlayOrDialogDecorator } from "storybook-helpers";
+
 import {
   fakeSkills,
   fakePools,

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -16,7 +16,6 @@ import {
 } from "@gc-digital-talent/i18n";
 
 import { FromArray } from "~/types/utility";
-
 import {
   PoolCandidateSearchInput,
   InputMaybe,
@@ -39,7 +38,6 @@ import {
   useGetSkillsQuery,
   PublishingGroup,
 } from "~/api/generated";
-
 import printStyles from "~/styles/printStyles";
 import useRoutes from "~/hooks/useRoutes";
 import BasicTable from "~/components/Table/ApiManagedTable/BasicTable";
@@ -68,7 +66,6 @@ import ProfileDocument from "~/components/ProfileDocument/ProfileDocument";
 import adminMessages from "~/messages/adminMessages";
 
 import usePoolCandidateCsvData from "./usePoolCandidateCsvData";
-
 import PoolCandidateTableFilterDialog, {
   FormValues,
 } from "./PoolCandidateTableFilterDialog";

--- a/apps/web/src/components/PoolCandidatesTable/SkillMatchDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/SkillMatchDialog.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
+import { useIntl } from "react-intl";
+
 import { Experience, Maybe, Skill } from "@gc-digital-talent/graphql";
 import { Button, Dialog } from "@gc-digital-talent/ui";
-import { useIntl } from "react-intl";
+
 import SkillTree from "~/pages/Applications/ApplicationSkillsPage/components/SkillTree";
 
 interface SkillMatchDialogProps {

--- a/apps/web/src/components/PoolCandidatesTable/usePoolCandidateCsvData.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/usePoolCandidateCsvData.tsx
@@ -15,6 +15,7 @@ import {
   getEducationRequirementOption,
   getLocalizedName,
 } from "@gc-digital-talent/i18n";
+import { notEmpty } from "@gc-digital-talent/helpers";
 
 import {
   yesOrNo,
@@ -29,7 +30,6 @@ import {
 } from "~/utils/csvUtils";
 import { Maybe, PoolCandidate, PositionDuration, Pool } from "~/api/generated";
 import adminMessages from "~/messages/adminMessages";
-import { notEmpty } from "@gc-digital-talent/helpers";
 
 const usePoolCandidateCsvData = (
   candidates: PoolCandidate[],

--- a/apps/web/src/components/PoolCard/PoolCard.stories.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.stories.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
+
 import { fakePools } from "@gc-digital-talent/fake-data";
+
 import { Pool } from "~/api/generated";
+
 import PoolCard from "./PoolCard";
 
 const fakedPools = fakePools();

--- a/apps/web/src/components/PoolCard/PoolCard.test.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.test.tsx
@@ -4,8 +4,10 @@
 import "@testing-library/jest-dom";
 import { screen } from "@testing-library/react";
 import React from "react";
+
 import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
 import { fakePools } from "@gc-digital-talent/fake-data";
+
 import PoolCard, { PoolCardProps } from "./PoolCard";
 
 const fakedPool = fakePools(1)[0];

--- a/apps/web/src/components/Profile/components/DiversityEquityInclusion/DiversityEquityInclusion.tsx
+++ b/apps/web/src/components/Profile/components/DiversityEquityInclusion/DiversityEquityInclusion.tsx
@@ -14,8 +14,8 @@ import { UpdateUserAsUserInput } from "@gc-digital-talent/graphql";
 import EquityOptions from "~/components/EmploymentEquity/EquityOptions";
 import { EquityKeys } from "~/components/EmploymentEquity/types";
 import { hasEmptyRequiredFields } from "~/validators/profile/diversityEquityInclusion";
-
 import applicationMessages from "~/messages/applicationMessages";
+
 import { SectionProps } from "../../types";
 import { getSectionTitle } from "../../utils";
 

--- a/apps/web/src/components/Profile/components/GovernmentInformation/Display.tsx
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/Display.tsx
@@ -7,11 +7,11 @@ import {
   getGovEmployeeType,
   getLocalizedName,
 } from "@gc-digital-talent/i18n";
+import { empty } from "@gc-digital-talent/helpers";
 
 import { wrapAbbr } from "~/utils/nameUtils";
 import { GovEmployeeType } from "~/api/generated";
 
-import { empty } from "@gc-digital-talent/helpers";
 import FieldDisplay from "../FieldDisplay";
 import { PartialUser } from "./types";
 

--- a/apps/web/src/components/Profile/components/GovernmentInformation/FormFields.tsx
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/FormFields.tsx
@@ -20,8 +20,8 @@ import { notEmpty } from "@gc-digital-talent/helpers";
 
 import { Classification, Department, GovEmployeeType } from "~/api/generated";
 
-import { getGroupOptions, getLevelOptions } from "./utils";
 import useDirtyFields from "../../hooks/useDirtyFields";
+import { getGroupOptions, getLevelOptions } from "./utils";
 
 const priorityEntitlementLink = (locale: string, chunks: React.ReactNode) => {
   const href =

--- a/apps/web/src/components/Profile/components/GovernmentInformation/GovernmentInformation.tsx
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/GovernmentInformation.tsx
@@ -17,13 +17,13 @@ import {
 
 import { SectionProps } from "../../types";
 import SectionTrigger from "../SectionTrigger";
+import FormActions from "../FormActions";
+import useSectionInfo from "../../hooks/useSectionInfo";
 import { dataToFormValues, formValuesToSubmitData } from "./utils";
 import { FormValues } from "./types";
-import FormActions from "../FormActions";
 import FormFields from "./FormFields";
 import NullDisplay from "./NullDisplay";
 import Display from "./Display";
-import useSectionInfo from "../../hooks/useSectionInfo";
 
 const GovernmentInformation = ({
   user,

--- a/apps/web/src/components/Profile/components/GovernmentInformation/types.ts
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/types.ts
@@ -1,4 +1,5 @@
 import { User } from "@gc-digital-talent/graphql";
+
 import { Classification, GovEmployeeType, Maybe } from "~/api/generated";
 
 type PartialClassification = Pick<Classification, "group" | "level">;

--- a/apps/web/src/components/Profile/components/LanguageProfile/FormFields.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/FormFields.tsx
@@ -4,9 +4,9 @@ import { useIntl } from "react-intl";
 import { Checklist, FieldLabels } from "@gc-digital-talent/forms";
 import { errorMessages } from "@gc-digital-talent/i18n";
 
+import useDirtyFields from "../../hooks/useDirtyFields";
 import ConsideredLanguages from "./ConsideredLanguages";
 import { getConsideredLangItems } from "./utils";
-import useDirtyFields from "../../hooks/useDirtyFields";
 
 interface FormFieldProps {
   labels: FieldLabels;

--- a/apps/web/src/components/Profile/components/LanguageProfile/LanguageProfile.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/LanguageProfile.tsx
@@ -17,13 +17,13 @@ import { getMissingLanguageRequirements } from "~/utils/languageUtils";
 
 import { SectionProps } from "../../types";
 import SectionTrigger from "../SectionTrigger";
-import { dataToFormValues, formValuesToSubmitData } from "./utils";
 import FormActions from "../FormActions";
+import useSectionInfo from "../../hooks/useSectionInfo";
+import { dataToFormValues, formValuesToSubmitData } from "./utils";
 import { FormValues } from "./types";
 import NullDisplay from "./NullDisplay";
 import Display from "./Display";
 import FormFields from "./FormFields";
-import useSectionInfo from "../../hooks/useSectionInfo";
 
 const LanguageProfile = ({
   user,

--- a/apps/web/src/components/Profile/components/PersonalInformation/FormFields.tsx
+++ b/apps/web/src/components/Profile/components/PersonalInformation/FormFields.tsx
@@ -19,8 +19,8 @@ import {
 import { Language, ProvinceOrTerritory } from "~/api/generated";
 
 import { FormFieldProps } from "../../types";
-import { armedForcesStatusOrdered, citizenshipStatusesOrdered } from "./utils";
 import useDirtyFields from "../../hooks/useDirtyFields";
+import { armedForcesStatusOrdered, citizenshipStatusesOrdered } from "./utils";
 
 const FormFields = ({ labels }: FormFieldProps) => {
   const intl = useIntl();

--- a/apps/web/src/components/Profile/components/PersonalInformation/PersonalInformation.tsx
+++ b/apps/web/src/components/Profile/components/PersonalInformation/PersonalInformation.tsx
@@ -13,15 +13,15 @@ import {
   hasEmptyRequiredFields,
 } from "~/validators/profile/about";
 
-import { formValuesToSubmitData, dataToFormValues } from "./utils";
-import { FormValues } from "./types";
 import { SectionProps } from "../../types";
 import SectionTrigger from "../SectionTrigger";
 import FormActions from "../FormActions";
+import useSectionInfo from "../../hooks/useSectionInfo";
+import { formValuesToSubmitData, dataToFormValues } from "./utils";
+import { FormValues } from "./types";
 import NullDisplay from "./NullDisplay";
 import Display from "./Display";
 import FormFields from "./FormFields";
-import useSectionInfo from "../../hooks/useSectionInfo";
 
 const PersonalInformation = ({
   user,

--- a/apps/web/src/components/Profile/components/PersonalInformation/utils.ts
+++ b/apps/web/src/components/Profile/components/PersonalInformation/utils.ts
@@ -8,6 +8,7 @@ import {
   UpdateUserAsUserInput,
   User,
 } from "~/api/generated";
+
 import { FormValues, PartialUser } from "./types";
 
 export const getLabels = (intl: IntlShape) => ({

--- a/apps/web/src/components/Profile/components/ProfileFormContext.tsx
+++ b/apps/web/src/components/Profile/components/ProfileFormContext.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { SectionKey } from "../types";
 
 interface ProfileFormContextState {

--- a/apps/web/src/components/Profile/components/StepNavigation.tsx
+++ b/apps/web/src/components/Profile/components/StepNavigation.tsx
@@ -23,6 +23,7 @@ import {
   PartialUser as DeiUser,
 } from "~/validators/profile/diversityEquityInclusion";
 import { useApplicationContext } from "~/pages/Applications/ApplicationContext";
+
 import { useProfileFormContext } from "./ProfileFormContext";
 
 type ProfileActionFormValues = {

--- a/apps/web/src/components/Profile/components/WorkPreferences/WorkPreferences.tsx
+++ b/apps/web/src/components/Profile/components/WorkPreferences/WorkPreferences.tsx
@@ -18,14 +18,14 @@ import {
 } from "~/validators/profile/workPreferences";
 
 import { SectionProps } from "../../types";
-import { dataToFormValues, formValuesToSubmitData } from "./utils";
-import { FormValues } from "./types";
 import SectionTrigger from "../SectionTrigger";
 import FormActions from "../FormActions";
+import useSectionInfo from "../../hooks/useSectionInfo";
+import { dataToFormValues, formValuesToSubmitData } from "./utils";
+import { FormValues } from "./types";
 import FormFields from "./FormFields";
 import NullDisplay from "./NullDisplay";
 import Display from "./Display";
-import useSectionInfo from "../../hooks/useSectionInfo";
 
 const WorkPreferences = ({
   user,

--- a/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
+++ b/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
@@ -1,12 +1,9 @@
 import React from "react";
-
 import { useIntl } from "react-intl";
+import isEmpty from "lodash/isEmpty";
 
 import { Heading } from "@gc-digital-talent/ui";
 import { insertBetween, notEmpty } from "@gc-digital-talent/helpers";
-
-import PrintExperienceByType from "~/components/UserProfile/PrintExperienceByType/PrintExperienceByType";
-
 import {
   commonMessages,
   getArmedForcesStatusesAdmin,
@@ -22,7 +19,6 @@ import {
   getWorkRegion,
   navigationMessages,
 } from "@gc-digital-talent/i18n";
-import { getFullNameLabel } from "~/utils/nameUtils";
 import { enumToOptions, unpackMaybes } from "@gc-digital-talent/forms";
 import {
   GovEmployeeType,
@@ -33,7 +29,9 @@ import {
   IndigenousCommunity,
   PoolCandidate,
 } from "@gc-digital-talent/graphql";
-import isEmpty from "lodash/isEmpty";
+
+import { getFullNameLabel } from "~/utils/nameUtils";
+import PrintExperienceByType from "~/components/UserProfile/PrintExperienceByType/PrintExperienceByType";
 import { anyCriteriaSelected as anyCriteriaSelectedDiversityEquityInclusion } from "~/validators/profile/diversityEquityInclusion";
 
 interface ProfileDocumentProps {

--- a/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.tsx
+++ b/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.tsx
@@ -22,8 +22,8 @@ import { categorizeSkill } from "~/utils/skillUtils";
 import { getRecruitmentType } from "~/utils/poolCandidate";
 import { Application } from "~/utils/applicationUtils";
 
-import { getQualifiedRecruitmentInfo, joinDepartments } from "./utils";
 import RecruitmentAvailabilityDialog from "../RecruitmentAvailabilityDialog/RecruitmentAvailabilityDialog";
+import { getQualifiedRecruitmentInfo, joinDepartments } from "./utils";
 
 export interface QualifiedRecruitmentCardProps {
   candidate: Application;

--- a/apps/web/src/components/QualifiedRecruitmentCard/utils.ts
+++ b/apps/web/src/components/QualifiedRecruitmentCard/utils.ts
@@ -2,9 +2,11 @@ import React from "react";
 import { IntlShape } from "react-intl";
 import NoSymbolIcon from "@heroicons/react/20/solid/NoSymbolIcon";
 import CheckCircleIcon from "@heroicons/react/20/solid/CheckCircleIcon";
+import ShieldCheckIcon from "@heroicons/react/20/solid/ShieldCheckIcon";
 
 import { Color, IconType } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
+import { PoolCandidate } from "@gc-digital-talent/graphql";
 
 import { Department, Maybe, PoolCandidateStatus } from "~/api/generated";
 import poolCandidateMessages from "~/messages/poolCandidateMessages";
@@ -21,8 +23,6 @@ import {
   isHiredLongTermCombinedStatus,
   isSuspendedCombinedStatus,
 } from "~/utils/poolCandidateCombinedStatus";
-import { PoolCandidate } from "@gc-digital-talent/graphql";
-import ShieldCheckIcon from "@heroicons/react/20/solid/ShieldCheckIcon";
 
 export const joinDepartments = (
   departments: Maybe<Maybe<Department>[]>,

--- a/apps/web/src/components/SearchRequestFilters/FilterBlock.tsx
+++ b/apps/web/src/components/SearchRequestFilters/FilterBlock.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useIntl } from "react-intl";
-
 import uniqueId from "lodash/uniqueId";
 import isEmpty from "lodash/isEmpty";
 

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -23,6 +23,7 @@ import {
   PoolCandidateFilter,
   PositionDuration,
 } from "~/api/generated";
+
 import FilterBlock from "./FilterBlock";
 
 type SimpleClassification = Pick<Classification, "group" | "level">;

--- a/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.stories.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-
 import { Meta, StoryFn } from "@storybook/react";
+
 import { fakeSearchRequests } from "@gc-digital-talent/fake-data";
 
 import SearchRequestsTable from "./SearchRequestsTableApi";

--- a/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.test.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.test.tsx
@@ -6,9 +6,9 @@ import "@testing-library/jest-dom";
 import React from "react";
 import { Provider as GraphqlProvider } from "urql";
 import { fromValue } from "wonka";
+import { act, screen } from "@testing-library/react";
 
 import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
-import { act, screen } from "@testing-library/react";
 import { fakeSearchRequests } from "@gc-digital-talent/fake-data";
 
 import SearchRequestsTable from "./SearchRequestsTableApi";

--- a/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
@@ -42,11 +42,11 @@ import {
 import adminMessages from "~/messages/adminMessages";
 import { PoolCandidateSearchRequest } from "~/api/generated";
 
+import tableClassificationPills from "../Table/ClientManagedTable/tableClassificationPills";
+import tableCommaList from "../Table/ClientManagedTable/tableCommaList";
 import SearchRequestsTableFilter, {
   FormValues,
 } from "./components/SearchRequestsTableFilterDialog";
-import tableClassificationPills from "../Table/ClientManagedTable/tableClassificationPills";
-import tableCommaList from "../Table/ClientManagedTable/tableCommaList";
 
 type Data = NonNullable<FromArray<PoolCandidateSearchRequestPaginator["data"]>>;
 

--- a/apps/web/src/components/SearchRequestTable/components/SearchRequestsTableFilter.stories.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/SearchRequestsTableFilter.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-
 import { Meta, StoryFn } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
+
 import {
   fakeClassifications,
   fakeDepartments,

--- a/apps/web/src/components/SearchRequestTable/components/SearchRequestsTableFilter.test.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/SearchRequestsTableFilter.test.tsx
@@ -6,9 +6,9 @@ import "@testing-library/jest-dom";
 import React from "react";
 import { Provider as GraphqlProvider } from "urql";
 import { fromValue } from "wonka";
+import { act, screen } from "@testing-library/react";
 
 import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
-import { act, screen } from "@testing-library/react";
 import {
   fakeClassifications,
   fakeDepartments,

--- a/apps/web/src/components/SearchRequestTable/components/SearchRequestsTableFilterDialog.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/SearchRequestsTableFilterDialog.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import { useIntl } from "react-intl";
 import { useFormContext, SubmitHandler } from "react-hook-form";
-
 import AdjustmentsVerticalIcon from "@heroicons/react/24/outline/AdjustmentsVerticalIcon";
+
 import { Dialog, Button } from "@gc-digital-talent/ui";
 import { BasicForm, MultiSelectField } from "@gc-digital-talent/forms";
 

--- a/apps/web/src/components/SkillDialog/SkillDialog.stories.tsx
+++ b/apps/web/src/components/SkillDialog/SkillDialog.stories.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { StoryFn } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { faker } from "@faker-js/faker";
+import { OverlayOrDialogDecorator } from "storybook-helpers";
 
 import Toast from "@gc-digital-talent/toast";
 import { getStaticSkills } from "@gc-digital-talent/fake-data";
-import { OverlayOrDialogDecorator } from "storybook-helpers";
 import { Skill } from "@gc-digital-talent/graphql";
 
 import SkillDialog from "./SkillDialog";

--- a/apps/web/src/components/SkillsInDetail/SkillsInDetail.stories.tsx
+++ b/apps/web/src/components/SkillsInDetail/SkillsInDetail.stories.tsx
@@ -6,6 +6,7 @@ import { fakeSkills } from "@gc-digital-talent/fake-data";
 import { BasicForm, Submit } from "@gc-digital-talent/forms";
 
 import type { FormSkills } from "~/types/experience";
+
 import SkillsInDetail, { SkillsInDetailProps } from "./SkillsInDetail";
 
 export default {

--- a/apps/web/src/components/SkillsInDetail/SkillsInDetail.tsx
+++ b/apps/web/src/components/SkillsInDetail/SkillsInDetail.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
 import { useForm } from "react-hook-form";
+import XCircleIcon from "@heroicons/react/20/solid/XCircleIcon";
 
 import { Button, Card } from "@gc-digital-talent/ui";
 import { TextArea } from "@gc-digital-talent/forms";
 import { getLocale, errorMessages } from "@gc-digital-talent/i18n";
 
 import type { FormSkills } from "~/types/experience";
-import XCircleIcon from "@heroicons/react/20/solid/XCircleIcon";
 
 export interface SkillsInDetailProps {
   skills: FormSkills;

--- a/apps/web/src/components/StatusItem/StatusItem.tsx
+++ b/apps/web/src/components/StatusItem/StatusItem.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-
 import CheckCircleIcon from "@heroicons/react/20/solid/CheckCircleIcon";
 import ExclamationCircleIcon from "@heroicons/react/20/solid/ExclamationCircleIcon";
 

--- a/apps/web/src/components/Table/ApiManagedTable/BasicTable.tsx
+++ b/apps/web/src/components/Table/ApiManagedTable/BasicTable.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from "react";
 import { useIntl } from "react-intl";
 
 import SortIcon from "../ClientManagedTable/SortIcon";
+import tableMessages from "../tableMessages";
 import {
   Column,
   ColumnsOf,
@@ -9,7 +10,6 @@ import {
   RecordWithId,
   SortingRule,
 } from "./helpers";
-import tableMessages from "../tableMessages";
 
 interface BasicTableProps<T extends RecordWithId = RecordWithId> {
   columns: ColumnsOf<T>;

--- a/apps/web/src/components/Table/ApiManagedTable/SearchForm.tsx
+++ b/apps/web/src/components/Table/ApiManagedTable/SearchForm.tsx
@@ -6,8 +6,8 @@ import ChevronDownIcon from "@heroicons/react/24/solid/ChevronDownIcon";
 
 import { Button, DropdownMenu } from "@gc-digital-talent/ui";
 
-import type { SearchColumn, SearchState } from "./helpers";
 import ResetButton from "../ResetButton";
+import type { SearchColumn, SearchState } from "./helpers";
 
 interface SearchFormProps {
   onChange: (val: string | undefined, col: string | undefined) => void;

--- a/apps/web/src/components/Table/ApiManagedTable/TableFooter.tsx
+++ b/apps/web/src/components/Table/ApiManagedTable/TableFooter.tsx
@@ -11,7 +11,6 @@ import {
 import { toast } from "@gc-digital-talent/toast";
 
 import Pagination from "~/components/Pagination";
-
 import { PaginatorInfo } from "~/api/generated";
 
 type Csv = Pick<DownloadCsvProps, "headers" | "data" | "fileName">;

--- a/apps/web/src/components/Table/ApiManagedTable/TableHeader.tsx
+++ b/apps/web/src/components/Table/ApiManagedTable/TableHeader.tsx
@@ -9,8 +9,8 @@ import { Field } from "@gc-digital-talent/forms";
 
 import adminMessages from "~/messages/adminMessages";
 
-import SearchForm from "./SearchForm";
 import IndeterminateCheckbox from "../ClientManagedTable/tableComponents";
+import SearchForm from "./SearchForm";
 import type {
   ColumnHiddenEvent,
   ColumnsOf,

--- a/apps/web/src/components/Table/ApiManagedTable/helpers.tsx
+++ b/apps/web/src/components/Table/ApiManagedTable/helpers.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { IntlShape } from "react-intl";
 
 import { CheckButton } from "@gc-digital-talent/forms";
+
 import { Scalars, InputMaybe, OrderByClause, SortOrder } from "~/api/generated";
 
 export interface RecordWithId extends Record<string, unknown> {

--- a/apps/web/src/components/Table/ApiManagedTable/useFilterOptions.test.tsx
+++ b/apps/web/src/components/Table/ApiManagedTable/useFilterOptions.test.tsx
@@ -7,6 +7,7 @@ import { IntlProvider } from "react-intl";
 import { Provider as GraphqlProvider } from "urql";
 import { pipe, fromValue, delay } from "wonka";
 import { waitFor, renderHook } from "@testing-library/react";
+
 import {
   fakeSkills,
   fakePools,
@@ -14,6 +15,7 @@ import {
   fakeRoles,
 } from "@gc-digital-talent/fake-data";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
+
 import useFilterOptions from "./useFilterOptions";
 
 describe("useFilterOptions", () => {

--- a/apps/web/src/components/Table/ClientManagedTable/Table.tsx
+++ b/apps/web/src/components/Table/ClientManagedTable/Table.tsx
@@ -22,10 +22,10 @@ import { Field } from "@gc-digital-talent/forms";
 import Pagination from "~/components/Pagination";
 import adminMessages from "~/messages/adminMessages";
 
+import tableMessages from "../tableMessages";
 import SortIcon from "./SortIcon";
 import SearchForm from "./SearchForm";
 import useInitialTableState from "./useInitialTableState";
-import tableMessages from "../tableMessages";
 
 export type ColumnsOf<T extends Record<string, unknown>> = Array<Column<T>>;
 

--- a/apps/web/src/components/Table/ClientManagedTable/index.ts
+++ b/apps/web/src/components/Table/ClientManagedTable/index.ts
@@ -2,7 +2,6 @@ import Table from "./Table";
 import tableEditButtonAccessor from "./TableEditButton";
 import tableViewItemButtonAccessor from "./TableViewItemButton";
 import tableActionsAccessor from "./TableActionButtons";
-
 import type { ColumnsOf } from "./Table";
 import type { Cell } from "./types";
 

--- a/apps/web/src/components/Table/ClientManagedTable/tableClassificationPills.tsx
+++ b/apps/web/src/components/Table/ClientManagedTable/tableClassificationPills.tsx
@@ -1,7 +1,9 @@
 import React from "react";
+
 import { notEmpty } from "@gc-digital-talent/helpers";
 import { Pill } from "@gc-digital-talent/ui";
 import { Maybe } from "@gc-digital-talent/graphql";
+
 import { Classification } from "~/api/generated";
 
 interface TableClassificationPillsProps {

--- a/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.stories.tsx
+++ b/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.stories.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
-
 import { OverlayOrDialogDecorator } from "storybook-helpers";
 
 import ThemeSwitcher from "./ThemeSwitcher";

--- a/apps/web/src/components/UserProfile/ExperienceSection.tsx
+++ b/apps/web/src/components/UserProfile/ExperienceSection.tsx
@@ -15,9 +15,9 @@ import {
 } from "~/utils/experienceUtils";
 import { AwardExperience, Experience } from "~/api/generated";
 
+import ExperienceCard from "../ExperienceCard/ExperienceCard";
 import SkillAccordion from "./SkillAccordion/SkillAccordion";
 import ExperienceByTypeListing from "./ExperienceByTypeListing";
-import ExperienceCard from "../ExperienceCard/ExperienceCard";
 
 interface ExperienceSectionProps {
   experiences?: Experience[];

--- a/apps/web/src/components/UserProfile/PrintExperienceByType/ExperienceItem.tsx
+++ b/apps/web/src/components/UserProfile/PrintExperienceByType/ExperienceItem.tsx
@@ -1,16 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-import {
-  getExperienceFormLabels,
-  isAwardExperience,
-  isCommunityExperience,
-  isEducationExperience,
-  isPersonalExperience,
-  isWorkExperience,
-  useExperienceInfo,
-} from "~/utils/experienceUtils";
-import { Experience, Maybe } from "~/api/generated";
 import { Heading } from "@gc-digital-talent/ui";
 import {
   commonMessages,
@@ -20,6 +10,17 @@ import {
   getLocalizedName,
 } from "@gc-digital-talent/i18n";
 import { Skill } from "@gc-digital-talent/graphql";
+
+import { Experience, Maybe } from "~/api/generated";
+import {
+  getExperienceFormLabels,
+  isAwardExperience,
+  isCommunityExperience,
+  isEducationExperience,
+  isPersonalExperience,
+  isWorkExperience,
+  useExperienceInfo,
+} from "~/utils/experienceUtils";
 import { getDateRange } from "~/utils/dateUtils";
 
 interface ExperienceItemProps {

--- a/apps/web/src/components/UserProfile/PrintExperienceByType/ExperienceType.tsx
+++ b/apps/web/src/components/UserProfile/PrintExperienceByType/ExperienceType.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 
+import { Heading } from "@gc-digital-talent/ui";
+
 import { Experience } from "~/api/generated";
 
-import { Heading } from "@gc-digital-talent/ui";
 import ExperienceItem from "./ExperienceItem";
 
 interface ExperienceTypeProps {

--- a/apps/web/src/components/UserProfile/PrintExperienceByType/PrintExperienceByType.tsx
+++ b/apps/web/src/components/UserProfile/PrintExperienceByType/PrintExperienceByType.tsx
@@ -10,6 +10,7 @@ import {
   isPersonalExperience,
   isWorkExperience,
 } from "~/utils/experienceUtils";
+
 import ExperienceType from "./ExperienceType";
 
 interface PrintExperienceByTypeProps {

--- a/apps/web/src/components/UserProfile/ProfileSections/DiversityEquityInclusionSection.tsx
+++ b/apps/web/src/components/UserProfile/ProfileSections/DiversityEquityInclusionSection.tsx
@@ -9,7 +9,6 @@ import {
 } from "@gc-digital-talent/i18n";
 
 import { User, IndigenousCommunity } from "~/api/generated";
-
 import firstNationsIcon from "~/assets/img/first-nations-true.png";
 import inuitIcon from "~/assets/img/inuit-true.png";
 import metisIcon from "~/assets/img/metis-true.png";

--- a/apps/web/src/components/UserProfile/UserProfile.tsx
+++ b/apps/web/src/components/UserProfile/UserProfile.tsx
@@ -15,9 +15,9 @@ import {
   Link,
   incrementHeadingRank,
 } from "@gc-digital-talent/ui";
+import { navigationMessages } from "@gc-digital-talent/i18n";
 
 import type { User } from "~/api/generated";
-
 import {
   aboutSectionHasEmptyRequiredFields,
   diversityEquityInclusionSectionHasEmptyRequiredFields,
@@ -27,9 +27,8 @@ import {
   workPreferencesSectionHasEmptyRequiredFields,
 } from "~/validators/profile";
 
-import { navigationMessages } from "@gc-digital-talent/i18n";
-import ExperienceSection from "./ExperienceSection";
 import StatusItem, { Status } from "../StatusItem/StatusItem";
+import ExperienceSection from "./ExperienceSection";
 import AboutSection from "./ProfileSections/AboutSection";
 import DiversityEquityInclusionSection from "./ProfileSections/DiversityEquityInclusionSection";
 import GovernmentInformationSection from "./ProfileSections/GovernmentInformationSection";

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 
 import Toast from "@gc-digital-talent/toast";
+
 import "@gc-digital-talent/forms/dist/index.css";
 import "@gc-digital-talent/ui/dist/index.css";
 import "@gc-digital-talent/toast/dist/index.css";
-
 import * as messages from "~/lang/frCompiled.json";
 import ContextContainer from "~/components/Context/ContextProvider";
 import Router from "~/components/Router";

--- a/apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.test.tsx
+++ b/apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.test.tsx
@@ -3,6 +3,7 @@
  */
 import "@testing-library/jest-dom";
 import React from "react";
+
 import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";
 
 import AccessibilityStatementPage from "./AccessibilityStatementPage";

--- a/apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.tsx
+++ b/apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.tsx
@@ -8,7 +8,6 @@ import Hero from "~/components/Hero";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import useRoutes from "~/hooks/useRoutes";
 import { wrapAbbr } from "~/utils/nameUtils";
-
 import heroImg from "~/assets/img/accessibility-statement-header.jpg";
 
 const digitalStandardsLink = (locale: Locales, chunks: React.ReactNode) => (

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -18,7 +18,6 @@ import SEO from "~/components/SEO/SEO";
 import { getFullNameHtml } from "~/utils/nameUtils";
 import { User, useMeQuery } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
-
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import adminMessages from "~/messages/adminMessages";
 

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/ApplicationCareerTimelineAddPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/ApplicationCareerTimelineAddPage.tsx
@@ -18,9 +18,9 @@ import { GetPageNavInfo } from "~/types/applicationStep";
 import applicationMessages from "~/messages/applicationMessages";
 
 import ApplicationApi, { ApplicationPageProps } from "../ApplicationApi";
+import { useApplicationContext } from "../ApplicationContext";
 import AddExperienceForm from "./components/AddExperienceForm";
 import { experienceTypeTitles } from "./messages";
-import { useApplicationContext } from "../ApplicationContext";
 
 export const getPageInfo: GetPageNavInfo = ({
   application,

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/messages.ts
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/messages.ts
@@ -1,4 +1,5 @@
 import { MessageDescriptor, defineMessages } from "react-intl";
+
 import { ExperienceType } from "~/types/experience";
 
 // Note: Expect this file to grow

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
@@ -15,8 +15,8 @@ import {
 import applicationMessages from "~/messages/applicationMessages";
 
 import { ApplicationPageProps } from "../ApplicationApi";
-import EditExperienceForm from "./components/ExperienceEditForm";
 import { useApplicationContext } from "../ApplicationContext";
+import EditExperienceForm from "./components/ExperienceEditForm";
 
 export const getPageInfo: GetPageNavInfo = ({
   application,

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
@@ -4,6 +4,7 @@ import { IntlShape, useIntl } from "react-intl";
 import StarIcon from "@heroicons/react/20/solid/StarIcon";
 import groupBy from "lodash/groupBy";
 import { FormProvider, useForm } from "react-hook-form";
+import { OperationContext } from "urql";
 
 import {
   Button,
@@ -35,7 +36,6 @@ import ExperienceSortAndFilter, {
 } from "~/components/ExperienceSortAndFilter/ExperienceSortAndFilter";
 import { sortAndFilterExperiences } from "~/components/ExperienceSortAndFilter/sortAndFilterUtil";
 
-import { OperationContext } from "urql";
 import { ApplicationPageProps } from "../ApplicationApi";
 import { useApplicationContext } from "../ApplicationContext";
 

--- a/apps/web/src/pages/Applications/ApplicationContext.tsx
+++ b/apps/web/src/pages/Applications/ApplicationContext.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { useTheme } from "@gc-digital-talent/theme";
 
 import { isIAPPool, getClassificationGroup } from "~/utils/poolUtils";

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
@@ -22,7 +22,12 @@ import {
   useUpdateApplicationMutation,
 } from "@gc-digital-talent/graphql";
 import { toast } from "@gc-digital-talent/toast";
-import useRoutes from "~/hooks/useRoutes";
+import { RadioGroup } from "@gc-digital-talent/forms";
+import { Radio } from "@gc-digital-talent/forms/src/components/RadioGroup";
+import { errorMessages, getLocale } from "@gc-digital-talent/i18n";
+import { notEmpty } from "@gc-digital-talent/helpers";
+
+import applicationMessages from "~/messages/applicationMessages";
 import {
   isAwardExperience,
   isCommunityExperience,
@@ -30,17 +35,13 @@ import {
   isPersonalExperience,
   isWorkExperience,
 } from "~/utils/experienceUtils";
-import applicationMessages from "~/messages/applicationMessages";
-
-import { RadioGroup } from "@gc-digital-talent/forms";
-import { Radio } from "@gc-digital-talent/forms/src/components/RadioGroup";
-import { errorMessages, getLocale } from "@gc-digital-talent/i18n";
-import { notEmpty } from "@gc-digital-talent/helpers";
+import useRoutes from "~/hooks/useRoutes";
 import { GetPageNavInfo } from "~/types/applicationStep";
 import { ExperienceForDate } from "~/types/experience";
+
 import { ApplicationPageProps } from "../ApplicationApi";
-import LinkCareerTimeline from "./LinkCareerTimeline";
 import { useApplicationContext } from "../ApplicationContext";
+import LinkCareerTimeline from "./LinkCareerTimeline";
 
 type EducationRequirementExperiences = {
   educationRequirementAwardExperiences: { sync: string[] };

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/LinkCareerTimeline.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/LinkCareerTimeline.tsx
@@ -3,19 +3,20 @@ import uniqueId from "lodash/uniqueId";
 import { defineMessages, useIntl } from "react-intl";
 
 import {
-  isAwardExperience,
-  isCommunityExperience,
-  isEducationExperience,
-  isPersonalExperience,
-  isWorkExperience,
-} from "~/utils/experienceUtils";
-import {
   EducationRequirementOption,
   Experience,
 } from "@gc-digital-talent/graphql";
 import { Checklist, CheckboxOption } from "@gc-digital-talent/forms";
 import { errorMessages } from "@gc-digital-talent/i18n";
 import { Heading, Link, Well } from "@gc-digital-talent/ui";
+
+import {
+  isAwardExperience,
+  isCommunityExperience,
+  isEducationExperience,
+  isPersonalExperience,
+  isWorkExperience,
+} from "~/utils/experienceUtils";
 
 const essentialExperienceMessages = defineMessages({
   computerScience: {

--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -14,11 +14,9 @@ import { empty, notEmpty } from "@gc-digital-talent/helpers";
 import SEO from "~/components/SEO/SEO";
 import Hero from "~/components/Hero/Hero";
 import IapContactDialog from "~/components/Dialog/IapContactDialog";
-
 import useRoutes from "~/hooks/useRoutes";
 import useCurrentPage from "~/hooks/useCurrentPage";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
-
 import { fullPoolTitle, isIAPPool } from "~/utils/poolUtils";
 import { useGetApplicationQuery } from "~/api/generated";
 import {

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.stories.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+
 import { fakePoolCandidates } from "@gc-digital-talent/fake-data";
 
 import { ApplicationProfile } from "./ApplicationProfilePage";

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
@@ -26,6 +26,7 @@ import WorkPreferences from "~/components/Profile/components/WorkPreferences/Wor
 import DiversityEquityInclusion from "~/components/Profile/components/DiversityEquityInclusion/DiversityEquityInclusion";
 import GovernmentInformation from "~/components/Profile/components/GovernmentInformation/GovernmentInformation";
 import LanguageProfile from "~/components/Profile/components/LanguageProfile/LanguageProfile";
+
 import { ApplicationPageProps } from "../ApplicationApi";
 import stepHasError from "../profileStep/profileStepValidation";
 import { useApplicationContext } from "../ApplicationContext";

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
@@ -15,11 +15,11 @@ import { useUpdateApplicationMutation } from "~/api/generated";
 import applicationMessages from "~/messages/applicationMessages";
 
 import ApplicationApi, { ApplicationPageProps } from "../ApplicationApi";
+import { useApplicationContext } from "../ApplicationContext";
 import { dataToFormValues, formValuesToSubmitData } from "./utils";
 import { FormValues } from "./types";
 import AnswerInput from "./components/AnswerInput";
 import FormActions from "./components/FormActions";
-import { useApplicationContext } from "../ApplicationContext";
 
 export const getPageInfo: GetPageNavInfo = ({
   application,

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/utils.ts
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/utils.ts
@@ -4,6 +4,7 @@ import {
   ScreeningQuestionResponse,
   UpdateScreeningQuestionResponseInput,
 } from "~/api/generated";
+
 import { FormValues } from "./types";
 
 export const dataToFormValues = (

--- a/apps/web/src/pages/Applications/ApplicationReviewPage/ReviewSection.tsx
+++ b/apps/web/src/pages/Applications/ApplicationReviewPage/ReviewSection.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { Heading, Link } from "@gc-digital-talent/ui";
 import { useIntl } from "react-intl";
+
+import { Heading, Link } from "@gc-digital-talent/ui";
 
 interface ReviewSectionProps {
   title: string;

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/SelfDeclarationForm.stories.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/SelfDeclarationForm.stories.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
+import { widthOf, heightOf } from "storybook-helpers";
+
 import { fakePoolCandidates } from "@gc-digital-talent/fake-data";
 import { IndigenousCommunity } from "@gc-digital-talent/graphql";
-
-import { widthOf, heightOf } from "storybook-helpers";
 
 import { ApplicationSelfDeclaration } from "../ApplicationSelfDeclarationPage";
 

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/SelfDeclarationForm.test.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/SelfDeclarationForm.test.tsx
@@ -14,8 +14,8 @@ import { Provider as GraphqlProvider } from "urql";
 import { pipe, fromValue, delay } from "wonka";
 
 import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
-
 import { fakePoolCandidates } from "@gc-digital-talent/fake-data";
+
 import { ApplicationSelfDeclaration } from "../ApplicationSelfDeclarationPage";
 
 const mockClient = {

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.stories.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.stories.tsx
@@ -5,8 +5,8 @@ import {
   fakePoolCandidates,
   fakeExperiences,
 } from "@gc-digital-talent/fake-data";
-
 import { notEmpty } from "@gc-digital-talent/helpers";
+
 import {
   ApplicationSkills,
   ApplicationSkillsProps,

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -27,12 +27,12 @@ import {
   useGetApplicationQuery,
 } from "~/api/generated";
 import { AnyExperience } from "~/types/experience";
-
 import { isIncomplete } from "~/validators/profile/skillRequirements";
-import SkillTree from "./components/SkillTree";
+
 import { ApplicationPageProps } from "../ApplicationApi";
-import SkillDescriptionAccordion from "./components/SkillDescriptionAccordion";
 import { useApplicationContext } from "../ApplicationContext";
+import SkillTree from "./components/SkillTree";
+import SkillDescriptionAccordion from "./components/SkillDescriptionAccordion";
 
 const careerTimelineLink = (children: React.ReactNode, href: string) => (
   <Link href={href}>{children}</Link>

--- a/apps/web/src/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage.tsx
@@ -7,6 +7,7 @@ import { useLocale } from "@gc-digital-talent/i18n";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetPageNavInfo } from "~/types/applicationStep";
+
 import ApplicationApi, { ApplicationPageProps } from "../ApplicationApi";
 import { useApplicationContext } from "../ApplicationContext";
 

--- a/apps/web/src/pages/Applications/MyApplicationsPage/components/ApplicationCard/ApplicationActions.tsx
+++ b/apps/web/src/pages/Applications/MyApplicationsPage/components/ApplicationCard/ApplicationActions.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { useIntl } from "react-intl";
+import CheckIcon from "@heroicons/react/20/solid/CheckIcon";
 
 import { AlertDialog, Button, Link } from "@gc-digital-talent/ui";
 
-import CheckIcon from "@heroicons/react/20/solid/CheckIcon";
 import { getFullPoolTitleHtml, getFullPoolTitleLabel } from "~/utils/poolUtils";
 import useRoutes from "~/hooks/useRoutes";
-
 import { PAGE_SECTION_ID } from "~/pages/Profile/CareerTimelineAndRecruitmentPage/constants";
+
 import type { Application } from "./ApplicationCard";
 
 interface ActionProps {

--- a/apps/web/src/pages/Applications/MyApplicationsPage/components/ApplicationCard/ApplicationCard.test.tsx
+++ b/apps/web/src/pages/Applications/MyApplicationsPage/components/ApplicationCard/ApplicationCard.test.tsx
@@ -6,11 +6,13 @@ import { screen } from "@testing-library/react";
 import React from "react";
 import { Provider as GraphqlProvider } from "urql";
 import { pipe, fromValue, delay } from "wonka";
+
 import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
 import { fakePoolCandidates } from "@gc-digital-talent/fake-data";
 import { FAR_PAST_DATE } from "@gc-digital-talent/date-helpers";
 
 import { PoolCandidateStatus } from "~/api/generated";
+
 import ApplicationCard, { type ApplicationCardProps } from "./ApplicationCard";
 
 const mockApplication = fakePoolCandidates()[0];

--- a/apps/web/src/pages/Applications/educationStep/educationStepValidation.tsx
+++ b/apps/web/src/pages/Applications/educationStep/educationStepValidation.tsx
@@ -4,6 +4,7 @@ import {
   Pool,
   PoolCandidate,
 } from "@gc-digital-talent/graphql";
+
 import { ExperienceForDate } from "~/types/experience";
 import { isEducationExperience } from "~/utils/experienceUtils";
 

--- a/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.test.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.test.tsx
@@ -10,6 +10,7 @@ import {
   fakeDepartments,
 } from "@gc-digital-talent/fake-data";
 import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
+
 import { CreateAccountForm, CreateAccountFormProps } from "./CreateAccountPage";
 
 const mockDepartments = fakeDepartments();

--- a/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
@@ -17,7 +17,6 @@ import { emptyToNull, notEmpty } from "@gc-digital-talent/helpers";
 
 import Hero from "~/components/Hero/Hero";
 import SEO from "~/components/SEO/SEO";
-
 import {
   Language,
   GovEmployeeType,
@@ -28,6 +27,7 @@ import {
   Department,
 } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
+
 import {
   formValuesToSubmitData,
   getGovernmentInfoLabels,

--- a/apps/web/src/pages/Auth/CreateAccountPage/components/GovernmentInfoForm/GovernmentInfoForm.stories.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/components/GovernmentInfoForm/GovernmentInfoForm.stories.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { Meta, Story } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import pick from "lodash/pick";
+
 import {
   fakeClassifications,
   fakeDepartments,
@@ -11,6 +12,7 @@ import {
 } from "@gc-digital-talent/fake-data";
 
 import { GovEmployeeType } from "~/api/generated";
+
 import GovernmentInfoForm from "./GovernmentInfoForm";
 
 export default {

--- a/apps/web/src/pages/Auth/CreateAccountPage/components/GovernmentInfoForm/GovernmentInfoForm.test.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/components/GovernmentInfoForm/GovernmentInfoForm.test.tsx
@@ -3,13 +3,15 @@
  */
 import "@testing-library/jest-dom";
 import React from "react";
+import { act, screen, fireEvent } from "@testing-library/react";
+
 import {
   fakeClassifications,
   fakeDepartments,
   fakeUsers,
 } from "@gc-digital-talent/fake-data";
-import { act, screen, fireEvent } from "@testing-library/react";
 import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";
+
 import GovernmentInfoForm, {
   GovernmentInfoFormProps,
 } from "./GovernmentInfoForm";

--- a/apps/web/src/pages/Auth/SignedOutPage/SignedOutPage.tsx
+++ b/apps/web/src/pages/Auth/SignedOutPage/SignedOutPage.tsx
@@ -7,7 +7,6 @@ import { getLocale } from "@gc-digital-talent/i18n";
 
 import Hero from "~/components/Hero/Hero";
 import SEO from "~/components/SEO/SEO";
-
 import useRoutes from "~/hooks/useRoutes";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import authMessages from "~/messages/authMessages";

--- a/apps/web/src/pages/Classifications/IndexClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/IndexClassificationPage.tsx
@@ -6,8 +6,8 @@ import PageHeader from "~/components/PageHeader";
 import SEO from "~/components/SEO/SEO";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRoutes from "~/hooks/useRoutes";
-
 import adminMessages from "~/messages/adminMessages";
+
 import ClassificationTableApi from "./components/ClassificationTable";
 
 export const IndexClassificationPage = () => {

--- a/apps/web/src/pages/Departments/CreateDepartmentForm.stories.tsx
+++ b/apps/web/src/pages/Departments/CreateDepartmentForm.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
+
 import { fakeDepartments } from "@gc-digital-talent/fake-data";
 
 import { CreateDepartmentForm } from "./CreateDepartmentPage";

--- a/apps/web/src/pages/Departments/IndexDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/IndexDepartmentPage.tsx
@@ -6,8 +6,8 @@ import PageHeader from "~/components/PageHeader";
 import SEO from "~/components/SEO/SEO";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRoutes from "~/hooks/useRoutes";
-
 import adminMessages from "~/messages/adminMessages";
+
 import DepartmentTableApi from "./components/DepartmentTable";
 
 export const DepartmentPage = () => {

--- a/apps/web/src/pages/DirectivePage/DirectivePage.test.tsx
+++ b/apps/web/src/pages/DirectivePage/DirectivePage.test.tsx
@@ -3,6 +3,7 @@
  */
 import "@testing-library/jest-dom";
 import React from "react";
+
 import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";
 
 import DirectivePage from "./DirectivePage";

--- a/apps/web/src/pages/DirectivePage/DirectivePage.tsx
+++ b/apps/web/src/pages/DirectivePage/DirectivePage.tsx
@@ -18,7 +18,6 @@ import { Locales, useLocale } from "@gc-digital-talent/i18n";
 import Hero from "~/components/Hero";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import useRoutes from "~/hooks/useRoutes";
-
 import talentPlanEn from "~/assets/documents/Forward_Talent_Plan_EN.docx";
 import talentPlanFr from "~/assets/documents/Plan_prospectif_sur_les_talents_FR.docx";
 import recruitmentEn from "~/assets/documents/Digital_Recruitment_Template_EN.docx";

--- a/apps/web/src/pages/Errors/ErrorPage/ErrorPage.stories.tsx
+++ b/apps/web/src/pages/Errors/ErrorPage/ErrorPage.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
 import { widthOf, heightOf } from "storybook-helpers";
+
 import Error404 from "./ErrorPage";
 
 type Meta = ComponentMeta<typeof Error404>;

--- a/apps/web/src/pages/Errors/ErrorPage/ErrorPage.tsx
+++ b/apps/web/src/pages/Errors/ErrorPage/ErrorPage.tsx
@@ -10,7 +10,6 @@ import { useLogger } from "@gc-digital-talent/logger";
 
 import useRoutes from "~/hooks/useRoutes";
 import useErrorMessages from "~/hooks/useErrorMessages";
-
 import darkPug from "~/assets/img/404_pug_dark.png";
 import lightPug from "~/assets/img/404_pug_light.png";
 

--- a/apps/web/src/pages/Home/ExecutiveHomePage/ExecutiveHomePage.tsx
+++ b/apps/web/src/pages/Home/ExecutiveHomePage/ExecutiveHomePage.tsx
@@ -27,7 +27,6 @@ import PoolCard from "~/components/PoolCard/PoolCard";
 import { Pool, useBrowsePoolsQuery } from "~/api/generated";
 import { isExecPool } from "~/utils/poolUtils";
 import { TALENTSEARCH_SUPPORT_EMAIL } from "~/constants/talentSearchConstants";
-
 import executiveHero from "~/assets/img/people-sitting-in-line-shaking-hands.jpg";
 import executiveProfileHero from "~/assets/img/person-with-hand-to-chin-looking-at-laptop.jpg";
 

--- a/apps/web/src/pages/Home/HomePage/HomePage.stories.tsx
+++ b/apps/web/src/pages/Home/HomePage/HomePage.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
 import { widthOf, heightOf } from "storybook-helpers";
+
 import Home from "./HomePage";
 
 type Meta = ComponentMeta<typeof Home>;

--- a/apps/web/src/pages/Home/HomePage/HomePage.test.tsx
+++ b/apps/web/src/pages/Home/HomePage/HomePage.test.tsx
@@ -3,6 +3,7 @@
  */
 import "@testing-library/jest-dom";
 import React from "react";
+
 import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";
 
 import HomePage from "./HomePage";

--- a/apps/web/src/pages/Home/HomePage/components/Featured/Featured.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/Featured/Featured.tsx
@@ -1,16 +1,15 @@
 import React from "react";
 import { useIntl } from "react-intl";
+import MagnifyingGlassCircleIcon from "@heroicons/react/24/outline/MagnifyingGlassCircleIcon";
 
 import { Heading } from "@gc-digital-talent/ui";
 
 import FeatureBlock from "~/components/FeatureBlock/FeatureBlock";
 import FlourishContainer from "~/components/FlourishContainer/FlourishContainer";
 import useRoutes from "~/hooks/useRoutes";
-
 import glassesOnBooks from "~/assets/img/glasses-on-books.jpg";
 // import digitalAmbitionImg from "~/assets/img/check_it_out_digital_ambition.jpg";
 import iapManagerImg from "~/assets/img/check_it_out_IAP_manager_callout.jpg";
-import MagnifyingGlassCircleIcon from "@heroicons/react/24/outline/MagnifyingGlassCircleIcon";
 
 const Featured = () => {
   const intl = useIntl();

--- a/apps/web/src/pages/Home/HomePage/components/Hero/Hero.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/Hero/Hero.tsx
@@ -8,7 +8,6 @@ import { Heading, Link } from "@gc-digital-talent/ui";
 import HomeHero from "~/components/Hero/HomeHero";
 import useRoutes from "~/hooks/useRoutes";
 import { wrapAbbr } from "~/utils/nameUtils";
-
 import hero1Landscape from "~/assets/img/hero-1-landscape.jpg";
 import hero2Landscape from "~/assets/img/hero-2-landscape.jpg";
 import hero3Landscape from "~/assets/img/hero-3-landscape.jpg";

--- a/apps/web/src/pages/Home/HomePage/components/Profile/Profile.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/Profile/Profile.tsx
@@ -6,7 +6,6 @@ import { Link } from "@gc-digital-talent/ui";
 
 import useRoutes from "~/hooks/useRoutes";
 import SkewedImageContainer from "~/components/SkewedContainer/SkewedImageContainer";
-
 import profileHeroImg from "~/assets/img/hero-profile.jpg";
 
 const Profile = () => {

--- a/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
@@ -4,12 +4,13 @@ import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
 import { widthOf, heightOf } from "storybook-helpers";
 
 import NestedLanguageProvider from "@gc-digital-talent/i18n/src/components/NestedLanguageProvider";
-
 import { Messages } from "@gc-digital-talent/i18n";
+
 import * as micMessages from "~/lang/micCompiled.json";
 import * as crgMessages from "~/lang/crgCompiled.json";
 import * as crkMessages from "~/lang/crkCompiled.json";
 import * as ojwMessages from "~/lang/ojwCompiled.json";
+
 import { Home } from "./Home";
 
 const messages: Map<string, Messages> = new Map([

--- a/apps/web/src/pages/Home/IAPHomePage/Home.test.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.test.tsx
@@ -3,6 +3,7 @@
  */
 import "@testing-library/jest-dom";
 import React from "react";
+
 import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";
 
 import { Home } from "./Home";

--- a/apps/web/src/pages/Home/IAPHomePage/Home.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.tsx
@@ -7,7 +7,6 @@ import { Link, Pending } from "@gc-digital-talent/ui";
 import { nowUTCDateTime } from "@gc-digital-talent/date-helpers";
 
 import useQuote from "~/hooks/useQuote";
-
 import iapHeroImg from "~/assets/img/iap-hero.jpg";
 import logoImg from "~/assets/img/iap-logo.svg";
 import womanSmiling from "~/assets/img/indigenous-woman-smiling.jpg";
@@ -21,7 +20,6 @@ import sash from "~/assets/img/sash.jpg";
 import lowerBack from "~/assets/img/lower-back.jpg";
 import iconWatermark from "~/assets/img/icon-watermark.svg";
 import indigenousWoman from "~/assets/img/indigenous-woman.png";
-
 import {
   useIapPublishedPoolsQuery,
   PublishingGroup,
@@ -37,7 +35,6 @@ import LanguageSelector from "./components/LanguageSelector";
 import Step from "./components/Step";
 import Quote from "./components/Quote";
 import ApplyLink from "./components/ApplyLink";
-
 import {
   BarChart,
   Calendar,

--- a/apps/web/src/pages/Home/IAPHomePage/components/Dialog/ApplyDialog.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Dialog/ApplyDialog.tsx
@@ -4,7 +4,6 @@ import { useIntl } from "react-intl";
 import { Button, Dialog, Link } from "@gc-digital-talent/ui";
 
 import CloseButton from "./CloseButton";
-
 import { BasicDialogProps } from "./types";
 
 const mailAccessor = (chunks: React.ReactNode) => (

--- a/apps/web/src/pages/Home/IAPHomePage/components/Dialog/DefinitionDialog.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Dialog/DefinitionDialog.tsx
@@ -4,7 +4,6 @@ import { useIntl } from "react-intl";
 import { Button, Dialog } from "@gc-digital-talent/ui";
 
 import CloseButton from "./CloseButton";
-
 import type { BasicDialogProps } from "./types";
 
 const DefinitionDialog = ({ children, btnProps }: BasicDialogProps) => {

--- a/apps/web/src/pages/Home/IAPHomePage/components/Dialog/LearnDialog.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Dialog/LearnDialog.tsx
@@ -5,7 +5,6 @@ import { Button, Dialog } from "@gc-digital-talent/ui";
 
 import Heading from "../Heading";
 import CloseButton from "./CloseButton";
-
 import { BasicDialogProps } from "./types";
 
 const LearnDialog = ({ btnProps }: BasicDialogProps) => {

--- a/apps/web/src/pages/Home/IAPHomePage/components/Dialog/RequirementDialog.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Dialog/RequirementDialog.tsx
@@ -4,7 +4,6 @@ import { useIntl } from "react-intl";
 import { Button, Dialog } from "@gc-digital-talent/ui";
 
 import CloseButton from "./CloseButton";
-
 import type { BasicDialogProps } from "./types";
 
 const RequirementDialog = ({ btnProps }: BasicDialogProps) => {

--- a/apps/web/src/pages/Home/IAPHomePage/components/Dialog/SelfDeclarationDialog.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Dialog/SelfDeclarationDialog.tsx
@@ -4,7 +4,6 @@ import { useIntl } from "react-intl";
 import { Button, Dialog } from "@gc-digital-talent/ui";
 
 import CloseButton from "./CloseButton";
-
 import type { BasicDialogProps } from "./types";
 
 const SelfDeclarationDialog = ({ children, btnProps }: BasicDialogProps) => {

--- a/apps/web/src/pages/Home/IAPHomePage/components/Dialog/VerificationDialog.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/components/Dialog/VerificationDialog.tsx
@@ -4,7 +4,6 @@ import { useIntl } from "react-intl";
 import { Button, Dialog } from "@gc-digital-talent/ui";
 
 import CloseButton from "./CloseButton";
-
 import type { BasicDialogProps } from "./types";
 
 const VerificationDialog = ({ children, btnProps }: BasicDialogProps) => {

--- a/apps/web/src/pages/Home/ManagerHomePage/ManagerHomePage.tsx
+++ b/apps/web/src/pages/Home/ManagerHomePage/ManagerHomePage.tsx
@@ -16,7 +16,6 @@ import SkewedContainer from "~/components/SkewedContainer/SkewedContainer";
 import SkewedImageContainer from "~/components/SkewedContainer/SkewedImageContainer";
 import FlourishContainer from "~/components/FlourishContainer/FlourishContainer";
 import FeatureBlock from "~/components/FeatureBlock/FeatureBlock";
-
 import managerHero from "~/assets/img/manager-hero.jpg";
 import managerProfileHero from "~/assets/img/manager-profile-hero.jpg";
 import peopleGatheredAroundLaptop from "~/assets/img/people-gathered-around-laptop.jpg";

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -44,14 +44,14 @@ import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWr
 import ExperienceTreeItems from "~/components/ExperienceTreeItems/ExperienceTreeItems";
 import PoolStatusTable from "~/components/PoolStatusTable/PoolStatusTable";
 
-import ApplicationStatusForm from "./components/ApplicationStatusForm";
-import CareerTimelineSection from "./components/CareerTimelineSection/CareerTimelineSection";
 import SkillTree from "../../Applications/ApplicationSkillsPage/components/SkillTree";
 import PersonalInformationDisplay from "../../../components/Profile/components/PersonalInformation/Display";
 import DiversityEquityInclusionDisplay from "../../../components/Profile/components/DiversityEquityInclusion/Display";
 import GovernmentInformationDisplay from "../../../components/Profile/components/GovernmentInformation/Display";
 import LanguageProfileDisplay from "../../../components/Profile/components/LanguageProfile/Display";
 import WorkPreferencesDisplay from "../../../components/Profile/components/WorkPreferences/Display";
+import CareerTimelineSection from "./components/CareerTimelineSection/CareerTimelineSection";
+import ApplicationStatusForm from "./components/ApplicationStatusForm";
 import AssetSkillsFiltered from "./components/ApplicationStatusForm/AssetSkillsFiltered";
 
 export interface ViewPoolCandidateProps {

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.stories.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.stories.tsx
@@ -5,6 +5,7 @@ import { action } from "@storybook/addon-actions";
 import { fakePoolCandidates } from "@gc-digital-talent/fake-data";
 
 import { UpdatePoolCandidateAsAdminInput } from "~/api/generated";
+
 import { ApplicationStatusForm } from "./ApplicationStatusForm";
 
 type Meta = ComponentMeta<typeof ApplicationStatusForm>;

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.test.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.test.tsx
@@ -9,6 +9,7 @@ import { fakePoolCandidates } from "@gc-digital-talent/fake-data";
 import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
 
 import { PoolCandidateStatus } from "~/api/generated";
+
 import {
   ApplicationStatusForm,
   type ApplicationStatusFormProps,

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CareerTimelineSection/CareerTimelineSection.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CareerTimelineSection/CareerTimelineSection.tsx
@@ -1,7 +1,9 @@
-import { notEmpty } from "@gc-digital-talent/helpers";
-import { Well } from "@gc-digital-talent/ui";
 import * as React from "react";
 import { useIntl } from "react-intl";
+
+import { notEmpty } from "@gc-digital-talent/helpers";
+import { Well } from "@gc-digital-talent/ui";
+
 import { Experience } from "~/api/generated";
 import ExperienceCard from "~/components/ExperienceCard/ExperienceCard";
 import ExperienceSortAndFilter, {

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.stories.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.stories.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
-
 import { widthOf, heightOf } from "storybook-helpers";
+
 import { fakePools } from "@gc-digital-talent/fake-data";
 
 import { PoolStatus, PublishingGroup } from "~/api/generated";

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.test.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.test.tsx
@@ -4,7 +4,6 @@
 import "@testing-library/jest-dom";
 import { screen, act } from "@testing-library/react";
 import React from "react";
-
 import { Provider as GraphqlProvider } from "urql";
 import { pipe, fromValue, delay } from "wonka";
 

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
@@ -23,7 +23,6 @@ import {
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import useRoutes from "~/hooks/useRoutes";
 import { wrapAbbr } from "~/utils/nameUtils";
-
 import browseHeroImg from "~/assets/img/browse_header.jpg";
 import flourishTopLight from "~/assets/img/browse_top_light.png";
 import flourishBottomLight from "~/assets/img/browse_bottom_light.png";

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/ActiveRecruitmentSection/ActiveRecruitmentSection.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/ActiveRecruitmentSection/ActiveRecruitmentSection.tsx
@@ -5,7 +5,6 @@ import { useIntl } from "react-intl";
 import { Heading } from "@gc-digital-talent/ui";
 
 import { Pool } from "~/api/generated";
-
 import PoolCard from "~/components/PoolCard/PoolCard";
 
 export interface ActiveRecruitmentSectionProps {

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.test.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.test.tsx
@@ -6,8 +6,11 @@ import "@testing-library/jest-dom";
 import { Provider as GraphqlProvider } from "urql";
 import { fromValue } from "wonka";
 import { screen, act, fireEvent } from "@testing-library/react";
+
 import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
+
 import { PoolStatus, Pool, PoolStream, PublishingGroup } from "~/api/generated";
+
 import OngoingRecruitmentSection, {
   OngoingRecruitmentSectionProps,
 } from "./OngoingRecruitmentSection";

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import CpuChipIcon from "@heroicons/react/24/outline/CpuChipIcon";
 import { useIntl } from "react-intl";
 import { useLocation } from "react-router-dom";
+import CheckIcon from "@heroicons/react/20/solid/CheckIcon";
+import ChevronDownIcon from "@heroicons/react/24/solid/ChevronDownIcon";
 
 import {
   Accordion,
@@ -21,8 +23,6 @@ import { PoolStream, Skill, Pool, useMySkillsQuery } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
 import { wrapAbbr } from "~/utils/nameUtils";
 
-import CheckIcon from "@heroicons/react/20/solid/CheckIcon";
-import ChevronDownIcon from "@heroicons/react/24/solid/ChevronDownIcon";
 import messages from "../../messages";
 
 // the shape of the data model to populate this component

--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -8,6 +8,7 @@ import { toast } from "@gc-digital-talent/toast";
 import { Select, Submit, unpackMaybes } from "@gc-digital-talent/forms";
 import { errorMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import { Pending, Link } from "@gc-digital-talent/ui";
+import { RoleAssignment } from "@gc-digital-talent/graphql";
 
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import PageHeader from "~/components/PageHeader/PageHeader";
@@ -22,7 +23,6 @@ import {
   Maybe,
   Team,
 } from "~/api/generated";
-import { RoleAssignment } from "@gc-digital-talent/graphql";
 import adminMessages from "~/messages/adminMessages";
 
 type Option<V> = { value: V; label: string };

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.stories.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Meta, Story } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
+
 import {
   fakeSkillFamilies,
   fakeClassifications,
@@ -13,6 +14,7 @@ import {
 } from "@gc-digital-talent/date-helpers";
 
 import { PoolStatus } from "~/api/generated";
+
 import { EditPoolForm, EditPoolFormProps } from "./EditPoolPage";
 
 const classifications = fakeClassifications();

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.test.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.test.tsx
@@ -4,10 +4,12 @@
 import "@testing-library/jest-dom";
 import React from "react";
 import { act, fireEvent, screen, within } from "@testing-library/react";
+
 import {
   renderWithProviders,
   updateDate,
 } from "@gc-digital-talent/jest-helpers";
+
 import { EditPoolForm, EditPoolFormProps } from "./EditPoolPage";
 import EditPoolStory, {
   DraftPool,

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -20,9 +20,9 @@ import {
   Skill,
 } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
-
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import adminMessages from "~/messages/adminMessages";
+
 import PoolNameSection, {
   type PoolNameSubmitData,
 } from "./components/PoolNameSection";

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.stories.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.stories.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
+
 import { fakePools } from "@gc-digital-talent/fake-data";
+
 import { PoolPoster } from "./PoolAdvertisementPage";
 
 const fakePool = fakePools(1)[0];

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/EducationRequirements.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/EducationRequirements.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-import applicationMessages from "~/messages/applicationMessages";
 import { Link, Heading } from "@gc-digital-talent/ui";
-
 import { getLocale } from "@gc-digital-talent/i18n";
+
+import applicationMessages from "~/messages/applicationMessages";
+
 import Text from "./Text";
 
 const RequirementCard = (props: React.HTMLProps<HTMLDivElement>) => (

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/GenericJobTitleAccordion.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/GenericJobTitleAccordion.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { useIntl } from "react-intl";
+
 import { Accordion, StandardAccordionHeader } from "@gc-digital-talent/ui";
+import { getLocalizedName } from "@gc-digital-talent/i18n";
 
 import { GenericJobTitle } from "~/api/generated";
-import { getLocalizedName } from "@gc-digital-talent/i18n";
+
 import ClassificationDefinition from "./ClassificationDefinition";
 
 interface GenericJobTitleAccordionProps {

--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -4,6 +4,7 @@ import { useParams } from "react-router-dom";
 import { FormProvider, useForm } from "react-hook-form";
 import CheckIcon from "@heroicons/react/24/outline/CheckIcon";
 import ClipboardIcon from "@heroicons/react/24/outline/ClipboardIcon";
+
 import {
   Pending,
   Chip,
@@ -25,12 +26,12 @@ import {
   parseDateTimeUtc,
   relativeClosingDate,
 } from "@gc-digital-talent/date-helpers";
+import { notEmpty } from "@gc-digital-talent/helpers";
 
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import { Scalars, SkillCategory, useGetPoolQuery, Pool } from "~/api/generated";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
-import { notEmpty } from "@gc-digital-talent/helpers";
 import adminMessages from "~/messages/adminMessages";
 
 interface ViewPoolProps {

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/CareerTimelineAndRecruitmentPage.stories.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/CareerTimelineAndRecruitmentPage.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-
 import { OverlayOrDialogDecorator } from "storybook-helpers";
+
 import { fakeSkills, fakeExperiences } from "@gc-digital-talent/fake-data";
 import { notEmpty } from "@gc-digital-talent/helpers";
 

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/CareerTimelineAndRecruitmentPage.test.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/CareerTimelineAndRecruitmentPage.test.tsx
@@ -3,6 +3,7 @@
  */
 import { compareByDate } from "~/utils/experienceUtils";
 import { User, Experience } from "~/api/generated";
+
 import { ExperienceForDate } from "./components/CareerTimelineAndRecruitment";
 
 const user: User = { email: "blank", id: "blank" };

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/CareerTimelineAndRecruitmentPage.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/CareerTimelineAndRecruitmentPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "~/api/generated";
 import profileMessages from "~/messages/profileMessages";
 import { Application } from "~/utils/applicationUtils";
+
 import CareerTimelineAndRecruitment from "./components/CareerTimelineAndRecruitment";
 
 interface CareerTimelineAndRecruitmentApiProps {

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
@@ -22,8 +22,8 @@ import useRoutes from "~/hooks/useRoutes";
 import { wrapAbbr } from "~/utils/nameUtils";
 import { Application } from "~/utils/applicationUtils";
 
-import CareerTimelineSection from "./CareerTimelineSection";
 import { PAGE_SECTION_ID, titles } from "../constants";
+import CareerTimelineSection from "./CareerTimelineSection";
 import QualifiedRecruitmentsSection from "./QualifiedRecruitmentsSection";
 
 type MergedExperiences = Array<

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceForm.stories.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceForm.stories.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import type { Meta, Story } from "@storybook/react";
+
 import { getStaticSkills } from "@gc-digital-talent/fake-data";
+
 import type { Skill } from "~/api/generated";
 import type { ExperienceType } from "~/types/experience";
+
 import { ExperienceForm } from "./ExperienceFormPage";
 
 const skillData = getStaticSkills();

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceForm.test.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceForm.test.tsx
@@ -12,7 +12,9 @@ import {
   renderWithProviders,
   updateDate,
 } from "@gc-digital-talent/jest-helpers";
+
 import type { ExperienceType } from "~/types/experience";
+
 import { ExperienceForm, ExperienceFormProps } from "./ExperienceFormPage";
 
 const mockUserId = "user-id";

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -23,7 +23,6 @@ import {
   useGetSkillsQuery,
 } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
-
 import {
   useDeleteExperienceMutation,
   useExperienceMutations,

--- a/apps/web/src/pages/Profile/ExperienceFormPage/components/AwardFormFields/AwardFormFields.stories.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/components/AwardFormFields/AwardFormFields.stories.tsx
@@ -5,8 +5,8 @@ import { Meta, Story } from "@storybook/react";
 
 import { BasicForm, Submit } from "@gc-digital-talent/forms";
 
-import AwardFormFields from "./AwardFormFields";
 import getExperienceFormLabels from "../../labels";
+import AwardFormFields from "./AwardFormFields";
 
 export default {
   component: AwardFormFields,

--- a/apps/web/src/pages/Profile/ExperienceFormPage/components/AwardFormFields/AwardFormFields.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/components/AwardFormFields/AwardFormFields.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useIntl } from "react-intl";
 
 import AwardFields from "~/components/ExperienceFormFields/AwardFields";
-
 import type { SubExperienceFormProps } from "~/types/experience";
 
 const AwardFormFields = ({ labels }: SubExperienceFormProps) => {

--- a/apps/web/src/pages/Profile/ExperienceFormPage/components/CommunityFormFields/CommunityFormFields.stories.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/components/CommunityFormFields/CommunityFormFields.stories.tsx
@@ -5,8 +5,8 @@ import { Meta, Story } from "@storybook/react";
 
 import { BasicForm, Submit } from "@gc-digital-talent/forms";
 
-import CommunityFormFields from "./CommunityFormFields";
 import getExperienceFormLabels from "../../labels";
+import CommunityFormFields from "./CommunityFormFields";
 
 export default {
   component: CommunityFormFields,

--- a/apps/web/src/pages/Profile/ExperienceFormPage/components/EducationFormFields/EducationFormFields.stories.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/components/EducationFormFields/EducationFormFields.stories.tsx
@@ -5,8 +5,8 @@ import { Meta, Story } from "@storybook/react";
 
 import { BasicForm, Submit } from "@gc-digital-talent/forms";
 
-import EducationFormFields from "./EducationFormFields";
 import getExperienceFormLabels from "../../labels";
+import EducationFormFields from "./EducationFormFields";
 
 export default {
   component: EducationFormFields,

--- a/apps/web/src/pages/Profile/ExperienceFormPage/components/ExperienceSkills.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/components/ExperienceSkills.tsx
@@ -11,7 +11,6 @@ import {
 
 import { Skill } from "~/api/generated";
 import SkillsInDetail from "~/components/SkillsInDetail/SkillsInDetail";
-
 import type { ExperienceType, FormSkill, FormSkills } from "~/types/experience";
 import SkillDialog from "~/components/SkillDialog/SkillDialog";
 import { FormValues as SkillDialogFormValues } from "~/components/SkillDialog/types";

--- a/apps/web/src/pages/Profile/ExperienceFormPage/components/PersonalFormFields/PersonalFormFields.stories.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/components/PersonalFormFields/PersonalFormFields.stories.tsx
@@ -5,8 +5,8 @@ import { Meta, Story } from "@storybook/react";
 
 import { BasicForm, Submit } from "@gc-digital-talent/forms";
 
-import PersonalFormFields from "./PersonalFormFields";
 import getExperienceFormLabels from "../../labels";
+import PersonalFormFields from "./PersonalFormFields";
 
 export default {
   component: PersonalFormFields,

--- a/apps/web/src/pages/Profile/ExperienceFormPage/components/WorkFormFields/WorkFormFields.stories.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/components/WorkFormFields/WorkFormFields.stories.tsx
@@ -5,8 +5,8 @@ import { Meta, Story } from "@storybook/react";
 
 import { BasicForm, Submit } from "@gc-digital-talent/forms";
 
-import WorkFormFields from "./WorkFormFields";
 import getExperienceFormLabels from "../../labels";
+import WorkFormFields from "./WorkFormFields";
 
 export default {
   component: WorkFormFields,

--- a/apps/web/src/pages/Profile/ExperienceFormPage/labels.ts
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/labels.ts
@@ -1,4 +1,5 @@
 import { IntlShape } from "react-intl";
+
 import { ExperienceType } from "~/types/experience";
 
 const getExperienceFormLabels = (

--- a/apps/web/src/pages/ProfileAndApplicationsPage/ProfileAndApplications.stories.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/ProfileAndApplications.stories.tsx
@@ -3,8 +3,8 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { PoolCandidateStatus } from "@gc-digital-talent/graphql";
 import { fakePoolCandidates, fakeUsers } from "@gc-digital-talent/fake-data";
-
 import { FAR_PAST_DATE } from "@gc-digital-talent/date-helpers";
+
 import { ProfileAndApplications } from "./ProfileAndApplicationsPage";
 
 const mockApplications = fakePoolCandidates(20);

--- a/apps/web/src/pages/ProfileAndApplicationsPage/ProfileAndApplicationsPage.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/ProfileAndApplicationsPage.tsx
@@ -10,7 +10,6 @@ import profileMessages from "~/messages/profileMessages";
 
 import ProfileAndApplicationsHeading from "./components/ProfileAndApplicationsHeading";
 import TrackApplications from "./components/TrackApplications/TrackApplications";
-
 import { PartialUser } from "./types";
 
 interface ProfileAndApplicationsProps {

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
 import { useSearchParams } from "react-router-dom";
-
 import BriefcaseIcon from "@heroicons/react/20/solid/BriefcaseIcon";
 import BookOpenIcon from "@heroicons/react/20/solid/BookOpenIcon";
 import UsersIcon from "@heroicons/react/20/solid/UsersIcon";
@@ -46,6 +45,7 @@ import HeroCard from "~/components/HeroCard/HeroCard";
 import { PAGE_SECTION_ID as PROFILE_PAGE_SECTION_ID } from "~/components/UserProfile/constants";
 import { isApplicationQualifiedRecruitment } from "~/utils/applicationUtils";
 import { PAGE_SECTION_ID as CAREER_TIMELINE_AND_RECRUITMENTS_PAGE_SECTION_ID } from "~/pages/Profile/CareerTimelineAndRecruitmentPage/constants";
+
 import { PartialUser } from "../types";
 
 function buildLink(

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplications.stories.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplications.stories.tsx
@@ -2,12 +2,13 @@ import React from "react";
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { fakePoolCandidates } from "@gc-digital-talent/fake-data";
-
 import {
   FAR_FUTURE_DATE,
   FAR_PAST_DATE,
 } from "@gc-digital-talent/date-helpers";
+
 import { PoolCandidateStatus } from "~/api/generated";
+
 import TrackApplications, { Application } from "./TrackApplications";
 
 type Story = ComponentStory<typeof TrackApplications>;

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplications.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplications.tsx
@@ -17,6 +17,7 @@ import { PoolCandidate, Scalars } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
 import { isApplicationInProgress } from "~/utils/applicationUtils";
 import { PAGE_SECTION_ID as CAREER_TIMELINE_AND_RECRUITMENTS_PAGE_SECTION_ID } from "~/pages/Profile/CareerTimelineAndRecruitmentPage/constants";
+
 import TrackApplicationsCard from "./TrackApplicationsCard";
 
 function buildLink(href: string, chunks: React.ReactNode): React.ReactElement {

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplicationsCard.stories.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplicationsCard.stories.tsx
@@ -5,8 +5,8 @@ import { fakePoolCandidates } from "@gc-digital-talent/fake-data";
 import { FAR_PAST_DATE } from "@gc-digital-talent/date-helpers";
 
 import { PoolCandidateStatus } from "~/api/generated";
-
 import { isExpired } from "~/pages/Applications/MyApplicationsPage/components/ApplicationCard/utils";
+
 import TrackApplicationsCard from "./TrackApplicationsCard";
 
 type Story = ComponentStory<typeof TrackApplicationsCard>;

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplicationsCard.test.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplicationsCard.test.tsx
@@ -6,15 +6,17 @@ import { screen } from "@testing-library/react";
 import React from "react";
 import { Provider as GraphqlProvider } from "urql";
 import { pipe, fromValue, delay } from "wonka";
+
 import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
 import { fakePoolCandidates } from "@gc-digital-talent/fake-data";
 import {
   FAR_FUTURE_DATE,
   FAR_PAST_DATE,
 } from "@gc-digital-talent/date-helpers";
-import { PAGE_SECTION_ID } from "~/pages/Profile/CareerTimelineAndRecruitmentPage/constants";
 
+import { PAGE_SECTION_ID } from "~/pages/Profile/CareerTimelineAndRecruitmentPage/constants";
 import { PoolCandidateStatus } from "~/api/generated";
+
 import TrackApplicationsCard, {
   TrackApplicationsCardProps,
 } from "./TrackApplicationsCard";

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplicationsCard.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplicationsCard.tsx
@@ -1,11 +1,13 @@
 import * as React from "react";
+import { useIntl } from "react-intl";
+import ShieldCheckIcon from "@heroicons/react/20/solid/ShieldCheckIcon";
+
 import { notEmpty } from "@gc-digital-talent/helpers";
 import { Heading, HeadingProps, Pill, Separator } from "@gc-digital-talent/ui";
-import { useIntl } from "react-intl";
 import { PoolCandidate, PoolCandidateStatus } from "@gc-digital-talent/graphql";
-import ShieldCheckIcon from "@heroicons/react/20/solid/ShieldCheckIcon";
 import { useAuthorization } from "@gc-digital-talent/auth";
 import { commonMessages } from "@gc-digital-talent/i18n";
+
 import ApplicationActions, {
   DeleteActionProps,
 } from "~/pages/Applications/MyApplicationsPage/components/ApplicationCard/ApplicationActions";
@@ -18,6 +20,7 @@ import { getStatusPillInfo } from "~/components/QualifiedRecruitmentCard/utils";
 import ApplicationLink from "~/pages/Pools/PoolAdvertisementPage/components/ApplicationLink";
 import useMutations from "~/pages/Applications/MyApplicationsPage/components/ApplicationCard/useMutations";
 import { getRecruitmentType, isQualifiedStatus } from "~/utils/poolCandidate";
+
 import { getApplicationDateInfo } from "./utils";
 
 type Application = Omit<

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/utils.ts
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/utils.ts
@@ -1,11 +1,13 @@
 import { IntlShape } from "react-intl";
+
 import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
+import { PoolCandidate } from "@gc-digital-talent/graphql";
+
 import {
   formatClosingDate,
   formatSubmittedAt,
   isDraft,
 } from "~/pages/Applications/MyApplicationsPage/components/ApplicationCard/utils";
-import { PoolCandidate } from "@gc-digital-talent/graphql";
 
 type Application = Omit<PoolCandidate, "user">;
 

--- a/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
@@ -6,10 +6,8 @@ import { Heading, ThrowNotFound, Button, Link } from "@gc-digital-talent/ui";
 
 import Hero from "~/components/Hero";
 import SEO from "~/components/SEO/SEO";
-
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import useRoutes from "~/hooks/useRoutes";
-
 import { Scalars } from "~/api/generated";
 
 type RequestConfirmationParams = {

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.stories.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Meta, Story } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
+
 import {
   fakeApplicantFilters,
   fakeClassifications,
@@ -8,7 +9,9 @@ import {
   fakePools,
   fakeSkills,
 } from "@gc-digital-talent/fake-data";
+
 import { CreatePoolCandidateSearchRequestInput } from "~/api/generated";
+
 import { RequestForm, RequestFormProps } from "./RequestForm";
 
 const classifications = fakeClassifications();

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -20,10 +20,6 @@ import {
   removeFromSessionStorage,
   setInSessionStorage,
 } from "@gc-digital-talent/storage";
-
-import SEO from "~/components/SEO/SEO";
-import SearchRequestFilters from "~/components/SearchRequestFilters/SearchRequestFilters";
-import useRoutes from "~/hooks/useRoutes";
 import {
   EquitySelections,
   Department,
@@ -42,6 +38,9 @@ import {
   PoolCandidateSearchPositionType,
 } from "@gc-digital-talent/graphql";
 
+import SEO from "~/components/SEO/SEO";
+import SearchRequestFilters from "~/components/SearchRequestFilters/SearchRequestFilters";
+import useRoutes from "~/hooks/useRoutes";
 import { SimpleClassification } from "~/types/pool";
 import {
   BrowserHistoryState,

--- a/apps/web/src/pages/SearchRequests/SearchPage/SearchPage.stories.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/SearchPage.stories.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { Meta, Story } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
+
 import { fakeClassifications, fakePools } from "@gc-digital-talent/fake-data";
 
 import { Classification, Pool } from "~/api/generated";
+
 import {
   SearchContainerComponent,
   SearchContainerProps as SearchPageProps,

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/CandidateResults.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/CandidateResults.tsx
@@ -4,6 +4,7 @@ import { useIntl } from "react-intl";
 import { Button, Heading, Separator } from "@gc-digital-talent/ui";
 
 import { SimpleClassification } from "~/types/pool";
+
 import SearchResultCard, {
   type SearchResultCardProps,
 } from "./SearchResultCard";

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchContainer.test.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchContainer.test.tsx
@@ -4,12 +4,14 @@
 import "@testing-library/jest-dom";
 import { screen } from "@testing-library/react";
 import React from "react";
+
 import {
   fakeClassifications,
   fakePools,
   fakeSkills,
 } from "@gc-digital-talent/fake-data";
 import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
+
 import { SearchContainerComponent } from "./SearchContainer";
 import type { SearchContainerProps } from "./SearchContainer";
 

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.stories.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Meta, Story } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import pick from "lodash/pick";
+
 import {
   fakeClassifications,
   fakePools,
@@ -9,6 +10,7 @@ import {
 } from "@gc-digital-talent/fake-data";
 
 import { Classification } from "~/api/generated";
+
 import {
   SearchContainerProps,
   SearchContainerComponent,

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.stories.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.stories.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-
 import type { Meta, StoryObj } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
 
 import { fakePools } from "@gc-digital-talent/fake-data";
-import { action } from "@storybook/addon-actions";
+
 import SearchResultCard from "./SearchResultCard";
 
 const meta: Meta<typeof SearchResultCard> = {

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
@@ -3,11 +3,11 @@ import { useIntl } from "react-intl";
 
 import { Button, Link, Pill } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
+import { Pool } from "@gc-digital-talent/graphql";
 
 import { getFullPoolTitleHtml } from "~/utils/poolUtils";
 import { SimpleClassification } from "~/types/pool";
 import useRoutes from "~/hooks/useRoutes";
-import { Pool } from "@gc-digital-talent/graphql";
 
 const testId = (text: React.ReactNode) => (
   <span data-testid="candidateCount">{text}</span>

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/ViewSearchRequestPage.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/ViewSearchRequestPage.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useParams } from "react-router-dom";
+import TicketIcon from "@heroicons/react/24/outline/TicketIcon";
 
 import SEO from "~/components/SEO/SEO";
 import { Scalars } from "~/api/generated";
-
 import PageHeader from "~/components/PageHeader";
-import TicketIcon from "@heroicons/react/24/outline/TicketIcon";
+
 import ViewSearchRequestApi from "./components/ViewSearchRequest";
 
 type RouteParams = {

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
@@ -18,9 +18,9 @@ import {
 } from "~/api/generated";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRoutes from "~/hooks/useRoutes";
-
 import adminMessages from "~/messages/adminMessages";
 import FilterBlock from "~/components/SearchRequestFilters/FilterBlock";
+
 import SingleSearchRequestTableApi from "./SearchRequestCandidatesTable";
 import UpdateSearchRequest from "./UpdateSearchRequest";
 

--- a/apps/web/src/pages/SkillFamilies/IndexSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/IndexSkillFamilyPage.tsx
@@ -6,8 +6,8 @@ import PageHeader from "~/components/PageHeader";
 import SEO from "~/components/SEO/SEO";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRoutes from "~/hooks/useRoutes";
-
 import adminMessages from "~/messages/adminMessages";
+
 import SkillFamilyTableApi from "./components/SkillFamilyTable";
 
 const IndexSkillFamilyPage = () => {

--- a/apps/web/src/pages/Skills/IndexSkillPage.tsx
+++ b/apps/web/src/pages/Skills/IndexSkillPage.tsx
@@ -6,8 +6,8 @@ import PageHeader from "~/components/PageHeader";
 import SEO from "~/components/SEO/SEO";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRoutes from "~/hooks/useRoutes";
-
 import adminMessages from "~/messages/adminMessages";
+
 import SkillTableApi from "./components/SkillTable";
 
 export const IndexSkillPage = () => {

--- a/apps/web/src/pages/SupportPage/SupportPage.stories.tsx
+++ b/apps/web/src/pages/SupportPage/SupportPage.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+
 import { SupportPage } from "./SupportPage";
 
 export default {

--- a/apps/web/src/pages/SupportPage/SupportPage.tsx
+++ b/apps/web/src/pages/SupportPage/SupportPage.tsx
@@ -6,7 +6,6 @@ import { useTheme } from "@gc-digital-talent/theme";
 import Hero from "~/components/Hero";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import useRoutes from "~/hooks/useRoutes";
-
 import flourishTopLight from "~/assets/img/support_top_light.png";
 import flourishTopDark from "~/assets/img/support_top_dark.png";
 import supportHeroImg from "~/assets/img/support_header.png";

--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.stories.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.stories.tsx
@@ -3,6 +3,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 
 import { fakeUsers } from "@gc-digital-talent/fake-data";
+
 import { FormValues, SupportFormComponent } from "./SupportForm";
 
 export default {

--- a/apps/web/src/pages/Teams/CreateTeamPage/CreateTeamPage.tsx
+++ b/apps/web/src/pages/Teams/CreateTeamPage/CreateTeamPage.tsx
@@ -10,13 +10,12 @@ import {
   useDepartmentsQuery,
   useCreateTeamMutation,
 } from "~/api/generated";
-
 import PageHeader from "~/components/PageHeader";
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
-
 import adminMessages from "~/messages/adminMessages";
+
 import CreateTeamForm from "./components/CreateTeamForm";
 
 const CreateTeamPage = () => {

--- a/apps/web/src/pages/Teams/IndexTeamPage/IndexTeamPage.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/IndexTeamPage.tsx
@@ -6,8 +6,8 @@ import useRoutes from "~/hooks/useRoutes";
 import SEO from "~/components/SEO/SEO";
 import PageHeader from "~/components/PageHeader/PageHeader";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
-
 import adminMessages from "~/messages/adminMessages";
+
 import TeamTableApi from "./components/TeamTable/TeamTable";
 
 const IndexTeamPage = () => {

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.test.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.test.tsx
@@ -4,8 +4,10 @@
 import "@testing-library/jest-dom";
 import { screen } from "@testing-library/react";
 import React from "react";
+
 import { renderWithProviders } from "@gc-digital-talent/jest-helpers";
 import { fakeTeams } from "@gc-digital-talent/fake-data";
+
 import { RoleAssignment } from "~/api/generated";
 
 import {

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
@@ -4,6 +4,7 @@ import { IntlShape, useIntl } from "react-intl";
 import { Pending, Link, Pill } from "@gc-digital-talent/ui";
 import { getLocalizedName, useLocale } from "@gc-digital-talent/i18n";
 import { notEmpty } from "@gc-digital-talent/helpers";
+import { RoleAssignment } from "@gc-digital-talent/graphql";
 
 import {
   LocalizedString,
@@ -18,7 +19,6 @@ import Table, {
   tableActionsAccessor,
   Cell,
 } from "~/components/Table/ClientManagedTable";
-import { RoleAssignment } from "@gc-digital-talent/graphql";
 
 export interface TeamTableProps {
   teams: Array<Team>;

--- a/apps/web/src/pages/Teams/TeamMembersPage/TeamMembersPage.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/TeamMembersPage.tsx
@@ -29,8 +29,8 @@ import { getFullNameLabel } from "~/utils/nameUtils";
 import { groupRoleAssignmentsByUser, TeamMember } from "~/utils/teamUtils";
 import useRoutes from "~/hooks/useRoutes";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
-
 import adminMessages from "~/messages/adminMessages";
+
 import AddTeamMemberDialog from "./components/AddTeamMemberDialog";
 import EditTeamMemberDialog from "./components/EditTeamMemberDialog";
 import RemoveTeamMemberDialog from "./components/RemoveTeamMemberDialog";

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/RemoveTeamMemberDialog.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/RemoveTeamMemberDialog.tsx
@@ -8,11 +8,11 @@ import {
   getLocalizedName,
   uiMessages,
 } from "@gc-digital-talent/i18n";
+import { toast } from "@gc-digital-talent/toast";
 
 import { Team, useUpdateUserAsAdminMutation } from "~/api/generated";
 import { getFullNameLabel } from "~/utils/nameUtils";
 import { TeamMember } from "~/utils/teamUtils";
-import { toast } from "@gc-digital-talent/toast";
 
 interface RemoveTeamMemberDialogProps {
   user: TeamMember;

--- a/apps/web/src/pages/Teams/UpdateTeamPage/UpdateTeamPage.tsx
+++ b/apps/web/src/pages/Teams/UpdateTeamPage/UpdateTeamPage.tsx
@@ -13,12 +13,11 @@ import {
   useGetTeamQuery,
   useUpdateTeamMutation,
 } from "~/api/generated";
-
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
-
 import adminMessages from "~/messages/adminMessages";
+
 import UpdateTeamForm from "./components/UpdateTeamForm";
 
 const EditTeamPage = () => {

--- a/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.test.tsx
+++ b/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.test.tsx
@@ -4,8 +4,10 @@
 import "@testing-library/jest-dom";
 import { screen, act, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
+
 import { renderWithProviders } from "@gc-digital-talent/jest-helpers";
 import { fakeTeams } from "@gc-digital-talent/fake-data";
+
 import UpdateTeamForm, { UpdateTeamFormProps } from "./UpdateTeamForm";
 
 // adjust mockTeam to enable testing expected values

--- a/apps/web/src/pages/Teams/ViewTeamPage/ViewTeamPage.tsx
+++ b/apps/web/src/pages/Teams/ViewTeamPage/ViewTeamPage.tsx
@@ -9,8 +9,8 @@ import SEO from "~/components/SEO/SEO";
 import { Scalars, Team, useViewTeamQuery } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
-
 import adminMessages from "~/messages/adminMessages";
+
 import ViewTeam from "./components/ViewTeam";
 
 type RouteParams = {

--- a/apps/web/src/pages/Teams/ViewTeamPage/components/ViewTeam.tsx
+++ b/apps/web/src/pages/Teams/ViewTeamPage/components/ViewTeam.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Team } from "~/api/generated";
 
 import { Pill } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
+
+import { Team } from "~/api/generated";
 import adminMessages from "~/messages/adminMessages";
 
 interface ViewTeamProps {

--- a/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
+++ b/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
@@ -12,8 +12,8 @@ import AdminAboutUserSection from "~/components/AdminAboutUserSection/AdminAbout
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRoutes from "~/hooks/useRoutes";
 import { getFullNameLabel } from "~/utils/nameUtils";
-
 import adminMessages from "~/messages/adminMessages";
+
 import UserProfilePrintButton from "./components/UserProfilePrintButton";
 
 interface AdminUserProfileProps {

--- a/apps/web/src/pages/Users/IndexUserPage/IndexUserPage.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/IndexUserPage.tsx
@@ -6,8 +6,8 @@ import SEO from "~/components/SEO/SEO";
 import PageHeader from "~/components/PageHeader";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRoutes from "~/hooks/useRoutes";
-
 import adminMessages from "~/messages/adminMessages";
+
 import UserTable from "./components/UserTable";
 
 export const IndexUserPage = () => {

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -53,7 +53,6 @@ import adminMessages from "~/messages/adminMessages";
 import tableCommaList from "~/components/Table/ClientManagedTable/tableCommaList";
 
 import useUserCsvData from "../hooks/useUserCsvData";
-
 import UserTableFilterDialog, {
   FormValues,
 } from "./UserTableFilterDialog/UserTableFilterDialog";

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.test.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.test.tsx
@@ -8,9 +8,10 @@ import { Provider as GraphqlProvider } from "urql";
 import { fromValue } from "wonka";
 import { IntlProvider } from "react-intl";
 
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+
 import { selectFilterOption, submitFilters } from "~/utils/jestUtils";
 
-import { ROLE_NAME } from "@gc-digital-talent/auth";
 import UserTableFilters from "./UserTableFilterDialog";
 import type { UserTableFiltersProps } from "./UserTableFilterDialog";
 

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTableFilterDialog/UserTableFilterDialog.tsx
@@ -11,9 +11,9 @@ import {
 } from "@gc-digital-talent/forms";
 
 import useFilterOptions from "~/components/Table/ApiManagedTable/useFilterOptions";
+import adminMessages from "~/messages/adminMessages";
 
 import "./UserTableFilterDialog.css";
-import adminMessages from "~/messages/adminMessages";
 
 type Option = { value: string; label: string };
 

--- a/apps/web/src/pages/Users/IndexUserPage/hooks/useUserCsvData.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/hooks/useUserCsvData.tsx
@@ -19,7 +19,6 @@ import {
   getOperationalRequirements,
   yesOrNo,
 } from "~/utils/csvUtils";
-
 import { User, PositionDuration } from "~/api/generated";
 import adminMessages from "~/messages/adminMessages";
 

--- a/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
@@ -25,13 +25,12 @@ import {
   useUpdateUserAsAdminMutation,
   useUserQuery,
 } from "~/api/generated";
-
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import { getFullNameLabel } from "~/utils/nameUtils";
-
 import adminMessages from "~/messages/adminMessages";
+
 import UserRoleTable from "./components/IndividualRoleTable";
 import TeamRoleTable from "./components/TeamRoleTable";
 

--- a/apps/web/src/pages/Users/UpdateUserPage/components/IndividualRoleTable.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/IndividualRoleTable.tsx
@@ -8,9 +8,9 @@ import { getLocalizedName } from "@gc-digital-talent/i18n";
 import Table, { ColumnsOf, Cell } from "~/components/Table/ClientManagedTable";
 import { Role, UpdateUserAsAdminInput, User } from "~/api/generated";
 
+import { UpdateUserFunc } from "../types";
 import AddIndividualRoleDialog from "./AddIndividualRoleDialog";
 import RemoveIndividualRoleDialog from "./RemoveIndividualRoleDialog";
-import { UpdateUserFunc } from "../types";
 
 const roleCell = (displayName: string) => {
   return (

--- a/apps/web/src/pages/Users/UpdateUserPage/components/RemoveIndividualRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/RemoveIndividualRoleDialog.tsx
@@ -12,6 +12,7 @@ import { toast } from "@gc-digital-talent/toast";
 
 import { Role, User } from "~/api/generated";
 import { getFullNameHtml } from "~/utils/nameUtils";
+
 import { UpdateUserFunc } from "../types";
 
 interface RemoveIndividualRoleDialogProps {

--- a/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
@@ -14,8 +14,8 @@ import { Scalars, useGetViewUserDataQuery } from "~/api/generated";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRoutes from "~/hooks/useRoutes";
 import { getFullNameLabel } from "~/utils/nameUtils";
-
 import adminMessages from "~/messages/adminMessages";
+
 import AboutSection from "./components/AboutSection";
 import { UserInformationProps } from "./types";
 import CandidateStatusSection from "./components/CandidateStatusSection";

--- a/apps/web/src/pages/Users/UserInformationPage/components/NotesSection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/NotesSection.tsx
@@ -7,7 +7,6 @@ import { toast } from "@gc-digital-talent/toast";
 import { BasicForm, TextArea, Submit } from "@gc-digital-talent/forms";
 
 import { getFullPoolTitleHtml } from "~/utils/poolUtils";
-
 import {
   UpdatePoolCandidateAsAdminInput,
   useUpdatePoolCandidateMutation,

--- a/apps/web/src/pages/Users/UserPlacementPage/UserPlacementPage.tsx
+++ b/apps/web/src/pages/Users/UserPlacementPage/UserPlacementPage.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { useParams } from "react-router";
 import { OperationContext } from "urql";
 import UserIcon from "@heroicons/react/24/outline/UserIcon";
+
 import { Scalars, useUserQuery } from "@gc-digital-talent/graphql";
 
 import PageHeader from "~/components/PageHeader";

--- a/apps/web/src/types/applicationStep.ts
+++ b/apps/web/src/types/applicationStep.ts
@@ -1,5 +1,6 @@
-import { ApplicationStep, Pool } from "@gc-digital-talent/graphql";
 import { IntlShape } from "react-intl";
+
+import { ApplicationStep, Pool } from "@gc-digital-talent/graphql";
 
 import { PoolCandidate, Scalars, User } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";

--- a/apps/web/src/types/experience.ts
+++ b/apps/web/src/types/experience.ts
@@ -1,7 +1,10 @@
 // Note: __typename comes from the API so can be ignored here
 /* eslint-disable no-underscore-dangle */
+import { OperationResult } from "urql";
+
 import { notEmpty } from "@gc-digital-talent/helpers";
 import { FieldLabels } from "@gc-digital-talent/forms";
+
 import {
   AwardExperience,
   AwardExperienceInput,
@@ -28,7 +31,6 @@ import {
   Skill,
   WorkExperience,
 } from "~/api/generated";
-import { OperationResult } from "urql";
 
 export type ExperienceType =
   | "award"

--- a/apps/web/src/utils/applicationUtils.ts
+++ b/apps/web/src/utils/applicationUtils.ts
@@ -1,6 +1,9 @@
 import { IntlShape } from "react-intl";
+import isPast from "date-fns/isPast";
 
 import { StepType } from "@gc-digital-talent/ui";
+import { PoolCandidateStatus } from "@gc-digital-talent/graphql";
+import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 
 import useRoutes from "~/hooks/useRoutes";
 import { ApplicationStep, Maybe, PoolCandidate } from "~/api/generated";
@@ -13,11 +16,7 @@ import educationStepInfo from "~/pages/Applications/educationStep/educationStepI
 import profileStepInfo from "~/pages/Applications/profileStep/profileStepInfo";
 import successPageInfo from "~/pages/Applications/successStep/successStepInfo";
 import skillsStepInfo from "~/pages/Applications/skillsStep/skillsStepInfo";
-
 import { isIAPPool } from "~/utils/poolUtils";
-import { PoolCandidateStatus } from "@gc-digital-talent/graphql";
-import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
-import isPast from "date-fns/isPast";
 import careerTimelineStepInfo from "~/pages/Applications/careerTimelineStep/careerTimelineStepInfo";
 
 type GetApplicationPagesArgs = {

--- a/apps/web/src/utils/dateUtils.ts
+++ b/apps/web/src/utils/dateUtils.ts
@@ -5,6 +5,7 @@ import {
   formatDate,
   formDateStringToDate,
 } from "@gc-digital-talent/date-helpers";
+
 import { Maybe, Scalars } from "~/api/generated";
 
 export function formattedDate(date: Scalars["Date"], intl: IntlShape) {

--- a/apps/web/src/utils/experienceUtils.tsx
+++ b/apps/web/src/utils/experienceUtils.tsx
@@ -5,6 +5,12 @@ import BriefcaseIcon from "@heroicons/react/20/solid/BriefcaseIcon";
 import LightBulbIcon from "@heroicons/react/20/solid/LightBulbIcon";
 import StarIcon from "@heroicons/react/20/solid/StarIcon";
 import UserGroupIcon from "@heroicons/react/20/solid/UserGroupIcon";
+import React from "react";
+import InformationCircleIcon from "@heroicons/react/24/solid/InformationCircleIcon";
+
+import { commonMessages } from "@gc-digital-talent/i18n";
+import { useAuthorization } from "@gc-digital-talent/auth";
+import { IconType } from "@gc-digital-talent/ui";
 
 import {
   AllExperienceFormValues,
@@ -15,11 +21,7 @@ import {
   ExperienceFormValues,
   ExperienceType,
 } from "~/types/experience";
-import { commonMessages } from "@gc-digital-talent/i18n";
-import React from "react";
-import { useAuthorization } from "@gc-digital-talent/auth";
-import { IconType } from "@gc-digital-talent/ui";
-import InformationCircleIcon from "@heroicons/react/24/solid/InformationCircleIcon";
+
 import {
   AwardExperience,
   CommunityExperience,

--- a/apps/web/src/utils/nameUtils.tsx
+++ b/apps/web/src/utils/nameUtils.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { IntlShape } from "react-intl";
+
 import { getAbbreviations } from "@gc-digital-talent/i18n";
 
 export const getFullNameLabel = (

--- a/apps/web/src/utils/poolCandidateCombinedStatus.tsx
+++ b/apps/web/src/utils/poolCandidateCombinedStatus.tsx
@@ -1,4 +1,5 @@
 import { defineMessage, defineMessages, MessageDescriptor } from "react-intl";
+
 import {
   PoolCandidateStatus,
   Maybe,

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -5,6 +5,9 @@ import Cog8ToothIcon from "@heroicons/react/24/outline/Cog8ToothIcon";
 import UserGroupIcon from "@heroicons/react/24/outline/UserGroupIcon";
 
 import { getLocalizedName, getPoolStream } from "@gc-digital-talent/i18n";
+import { ROLE_NAME, RoleName } from "@gc-digital-talent/auth";
+import { notEmpty } from "@gc-digital-talent/helpers";
+
 import {
   PublishingGroup,
   RoleAssignment,
@@ -17,9 +20,6 @@ import {
 import { PageNavInfo } from "~/types/pages";
 import useRoutes from "~/hooks/useRoutes";
 import { ONGOING_PUBLISHING_GROUPS } from "~/constants/pool";
-import { ROLE_NAME, RoleName } from "@gc-digital-talent/auth";
-import { notEmpty } from "@gc-digital-talent/helpers";
-
 import { PageNavKeys, SimpleClassification, SimplePool } from "~/types/pool";
 
 import { wrapAbbr } from "./nameUtils";

--- a/apps/web/src/utils/teamUtils.ts
+++ b/apps/web/src/utils/teamUtils.ts
@@ -1,5 +1,6 @@
 import { RoleName } from "@gc-digital-talent/auth";
 import { notEmpty } from "@gc-digital-talent/helpers";
+
 import {
   Maybe,
   Role,

--- a/apps/web/src/validators/profile/index.ts
+++ b/apps/web/src/validators/profile/index.ts
@@ -2,37 +2,29 @@ import {
   hasEmptyRequiredFields as aboutSectionHasEmptyRequiredFields,
   PartialUser as PartialUserAbout,
 } from "./about";
-
 import {
   hasEmptyRequiredFields as diversityEquityInclusionSectionHasEmptyRequiredFields,
   PartialUser as PartialUserDei,
 } from "./diversityEquityInclusion";
-
 import {
   hasEmptyRequiredFields as governmentInformationSectionHasEmptyRequiredFields,
   PartialUser as PartialUserGovernment,
 } from "./governmentInformation";
-
 import {
   hasEmptyRequiredFields as languageInformationSectionHasEmptyRequiredFields,
   hasUnsatisfiedRequirements as languageInformationSectionHasUnsatisfiedRequirements,
   PartialUser as PartialUserLanguage,
 } from "./languageInformation";
-
 import {
   hasEmptyRequiredFields as workLocationSectionHasEmptyRequiredFields,
   PartialUser as PartialUserLocation,
 } from "./workLocation";
-
 import {
   hasEmptyRequiredFields as workPreferencesSectionHasEmptyRequiredFields,
   PartialUser as PartialUserPreferences,
 } from "./workPreferences";
-
 import { isIncomplete as careerTimelineIsIncomplete } from "./careerTimeline";
-
 import { isIncomplete as skillRequirementsIsIncomplete } from "./skillRequirements";
-
 import { hasMissingResponses as screeningQuestionsSectionHasMissingResponses } from "./screeningQuestions";
 
 export {

--- a/apps/web/src/validators/profile/languageInformation.ts
+++ b/apps/web/src/validators/profile/languageInformation.ts
@@ -1,4 +1,5 @@
 import { User, BilingualEvaluation, Pool } from "@gc-digital-talent/graphql";
+
 import { getMissingLanguageRequirements } from "~/utils/languageUtils";
 
 export type PartialUser = Pick<

--- a/apps/web/src/validators/profile/workLocation.ts
+++ b/apps/web/src/validators/profile/workLocation.ts
@@ -1,5 +1,6 @@
-import { User } from "@gc-digital-talent/graphql";
 import isEmpty from "lodash/isEmpty";
+
+import { User } from "@gc-digital-talent/graphql";
 
 export type PartialUser = Pick<
   User,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9767,6 +9767,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.2.tgz",
+      "integrity": "sha512-tb5thFFlUcp7NdNF6/MpDk/1r/4awWG1FIz3YqDf+/zJSTezBb+/5WViH41obXULHVpDzoiCLpJ/ZO9YbJMsdw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array.prototype.flat": {
       "version": "1.3.1",
       "dev": true,
@@ -13950,25 +13969,29 @@
       "license": "ISC"
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.27.5",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.0.tgz",
+      "integrity": "sha512-B8s/n+ZluN7sxj9eUf7/pRFERX0r5bnFA2dCaLHy2ZeaQEAz0k+ZZkFWRFHJAqxfxQDx6KLv9LeIki7cFdwW+Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "array-includes": "^3.1.6",
+        "array.prototype.findlastindex": "^1.2.2",
         "array.prototype.flat": "^1.3.1",
         "array.prototype.flatmap": "^1.3.1",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.7",
-        "eslint-module-utils": "^2.7.4",
+        "eslint-module-utils": "^2.8.0",
         "has": "^1.0.3",
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.12.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.6",
+        "object.groupby": "^1.0.0",
         "object.values": "^1.1.6",
-        "resolve": "^1.22.1",
-        "semver": "^6.3.0",
-        "tsconfig-paths": "^3.14.1"
+        "resolve": "^1.22.3",
+        "semver": "^6.3.1",
+        "tsconfig-paths": "^3.14.2"
       },
       "engines": {
         "node": ">=4"
@@ -16370,8 +16393,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.1",
-      "license": "MIT",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -19589,6 +19613,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object.groupby": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.0.tgz",
+      "integrity": "sha512-70MWG6NfRH9GnbZOikuhPPYzpUpof9iW2J9E4dW7FXTqPNb6rllE6u39SKwwiNh8lCwX3DDb5OgcKGiEBrTTyw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.21.2",
+        "get-intrinsic": "^1.2.1"
+      }
+    },
     "node_modules/object.hasown": {
       "version": "1.1.2",
       "dev": true,
@@ -22025,10 +22061,11 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
-      "license": "MIT",
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -25550,7 +25587,7 @@
         "eslint-import-resolver-alias": "^1.1.2",
         "eslint-import-resolver-typescript": "^3.6.0",
         "eslint-plugin-formatjs": "^4.10.3",
-        "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-import": "^2.28.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.2.1",
@@ -32663,6 +32700,19 @@
       "version": "2.1.0",
       "dev": true
     },
+    "array.prototype.findlastindex": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.2.tgz",
+      "integrity": "sha512-tb5thFFlUcp7NdNF6/MpDk/1r/4awWG1FIz3YqDf+/zJSTezBb+/5WViH41obXULHVpDzoiCLpJ/ZO9YbJMsdw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
+      }
+    },
     "array.prototype.flat": {
       "version": "1.3.1",
       "dev": true,
@@ -35363,7 +35413,7 @@
         "eslint-import-resolver-alias": "^1.1.2",
         "eslint-import-resolver-typescript": "^3.6.0",
         "eslint-plugin-formatjs": "^4.10.3",
-        "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-import": "^2.28.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.2.1",
@@ -35541,24 +35591,29 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.27.5",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.0.tgz",
+      "integrity": "sha512-B8s/n+ZluN7sxj9eUf7/pRFERX0r5bnFA2dCaLHy2ZeaQEAz0k+ZZkFWRFHJAqxfxQDx6KLv9LeIki7cFdwW+Q==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.6",
+        "array.prototype.findlastindex": "^1.2.2",
         "array.prototype.flat": "^1.3.1",
         "array.prototype.flatmap": "^1.3.1",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.7",
-        "eslint-module-utils": "^2.7.4",
+        "eslint-module-utils": "^2.8.0",
         "has": "^1.0.3",
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.12.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.6",
+        "object.groupby": "^1.0.0",
         "object.values": "^1.1.6",
-        "resolve": "^1.22.1",
-        "semver": "^6.3.0",
-        "tsconfig-paths": "^3.14.1"
+        "resolve": "^1.22.3",
+        "semver": "^6.3.1",
+        "tsconfig-paths": "^3.14.2"
       },
       "dependencies": {
         "debug": {
@@ -37072,7 +37127,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.12.1",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -39230,6 +39287,18 @@
         "es-abstract": "^1.20.4"
       }
     },
+    "object.groupby": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.0.tgz",
+      "integrity": "sha512-70MWG6NfRH9GnbZOikuhPPYzpUpof9iW2J9E4dW7FXTqPNb6rllE6u39SKwwiNh8lCwX3DDb5OgcKGiEBrTTyw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.21.2",
+        "get-intrinsic": "^1.2.1"
+      }
+    },
     "object.hasown": {
       "version": "1.1.2",
       "dev": true,
@@ -40775,9 +40844,11 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.22.2",
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
       "requires": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }

--- a/packages/app-insights/src/index.tsx
+++ b/packages/app-insights/src/index.tsx
@@ -1,8 +1,6 @@
 import { AppInsightsContext, AppInsightsProvider } from "./components/Provider";
-
 import useAppInsightsContext from "./hooks/useAppInsightsContext";
 import useAppInsightsCustomEvent from "./hooks/useAppInsightsCustomEvent";
-
 import { reactPlugin, appInsights } from "./utils/reactPlugin";
 
 export { AppInsightsContext, AppInsightsProvider };

--- a/packages/auth/src/index.tsx
+++ b/packages/auth/src/index.tsx
@@ -3,13 +3,10 @@ import { AuthorizationContext } from "./components/AuthorizationContainer";
 import RequireAuth from "./components/RequireAuth";
 import AuthenticationProvider from "./components/AuthenticationProvider";
 import AuthorizationProvider from "./components/AuthorizationProvider";
-
 import useAuthentication from "./hooks/useAuthentication";
 import useAuthorization from "./hooks/useAuthorization";
 import apiRoutes, { useApiRoutes } from "./hooks/useApiRoutes";
-
 import hasRole from "./utils/hasRole";
-
 import {
   ACCESS_TOKEN,
   REFRESH_TOKEN,

--- a/packages/auth/src/utils/hasRole.ts
+++ b/packages/auth/src/utils/hasRole.ts
@@ -1,5 +1,6 @@
 import { Maybe, RoleAssignment } from "@gc-digital-talent/graphql";
 import { notEmpty } from "@gc-digital-talent/helpers";
+
 import { RoleName } from "../const";
 
 const hasRole = (

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -1,5 +1,4 @@
 import ClientProvider from "./components/ClientProvider/ClientProvider";
-
 import { isUuidError } from "./utils/errors";
 
 export default ClientProvider;

--- a/packages/date-helpers/src/index.ts
+++ b/packages/date-helpers/src/index.ts
@@ -11,8 +11,8 @@ import toDate from "date-fns-tz/toDate";
 
 import { Scalars } from "@gc-digital-talent/graphql";
 import { getLocale } from "@gc-digital-talent/i18n";
-
 import { dateMessages } from "@gc-digital-talent/i18n";
+
 import { FormatDateOptions } from "./types";
 import {
   DATETIME_FORMAT_STRING,

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -64,6 +64,23 @@ module.exports = {
     "import/extensions": ["warn", "never", { json: "always" }],
     // Note: Re-enable with #7453
     //"import/no-unused-modules": [1, { unusedExports: true, ignoreExports: ["src/index.{ts,tsx}"] }],
+    "import/order": [
+      "error",
+      {
+        "newlines-between": "always",
+        groups: ["builtin", "external", "internal", ["parent", "sibling"], "index"],
+        pathGroups: [
+          {
+            "pattern": "@gc-digital-talent/**",
+            "group": "external"
+          },
+          {
+            "pattern": "~/**",
+            "group": "internal"
+          }
+        ]
+      }
+    ],
     "react/display-name": "off",
     "react/prop-types": "off",
     "react/jsx-filename-extension": [

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -68,17 +68,19 @@ module.exports = {
       "error",
       {
         "newlines-between": "always",
-        groups: ["builtin", "external", "internal", ["parent", "sibling"], "index"],
+        "distinctGroup": false,
+        groups: ["builtin", "external", "unknown", "internal", ["parent", "sibling"], "index"],
         pathGroups: [
           {
             "pattern": "@gc-digital-talent/**",
-            "group": "external"
+            "group": "unknown",
           },
           {
             "pattern": "~/**",
             "group": "internal"
           }
-        ]
+        ],
+        pathGroupsExcludedImportTypes: ["@gc-digital-talent/**"]
       }
     ],
     "react/display-name": "off",

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -11,7 +11,7 @@
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-import-resolver-typescript": "^3.6.0",
     "eslint-plugin-formatjs": "^4.10.3",
-    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-import": "^2.28.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/packages/fake-data/src/fakeClassifications.ts
+++ b/packages/fake-data/src/fakeClassifications.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+
 import { Classification } from "@gc-digital-talent/graphql";
 
 export default (): Classification[] => {

--- a/packages/fake-data/src/fakeExperiences.ts
+++ b/packages/fake-data/src/fakeExperiences.ts
@@ -17,6 +17,7 @@ import {
   EducationType,
   EducationStatus,
 } from "@gc-digital-talent/graphql";
+
 import { getStaticSkills } from "./fakeSkills";
 
 type WithTypename<T extends { __typename?: string }> = T & {

--- a/packages/fake-data/src/fakePoolCandidateTypes.ts
+++ b/packages/fake-data/src/fakePoolCandidateTypes.ts
@@ -1,4 +1,5 @@
 import { PoolCandidate } from "@gc-digital-talent/graphql";
+
 import {
   GeneratedAwardExperience,
   GeneratedCommunityExperience,

--- a/packages/fake-data/src/fakePoolCandidates.ts
+++ b/packages/fake-data/src/fakePoolCandidates.ts
@@ -10,6 +10,7 @@ import {
   Pool,
   User,
 } from "@gc-digital-talent/graphql";
+
 import fakePools from "./fakePools";
 import fakeUsers from "./fakeUsers";
 

--- a/packages/fake-data/src/fakePools.ts
+++ b/packages/fake-data/src/fakePools.ts
@@ -6,7 +6,6 @@ import {
   FAR_PAST_DATE,
   PAST_DATE,
 } from "@gc-digital-talent/date-helpers";
-
 import {
   PoolStatus,
   Classification,

--- a/packages/fake-data/src/fakeRoles.ts
+++ b/packages/fake-data/src/fakeRoles.ts
@@ -1,4 +1,5 @@
 import { Role } from "@gc-digital-talent/graphql";
+
 import toLocalizedString from "./fakeLocalizedString";
 
 export default (): Role[] => {

--- a/packages/fake-data/src/fakeTeams.ts
+++ b/packages/fake-data/src/fakeTeams.ts
@@ -1,8 +1,8 @@
 import { faker } from "@faker-js/faker";
 
 import { Department, Team } from "@gc-digital-talent/graphql";
-import toLocalizedString from "./fakeLocalizedString";
 
+import toLocalizedString from "./fakeLocalizedString";
 import fakeDepartments from "./fakeDepartments";
 
 const generateTeam = (departments: Department[]): Team => {

--- a/packages/forms/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/forms/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import Checkbox from ".";
-import type { CheckboxProps } from ".";
 
 import Form from "../BasicForm";
 import Submit from "../Submit";
+
+import Checkbox from ".";
+import type { CheckboxProps } from ".";
 
 export default {
   component: Checkbox,

--- a/packages/forms/src/components/Checklist/Checklist.stories.tsx
+++ b/packages/forms/src/components/Checklist/Checklist.stories.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { StoryFn } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 
-import Checklist from "./Checklist";
 import Form from "../BasicForm";
 import Submit from "../Submit";
+import Checklist from "./Checklist";
 
 export default {
   component: Checklist,

--- a/packages/forms/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/forms/src/components/Combobox/Combobox.stories.tsx
@@ -6,7 +6,6 @@ import { getStaticSkills } from "@gc-digital-talent/fake-data";
 
 import BasicForm from "../BasicForm";
 import Submit from "../Submit";
-
 import Combobox, { Option, ComboboxProps } from "./Combobox";
 
 const skills = getStaticSkills().map((skill) => ({

--- a/packages/forms/src/components/Combobox/Combobox.tsx
+++ b/packages/forms/src/components/Combobox/Combobox.tsx
@@ -13,11 +13,10 @@ import { CommonInputProps, HTMLInputProps } from "../../types";
 import useFieldState from "../../hooks/useFieldState";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
 import useCommonInputStyles from "../../hooks/useCommonInputStyles";
+import useInputDescribedBy from "../../hooks/useInputDescribedBy";
 import Actions from "./Actions";
 import NoOptions from "./NoOptions";
-
 import "./combobox.css";
-import useInputDescribedBy from "../../hooks/useInputDescribedBy";
 
 export interface Option {
   /** The data used on form submission  */

--- a/packages/forms/src/components/DateInput/ControlledInput.tsx
+++ b/packages/forms/src/components/DateInput/ControlledInput.tsx
@@ -9,6 +9,7 @@ import { useIntl } from "react-intl";
 
 import { dateMessages } from "@gc-digital-talent/i18n";
 
+import useCommonInputStyles from "../../hooks/useCommonInputStyles";
 import { DateSegment, DATE_SEGMENT } from "./types";
 import {
   getMonthOptions,
@@ -16,8 +17,6 @@ import {
   setComputedValue,
   splitSegments,
 } from "./utils";
-
-import useCommonInputStyles from "../../hooks/useCommonInputStyles";
 
 interface ControlledInputProps {
   field: ControllerRenderProps<FieldValues, string>;

--- a/packages/forms/src/components/DateInput/DateInput.stories.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.stories.tsx
@@ -17,11 +17,11 @@ import { Pool } from "@gc-digital-talent/graphql";
 import { Pending } from "@gc-digital-talent/ui";
 import { fakePools } from "@gc-digital-talent/fake-data";
 
-import DateInput, { DateInputProps } from "./DateInput";
 import Form from "../BasicForm";
 import Submit from "../Submit";
-import { DATE_SEGMENT } from "./types";
 import Input from "../Input/Input";
+import { DATE_SEGMENT } from "./types";
+import DateInput, { DateInputProps } from "./DateInput";
 
 export default {
   component: DateInput,

--- a/packages/forms/src/components/DateInput/DateInput.test.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.test.tsx
@@ -7,6 +7,7 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FormProvider, useForm } from "react-hook-form";
 import type { FieldValues, SubmitHandler } from "react-hook-form";
+
 import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
 
 import DateInput, { DateInputProps } from "./DateInput";

--- a/packages/forms/src/components/DateInput/DateInput.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.tsx
@@ -16,7 +16,6 @@ import Field from "../Field";
 import { CommonInputProps, HTMLFieldsetProps } from "../../types";
 import useFieldState from "../../hooks/useFieldState";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
-
 import ControlledInput from "./ControlledInput";
 import { splitSegments } from "./utils";
 import { DateRegisterOptions, DateSegment, DATE_SEGMENT } from "./types";

--- a/packages/forms/src/components/Field/Descriptions.tsx
+++ b/packages/forms/src/components/Field/Descriptions.tsx
@@ -3,7 +3,6 @@ import { FieldError } from "react-hook-form";
 
 import { DescriptionIds } from "../../hooks/useInputDescribedBy";
 import { CommonInputProps } from "../../types";
-
 import Context from "./Context";
 import Error from "./Error";
 

--- a/packages/forms/src/components/Input/Input.stories.tsx
+++ b/packages/forms/src/components/Input/Input.stories.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import Input from ".";
-import type { InputProps } from ".";
+
 import Form from "../BasicForm";
 import Submit from "../Submit";
+
+import Input from ".";
+import type { InputProps } from ".";
 
 export default {
   component: Input,

--- a/packages/forms/src/components/MultiSelect/MultiSelectField.test.tsx
+++ b/packages/forms/src/components/MultiSelect/MultiSelectField.test.tsx
@@ -13,6 +13,7 @@ import {
 import { FormProvider, useForm } from "react-hook-form";
 import type { FieldValues, SubmitHandler } from "react-hook-form";
 import IntlProvider from "react-intl/src/components/provider";
+
 import MultiSelectField from "./MultiSelectField";
 
 const Providers = ({

--- a/packages/forms/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/forms/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { StoryFn } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 
-import RadioGroup from "./RadioGroup";
 import Form from "../BasicForm";
 import Submit from "../Submit";
+import RadioGroup from "./RadioGroup";
 
 export default {
   component: RadioGroup,

--- a/packages/forms/src/components/Repeater/Repeater.stories.tsx
+++ b/packages/forms/src/components/Repeater/Repeater.stories.tsx
@@ -9,7 +9,6 @@ import { Announcer, Well } from "@gc-digital-talent/ui";
 import BasicForm from "../BasicForm";
 import Submit from "../Submit";
 import TextArea from "../TextArea";
-
 import Repeater, { RepeaterFieldsetProps, RepeaterProps } from "./Repeater";
 
 type StoryProps = RepeaterProps &

--- a/packages/forms/src/components/Repeater/Repeater.test.tsx
+++ b/packages/forms/src/components/Repeater/Repeater.test.tsx
@@ -12,10 +12,11 @@ import {
   useFormContext,
 } from "react-hook-form";
 import type { FieldValues, SubmitHandler } from "react-hook-form";
+
 import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
 
-import Repeater, { RepeaterProps, RepeaterFieldsetProps } from "./Repeater";
 import Input, { InputProps } from "../Input";
+import Repeater, { RepeaterProps, RepeaterFieldsetProps } from "./Repeater";
 
 interface RenderRepeaterProps {
   formProps: Omit<FormProps, "children">;

--- a/packages/forms/src/components/Select/MultiSelectFieldBase.test.tsx
+++ b/packages/forms/src/components/Select/MultiSelectFieldBase.test.tsx
@@ -14,6 +14,7 @@ import {
 import { FormProvider, useForm, RegisterOptions } from "react-hook-form";
 import type { FieldValues, SubmitHandler } from "react-hook-form";
 import IntlProvider from "react-intl/src/components/provider";
+
 import MultiSelectFieldBase, {
   useRulesWithDefaultMessages,
 } from "./MultiSelectFieldBase";

--- a/packages/forms/src/components/Select/Select.stories.tsx
+++ b/packages/forms/src/components/Select/Select.stories.tsx
@@ -8,9 +8,10 @@ import { fakeDepartments, fakePools } from "@gc-digital-talent/fake-data";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 
 import Form from "../BasicForm";
-import Select, { OptGroup, Option } from "./Select";
-import type { SelectProps } from ".";
 import Submit from "../Submit";
+import Select, { OptGroup, Option } from "./Select";
+
+import type { SelectProps } from ".";
 
 export default {
   component: Select,

--- a/packages/forms/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/forms/src/components/TextArea/TextArea.stories.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
 import { StoryFn } from "@storybook/react";
+
 import Form from "../BasicForm";
 import Submit from "../Submit";
+
 import TextArea from ".";
 import type { TextAreaProps } from ".";
 

--- a/packages/forms/src/hooks/useFieldStateStyles.ts
+++ b/packages/forms/src/hooks/useFieldStateStyles.ts
@@ -1,5 +1,5 @@
-import useFieldState from "./useFieldState";
 import fieldStateStyles from "../styles";
+import useFieldState from "./useFieldState";
 
 /**
  * Gets hydrogen styles for a form input

--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -31,14 +31,12 @@ import Select, {
 import Submit, { type SubmitProps } from "./components/Submit";
 import TextArea, { type TextAreaProps } from "./components/TextArea";
 import WordCounter, { type WordCounterProps } from "./components/WordCounter";
-
 import BasicForm, {
   type BasicFormProps,
   type FieldLabels,
 } from "./components/BasicForm";
 import ErrorSummary from "./components/ErrorSummary";
 import UnsavedChanges from "./components/UnsavedChanges";
-
 import {
   unpackMaybes,
   unpackIds,
@@ -51,7 +49,6 @@ import {
   countNumberOfWords,
   objectsToSortedOptions,
 } from "./utils";
-
 import useCommonInputStyles from "./hooks/useCommonInputStyles";
 
 export {

--- a/packages/helpers/src/index.tsx
+++ b/packages/helpers/src/index.tsx
@@ -2,7 +2,6 @@ import {
   keyStringRegex,
   phoneNumberRegex,
 } from "./constants/regularExpressions";
-
 import lazyRetry from "./utils/lazyRetry";
 import sanitizeUrl from "./utils/sanitizeUrl";
 import isUuidError from "./utils/uuid";
@@ -21,7 +20,6 @@ import {
   uniqueItems,
   groupBy,
 } from "./utils/util";
-
 import useIsSmallScreen from "./hooks/useIsSmallScreen";
 
 export {

--- a/packages/i18n/src/cli.ts
+++ b/packages/i18n/src/cli.ts
@@ -2,8 +2,9 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable no-console */
 const fs = require("fs");
-const yargs = require("yargs");
 const path = require("path");
+
+const yargs = require("yargs");
 const yaml = require("js-yaml");
 const stringify = require("json-stable-stringify"); // provides sorted output
 

--- a/packages/i18n/src/components/LanguageProvider.tsx
+++ b/packages/i18n/src/components/LanguageProvider.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { IntlProvider } from "react-intl";
 
-import defaultRichTextElements from "./richTextElements";
 import useLocale from "../hooks/useLocale";
 import useIntlLanguages from "../hooks/useIntlMessages";
 import { Messages } from "../types";
+import defaultRichTextElements from "./richTextElements";
 
 interface LanguageProviderProps {
   messages: Messages;

--- a/packages/i18n/src/components/NestedLanguageProvider.tsx
+++ b/packages/i18n/src/components/NestedLanguageProvider.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { IntlProvider, useIntl } from "react-intl";
 import { useSearchParams } from "react-router-dom";
 
-import defaultRichTextElements from "./richTextElements";
 import { Messages } from "../types";
+import defaultRichTextElements from "./richTextElements";
 
 interface NestedLanguageProvider {
   messages: Map<string, Messages>;

--- a/packages/i18n/src/index.tsx
+++ b/packages/i18n/src/index.tsx
@@ -3,10 +3,8 @@ import richTextElements from "./components/richTextElements";
 import LanguageProvider from "./components/LanguageProvider";
 import LocaleProvider from "./components/LocaleProvider";
 import NestedLanguageProvider from "./components/NestedLanguageProvider";
-
 import useIntlLanguages from "./hooks/useIntlMessages";
 import useLocale from "./hooks/useLocale";
-
 import {
   isLocale,
   getLocale,
@@ -18,7 +16,6 @@ import {
   localizeCurrency,
   localizeSalaryRange,
 } from "./utils/localize";
-
 import {
   apiMessages,
   commonMessages,
@@ -29,7 +26,6 @@ import {
   uiMessages,
   formMessages,
 } from "./messages";
-
 import {
   getEmploymentEquityGroup,
   getEmploymentEquityStatement,
@@ -76,7 +72,6 @@ import {
   getCandidateExpiryFilterStatus,
   getCandidateSuspendedFilterStatus,
 } from "./messages/localizedConstants";
-
 import { STORED_LOCALE } from "./const";
 import type { Locales, Messages } from "./types";
 

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -1,4 +1,5 @@
 import { defineMessages, MessageDescriptor } from "react-intl";
+
 import {
   Language,
   LanguageAbility,

--- a/packages/i18n/src/utils/localize.test.ts
+++ b/packages/i18n/src/utils/localize.test.ts
@@ -3,8 +3,9 @@
  */
 
 import { IntlShape } from "react-intl";
-import { getLocale, localizePath, oppositeLocale } from "./localize";
+
 import { Locales } from "../types";
+import { getLocale, localizePath, oppositeLocale } from "./localize";
 
 describe("localize helper tests", () => {
   describe("getLocale", () => {

--- a/packages/jest-helpers/src/index.ts
+++ b/packages/jest-helpers/src/index.ts
@@ -1,7 +1,6 @@
 import "./mocks/matchMeta";
 
 import Providers from "./components/Providers";
-
 import axeTest from "./utils/axe";
 import updateDate from "./utils/date";
 import renderWithProviders from "./utils/render";

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -3,7 +3,6 @@ import {
   levelIncludes,
   getLoggingLevel,
 } from "./utils/logger";
-
 import useLogger, { defaultLogger } from "./hooks/useLogger";
 
 export {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -4,7 +4,6 @@ import {
   removeFromLocalStorage,
   useLocalStorage,
 } from "./local";
-
 import {
   getFromSessionStorage,
   setInSessionStorage,

--- a/packages/toast/src/components/Toast/Toast.stories.tsx
+++ b/packages/toast/src/components/Toast/Toast.stories.tsx
@@ -2,10 +2,9 @@ import React from "react";
 import type { Story, Meta } from "@storybook/react";
 import { faker } from "@faker-js/faker";
 
-import Toast from "./Toast";
 import toast from "../../toast";
+import Toast from "./Toast";
 import "./toast.css";
-
 import ToastDocs from "./Toast.docs.mdx";
 
 interface StoryArgs {

--- a/packages/toast/src/components/Toast/Toast.tsx
+++ b/packages/toast/src/components/Toast/Toast.tsx
@@ -5,7 +5,6 @@ import {
   CloseButtonProps,
   ToastContainerProps,
 } from "react-toastify";
-
 import XCircleIcon from "@heroicons/react/24/solid/XCircleIcon";
 
 import closeButtonStyles from "./styles";

--- a/packages/tooling/src/checkIntegrity.ts
+++ b/packages/tooling/src/checkIntegrity.ts
@@ -3,7 +3,9 @@
 /* eslint-disable no-console */
 
 const fs = require("fs");
+
 const yargs = require("yargs");
+
 const { countInvalidIntegrityValues } = require("./utils");
 
 const { argv } = yargs(process.argv.slice(2))

--- a/packages/ui/src/components/Accordion/Accordion.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.tsx
@@ -7,7 +7,6 @@ import ChevronDownIcon from "@heroicons/react/24/solid/ChevronDownIcon";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 
 import type { HeadingRank } from "../../types";
-
 import { AccordionMode } from "./types";
 import styleMap from "./styles";
 

--- a/packages/ui/src/components/Accordion/StandardHeader.tsx
+++ b/packages/ui/src/components/Accordion/StandardHeader.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 
-import Accordion, { AccordionHeaderProps } from "./Accordion";
 import { IconType } from "../../types";
+import Accordion, { AccordionHeaderProps } from "./Accordion";
 
 type TitleProps = React.HTMLAttributes<HTMLSpanElement> & {
   [data: string]: string;

--- a/packages/ui/src/components/Alert/Alert.stories.tsx
+++ b/packages/ui/src/components/Alert/Alert.stories.tsx
@@ -4,9 +4,9 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { faker } from "@faker-js/faker";
 
+import Link from "../Link";
 import Alert from "./Alert";
 import { AlertType } from "./types";
-import Link from "../Link";
 
 const types: Array<AlertType> = ["info", "success", "warning", "error"];
 

--- a/packages/ui/src/components/Alert/Alert.tsx
+++ b/packages/ui/src/components/Alert/Alert.tsx
@@ -5,7 +5,6 @@ import { useIntl } from "react-intl";
 import { uiMessages } from "@gc-digital-talent/i18n";
 
 import Separator from "../Separator";
-
 import {
   styleMap,
   iconStyleMap,
@@ -13,7 +12,6 @@ import {
   dismissStyleMap,
   getAlertLevelTitle,
 } from "./utils";
-
 import { AlertHeadingLevel, AlertType } from "./types";
 
 import "./alert.css";

--- a/packages/ui/src/components/Alert/utils.ts
+++ b/packages/ui/src/components/Alert/utils.ts
@@ -7,8 +7,8 @@ import ExclamationTriangleIcon from "@heroicons/react/24/outline/ExclamationTria
 
 import { uiMessages } from "@gc-digital-talent/i18n";
 
-import { AlertType } from "./types";
 import { IconType } from "../../types";
+import { AlertType } from "./types";
 
 export const styleMap: Record<AlertType, Record<string, string>> = {
   success: {

--- a/packages/ui/src/components/AlertDialog/AlertDialog.stories.tsx
+++ b/packages/ui/src/components/AlertDialog/AlertDialog.stories.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
-
 import { OverlayOrDialogDecorator } from "storybook-helpers";
 
 import Button from "../Button";
-
 import AlertDialogDocs from "./AlertDialog.docs.mdx";
 import AlertDialog from "./AlertDialog";
 

--- a/packages/ui/src/components/AlertDialog/AlertDialog.test.tsx
+++ b/packages/ui/src/components/AlertDialog/AlertDialog.test.tsx
@@ -7,8 +7,8 @@ import React from "react";
 
 import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";
 
-import AlertDialog from "./AlertDialog";
 import Button from "../Button";
+import AlertDialog from "./AlertDialog";
 
 type AlertDialogRootPrimitivePropsWithoutRef = React.ComponentPropsWithoutRef<
   typeof AlertDialog.Root

--- a/packages/ui/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/ui/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+
 import Breadcrumbs from "./Breadcrumbs";
 
 export default {

--- a/packages/ui/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/ui/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -4,7 +4,6 @@ import { useIntl } from "react-intl";
 import { uiMessages } from "@gc-digital-talent/i18n";
 
 import Flourish from "../Flourish";
-
 import Crumb from "./Crumb";
 
 export interface BreadcrumbsProps {

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -3,9 +3,9 @@ import { StoryFn } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import InformationCircleIcon from "@heroicons/react/20/solid/InformationCircleIcon";
 
+import { Color } from "../../types";
 import Button from "./Button";
 import type { ButtonProps } from "./Button";
-import { Color } from "../../types";
 
 type Story = StoryFn<Omit<ButtonProps, "color" | "ref"> & { label: string }>;
 

--- a/packages/ui/src/components/ButtonLinkContent/IconWrapper.tsx
+++ b/packages/ui/src/components/ButtonLinkContent/IconWrapper.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { ButtonLinkMode, IconType } from "../../types";
 
 interface IconWrapperProps {

--- a/packages/ui/src/components/CardLink/CardLink.stories.tsx
+++ b/packages/ui/src/components/CardLink/CardLink.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
+
 import CardLink from "./CardLink";
 
 const ExternalLink = (props: () => React.ReactElement) => (

--- a/packages/ui/src/components/Chip/Chips.tsx
+++ b/packages/ui/src/components/Chip/Chips.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from "react";
 import isArray from "lodash/isArray";
+
 import { ChipProps } from "./Chip";
 
 interface ChipsProps {

--- a/packages/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.stories.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
 import { faker } from "@faker-js/faker";
-
 import { OverlayOrDialogDecorator } from "storybook-helpers";
 
 import Button from "../Button";
-
 import DialogDocs from "./Dialog.docs.mdx";
 import Dialog from "./Dialog";
 

--- a/packages/ui/src/components/Dialog/Dialog.test.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.test.tsx
@@ -9,8 +9,9 @@ import { faker } from "@faker-js/faker";
 
 import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";
 
-import Dialog from ".";
 import Button from "../Button";
+
+import Dialog from ".";
 
 type DialogRootPrimitivePropsWithoutRef = React.ComponentPropsWithoutRef<
   typeof Dialog.Root

--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import type { StoryFn, Meta } from "@storybook/react";
 import CheckIcon from "@heroicons/react/24/solid/CheckIcon";
-
 import { OverlayOrDialogDecorator } from "storybook-helpers";
 
 import Button from "../Button";
-
 import DropdownMenuDocs from "./DropdownMenu.docs.mdx";
 import DropdownMenu from "./DropdownMenu";
 

--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -7,8 +7,9 @@ import React from "react";
 
 import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";
 
-import DropdownMenu from ".";
 import Button from "../Button";
+
+import DropdownMenu from ".";
 
 type DropdownMenuRootPrimitivePropsWithoutRef = React.ComponentPropsWithoutRef<
   typeof DropdownMenu.Root

--- a/packages/ui/src/components/Heading/Heading.tsx
+++ b/packages/ui/src/components/Heading/Heading.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
-import { headingStyles, iconStyles } from "./styles";
 import { IconType, Color } from "../../types";
+import { headingStyles, iconStyles } from "./styles";
 
 export type HeadingLevel = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 export type HeadingRef = HTMLHeadingElement;

--- a/packages/ui/src/components/Link/DownloadCsv.tsx
+++ b/packages/ui/src/components/Link/DownloadCsv.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { CSVLink } from "react-csv";
 
-import type { LinkProps } from "./Link";
 import useCommonButtonLinkStyles from "../../hooks/useCommonButtonLinkStyles";
+import type { LinkProps } from "./Link";
 
 interface CsvHeader {
   key: string;

--- a/packages/ui/src/components/Link/Link.stories.tsx
+++ b/packages/ui/src/components/Link/Link.stories.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { StoryFn } from "@storybook/react";
 import InformationCircleIcon from "@heroicons/react/20/solid/InformationCircleIcon";
 
+import { Color } from "../../types";
 import Link from "./Link";
 import type { LinkProps } from "./Link";
-import { Color } from "../../types";
 
 export default {
   component: Link,

--- a/packages/ui/src/components/Link/MenuLink.tsx
+++ b/packages/ui/src/components/Link/MenuLink.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { NavLink, NavLinkProps } from "react-router-dom";
+
 import { LinkProps } from "./Link";
 
 export type MenuLinkProps = Omit<LinkProps, "href"> & NavLinkProps;

--- a/packages/ui/src/components/NotFound/NotFound.stories.tsx
+++ b/packages/ui/src/components/NotFound/NotFound.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
+
 import NotFound from "./NotFound";
 
 export default {

--- a/packages/ui/src/components/Pending/Pending.stories.tsx
+++ b/packages/ui/src/components/Pending/Pending.stories.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 import { Story, Meta } from "@storybook/react";
 import type { CombinedError } from "urql";
-
 import { OverlayOrDialogDecorator } from "storybook-helpers";
-import NotFound from "../NotFound";
 
+import NotFound from "../NotFound";
 import Pending from "./Pending";
 
 export default {

--- a/packages/ui/src/components/Pending/Pending.tsx
+++ b/packages/ui/src/components/Pending/Pending.tsx
@@ -6,7 +6,6 @@ import { commonMessages } from "@gc-digital-talent/i18n";
 import { isUuidError } from "@gc-digital-talent/helpers";
 
 import Loading, { LoadingProps } from "../Loading";
-
 import ErrorMessage from "./ErrorMessage";
 
 import "./pending.css";

--- a/packages/ui/src/components/SideMenu/SideMenu.stories.tsx
+++ b/packages/ui/src/components/SideMenu/SideMenu.stories.tsx
@@ -3,10 +3,9 @@ import { Story, Meta } from "@storybook/react";
 import HomeIcon from "@heroicons/react/24/outline/HomeIcon";
 import ArrowRightOnRectangleIcon from "@heroicons/react/24/solid/ArrowRightOnRectangleIcon";
 
+import Button from "../Button";
 import SideMenuComponent from "./SideMenu";
 import { SideMenuButton } from "./SideMenuItem";
-
-import Button from "../Button";
 import SideMenuContentWrapper from "./SideMenuContentWrapper";
 
 export default {

--- a/packages/ui/src/components/SideMenu/SideMenu.test.tsx
+++ b/packages/ui/src/components/SideMenu/SideMenu.test.tsx
@@ -4,8 +4,10 @@
 import "@testing-library/jest-dom";
 import React from "react";
 import { screen } from "@testing-library/react";
-import { renderWithProviders } from "@gc-digital-talent/jest-helpers";
 import MagnifyingGlassIcon from "@heroicons/react/24/solid/MagnifyingGlassIcon";
+
+import { renderWithProviders } from "@gc-digital-talent/jest-helpers";
+
 import SideMenu from "./SideMenu";
 import type { SideMenuProps } from "./SideMenu";
 import SideMenuItem from "./SideMenuItem";

--- a/packages/ui/src/components/SideMenu/SideMenu.tsx
+++ b/packages/ui/src/components/SideMenu/SideMenu.tsx
@@ -9,9 +9,9 @@ import { motion, AnimatePresence } from "framer-motion";
 import { uiMessages } from "@gc-digital-talent/i18n";
 import { useIsSmallScreen } from "@gc-digital-talent/helpers";
 
+import useControllableState from "../../hooks/useControllableState";
 import { SideMenuButton } from "./SideMenuItem";
 import { SideMenuProvider } from "./SideMenuProvider";
-import useControllableState from "../../hooks/useControllableState";
 
 export interface SideMenuProps {
   /** Sets the section to be 'open' by default */

--- a/packages/ui/src/components/Stepper/Step.tsx
+++ b/packages/ui/src/components/Stepper/Step.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { useIntl } from "react-intl";
 import { Link } from "react-router-dom";
 
+import { IconType } from "../../types";
 import { StepState } from "./types";
 import { linkStyleMap, getIconFromState, messageMap } from "./utils";
-import { IconType } from "../../types";
 
 interface StepLinkProps {
   children: React.ReactNode;

--- a/packages/ui/src/components/Stepper/Stepper.test.tsx
+++ b/packages/ui/src/components/Stepper/Stepper.test.tsx
@@ -3,7 +3,6 @@
  */
 import "@testing-library/jest-dom";
 import React from "react";
-
 import { screen } from "@testing-library/react";
 
 import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";

--- a/packages/ui/src/components/Stepper/Stepper.tsx
+++ b/packages/ui/src/components/Stepper/Stepper.tsx
@@ -5,7 +5,6 @@ import { uiMessages } from "@gc-digital-talent/i18n";
 import { Maybe } from "@gc-digital-talent/graphql";
 
 import Heading, { HeadingLevel } from "../Heading";
-
 import Step from "./Step";
 import { StepState, StepType } from "./types";
 

--- a/packages/ui/src/components/Stepper/utils.ts
+++ b/packages/ui/src/components/Stepper/utils.ts
@@ -5,8 +5,8 @@ import { MessageDescriptor } from "react-intl";
 
 import { uiMessages } from "@gc-digital-talent/i18n";
 
-import { StepState } from "./types";
 import { IconType } from "../../types";
+import { StepState } from "./types";
 
 export const getIconFromState = (state: StepState, defaultIcon: IconType) => {
   const iconMap = new Map<StepState, IconType>([

--- a/packages/ui/src/components/TableOfContents/AnchorLink.tsx
+++ b/packages/ui/src/components/TableOfContents/AnchorLink.tsx
@@ -1,4 +1,5 @@
 import React, { HTMLAttributes } from "react";
+
 import { ScrollLinkClickFunc, ScrollToLink } from "../Link";
 
 export interface AnchorLinkProps extends HTMLAttributes<HTMLAnchorElement> {

--- a/packages/ui/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/packages/ui/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -3,8 +3,9 @@ import { StoryFn } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { faker } from "@faker-js/faker";
 
-import TableOfContents from ".";
 import Button from "../Button";
+
+import TableOfContents from ".";
 
 export default {
   component: TableOfContents.Wrapper,

--- a/packages/ui/src/components/ToggleSection/ToggleSection.stories.tsx
+++ b/packages/ui/src/components/ToggleSection/ToggleSection.stories.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
 import AcademicCapIcon from "@heroicons/react/24/solid/AcademicCapIcon";
-
 import { action } from "@storybook/addon-actions";
-import ToggleSection from "./ToggleSection";
+
 import Button from "../Button";
+import ToggleSection from "./ToggleSection";
 
 const Toggle = () => {
   const context = ToggleSection.useContext();

--- a/packages/ui/src/components/ToggleSection/ToggleSection.tsx
+++ b/packages/ui/src/components/ToggleSection/ToggleSection.tsx
@@ -4,7 +4,6 @@ import * as TogglePrimitive from "@radix-ui/react-toggle";
 
 import Heading, { HeadingProps } from "../Heading";
 import useControllableState from "../../hooks/useControllableState";
-
 import {
   ToggleSectionProvider,
   useToggleSectionContext,

--- a/packages/ui/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/ui/src/components/TreeView/TreeView.stories.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { Meta, ComponentStory } from "@storybook/react";
 import { faker } from "@faker-js/faker";
-import TreeView from "./TreeView";
+
 import Button from "../Button";
 import Accordion from "../Accordion";
 import Card from "../Card";
 import Alert from "../Alert";
 import StandardHeader from "../Accordion/StandardHeader";
+import TreeView from "./TreeView";
 
 faker.seed(0);
 

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -5,7 +5,6 @@ import {
   IconProps,
   ButtonLinkMode,
 } from "./types";
-
 import Accordion from "./components/Accordion";
 import StandardAccordionHeader, {
   StandardHeaderProps as StandardAccordionHeaderProps,
@@ -81,7 +80,6 @@ import ToggleGroup from "./components/ToggleGroup";
 import ToggleSection from "./components/ToggleSection/ToggleSection";
 import TreeView from "./components/TreeView";
 import Well, { WellProps } from "./components/Well";
-
 import { incrementHeadingRank, decrementHeadingRank } from "./utils";
 
 export type {


### PR DESCRIPTION
🤖 Resolves #7514 

## 👋 Introduction

This bumps `eslint-plugin-import`, updates the configuration rule for `import/order` and fixes any related errors.

## 🕵️ Details

The order is high subjective so let me know if you have any opinions! By default, anything found in `node_modules` is treated as an external dependency. Since that technically applies to our `@gc-digital-talent/**` packages, I added them to the `unknown` group and placed them in between `external` and `internal`. Should we just leave it as an external since it _technically_ is?

I went with the following order:

```tsx
// External
import React from "react";
import { useIntl } from "react-intl";

// Unknown (only free group 😅 )
import { Button } from "@gc-digital-talent/ui";

// Internal
import Hero from "~/components/Hero/Hero";
import useRoutes from "~/hooks/useRoutes";

// Parent, Sibling
import Parent from "../../Parent";
import Sibling from "./Sibling";

// Index
import index from "./";
```

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run lint `npm run lint -- --force`
2. Confirm is succeeds
3. Reorder imports in a file
4. Confirm it is logged as an error