### PR TITLE
[Debt] Create account page story

### DIFF
--- a/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountForm.stories.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountForm.stories.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Meta, StoryFn } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+
+import {
+  fakeClassifications,
+  fakeDepartments,
+} from "@gc-digital-talent/fake-data";
+
+import { CreateAccountForm } from "./CreateAccountPage";
+
+const departments = fakeDepartments();
+const classifications = fakeClassifications();
+
+export default {
+  component: CreateAccountForm,
+  title: "Pages/Create account",
+} as Meta<typeof CreateAccountForm>;
+
+const Template: StoryFn<typeof CreateAccountForm> = () => {
+  return (
+    <CreateAccountForm
+      departments={departments}
+      classifications={classifications}
+      handleCreateAccount={async (data) => {
+        action("submit")(data);
+      }}
+    />
+  );
+};
+
+export const Default = Template.bind({});


### PR DESCRIPTION
🤖 Resolves #7528

## 👋 Introduction

Adds a story for the Create account page form. 

## 🕵️ Details

Added the story. 
`GovernmentInfoForm.stories.tsx` was removed in #7644 

## 🧪 Testing

1. Run storybook
2. Navigate to Create account story

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/644e5b91-96ec-4039-b19a-081f94a1446e)

