### PR TITLE
[Debt] Removes `poolCandidateSearchRequests` GraphQL query

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -776,14 +776,6 @@ type Query {
     @find
     @guard
     @can(ability: "view", query: true)
-  poolCandidateSearchRequests(limit: Int @limit): [PoolCandidateSearchRequest]!
-    @all
-    @guard
-    @can(ability: "viewAny")
-    @orderBy(column: "created_at", direction: DESC)
-    @deprecated(
-      reason: "poolCandidateSearchRequests is deprecated. Use poolCandidateSearchRequestsPaginated instead. Remove in #7659."
-    )
   poolCandidateSearchRequestsPaginated(
     where: PoolCandidateSearchRequestInput
     orderBy: [OrderByClause!] @orderBy

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -30,7 +30,6 @@ type Query {
   applicantFilter(id: ID!): ApplicantFilter @deprecated(reason: "applicantFilter is deprecated. Use poolCandidateSearchRequest.applicantFilter instead. Remove in #7653.")
   applicantFilters: [ApplicantFilter]! @deprecated(reason: "applicantFilters is deprecated. Use poolCandidateSearchRequest.applicantFilter instead. Remove in #7654.")
   poolCandidateSearchRequest(id: ID!): PoolCandidateSearchRequest
-  poolCandidateSearchRequests(limit: Int): [PoolCandidateSearchRequest]! @deprecated(reason: "poolCandidateSearchRequests is deprecated. Use poolCandidateSearchRequestsPaginated instead. Remove in #7659.")
   skillFamily(id: UUID!): SkillFamily
   skillFamilies: [SkillFamily]!
   skill(id: UUID!): Skill

--- a/api/tests/Feature/PoolCandidateSearchRequestTest.php
+++ b/api/tests/Feature/PoolCandidateSearchRequestTest.php
@@ -189,10 +189,10 @@ class PoolCandidateSearchRequestTest extends TestCase
 
         // test viewing collection of search requests
         $this->actingAs($baseUser, 'api')
-            ->graphQL('query { poolCandidateSearchRequests { id } }')
+            ->graphQL('query { poolCandidateSearchRequestsPaginated(first: 500) { data { id } } }')
             ->assertJsonFragment(['message' => 'This action is unauthorized.']);
         $this->actingAs($requestResponder, 'api')
-            ->graphQL('query { poolCandidateSearchRequests { id } }')
+            ->graphQL('query { poolCandidateSearchRequestsPaginated(first: 500) { data { id } } }')
             ->assertJsonFragment(['id' => $searchRequest1->id]);
 
         // test updating a search request

--- a/apps/web/src/pages/SearchRequests/poolCandidateSearchRequestOperations.graphql
+++ b/apps/web/src/pages/SearchRequests/poolCandidateSearchRequestOperations.graphql
@@ -102,12 +102,6 @@ fragment poolCandidateSearchRequest on PoolCandidateSearchRequest {
     qualifiedStreams
   }
 }
-query getPoolCandidateSearchRequests {
-  poolCandidateSearchRequests {
-    ...poolCandidateSearchRequest
-  }
-}
-
 query getPoolCandidateSearchRequest($id: ID!) {
   poolCandidateSearchRequest(id: $id) {
     ...poolCandidateSearchRequest


### PR DESCRIPTION
🤖 Resolves #7659.

## 👋 Introduction

This PR removes the `poolCandidateSearchRequests` GraphQL query from the schema. Additionally, it removes the unused `getPoolCandidateSearchRequests ` query.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure no references to `poolCandidateSearchRequests` GraphQL query exist in codebase