### PR TITLE
[Bug] Skill dialog in skill showcases should save ranking

### DIFF
--- a/apps/web/src/pages/Skills/ImproveBehaviouralSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/ImproveBehaviouralSkillsPage.tsx
@@ -141,6 +141,41 @@ const ImproveBehaviouralSkills = ({
       });
   };
 
+  const updateRankingsAfterAddingSkill = (
+    initialSkillRanking: string[],
+    newSkillId: string,
+  ) => {
+    const mergedSkillIds = [...initialSkillRanking, newSkillId];
+    executeMutation({
+      userId: user?.id,
+      userSkillRanking: {
+        improveBehaviouralSkillsRanked: mergedSkillIds,
+      },
+    })
+      .then((res) => {
+        if (res.data) {
+          toast.success(
+            intl.formatMessage({
+              defaultMessage: "Successfully updated improve behavioural skills",
+              id: "B6SS7l",
+              description:
+                "Success message displayed after updating improve behavioural skills",
+            }),
+          );
+        }
+      })
+      .catch(() => {
+        toast.error(
+          intl.formatMessage({
+            defaultMessage: "Error: updating improve behavioural skills failed",
+            id: "O53DAg",
+            description:
+              "Message displayed to user after improve behavioural skills fails to update",
+          }),
+        );
+      });
+  };
+
   return (
     <UpdateSkillShowcase
       userId={user?.id}
@@ -150,6 +185,7 @@ const ImproveBehaviouralSkills = ({
       userSkills={userSkills}
       initialSkills={initialSkills}
       handleSubmit={handleUpdateUserSkillRankings}
+      onAddition={updateRankingsAfterAddingSkill}
     />
   );
 };

--- a/apps/web/src/pages/Skills/ImproveTechnicalSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/ImproveTechnicalSkillsPage.tsx
@@ -141,6 +141,41 @@ const ImproveTechnicalSkills = ({
       });
   };
 
+  const updateRankingsAfterAddingSkill = (
+    initialSkillRanking: string[],
+    newSkillId: string,
+  ) => {
+    const mergedSkillIds = [...initialSkillRanking, newSkillId];
+    executeMutation({
+      userId: user?.id,
+      userSkillRanking: {
+        improveTechnicalSkillsRanked: mergedSkillIds,
+      },
+    })
+      .then((res) => {
+        if (res.data) {
+          toast.success(
+            intl.formatMessage({
+              defaultMessage: "Successfully updated improve technical skills",
+              id: "z5f+GT",
+              description:
+                "Success message displayed after updating improve technical skills",
+            }),
+          );
+        }
+      })
+      .catch(() => {
+        toast.error(
+          intl.formatMessage({
+            defaultMessage: "Error: updating improve technical skills failed",
+            id: "dpvwTf",
+            description:
+              "Message displayed to user after improve technical skills fails to update",
+          }),
+        );
+      });
+  };
+
   return (
     <UpdateSkillShowcase
       userId={user?.id}
@@ -150,6 +185,7 @@ const ImproveTechnicalSkills = ({
       userSkills={userSkills}
       initialSkills={initialSkills}
       handleSubmit={handleUpdateUserSkillRankings}
+      onAddition={updateRankingsAfterAddingSkill}
     />
   );
 };

--- a/apps/web/src/pages/Skills/TopBehaviouralSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/TopBehaviouralSkillsPage.tsx
@@ -141,6 +141,41 @@ const TopBehaviouralSkills = ({
       });
   };
 
+  const updateRankingsAfterAddingSkill = (
+    initialSkillRanking: string[],
+    newSkillId: string,
+  ) => {
+    const mergedSkillIds = [...initialSkillRanking, newSkillId];
+    executeMutation({
+      userId: user?.id,
+      userSkillRanking: {
+        topBehaviouralSkillsRanked: mergedSkillIds,
+      },
+    })
+      .then((res) => {
+        if (res.data) {
+          toast.success(
+            intl.formatMessage({
+              defaultMessage: "Successfully updated top behavioural skills",
+              id: "GfjNqa",
+              description:
+                "Success message displayed after updating top behavioural skills",
+            }),
+          );
+        }
+      })
+      .catch(() => {
+        toast.error(
+          intl.formatMessage({
+            defaultMessage: "Error: updating top behavioural skills failed",
+            id: "+dmNpa",
+            description:
+              "Message displayed to user after top behavioural skills fails to update",
+          }),
+        );
+      });
+  };
+
   return (
     <UpdateSkillShowcase
       userId={user?.id}
@@ -150,6 +185,7 @@ const TopBehaviouralSkills = ({
       userSkills={userSkills}
       initialSkills={initialSkills}
       handleSubmit={handleUpdateUserSkillRankings}
+      onAddition={updateRankingsAfterAddingSkill}
     />
   );
 };

--- a/apps/web/src/pages/Skills/TopTechnicalSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/TopTechnicalSkillsPage.tsx
@@ -141,6 +141,41 @@ const TopTechnicalSkills = ({
       });
   };
 
+  const updateRankingsAfterAddingSkill = (
+    initialSkillRanking: string[],
+    newSkillId: string,
+  ) => {
+    const mergedSkillIds = [...initialSkillRanking, newSkillId];
+    executeMutation({
+      userId: user?.id,
+      userSkillRanking: {
+        topTechnicalSkillsRanked: mergedSkillIds,
+      },
+    })
+      .then((res) => {
+        if (res.data) {
+          toast.success(
+            intl.formatMessage({
+              defaultMessage: "Successfully updated top technical skills",
+              id: "iqmE+5",
+              description:
+                "Success message displayed after updating top technical skills",
+            }),
+          );
+        }
+      })
+      .catch(() => {
+        toast.error(
+          intl.formatMessage({
+            defaultMessage: "Error: updating top technical skills failed",
+            id: "D1+SmE",
+            description:
+              "Message displayed to user after top technical skills fails to update",
+          }),
+        );
+      });
+  };
+
   return (
     <UpdateSkillShowcase
       userId={user?.id}
@@ -150,6 +185,7 @@ const TopTechnicalSkills = ({
       userSkills={userSkills}
       initialSkills={initialSkills}
       handleSubmit={handleUpdateUserSkillRankings}
+      onAddition={updateRankingsAfterAddingSkill}
     />
   );
 };

--- a/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
+++ b/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
@@ -113,7 +113,7 @@ const UpdateSkillShowcase = ({
     defaultValues: initialSkills,
   });
   const { control, watch, formState } = methods;
-  const { remove, move, append, fields } = useFieldArray({
+  const { remove, move, fields } = useFieldArray({
     control,
     name: "userSkills",
   });
@@ -164,13 +164,6 @@ const UpdateSkillShowcase = ({
         },
       })
         .then((res) => {
-          append(
-            {
-              skill: res.data?.updateUserSkill?.skill.id,
-              skillLevel: res.data?.updateUserSkill?.skillLevel ?? undefined,
-            },
-            { shouldFocus: false },
-          );
           handleSuccess();
           if (res.data?.updateUserSkill?.skill.id) {
             // having claimed a user skill in the modal and the mutation successful, update the ranking
@@ -191,13 +184,6 @@ const UpdateSkillShowcase = ({
         },
       })
         .then((res) => {
-          append(
-            {
-              skill: res.data?.createUserSkill?.skill.id,
-              skillLevel: res.data?.createUserSkill?.skillLevel ?? undefined,
-            },
-            { shouldFocus: false },
-          );
           handleSuccess();
           if (res.data?.createUserSkill?.skill.id) {
             onAddition(


### PR DESCRIPTION
🤖 Resolves #8087

## 👋 Introduction

Updating/claiming a skill in the showcase context will update the ranking after the first mutation completes.

## 🕵️ Details

Elected to add another mutation via function that returns nothing, given the other is tightly coupled to the form it seemed better to not try and adjust the handler to fit two very different shapes. 
Removed the `append` call as updating the ranking reloads the parent component anyway. 

## 🧪 Testing

1. Pick a showcase type, open it up and add a skill
2. Note showcase is updated without requiring another save action on your part

Recording

https://recordit.co/imrrXJUohq

