### PR TITLE
[Fix] Application snapshot fields

### DIFF
--- a/api/app/GraphQL/Mutations/SubmitApplication.php
+++ b/api/app/GraphQL/Mutations/SubmitApplication.php
@@ -35,6 +35,10 @@ final class SubmitApplication
         $application->submitted_at = $dateNow;
         $application->pool_candidate_status = ApiEnums::CANDIDATE_STATUS_NEW_APPLICATION;
         $application->setInsertSubmittedStepAttribute(ApiEnums::APPLICATION_STEP_REVIEW_AND_SUBMIT);
+
+        // need to save application before setting application snapshot since fields have yet to be saved to the database.
+        $application->save();
+
         $application->setApplicationSnapshot();
 
         $application->save();


### PR DESCRIPTION
🤖 Resolves #7830.

## 👋 Introduction

This PR fixes missing input data from an application snapshot.

## 🕵️ Details

Several inputs that are part of the last step of the application process were not being saved.

## 🎩 Thanks

@esizer!

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Submit an application
2. Open the snapshot on admin side in code
3. Observe the `signature` and `submittedAt` fields were values that were submitted

## 📸 Screenshots

![Screen Shot 2023-09-18 at 13 51 52](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/d1831fec-5b93-4101-99f2-0730f00e6a27)
![Screen Shot 2023-09-18 at 13 51 29](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/2d94ec75-96d8-4c25-a8d0-e30223b3a2ce)
