### PR TITLE
[Debt] Removes `latestPoolCandidateSearchRequests` query

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -790,16 +790,6 @@ type Query {
     @deprecated(
       reason: "poolCandidateSearchRequests is deprecated. Use poolCandidateSearchRequestsPaginated instead. Remove in #7659."
     )
-  latestPoolCandidateSearchRequests(
-    limit: Int @limit
-  ): [PoolCandidateSearchRequest]!
-    @all
-    @orderBy(column: "created_at", direction: DESC)
-    @guard
-    @can(ability: "viewAny")
-    @deprecated(
-      reason: "latestPoolCandidateSearchRequests is deprecated. Use poolCandidateSearchRequestsPaginated instead. Remove in #7655."
-    )
   poolCandidateSearchRequestsPaginated(
     where: PoolCandidateSearchRequestInput
     orderBy: [OrderByClause!] @orderBy

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -32,7 +32,6 @@ type Query {
   applicantFilters: [ApplicantFilter]! @deprecated(reason: "applicantFilters is deprecated. Use poolCandidateSearchRequest.applicantFilter instead. Remove in #7654.")
   poolCandidateSearchRequest(id: ID!): PoolCandidateSearchRequest
   poolCandidateSearchRequests(limit: Int): [PoolCandidateSearchRequest]! @deprecated(reason: "poolCandidateSearchRequests is deprecated. Use poolCandidateSearchRequestsPaginated instead. Remove in #7659.")
-  latestPoolCandidateSearchRequests(limit: Int): [PoolCandidateSearchRequest]! @deprecated(reason: "latestPoolCandidateSearchRequests is deprecated. Use poolCandidateSearchRequestsPaginated instead. Remove in #7655.")
   skillFamily(id: UUID!): SkillFamily
   skillFamilies: [SkillFamily]!
   skill(id: UUID!): Skill


### PR DESCRIPTION
🤖 Resolves #7655.

## 👋 Introduction

This PR removes the `latestPoolCandidateSearchRequests` query, that is no longer used, from the GraphQL schema.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Confirm there are no instances or references to the query `latestPoolCandidateSearchRequests` left in the codebase