### PR TITLE
[Debt] Remove expectedGenericJobTitle from schema

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -141,11 +141,6 @@ type User {
     ) # Pools a user owns
   # Profile Status
   isProfileComplete: Boolean
-  expectedGenericJobTitles: [GenericJobTitle]
-    @belongsToMany
-    @deprecated(
-      reason: "expectedGenericJobTitles is deprecated. Remove in #7645."
-    )
   priorityWeight: Int @rename(attribute: "priority_weight")
   # teams and roles
   roleAssignments: [RoleAssignment!] @hasMany

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -231,7 +231,6 @@ type User {
   improveBehaviouralSkillsRanking: [UserSkill]
   pools: [Pool] @deprecated(reason: "pools is deprecated. user.roles.team.pools instead. Remove in #7664.")
   isProfileComplete: Boolean
-  expectedGenericJobTitles: [GenericJobTitle] @deprecated(reason: "expectedGenericJobTitles is deprecated. Remove in #7645.")
   priorityWeight: Int
   roleAssignments: [RoleAssignment!]
   unreadNotifications: [Notification!]


### PR DESCRIPTION
🤖 Resolves #7645

## 👋 Introduction

- Removes `User.expectedGenericJobTitle` from schema.
- The field was not found in any queries throughout the app.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure app runs correctly and all tests pass
