### PR TITLE
[Debt] Removes `applicant` GraphQL query

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -665,13 +665,6 @@ type Query {
     @paginate(defaultCount: 10, maxCount: 1000, scopes: ["authorizedToView"])
     @guard
     @can(ability: "view", resolved: true)
-  applicant(id: UUID! @eq): User
-    @find(model: "User")
-    @guard
-    @can(ability: "view", query: true, model: "User")
-    @deprecated(
-      reason: "applicant is deprecated. Use user instead. Remove in #7651."
-    )
   applicants(includeIds: [ID]! @in(key: "id")): [User]!
     @all(model: "User")
     @guard

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -11,7 +11,6 @@ type Query {
     "Allows to filter if trashed elements should be fetched."
     trashed: Trashed
   ): [User]! @deprecated(reason: "users is deprecated. Use usersPaginated instead. Remove in #7660.")
-  applicant(id: UUID!): User @deprecated(reason: "applicant is deprecated. Use user instead. Remove in #7651.")
   applicants(includeIds: [ID]!): [User]! @deprecated(reason: "applicants is deprecated. Use usersPaginated instead. Remove in #7652.")
   userPublicProfiles: [UserPublicProfile]! @deprecated(reason: "We should avoid non-paginated queries when we know a query will return thousands of values. In this case, we must write an alternative first!")
   countApplicants(where: ApplicantFilterInput): Int!

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/CareerTimelineAndRecruitmentPage.stories.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/CareerTimelineAndRecruitmentPage.stories.tsx
@@ -11,7 +11,7 @@ import AddExperienceDialog from "./components/AddExperienceDialog";
 export default {
   title: "Pages/Career timeline and recruitment",
   args: {
-    applicantId: "test",
+    userId: "test",
   },
 } as ComponentMeta<typeof CareerTimelineAndRecruitment>;
 

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/CareerTimelineAndRecruitmentPage.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/CareerTimelineAndRecruitmentPage.tsx
@@ -17,14 +17,14 @@ const CareerTimelineAndRecruitmentPage = () => {
     variables: { id: userAuthInfo?.id || "" },
   });
 
-  const experiences = data?.applicant?.experiences?.filter(notEmpty);
-  const applications = data?.applicant?.poolCandidates?.filter(notEmpty);
+  const experiences = data?.user?.experiences?.filter(notEmpty);
+  const applications = data?.user?.poolCandidates?.filter(notEmpty);
 
   return (
     <Pending fetching={fetching} error={error}>
-      {data?.applicant ? (
+      {data?.user ? (
         <CareerTimelineAndRecruitment
-          applicantId={data?.applicant.id}
+          userId={data?.user.id}
           experiences={experiences || []}
           applications={applications || []}
         />

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/careerTimelineAndRecruitmentOperations.graphql
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/careerTimelineAndRecruitmentOperations.graphql
@@ -145,7 +145,7 @@ fragment applicationTimelineAndRecruitment on PoolCandidate {
 }
 
 query getAllApplicantExperiences($id: UUID!) {
-  applicant(id: $id) {
+  user(id: $id) {
     ...applicantExperiences
     poolCandidates {
       ...applicationTimelineAndRecruitment
@@ -153,11 +153,8 @@ query getAllApplicantExperiences($id: UUID!) {
   }
 }
 
-query getAllApplicantExperiencesAndPoolSkills(
-  $applicantId: UUID!
-  $poolId: UUID!
-) {
-  applicant(id: $applicantId) {
+query getAllApplicantExperiencesAndPoolSkills($userId: UUID!, $poolId: UUID!) {
+  user(id: $userId) {
     ...applicantExperiences
   }
   pool(id: $poolId) {

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/careerTimelineAndRecruitmentOperations.graphql
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/careerTimelineAndRecruitmentOperations.graphql
@@ -152,17 +152,3 @@ query getAllApplicantExperiences($id: UUID!) {
     }
   }
 }
-
-query getAllApplicantExperiencesAndPoolSkills($userId: UUID!, $poolId: UUID!) {
-  user(id: $userId) {
-    ...applicantExperiences
-  }
-  pool(id: $poolId) {
-    essentialSkills {
-      ...poolSkills
-    }
-    nonessentialSkills {
-      ...poolSkills
-    }
-  }
-}

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/AddExperienceDialog.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/AddExperienceDialog.tsx
@@ -16,7 +16,7 @@ import { Scalars } from "~/api/generated";
 import { ExperienceType } from "~/types/experience";
 
 type AddExperienceDialogProps = {
-  applicantId: Scalars["UUID"];
+  userId: Scalars["UUID"];
   defaultOpen?: boolean;
 };
 
@@ -30,7 +30,7 @@ interface ExperienceSection {
 }
 
 const AddExperienceDialog = ({
-  applicantId,
+  userId,
   defaultOpen = false,
 }: AddExperienceDialogProps): JSX.Element => {
   const intl = useIntl();
@@ -55,7 +55,7 @@ const AddExperienceDialog = ({
         id: "WkD8tV",
         description: "Button text to add a work experience to the profile",
       }),
-      buttonPath: paths.createWork(applicantId),
+      buttonPath: paths.createWork(userId),
       experienceType: "work",
     },
 
@@ -78,7 +78,7 @@ const AddExperienceDialog = ({
         description:
           "Button text to add an education experience to the profile",
       }),
-      buttonPath: paths.createEducation(applicantId),
+      buttonPath: paths.createEducation(userId),
       experienceType: "education",
     },
 
@@ -100,7 +100,7 @@ const AddExperienceDialog = ({
         id: "AKRd34",
         description: "Button text to add a community experience to the profile",
       }),
-      buttonPath: paths.createCommunity(applicantId),
+      buttonPath: paths.createCommunity(userId),
       experienceType: "community",
     },
 
@@ -122,7 +122,7 @@ const AddExperienceDialog = ({
         id: "L6UnSl",
         description: "Button text to add a personal experience to the profile",
       }),
-      buttonPath: paths.createPersonal(applicantId),
+      buttonPath: paths.createPersonal(userId),
       experienceType: "personal",
     },
 
@@ -144,7 +144,7 @@ const AddExperienceDialog = ({
         id: "CSg8cH",
         description: "Button text to add an award to the profile",
       }),
-      buttonPath: paths.createAward(applicantId),
+      buttonPath: paths.createAward(userId),
       experienceType: "award",
     },
   ];

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
@@ -41,7 +41,7 @@ export type ExperienceForDate =
   | WorkExperience;
 
 interface CareerTimelineAndRecruitmentProps {
-  applicantId: string;
+  userId: string;
   experiences?: MergedExperiences;
   applications: Application[];
   missingSkills?: {
@@ -54,7 +54,7 @@ const CareerTimelineAndRecruitment = ({
   experiences,
   applications,
   missingSkills,
-  applicantId,
+  userId,
 }: CareerTimelineAndRecruitmentProps) => {
   const intl = useIntl();
   const paths = useRoutes();
@@ -79,7 +79,7 @@ const CareerTimelineAndRecruitment = ({
     },
     {
       label: intl.formatMessage(titles.careerTimelineAndRecruitment),
-      url: paths.careerTimelineAndRecruitment(applicantId),
+      url: paths.careerTimelineAndRecruitment(userId),
     },
   ];
 
@@ -160,7 +160,7 @@ const CareerTimelineAndRecruitment = ({
               <div data-h2-margin-top="base(x2)">
                 <CareerTimelineSection
                   experiences={experiences}
-                  applicantId={applicantId}
+                  userId={userId}
                 />
               </div>
             </TableOfContents.Section>

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineSection.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineSection.tsx
@@ -15,14 +15,14 @@ interface CareerTimelineSectionProps {
   experiences?: Experience[];
   editParam?: string;
   headingLevel?: HeadingRank;
-  applicantId?: string;
+  userId?: string;
 }
 
 const CareerTimelineSection = ({
   experiences,
   editParam,
   headingLevel = "h3",
-  applicantId,
+  userId,
 }: CareerTimelineSectionProps) => {
   const intl = useIntl();
 
@@ -52,12 +52,12 @@ const CareerTimelineSection = ({
         />
 
         <div data-h2-flex-item="base(0of1) p-tablet(fill)">{/* spacer */}</div>
-        {applicantId ? (
+        {userId ? (
           <div
             data-h2-flex-item="base(1of1) p-tablet(content)"
             data-h2-align-self="base(flex-end)"
           >
-            <AddExperienceDialog applicantId={applicantId} />
+            <AddExperienceDialog userId={userId} />
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
🤖 Resolves #7651.

## 👋 Introduction

This PR removes the `applicant` GraphQL query from the schema and replaces it with the `user` GraphQL query. Additionally, it removes the unused `getAllApplicantExperiencesAndPoolSkills` query.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `users/:user-id/personal-information/career-timeline`
2. Observe experiences with skills render as before