### PR TITLE
[Fix] Experience cards surface single skill

### DIFF
--- a/apps/web/src/components/ExperienceCard/ExperienceCard.stories.tsx
+++ b/apps/web/src/components/ExperienceCard/ExperienceCard.stories.tsx
@@ -1,9 +1,15 @@
 import React from "react";
 import { StoryFn } from "@storybook/react";
+import { faker } from "@faker-js/faker";
 
-import { experienceGenerators } from "@gc-digital-talent/fake-data";
+import {
+  experienceGenerators,
+  getStaticSkills,
+} from "@gc-digital-talent/fake-data";
 
 import ExperienceCard from "./ExperienceCard";
+
+faker.seed(0);
 
 export default {
   component: ExperienceCard,
@@ -45,4 +51,21 @@ NoSkillsExperienceCard.args = {
     ...experienceGenerators.workExperiences()[0],
     skills: [],
   },
+};
+
+const experienceSkill = faker.helpers.arrayElement(getStaticSkills());
+export const SingleSkillExperienceCard = Template.bind({});
+SingleSkillExperienceCard.args = {
+  experience: {
+    ...experienceGenerators.workExperiences()[0],
+    skills: [
+      {
+        ...experienceSkill,
+        experienceSkillRecord: {
+          details: faker.lorem.paragraph(),
+        },
+      },
+    ],
+  },
+  showSkills: experienceSkill,
 };

--- a/apps/web/src/components/ExperienceCard/ExperienceCard.tsx
+++ b/apps/web/src/components/ExperienceCard/ExperienceCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import isArray from "lodash/isArray";
+import isBoolean from "lodash/isBoolean";
 import ChevronRightIcon from "@heroicons/react/20/solid/ChevronRightIcon";
 
 import {
@@ -37,7 +38,7 @@ import EditLink from "./EditLink";
 interface ExperienceCardProps {
   experience: AnyExperience;
   headingLevel?: HeadingRank;
-  showSkills?: boolean | Array<Skill>;
+  showSkills?: boolean | Skill | Array<Skill>;
   showEdit?: boolean;
   editParam?: string;
   // If the edit button is a button, pass the onClick function
@@ -68,6 +69,10 @@ const ExperienceCard = ({
         showSkills.some((showSkill) => showSkill.id === skill.id),
       )
     : experience.skills;
+  const singleSkill =
+    !isBoolean(showSkills) && !isArray(showSkills) && "id" in showSkills
+      ? experience.skills?.find((skill) => skill.id === showSkills.id)
+      : false;
 
   const skillCount = skills?.length;
 
@@ -159,6 +164,31 @@ const ExperienceCard = ({
           </>
         )}
       </p>
+      {singleSkill && singleSkill.experienceSkillRecord?.details && (
+        <>
+          <Heading
+            level={contentHeadingLevel}
+            size="h6"
+            data-h2-font-size="base(copy)"
+            data-h2-margin="base(x1 0 x.5 0)"
+          >
+            {intl.formatMessage(
+              {
+                defaultMessage:
+                  'How you applied "{skillName}" in this experience',
+                id: "J8Nltm",
+                description: "Heading for a single skill on an experience.",
+              },
+              {
+                skillName: getLocalizedName(singleSkill.name, intl),
+              },
+            )}
+          </Heading>
+          <p data-h2-margin-bottom="base(x1)">
+            {singleSkill.experienceSkillRecord.details}
+          </p>
+        </>
+      )}
       <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
         <Collapsible.Trigger asChild>
           <Button
@@ -270,7 +300,7 @@ const ExperienceCard = ({
             {experience.details ??
               intl.formatMessage(commonMessages.notAvailable)}
           </ContentSection>
-          {showSkills && (
+          {showSkills && !singleSkill && (
             <>
               <Separator
                 orientation="horizontal"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3203,6 +3203,10 @@
     "defaultMessage": "Exigence de sélection : <strong>{educationRequirementOption}</strong>.",
     "description": "Application snapshot minimum experience section description"
   },
+  "J8Nltm": {
+    "defaultMessage": "Comment vous avez pu mettre en œuvre la compétence \"{skillName}\" dans le cadre de cette expérience",
+    "description": "Heading for a single skill on an experience."
+  },
   "J8kIar": {
     "defaultMessage": "Recruter et gérer des employés en TI au gouvernement du Canada.",
     "description": "Meta tag description for Admin site"

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/components/SkillTree.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/components/SkillTree.tsx
@@ -113,7 +113,7 @@ const SkillTree = ({
                   experience={filterExperienceSkills(experience, skill)}
                   headingLevel={contentHeadingLevel}
                   showEdit={!hideEdit}
-                  showSkills={[skill]}
+                  showSkills={skill}
                   onEditClick={
                     !hideEdit
                       ? () => handleExperienceEdit(experience)

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -554,7 +554,7 @@ export const UpdateUserSkillForm = ({
                       experience={experience}
                       headingLevel="h3"
                       showEdit
-                      showSkills={false}
+                      showSkills={skill}
                       onEditClick={() => {
                         setCurrentExperience(experience);
                         setFormDialogOpen(true);


### PR DESCRIPTION
🤖 Resolves #7818 

## 👋 Introduction

Allows devs to pass a single skill to `ExperienceCard`.

## 🕵️ Details

When you pass a single skill, the card should show the `experienceSkillRecord.details` above the `Collapisble` component and not inside it.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run storybook `npm run storybook`
2. Navigate to the "Single skill - Experience card" story
3. Confirm details are shown without opening the collapsible element
4. Confirm other card stories work as expected
5. Build `npm run dev`
6. Navigate to a application skills step
7. Confirm details are shown without opening the collapsible element
8. Navigate to the skill library and edit  a skill
9. Link an experience
10. Confirm details are shown without opening the collapsible element

## 📸 Screenshot
![Screenshot 2023-09-19 134528](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/aa97b3aa-d81b-4981-bc71-1aba9ba0cd9c)

