### PR TITLE
[Bug] Restore UserSkill persists values

### DIFF
--- a/api/app/GraphQL/Mutations/CreateUserSkill.php
+++ b/api/app/GraphQL/Mutations/CreateUserSkill.php
@@ -24,6 +24,13 @@ final class CreateUserSkill
             if (($existingModel->deleted_at !== null)) {
                 $existingModel->restore();
 
+                // if restoring, persist new values if applicable
+                $existingModel->update([
+                    'skill_level' => isset($args['skill_level']) ? $args['skill_level'] : $existingModel->skill_level,
+                    'when_skill_used' => isset($args['when_skill_used']) ? $args['when_skill_used'] : $existingModel->when_skill_used,
+                ]);
+                $existingModel->refresh();
+
                 return $existingModel;
             }
             throw ValidationException::withMessages(['DuplicateUserSkill']);


### PR DESCRIPTION
🤖 Resolves #7837

## 👋 Introduction

Have it so restoring a UserSkill model via mutation class updates values, if applicable. 
Elected to go with a single update call rather than multiple ifs each running a call, that way if another field is added down the line it is easy to keep it all in one call rather than a series of `if (...)` 

## 🧪 Testing

1. Get to a UserSkill instance (/en/applicant/profile-and-applications/skills/:skillId)
2. Set it with values, and note them
3. Delete it
4. Navigate back to it
5. Claim again, with different values
6. Ensure it is restored with new values

