### PR TITLE
[Debt] Rename 'view-team-user'

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -859,7 +859,7 @@ class User extends Model implements Authenticatable, LaratrustUser
 
         if (! $user->isAbleTo('view-any-user')) {
             $query->where(function (Builder $query) use ($user) {
-                if ($user->isAbleTo('view-team-user')) {
+                if ($user->isAbleTo('view-team-applicantProfile')) {
                     $query->orWhereHas('poolCandidates', function (Builder $query) use ($user) {
                         $teamIds = $user->rolesTeams()->get()->pluck('id');
                         $query->whereHas('pool', function (Builder $query) use ($teamIds) {

--- a/api/app/Policies/UserPolicy.php
+++ b/api/app/Policies/UserPolicy.php
@@ -28,7 +28,7 @@ class UserPolicy
     public function view(User $user, User $model)
     {
         return $user->isAbleTo('view-any-user')
-            || ($user->isAbleTo('view-own-user') && $user->id === $model->id) || ($user->isAbleTo('view-team-user')
+            || ($user->isAbleTo('view-own-user') && $user->id === $model->id) || ($user->isAbleTo('view-team-applicantProfile')
                 && $this->applicantHasAppliedToPoolInTeams(
                     $model,
                     $user->rolesTeams()->get()->pluck('id')

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -77,6 +77,7 @@ return [
         'teamMembers' => 'teamMembers',
         'role' => 'role',
         'directiveForm' => 'directiveForm',
+        'applicantProfile' => 'applicantProfile',
     ],
 
     /*
@@ -189,7 +190,7 @@ return [
             'en' => 'View Own User',
             'fr' => 'Visionner son propre utilisateur',
         ],
-        'view-team-user' => [
+        'view-team-applicantProfile' => [
             'en' => 'View Team User',
             'fr' => 'Visionner l\'utilisateur de l\'équipe',
         ],
@@ -604,7 +605,7 @@ return [
             'role' => [
                 'any' => ['view'],
             ],
-            'user' => [
+            'applicantProfile' => [
                 'team' => ['view'],
             ],
         ],

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -145,6 +145,7 @@ class RolePermissionTest extends TestCase
             'view-team-submittedApplication',
             'update-team-applicationStatus',
             'view-team-teamMembers',
+            'view-team-applicantProfile',
         ];
 
         $this->assertTrue($this->user->hasRole('pool_operator', $this->ownedTeam));


### PR DESCRIPTION
🤖 Resolves #7827 

## 👋 Introduction

Renames it to 'view-team-applicantProfile'

## 🕵️ Details

Not too many moving parts, noted a bug here #8232 

## 🧪 Testing

1. Seed fresh
2. Log in as `pool@test.com`, exercise the admin dashboard
3. 'view-team-user' no longer present

## 🚚 Deployment

Re-run the roles and permission seeder

`php artisan db:seed --class=RolePermissionSeeder`
