### PR TITLE
[Debt] UAT user role seeding

### DIFF
--- a/api/database/seeders/UserSeederLocal.php
+++ b/api/database/seeders/UserSeederLocal.php
@@ -4,9 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\User;
 use App\Models\Role;
-use App\Models\Team;
 use Illuminate\Database\Seeder;
-use Database\Helpers\ApiEnums;
 
 class UserSeederLocal extends Seeder
 {
@@ -20,23 +18,6 @@ class UserSeederLocal extends Seeder
     {
         // collect roles and teams for assignment
         $roles = Role::all();
-        $baseUserRole = $roles->sole(function ($r) {
-            return $r->name == "base_user";
-        });
-        $applicantRole = $roles->sole(function ($r) {
-            return $r->name == "applicant";
-        });
-        $poolOperatorRole = $roles->sole(function ($r) {
-            return $r->name == "pool_operator";
-        });
-        $platformAdminRole = $roles->sole(function ($r) {
-            return $r->name == "platform_admin";
-        });
-        $requestResponderRole = $roles->sole(function ($r) {
-            return $r->name == "request_responder";
-        });
-        $dcmTeam = Team::where('name', 'digital-community-management')->sole();
-        $testTeam = Team::where('name', 'test-team')->sole();
 
         // shared auth users for testing
         User::factory()

--- a/api/database/seeders/UserSeederUat.php
+++ b/api/database/seeders/UserSeederUat.php
@@ -3,8 +3,8 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use App\Models\Team;
 use Illuminate\Database\Seeder;
-use Database\Helpers\ApiEnums;
 
 class UserSeederUat extends Seeder
 {
@@ -16,6 +16,7 @@ class UserSeederUat extends Seeder
      */
     public function run()
     {
+        $dcmTeam = Team::where('name', 'digital-community-management')->first();
         // users with sub values from Sign In Canada, redirecting to uat-talentcloud.tbs-sct.gc.ca
         // Ensure we don't create duplicates if users already exist, since we don't truncate tables by default (unlike on local).
         User::updateOrCreate(
@@ -25,7 +26,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Maximoff',
                 'email' => 'usertester923@gmail.com',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => 'b4c734a1-dcf3-4fb8-a860-c642700cb0b8'],
             [
@@ -33,7 +39,12 @@ class UserSeederUat extends Seeder
                 'last_name' => "O'Rourke",
                 'email' => "tristan.o'rourke@tbs-sct.gc.ca",
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => '5d0ce9a8-8164-46a5-9fe1-b7a2b42d61fc'],
             [
@@ -41,7 +52,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Giles',
                 'email' => 'peter.giles@tbs-sct.gc.ca',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => 'fcd5d233-66d9-4ac6-81e0-fabf379b0a70'],
             [
@@ -49,7 +65,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Sasikumar',
                 'email' => 'biruntha.sasikumar@tbs-sct.gc.ca',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => 'b9305997-b221-43f7-9c25-bc0d460b6464'],
             [
@@ -57,7 +78,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Test',
                 'email' => 'testing@gmail.com',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => 'a5bf84fe-7003-44df-bbdd-ce2d35cac2fb'],
             [
@@ -65,7 +91,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Kidanemariam',
                 'email' => 'Yonathan.Kidanemariam@tbs-sct.gc.ca',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => 'ecbf3c81-9bc0-4d9e-bb88-8a4554b651ea'],
             [
@@ -73,7 +104,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Harrison',
                 'email' => 'julie.harrison@tbs-sct.gc.ca',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => '43a2b0f0-218b-447b-9208-9254b487ebab'],
             [
@@ -81,7 +117,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Fraser',
                 'email' => 'corinne.fraser@tbs-sct.gc.ca',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => 'ebd3e68a-0369-4d3f-92f0-46532638a54c'],
             [
@@ -89,7 +130,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Sizer',
                 'email' => 'eric.sizer@tbs-sct.gc.ca',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => '5c3315f2-2802-4a0a-9954-815544344cc4'],
             [
@@ -97,7 +143,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Sasikumar',
                 'email' => 'ts@test.com',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => 'cfab235d-192c-42c8-930e-6e8ee2707068'],
             [
@@ -105,7 +156,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Estey',
                 'email' => 'jamie.estey@tbs-sct.gc.ca',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => '8fc3674f-4ae9-4ad2-a62d-378717211677'],
             [
@@ -113,7 +169,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Sasikumar',
                 'email' => 'ad@test.com',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => '3451d853-6531-4923-94ae-4b5eaea8a4b2'],
             [
@@ -121,7 +182,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Test1',
                 'email' => 'madeleine.daigle@tbs-sct.gc.ca',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => '345e5bc5-3906-495e-9900-986e5e7747d2'],
             [
@@ -129,7 +195,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Daigle',
                 'email' => 'maddy.daigle@gmail.com',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => 'c7301a8b-4c62-4767-b131-69920ff39e72'],
             [
@@ -137,7 +208,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Testcandon',
                 'email' => 'jerryescandon@gmail.com',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => 'c04defba-8470-4118-a5d8-1b3c1e4d800d'],
             [
@@ -145,7 +221,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'McGrath',
                 'email' => 'rosalie.mcgrath@tbs-sct.gc.ca',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => 'b1e156d1-a1ff-4c3d-a86e-c875922394ca'],
             [
@@ -153,7 +234,12 @@ class UserSeederUat extends Seeder
                 'last_name' => "O'Byrne",
                 'email' => 'gray.obyrne@tbs-sct.gc.ca',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => '49baaa3f-ff93-4cf7-9d0c-a389a40ac290'],
             [
@@ -161,7 +247,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Petrova',
                 'email' => 'daria.petrova@tbs-sct.gc.ca',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => '2ccb3e5e-6b5f-49eb-95e1-e1b4628fb492'],
             [
@@ -169,7 +260,12 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Test',
                 'email' => 'secuity@test.test',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
         User::updateOrCreate(
             ['sub' => 'fddd293e-0882-49fa-94bb-30854f06f0cd'],
             [
@@ -177,6 +273,11 @@ class UserSeederUat extends Seeder
                 'last_name' => 'Estey',
                 'email' => 'Jamie.estey@tbs-sct.gc.ca',
             ]
-        );
+        )->syncRoles([
+            "guest",
+            "base_user",
+            "request_responder",
+            "platform_admin",
+        ])->addRoles(["pool_operator"], $dcmTeam);
     }
 }

--- a/api/database/seeders/UserSeederUat.php
+++ b/api/database/seeders/UserSeederUat.php
@@ -28,6 +28,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -41,6 +42,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -54,6 +56,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -67,6 +70,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -80,6 +84,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -93,6 +98,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -106,6 +112,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -119,6 +126,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -132,6 +140,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -145,6 +154,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -158,6 +168,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -171,6 +182,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -184,6 +196,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -197,6 +210,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -210,6 +224,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -223,6 +238,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -236,6 +252,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -249,6 +266,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -262,6 +280,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",
@@ -275,6 +294,7 @@ class UserSeederUat extends Seeder
             ]
         )->syncRoles([
             "guest",
+            "applicant",
             "base_user",
             "request_responder",
             "platform_admin",


### PR DESCRIPTION
🤖 Resolves #6405 

## 👋 Introduction

Updates the seeder to utilize the current role system. 

## 🕵️ Details

Seeder updates non-destructively, adding the range of roles to the users. 
Deleted some unused stuff in `UserSeederLocal` as was mentioned in issue discussion. 

## 🧪 Testing

1. Off main
2. Run `php artisan migrate:fresh`
3. Run `php artisan db:seed --class=UatSeeder`
4. Open up a database client and observe the user and role tables
5. Switch to branch
6. Run `php artisan db:seed --class=UatSeeder` (run it more than once too)
7. Role and user pivot populated with no users deleted, no duplication
8. Login as a UAT user, observe you have roleAssignments

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/907ee241-4c0d-4f7a-aeaf-6c59608ee60e)

## 🚚 Deployment

Run the following solely on UAT

`php artisan db:seed --class=UatSeeder`


