### PR TITLE
[Feature] Add version link to footer

### DIFF
--- a/apps/web/src/components/Footer/Footer.tsx
+++ b/apps/web/src/components/Footer/Footer.tsx
@@ -4,8 +4,6 @@ import { useIntl } from "react-intl";
 
 import { Link, LinkProps } from "@gc-digital-talent/ui";
 
-import { VERSION } from "~/constants/talentSearchConstants";
-
 import { CanadaLogo, CanadaLogoWhite } from "../Svg";
 import VersionLink from "./VersionLink";
 

--- a/apps/web/src/components/Footer/Footer.tsx
+++ b/apps/web/src/components/Footer/Footer.tsx
@@ -4,7 +4,10 @@ import { useIntl } from "react-intl";
 
 import { Link, LinkProps } from "@gc-digital-talent/ui";
 
+import { VERSION } from "~/constants/talentSearchConstants";
+
 import { CanadaLogo, CanadaLogoWhite } from "../Svg";
+import VersionLink from "./VersionLink";
 
 interface FooterProps {
   width?: string;
@@ -108,21 +111,24 @@ const Footer = ({ width }: FooterProps) => {
                 data-h2-color="base(black.70) base:dark(white.70)"
                 data-h2-font-size="base(caption)"
               >
-                {intl.formatMessage(
-                  {
-                    defaultMessage: "Date Modified: {modifiedDate}",
-                    id: "Fc/i3e",
-                    description:
-                      "Header for the sites last date modification found in the footer.",
-                  },
-                  {
-                    modifiedDate: new Date(
-                      process.env.BUILD_DATE ?? "1970-01-01",
-                    )
-                      .toISOString()
-                      .slice(0, 10),
-                  },
-                )}
+                <span>
+                  {intl.formatMessage(
+                    {
+                      defaultMessage: "Date Modified: {modifiedDate}",
+                      id: "Fc/i3e",
+                      description:
+                        "Header for the sites last date modification found in the footer.",
+                    },
+                    {
+                      modifiedDate: new Date(
+                        process.env.BUILD_DATE ?? "1970-01-01",
+                      )
+                        .toISOString()
+                        .slice(0, 10),
+                    },
+                  )}
+                </span>
+                <VersionLink />
               </p>
             </div>
           </div>

--- a/apps/web/src/components/Footer/VersionLink.tsx
+++ b/apps/web/src/components/Footer/VersionLink.tsx
@@ -6,9 +6,14 @@ import { commonMessages } from "@gc-digital-talent/i18n";
 
 const VersionLink = () => {
   const intl = useIntl();
-  let content = process.env.COMMIT_HASH;
+  let content;
+  let url;
   if (process.env.VERSION) {
     content = process.env.VERSION;
+    url = `https://github.com/GCTC-NTGC/gc-digital-talent/releases/tag/${process.env.VERSION}`;
+  } else if (process.env.COMMIT_HASH) {
+    content = process.env.COMMIT_HASH;
+    url = `https://github.com/GCTC-NTGC/gc-digital-talent/commit/${process.env.COMMIT_HASH}`;
   }
 
   if (!content) {
@@ -25,13 +30,7 @@ const VersionLink = () => {
         description: "Label for the specific version number of the site",
       })}
       {intl.formatMessage(commonMessages.dividingColon)}
-      <Link
-        external
-        fontSize="caption"
-        href={`https://github.com/GCTC-NTGC/gc-digital-talent/releases${
-          process.env.VERSION ? `/tag/${process.env.VERSION}` : ``
-        }`}
-      >
+      <Link external fontSize="caption" href={url}>
         {content}
       </Link>
     </span>

--- a/apps/web/src/components/Footer/VersionLink.tsx
+++ b/apps/web/src/components/Footer/VersionLink.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { Link } from "@gc-digital-talent/ui";
+import { commonMessages } from "@gc-digital-talent/i18n";
+
+const VersionLink = () => {
+  const intl = useIntl();
+  let content = process.env.COMMIT_HASH;
+  if (process.env.VERSION) {
+    content = process.env.VERSION;
+  }
+
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <span>
+      {" "}
+      &mdash;{" "}
+      {intl.formatMessage({
+        id: "C3fUwm",
+        defaultMessage: "Version",
+        description: "Label for the specific version number of the site",
+      })}
+      {intl.formatMessage(commonMessages.dividingColon)}
+      <Link
+        external
+        fontSize="caption"
+        href={`https://github.com/GCTC-NTGC/gc-digital-talent/releases${
+          process.env.VERSION ? `/tags/${process.env.VERSION}` : ``
+        }`}
+      >
+        {content}
+      </Link>
+    </span>
+  );
+};
+
+export default VersionLink;

--- a/apps/web/src/components/Footer/VersionLink.tsx
+++ b/apps/web/src/components/Footer/VersionLink.tsx
@@ -29,7 +29,7 @@ const VersionLink = () => {
         external
         fontSize="caption"
         href={`https://github.com/GCTC-NTGC/gc-digital-talent/releases${
-          process.env.VERSION ? `/tags/${process.env.VERSION}` : ``
+          process.env.VERSION ? `/tag/${process.env.VERSION}` : ``
         }`}
       >
         {content}

--- a/apps/web/src/constants/talentSearchConstants.ts
+++ b/apps/web/src/constants/talentSearchConstants.ts
@@ -3,4 +3,3 @@ export const TALENTSEARCH_SUPPORT_EMAIL =
   "gctalent-talentgc@support-soutien.gc.ca";
 export const API_SUPPORT_ENDPOINT =
   (process.env.API_SUPPORT_ENDPOINT as string) ?? "/api/support/tickets";
-export const VERSION = (process.env.VERSION as string) ?? false;

--- a/apps/web/src/constants/talentSearchConstants.ts
+++ b/apps/web/src/constants/talentSearchConstants.ts
@@ -3,3 +3,4 @@ export const TALENTSEARCH_SUPPORT_EMAIL =
   "gctalent-talentgc@support-soutien.gc.ca";
 export const API_SUPPORT_ENDPOINT =
   (process.env.API_SUPPORT_ENDPOINT as string) ?? "/api/support/tickets";
+export const VERSION = (process.env.VERSION as string) ?? false;

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2518,6 +2518,10 @@
     "defaultMessage": "Cette section vous permet de gérer toutes les compétences comportementales associées à votre profil, vos expériences et vos réalisations. Cliquez sur le nom d’une compétence pour obtenir une description détaillée.",
     "description": "Description on how to use behavioural skills"
   },
+  "C3fUwm": {
+    "defaultMessage": "Version",
+    "description": "Label for the specific version number of the site"
+  },
   "C43ZgD": {
     "defaultMessage": "La plupart des offres d’emploi ne nécessiteront pas de note spéciale. Cette section est réservée à des circonstances particulières. Cette note spéciale peut notamment servir à indiquer si un processus peut être utilisé pour embaucher dans plusieurs classifications ou non et si le processus est limité aux candidatures d’un groupe visé par l’équité en matière d’emploi spécifique.",
     "description": "Describes the 'special note' section of a process' advertisement."

--- a/apps/web/src/lang/whitelist.yml
+++ b/apps/web/src/lang/whitelist.yml
@@ -33,4 +33,4 @@
 - HX/Tj+ # 'Secret' - Secret screening level
 - Raho+z # 'Questionnaire' - Heading for the Questionnaire section on the digital services contracting questionnaire
 - a5FZSP # 'Variable' - Contract start timeframe is variable
-
+- C3fUwm # 'Version' - App version number in the footer

--- a/packages/webpack-config/webpack.base.js
+++ b/packages/webpack-config/webpack.base.js
@@ -19,7 +19,16 @@ const meta = {
   type: "website",
 };
 
+const gitCommand = (cmd) => {
+  return require('child_process')
+    .execSync('git ' + cmd)
+    .toString()
+    .trim()
+}
+
 module.exports = (basePath) => {
+  let version = gitCommand('describe --abbrev=0');
+  let commitHash = gitCommand('rev-parse --short HEAD');
   return {
     plugins: [
       // process and copy CSS files
@@ -54,6 +63,8 @@ module.exports = (basePath) => {
           TALENTSEARCH_SUPPORT_EMAIL: JSON.stringify(
             process.env.TALENTSEARCH_SUPPORT_EMAIL,
           ),
+          VERSION: JSON.stringify(version),
+          COMMIT_HASH: JSON.stringify(commitHash)
         },
       }),
 

--- a/packages/webpack-config/webpack.base.js
+++ b/packages/webpack-config/webpack.base.js
@@ -20,15 +20,29 @@ const meta = {
 };
 
 const gitCommand = (cmd) => {
-  return require('child_process')
-    .execSync('git ' + cmd)
-    .toString()
-    .trim()
+  let result;
+  try {
+    result = require('child_process')
+      .execSync('git ' + cmd);
+  } catch (err) {
+    console.log(err);
+  }
+
+
+  if (result) {
+    result = result.toString()
+      .trim()
+  }
+
+  return result;
 }
 
 module.exports = (basePath) => {
-  let version = gitCommand('describe --abbrev=0');
-  let commitHash = gitCommand('rev-parse --short HEAD');
+  let version, commitHash;
+  if (gitCommand("--version")) {
+    version = gitCommand('describe --abbrev=0');
+    commitHash = gitCommand('rev-parse --short HEAD');
+  }
   return {
     plugins: [
       // process and copy CSS files
@@ -63,8 +77,8 @@ module.exports = (basePath) => {
           TALENTSEARCH_SUPPORT_EMAIL: JSON.stringify(
             process.env.TALENTSEARCH_SUPPORT_EMAIL,
           ),
-          VERSION: JSON.stringify(version),
-          COMMIT_HASH: JSON.stringify(commitHash)
+          VERSION: version ? JSON.stringify(version) : undefined,
+          COMMIT_HASH: commitHash ? JSON.stringify(commitHash) : undefined
         },
       }),
 


### PR DESCRIPTION
🤖 Resolves #4691 

## 👋 Introduction

Adds a link to the footer that shows the current tag or commit hash (if they exist).

## 🕵️ Details

This only works with annotated tags. If there is no annotated tag, it falls back to the commit hash.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Scroll to the footer and confirm you see the version link and it functions as expected

## 📸 Screenshot

![Screenshot 2023-10-30 105155](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/5cd9f08a-73c6-4bd7-a1ef-7cb275633588)
