### PR TITLE
[Fix] `User.scopeAuthorizedToView` to include view own

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -808,6 +808,9 @@ class User extends Model implements Authenticatable, LaratrustUser
                         });
                     });
                 }
+                if ($user->isAbleTo('view-own-user')) {
+                    $query->orWhere('id', $user->id);
+                }
             });
         }
 

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -797,9 +797,9 @@ class User extends Model implements Authenticatable, LaratrustUser
         if (! $user->isAbleTo('view-any-user')) {
             $query->where(function (Builder $query) use ($user) {
                 if ($user->isAbleTo('view-team-user')) {
-                    $query->whereHas('poolCandidates', function (Builder $query) use ($user) {
+                    $query->orWhereHas('poolCandidates', function (Builder $query) use ($user) {
                         $teamIds = $user->rolesTeams()->get()->pluck('id');
-                        $query->orWhereHas('pool', function (Builder $query) use ($teamIds) {
+                        $query->whereHas('pool', function (Builder $query) use ($teamIds) {
                             return $query
                                 ->where('submitted_at', '<=', Carbon::now()->toDateTimeString())
                                 ->whereHas('team', function (Builder $query) use ($teamIds) {


### PR DESCRIPTION
## 👋 Introduction

Adds a gap in the authorization scope for the user model.

## 🕵️ Details

I think `id` is the correct column. Scopes run on the table of the current model, not the parent correct? 🤔 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run a query for `poolCandidates.user` where the user is owned by the authenticated user
2. Confirm the user appears in the results instead of `null`