### PR TITLE
[Feature] Split storybook scripts

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,8 @@
     "production": "npm run build",
     "build-storybook": "storybook build",
     "storybook": "storybook dev -p 6006",
+    "storybook:design-system": "SB_APP=design storybook dev -p 6006",
+    "storybook:web": "SB_APP=web storybook dev -p 6006",
     "test": "jest --detectOpenHandles --forceExit",
     "test:watch": "jest --watch",
     "tsc": "tsc --project tsconfig.json --noEmit",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "lint": "turbo run lint",
     "storybook:project": "npm run storybook",
     "storybook": "npm run storybook --workspace=@gc-digital-talent/web",
+    "storybook:design-system": "npm run storybook:design-system --workspace=@gc-digital-talent/web",
+    "storybook:web": "npm run storybook:web --workspace=@gc-digital-talent/web",
     "build-storybook": "npm run build-storybook --workspace=@gc-digital-talent/web",
     "test": "turbo run test",
     "watch": "turbo run watch --concurrency=30",

--- a/packages/forms/src/utils.ts
+++ b/packages/forms/src/utils.ts
@@ -214,7 +214,7 @@ export function sanitizeString(original: string): string {
   let str = original;
   Object.keys(sanitizeSubstitutions).forEach((key) => {
     const replacement = sanitizeSubstitutions[key];
-    str = str.replaceAll(key, replacement);
+    str = str.replace(new RegExp(key, "g"), replacement);
   });
   return str;
 }

--- a/packages/storybook-helpers/main.ts
+++ b/packages/storybook-helpers/main.ts
@@ -4,8 +4,6 @@ const HydrogenPlugin = require("hydrogen-webpack-plugin");
 const TsTransformer = require("@formatjs/ts-transformer");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const transform = TsTransformer.transform;
-const shell = require("shelljs");
-const fs = require("fs");
 
 // This uses ts-loader to inject generated ids into react-intl messages.
 const reactIntlTransformRule = {
@@ -34,11 +32,21 @@ const staticDocumentsRule = {
   },
 };
 
+const webStories = "../src/**/*.stories.@(js|jsx|ts|tsx|mdx)";
+const designStories =
+  "../../../packages/**/src/**/*.stories.@(js|jsx|ts|tsx|mdx)";
+let stories = [webStories, designStories];
+const sbApp = process.env.SB_APP;
+if (sbApp) {
+  if (sbApp === "web") {
+    stories = [webStories];
+  } else if (sbApp === "design") {
+    stories = [designStories];
+  }
+}
+
 const config: StorybookConfig = {
-  stories: [
-    "../src/**/*.stories.@(js|jsx|ts|tsx|mdx)",
-    "../../../packages/**/src/**/*.stories.@(js|jsx|ts|tsx|mdx)",
-  ],
+  stories,
   addons: [
     "@storybook/addon-a11y",
     "@storybook/addon-essentials",
@@ -46,6 +54,7 @@ const config: StorybookConfig = {
     "@storybook/addon-viewport",
     "storybook-addon-intl",
   ],
+  logLevel: "debug",
   framework: {
     name: "@storybook/react-webpack5",
     options: {},

--- a/packages/storybook-helpers/main.ts
+++ b/packages/storybook-helpers/main.ts
@@ -54,7 +54,6 @@ const config: StorybookConfig = {
     "@storybook/addon-viewport",
     "storybook-addon-intl",
   ],
-  logLevel: "debug",
   framework: {
     name: "@storybook/react-webpack5",
     options: {},


### PR DESCRIPTION
🤖 Resolves #8128 

## 👋 Introduction

splits up our storybooks to be more targeted and speed up start up times.

## 🕵️ Details

This adds two new commands to run specific story files. The more story files we load, the longer the start up times. This was growing too large so this splits up storybook into 3 different scripts:

 - `npm run storybook` - Runs all story files
 - `npm run storybook:web` - Runs just story files in `apps/web/**`
 - `npm run storyook:design-system` - Runs just story files in `packages/**`

We also had to refactor the new `santizeString` which was using a function that was not available in storybook.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run the different commands noted in the details section
2. Confirm the expected story files are loaded
3. Confirm this actually improves start up times
4. Confirm the `sanitizeString` function still works for our textareas and inputs.
