### PR TITLE
[Feature] Add snapshot link to pool status table

### DIFF
--- a/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
+++ b/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
@@ -4,7 +4,7 @@ import isEmpty from "lodash/isEmpty";
 import isPast from "date-fns/isPast";
 
 import { Link, Well } from "@gc-digital-talent/ui";
-import { getPoolCandidateStatus } from "@gc-digital-talent/i18n";
+import { getPoolCandidateStatus, getPoolStream } from "@gc-digital-talent/i18n";
 import { PoolCandidate } from "@gc-digital-talent/graphql";
 import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 
@@ -45,7 +45,7 @@ const PoolStatusTable = ({ user, pools }: UserInformationProps) => {
           data-h2-background-color="base(gray.dark)"
           data-h2-color="base(white)"
         >
-          <th data-h2-padding="base(x.25, 0)" data-h2-width="base(25%)">
+          <th data-h2-padding="base(x.25)" data-h2-width="base(25%)">
             {intl.formatMessage({
               defaultMessage: "Pool",
               id: "icYqDt",
@@ -53,7 +53,7 @@ const PoolStatusTable = ({ user, pools }: UserInformationProps) => {
                 "Title of the 'Pool' column for the table on view-user page",
             })}
           </th>
-          <th data-h2-padding="base(x.25, 0)" data-h2-width="base(25%)">
+          <th data-h2-padding="base(x.25)" data-h2-width="base(25%)">
             {intl.formatMessage({
               defaultMessage: "Status",
               id: "sUx3ZS",
@@ -61,14 +61,21 @@ const PoolStatusTable = ({ user, pools }: UserInformationProps) => {
                 "Title of the 'Status' column for the table on view-user page",
             })}
           </th>
-          <th data-h2-padding="base(x.25, 0)" data-h2-width="base(25%)">
+          <th data-h2-padding="base(x.25)" data-h2-width="base(25%)">
             {intl.formatMessage({
               defaultMessage: "Availability",
               id: "mevv+t",
               description: "Availability label",
             })}
           </th>
-          <th data-h2-padding="base(x.25, 0)" data-h2-width="base(25%)">
+          <th data-h2-padding="base(x.25)" data-h2-width="base(25%)">
+            {intl.formatMessage({
+              defaultMessage: "Application",
+              id: "cF8idC",
+              description: "Label for the application link column",
+            })}
+          </th>
+          <th data-h2-padding="base(x.25)" data-h2-width="base(25%)">
             {intl.formatMessage({
               defaultMessage: "Expiry date",
               id: "STDYoR",
@@ -85,7 +92,7 @@ const PoolStatusTable = ({ user, pools }: UserInformationProps) => {
               <tr key={candidate.id}>
                 <td
                   data-h2-background-color="base(gray.light)"
-                  data-h2-padding="base(x.25, 0)"
+                  data-h2-padding="base(x.25)"
                 >
                   {candidate.pool ? (
                     <Link
@@ -100,7 +107,7 @@ const PoolStatusTable = ({ user, pools }: UserInformationProps) => {
                 </td>
                 <td
                   data-h2-background-color="base(gray.light)"
-                  data-h2-padding="base(x.25, 0)"
+                  data-h2-padding="base(x.25)"
                 >
                   {intl.formatMessage(
                     getPoolCandidateStatus(candidate.status as string),
@@ -114,7 +121,7 @@ const PoolStatusTable = ({ user, pools }: UserInformationProps) => {
                 </td>
                 <td
                   data-h2-background-color="base(gray.light)"
-                  data-h2-padding="base(x.25, 0)"
+                  data-h2-padding="base(x.25)"
                 >
                   {isSuspended(candidate.suspendedAt)
                     ? intl.formatMessage({
@@ -131,9 +138,30 @@ const PoolStatusTable = ({ user, pools }: UserInformationProps) => {
                       })}
                 </td>
                 <td
+                  data-h2-background-color="base(gray.light)"
+                  data-h2-padding="base(x.25)"
+                >
+                  <Link href={paths.poolCandidateApplication(candidate.id)}>
+                    {intl.formatMessage(
+                      {
+                        defaultMessage: "View {title} application",
+                        id: "+PCQ8p",
+                        description:
+                          "Link text to view a specific application of a candidate",
+                      },
+                      {
+                        title: intl.formatMessage(
+                          getPoolStream(candidate.pool.stream ?? ""),
+                        ),
+                      },
+                    )}
+                  </Link>
+                </td>
+                <td
                   data-h2-text-decoration="base(underline)"
                   data-h2-background-color="base(gray.light)"
-                  data-h2-padding="base(x.25, 0)"
+                  data-h2-padding="base(x.25)"
+                  data-h2-white-space="base(nowrap)"
                 >
                   <ChangeDateDialog selectedCandidate={candidate} user={user} />
                 </td>

--- a/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
+++ b/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
@@ -3,7 +3,11 @@ import { useIntl } from "react-intl";
 import isPast from "date-fns/isPast";
 
 import { Link, Well } from "@gc-digital-talent/ui";
-import { getPoolCandidateStatus, getPoolStream } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  getPoolCandidateStatus,
+  getPoolStream,
+} from "@gc-digital-talent/i18n";
 import { PoolCandidate, PoolCandidateStatus } from "@gc-digital-talent/graphql";
 import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 import { notEmpty } from "@gc-digital-talent/helpers";
@@ -193,7 +197,9 @@ const PoolStatusTable = ({ user, pools }: UserInformationProps) => {
                       },
                       {
                         title: intl.formatMessage(
-                          getPoolStream(candidate.pool.stream ?? ""),
+                          candidate.pool.stream
+                            ? getPoolStream(candidate.pool.stream)
+                            : commonMessages.notAvailable,
                         ),
                       },
                     )}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -39,6 +39,10 @@
     "defaultMessage": "(Aucun sélectionné)",
     "description": "Text shown when the filter was not selected"
   },
+  "+PCQ8p": {
+    "defaultMessage": "Consultez l’application {title}",
+    "description": "Link text to view a specific application of a candidate"
+  },
   "+PLUZ8": {
     "defaultMessage": "Sélectionnez la capacité linguistique de travail dont le candidat a besoin pour ce poste. La capacité linguistique sélectionnée sera comparée à celle choisie par les candidats dans leur demande. À noter, les candidats qui ont sélectionné Bilingue peuvent ne pas avoir des résultats d’évaluation de langue seconde du gouvernement du Canada.",
     "description": "Message describing the work language ability filter in the search form."

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -39,10 +39,6 @@
     "defaultMessage": "(Aucun sélectionné)",
     "description": "Text shown when the filter was not selected"
   },
-  "+PCQ8p": {
-    "defaultMessage": "Consulter la demande de {title}",
-    "description": "Link text to view a specific application of a candidate"
-  },
   "+PLUZ8": {
     "defaultMessage": "Sélectionnez la capacité linguistique de travail dont le candidat a besoin pour ce poste. La capacité linguistique sélectionnée sera comparée à celle choisie par les candidats dans leur demande. À noter, les candidats qui ont sélectionné Bilingue peuvent ne pas avoir des résultats d’évaluation de langue seconde du gouvernement du Canada.",
     "description": "Message describing the work language ability filter in the search form."

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -39,6 +39,10 @@
     "defaultMessage": "(Aucun sélectionné)",
     "description": "Text shown when the filter was not selected"
   },
+  "+PCQ8p": {
+    "defaultMessage": "Consulter la demande de {title}",
+    "description": "Link text to view a specific application of a candidate"
+  },
   "+PLUZ8": {
     "defaultMessage": "Sélectionnez la capacité linguistique de travail dont le candidat a besoin pour ce poste. La capacité linguistique sélectionnée sera comparée à celle choisie par les candidats dans leur demande. À noter, les candidats qui ont sélectionné Bilingue peuvent ne pas avoir des résultats d’évaluation de langue seconde du gouvernement du Canada.",
     "description": "Message describing the work language ability filter in the search form."
@@ -6000,6 +6004,10 @@
   "cEeW3m": {
     "defaultMessage": "Emplacement (français) : {locationFr}",
     "description": "Pool advertisement location requirement, French"
+  },
+  "cF8idC": {
+    "defaultMessage": "Candidature",
+    "description": "Label for the application link column"
   },
   "cIqhQK": {
     "defaultMessage": "Il n'y a aucun élément à afficher.",


### PR DESCRIPTION
🤖 Resolves #7372 

## 👋 Introduction

Adds a link to the application snapshot to the pool status table on a users profile.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to a users profile in admin
3. If they are not in a pool, use the "Add user to pool" button to add them to one
4. Confirm there is a new column for "Application" that links to the snapshot

## 📸 Screenshot

![Screenshot 2023-09-25 111746](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/40351b76-18b8-408a-96a6-75bff92353d8)
