### PR TITLE
[Dep] Split app insights into chunk

### DIFF
--- a/packages/webpack-config/webpack.base.js
+++ b/packages/webpack-config/webpack.base.js
@@ -145,6 +145,15 @@ module.exports = (basePath) => {
         `...`, // Includes default minimizers
         new CssMinimizerPlugin(),
       ],
+      splitChunks: {
+        cacheGroups: {
+          appInsights: {
+            test: /[\\/]node_modules[\\/](@microsoft)[\\/]/,
+            name: 'appInsights',
+            chunks: 'all',
+          },
+        },
+      },
     },
     output: {
       publicPath: "/talent/", // final path for routing


### PR DESCRIPTION
🤖 Resolves #7228 

## 👋 Introduction

Splits off `@microsoft/*` dependencies into a chunk to reduce initial bundle size.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Do a fresh build `npm run build:fresh`
2. Confirm you see the new `appInsights.[hash].js` bundle
3. Confirm the initial bundle has been reduced
4. Confirm app insights still functions as expected

## 📸 Screenshot

![Screenshot 2023-10-24 090324](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/8d03819d-7717-45d7-8d76-0c18d70a521e)
