### PR TITLE
[Debt] Removes `applicantFilter` GraphQL query

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -757,13 +757,6 @@ type Query {
     @deprecated(
       reason: "poolCandidateFilters is deprecated. Use poolCandidateSearchRequest.poolCandidateFilter instead. Remove in #7658."
     )
-  applicantFilter(id: ID! @eq): ApplicantFilter
-    @find
-    @guard
-    @can(ability: "viewAny", model: "PoolCandidateSearchRequest")
-    @deprecated(
-      reason: "applicantFilter is deprecated. Use poolCandidateSearchRequest.applicantFilter instead. Remove in #7653."
-    )
   applicantFilters: [ApplicantFilter]!
     @all
     @guard

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -27,7 +27,6 @@ type Query {
   departments: [Department]!
   poolCandidateFilter(id: UUID!): PoolCandidateFilter @deprecated(reason: "poolCandidateFilter is deprecated. Use poolCandidateSearchRequest.poolCandidateFilter instead. Remove in #7657.")
   poolCandidateFilters: [PoolCandidateFilter]! @deprecated(reason: "poolCandidateFilters is deprecated. Use poolCandidateSearchRequest.poolCandidateFilter instead. Remove in #7658.")
-  applicantFilter(id: ID!): ApplicantFilter @deprecated(reason: "applicantFilter is deprecated. Use poolCandidateSearchRequest.applicantFilter instead. Remove in #7653.")
   applicantFilters: [ApplicantFilter]! @deprecated(reason: "applicantFilters is deprecated. Use poolCandidateSearchRequest.applicantFilter instead. Remove in #7654.")
   poolCandidateSearchRequest(id: ID!): PoolCandidateSearchRequest
   skillFamily(id: UUID!): SkillFamily

--- a/api/tests/Feature/ApplicantFilterTest.php
+++ b/api/tests/Feature/ApplicantFilterTest.php
@@ -166,59 +166,6 @@ class ApplicantFilterTest extends TestCase
     }
 
     /**
-     * Test that querying a single ApplicantFilter returns the right one, with correct attributes.
-     *
-     * @return void
-     */
-    public function testQueryApplicantFilterById()
-    {
-        $filters = ApplicantFilter::factory()->count(3)->create();
-
-        $response = $this->actingAs($this->adminUser, 'api')->graphQL(
-            /** @lang GraphQL */
-            '
-            query ($id: ID!) {
-                applicantFilter(id: $id) {
-                    id
-                    hasDiploma
-                    equity {
-                        isWoman
-                        hasDisability
-                        isIndigenous
-                        isVisibleMinority
-                    }
-                    languageAbility
-                    operationalRequirements
-                    locationPreferences
-                    positionDuration
-                }
-            }
-        ',
-            [
-                'id' => $filters[1]->id,
-            ]
-        );
-        $response->assertJson([
-            'data' => [
-                'applicantFilter' => [
-                    'id' => $filters[1]->id,
-                    'hasDiploma' => $filters[1]->has_diploma,
-                    'equity' => [
-                        'isWoman' => $filters[1]->is_woman,
-                        'hasDisability' => $filters[1]->has_disability,
-                        'isIndigenous' => $filters[1]->is_indigenous,
-                        'isVisibleMinority' => $filters[1]->is_visible_minority,
-                    ],
-                    'languageAbility' => $filters[1]->language_ability,
-                    'operationalRequirements' => $filters[1]->operational_requirements,
-                    'locationPreferences' => $filters[1]->location_preferences,
-                    'positionDuration' => $filters[1]->position_duration,
-                ],
-            ],
-        ]);
-    }
-
-    /**
      * Test that factory creates relationships correctly.
      */
     public function testFactoryRelationships()


### PR DESCRIPTION
🤖 Resolves #7653.

## 👋 Introduction

This PR removes the `applicantFilter` GraphQL query from the schema. Also, it removes the `testQueryApplicantFilterById` test that is no longer applicable.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure no references to `applicantFilter` GraphQL query exist in codebase