### PR TITLE
[Fix] Experience card modal focus management

### DIFF
--- a/apps/web/src/components/ExperienceCard/ExperienceCard.tsx
+++ b/apps/web/src/components/ExperienceCard/ExperienceCard.tsx
@@ -27,6 +27,7 @@ import {
   useExperienceInfo,
 } from "~/utils/experienceUtils";
 
+import ExperienceSkillFormDialog from "../ExperienceSkillFormDialog/ExperienceSkillFormDialog";
 import AwardContent from "./AwardContent";
 import ContentSection from "./ContentSection";
 import CommunityContent from "./CommunityContent";
@@ -35,23 +36,30 @@ import PersonalContent from "./PersonalContent";
 import WorkContent from "./WorkContent";
 import EditLink from "./EditLink";
 
+type EditMode = "link" | "dialog";
+
 interface ExperienceCardProps {
   experience: AnyExperience;
   headingLevel?: HeadingRank;
   showSkills?: boolean | Skill | Array<Skill>;
   showEdit?: boolean;
   editParam?: string;
-  // If the edit button is a button, pass the onClick function
-  onEditClick?: () => void;
   // Override the edit path if needed
   editPath?: string;
+  editMode?: EditMode;
+  onSave?: () => void;
+  linkTo?: Skill;
+  editTrigger?: React.ReactNode;
 }
 
 const ExperienceCard = ({
   experience,
-  onEditClick,
   editParam,
   editPath: editPathProp,
+  editMode = "link",
+  onSave,
+  linkTo,
+  editTrigger,
   headingLevel = "h2",
   showSkills = true,
   showEdit = true,
@@ -76,6 +84,38 @@ const ExperienceCard = ({
 
   const skillCount = skills?.length;
 
+  const edit =
+    (editPath || editParam) && editMode === "link" ? (
+      <EditLink
+        editUrl={`${editPathProp || editPath}${editParam || ""}`}
+        ariaLabel={intl
+          .formatMessage(
+            {
+              defaultMessage: "Edit {experienceName}",
+              id: "CDV1Cw",
+              description: "Link text to edit a specific experience",
+            },
+            {
+              experienceName: title,
+            },
+          )
+          .toString()}
+      >
+        {intl.formatMessage({
+          defaultMessage: "Edit",
+          id: "vXwT4K",
+          description: "Generic link text to edit a miscellaneous item",
+        })}
+      </EditLink>
+    ) : (
+      <ExperienceSkillFormDialog
+        onSave={onSave}
+        skill={linkTo}
+        trigger={editTrigger}
+        experience={experience}
+      />
+    );
+
   return (
     <div
       data-h2-border-left="base(x.5 solid tertiary)"
@@ -99,34 +139,7 @@ const ExperienceCard = ({
         >
           {titleHtml}
         </Heading>
-        {showEdit && (editPathProp || editPath || onEditClick) && (
-          <EditLink
-            editUrl={
-              onEditClick
-                ? undefined
-                : `${editPathProp || editPath}${editParam || ""}`
-            }
-            onEditClick={onEditClick}
-            ariaLabel={intl
-              .formatMessage(
-                {
-                  defaultMessage: "Edit {experienceName}",
-                  id: "CDV1Cw",
-                  description: "Link text to edit a specific experience",
-                },
-                {
-                  experienceName: title,
-                },
-              )
-              .toString()}
-          >
-            {intl.formatMessage({
-              defaultMessage: "Edit",
-              id: "vXwT4K",
-              description: "Generic link text to edit a miscellaneous item",
-            })}
-          </EditLink>
-        )}
+        {showEdit && edit}
       </div>
       <p
         data-h2-display="base(flex)"

--- a/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillFormDialog.tsx
+++ b/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillFormDialog.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
+import PencilSquareIcon from "@heroicons/react/20/solid/PencilSquareIcon";
 
-import { Dialog } from "@gc-digital-talent/ui";
+import { Button, Dialog } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 import { Skill } from "@gc-digital-talent/graphql";
 
@@ -30,24 +31,51 @@ const deriveDefaultValues = (
 };
 
 interface ExperienceSkillFormDialogProps {
-  open: boolean;
-  onOpenChange: (newOpen: boolean) => void;
+  onSave?: () => void;
   skill?: Skill;
   experience?: Experience;
-  availableExperiences: Experience[];
+  availableExperiences?: Experience[];
+  trigger?: React.ReactNode;
 }
 
 const ExperienceSkillFormDialog = ({
-  open,
-  onOpenChange,
   skill,
   experience,
+  trigger,
   availableExperiences,
+  onSave,
 }: ExperienceSkillFormDialogProps) => {
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const intl = useIntl();
+  let experiences = availableExperiences ?? [];
+  if (experience) {
+    experiences = !availableExperiences
+      ? [experience]
+      : availableExperiences.filter(
+          (availableExperience) => availableExperience.id !== experience.id,
+        );
+  }
+
+  const handleSuccess = () => {
+    if (onSave) {
+      onSave();
+    }
+    setIsOpen(false);
+  };
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+    <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
+      <Dialog.Trigger>
+        {trigger || (
+          <Button icon={PencilSquareIcon} color="secondary" mode="inline">
+            {intl.formatMessage({
+              defaultMessage: "Edit",
+              id: "vXwT4K",
+              description: "Generic link text to edit a miscellaneous item",
+            })}
+          </Button>
+        )}
+      </Dialog.Trigger>
       <Dialog.Content>
         <Dialog.Header>
           {intl.formatMessage(
@@ -62,9 +90,9 @@ const ExperienceSkillFormDialog = ({
         </Dialog.Header>
         <Dialog.Body>
           <ExperienceSkillForm
-            experiences={availableExperiences}
+            experiences={experiences}
             defaultValues={deriveDefaultValues(skill, experience)}
-            onSuccess={() => onOpenChange(false)}
+            onSuccess={handleSuccess}
           />
         </Dialog.Body>
       </Dialog.Content>

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/components/SkillTree.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/components/SkillTree.tsx
@@ -47,32 +47,15 @@ const SkillTree = ({
 }: SkillTreeProps) => {
   const intl = useIntl();
   const contentHeadingLevel = incrementHeadingRank(headingAs);
-  const [isFormOpen, setIsFormOpen] = React.useState<boolean>(false);
-  const [currentExperience, setCurrentExperience] =
-    React.useState<Experience | null>(null);
 
   const title = getLocalizedName(skill.name, intl);
   const skillExperiences = getExperienceSkills(experiences, skill);
   const availableExperiences = experiences.filter(
     (exp) =>
       !skillExperiences.find(
-        (existingExperience) =>
-          existingExperience.id === exp.id && exp.id !== currentExperience?.id,
+        (existingExperience) => existingExperience.id === exp.id,
       ),
   );
-
-  const handleExperienceEdit = (experience: Experience) => {
-    setCurrentExperience(experience);
-    setIsFormOpen(true);
-  };
-
-  const handleFormOpenChange = (newIsFormOpen: boolean) => {
-    setIsFormOpen(newIsFormOpen);
-    // reset current experience when we close the form
-    if (!newIsFormOpen) {
-      setCurrentExperience(null);
-    }
-  };
 
   const disclaimer = showDisclaimer ? (
     <TreeView.Item>
@@ -93,69 +76,58 @@ const SkillTree = ({
   ) : null;
 
   return (
-    <>
-      <TreeView.Root data-h2-margin="base(x2, 0)">
-        <TreeView.Head>
-          <CardBasic>
-            <Heading level={headingAs} size="h6" data-h2-margin-top="base(0)">
-              {title}
-            </Heading>
-            {skill.description && (
-              <p>{getLocalizedName(skill.description, intl)}</p>
-            )}
-          </CardBasic>
-        </TreeView.Head>
-        {skillExperiences.length ? (
-          <>
-            {skillExperiences.map((experience) => (
-              <TreeView.Item key={experience.id}>
-                <ExperienceCard
-                  experience={filterExperienceSkills(experience, skill)}
-                  headingLevel={contentHeadingLevel}
-                  showEdit={!hideEdit}
-                  showSkills={skill}
-                  onEditClick={
-                    !hideEdit
-                      ? () => handleExperienceEdit(experience)
-                      : undefined
-                  }
-                />
-              </TreeView.Item>
-            ))}
-          </>
-        ) : (
-          disclaimer
-        )}
-        {!hideConnectButton && availableExperiences.length > 0 ? (
-          <TreeView.Item>
-            <Button
-              type="button"
-              color="secondary"
-              mode="solid"
-              onClick={() => setIsFormOpen(true)}
-            >
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "Connect a career timeline experience<hidden> to {skillName}</hidden>",
-                  id: "fRwqM9",
-                  description:
-                    "Button text to open form to connect an experience to a skill",
-                },
-                { skillName: title },
-              )}
-            </Button>
-          </TreeView.Item>
-        ) : null}
-      </TreeView.Root>
-      <ExperienceSkillFormDialog
-        open={isFormOpen}
-        onOpenChange={handleFormOpenChange}
-        skill={skill}
-        availableExperiences={availableExperiences}
-        experience={currentExperience || undefined}
-      />
-    </>
+    <TreeView.Root data-h2-margin="base(x2, 0)">
+      <TreeView.Head>
+        <CardBasic>
+          <Heading level={headingAs} size="h6" data-h2-margin-top="base(0)">
+            {title}
+          </Heading>
+          {skill.description && (
+            <p>{getLocalizedName(skill.description, intl)}</p>
+          )}
+        </CardBasic>
+      </TreeView.Head>
+      {skillExperiences.length ? (
+        <>
+          {skillExperiences.map((experience) => (
+            <TreeView.Item key={experience.id}>
+              <ExperienceCard
+                experience={filterExperienceSkills(experience, skill)}
+                headingLevel={contentHeadingLevel}
+                showEdit={!hideEdit}
+                showSkills={skill}
+                linkTo={skill}
+                editMode="dialog"
+              />
+            </TreeView.Item>
+          ))}
+        </>
+      ) : (
+        disclaimer
+      )}
+      {!hideConnectButton && availableExperiences.length > 0 ? (
+        <TreeView.Item>
+          <ExperienceSkillFormDialog
+            skill={skill}
+            availableExperiences={availableExperiences}
+            trigger={
+              <Button type="button" color="secondary" mode="solid">
+                {intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "Connect a career timeline experience<hidden> to {skillName}</hidden>",
+                    id: "fRwqM9",
+                    description:
+                      "Button text to open form to connect an experience to a skill",
+                  },
+                  { skillName: title },
+                )}
+              </Button>
+            }
+          />
+        </TreeView.Item>
+      ) : null}
+    </TreeView.Root>
   );
 };
 

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -118,9 +118,6 @@ export const UpdateUserSkillForm = ({
   const intl = useIntl();
   const paths = useRoutes();
   const navigate = useNavigate();
-  const [isFormDialogOpen, setFormDialogOpen] = React.useState<boolean>(false);
-  const [currentExperience, setCurrentExperience] =
-    React.useState<Experience | null>(null);
   const skillName = getLocalizedName(skill.name, intl);
   const skillDescription = getLocalizedName(skill.description, intl);
   const hasUserSkill = notEmpty(userSkill);
@@ -209,14 +206,6 @@ export const UpdateUserSkillForm = ({
           }),
         ),
       );
-  };
-
-  const handleFormOpenChange = (newIsFormOpen: boolean) => {
-    setFormDialogOpen(newIsFormOpen);
-    // reset current experience when we close the form
-    if (!newIsFormOpen) {
-      setCurrentExperience(null);
-    }
   };
 
   const crumbs = [
@@ -528,18 +517,20 @@ export const UpdateUserSkillForm = ({
                   data-h2-justify-content="base(flex-end)"
                   data-h2-margin="base(x.5 0)"
                 >
-                  <Button
-                    color="secondary"
-                    icon={PlusCircleIcon}
-                    onClick={() => setFormDialogOpen(true)}
-                  >
-                    {intl.formatMessage({
-                      defaultMessage: "Link an experience",
-                      id: "Y2ULHN",
-                      description:
-                        "Button text to open the form allowing a user to link an experience to a skill",
-                    })}
-                  </Button>
+                  <ExperienceSkillFormDialog
+                    skill={skill}
+                    availableExperiences={availableExperiences}
+                    trigger={
+                      <Button color="secondary" icon={PlusCircleIcon}>
+                        {intl.formatMessage({
+                          defaultMessage: "Link an experience",
+                          id: "Y2ULHN",
+                          description:
+                            "Button text to open the form allowing a user to link an experience to a skill",
+                        })}
+                      </Button>
+                    }
+                  />
                 </div>
               ) : null}
               {linkedExperiences?.length ? (
@@ -553,12 +544,8 @@ export const UpdateUserSkillForm = ({
                       key={experience.id}
                       experience={experience}
                       headingLevel="h3"
-                      showEdit
+                      editMode="dialog"
                       showSkills={skill}
-                      onEditClick={() => {
-                        setCurrentExperience(experience);
-                        setFormDialogOpen(true);
-                      }}
                     />
                   ))}
                 </div>
@@ -571,15 +558,6 @@ export const UpdateUserSkillForm = ({
           </TableOfContents.Content>
         </TableOfContents.Wrapper>
       </div>
-      <ExperienceSkillFormDialog
-        open={isFormDialogOpen}
-        onOpenChange={handleFormOpenChange}
-        skill={skill}
-        availableExperiences={
-          currentExperience ? [currentExperience] : availableExperiences
-        }
-        experience={currentExperience || undefined}
-      />
     </>
   );
 };

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -546,6 +546,7 @@ export const UpdateUserSkillForm = ({
                       headingLevel="h3"
                       editMode="dialog"
                       showSkills={skill}
+                      linkTo={skill}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
🤖 Resolves #8107 

## 👋 Introduction

Refactors the experience card to fix focus management in the edit dialog.

## 🕵️ Details

I tried a few different approaches before landing on this one. All of the following solutions failed, leading to the final trigger being focused instead of the proper one.

- Multiple triggers per dialog
- Passing the entire dialog into the card
- Passing a ref of the trigger to card

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to a user skilll edit page
3. Use your keyboard to invoke the "Link an experience" dialog
4. Dismiss the dialog with your keyboard
5. Confirm focus returns to the button that triggered it
6. Edit a linked experience
7. Repeat steps 4+5
8. Navigate to the skills page in an application
9. Activate the connect an experience dialog
10. Repeat steps 4+5
11. Edit a connected experience
12. Repeat steps 4+5

