### PR TITLE
[Fix] Properly assign `aria-selected` to multi select combobox

### DIFF
--- a/packages/forms/src/components/Combobox/Menu.tsx
+++ b/packages/forms/src/components/Combobox/Menu.tsx
@@ -115,6 +115,7 @@ const Item = React.forwardRef<HTMLLIElement, ItemProps>(
   ({ active, selected, children, ...rest }, forwardedRef) => (
     <li
       ref={forwardedRef}
+      role="option"
       data-h2-display="base(flex)"
       data-h2-align-items="base(center)"
       data-h2-gap="base(0 x.25)"

--- a/packages/forms/src/components/Combobox/Menu.tsx
+++ b/packages/forms/src/components/Combobox/Menu.tsx
@@ -3,12 +3,12 @@ import { useIntl } from "react-intl";
 import CheckIcon from "@heroicons/react/20/solid/CheckIcon";
 import ArrowPathIcon from "@heroicons/react/24/solid/ArrowPathIcon";
 import { motion, useReducedMotion } from "framer-motion";
+import omit from "lodash/omit";
 
 import { formMessages, uiMessages } from "@gc-digital-talent/i18n";
 
 import useCommonInputStyles from "../../hooks/useCommonInputStyles";
 import { HTMLSpanProps } from "./types";
-import omit from "lodash/omit";
 
 type WrapperProps = React.DetailedHTMLProps<
   React.HTMLAttributes<HTMLDivElement>,

--- a/packages/forms/src/components/Combobox/Menu.tsx
+++ b/packages/forms/src/components/Combobox/Menu.tsx
@@ -8,6 +8,7 @@ import { formMessages, uiMessages } from "@gc-digital-talent/i18n";
 
 import useCommonInputStyles from "../../hooks/useCommonInputStyles";
 import { HTMLSpanProps } from "./types";
+import omit from "lodash/omit";
 
 type WrapperProps = React.DetailedHTMLProps<
   React.HTMLAttributes<HTMLDivElement>,
@@ -133,7 +134,8 @@ const Item = React.forwardRef<HTMLLIElement, ItemProps>(
       {...(active && {
         "data-h2-background-color": "base(focus)",
       })}
-      {...rest}
+      {...omit(rest, "aria-selected")}
+      aria-selected={selected ? "true" : "false"}
     >
       {selected && (
         <CheckIcon data-h2-height="base(1rem)" data-h2-width="base(1rem)" />


### PR DESCRIPTION
🤖 Resolves #8424 

## 👋 Introduction

This fixes a bug where downshift was applying `aria-selected=true` to the highlighted item and not the selected item.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run storybook `npm run storybook:design-system`
2. Navigate to the multi combobox story
3. Open the dropdown and select some items
4. Confirm only the selected items in the list have `aria-selected` set to `true`
