### PR TITLE
[Bug] Profile form updating and errors

### DIFF
--- a/apps/web/src/components/EmploymentEquity/EquityOptions.tsx
+++ b/apps/web/src/components/EmploymentEquity/EquityOptions.tsx
@@ -90,16 +90,18 @@ const EquityOptions = ({
   const handleOptionSave = (key: EquityKeys, value: boolean) => {
     const handler = value ? onAdd : onRemove;
     handler(key)
-      .then(() => {
-        toast.success(
-          intl.formatMessage({
-            defaultMessage:
-              "Diversity, equity and inclusion information updated successfully!",
-            id: "SUUqzt",
-            description:
-              "Message displayed when a user successfully updates their diversity, equity and inclusion information.",
-          }),
-        );
+      .then((response) => {
+        if (response) {
+          toast.success(
+            intl.formatMessage({
+              defaultMessage:
+                "Diversity, equity and inclusion information updated successfully!",
+              id: "SUUqzt",
+              description:
+                "Message displayed when a user successfully updates their diversity, equity and inclusion information.",
+            }),
+          );
+        }
       })
       .catch(() => {
         toast.error(intl.formatMessage(profileMessages.updatingFailed));

--- a/apps/web/src/components/Profile/components/GovernmentInformation/GovernmentInformation.tsx
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/GovernmentInformation.tsx
@@ -50,16 +50,18 @@ const GovernmentInformation = ({
       user.id,
       formValuesToSubmitData(formValues, classifications),
     )
-      .then(() => {
-        toast.success(
-          intl.formatMessage({
-            defaultMessage: "Government information updated successfully!",
-            id: "dVc2uY",
-            description:
-              "Message displayed when a user successfully updates their government employee information.",
-          }),
-        );
-        setIsEditing(false);
+      .then((response) => {
+        if (response) {
+          toast.success(
+            intl.formatMessage({
+              defaultMessage: "Government information updated successfully!",
+              id: "dVc2uY",
+              description:
+                "Message displayed when a user successfully updates their government employee information.",
+            }),
+          );
+          setIsEditing(false);
+        }
       })
       .catch(() => {
         toast.error(intl.formatMessage(profileMessages.updatingFailed));

--- a/apps/web/src/components/Profile/components/LanguageProfile/LanguageProfile.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/LanguageProfile.tsx
@@ -49,16 +49,18 @@ const LanguageProfile = ({
 
   const handleSubmit: SubmitHandler<FormValues> = async (formValues) => {
     return onUpdate(user.id, formValuesToSubmitData(formValues))
-      .then(() => {
-        toast.success(
-          intl.formatMessage({
-            defaultMessage: "Language profile updated successfully!",
-            id: "43VEQA",
-            description:
-              "Message displayed when a user successfully updates their language profile.",
-          }),
-        );
-        setIsEditing(false);
+      .then((response) => {
+        if (response) {
+          toast.success(
+            intl.formatMessage({
+              defaultMessage: "Language profile updated successfully!",
+              id: "43VEQA",
+              description:
+                "Message displayed when a user successfully updates their language profile.",
+            }),
+          );
+          setIsEditing(false);
+        }
       })
       .catch(() => {
         toast.error(intl.formatMessage(profileMessages.updatingFailed));

--- a/apps/web/src/components/Profile/components/PersonalInformation/PersonalInformation.tsx
+++ b/apps/web/src/components/Profile/components/PersonalInformation/PersonalInformation.tsx
@@ -41,17 +41,19 @@ const PersonalInformation = ({
 
   const handleSubmit: SubmitHandler<FormValues> = async (formValues) => {
     return onUpdate(user.id, formValuesToSubmitData(formValues, user))
-      .then(() => {
-        toast.success(
-          intl.formatMessage({
-            defaultMessage:
-              "Personal and contact information updated successfully!",
-            id: "J+MAUg",
-            description:
-              "Message displayed when a user successfully updates their personal and contact information.",
-          }),
-        );
-        setIsEditing(false);
+      .then((response) => {
+        if (response) {
+          toast.success(
+            intl.formatMessage({
+              defaultMessage:
+                "Personal and contact information updated successfully!",
+              id: "J+MAUg",
+              description:
+                "Message displayed when a user successfully updates their personal and contact information.",
+            }),
+          );
+          setIsEditing(false);
+        }
       })
       .catch(() => {
         toast.error(intl.formatMessage(profileMessages.updatingFailed));

--- a/apps/web/src/components/Profile/components/WorkPreferences/WorkPreferences.tsx
+++ b/apps/web/src/components/Profile/components/WorkPreferences/WorkPreferences.tsx
@@ -48,16 +48,18 @@ const WorkPreferences = ({
 
   const handleSubmit: SubmitHandler<FormValues> = async (formValues) => {
     return onUpdate(user.id, formValuesToSubmitData(formValues))
-      .then(() => {
-        toast.success(
-          intl.formatMessage({
-            defaultMessage: "Work preferences updated successfully!",
-            id: "bt0WcN",
-            description:
-              "Message displayed when a user successfully updates their work preferences.",
-          }),
-        );
-        setIsEditing(false);
+      .then((response) => {
+        if (response) {
+          toast.success(
+            intl.formatMessage({
+              defaultMessage: "Work preferences updated successfully!",
+              id: "bt0WcN",
+              description:
+                "Message displayed when a user successfully updates their work preferences.",
+            }),
+          );
+          setIsEditing(false);
+        }
       })
       .catch(() => {
         toast.error(intl.formatMessage(profileMessages.updatingFailed));


### PR DESCRIPTION
🤖 Resolves #7804

## 👋 Introduction

Proper erroring for updating the form, specifically certain errors like deleted user causing a failed update. 

## 🕵️ Details

Some error handling and toasting was already added somewhere along the line making this issue more straightforward.
Adjusting so success toasts check response first. 

## 🧪 Testing

1. Head to `/en/users/:id/profile`
2. Everything should function unchanged
3. Set your user as deleted
4. Toasts should adjust to reflect errors, no success toasts

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/f74909e0-0560-4048-807a-9572cab37794)

