### PR TITLE
[Fix] Stabilize team members table

### DIFF
--- a/apps/web/src/pages/Teams/teamsOperations.graphql
+++ b/apps/web/src/pages/Teams/teamsOperations.graphql
@@ -131,6 +131,31 @@ query ViewTeam($id: UUID!) {
   }
 }
 
+query TeamMembers($id: UUID!) {
+  team(id: $id) {
+    ...team
+  }
+  roles {
+    id
+    name
+    isTeamBased
+    displayName {
+      en
+      fr
+    }
+  }
+  users {
+    id
+    email
+    firstName
+    lastName
+    telephone
+    preferredLang
+    preferredLanguageForInterview
+    preferredLanguageForExam
+  }
+}
+
 query TeamName($id: UUID!) {
   team(id: $id) {
     id


### PR DESCRIPTION
🤖 Resolves #8123 

## 👋 Introduction

This fixes an issue that was causing our team members table to infinitely re-render.

## 🕵️ Details

We were running three separate queries that go similar data. The data was changing causing re-renders to happen at different intervals. This combines all three queries into one and memoizes the data being passed into and used by the table to stabilize it.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to a team members page `/admin/teams/{teamId}/members`
2. Confirm the table is not re-rendering infinitely 
