### PR TITLE
[Fix] Hide user skills in skill dialog, showcase context

### DIFF
--- a/apps/web/src/components/SkillDialog/SkillDialog.tsx
+++ b/apps/web/src/components/SkillDialog/SkillDialog.tsx
@@ -111,7 +111,10 @@ const SkillDialog = ({
     }
   }, [watchSkill, formTrigger]);
 
-  const shouldShowDetails = showDetails(context);
+  const skillInLibrary = !!inLibrary?.find(
+    (librarySkill) => selectedSkill?.id === librarySkill.id,
+  );
+  const shouldShowDetails = showDetails(skillInLibrary, context);
 
   return (
     <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>

--- a/apps/web/src/components/SkillDialog/utils.ts
+++ b/apps/web/src/components/SkillDialog/utils.ts
@@ -150,9 +150,15 @@ export const getSkillDialogMessages: GetSkillDialogMessages = ({
 };
 
 export const showDetails = (
+  skillInLibrary: boolean,
   context: SkillDialogContext | undefined,
 ): boolean => {
   const detailContexts: SkillDialogContext[] = ["library", "showcase"];
+
+  // We do not need details if already in library when on showcase context
+  if (context === "showcase" && skillInLibrary) {
+    return false;
+  }
 
   return context ? detailContexts.includes(context) : false;
 };

--- a/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
+++ b/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
@@ -231,6 +231,9 @@ const UpdateSkillShowcase = ({
                       showAdd={canAdd}
                       customButton={
                         <SkillDialog
+                          inLibrary={userSkills.map(
+                            (userSkill) => userSkill.skill,
+                          )}
                           trigger={
                             canAdd
                               ? {


### PR DESCRIPTION
🤖 Resolves #8088 

## 👋 Introduction

This hides any claimed skills when accessing the skill dialog in the context library.

## 🕵️ Details

The `SkillDialog` had an option to pass skills already in a user's library. This uses that, in combination with the context to prevent the details from appearing when the selected skill is in that array of skills.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Login and confirm a skill you do and do not have in your library
2. Navigate to the appropriate skill show case page
3. Activate "Add a new item" to open the skill dialog
4. First, select a skill you know you do not have, confirm the details section appear
5. Now, select the skill you know you do have, confirm the details do not appear
6. Bonus, do this with the library dialog and confirm the details always appear