### PR TITLE
[Fix] Typo on French pool advertisement page

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4168,7 +4168,7 @@
     "description": "Tab name for a list of behavioural skills"
   },
   "LnISTX": {
-    "defaultMessage": "{title} Les exigent un minimum d’expérience ou un diplôme pertinent.",
+    "defaultMessage": "{title} exigent un minimum d’expérience ou un diplôme pertinent.",
     "description": "Descriptive text about experience or education requirements of a pool advertisement"
   },
   "LoKxJe": {


### PR DESCRIPTION
🤖 Resolves #8468 

## 👋 Introduction

Fixes a typo for the education requirements on the French pool advertisement page.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to a pool advertisement
3. Scroll to education requirements
4. Confirm "Les" does not appear after the pool title

