### PR TITLE
Updates Hydrogen to 2.0.3

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -80,7 +80,7 @@
     "@graphql-codegen/typescript": "^3.0.4",
     "@graphql-codegen/typescript-operations": "^3.0.4",
     "@graphql-codegen/typescript-urql": "^3.7.3",
-    "@hydrogen-css/hydrogen": "2.0.2",
+    "@hydrogen-css/hydrogen": "2.0.3",
     "@mdx-js/react": "^2.3.0",
     "@storybook/addon-actions": "^7.4.5",
     "@storybook/addon-essentials": "^7.4.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "devDependencies": {
         "@graphql-codegen/cli": "5.0.0",
-        "@hydrogen-css/hydrogen": "2.0.2",
+        "@hydrogen-css/hydrogen": "2.0.3",
         "eslint-config-custom": "*",
         "jest-fail-on-console": "^3.1.1",
         "prettier": "^2.8.8",
@@ -110,7 +110,7 @@
         "@graphql-codegen/typescript": "^3.0.4",
         "@graphql-codegen/typescript-operations": "^3.0.4",
         "@graphql-codegen/typescript-urql": "^3.7.3",
-        "@hydrogen-css/hydrogen": "2.0.2",
+        "@hydrogen-css/hydrogen": "2.0.3",
         "@mdx-js/react": "^2.3.0",
         "@storybook/addon-actions": "^7.4.5",
         "@storybook/addon-essentials": "^7.4.5",
@@ -4014,8 +4014,9 @@
       "dev": true
     },
     "node_modules/@hydrogen-css/hydrogen": {
-      "version": "2.0.2",
-      "license": "MIT",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@hydrogen-css/hydrogen/-/hydrogen-2.0.3.tgz",
+      "integrity": "sha512-3CFecIteVnv5Iyok5UbmGFpHN/AfS0j813odjqaIinLUknEGhAkVC3o6wzb8KvccZ8165IW3msr3nx8lavlErg==",
       "dependencies": {
         "autoprefixer": "^10.4.14",
         "browserslist": "^4.21.9",
@@ -29106,7 +29107,7 @@
         "@graphql-codegen/typescript-operations": "^3.0.4",
         "@graphql-codegen/typescript-urql": "^3.7.3",
         "@heroicons/react": "^2.0.18",
-        "@hydrogen-css/hydrogen": "2.0.2",
+        "@hydrogen-css/hydrogen": "2.0.3",
         "@mdx-js/react": "^2.3.0",
         "@microsoft/applicationinsights-react-js": "^17.0.0",
         "@microsoft/applicationinsights-web": "^3.0.2",
@@ -29891,7 +29892,9 @@
       "dev": true
     },
     "@hydrogen-css/hydrogen": {
-      "version": "2.0.2",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@hydrogen-css/hydrogen/-/hydrogen-2.0.3.tgz",
+      "integrity": "sha512-3CFecIteVnv5Iyok5UbmGFpHN/AfS0j813odjqaIinLUknEGhAkVC3o6wzb8KvccZ8165IW3msr3nx8lavlErg==",
       "requires": {
         "autoprefixer": "^10.4.14",
         "browserslist": "^4.21.9",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@graphql-codegen/cli": "5.0.0",
-    "@hydrogen-css/hydrogen": "2.0.2",
+    "@hydrogen-css/hydrogen": "2.0.3",
     "eslint-config-custom": "*",
     "jest-fail-on-console": "^3.1.1",
     "prettier": "^2.8.8",


### PR DESCRIPTION
![248918762-a2485099-6b4d-404b-83c6-0de775964b6d](https://github.com/GCTC-NTGC/gc-digital-talent/assets/6960386/a054818d-49d0-4e69-a356-748d8aa0a8d5)

## ✨ Summary

This pull request updates Hydrogen to `2.0.3`. You can see a full list of changes here: https://hydrogen.design/en/docs/releases/#2.0.3

This release contains a bugfix for the the `data-h2-shadow` property, but otherwise doesn't have an effect on core processing.

```[tasklist]
### ✅ Review steps
- [ ] Bust your cached local resources
- [ ] Rebuild using the maintenance script
- [ ] Run `npm run dev`, `npm run storybook`, etc. to ensure compiles happen a-okay
``` 