### PR TITLE
[Feature] Add feature flags to storybook

### DIFF
--- a/apps/web/.storybook/preview.js
+++ b/apps/web/.storybook/preview.js
@@ -3,6 +3,7 @@ import {
   MINIMAL_VIEWPORTS,
 } from "@storybook/addon-viewport";
 import {
+  FeatureFlagDecorator,
   HelmetDecorator,
   MockGraphqlDecorator,
   ReducedMotionDecorator,
@@ -66,6 +67,7 @@ export const globalTypes = {
 };
 
 export const decorators = [
+  FeatureFlagDecorator,
   HelmetDecorator,
   ReducedMotionDecorator,
   MockGraphqlDecorator,

--- a/apps/web/src/components/Context/ContextProvider.tsx
+++ b/apps/web/src/components/Context/ContextProvider.tsx
@@ -8,6 +8,7 @@ import {
   AuthorizationProvider,
 } from "@gc-digital-talent/auth";
 import ClientProvider from "@gc-digital-talent/client";
+import { FeatureFlagProvider } from "@gc-digital-talent/env";
 import {
   LanguageProvider,
   LocaleProvider,
@@ -22,25 +23,27 @@ interface ContextContainerProps {
 }
 
 const ContextContainer = ({ messages, children }: ContextContainerProps) => (
-  <HelmetProvider>
-    <LocaleProvider>
-      <AuthenticationProvider>
-        <LanguageProvider messages={messages}>
-          <ThemeProvider>
-            <ClientProvider>
-              <AppInsightsProvider>
-                <AuthorizationProvider>
-                  <MotionConfig reducedMotion="user">
-                    <Announcer>{children}</Announcer>
-                  </MotionConfig>
-                </AuthorizationProvider>
-              </AppInsightsProvider>
-            </ClientProvider>
-          </ThemeProvider>
-        </LanguageProvider>
-      </AuthenticationProvider>
-    </LocaleProvider>
-  </HelmetProvider>
+  <FeatureFlagProvider>
+    <HelmetProvider>
+      <LocaleProvider>
+        <AuthenticationProvider>
+          <LanguageProvider messages={messages}>
+            <ThemeProvider>
+              <ClientProvider>
+                <AppInsightsProvider>
+                  <AuthorizationProvider>
+                    <MotionConfig reducedMotion="user">
+                      <Announcer>{children}</Announcer>
+                    </MotionConfig>
+                  </AuthorizationProvider>
+                </AppInsightsProvider>
+              </ClientProvider>
+            </ThemeProvider>
+          </LanguageProvider>
+        </AuthenticationProvider>
+      </LocaleProvider>
+    </HelmetProvider>
+  </FeatureFlagProvider>
 );
 
 export default ContextContainer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -26302,7 +26302,12 @@
       "version": "1.0.0",
       "license": "AGPL-3.0",
       "devDependencies": {
+        "@swc/core": "^1.3.95",
+        "@types/react": "^18.2.33",
+        "eslint": "^8.52.0",
         "eslint-config-custom": "*",
+        "react": "^18.2.0",
+        "tsconfig": "*",
         "tsup": "^7.2.0",
         "typescript": "^5.1.3"
       }
@@ -28635,7 +28640,12 @@
     "@gc-digital-talent/env": {
       "version": "file:packages/env",
       "requires": {
+        "@swc/core": "^1.3.95",
+        "@types/react": "^18.2.33",
+        "eslint": "^8.52.0",
         "eslint-config-custom": "*",
+        "react": "^18.2.0",
+        "tsconfig": "*",
         "tsup": "^7.2.0",
         "typescript": "^5.1.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26544,6 +26544,7 @@
       "version": "0.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
+        "@gc-digital-talent/env": "*",
         "@gc-digital-talent/theme": "*",
         "@storybook/react": "^7.5.1",
         "chromatic": "^7.3.0",
@@ -28810,6 +28811,7 @@
       "version": "file:packages/storybook-helpers",
       "requires": {
         "@formatjs/ts-transformer": "^3.13.6",
+        "@gc-digital-talent/env": "*",
         "@gc-digital-talent/theme": "*",
         "@storybook/addon-a11y": "^7.5.1",
         "@storybook/addon-essentials": "^7.5.1",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -13,10 +13,16 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsup",
     "watch": "tsup --watch",
-    "lint": "eslint \"src/**/*.ts*\""
+    "lint": "eslint \"src/**/*.ts*\"",
+    "tsc": "tsc --project tsconfig.json --noEmit"
   },
   "devDependencies": {
+    "@swc/core": "^1.3.95",
+    "@types/react": "^18.2.33",
+    "eslint": "^8.52.0",
     "eslint-config-custom": "*",
+    "react": "^18.2.0",
+    "tsconfig": "*",
     "tsup": "^7.2.0",
     "typescript": "^5.1.3"
   }

--- a/packages/env/src/FeatureFlagProvider.tsx
+++ b/packages/env/src/FeatureFlagProvider.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import { getFeatureFlags, FeatureFlags } from "./utils";
+
+export const FeatureFlagContext = React.createContext(getFeatureFlags());
+
+interface FeatureFlagProviderProps {
+  children: React.ReactNode;
+  flags?: FeatureFlags;
+}
+
+const FeatureFlagProvider = ({ children, flags }: FeatureFlagProviderProps) => {
+  const featureFlags: FeatureFlags = React.useMemo(
+    () => ({
+      ...getFeatureFlags(),
+      ...(flags ?? {}),
+    }),
+    [flags],
+  );
+
+  return (
+    <FeatureFlagContext.Provider value={featureFlags}>
+      {children}
+    </FeatureFlagContext.Provider>
+  );
+};
+
+export default FeatureFlagProvider;

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,14 +1,17 @@
-import useFeatureFlags, { type FeatureFlags } from "./useFeatureFlags";
+import FeatureFlagProvider from "./FeatureFlagProvider";
+import useFeatureFlags from "./useFeatureFlags";
 import {
   getRuntimeVariable,
   getRuntimeVariableNotNull,
   checkFeatureFlag,
   getFeatureFlags,
+  type FeatureFlags,
 } from "./utils";
 
 export type { FeatureFlags };
 
 export {
+  FeatureFlagProvider,
   getRuntimeVariable,
   getRuntimeVariableNotNull,
   checkFeatureFlag,

--- a/packages/env/src/useFeatureFlags.ts
+++ b/packages/env/src/useFeatureFlags.ts
@@ -1,8 +1,9 @@
-import { getFeatureFlags } from "./utils";
+import React from "react";
 
-export type FeatureFlags = ReturnType<typeof getFeatureFlags>;
+import { FeatureFlagContext } from "./FeatureFlagProvider";
+
 const useFeatureFlags = () => {
-  return getFeatureFlags();
+  return React.useContext(FeatureFlagContext);
 };
 
 export default useFeatureFlags;

--- a/packages/env/src/utils.ts
+++ b/packages/env/src/utils.ts
@@ -44,3 +44,5 @@ export const getFeatureFlags = () => ({
   recordOfDecision: checkFeatureFlag("FEATURE_RECORD_OF_DECISION"),
   executiveTeaser: checkFeatureFlag("FEATURE_EXECUTIVE_TEASER"),
 });
+
+export type FeatureFlags = ReturnType<typeof getFeatureFlags>;

--- a/packages/env/tsconfig.json
+++ b/packages/env/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/lib.json",
+  "extends": "tsconfig/react-lib.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
@@ -7,5 +7,5 @@
     "lib": ["dom", "ES2015"]
   },
   "include": ["src"],
-  "exclude": ["node_modules"]
+  "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/storybook-helpers/decorators/FeatureFlagDecorator.tsx
+++ b/packages/storybook-helpers/decorators/FeatureFlagDecorator.tsx
@@ -1,0 +1,17 @@
+import { FeatureFlagProvider, FeatureFlags } from "@gc-digital-talent/env";
+import { useParameter } from "@storybook/addons";
+import { StoryFn } from "@storybook/react";
+
+const FeatureFlagDecorator = (Story: StoryFn) => {
+  const flags = useParameter<FeatureFlags | undefined>(
+    "featureFlags",
+    undefined,
+  );
+  return (
+    <FeatureFlagProvider {...{ flags }}>
+      <Story />
+    </FeatureFlagProvider>
+  );
+};
+
+export default FeatureFlagDecorator;

--- a/packages/storybook-helpers/index.ts
+++ b/packages/storybook-helpers/index.ts
@@ -1,3 +1,4 @@
+import FeatureFlagDecorator from "./decorators/FeatureFlagDecorator";
 import HelmetDecorator from "./decorators/HelmetDecorator";
 import MockGraphqlDecorator from "./decorators/MockGraphqlDecorator";
 import OverlayOrDialogDecorator from "./decorators/OverlayOrDialogDecorator";
@@ -11,6 +12,7 @@ import ThemeDecorator, {
 import { widthOf, heightOf } from "./utils";
 
 export {
+  FeatureFlagDecorator,
   HelmetDecorator,
   MockGraphqlDecorator,
   OverlayOrDialogDecorator,

--- a/packages/storybook-helpers/package.json
+++ b/packages/storybook-helpers/package.json
@@ -7,6 +7,7 @@
     "main.ts"
   ],
   "dependencies": {
+    "@gc-digital-talent/env": "*",
     "@gc-digital-talent/theme": "*",
     "@storybook/react": "^7.5.1",
     "chromatic": "^7.3.0",


### PR DESCRIPTION
🤖 Resolves #7097 

## 👋 Introduction

Adds the ability to check and control feature flags in storybook.

## 🕵️ Details

This does a two things:

- Moves feature flags to context
- Creates a decorator that adds the context to storybook, allowing users to override with `parameters.featureFlags`

### Override example

```tsx
export default {
  component: FeatureFlagComponent,
  title: "A Feature Flag Component",
  parameters: {
    featureFlags: {
      flag: true,
    }
  }
} as Meta;
```

## 🧪 Testing

> **Note**
> I found working with `ProfileAndApplicationsHeading` works well since it implements a feature flag that can be toggled and it is obvious.

1. Install and build `npm i && npm run dev`
2. Start storybook `npm run storybook:web`
3. Navigate to the story and confirm it appears as you expect
4. Add the feature flags parameter temporarily
5. Toggle the flag back and forth and confirm you see the expected result
