### PR TITLE
[Bug] Remove education filtering of results

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -92,7 +92,9 @@ type User {
     @rename(attribute: "indigenous_declaration_signature")
 
   # Applicant info
-  hasDiploma: Boolean @rename(attribute: "has_diploma")
+  hasDiploma: Boolean
+    @rename(attribute: "has_diploma")
+    @deprecated(reason: "hasDiploma to be replaced")
   locationPreferences: [WorkRegion] @rename(attribute: "location_preferences")
   locationExemptions: String @rename(attribute: "location_exemptions")
   acceptedOperationalRequirements: [OperationalRequirement]
@@ -551,7 +553,9 @@ input EquitySelectionsInput {
 type PoolCandidateFilter {
   id: ID!
   classifications: [Classification] @belongsToMany
-  hasDiploma: Boolean @rename(attribute: "has_diploma")
+  hasDiploma: Boolean
+    @rename(attribute: "has_diploma")
+    @deprecated(reason: "hasDiploma to be replaced")
   equity: EquitySelections
   languageAbility: LanguageAbility @rename(attribute: "language_ability")
   operationalRequirements: [OperationalRequirement]
@@ -563,7 +567,9 @@ type PoolCandidateFilter {
 # ApplicantFilter only includes the fields which Talent Seekers can use to search for candidates.
 type ApplicantFilter {
   id: ID!
-  hasDiploma: Boolean @rename(attribute: "has_diploma")
+  hasDiploma: Boolean
+    @rename(attribute: "has_diploma")
+    @deprecated(reason: "hasDiploma to be replaced")
   equity: EquitySelections
   languageAbility: LanguageAbility @rename(attribute: "language_ability")
   operationalRequirements: [OperationalRequirement]
@@ -827,7 +833,7 @@ input UserFilterInput {
 # Changes to this input will require some manual updates to api/app/GraphQL/Queries/CountPoolCandidatesByPool.php since it doesn't use the directives for automatic resolution
 input ApplicantFilterInput {
   equity: EquitySelectionsInput @scope
-  hasDiploma: Boolean @scope
+  hasDiploma: Boolean @scope @deprecated(reason: "hasDiploma to be replaced")
   languageAbility: LanguageAbility @scope
   locationPreferences: [WorkRegion] @scope
   operationalRequirements: [OperationalRequirement] @scope
@@ -1107,7 +1113,9 @@ input CreateUserInput {
     @rename(attribute: "indigenous_declaration_signature")
 
   # Applicant info
-  hasDiploma: Boolean @rename(attribute: "has_diploma")
+  hasDiploma: Boolean
+    @rename(attribute: "has_diploma")
+    @deprecated(reason: "hasDiploma to be replaced")
   locationPreferences: [WorkRegion] @rename(attribute: "location_preferences")
   locationExemptions: String @rename(attribute: "location_exemptions")
   acceptedOperationalRequirements: [OperationalRequirement]
@@ -1175,7 +1183,9 @@ input UpdateUserAsAdminInput
     @rename(attribute: "indigenous_declaration_signature")
 
   # Applicant info
-  hasDiploma: Boolean @rename(attribute: "has_diploma")
+  hasDiploma: Boolean
+    @rename(attribute: "has_diploma")
+    @deprecated(reason: "hasDiploma to be replaced")
   locationPreferences: [WorkRegion] @rename(attribute: "location_preferences")
   locationExemptions: String @rename(attribute: "location_exemptions")
   acceptedOperationalRequirements: [OperationalRequirement]
@@ -1241,7 +1251,9 @@ input UpdateUserAsUserInput
     @rename(attribute: "indigenous_declaration_signature")
 
   # Applicant info
-  hasDiploma: Boolean @rename(attribute: "has_diploma")
+  hasDiploma: Boolean
+    @rename(attribute: "has_diploma")
+    @deprecated(reason: "hasDiploma to be replaced")
   locationPreferences: [WorkRegion] @rename(attribute: "location_preferences")
   locationExemptions: String @rename(attribute: "location_exemptions")
   acceptedOperationalRequirements: [OperationalRequirement]
@@ -1354,7 +1366,9 @@ input UpdateTeamInput {
 }
 
 input CreateApplicantFilterInput {
-  hasDiploma: Boolean @rename(attribute: "has_diploma")
+  hasDiploma: Boolean
+    @rename(attribute: "has_diploma")
+    @deprecated(reason: "hasDiploma to be replaced")
   equity: EquitySelectionsInput @spread
   languageAbility: LanguageAbility @rename(attribute: "language_ability")
   operationalRequirements: [OperationalRequirement]

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -197,7 +197,7 @@ type User {
   isVisibleMinority: Boolean
   indigenousCommunities: [IndigenousCommunity]
   indigenousDeclarationSignature: String
-  hasDiploma: Boolean
+  hasDiploma: Boolean @deprecated(reason: "hasDiploma to be replaced")
   locationPreferences: [WorkRegion]
   locationExemptions: String
   acceptedOperationalRequirements: [OperationalRequirement]
@@ -594,7 +594,7 @@ input EquitySelectionsInput {
 type PoolCandidateFilter {
   id: ID!
   classifications: [Classification]
-  hasDiploma: Boolean
+  hasDiploma: Boolean @deprecated(reason: "hasDiploma to be replaced")
   equity: EquitySelections
   languageAbility: LanguageAbility
   operationalRequirements: [OperationalRequirement]
@@ -604,7 +604,7 @@ type PoolCandidateFilter {
 
 type ApplicantFilter {
   id: ID!
-  hasDiploma: Boolean
+  hasDiploma: Boolean @deprecated(reason: "hasDiploma to be replaced")
   equity: EquitySelections
   languageAbility: LanguageAbility
   operationalRequirements: [OperationalRequirement]

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -480,7 +480,10 @@ const PoolCandidatesTable = ({
       notes: searchType === "notes" ? searchBarTerm : undefined,
 
       // from fancy filter
-      applicantFilter: fancyFilterState?.applicantFilter,
+      applicantFilter: {
+        ...fancyFilterState?.applicantFilter,
+        hasDiploma: null, // disconnect education selection for useGetPoolCandidatesPaginatedQuery
+      },
       poolCandidateStatus: fancyFilterState?.poolCandidateStatus,
       priorityWeight: fancyFilterState?.priorityWeight,
       expiryStatus: fancyFilterState?.expiryStatus,

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchContainer.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchContainer.tsx
@@ -61,6 +61,7 @@ const applicantFilterToQueryArgs = (
           ? pickMap(filter.qualifiedClassifications, ["group", "level"])
           : undefined,
         skills: filter?.skills ? pickMap(filter.skills, "id") : undefined,
+        hasDiploma: null, // disconnect education selection for useCountApplicantsAndCountPoolCandidatesByPoolQuery
 
         // Override the filter's pool if one is provided separately.
         pools: poolId ? [{ id: poolId }] : pickMap(filter?.pools, "id"),


### PR DESCRIPTION
🤖 Resolves #5976 

## 👋 Introduction

Prevents the selection of education option from having an effect on API operations. 

## 🕵️ Details

Disconnects the education field in the data massage function called before an operation is submitted to the API. Otherwise, the education option is unchanged in that it is select-able everywhere. 
Deprecates the field `hasDiploma` as well. 

## 🧪 Testing

1. Note results logged for search results off main at `/en/search` and `/en/admin/pools/:id/pool-candidates`
2. Switch to branch and build
3. Check the places from step one again, observe education filtering no longer changes result count
4. Submit a request with education selected, observe it is unchanged aside from no longer filtering results
5. Open the request from the admin dashboard, observe things are unchanged aside from the results count

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/0f598bb6-264e-4900-8768-db98d4c106ea)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/61692b52-6247-44d9-b926-d394550f2883)

