### PR TITLE
Make Skill keyword fields not required

### DIFF
--- a/apps/web/src/pages/Skills/CreateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/CreateSkillPage.tsx
@@ -34,6 +34,7 @@ import {
 } from "~/api/generated";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import adminMessages from "~/messages/adminMessages";
+import { parseKeywords } from "~/utils/skillUtils";
 
 type Option<V> = { value: V; label: string };
 
@@ -78,14 +79,8 @@ export const CreateSkillForm = ({
   const formValuesToSubmitData = (values: FormValues): CreateSkillInput => ({
     ...values,
     keywords: {
-      en: values.keywords.en
-        .split(",")
-        .map((key) => key.trim())
-        .filter((key) => key !== ""),
-      fr: values.keywords.fr
-        .split(",")
-        .map((key) => key.trim())
-        .filter((key) => key !== ""),
+      en: parseKeywords(values.keywords.en),
+      fr: parseKeywords(values.keywords.fr),
     },
     families: {
       sync: values.families,
@@ -240,9 +235,6 @@ export const CreateSkillForm = ({
                   "Additional context describing the purpose of the skills 'keyword' field.",
               })}
               type="text"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <Input
               id="keywords_fr"
@@ -261,9 +253,6 @@ export const CreateSkillForm = ({
                   "Additional context describing the purpose of the skills 'keyword' field.",
               })}
               type="text"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <Select
               id="category"

--- a/apps/web/src/pages/Skills/UpdateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateSkillPage.tsx
@@ -38,6 +38,7 @@ import {
 import useRoutes from "~/hooks/useRoutes";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import adminMessages from "~/messages/adminMessages";
+import { parseKeywords } from "~/utils/skillUtils";
 
 type Option<V> = { value: V; label: string };
 
@@ -84,14 +85,8 @@ export const UpdateSkillForm = ({
   const formValuesToSubmitData = (values: FormValues): UpdateSkillInput => ({
     ...values,
     keywords: {
-      en: values.keywords.en
-        .split(",")
-        .map((key) => key.trim())
-        .filter((key) => key !== ""),
-      fr: values.keywords.fr
-        .split(",")
-        .map((key) => key.trim())
-        .filter((key) => key !== ""),
+      en: parseKeywords(values.keywords.en),
+      fr: parseKeywords(values.keywords.fr),
     },
     families: {
       sync: values.families,
@@ -232,9 +227,6 @@ export const UpdateSkillForm = ({
                   "Additional context describing the purpose of the skills 'keyword' field.",
               })}
               type="text"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <Input
               id="keywords_fr"
@@ -253,9 +245,6 @@ export const UpdateSkillForm = ({
                   "Additional context describing the purpose of the skills 'keyword' field.",
               })}
               type="text"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
             />
             <Select
               id="category"

--- a/apps/web/src/utils/skillUtils.test.ts
+++ b/apps/web/src/utils/skillUtils.test.ts
@@ -10,6 +10,7 @@ import {
   InvertedSkillExperience,
   invertSkillExperienceTree,
   invertSkillSkillFamilyTree,
+  parseKeywords,
 } from "./skillUtils";
 
 const fakeApplicant = fakeApplicants(1)[0];
@@ -474,5 +475,29 @@ describe("skill util tests", () => {
     ];
     const actual = invertSkillExperienceTree(experiences);
     expect(actual).toEqual(expected);
+  });
+  describe("parseKeywords", () => {
+    test("returns null for falsy inputs", () => {
+      expect(parseKeywords("")).toBeNull();
+      expect(parseKeywords(null)).toBeNull();
+      expect(parseKeywords(undefined)).toBeNull();
+      expect(parseKeywords("  ")).toBeNull();
+    });
+    test("splits a nicely formatted list", () => {
+      expect(parseKeywords("hello,world,nice,day")).toEqual([
+        "hello",
+        "world",
+        "nice",
+        "day",
+      ]);
+    });
+    test("trims each list item", () => {
+      expect(parseKeywords("hello  ,world,   nice,   day   ")).toEqual([
+        "hello",
+        "world",
+        "nice",
+        "day",
+      ]);
+    });
   });
 });

--- a/apps/web/src/utils/skillUtils.ts
+++ b/apps/web/src/utils/skillUtils.ts
@@ -225,7 +225,7 @@ export const parseKeywords = (
 ): string[] | null => {
   return value?.trim()
     ? value
-        .split(".")
+        .split(",")
         .map((word) => word.trim())
         .filter((word) => word !== "")
     : null;

--- a/apps/web/src/utils/skillUtils.ts
+++ b/apps/web/src/utils/skillUtils.ts
@@ -214,3 +214,19 @@ export const getExperiencesSkillIds = (experiences: Experience[]): string[] => {
 
   return deDupedIdCollection;
 };
+
+/**
+ * Parse a comma-separated list into an array of strings
+ * @param {string | null | undefined} value A single string, representing a comma-separated list. Or, may be an empty list or undefined.
+ * @returns {string[] | null}
+ */
+export const parseKeywords = (
+  value: string | null | undefined,
+): string[] | null => {
+  return value?.trim()
+    ? value
+        .split(".")
+        .map((word) => word.trim())
+        .filter((word) => word !== "")
+    : null;
+};


### PR DESCRIPTION
🤖 Resolves #7765

## 👋 Introduction

Allow platform admins to create or edit skills without filling in keywords.

## 🕵️ Details

Keywords ended up not being used, or even defined, for our skills library.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Log in as [admin@test.com](mailto:admin@test.com)
2. Go to http://localhost:8000/en/admin/settings/skills
3. Edit a skill
4. Edit skill family (or anything else) while leaving keywords blank
5. Try to submit
6. Do the same with creating a new skill

