### PR TITLE
[Feature] Executive teaser

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -12,6 +12,7 @@ FEATURE_SKILL_LIBRARY=true
 #FEATURE_STATUS_NOTIFICATIONS=true  // not yet implemented on the client side
 FEATURE_DIRECTIVE_FORMS=true
 FEATURE_RECORD_OF_DECISION=true
+FEATURE_EXECUTIVE_TEASER=true
 
 # Logging - enable by setting the logging level. Eight severity levels from rfc5424.
 LOG_CONSOLE_LEVEL="debug"

--- a/apps/web/public/config.ejs
+++ b/apps/web/public/config.ejs
@@ -16,6 +16,7 @@ const data = new Map([
     ["FEATURE_SKILL_LIBRARY", filterUnusable("$FEATURE_SKILL_LIBRARY") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_SKILL_LIBRARY %>"],
     ["FEATURE_DIRECTIVE_FORMS", filterUnusable("$FEATURE_DIRECTIVE_FORMS") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_DIRECTIVE_FORMS %>"],
     ["FEATURE_RECORD_OF_DECISION", filterUnusable("$FEATURE_RECORD_OF_DECISION") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_RECORD_OF_DECISION %>"],
+    ["FEATURE_EXECUTIVE_TEASER", filterUnusable("$FEATURE_EXECUTIVE_TEASER") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_EXECUTIVE_TEASER %>"],
 
     // Azure application insights not used in dev
     ["APPLICATIONINSIGHTS_CONNECTION_STRING", filterUnusable("$APPLICATIONINSIGHTS_CONNECTION_STRING")],

--- a/apps/web/src/components/CallToActionCard/CallToActionCard.stories.tsx
+++ b/apps/web/src/components/CallToActionCard/CallToActionCard.stories.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Meta, StoryFn } from "@storybook/react";
+import { faker } from "@faker-js/faker";
+
+import CallToActionCard from "./CallToActionCard";
+
+faker.seed(0);
+
+export default {
+  component: CallToActionCard,
+  title: "Components/Call to Action Card",
+  args: {
+    heading: faker.lorem.lines(1),
+    link: {
+      href: "/#",
+      label: faker.lorem.words(3),
+    },
+    children: <p>{faker.lorem.sentence()}</p>,
+  },
+} as Meta<typeof CallToActionCard>;
+
+const Template: StoryFn<typeof CallToActionCard> = (args) => {
+  return <CallToActionCard {...args} />;
+};
+
+export const Default = Template.bind({});

--- a/apps/web/src/components/CallToActionCard/CallToActionCard.tsx
+++ b/apps/web/src/components/CallToActionCard/CallToActionCard.tsx
@@ -2,10 +2,13 @@ import React from "react";
 
 import { Heading, Link, HeadingRank, LinkProps } from "@gc-digital-talent/ui";
 
-interface CallToActionCardProps {
-  title: React.ReactNode;
-  titleAs?: HeadingRank;
-  children: React.ReactNode;
+interface CallToActionCardProps
+  extends React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  > {
+  heading: React.ReactNode;
+  headingAs?: HeadingRank;
   link: {
     href: string;
     label: React.ReactNode;
@@ -14,10 +17,11 @@ interface CallToActionCardProps {
 }
 
 const CallToActionCard = ({
-  title,
-  titleAs = "h3",
+  heading,
+  headingAs = "h3",
   children,
   link,
+  ...rest
 }: CallToActionCardProps) => (
   <div
     data-h2-background-color="base(white) base:dark(black.light)"
@@ -25,6 +29,7 @@ const CallToActionCard = ({
     data-h2-shadow="base(large)"
     data-h2-padding="base(x1)"
     data-h2-radius="base(rounded)"
+    {...rest}
   >
     <div
       data-h2-display="p-tablet(flex)"
@@ -32,8 +37,12 @@ const CallToActionCard = ({
       data-h2-align-items="base(center)"
     >
       <div>
-        <Heading level={titleAs} size="h6" data-h2-margin="base(0, 0, x.5, 0)">
-          {title}
+        <Heading
+          level={headingAs}
+          size="h6"
+          data-h2-margin="base(0, 0, x.5, 0)"
+        >
+          {heading}
         </Heading>
         {children}
       </div>

--- a/apps/web/src/components/CallToActionCard/CallToActionCard.tsx
+++ b/apps/web/src/components/CallToActionCard/CallToActionCard.tsx
@@ -35,6 +35,7 @@ const CallToActionCard = ({
       data-h2-display="p-tablet(flex)"
       data-h2-gap="base(x3)"
       data-h2-align-items="base(center)"
+      data-h2-justify-content="base(space-between)"
     >
       <div>
         <Heading
@@ -46,7 +47,10 @@ const CallToActionCard = ({
         </Heading>
         {children}
       </div>
-      <div data-h2-margin="base(x1, 0, 0, 0) p-tablet(0)">
+      <div
+        data-h2-margin="base(x1, 0, 0, 0) p-tablet(0)"
+        data-h2-flex-shrink="base(0)"
+      >
         <Link
           color="secondary"
           mode="solid"

--- a/apps/web/src/components/CallToActionCard/CallToActionCard.tsx
+++ b/apps/web/src/components/CallToActionCard/CallToActionCard.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+import { Heading, Link, HeadingRank, LinkProps } from "@gc-digital-talent/ui";
+
+interface CallToActionCardProps {
+  title: React.ReactNode;
+  titleAs?: HeadingRank;
+  children: React.ReactNode;
+  link: {
+    href: string;
+    label: React.ReactNode;
+    linkProps?: Omit<LinkProps, "children" | "href">;
+  };
+}
+
+const CallToActionCard = ({
+  title,
+  titleAs = "h3",
+  children,
+  link,
+}: CallToActionCardProps) => (
+  <div
+    data-h2-background-color="base(white) base:dark(black.light)"
+    data-h2-color="base(black) base:dark(white)"
+    data-h2-shadow="base(large)"
+    data-h2-padding="base(x1)"
+    data-h2-radius="base(rounded)"
+  >
+    <div
+      data-h2-display="p-tablet(flex)"
+      data-h2-gap="base(x3)"
+      data-h2-align-items="base(center)"
+    >
+      <div>
+        <Heading level={titleAs} size="h6" data-h2-margin="base(0, 0, x.5, 0)">
+          {title}
+        </Heading>
+        {children}
+      </div>
+      <div data-h2-margin="base(x1, 0, 0, 0) p-tablet(0)">
+        <Link
+          color="secondary"
+          mode="solid"
+          href={link.href}
+          style={{ whiteSpace: "nowrap" }}
+          {...link?.linkProps}
+        >
+          {link.label}
+        </Link>
+      </div>
+    </div>
+  </div>
+);
+
+export default CallToActionCard;

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1063,6 +1063,10 @@
     "defaultMessage": "Voir les résultats",
     "description": "A link to view the pools that contain matching talent."
   },
+  "3yg5j7": {
+    "defaultMessage": "Notre premier processus exécutif (EX) pour un poste EX-03 sera publié sur la plateforme des talents numériques du GC en novembre 2023. Gardez l’œil ouvert pour une possibilité d’emploi où vous pourrez soumettre votre candidature pour devenir un leader du numérique au sein du gouvernement.",
+    "description": "Text describing upcoming executive opportunities instructing users to create a profile when anonymous"
+  },
   "404R1N": {
     "defaultMessage": "Ce programme a été pour moi une occasion de changer ma vie et je vois <b>un meilleur avenir</b>.",
     "description": "testimonial number one"
@@ -7120,6 +7124,10 @@
   "dE2WB1": {
     "defaultMessage": "Équité en matière d’emploi ({equityFiltersActive})",
     "description": "Employment equity with a number in parentheses"
+  },
+  "dFCH1c": {
+    "defaultMessage": "Processus exécutif à venir sous peu",
+    "description": "Heading for the teaser of executive processes"
   },
   "dImJqI": {
     "defaultMessage": "Publiez votre annonce pour commencer à recevoir des candidatures",

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
@@ -137,8 +137,8 @@ export const BrowsePools = ({ pools }: BrowsePoolsProps) => {
           {executiveTeaser && (
             <CallToActionCard
               heading={intl.formatMessage({
-                defaultMessage: "Coming end of November 2023: EX-03",
-                id: "+DHW06",
+                defaultMessage: "Executive (EX) process coming soon",
+                id: "dFCH1c",
                 description: "Heading for the teaser of executive processes",
               })}
               link={profileLink}
@@ -147,8 +147,8 @@ export const BrowsePools = ({ pools }: BrowsePoolsProps) => {
               <p>
                 {intl.formatMessage({
                   defaultMessage:
-                    "Our first executive (EX) process will be live on the GC Talent platform in November of this year. Keep an eye on this page for an opportunity to submit your candidacy to be a digital leader in government.",
-                  id: "XX3BfH",
+                    "Our first executive (EX) process for an EX-03 position will be published on the GC Digital Talent platform in November 2023. Check this space for an opportunity to submit your candidacy to be a digital leader in government.",
+                  id: "3yg5j7",
                   description:
                     "Text describing upcoming executive opportunities instructing users to create a profile when anonymous",
                 })}

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
@@ -5,6 +5,7 @@ import { CardFlat, Flourish, Pending } from "@gc-digital-talent/ui";
 import { useTheme } from "@gc-digital-talent/theme";
 import { useAuthentication } from "@gc-digital-talent/auth";
 import { nowUTCDateTime } from "@gc-digital-talent/date-helpers";
+import { useFeatureFlags } from "@gc-digital-talent/env";
 
 import SEO from "~/components/SEO/SEO";
 import Hero from "~/components/Hero";
@@ -45,6 +46,7 @@ export const BrowsePools = ({ pools }: BrowsePoolsProps) => {
   const intl = useIntl();
   const { loggedIn } = useAuthentication();
   const paths = useRoutes();
+  const { executiveTeaser } = useFeatureFlags();
 
   const title = intl.formatMessage({
     defaultMessage: "Browse jobs",
@@ -132,14 +134,35 @@ export const BrowsePools = ({ pools }: BrowsePoolsProps) => {
           <div data-h2-padding="base(x3, 0, 0, 0) p-tablet(x4, 0, 0, 0)">
             <ActiveRecruitmentSection pools={activeRecruitmentPools} />
           </div>
+          {executiveTeaser && (
+            <CallToActionCard
+              heading={intl.formatMessage({
+                defaultMessage: "Coming end of November 2023: EX-03",
+                id: "+DHW06",
+                description: "Heading for the teaser of executive processes",
+              })}
+              link={profileLink}
+              data-h2-margin="base(x3, 0) p-tablet(x4, 0)"
+            >
+              <p>
+                {intl.formatMessage({
+                  defaultMessage:
+                    "Our first executive (EX) process will be live on the GC Talent platform in November of this year. Keep an eye on this page for an opportunity to submit your candidacy to be a digital leader in government.",
+                  id: "XX3BfH",
+                  description:
+                    "Text describing upcoming executive opportunities instructing users to create a profile when anonymous",
+                })}
+              </p>
+            </CallToActionCard>
+          )}
           {ongoingRecruitmentPools.length > 0 && (
             <div data-h2-padding="base(x3, 0, 0, 0) p-tablet(x4, 0, 0, 0)">
               <OngoingRecruitmentSection pools={ongoingRecruitmentPools} />
             </div>
           )}
-          <div data-h2-padding="base(x3, 0) p-tablet(x4, 0)">
+          {!executiveTeaser && (
             <CallToActionCard
-              title={
+              heading={
                 areOpportunitiesShowing
                   ? intl.formatMessage({
                       defaultMessage: "More opportunities are coming soon!",
@@ -156,6 +179,7 @@ export const BrowsePools = ({ pools }: BrowsePoolsProps) => {
                     })
               }
               link={profileLink}
+              data-h2-margin="base(x3, 0) p-tablet(x4, 0)"
             >
               <p>
                 {loggedIn
@@ -175,7 +199,7 @@ export const BrowsePools = ({ pools }: BrowsePoolsProps) => {
                     })}
               </p>
             </CallToActionCard>
-          </div>
+          )}
         </div>
         <img
           alt=""

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
@@ -1,13 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-import {
-  CardFlat,
-  Flourish,
-  Heading,
-  Link,
-  Pending,
-} from "@gc-digital-talent/ui";
+import { CardFlat, Flourish, Pending } from "@gc-digital-talent/ui";
 import { useTheme } from "@gc-digital-talent/theme";
 import { useAuthentication } from "@gc-digital-talent/auth";
 import { nowUTCDateTime } from "@gc-digital-talent/date-helpers";
@@ -28,6 +22,7 @@ import flourishTopLight from "~/assets/img/browse_top_light.png";
 import flourishBottomLight from "~/assets/img/browse_bottom_light.png";
 import flourishTopDark from "~/assets/img/browse_top_dark.png";
 import flourishBottomDark from "~/assets/img/browse_bottom_dark.png";
+import CallToActionCard from "~/components/CallToActionCard/CallToActionCard";
 
 import OngoingRecruitmentSection from "./components/OngoingRecruitmentSection/OngoingRecruitmentSection";
 import ActiveRecruitmentSection from "./components/ActiveRecruitmentSection/ActiveRecruitmentSection";
@@ -80,6 +75,23 @@ export const BrowsePools = ({ pools }: BrowsePoolsProps) => {
   const areOpportunitiesShowing =
     activeRecruitmentPools.length || ongoingRecruitmentPools.length;
 
+  const profileLink = {
+    href: loggedIn ? paths.myProfile() : paths.login(),
+    label: loggedIn
+      ? intl.formatMessage({
+          defaultMessage: "Update my profile",
+          id: "jfCwes",
+          description:
+            "Link text to direct users to the profile page when signed in",
+        })
+      : intl.formatMessage({
+          defaultMessage: "Create a profile",
+          id: "wPpvvm",
+          description:
+            "Link text to direct users to the profile page when anonymous",
+        }),
+  };
+
   return (
     <>
       <SEO
@@ -126,81 +138,43 @@ export const BrowsePools = ({ pools }: BrowsePoolsProps) => {
             </div>
           )}
           <div data-h2-padding="base(x3, 0) p-tablet(x4, 0)">
-            <div
-              data-h2-background-color="base(white) base:dark(black.light)"
-              data-h2-color="base(black) base:dark(white)"
-              data-h2-shadow="base(large)"
-              data-h2-padding="base(x1) p-tablet(x2)"
-              data-h2-radius="base(rounded)"
+            <CallToActionCard
+              title={
+                areOpportunitiesShowing
+                  ? intl.formatMessage({
+                      defaultMessage: "More opportunities are coming soon!",
+                      id: "g+JcDC",
+                      description:
+                        "Heading for message about upcoming opportunities",
+                    })
+                  : intl.formatMessage({
+                      defaultMessage:
+                        "No opportunities are available right now, but more are coming soon!",
+                      id: "xHjgXz",
+                      description:
+                        "Text displayed when there are no pool advertisements to display",
+                    })
+              }
+              link={profileLink}
             >
-              <div
-                data-h2-display="p-tablet(flex)"
-                data-h2-gap="base(x3)"
-                data-h2-align-items="base(center)"
-              >
-                <div>
-                  <Heading
-                    level="h3"
-                    size="h6"
-                    data-h2-margin="base(0, 0, x1, 0)"
-                  >
-                    {areOpportunitiesShowing
-                      ? intl.formatMessage({
-                          defaultMessage: "More opportunities are coming soon!",
-                          id: "g+JcDC",
-                          description:
-                            "Heading for message about upcoming opportunities",
-                        })
-                      : intl.formatMessage({
-                          defaultMessage:
-                            "No opportunities are available right now, but more are coming soon!",
-                          id: "xHjgXz",
-                          description:
-                            "Text displayed when there are no pool advertisements to display",
-                        })}
-                  </Heading>
-                  <p>
-                    {loggedIn
-                      ? intl.formatMessage({
-                          defaultMessage:
-                            "We're posting new opportunities all the time. By keeping your profile up to date, you'll be able to submit applications lightning fast when the time comes.",
-                          id: "9SZDCq",
-                          description:
-                            "Text describing upcoming opportunities instructing users to update a profile when signed in",
-                        })
-                      : intl.formatMessage({
-                          defaultMessage:
-                            "We're posting new opportunities all the time. By starting your profile now, you'll be able to submit applications lightning fast when the time comes.",
-                          id: "3sbLPV",
-                          description:
-                            "Text describing upcoming opportunities instructing users to create a profile when anonymous",
-                        })}
-                  </p>
-                </div>
-                <div data-h2-margin="base(x1, 0, 0, 0) p-tablet(0)">
-                  <Link
-                    color="secondary"
-                    mode="solid"
-                    href={loggedIn ? paths.myProfile() : paths.login()}
-                    style={{ whiteSpace: "nowrap" }}
-                  >
-                    {loggedIn
-                      ? intl.formatMessage({
-                          defaultMessage: "Update my profile",
-                          id: "jfCwes",
-                          description:
-                            "Link text to direct users to the profile page when signed in",
-                        })
-                      : intl.formatMessage({
-                          defaultMessage: "Create a profile",
-                          id: "wPpvvm",
-                          description:
-                            "Link text to direct users to the profile page when anonymous",
-                        })}
-                  </Link>
-                </div>
-              </div>
-            </div>
+              <p>
+                {loggedIn
+                  ? intl.formatMessage({
+                      defaultMessage:
+                        "We're posting new opportunities all the time. By keeping your profile up to date, you'll be able to submit applications lightning fast when the time comes.",
+                      id: "9SZDCq",
+                      description:
+                        "Text describing upcoming opportunities instructing users to update a profile when signed in",
+                    })
+                  : intl.formatMessage({
+                      defaultMessage:
+                        "We're posting new opportunities all the time. By starting your profile now, you'll be able to submit applications lightning fast when the time comes.",
+                      id: "3sbLPV",
+                      description:
+                        "Text describing upcoming opportunities instructing users to create a profile when anonymous",
+                    })}
+              </p>
+            </CallToActionCard>
           </div>
         </div>
         <img

--- a/packages/env/src/utils.ts
+++ b/packages/env/src/utils.ts
@@ -42,4 +42,5 @@ export const getFeatureFlags = () => ({
   skillLibrary: checkFeatureFlag("FEATURE_SKILL_LIBRARY"),
   directiveForms: checkFeatureFlag("FEATURE_DIRECTIVE_FORMS"),
   recordOfDecision: checkFeatureFlag("FEATURE_RECORD_OF_DECISION"),
+  executiveTeaser: checkFeatureFlag("FEATURE_EXECUTIVE_TEASER"),
 });


### PR DESCRIPTION
🤖 Resolves #8286 

## 👋 Introduction

Adds a teaser for upcoming exec processes on the brow jobs page.

## 🕵️ Details

This adds a new feature flag so we can remove the alert quickly. This flag, when true, shows the exec teaser just below active recruitments and hides the "more opportunities" card at the bottom of the page.

> **Warning**
> There was a copy change from the original ticket

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Update your `.env` with the new feature flag in the `.env.example` file
2. Build `npm run dev`
3. Navigate to `/browse/pools`
4. Confirm the exec teaser appears instead of the "more opportunities" card

## 📸 Screenshot

![Screenshot 2023-10-19 141107](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/593943c3-9d06-4c5d-986d-a7b8205cc554)

## 🚚 Deployment

- Add env variable `FEATURE_EXECUTIVE_TEASER=true`

> **Note**
> I assume we want this to true so it shows immediately and we will be setting it to false once the EX-03 advertisement is published.
