### PR TITLE
[Fix] First nations guillemets mistake

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5487,7 +5487,7 @@
     "description": "Sentence describing what priority entitlement is"
   },
   "Wpj2OY": {
-    "defaultMessage": "\"Je suis membre d’une Première Nation\"",
+    "defaultMessage": "« Je suis membre d’une Première Nation »",
     "description": "Text for the option to self-declare as first nations"
   },
   "WqOnFF": {


### PR DESCRIPTION
## 👋 Introduction

Fixes a translation mistake that wasn't caught in review 😢 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to your "Profile information"
3. Switch to French
4. Open the Indigenous identity dialog
5. Confirm the First Nations option uses guillemets and not double quotes

## 📸 Screenshot

![Screenshot 2023-10-17 134907](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/38529e6c-a5de-4d6b-8020-b3944dda98e7)
