### PR TITLE
[Debt] Update support link in error summary

### DIFF
--- a/packages/forms/src/components/ErrorSummary.tsx
+++ b/packages/forms/src/components/ErrorSummary.tsx
@@ -9,7 +9,11 @@ import {
   ScrollLinkClickFunc,
   Link,
 } from "@gc-digital-talent/ui";
-import { commonMessages, errorMessages } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  errorMessages,
+  useLocale,
+} from "@gc-digital-talent/i18n";
 
 import type { FieldLabels } from "./BasicForm";
 import { flattenErrors } from "../utils";
@@ -94,8 +98,8 @@ interface ErrorSummaryProps {
   show: boolean;
 }
 
-const a = (chunks: React.ReactNode) => (
-  <Link external href="mailto:gctalent-talentgc@support-soutien.gc.ca">
+const supportLink = (chunks: React.ReactNode, locale: string) => (
+  <Link href={`/${locale}/support`} state={{ referrer: window.location.href }}>
     {chunks}
   </Link>
 );
@@ -105,6 +109,7 @@ const ErrorSummary = React.forwardRef<
   ErrorSummaryProps
 >(({ labels, show }, forwardedRef) => {
   const intl = useIntl();
+  const { locale } = useLocale();
   const { errors } = useFormState();
 
   // Don't show if the form is valid
@@ -153,7 +158,11 @@ const ErrorSummary = React.forwardRef<
         })}
       </ul>
       <Alert.Footer>
-        <p>{intl.formatMessage(errorMessages.summaryContact, { a })}</p>
+        <p>
+          {intl.formatMessage(errorMessages.summaryContact, {
+            a: (chunks: React.ReactNode) => supportLink(chunks, locale),
+          })}
+        </p>
       </Alert.Footer>
     </Alert.Root>
   ) : null;

--- a/packages/forms/src/components/ErrorSummary.tsx
+++ b/packages/forms/src/components/ErrorSummary.tsx
@@ -99,7 +99,11 @@ interface ErrorSummaryProps {
 }
 
 const supportLink = (chunks: React.ReactNode, locale: string) => (
-  <Link href={`/${locale}/support`} state={{ referrer: window.location.href }}>
+  <Link
+    href={`/${locale}/support`}
+    state={{ referrer: window.location.href }}
+    newTab
+  >
     {chunks}
   </Link>
 );


### PR DESCRIPTION
🤖 Resolves #8349 

## 👋 Introduction

This updates the support link in the error summary footer to go to `/support` instead of a `mailto`

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to a form and trigger the error summary
3. Confirm that clicking the support link takes you to the support page in the appropriate locale
