### PR TITLE
[Fix] Update select styles for FF

### DIFF
--- a/packages/forms/src/components/DateInput/ControlledInput.tsx
+++ b/packages/forms/src/components/DateInput/ControlledInput.tsx
@@ -17,18 +17,21 @@ import {
   setComputedValue,
   splitSegments,
 } from "./utils";
+import { StyleRecord } from "../../types";
 
 interface ControlledInputProps {
   field: ControllerRenderProps<FieldValues, string>;
   fieldState: ControllerFieldState;
   formState: UseFormStateReturn<FieldValues>;
   show: Array<DateSegment>;
+  stateStyles: StyleRecord;
 }
 
 const ControlledInput = ({
   field: { onChange, value, name },
   formState: { defaultValues },
   show,
+  stateStyles,
 }: ControlledInputProps) => {
   const intl = useIntl();
   const inputStyles = useCommonInputStyles();
@@ -90,6 +93,7 @@ const ControlledInput = ({
             data-h2-width="base(100%)"
             min={1900}
             {...inputStyles}
+            {...stateStyles}
           />
         </div>
       )}
@@ -105,6 +109,7 @@ const ControlledInput = ({
             defaultValue={month || ""}
             data-h2-width="base(100%)"
             {...inputStyles}
+            {...stateStyles}
           >
             <option value="">
               {intl.formatMessage(dateMessages.selectAMonth)}
@@ -133,6 +138,7 @@ const ControlledInput = ({
             placeholder={intl.formatMessage(dateMessages.dayPlaceholder)}
             data-h2-width="base(100%)"
             {...inputStyles}
+            {...stateStyles}
           />
         </div>
       )}

--- a/packages/forms/src/components/DateInput/DateInput.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.tsx
@@ -19,6 +19,7 @@ import useInputDescribedBy from "../../hooks/useInputDescribedBy";
 import ControlledInput from "./ControlledInput";
 import { splitSegments } from "./utils";
 import { DateRegisterOptions, DateSegment, DATE_SEGMENT } from "./types";
+import useFieldStateStyles from "../../hooks/useFieldStateStyles";
 
 export type DateInputProps = Omit<CommonInputProps, "rules" | "label"> &
   HTMLFieldsetProps & {
@@ -56,6 +57,7 @@ const DateInput = ({
   const error = get(errors, name)?.message as FieldError;
   const required = !!rules.required;
   const fieldState = useFieldState(name, !trackUnsaved);
+  const stateStyles = useFieldStateStyles(name, !trackUnsaved);
   const isUnsaved = fieldState === "dirty" && trackUnsaved;
   const [descriptionIds, ariaDescribedBy] = useInputDescribedBy({
     id,
@@ -128,7 +130,13 @@ const DateInput = ({
                 isBeforeMax,
               },
             }}
-            render={(props) => <ControlledInput {...props} show={show} />}
+            render={(props) => (
+              <ControlledInput
+                {...props}
+                show={show}
+                stateStyles={stateStyles}
+              />
+            )}
           />
         </Field.BoundingBox>
       </Field.Fieldset>

--- a/packages/forms/src/styles.ts
+++ b/packages/forms/src/styles.ts
@@ -10,6 +10,7 @@ const fieldStateStyles: Record<FieldState, Record<string, string>> = {
     "data-h2-background-color": "base(error.lightest)",
   },
   dirty: {
+    "data-h2-background-color": "base(foreground)",
     "data-h2-border-color": "base(secondary.darker) base:focus-visible(focus)",
   },
 };


### PR DESCRIPTION
🤖 Resolves #8003 

## 👋 Introduction

This fixes `select` styles for Firefox, preventing them from looking disabled in comparison to other inputs.

## 🕵️ Details

This does a few things in order to fix it:

- Passes field state styles to the controlled inputs on the `DateInput`
    - This will also now show inputs as red when there is an error
- Updates the state styles to also apply background on the dirty state
    - This was an issue for all `select` once the value had been changed they looked to be disabled

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> **Note**
> Since this is a Firefox specific bug, you must do the testing in Firefox. Also, confirm no changes in other browsers.

1. Run storybook `npm run storybook`
2. Navigate to the date input stories
3. Confirm the month input does not appear with a grey background and looks active
4. Force an error and confirm input styles change to an error state
5. Navigate to the regular select story
6. Update the value
7. Confirm the input does not look disabled

## 📸 Screenshot

![Screenshot 2023-10-04 084311](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/86a490cf-399b-469b-a7fa-76c229d3504b)
