### PR TITLE
[Fix] Qualified recruitment card spacing

### DIFF
--- a/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.tsx
+++ b/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.tsx
@@ -235,7 +235,7 @@ const QualifiedRecruitmentCard = ({
               <ul
                 data-h2-display="base(grid)"
                 data-h2-grid-template-columns="p-tablet(repeat(2, 1fr))"
-                data-h2-gap="base(x.125 x.5)"
+                data-h2-gap="base(x.125 x1.5)"
               >
                 {categorizedSkills[SkillCategory.Technical]?.map((skill) => (
                   <li key={skill.id}>{getLocalizedName(skill.name, intl)}</li>


### PR DESCRIPTION
🤖 Resolves #7755 

## 👋 Introduction

Adds additional column spacing to the skills list on the `QualifedRecruitmentCard`.

## 🕵️ Details

Since we are using `ul`, the bullet appears outside of the container which was creating the issue. This just increases the spacing to account for the bullets.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run storybook `npm run storybook`
2. Hardcode in some long skill names to ensure it uses all the available space
3. Confirm there is an appropriate amount of space between columns in the list grid

## 📸 Screenshot

![Screenshot 2023-09-05 153039](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/49fb7d2c-c07a-4c13-a33f-8d6980dfc15f)
