### PR TITLE
[Debt] Removes `poolByKey` GraphQL query

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -690,7 +690,6 @@ type Query {
   ): [Pool!]!
     @all(scopes: ["wasPublished", "notArchived"])
     @can(ability: "viewAnyPublished", model: "Pool")
-  poolByKey(key: String! @eq): Pool @find @can(ability: "view", query: true)
   pools: [Pool]!
     @all(scopes: ["authorizedToView", "notArchived"])
     @can(ability: "view", resolved: true)

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -16,7 +16,6 @@ type Query {
   countApplicants(where: ApplicantFilterInput): Int!
   pool(id: UUID!): Pool
   publishedPools(closingAfter: DateTime, publishingGroup: PublishingGroup): [Pool!]!
-  poolByKey(key: String!): Pool
   pools: [Pool]!
   poolCandidate(id: UUID!): PoolCandidate
   poolCandidates(includeIds: [ID]): [PoolCandidate]! @deprecated(reason: "poolCandidates is deprecated. Use poolCandidatesPaginated instead. Remove in #7656.")


### PR DESCRIPTION
🤖 Resolves #8481.

## 👋 Introduction

This PR removes the `poolByKey` GraphQL query that is not used.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure no instances of the `poolByKey` GraphQL query in the codebase