### PR TITLE
[Fix] Remove unused delete action from teams table

### DIFF
--- a/apps/web/src/components/Table/Actions.tsx
+++ b/apps/web/src/components/Table/Actions.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import PencilIcon from "@heroicons/react/24/outline/PencilIcon";
-import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
 
-import { Link, Button } from "@gc-digital-talent/ui";
+import { Link } from "@gc-digital-talent/ui";
 
 import { Maybe } from "~/api/generated";
 
@@ -18,51 +17,26 @@ const Actions = ({ id, label, editPathFunc }: ActionsProps) => {
   const editPath = editPathFunc(id);
 
   return (
-    <div
-      data-h2-display="base(flex)"
-      data-h2-flex-wrap="base(wrap)"
-      data-h2-gap="base(x.25)"
+    <Link
+      href={editPath}
+      mode="solid"
+      data-h2-padding="base(x.5)"
+      color="secondary"
+      aria-label={intl.formatMessage(
+        {
+          defaultMessage: "Edit {label}",
+          id: "2jFKrM",
+          description: "Label for link to edit a specific item in a table",
+        },
+        { label },
+      )}
     >
-      <Link
-        href={editPath}
-        mode="solid"
-        data-h2-padding="base(x.5)"
-        color="secondary"
-        aria-label={intl.formatMessage(
-          {
-            defaultMessage: "Edit {label}",
-            id: "2jFKrM",
-            description: "Label for link to edit a specific item in a table",
-          },
-          { label },
-        )}
-      >
-        <PencilIcon
-          data-h2-display="base(block)"
-          data-h2-height="base(x.75)"
-          data-h2-width="base(x.75)"
-        />
-      </Link>
-      <Button
-        mode="solid"
-        data-h2-padding="base(x.5)"
-        color="secondary"
-        aria-label={intl.formatMessage(
-          {
-            defaultMessage: "Delete {label}",
-            id: "NLX/aa",
-            description: "Label for link to delete a specific item in a table",
-          },
-          { label },
-        )}
-      >
-        <TrashIcon
-          data-h2-display="base(block)"
-          data-h2-height="base(x.75)"
-          data-h2-width="base(x.75)"
-        />
-      </Button>
-    </div>
+      <PencilIcon
+        data-h2-display="base(block)"
+        data-h2-height="base(x.75)"
+        data-h2-width="base(x.75)"
+      />
+    </Link>
   );
 };
 


### PR DESCRIPTION
🤖 Resolves #8233 

## 👋 Introduction

Removes the delete action from the teams table.

## 🕵️ Details

We has a delete button in the `cells.actions()` table helper but it wasn't doing anything. This removes that to reduce confusion for users.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/admin/teams`
3. Confirm only an edit button appears in the actions column
4. Confirm no other tables are impacted

## 📸 Screenshot

![Screenshot 2023-10-19 151357](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/512dd702-31b1-4daf-a6e8-a563c64aa631)
