### PR TITLE
[Fix] Update directive form to support field arrays in error summary

### DIFF
--- a/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/fieldsSets/PersonnelRequirementFieldset.tsx
+++ b/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/fieldsSets/PersonnelRequirementFieldset.tsx
@@ -137,7 +137,7 @@ const PersonnelRequirementFieldset = ({
         id={`${fieldsetName}.resourceType`}
         name={`${fieldsetName}.resourceType`}
         type="text"
-        label={labels.resourceType}
+        label={labels["personnelRequirements.*.resourceType"]}
         rules={{
           required: intl.formatMessage(errorMessages.required),
         }}
@@ -285,7 +285,7 @@ const PersonnelRequirementFieldset = ({
       <Select
         id={`${fieldsetName}.language`}
         name={`${fieldsetName}.language`}
-        label={labels.language}
+        label={labels["personnelRequirements.*.language"]}
         nullSelection={intl.formatMessage(formMessages.defaultPlaceholder)}
         rules={{
           required: intl.formatMessage(errorMessages.required),
@@ -306,7 +306,7 @@ const PersonnelRequirementFieldset = ({
           id={`${fieldsetName}.languageOther`}
           name={`${fieldsetName}.languageOther`}
           type="text"
-          label={labels.languageOther}
+          label={labels["personnelRequirements.*.languageOther"]}
           rules={{
             required: intl.formatMessage(errorMessages.required),
           }}
@@ -315,7 +315,7 @@ const PersonnelRequirementFieldset = ({
       <Select
         id={`${fieldsetName}.security`}
         name={`${fieldsetName}.security`}
-        label={labels.security}
+        label={labels["personnelRequirements.*.security"]}
         nullSelection={intl.formatMessage(formMessages.defaultPlaceholder)}
         rules={{
           required: intl.formatMessage(errorMessages.required),
@@ -336,7 +336,7 @@ const PersonnelRequirementFieldset = ({
           id={`${fieldsetName}.securityOther`}
           name={`${fieldsetName}.securityOther`}
           type="text"
-          label={labels.securityOther}
+          label={labels["personnelRequirements.*.securityOther"]}
           rules={{
             required: intl.formatMessage(errorMessages.required),
           }}
@@ -345,7 +345,7 @@ const PersonnelRequirementFieldset = ({
       <Select
         id={`${fieldsetName}.telework`}
         name={`${fieldsetName}.telework`}
-        label={labels.telework}
+        label={labels["personnelRequirements.*.telework"]}
         nullSelection={intl.formatMessage(formMessages.defaultPlaceholder)}
         rules={{
           required: intl.formatMessage(errorMessages.required),
@@ -365,7 +365,7 @@ const PersonnelRequirementFieldset = ({
         id={`${fieldsetName}.quantity`}
         name={`${fieldsetName}.quantity`}
         type="number"
-        label={labels.quantity}
+        label={labels["personnelRequirements.*.quantity"]}
         rules={{
           required: intl.formatMessage(errorMessages.required),
           min: {

--- a/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/useLabels.ts
+++ b/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/useLabels.ts
@@ -317,43 +317,43 @@ const getLabels = (intl: IntlShape) => {
     }),
 
     // Personnel requirements section
-    resourceType: intl.formatMessage({
+    "personnelRequirements.*.resourceType": intl.formatMessage({
       defaultMessage: "Type of personnel",
       id: "Yik/xN",
       description:
         "Label for _type of resource_ fieldset in the _digital services contracting questionnaire_",
     }),
-    language: intl.formatMessage({
+    "personnelRequirements.*.language": intl.formatMessage({
       defaultMessage: "Official language requirement",
       id: "gZKJeF",
       description:
         "Label for _official language requirement_ fieldset in the _digital services contracting questionnaire_",
     }),
-    languageOther: intl.formatMessage({
+    "personnelRequirements.*.languageOther": intl.formatMessage({
       defaultMessage: "Please specify the language requirement",
       id: "P6jGb4",
       description:
         "Label for _other official language requirement_ fieldset in the _digital services contracting questionnaire_",
     }),
-    security: intl.formatMessage({
+    "personnelRequirements.*.security": intl.formatMessage({
       defaultMessage: "Security level",
       id: "zemp3H",
       description:
         "Label for _security level_ fieldset in the _digital services contracting questionnaire_",
     }),
-    securityOther: intl.formatMessage({
+    "personnelRequirements.*.securityOther": intl.formatMessage({
       defaultMessage: "Please specify the security level",
       id: "yXWaAj",
       description:
         "Label for _other security level_ fieldset in the _digital services contracting questionnaire_",
     }),
-    telework: intl.formatMessage({
+    "personnelRequirements.*.telework": intl.formatMessage({
       defaultMessage: "Telework allowed",
       id: "DeQTkE",
       description:
         "Label for _telework option_ fieldset in the _digital services contracting questionnaire_",
     }),
-    quantity: intl.formatMessage({
+    "personnelRequirements.*.quantity": intl.formatMessage({
       defaultMessage: "Quantity",
       id: "5yv4Ko",
       description:


### PR DESCRIPTION
🤖 Resolves #7814 

## 👋 Introduction

This updates the directive form labels with the wildcard approach for field arrays so they appear in the error summary.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/directive-on-digital-talent/digital-services-contracting-questionnaire`
3. Fill out the form ensuring the following (to force an error)
  - _Does the contract have specific personnel requirements?_  -> Yes
  - Add at least one personnel requirement, leaving it entirely blank\
4. Submit the form
5. Confirm error summary appears with errors for the nested fields

## 📸 Screenshot

![Screenshot 2023-10-30 134602](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/8aeb2f23-dcae-439e-afa4-5ee8c1831b42)
