### PR TITLE
[Copy] Refactors document links to be current locale only

### DIFF
--- a/apps/e2e/cypress/e2e/talentsearch/static-pages.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/static-pages.cy.js
@@ -117,14 +117,14 @@ describe("Static pages", () => {
       });
 
       cy.findByRole("link", {
-        name: /formulaire de recrutement propre à un ministère/i,
+        name: /le formulaire recrutement particulier à un ministère/i,
       }).click();
       cy.verifyDownload("Modele_de_recrutement_numerique_FR.docx", {
         contains: true,
       });
 
       cy.findByRole("link", {
-        name: /formulaire d’octroi de contrat de services numériques/i,
+        name: /le formulaire octroi de contrat pour des services numériques/i,
       }).click();
       cy.verifyDownload(
         "Questionnaire_d'octroi_de_contrats_numeriques_FR.docx",
@@ -132,7 +132,7 @@ describe("Static pages", () => {
       );
 
       cy.findByRole("link", {
-        name: /faire suivre le plan de talents/i,
+        name: /le formulaire faire suivre le plan de talents/i,
       }).click();
       cy.verifyDownload("Plan_prospectif_sur_les_talents_FR.docx", {
         contains: true,

--- a/apps/e2e/cypress/e2e/talentsearch/static-pages.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/static-pages.cy.js
@@ -7,8 +7,8 @@ describe("Static pages", () => {
       );
     });
 
-    it('should have no accessibility errors', () => {
-      cy.visit('/en/privacy-notice');
+    it("should have no accessibility errors", () => {
+      cy.visit("/en/privacy-notice");
       cy.findByRole("heading", { name: "Privacy notice", level: 1 }).should(
         "exist",
       );
@@ -26,8 +26,8 @@ describe("Static pages", () => {
       }).should("exist");
     });
 
-    it('should have no accessibility errors', () => {
-      cy.visit('/en/terms-and-conditions');
+    it("should have no accessibility errors", () => {
+      cy.visit("/en/terms-and-conditions");
       cy.findByRole("heading", {
         name: "Terms and conditions",
         level: 1,
@@ -35,64 +35,108 @@ describe("Static pages", () => {
       cy.injectAxe();
       cy.checkA11y();
     });
-  })
+  });
 
-  context('Accessibility Statement page', () => {
-    it('should exist', () => {
-      cy.visit('/en/accessibility-statement')
-      cy.findByRole('heading', { name: 'Accessibility statement', level: 1 }).should('exist')
-    })
+  context("Accessibility Statement page", () => {
+    it("should exist", () => {
+      cy.visit("/en/accessibility-statement");
+      cy.findByRole("heading", {
+        name: "Accessibility statement",
+        level: 1,
+      }).should("exist");
+    });
 
-    it('should have no accessibility errors', () => {
-      cy.visit('/en/accessibility-statement');
+    it("should have no accessibility errors", () => {
+      cy.visit("/en/accessibility-statement");
       cy.injectAxe();
-      cy.findByRole('heading', { name: 'Accessibility statement', level: 1 }).should('exist');
+      cy.findByRole("heading", {
+        name: "Accessibility statement",
+        level: 1,
+      }).should("exist");
       cy.checkA11y();
     });
   });
 
-  context('Directive page', () => {
-    it('should exist', () => {
-      cy.visit('/en/directive-on-digital-talent')
-      cy.findByRole('heading', { name: 'Directive on Digital Talent', level: 1 }).should('exist')
-    })
+  context("Directive page", () => {
+    it("should exist", () => {
+      cy.visit("/en/directive-on-digital-talent");
+      cy.findByRole("heading", {
+        name: "Directive on Digital Talent",
+        level: 1,
+      }).should("exist");
+    });
 
-    it('should have no accessibility errors', () => {
-      cy.visit('/en/directive-on-digital-talent');
+    it("should have no accessibility errors", () => {
+      cy.visit("/en/directive-on-digital-talent");
       cy.injectAxe();
-      cy.findByRole('heading', { name: 'Directive on Digital Talent', level: 1 }).should('exist');
+      cy.findByRole("heading", {
+        name: "Directive on Digital Talent",
+        level: 1,
+      }).should("exist");
       cy.checkA11y();
     });
 
-    it('should download files', () => {
-      cy.visit('/en/directive-on-digital-talent');
+    it("should download files in english", () => {
+      cy.visit("/en/directive-on-digital-talent");
 
       // Open accordion
       cy.findByRole("button", { name: /enabling conditions/i }).click();
 
-      cy.findByRole("link", { name: /download the guidance \(en\)/i }).click();
-      cy.verifyDownload("Enabling_Conditions_Guidance_EN.docx", { contains: true });
+      cy.findByRole("link", { name: /download the guidance/i }).click();
+      cy.verifyDownload("Enabling_Conditions_Guidance_EN.docx", {
+        contains: true,
+      });
 
-      cy.findByRole("link", { name: /download the guidance \(fr\)/i }).click();
-      cy.verifyDownload("Orientation_sur_les_conditions_habilitantes_FR.docx", { contains: true });
+      cy.findByRole("link", {
+        name: /department-specific recruitment form/i,
+      }).click();
+      cy.verifyDownload("Digital_Recruitment_Template_EN.docx", {
+        contains: true,
+      });
 
-      cy.findByRole("link", { name: /department-specific recruitment form \(en\)/i }).click();
-      cy.verifyDownload("Digital_Recruitment_Template_EN.docx", { contains: true });
+      cy.findByRole("link", {
+        name: /digital services contracting form/i,
+      }).click();
+      cy.verifyDownload("Digital_Contracting_Questionnaire_EN.docx", {
+        contains: true,
+      });
 
-      cy.findByRole("link", { name: /department-specific recruitment form \(fr\)/i }).click();
-      cy.verifyDownload("Modele_de_recrutement_numerique_FR.docx", { contains: true });
-
-      cy.findByRole("link", { name: /digital services contracting form \(en\)/i }).click();
-      cy.verifyDownload("Digital_Contracting_Questionnaire_EN.docx", { contains: true });
-
-      cy.findByRole("link", { name: /digital services contracting form \(fr\)/i }).click();
-      cy.verifyDownload("Questionnaire_d'octroi_de_contrats_numeriques_FR.docx", { contains: true });
-
-      cy.findByRole("link", { name: /forward talent plan form \(en\)/i }).click();
+      cy.findByRole("link", { name: /forward talent plan form/i }).click();
       cy.verifyDownload("Forward_Talent_Plan_EN.docx", { contains: true });
+    });
 
-      cy.findByRole("link", { name: /forward talent plan form \(fr\)/i }).click();
-      cy.verifyDownload("Plan_prospectif_sur_les_talents_FR.docx", { contains: true });
+    it("should download files in french", () => {
+      cy.visit("/fr/directive-on-digital-talent");
+
+      // Open accordion
+      cy.findByRole("button", { name: /conditions favorables/i }).click();
+
+      cy.findByRole("link", { name: /télécharger le guide/i }).click();
+      cy.verifyDownload("Orientation_sur_les_conditions_habilitantes_FR.docx", {
+        contains: true,
+      });
+
+      cy.findByRole("link", {
+        name: /formulaire de recrutement propre à un ministère/i,
+      }).click();
+      cy.verifyDownload("Modele_de_recrutement_numerique_FR.docx", {
+        contains: true,
+      });
+
+      cy.findByRole("link", {
+        name: /formulaire d’octroi de contrat de services numériques/i,
+      }).click();
+      cy.verifyDownload(
+        "Questionnaire_d'octroi_de_contrats_numeriques_FR.docx",
+        { contains: true },
+      );
+
+      cy.findByRole("link", {
+        name: /faire suivre le plan de talents/i,
+      }).click();
+      cy.verifyDownload("Plan_prospectif_sur_les_talents_FR.docx", {
+        contains: true,
+      });
     });
   });
 });

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -357,10 +357,6 @@
   "0/8x/z": {
     "defaultMessage": "N’importe quelle langue"
   },
-  "000m9d": {
-    "defaultMessage": "Télécharger le formulaire<hidden>{formName} </hidden> (FR)",
-    "description": "Link text for an French form download"
-  },
   "00lloL": {
     "defaultMessage": "Les compétences qui ne sont pas liées à cette demande seront dissimulées dans le cadre de l’évaluation initiale de votre demande, mais elles seront toujours visibles dans votre profil.",
     "description": "Text that appears during an application to explain skills appearing missing from their profile."
@@ -4443,6 +4439,10 @@
     "defaultMessage": "Aidez-nous à vous apparier avec les meilleurs candidats en partageant de plus amples renseignements avec notre équipe sur les compétences particulières dont vous recherchez.",
     "description": "Describing the purpose of the skill filters on the Search page."
   },
+  "RA6v6+": {
+    "defaultMessage": "Télécharger le formulaire<hidden>{formName} </hidden>",
+    "description": "Link text for form download"
+  },
   "RBsGRp": {
     "defaultMessage": "Postulez au recrutement en cours",
     "description": "title for section with ongoing pool advertisements"
@@ -5452,10 +5452,6 @@
   "YCqTbH": {
     "defaultMessage": "Apprendre comment décrire le mieux possible votre expérience d’une compétence",
     "description": "Button text to open accordion describing skill experience"
-  },
-  "YDJiAT": {
-    "defaultMessage": "Télécharger le formulaire<hidden>{formName} </hidden> (EN)",
-    "description": "Link text for an English form download"
   },
   "YGM/D5": {
     "defaultMessage": "Le programme dure 24 mois et les apprentis ont accès à un soutien pendant leur période de participation au programme.",
@@ -6640,10 +6636,6 @@
   "fpdcE/": {
     "defaultMessage": "<strong>Établissement de rapports obligatoires</strong>. Désormais nécessaires lorsque vous souhaitez lancer un processus d’acquisition de talents numériques, en particulier si vous envisagez d’établir un contrat parce que vous avez du mal à trouver les bons talents à embaucher. Pas d’approbation supplémentaire – il suffit de nous faire part de vos projets!",
     "description": "Description for the digital Services contracting form"
-  },
-  "ft6q8G": {
-    "defaultMessage": "Télécharger le guide (FR)",
-    "description": "Link text for French guidance resource download"
   },
   "ftg8sT": {
     "defaultMessage": "L’identification de votre demande {title} a été copiée ",
@@ -9027,10 +9019,6 @@
     "defaultMessage": "Signaler un bogue",
     "description": "Support form subject field bug option label"
   },
-  "wMp4x6": {
-    "defaultMessage": "Télécharger le guide (EN)",
-    "description": "Link text for English guidance resource download"
-  },
   "wNJSJ7": {
     "defaultMessage": "En valorisant et en misant sur le potentiel d’une personne plutôt que sur son niveau de scolarité, le programme élimine l’un des plus grands obstacles qui existe en matière d’emploi dans l’économie numérique. Le programme a été élaboré par, avec et pour des personnes autochtones à travers le Canada. Il intègre les préférences et les besoins des apprenants autochtones tout en reconnaissant l’importance de la communauté.",
     "description": "Second paragraph about the program"
@@ -9286,6 +9274,10 @@
   "ySkRmX": {
     "defaultMessage": "Bibliothèque des compétences",
     "description": "Page title for the skill library page"
+  },
+  "yVOpEI": {
+    "defaultMessage": "Télécharger le guide",
+    "description": "Link text for guidance resource download"
   },
   "yXXj1D": {
     "defaultMessage": "Commencez <hidden> à remplir la section sur vos renseignements en tant que fonctionnaire </hidden>",

--- a/apps/web/src/pages/DirectivePage/DirectivePage.tsx
+++ b/apps/web/src/pages/DirectivePage/DirectivePage.tsx
@@ -27,7 +27,7 @@ import guidanceFr from "~/assets/documents/Orientation_sur_les_conditions_habili
 import contractingEn from "~/assets/documents/Digital_Contracting_Questionnaire_EN.docx";
 import contractingFr from "~/assets/documents/Questionnaire_d'octroi_de_contrats_numeriques_FR.docx";
 
-import { getFormLinks, getGenericLinks } from "./utils";
+import getFormLinks from "./utils";
 
 const policyLink = (locale: Locales, chunks: React.ReactNode) => (
   <Link
@@ -115,26 +115,6 @@ const DirectivePage = () => {
       id: "G0RoYe",
       description: "Short name for Forward Talent Plan Form",
     }),
-  });
-
-  const guidanceLinks = getGenericLinks({
-    intl,
-    files: {
-      en: guidanceEn,
-      fr: guidanceFr,
-    },
-    labels: {
-      en: intl.formatMessage({
-        defaultMessage: "Download the guidance (EN)",
-        id: "wMp4x6",
-        description: "Link text for English guidance resource download",
-      }),
-      fr: intl.formatMessage({
-        defaultMessage: "Download the guidance (FR)",
-        id: "ft6q8G",
-        description: "Link text for French guidance resource download",
-      }),
-    },
   });
 
   return (
@@ -366,14 +346,20 @@ const DirectivePage = () => {
                     data-h2-flex-wrap="base(wrap)"
                     data-h2-gap="base(x.25)"
                   >
-                    {guidanceLinks.map((guidanceLink) => (
-                      <Link
-                        key={guidanceLink.naturalKey ?? guidanceLink.href}
-                        external
-                        color="primary"
-                        {...guidanceLink}
-                      />
-                    ))}
+                    <Link
+                      external
+                      color="primary"
+                      mode="solid"
+                      data-h2-padding="base(x.5, x1)"
+                      href={locale === "en" ? guidanceEn : guidanceFr}
+                      download
+                    >
+                      {intl.formatMessage({
+                        defaultMessage: "Download the guidance",
+                        id: "yVOpEI",
+                        description: "Link text for guidance resource download",
+                      })}
+                    </Link>
                   </div>
                 </Accordion.Content>
               </Accordion.Item>

--- a/apps/web/src/pages/DirectivePage/utils.ts
+++ b/apps/web/src/pages/DirectivePage/utils.ts
@@ -1,7 +1,7 @@
 import React from "react";
 import { IntlShape } from "react-intl";
 
-import { CardFlatProps, LinkProps } from "@gc-digital-talent/ui";
+import { CardFlatProps } from "@gc-digital-talent/ui";
 
 interface GetFormLinkArgs {
   formName: React.ReactNode;
@@ -10,14 +10,12 @@ interface GetFormLinkArgs {
 }
 
 /**
- * Gets English and French form link props and reverses
- * them so the active language is the first item
- * in an array and injects form name in the link as hidden
- * text
+ * Gets English and French form link props
+ * and injects form name in the link as hidden text
  *
  * @returns CardFlatProps["links"] A tuple of the link props
  */
-export const getFormLinks = ({
+const getFormLinks = ({
   formName,
   files,
   intl,
@@ -26,82 +24,21 @@ export const getFormLinks = ({
     {
       label: intl.formatMessage(
         {
-          defaultMessage: "Download <hidden>{formName} </hidden>form (EN)",
-          id: "YDJiAT",
-          description: "Link text for an English form download",
+          defaultMessage: "Download <hidden>{formName} </hidden>form",
+          id: "RA6v6+",
+          description: "Link text for form download",
         },
         { formName },
       ),
-      href: files.en,
-      mode: intl.locale === "en" ? "solid" : "inline",
+      href: intl.locale === "en" ? files.en : files.fr,
+      mode: "solid",
       "data-h2-padding": "base(x.5, x1)",
       download: true,
       external: true,
-      naturalKey: `${formName}EN${files.en}`,
-    },
-    {
-      label: intl.formatMessage(
-        {
-          defaultMessage: "Download <hidden>{formName} </hidden>form (FR)",
-          id: "000m9d",
-          description: "Link text for an French form download",
-        },
-        { formName },
-      ),
-      href: files.fr,
-      mode: intl.locale === "en" ? "inline" : "solid",
-      "data-h2-padding": "base(x.5, x1)",
-      download: true,
-      external: true,
-      naturalKey: `${formName}FR${files.fr}`,
     },
   ];
 
-  return intl.locale === "en" ? links : links.reverse();
+  return links;
 };
 
-interface GetGenericLinksArgs {
-  labels: {
-    en: React.ReactNode;
-    fr: React.ReactNode;
-  };
-  files: { en: string; fr: string };
-  intl: IntlShape;
-}
-
-// add a natural key since mocked files do not have unique hrefs
-type GenericLinkType = LinkProps & { naturalKey?: string };
-
-/**
- * Gets English and French link props and reverses
- * them so the active language is the first item
- * in an array
- *
- * @returns Array<LinkProps> A tuple of the link props
- */
-export const getGenericLinks = ({
-  labels,
-  files,
-  intl,
-}: GetGenericLinksArgs) => {
-  const links: Array<GenericLinkType> = [
-    {
-      children: labels.en,
-      href: files.en,
-      mode: intl.locale === "en" ? "solid" : "inline",
-      "data-h2-padding": "base(x.5, x1)",
-      download: true,
-      naturalKey: `${labels.en}${files.en}`,
-    },
-    {
-      children: labels.fr,
-      href: files.fr,
-      mode: intl.locale === "en" ? "inline" : "solid",
-      "data-h2-padding": "base(x.5, x1)",
-      download: true,
-      naturalKey: `${labels.fr}${files.fr}`,
-    },
-  ];
-
-  return intl.locale === "en" ? links : links.reverse();
-};
+export default getFormLinks;


### PR DESCRIPTION
🤖 Resolves #8156.

## 👋 Introduction

This PR refactors document links to render only a link to the current locale and removes the **(`{locale}`)** copy that was previously was at the end of the labels of those links.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/en/directive-on-digital-talent`
2. Observe document links are to English documents only
3. Switch to French
4. Observe document links are to French documents only

## 📸 Screenshots
<img width="834" alt="Screen Shot 2023-10-05 at 15 02 53" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/8c9c344f-310a-4846-9a19-cfcc5dc380a9">
<img width="835" alt="Screen Shot 2023-10-05 at 15 02 34" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/0282631a-ddcd-454f-8f4b-bb9495623d66">