### PR TITLE
[a11y] Adjust table control tab order

### DIFF
--- a/apps/web/src/components/Table/ResponsiveTable/SearchForm.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/SearchForm.tsx
@@ -189,7 +189,7 @@ const SearchForm = <T,>({
             data-h2-background-color="base(foreground)"
             data-h2-border-color="base(gray) base:focus-visible(focus)"
             data-h2-margin-left="base(0)"
-            data-h2-padding="base(x.5 x1.5)"
+            data-h2-padding="base(x.5 x1.5 x.5 x.5)"
             data-h2-width="base(100%) l-tablet(auto)"
             {...(showDropdown
               ? {

--- a/apps/web/src/components/Table/ResponsiveTable/Table.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/Table.tsx
@@ -230,17 +230,18 @@ const Controls = ({ children, add }: ControlsProps) => (
     data-h2-justify-content="base(space-between)"
     data-h2-font-size="base(caption)"
   >
+    {add && <AddAction add={add} />}
     <div
       data-h2-display="base(flex)"
       data-h2-align-items="base(flex-end)"
       data-h2-flex-direction="base(column) l-tablet(row)"
       data-h2-gap="base(x.25 0) l-tablet(0 x.25)"
       data-h2-flex-grow="base(1)"
+      data-h2-order="base(-1)"
       data-h2-width="base(100%) l-tablet(auto)"
     >
       {children}
     </div>
-    {add && <AddAction add={add} />}
   </div>
 );
 


### PR DESCRIPTION
🤖 Resolves #8109 

## 👋 Introduction

Updates the tab order of table action buttons to make the "add" item the first in the tab order.

> **Note**
> This also fixes some extra padding in the search input where the icon used to be but was removed.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate tot a table with an "add" option
3. Hit tab and confirm focus goes first to the "add" button then the search form/filters
