### PR TITLE
[Fix] Table sorting for strings with diacritics

### DIFF
--- a/apps/web/src/components/SkillSummaryTable/SkillSummaryTable.tsx
+++ b/apps/web/src/components/SkillSummaryTable/SkillSummaryTable.tsx
@@ -24,6 +24,7 @@ import { unpackMaybes } from "@gc-digital-talent/forms";
 
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import cells from "~/components/Table/cells";
+import { diacritic } from "~/components/Table/sortingFns";
 
 const columnHelper = createColumnHelper<PoolSkill>();
 
@@ -227,6 +228,7 @@ const SkillSummaryTable = ({
         description: "Skill name column header for the skill library table",
       }),
       enableHiding: false,
+      sortingFn: diacritic,
     }),
     columnHelper.display({
       id: "type",

--- a/apps/web/src/components/Table/sortingFns.ts
+++ b/apps/web/src/components/Table/sortingFns.ts
@@ -1,0 +1,26 @@
+import { SortingFn } from "@tanstack/react-table";
+
+import { normalizeString } from "@gc-digital-talent/helpers";
+
+/**
+ * Diacritic sort
+ *
+ * Basic sorting function that first normalizes the string
+ *
+ * @param {string} strA
+ * @param {string} strB
+ * @returns {number}
+ */
+export const diacriticSort = (strA: string, strB: string): number => {
+  const a = normalizeString(strA);
+  const b = normalizeString(strB);
+
+  if (a === b) return 0;
+
+  return a > b ? 1 : -1;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const diacritic: SortingFn<any> = (rowA, rowB, columnId) => {
+  return diacriticSort(rowA.getValue(columnId), rowB.getValue(columnId));
+};

--- a/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
+++ b/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
@@ -16,6 +16,7 @@ import useRoutes from "~/hooks/useRoutes";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import cells from "~/components/Table/cells";
 import adminMessages from "~/messages/adminMessages";
+import { diacritic } from "~/components/Table/sortingFns";
 
 const columnHelper = createColumnHelper<Classification>();
 
@@ -41,6 +42,7 @@ export const ClassificationTable = ({
       meta: {
         isRowTitle: true,
       },
+      sortingFn: diacritic,
       header: intl.formatMessage({
         defaultMessage: "Name",
         id: "HUCIzc",

--- a/apps/web/src/pages/Departments/components/DepartmentTable.tsx
+++ b/apps/web/src/pages/Departments/components/DepartmentTable.tsx
@@ -11,6 +11,7 @@ import useRoutes from "~/hooks/useRoutes";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import cells from "~/components/Table/cells";
 import adminMessages from "~/messages/adminMessages";
+import { diacritic } from "~/components/Table/sortingFns";
 
 const columnHelper = createColumnHelper<Department>();
 
@@ -38,6 +39,7 @@ export const DepartmentTable = ({
     }),
     columnHelper.accessor((row) => getLocalizedName(row.name, intl), {
       id: "name",
+      sortingFn: diacritic,
       header: intl.formatMessage({
         defaultMessage: "Name",
         id: "2wmzS1",

--- a/apps/web/src/pages/Pools/EditPoolPage/components/SkillTable.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/SkillTable.tsx
@@ -8,6 +8,7 @@ import { Button } from "@gc-digital-talent/ui";
 
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import SkillBrowserDialog from "~/components/SkillBrowser/SkillBrowserDialog";
+import { diacritic } from "~/components/Table/sortingFns";
 
 const columnHelper = createColumnHelper<Skill>();
 
@@ -69,6 +70,7 @@ const SkillTable = ({
       }),
       enableHiding: false,
       enableColumnFilter: false,
+      sortingFn: diacritic,
       meta: {
         isRowTitle: true,
       },

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -53,6 +53,7 @@ export const PoolTable = ({ pools, title }: PoolTableProps) => {
     }),
     columnHelper.accessor((row) => poolNameAccessor(row, intl), {
       id: "name",
+      sortingFn: diacritic,
       header: intl.formatMessage({
         defaultMessage: "Pool Name",
         id: "HocLRh",
@@ -73,6 +74,7 @@ export const PoolTable = ({ pools, title }: PoolTableProps) => {
         ),
       {
         id: "publishingGroup",
+        sortingFn: diacritic,
         header: intl.formatMessage({
           defaultMessage: "Publishing group",
           id: "rYgaTA",
@@ -98,6 +100,7 @@ export const PoolTable = ({ pools, title }: PoolTableProps) => {
         ),
       {
         id: "status",
+        sortingFn: diacritic,
         header: intl.formatMessage({
           defaultMessage: "Status",
           id: "ioqFVF",

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -19,6 +19,7 @@ import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import accessors from "~/components/Table/accessors";
 import cells from "~/components/Table/cells";
 import adminMessages from "~/messages/adminMessages";
+import { diacritic } from "~/components/Table/sortingFns";
 
 import {
   classificationAccessor,
@@ -129,6 +130,7 @@ export const PoolTable = ({ pools, title }: PoolTableProps) => {
           id: "fCXZ4R",
           description: "Title displayed for the Pool table Team column",
         }),
+        sortingFn: diacritic,
         cell: ({ row: { original: pool } }) =>
           viewTeamLinkCell(
             paths.teamView(pool.team?.id ? pool.team?.id : ""),

--- a/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
+++ b/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
@@ -11,6 +11,7 @@ import { SkillFamily, useAllSkillFamiliesQuery } from "~/api/generated";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import cells from "~/components/Table/cells";
 import adminMessages from "~/messages/adminMessages";
+import { diacritic } from "~/components/Table/sortingFns";
 
 const columnHelper = createColumnHelper<SkillFamily>();
 
@@ -35,6 +36,7 @@ export const SkillFamilyTable = ({
       (skillFamily) => getLocalizedName(skillFamily.name, intl),
       {
         id: "name",
+        sortingFn: diacritic,
         header: intl.formatMessage({
           defaultMessage: "Name",
           id: "VphXhu",
@@ -50,6 +52,7 @@ export const SkillFamilyTable = ({
       (skillFamily) => getLocalizedName(skillFamily.description, intl, true),
       {
         id: "description",
+        sortingFn: diacritic,
         header: intl.formatMessage({
           defaultMessage: "Description",
           id: "XSo129",

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -64,6 +64,7 @@ export const SkillTable = ({ skills, title }: SkillTableProps) => {
     ),
     columnHelper.accessor((skill) => keywordsAccessor(skill, intl), {
       id: "keywords",
+      sortingFn: diacritic,
       header: intl.formatMessage({
         defaultMessage: "Keywords",
         id: "I7rxxQ",
@@ -72,12 +73,14 @@ export const SkillTable = ({ skills, title }: SkillTableProps) => {
     }),
     columnHelper.accessor((skill) => familiesAccessor(skill, intl), {
       id: "skillFamilies",
+      sortingFn: diacritic,
       header: intl.formatMessage(adminMessages.skillFamilies),
       cell: ({ row: { original: skill } }) =>
         skillFamiliesCell(skill.families, intl),
     }),
     columnHelper.accessor(({ category }) => categoryAccessor(category, intl), {
       id: "category",
+      sortingFn: diacritic,
       header: intl.formatMessage({
         defaultMessage: "Category",
         id: "m5RwGF",

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -12,6 +12,7 @@ import { Skill, useAllSkillsQuery } from "~/api/generated";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import cells from "~/components/Table/cells";
 import adminMessages from "~/messages/adminMessages";
+import { diacritic } from "~/components/Table/sortingFns";
 
 import {
   categoryAccessor,
@@ -43,6 +44,7 @@ export const SkillTable = ({ skills, title }: SkillTableProps) => {
         id: "BOeBpE",
         description: "Title displayed for the skill table Name column.",
       }),
+      sortingFn: diacritic,
       meta: {
         isRowTitle: true,
       },
@@ -51,6 +53,7 @@ export const SkillTable = ({ skills, title }: SkillTableProps) => {
       (skill) => getLocalizedName(skill.description, intl, true),
       {
         id: "description",
+        sortingFn: diacritic,
         header: intl.formatMessage({
           defaultMessage: "Description",
           id: "9yGJ6k",

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
@@ -74,6 +74,7 @@ export const TeamTable = ({
       (team) => myRolesAccessor(team.id, myRolesAndTeams, intl),
       {
         id: "myRoles",
+        sortingFn: diacritic,
         header: intl.formatMessage({
           defaultMessage: "My Roles",
           id: "+agJAH",
@@ -86,6 +87,7 @@ export const TeamTable = ({
     ),
     columnHelper.accessor((team) => departmentAccessor(team, intl), {
       id: "departments",
+      sortingFn: diacritic,
       header: intl.formatMessage({
         defaultMessage: "Department",
         id: "BDo1aH",

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
@@ -14,6 +14,7 @@ import {
 import useRoutes from "~/hooks/useRoutes";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import cells from "~/components/Table/cells";
+import { diacritic } from "~/components/Table/sortingFns";
 
 import { MyRoleTeam } from "./types";
 import {
@@ -57,6 +58,7 @@ export const TeamTable = ({
     }),
     columnHelper.accessor((team) => getLocalizedName(team.displayName, intl), {
       id: "teamName",
+      sortingFn: diacritic,
       header: intl.formatMessage({
         defaultMessage: "Team",
         id: "KIWVbp",

--- a/apps/web/src/pages/Users/UpdateUserPage/components/IndividualRoleTable.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/IndividualRoleTable.tsx
@@ -8,6 +8,7 @@ import { getLocalizedName } from "@gc-digital-talent/i18n";
 
 import { Role, UpdateUserAsAdminInput, User } from "~/api/generated";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
+import { diacritic } from "~/components/Table/sortingFns";
 
 import { UpdateUserFunc } from "../types";
 import AddIndividualRoleDialog from "./AddIndividualRoleDialog";
@@ -40,6 +41,7 @@ const IndividualRoleTable = ({
     }),
     columnHelper.accessor((role) => getLocalizedName(role.displayName, intl), {
       id: "role",
+      sortingFn: diacritic,
       header: intl.formatMessage({
         defaultMessage: "Role",
         id: "uBmoxQ",

--- a/apps/web/src/pages/Users/UpdateUserPage/components/TeamRoleTable.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/TeamRoleTable.tsx
@@ -15,6 +15,7 @@ import {
 } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
+import { diacritic } from "~/components/Table/sortingFns";
 
 import { TeamAssignment, UpdateUserFunc } from "../types";
 import AddTeamRoleDialog from "./AddTeamRoleDialog";
@@ -71,6 +72,7 @@ const TeamRoleTable = ({
         getLocalizedName(teamAssignment.team.displayName, intl),
       {
         id: "team",
+        sortingFn: diacritic,
         header: intl.formatMessage({
           defaultMessage: "Team",
           id: "3IZ3mN",

--- a/packages/helpers/src/index.tsx
+++ b/packages/helpers/src/index.tsx
@@ -3,6 +3,7 @@ import {
   phoneNumberRegex,
 } from "./constants/regularExpressions";
 import lazyRetry from "./utils/lazyRetry";
+import normalizeString from "./utils/normalizeString";
 import sanitizeUrl from "./utils/sanitizeUrl";
 import isUuidError from "./utils/uuid";
 import {
@@ -38,6 +39,7 @@ export {
   emptyToUndefined,
   uniqueItems,
   lazyRetry,
+  normalizeString,
   sanitizeUrl,
   isUuidError,
   useIsSmallScreen,

--- a/packages/helpers/src/utils/normalizeString.ts
+++ b/packages/helpers/src/utils/normalizeString.ts
@@ -1,0 +1,19 @@
+/**
+ * Normalize string
+ *
+ * Removes diacritics, converts to lower case
+ *
+ * @param {string} str - The string to be normalized
+ * @return {string}
+ *
+ * @example `const normalized = normalizeString("numériques");`
+ *
+ */
+const normalizeString = (str: string): string => {
+  return str
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+};
+
+export default normalizeString;


### PR DESCRIPTION
🤖 Resolves #5655 

## 👋 Introduction

This adds and implements a new, normalized, sorting function for our tables.

## 🕵️ Details

Uses the the helpful normalizing @mnigh figured out for our select inputs to normalize the string before sorting.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/admin`
3. Change locale to French
4. Sort table columns that include diacritics
5. Confirm they sort as expected

## 📸 Screenshot

![Screenshot 2023-10-24 162816](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/1339a907-d769-41ac-bbd2-26cb653cf403)
