### PR TITLE
[Fix] Updates tab trigger value for `ExperienceSection`

### DIFF
--- a/apps/web/src/components/UserProfile/ExperienceSection.tsx
+++ b/apps/web/src/components/UserProfile/ExperienceSection.tsx
@@ -132,8 +132,8 @@ const ExperienceSection = ({
   return isExperience ? (
     <Tabs.Root defaultValue="0">
       <Tabs.List>
-        {tabs.map((tab) => (
-          <Tabs.Trigger key={tab} value={tab}>
+        {tabs.map((tab, index) => (
+          <Tabs.Trigger key={tab} value={`${index}`}>
             {tab}
           </Tabs.Trigger>
         ))}


### PR DESCRIPTION
🤖 Resolves #7687.

## 👋 Introduction

This PR updates the tab trigger value for `ExperienceSection` (changed in c9a2747529a45d5f5ed19a64217547e97e6cc352) to its original working state.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Log in as admin, go to users table
2. Find user that has filled out their career timeline
3. Click to view their profile
4. Scroll to the bottom of the page to see the Career timeline and recruitment section
5. Click the "By Type" tab
6. Tab content is rendered and can be switched by clicking on other tabs

## 📸 Screenshot
![Screen Shot 2023-08-24 at 12 34 13](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/d9383c68-1228-4b0f-8f88-7fa43bb55abb)

