### PR TITLE
[Fix] Combobox available options count

### DIFF
--- a/apps/web/src/components/SkillDialog/SkillSelection.tsx
+++ b/apps/web/src/components/SkillDialog/SkillSelection.tsx
@@ -254,6 +254,7 @@ const SkillSelection = ({
               name="skill"
               rules={{ required: intl.formatMessage(errorMessages.required) }}
               trackUnsaved={false}
+              total={filteredSkills.length}
               label={intl.formatMessage({
                 defaultMessage: "Skill",
                 id: "+K/smr",

--- a/packages/forms/src/components/Combobox/Multi.tsx
+++ b/packages/forms/src/components/Combobox/Multi.tsx
@@ -188,6 +188,10 @@ const Multi = ({
     },
   });
 
+  React.useEffect(() => {
+    setAvailable(options);
+  }, [options]);
+
   const handleClear = () => {
     if (onInputChange) {
       onInputChange("");

--- a/packages/forms/src/components/Combobox/Single.tsx
+++ b/packages/forms/src/components/Combobox/Single.tsx
@@ -76,6 +76,10 @@ const Single = ({
     inputRef?.current?.focus();
   };
 
+  React.useEffect(() => {
+    setAvailable(options);
+  }, [options]);
+
   return (
     <>
       <Field.Label {...getLabelProps()} required={isRequired}>


### PR DESCRIPTION
🤖 Resolves #8120 

## 👋 Introduction

Fixes the available options count when the number of options passed updates.

## 🕵️ Details

Uses an effect to sync the internal state when the passed in options array changes length.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to a page with the skill picker
3. Select a skill family
4. Open the combox menu
5. Confirm available options matches expected number
6. Select a new skill family
7. Repeat steps 4 and 5