### PR TITLE
[Bug] Add missing suspendedAt to graphql file

### DIFF
--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/viewPoolCandidatePage.graphql
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/viewPoolCandidatePage.graphql
@@ -10,6 +10,7 @@ query getPoolCandidateSnapshot($poolCandidateId: UUID!) {
         status
         expiryDate
         notes
+        suspendedAt
         user {
           id
         }


### PR DESCRIPTION
🤖 Resolves #8248

## 👋 Introduction

Add `suspendedAt` to graphql file

## 🕵️ Details

`<PoolStatusTable>` renders availibility and for that, need to pass in the field to render correctly. It was missing for this page that renders the snapshot page, which is the second place that table appears. 

## 🧪 Testing

1. Snapshot page's info table accounts for availability in rendering 

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/f70de07e-0742-4c6f-ad9c-08789b17ea1f)

