### PR TITLE
[Fix] Remove status icon from user profile on admin

### DIFF
--- a/apps/web/src/components/UserProfile/UserProfile.tsx
+++ b/apps/web/src/components/UserProfile/UserProfile.tsx
@@ -19,7 +19,6 @@ import { navigationMessages } from "@gc-digital-talent/i18n";
 
 import type { User } from "~/api/generated";
 
-import StatusItem from "../StatusItem/StatusItem";
 import ExperienceSection from "./ExperienceSection";
 import AboutSection from "./ProfileSections/AboutSection";
 import DiversityEquityInclusionSection from "./ProfileSections/DiversityEquityInclusionSection";
@@ -137,56 +136,37 @@ const UserProfile = ({
             {showSection("about") && (
               <TableOfContents.ListItem>
                 <TableOfContents.AnchorLink id={PAGE_SECTION_ID.ABOUT}>
-                  <StatusItem
-                    asListItem={false}
-                    title={intl.formatMessage(navigationMessages.aboutMe)}
-                  />
+                  {intl.formatMessage(navigationMessages.aboutMe)}
                 </TableOfContents.AnchorLink>
               </TableOfContents.ListItem>
             )}
             {showSection("employmentEquity") && (
               <TableOfContents.ListItem>
                 <TableOfContents.AnchorLink id={PAGE_SECTION_ID.DEI}>
-                  <StatusItem
-                    asListItem={false}
-                    title={intl.formatMessage(
-                      navigationMessages.diversityEquityInclusion,
-                    )}
-                  />
+                  {intl.formatMessage(
+                    navigationMessages.diversityEquityInclusion,
+                  )}
                 </TableOfContents.AnchorLink>
               </TableOfContents.ListItem>
             )}
             {showSection("language") && (
               <TableOfContents.ListItem>
                 <TableOfContents.AnchorLink id={PAGE_SECTION_ID.LANGUAGE}>
-                  <StatusItem
-                    asListItem={false}
-                    title={intl.formatMessage(
-                      navigationMessages.languageInformation,
-                    )}
-                  />
+                  {intl.formatMessage(navigationMessages.languageInformation)}
                 </TableOfContents.AnchorLink>
               </TableOfContents.ListItem>
             )}
             {showSection("government") && (
               <TableOfContents.ListItem>
                 <TableOfContents.AnchorLink id={PAGE_SECTION_ID.GOVERNMENT}>
-                  <StatusItem
-                    asListItem={false}
-                    title={intl.formatMessage(
-                      navigationMessages.governmentInformation,
-                    )}
-                  />
+                  {intl.formatMessage(navigationMessages.governmentInformation)}
                 </TableOfContents.AnchorLink>
               </TableOfContents.ListItem>
             )}
             {showSection("workLocation") && (
               <TableOfContents.ListItem>
                 <TableOfContents.AnchorLink id={PAGE_SECTION_ID.WORK_LOCATION}>
-                  <StatusItem
-                    asListItem={false}
-                    title={intl.formatMessage(navigationMessages.workLocation)}
-                  />
+                  {intl.formatMessage(navigationMessages.workLocation)}
                 </TableOfContents.AnchorLink>
               </TableOfContents.ListItem>
             )}
@@ -195,12 +175,7 @@ const UserProfile = ({
                 <TableOfContents.AnchorLink
                   id={PAGE_SECTION_ID.WORK_PREFERENCES}
                 >
-                  <StatusItem
-                    asListItem={false}
-                    title={intl.formatMessage(
-                      navigationMessages.workPreferences,
-                    )}
-                  />
+                  {intl.formatMessage(navigationMessages.workPreferences)}
                 </TableOfContents.AnchorLink>
               </TableOfContents.ListItem>
             )}

--- a/apps/web/src/components/UserProfile/UserProfile.tsx
+++ b/apps/web/src/components/UserProfile/UserProfile.tsx
@@ -18,16 +18,8 @@ import {
 import { navigationMessages } from "@gc-digital-talent/i18n";
 
 import type { User } from "~/api/generated";
-import {
-  aboutSectionHasEmptyRequiredFields,
-  diversityEquityInclusionSectionHasEmptyRequiredFields,
-  governmentInformationSectionHasEmptyRequiredFields,
-  languageInformationSectionHasEmptyRequiredFields,
-  workLocationSectionHasEmptyRequiredFields,
-  workPreferencesSectionHasEmptyRequiredFields,
-} from "~/validators/profile";
 
-import StatusItem, { Status } from "../StatusItem/StatusItem";
+import StatusItem from "../StatusItem/StatusItem";
 import ExperienceSection from "./ExperienceSection";
 import AboutSection from "./ProfileSections/AboutSection";
 import DiversityEquityInclusionSection from "./ProfileSections/DiversityEquityInclusionSection";
@@ -137,14 +129,6 @@ const UserProfile = ({
     return sections[key] && sections[key]?.isVisible;
   };
 
-  const sectionStatus = (
-    hasEmptyRequiredFields: (user: User) => boolean,
-  ): Status | undefined => {
-    if (hasEmptyRequiredFields(user)) return "error";
-
-    return "success";
-  };
-
   return (
     <Container show={isNavigationVisible}>
       {isNavigationVisible && (
@@ -156,7 +140,6 @@ const UserProfile = ({
                   <StatusItem
                     asListItem={false}
                     title={intl.formatMessage(navigationMessages.aboutMe)}
-                    status={sectionStatus(aboutSectionHasEmptyRequiredFields)}
                   />
                 </TableOfContents.AnchorLink>
               </TableOfContents.ListItem>
@@ -168,9 +151,6 @@ const UserProfile = ({
                     asListItem={false}
                     title={intl.formatMessage(
                       navigationMessages.diversityEquityInclusion,
-                    )}
-                    status={sectionStatus(
-                      diversityEquityInclusionSectionHasEmptyRequiredFields,
                     )}
                   />
                 </TableOfContents.AnchorLink>
@@ -184,9 +164,6 @@ const UserProfile = ({
                     title={intl.formatMessage(
                       navigationMessages.languageInformation,
                     )}
-                    status={sectionStatus(
-                      languageInformationSectionHasEmptyRequiredFields,
-                    )}
                   />
                 </TableOfContents.AnchorLink>
               </TableOfContents.ListItem>
@@ -199,9 +176,6 @@ const UserProfile = ({
                     title={intl.formatMessage(
                       navigationMessages.governmentInformation,
                     )}
-                    status={sectionStatus(
-                      governmentInformationSectionHasEmptyRequiredFields,
-                    )}
                   />
                 </TableOfContents.AnchorLink>
               </TableOfContents.ListItem>
@@ -212,9 +186,6 @@ const UserProfile = ({
                   <StatusItem
                     asListItem={false}
                     title={intl.formatMessage(navigationMessages.workLocation)}
-                    status={sectionStatus(
-                      workLocationSectionHasEmptyRequiredFields,
-                    )}
                   />
                 </TableOfContents.AnchorLink>
               </TableOfContents.ListItem>
@@ -228,9 +199,6 @@ const UserProfile = ({
                     asListItem={false}
                     title={intl.formatMessage(
                       navigationMessages.workPreferences,
-                    )}
-                    status={sectionStatus(
-                      workPreferencesSectionHasEmptyRequiredFields,
                     )}
                   />
                 </TableOfContents.AnchorLink>


### PR DESCRIPTION
🤖 Resolves #7757 

## 👋 Introduction

Removes the status icon from the table of contents on the admin user profile page.

## 🕵️ Details

These icons are meant to communicate completeness to the user. It is less helpful for admins so we are removing it.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/admin/users`
3. "View" a user and go to the "User profile" page
4. Confirm the table of contents does not include icons and just shows the bullet

## 📸 Screenshot

![Screenshot 2023-09-05 113151](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/f00f4a31-5126-4b09-8453-f9c1e0ee50a7)

