### PR TITLE
[Tooling] Add `/api` folder to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,11 +7,13 @@ on:
       - .github/workflows/*lint*.yml
       - apps/**
       - packages/**
+      - api/**
   pull_request:
     paths:
       - .github/workflows/*lint*.yml
       - apps/**
       - packages/**
+      - api/**
   merge_group:
     branches: [main]
 jobs:


### PR DESCRIPTION
🤖 Resolves #7871 

## 👋 Introduction

Adds the `/api` folder to the triggers for the lint workflow.

## 🕵️ Details

Now that we have a PHP linter, we should be running it in CI when changes are made to PHP files.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> **Note**
> I'm not sure how we would test this since it also runs on changes to that file (which has happened in this PR).