### PR TITLE
[Debt] Moved experiences from page query to SkillMatchDialogs

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -713,8 +713,8 @@ const PoolCandidatesTable = ({
             allSkills?.filter(
               (skill) => filteredSkillIds?.includes(skill.id),
             ) ?? [],
-            user.experiences?.filter(notEmpty) ?? [],
             skillCount,
+            user.id,
             `${user.firstName} ${user.lastName}`,
           ),
       },

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/poolCandidatesOperations.graphql
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/poolCandidatesOperations.graphql
@@ -64,72 +64,6 @@ fragment poolCandidateTable on PoolCandidate {
     locationPreferences
     locationExemptions
     acceptedOperationalRequirements
-    # Experiences
-    experiences {
-      id
-      __typename
-      user {
-        id
-        email
-      }
-      details
-      skills {
-        id
-        key
-        name {
-          en
-          fr
-        }
-        description {
-          en
-          fr
-        }
-        keywords {
-          en
-          fr
-        }
-        category
-        experienceSkillRecord {
-          details
-        }
-      }
-      ... on AwardExperience {
-        title
-        issuedBy
-        awardedDate
-        awardedTo
-        awardedScope
-      }
-      ... on CommunityExperience {
-        title
-        organization
-        project
-        startDate
-        endDate
-      }
-      ... on EducationExperience {
-        institution
-        areaOfStudy
-        thesisTitle
-        startDate
-        endDate
-        type
-        status
-      }
-      ... on PersonalExperience {
-        title
-        description
-        startDate
-        endDate
-      }
-      ... on WorkExperience {
-        role
-        organization
-        division
-        startDate
-        endDate
-      }
-    }
     positionDuration
     priorityWeight
   }
@@ -140,6 +74,74 @@ fragment poolCandidateTable on PoolCandidate {
   notes
   archivedAt
   suspendedAt
+}
+
+fragment skillMatchDialog on User {
+  experiences {
+    id
+    __typename
+    user {
+      id
+      email
+    }
+    details
+    skills {
+      id
+      key
+      name {
+        en
+        fr
+      }
+      description {
+        en
+        fr
+      }
+      keywords {
+        en
+        fr
+      }
+      category
+      experienceSkillRecord {
+        details
+      }
+    }
+    ... on AwardExperience {
+      title
+      issuedBy
+      awardedDate
+      awardedTo
+      awardedScope
+    }
+    ... on CommunityExperience {
+      title
+      organization
+      project
+      startDate
+      endDate
+    }
+    ... on EducationExperience {
+      institution
+      areaOfStudy
+      thesisTitle
+      startDate
+      endDate
+      type
+      status
+    }
+    ... on PersonalExperience {
+      title
+      description
+      startDate
+      endDate
+    }
+    ... on WorkExperience {
+      role
+      organization
+      division
+      startDate
+      endDate
+    }
+  }
 }
 
 fragment poolCandidateForm on PoolCandidate {
@@ -494,6 +496,12 @@ query getPoolCandidatesByPool($id: UUID!) {
     poolCandidates {
       ...poolCandidateTable
     }
+  }
+}
+
+query getSkillMatchDialogData($id: UUID!) {
+  user(id: $id) {
+    ...skillMatchDialog
   }
 }
 


### PR DESCRIPTION
🤖 Resolves #8523

## 👋 Introduction

Removes experiences from the main `PoolCandidatesTable` query moving them to a smaller query when opening the `SkillMatchDialog`.

## 🧪 Testing

1. Navigate to the pool candidates page and add a skill to the skill filter.
2. Confirm Experiences are not included in the main query.
3. Open the `SkillMatchDialog` for one of the candidates and confirm a smaller query runs for just that candidates experiences.
