### PR TITLE
Remove withTrashed scope from User->experience relationships

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -119,27 +119,27 @@ class User extends Model implements Authenticatable, LaratrustUser
     // All the relationships for experiences
     public function awardExperiences(): HasMany
     {
-        return $this->hasMany(AwardExperience::class)->withTrashed();
+        return $this->hasMany(AwardExperience::class);
     }
 
     public function communityExperiences(): HasMany
     {
-        return $this->hasMany(CommunityExperience::class)->withTrashed();
+        return $this->hasMany(CommunityExperience::class);
     }
 
     public function educationExperiences(): HasMany
     {
-        return $this->hasMany(EducationExperience::class)->withTrashed();
+        return $this->hasMany(EducationExperience::class);
     }
 
     public function personalExperiences(): HasMany
     {
-        return $this->hasMany(PersonalExperience::class)->withTrashed();
+        return $this->hasMany(PersonalExperience::class);
     }
 
     public function workExperiences(): HasMany
     {
-        return $this->hasMany(WorkExperience::class)->withTrashed();
+        return $this->hasMany(WorkExperience::class);
     }
 
     public function getExperiencesAttribute()


### PR DESCRIPTION
🤖 Resolves #7828 

## 👋 Introduction

Stop deleted experiences from appearing on Career Timeline

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

### Resolve the bug
1. Log in as applicant
2. Add an experience to your profile
3. Delete the experience
4. Ensure it doesn't appear on career timeline page

### make sure the deleted code wasn't there for a good reason
1. Log in as admin@test.com
2. View a user on admin site
3. Note that user's id and the url, and the user's experiences
4. Delete the user
5. go back to viewing the user (by manually going to the url if necessary)
6. Ensure you can still see the user's experiences.
