### PR TITLE
[Design] Fix accessibility statement page layout

### DIFF
--- a/apps/web/src/components/Hero/Hero.tsx
+++ b/apps/web/src/components/Hero/Hero.tsx
@@ -133,7 +133,13 @@ const Hero = ({
           data-h2-container="base(center, large, x1) p-tablet(center, large, x2)"
           data-h2-layer="base(3, relative)"
         >
-          <div data-h2-color="base:all(white)" {...textAlignment}>
+          <div
+            data-h2-color="base:all(white)"
+            {...textAlignment}
+            {...(showImg && {
+              "data-h2-margin-right": "l-tablet(x18)",
+            })}
+          >
             <Heading
               ref={headingRef}
               tabIndex={-1}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1619,6 +1619,10 @@
     "defaultMessage": "Activez le mode sombre",
     "description": "Button text to set theme mode to dark"
   },
+  "7+GPYf": {
+    "defaultMessage": "Des évaluations avec de réels utilisateurs",
+    "description": "Heading for how we test accessibility."
+  },
   "706kTz": {
     "defaultMessage": "Exigences en matière de compétences",
     "description": "Title for skill requirements section of a pool advertisement"
@@ -2186,6 +2190,10 @@
   "ASNC88": {
     "defaultMessage": "Exigence en matière de sécurité",
     "description": "Label displayed on the edit pool form security requirement field."
+  },
+  "ASYJlr": {
+    "defaultMessage": "Notre application Web doit s’adapter aisément à différentes tailles d’écran et permettre à nos utilisateurs d’accéder à la plateforme sur des appareils qui répondent à leurs besoins. Chaque fonctionnalité que nous créons doit être accessible, mais, comme pour préparer une bonne assiette de nachos, il faut les bons ingrédients pour commencer. Nous partons donc de ces ingrédients pratiques : ",
+    "description": "Lead in text for list of items we consider for accessibility"
   },
   "ATO0GK": {
     "defaultMessage": "Tâches courantes dans ce poste",
@@ -3442,10 +3450,6 @@
   "HBuWZ0": {
     "defaultMessage": "Titre de l’emploi",
     "description": "Title for job title for a position"
-  },
-  "HCWGjZ": {
-    "defaultMessage": "<strong>Des évaluations avec de réels utilisateurs.</strong> Avant que nous considérions qu'un produit est prêt à être lancé, nous travaillons avec <fableLink>Fable Tech Labs</fableLink> pour nous assurer que nos produits et nos fonctionnalités sont évalués par des utilisateurs qui ont besoin de technologies informatiques adaptées pour accéder au Web. Il s'agit d'une étape importante pour s'assurer que nos produits conviennent à de vraies personnes.",
-    "description": "Text describing our user testing for accessibility"
   },
   "HDiUEc": {
     "defaultMessage": "État d'expiration",
@@ -6679,6 +6683,10 @@
     "defaultMessage": "Je suis actuellement actif dans cette expérience.",
     "description": "Label displayed on Personal Experience form for current experience input"
   },
+  "agcOO1": {
+    "defaultMessage": "Rendre nos produits accessibles et utilisables par tous",
+    "description": "Heading for the items we consider for accessibility."
+  },
   "agiL8L": {
     "defaultMessage": "Afficher les candidatures en cours ({applicationCount})",
     "description": "Heading for applications in progress accordion on profile and applications."
@@ -7098,10 +7106,6 @@
   "d8CQJr": {
     "defaultMessage": " Création réussie de la famille de compétences!",
     "description": "Message displayed to user after skill family is created successfully."
-  },
-  "d8FGfc": {
-    "defaultMessage": "<strong>Rendre nos produits accessibles et utilisables par tous.</strong> Notre application Web doit s’adapter aisément à différentes tailles d’écran et permettre à nos utilisateurs d’accéder à la plateforme sur des appareils qui répondent à leurs besoins. Chaque fonctionnalité que nous créons doit être accessible, mais, comme pour préparer une bonne assiette de nachos, il faut les bons ingrédients pour commencer. Nous partons donc de ces ingrédients pratiques : ",
-    "description": "Lead in text for list of items we consider for accessibility"
   },
   "d8j/Sr": {
     "defaultMessage": "Processus de recrutement auxquels vous vous êtes qualifié(e)",
@@ -7686,6 +7690,10 @@
   "gC74ro": {
     "defaultMessage": "Parcourez les emplois",
     "description": "Breadcrumb title for the browse pools page."
+  },
+  "gEnOmo": {
+    "defaultMessage": "Avant que nous considérions qu'un produit est prêt à être lancé, nous travaillons avec <fableLink>Fable Tech Labs</fableLink> pour nous assurer que nos produits et nos fonctionnalités sont évalués par des utilisateurs qui ont besoin de technologies informatiques adaptées pour accéder au Web. Il s'agit d'une étape importante pour s'assurer que nos produits conviennent à de vraies personnes.",
+    "description": "Text describing our user testing for accessibility"
   },
   "gHMj31": {
     "defaultMessage": "Aucune expérience trouvée",

--- a/apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.tsx
+++ b/apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { Heading, Link } from "@gc-digital-talent/ui";
+import { Heading, Link, TableOfContents } from "@gc-digital-talent/ui";
 import { getLocale, Locales } from "@gc-digital-talent/i18n";
 
 import Hero from "~/components/Hero";
@@ -200,6 +200,11 @@ const tollFreeLink = (chunks: React.ReactNode) => (
   </Link>
 );
 
+type Section = {
+  id: string;
+  title: React.ReactNode;
+};
+
 const AccessibilityStatementPage = () => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -211,12 +216,48 @@ const AccessibilityStatementPage = () => {
     description: "Title for the websites accessibility statement",
   });
 
+  const sections: Section[] = [
+    {
+      id: "standards",
+      title: intl.formatMessage({
+        defaultMessage: "Our standards",
+        id: "vC9NsS",
+        description: "Title for the accessibility standards",
+      }),
+    },
+    {
+      id: "by-choice",
+      title: intl.formatMessage({
+        defaultMessage: "Accessible by choice and by design",
+        id: "ztQSF+",
+        description: "Title for the accessible by design section",
+      }),
+    },
+    {
+      id: "feedback",
+      title: intl.formatMessage({
+        defaultMessage: "Feedback and contact information",
+        id: "6bvAQ+",
+        description: "Title for the accessibility feedback section",
+      }),
+    },
+    {
+      id: "compliance",
+      title: intl.formatMessage({
+        defaultMessage: "Proactive compliance and enforcement framework",
+        id: "quxa4Q",
+        description: "Title for the compliance enforcement section.",
+      }),
+    },
+  ];
+
   const crumbs = useBreadcrumbs([
     {
       label: pageTitle,
       url: paths.accessibility(),
     },
   ]);
+
   return (
     <>
       <Hero
@@ -230,401 +271,407 @@ const AccessibilityStatementPage = () => {
         })}
         crumbs={crumbs}
       />
-      <div data-h2-padding="base(x3, 0)">
-        <div
-          data-h2-container="base(center, small, x1) p-tablet(center, small, x2)"
-          data-h2-margin="base:children[p:not(:first-child), ul](x1, 0, 0, 0)"
-        >
-          <p>
-            {intl.formatMessage(
-              {
-                id: "fzqya3",
-                defaultMessage:
-                  "<abbreviation>GC</abbreviation> Digital Talent is committed to building an accessible and inclusive digital service. At the heart of our platform design and development is an endeavour to create equal employment opportunities for all. To us, building accessible services means meeting the needs of as many people as possible, including edge cases. We are working across all disciplines - research, development, design, and accessibility - to ensure our service is intentional, accessible, and inclusive.",
-                description: "Opening paragraph for accessibility statement",
-              },
-              {
-                abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
-              },
-            )}
-          </p>
-          <Heading level="h2" size="h3" data-h2-margin="base(x2, 0, x1, 0)">
-            {intl.formatMessage({
-              defaultMessage: "Our standards",
-              id: "vC9NsS",
-              description: "Title for the accessibility standards",
-            })}
-          </Heading>
-          <p>
-            {intl.formatMessage(
-              {
-                defaultMessage:
-                  "The GC Digital Talent team follows inclusive <digitalStandardsLink>Government of Canada Digital Standards</digitalStandardsLink>.",
-                id: "tu2Z17",
-                description: "Paragraph describing accessibility standards",
-              },
-              {
-                digitalStandardsLink: (chunks: React.ReactNode) =>
-                  digitalStandardsLink(locale, chunks),
-              },
-            )}
-          </p>
-          <Heading level="h2" size="h3" data-h2-margin="base(x2, 0, x1, 0)">
-            {intl.formatMessage({
-              defaultMessage: "Accessible by choice and by design",
-              id: "ztQSF+",
-              description: "Title for the accessible by design section",
-            })}
-          </Heading>
-          <p>
-            {intl.formatMessage(
-              {
-                id: "5Cwvgi",
-                defaultMessage:
-                  "While <wcagLink>Web Content Accessibility Guidelines (WCAG) 2.1</wcagLink> AA standards set out a baseline for conformance, audits from real users allow us to deliver beyond the minimum requirements. Accessibility is considered at every stage of our product design and development cycle. We try to make sure everyone has a pleasant experience on our platform.",
-                description:
-                  "Paragraph describing accessibility at every level of development",
-              },
-              { wcagLink },
-            )}
-          </p>
-          <p>
-            {intl.formatMessage({
-              id: "d8FGfc",
-              defaultMessage:
-                "<strong>Making our products accessible and usable by all.</strong> Our web application should adjust smoothly to various screen sizes and allow our users to access the platform on devices that meet their needs. Every feature we build needs to be accessible, but like making a great plate of nachos, you need the right ingredients to even get started. We start with these practical ingredients:",
-              description:
-                "Lead in text for list of items we consider for accessibility",
-            })}
-          </p>
-          <ul>
-            <li>
-              {intl.formatMessage({
-                defaultMessage: "Our designers pay attention to:",
-                id: "Iodi0/",
-                description:
-                  "Intro to list of items designers consider for accessibility",
-              })}
+      <div data-h2-container="base(center, large, x1) p-tablet(center, large, x2)">
+        <TableOfContents.Wrapper data-h2-margin-top="base(x3)">
+          <TableOfContents.Navigation>
+            <TableOfContents.List>
+              {sections.map((section) => (
+                <TableOfContents.ListItem key={section.id}>
+                  <TableOfContents.AnchorLink id={section.id}>
+                    {section.title}
+                  </TableOfContents.AnchorLink>
+                </TableOfContents.ListItem>
+              ))}
+            </TableOfContents.List>
+          </TableOfContents.Navigation>
+          <TableOfContents.Content>
+            <p data-h2-margin-bottom="base(x1)">
+              {intl.formatMessage(
+                {
+                  id: "fzqya3",
+                  defaultMessage:
+                    "<abbreviation>GC</abbreviation> Digital Talent is committed to building an accessible and inclusive digital service. At the heart of our platform design and development is an endeavour to create equal employment opportunities for all. To us, building accessible services means meeting the needs of as many people as possible, including edge cases. We are working across all disciplines - research, development, design, and accessibility - to ensure our service is intentional, accessible, and inclusive.",
+                  description: "Opening paragraph for accessibility statement",
+                },
+                {
+                  abbreviation: (text: React.ReactNode) => wrapAbbr(text, intl),
+                },
+              )}
+            </p>
+            <TableOfContents.Section id={sections[0].id}>
+              <TableOfContents.Heading>
+                {sections[0].title}
+              </TableOfContents.Heading>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "The GC Digital Talent team follows inclusive <digitalStandardsLink>Government of Canada Digital Standards</digitalStandardsLink>.",
+                    id: "tu2Z17",
+                    description: "Paragraph describing accessibility standards",
+                  },
+                  {
+                    digitalStandardsLink: (chunks: React.ReactNode) =>
+                      digitalStandardsLink(locale, chunks),
+                  },
+                )}
+              </p>
+            </TableOfContents.Section>
+            <TableOfContents.Section id={sections[1].id}>
+              <TableOfContents.Heading>
+                {sections[1].title}
+              </TableOfContents.Heading>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage(
+                  {
+                    id: "5Cwvgi",
+                    defaultMessage:
+                      "While <wcagLink>Web Content Accessibility Guidelines (WCAG) 2.1</wcagLink> AA standards set out a baseline for conformance, audits from real users allow us to deliver beyond the minimum requirements. Accessibility is considered at every stage of our product design and development cycle. We try to make sure everyone has a pleasant experience on our platform.",
+                    description:
+                      "Paragraph describing accessibility at every level of development",
+                  },
+                  { wcagLink },
+                )}
+              </p>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage({
+                  id: "d8FGfc",
+                  defaultMessage:
+                    "<strong>Making our products accessible and usable by all.</strong> Our web application should adjust smoothly to various screen sizes and allow our users to access the platform on devices that meet their needs. Every feature we build needs to be accessible, but like making a great plate of nachos, you need the right ingredients to even get started. We start with these practical ingredients:",
+                  description:
+                    "Lead in text for list of items we consider for accessibility",
+                })}
+              </p>
               <ul>
                 <li>
                   {intl.formatMessage({
-                    defaultMessage:
-                      "Designing accessible layouts and interactive elements",
-                    id: "BFvwdM",
+                    defaultMessage: "Our designers pay attention to:",
+                    id: "Iodi0/",
                     description:
-                      "List item one, things designers consider for accessibility",
+                      "Intro to list of items designers consider for accessibility",
                   })}
+                  <ul>
+                    <li>
+                      {intl.formatMessage({
+                        defaultMessage:
+                          "Designing accessible layouts and interactive elements",
+                        id: "BFvwdM",
+                        description:
+                          "List item one, things designers consider for accessibility",
+                      })}
+                    </li>
+                    <li>
+                      {intl.formatMessage({
+                        defaultMessage: "Improving colour accessibility",
+                        id: "tZmXOj",
+                        description:
+                          "List item two, things designers consider for accessibility",
+                      })}
+                    </li>
+                    <li>
+                      {intl.formatMessage({
+                        defaultMessage:
+                          "Building accessible features and tools like dark mode",
+                        id: "NdvdT2",
+                        description:
+                          "List item three, things designers consider for accessibility",
+                      })}
+                    </li>
+                    <li>
+                      {intl.formatMessage({
+                        defaultMessage: "Optimizing UX research results",
+                        id: "dAopan",
+                        description:
+                          "List item four, things designers consider for accessibility",
+                      })}
+                    </li>
+                  </ul>
                 </li>
-                <li>
+                <li data-h2-margin="base(x.5, 0, 0, 0)">
                   {intl.formatMessage({
-                    defaultMessage: "Improving colour accessibility",
-                    id: "tZmXOj",
+                    defaultMessage: "Our developers pay attention to:",
+                    id: "Wi4tia",
                     description:
-                      "List item two, things designers consider for accessibility",
+                      "Intro to list of items developers consider for accessibility",
                   })}
-                </li>
-                <li>
-                  {intl.formatMessage({
-                    defaultMessage:
-                      "Building accessible features and tools like dark mode",
-                    id: "NdvdT2",
-                    description:
-                      "List item three, things designers consider for accessibility",
-                  })}
-                </li>
-                <li>
-                  {intl.formatMessage({
-                    defaultMessage: "Optimizing UX research results",
-                    id: "dAopan",
-                    description:
-                      "List item four, things designers consider for accessibility",
-                  })}
+                  <ul>
+                    <li>
+                      {intl.formatMessage(
+                        {
+                          defaultMessage:
+                            "<wcagLink>WCAG 2.1</wcagLink> conformance",
+                          id: "KXEuON",
+                          description:
+                            "List item one, things developers consider for accessibility",
+                        },
+                        { wcagLink },
+                      )}
+                    </li>
+                    <li>
+                      {intl.formatMessage(
+                        {
+                          defaultMessage:
+                            "<atagLink>ATAG 2.0</atagLink> conformance",
+                          id: "9LyLWf",
+                          description:
+                            "List item two, things developers consider for accessibility",
+                        },
+                        {
+                          atagLink,
+                        },
+                      )}
+                    </li>
+                    <li>
+                      {intl.formatMessage({
+                        defaultMessage: "Automated accessibility test results",
+                        id: "V9XmLH",
+                        description:
+                          "List item three, things developers consider for accessibility",
+                      })}
+                    </li>
+                    <li>
+                      {intl.formatMessage({
+                        defaultMessage: "User acceptance test results",
+                        id: "bBz/OJ",
+                        description:
+                          "List item four, things developers consider for accessibility",
+                      })}
+                    </li>
+                  </ul>
                 </li>
               </ul>
-            </li>
-            <li data-h2-margin="base(x.5, 0, 0, 0)">
-              {intl.formatMessage({
-                defaultMessage: "Our developers pay attention to:",
-                id: "Wi4tia",
-                description:
-                  "Intro to list of items developers consider for accessibility",
-              })}
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "<strong>Testing with Real Users.</strong> Before we consider anything to be ready for release, we work with <fableLink>Fable Tech Labs</fableLink> to get our products and features evaluated by users who require adaptive technologies to access the web. This is an important step to make sure our products work for real people.",
+                    id: "HCWGjZ",
+                    description:
+                      "Text describing our user testing for accessibility",
+                  },
+                  { fableLink },
+                )}
+              </p>
+            </TableOfContents.Section>
+            <TableOfContents.Section id={sections[2].id}>
+              <TableOfContents.Heading>
+                {sections[2].title}
+              </TableOfContents.Heading>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "Despite all efforts to make our website fully accessible, if you encounter a problem we missed, or require a different format, we encourage you to contact us at:",
+                  id: "Txu5Yq",
+                  description:
+                    "Lead in text for accessibility contact information",
+                })}
+              </p>
+              <p data-h2-margin="base(x1 0)">
+                <Link
+                  external
+                  href="mailto:gctalent-talentgc@support-soutien.gc.ca"
+                >
+                  gctalent-talentgc@support-soutien.gc.ca
+                </Link>
+              </p>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "We try to reply to inquiries within five business days. We also welcome your feedback on our accessibility efforts.",
+                  id: "hTeiV1",
+                  description: "Disclaimer for support email response time",
+                })}
+              </p>
+            </TableOfContents.Section>
+            <TableOfContents.Section id={sections[3].id}>
+              <TableOfContents.Heading>
+                {sections[3].title}
+              </TableOfContents.Heading>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage(
+                  {
+                    id: "WSo3Y/",
+                    defaultMessage:
+                      "The Accessibility Commissioner is responsible for enforcing the <acaLink>Accessible Canada Act</acaLink> and the <acrLink>Accessible Canada Regulations</acrLink>  in the federal public service. They will also deal with certain <complaintsLink>accessibility complaints</complaintsLink>. The Accessibility Commissioner is a member of the Canadian Human Rights Commission.",
+                    description: "Text describing accessibility commissioner",
+                  },
+                  {
+                    acaLink: (chunks: React.ReactNode) =>
+                      acaLink(locale, chunks),
+                    acrLink: (chunks: React.ReactNode) =>
+                      acrLink(locale, chunks),
+                    complaintsLink: (chunks: React.ReactNode) =>
+                      complaintsLink(locale, chunks),
+                  },
+                )}
+              </p>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "Not all complaints will go directly to the Accessibility Commissioner. There are some exceptions:",
+                  id: "SXyhoR",
+                  description:
+                    "Disclaimer about accessibility complaint exceptions.",
+                })}
+              </p>
               <ul>
                 <li>
                   {intl.formatMessage(
                     {
                       defaultMessage:
-                        "<wcagLink>WCAG 2.1</wcagLink> conformance",
-                      id: "KXEuON",
+                        "The <crtcLink>Canadian Radio-television and Telecommunications Commission</crtcLink> (CRTC) deals with broadcasting and telecommunications provider complaints under the <crtcActLink>Canadian Radio-television and Telecommunications Commission Act</crtcActLink>",
+                      id: "+G/4Zs",
                       description:
-                        "List item one, things developers consider for accessibility",
+                        "Description of complaints to the Canadian Radio-television and Telecommunications Commission",
                     },
-                    { wcagLink },
+                    {
+                      crtcLink: (chunks: React.ReactNode) =>
+                        crtcLink(locale, chunks),
+                      crtcActLink: (chunks: React.ReactNode) =>
+                        crtcActLink(locale, chunks),
+                    },
                   )}
                 </li>
                 <li>
                   {intl.formatMessage(
                     {
                       defaultMessage:
-                        "<atagLink>ATAG 2.0</atagLink> conformance",
-                      id: "9LyLWf",
+                        "The <chrcLink>Canadian Human Rights Commission</chrcLink> (CHRC) deals with discrimination complaints under the <chraLink>Canadian Human Rights Act</chraLink>.",
+                      id: "UoZLL/",
                       description:
-                        "List item two, things developers consider for accessibility",
+                        "Description of complaints to the Canadian Human Rights Commission",
                     },
                     {
-                      atagLink,
+                      chrcLink: (chunks: React.ReactNode) =>
+                        chrcLink(locale, chunks),
+                      chraLink: (chunks: React.ReactNode) =>
+                        chraLink(locale, chunks),
+                    },
+                  )}
+                </li>
+                <li>
+                  {intl.formatMessage(
+                    {
+                      defaultMessage:
+                        "The <ctaLink>Canadian Transportation Agency</ctaLink> (CTA) deals with federal transportation complaints.",
+                      id: "/fysAY",
+                      description:
+                        "Description of complaints to the Canadian Transportation Agency",
+                    },
+                    {
+                      ctaLink: (chunks: React.ReactNode) =>
+                        ctaLink(locale, chunks),
+                    },
+                  )}
+                </li>
+                <li>
+                  {intl.formatMessage(
+                    {
+                      defaultMessage:
+                        "The <relationsLink>Federal Public Sector Labour Relations and Employment Board</relationsLink> deals with complaints from some federal public service employees, RCMP members and employees of Parliament.",
+                      id: "ZgeBBn",
+                      description:
+                        "Description of complaints to the Federal Public Sector Labour Relations and Employment Board<",
+                    },
+                    {
+                      relationsLink: (chunks: React.ReactNode) =>
+                        relationsLink(locale, chunks),
+                    },
+                  )}
+                </li>
+              </ul>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "If you are not happy with how we respond to your complaint, reach out to the CHRC at the coordinates below:",
+                  id: "Zre7E9",
+                  description:
+                    "Description of what to do if users are not content with complaint response",
+                })}
+              </p>
+              <ul data-h2-list-style="base(none)">
+                <li>
+                  {intl.formatMessage(
+                    {
+                      defaultMessage:
+                        "<strong>Phone:</strong> <phoneLink>613-995-1151</phoneLink>",
+                      id: "OArzY6",
+                      description: "Phone contact info",
+                    },
+                    { phoneLink },
+                  )}
+                </li>
+                <li>
+                  {intl.formatMessage(
+                    {
+                      defaultMessage:
+                        "<strong>Toll free:</strong> <tollFreeLink>1-888-214-1090</tollFreeLink>",
+                      id: "k29AEC",
+                      description: "Toll free phone contact info",
+                    },
+                    { tollFreeLink },
+                  )}
+                </li>
+                <li>
+                  {intl.formatMessage({
+                    defaultMessage: "<strong>TTY:</strong> 1-888-643-3304",
+                    id: "G4fR8L",
+                    description: "TTY contact info",
+                  })}
+                </li>
+                <li>
+                  {intl.formatMessage(
+                    {
+                      defaultMessage:
+                        "<strong>VRS:</strong> CHRC accepts video relay service calls made through <relayServiceLink>Canada VRS</relayServiceLink>.",
+                      id: "8M2Tbu",
+                      description: "VRS contact info",
+                    },
+                    {
+                      relayServiceLink: (chunks: React.ReactNode) =>
+                        relayServiceLink(locale, chunks),
                     },
                   )}
                 </li>
                 <li>
                   {intl.formatMessage({
-                    defaultMessage: "Automated accessibility test results",
-                    id: "V9XmLH",
-                    description:
-                      "List item three, things developers consider for accessibility",
+                    defaultMessage: "<strong>Fax:</strong> 613-996-9661",
+                    id: "Yln61n",
+                    description: "Fax contact info",
                   })}
                 </li>
                 <li>
                   {intl.formatMessage({
-                    defaultMessage: "User acceptance test results",
-                    id: "bBz/OJ",
-                    description:
-                      "List item four, things developers consider for accessibility",
+                    defaultMessage:
+                      "<strong>Hours:</strong> Monday to Friday, 8:00 a.m. to 8:00 p.m. (Eastern Time)",
+                    id: "Q79qKT",
+                    description: "Hours of operation info",
                   })}
                 </li>
+                <li>
+                  {intl.formatMessage(
+                    {
+                      defaultMessage:
+                        "<strong>Email:</strong> <chrcMailLink>Info.Com@chrc-ccdp.gc.ca</chrcMailLink>",
+                      id: "UJ/rX1",
+                      description: "Email contact info",
+                    },
+                    { chrcMailLink },
+                  )}
+                </li>
               </ul>
-            </li>
-          </ul>
-          <p>
-            {intl.formatMessage(
-              {
-                defaultMessage:
-                  "<strong>Testing with Real Users.</strong> Before we consider anything to be ready for release, we work with <fableLink>Fable Tech Labs</fableLink> to get our products and features evaluated by users who require adaptive technologies to access the web. This is an important step to make sure our products work for real people.",
-                id: "HCWGjZ",
-                description:
-                  "Text describing our user testing for accessibility",
-              },
-              { fableLink },
-            )}
-          </p>
-          <Heading level="h2" size="h3" data-h2-margin="base(x2, 0, x1, 0)">
-            {intl.formatMessage({
-              defaultMessage: "Feedback and contact information",
-              id: "6bvAQ+",
-              description: "Title for the accessibility feedback section",
-            })}
-          </Heading>
-          <p>
-            {intl.formatMessage({
-              defaultMessage:
-                "Despite all efforts to make our website fully accessible, if you encounter a problem we missed, or require a different format, we encourage you to contact us at:",
-              id: "Txu5Yq",
-              description: "Lead in text for accessibility contact information",
-            })}
-          </p>
-          <p>
-            <Link
-              external
-              href="mailto:gctalent-talentgc@support-soutien.gc.ca"
-            >
-              gctalent-talentgc@support-soutien.gc.ca
-            </Link>
-          </p>
-          <p>
-            {intl.formatMessage({
-              defaultMessage:
-                "We try to reply to inquiries within five business days. We also welcome your feedback on our accessibility efforts.",
-              id: "hTeiV1",
-              description: "Disclaimer for support email response time",
-            })}
-          </p>
-          <Heading level="h2" size="h3" data-h2-margin="base(x2, 0, x1, 0)">
-            {intl.formatMessage({
-              defaultMessage: "Proactive compliance and enforcement framework",
-              id: "quxa4Q",
-              description: "Title for the compliance enforcement section.",
-            })}
-          </Heading>
-          <p>
-            {intl.formatMessage(
-              {
-                id: "WSo3Y/",
-                defaultMessage:
-                  "The Accessibility Commissioner is responsible for enforcing the <acaLink>Accessible Canada Act</acaLink> and the <acrLink>Accessible Canada Regulations</acrLink>  in the federal public service. They will also deal with certain <complaintsLink>accessibility complaints</complaintsLink>. The Accessibility Commissioner is a member of the Canadian Human Rights Commission.",
-                description: "Text describing accessibility commissioner",
-              },
-              {
-                acaLink: (chunks: React.ReactNode) => acaLink(locale, chunks),
-                acrLink: (chunks: React.ReactNode) => acrLink(locale, chunks),
-                complaintsLink: (chunks: React.ReactNode) =>
-                  complaintsLink(locale, chunks),
-              },
-            )}
-          </p>
-          <p>
-            {intl.formatMessage({
-              defaultMessage:
-                "Not all complaints will go directly to the Accessibility Commissioner. There are some exceptions:",
-              id: "SXyhoR",
-              description:
-                "Disclaimer about accessibility complaint exceptions.",
-            })}
-          </p>
-          <ul>
-            <li>
-              {intl.formatMessage(
-                {
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage({
                   defaultMessage:
-                    "The <crtcLink>Canadian Radio-television and Telecommunications Commission</crtcLink> (CRTC) deals with broadcasting and telecommunications provider complaints under the <crtcActLink>Canadian Radio-television and Telecommunications Commission Act</crtcActLink>",
-                  id: "+G/4Zs",
+                    "This statement was prepared on November 8, 2022.",
+                  id: "om2bZu",
                   description:
-                    "Description of complaints to the Canadian Radio-television and Telecommunications Commission",
-                },
-                {
-                  crtcLink: (chunks: React.ReactNode) =>
-                    crtcLink(locale, chunks),
-                  crtcActLink: (chunks: React.ReactNode) =>
-                    crtcActLink(locale, chunks),
-                },
-              )}
-            </li>
-            <li>
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "The <chrcLink>Canadian Human Rights Commission</chrcLink> (CHRC) deals with discrimination complaints under the <chraLink>Canadian Human Rights Act</chraLink>.",
-                  id: "UoZLL/",
-                  description:
-                    "Description of complaints to the Canadian Human Rights Commission",
-                },
-                {
-                  chrcLink: (chunks: React.ReactNode) =>
-                    chrcLink(locale, chunks),
-                  chraLink: (chunks: React.ReactNode) =>
-                    chraLink(locale, chunks),
-                },
-              )}
-            </li>
-            <li>
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "The <ctaLink>Canadian Transportation Agency</ctaLink> (CTA) deals with federal transportation complaints.",
-                  id: "/fysAY",
-                  description:
-                    "Description of complaints to the Canadian Transportation Agency",
-                },
-                {
-                  ctaLink: (chunks: React.ReactNode) => ctaLink(locale, chunks),
-                },
-              )}
-            </li>
-            <li>
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "The <relationsLink>Federal Public Sector Labour Relations and Employment Board</relationsLink> deals with complaints from some federal public service employees, RCMP members and employees of Parliament.",
-                  id: "ZgeBBn",
-                  description:
-                    "Description of complaints to the Federal Public Sector Labour Relations and Employment Board<",
-                },
-                {
-                  relationsLink: (chunks: React.ReactNode) =>
-                    relationsLink(locale, chunks),
-                },
-              )}
-            </li>
-          </ul>
-          <p>
-            {intl.formatMessage({
-              defaultMessage:
-                "If you are not happy with how we respond to your complaint, reach out to the CHRC at the coordinates below:",
-              id: "Zre7E9",
-              description:
-                "Description of what to do if users are not content with complaint response",
-            })}
-          </p>
-          <ul data-h2-list-style="base(none)">
-            <li>
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "<strong>Phone:</strong> <phoneLink>613-995-1151</phoneLink>",
-                  id: "OArzY6",
-                  description: "Phone contact info",
-                },
-                { phoneLink },
-              )}
-            </li>
-            <li>
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "<strong>Toll free:</strong> <tollFreeLink>1-888-214-1090</tollFreeLink>",
-                  id: "k29AEC",
-                  description: "Toll free phone contact info",
-                },
-                { tollFreeLink },
-              )}
-            </li>
-            <li>
-              {intl.formatMessage({
-                defaultMessage: "<strong>TTY:</strong> 1-888-643-3304",
-                id: "G4fR8L",
-                description: "TTY contact info",
-              })}
-            </li>
-            <li>
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "<strong>VRS:</strong> CHRC accepts video relay service calls made through <relayServiceLink>Canada VRS</relayServiceLink>.",
-                  id: "8M2Tbu",
-                  description: "VRS contact info",
-                },
-                {
-                  relayServiceLink: (chunks: React.ReactNode) =>
-                    relayServiceLink(locale, chunks),
-                },
-              )}
-            </li>
-            <li>
-              {intl.formatMessage({
-                defaultMessage: "<strong>Fax:</strong> 613-996-9661",
-                id: "Yln61n",
-                description: "Fax contact info",
-              })}
-            </li>
-            <li>
-              {intl.formatMessage({
-                defaultMessage:
-                  "<strong>Hours:</strong> Monday to Friday, 8:00 a.m. to 8:00 p.m. (Eastern Time)",
-                id: "Q79qKT",
-                description: "Hours of operation info",
-              })}
-            </li>
-            <li>
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "<strong>Email:</strong> <chrcMailLink>Info.Com@chrc-ccdp.gc.ca</chrcMailLink>",
-                  id: "UJ/rX1",
-                  description: "Email contact info",
-                },
-                { chrcMailLink },
-              )}
-            </li>
-          </ul>
-          <p>
-            {intl.formatMessage({
-              defaultMessage:
-                "This statement was prepared on November 8, 2022.",
-              id: "om2bZu",
-              description:
-                "Disclaimer for the when the accessibility statement was last updated",
-            })}
-          </p>
-        </div>
+                    "Disclaimer for the when the accessibility statement was last updated",
+                })}
+              </p>
+            </TableOfContents.Section>
+          </TableOfContents.Content>
+        </TableOfContents.Wrapper>
       </div>
       <div
         data-h2-background-image="base(main-linear)"

--- a/apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.tsx
+++ b/apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.tsx
@@ -299,7 +299,7 @@ const AccessibilityStatementPage = () => {
               )}
             </p>
             <TableOfContents.Section id={sections[0].id}>
-              <TableOfContents.Heading>
+              <TableOfContents.Heading size="h2">
                 {sections[0].title}
               </TableOfContents.Heading>
               <p data-h2-margin="base(x1 0)">
@@ -318,7 +318,7 @@ const AccessibilityStatementPage = () => {
               </p>
             </TableOfContents.Section>
             <TableOfContents.Section id={sections[1].id}>
-              <TableOfContents.Heading>
+              <TableOfContents.Heading size="h2">
                 {sections[1].title}
               </TableOfContents.Heading>
               <p data-h2-margin="base(x1 0)">
@@ -333,11 +333,20 @@ const AccessibilityStatementPage = () => {
                   { wcagLink },
                 )}
               </p>
+              <Heading level="h3">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "Making our products accessible and usable by all",
+                  id: "agcOO1",
+                  description:
+                    "Heading for the items we consider for accessibility.",
+                })}
+              </Heading>
               <p data-h2-margin="base(x1 0)">
                 {intl.formatMessage({
-                  id: "d8FGfc",
+                  id: "ASYJlr",
                   defaultMessage:
-                    "<strong>Making our products accessible and usable by all.</strong> Our web application should adjust smoothly to various screen sizes and allow our users to access the platform on devices that meet their needs. Every feature we build needs to be accessible, but like making a great plate of nachos, you need the right ingredients to even get started. We start with these practical ingredients:",
+                    "Our web application should adjust smoothly to various screen sizes and allow our users to access the platform on devices that meet their needs. Every feature we build needs to be accessible, but like making a great plate of nachos, you need the right ingredients to even get started. We start with these practical ingredients:",
                   description:
                     "Lead in text for list of items we consider for accessibility",
                 })}
@@ -440,12 +449,19 @@ const AccessibilityStatementPage = () => {
                   </ul>
                 </li>
               </ul>
+              <Heading level="h3">
+                {intl.formatMessage({
+                  defaultMessage: "Testing with real users",
+                  id: "7+GPYf",
+                  description: "Heading for how we test accessibility.",
+                })}
+              </Heading>
               <p data-h2-margin="base(x1 0)">
                 {intl.formatMessage(
                   {
                     defaultMessage:
-                      "<strong>Testing with Real Users.</strong> Before we consider anything to be ready for release, we work with <fableLink>Fable Tech Labs</fableLink> to get our products and features evaluated by users who require adaptive technologies to access the web. This is an important step to make sure our products work for real people.",
-                    id: "HCWGjZ",
+                      "Before we consider anything to be ready for release, we work with <fableLink>Fable Tech Labs</fableLink> to get our products and features evaluated by users who require adaptive technologies to access the web. This is an important step to make sure our products work for real people.",
+                    id: "gEnOmo",
                     description:
                       "Text describing our user testing for accessibility",
                   },
@@ -454,7 +470,7 @@ const AccessibilityStatementPage = () => {
               </p>
             </TableOfContents.Section>
             <TableOfContents.Section id={sections[2].id}>
-              <TableOfContents.Heading>
+              <TableOfContents.Heading size="h2">
                 {sections[2].title}
               </TableOfContents.Heading>
               <p data-h2-margin="base(x1 0)">
@@ -484,7 +500,7 @@ const AccessibilityStatementPage = () => {
               </p>
             </TableOfContents.Section>
             <TableOfContents.Section id={sections[3].id}>
-              <TableOfContents.Heading>
+              <TableOfContents.Heading size="h2">
                 {sections[3].title}
               </TableOfContents.Heading>
               <p data-h2-margin="base(x1 0)">


### PR DESCRIPTION
🤖 Resolves #8359 

## 👋 Introduction

Makes some minor layout changes to the accessibility statement to align it with other pages.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigagte to `/accessibility-statement`
3. Confirm the following:
    - Hero subtitle does not overlap image on right
    - Table of contents exists and functions as expected
    - Headings updated to match expected size
    - Container is wider matching other pages


## 📸 Screenshot
![localhost_8000_en_accessibility-statement](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/f0340f91-15da-4785-8ef6-7c7937493e39)

