### PR TITLE
[Fix] Handle firewall reject characters

### DIFF
--- a/api/app/Http/Kernel.php
+++ b/api/app/Http/Kernel.php
@@ -21,6 +21,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        // \App\Http\Middleware\SimulateFirewallMiddleware::class,
     ];
 
     /**

--- a/api/app/Http/Middleware/SimulateFirewallMiddleware.php
+++ b/api/app/Http/Middleware/SimulateFirewallMiddleware.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Simulates the behavior of the production firewall
+ */
+class SimulateFirewallMiddleware
+{
+    const BANNED_CHARACTERS = [
+        "\u{202F}", // https://symbl.cc/en/202F/
+    ];
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * @return mixed Any kind of response
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        Log::debug('firewall handling');
+        $content = (string) $request->getContent();
+
+        foreach (SimulateFirewallMiddleware::BANNED_CHARACTERS as $bannedCharacter) {
+            if (str_contains($content, $bannedCharacter)) {
+                return response("<html><head><title>Request Rejected</title></head><body>The requested URL was rejected.<a href='javascript:history.back();'>[Go Back]</a></body></html>", 403);
+            }
+        }
+
+        return $next($request);
+
+    }
+}

--- a/packages/client/src/components/ClientProvider/ClientProvider.tsx
+++ b/packages/client/src/components/ClientProvider/ClientProvider.tsx
@@ -27,6 +27,7 @@ import {
   extractErrorMessages,
   extractValidationMessageKeys,
 } from "../../utils/errors";
+import specialErrorExchange from "../../exchanges/specialErrorExchange";
 
 const apiUri = process.env.API_URI ?? "http://localhost:8000/graphql";
 
@@ -198,6 +199,7 @@ const ClientProvider = ({
             didAuthError,
             willAuthError,
           }),
+          specialErrorExchange({ intl }),
           fetchExchange,
         ],
       })

--- a/packages/client/src/exchanges/specialErrorExchange.ts
+++ b/packages/client/src/exchanges/specialErrorExchange.ts
@@ -1,0 +1,36 @@
+import { pipe, tap } from "wonka";
+import type { Exchange } from "@urql/core";
+import { IntlShape } from "react-intl";
+
+import { toast } from "@gc-digital-talent/toast";
+import { errorMessages } from "@gc-digital-talent/i18n";
+
+/** Input parameters for the specialErrorExchange. */
+export interface SpecialErrorExchangeOptions {
+  intl: IntlShape;
+}
+
+// A custom exchange that watches for special errors that are meaningful to us and need special handling.
+const specialErrorExchange = ({ intl }: SpecialErrorExchangeOptions) => {
+  const exchange: Exchange =
+    ({ forward }) =>
+    (ops$) =>
+      pipe(
+        ops$,
+        // eslint-disable-next-line no-console
+        // tap((op) => console.log("[Exchange debug]: Incoming operation: ", op)),
+        forward,
+        tap((result) => {
+          if (
+            result.error?.response.status === 403 &&
+            result.error.networkError?.message.includes("Request Rejected")
+          ) {
+            toast.error(intl.formatMessage(errorMessages.specialCharacters));
+          }
+        }),
+      );
+
+  return exchange;
+};
+
+export default specialErrorExchange;

--- a/packages/forms/src/components/Input/Input.tsx
+++ b/packages/forms/src/components/Input/Input.tsx
@@ -8,6 +8,7 @@ import useFieldState from "../../hooks/useFieldState";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
 import useCommonInputStyles from "../../hooks/useCommonInputStyles";
+import { sanitizeString } from "../../utils";
 
 export type InputProps = HTMLInputProps &
   CommonInputProps & {
@@ -51,11 +52,13 @@ const Input = ({
     },
   });
 
-  const whitespaceTrimmer = (e: React.FocusEvent<HTMLInputElement>) => {
+  const normalizeInput = (e: React.FocusEvent<HTMLInputElement>) => {
+    let inputValue = e.target.value;
     if (whitespaceTrim) {
-      const value = e.target.value.trim();
-      setValue(name, value);
+      inputValue = inputValue.trim();
     }
+    inputValue = sanitizeString(inputValue);
+    setValue(name, inputValue);
   };
 
   return (
@@ -73,7 +76,7 @@ const Input = ({
         {...stateStyles}
         {...register(name, {
           ...rules,
-          onBlur: whitespaceTrimmer,
+          onBlur: normalizeInput,
         })}
         {...(readOnly
           ? {

--- a/packages/forms/src/components/TextArea/TextArea.tsx
+++ b/packages/forms/src/components/TextArea/TextArea.tsx
@@ -8,7 +8,7 @@ import { errorMessages } from "@gc-digital-talent/i18n";
 import Field from "../Field";
 import WordCounter from "../WordCounter";
 import type { CommonInputProps } from "../../types";
-import { countNumberOfWords } from "../../utils";
+import { countNumberOfWords, sanitizeString } from "../../utils";
 import useFieldState from "../../hooks/useFieldState";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
@@ -62,11 +62,13 @@ const TextArea = ({
     },
   });
 
-  const whitespaceTrimmer = (e: React.FocusEvent<HTMLTextAreaElement>) => {
+  const normalizeInput = (e: React.FocusEvent<HTMLTextAreaElement>) => {
+    let inputValue = e.target.value;
     if (whitespaceTrim) {
-      const value = e.target.value.trim();
-      setValue(name, value);
+      inputValue = inputValue.trim();
     }
+    inputValue = sanitizeString(inputValue);
+    setValue(name, inputValue);
   };
 
   let wordLimitRule = {};
@@ -108,7 +110,7 @@ const TextArea = ({
               ...rules.validate,
               ...wordLimitRule,
             },
-            onBlur: whitespaceTrimmer,
+            onBlur: normalizeInput,
           })}
           {...(readOnly
             ? {

--- a/packages/forms/src/utils.ts
+++ b/packages/forms/src/utils.ts
@@ -205,3 +205,16 @@ export function enumToOptionsWorkRegionSorted(
 export function htmlToRichTextJSON(html: string): Node {
   return generateJSON(html, [StarterKit, Link]) as Node;
 }
+
+const sanitizeSubstitutions: Record<string, string> = {
+  "\u202F": "\u00A0", // Narrow No-Break Space ➡️ No-Break Space
+} as const;
+
+export function sanitizeString(original: string): string {
+  let str = original;
+  Object.keys(sanitizeSubstitutions).forEach((key) => {
+    const replacement = sanitizeSubstitutions[key];
+    str = str.replaceAll(key, replacement);
+  });
+  return str;
+}

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -646,6 +646,10 @@
     "defaultMessage": "La date doit être avant ou égale au {date}",
     "description": "Error message when a date was entered that is greater than the maximum required"
   },
+  "Q3Pc71": {
+    "defaultMessage": "Il n’est pas possible de sauvegarder ce texte. Veillez à ce que le texte soit dépourvu de formatage ou de caractères spéciaux, et essayez de nouveau.",
+    "description": "Error message that there might be a special character."
+  },
   "QCcpJr": {
     "defaultMessage": "Éliminé à la présélection – non réactif",
     "description": "The pool candidate's status is Screened Out because no longer responding"

--- a/packages/i18n/src/messages/errorMessages.ts
+++ b/packages/i18n/src/messages/errorMessages.ts
@@ -99,6 +99,12 @@ const errorMessages = defineMessages({
     description:
       "Error message when a date was entered that is greater than the maximum required",
   },
+  specialCharacters: {
+    defaultMessage:
+      "The text cannot be saved. Please ensure the text has no formatting or special characters and try again.",
+    id: "Q3Pc71",
+    description: "Error message that there might be a special character.",
+  },
 });
 
 export default errorMessages;


### PR DESCRIPTION
🤖 Resolves #7812 

## 👋 Introduction

This branch (attempts) to add an error message to help users identify when a request has been rejected due to banned characters.  It also adds a graceful handling for the narrow no-break space.

## 🕵️ Details

Since this behaviour only occurs on the production site behind the production firewall, I added a middleware that can be activated to simulate this behaviour locally.

For the narrow no-break space, I hooked into the whitespace trimming logic that already existed.  I did test that a regular no-break space is OK in production.

## 🧪 Testing

1. Uncomment the `SimulateFirewallMiddleware` class in kernel.php
2. Open a form and add a [narrow no-break space](https://symbl.cc/en/202F/) to an input and submit it.
3. Observe that it was converted to a regular no-break space onBlur.
![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/44d92d39-e41b-43a8-ae0f-139729960113)
4. Add another character to the banned character list in `SimulateFirewallMiddleware`.
![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/47556bdf-c583-4e34-8085-685a2bc0f163)
5. Attempt to submit a form with that other banned character.
6. Observe that a descriptive toast message appears when the request is rejected.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/c6e9ab52-43ce-4c06-ae45-f1d692e760bf)
