### PR TITLE
[Debt] Replaces "Cancel and go back" with single source

### DIFF
--- a/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillForm.tsx
+++ b/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillForm.tsx
@@ -11,7 +11,7 @@ import {
   Well,
 } from "@gc-digital-talent/ui";
 import { Select, TextArea } from "@gc-digital-talent/forms";
-import { errorMessages } from "@gc-digital-talent/i18n";
+import { errorMessages, formMessages } from "@gc-digital-talent/i18n";
 import { toast } from "@gc-digital-talent/toast";
 
 import { Experience, Scalars } from "~/api/generated";
@@ -282,11 +282,7 @@ const ExperienceSkillForm = ({
         <Dialog.Footer>
           <Dialog.Close>
             <Button type="button" mode="inline" color="secondary">
-              {intl.formatMessage({
-                defaultMessage: "Cancel and go back",
-                id: "tiF/jI",
-                description: "Close dialog button",
-              })}
+              {intl.formatMessage(formMessages.cancelGoBack)}
             </Button>
           </Dialog.Close>
           {defaultValues.experience && (

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6209,10 +6209,6 @@
     "defaultMessage": "Courriel",
     "description": "Title for email"
   },
-  "dJxNRU": {
-    "defaultMessage": "Annuler et revenir en arrière",
-    "description": "Label displayed on cancel button for new pool form."
-  },
   "dQseX7": {
     "defaultMessage": "1 expérience",
     "description": "Pluralization for one experience"
@@ -8616,10 +8612,6 @@
   "tZmXOj": {
     "defaultMessage": "l’amélioration de l'accessibilité des couleurs",
     "description": "List item two, things designers consider for accessibility"
-  },
-  "tiF/jI": {
-    "defaultMessage": "Annuler et revenir en arrière",
-    "description": "Close dialog button"
   },
   "tiv5J7": {
     "defaultMessage": "Enregistrer les tâches de travail",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6533,10 +6533,6 @@
     "defaultMessage": "Autodéclaration",
     "description": "Link text for the self-declaration page"
   },
-  "fMcKtJ": {
-    "defaultMessage": "Annuler et revenir en arrière",
-    "description": "Text to cancel changes to a form"
-  },
   "fNYEBT": {
     "defaultMessage": "Rappel : Les candidats doivent fournir des renseignements sur la manière dont leurs compétences répondent à chaque exigence dans le cadre du processus de candidature normale.",
     "description": "Disclaimer reminding admins of how the application process works when they reach the maximum screening questions"

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/components/AddExperienceForm.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/components/AddExperienceForm.tsx
@@ -6,7 +6,7 @@ import { useForm, FormProvider, SubmitHandler } from "react-hook-form";
 import { toast } from "@gc-digital-talent/toast";
 import { Button, Heading, Link, Separator } from "@gc-digital-talent/ui";
 import { Select } from "@gc-digital-talent/forms";
-import { errorMessages } from "@gc-digital-talent/i18n";
+import { errorMessages, formMessages } from "@gc-digital-talent/i18n";
 import { useAuthorization } from "@gc-digital-talent/auth";
 
 import useRoutes from "~/hooks/useRoutes";
@@ -196,11 +196,7 @@ const AddExperienceForm = ({ applicationId }: AddExperienceFormProps) => {
             mode="inline"
             href={paths.applicationCareerTimeline(applicationId)}
           >
-            {intl.formatMessage({
-              defaultMessage: "Cancel and go back",
-              id: "fMcKtJ",
-              description: "Text to cancel changes to a form",
-            })}
+            {intl.formatMessage(formMessages.cancelGoBack)}
           </Link>
         </div>
       </form>

--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -6,7 +6,11 @@ import Squares2X2Icon from "@heroicons/react/24/outline/Squares2X2Icon";
 
 import { toast } from "@gc-digital-talent/toast";
 import { Select, Submit, unpackMaybes } from "@gc-digital-talent/forms";
-import { errorMessages, getLocalizedName } from "@gc-digital-talent/i18n";
+import {
+  errorMessages,
+  formMessages,
+  getLocalizedName,
+} from "@gc-digital-talent/i18n";
 import { Pending, Link } from "@gc-digital-talent/ui";
 import { RoleAssignment } from "@gc-digital-talent/graphql";
 
@@ -192,11 +196,7 @@ export const CreatePoolForm = ({
 
       <div data-h2-margin="base(x2, 0, 0, 0)">
         <Link href={paths.poolTable()} mode="solid" color="primary">
-          {intl.formatMessage({
-            defaultMessage: "Cancel and go back",
-            id: "dJxNRU",
-            description: "Label displayed on cancel button for new pool form.",
-          })}
+          {intl.formatMessage(formMessages.cancelGoBack)}
         </Link>
       </div>
     </section>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/ArchiveDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/ArchiveDialog.tsx
@@ -3,7 +3,7 @@ import { useIntl } from "react-intl";
 
 import { Button, Dialog } from "@gc-digital-talent/ui";
 import { Pool } from "@gc-digital-talent/graphql";
-import { uiMessages } from "@gc-digital-talent/i18n";
+import { formMessages, uiMessages } from "@gc-digital-talent/i18n";
 
 import { getFullPoolTitleLabel } from "~/utils/poolUtils";
 
@@ -22,11 +22,7 @@ const ArchiveDialog = ({
       <>
         <Dialog.Close>
           <Button color="secondary" mode="inline">
-            {intl.formatMessage({
-              defaultMessage: "Cancel and go back",
-              id: "tiF/jI",
-              description: "Close dialog button",
-            })}
+            {intl.formatMessage(formMessages.cancelGoBack)}
           </Button>
         </Dialog.Close>
 

--- a/apps/web/src/pages/Pools/EditPoolPage/components/CloseDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/CloseDialog.tsx
@@ -4,6 +4,7 @@ import { FormProvider, useForm } from "react-hook-form";
 
 import { Dialog, Button } from "@gc-digital-talent/ui";
 import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
+import { formMessages } from "@gc-digital-talent/i18n";
 
 import { Pool } from "~/api/generated";
 
@@ -27,11 +28,7 @@ const CloseDialog = ({
         <div style={{ flexGrow: 2 } /* push other div to the right */}>
           <Dialog.Close>
             <Button color="secondary">
-              {intl.formatMessage({
-                defaultMessage: "Cancel and go back",
-                id: "tiF/jI",
-                description: "Close dialog button",
-              })}
+              {intl.formatMessage(formMessages.cancelGoBack)}
             </Button>
           </Dialog.Close>
         </div>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/DeleteDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/DeleteDialog.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useIntl } from "react-intl";
 
 import { Button, Dialog } from "@gc-digital-talent/ui";
+import { formMessages } from "@gc-digital-talent/i18n";
 
 type DeleteDialogProps = {
   onDelete: () => void;
@@ -15,11 +16,7 @@ const DeleteDialog = ({ onDelete }: DeleteDialogProps): JSX.Element => {
         <div style={{ flexGrow: 2 } /* push other div to the right */}>
           <Dialog.Close>
             <Button color="secondary">
-              {intl.formatMessage({
-                defaultMessage: "Cancel and go back",
-                id: "tiF/jI",
-                description: "Close dialog button",
-              })}
+              {intl.formatMessage(formMessages.cancelGoBack)}
             </Button>
           </Dialog.Close>
         </div>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/DuplicateDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/DuplicateDialog.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 
 import { Dialog, Button, Heading } from "@gc-digital-talent/ui";
 import { ROLE_NAME, useAuthorization } from "@gc-digital-talent/auth";
+import { formMessages } from "@gc-digital-talent/i18n";
 
 import { Pool } from "~/api/generated";
 import { getFullPoolTitleHtml } from "~/utils/poolUtils";
@@ -83,11 +84,7 @@ const DuplicateDialog = ({ pool, onDuplicate }: DuplicateDialogProps) => {
             <Dialog.Footer>
               <Dialog.Close>
                 <Button color="secondary">
-                  {intl.formatMessage({
-                    defaultMessage: "Cancel and go back",
-                    id: "tiF/jI",
-                    description: "Close dialog button",
-                  })}
+                  {intl.formatMessage(formMessages.cancelGoBack)}
                 </Button>
               </Dialog.Close>
               <Button

--- a/apps/web/src/pages/Pools/EditPoolPage/components/ExtendDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/ExtendDialog.tsx
@@ -4,7 +4,11 @@ import { FormProvider, useForm } from "react-hook-form";
 
 import { Dialog, Button } from "@gc-digital-talent/ui";
 import { DateInput } from "@gc-digital-talent/forms";
-import { commonMessages, errorMessages } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  errorMessages,
+  formMessages,
+} from "@gc-digital-talent/i18n";
 import {
   convertDateTimeZone,
   strToFormDate,
@@ -116,11 +120,7 @@ const ExtendDialog = ({
                 <div style={{ flexGrow: 2 } /* push other div to the right */}>
                   <Dialog.Close>
                     <Button color="secondary">
-                      {intl.formatMessage({
-                        defaultMessage: "Cancel and go back",
-                        id: "tiF/jI",
-                        description: "Close dialog button",
-                      })}
+                      {intl.formatMessage(formMessages.cancelGoBack)}
                     </Button>
                   </Dialog.Close>
                 </div>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PublishDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PublishDialog.tsx
@@ -7,6 +7,7 @@ import {
   parseDateTimeUtc,
   relativeClosingDate,
 } from "@gc-digital-talent/date-helpers";
+import { formMessages } from "@gc-digital-talent/i18n";
 
 import { Pool } from "~/api/generated";
 
@@ -34,11 +35,7 @@ const PublishDialog = ({
               data-h2-display="base(flex)"
               data-h2-align-items="base(center)"
             >
-              {intl.formatMessage({
-                defaultMessage: "Cancel and go back",
-                id: "tiF/jI",
-                description: "Close dialog button",
-              })}
+              {intl.formatMessage(formMessages.cancelGoBack)}
             </Button>
           </Dialog.Close>
         </div>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/UnarchiveDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/UnarchiveDialog.tsx
@@ -3,7 +3,7 @@ import { useIntl } from "react-intl";
 
 import { Button, Dialog } from "@gc-digital-talent/ui";
 import { Pool } from "@gc-digital-talent/graphql";
-import { uiMessages } from "@gc-digital-talent/i18n";
+import { formMessages, uiMessages } from "@gc-digital-talent/i18n";
 
 import { getFullPoolTitleLabel } from "~/utils/poolUtils";
 
@@ -22,11 +22,7 @@ const UnarchiveDialog = ({
       <>
         <Dialog.Close>
           <Button color="secondary" mode="inline">
-            {intl.formatMessage({
-              defaultMessage: "Cancel and go back",
-              id: "tiF/jI",
-              description: "Close dialog button",
-            })}
+            {intl.formatMessage(formMessages.cancelGoBack)}
           </Button>
         </Dialog.Close>
 

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/AddExperienceDialog.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/AddExperienceDialog.tsx
@@ -9,6 +9,7 @@ import PlusCircleIcon from "@heroicons/react/20/solid/PlusCircleIcon";
 import ArrowLeftIcon from "@heroicons/react/24/solid/ArrowLeftIcon";
 
 import { Dialog, Button, IconType, Link } from "@gc-digital-talent/ui";
+import { formMessages } from "@gc-digital-talent/i18n";
 
 import useRoutes from "~/hooks/useRoutes";
 import { Scalars } from "~/api/generated";
@@ -237,11 +238,7 @@ const AddExperienceDialog = ({
           <Dialog.Footer>
             <Dialog.Close>
               <Button color="primary" icon={ArrowLeftIcon}>
-                {intl.formatMessage({
-                  defaultMessage: "Cancel and go back",
-                  id: "tiF/jI",
-                  description: "Close dialog button",
-                })}
+                {intl.formatMessage(formMessages.cancelGoBack)}
               </Button>
             </Dialog.Close>
           </Dialog.Footer>

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -468,11 +468,7 @@ export const ExperienceForm = ({
                       })}
                     </Button>
                     <Link mode="inline" href={returnPath}>
-                      {intl.formatMessage({
-                        defaultMessage: "Cancel and go back",
-                        id: "fMcKtJ",
-                        description: "Text to cancel changes to a form",
-                      })}
+                      {intl.formatMessage(formMessages.cancelGoBack)}
                     </Link>
                   </div>
                 )}

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/AddTeamMemberDialog.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/AddTeamMemberDialog.tsx
@@ -9,6 +9,7 @@ import { toast } from "@gc-digital-talent/toast";
 import {
   commonMessages,
   errorMessages,
+  formMessages,
   getLocalizedName,
   uiMessages,
 } from "@gc-digital-talent/i18n";
@@ -191,11 +192,7 @@ AddTeamMemberDialogProps) => {
               <Dialog.Footer>
                 <Dialog.Close>
                   <Button color="secondary">
-                    {intl.formatMessage({
-                      defaultMessage: "Cancel and go back",
-                      id: "tiF/jI",
-                      description: "Close dialog button",
-                    })}
+                    {intl.formatMessage(formMessages.cancelGoBack)}
                   </Button>
                 </Dialog.Close>
                 <Button

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/EditTeamMemberDialog.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/EditTeamMemberDialog.tsx
@@ -194,11 +194,7 @@ const EditTeamMemberDialog = ({
               <Dialog.Footer>
                 <Dialog.Close>
                   <Button color="secondary">
-                    {intl.formatMessage({
-                      defaultMessage: "Cancel and go back",
-                      id: "tiF/jI",
-                      description: "Close dialog button",
-                    })}
+                    {intl.formatMessage(formMessages.cancelGoBack)}
                   </Button>
                 </Dialog.Close>
                 <Button

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/RemoveTeamMemberDialog.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/RemoveTeamMemberDialog.tsx
@@ -5,6 +5,7 @@ import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
 import { Dialog, Button, Pill } from "@gc-digital-talent/ui";
 import {
   commonMessages,
+  formMessages,
   getLocalizedName,
   uiMessages,
 } from "@gc-digital-talent/i18n";
@@ -132,11 +133,7 @@ const RemoveTeamMemberDialog = ({
           <Dialog.Footer>
             <Dialog.Close>
               <Button color="secondary">
-                {intl.formatMessage({
-                  defaultMessage: "Cancel and go back",
-                  id: "tiF/jI",
-                  description: "Close dialog button",
-                })}
+                {intl.formatMessage(formMessages.cancelGoBack)}
               </Button>
             </Dialog.Close>
             <Button

--- a/apps/web/src/pages/Users/UpdateUserPage/components/AddIndividualRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/AddIndividualRoleDialog.tsx
@@ -135,11 +135,7 @@ const AddIndividualRoleDialog = ({
               <Dialog.Footer>
                 <Dialog.Close>
                   <Button color="secondary">
-                    {intl.formatMessage({
-                      defaultMessage: "Cancel and go back",
-                      id: "tiF/jI",
-                      description: "Close dialog button",
-                    })}
+                    {intl.formatMessage(formMessages.cancelGoBack)}
                   </Button>
                 </Dialog.Close>
                 <Button

--- a/apps/web/src/pages/Users/UpdateUserPage/components/AddTeamRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/AddTeamRoleDialog.tsx
@@ -184,11 +184,7 @@ const AddTeamRoleDialog = ({
               <Dialog.Footer>
                 <Dialog.Close>
                   <Button color="secondary">
-                    {intl.formatMessage({
-                      defaultMessage: "Cancel and go back",
-                      id: "tiF/jI",
-                      description: "Close dialog button",
-                    })}
+                    {intl.formatMessage(formMessages.cancelGoBack)}
                   </Button>
                 </Dialog.Close>
                 <Button

--- a/apps/web/src/pages/Users/UpdateUserPage/components/DeleteUserDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/DeleteUserDialog.tsx
@@ -138,11 +138,7 @@ const DeleteUserDialog = ({ user, onDeleteUser }: AddTeamRoleDialogProps) => {
               <Dialog.Footer>
                 <Dialog.Close>
                   <Button color="secondary">
-                    {intl.formatMessage({
-                      defaultMessage: "Cancel and go back",
-                      id: "tiF/jI",
-                      description: "Close dialog button",
-                    })}
+                    {intl.formatMessage(formMessages.cancelGoBack)}
                   </Button>
                 </Dialog.Close>
                 <Button

--- a/apps/web/src/pages/Users/UpdateUserPage/components/DeleteUserDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/DeleteUserDialog.tsx
@@ -6,7 +6,11 @@ import TrashIcon from "@heroicons/react/24/solid/TrashIcon";
 import { Dialog, Button } from "@gc-digital-talent/ui";
 import { Input } from "@gc-digital-talent/forms";
 import { toast } from "@gc-digital-talent/toast";
-import { commonMessages, errorMessages } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  errorMessages,
+  formMessages,
+} from "@gc-digital-talent/i18n";
 import { User, DeleteUserMutation } from "@gc-digital-talent/graphql";
 
 import { getFullNameHtml, getFullNameLabel } from "~/utils/nameUtils";

--- a/apps/web/src/pages/Users/UpdateUserPage/components/EditTeamRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/EditTeamRoleDialog.tsx
@@ -165,11 +165,7 @@ const EditTeamRoleDialog = ({
               <Dialog.Footer>
                 <Dialog.Close>
                   <Button color="secondary">
-                    {intl.formatMessage({
-                      defaultMessage: "Cancel and go back",
-                      id: "tiF/jI",
-                      description: "Close dialog button",
-                    })}
+                    {intl.formatMessage(formMessages.cancelGoBack)}
                   </Button>
                 </Dialog.Close>
                 <Button

--- a/apps/web/src/pages/Users/UpdateUserPage/components/RemoveIndividualRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/RemoveIndividualRoleDialog.tsx
@@ -5,6 +5,7 @@ import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
 import { Dialog, Button, Pill } from "@gc-digital-talent/ui";
 import {
   commonMessages,
+  formMessages,
   getLocalizedName,
   uiMessages,
 } from "@gc-digital-talent/i18n";
@@ -109,11 +110,7 @@ const RemoveIndividualRoleDialog = ({
           <Dialog.Footer>
             <Dialog.Close>
               <Button color="secondary">
-                {intl.formatMessage({
-                  defaultMessage: "Cancel and go back",
-                  id: "tiF/jI",
-                  description: "Close dialog button",
-                })}
+                {intl.formatMessage(formMessages.cancelGoBack)}
               </Button>
             </Dialog.Close>
             <Button

--- a/apps/web/src/pages/Users/UpdateUserPage/components/RemoveTeamRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/RemoveTeamRoleDialog.tsx
@@ -5,6 +5,7 @@ import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
 import { Dialog, Button, Pill } from "@gc-digital-talent/ui";
 import {
   commonMessages,
+  formMessages,
   getLocalizedName,
   uiMessages,
 } from "@gc-digital-talent/i18n";
@@ -144,11 +145,7 @@ const RemoveTeamRoleDialog = ({
           <Dialog.Footer>
             <Dialog.Close>
               <Button color="secondary">
-                {intl.formatMessage({
-                  defaultMessage: "Cancel and go back",
-                  id: "tiF/jI",
-                  description: "Close dialog button",
-                })}
+                {intl.formatMessage(formMessages.cancelGoBack)}
               </Button>
             </Dialog.Close>
             <Button

--- a/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
@@ -6,7 +6,11 @@ import zipWith from "lodash/zipWith";
 import { Dialog, Button } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
 import { DateInput, MultiSelectField } from "@gc-digital-talent/forms";
-import { commonMessages, errorMessages } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  errorMessages,
+  formMessages,
+} from "@gc-digital-talent/i18n";
 import { currentDate } from "@gc-digital-talent/date-helpers";
 import { emptyToNull, notEmpty } from "@gc-digital-talent/helpers";
 
@@ -242,11 +246,7 @@ const AddToPoolDialog = ({ user, pools }: AddToPoolDialogProps) => {
                 <Dialog.Close>
                   <Button type="button" color="secondary">
                     <span data-h2-text-decoration="base(underline)">
-                      {intl.formatMessage({
-                        defaultMessage: "Cancel and go back",
-                        id: "tiF/jI",
-                        description: "Close dialog button",
-                      })}
+                      {intl.formatMessage(formMessages.cancelGoBack)}
                     </span>
                   </Button>
                 </Dialog.Close>

--- a/apps/web/src/pages/Users/UserInformationPage/components/ChangeDateDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/ChangeDateDialog.tsx
@@ -5,7 +5,11 @@ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { Dialog, Button } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
 import { DateInput } from "@gc-digital-talent/forms";
-import { commonMessages, errorMessages } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  errorMessages,
+  formMessages,
+} from "@gc-digital-talent/i18n";
 import { currentDate } from "@gc-digital-talent/date-helpers";
 import { emptyToNull } from "@gc-digital-talent/helpers";
 
@@ -159,11 +163,7 @@ const ChangeDateDialog = ({
                 <Dialog.Close>
                   <Button type="button" color="secondary">
                     <span data-h2-text-decoration="base(underline)">
-                      {intl.formatMessage({
-                        defaultMessage: "Cancel and go back",
-                        id: "tiF/jI",
-                        description: "Close dialog button",
-                      })}
+                      {intl.formatMessage(formMessages.cancelGoBack)}
                     </span>
                   </Button>
                 </Dialog.Close>

--- a/apps/web/src/pages/Users/UserInformationPage/components/ChangeStatusDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/ChangeStatusDialog.tsx
@@ -13,6 +13,7 @@ import {
 import {
   commonMessages,
   errorMessages,
+  formMessages,
   getPoolCandidateStatus,
 } from "@gc-digital-talent/i18n";
 import { notEmpty } from "@gc-digital-talent/helpers";
@@ -291,11 +292,7 @@ const ChangeStatusDialog = ({
                 <Dialog.Close>
                   <Button type="button" color="secondary">
                     <span data-h2-text-decoration="base(underline)">
-                      {intl.formatMessage({
-                        defaultMessage: "Cancel and go back",
-                        id: "tiF/jI",
-                        description: "Close dialog button",
-                      })}
+                      {intl.formatMessage(formMessages.cancelGoBack)}
                     </span>
                   </Button>
                 </Dialog.Close>


### PR DESCRIPTION
🤖 Resolves #8012.

## 👋 Introduction

This PR replaces all instances of the string "Cancel and go back" with the `formMessages` definition.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Search for instances of string "Cancel and go back"
2. Observe only one instance in codebase for "Cancel and go back"