### PR TITLE
[Fix] Prevent table resetting parameters

### DIFF
--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -135,6 +135,7 @@ const ResponsiveTable = <TData extends object>({
       ...state,
       rowSelection,
     },
+    autoResetPageIndex: false,
     enableGlobalFilter: isInternalSearch,
     enableRowSelection: !!rowSelect,
     enableSorting: !!sort,
@@ -185,7 +186,9 @@ const ResponsiveTable = <TData extends object>({
         (previous) => {
           const newParams = new URLSearchParams(previous);
 
-          if (isEqual(sortingState, sort?.initialState ?? [])) {
+          const initialSortState =
+            sort?.initialState ?? INITIAL_STATE.sortState;
+          if (isEqual(sortingState, initialSortState)) {
             newParams.delete(SEARCH_PARAM_KEY.SORT_RULE);
           } else {
             newParams.set(
@@ -203,7 +206,10 @@ const ResponsiveTable = <TData extends object>({
             );
           }
 
-          if (paginationState.pageSize === pagination?.initialState?.pageSize) {
+          const initialPageSize =
+            pagination?.initialState?.pageSize ??
+            INITIAL_STATE.paginationState.pageSize;
+          if (paginationState.pageSize === initialPageSize) {
             newParams.delete(SEARCH_PARAM_KEY.PAGE_SIZE);
           } else {
             newParams.set(
@@ -212,11 +218,10 @@ const ResponsiveTable = <TData extends object>({
             );
           }
 
-          if (
-            paginationState.pageIndex === pagination?.initialState?.pageIndex
-              ? pagination.initialState.pageIndex + 1
-              : 0
-          ) {
+          const initialPageIndex =
+            pagination?.initialState?.pageIndex ??
+            INITIAL_STATE.paginationState.pageIndex;
+          if (paginationState.pageIndex === initialPageIndex) {
             newParams.delete(SEARCH_PARAM_KEY.PAGE);
           } else {
             newParams.set(
@@ -225,7 +230,9 @@ const ResponsiveTable = <TData extends object>({
             );
           }
 
-          if (isEqual(search?.initialState, searchState)) {
+          const initialSearchState =
+            search?.initialState ?? INITIAL_STATE.searchState;
+          if (isEqual(initialSearchState, searchState)) {
             newParams.delete(SEARCH_PARAM_KEY.SEARCH_COLUMN);
             newParams.delete(SEARCH_PARAM_KEY.SEARCH_TERM);
           } else if (columnFilterState.length > 0) {

--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -108,15 +108,16 @@ const ResponsiveTable = <TData extends object>({
     data,
     rowSelect,
   );
-  const { state, initialState, updaters } = useControlledTableState({
-    columnIds,
-    initialState: {
-      hiddenColumnIds,
-      searchState: search?.initialState,
-      sortState: sort?.initialState,
-      paginationState: pagination?.initialState,
-    },
-  });
+  const { state, initialState, initialParamState, updaters } =
+    useControlledTableState({
+      columnIds,
+      initialState: {
+        hiddenColumnIds,
+        searchState: search?.initialState,
+        sortState: sort?.initialState,
+        paginationState: pagination?.initialState,
+      },
+    });
 
   const manualPageSize = !pagination?.internal
     ? Math.ceil(
@@ -129,6 +130,7 @@ const ResponsiveTable = <TData extends object>({
   const table = useReactTable({
     data,
     columns: memoizedColumns,
+    initialState,
     state: {
       ...state,
       rowSelection,
@@ -289,7 +291,7 @@ const ResponsiveTable = <TData extends object>({
           <SearchForm
             id={`${id}-search`}
             table={table}
-            state={initialState.searchState}
+            state={initialParamState.searchState}
             searchBy={searchColumns}
             {...search}
           />

--- a/apps/web/src/components/Table/ResponsiveTable/SearchForm.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/SearchForm.tsx
@@ -46,7 +46,7 @@ const SearchForm = <T,>({
 
   const updateTable = React.useCallback(
     (newState: SearchState) => {
-      table.resetPageIndex(); // Go to first page when searching
+      table.resetPageIndex(true); // Go to first page when searching
       if (newState.type && newState.type !== "") {
         table.setGlobalFilter("");
         table.setColumnFilters([

--- a/apps/web/src/components/Table/ResponsiveTable/useControlledTableState.ts
+++ b/apps/web/src/components/Table/ResponsiveTable/useControlledTableState.ts
@@ -99,7 +99,8 @@ export const useTableStateFromSearchParams = (
 };
 
 type UseControlledTableStateReturn = {
-  initialState: Partial<InitialState>;
+  initialParamState: Partial<InitialState>;
+  initialState: Partial<TableState>;
   state: Partial<TableState>;
   updaters: {
     onColumnFiltersChange?: OnChangeFn<ColumnFiltersState>;
@@ -174,6 +175,26 @@ const useControlledTableState: UseControlledTableState = ({
   const handlePaginationChange = (updater: Updater<PaginationState>) =>
     updateState(setPagination, updater);
 
+  const memoizedInitialState: Partial<TableState> = useMemo(
+    () => ({
+      columnFilters: getColumnFilters(initialStateFromParams.searchState),
+      globalFilter: initialStateFromParams.searchState?.term,
+      columnVisibility: getColumnVisibility(
+        columnIds,
+        initialStateFromParams.hiddenColumnIds,
+      ),
+      pagination: initialStateFromParams.paginationState,
+      sorting: initialStateFromParams.sortState ?? INITIAL_STATE.sortState,
+    }),
+    [
+      columnIds,
+      initialStateFromParams.hiddenColumnIds,
+      initialStateFromParams.paginationState,
+      initialStateFromParams.searchState,
+      initialStateFromParams.sortState,
+    ],
+  );
+
   const memoizedState: Partial<TableState> = useMemo(
     () => ({
       columnFilters,
@@ -186,7 +207,8 @@ const useControlledTableState: UseControlledTableState = ({
   );
 
   return {
-    initialState: initialStateFromParams,
+    initialParamState: initialStateFromParams,
+    initialState: memoizedInitialState,
     state: memoizedState,
     updaters: {
       onColumnFiltersChange: handleColumnFiltersChange,


### PR DESCRIPTION
🤖 Resolves #8343 

## 👋 Introduction

Fixes the new `<ResponsiveTable />` resetting some state variables on initial page load.

## 🕵️ Details

Looks like we forgot to supply the table with `initialState` when it exists. This meant that our table was starting out with an empty state. Then, when that state did not match our current state, it tried to overwrite the URL and use that to update our controlled state.

Simply providing the table with an initial state prevents that. 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run `npm run dev`
2. Navigate to `/admin/skills`
3. Change the state, confirm URL updates
4. Navigate away from that page
5. Click the browser back button
6. Confirm the URL matches that in step 3
7. Confirm the table state matches the URL state with expected date