### PR TITLE
[Bugfix] update user policy

### DIFF
--- a/api/app/Policies/UserPolicy.php
+++ b/api/app/Policies/UserPolicy.php
@@ -73,7 +73,7 @@ class UserPolicy
             }
         }
         if ($injected && isset($injected['sub'])) {
-            if (! $user->isAbleTo('assign-any-userSub')) {
+            if (! $user->isAbleTo('update-any-userSub')) {
                 return false;
             }
         }

--- a/api/app/Policies/UserPolicy.php
+++ b/api/app/Policies/UserPolicy.php
@@ -61,18 +61,18 @@ class UserPolicy
      *
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function update(User $user, User $model, array $injected = null)
+    public function update(User $user, User $model, array $request = null)
     {
         // TODO: This implementation means that assigning roles or updating sub also requires the `update` permission, which doesn't strictly match our permissions spreadsheet :(
         /**
          * If a user is assigning a role or updating 'sub', check for extra permissions and fail early
          */
-        if ($injected && isset($injected['roleAssignmentsInput'])) {
+        if ($request && isset($request['roleAssignmentsInput'])) {
             if (! $user->isAbleTo('assign-any-role')) {
                 return false;
             }
         }
-        if ($injected && isset($injected['sub'])) {
+        if ($request && isset($request['sub'])) {
             if (! $user->isAbleTo('update-any-userSub')) {
                 return false;
             }

--- a/api/app/Policies/UserPolicy.php
+++ b/api/app/Policies/UserPolicy.php
@@ -63,17 +63,21 @@ class UserPolicy
      */
     public function update(User $user, User $model, array $injected = null)
     {
+        // TODO: This implementation means that assigning roles or updating sub also requires the `update` permission, which doesn't strictly match our permissions spreadsheet :(
         /**
-         * If a user is assigning a role here, check all actions
-         * and fail early
+         * If a user is assigning a role or updating 'sub', check for extra permissions and fail early
          */
-        if ($injected && isset($injected['roles'])) {
+        if ($injected && isset($injected['roleAssignmentsInput'])) {
             if (! $user->isAbleTo('assign-any-role')) {
                 return false;
             }
         }
+        if ($injected && isset($injected['sub'])) {
+            if (! $user->isAbleTo('assign-any-userSub')) {
+                return false;
+            }
+        }
 
-        // TODO: Right now, for a user to assign-any-role they ALSO need to be able to update-any-user! That doesn't quite match the permissions table.
         return $user->isAbleTo('update-any-user')
             || ($user->isAbleTo('update-own-user') && $user->id === $model->id);
     }

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -62,6 +62,7 @@ return [
         'skillFamily' => 'skillFamily',
         'user' => 'user',
         'userBasicInfo' => 'userBasicInfo',
+        'userSub' => 'userSub',
         'pool' => 'pool',
         'publishedPool' => 'publishedPool',
         'draftPool' => 'draftPool',
@@ -193,12 +194,16 @@ return [
             'fr' => 'Visionner l\'utilisateur de l\'équipe',
         ],
         'update-any-user' => [
-            'en' => 'Update Any User',
-            'fr' => 'Mettre à jour tout utilisateur',
+            'en' => 'Update Any User (does not include updating the "sub" field or role assignments)',
+            'fr' => 'Mettre à jour tout utilisateur (ne comprend pas la mise à jour du champ "sub" ou des attributions de rôles)',
+        ],
+        'update-any-userSub' => [
+            'en' => 'Update the "sub" field of any user',
+            'fr' => 'Mettre à jour le champ "sub" de n\'importe quel utilisateur',
         ],
         'update-own-user' => [
-            'en' => 'Update Own User',
-            'fr' => 'Mettre à jour son propre utilisateur',
+            'en' => 'Update Own User (does not include updating the "sub" field or role assignments)',
+            'fr' => 'Mettre à jour son propre utilisateur (ne comprend pas la mise à jour du champ "sub" ou des attributions de rôles)',
         ],
         'delete-any-user' => [
             'en' => 'Delete Any User',

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -643,6 +643,9 @@ return [
             'user' => [
                 'any' => ['create', 'view', 'update', 'delete'],
             ],
+            'userSub' => [
+                'any' => ['update']
+            ],
             'userBasicInfo' => [
                 'any' => ['view'],
             ],

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -644,7 +644,7 @@ return [
                 'any' => ['create', 'view', 'update', 'delete'],
             ],
             'userSub' => [
-                'any' => ['update']
+                'any' => ['update'],
             ],
             'userBasicInfo' => [
                 'any' => ['view'],

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1633,8 +1633,7 @@ type Mutation {
     @can(ability: "delete", find: "id")
 
   # Notifications
-  markNotificationAsRead(id: UUID!): Notification
-
+  markNotificationAsRead(id: UUID!): Notification @guard # can only affect notifications belonging to the logged-in user
   # UserSkill mutations
   createUserSkill(
     userId: UUID! @rename(attribute: "user_id")

--- a/api/programmatic-types.graphql
+++ b/api/programmatic-types.graphql
@@ -258,6 +258,439 @@ dealing with really large numbers to be on the safe side.
 """
 scalar Mixed
 
+enum Language {
+  EN
+  FR
+}
+
+enum ProvinceOrTerritory {
+  BRITISH_COLUMBIA
+  ALBERTA
+  SASKATCHEWAN
+  MANITOBA
+  ONTARIO
+  QUEBEC
+  NEW_BRUNSWICK
+  NOVA_SCOTIA
+  PRINCE_EDWARD_ISLAND
+  NEWFOUNDLAND_AND_LABRADOR
+  YUKON
+  NORTHWEST_TERRITORIES
+  NUNAVUT
+}
+
+enum GovEmployeeType {
+  STUDENT
+  CASUAL
+  TERM
+  INDETERMINATE
+}
+
+enum BilingualEvaluation {
+  COMPLETED_ENGLISH
+  COMPLETED_FRENCH
+  NOT_COMPLETED
+}
+
+enum EvaluatedLanguageAbility {
+  X
+  A
+  B
+  C
+  E
+  P
+}
+
+enum EstimatedLanguageAbility {
+  BEGINNER
+  INTERMEDIATE
+  ADVANCED
+}
+
+enum CitizenshipStatus {
+  PERMANENT_RESIDENT
+  CITIZEN
+  OTHER
+}
+
+enum ArmedForcesStatus {
+  VETERAN
+  MEMBER
+  NON_CAF
+}
+
+enum PositionDuration {
+  TEMPORARY
+  PERMANENT
+}
+
+enum IndigenousCommunity {
+  STATUS_FIRST_NATIONS
+  NON_STATUS_FIRST_NATIONS
+  INUIT
+  METIS
+  OTHER
+  LEGACY_IS_INDIGENOUS
+}
+
+enum PoolStream {
+  ACCESS_INFORMATION_PRIVACY
+  BUSINESS_ADVISORY_SERVICES
+  DATABASE_MANAGEMENT
+  ENTERPRISE_ARCHITECTURE
+  INFRASTRUCTURE_OPERATIONS
+  PLANNING_AND_REPORTING
+  PROJECT_PORTFOLIO_MANAGEMENT
+  SECURITY
+  SOFTWARE_SOLUTIONS
+  INFORMATION_DATA_FUNCTIONS
+}
+
+enum PoolStatus {
+  DRAFT
+  PUBLISHED
+  CLOSED
+  ARCHIVED
+}
+
+enum PoolCandidateStatus {
+  DRAFT
+  DRAFT_EXPIRED
+  NEW_APPLICATION
+  APPLICATION_REVIEW
+  SCREENED_IN
+  SCREENED_OUT_APPLICATION
+  SCREENED_OUT_NOT_INTERESTED
+  SCREENED_OUT_NOT_RESPONSIVE
+  UNDER_ASSESSMENT
+  SCREENED_OUT_ASSESSMENT
+  QUALIFIED_AVAILABLE
+  QUALIFIED_UNAVAILABLE
+  QUALIFIED_WITHDREW
+  PLACED_CASUAL
+  PLACED_TERM
+  PLACED_INDETERMINATE
+  EXPIRED
+  REMOVED
+}
+
+enum SecurityStatus {
+  RELIABILITY
+  SECRET
+  TOP_SECRET
+}
+
+enum PoolLanguage {
+  ENGLISH
+  FRENCH
+  VARIOUS
+  BILINGUAL_INTERMEDIATE
+  BILINGUAL_ADVANCED
+}
+
+enum PublishingGroup {
+  IAP
+  IT_JOBS
+  IT_JOBS_ONGOING
+  EXECUTIVE_JOBS
+  OTHER
+}
+
+enum ApplicationStep {
+  WELCOME
+  SELF_DECLARATION
+  REVIEW_YOUR_PROFILE
+  REVIEW_YOUR_RESUME
+  EDUCATION_REQUIREMENTS
+  SKILL_REQUIREMENTS
+  SCREENING_QUESTIONS
+  REVIEW_AND_SUBMIT
+}
+
+enum EducationRequirementOption {
+  APPLIED_WORK
+  EDUCATION
+}
+
+enum LanguageAbility {
+  ENGLISH
+  FRENCH
+  BILINGUAL
+}
+
+enum WorkRegion {
+  TELEWORK
+  NATIONAL_CAPITAL
+  ATLANTIC
+  QUEBEC
+  ONTARIO
+  PRAIRIE
+  BRITISH_COLUMBIA
+  NORTH
+}
+
+enum OperationalRequirement {
+  SHIFT_WORK
+  ON_CALL
+  TRAVEL
+  TRANSPORT_EQUIPMENT
+  DRIVERS_LICENSE
+  OVERTIME_SCHEDULED
+  OVERTIME_SHORT_NOTICE
+  OVERTIME_OCCASIONAL
+  OVERTIME_REGULAR
+}
+
+enum SalaryRange {
+  _50_59K
+  _60_69K
+  _70_79K
+  _80_89K
+  _90_99K
+  _100K_PLUS
+}
+
+enum GenericJobTitleKey {
+  TECHNICIAN_IT01
+  ANALYST_IT02
+  TEAM_LEADER_IT03
+  TECHNICAL_ADVISOR_IT03
+  SENIOR_ADVISOR_IT04
+  MANAGER_IT04
+}
+
+enum PoolCandidateSearchStatus {
+  NEW
+  IN_PROGRESS
+  WAITING
+  DONE
+}
+
+enum PoolCandidateSearchPositionType {
+  INDIVIDUAL_CONTRIBUTOR
+  TEAM_LEAD
+}
+
+enum SkillCategory {
+  TECHNICAL
+  BEHAVIOURAL
+}
+
+enum SkillLevel {
+  BEGINNER
+  INTERMEDIATE
+  ADVANCED
+  LEAD
+}
+
+enum WhenSkillUsed {
+  CURRENT
+  PAST
+}
+
+enum AwardedTo {
+  ME
+  MY_TEAM
+  MY_PROJECT
+  MY_ORGANIZATION
+}
+
+enum AwardedScope {
+  INTERNATIONAL
+  NATIONAL
+  PROVINCIAL
+  LOCAL
+  COMMUNITY
+  ORGANIZATIONAL
+  SUB_ORGANIZATIONAL
+}
+
+enum EducationType {
+  DIPLOMA
+  BACHELORS_DEGREE
+  MASTERS_DEGREE
+  PHD
+  POST_DOCTORAL_FELLOWSHIP
+  ONLINE_COURSE
+  CERTIFICATION
+  OTHER
+}
+
+enum EducationStatus {
+  SUCCESS_CREDENTIAL
+  SUCCESS_NO_CREDENTIAL
+  IN_PROGRESS
+  AUDITED
+  DID_NOT_COMPLETE
+}
+
+enum CandidateExpiryFilter {
+  ACTIVE
+  EXPIRED
+  ALL
+}
+
+enum CandidateSuspendedFilter {
+  ACTIVE
+  SUSPENDED
+  ALL
+}
+
+enum AdvertisementType {
+  INTERNAL
+  EXTERNAL
+}
+
+enum AdvertisingPlatform {
+  GCJOBS
+  GCCONNEX
+  GCXCHNAGE
+  GC_COLLAB
+  FACEBOOK
+  LINKEDIN
+  OTHER
+}
+
+enum ContractAuthority {
+  HR
+  PROCUREMENT
+  FINANCE
+  LABOUR_RELATIONS
+  OTHER
+}
+
+enum YesNo {
+  YES
+  NO
+}
+
+enum YesNoUnsure {
+  YES
+  NO
+  I_DONT_KNOW
+}
+
+enum ContractValueRange {
+  FROM_0_TO_10K
+  FROM_10K_TO_25K
+  FROM_25K_TO_50K
+  FROM_50K_TO_1M
+  FROM_1M_TO_2500K
+  FROM_2500K_TO_5M
+  FROM_5M_TO_10M
+  FROM_10M_TO_15M
+  FROM_15M_TO_25M
+  GREATER_THAN_25M
+}
+
+enum ContractStartTimeframe {
+  FROM_0_TO_3M
+  FROM_3M_TO_6M
+  FROM_6M_TO_1Y
+  FROM_1Y_TO_2Y
+  UNKNOWN
+  VARIABLE
+}
+
+enum ContractCommodity {
+  TELECOM_SERVICES
+  SUPPORT_SERVICES
+  OTHER
+}
+
+enum ContractInstrument {
+  SUPPLY_ARRANGEMENT
+  STANDING_OFFER
+  CONTRACT
+  AMENDMENT
+}
+
+enum ContractSupplyMethod {
+  NOT_APPLICABLE
+  SOLUTIONS_BASED_INFORMATICS_PROFESSIONAL_SERVICES
+  TASK_BASED_INFORMATICS_PROFESSIONAL_SERVICES
+  TEMPORARY_HELP
+  OTHER
+}
+
+enum ContractSolicitationProcedure {
+  ADVANCE_CONTRACT_AWARD_NOTICE
+  COMPETITIVE
+  NON_COMPETITIVE
+}
+
+enum PersonnelScreeningLevel {
+  RELIABILITY
+  ENHANCED_RELIABILITY
+  SECRET
+  TOP_SECRET
+  OTHER
+}
+
+enum PersonnelLanguage {
+  ENGLISH_ONLY
+  FRENCH_ONLY
+  BILINGUAL_INTERMEDIATE
+  BILINGUAL_ADVANCED
+  OTHER
+}
+
+enum PersonnelWorkLocation {
+  GC_PREMISES
+  OFFSITE_SPECIFIC
+  OFFSITE_ANY
+}
+
+enum PositionEmploymentType {
+  INDETERMINATE
+  TERM
+  LATERAL_DEPLOYMENT
+  SECONDMENT
+  ASSIGNMENT
+  OTHER
+}
+
+enum PersonnelOtherRequirement {
+  SHIFT_WORK
+  ON_CALL_24_7
+  OVERTIME_SHORT_NOTICE
+  AS_NEEDED
+  OTHER
+}
+
+enum PersonnelSkillExpertiseLevel {
+  BEGINNER
+  INTERMEDIATE
+  EXPERT
+  LEAD
+}
+
+enum PersonnelTeleworkOption {
+  FULL_TIME
+  PART_TIME
+  NO
+}
+
+enum OperationsConsideration {
+  FINANCE_VEHICLE_NOT_USABLE
+  FUNDING_SECURED_COST_RECOVERY_BASIS
+  UNABLE_CREATE_NEW_INDETERMINATE
+  UNABLE_CREATE_NEW_TERM
+  UNABLE_CREATE_CLASSIFICATION_RESTRICTION
+  STAFFING_FREEZE
+  OTHER
+}
+
+enum ContractingRationale {
+  SHORTAGE_OF_TALENT
+  TIMING_REQUIREMENTS
+  HR_SITUATION
+  FINANCIAL_SITUATION
+  REQUIRES_INDEPENDENT
+  INTELLECTUAL_PROPERTY_FACTORS
+  OTHER
+}
+
 "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations."
 type __Schema {
   "A list of all types supported by this server."

--- a/api/schema-directives.graphql
+++ b/api/schema-directives.graphql
@@ -1518,7 +1518,7 @@ directive @clearCache(
 ) repeatable on FIELD_DEFINITION
 
 """
-Options for the `id` argument on `@clearCache`.
+Options for the `idSource` argument of `@clearCache`.
 
 Exactly one of the fields must be given.
 """
@@ -1636,7 +1636,7 @@ directive @orderBy(
 ) on ARGUMENT_DEFINITION | FIELD_DEFINITION
 
 """
-Options for the `direction` argument on `@orderBy`.
+Options for the `direction` argument of `@orderBy`.
 """
 enum OrderByDirection {
     """
@@ -1651,7 +1651,7 @@ enum OrderByDirection {
 }
 
 """
-Options for the `relations` argument on `@orderBy`.
+Options for the `relations` argument of `@orderBy`.
 """
 input OrderByRelation {
     """

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -211,6 +211,7 @@ class RolePermissionTest extends TestCase
             'view-any-user',
             'view-any-userBasicInfo',
             'update-any-user',
+            'update-any-userSub',
             'delete-any-user',
             'view-any-pool',
             'publish-any-pool',


### PR DESCRIPTION
## 👋 Introduction

Updates the User Policy permission to correctly protect roleAssignment and sub.

## 🕵️ Details

This is the bare-minimum quick fix. I'd like to change the updateUserAsAdmin mutation a bit further, to make these kinds of bugs easier to avoid in the future.

I added an one more permission, `update-any-userSub`, to reflect the fact that admins can update MORE fields on the user object than users can touch themselves. Also fixed the field name used to check for role assignment.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. set `AUTH_DEFAULT_USER='applicant@test.com'` in api/.env 
2. Go to http://localhost:8000/graphiql
3. As a non-admin user, try to edit your own sub field. You can find <applicant-user-id> by running the `me` query. The following mutation should fail:
```
mutation UpdateUserAsAdmin {
  updateUserAsAdmin(    
    id: "<applicant-user-id>" 
    user: {sub: "applicant@test.com_edited"} 
  ) {
    id
    sub
    email
  }
}
```
4. As a non-admin user, try to edit your own sub field. The role id can be found by looking in the database, or by running the `roles` as an admin. The following mutation should fail:
```
mutation UpdateUserAsAdmin {
  updateUserAsAdmin(
    user: {sub: "applicant@test.com", roleAssignmentsInput: {attach: {roles: "<platform-admin-role-id>"}}}
    id: "29ffd391-aa4c-4386-8f68-e704f904fb92"
  ) {
    id
    sub
    email
    roleAssignments {
      id
      role {
        name
      }
      team {
        name
      }
    }
  }
}
```

## 🚚 Deployment

Run `php artisan db:seed --class=RolePermissionSeeder`
