### PR TITLE
[Fix] Adds `SupportForm` missing endpoint or key response

### DIFF
--- a/api/app/Http/Controllers/SupportController.php
+++ b/api/app/Http/Controllers/SupportController.php
@@ -9,6 +9,11 @@ class SupportController extends Controller
 {
     public function createTicket(Request $request)
     {
+        if (!config('freshdesk.api.tickets_endpoint') || !config('freshdesk.api.key')) {
+            return response([
+                'apiResponse' => 'Missing parameters',
+            ], 422);
+        }
         $parameters = [
             'description' => $request->input('description'),
             'subject' => $request->input('subject'),

--- a/api/app/Http/Controllers/SupportController.php
+++ b/api/app/Http/Controllers/SupportController.php
@@ -9,7 +9,7 @@ class SupportController extends Controller
 {
     public function createTicket(Request $request)
     {
-        if (!config('freshdesk.api.tickets_endpoint') || !config('freshdesk.api.key')) {
+        if (! config('freshdesk.api.tickets_endpoint') || ! config('freshdesk.api.key')) {
             return response([
                 'apiResponse' => 'Missing parameters',
             ], 422);

--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
@@ -274,6 +274,11 @@ const SupportFormApi = () => {
         );
         return Promise.resolve(response.status);
       }
+      if (response.status === 422) {
+        // status code 422 = missing params.
+        toast.error(intl.formatMessage(errorMessages.unknown));
+        return Promise.reject(response.status);
+      }
       if (response.status === 429) {
         toast.error(<>{intl.formatMessage(apiMessages.RATE_LIMIT)}</>, {
           autoClose: 20000,


### PR DESCRIPTION
🤖 Resolves #8581.

## 👋 Introduction

This PR adds a response for the `SupportForm` when there is a missing endpoint or key in the app's `api`.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure `FRESHDESK_API_TICKETS_ENDPOINT` or `FRESHDESK_API_KEY` in `api/.env` are not set
2. `npm run dev`
3. Navigate to `/support`
4. Fill out and submit form
5. Observe error toast
6. Witness a vast somethingness

## 📸 Screenshot

![Screen Shot 2023-11-23 at 10 26 30](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/0c6a27fd-da22-48a2-8795-8dae37e2ff8f)
