### PR TITLE
[Bug] Skill dialog scrolling

### DIFF
--- a/apps/web/src/components/SkillDialog/SkillDialog.tsx
+++ b/apps/web/src/components/SkillDialog/SkillDialog.tsx
@@ -119,7 +119,7 @@ const SkillDialog = ({
       <Dialog.Trigger>
         <Button {...triggerProps} {...rest} color="secondary" />
       </Dialog.Trigger>
-      <Dialog.Content data-h2-position="base(absolute)">
+      <Dialog.Content>
         <Dialog.Header subtitle={subtitle}>{title}</Dialog.Header>
         <Dialog.Body>
           <FormProvider {...methods}>


### PR DESCRIPTION
🤖 Resolves #8086 

## 👋 Introduction

Resolve the inability to scroll up for skill dialogs. 

## 🕵️ Details

Tried the method in docs, didn't get anywhere. Gave deleting styling in the component a go and it appears... to have worked?
Don't know what the styling bit did, removing it didn't seem to throw any issue. 

http://recordit.co/oKiXB9mWco

## 🧪 Testing

1. Head to skill showcase and edit
2. Play with opening the dialog

## 📸 Screenshot

The lost, top of the dialog

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/e3a0cb45-d1dd-423f-8b74-c00e1ed91493)

