### PR TITLE
[Feature] Skill card validation, skill count

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -684,8 +684,8 @@
     "defaultMessage": "Gestion d’un processus de recrutement",
     "description": "Heading for pool operator dashboard links"
   },
-  "2A1UT9": {
-    "defaultMessage": "Compétence à améliorer",
+  "FvbONe": {
+    "defaultMessage": "Compétences à améliorer",
     "description": "Title for skills to improve showcase section"
   },
   "2Ckihd": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -684,10 +684,6 @@
     "defaultMessage": "Gestion d’un processus de recrutement",
     "description": "Heading for pool operator dashboard links"
   },
-  "FvbONe": {
-    "defaultMessage": "Compétences à améliorer",
-    "description": "Title for skills to improve showcase section"
-  },
   "2Ckihd": {
     "defaultMessage": "Trouvé <primary>{skillCount}</primary> compétences.",
     "description": "The number of skills found within the skill picker."
@@ -2746,6 +2742,10 @@
   "FtlwFY": {
     "defaultMessage": "Afficher les bassins ouverts",
     "description": "Link text to view all open pools"
+  },
+  "FvbONe": {
+    "defaultMessage": "Compétences à améliorer",
+    "description": "Title for skills to improve showcase section"
   },
   "G/MFLe": {
     "defaultMessage": "Annonce du bassin",

--- a/apps/web/src/pages/ProfileAndApplicationsPage/applicantOperations.graphql
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/applicantOperations.graphql
@@ -35,6 +35,22 @@ fragment application on PoolCandidate {
   }
 }
 
+fragment userSkill on UserSkill {
+  id
+  user {
+    id
+  }
+  skill {
+    id
+    key
+    category
+    name {
+      en
+      fr
+    }
+  }
+}
+
 query ApplicantInformation {
   me {
     id
@@ -161,6 +177,21 @@ query ApplicantInformation {
     }
     poolCandidates {
       ...application
+    }
+    userSkills {
+      ...userSkill
+    }
+    topTechnicalSkillsRanking {
+      ...userSkill
+    }
+    topBehaviouralSkillsRanking {
+      ...userSkill
+    }
+    improveTechnicalSkillsRanking {
+      ...userSkill
+    }
+    improveBehaviouralSkillsRanking {
+      ...userSkill
     }
   }
 }

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
@@ -47,6 +47,7 @@ import { isApplicationQualifiedRecruitment } from "~/utils/applicationUtils";
 import { PAGE_SECTION_ID as CAREER_TIMELINE_AND_RECRUITMENTS_PAGE_SECTION_ID } from "~/pages/Profile/CareerTimelineAndRecruitmentPage/constants";
 
 import { PartialUser } from "../types";
+import { categorizeUserSkill } from "../../../utils/skillUtils";
 
 function buildLink(
   href: string,
@@ -103,15 +104,31 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
   const skillShowcaseUrl = paths.skillShowcase();
   const skillLibraryUrl = paths.skillLibrary();
 
-  const behaviouralSkillLibraryCount = 0;
-  const technicalSkillLibraryCount = 0;
+  const categorizedSkills = categorizeUserSkill(
+    user?.userSkills?.filter(notEmpty) ?? [],
+  );
+
+  const hasTopSkills =
+    user.topBehaviouralSkillsRanking?.length &&
+    user.topTechnicalSkillsRanking?.length;
+  const hasSkillsToImprove =
+    user.improveBehaviouralSkillsRanking?.length &&
+    user.improveTechnicalSkillsRanking?.length;
+
+  const behaviouralSkillLibraryCount =
+    categorizedSkills.BEHAVIOURAL?.length ?? 0;
+  const technicalSkillLibraryCount = categorizedSkills.TECHNICAL?.length ?? 0;
   // The completion states are determined by the following rules:
   //   The skill library items need to have at least 1 skill
   //   The showcase items need to have at least 1 skill added to each of the 4 showcases
-  const behaviouralSkillLibraryStatus = "success";
-  const technicalSkillLibraryStatus = "success";
-  const topSkillsStatus = "success";
-  const skillsToImproveStatus = "success";
+  const behaviouralSkillLibraryStatus = behaviouralSkillLibraryCount
+    ? "success"
+    : "error";
+  const technicalSkillLibraryStatus = technicalSkillLibraryCount
+    ? "success"
+    : "error";
+  const topSkillsStatus = hasTopSkills ? "success" : "error";
+  const skillsToImproveStatus = hasSkillsToImprove ? "success" : "error";
 
   return (
     <Hero

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
@@ -498,8 +498,8 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
             />
             <StatusItem
               title={intl.formatMessage({
-                defaultMessage: "Skill to improve",
-                id: "2A1UT9",
+                defaultMessage: "Skills to improve",
+                id: "FvbONe",
                 description: "Title for skills to improve showcase section",
               })}
               status={skillsToImproveStatus}


### PR DESCRIPTION
🤖 Resolves #6989 

## 👋 Introduction

Adds proper validation and skill counts on the skill card on the "Profile and applications" page.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> **Note**
> If https://github.com/GCTC-NTGC/gc-digital-talent/issues/7933 is not merged, you will need to tweak the skill showcase manually to test different cases.

1. Build `npm run build`
2. Navigate to `/applicant/profile-and-applications`
3. Confirm the validation and skill counts match the expected outcome from the issue https://github.com/GCTC-NTGC/gc-digital-talent/issues/6989

## 📸 Screenshot

![Screenshot 2023-09-19 112353](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/06952dc0-ae2d-46ff-9200-5f2be3c9c82a)
