### PR TITLE
[Fix] Enables i18n for the `DuplicateUserSkill` error message

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3584,7 +3584,7 @@
     "description": "Sub title for pool closing date"
   },
   "ID6PLP": {
-    "defaultMessage": "<strong>Non </strong>, c’est une compétence que j’ai utilisée dans le passé.",
+    "defaultMessage": "<strong>Non</strong>, c’est une compétence que j’ai utilisée dans le passé.",
     "description": "Option for when a skill was only used in the past"
   },
   "IDNjBI": {
@@ -10812,7 +10812,7 @@
     "description": "Titre du modèle qui apparaît lorsqu’un utilisateur tente d’archiver une candidature"
   },
   "yiqfHr": {
-    "defaultMessage": "<strong>Oui </strong>, J’utilise cette compétence dans mon rôle actuel.",
+    "defaultMessage": "<strong>Oui</strong>, J’utilise cette compétence dans mon rôle actuel.",
     "description": "Option for when a skill is currently being used"
   },
   "ynGRwF": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -10812,7 +10812,7 @@
     "description": "Titre du modèle qui apparaît lorsqu’un utilisateur tente d’archiver une candidature"
   },
   "yiqfHr": {
-    "defaultMessage": "<strong>Oui</strong>, J’utilise cette compétence dans mon rôle actuel.",
+    "defaultMessage": "<strong>Oui</strong>, j’utilise cette compétence dans mon rôle actuel.",
     "description": "Option for when a skill is currently being used"
   },
   "ynGRwF": {

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1731,6 +1731,10 @@
     "defaultMessage": "Français seulement",
     "description": "The language ability is French only."
   },
+  "wUJqDi": {
+    "defaultMessage": "La compétence que vous avez sélectionnée est déjà reliée à votre profil.",
+    "description": "Error message that the skill selected is already linked to the user profile."
+  },
   "x61BXA": {
     "defaultMessage": "Mars",
     "description": "Name of the third month"

--- a/packages/i18n/src/messages/apiMessages.ts
+++ b/packages/i18n/src/messages/apiMessages.ts
@@ -46,6 +46,13 @@ export const apiMessages: { [key: string]: MessageDescriptor } = defineMessages(
       id: "xSecEX",
       description: "Error message that the given skill key is already in use.",
     },
+    DuplicateUserSkill: {
+      defaultMessage:
+        "The skill you selected is already linked to your profile.",
+      id: "wUJqDi",
+      description:
+        "Error message that the skill selected is already linked to the user profile.",
+    },
 
     // team validation
     TeamNameInUse: {


### PR DESCRIPTION
🤖 Resolves #8465.

## 👋 Introduction

This PR enables i18n for the `DuplicateUserSkill` error message and adds copy in English and in French.

## 🕵️ Details

In English, the error returned is: "The skill you selected is already linked to your profile."
In French, the error returned is: "La compétence que vous avez sélectionnée est déjà reliée à votre profil."

## 🎁 Bonus

The French strings for the options for when a skill is currently being used and was only used in the past had extra trailing spaces after the first word in the string and an incorrect `majuscule`.

### Screenshots
#### Before
![Screen Shot 2023-11-20 at 15 24 14](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/1df500e3-77d2-4802-8567-62acfb8f8e79)

#### After
![Screen Shot 2023-11-20 at 15 43 41](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/2bc955be-1d33-4637-8d87-5a21b51ec557)


## 🎩 Gratitude

@Jerryescandon for "Work with a designer to pick an error message"!

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `applicant/profile-and-applications/skills`
2. Click **Add a new skill** button
3. Choose a skill that is already linked to the user's profile
4. Click **Save and add this skill** button
5. Observe error returned is: "The skill you selected is already linked to your profile."
6. Switch to French
7. Repeat steps 2 through 4
8. Observe error returned is: "La compétence que vous avez sélectionnée est déjà reliée à votre profil."

## 📸 Screenshots

### English
![Screen Shot 2023-11-20 at 15 26 11](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/5c7b3eeb-02a6-4f87-bdfc-acc24dc5d1e3)

### French
![Screen Shot 2023-11-20 at 15 27 34](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/709a8724-f096-4ed7-8745-a5cfd1f4dc00)
