### PR TITLE
[Debt] Pause row selection queries

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo } from "react";
 import { IntlShape, useIntl } from "react-intl";
 import LockClosedIcon from "@heroicons/react/24/solid/LockClosedIcon";
 import { SubmitHandler } from "react-hook-form";
@@ -63,6 +63,7 @@ import {
 import { getFullNameLabel } from "~/utils/nameUtils";
 import adminMessages from "~/messages/adminMessages";
 import UserProfilePrintButton from "~/pages/Users/AdminUserProfilePage/components/UserProfilePrintButton";
+import useSelectedRows from "~/hooks/useSelectedRows";
 
 import usePoolCandidateCsvData from "./usePoolCandidateCsvData";
 import PoolCandidateTableFilterDialog, {
@@ -401,9 +402,8 @@ const PoolCandidatesTable = ({
     filters: applicantFilterInput,
   } = tableState;
 
-  const [selectedRows, setSelectedRows] = useState<
-    PoolCandidateWithSkillCount[]
-  >([]);
+  const { selectedRows, setSelectedRows, hasSelected } =
+    useSelectedRows<PoolCandidateWithSkillCount>([]);
 
   // a bit more complicated API call as it has multiple sorts as well as sorts based off a connected database table
   // this smooths the table sort value into appropriate API calls
@@ -553,7 +553,7 @@ const PoolCandidatesTable = ({
 
   useEffect(() => {
     setSelectedRows([]);
-  }, [currentPage, pageSize, searchState, sortingRule]);
+  }, [currentPage, pageSize, searchState, setSelectedRows, sortingRule]);
 
   const [result] = useGetPoolCandidatesPaginatedQuery({
     variables: {
@@ -756,7 +756,15 @@ const PoolCandidatesTable = ({
         sortColumnName: "submitted_at",
       },
     ],
-    [intl, selectedRows, filteredData, paths, allSkills, filteredSkillIds],
+    [
+      intl,
+      selectedRows,
+      filteredData,
+      setSelectedRows,
+      paths,
+      allSkills,
+      filteredSkillIds,
+    ],
   );
 
   const allColumnIds = columns.map((c) => c.id);
@@ -772,6 +780,7 @@ const PoolCandidatesTable = ({
     variables: {
       ids: selectedCandidateIds,
     },
+    pause: !hasSelected,
   });
 
   const selectedCandidates =

--- a/apps/web/src/hooks/useSelectedRows.ts
+++ b/apps/web/src/hooks/useSelectedRows.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef, useState } from "react";
+
+interface UseSelectedRowsReturn<T> {
+  setSelectedRows: React.Dispatch<React.SetStateAction<T[]>>;
+  selectedRows: T[];
+  hasSelected: boolean;
+}
+
+function useSelectedRows<T>(defaultSelected?: T[]): UseSelectedRowsReturn<T> {
+  const hasSelected = useRef<boolean>(false);
+  const [selectedRows, setSelectedRows] = useState<T[]>(defaultSelected ?? []);
+
+  useEffect(() => {
+    if (selectedRows.length > 0 && !hasSelected.current) {
+      hasSelected.current = true;
+    }
+  }, [selectedRows]);
+
+  let pause = !hasSelected.current;
+  if (selectedRows.length > 0) {
+    pause = false;
+  }
+
+  return {
+    selectedRows,
+    setSelectedRows,
+    hasSelected: !pause,
+  };
+}
+
+export default useSelectedRows;

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo } from "react";
 import { IntlShape, useIntl } from "react-intl";
 import { useLocation } from "react-router-dom";
 import { SubmitHandler } from "react-hook-form";
@@ -46,6 +46,7 @@ import {
   stringToEnumOperational,
 } from "~/utils/userUtils";
 import adminMessages from "~/messages/adminMessages";
+import useSelectedRows from "~/hooks/useSelectedRows";
 
 import useUserCsvData from "../hooks/useUserCsvData";
 import UserTableFilterDialog, {
@@ -250,7 +251,9 @@ const UserTable = ({ title }: { title: string }) => {
     filters: userFilterInput,
   } = tableState;
 
-  const [selectedRows, setSelectedRows] = useState<User[]>([]);
+  const { selectedRows, setSelectedRows, hasSelected } = useSelectedRows<User>(
+    [],
+  );
 
   // merge search bar input with fancy filter state
   const addSearchToUserFilterInput = (
@@ -294,7 +297,7 @@ const UserTable = ({ title }: { title: string }) => {
 
   useEffect(() => {
     setSelectedRows([]);
-  }, [currentPage, pageSize, searchState, sortingRule]);
+  }, [currentPage, pageSize, searchState, setSelectedRows, sortingRule]);
 
   const [result] = useAllUsersPaginatedQuery({
     variables: {
@@ -459,6 +462,7 @@ const UserTable = ({ title }: { title: string }) => {
     variables: {
       ids: selectedApplicantIds,
     },
+    pause: !hasSelected,
   });
 
   const selectedApplicants =


### PR DESCRIPTION
🤖 Resolves #7681 

## 👋 Introduction

Pauses the row selection queries until users make at least one selection.

## 🕵️ Details

This was slightly tricker than I first assumed. I used a ref to track if any selection has been made so we still run the query once all items have been selected so we can empty out the in memory cache of the result. Maybe a better approach would be to try and empty that in memory cache instead of making a trip to the server when we know the response will be an empty array? 🤔 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/admin/users`
3. Confirm the initial selected query is not run
4. Select a row
5. Confirm the query runs and printing works
6. Deselect a row
7. Confirm print is empty
8. Navigate to a pool candidates table
9. Repeat steps 4-7
