### PR TITLE
Remove user languageAbility

### DIFF
--- a/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
@@ -15,7 +15,6 @@ query getProfile($userId: UUID!) {
     currentCity
     citizenship
     armedForcesStatus
-    languageAbility
     lookingForEnglish
     lookingForFrench
     lookingForBilingual

--- a/api/app/Http/Resources/UserResource.php
+++ b/api/app/Http/Resources/UserResource.php
@@ -64,7 +64,6 @@ class UserResource extends JsonResource
             'currentCity' => $this->current_city,
             'citizenship' => $this->citizenship,
             'armedForcesStatus' => $this->armed_forces_status,
-            'languageAbility' => $this->language_ability,
             'lookingForEnglish' => $this->looking_for_english,
             'lookingForFrench' => $this->looking_for_french,
             'lookingForBilingual' => $this->looking_for_bilingual,

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -696,37 +696,6 @@ class User extends Model implements Authenticatable, LaratrustUser
         return null; // if indigenousCommunities is null then so is isIndigenous
     }
 
-    /* accessor to maintain functionality of to be deprecated languageAbility field, its logic comes from migration drop_language_ability*/
-    public function getLanguageAbilityAttribute($languageAbility = null)
-    {
-        // if the field exists, say for migration purposes, must stop accessor overriding
-        if ($languageAbility !== null) {
-            return $languageAbility;
-        }
-
-        $lookingForEnglish = $this->looking_for_english;
-        $lookingForFrench = $this->looking_for_french;
-        $lookingForBilingual = $this->looking_for_bilingual;
-
-        // only english case
-        if ($lookingForEnglish && ! $lookingForFrench && ! $lookingForBilingual) {
-            return LanguageAbility::ENGLISH->name;
-        }
-
-        // only french case
-        if (! $lookingForEnglish && $lookingForFrench && ! $lookingForBilingual) {
-            return LanguageAbility::FRENCH->name;
-        }
-
-        // bilingual case just depends on the one field being true
-        // or ignore the field if english and french are both true
-        if (($lookingForBilingual) || ($lookingForEnglish && $lookingForFrench)) {
-            return LanguageAbility::BILINGUAL->name;
-        }
-
-        // in all other cases the field stays null, so cases where all fields tested are false/null for instance
-    }
-
     // Prepares the parameters for Laratrust and then calls the function to modify the roles
     private function callRolesFunction($rolesInput, $functionName)
     {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -48,11 +48,6 @@ type User {
   armedForcesStatus: ArmedForcesStatus @rename(attribute: "armed_forces_status")
 
   # Language
-  languageAbility: LanguageAbility
-    @rename(attribute: "language_ability")
-    @deprecated(
-      reason: "languageAbility is deprecated. Use lookingFor<Language> instead. Remove in #7661."
-    )
   lookingForEnglish: Boolean @rename(attribute: "looking_for_english")
   lookingForFrench: Boolean @rename(attribute: "looking_for_french")
   lookingForBilingual: Boolean @rename(attribute: "looking_for_bilingual")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -193,7 +193,6 @@ type User {
   currentCity: String
   citizenship: CitizenshipStatus
   armedForcesStatus: ArmedForcesStatus
-  languageAbility: LanguageAbility @deprecated(reason: "languageAbility is deprecated. Use lookingFor<Language> instead. Remove in #7661.")
   lookingForEnglish: Boolean
   lookingForFrench: Boolean
   lookingForBilingual: Boolean

--- a/apps/e2e/cypress/support/userCommands.ts
+++ b/apps/e2e/cypress/support/userCommands.ts
@@ -24,7 +24,6 @@ const defaultUser = {
   email: undefined,
   currentProvince: undefined,
   currentCity: undefined,
-  languageAbility: undefined,
   lookingForEnglish: undefined,
   lookingForFrench: undefined,
   lookingForBilingual: undefined,

--- a/apps/e2e/cypress/support/userHelpers.ts
+++ b/apps/e2e/cypress/support/userHelpers.ts
@@ -36,7 +36,6 @@ export function createApplicant({
     armedForcesStatus: ArmedForcesStatus.NonCaf,
     citizenship: CitizenshipStatus.Citizen,
     lookingForEnglish: true,
-    //languageAbility: LanguageAbility.English,
     isGovEmployee: false,
     isWoman: true,
     hasPriorityEntitlement: false,

--- a/apps/web/src/components/UserProfile/UserProfile.stories.tsx
+++ b/apps/web/src/components/UserProfile/UserProfile.stories.tsx
@@ -64,7 +64,6 @@ UserProfileNull.args = {
   preferredLanguageForExam: null,
   currentCity: null,
   currentProvince: null,
-  languageAbility: null,
   lookingForEnglish: null,
   lookingForFrench: null,
   lookingForBilingual: null,

--- a/apps/web/src/pages/Applications/applicationOperations.graphql
+++ b/apps/web/src/pages/Applications/applicationOperations.graphql
@@ -101,7 +101,6 @@ query GetApplication($id: UUID!) {
       currentProvince
       currentCity
       citizenship
-      languageAbility
       lookingForEnglish
       lookingForFrench
       lookingForBilingual

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/poolCandidatesOperations.graphql
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/poolCandidatesOperations.graphql
@@ -19,7 +19,6 @@ fragment poolCandidateTable on PoolCandidate {
     armedForcesStatus
 
     # Language
-    languageAbility
     lookingForEnglish
     lookingForFrench
     lookingForBilingual

--- a/apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql
+++ b/apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql
@@ -15,7 +15,6 @@ query getMe {
     currentCity
     citizenship
     armedForcesStatus
-    languageAbility
     lookingForEnglish
     lookingForFrench
     lookingForBilingual

--- a/apps/web/src/pages/ProfileAndApplicationsPage/applicantOperations.graphql
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/applicantOperations.graphql
@@ -66,7 +66,6 @@ query ApplicantInformation {
     currentCity
     citizenship
     armedForcesStatus
-    languageAbility
     lookingForEnglish
     lookingForFrench
     lookingForBilingual

--- a/apps/web/src/pages/Users/userOperations.graphql
+++ b/apps/web/src/pages/Users/userOperations.graphql
@@ -67,7 +67,6 @@ mutation CreateUser($user: CreateUserInput!) {
     currentProvince
     currentCity
 
-    languageAbility
     preferredLang
     preferredLanguageForInterview
     preferredLanguageForExam
@@ -130,7 +129,6 @@ mutation UpdateUserAsUser($id: ID!, $user: UpdateUserAsUserInput!) {
     currentProvince
     currentCity
 
-    languageAbility
     preferredLang
     lookingForEnglish
     lookingForFrench
@@ -189,7 +187,6 @@ mutation UpdateUserAsAdmin($id: ID!, $user: UpdateUserAsAdminInput!) {
     currentProvince
     currentCity
 
-    languageAbility
     preferredLang
     preferredLanguageForInterview
     preferredLanguageForExam

--- a/packages/fake-data/src/fakeUsers.ts
+++ b/packages/fake-data/src/fakeUsers.ts
@@ -91,9 +91,6 @@ const generateUser = (
     ]),
 
     // Language
-    languageAbility: faker.helpers.arrayElement<LanguageAbility>(
-      Object.values(LanguageAbility),
-    ),
     lookingForEnglish: faker.datatype.boolean(),
     lookingForFrench: faker.datatype.boolean(),
     lookingForBilingual: faker.datatype.boolean(),


### PR DESCRIPTION
🤖 Resolves #7661

## 👋 Introduction

Removes the deprecated `languageAbility` field from the User model as well as a few remaining references to it.

## 🧪 Testing

1. Confirm the  `languageAbility` field is removed from the User model
2. Look for anything that may have still been using the field and have broken now.