### PR TITLE
[Feature] First Nations status radio group

### DIFF
--- a/apps/e2e/cypress/e2e/talentsearch/submit-application-iap.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/submit-application-iap.cy.js
@@ -156,7 +156,7 @@ describe("Submit Application for IAP Workflow Tests", () => {
     }).click();
     cy.findByRole("button", { name: /Sign and continue/i }).should("not.exist"); // check that you cannot proceed without affirmation
 
-    cy.findByRole("checkbox", {
+    cy.findByRole("radio", {
       // affirmation
       name: /i affirm that i am first nations/i,
     }).click();

--- a/apps/e2e/cypress/e2e/talentsearch/submit-application-iap.cy.js
+++ b/apps/e2e/cypress/e2e/talentsearch/submit-application-iap.cy.js
@@ -156,15 +156,19 @@ describe("Submit Application for IAP Workflow Tests", () => {
     }).click();
     cy.findByRole("button", { name: /Sign and continue/i }).should("not.exist"); // check that you cannot proceed without affirmation
 
-    cy.findByRole("radio", {
+    cy.findByRole("checkbox", {
       // affirmation
-      name: /I am First Nations/i,
+      name: /i affirm that i am first nations/i,
     }).click();
     cy.findByRole("button", { name: /Sign and continue/i }).should("not.exist"); // check that you cannot proceed without community selection
 
     cy.findByRole("checkbox", {
       // community selection
-      name: /I am Status First Nations/i,
+      name: /i am first nations/i,
+    }).click();
+    cy.findByRole("radio", {
+      // affirmation
+      name: /i am status first nations/i,
     }).click();
     cy.findByRole("textbox", {
       name: /signature/i,

--- a/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
@@ -24,7 +24,7 @@ import DialogFooter from "./DialogFooter";
 import UnderReview from "./UnderReview";
 
 interface FormValuesWithSignature extends FormValues {
-  signature: string | undefined;
+  signature: string | undefined | null;
 }
 
 const IndigenousDialog = ({
@@ -48,9 +48,11 @@ const IndigenousDialog = ({
   const submitHandler: SubmitHandler<FormValuesWithSignature> = async (
     data: FormValuesWithSignature,
   ) => {
+    const newCommunities = formValuesToApiCommunities(data);
     onSave({
-      indigenousCommunities: formValuesToApiCommunities(data),
-      indigenousDeclarationSignature: data.signature,
+      indigenousCommunities: newCommunities,
+      indigenousDeclarationSignature:
+        indigenousCommunities.length > 0 ? data.signature : null,
     });
   };
 

--- a/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
@@ -52,7 +52,7 @@ const IndigenousDialog = ({
     onSave({
       indigenousCommunities: newCommunities,
       indigenousDeclarationSignature:
-        indigenousCommunities.length > 0 ? data.signature : null,
+        newCommunities.length > 0 ? data.signature : null,
     });
   };
 

--- a/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { FormProvider, useForm, type SubmitHandler } from "react-hook-form";
+import { registerShortcuts } from "@storybook/addon-viewport/*";
 
 import { Dialog } from "@gc-digital-talent/ui";
 import { Input } from "@gc-digital-talent/forms";
 import {
   errorMessages,
+  formMessages,
   getEmploymentEquityGroup,
 } from "@gc-digital-talent/i18n";
 
@@ -40,7 +42,9 @@ const IndigenousDialog = ({
       signature,
     },
   });
-  const { handleSubmit } = methods;
+  const { handleSubmit, watch } = methods;
+  const communities = watch("communities");
+  const hasCommunitiesSelected = communities && communities.length > 0;
 
   const submitHandler: SubmitHandler<FormValuesWithSignature> = async (
     data: FormValuesWithSignature,
@@ -100,31 +104,42 @@ const IndigenousDialog = ({
               <div data-h2-margin="base(x1, 0, x1.5, 0)">
                 <CommunityList labels={labels} />
               </div>
-              <p data-h2-padding-bottom="base(x1)">
-                {intl.formatMessage({
-                  defaultMessage:
-                    "By submitting your signature (typing your full name), you are contributing to an honest and safe space for Indigenous Peoples to access these opportunities.",
-                  id: "cVszq/",
-                  description:
-                    "Sentence before signature space on the add indigenous identity dialog",
-                })}
-              </p>
-              <Input
-                id="signature"
-                name="signature"
-                type="text"
-                label={labels.signature}
-                rules={{ required: intl.formatMessage(errorMessages.required) }}
-              />
+
+              {hasCommunitiesSelected && (
+                <>
+                  <p data-h2-padding-bottom="base(x1)">
+                    {intl.formatMessage({
+                      defaultMessage:
+                        "By submitting your signature (typing your full name), you are contributing to an honest and safe space for Indigenous Peoples to access these opportunities.",
+                      id: "cVszq/",
+                      description:
+                        "Sentence before signature space on the add indigenous identity dialog",
+                    })}
+                  </p>
+                  <Input
+                    id="signature"
+                    name="signature"
+                    type="text"
+                    label={labels.signature}
+                    rules={{
+                      required: intl.formatMessage(errorMessages.required),
+                    }}
+                  />
+                </>
+              )}
               <Dialog.Footer>
                 <DialogFooter
                   disabled={disabled}
-                  saveText={intl.formatMessage({
-                    defaultMessage: "Sign and save changes",
-                    id: "fgVziE",
-                    description:
-                      "Button text to submit indigenous identity form.",
-                  })}
+                  saveText={
+                    hasCommunitiesSelected
+                      ? intl.formatMessage({
+                          defaultMessage: "Sign and save changes",
+                          id: "fgVziE",
+                          description:
+                            "Button text to submit indigenous identity form.",
+                        })
+                      : intl.formatMessage(formMessages.saveChanges)
+                  }
                 />
               </Dialog.Footer>
             </form>

--- a/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { FormProvider, useForm, type SubmitHandler } from "react-hook-form";
-import { registerShortcuts } from "@storybook/addon-viewport/*";
 
 import { Dialog } from "@gc-digital-talent/ui";
 import { Input } from "@gc-digital-talent/forms";

--- a/apps/web/src/components/EmploymentEquity/types.ts
+++ b/apps/web/src/components/EmploymentEquity/types.ts
@@ -19,7 +19,7 @@ export interface EquityDialogProps {
 
 export interface IndigenousUpdateProps {
   indigenousCommunities: Array<IndigenousCommunity>;
-  indigenousDeclarationSignature: string | undefined;
+  indigenousDeclarationSignature?: string | null;
 }
 
 export interface IndigenousDialogProps {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -413,6 +413,10 @@
     "defaultMessage": "Veuillez sélectionner les options qui reflètent le mieux vos qualifications",
     "description": "Legend for the radio group in the application education page - IAP variant."
   },
+  "0KY1My": {
+    "defaultMessage": "Statut des Premières Nations",
+    "description": "Legend for selecting First Nations status or non-status"
+  },
   "0L0MWD": {
     "defaultMessage": "Modifier la classification",
     "description": "Link text to scroll to the section and change a process' classification"
@@ -2985,10 +2989,6 @@
     "defaultMessage": "Autre experience connexe (p. ex., personnelle, communautaire, familiale).",
     "description": "Experience requirement, other."
   },
-  "GSqmjE": {
-    "defaultMessage": "Premières Nations",
-    "description": "Label for First Nations community"
-  },
   "GTHuSJ": {
     "defaultMessage": "Répondez aux questions clés sur votre adéquation à ce rôle.",
     "description": "Subtitle for the application screening questions page"
@@ -5155,6 +5155,10 @@
     "defaultMessage": "Niveau de la langue seconde",
     "description": "Estimated skill in second language"
   },
+  "VUPlmN": {
+    "defaultMessage": "Premières Nations (inscrites ou non)",
+    "description": "Label for First Nations community"
+  },
   "VW3KlZ": {
     "defaultMessage": "Partagez vos diplômes, certificats, cours en ligne, stages, licences ou autres justificatifs ayant été reçus de la part d’établissements d’enseignement.",
     "description": "Description for education experience section"
@@ -5381,6 +5385,10 @@
   "WpVd0l": {
     "defaultMessage": "Le droit de priorité est un statut offert par la Commission de la fonction publique du Canada. Pour en apprendre davantage, <priorityEntitlementLink>consultez le site Web Information sur les droits de priorité</priorityEntitlementLink>.",
     "description": "Sentence describing what priority entitlement is"
+  },
+  "Wpj2OY": {
+    "defaultMessage": "\"Je suis membre d’une Première Nation\"",
+    "description": "Text for the option to self-declare as first nations"
   },
   "WqOnFF": {
     "defaultMessage": "Autres commentaires",

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/ApplicationSelfDeclarationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/ApplicationSelfDeclarationPage.tsx
@@ -375,12 +375,14 @@ const ApplicationSelfDeclarationPage = () => {
       navigate(paths.browsePools());
       return;
     }
+    const newCommunities = formValuesToApiCommunities(formValues);
     // Have to update both the user and the pool candidate in same request.  If you try to update just the user first and the application afterwards it interferes with the navigation.  I guess it creates a race condition as one of the contexts automatically refreshes.
     executeMutation({
       userId: userData?.me?.id || "",
       userInput: {
-        indigenousDeclarationSignature: formValues.signature,
-        indigenousCommunities: formValuesToApiCommunities(formValues),
+        indigenousCommunities: newCommunities,
+        indigenousDeclarationSignature:
+          newCommunities.length > 0 ? formValues.signature : null,
       },
       applicationId: applicationId || "",
       applicationInput: {

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunityChips.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunityChips.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { Chips, Chip } from "@gc-digital-talent/ui";
+import { notEmpty } from "@gc-digital-talent/helpers";
+
+import { FirstNationsStatus } from "~/utils/indigenousDeclaration";
+
+import { getCommunityLabel } from "./utils";
+
+interface CommunityChipsProps {
+  communities: string[];
+  status: FirstNationsStatus;
+  otherAlert: boolean;
+  onDismiss: (community: string) => void;
+}
+
+const CommunityChips = ({
+  communities,
+  status,
+  otherAlert,
+  onDismiss,
+}: CommunityChipsProps) => {
+  const intl = useIntl();
+  const communitiesWithLabels = communities
+    .map((community) => {
+      const label = getCommunityLabel({ community, intl, status });
+
+      return label
+        ? {
+            community,
+            label,
+          }
+        : null;
+    })
+    .filter(notEmpty);
+
+  return communitiesWithLabels.length > 0 ? (
+    <Chips data-h2-margin-bottom="base(x1)">
+      {communitiesWithLabels.map(({ community, label }) => {
+        return (
+          <Chip
+            key={community}
+            mode="outline"
+            color={otherAlert && community === "other" ? "warning" : "primary"}
+            onDismiss={() => onDismiss(community)}
+            label={label}
+          />
+        );
+      })}
+    </Chips>
+  ) : null;
+};
+
+export default CommunityChips;

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunityChips.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunityChips.tsx
@@ -10,7 +10,7 @@ import { getCommunityLabel } from "./utils";
 
 interface CommunityChipsProps {
   communities: string[];
-  status: FirstNationsStatus;
+  status?: FirstNationsStatus;
   otherAlert: boolean;
   onDismiss: (community: string) => void;
 }

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunitySelection.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunitySelection.tsx
@@ -7,12 +7,15 @@ import {
   Checklist,
   Field,
   Checkbox,
+  RadioGroup,
 } from "@gc-digital-talent/forms";
-import { Alert, Chip, Chips } from "@gc-digital-talent/ui";
+import { Alert } from "@gc-digital-talent/ui";
+import { errorMessages } from "@gc-digital-talent/i18n";
 
 import HelpLink from "./HelpLink";
-import { getCommunityLabels, hasCommunityAndOther } from "./utils";
+import { hasCommunityAndOther } from "./utils";
 import CommunityIcon from "./CommunityIcon";
+import CommunityChips from "./CommunityChips";
 
 interface RowProps {
   children: React.ReactNode;
@@ -38,12 +41,10 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
   const [isAlertOpen, setIsAlertOpen] = React.useState<boolean>(false);
   const [hasDismissedAlert, setHasDismissedAlert] =
     React.useState<boolean>(false);
-  const { watch, setValue, setError, clearErrors, formState } =
+  const { watch, setValue, resetField, setError, clearErrors, formState } =
     useFormContext();
 
-  const communityLabels = getCommunityLabels(intl);
-
-  const [communitiesValue] = watch(["communities"]);
+  const [communitiesValue, isStatus] = watch(["communities", "isStatus"]);
 
   const isOtherAndHasCommunity = hasCommunityAndOther(communitiesValue);
 
@@ -83,6 +84,9 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
       (value: string) => value !== community,
     );
     setValue("communities", newCommunities);
+    if (community === "firstNations") {
+      resetField("isStatus");
+    }
   };
 
   return (
@@ -94,32 +98,19 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
       >
         <Row>
           <div data-h2-grid-column="base(span 3)">
-            <Checklist
-              idPrefix="firstNations"
+            <Checkbox
               id="firstNations"
               name="communities"
-              legend={labels.firstNations}
+              boundingBox
+              boundingBoxLabel={labels.firstNations}
               trackUnsaved={false}
-              items={[
-                {
-                  value: "status",
-                  label: intl.formatMessage({
-                    defaultMessage: '"I am Status First Nations"',
-                    id: "ssJxrj",
-                    description:
-                      "Text for the option to self-declare as a status first nations",
-                  }),
-                },
-                {
-                  value: "nonStatus",
-                  label: intl.formatMessage({
-                    defaultMessage: '"I am Non-Status First Nations"',
-                    id: "sSE4kt",
-                    description:
-                      "Text for the option to self-declare as a non-status first nations",
-                  }),
-                },
-              ]}
+              value="firstNations"
+              label={intl.formatMessage({
+                defaultMessage: '"I am First Nations"',
+                id: "Wpj2OY",
+                description:
+                  "Text for the option to self-declare as first nations",
+              })}
               aria-describedby={customAlertId}
             />
             {formState.errors.firstNationsCustom && (
@@ -129,9 +120,50 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
             )}
           </div>
           <div>
-            <CommunityIcon values={["status"]} community="first-nations" />
+            <CommunityIcon
+              values={["firstNations"]}
+              community="first-nations"
+            />
           </div>
         </Row>
+        {communitiesValue.includes("firstNations") && (
+          <Row>
+            <div data-h2-grid-column="base(span 3)">
+              <RadioGroup
+                idPrefix="firstNationsStatus"
+                name="isStatus"
+                legend={intl.formatMessage({
+                  defaultMessage: "First Nations status",
+                  id: "0KY1My",
+                  description:
+                    "Legend for selecting First Nations status or non-status",
+                })}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
+                items={[
+                  {
+                    value: "status",
+                    label: intl.formatMessage({
+                      defaultMessage: '"I am Status First Nations"',
+                      id: "ssJxrj",
+                      description:
+                        "Text for the option to self-declare as a status first nations",
+                    }),
+                  },
+                  {
+                    value: "nonStatus",
+                    label: intl.formatMessage({
+                      defaultMessage: '"I am Non-Status First Nations"',
+                      id: "sSE4kt",
+                      description:
+                        "Text for the option to self-declare as a non-status first nations",
+                    }),
+                  },
+                ]}
+              />
+            </div>
+            <div />
+          </Row>
+        )}
         <Row>
           <div data-h2-grid-column="base(span 3)">
             <Checklist
@@ -206,26 +238,12 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
           </div>
         </Row>
       </div>
-      {communitiesValue && communitiesValue.length > 0 ? (
-        <Chips data-h2-margin-bottom="base(x1)">
-          {communitiesValue.map((community: string) => {
-            const label = communityLabels.get(community);
-            return label ? (
-              <Chip
-                key={community}
-                mode="outline"
-                color={
-                  isOtherAndHasCommunity && isAlertOpen && community === "other"
-                    ? "warning"
-                    : "primary"
-                }
-                onDismiss={() => handleDismissCommunity(community)}
-                label={label}
-              />
-            ) : null;
-          })}
-        </Chips>
-      ) : null}
+      <CommunityChips
+        communities={communitiesValue}
+        status={isStatus}
+        otherAlert={!!(isOtherAndHasCommunity && isAlertOpen)}
+        onDismiss={handleDismissCommunity}
+      />
       {isAlertOpen && (
         <Alert.Root type="warning" dismissible onDismiss={handleAlertDismiss}>
           <Alert.Title>

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunitySelection.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunitySelection.tsx
@@ -12,6 +12,8 @@ import {
 import { Alert } from "@gc-digital-talent/ui";
 import { errorMessages } from "@gc-digital-talent/i18n";
 
+import { FirstNationsStatus } from "~/utils/indigenousDeclaration";
+
 import HelpLink from "./HelpLink";
 import { hasCommunityAndOther } from "./utils";
 import CommunityIcon from "./CommunityIcon";
@@ -44,7 +46,10 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
   const { watch, setValue, resetField, setError, clearErrors, formState } =
     useFormContext();
 
-  const [communitiesValue, isStatus] = watch(["communities", "isStatus"]);
+  const [communitiesValue, isStatus]: [
+    string[],
+    FirstNationsStatus | undefined,
+  ] = watch(["communities", "isStatus"]);
 
   const isOtherAndHasCommunity = hasCommunityAndOther(communitiesValue);
 

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunitySelection.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunitySelection.tsx
@@ -2,12 +2,32 @@ import React from "react";
 import { useFormContext } from "react-hook-form";
 import { useIntl } from "react-intl";
 
-import { FieldLabels, Checklist, Field } from "@gc-digital-talent/forms";
+import {
+  FieldLabels,
+  Checklist,
+  Field,
+  Checkbox,
+} from "@gc-digital-talent/forms";
 import { Alert, Chip, Chips } from "@gc-digital-talent/ui";
 
 import HelpLink from "./HelpLink";
 import { getCommunityLabels, hasCommunityAndOther } from "./utils";
 import CommunityIcon from "./CommunityIcon";
+
+interface RowProps {
+  children: React.ReactNode;
+}
+
+const Row = ({ children }: RowProps) => (
+  <div
+    data-h2-display="base(grid)"
+    data-h2-grid-template-columns="base(repeat(4, 1fr))"
+    data-h2-align-items="base(center)"
+    data-h2-gap="base(0 x1)"
+  >
+    {children}
+  </div>
+);
 
 interface CommunityListProps {
   labels: FieldLabels;
@@ -67,118 +87,127 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
 
   return (
     <>
-      <div data-h2-flex-grid="base(center, x1, x0)">
-        <div data-h2-flex-item="base(3of4)" data-h2-align-self="base(center)">
-          <Checklist
-            idPrefix="firstNations"
-            id="firstNations"
-            name="communities"
-            legend={labels.firstNations}
-            trackUnsaved={false}
-            items={[
-              {
-                value: "status",
-                label: intl.formatMessage({
-                  defaultMessage: '"I am Status First Nations"',
-                  id: "ssJxrj",
-                  description:
-                    "Text for the option to self-declare as a status first nations",
-                }),
-              },
-              {
-                value: "nonStatus",
-                label: intl.formatMessage({
-                  defaultMessage: '"I am Non-Status First Nations"',
-                  id: "sSE4kt",
-                  description:
-                    "Text for the option to self-declare as a non-status first nations",
-                }),
-              },
-            ]}
-            aria-describedby={customAlertId}
-          />
-          {formState.errors.firstNationsCustom && (
-            <Field.Error id={customAlertId} data-h2-margin-top="base(x.25)">
-              {formState.errors.firstNationsCustom.message?.toString()}
-            </Field.Error>
-          )}
-        </div>
-        <div data-h2-flex-item="base(1of4)" data-h2-align-self="base(center)">
-          <CommunityIcon
-            values={["status", "nonStatus"]}
-            community="first-nations"
-          />
-        </div>
-        <div data-h2-flex-item="base(3of4)" data-h2-align-self="base(center)">
-          <Checklist
-            idPrefix="inuk"
-            id="inuk"
-            name="communities"
-            legend={labels.inuk}
-            trackUnsaved={false}
-            items={[
-              {
-                value: "inuk",
-                label: intl.formatMessage({
-                  defaultMessage: `"I am Inuk"`,
-                  id: "vDb+O+",
-                  description: "Label text for Inuk community declaration",
-                }),
-              },
-            ]}
-          />
-        </div>
-        <div data-h2-flex-item="base(1of4)" data-h2-align-self="base(center)">
-          <CommunityIcon values={["inuk"]} community="inuit" />
-        </div>
-        <div data-h2-flex-item="base(3of4)" data-h2-align-self="base(center)">
-          <Checklist
-            idPrefix="metis"
-            id="metis"
-            name="communities"
-            legend={labels.metis}
-            trackUnsaved={false}
-            items={[
-              {
-                value: "metis",
-                label: intl.formatMessage({
-                  defaultMessage: `"I am Métis"`,
-                  id: "/81xCT",
-                  description: "Label text for Métis community declaration",
-                }),
-              },
-            ]}
-          />
-        </div>
-        <div data-h2-flex-item="base(1of4)" data-h2-align-self="base(center)">
-          <CommunityIcon values={["metis"]} community="metis" />
-        </div>
-        <div data-h2-flex-item="base(3of4)" data-h2-align-self="base(center)">
-          <Checklist
-            idPrefix="other"
-            id="other"
-            name="communities"
-            legend={labels.other}
-            trackUnsaved={false}
-            items={[
-              {
-                value: "other",
-                label: intl.formatMessage({
-                  defaultMessage: `"I am Indigenous and I don't see my community here"`,
-                  id: "FRcbbi",
-                  description:
-                    "Label text for not represented community declaration",
-                }),
-              },
-            ]}
-          />
-        </div>
-        <div data-h2-flex-item="base(1of4)" data-h2-align-self="base(center)">
-          <CommunityIcon values={["other"]} community="other" />
-        </div>
+      <div
+        data-h2-display="base(flex)"
+        data-h2-gap="base(x1 0)"
+        data-h2-flex-direction="base(column)"
+      >
+        <Row>
+          <div data-h2-grid-column="base(span 3)">
+            <Checklist
+              idPrefix="firstNations"
+              id="firstNations"
+              name="communities"
+              legend={labels.firstNations}
+              trackUnsaved={false}
+              items={[
+                {
+                  value: "status",
+                  label: intl.formatMessage({
+                    defaultMessage: '"I am Status First Nations"',
+                    id: "ssJxrj",
+                    description:
+                      "Text for the option to self-declare as a status first nations",
+                  }),
+                },
+                {
+                  value: "nonStatus",
+                  label: intl.formatMessage({
+                    defaultMessage: '"I am Non-Status First Nations"',
+                    id: "sSE4kt",
+                    description:
+                      "Text for the option to self-declare as a non-status first nations",
+                  }),
+                },
+              ]}
+              aria-describedby={customAlertId}
+            />
+            {formState.errors.firstNationsCustom && (
+              <Field.Error id={customAlertId} data-h2-margin-top="base(x.25)">
+                {formState.errors.firstNationsCustom.message?.toString()}
+              </Field.Error>
+            )}
+          </div>
+          <div>
+            <CommunityIcon values={["status"]} community="first-nations" />
+          </div>
+        </Row>
+        <Row>
+          <div data-h2-grid-column="base(span 3)">
+            <Checklist
+              idPrefix="inuk"
+              id="inuk"
+              name="communities"
+              legend={labels.inuk}
+              trackUnsaved={false}
+              items={[
+                {
+                  value: "inuk",
+                  label: intl.formatMessage({
+                    defaultMessage: `"I am Inuk"`,
+                    id: "vDb+O+",
+                    description: "Label text for Inuk community declaration",
+                  }),
+                },
+              ]}
+            />
+          </div>
+          <div>
+            <CommunityIcon values={["inuk"]} community="inuit" />
+          </div>
+        </Row>
+        <Row>
+          <div data-h2-grid-column="base(span 3)">
+            <Checklist
+              idPrefix="metis"
+              id="metis"
+              name="communities"
+              legend={labels.metis}
+              trackUnsaved={false}
+              items={[
+                {
+                  value: "metis",
+                  label: intl.formatMessage({
+                    defaultMessage: `"I am Métis"`,
+                    id: "/81xCT",
+                    description: "Label text for Métis community declaration",
+                  }),
+                },
+              ]}
+            />
+          </div>
+          <div>
+            <CommunityIcon values={["metis"]} community="metis" />
+          </div>
+        </Row>
+        <Row>
+          <div data-h2-grid-column="base(span 3)">
+            <Checklist
+              idPrefix="other"
+              id="other"
+              name="communities"
+              legend={labels.other}
+              trackUnsaved={false}
+              items={[
+                {
+                  value: "other",
+                  label: intl.formatMessage({
+                    defaultMessage: `"I am Indigenous and I don't see my community here"`,
+                    id: "FRcbbi",
+                    description:
+                      "Label text for not represented community declaration",
+                  }),
+                },
+              ]}
+            />
+          </div>
+          <div>
+            <CommunityIcon values={["other"]} community="other" />
+          </div>
+        </Row>
       </div>
       {communitiesValue && communitiesValue.length > 0 ? (
-        <Chips>
+        <Chips data-h2-margin-bottom="base(x1)">
           {communitiesValue.map((community: string) => {
             const label = communityLabels.get(community);
             return label ? (

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/SelfDeclarationForm.test.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/SelfDeclarationForm.test.tsx
@@ -71,12 +71,7 @@ describe("SelfDeclarationForm", () => {
 
     expect(
       await screen.findByRole("checkbox", {
-        name: /I am Status First Nations/i,
-      }),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByRole("checkbox", {
-        name: /I am non-Status First Nations/i,
+        name: /I am First Nations/i,
       }),
     ).toBeInTheDocument();
 
@@ -127,6 +122,12 @@ describe("SelfDeclarationForm", () => {
 
     fireEvent.click(
       await screen.findByRole("checkbox", {
+        name: /i am first nations/i,
+      }),
+    );
+
+    fireEvent.click(
+      await screen.findByRole("radio", {
         name: /i am status first nations/i,
       }),
     );

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/utils.ts
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/utils.ts
@@ -7,8 +7,8 @@ export const getSelfDeclarationLabels = (intl: IntlShape) => ({
     description: "label for the Indigenous self-declaration input",
   }),
   firstNations: intl.formatMessage({
-    id: "GSqmjE",
-    defaultMessage: "First Nations",
+    id: "VUPlmN",
+    defaultMessage: "First Nations (Status or Non-status)",
     description: "Label for First Nations community",
   }),
   inuk: intl.formatMessage({

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/utils.ts
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/utils.ts
@@ -1,5 +1,9 @@
 import { IntlShape } from "react-intl";
 
+import { empty } from "@gc-digital-talent/helpers";
+
+import { FirstNationsStatus } from "~/utils/indigenousDeclaration";
+
 export const getSelfDeclarationLabels = (intl: IntlShape) => ({
   isIndigenous: intl.formatMessage({
     defaultMessage: "Self-Declaration",
@@ -91,3 +95,24 @@ export const getCommunityLabels = (intl: IntlShape) =>
       }),
     ],
   ]);
+
+type GetCommunityLabelArgs = {
+  community: string;
+  intl: IntlShape;
+  status?: FirstNationsStatus;
+};
+
+export const getCommunityLabel = ({
+  community,
+  status,
+  intl,
+}: GetCommunityLabelArgs) => {
+  const labels = getCommunityLabels(intl);
+  if (community === "firstNations") {
+    if (empty(status)) return null;
+
+    return labels.get(status);
+  }
+
+  return labels.get(community);
+};

--- a/apps/web/src/utils/indigenousDeclaration.ts
+++ b/apps/web/src/utils/indigenousDeclaration.ts
@@ -1,15 +1,19 @@
 import { IndigenousCommunity } from "@gc-digital-talent/graphql";
 
 // constrained list of community form values to avoid typos
-type FormCommunity = "status" | "nonStatus" | "inuk" | "metis" | "other";
+type FormCommunity = "firstNations" | "inuk" | "metis" | "other";
+export type FirstNationsStatus = "status" | "nonStatus";
 
 interface FormFields {
   communities: Array<FormCommunity>;
+  isStatus?: FirstNationsStatus;
 }
+
+type FormYesNo = "yes" | "no" | null;
 
 // for use with forms with a radio button, like the application self-declaration
 export interface FormValuesWithYesNo extends FormFields {
-  isIndigenous: "yes" | "no" | null;
+  isIndigenous: FormYesNo;
 }
 
 // for use with forms with a checkbox, like the profile dialog
@@ -22,11 +26,18 @@ function apiCommunitiesToFormCommunityFields(
 ): FormFields {
   // array of form communities that will be built and returned
   const formCommunities: Array<FormCommunity> = [];
+  let isStatus: FirstNationsStatus | null = null;
 
-  if (apiCommunities.includes(IndigenousCommunity.StatusFirstNations))
-    formCommunities.push("status");
-  if (apiCommunities.includes(IndigenousCommunity.NonStatusFirstNations))
-    formCommunities.push("nonStatus");
+  if (apiCommunities.includes(IndigenousCommunity.StatusFirstNations)) {
+    formCommunities.push("firstNations");
+    isStatus = "status";
+  }
+
+  if (apiCommunities.includes(IndigenousCommunity.NonStatusFirstNations)) {
+    formCommunities.push("firstNations");
+    isStatus = "nonStatus";
+  }
+
   if (apiCommunities.includes(IndigenousCommunity.Inuit))
     formCommunities.push("inuk");
   if (apiCommunities.includes(IndigenousCommunity.Metis))
@@ -37,6 +48,7 @@ function apiCommunitiesToFormCommunityFields(
   // assemble object from pre-computed values
   return {
     communities: formCommunities,
+    ...(isStatus && { isStatus }),
   };
 }
 
@@ -46,6 +58,7 @@ export function apiCommunitiesToFormValuesWithYesNo(
   let isIndigenous: FormValuesWithYesNo["isIndigenous"];
   if (apiCommunities === undefined) isIndigenous = null;
   else isIndigenous = apiCommunities.length > 0 ? "yes" : "no";
+
   // assemble object from pre-computed values
   return {
     ...apiCommunitiesToFormCommunityFields(apiCommunities ?? []),
@@ -69,9 +82,15 @@ export function formValuesToApiCommunities(
   // array of API communities that will be built and returned
   const apiCommunities: Array<IndigenousCommunity> = [];
 
-  if (formValues.communities.includes("status"))
+  if (
+    formValues.communities.includes("firstNations") &&
+    formValues.isStatus === "status"
+  )
     apiCommunities.push(IndigenousCommunity.StatusFirstNations);
-  if (formValues.communities.includes("nonStatus"))
+  if (
+    formValues.communities.includes("firstNations") &&
+    formValues.isStatus === "nonStatus"
+  )
     apiCommunities.push(IndigenousCommunity.NonStatusFirstNations);
   if (formValues.communities.includes("inuk"))
     apiCommunities.push(IndigenousCommunity.Inuit);

--- a/packages/ui/src/components/Alert/Alert.tsx
+++ b/packages/ui/src/components/Alert/Alert.tsx
@@ -110,7 +110,13 @@ const Alert = React.forwardRef<React.ElementRef<"div">, AlertProps>(
             <div
               style={{ flexGrow: 1 }}
               data-h2-align-self="base(center)"
-              data-h2-padding="base(x1) p-tablet(x1, x1, x1, x1.5)"
+              {...(dismissible
+                ? {
+                    "data-h2-padding": "base(x1) p-tablet(x1, x2.5, x1, x1.5)",
+                  }
+                : {
+                    "data-h2-padding": "base(x1) p-tablet(x1, x1, x1, x1.5)",
+                  })}
               {...(banner ? { ...bannerStyleMap[type] } : {})}
             >
               {children}
@@ -132,8 +138,8 @@ const Alert = React.forwardRef<React.ElementRef<"div">, AlertProps>(
                 onClick={close}
               >
                 <XCircleIcon
-                  data-h2-width="base(1.5rem)"
-                  data-h2-height="base(1.5rem)"
+                  data-h2-width="base(x1)"
+                  data-h2-height="base(x1)"
                   strokeWidth="2px"
                 />
                 <span data-h2-visually-hidden="base(invisible)">
@@ -168,7 +174,7 @@ const Title = ({ as = "h2", children, ...rest }: AlertTitleProps) => {
 
   return (
     <Heading
-      data-h2-font-size="base(h6, 1)"
+      data-h2-font-size="base(h6)"
       data-h2-font-weight="base(700)"
       data-h2-margin="base(0, 0, x.5, 0)"
       {...rest}

--- a/packages/ui/src/components/Chip/Chips.tsx
+++ b/packages/ui/src/components/Chip/Chips.tsx
@@ -3,17 +3,18 @@ import isArray from "lodash/isArray";
 
 import { ChipProps } from "./Chip";
 
-interface ChipsProps {
+type ChipsProps = Omit<React.HTMLProps<HTMLUListElement>, "children"> & {
   children: ReactElement<ChipProps> | Array<ReactElement<ChipProps>>;
-}
+};
 
-const Chips = ({ children }: ChipsProps) => (
+const Chips = ({ children, ...rest }: ChipsProps) => (
   <ul
     data-h2-display="base(flex)"
     data-h2-flex-wrap="base(wrap)"
     data-h2-gap="base(x.25, x.125)"
     data-h2-list-style="base(none)"
     data-h2-padding="base(0)"
+    {...rest}
   >
     {isArray(children) ? (
       children.map((child) => <li key={child.key}>{child}</li>)


### PR DESCRIPTION
🤖 Resolves #7525 

## 👋 Introduction

Updates the Indigenous self-declaration form to use a radio group for First Nations status.

## 🕵️ Details

This was done to force a user to only select one or the other but not both. Some other changes were made as well:

- Spacing has been updated
- Signature field hidden when no community is selected
- Submit button changes content based on the form values (removes the term "sign" when no signature field appears)

> **Note**
> I left in the "select both" error message since we already have it and to guard against any edge cases

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to your profile
3. Scroll down to the DEI section
4. Open the Indigenous identify dialog
5. Interact with the form and confirm the First Nations status is required when selecting that as a community
6. Confirm values are submitted to the API properly

## 📸 Screenshot

![Screenshot 2023-10-13 092543](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/015bf9d0-315e-4d44-9127-bc3156a660a9)
