### PR TITLE
[Fix] Uncheck disclaimer when form changes

### DIFF
--- a/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
@@ -17,7 +17,10 @@ import { SubExperienceFormProps } from "~/types/experience";
 const PersonalFields = ({ labels }: SubExperienceFormProps) => {
   const intl = useIntl();
   const todayDate = new Date();
-  const { setValue } = useFormContext();
+  const {
+    setValue,
+    formState: { defaultValues },
+  } = useFormContext();
   // to toggle whether End Date is required, the state of the Current Role checkbox must be monitored and have to adjust the form accordingly
   const isCurrent = useWatch({ name: "currentRole" });
   // ensuring end date isn't before the start date, using this as a minimum value
@@ -25,8 +28,10 @@ const PersonalFields = ({ labels }: SubExperienceFormProps) => {
   const watchDescription = useWatch({ name: "experienceDescription" });
 
   React.useEffect(() => {
-    setValue("disclaimer", false);
-  }, [setValue, watchDescription]);
+    if (watchDescription !== defaultValues?.experienceDescription) {
+      setValue("disclaimer", false);
+    }
+  }, [defaultValues?.experienceDescription, setValue, watchDescription]);
 
   return (
     <div

--- a/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useFormContext, useWatch } from "react-hook-form";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 
 import {
   Checkbox,

--- a/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
@@ -32,9 +32,12 @@ const PersonalFields = ({ labels }: SubExperienceFormProps) => {
   React.useEffect(() => {
     const subscription = watch((values, { name }) => {
       if (
-        // Skills are not really part of the overall form
-        !["disclaimer", "skills"].includes(name ?? "") &&
-        !isEqual(values, defaultValues)
+        // Only uncheck when the description changes
+        name === "experienceDescription" &&
+        !isEqual(
+          values?.experienceDescription,
+          defaultValues?.experienceDescription,
+        )
       ) {
         setValue("disclaimer", false);
       }

--- a/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useFormContext, useWatch } from "react-hook-form";
-import isEqual from "lodash/isEqual";
 
 import {
   Checkbox,
@@ -18,34 +17,16 @@ import { SubExperienceFormProps } from "~/types/experience";
 const PersonalFields = ({ labels }: SubExperienceFormProps) => {
   const intl = useIntl();
   const todayDate = new Date();
-  const {
-    setValue,
-    watch,
-    formState: { defaultValues },
-  } = useFormContext();
+  const { setValue } = useFormContext();
   // to toggle whether End Date is required, the state of the Current Role checkbox must be monitored and have to adjust the form accordingly
   const isCurrent = useWatch({ name: "currentRole" });
   // ensuring end date isn't before the start date, using this as a minimum value
   const watchStartDate = useWatch({ name: "startDate" });
+  const watchDescription = useWatch({ name: "experienceDescription" });
 
-  // Callback version of watch.  It's your responsibility to unsubscribe when done.
   React.useEffect(() => {
-    const subscription = watch((values, { name }) => {
-      if (
-        // Only uncheck when the description changes
-        name === "experienceDescription" &&
-        !isEqual(
-          values?.experienceDescription,
-          defaultValues?.experienceDescription,
-        )
-      ) {
-        setValue("disclaimer", false);
-      }
-    });
-
-    return () => subscription.unsubscribe();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [watch]);
+    setValue("disclaimer", false);
+  }, [setValue, watchDescription]);
 
   return (
     <div

--- a/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useWatch } from "react-hook-form";
+import { useFormContext, useWatch } from "react-hook-form";
+import { isEqual } from "lodash";
 
 import {
   Checkbox,
@@ -17,10 +18,31 @@ import { SubExperienceFormProps } from "~/types/experience";
 const PersonalFields = ({ labels }: SubExperienceFormProps) => {
   const intl = useIntl();
   const todayDate = new Date();
+  const {
+    setValue,
+    watch,
+    formState: { defaultValues },
+  } = useFormContext();
   // to toggle whether End Date is required, the state of the Current Role checkbox must be monitored and have to adjust the form accordingly
   const isCurrent = useWatch({ name: "currentRole" });
   // ensuring end date isn't before the start date, using this as a minimum value
   const watchStartDate = useWatch({ name: "startDate" });
+
+  // Callback version of watch.  It's your responsibility to unsubscribe when done.
+  React.useEffect(() => {
+    const subscription = watch((values, { name }) => {
+      if (
+        // Skills are not really part of the overall form
+        !["disclaimer", "skills"].includes(name ?? "") &&
+        !isEqual(values, defaultValues)
+      ) {
+        setValue("disclaimer", false);
+      }
+    });
+
+    return () => subscription.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [watch]);
 
   return (
     <div

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -83,6 +83,8 @@ export const ExperienceForm = ({
       ? queryResultToDefaultValues(experienceType, experience)
       : { experienceType };
 
+  console.log(defaultValues);
+
   const methods = useForm<FormValues>({
     shouldFocusError: false,
     mode: "onSubmit",

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -83,8 +83,6 @@ export const ExperienceForm = ({
       ? queryResultToDefaultValues(experienceType, experience)
       : { experienceType };
 
-  console.log(defaultValues);
-
   const methods = useForm<FormValues>({
     shouldFocusError: false,
     mode: "onSubmit",

--- a/apps/web/src/types/experience.ts
+++ b/apps/web/src/types/experience.ts
@@ -106,6 +106,7 @@ type EducationFormValues = FormValueDateRange & {
 type PersonalFormValues = FormValueDateRange & {
   experienceTitle: string;
   experienceDescription: string;
+  disclaimer: boolean;
 };
 
 type WorkFormValues = FormValueDateRange & {

--- a/apps/web/src/utils/experienceUtils.tsx
+++ b/apps/web/src/utils/experienceUtils.tsx
@@ -498,6 +498,7 @@ const getPersonalExperienceDefaultValues = (experience: PersonalExperience) => {
     startDate,
     currentRole: endDate === null,
     endDate,
+    disclaimer: true,
   };
 };
 


### PR DESCRIPTION
🤖 Resolves #3709 

## 👋 Introduction

This makes a couple of changes to the personal experience form:

- Makes the disclaimer checkbox checked by default if editing an experience
- Unchecks the disclaimer if a field other than it has changed from the default values

## 🕵️ Details

If users change their information, we want to make sure they re-agree to share the information since it is technically new info.

## 🧪 Testing

> **Note**
> I ran chromatic as part of this to test #7746

1. Build `npm run dev`
2. Create a personal experience
3. Check the disclaimer
4. Make a change
5. Confirm disclaimer unchecks
6. Save experience
7. Edit the same experience
8. Repeat steps 4-5