### PR TITLE
[Feature] Admin Skill table improvements

### DIFF
--- a/apps/web/src/components/Table/Actions.tsx
+++ b/apps/web/src/components/Table/Actions.tsx
@@ -17,7 +17,7 @@ const Actions = ({ id, label, editPathFunc }: ActionsProps) => {
   const intl = useIntl();
   const editPath = editPathFunc(id);
   const { pathname, search, hash } = useLocation();
-  const currentUrl = `${pathname}${search}${hash}`;
+  const currentUrl = `${pathname}${search}${hash}`; // Passing the current url, including search params, allows the next page to return to current table state.
   return (
     <Link
       href={editPath}

--- a/apps/web/src/components/Table/Actions.tsx
+++ b/apps/web/src/components/Table/Actions.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import PencilIcon from "@heroicons/react/24/outline/PencilIcon";
+import { useLocation } from "react-router-dom";
 
 import { Link } from "@gc-digital-talent/ui";
 
@@ -15,7 +16,8 @@ export interface ActionsProps {
 const Actions = ({ id, label, editPathFunc }: ActionsProps) => {
   const intl = useIntl();
   const editPath = editPathFunc(id);
-
+  const { pathname, search, hash } = useLocation();
+  const currentUrl = `${pathname}${search}${hash}`;
   return (
     <Link
       href={editPath}
@@ -30,6 +32,7 @@ const Actions = ({ id, label, editPathFunc }: ActionsProps) => {
         },
         { label },
       )}
+      state={{ from: currentUrl }}
     >
       <PencilIcon
         data-h2-display="base(block)"

--- a/apps/web/src/components/Table/EditLink.tsx
+++ b/apps/web/src/components/Table/EditLink.tsx
@@ -13,17 +13,20 @@ interface EditLinkProps {
   editUrlRoot: string;
   /** Label for link text  */
   label?: Maybe<string>;
+  /** Visible text for the string, if you want to override default. */
+  text?: Maybe<string>;
 }
 
 function EditLink({
   id,
   editUrlRoot,
   label,
+  text,
 }: EditLinkProps): React.ReactElement {
   const intl = useIntl();
   const href = `${editUrlRoot}/${id}/edit`;
   const { pathname, search, hash } = useLocation();
-  const currentUrl = `${pathname}${search}${hash}`;
+  const currentUrl = `${pathname}${search}${hash}`; // Passing the current url, including search params, allows the next page to return to current table state.
   return (
     <Link
       href={href}
@@ -38,14 +41,15 @@ function EditLink({
       )}
       state={{ from: currentUrl }}
     >
-      {intl.formatMessage(
-        {
-          defaultMessage: "Edit<hidden> {label}</hidden>",
-          id: "i9ND/M",
-          description: "Title displayed for the Edit column.",
-        },
-        { label },
-      )}
+      {text ??
+        intl.formatMessage(
+          {
+            defaultMessage: "Edit<hidden> {label}</hidden>",
+            id: "i9ND/M",
+            description: "Title displayed for the Edit column.",
+          },
+          { label },
+        )}
     </Link>
   );
 }

--- a/apps/web/src/components/Table/EditLink.tsx
+++ b/apps/web/src/components/Table/EditLink.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
+import { useLocation } from "react-router-dom";
 
 import { Link } from "@gc-digital-talent/ui";
 
@@ -21,6 +22,8 @@ function EditLink({
 }: EditLinkProps): React.ReactElement {
   const intl = useIntl();
   const href = `${editUrlRoot}/${id}/edit`;
+  const { pathname, search, hash } = useLocation();
+  const currentUrl = `${pathname}${search}${hash}`;
   return (
     <Link
       href={href}
@@ -33,6 +36,7 @@ function EditLink({
         },
         { label },
       )}
+      state={{ from: currentUrl }}
     >
       {intl.formatMessage(
         {

--- a/apps/web/src/components/Table/ViewLink.tsx
+++ b/apps/web/src/components/Table/ViewLink.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
+import { useLocation } from "react-router-dom";
 
 import { Link, LinkProps } from "@gc-digital-talent/ui";
 
@@ -19,8 +20,10 @@ function ViewLink({
   ...rest
 }: ViewLinkProps): React.ReactElement {
   const intl = useIntl();
+  const { pathname, search, hash } = useLocation();
+  const currentUrl = `${pathname}${search}${hash}`; // Passing the current url, including search params, allows the next page to return to current table state.
   return (
-    <Link href={href} {...rest}>
+    <Link href={href} {...rest} state={{ from: currentUrl }}>
       {intl.formatMessage(
         {
           defaultMessage: "View {name} <hidden>{hiddenLabel}</hidden>",

--- a/apps/web/src/components/Table/cells.tsx
+++ b/apps/web/src/components/Table/cells.tsx
@@ -15,8 +15,15 @@ function commaListCell(props: CommaListProps) {
   return <CommaList {...props} />;
 }
 
-function editCell(id: string, editUrlRoot: string, label?: Maybe<string>) {
-  return <EditLink id={id} editUrlRoot={editUrlRoot} label={label} />;
+function editCell(
+  id: string,
+  editUrlRoot: string,
+  label?: Maybe<string>,
+  text?: Maybe<string>,
+) {
+  return (
+    <EditLink id={id} editUrlRoot={editUrlRoot} label={label} text={text} />
+  );
 }
 
 function viewCell(

--- a/apps/web/src/pages/Skills/UpdateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateSkillPage.tsx
@@ -109,7 +109,7 @@ export const UpdateSkillForm = ({
   const { handleSubmit } = methods;
 
   const { state } = useLocation();
-  const navigateTo = state.from ?? paths.skillTable(); // If location state includes a `from` parameter, navigate to that url on success.
+  const navigateTo = state?.from ?? paths.skillTable(); // If location state includes a `from` parameter, navigate to that url on success.
 
   const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
     return handleUpdateSkill(initialSkill.id, formValuesToSubmitData(data))

--- a/apps/web/src/pages/Skills/UpdateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateSkillPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useIntl } from "react-intl";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import pick from "lodash/pick";
@@ -108,10 +108,13 @@ export const UpdateSkillForm = ({
   });
   const { handleSubmit } = methods;
 
+  const { state } = useLocation();
+  const navigateTo = state.from ?? paths.skillTable(); // If location state includes a `from` parameter, navigate to that url on success.
+
   const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
     return handleUpdateSkill(initialSkill.id, formValuesToSubmitData(data))
       .then(() => {
-        navigate(paths.skillTable());
+        navigate(navigateTo);
         toast.success(
           intl.formatMessage({
             defaultMessage: "Skill updated successfully!",

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -46,6 +46,10 @@ export const SkillTable = ({ skills, title }: SkillTableProps) => {
       meta: {
         isRowTitle: true,
       },
+      cell: ({ row: { original: skill } }) => {
+        const skillName = getLocalizedName(skill.name, intl);
+        return cells.edit(skill.id, paths.skillTable(), skillName, skillName);
+      },
     }),
     columnHelper.accessor(
       (skill) => getLocalizedName(skill.description, intl, true),
@@ -82,16 +86,6 @@ export const SkillTable = ({ skills, title }: SkillTableProps) => {
           "Title displayed for the Skill Family table Category column.",
       }),
     }),
-    columnHelper.display({
-      id: "edit",
-      header: intl.formatMessage(adminMessages.edit),
-      cell: ({ row: { original: skill } }) =>
-        cells.edit(
-          skill.id,
-          paths.skillTable(),
-          getLocalizedName(skill.name, intl),
-        ),
-    }),
   ] as ColumnDef<Skill>[];
 
   const data = skills.filter(notEmpty);
@@ -109,6 +103,7 @@ export const SkillTable = ({ skills, title }: SkillTableProps) => {
       }}
       sort={{
         internal: true,
+        initialState: [{ id: "name", desc: false }],
       }}
       search={{
         internal: true,

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -101,7 +101,7 @@ export const SkillTable = ({ skills, title }: SkillTableProps) => {
       caption={title}
       data={data}
       columns={columns}
-      hiddenColumnIds={["id"]}
+      hiddenColumnIds={["id", "keywords"]}
       pagination={{
         internal: true,
         total: data.length,


### PR DESCRIPTION
🤖 Resolves #8339

## 👋 Introduction

Makes it easier to navigate the skill table, edit a single skill, and return to where you were on the table.

## 🕵️ Details

I'm trying a new pattern here, where the table link cell components add a `from` url to the location state, and the edit/view/create page can navigate to that url (which includes table state) if its available. I really like the way this works! I'd be interested in adopting this on other edit/view/create pages.

## 🧪 Testing

1. Log in ad admin@test.com
2. Go to skills table
3. Add a search filter, change visible columns and navigate to a later page
4. Narrow your screen so you can't see all columns at once
5. Can you get to the skill edit page without horizontal scrolling?
6. Edit a skill, submit changes
7. Did you come back to the table in the state you left it in? (page and filters and columns)
8. Open a link to edit skill page in a new tab
9. Can you edit the skill in the new tab? It should send you to a table in the default state this time
