### PR TITLE
[Bug] Remove default name for AuthService

### DIFF
--- a/api/app/Providers/AuthServiceProvider.php
+++ b/api/app/Providers/AuthServiceProvider.php
@@ -98,7 +98,6 @@ class AuthServiceProvider extends ServiceProvider
             } else {
                 // No user found for given subscriber - lets auto-register them
                 $newUser = new User;
-                $newUser->first_name = $sub;  // displayed on the landing page so should help us find the user
                 $newUser->sub = $sub;
                 $newUser->save();
                 $newUser->syncRoles([  // every new user is automatically an base_user and an applicant


### PR DESCRIPTION
🤖 Resolves #7684

## 👋 Introduction

No longer gives a default first name, forcing it to be updated before you can submit applications. 

## 🕵️ Details

Peter did the legwork with identifying the root of the problem. 

## 🧪 Testing


1. Be logged out and then navigate to a pool poster
2. Click apply, be directed to the mock auth
3. Fill in for credentials a completely new user, so fill in random letters for the sub for auth, say "tester1397"
4. Upon signing in you get bounced back to the application and not an account creation page
5. Observe the emptiness

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/1c8a75d7-25ef-4c81-92fb-ed3afa15f9ea)


