### PR TITLE
[Dependencies] Jwt-decode 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21157,8 +21157,12 @@
       }
     },
     "node_modules/jwt-decode": {
-      "version": "3.1.2",
-      "license": "MIT"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -28361,7 +28365,7 @@
         "@gc-digital-talent/helpers": "*",
         "@gc-digital-talent/logger": "*",
         "@gc-digital-talent/ui": "*",
-        "jwt-decode": "^3.1.2",
+        "jwt-decode": "4.0.0",
         "path-browserify": "^1.0.1",
         "react-router-dom": "^6.18.0",
         "urql": "3.0.4"
@@ -28391,7 +28395,7 @@
         "@urql/core": "^3.0.0",
         "@urql/exchange-auth": "1.0.0",
         "graphql": "^16.8.1",
-        "jwt-decode": "^3.1.2",
+        "jwt-decode": "4.0.0",
         "lodash": "4.17.21",
         "react-intl": "^6.5.2",
         "urql": "3.0.4"
@@ -30781,7 +30785,7 @@
         "@types/react": "^18.2.34",
         "eslint": "^8.53.0",
         "eslint-config-custom": "*",
-        "jwt-decode": "^3.1.2",
+        "jwt-decode": "4.0.0",
         "path-browserify": "^1.0.1",
         "react": "^18.2.0",
         "react-router-dom": "^6.18.0",
@@ -30810,7 +30814,7 @@
         "graphql": "^16.8.1",
         "jest": "^29.7.0",
         "jest-presets": "*",
-        "jwt-decode": "^3.1.2",
+        "jwt-decode": "4.0.0",
         "lodash": "4.17.21",
         "react": "^18.2.0",
         "react-intl": "^6.5.2",
@@ -43410,7 +43414,9 @@
       "dev": true
     },
     "jwt-decode": {
-      "version": "3.1.2"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="
     },
     "kind-of": {
       "version": "6.0.3",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -26,7 +26,7 @@
     "@gc-digital-talent/helpers": "*",
     "@gc-digital-talent/logger": "*",
     "@gc-digital-talent/ui": "*",
-    "jwt-decode": "^3.1.2",
+    "jwt-decode": "4.0.0",
     "path-browserify": "^1.0.1",
     "react-router-dom": "^6.18.0",
     "urql": "3.0.4"

--- a/packages/auth/src/components/AuthenticationContainer.tsx
+++ b/packages/auth/src/components/AuthenticationContainer.tsx
@@ -1,7 +1,7 @@
 // Note: We need snake case for tokens
 /* eslint-disable camelcase */
 import React, { useEffect, useMemo, useState } from "react";
-import jwtDecode, { JwtPayload } from "jwt-decode";
+import { JwtPayload, jwtDecode } from "jwt-decode";
 
 import { defaultLogger } from "@gc-digital-talent/logger";
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -28,7 +28,7 @@
     "@gc-digital-talent/toast": "*",
     "@urql/exchange-auth": "1.0.0",
     "graphql": "^16.8.1",
-    "jwt-decode": "^3.1.2",
+    "jwt-decode": "4.0.0",
     "lodash": "4.17.21",
     "react-intl": "^6.5.2",
     "urql": "3.0.4",

--- a/packages/client/src/components/ClientProvider/ClientProvider.tsx
+++ b/packages/client/src/components/ClientProvider/ClientProvider.tsx
@@ -1,5 +1,5 @@
 import { authExchange } from "@urql/exchange-auth";
-import jwtDecode, { JwtPayload } from "jwt-decode";
+import { JwtPayload, jwtDecode } from "jwt-decode";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   Client,


### PR DESCRIPTION
🤖 Resolves #8396

## 👋 Introduction

Updates the dependency from 3.1.2 to 4.0.0

## 🕵️ Details

The applicable breaking change was the import no longer being a default export. 
https://github.com/auth0/jwt-decode/releases/tag/v4.0.0

## 🧪 Testing

1. Login and logout, so auth tasks succeed still

