### PR TITLE
[Feature] Combobox and formatting changes in add team member dialog

### DIFF
--- a/apps/web/src/pages/Teams/TeamMembersPage/components/AddTeamMemberDialog.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/AddTeamMemberDialog.tsx
@@ -4,7 +4,7 @@ import { useIntl } from "react-intl";
 import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
 
 import { Dialog, Button } from "@gc-digital-talent/ui";
-import { MultiSelectField, Select } from "@gc-digital-talent/forms";
+import { Combobox, MultiSelectField, Select } from "@gc-digital-talent/forms";
 import { toast } from "@gc-digital-talent/toast";
 import {
   commonMessages,
@@ -20,7 +20,7 @@ import {
   UserPublicProfile,
   useUpdateUserTeamRolesMutation,
 } from "~/api/generated";
-import { getFullNameLabel } from "~/utils/nameUtils";
+import { getFullNameAndEmailLabel } from "~/utils/nameUtils";
 
 import { TeamMemberFormValues } from "./types";
 import { getTeamBasedRoleOptions } from "./utils";
@@ -95,7 +95,12 @@ AddTeamMemberDialogProps) => {
   const roleOptions = getTeamBasedRoleOptions(availableRoles, intl);
   const userOptions = availableUsers?.map((user) => ({
     value: user.id,
-    label: getFullNameLabel(user.firstName, user.lastName, intl),
+    label: getFullNameAndEmailLabel(
+      user.firstName,
+      user.lastName,
+      user.email,
+      intl,
+    ),
   }));
 
   const label = intl.formatMessage({
@@ -132,14 +137,9 @@ AddTeamMemberDialogProps) => {
                 data-h2-flex-direction="base(column)"
                 data-h2-gap="base(x1 0)"
               >
-                <Select
+                <Combobox
                   id="userId"
                   name="userId"
-                  nullSelection={
-                    fetchingUsers
-                      ? intl.formatMessage(commonMessages.loading)
-                      : intl.formatMessage(uiMessages.nullSelectionOption)
-                  }
                   disabled={fetchingUsers}
                   rules={{
                     required: intl.formatMessage(errorMessages.required),

--- a/apps/web/src/pages/Teams/teamsOperations.graphql
+++ b/apps/web/src/pages/Teams/teamsOperations.graphql
@@ -180,6 +180,7 @@ query AllUsersNames {
     id
     firstName
     lastName
+    email
   }
 }
 

--- a/apps/web/src/utils/nameUtils.tsx
+++ b/apps/web/src/utils/nameUtils.tsx
@@ -32,6 +32,45 @@ export const getFullNameLabel = (
   return `${firstName} ${lastName}`;
 };
 
+export const getFullNameAndEmailLabel = (
+  firstName: string | null | undefined,
+  lastName: string | null | undefined,
+  email: string | null | undefined,
+  intl: IntlShape,
+): string => {
+  const emailDefined =
+    email ??
+    intl.formatMessage({
+      defaultMessage: "No email provided",
+      id: "1JCjTP",
+      description: "Fallback for email value",
+    });
+
+  if (!firstName && !lastName) {
+    return `${intl.formatMessage({
+      defaultMessage: "No name provided",
+      id: "n80lVV",
+      description: "Fallback for name value",
+    })} - ${emailDefined}`;
+  }
+
+  if (!firstName) {
+    return `${intl.formatMessage({
+      defaultMessage: "No first name provided",
+      id: "ZLPqdF",
+      description: "Fallback for first name value",
+    })} ${lastName} - ${emailDefined}`;
+  }
+  if (!lastName) {
+    return `${firstName} ${intl.formatMessage({
+      defaultMessage: "No last name provided",
+      id: "r7lf0k",
+      description: "Fallback for last name value",
+    })} - ${emailDefined}`;
+  }
+  return `${firstName} ${lastName} - ${emailDefined}`;
+};
+
 export const getFullNameHtml = (
   firstName: string | null | undefined,
   lastName: string | null | undefined,


### PR DESCRIPTION
🤖 Resolves #8243

## 👋 Introduction

Replace the select with the combobox, and add email to the label formatting. 

## 🧪 Testing

1. Head to a team and then the view team member page
2. Observe the dialog's inputs and add people to teams after searching for them

## 📸 Screenshot

Formatted user labels

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/3703c1f3-4faa-4310-a3e7-ccec24463af0)

Searched for and found a correctly labelled user missing email

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/39b9c8d1-af34-4630-8fdf-3d9a8c454320)



