### PR TITLE
[Feature] Sends user id to support form ticket if logged in

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -76,7 +76,7 @@ OAUTH_API_CLIENT_SECRET="ignored-secret"
 # gckeymfa for MFA on (production); gckey for MFA off (for testing purposes on local, dev, or uat: cannot be overridden in production)
 # OAUTH_ACR_VALUES=gckeymfa
 
-# for Freshdesk API
+# Freshdesk API (for docs: api/config/freshdesk.php)
 FRESHDESK_API_TICKETS_ENDPOINT=
 FRESHDESK_API_KEY=
 FRESHDESK_API_TICKET_TAG=

--- a/api/app/Http/Controllers/SupportController.php
+++ b/api/app/Http/Controllers/SupportController.php
@@ -17,6 +17,9 @@ class SupportController extends Controller
             'status' => 2, // Required by Freshdesk API. Status of the ticket. The default value is 2.
             'tags' => [config('freshdesk.api.ticket_tag')],
         ];
+        if ($request->input('user_id')) {
+            $parameters['unique_external_id'] = (string) $request->input('user_id');
+        }
         if (config('freshdesk.api.product_id')) {
             $parameters['product_id'] = (int) config('freshdesk.api.product_id');
         }

--- a/api/config/freshdesk.php
+++ b/api/config/freshdesk.php
@@ -64,7 +64,7 @@ return [
         | Freshdesk
         |--------------------------------------------------------------------------
         |
-        | This can be likely be left empty unless the Freshdesk account.
+        | This can be left empty.
         | If the product_id is given and email_config_id is not given,
         | the product's primary email_config_id will be set.
         |

--- a/api/config/freshdesk.php
+++ b/api/config/freshdesk.php
@@ -1,10 +1,76 @@
 <?php
+
 return [
+    /*
+    |--------------------------------------------------------------------------
+    | Freshdesk
+    |--------------------------------------------------------------------------
+    |
+    | Obtaining a domain requires creating a Freshdesk account.
+    | REF: https://www.freshworks.com/freshdesk/signup/
+    |
+    | Developer documentation
+    | REF: https://developers.freshdesk.com/api/#getting-started
+    |
+    */
     'api' => [
+        /*
+        |--------------------------------------------------------------------------
+        | Freshdesk tickets endpoint
+        |--------------------------------------------------------------------------
+        |
+        | Example: "https://domain.freshdesk.com/api/v2/tickets"
+        |
+        */
         'tickets_endpoint' => env('FRESHDESK_API_TICKETS_ENDPOINT', ''),
+        /*
+        |--------------------------------------------------------------------------
+        | Freshdesk
+        |--------------------------------------------------------------------------
+        |
+        | Finding API key
+        | REF: https://support.freshdesk.com/en/support/solutions/articles/215517-how-to-find-your-api-key
+        |
+        | Example: "abcdefghij1234567890"
+        |
+        */
         'key' => env('FRESHDESK_API_KEY', ''),
+        /*
+        |--------------------------------------------------------------------------
+        | Freshdesk
+        |--------------------------------------------------------------------------
+        |
+        | This should be left empty unless testing a production account in which case
+        | the string "test" should be set.
+        |
+        | Example: "test"
+        |
+        */
         'ticket_tag' => env('FRESHDESK_API_TICKET_TAG', ''),
+        /*
+        |--------------------------------------------------------------------------
+        | Freshdesk
+        |--------------------------------------------------------------------------
+        |
+        | This can be left empty unless the Freshdesk account filters tickets
+        | based on a list of products (GC Digital Talent being a product).
+        |
+        | Example: 1234567890
+        |
+        */
         'product_id' => env('FRESHDESK_API_PRODUCT_ID', ''),
+        /*
+        |--------------------------------------------------------------------------
+        | Freshdesk
+        |--------------------------------------------------------------------------
+        |
+        | This can be likely be left empty unless the Freshdesk account.
+        | If the product_id is given and email_config_id is not given,
+        | the product's primary email_config_id will be set.
+        |
+        | Example: 1234567890
+        |
+        */
         'email_config_id' => env('FRESHDESK_API_EMAIL_CONFIG_ID', ''),
     ]
 ];

--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
@@ -19,6 +19,7 @@ import {
 } from "~/constants/talentSearchConstants";
 
 export type FormValues = {
+  user_id: string;
   name: string;
   email: string;
   description: string;
@@ -29,7 +30,7 @@ interface SupportFormProps {
   showSupportForm: boolean;
   onFormToggle: (show: boolean) => void;
   handleCreateTicket: (data: FormValues) => Promise<number | null | void>;
-  currentUser?: Pick<User, "firstName" | "lastName" | "email"> | null;
+  currentUser?: Pick<User, "id" | "firstName" | "lastName" | "email"> | null;
 }
 
 interface SupportFormSuccessProps {
@@ -103,6 +104,7 @@ const SupportForm = ({
   const intl = useIntl();
   const methods = useForm<FormValues>({
     defaultValues: {
+      user_id: currentUser?.id || "",
       name: currentUser
         ? getFullNameLabel(currentUser.firstName, currentUser.lastName, intl)
         : "",


### PR DESCRIPTION
🤖 Resolves #4190.

## 👋 Introduction

This PR submits the user ID value via the support form to the support tickets created in Freshdesk when a user is logged in to the GC Digital Talent application.

## 🧪 Testing

> [!NOTE]  
> Testing requires the creation of a Freshdesk account (documentation added in this PR in f2717b2100f583f2d4a6ebd62f7f2109b8515520).

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Submit form at `/support` without signing in to the application
2. Verify there is no **Unique External ID** section on created ticket in Freshdesk
3. Sign in to application `/login-info'
4. Submit form at `/support`
5. Verify **Unique External ID** section on created ticket in Freshdesk is the same value as the user id from the GC Digital Talent application

## 📸 Screenshot

![Screen Shot 2023-08-21 at 10 03 36](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/92d5bc13-0902-48a8-9694-f90974e313c4)
