### PR TITLE
[Fix] Hide "removed" applications from applicants

### DIFF
--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplications.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplications.tsx
@@ -15,7 +15,7 @@ import {
 
 import { PoolCandidate, Scalars } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
-import { isApplicationInProgress } from "~/utils/applicationUtils";
+import { isApplicationInProgress, notRemoved } from "~/utils/applicationUtils";
 import { PAGE_SECTION_ID as CAREER_TIMELINE_AND_RECRUITMENTS_PAGE_SECTION_ID } from "~/pages/Profile/CareerTimelineAndRecruitmentPage/constants";
 
 import TrackApplicationsCard from "./TrackApplicationsCard";
@@ -40,13 +40,13 @@ const TrackApplications = ({
   const intl = useIntl();
   const paths = useRoutes();
 
-  const inProgressApplications = applications.filter((a) => {
-    return isApplicationInProgress(a);
-  });
+  const inProgressApplications = applications.filter(isApplicationInProgress);
 
-  const pastApplications = applications.filter((a) => {
-    return !isApplicationInProgress(a);
-  });
+  const pastApplications = applications
+    .filter((a) => {
+      return !isApplicationInProgress(a);
+    })
+    .filter(notRemoved);
 
   const [currentAccordionItems, setCurrentAccordionItems] =
     React.useState<AccordionItems>(["in_progress", "past"]); // start with both open

--- a/apps/web/src/utils/applicationUtils.ts
+++ b/apps/web/src/utils/applicationUtils.ts
@@ -181,3 +181,7 @@ export function isApplicationQualifiedRecruitment(a: Application): boolean {
     a.status === PoolCandidateStatus.Expired
   );
 }
+
+export function notRemoved(a: Application): boolean {
+  return a.status !== PoolCandidateStatus.Removed;
+}


### PR DESCRIPTION
🤖 Resolves #7441

## 👋 Introduction

This ensures users do not see applications with the "removed" status.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Create an application and set the status to "REMOVED"
3. Navigate to the following pages and ensure it does not appears
    - `/users/{userIs}/profile`, in the "Hide recruitment availability" accordion
    - `/applicant/profile-and-applications`, both current and past accordions
    - `/users/{userId}/profile/career-timeline-and-recruitment`, qualified recruitments section
