### PR TITLE
[Debt] Throw error with unexpected URL params

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -63,7 +63,6 @@
     "react-router-dom": "^6.16.0",
     "react-to-print": "^2.14.15",
     "react-toastify": "^9.1.3",
-    "tiny-invariant": "^1.3.1",
     "urql": "3.0.4"
   },
   "devDependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,9 +47,9 @@
     "@gc-digital-talent/toast": "*",
     "@gc-digital-talent/ui": "*",
     "@heroicons/react": "^2.0.18",
-    "@tanstack/react-table": "^8.10.7",
     "@microsoft/applicationinsights-react-js": "^17.0.0",
     "@microsoft/applicationinsights-web": "^3.0.2",
+    "@tanstack/react-table": "^8.10.7",
     "date-fns": "^2.30.0",
     "dotenv": "^16.3.1",
     "framer-motion": "^10.16.4",
@@ -63,6 +63,7 @@
     "react-router-dom": "^6.16.0",
     "react-to-print": "^2.14.15",
     "react-toastify": "^9.1.3",
+    "tiny-invariant": "^1.3.1",
     "urql": "3.0.4"
   },
   "devDependencies": {

--- a/apps/web/src/hooks/useRequiredParam.ts
+++ b/apps/web/src/hooks/useRequiredParam.ts
@@ -1,0 +1,41 @@
+import invariant from "tiny-invariant";
+import { Params, useParams } from "react-router-dom";
+
+import { notEmpty } from "@gc-digital-talent/helpers";
+
+export const uuidRegEx =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}/;
+
+export const isUUID = (str: string): boolean => {
+  return !!str.match(uuidRegEx);
+};
+
+const assertParam = (param?: string, enforceUUID: boolean = false) => {
+  invariant(
+    notEmpty(param),
+    `Could not find required URL parameter "${param}"`,
+  );
+
+  if (enforceUUID) {
+    invariant(isUUID(param), `URL parameter "${param}" must be a UUID.`);
+  }
+};
+
+const useRequiredParams = <T extends Record<string, string | undefined>>(
+  keys: string | string[],
+  enforceUUID: boolean = false,
+): Record<string, string> => {
+  const params: Params<string> = useParams<T>();
+  const keyArray = Array.isArray(keys) ? keys : [keys];
+
+  let nonEmptyParams = {};
+  keyArray.forEach((key) => {
+    const param = params[key];
+    assertParam(param, enforceUUID);
+    nonEmptyParams = { ...nonEmptyParams, [key]: param };
+  });
+
+  return nonEmptyParams;
+};
+
+export default useRequiredParams;

--- a/apps/web/src/hooks/useRequiredParams.ts
+++ b/apps/web/src/hooks/useRequiredParams.ts
@@ -10,7 +10,7 @@ export const isUUID = (str: string): boolean => {
   return !!str.match(uuidRegEx);
 };
 
-const assertParam = (param?: string, enforceUUID: boolean = false) => {
+const assertParam = (param?: string, enforceUUID: boolean = true) => {
   invariant(
     notEmpty(param),
     `Could not find required URL parameter "${param}"`,
@@ -21,18 +21,28 @@ const assertParam = (param?: string, enforceUUID: boolean = false) => {
   }
 };
 
-const useRequiredParams = <T extends Record<string, string | undefined>>(
-  keys: string | string[],
-  enforceUUID: boolean = false,
+type Keys<T, K extends keyof T> = K | Array<K>;
+
+const useRequiredParams = <
+  T extends Record<
+    keyof {
+      [P in keyof T as T[P] extends string ? P : never]: string | undefined;
+    },
+    string
+  >,
+>(
+  keys: Keys<T, keyof T>,
+  enforceUUID: boolean = true,
 ): Record<string, string> => {
   const params: Params<string> = useParams<T>();
   const keyArray = Array.isArray(keys) ? keys : [keys];
 
   let nonEmptyParams = {};
   keyArray.forEach((key) => {
-    const param = params[key];
+    const param = params[String(key)];
     assertParam(param, enforceUUID);
-    nonEmptyParams = { ...nonEmptyParams, [key]: param };
+
+    nonEmptyParams = { ...nonEmptyParams, [key]: param ?? "" };
   });
 
   return nonEmptyParams;

--- a/apps/web/src/hooks/useRequiredParams.ts
+++ b/apps/web/src/hooks/useRequiredParams.ts
@@ -1,7 +1,13 @@
-import invariant from "tiny-invariant";
 import { Params, useParams } from "react-router-dom";
 
+import {
+  useLogger,
+  defaultLogger,
+  type Logger,
+} from "@gc-digital-talent/logger";
 import { notEmpty } from "@gc-digital-talent/helpers";
+
+import invariant from "~/utils/invariant";
 
 export const uuidRegEx =
   /[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}/;
@@ -10,14 +16,23 @@ export const isUUID = (str: string): boolean => {
   return !!str.match(uuidRegEx);
 };
 
-const assertParam = (param?: string, enforceUUID: boolean = true) => {
+const assertParam = (
+  param?: string,
+  enforceUUID: boolean = true,
+  logger: Logger = defaultLogger,
+) => {
   invariant(
     notEmpty(param),
     `Could not find required URL parameter "${param}"`,
+    logger,
   );
 
   if (enforceUUID) {
-    invariant(isUUID(param), `URL parameter "${param}" must be a UUID.`);
+    invariant(
+      isUUID(param),
+      `URL parameter "${param}" must be a UUID.`,
+      logger,
+    );
   }
 };
 
@@ -48,13 +63,14 @@ const useRequiredParams = <
   keys: Keys<T, keyof T>,
   enforceUUID: boolean = true,
 ): Record<string, string> => {
+  const logger = useLogger();
   const params: Params<string> = useParams<T>();
   const keyArray = Array.isArray(keys) ? keys : [keys];
 
   let nonEmptyParams = {};
   keyArray.forEach((key) => {
     const param = params[String(key)];
-    assertParam(param, enforceUUID);
+    assertParam(param, enforceUUID, logger);
 
     nonEmptyParams = { ...nonEmptyParams, [key]: param ?? "" };
   });

--- a/apps/web/src/hooks/useRequiredParams.ts
+++ b/apps/web/src/hooks/useRequiredParams.ts
@@ -25,6 +25,20 @@ type Keys<T, K extends keyof T> = K | Array<K>;
 
 const useRequiredParams = <
   T extends Record<
+    /**
+     * This is a way to self-reference the type to only allow string keys.
+     *
+     * Constrains keys of `T` to be the `P` alias which
+     * is constrained to type `string` and, a key of the passed in generic type.
+     *
+     * Right side could be `any` (we don't actually use this)
+     * but should be `string | undefined` to satisfy the type.
+     *
+     * The resulting type should be constrained to: `Record<keyof Record<string, string>, string>`
+     *
+     * We then use this in the `keys: Key<T, keyof T>` to constrain
+     * the argument to be a key of the generic record passed in.
+     */
     keyof {
       [P in keyof T as T[P] extends string ? P : never]: string | undefined;
     },

--- a/apps/web/src/pages/Applications/ApplicationApi.tsx
+++ b/apps/web/src/pages/Applications/ApplicationApi.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { ThrowNotFound, Pending } from "@gc-digital-talent/ui";
 
 import { PoolCandidate, useGetApplicationQuery } from "~/api/generated";
-import useRequiredParams from "~/hooks/useRequiredParams";
 
 import useApplicationId from "./useApplicationId";
 

--- a/apps/web/src/pages/Applications/ApplicationApi.tsx
+++ b/apps/web/src/pages/Applications/ApplicationApi.tsx
@@ -1,9 +1,11 @@
 import React from "react";
-import { useParams } from "react-router-dom";
 
 import { ThrowNotFound, Pending } from "@gc-digital-talent/ui";
 
 import { PoolCandidate, useGetApplicationQuery } from "~/api/generated";
+import useRequiredParams from "~/hooks/useRequiredParams";
+
+import useApplicationId from "./useApplicationId";
 
 export type ApplicationPageProps = {
   application: PoolCandidate;
@@ -14,11 +16,11 @@ interface ApplicationApiProps {
 }
 
 const ApplicationApi = ({ PageComponent }: ApplicationApiProps) => {
-  const { applicationId } = useParams();
+  const id = useApplicationId();
   const [{ data, fetching, error, stale }] = useGetApplicationQuery({
     requestPolicy: "cache-first",
     variables: {
-      id: applicationId || "",
+      id,
     },
   });
 

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useParams } from "react-router-dom";
 import StarIcon from "@heroicons/react/20/solid/StarIcon";
 
 import { Heading, Pending, ThrowNotFound } from "@gc-digital-talent/ui";
@@ -13,6 +12,7 @@ import {
   useGetMyExperiencesQuery,
 } from "~/api/generated";
 import applicationMessages from "~/messages/applicationMessages";
+import useRequiredParams from "~/hooks/useRequiredParams";
 
 import { ApplicationPageProps } from "../ApplicationApi";
 import { useApplicationContext } from "../ApplicationContext";
@@ -65,6 +65,11 @@ export const getPageInfo: GetPageNavInfo = ({
   };
 };
 
+type RouteParams = {
+  experienceId: string;
+  applicationId: string;
+};
+
 interface ApplicationCareerTimelineEditProps extends ApplicationPageProps {
   experience: AnyExperience;
 }
@@ -75,7 +80,7 @@ const ApplicationCareerTimelineEdit = ({
 }: ApplicationCareerTimelineEditProps) => {
   const intl = useIntl();
   const paths = useRoutes();
-  const { experienceId } = useParams();
+  const { experienceId } = useRequiredParams<RouteParams>("experienceId", true);
   const { currentStepOrdinal } = useApplicationContext();
   const pageInfo = getPageInfo({
     intl,
@@ -105,7 +110,10 @@ const ApplicationCareerTimelineEdit = ({
 };
 
 const ApplicationCareerTimelineEditPage = () => {
-  const { applicationId, experienceId } = useParams();
+  const { applicationId, experienceId } = useRequiredParams<RouteParams>(
+    ["experienceId", "applicationId"],
+    true,
+  );
   const [
     {
       data: applicationData,
@@ -114,7 +122,7 @@ const ApplicationCareerTimelineEditPage = () => {
     },
   ] = useGetApplicationQuery({
     variables: {
-      id: applicationId || "",
+      id: applicationId,
     },
     requestPolicy: "cache-first",
   });

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { IntlShape, useIntl } from "react-intl";
 import StarIcon from "@heroicons/react/20/solid/StarIcon";
 import groupBy from "lodash/groupBy";
@@ -38,6 +38,7 @@ import { sortAndFilterExperiences } from "~/components/ExperienceSortAndFilter/s
 
 import { ApplicationPageProps } from "../ApplicationApi";
 import { useApplicationContext } from "../ApplicationContext";
+import useApplicationId from "../useApplicationId";
 
 type SortOptions = "date_desc" | "type_asc";
 
@@ -446,7 +447,7 @@ const context: Partial<OperationContext> = {
 };
 
 const ApplicationCareerTimelinePage = () => {
-  const { applicationId } = useParams();
+  const id = useApplicationId();
   const [
     {
       data: applicationData,
@@ -455,7 +456,7 @@ const ApplicationCareerTimelinePage = () => {
     },
   ] = useGetApplicationQuery({
     variables: {
-      id: applicationId || "",
+      id,
     },
     requestPolicy: "cache-first",
   });

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import PresentationChartBarIcon from "@heroicons/react/20/solid/PresentationChartBarIcon";
 import uniqueId from "lodash/uniqueId";
 
@@ -42,6 +42,7 @@ import { ExperienceForDate } from "~/types/experience";
 import { ApplicationPageProps } from "../ApplicationApi";
 import { useApplicationContext } from "../ApplicationContext";
 import LinkCareerTimeline from "./LinkCareerTimeline";
+import useApplicationId from "../useApplicationId";
 
 type EducationRequirementExperiences = {
   educationRequirementAwardExperiences: { sync: string[] };
@@ -528,7 +529,7 @@ const ApplicationEducation = ({
 };
 
 const ApplicationEducationPage = () => {
-  const { applicationId } = useParams();
+  const id = useApplicationId();
   const [
     {
       data: applicationData,
@@ -538,7 +539,7 @@ const ApplicationEducationPage = () => {
     },
   ] = useGetApplicationQuery({
     variables: {
-      id: applicationId || "",
+      id,
     },
     requestPolicy: "cache-first",
   });

--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl, defineMessage } from "react-intl";
-import { Outlet, useParams, useNavigate } from "react-router-dom";
+import { Outlet, useNavigate, useParams } from "react-router-dom";
 import flatMap from "lodash/flatMap";
 
 import {
@@ -29,12 +29,17 @@ import {
 import { ApplicationPageProps } from "./ApplicationApi";
 import StepDisabledPage from "./StepDisabledPage/StepDisabledPage";
 import ApplicationContextProvider from "./ApplicationContext";
+import useApplicationId from "./useApplicationId";
+
+type RouteParams = {
+  experienceId: string;
+};
 
 const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
   const intl = useIntl();
   const paths = useRoutes();
   const navigate = useNavigate();
-  const { experienceId } = useParams();
+  const { experienceId } = useParams<RouteParams>();
   const steps = getApplicationSteps({
     intl,
     paths,
@@ -158,11 +163,11 @@ const ApplicationPageWrapper = ({ application }: ApplicationPageProps) => {
 };
 
 const ApplicationLayout = () => {
-  const { applicationId } = useParams();
+  const id = useApplicationId();
   const [{ data, fetching, error, stale }] = useGetApplicationQuery({
     requestPolicy: "cache-first",
     variables: {
-      id: applicationId || "",
+      id,
     },
   });
 

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useParams } from "react-router";
 import { useIntl } from "react-intl";
 import UserCircleIcon from "@heroicons/react/20/solid/UserCircleIcon";
 
@@ -30,6 +29,7 @@ import LanguageProfile from "~/components/Profile/components/LanguageProfile/Lan
 import { ApplicationPageProps } from "../ApplicationApi";
 import stepHasError from "../profileStep/profileStepValidation";
 import { useApplicationContext } from "../ApplicationContext";
+import useApplicationId from "../useApplicationId";
 
 export const getPageInfo: GetPageNavInfo = ({
   application,
@@ -138,7 +138,7 @@ export const ApplicationProfile = ({
 };
 
 const ApplicationProfilePage = () => {
-  const { applicationId } = useParams();
+  const id = useApplicationId();
   const [
     {
       data: applicationData,
@@ -149,7 +149,7 @@ const ApplicationProfilePage = () => {
   ] = useGetApplicationQuery({
     requestPolicy: "cache-first",
     variables: {
-      id: applicationId || "",
+      id,
     },
   });
   const [{ data: userData, fetching: userFetching, error: userError }] =

--- a/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { FormProvider, useForm } from "react-hook-form";
 import RocketLaunchIcon from "@heroicons/react/20/solid/RocketLaunchIcon";
 
@@ -37,6 +37,7 @@ import SkillTree from "../ApplicationSkillsPage/components/SkillTree";
 import { ApplicationPageProps } from "../ApplicationApi";
 import { useApplicationContext } from "../ApplicationContext";
 import ReviewSection from "./ReviewSection";
+import useApplicationId from "../useApplicationId";
 
 type FormValues = {
   signature: string;
@@ -523,7 +524,7 @@ const ApplicationReview = ({
 };
 
 const ApplicationReviewPage = () => {
-  const { applicationId } = useParams();
+  const id = useApplicationId();
   const [
     {
       data: applicationData,
@@ -532,7 +533,7 @@ const ApplicationReviewPage = () => {
     },
   ] = useGetApplicationQuery({
     variables: {
-      id: applicationId || "",
+      id,
     },
     requestPolicy: "cache-first",
   });

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/ApplicationSelfDeclarationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/ApplicationSelfDeclarationPage.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useIntl } from "react-intl";
 import HeartIcon from "@heroicons/react/20/solid/HeartIcon";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 
 import {
   Button,
@@ -41,6 +41,7 @@ import { ApplicationPageProps } from "../ApplicationApi";
 import { useApplicationContext } from "../ApplicationContext";
 import HelpLink from "./SelfDeclaration/HelpLink";
 import CommunitySelection from "./SelfDeclaration/CommunitySelection";
+import useApplicationId from "../useApplicationId";
 
 export const getPageInfo: GetPageNavInfo = ({
   application,
@@ -343,7 +344,7 @@ export const ApplicationSelfDeclaration = ({
 const ApplicationSelfDeclarationPage = () => {
   const intl = useIntl();
   const paths = useRoutes();
-  const { applicationId } = useParams();
+  const id = useApplicationId();
   const [
     {
       data: applicationData,
@@ -354,7 +355,7 @@ const ApplicationSelfDeclarationPage = () => {
   ] = useGetApplicationQuery({
     requestPolicy: "cache-first",
     variables: {
-      id: applicationId || "",
+      id,
     },
   });
   const [{ data: userData, fetching: userFetching, error: userError }] =
@@ -384,7 +385,7 @@ const ApplicationSelfDeclarationPage = () => {
         indigenousDeclarationSignature:
           newCommunities.length > 0 ? formValues.signature : null,
       },
-      applicationId: applicationId || "",
+      applicationId: id,
       applicationInput: {
         insertSubmittedStep: ApplicationStep.SelfDeclaration,
       },

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { FormProvider, useForm } from "react-hook-form";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import SparklesIcon from "@heroicons/react/20/solid/SparklesIcon";
 
 import {
@@ -34,6 +34,7 @@ import { ApplicationPageProps } from "../ApplicationApi";
 import { useApplicationContext } from "../ApplicationContext";
 import SkillTree from "./components/SkillTree";
 import SkillDescriptionAccordion from "./components/SkillDescriptionAccordion";
+import useApplicationId from "../useApplicationId";
 
 const careerTimelineLink = (children: React.ReactNode, href: string) => (
   <Link href={href}>{children}</Link>
@@ -337,7 +338,7 @@ export const ApplicationSkills = ({
 };
 
 const ApplicationSkillsPage = () => {
-  const { applicationId } = useParams();
+  const id = useApplicationId();
   const [
     {
       data: applicationData,
@@ -346,7 +347,7 @@ const ApplicationSkillsPage = () => {
     },
   ] = useGetApplicationQuery({
     variables: {
-      id: applicationId || "",
+      id,
     },
     requestPolicy: "cache-first",
   });

--- a/apps/web/src/pages/Applications/useApplicationId.ts
+++ b/apps/web/src/pages/Applications/useApplicationId.ts
@@ -1,0 +1,13 @@
+import useRequiredParams from "~/hooks/useRequiredParams";
+
+type RouteParams = {
+  applicationId: string;
+};
+
+const useApplicationId = () => {
+  const { applicationId } = useRequiredParams<RouteParams>("applicationId");
+
+  return applicationId;
+};
+
+export default useApplicationId;

--- a/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import pick from "lodash/pick";
 import upperCase from "lodash/upperCase";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
@@ -21,6 +21,7 @@ import {
 } from "~/api/generated";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import adminMessages from "~/messages/adminMessages";
+import useRequiredParams from "~/hooks/useRequiredParams";
 
 type FormValues = UpdateClassificationInput;
 interface UpdateClassificationFormProps {
@@ -222,10 +223,11 @@ type RouteParams = {
 const UpdateClassification = () => {
   const intl = useIntl();
   const routes = useRoutes();
-  const { classificationId } = useParams<RouteParams>();
+  const { classificationId } =
+    useRequiredParams<RouteParams>("classificationId");
   const [{ data: classificationData, fetching, error }] =
     useGetClassificationQuery({
-      variables: { id: classificationId || "" },
+      variables: { id: classificationId },
     });
 
   const [, executeMutation] = useUpdateClassificationMutation();

--- a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
+++ b/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { Loading } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
@@ -12,6 +12,7 @@ import {
 import { useAuthorization } from "@gc-digital-talent/auth";
 
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import {
   Scalars,
   useCreateApplicationMutation,
@@ -28,7 +29,7 @@ type RouteParams = {
  * and forward a user on
  */
 const CreateApplication = () => {
-  const { poolId } = useParams<RouteParams>();
+  const { poolId } = useRequiredParams<RouteParams>("poolId");
   const intl = useIntl();
   const paths = useRoutes();
   const navigate = useNavigate();
@@ -38,7 +39,7 @@ const CreateApplication = () => {
   const [{ data: existingApplicationsData }] = useMyApplicationsQuery();
 
   // Store path to redirect to later on
-  let redirectPath = paths.pool(poolId || "");
+  let redirectPath = paths.pool(poolId);
 
   const genericErrorMessage = intl.formatMessage({
     defaultMessage: "Error application creation failed",

--- a/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
 import pick from "lodash/pick";
@@ -21,6 +21,7 @@ import {
 } from "~/api/generated";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import adminMessages from "~/messages/adminMessages";
+import useRequiredParams from "~/hooks/useRequiredParams";
 
 type FormValues = UpdateDepartmentInput;
 
@@ -150,9 +151,9 @@ type RouteParams = {
 const UpdateDepartmentPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
-  const { departmentId } = useParams<RouteParams>();
+  const { departmentId } = useRequiredParams<RouteParams>("departmentId");
   const [{ data: departmentData, fetching, error }] = useDepartmentQuery({
-    variables: { id: departmentId || "" },
+    variables: { id: departmentId },
   });
   const [, executeMutation] = useUpdateDepartmentMutation();
   const handleUpdateDepartment = (id: string, data: UpdateDepartmentInput) =>

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useParams } from "react-router-dom";
 
 import { Pending } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
@@ -11,6 +10,7 @@ import PoolCandidatesTable from "~/components/PoolCandidatesTable/PoolCandidates
 import SEO from "~/components/SEO/SEO";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import adminMessages from "~/messages/adminMessages";
+import useRequiredParams from "~/hooks/useRequiredParams";
 
 type RouteParams = {
   poolId: Scalars["ID"];
@@ -19,13 +19,13 @@ type RouteParams = {
 export const IndexPoolCandidatePage = () => {
   const intl = useIntl();
   const routes = useRoutes();
-  const { poolId } = useParams<RouteParams>();
+  const { poolId } = useRequiredParams<RouteParams>("poolId");
 
   const pageTitle = intl.formatMessage(adminMessages.poolsCandidates);
 
   const [{ data, fetching, error }] = useGetPoolQuery({
     variables: {
-      id: poolId || "",
+      id: poolId,
     },
   });
 

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
-import { useParams } from "react-router-dom";
 import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
 
 import {
@@ -36,6 +35,7 @@ import {
   useAdminPoolPages,
 } from "~/utils/poolUtils";
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import { getFullNameLabel } from "~/utils/nameUtils";
 import { categorizeSkill } from "~/utils/skillUtils";
 import adminMessages from "~/messages/adminMessages";
@@ -723,9 +723,9 @@ type RouteParams = {
 export const ViewPoolCandidatePage = () => {
   const intl = useIntl();
   const routes = useRoutes();
-  const { poolCandidateId } = useParams<RouteParams>();
+  const { poolCandidateId } = useRequiredParams<RouteParams>("poolCandidateId");
   const [{ data, fetching, error }] = useGetPoolCandidateSnapshotQuery({
-    variables: { poolCandidateId: poolCandidateId || "" },
+    variables: { poolCandidateId },
   });
 
   const navigationCrumbs = [

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useParams } from "react-router-dom";
 import { useIntl } from "react-intl";
 import ClipboardDocumentListIcon from "@heroicons/react/24/outline/ClipboardDocumentListIcon";
 
@@ -20,6 +19,7 @@ import {
 import { notEmpty } from "@gc-digital-talent/helpers";
 
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import adminMessages from "~/messages/adminMessages";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import {
@@ -126,7 +126,7 @@ type RouteParams = {
 
 export const AssessmentPlanBuilderPage = () => {
   const intl = useIntl();
-  const { poolId } = useParams<RouteParams>();
+  const { poolId } = useRequiredParams<RouteParams>("poolId");
   const routes = useRoutes();
 
   const notFoundMessage = intl.formatMessage(
@@ -147,7 +147,7 @@ export const AssessmentPlanBuilderPage = () => {
 
   const [{ data: queryData, fetching: queryFetching, error: queryError }] =
     useGetAssessmentPlanBuilderDataQuery({
-      variables: { poolId: poolId || "" },
+      variables: { poolId },
     });
 
   const navigationCrumbs = [

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useParams } from "react-router-dom";
 import { defineMessage, useIntl } from "react-intl";
 import RocketLaunchIcon from "@heroicons/react/24/outline/RocketLaunchIcon";
 import ChevronDoubleLeftIcon from "@heroicons/react/24/solid/ChevronDoubleLeftIcon";
@@ -26,6 +25,7 @@ import {
   Skill,
 } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import adminMessages from "~/messages/adminMessages";
 import { hasEmptyRequiredFields as poolNameError } from "~/validators/process/classification";
@@ -423,7 +423,7 @@ type RouteParams = {
 
 export const EditPoolPage = () => {
   const intl = useIntl();
-  const { poolId } = useParams<RouteParams>();
+  const { poolId } = useRequiredParams<RouteParams>("poolId");
   const routes = useRoutes();
 
   const notFoundMessage = intl.formatMessage(
@@ -443,7 +443,7 @@ export const EditPoolPage = () => {
   }
 
   const [{ data, fetching, error }] = useGetEditPoolDataQuery({
-    variables: { poolId: poolId || "" },
+    variables: { poolId },
   });
 
   const { isFetching, mutations } = usePoolMutations();

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useParams } from "react-router-dom";
 import CurrencyDollarIcon from "@heroicons/react/24/outline/CurrencyDollarIcon";
 import BoltIcon from "@heroicons/react/24/outline/BoltIcon";
 import MapPinIcon from "@heroicons/react/24/outline/MapPinIcon";
@@ -55,6 +54,7 @@ import Hero from "~/components/Hero/Hero";
 import useRoutes from "~/hooks/useRoutes";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import EducationRequirements from "~/components/EducationRequirements/EducationRequirements";
+import useRequiredParams from "~/hooks/useRequiredParams";
 
 import ApplicationLink from "./components/ApplicationLink";
 import Text from "./components/Text";
@@ -852,11 +852,11 @@ type RouteParams = {
 };
 
 const PoolAdvertisementPage = () => {
-  const { poolId } = useParams<RouteParams>();
+  const { poolId } = useRequiredParams<RouteParams>("poolId", true);
   const auth = useAuthorization();
 
   const [{ data, fetching, error }] = useGetPoolQuery({
-    variables: { id: poolId || "" },
+    variables: { id: poolId },
   });
 
   const isVisible = isAdvertisementVisible(

--- a/apps/web/src/pages/Pools/PoolLayout.tsx
+++ b/apps/web/src/pages/Pools/PoolLayout.tsx
@@ -3,7 +3,6 @@ import { useIntl } from "react-intl";
 import { Outlet } from "react-router-dom";
 
 import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
-import { Scalars } from "@gc-digital-talent/graphql";
 
 import PageHeader from "~/components/PageHeader";
 import SEO from "~/components/SEO/SEO";

--- a/apps/web/src/pages/Pools/PoolLayout.tsx
+++ b/apps/web/src/pages/Pools/PoolLayout.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useParams, Outlet } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 
 import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
+import { Scalars } from "@gc-digital-talent/graphql";
 
 import PageHeader from "~/components/PageHeader";
 import SEO from "~/components/SEO/SEO";
@@ -10,6 +11,8 @@ import useCurrentPage from "~/hooks/useCurrentPage";
 import { Pool, useGetBasicPoolInfoQuery } from "~/api/generated";
 import { getFullPoolTitleLabel, useAdminPoolPages } from "~/utils/poolUtils";
 import { PageNavKeys } from "~/types/pool";
+
+import useRequiredParams from "../../hooks/useRequiredParams";
 
 interface PoolHeaderProps {
   pool: Pick<Pool, "id" | "classifications" | "stream" | "name">;
@@ -37,11 +40,15 @@ const PoolHeader = ({ pool }: PoolHeaderProps) => {
   );
 };
 
+type RouteParams = {
+  poolId: string;
+};
+
 const PoolLayout = () => {
-  const { poolId } = useParams();
+  const { poolId } = useRequiredParams<RouteParams>("poolId");
   const [{ data, fetching, error }] = useGetBasicPoolInfoQuery({
     variables: {
-      poolId: poolId || "",
+      poolId,
     },
   });
 

--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from "react";
 import { useIntl } from "react-intl";
-import { useParams } from "react-router-dom";
 import UserGroupIcon from "@heroicons/react/24/outline/UserGroupIcon";
 
 import { Pending, NotFound, Link, Heading, Pill } from "@gc-digital-talent/ui";
@@ -21,6 +20,7 @@ import { ROLE_NAME, useAuthorization } from "@gc-digital-talent/auth";
 
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import adminMessages from "~/messages/adminMessages";
 import ProcessCard from "~/components/ProcessCard/ProcessCard";
@@ -402,10 +402,10 @@ type RouteParams = {
 const ViewPoolPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
-  const { poolId } = useParams<RouteParams>();
+  const { poolId } = useRequiredParams<RouteParams>("poolId");
   const { isFetching, mutations } = usePoolMutations();
   const [{ data, fetching, error }] = useGetProcessInfoQuery({
-    variables: { id: poolId || "" },
+    variables: { id: poolId },
   });
 
   const navigationCrumbs = [

--- a/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useParams } from "react-router-dom";
 
 import { Heading, ThrowNotFound, Button, Link } from "@gc-digital-talent/ui";
 
@@ -8,6 +7,7 @@ import Hero from "~/components/Hero";
 import SEO from "~/components/SEO/SEO";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import { Scalars } from "~/api/generated";
 
 type RequestConfirmationParams = {
@@ -29,8 +29,8 @@ const mailLink = (chunks: React.ReactNode) => (
 const RequestConfirmationPage = () => {
   const intl = useIntl();
   const paths = useRoutes();
-  const params = useParams<RequestConfirmationParams>();
-  const { requestId } = params;
+  const { requestId } =
+    useRequiredParams<RequestConfirmationParams>("requestId");
 
   const crumbs = useBreadcrumbs([
     {
@@ -47,7 +47,7 @@ const RequestConfirmationPage = () => {
         id: "0zo274",
         description: "Link text for request confirmation breadcrumb",
       }),
-      url: paths.requestConfirmation(requestId || ""),
+      url: paths.requestConfirmation(requestId),
     },
   ]);
 

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/ViewSearchRequestPage.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/ViewSearchRequestPage.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useParams } from "react-router-dom";
 import TicketIcon from "@heroicons/react/24/outline/TicketIcon";
 
 import SEO from "~/components/SEO/SEO";
 import { Scalars } from "~/api/generated";
 import PageHeader from "~/components/PageHeader";
+import useRequiredParams from "~/hooks/useRequiredParams";
 
 import ViewSearchRequestApi from "./components/ViewSearchRequest";
 
@@ -15,7 +15,7 @@ type RouteParams = {
 
 export const SingleSearchRequestPage = () => {
   const intl = useIntl();
-  const { searchRequestId } = useParams<RouteParams>();
+  const { searchRequestId } = useRequiredParams<RouteParams>("searchRequestId");
   const pageTitle = intl.formatMessage({
     defaultMessage: "Request",
     id: "WYJnLs",
@@ -32,7 +32,7 @@ export const SingleSearchRequestPage = () => {
         </header>
       </div>
 
-      <ViewSearchRequestApi searchRequestId={searchRequestId || ""} />
+      <ViewSearchRequestApi searchRequestId={searchRequestId} />
     </>
   );
 };

--- a/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useIntl } from "react-intl";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import pick from "lodash/pick";
@@ -23,6 +23,7 @@ import { Pending, NotFound, Heading } from "@gc-digital-talent/ui";
 
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import {
   Skill,
   SkillFamily,
@@ -225,7 +226,7 @@ type RouteParams = {
 const UpdateSkillFamilyPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
-  const { skillFamilyId } = useParams<RouteParams>();
+  const { skillFamilyId } = useRequiredParams<RouteParams>("skillFamilyId");
   const [{ data: lookupData, fetching, error }] =
     useGetUpdateSkillFamilyDataQuery({
       variables: { id: skillFamilyId || "" },

--- a/apps/web/src/pages/Skills/UpdateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateSkillPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useIntl } from "react-intl";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import pick from "lodash/pick";
@@ -36,6 +36,7 @@ import {
   SkillCategory,
 } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import adminMessages from "~/messages/adminMessages";
 import { parseKeywords } from "~/utils/skillUtils";
@@ -303,7 +304,7 @@ type RouteParams = {
 export const UpdateSkill = () => {
   const intl = useIntl();
   const routes = useRoutes();
-  const { skillId } = useParams<RouteParams>();
+  const { skillId } = useRequiredParams<RouteParams>("skillId");
   const [{ data: lookupData, fetching, error }] = useGetUpdateSkillDataQuery({
     variables: { id: skillId || "" },
   });

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useIntl } from "react-intl";
 import LightBulbIcon from "@heroicons/react/24/outline/LightBulbIcon";
 import BookmarkSquareIcon from "@heroicons/react/24/outline/BookmarkSquareIcon";
@@ -42,6 +42,7 @@ import UserSkillFormFields from "~/components/UserSkillFormFields/UserSkillFormF
 import ExperienceCard from "~/components/ExperienceCard/ExperienceCard";
 import ExperienceSkillFormDialog from "~/components/ExperienceSkillFormDialog/ExperienceSkillFormDialog";
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 
 type PageSection = {
   id: string;
@@ -569,11 +570,11 @@ type RouteParams = {
 
 const UpdateUserSkillPage = () => {
   const intl = useIntl();
-  const { skillId } = useParams<RouteParams>();
+  const { skillId } = useRequiredParams<RouteParams>("skillId");
 
   const [{ data, fetching, error }] = useUserSkillQuery({
     variables: {
-      skillId: skillId ?? "",
+      skillId,
     },
   });
 

--- a/apps/web/src/pages/Teams/TeamLayout.tsx
+++ b/apps/web/src/pages/Teams/TeamLayout.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useParams, Outlet } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 import UserGroupIcon from "@heroicons/react/24/outline/UserGroupIcon";
 import Cog8ToothIcon from "@heroicons/react/24/outline/Cog8ToothIcon";
 import ClipboardDocumentListIcon from "@heroicons/react/24/outline/ClipboardDocumentListIcon";
@@ -12,6 +12,7 @@ import SEO from "~/components/SEO/SEO";
 import PageHeader from "~/components/PageHeader";
 import useRoutes from "~/hooks/useRoutes";
 import useCurrentPage from "~/hooks/useCurrentPage";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import { Team, useTeamNameQuery } from "~/api/generated";
 import { PageNavInfo } from "~/types/pages";
 
@@ -88,11 +89,15 @@ const TeamHeader = ({ team }: TeamHeaderProps) => {
   );
 };
 
+type RouteParams = {
+  teamId: string;
+};
+
 const TeamLayout = () => {
-  const { teamId } = useParams();
+  const { teamId } = useRequiredParams<RouteParams>("teamId");
   const [{ data, fetching, error }] = useTeamNameQuery({
     variables: {
-      id: teamId || "",
+      id: teamId,
     },
   });
 

--- a/apps/web/src/pages/Teams/TeamMembersPage/TeamMembersPage.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/TeamMembersPage.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { useIntl } from "react-intl";
-import { useParams } from "react-router-dom";
 
 import { Heading, Pending, ThrowNotFound } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
@@ -20,6 +19,7 @@ import {
 import { getFullNameLabel } from "~/utils/nameUtils";
 import { groupRoleAssignmentsByUser, TeamMember } from "~/utils/teamUtils";
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import adminMessages from "~/messages/adminMessages";
@@ -143,9 +143,9 @@ type RouteParams = {
 const TeamMembersPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
-  const { teamId } = useParams<RouteParams>();
+  const { teamId } = useRequiredParams<RouteParams>("teamId");
   const [{ data, fetching, error }] = useGetTeamQuery({
-    variables: { teamId: teamId || "" },
+    variables: { teamId },
   });
   const [{ data: rolesData, fetching: rolesFetching, error: rolesError }] =
     useListRolesQuery();

--- a/apps/web/src/pages/Teams/UpdateTeamPage/UpdateTeamPage.tsx
+++ b/apps/web/src/pages/Teams/UpdateTeamPage/UpdateTeamPage.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
-import { useParams } from "react-router-dom";
 
 import { Pending, NotFound } from "@gc-digital-talent/ui";
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
@@ -15,19 +14,24 @@ import {
 } from "~/api/generated";
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import adminMessages from "~/messages/adminMessages";
 
 import UpdateTeamForm from "./components/UpdateTeamForm";
 
+type RouteParams = {
+  teamId: string;
+};
+
 const EditTeamPage = () => {
   const intl = useIntl();
-  const { teamId } = useParams();
+  const { teamId } = useRequiredParams<RouteParams>("teamId");
   const routes = useRoutes();
   const [{ data: teamData, fetching: teamFetching, error: teamError }] =
     useGetTeamQuery({
       variables: {
-        teamId: teamId || "",
+        teamId,
       },
     });
   const [

--- a/apps/web/src/pages/Teams/ViewTeamPage/ViewTeamPage.tsx
+++ b/apps/web/src/pages/Teams/ViewTeamPage/ViewTeamPage.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
-import { useParams } from "react-router-dom";
 
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import { Pending, NotFound, Link, Separator } from "@gc-digital-talent/ui";
@@ -8,6 +7,7 @@ import { Pending, NotFound, Link, Separator } from "@gc-digital-talent/ui";
 import SEO from "~/components/SEO/SEO";
 import { Scalars, Team, useViewTeamQuery } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import adminMessages from "~/messages/adminMessages";
 
@@ -48,9 +48,9 @@ const ViewTeamPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
 
-  const { teamId } = useParams<RouteParams>();
+  const { teamId } = useRequiredParams<RouteParams>("teamId");
   const [{ data, fetching, error }] = useViewTeamQuery({
-    variables: { id: teamId || "" },
+    variables: { id: teamId },
   });
 
   const navigationCrumbs = [

--- a/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
+++ b/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useParams } from "react-router-dom";
 
 import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
 
@@ -10,6 +9,7 @@ import { User, Scalars, useGetViewUserDataQuery } from "~/api/generated";
 import AdminAboutUserSection from "~/components/AdminAboutUserSection/AdminAboutUserSection";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import { getFullNameLabel } from "~/utils/nameUtils";
 import adminMessages from "~/messages/adminMessages";
 
@@ -54,7 +54,7 @@ type RouteParams = {
 };
 
 const AdminUserProfilePage = () => {
-  const { userId } = useParams<RouteParams>();
+  const { userId } = useRequiredParams<RouteParams>("userId");
   const intl = useIntl();
   const routes = useRoutes();
   const [{ data: lookupData, fetching, error }] = useGetViewUserDataQuery({

--- a/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useIntl } from "react-intl";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { OperationContext } from "urql";
@@ -28,6 +28,7 @@ import {
 } from "~/api/generated";
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import { getFullNameLabel } from "~/utils/nameUtils";
 import adminMessages from "~/messages/adminMessages";
@@ -267,11 +268,11 @@ type RouteParams = {
 const UpdateUserPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
-  const { userId } = useParams<RouteParams>();
+  const { userId } = useRequiredParams<RouteParams>("userId");
   const [{ data: rolesData, fetching: rolesFetching, error: rolesError }] =
     useListRolesQuery();
   const [{ data: userData, fetching, error }] = useUserQuery({
-    variables: { id: userId || "" },
+    variables: { id: userId },
     context,
   });
 

--- a/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useParams } from "react-router-dom";
 import CalculatorIcon from "@heroicons/react/24/outline/CalculatorIcon";
 import InformationCircleIcon from "@heroicons/react/24/outline/InformationCircleIcon";
 import PencilSquareIcon from "@heroicons/react/24/outline/PencilSquareIcon";
@@ -13,6 +12,7 @@ import SEO from "~/components/SEO/SEO";
 import { Scalars, useGetViewUserDataQuery } from "~/api/generated";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import { getFullNameLabel } from "~/utils/nameUtils";
 import adminMessages from "~/messages/adminMessages";
 
@@ -108,11 +108,11 @@ type RouteParams = {
 };
 
 const UserInformationPage = () => {
-  const { userId } = useParams<RouteParams>();
+  const { userId } = useRequiredParams<RouteParams>("userId");
   const intl = useIntl();
   const routes = useRoutes();
   const [{ data: lookupData, fetching, error }] = useGetViewUserDataQuery({
-    variables: { id: userId || "" },
+    variables: { id: userId },
   });
 
   const user = lookupData?.user;

--- a/apps/web/src/pages/Users/UserLayout.tsx
+++ b/apps/web/src/pages/Users/UserLayout.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useParams, Outlet } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 import UserIcon from "@heroicons/react/24/outline/UserIcon";
 import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
 import Cog8ToothIcon from "@heroicons/react/24/outline/Cog8ToothIcon";
@@ -10,6 +10,7 @@ import { ThrowNotFound, Pending, Alert } from "@gc-digital-talent/ui";
 import SEO from "~/components/SEO/SEO";
 import PageHeader from "~/components/PageHeader";
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import useCurrentPage from "~/hooks/useCurrentPage";
 import { getFullNameHtml } from "~/utils/nameUtils";
 import { User, useUserNameQuery } from "~/api/generated";
@@ -104,8 +105,12 @@ const UserHeader = ({ user }: UserHeaderProps) => {
   );
 };
 
+type RouteParams = {
+  userId: string;
+};
+
 const UserLayout = () => {
-  const { userId } = useParams();
+  const { userId } = useRequiredParams<RouteParams>("userId");
   const [{ data, fetching, error }] = useUserNameQuery({
     variables: {
       userId: userId || "",

--- a/apps/web/src/pages/Users/UserPlacementPage/UserPlacementPage.tsx
+++ b/apps/web/src/pages/Users/UserPlacementPage/UserPlacementPage.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
-import { useParams } from "react-router";
 import { OperationContext } from "urql";
 import UserIcon from "@heroicons/react/24/outline/UserIcon";
 
@@ -9,6 +8,7 @@ import { Scalars, useUserQuery } from "@gc-digital-talent/graphql";
 import PageHeader from "~/components/PageHeader";
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import { getFullNameLabel } from "~/utils/nameUtils";
 import adminMessages from "~/messages/adminMessages";
@@ -25,9 +25,9 @@ type RouteParams = {
 const UserPlacementPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
-  const { userId } = useParams<RouteParams>();
+  const { userId } = useRequiredParams<RouteParams>("userId");
   const [{ data: userData /* , fetching, error */ }] = useUserQuery({
-    variables: { id: userId || "" },
+    variables: { id: userId },
     context,
   });
 

--- a/apps/web/src/utils/invariant.ts
+++ b/apps/web/src/utils/invariant.ts
@@ -1,0 +1,33 @@
+import { type Logger, defaultLogger } from "@gc-digital-talent/logger";
+
+type LogMessage = string | (() => string);
+
+const defaultMessage: string = "Condition failed";
+
+type LogInvariantArgs = {
+  logger?: Logger;
+  message?: string;
+};
+
+function logInvariant({
+  logger = defaultLogger,
+  message = defaultMessage,
+}: LogInvariantArgs) {
+  logger.error(message);
+  throw new Error(message);
+}
+
+function invariant(
+  condition: boolean,
+  message?: LogMessage,
+  logger?: Logger,
+): asserts condition {
+  if (condition) return;
+
+  logInvariant({
+    message: typeof message === "function" ? message() : message,
+    logger,
+  });
+}
+
+export default invariant;

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,6 @@
         "react-router-dom": "^6.16.0",
         "react-to-print": "^2.14.15",
         "react-toastify": "^9.1.3",
-        "tiny-invariant": "^1.3.1",
         "urql": "3.0.4"
       },
       "devDependencies": {
@@ -29217,7 +29216,6 @@
         "react-to-print": "^2.14.15",
         "react-toastify": "^9.1.3",
         "storybook-addon-intl": "^3.2.0",
-        "tiny-invariant": "*",
         "ts-jest": "^29.1.1",
         "tsconfig": "*",
         "typescript": "^5.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "react-router-dom": "^6.16.0",
         "react-to-print": "^2.14.15",
         "react-toastify": "^9.1.3",
+        "tiny-invariant": "^1.3.1",
         "urql": "3.0.4"
       },
       "devDependencies": {
@@ -24392,7 +24393,8 @@
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
     },
     "node_modules/tippy.js": {
       "version": "6.3.7",
@@ -29215,6 +29217,7 @@
         "react-to-print": "^2.14.15",
         "react-toastify": "^9.1.3",
         "storybook-addon-intl": "^3.2.0",
+        "tiny-invariant": "*",
         "ts-jest": "^29.1.1",
         "tsconfig": "*",
         "typescript": "^5.1.3",
@@ -43175,7 +43178,9 @@
       }
     },
     "tiny-invariant": {
-      "version": "1.3.1"
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
     },
     "tippy.js": {
       "version": "6.3.7",

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -4,6 +4,7 @@ import {
   getLoggingLevel,
 } from "./utils/logger";
 import useLogger, { defaultLogger } from "./hooks/useLogger";
+import type { Logger } from "./types";
 
 export {
   tryParseSeverityLevelString,
@@ -12,3 +13,5 @@ export {
   useLogger,
   defaultLogger,
 };
+
+export type { Logger };


### PR DESCRIPTION
🤖 Resolves #4801 

## 👋 Introduction

This is an attempt to constrain our URL params by throwing an error earlier in the code.

## 🕵️ Details

Currently, our URL params are very loosely typed as `Record<string, string | undefined>`. This has lead to a pattern of passing `param || ""` to the API and wait for it to return something. This will throw an error when we know a param will fail (it doesn't exist or is not an ID).

## ❓ Questions

### API

First of all, does the type of the hook and its args make sense? 

```ts
type UseRequiredParams<T extends Record<string, string>>(
  keys: keyof T | Array<keyof T>, 
  enforceUUID: boolean = true
) => Record<string, string>;

type RouteParams = {
  userId: string
  poolId: string;
};

// Ok
const { userId } = useRequiredParams<RouteParams>("userId");

// Ok
const { userId, poolId } = useRequiredParams<RouteParams>(["userId", "poolId"]);

// Fails
const { skillId} = useRequiredParams<RouteParams>("skillId");
```

### Return Type

I couldn't figure out how to enforce the return type. Can anyone assist me there? It is not required but it would be nice to have the return type be enforced as well. Right now it just returns `Record<string, string>`.

So, something like the following is totally okay until runtime.

```ts
type RouteParams = {
  userId: string
};

// Currently this is fine (until runtime). pool ID will just be undefined.
const { poold } = useRequiredParams<RouteParams>("userId");
```

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to pages confirming they load properly
3. Mess with an ID in the URL
4. Confirm an error is thrown instead of making an API request and you see the error page

## 📸 Screenshot

![Screenshot 2023-10-20 144106](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/e1b707af-8734-466d-abb8-e6a03f112eaa)