### PR TITLE
[Bug] Call GenericJobTitleSeeder in base seeder 

### DIFF
--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -47,6 +47,7 @@ class DatabaseSeeder extends Seeder
         $this->call(RolePermissionSeeder::class);
         $this->call(ClassificationSeeder::class);
         $this->call(DepartmentSeeder::class);
+        $this->call(GenericJobTitleSeeder::class);
         $this->call(SkillFamilySeeder::class);
         $this->call(SkillSeeder::class);
         $this->call(TeamSeederLocal::class);


### PR DESCRIPTION
🤖 Resolves #7756 

## 👋 Introduction

Call the seeder in the base seeder that runs locally/by default. 

## 🧪 Testing

1. Seed fresh
2. Ensure e2e succeeds locally 

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/ee7d8872-c111-43c1-8bc5-9dab6f16afef)

