### PR TITLE
[Fix] Custom validation for First Nations validation

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7876,6 +7876,10 @@
     "defaultMessage": "Langue",
     "description": "Legend for the Working Language Ability radio buttons"
   },
+  "skfKnv": {
+    "defaultMessage": "Veuillez sélectionner les Premières Nations qui détiennent le statut ou les Premières Nations qui ne détiennent pas le statut.",
+    "description": "Error message that the user has selected both status and non-status first nations."
+  },
   "sr20Tb": {
     "defaultMessage": "Citoyenneté",
     "description": "Citizenship label"

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunitySelection.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunitySelection.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useFormContext } from "react-hook-form";
 import { useIntl } from "react-intl";
 
-import { FieldLabels, Checklist } from "@gc-digital-talent/forms";
+import { FieldLabels, Checklist, Field } from "@gc-digital-talent/forms";
 import { Alert, Chip, Chips } from "@gc-digital-talent/ui";
 
 import HelpLink from "./HelpLink";
@@ -18,7 +18,8 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
   const [isAlertOpen, setIsAlertOpen] = React.useState<boolean>(false);
   const [hasDismissedAlert, setHasDismissedAlert] =
     React.useState<boolean>(false);
-  const { watch, setValue } = useFormContext();
+  const { watch, setValue, setError, clearErrors, formState } =
+    useFormContext();
 
   const communityLabels = getCommunityLabels(intl);
 
@@ -30,6 +31,27 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
     // Is not represented and has at least on other community selected
     setIsAlertOpen(!!(isOtherAndHasCommunity && !hasDismissedAlert));
   }, [isOtherAndHasCommunity, setIsAlertOpen, hasDismissedAlert]);
+
+  React.useEffect(() => {
+    if (
+      communitiesValue.includes("status") &&
+      communitiesValue.includes("nonStatus")
+    ) {
+      setError("firstNationsCustom", {
+        type: "validation",
+        message: intl.formatMessage({
+          defaultMessage:
+            "Please select either Status First Nations or Non-Status First Nations.",
+          id: "skfKnv",
+          description:
+            "Error message that the user has selected both status and non-status first nations.",
+        }),
+      });
+    } else {
+      clearErrors("firstNationsCustom");
+    }
+  }, [clearErrors, communitiesValue, intl, setError]);
+  const customAlertId = React.useId();
 
   const handleAlertDismiss = () => {
     setIsAlertOpen(false);
@@ -73,7 +95,13 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
                 }),
               },
             ]}
+            aria-describedby={customAlertId}
           />
+          {formState.errors.firstNationsCustom && (
+            <Field.Error id={customAlertId}>
+              {formState.errors.firstNationsCustom.message?.toString()}
+            </Field.Error>
+          )}
         </div>
         <div data-h2-flex-item="base(1of4)" data-h2-align-self="base(center)">
           <CommunityIcon

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunitySelection.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunitySelection.tsx
@@ -98,7 +98,7 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
             aria-describedby={customAlertId}
           />
           {formState.errors.firstNationsCustom && (
-            <Field.Error id={customAlertId}>
+            <Field.Error id={customAlertId} data-h2-margin-top="base(x.25)">
               {formState.errors.firstNationsCustom.message?.toString()}
             </Field.Error>
           )}

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1287,6 +1287,10 @@
     "defaultMessage": "cela m'oblige à faire <strong>des heures supplémentaires occasionnelles</strong>.",
     "description": "The operational requirement described as occasional overtime."
   },
+  "skfKnv": {
+    "defaultMessage": "Veuillez sélectionner les Premières Nations qui détiennent le statut ou les Premières Nations qui ne détiennent pas le statut.",
+    "description": "Error message that the user has selected both status and non-status first nations."
+  },
   "spP+Tz": {
     "defaultMessage": "Nunavut",
     "description": "Nunavut selection for province or territory input"
@@ -1465,9 +1469,6 @@
   "yRxy3a": {
     "defaultMessage": "Retrait qualifié",
     "description": "The pool candidate's status is Qualified Withdrew."
-  },
-  "ybzpGb": {
-    "defaultMessage": "BothStatusNonStatus"
   },
   "ylHC90": {
     "defaultMessage": "Chargement...",

--- a/packages/i18n/src/messages/apiMessages.ts
+++ b/packages/i18n/src/messages/apiMessages.ts
@@ -27,9 +27,11 @@ export const apiMessages: { [key: string]: MessageDescriptor } = defineMessages(
         "Error message that the given email address is already in use when updating.",
     },
     BothStatusNonStatus: {
-      // TODO replace with proper message
-      defaultMessage: "BothStatusNonStatus",
-      id: "ybzpGb",
+      defaultMessage:
+        "Please select either Status First Nations or Non-Status First Nations.",
+      id: "skfKnv",
+      description:
+        "Error message that the user has selected both status and non-status first nations.",
     },
 
     // skill validation


### PR DESCRIPTION
🤖 Resolves #7360 

## 👋 Introduction

This branch adds the new message for API validation and also adds custom for validation.

## 🕵️ Details

This is a bit of a hack, for sure.  The form treats the four different checklist groups as a single element so a regular validation rule causes all the groups to go into a visual error state with the message.  It also doesn't have the submit handler in the component so you can't hook in there.  I tried breaking the form up into separate elements (which is probably the best solution) but it quickly got out of hand with the chips and illustrations and broke everything.  I opted for an independent validation rule that only brings up one standalone validation message.  It looks better but behaves differently in that it doesn't focus the input element and validates onChange.

## 🧪 Testing

1. Rule prevents submission if both First Nations boxes are checked.
2. Can submit normally if one or neither boxes are checked.
3. Works on profile inline form IAP submission form.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/7c86fa87-7cf0-4b99-89fb-6bd3f51e8478)