### PR TITLE
[Fix] Updates screened out FR string

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7702,7 +7702,7 @@
     "description": "Descriptive text explaining the work preferences section of the application profile"
   },
   "njJCTd": {
-    "defaultMessage": "Sélectionné",
+    "defaultMessage": "Éliminé à la présélection",
     "description": "Status for an application that has been screened out of eligibility"
   },
   "nmImtK": {


### PR DESCRIPTION
🤖 Resolves #7952.

## 👋 Introduction

This PR fixes the French string **status for an application that has been screened out of eligibility** to use a correct translation of the English string **Screened out**.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Set application status to  **Screened out**
2. Switch to French
3. Observe _Éliminé à la présélection_ on card

## 📸 Screenshot

![Screen Shot 2023-09-21 at 11 54 14](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/bc5cb1ce-dc08-4398-8277-ce22d1ff474c)

