### PR TITLE
[Fix] Reduce width of row selection column

### DIFF
--- a/apps/web/src/components/Table/ResponsiveTable/Table.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/Table.tsx
@@ -131,7 +131,6 @@ const HeadCell = <T,>({ header, ...rest }: HeadCellProps<T>) => {
       {...(!isRowSelect &&
         !shouldShrink && {
           "data-h2-min-width": "base(x8)",
-          "data-h2-width": "base(100%)",
         })}
       {...styles.cell}
       {...rest}

--- a/apps/web/src/components/Table/ResponsiveTable/Table.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/Table.tsx
@@ -116,26 +116,34 @@ type HeadCellProps<T> = {
   header: Header<T, unknown>;
 } & CellHTMLProps;
 
-const HeadCell = <T,>({ header, ...rest }: HeadCellProps<T>) => (
-  <th
-    role="columnheader"
-    data-h2-background-color="base(black)"
-    data-h2-color="base(white)"
-    data-h2-display="base(none) l-tablet(table-cell)"
-    data-h2-font-size="base(caption)"
-    data-h2-vertical-align="base(middle)"
-    data-h2-font-weight="base(400)"
-    data-h2-min-width="base(x8)"
-    {...styles.cell}
-    {...rest}
-  >
-    {header.isPlaceholder ? null : (
-      <SortButton column={header.column}>
-        {flexRender(header.column.columnDef.header, header.getContext())}
-      </SortButton>
-    )}
-  </th>
-);
+const HeadCell = <T,>({ header, ...rest }: HeadCellProps<T>) => {
+  const isRowSelect = header.column.columnDef.meta?.isRowSelect;
+  const shouldShrink = header.column.columnDef.meta?.shrink;
+  return (
+    <th
+      role="columnheader"
+      data-h2-background-color="base(black)"
+      data-h2-color="base(white)"
+      data-h2-display="base(none) l-tablet(table-cell)"
+      data-h2-font-size="base(caption)"
+      data-h2-vertical-align="base(middle)"
+      data-h2-font-weight="base(400)"
+      {...(!isRowSelect &&
+        !shouldShrink && {
+          "data-h2-min-width": "base(x8)",
+          "data-h2-width": "base(100%)",
+        })}
+      {...styles.cell}
+      {...rest}
+    >
+      {header.isPlaceholder ? null : (
+        <SortButton column={header.column}>
+          {flexRender(header.column.columnDef.header, header.getContext())}
+        </SortButton>
+      )}
+    </th>
+  );
+};
 
 type CellProps<T> = {
   cell: Cell<T, unknown>;
@@ -145,9 +153,11 @@ const Cell = <T,>({ cell, ...rest }: CellProps<T>) => {
   const intl = useIntl();
   const isRowTitle = cell.column.columnDef.meta?.isRowTitle;
   const isRowSelect = cell.column.columnDef.meta?.isRowSelect;
+  const shouldShrink = cell.column.columnDef.meta?.shrink;
   const cellStyles = getCellStyles({
     isRowTitle,
     isRowSelect,
+    shouldShrink,
   });
   const header = getColumnHeader(cell.column, "mobileHeader");
 

--- a/apps/web/src/components/Table/ResponsiveTable/styles.ts
+++ b/apps/web/src/components/Table/ResponsiveTable/styles.ts
@@ -37,14 +37,10 @@ export const getCellStyles: GetCellStyles = ({
           "data-h2-order": "base(3)",
         }),
 
-      ...(shrinkCol
-        ? {
-            "data-h2-flex-shrink": "base(0)",
-            "data-h2-width": "base(auto)",
-          }
-        : {
-            "data-h2-width": "base(100%)",
-          }),
+      ...(shrinkCol && {
+        "data-h2-flex-shrink": "base(0)",
+        "data-h2-width": "base(auto)",
+      }),
 
       // Custom styles for row selection cell
       ...(isRowSelect && {

--- a/apps/web/src/components/Table/ResponsiveTable/styles.ts
+++ b/apps/web/src/components/Table/ResponsiveTable/styles.ts
@@ -3,6 +3,8 @@ type GetCellStyleArgs = {
   isRowTitle?: boolean;
   /** Determine if this cell is the selection cell  */
   isRowSelect?: boolean;
+  /** Determine if this cell should shrink below the min width of x8  */
+  shouldShrink?: boolean;
 };
 
 type CellStyles = {
@@ -20,25 +22,32 @@ type GetCellStyles = (args: GetCellStyleArgs) => CellStyles;
  * Creates the style attributes for cells changing for
  * row titles (mobile) and row selection columns
  */
-export const getCellStyles: GetCellStyles = ({ isRowTitle, isRowSelect }) => {
+export const getCellStyles: GetCellStyles = ({
+  isRowTitle,
+  isRowSelect,
+  shouldShrink,
+}) => {
+  const shrinkCol = shouldShrink || isRowSelect;
   return {
     td: {
-      ...(!isRowTitle && !isRowSelect
+      ...(!isRowTitle &&
+        !isRowSelect && {
+          // Not a title or selection
+          "data-h2-display": "base(block) l-tablet(table-cell)",
+          "data-h2-order": "base(3)",
+        }),
+
+      ...(shrinkCol
         ? {
-            // Not a title or selection
-            "data-h2-display": "base(block) l-tablet(table-cell)",
-            // "data-h2-grid-template-columns": "base(6rem auto)",
-            // "data-h2-gap": "base(x.5 x.25) l-tablet(0)",
-            "data-h2-width": "base(100%) l-tablet(auto)",
-            "data-h2-order": "base(3)",
+            "data-h2-flex-shrink": "base(0)",
+            "data-h2-width": "base(auto)",
           }
         : {
-            "data-h2-width": "base(auto)",
+            "data-h2-width": "base(100%)",
           }),
 
       // Custom styles for row selection cell
       ...(isRowSelect && {
-        "data-h2-flex-shrink": "base(0)",
         "data-h2-order": "base(2)",
       }),
 

--- a/apps/web/src/table.d.ts
+++ b/apps/web/src/table.d.ts
@@ -14,5 +14,7 @@ declare module "@tanstack/table-core" {
     hideMobileHeader?: boolean;
     /** Header for the search column dropdown */
     searchHeader?: React.ReactNode;
+    /** Allows the column to shrink below the min width (x8) */
+    shrink?: boolean;
   }
 }


### PR DESCRIPTION
🤖 Resolves #8222 

## 👋 Introduction

This allows the row selection column to shrink. As well, you can force columns to shrink below the min width of `x8` with `meta.shrink?: boolean` in the column def.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run storybook `npm run storybook:web`
2. Navigate to the  "Tables\Responsive Table\Row Selection" story
3. Confirm the column with checkboxes is smaller than the other columns

## 📸 Screenshot

![Screenshot 2023-10-19 092246](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/caceb0fe-b46b-4cc3-a050-d8de8106c275)
