### PR TITLE
[Copy] Update Profile and applications page content

### DIFF
--- a/apps/e2e/cypress/e2e/talentsearch/profile-page.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/profile-page.cy.js
@@ -30,7 +30,7 @@ describe("Talentsearch Profile Page", () => {
       [
         "/en/talent/profile",
         "/en/users/test-no-role/profile",
-        "/en/users/test-no-role/profile/career-timeline-and-recruitment",
+        "/en/users/test-no-role/profile/career-timeline",
       ].forEach((restrictedPath) => {
         cy.visit(restrictedPath);
         cy.contains("not authorized");

--- a/apps/e2e/cypress/e2e/talentsearch/redirects.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/redirects.cy.js
@@ -5,7 +5,10 @@ const uuidRegEx =
 
 describe("Redirects", () => {
   const expectToBeOnProfile = () => {
-    cy.url().should("match", new RegExp("users" + uuidRegEx + "profile", "gi"));
+    cy.url().should(
+      "match",
+      new RegExp("users" + uuidRegEx + "personal-information", "gi"),
+    );
   };
 
   beforeEach(() => {

--- a/apps/web/src/components/Redirects/TalentRedirect.tsx
+++ b/apps/web/src/components/Redirects/TalentRedirect.tsx
@@ -19,7 +19,7 @@ const TalentRedirect = () => {
       if (pathname.includes("create-account")) {
         profilePath = paths.createAccount();
       }
-      if (pathname.includes("career-timeline-and-recruitment")) {
+      if (pathname.includes("career-timeline")) {
         profilePath = paths.careerTimelineAndRecruitment(id);
 
         if (pathname.includes("create")) {

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -948,7 +948,7 @@ const createRoute = (
                   path: ":userId",
                   children: [
                     {
-                      path: "profile",
+                      path: "personal-information",
                       children: [
                         {
                           index: true,
@@ -962,7 +962,7 @@ const createRoute = (
                           ),
                         },
                         {
-                          path: "career-timeline-and-recruitment",
+                          path: "career-timeline",
                           children: [
                             {
                               index: true,

--- a/apps/web/src/components/UserProfile/constants.ts
+++ b/apps/web/src/components/UserProfile/constants.ts
@@ -6,7 +6,7 @@ export const PAGE_SECTION_ID = {
   WORK_LOCATION: "work-location-section",
   WORK_PREFERENCES: "work-preferences-section",
   ROLE_AND_SALARY: "role-and-salary-section",
-  CAREER_TIMELINE_AND_RECRUITMENT: "career-timeline-and-recruitment-section",
+  CAREER_TIMELINE_AND_RECRUITMENT: "career-timeline-section",
   ACCOUNT_AND_PRIVACY: "account-and-privacy-section",
 } as const;
 

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -34,8 +34,8 @@ const getRoutes = (lang: Locales) => {
   const createExperienceUrl = (userId: string) =>
     `${path.join(
       userUrl(userId),
-      "profile",
-      "career-timeline-and-recruitment",
+      "personal-information",
+      "career-timeline",
       "create",
     )}`;
 
@@ -91,7 +91,7 @@ const getRoutes = (lang: Locales) => {
     userCreate: () => path.join(adminUrl, "users", "create"),
     userView: (userId: string) => path.join(adminUrl, "users", userId),
     userProfile: (userId: string) =>
-      path.join(adminUrl, "users", userId, "profile"),
+      path.join(adminUrl, "users", userId, "personal-information"),
     userUpdate: (userId: string) =>
       path.join(adminUrl, "users", userId, "edit"),
     userPlacement: (userId: string) =>
@@ -174,7 +174,7 @@ const getRoutes = (lang: Locales) => {
     applicationSelfDeclaration: (applicationId: string) =>
       path.join(baseUrl, "applications", applicationId, "self-declaration"),
     applicationProfile: (applicationId: string) =>
-      path.join(baseUrl, "applications", applicationId, "profile"),
+      path.join(baseUrl, "applications", applicationId, "personal-information"),
     applicationCareerTimeline: (applicationId: string) =>
       path.join(baseUrl, "applications", applicationId, "career-timeline"),
     applicationCareerTimelineIntro: (applicationId: string) =>
@@ -234,7 +234,7 @@ const getRoutes = (lang: Locales) => {
     // Profile Routes
     profile: (userId: string, section?: UserProfilePageSectionId) => {
       const fragment = section ? `#${section}` : "";
-      return path.join(userUrl(userId), "profile") + fragment;
+      return path.join(userUrl(userId), "personal-information") + fragment;
     },
     myProfile: () => path.join(baseUrl, "users", "me"),
 
@@ -248,8 +248,8 @@ const getRoutes = (lang: Locales) => {
       const fragment = opts?.section ? `#${opts.section}` : "";
       return `${path.join(
         userUrl(userId),
-        "profile",
-        "career-timeline-and-recruitment",
+        "personal-information",
+        "career-timeline",
       )}${fragment}`;
     },
     editExperience: (
@@ -259,8 +259,8 @@ const getRoutes = (lang: Locales) => {
     ) =>
       path.join(
         userUrl(userId),
-        "profile",
-        "career-timeline-and-recruitment",
+        "personal-information",
+        "career-timeline",
         experienceId,
         "edit",
       ),

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2138,10 +2138,6 @@
     "defaultMessage": "Équité en matière d'emploi",
     "description": "Title of the 'Employment equity' section of the view-user page"
   },
-  "BYxqL/": {
-    "defaultMessage": "Parcours professionnel et recrutements",
-    "description": "Profile and applications card title for career timeline card"
-  },
   "Badvbb": {
     "defaultMessage": "Groupe/Organisation/Collectivité",
     "description": "Label displayed on Community Experience form for organization input"
@@ -3214,10 +3210,6 @@
     "defaultMessage": "Ajouter une nouvelle adhésion",
     "description": "Label for the form to add a team membership to a user"
   },
-  "Icl1fF": {
-    "defaultMessage": "Parcours professionnel et recrutement",
-    "description": "Name of Career timeline and recruitment page"
-  },
   "IexFo4": {
     "defaultMessage": "Connaissance de l’autre langue officielle",
     "description": "Second language proficiency label"
@@ -4051,10 +4043,6 @@
     "defaultMessage": "Annuler",
     "description": "Button text to cancel and close the skill dialog"
   },
-  "OXyqf7": {
-    "defaultMessage": "Mise en valeur des compétences showcase",
-    "description": "applicant dashboard card title for skill showcase"
-  },
   "OY6KVG": {
     "defaultMessage": "Montrez aux gestionnaires les cinq compétences comportementales les plus fortes qui font de vous un membre formidable de l’équipe. Vous pouvez modifier cette vitrine à tout moment et vous êtes libre de mettre les compétences dans l’ordre qui vous convient. Les compétences que vous ajoutez à la vitrine qui ne sont pas déjà dans votre bibliothèque seront ajoutées automatiquement.",
     "description": "Page blurb for the top behavioural skills page"
@@ -4722,6 +4710,10 @@
   "TS63OC": {
     "defaultMessage": "Veuillez indiquer la classification et le niveau de votre groupe de travail actuel.",
     "description": "Text blurb, asking about classification and level in the government info form"
+  },
+  "TUfJUD": {
+    "defaultMessage": "Parcours professionnel",
+    "description": "Name of Career timeline page"
   },
   "TUi+jx": {
     "defaultMessage": "Conçu par la communauté autochtone pour la communauté autochtone, ce programme recrute des candidats au niveau débutant pour des occasions d’apprentissage et de perfectionnement en matière de TI au sein du gouvernement.",
@@ -6061,6 +6053,10 @@
     "defaultMessage": "Langue parlée préférée pour l'entretien :",
     "description": "Preferred Language for interviews label and colon"
   },
+  "cA0iH+": {
+    "defaultMessage": "Renseignements personnels",
+    "description": "Profile and applications card title for profile card"
+  },
   "cAOf3a": {
     "defaultMessage": "Je suis <strong>disponible</strong> à des fins d’embauche, et je souhaite que l’on communique avec moi au sujet de possibilités découlant de ce processus de recrutement.",
     "description": "Radio button label for available for opportunities option"
@@ -6693,6 +6689,10 @@
     "defaultMessage": "Collectivité des gestionnaires.",
     "description": "Heading for the Managers community page"
   },
+  "g8Ur9z": {
+    "defaultMessage": "Renseignements personnels",
+    "description": "applicant dashboard card title for profile card"
+  },
   "g8Xd4a": {
     "defaultMessage": "Lecture",
     "description": "Label displayed on the language information form reading comprehension field."
@@ -6744,10 +6744,6 @@
   "gQl1LT": {
     "defaultMessage": "Aidez-nous à comprendre votre collectivité.",
     "description": "Subtitle for the self-declaration page"
-  },
-  "gTjLic": {
-    "defaultMessage": "Renseignements du profil",
-    "description": "applicant dashboard card title for profile card"
   },
   "gURsqG": {
     "defaultMessage": "Consultez les processus de recrutement de gestionnaires les plus récents pour des possibilités précises ou présentez votre candidature dans le cadre de processus de recrutement en cours dans l’un des volets de travail génériques de la technologie de l’information. Revenez souvent pour consulter de nouvelles possibilités.",
@@ -7090,6 +7086,10 @@
   "iWD2Pz": {
     "defaultMessage": "Expériences communautaires",
     "description": "Heading for community experiences in experience by type listing"
+  },
+  "iWzkOn": {
+    "defaultMessage": "Bibliothèque de compétences",
+    "description": "applicant dashboard card title for skill library"
   },
   "iXdeVu": {
     "defaultMessage": "Toutes les compétences suivantes sont facultativement avantageuses pour le poste, et le fait de les démontrer pourrait vous être utile lorsque vous êtes pris en considération.",
@@ -7978,6 +7978,10 @@
     "defaultMessage": "Autre expérience dans un domaine connexe",
     "description": "Experience requirement, other."
   },
+  "oJAAnh": {
+    "defaultMessage": "Gérer <a1>vos renseignements personnels</a1>, <a2>votre parcours professionnel</a2>, <a3>vos compétences</a3>, et <a4>faire le suivi de vos candidatures</a4>.",
+    "description": "Subtitle for profile and applications hero"
+  },
   "oJri9k": {
     "defaultMessage": "Vous êtes sur le point de dupliquer le bassin suivant : {poolName}",
     "description": "Text to confirm the pool to be duplicated"
@@ -8528,6 +8532,10 @@
   "sde2Dj": {
     "defaultMessage": "Bienvenue",
     "description": "Link text for the application welcome page"
+  },
+  "sdvCNP": {
+    "defaultMessage": "Parcours professionnel",
+    "description": "Profile and applications card title for career timeline card"
   },
   "sfyaOe": {
     "defaultMessage": "De nouvelles possibilités d’emploi sont publiées tout au long de l’année. En créant votre profil dès maintenant, vous serez mieux préparé pour présenter une candidature solide le moment venu.",
@@ -9418,14 +9426,6 @@
   "zS2PN+": {
     "defaultMessage": "Toutes les catégories ({count})",
     "description": "Label for removing the skill category filter"
-  },
-  "zTJ2DT": {
-    "defaultMessage": "Gérer <a1>votre profil</a1>, <a2>votre parcours professionnel</a2> et <a3>vos compétences</a3>, et <a4>faire le suivi de vos candidatures</a4>.",
-    "description": "Subtitle for profile and applications hero"
-  },
-  "zd/ve4": {
-    "defaultMessage": "Renseignements du profil",
-    "description": "Profile and applications card title for profile card"
   },
   "zdeoxH": {
     "defaultMessage": "Diplôme d’études secondaires",

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/constants.ts
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/constants.ts
@@ -10,9 +10,9 @@ export type PageSectionId = ObjectValues<typeof PAGE_SECTION_ID>;
 
 export const titles = defineMessages({
   careerTimelineAndRecruitment: {
-    defaultMessage: "Career timeline and recruitment",
-    id: "Icl1fF",
-    description: "Name of Career timeline and recruitment page",
+    defaultMessage: "Career timeline",
+    id: "TUfJUD",
+    description: "Name of Career timeline page",
   },
   manageYourCareerTimeline: {
     defaultMessage: "Manage your career timeline",

--- a/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
@@ -28,8 +28,8 @@ export const ProfileForm = ({ user }: ProfilePageProps) => {
   const intl = useIntl();
 
   const pageTitle = intl.formatMessage({
-    defaultMessage: "Profile information",
-    id: "gTjLic",
+    defaultMessage: "Personal information",
+    id: "g8Ur9z",
     description: "applicant dashboard card title for profile card",
   });
 

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
@@ -147,8 +147,8 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
       subtitle={intl.formatMessage(
         {
           defaultMessage:
-            "Manage your <a1>profile</a1>, <a2>career timeline</a2>, <a3>skills</a3>, and <a4>track applications</a4>.",
-          id: "zTJ2DT",
+            "Manage your <a1>personal info</a1>, <a2>career timeline</a2>, <a3>skills</a3>, and <a4>track applications</a4>.",
+          id: "oJAAnh",
           description: "Subtitle for profile and applications hero",
         },
         {
@@ -292,8 +292,8 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
           asNav
           color="secondary"
           title={intl.formatMessage({
-            defaultMessage: "Profile information",
-            id: "zd/ve4",
+            defaultMessage: "Personal information",
+            id: "cA0iH+",
             description: "Profile and applications card title for profile card",
           })}
           href={paths.profile(user.id)}
@@ -388,8 +388,8 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
         <HeroCard
           color="tertiary"
           title={intl.formatMessage({
-            defaultMessage: "Career timeline and recruitments",
-            id: "BYxqL/",
+            defaultMessage: "Career timeline",
+            id: "sdvCNP",
             description:
               "Profile and applications card title for career timeline card",
           })}
@@ -461,11 +461,11 @@ const DashboardHeading = ({ user }: DashboardHeadingProps) => {
           <HeroCard
             color="quaternary"
             title={intl.formatMessage({
-              defaultMessage: "Skill showcase",
-              id: "OXyqf7",
-              description: "applicant dashboard card title for skill showcase",
+              defaultMessage: "Skill library",
+              id: "iWzkOn",
+              description: "applicant dashboard card title for skill library",
             })}
-            href={skillShowcaseUrl}
+            href={skillLibraryUrl}
           >
             <StatusItem
               title={intl.formatMessage({

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -470,10 +470,6 @@
     "defaultMessage": "Aucun résultat n’a été trouvé.",
     "description": "Message displayed when combobox has no options available"
   },
-  "Icl1fF": {
-    "defaultMessage": "Parcours professionnel et recrutement",
-    "description": "Name of Career timeline and recruitment page"
-  },
   "Ij1cFC": {
     "defaultMessage": "Contributeur individuel",
     "description": "The position type is an individual contributor."
@@ -793,6 +789,10 @@
   "TRDfnp": {
     "defaultMessage": "Je suis un membre actif des Forces armées canadiennes.",
     "description": "declare self to be a CAF member without bolding"
+  },
+  "TUfJUD": {
+    "defaultMessage": "Parcours professionnel",
+    "description": "Name of Career timeline page"
   },
   "TiIkSF": {
     "defaultMessage": "Deux années post-secondaire",

--- a/packages/i18n/src/messages/navigationMessages.ts
+++ b/packages/i18n/src/messages/navigationMessages.ts
@@ -47,9 +47,9 @@ const navigationMessages = defineMessages({
     description: "Name of Work preferences page",
   },
   careerTimelineAndRecruitment: {
-    defaultMessage: "Career timeline and recruitment",
-    id: "Icl1fF",
-    description: "Name of Career timeline and recruitment page",
+    defaultMessage: "Career timeline",
+    id: "TUfJUD",
+    description: "Name of Career timeline page",
   },
 });
 


### PR DESCRIPTION
🤖 Resolves #8103.

## 👋 Introduction

This PR updates **Profile and applications** page content copy include some its sub-pages and its corresponding links, titles, breadcrumbs, and URLs to match.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/applicant/profile-and-applications`
2. Observe copy changes
3. Observe the Skills library card links to the library, not the showcase
4. Observe links, titles, breadcrumbs, URLs in the page subtitle are updated to match
5. Ensure no broken links

## 📸 Screenshots

![Screen Shot 2023-10-10 at 14 06 45](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/f6152f60-6bc0-4fdb-8974-1b8854d34a4b)
![Screen Shot 2023-10-10 at 14 07 09](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/6f859913-f814-4129-a7db-bae6ec9b1df7)
![Screen Shot 2023-10-10 at 14 07 26](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/22c3068c-db43-465e-bd27-0283755b30fd)
