### PR TITLE
[Feature] Add no candidates found status

### DIFF
--- a/api/app/Enums/PoolCandidateSearchStatus.php
+++ b/api/app/Enums/PoolCandidateSearchStatus.php
@@ -8,4 +8,5 @@ enum PoolCandidateSearchStatus
     case IN_PROGRESS;
     case WAITING;
     case DONE;
+    case DONE_NO_CANDIDATES;
 }

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1984,6 +1984,7 @@ enum PoolCandidateSearchStatus {
   IN_PROGRESS
   WAITING
   DONE
+  DONE_NO_CANDIDATES
 }
 
 enum PoolCandidateSearchPositionType {

--- a/apps/web/src/components/SearchRequestTable/components/utils.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/utils.tsx
@@ -48,6 +48,7 @@ export default function useFilterOptions() {
       PoolCandidateSearchStatus.InProgress,
       PoolCandidateSearchStatus.Waiting,
       PoolCandidateSearchStatus.Done,
+      PoolCandidateSearchStatus.DoneNoCandidates,
     ]).map(({ value }) => ({
       value,
       label: intl.formatMessage(getPoolCandidateSearchStatus(value)),

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/UpdateSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/UpdateSearchRequest.tsx
@@ -209,6 +209,7 @@ export const UpdateSearchRequestForm = ({
                   PoolCandidateSearchStatus.InProgress,
                   PoolCandidateSearchStatus.Waiting,
                   PoolCandidateSearchStatus.Done,
+                  PoolCandidateSearchStatus.DoneNoCandidates,
                 ]).map(({ value }) => ({
                   value,
                   label: intl.formatMessage(

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -635,6 +635,10 @@
     "defaultMessage": "B",
     "description": "The evaluated language ability level of B"
   },
+  "Mau9e6": {
+    "defaultMessage": "Fait - aucun candidat trouvé",
+    "description": "The search status is done with no candidates found"
+  },
   "Mco0Km": {
     "defaultMessage": "Vous devez posséder au moins une compétence essentielle.",
     "description": "Error message that at least one Essential Skill is required"

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -779,6 +779,11 @@ const poolCandidateSearchStatuses = defineMessages({
     id: "prkkM+",
     description: "The search status is Done.",
   },
+  [PoolCandidateSearchStatus.DoneNoCandidates]: {
+    defaultMessage: "Done - no candidates found",
+    id: "Mau9e6",
+    description: "The search status is done with no candidates found",
+  },
 });
 
 export const getPoolCandidateSearchStatus = (


### PR DESCRIPTION
🤖 Resolves #8542 

## 👋 Introduction

Adds a new status enum for search requests. 

## 🧪 Testing

1. Optionally seed fresh to generate requests with the new status
2. Head to requests
3. Set requests as the new status, filter, and observe 

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/0333b7ab-f8d6-4891-ad7e-29d9afe07ed6)

