### PR TITLE
[Feature] Allow filtering pool candidates by gov employee field

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -370,6 +370,17 @@ class PoolCandidate extends Model
         return $query;
     }
 
+    public static function scopeIsGovEmployee(Builder $query, ?bool $isGovEmployee): Builder
+    {
+        if ($isGovEmployee) {
+            $query->whereHas('user', function ($query) {
+                User::scopeIsGovEmployee($query, true);
+            });
+        }
+
+        return $query;
+    }
+
     public static function scopeNotes(Builder $query, ?string $notes): Builder
     {
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -872,6 +872,7 @@ input PoolCandidateSearchInput {
   generalSearch: String @scope
   name: String @scope
   notes: String @scope
+  isGovEmployee: Boolean @scope
   priorityWeight: [Int] @scope(name: "priorityWeight")
   poolCandidateStatus: [PoolCandidateStatus]
     @scope(name: "poolCandidateStatuses")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -894,6 +894,7 @@ input PoolCandidateSearchInput {
   generalSearch: String
   name: String
   notes: String
+  isGovEmployee: Boolean
   priorityWeight: [Int]
   poolCandidateStatus: [PoolCandidateStatus]
   expiryStatus: CandidateExpiryFilter

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateTableFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateTableFilterDialog.tsx
@@ -33,6 +33,7 @@ export type FormValues = {
   expiryStatus: Option["value"][];
   suspendedStatus: Option["value"][];
   publishingGroups: Option["value"][];
+  govEmployee: Option["value"][];
 };
 
 const Footer = () => {
@@ -256,6 +257,30 @@ const PoolCandidateTableFilterDialog = ({
                   options={optionsData.poolCandidateStatus}
                 />
               </div>
+              <div data-h2-flex-item="base(1of1) p-tablet(1of2) laptop(3of5)">
+                <MultiSelectField
+                  id="skills"
+                  name="skills"
+                  label={formatMessage({
+                    defaultMessage: "Skill Filter",
+                    id: "GGaxMx",
+                  })}
+                  options={optionsData.skills}
+                  isLoading={rawGraphqlResults.skills.fetching}
+                />
+              </div>
+              <div data-h2-flex-item="base(1of1) p-tablet(1of2) laptop(1of3)">
+                <MultiSelectFieldBase
+                  forceArrayFormValue
+                  id="govEmployee"
+                  name="govEmployee"
+                  label={formatMessage({
+                    defaultMessage: "Government Employee",
+                    id: "YojrdC",
+                  })}
+                  options={optionsData.govEmployee}
+                />
+              </div>
               <div data-h2-flex-item="base(1of1) p-tablet(1of2) laptop(1of3)">
                 <MultiSelectField
                   id="priorityWeight"
@@ -267,18 +292,6 @@ const PoolCandidateTableFilterDialog = ({
                       "Title displayed for the Pool Candidates table Priority column.",
                   })}
                   options={optionsData.priorityWeight}
-                />
-              </div>
-              <div data-h2-flex-item="base(1of1) p-tablet(1of2) laptop(3of5)">
-                <MultiSelectField
-                  id="skills"
-                  name="skills"
-                  label={formatMessage({
-                    defaultMessage: "Skill Filter",
-                    id: "GGaxMx",
-                  })}
-                  options={optionsData.skills}
-                  isLoading={rawGraphqlResults.skills.fetching}
                 />
               </div>
             </div>

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -121,6 +121,7 @@ function transformPoolCandidateSearchInputToFormValues(
     suspendedStatus: input?.suspendedStatus
       ? [input.suspendedStatus]
       : [CandidateSuspendedFilter.Active],
+    govEmployee: input?.isGovEmployee ? ["true"] : [],
   };
 }
 
@@ -382,6 +383,7 @@ const PoolCandidatesTable = ({
         suspendedStatus: initialFilterInput?.suspendedStatus
           ? initialFilterInput.suspendedStatus
           : CandidateSuspendedFilter.Active,
+        isGovEmployee: undefined,
       },
     }),
     [initialFilterInput],
@@ -488,6 +490,7 @@ const PoolCandidatesTable = ({
       priorityWeight: fancyFilterState?.priorityWeight,
       expiryStatus: fancyFilterState?.expiryStatus,
       suspendedStatus: fancyFilterState?.suspendedStatus,
+      isGovEmployee: fancyFilterState?.isGovEmployee,
       publishingGroups: fancyFilterState?.publishingGroups,
     };
   };
@@ -539,6 +542,7 @@ const PoolCandidatesTable = ({
       suspendedStatus: data.suspendedStatus[0]
         ? stringToEnumCandidateSuspended(data.suspendedStatus[0])
         : undefined,
+      isGovEmployee: data.govEmployee[0] ? true : undefined, // massage from FormValue type to PoolCandidateSearchInput
       publishingGroups: data.publishingGroups as PublishingGroup[],
     };
 


### PR DESCRIPTION
🤖 Resolves #7816 

## 👋 Introduction

Enable filtering pool candidates by government employee field values, this applies to all instances utilizing the pool candidates table. 

## 🕵️ Details

Scope, schema tweak, tested, and then connected the pieces in the frontend. 

## 🧪 Testing

1. Test you can use the filter, go to a request and open the filter dialog
2. Test the filtering works, see below for an example

## 📸 Screenshot

Get values through your preferred method, here is the total candidate count excluding draft, and candidate count that are government employees. In this case, 49 and 18 respectively. 

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/ff9e90e7-b127-4e1b-b7d1-01c5cf82e647)

Observe this lines up with filtering for pool candidates in that pool. Matches the numbers from above

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/46f5e53b-ceb2-41fb-8c9c-311463706ca2)

Filter state for just government employee, everything else cleared aside from the needed pool selection

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/2e5e5705-5e72-4ce3-82aa-df0de033ba33)

