### PR TITLE
[Feature] Allow pool operator and request responder access to users and pool candidates

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -636,7 +636,7 @@ type Query {
     @orderBy(column: "created_at", direction: DESC)
     @paginate(defaultCount: 10, maxCount: 1000, scopes: ["authorizedToView"])
     @guard
-    @can(ability: "viewAny")
+    @can(ability: "view", resolved: true)
   applicant(id: UUID! @eq): User
     @find(model: "User")
     @guard

--- a/apps/web/src/components/AdminSideMenu/AdminSideMenu.tsx
+++ b/apps/web/src/components/AdminSideMenu/AdminSideMenu.tsx
@@ -80,7 +80,11 @@ const AdminSideMenu = ({ isOpen, onToggle }: AdminSideMenuProps) => {
       key: "users",
       href: paths.userTable(),
       icon: UserIcon,
-      roles: [ROLE_NAME.PlatformAdmin],
+      roles: [
+        ROLE_NAME.PoolOperator,
+        ROLE_NAME.RequestResponder,
+        ROLE_NAME.PlatformAdmin,
+      ],
       text: intl.formatMessage(adminMessages.users),
     },
     {

--- a/apps/web/src/components/AdminSideMenu/AdminSideMenu.tsx
+++ b/apps/web/src/components/AdminSideMenu/AdminSideMenu.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import AcademicCapIcon from "@heroicons/react/24/outline/AcademicCapIcon";
+import BoltIcon from "@heroicons/react/24/outline/BoltIcon";
 import CloudIcon from "@heroicons/react/24/outline/CloudIcon";
 import HomeIcon from "@heroicons/react/24/outline/HomeIcon";
 import BuildingOfficeIcon from "@heroicons/react/24/outline/BuildingOfficeIcon";
@@ -129,7 +129,7 @@ const AdminSideMenu = ({ isOpen, onToggle }: AdminSideMenuProps) => {
     {
       key: "skills",
       href: paths.skillTable(),
-      icon: AcademicCapIcon,
+      icon: BoltIcon,
       roles: [ROLE_NAME.PlatformAdmin],
       text: intl.formatMessage(adminMessages.skills),
     },

--- a/apps/web/src/components/AdminSideMenu/AdminSideMenu.tsx
+++ b/apps/web/src/components/AdminSideMenu/AdminSideMenu.tsx
@@ -5,9 +5,9 @@ import CloudIcon from "@heroicons/react/24/outline/CloudIcon";
 import HomeIcon from "@heroicons/react/24/outline/HomeIcon";
 import BuildingOfficeIcon from "@heroicons/react/24/outline/BuildingOfficeIcon";
 import BuildingOffice2Icon from "@heroicons/react/24/outline/BuildingOffice2Icon";
-import TagIcon from "@heroicons/react/24/outline/TagIcon";
+import PuzzlePieceIcon from "@heroicons/react/24/outline/PuzzlePieceIcon";
 import TicketIcon from "@heroicons/react/24/outline/TicketIcon";
-import UserGroupIcon from "@heroicons/react/24/outline/UserGroupIcon";
+import IdentificationIcon from "@heroicons/react/24/outline/IdentificationIcon";
 import UserIcon from "@heroicons/react/24/outline/UserIcon";
 import Squares2X2Icon from "@heroicons/react/24/outline/Squares2X2Icon";
 
@@ -68,7 +68,7 @@ const AdminSideMenu = ({ isOpen, onToggle }: AdminSideMenuProps) => {
     {
       key: "pool-candidates",
       href: paths.poolCandidates(),
-      icon: UserGroupIcon,
+      icon: IdentificationIcon,
       roles: [
         ROLE_NAME.PoolOperator,
         ROLE_NAME.RequestResponder,
@@ -97,7 +97,7 @@ const AdminSideMenu = ({ isOpen, onToggle }: AdminSideMenuProps) => {
     {
       key: "classifications",
       href: paths.classificationTable(),
-      icon: TagIcon,
+      icon: PuzzlePieceIcon,
       roles: [ROLE_NAME.PlatformAdmin],
       text: intl.formatMessage(adminMessages.classifications),
     },

--- a/apps/web/src/components/AdminSideMenu/AdminSideMenu.tsx
+++ b/apps/web/src/components/AdminSideMenu/AdminSideMenu.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import AcademicCapIcon from "@heroicons/react/24/outline/AcademicCapIcon";
+import CloudIcon from "@heroicons/react/24/outline/CloudIcon";
 import HomeIcon from "@heroicons/react/24/outline/HomeIcon";
 import BuildingOfficeIcon from "@heroicons/react/24/outline/BuildingOfficeIcon";
 import BuildingOffice2Icon from "@heroicons/react/24/outline/BuildingOffice2Icon";
@@ -65,6 +66,17 @@ const AdminSideMenu = ({ isOpen, onToggle }: AdminSideMenuProps) => {
       text: intl.formatMessage(adminMessages.pools),
     },
     {
+      key: "pool-candidates",
+      href: paths.poolCandidates(),
+      icon: UserGroupIcon,
+      roles: [
+        ROLE_NAME.PoolOperator,
+        ROLE_NAME.RequestResponder,
+        ROLE_NAME.PlatformAdmin,
+      ],
+      text: intl.formatMessage(adminMessages.poolsCandidates),
+    },
+    {
       key: "users",
       href: paths.userTable(),
       icon: UserIcon,
@@ -106,7 +118,7 @@ const AdminSideMenu = ({ isOpen, onToggle }: AdminSideMenuProps) => {
     {
       key: "skill-families",
       href: paths.skillFamilyTable(),
-      icon: UserGroupIcon,
+      icon: CloudIcon,
       roles: [ROLE_NAME.PlatformAdmin],
       text: intl.formatMessage(adminMessages.skillFamilies),
     },

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -1243,7 +1243,11 @@ const createRoute = (
                   index: true,
                   element: (
                     <RequireAuth
-                      roles={[ROLE_NAME.PlatformAdmin]}
+                      roles={[
+                        ROLE_NAME.PoolOperator,
+                        ROLE_NAME.RequestResponder,
+                        ROLE_NAME.PlatformAdmin,
+                      ]}
                       loginPath={loginPath}
                     >
                       <IndexUserPage />

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -482,6 +482,14 @@ const UpdateClassificationPage = React.lazy(() =>
 );
 
 /** Pool Candidates */
+const AllPoolCandidatesPage = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "adminAllPoolCandidatesPage" */ "../pages/PoolCandidates/AllPoolCandidatesPage/AllPoolCandidatesPage"
+      ),
+  ),
+);
 const IndexPoolCandidatePage = React.lazy(() =>
   lazyRetry(
     () =>
@@ -1544,10 +1552,29 @@ const createRoute = (
               ],
             },
             {
+              path: "pool-candidates",
+              element: (
+                <RequireAuth
+                  roles={[
+                    ROLE_NAME.PoolOperator,
+                    ROLE_NAME.RequestResponder,
+                    ROLE_NAME.PlatformAdmin,
+                  ]}
+                  loginPath={loginPath}
+                >
+                  <AllPoolCandidatesPage />
+                </RequireAuth>
+              ),
+            },
+            {
               path: "candidates/:poolCandidateId/application",
               element: (
                 <RequireAuth
-                  roles={[ROLE_NAME.PoolOperator]}
+                  roles={[
+                    ROLE_NAME.PoolOperator,
+                    ROLE_NAME.RequestResponder,
+                    ROLE_NAME.PlatformAdmin,
+                  ]}
                   loginPath={loginPath}
                 >
                   <ViewPoolCandidatePage />

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -71,6 +71,7 @@ const getRoutes = (lang: Locales) => {
       path.join(adminUrl, "pools", poolId, "plan"),
 
     // Admin - Pool Candidates
+    poolCandidates: () => path.join(adminUrl, "pool-candidates"),
     poolCandidateTable: (poolId: string) =>
       path.join(adminUrl, "pools", poolId, "pool-candidates"),
     poolCandidateCreate: (poolId: string) =>

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -119,6 +119,11 @@ const DashboardPage = ({ currentUser }: DashboardPageProps) => {
                 icon: IdentificationIcon,
               },
               {
+                label: intl.formatMessage(adminMessages.users),
+                href: adminRoutes.userTable(),
+                icon: UserIcon,
+              },
+              {
                 label: intl.formatMessage({
                   defaultMessage: "My Teams",
                   id: "N3uD4m",
@@ -142,6 +147,16 @@ const DashboardPage = ({ currentUser }: DashboardPageProps) => {
                 label: intl.formatMessage(adminMessages.requests),
                 href: adminRoutes.searchRequestTable(),
                 icon: TicketIcon,
+              },
+              {
+                label: intl.formatMessage(adminMessages.poolsCandidates),
+                href: adminRoutes.poolCandidates(),
+                icon: IdentificationIcon,
+              },
+              {
+                label: intl.formatMessage(adminMessages.users),
+                href: adminRoutes.userTable(),
+                icon: UserIcon,
               },
             ]}
           />

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import BoltIcon from "@heroicons/react/20/solid/BoltIcon";
+import CloudIcon from "@heroicons/react/20/solid/CloudIcon";
 import HomeIconOutline from "@heroicons/react/24/outline/HomeIcon";
 import BuildingOfficeIcon from "@heroicons/react/20/solid/BuildingOfficeIcon";
 import BuildingOffice2Icon from "@heroicons/react/20/solid/BuildingOffice2Icon";
@@ -113,6 +114,11 @@ const DashboardPage = ({ currentUser }: DashboardPageProps) => {
                 icon: Squares2X2Icon,
               },
               {
+                label: intl.formatMessage(adminMessages.poolsCandidates),
+                href: adminRoutes.poolCandidates(),
+                icon: UserGroupIcon,
+              },
+              {
                 label: intl.formatMessage({
                   defaultMessage: "My Teams",
                   id: "N3uD4m",
@@ -196,7 +202,7 @@ const DashboardPage = ({ currentUser }: DashboardPageProps) => {
               {
                 label: intl.formatMessage(adminMessages.skillFamilies),
                 href: adminRoutes.skillFamilyTable(),
-                icon: UserGroupIcon,
+                icon: CloudIcon,
               },
               {
                 label: intl.formatMessage({

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -6,7 +6,7 @@ import HomeIconOutline from "@heroicons/react/24/outline/HomeIcon";
 import BuildingOfficeIcon from "@heroicons/react/20/solid/BuildingOfficeIcon";
 import BuildingOffice2Icon from "@heroicons/react/20/solid/BuildingOffice2Icon";
 import TicketIcon from "@heroicons/react/20/solid/TicketIcon";
-import UserGroupIcon from "@heroicons/react/20/solid/UserGroupIcon";
+import IdentificationIcon from "@heroicons/react/20/solid/IdentificationIcon";
 import UserIcon from "@heroicons/react/20/solid/UserIcon";
 import Squares2X2Icon from "@heroicons/react/20/solid/Squares2X2Icon";
 import PuzzlePieceIcon from "@heroicons/react/20/solid/PuzzlePieceIcon";
@@ -116,7 +116,7 @@ const DashboardPage = ({ currentUser }: DashboardPageProps) => {
               {
                 label: intl.formatMessage(adminMessages.poolsCandidates),
                 href: adminRoutes.poolCandidates(),
-                icon: UserGroupIcon,
+                icon: IdentificationIcon,
               },
               {
                 label: intl.formatMessage({

--- a/apps/web/src/pages/PoolCandidates/AllPoolCandidatesPage/AllPoolCandidatesPage.tsx
+++ b/apps/web/src/pages/PoolCandidates/AllPoolCandidatesPage/AllPoolCandidatesPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import UserIcon from "@heroicons/react/24/outline/UserIcon";
+import IdentificationIcon from "@heroicons/react/24/outline/IdentificationIcon";
 
 import useRoutes from "~/hooks/useRoutes";
 import PoolCandidatesTable from "~/components/PoolCandidatesTable/PoolCandidatesTable";
@@ -37,7 +37,7 @@ export const AllPoolCandidatesPage = () => {
   return (
     <AdminContentWrapper crumbs={navigationCrumbs}>
       <SEO title={pageTitle} />
-      <PageHeader icon={UserIcon}>{pageTitle}</PageHeader>
+      <PageHeader icon={IdentificationIcon}>{pageTitle}</PageHeader>
       <PoolCandidatesTable title={pageTitle} />
     </AdminContentWrapper>
   );

--- a/apps/web/src/pages/PoolCandidates/AllPoolCandidatesPage/AllPoolCandidatesPage.tsx
+++ b/apps/web/src/pages/PoolCandidates/AllPoolCandidatesPage/AllPoolCandidatesPage.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import UserIcon from "@heroicons/react/24/outline/UserIcon";
+
+import useRoutes from "~/hooks/useRoutes";
+import PoolCandidatesTable from "~/components/PoolCandidatesTable/PoolCandidatesTable";
+import SEO from "~/components/SEO/SEO";
+import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
+import adminMessages from "~/messages/adminMessages";
+import PageHeader from "~/components/PageHeader";
+
+export const AllPoolCandidatesPage = () => {
+  const intl = useIntl();
+  const routes = useRoutes();
+
+  const pageTitle = intl.formatMessage(adminMessages.poolsCandidates);
+
+  const navigationCrumbs = [
+    {
+      label: intl.formatMessage({
+        defaultMessage: "Home",
+        id: "EBmWyo",
+        description: "Link text for the home link in breadcrumbs.",
+      }),
+      url: routes.adminDashboard(),
+    },
+    {
+      label: intl.formatMessage({
+        defaultMessage: "Candidates",
+        id: "zzf16k",
+        description: "Breadcrumb for the All Candidates page",
+      }),
+      url: routes.poolCandidates(),
+    },
+  ];
+
+  return (
+    <AdminContentWrapper crumbs={navigationCrumbs}>
+      <SEO title={pageTitle} />
+      <PageHeader icon={UserIcon}>{pageTitle}</PageHeader>
+      <PoolCandidatesTable title={pageTitle} />
+    </AdminContentWrapper>
+  );
+};
+
+export default AllPoolCandidatesPage;


### PR DESCRIPTION
🤖 Resolves #8304 

## 👋 Introduction

This allows users with the pool operator and request responder roles to view a table of users and all pool candidates. These are scoped specifically to the records they have access to.

## 🕵️ Details

We also had some icon discrepancies that were resolved while adding the root pool candidates page thanks to assistance from @Jerryescandon 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login with `pool@test.com`
3. Confirm you see both "Pools candidates" and "Users" in the sidebar
4. Confirm accessing them shows the scoped records
5. Login with `request@test.com`
6. Repeat steps 3-4

## 📸 Screenshot

### Pool operator
![localhost_8000_en_applicant_profile-and-applications_token_type=Bearer id_token=eyJraWQiOiJveGF1dGgiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9 eyJzdWIiOiJwb29sQHRlc3QuY29tIiwiY29kZSI6IjAwMDAwMDAwLTAwMDAtMDAwMC0wMTIzLTQ1Nj](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/86660886-6235-407e-90c6-b9de3a89248f)

### Request responder
![localhost_8000_en_applicant_profile-and-applications_token_type=Bearer id_token=eyJraWQiOiJveGF1dGgiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9 eyJzdWIiOiJyZXF1ZXN0QHRlc3QuY29tIiwiY29kZSI6IjAwMDAwMDAwLTAwMDAtMDAwMC0wMT (1)](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/5981ac0f-668b-4889-9e14-e0902b62124c)
