### PR TITLE
[Fix] Skill dialog validation on  submission

### DIFF
--- a/apps/web/src/components/SkillDialog/SkillDialog.tsx
+++ b/apps/web/src/components/SkillDialog/SkillDialog.tsx
@@ -72,7 +72,6 @@ const SkillDialog = ({
   });
 
   const {
-    getValues,
     trigger: formTrigger,
     reset,
     watch,
@@ -123,7 +122,7 @@ const SkillDialog = ({
         <Dialog.Header subtitle={subtitle}>{title}</Dialog.Header>
         <Dialog.Body>
           <FormProvider {...methods}>
-            <form>
+            <form onSubmit={methods.handleSubmit(handleAddSkill)}>
               <SkillSelection
                 {...{ showCategory, skills, inLibrary }}
                 onSelectSkill={setSelectedSkill}
@@ -140,7 +139,7 @@ const SkillDialog = ({
                   type="button"
                   color="secondary"
                   disabled={isSubmitting}
-                  onClick={() => handleAddSkill(getValues())}
+                  onClick={() => methods.handleSubmit(handleAddSkill)()}
                 >
                   {isSubmitting
                     ? intl.formatMessage(commonMessages.saving)


### PR DESCRIPTION
🤖 Resolves #8104 

## 👋 Introduction

Fixes a bug where the skill dialog was not validating inputs on submission.

## 🕵️ Details

Since this form can be nested, we had some hacks to prevent triggering the parent form submission. However, this also prevented the skill dialog from triggering a submission which bypassed validation. This just modifies the hack to trigger an artificial submission which checks validation before adding the skill.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to the skill library /applicant/profile-and-applications/skills
2. Activate one of the "Add a skill" buttons
3. Select a skill
4. Do not select a skill level or if you are currently using it
5. Submit the form and observe it properly validates
6. Navigate to an experience
7. Link a skill
8. Confirm the experience form does not submit