### PR TITLE
[Fix] Sends name to support form

### DIFF
--- a/api/app/Http/Controllers/SupportController.php
+++ b/api/app/Http/Controllers/SupportController.php
@@ -13,6 +13,7 @@ class SupportController extends Controller
             'description' => $request->input('description'),
             'subject' => $request->input('subject'),
             'email' => $request->input('email'),
+            'name' => $request->input('name'),
             'priority' => 1, // Required by Freshdesk API. Priority of the ticket. The default value is 1.
             'status' => 2, // Required by Freshdesk API. Status of the ticket. The default value is 2.
             'tags' => [config('freshdesk.api.ticket_tag')],


### PR DESCRIPTION
🤖 Resolves #7671.

## 👋 Introduction

This PR submits the name value via the support form to the support tickets created in Freshdesk when a user is logged in to the GC Digital Talent application. When creating a contact via a ticket object, Freshdesk uses the left side of the value of an email address. For example, jose.mourinho@test.com create a contact called jose mourinho.

## 🧪 Testing

> [!NOTE]  
> Testing requires the creation of a Freshdesk account (documentation added in another PR in f2717b2100f583f2d4a6ebd62f7f2109b8515520).

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Submit form at `/support` by filling out an email address that is different than the name value
2. Verify that the contact name created is not derived from the email

## 📸 Screenshot
![Screen Shot 2023-08-21 at 16 40 14](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/4840b7f3-17fd-485e-9e2b-25c05717f52a)


