### PR TITLE
[Feature] Search by ID on search request table

### DIFF
--- a/api/app/Models/PoolCandidateSearchRequest.php
+++ b/api/app/Models/PoolCandidateSearchRequest.php
@@ -64,6 +64,15 @@ class PoolCandidateSearchRequest extends Model
         return $this->belongsTo(ApplicantFilter::class);
     }
 
+    public static function scopeId(Builder $query, ?string $id)
+    {
+        if ($id) {
+            $query->where('id', 'ilike', "%{$id}%");
+        }
+
+        return $query;
+    }
+
     /**
      * Scopes/filters
      */
@@ -174,6 +183,9 @@ class PoolCandidateSearchRequest extends Model
         if ($search) {
             $query->where(function ($query) use ($search) {
                 self::scopeFullName($query, $search);
+                $query->orWhere(function ($query) use ($search) {
+                    self::scopeId($query, $search);
+                });
                 $query->orWhere(function ($query) use ($search) {
                     self::scopeEmail($query, $search);
                 });

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -605,6 +605,7 @@ input PoolCandidateSearchRequestInput {
   streams: [PoolStream] @scope
   fullName: String @scope
   email: String @scope
+  id: ID @scope
   jobTitle: String @scope
   additionalComments: String @scope
   adminNotes: String @scope

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -635,6 +635,7 @@ input PoolCandidateSearchRequestInput {
   streams: [PoolStream]
   fullName: String
   email: String
+  id: ID
   jobTitle: String
   additionalComments: String
   adminNotes: String

--- a/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestsTableApi.tsx
@@ -192,6 +192,7 @@ const SearchRequestsTableApi = ({
     return {
       // search bar
       generalSearch: !!searchBarTerm && !searchType ? searchBarTerm : undefined,
+      id: searchType === "id" && !!searchBarTerm ? searchBarTerm : undefined,
       fullName:
         searchType === "fullName" && !!searchBarTerm
           ? searchBarTerm
@@ -439,6 +440,10 @@ const SearchRequestsTableApi = ({
           {
             label: intl.formatMessage(adminMessages.manager),
             value: "fullName",
+          },
+          {
+            label: intl.formatMessage(adminMessages.id),
+            value: "id",
           },
           {
             label: intl.formatMessage(adminMessages.email),

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2941,6 +2941,10 @@
     "defaultMessage": "Postulez d’ici le :",
     "description": "Label for the pool expiry date"
   },
+  "GplLic": {
+    "defaultMessage": "Identifiant",
+    "description": "Title for unique ID of a resource"
+  },
   "Gr3BwB": {
     "defaultMessage": "Équité en matière d’emploi"
   },

--- a/apps/web/src/messages/adminMessages.ts
+++ b/apps/web/src/messages/adminMessages.ts
@@ -1,6 +1,11 @@
 import { defineMessages } from "react-intl";
 
 const messages = defineMessages({
+  id: {
+    defaultMessage: "Id",
+    id: "GplLic",
+    description: "Title for unique ID of a resource",
+  },
   classifications: {
     defaultMessage: "Classifications",
     id: "kvpRgN",


### PR DESCRIPTION
🤖 Resolves #7944 

## 👋 Introduction

Adds the e ability to search for requests by ID on the search request table in the admin.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Rebuild `npm run dev`
2. Navigate to `/admin/talent-requests`
3. ?Use both the general and specific ID search
4. Confirm the expected results are returned

## 📸 Screenshot

![Screenshot 2023-09-25 092754](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/ff8b97a5-6c42-4c1c-a04c-8a81152f1e02)
