### PR TITLE
[Fix] Revert auth bump

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -62,7 +62,7 @@
     "react-table": "^7.8.0",
     "react-to-print": "^2.14.13",
     "react-toastify": "^9.1.3",
-    "urql": "^4.0.2"
+    "urql": "3.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.22.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,7 @@
         "react-table": "^7.8.0",
         "react-to-print": "^2.14.13",
         "react-toastify": "^9.1.3",
-        "urql": "^4.0.2"
+        "urql": "3.0.4"
       },
       "devDependencies": {
         "@babel/core": "^7.22.15",
@@ -182,19 +182,6 @@
         "webpack-cli": "^5.1.4",
         "webpack-config": "*",
         "webpack-merge": "^5.9.0"
-      }
-    },
-    "node_modules/@0no-co/graphql.web": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.4.tgz",
-      "integrity": "sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==",
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      },
-      "peerDependenciesMeta": {
-        "graphql": {
-          "optional": true
-        }
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -8789,21 +8776,14 @@
       }
     },
     "node_modules/@urql/core": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@urql/core/-/core-4.1.1.tgz",
-      "integrity": "sha512-iIoAy6BY+BUZZ7KIpnMT7C9q+ULf5ZCVxGe3/i7WZSJBrQa2h1QkIMhL+8fAKmOn9gt83jSIv5drWWnhZ9izEA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-3.2.2.tgz",
+      "integrity": "sha512-i046Cz8cZ4xIzGMTyHZrbdgzcFMcKD7+yhCAH5FwWBRjcKrc+RjEOuR9X5AMuBvr8c6IAaE92xAqa4wmlGfWTQ==",
       "dependencies": {
-        "@0no-co/graphql.web": "^1.0.1",
-        "wonka": "^6.3.2"
-      }
-    },
-    "node_modules/@urql/exchange-auth": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@urql/exchange-auth/-/exchange-auth-2.1.6.tgz",
-      "integrity": "sha512-snOlt7p5kYq0KnPDuXkKe2qW3/BucQZOElvTeo3svLQuk9JiNJVnm6ffQ6QGiGO+G3AtMrctnno1+X44fLtDuQ==",
-      "dependencies": {
-        "@urql/core": ">=4.1.0",
-        "wonka": "^6.3.2"
+        "wonka": "^6.1.2"
+      },
+      "peerDependencies": {
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -23686,14 +23666,15 @@
       "license": "MIT"
     },
     "node_modules/urql": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/urql/-/urql-4.0.5.tgz",
-      "integrity": "sha512-VicPBQXWicSbE+0oPzU2HMyDa//76FmwyQ7LayaYQxX97nhvMLs2ZWQdUmEzQQqvmw4YFaI0wPz1Qisp+PrZIQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/urql/-/urql-3.0.4.tgz",
+      "integrity": "sha512-okmQKQ9pF4t8O8iCC5gH9acqfFji5lkhW3nLBjx8WKDd2zZG7PXoUpUK19VQEMK87L6VFBOO/XZ52MMKFEI0AA==",
       "dependencies": {
-        "@urql/core": "^4.1.0",
-        "wonka": "^6.3.2"
+        "@urql/core": "^3.2.0",
+        "wonka": "^6.0.0"
       },
       "peerDependencies": {
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
         "react": ">= 16.8.0"
       }
     },
@@ -24629,13 +24610,14 @@
         "@gc-digital-talent/logger": "*",
         "@gc-digital-talent/toast": "*",
         "@gc-digital-talent/ui": "*",
-        "@urql/exchange-auth": "^2.1.6",
+        "@urql/core": "^3.0.0",
+        "@urql/exchange-auth": "1.0.0",
         "graphql": "^16.8.0",
         "jwt-decode": "^3.1.2",
         "lodash": "4.17.21",
         "react-dom": "^18.2.0",
         "react-intl": "^6.4.4",
-        "urql": "^4.0.2"
+        "urql": "3.0.4"
       },
       "devDependencies": {
         "@swc/core": "^1.3.82",
@@ -24652,6 +24634,18 @@
         "tsconfig": "*",
         "tsup": "^7.2.0",
         "typescript": "^5.1.3"
+      }
+    },
+    "packages/client/node_modules/@urql/exchange-auth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@urql/exchange-auth/-/exchange-auth-1.0.0.tgz",
+      "integrity": "sha512-79hqPQab+ifeINOxvQykvqub4ixWHBEIagN4U67ijcHGMfp3c4yEWRk4IJMPwF+OMT7LrRFuv+jRIZTQn/9VwQ==",
+      "dependencies": {
+        "@urql/core": ">=3.0.0",
+        "wonka": "^6.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "packages/date-helpers": {
@@ -24739,7 +24733,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.15.0",
         "react-select": "^5.7.4",
-        "urql": "^4.0.2"
+        "urql": "3.0.4"
       },
       "devDependencies": {
         "@faker-js/faker": "^8.0.2",
@@ -24781,7 +24775,8 @@
         "@graphql-codegen/typescript-urql": "^3.7.3",
         "rimraf": "^5.0.1",
         "tsup": "^7.2.0",
-        "typescript": "^5.1.3"
+        "typescript": "^5.1.3",
+        "urql": "3.0.4"
       }
     },
     "packages/helpers": {
@@ -24794,7 +24789,7 @@
         "graphql": "^16.8.0",
         "path-browserify": "^1.0.1",
         "react": "^18.2.0",
-        "urql": "^4.0.2"
+        "urql": "3.0.4"
       },
       "devDependencies": {
         "@swc/core": "^1.3.82",
@@ -24933,7 +24928,7 @@
         "react-router-dom": "^6.15.0",
         "storybook-addon-intl": "^3.2.0",
         "tsconfig-paths-webpack-plugin": "^4.1.0",
-        "urql": "^4.0.2",
+        "urql": "3.0.4",
         "wonka": "^6.3.4"
       },
       "devDependencies": {
@@ -25039,7 +25034,7 @@
         "react-focus-lock": "^2.9.5",
         "react-remove-scroll": "^2.5.6",
         "react-router-dom": "^6.15.0",
-        "urql": "^4.0.2"
+        "urql": "3.0.4"
       },
       "devDependencies": {
         "@faker-js/faker": "^8.0.2",
@@ -25097,12 +25092,6 @@
     }
   },
   "dependencies": {
-    "@0no-co/graphql.web": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.4.tgz",
-      "integrity": "sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==",
-      "requires": {}
-    },
     "@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "dev": true
@@ -26880,7 +26869,8 @@
         "@types/lodash": "4.14.198",
         "@types/react": "^18.2.21",
         "@types/react-dom": "^18.2.7",
-        "@urql/exchange-auth": "^2.1.6",
+        "@urql/core": "^3.0.0",
+        "@urql/exchange-auth": "1.0.0",
         "eslint": "^8.48.0",
         "eslint-config-custom": "*",
         "graphql": "^16.8.0",
@@ -26895,7 +26885,18 @@
         "tsconfig": "*",
         "tsup": "^7.2.0",
         "typescript": "^5.1.3",
-        "urql": "^4.0.2"
+        "urql": "3.0.4"
+      },
+      "dependencies": {
+        "@urql/exchange-auth": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@urql/exchange-auth/-/exchange-auth-1.0.0.tgz",
+          "integrity": "sha512-79hqPQab+ifeINOxvQykvqub4ixWHBEIagN4U67ijcHGMfp3c4yEWRk4IJMPwF+OMT7LrRFuv+jRIZTQn/9VwQ==",
+          "requires": {
+            "@urql/core": ">=3.0.0",
+            "wonka": "^6.0.0"
+          }
+        }
       }
     },
     "@gc-digital-talent/date-helpers": {
@@ -27020,7 +27021,7 @@
         "tsconfig": "*",
         "tsup": "^7.2.0",
         "typescript": "^5.1.3",
-        "urql": "^4.0.2"
+        "urql": "3.0.4"
       }
     },
     "@gc-digital-talent/graphql": {
@@ -27033,7 +27034,8 @@
         "@graphql-codegen/typescript-urql": "^3.7.3",
         "rimraf": "^5.0.1",
         "tsup": "^7.2.0",
-        "typescript": "^5.1.3"
+        "typescript": "^5.1.3",
+        "urql": "3.0.4"
       }
     },
     "@gc-digital-talent/helpers": {
@@ -27047,7 +27049,7 @@
         "path-browserify": "^1.0.1",
         "react": "^18.2.0",
         "tsup": "^7.2.0",
-        "urql": "^4.0.2"
+        "urql": "3.0.4"
       }
     },
     "@gc-digital-talent/i18n": {
@@ -27146,7 +27148,7 @@
         "storybook": "^7.3.2",
         "storybook-addon-intl": "^3.2.0",
         "tsconfig-paths-webpack-plugin": "^4.1.0",
-        "urql": "^4.0.2",
+        "urql": "3.0.4",
         "wonka": "^6.3.4"
       }
     },
@@ -27256,7 +27258,7 @@
         "tsconfig": "*",
         "tsup": "^7.2.0",
         "typescript": "^5.1.3",
-        "urql": "^4.0.2"
+        "urql": "3.0.4"
       }
     },
     "@gc-digital-talent/web": {
@@ -27341,7 +27343,7 @@
         "ts-jest": "^29.1.1",
         "tsconfig": "*",
         "typescript": "^5.1.3",
-        "urql": "^4.0.2",
+        "urql": "3.0.4",
         "webpack": "^5.88.2",
         "webpack-cli": "^5.1.4",
         "webpack-config": "*",
@@ -30963,21 +30965,11 @@
       }
     },
     "@urql/core": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@urql/core/-/core-4.1.1.tgz",
-      "integrity": "sha512-iIoAy6BY+BUZZ7KIpnMT7C9q+ULf5ZCVxGe3/i7WZSJBrQa2h1QkIMhL+8fAKmOn9gt83jSIv5drWWnhZ9izEA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-3.2.2.tgz",
+      "integrity": "sha512-i046Cz8cZ4xIzGMTyHZrbdgzcFMcKD7+yhCAH5FwWBRjcKrc+RjEOuR9X5AMuBvr8c6IAaE92xAqa4wmlGfWTQ==",
       "requires": {
-        "@0no-co/graphql.web": "^1.0.1",
-        "wonka": "^6.3.2"
-      }
-    },
-    "@urql/exchange-auth": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@urql/exchange-auth/-/exchange-auth-2.1.6.tgz",
-      "integrity": "sha512-snOlt7p5kYq0KnPDuXkKe2qW3/BucQZOElvTeo3svLQuk9JiNJVnm6ffQ6QGiGO+G3AtMrctnno1+X44fLtDuQ==",
-      "requires": {
-        "@urql/core": ">=4.1.0",
-        "wonka": "^6.3.2"
+        "wonka": "^6.1.2"
       }
     },
     "@webassemblyjs/ast": {
@@ -40137,12 +40129,12 @@
       "dev": true
     },
     "urql": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/urql/-/urql-4.0.5.tgz",
-      "integrity": "sha512-VicPBQXWicSbE+0oPzU2HMyDa//76FmwyQ7LayaYQxX97nhvMLs2ZWQdUmEzQQqvmw4YFaI0wPz1Qisp+PrZIQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/urql/-/urql-3.0.4.tgz",
+      "integrity": "sha512-okmQKQ9pF4t8O8iCC5gH9acqfFji5lkhW3nLBjx8WKDd2zZG7PXoUpUK19VQEMK87L6VFBOO/XZ52MMKFEI0AA==",
       "requires": {
-        "@urql/core": "^4.1.0",
-        "wonka": "^6.3.2"
+        "@urql/core": "^3.2.0",
+        "wonka": "^6.0.0"
       }
     },
     "use-callback-ref": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,13 +29,14 @@
     "@gc-digital-talent/logger": "*",
     "@gc-digital-talent/toast": "*",
     "@gc-digital-talent/ui": "*",
-    "@urql/exchange-auth": "^2.1.6",
+    "@urql/exchange-auth": "1.0.0",
     "graphql": "^16.8.0",
     "jwt-decode": "^3.1.2",
     "lodash": "4.17.21",
     "react-dom": "^18.2.0",
     "react-intl": "^6.4.4",
-    "urql": "^4.0.2"
+    "urql": "3.0.4",
+    "@urql/core": "^3.0.0"
   },
   "devDependencies": {
     "@swc/core": "^1.3.82",

--- a/packages/client/src/components/ClientProvider/ClientProvider.test.tsx
+++ b/packages/client/src/components/ClientProvider/ClientProvider.test.tsx
@@ -9,37 +9,41 @@ import { exportedForTesting } from "./ClientProvider";
 
 const { willAuthError, extractErrorMessages } = exportedForTesting;
 
-describe("ClientProvider tests", () => {
+describe("LanguageRedirectContainer tests", () => {
   // some API requests do not require auth to succeed
   test("If there is no auth then willAuthError is false", async () => {
     const authState = null;
-    const result = willAuthError(authState);
+    const result = willAuthError({ authState });
     expect(result).toEqual(false);
   });
 
   // some API requests do not require auth to succeed
   test("If there is auth but no accessToken then willAuthError is false", async () => {
     const authState = { accessToken: null, refreshToken: null, idToken: null };
-    const result = willAuthError(authState);
+    const result = willAuthError({ authState });
     expect(result).toEqual(false);
   });
 
   test("If there is an accessToken that has not expired then willAuthError is false", async () => {
     const result = willAuthError({
-      accessToken:
-        "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjIxNDc0ODM2NDcsImlhdCI6MH0.v5o7sfcTiqB21JrCZ1ytP0gJp4JeTuiEdO8yVBVro7Y", // expires Jan 18 2038
-      refreshToken: null,
-      idToken: null,
+      authState: {
+        accessToken:
+          "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjIxNDc0ODM2NDcsImlhdCI6MH0.v5o7sfcTiqB21JrCZ1ytP0gJp4JeTuiEdO8yVBVro7Y", // expires Jan 18 2038
+        refreshToken: null,
+        idToken: null,
+      },
     });
     expect(result).toEqual(false);
   });
 
   test("If there is an accessToken that has expired then willAuthError is true", async () => {
     const result = willAuthError({
-      accessToken:
-        "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjEsImlhdCI6MH0.d5nyMUDCvbvfTmg3ow_cN4YZX4jmfoXAGq3DbCw5LAc", // expires Dec 31 1969
-      refreshToken: null,
-      idToken: null,
+      authState: {
+        accessToken:
+          "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjEsImlhdCI6MH0.d5nyMUDCvbvfTmg3ow_cN4YZX4jmfoXAGq3DbCw5LAc", // expires Dec 31 1969
+        refreshToken: null,
+        idToken: null,
+      },
     });
     expect(result).toEqual(true);
   });

--- a/packages/client/src/components/ClientProvider/ClientProvider.tsx
+++ b/packages/client/src/components/ClientProvider/ClientProvider.tsx
@@ -1,28 +1,27 @@
-import React, { useMemo } from "react";
 import { authExchange } from "@urql/exchange-auth";
 import jwtDecode, { JwtPayload } from "jwt-decode";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   Client,
+  CombinedError,
   createClient,
+  dedupExchange,
   cacheExchange,
   fetchExchange,
+  errorExchange,
   Provider,
-  mapExchange,
+  Operation,
+  makeOperation,
+  AnyVariables,
 } from "urql";
 import { useIntl } from "react-intl";
 
-import {
-  ACCESS_TOKEN,
-  REFRESH_TOKEN,
-  useAuthentication,
-} from "@gc-digital-talent/auth";
-import { uniqueItems } from "@gc-digital-talent/helpers";
+import { useAuthentication } from "@gc-digital-talent/auth";
 import { useLogger } from "@gc-digital-talent/logger";
 import { toast } from "@gc-digital-talent/toast";
 
 import {
   buildValidationErrorMessageNode,
-  containsAuthenticationError,
   extractErrorMessages,
   extractValidationMessageKeys,
 } from "../../utils/errors";
@@ -35,7 +34,44 @@ interface AuthState {
   idToken: string | null;
 }
 
-const willAuthError = (authState: AuthState | null) => {
+const addAuthToOperation = ({
+  authState,
+  operation,
+}: {
+  authState: AuthState | null;
+  operation: Operation;
+}): Operation => {
+  if (!authState || !authState.accessToken) {
+    return operation;
+  }
+
+  const fetchOptions =
+    typeof operation.context.fetchOptions === "function"
+      ? operation.context.fetchOptions()
+      : operation.context.fetchOptions || {};
+
+  return makeOperation(operation.kind, operation, {
+    ...operation.context,
+    fetchOptions: {
+      ...fetchOptions,
+      headers: {
+        ...fetchOptions.headers,
+        Authorization: `Bearer ${authState.accessToken}`,
+      },
+    },
+  });
+};
+
+const didAuthError = ({ error }: { error: CombinedError }): boolean => {
+  return error && error.response
+    ? error.response.status === 401 ||
+        error.graphQLErrors.some(
+          (e) => e.extensions?.category === "authentication",
+        )
+    : false;
+};
+
+const willAuthError = ({ authState }: { authState: AuthState | null }) => {
   let tokenIsKnownToBeExpired = false;
   if (authState?.accessToken) {
     const decoded = jwtDecode<JwtPayload>(authState.accessToken);
@@ -55,13 +91,61 @@ const ClientProvider = ({
   children?: React.ReactNode;
 }) => {
   const intl = useIntl();
-  const authCtx = useAuthentication();
+  const authContext = useAuthentication();
   const logger = useLogger();
-  const authRef = React.useRef(authCtx);
+  // Create a mutable object to hold the auth state
+  const authRef = useRef(authContext);
+  // Keep the contents of that mutable object up to date
+  useEffect(() => {
+    authRef.current = authContext;
+  }, [authContext]);
 
-  React.useEffect(() => {
-    authRef.current = authCtx;
-  }, [authCtx]);
+  const getAuth: (params: {
+    authState: AuthState | null;
+  }) => Promise<AuthState | null> = useCallback(
+    async ({ authState: existingAuthState }) => {
+      // getAuth could be called for the first request or as the result of an error
+
+      // At runtime, get the current auth state
+      const { accessToken, refreshToken, idToken, logout, refreshTokenSet } =
+        authRef.current;
+
+      if (!existingAuthState) {
+        // no existing auth state so this is probably just the first request
+        if (accessToken) {
+          return { accessToken, refreshToken, idToken };
+        }
+        return null;
+      }
+
+      /**
+       * Logout the user and return null AuthState
+       *
+       * @returns null
+       */
+      const logoutNullState = () => {
+        const currentLocation = window.location.pathname; // Can't use react-router hooks because we may not be inside the Router context.
+        logout(currentLocation); // After logging out, try to return to the page the user was on.
+        return null;
+      };
+
+      // If authState is not null, and getAuth is called again, then it means authentication failed for some reason.
+      // let's try to use a refresh token to get new tokens
+      if (refreshToken) {
+        const refreshedAuthState = await refreshTokenSet();
+        if (refreshedAuthState) {
+          return refreshedAuthState;
+        }
+
+        return logoutNullState();
+      }
+
+      return logoutNullState();
+    },
+    // This function is inside of `useCallback` to prevent breaking the memoization of internalClient.
+    // If internalClient is re-instantiated it will lose its error count and can cause refresh loops.
+    [],
+  );
 
   const internalClient = useMemo(() => {
     return (
@@ -70,9 +154,24 @@ const ClientProvider = ({
         url: apiUri,
         requestPolicy: "cache-and-network",
         exchanges: [
-          cacheExchange,
-          mapExchange({
-            onError(error, operation) {
+          errorExchange({
+            onError: (
+              error: CombinedError,
+              operation: Operation<unknown, AnyVariables>,
+            ) => {
+              let errorMessages = extractErrorMessages(error);
+
+              const validationMessageKeys = extractValidationMessageKeys(error);
+              if (validationMessageKeys.length > 0) {
+                errorMessages = validationMessageKeys;
+              }
+
+              const errorMessageNode = buildValidationErrorMessageNode(
+                errorMessages,
+                intl,
+              );
+              if (errorMessageNode) toast.error(errorMessageNode);
+
               if (error.graphQLErrors || error.networkError) {
                 logger.error(
                   JSON.stringify({
@@ -82,81 +181,21 @@ const ClientProvider = ({
                   }),
                 );
               }
-
-              const isAuthError = containsAuthenticationError(error);
-              if (isAuthError) {
-                authRef.current.logout("/logged-out");
-              }
-
-              let errorMessages = extractErrorMessages(error);
-
-              const validationMessageKeys = extractValidationMessageKeys(error);
-              if (validationMessageKeys.length > 0) {
-                errorMessages = validationMessageKeys;
-              }
-
-              const errorMessageNode = buildValidationErrorMessageNode(
-                uniqueItems(errorMessages),
-                intl,
-              );
-              if (errorMessageNode) toast.error(errorMessageNode);
             },
           }),
-          authExchange(async (utils) => {
-            return {
-              addAuthToOperation: (operation) => {
-                const accessToken = localStorage.getItem(ACCESS_TOKEN);
-                if (accessToken) {
-                  return utils.appendHeaders(operation, {
-                    Authorization: `Bearer ${accessToken}`,
-                  });
-                }
-                return operation;
-              },
-              willAuthError() {
-                const accessToken = localStorage.getItem(ACCESS_TOKEN);
-                let tokenIsKnownToBeExpired = false;
-                if (accessToken) {
-                  const decoded = jwtDecode<JwtPayload>(accessToken);
-                  if (decoded.exp)
-                    tokenIsKnownToBeExpired = Date.now() > decoded.exp * 1000; // JWT expiry date in seconds, not milliseconds
-                }
-
-                if (tokenIsKnownToBeExpired) return true;
-
-                return false;
-              },
-              didAuthError(error) {
-                const didError =
-                  error && error.response
-                    ? error.response.status === 401 ||
-                      error.graphQLErrors.some(
-                        (e) => e.extensions?.category === "authentication",
-                      )
-                    : false;
-
-                return didError;
-              },
-              async refreshAuth() {
-                // If authState is not null, and getAuth is called again, then it means authentication failed for some reason.
-                // let's try to use a refresh token to get new tokens
-                let refreshedAuthState;
-                const refreshToken = localStorage.getItem(REFRESH_TOKEN);
-                if (refreshToken) {
-                  refreshedAuthState = await authRef.current.refreshTokenSet();
-                }
-
-                if (!refreshedAuthState) {
-                  authRef.current.logout(window.location.pathname);
-                }
-              },
-            };
+          dedupExchange,
+          cacheExchange,
+          authExchange({
+            getAuth,
+            addAuthToOperation,
+            didAuthError,
+            willAuthError,
           }),
           fetchExchange,
         ],
       })
     );
-  }, [client, intl, logger]);
+  }, [client, getAuth, intl, logger]);
 
   return <Provider value={internalClient}>{children}</Provider>;
 };
@@ -165,6 +204,6 @@ export default ClientProvider;
 
 // https://stackoverflow.com/questions/54116070/how-can-i-unit-test-non-exported-functions
 export const exportedForTesting = {
-  extractErrorMessages,
   willAuthError,
+  extractErrorMessages,
 };

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -37,7 +37,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.15.0",
     "react-select": "^5.7.4",
-    "urql": "^4.0.2"
+    "urql": "3.0.4"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -23,6 +23,7 @@
     "@graphql-codegen/typescript-urql": "^3.7.3",
     "rimraf": "^5.0.1",
     "tsup": "^7.2.0",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.3",
+    "urql": "3.0.4"
   }
 }

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -21,7 +21,7 @@
     "graphql": "^16.8.0",
     "path-browserify": "^1.0.1",
     "react": "^18.2.0",
-    "urql": "^4.0.2"
+    "urql": "3.0.4"
   },
   "devDependencies": {
     "@swc/core": "^1.3.82",

--- a/packages/storybook-helpers/package.json
+++ b/packages/storybook-helpers/package.json
@@ -25,7 +25,7 @@
     "react-router-dom": "^6.15.0",
     "storybook-addon-intl": "^3.2.0",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
-    "urql": "^4.0.2",
+    "urql": "3.0.4",
     "wonka": "^6.3.4"
   },
   "devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -48,7 +48,7 @@
     "react-focus-lock": "^2.9.5",
     "react-remove-scroll": "^2.5.6",
     "react-router-dom": "^6.15.0",
-    "urql": "^4.0.2"
+    "urql": "3.0.4"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",


### PR DESCRIPTION
🤖 Resolves #7885 

## 👋 Introduction

There was a previously undetected issue with the auth bump branch where prod builds would fail to authenticate properly.  This is a quick fix to roll back that bump so we can try again later.

## 🧪 Testing

1. Rebuild in prod mode (`npm run build`), not dev.
2. Log in works.
3. First graphql request after login has authorization header and succeeds.
4. Token refresh succeeds.
5. Log in as deleted user redirects to "deleted user" page.
6. [Introspection corner case](https://github.com/GCTC-NTGC/gc-digital-talent/pull/6547#pullrequestreview-1602788860) does not cause refresh loop.
7. Steps 2 - 6 work with SiC, too.