### PR TITLE
[Fix] Fix link dialog for rich text input

### DIFF
--- a/packages/forms/src/components/RichTextInput/LinkDialog.tsx
+++ b/packages/forms/src/components/RichTextInput/LinkDialog.tsx
@@ -29,7 +29,7 @@ const prependHttp = (url: string, https: boolean = false): string => {
     return transformedUrl;
   }
 
-  // Append to beginning of string if protoical does not exist
+  // Append to beginning of string if protocol does not exist
   return transformedUrl.replace(
     looseProtocolRegex,
     https ? "https://" : "http://",

--- a/packages/forms/src/components/RichTextInput/LinkDialog.tsx
+++ b/packages/forms/src/components/RichTextInput/LinkDialog.tsx
@@ -33,11 +33,11 @@ const LinkDialog = ({ editor }: LinkDialogProps) => {
   const intl = useIntl();
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
 
-  const handleSubmit: SubmitHandler<FormValues> = ({
-    href,
-    newTab,
-    action,
-  }) => {
+  const handleSubmit: SubmitHandler<FormValues> = (
+    { href, newTab, action },
+    e,
+  ) => {
+    e?.stopPropagation();
     if (action === "add") {
       editor
         ?.chain()
@@ -51,6 +51,7 @@ const LinkDialog = ({ editor }: LinkDialogProps) => {
       editor?.chain().focus().unsetLink().run();
     }
     setIsOpen(false);
+    return false;
   };
 
   const methods = useForm<FormValues>();
@@ -78,6 +79,13 @@ const LinkDialog = ({ editor }: LinkDialogProps) => {
     }
 
     setIsOpen(newOpen);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSave("add");
+    }
   };
 
   const isValidLink = (value: string) => {
@@ -121,6 +129,7 @@ const LinkDialog = ({ editor }: LinkDialogProps) => {
                     name="href"
                     type="text"
                     label={intl.formatMessage(richTextMessages.url)}
+                    onKeyDown={handleKeyDown}
                     rules={{
                       required: intl.formatMessage(errorMessages.required),
                       validate: {

--- a/packages/forms/src/components/RichTextInput/LinkDialog.tsx
+++ b/packages/forms/src/components/RichTextInput/LinkDialog.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { createIntlCache, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 import { Editor } from "@tiptap/react";
 import { useForm, FormProvider, SubmitHandler } from "react-hook-form";
 import LinkIcon from "@heroicons/react/20/solid/LinkIcon";

--- a/packages/forms/src/components/RichTextInput/LinkDialog.tsx
+++ b/packages/forms/src/components/RichTextInput/LinkDialog.tsx
@@ -62,15 +62,21 @@ const LinkDialog = ({ editor }: LinkDialogProps) => {
   };
 
   const handleOpenChange = (newOpen: boolean) => {
-    const attributes = editor?.getAttributes("link");
-    if (newOpen && (attributes?.href || attributes?.target)) {
-      if (attributes?.href) {
-        methods.setValue("href", attributes.href);
+    if (newOpen) {
+      const attributes = editor?.getAttributes("link");
+      if (newOpen && (attributes?.href || attributes?.target)) {
+        if (attributes?.href) {
+          methods.setValue("href", attributes.href);
+        }
+        if (attributes?.target) {
+          methods.setValue("newTab", attributes.target === "_blank");
+        }
       }
-      if (attributes?.target) {
-        methods.setValue("newTab", attributes.target === "_blank");
-      }
+    } else {
+      methods.resetField("href");
+      methods.resetField("newTab");
     }
+
     setIsOpen(newOpen);
   };
 


### PR DESCRIPTION
🤖 Resolves #8341 

## 👋 Introduction

This fixes a few bugs and adds a quality of life improvement to the link dialog in the rich text input.

## 🕵️ Details

There were two bugs fixed in this:

- Pressing "Enter" no longer submits the parent form ( https://github.com/GCTC-NTGC/gc-digital-talent/commit/b77747a491b1810aeb4ec52cab6e85d438734290 )
- Form is reset when closing the dialog  ( https://github.com/GCTC-NTGC/gc-digital-talent/commit/57bc9e792968b80441301d448b4260ddd318e551 )

As well, the link dialog now does not require a protocol. If one is not present, it will prepend the URL with `http://`.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/admin/pools`
3. Click "Create pool" and continue to edit page or, edit an existing draft pool
4. Open one of the forms that contain a rich text input (your impact, work tasks, after you apply, etc.)
5. Type in some text, select it and then click on the "Link" button in the toolbar
6. Type in an invalid URL and press "Enter"
7. Confirm you get an error for the link but not the parent form
8. Type in an valid URL with no protocol (google.com)
9. Confirm submitting works
10. Reopen the link dialog
11. Confirm `http://` was prepended to the URL
12. Repeat steps 8-10 but with a specific protocol
13. Confirm an additional protocol is not prepended to the URL