### PR TITLE
[Feature] Card Option Group Component

### DIFF
--- a/axe-linter.yml
+++ b/axe-linter.yml
@@ -27,3 +27,4 @@ global-components:
   Submit: button[type="submit"]
   TextArea: textarea
   BasicForm: form
+  CardOptionGroup: fieldset

--- a/packages/forms/src/components/CardOptionGroup/CardOptionGroup.stories.tsx
+++ b/packages/forms/src/components/CardOptionGroup/CardOptionGroup.stories.tsx
@@ -15,12 +15,27 @@ export default {
 
 const TemplateCardOptionGroup: StoryFn<typeof CardOptionGroup> = (args) => {
   return (
-    <Form onSubmit={action("Submit Form")}>
-      <CardOptionGroup {...args} />
-      <p data-h2-margin-top="base(x1)">
-        <Submit />
-      </p>
-    </Form>
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(1fr 1fr)"
+    >
+      <div data-h2="light" data-h2-background="base(background)">
+        <Form onSubmit={action("Submit Form")}>
+          <CardOptionGroup {...args} name="light" idPrefix="light" />
+          <p data-h2-margin-top="base(x1)">
+            <Submit />
+          </p>
+        </Form>
+      </div>
+      <div data-h2="dark" data-h2-background="base(background)">
+        <Form onSubmit={action("Submit Form")}>
+          <CardOptionGroup {...args} name="dark" idPrefix="dark" />
+          <p data-h2-margin-top="base(x1)">
+            <Submit />
+          </p>
+        </Form>
+      </div>
+    </div>
   );
 };
 

--- a/packages/forms/src/components/CardOptionGroup/CardOptionGroup.stories.tsx
+++ b/packages/forms/src/components/CardOptionGroup/CardOptionGroup.stories.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { StoryFn } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import SolidTrashIcon from "@heroicons/react/24/solid/TrashIcon";
+import OutlineTrashIcon from "@heroicons/react/24/outline/TrashIcon";
+
+import Form from "../BasicForm";
+import Submit from "../Submit";
+import CardOptionGroup from "./CardOptionGroup";
+
+export default {
+  component: CardOptionGroup,
+  title: "Form/CardOptionGroup",
+};
+
+const TemplateCardOptionGroup: StoryFn<typeof CardOptionGroup> = (args) => {
+  return (
+    <Form onSubmit={action("Submit Form")}>
+      <CardOptionGroup {...args} />
+      <p data-h2-margin-top="base(x1)">
+        <Submit />
+      </p>
+    </Form>
+  );
+};
+
+export const BasicCardOptionGroup = TemplateCardOptionGroup.bind({});
+BasicCardOptionGroup.args = {
+  idPrefix: "CardOptiongroup",
+  legend: "Which item do you want to check?",
+  name: "CardOptiongroup",
+  items: [
+    {
+      value: "one",
+      label: "Box One",
+      unselectedIcon: OutlineTrashIcon,
+      selectedIcon: SolidTrashIcon,
+      selectedIconColor: "warning",
+    },
+    {
+      value: "two",
+      label: "Box Two",
+      unselectedIcon: OutlineTrashIcon,
+      selectedIcon: SolidTrashIcon,
+      selectedIconColor: "error",
+    },
+    // { value: "three", label: "Box Three" },
+  ],
+};

--- a/packages/forms/src/components/CardOptionGroup/CardOptionGroup.stories.tsx
+++ b/packages/forms/src/components/CardOptionGroup/CardOptionGroup.stories.tsx
@@ -1,17 +1,29 @@
 import React from "react";
 import { StoryFn } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import SolidTrashIcon from "@heroicons/react/24/solid/TrashIcon";
-import OutlineTrashIcon from "@heroicons/react/24/outline/TrashIcon";
+import SolidHandThumbUpIcon from "@heroicons/react/24/solid/HandThumbUpIcon";
+import OutlineHandThumbUpIcon from "@heroicons/react/24/outline/HandThumbUpIcon";
 
 import Form from "../BasicForm";
 import Submit from "../Submit";
-import CardOptionGroup from "./CardOptionGroup";
+import CardOptionGroup, { CardOption } from "./CardOptionGroup";
 
 export default {
   component: CardOptionGroup,
   title: "Form/CardOptionGroup",
 };
+
+const colors: Array<CardOption["selectedIconColor"]> = [
+  "primary",
+  "secondary",
+  "tertiary",
+  "quaternary",
+  "quinary",
+  "success",
+  "warning",
+  "error",
+  "black",
+];
 
 const TemplateCardOptionGroup: StoryFn<typeof CardOptionGroup> = (args) => {
   return (
@@ -21,7 +33,12 @@ const TemplateCardOptionGroup: StoryFn<typeof CardOptionGroup> = (args) => {
     >
       <div data-h2="light" data-h2-background="base(background)">
         <Form onSubmit={action("Submit Form")}>
-          <CardOptionGroup {...args} name="light" idPrefix="light" />
+          <CardOptionGroup
+            {...args}
+            name="light"
+            idPrefix="light"
+            rules={{ required: "This field is required" }}
+          />
           <p data-h2-margin-top="base(x1)">
             <Submit />
           </p>
@@ -29,7 +46,12 @@ const TemplateCardOptionGroup: StoryFn<typeof CardOptionGroup> = (args) => {
       </div>
       <div data-h2="dark" data-h2-background="base(background)">
         <Form onSubmit={action("Submit Form")}>
-          <CardOptionGroup {...args} name="dark" idPrefix="dark" />
+          <CardOptionGroup
+            {...args}
+            name="dark"
+            idPrefix="dark"
+            rules={{ required: "This field is also required" }}
+          />
           <p data-h2-margin-top="base(x1)">
             <Submit />
           </p>
@@ -39,26 +61,16 @@ const TemplateCardOptionGroup: StoryFn<typeof CardOptionGroup> = (args) => {
   );
 };
 
-export const BasicCardOptionGroup = TemplateCardOptionGroup.bind({});
-BasicCardOptionGroup.args = {
-  idPrefix: "CardOptiongroup",
+export const Default = TemplateCardOptionGroup.bind({});
+Default.args = {
+  idPrefix: "CardOptionGroup",
   legend: "Which item do you want to check?",
-  name: "CardOptiongroup",
-  items: [
-    {
-      value: "one",
-      label: "Box One",
-      unselectedIcon: OutlineTrashIcon,
-      selectedIcon: SolidTrashIcon,
-      selectedIconColor: "warning",
-    },
-    {
-      value: "two",
-      label: "Box Two",
-      unselectedIcon: OutlineTrashIcon,
-      selectedIcon: SolidTrashIcon,
-      selectedIconColor: "error",
-    },
-    // { value: "three", label: "Box Three" },
-  ],
+  name: "CardOptionGroup",
+  items: colors.map<CardOption>((color) => ({
+    value: color,
+    label: color,
+    unselectedIcon: OutlineHandThumbUpIcon,
+    selectedIcon: SolidHandThumbUpIcon,
+    selectedIconColor: color,
+  })),
 };

--- a/packages/forms/src/components/CardOptionGroup/CardOptionGroup.stories.tsx
+++ b/packages/forms/src/components/CardOptionGroup/CardOptionGroup.stories.tsx
@@ -13,6 +13,8 @@ export default {
   title: "Form/CardOptionGroup",
 };
 
+const themes = ["light", "dark"];
+
 const colors: Array<CardOption["selectedIconColor"]> = [
   "primary",
   "secondary",
@@ -31,32 +33,26 @@ const TemplateCardOptionGroup: StoryFn<typeof CardOptionGroup> = (args) => {
       data-h2-display="base(grid)"
       data-h2-grid-template-columns="base(1fr 1fr)"
     >
-      <div data-h2="light" data-h2-background="base(background)">
-        <Form onSubmit={action("Submit Form")}>
-          <CardOptionGroup
-            {...args}
-            name="light"
-            idPrefix="light"
-            rules={{ required: "This field is required" }}
-          />
-          <p data-h2-margin-top="base(x1)">
-            <Submit />
-          </p>
-        </Form>
-      </div>
-      <div data-h2="dark" data-h2-background="base(background)">
-        <Form onSubmit={action("Submit Form")}>
-          <CardOptionGroup
-            {...args}
-            name="dark"
-            idPrefix="dark"
-            rules={{ required: "This field is also required" }}
-          />
-          <p data-h2-margin-top="base(x1)">
-            <Submit />
-          </p>
-        </Form>
-      </div>
+      {themes.map((theme) => (
+        <div
+          data-h2={theme}
+          data-h2-background="base(background)"
+          data-h2-padding="base(x1)"
+          key={theme}
+        >
+          <Form onSubmit={action("Submit Form")}>
+            <CardOptionGroup
+              {...args}
+              name={theme}
+              idPrefix={theme}
+              rules={{ required: "This field is required" }}
+            />
+            <p data-h2-margin-top="base(x1)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      ))}
     </div>
   );
 };

--- a/packages/forms/src/components/CardOptionGroup/CardOptionGroup.tsx
+++ b/packages/forms/src/components/CardOptionGroup/CardOptionGroup.tsx
@@ -169,7 +169,13 @@ const CardOptionGroup = ({
         aria-describedby={ariaDescribedBy}
         {...rest}
       >
-        <Field.Legend required={!!rules.required}>{legend}</Field.Legend>
+        <Field.Legend
+          required={!!rules.required}
+          data-h2-color="base(black)"
+          data-h2-margin-bottom="base(x.5)"
+        >
+          {legend}
+        </Field.Legend>
         {items.map(
           ({
             value,
@@ -212,6 +218,7 @@ const CardOptionGroup = ({
                   data-h2-margin-bottom="base(x.25)"
                   htmlFor={id}
                   data-h2-cursor="base(pointer)"
+                  data-h2-color="base(black)"
                 >
                   <Icon data-h2-height="base(x1)" data-h2-width="base(x1)" />
                   <span>{label}</span>

--- a/packages/forms/src/components/CardOptionGroup/CardOptionGroup.tsx
+++ b/packages/forms/src/components/CardOptionGroup/CardOptionGroup.tsx
@@ -143,12 +143,11 @@ const CardOptionGroup = ({
         id={idPrefix}
         aria-describedby={ariaDescribedBy}
         {...rest}
+        data-h2-display="base(flex)"
+        data-h2-flex-direction="base(column)"
+        data-h2-gap="base(x.25)"
       >
-        <Field.Legend
-          required={!!rules.required}
-          data-h2-color="base(black)"
-          data-h2-margin-bottom="base(x.5)"
-        >
+        <Field.Legend required={!!rules.required} data-h2-color="base(black)">
           {legend}
         </Field.Legend>
         {items.map(
@@ -163,7 +162,7 @@ const CardOptionGroup = ({
             const isSelected = selectedValue === value;
             const Icon = isSelected ? selectedIcon : unselectedIcon;
             return (
-              <div key={value}>
+              <React.Fragment key={value}>
                 <input
                   id={id}
                   {...register(name, rules)}
@@ -177,7 +176,7 @@ const CardOptionGroup = ({
                   data-h2-height="base(0)"
                   data-h2-width="base(0)"
                   // style the sibling label when focused and/or checked
-                  data-h2-background-color="base:focus-visible:children[+ label](focus)"
+                  data-h2-background-color="base:children[+ label](foreground) base:focus-visible:children[+ label](focus)"
                   data-h2-font-weight="base:selectors[:checked]:children[+ label](700)"
                   data-h2-border="base:selectors[:checked]:children[+ label](2px solid black)"
                   // color the sibling label's icon when focused and/or checked
@@ -185,12 +184,11 @@ const CardOptionGroup = ({
                 />
                 <Field.Label
                   data-h2-display="base(flex)"
+                  data-h2-padding="base(x.5)"
                   data-h2-align-items="base(center)"
                   data-h2-gap="base(x.5)"
-                  data-h2-padding="base(x.5)"
-                  data-h2-shadow="base(s)"
+                  data-h2-shadow="base(large)"
                   data-h2-radius="base(s)"
-                  data-h2-margin-bottom="base(x.25)"
                   htmlFor={id}
                   data-h2-cursor="base(pointer)"
                   data-h2-color="base(black)"
@@ -198,7 +196,7 @@ const CardOptionGroup = ({
                   <Icon data-h2-height="base(x1)" data-h2-width="base(x1)" />
                   <span>{label}</span>
                 </Field.Label>
-              </div>
+              </React.Fragment>
             );
           },
         )}

--- a/packages/forms/src/components/CardOptionGroup/CardOptionGroup.tsx
+++ b/packages/forms/src/components/CardOptionGroup/CardOptionGroup.tsx
@@ -193,7 +193,6 @@ const CardOptionGroup = ({
                   // hide the input - this radio group does not show the radio buttons
                   data-h2-position="base(absolute)"
                   data-h2-opacity="base(0)"
-                  data-h2-cursor="base(pointer)"
                   data-h2-height="base(0)"
                   data-h2-width="base(0)"
                   // style the sibling label when focused and/or checked
@@ -210,7 +209,9 @@ const CardOptionGroup = ({
                   data-h2-padding="base(x.5)"
                   data-h2-shadow="base(s)"
                   data-h2-radius="base(s)"
+                  data-h2-margin-bottom="base(x.25)"
                   htmlFor={id}
+                  data-h2-cursor="base(pointer)"
                 >
                   <Icon data-h2-height="base(x1)" data-h2-width="base(x1)" />
                   <span>{label}</span>

--- a/packages/forms/src/components/CardOptionGroup/CardOptionGroup.tsx
+++ b/packages/forms/src/components/CardOptionGroup/CardOptionGroup.tsx
@@ -1,0 +1,228 @@
+import * as React from "react";
+import get from "lodash/get";
+import { FieldError, useFormContext } from "react-hook-form";
+
+import { Color, IconType } from "@gc-digital-talent/ui";
+
+import Field from "../Field";
+import type { CommonInputProps, HTMLFieldsetProps } from "../../types";
+import useFieldState from "../../hooks/useFieldState";
+import useInputDescribedBy from "../../hooks/useInputDescribedBy";
+
+export type CardOption = {
+  value: string;
+  label: string | React.ReactNode;
+  unselectedIcon: IconType;
+  selectedIcon: IconType;
+  selectedIconColor: Color;
+};
+
+const getIconStyle = (color: Color): Record<string, string> => {
+  if (color === "primary") {
+    return {
+      "data-h2-color": `
+          base:children[+ label>svg](black)
+          base:selectors[:checked]:children[+ label>svg](primary.dark)
+          base:focus-visible:children[+ label>svg](black)`,
+    };
+  }
+  if (color === "secondary") {
+    return {
+      "data-h2-color": `
+          base:children[+ label>svg](black)
+          base:selectors[:checked]:children[+ label>svg](secondary.dark)
+          base:focus-visible:children[+ label>svg](black)`,
+    };
+  }
+  if (color === "tertiary") {
+    return {
+      "data-h2-color": `
+          base:children[+ label>svg](black)
+          base:selectors[:checked]:children[+ label>svg](tertiary.dark)
+          base:focus-visible:children[+ label>svg](black)`,
+    };
+  }
+  if (color === "quaternary") {
+    return {
+      "data-h2-color": `
+          base:children[+ label>svg](black)
+          base:selectors[:checked]:children[+ label>svg](quaternary.dark)
+          base:focus-visible:children[+ label>svg](black)`,
+    };
+  }
+  if (color === "quinary") {
+    return {
+      "data-h2-color": `
+          base:children[+ label>svg](black)
+          base:selectors[:checked]:children[+ label>svg](quinary.dark)
+          base:focus-visible:children[+ label>svg](black)`,
+    };
+  }
+  if (color === "success") {
+    return {
+      "data-h2-color": `
+          base:children[+ label>svg](black)
+          base:selectors[:checked]:children[+ label>svg](success.dark)
+          base:focus-visible:children[+ label>svg](black)`,
+    };
+  }
+  if (color === "warning") {
+    return {
+      "data-h2-color": `
+          base:children[+ label>svg](black)
+          base:selectors[:checked]:children[+ label>svg](warning.dark)
+          base:focus-visible:children[+ label>svg](black)`,
+    };
+  }
+  if (color === "error") {
+    return {
+      "data-h2-color": `
+          base:children[+ label>svg](black)
+          base:selectors[:checked]:children[+ label>svg](error.dark)
+          base:focus-visible:children[+ label>svg](black)`,
+    };
+  }
+  if (color === "black") {
+    return {
+      "data-h2-color": `
+          base:children[+ label>svg](black)
+          base:selectors[:checked]:children[+ label>svg](black.dark)
+          base:focus-visible:children[+ label>svg](black)`,
+    };
+  }
+  if (color === "white") {
+    return {
+      "data-h2-color": `
+          base:children[+ label>svg](black)
+          base:selectors[:checked]:children[+ label>svg](white.dark)
+          base:focus-visible:children[+ label>svg](black)`,
+    };
+  }
+
+  return {
+    "data-h2-color": `
+      base:children[+ label>svg](black)
+      base:selectors[:checked]:children[+ label>svg](black.dark)
+      base:focus-visible:children[+ label>svg](black)`,
+  };
+};
+
+export type CardOptionGroupProps = Omit<CommonInputProps, "id" | "label"> &
+  HTMLFieldsetProps & {
+    /** Each input element will be given an id to match to its label, of the form `${idPrefix}-${value}` */
+    idPrefix: string;
+    /** Holds text for the legend associated with the CardOptionGroup fieldset. */
+    legend: React.ReactNode;
+    /** A list of value and label representing the CardOptions shown.
+     * The form will represent the data at `name` as a string containing the chosen value. */
+    items: CardOption[];
+    /** If set to the value of an input element that element will start selected */
+    defaultSelected?: string;
+    /** If true, all input elements in this fieldset will be disabled. */
+    disabled?: boolean;
+    /** ID of a field description (help text) */
+    describedBy?: string;
+  };
+
+/**
+ * Must be part of a form controlled by react-hook-form.
+ * The form will represent the data at `name` as an array, containing the values of the checked boxes.
+ */
+const CardOptionGroup = ({
+  idPrefix,
+  legend,
+  name,
+  items,
+  rules = {},
+  context,
+  defaultSelected,
+  trackUnsaved = true,
+  describedBy,
+  disabled,
+  ...rest
+}: CardOptionGroupProps) => {
+  const {
+    register,
+    watch,
+    formState: { errors },
+  } = useFormContext();
+  // To grab errors in nested objects we need to use lodash's get helper.
+  const error = get(errors, name)?.message as FieldError;
+  const fieldState = useFieldState(name, !trackUnsaved);
+  const isUnsaved = fieldState === "dirty" && trackUnsaved;
+  const [descriptionIds, ariaDescribedBy] = useInputDescribedBy({
+    id: idPrefix,
+    describedBy,
+    show: {
+      error,
+      unsaved: trackUnsaved && isUnsaved,
+      context,
+    },
+  });
+
+  const selectedValue = watch(name);
+
+  return (
+    <Field.Wrapper>
+      <Field.Fieldset
+        id={idPrefix}
+        aria-describedby={ariaDescribedBy}
+        {...rest}
+      >
+        <Field.Legend required={!!rules.required}>{legend}</Field.Legend>
+        {items.map(
+          ({
+            value,
+            label,
+            unselectedIcon,
+            selectedIcon,
+            selectedIconColor,
+          }) => {
+            const id = `${idPrefix}-${value}`;
+            const isSelected = selectedValue === value;
+            const Icon = isSelected ? selectedIcon : unselectedIcon;
+            return (
+              <div key={value}>
+                <input
+                  id={id}
+                  {...register(name, rules)}
+                  value={value}
+                  type="radio"
+                  disabled={disabled}
+                  defaultChecked={defaultSelected === value}
+                  // hide the input - this radio group does not show the radio buttons
+                  data-h2-position="base(absolute)"
+                  data-h2-opacity="base(0)"
+                  data-h2-cursor="base(pointer)"
+                  data-h2-height="base(0)"
+                  data-h2-width="base(0)"
+                  // style the sibling label when focused and/or checked
+                  data-h2-background-color="base:focus-visible:children[+ label](focus)"
+                  data-h2-font-weight="base:selectors[:checked]:children[+ label](700)"
+                  data-h2-border="base:selectors[:checked]:children[+ label](2px solid black)"
+                  // color the sibling label's icon when focused and/or checked
+                  {...getIconStyle(selectedIconColor)}
+                />
+                <Field.Label
+                  data-h2-display="base(flex)"
+                  data-h2-align-items="base(center)"
+                  data-h2-gap="base(x.5)"
+                  data-h2-padding="base(x.5)"
+                  data-h2-shadow="base(s)"
+                  data-h2-radius="base(s)"
+                  htmlFor={id}
+                >
+                  <Icon data-h2-height="base(x1)" data-h2-width="base(x1)" />
+                  <span>{label}</span>
+                </Field.Label>
+              </div>
+            );
+          },
+        )}
+      </Field.Fieldset>
+      <Field.Descriptions ids={descriptionIds} {...{ error, context }} />
+    </Field.Wrapper>
+  );
+};
+
+export default CardOptionGroup;

--- a/packages/forms/src/components/CardOptionGroup/CardOptionGroup.tsx
+++ b/packages/forms/src/components/CardOptionGroup/CardOptionGroup.tsx
@@ -9,102 +9,77 @@ import type { CommonInputProps, HTMLFieldsetProps } from "../../types";
 import useFieldState from "../../hooks/useFieldState";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
 
+type IconColor = Exclude<Color, "white">;
+
 export type CardOption = {
+  /** form value */
   value: string;
+  /** label beside the icon */
   label: string | React.ReactNode;
+  /** icon when unselected - usually the outline version of the selected icon */
   unselectedIcon: IconType;
+  /** icon when selected - usually the solid version of the unselected icon */
   selectedIcon: IconType;
-  selectedIconColor: Color;
+  /** icon color when selected */
+  selectedIconColor: IconColor;
 };
 
-const getIconStyle = (color: Color): Record<string, string> => {
-  if (color === "primary") {
-    return {
-      "data-h2-color": `
+const siblingIconColor: Record<IconColor, Record<string, string>> = {
+  primary: {
+    "data-h2-color": `
           base:children[+ label>svg](black)
           base:selectors[:checked]:children[+ label>svg](primary.dark)
           base:focus-visible:children[+ label>svg](black)`,
-    };
-  }
-  if (color === "secondary") {
-    return {
-      "data-h2-color": `
-          base:children[+ label>svg](black)
-          base:selectors[:checked]:children[+ label>svg](secondary.dark)
-          base:focus-visible:children[+ label>svg](black)`,
-    };
-  }
-  if (color === "tertiary") {
-    return {
-      "data-h2-color": `
-          base:children[+ label>svg](black)
-          base:selectors[:checked]:children[+ label>svg](tertiary.dark)
-          base:focus-visible:children[+ label>svg](black)`,
-    };
-  }
-  if (color === "quaternary") {
-    return {
-      "data-h2-color": `
-          base:children[+ label>svg](black)
-          base:selectors[:checked]:children[+ label>svg](quaternary.dark)
-          base:focus-visible:children[+ label>svg](black)`,
-    };
-  }
-  if (color === "quinary") {
-    return {
-      "data-h2-color": `
-          base:children[+ label>svg](black)
-          base:selectors[:checked]:children[+ label>svg](quinary.dark)
-          base:focus-visible:children[+ label>svg](black)`,
-    };
-  }
-  if (color === "success") {
-    return {
-      "data-h2-color": `
-          base:children[+ label>svg](black)
-          base:selectors[:checked]:children[+ label>svg](success.dark)
-          base:focus-visible:children[+ label>svg](black)`,
-    };
-  }
-  if (color === "warning") {
-    return {
-      "data-h2-color": `
-          base:children[+ label>svg](black)
-          base:selectors[:checked]:children[+ label>svg](warning.dark)
-          base:focus-visible:children[+ label>svg](black)`,
-    };
-  }
-  if (color === "error") {
-    return {
-      "data-h2-color": `
-          base:children[+ label>svg](black)
-          base:selectors[:checked]:children[+ label>svg](error.dark)
-          base:focus-visible:children[+ label>svg](black)`,
-    };
-  }
-  if (color === "black") {
-    return {
-      "data-h2-color": `
-          base:children[+ label>svg](black)
-          base:selectors[:checked]:children[+ label>svg](black.dark)
-          base:focus-visible:children[+ label>svg](black)`,
-    };
-  }
-  if (color === "white") {
-    return {
-      "data-h2-color": `
-          base:children[+ label>svg](black)
-          base:selectors[:checked]:children[+ label>svg](white.dark)
-          base:focus-visible:children[+ label>svg](black)`,
-    };
-  }
+  },
 
-  return {
+  secondary: {
     "data-h2-color": `
-      base:children[+ label>svg](black)
-      base:selectors[:checked]:children[+ label>svg](black.dark)
-      base:focus-visible:children[+ label>svg](black)`,
-  };
+        base:children[+ label>svg](black)
+        base:selectors[:checked]:children[+ label>svg](secondary.dark)
+        base:focus-visible:children[+ label>svg](black)`,
+  },
+  tertiary: {
+    "data-h2-color": `
+        base:children[+ label>svg](black)
+        base:selectors[:checked]:children[+ label>svg](tertiary.dark)
+        base:focus-visible:children[+ label>svg](black)`,
+  },
+  quaternary: {
+    "data-h2-color": `
+        base:children[+ label>svg](black)
+        base:selectors[:checked]:children[+ label>svg](quaternary.dark)
+        base:focus-visible:children[+ label>svg](black)`,
+  },
+  quinary: {
+    "data-h2-color": `
+        base:children[+ label>svg](black)
+        base:selectors[:checked]:children[+ label>svg](quinary.dark)
+        base:focus-visible:children[+ label>svg](black)`,
+  },
+  success: {
+    "data-h2-color": `
+        base:children[+ label>svg](black)
+        base:selectors[:checked]:children[+ label>svg](success.dark)
+        base:focus-visible:children[+ label>svg](black)`,
+  },
+  warning: {
+    "data-h2-color": `
+        base:children[+ label>svg](black)
+        base:selectors[:checked]:children[+ label>svg](warning.dark)
+        base:focus-visible:children[+ label>svg](black)`,
+  },
+  error: {
+    "data-h2-color": `
+        base:children[+ label>svg](black)
+        base:selectors[:checked]:children[+ label>svg](error.dark)
+        base:focus-visible:children[+ label>svg](black)`,
+  },
+  black: {
+    "data-h2-color": `
+        base:children[+ label>svg](black)
+        base:selectors[:checked]:children[+ label>svg](black)
+        base:focus-visible:children[+ label>svg](black)`,
+  },
 };
 
 export type CardOptionGroupProps = Omit<CommonInputProps, "id" | "label"> &
@@ -206,7 +181,7 @@ const CardOptionGroup = ({
                   data-h2-font-weight="base:selectors[:checked]:children[+ label](700)"
                   data-h2-border="base:selectors[:checked]:children[+ label](2px solid black)"
                   // color the sibling label's icon when focused and/or checked
-                  {...getIconStyle(selectedIconColor)}
+                  {...siblingIconColor[selectedIconColor]}
                 />
                 <Field.Label
                   data-h2-display="base(flex)"

--- a/packages/forms/src/components/CardOptionGroup/index.ts
+++ b/packages/forms/src/components/CardOptionGroup/index.ts
@@ -1,0 +1,5 @@
+import CardOptionGroup from "./CardOptionGroup";
+import type { CardOptionGroupProps, CardOption } from "./CardOptionGroup";
+
+export default CardOptionGroup;
+export type { CardOptionGroupProps, CardOption };


### PR DESCRIPTION
🤖 Resolves #8223 

## 👋 Introduction

This branch introduces the new Card Option Group that can be used as a radio group in a form.  Note that the checkbox behaviour was removed from the issue scope.  I suppose it will be added (or have the option card factored out) later.  Also note that there were no dark mode designs but I tried to support it anyway.

## 🧪 Testing

Load up storybook:design-system and find the CardOptionGroup story.

- [ ] Properly submits the option in a form.
- [ ] Looks like the Figma design.
- [ ] Focus behaviour works properly.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/026d60e7-51d5-496b-aa26-b026fb8eeb7b)