### PR TITLE
[Fix] Hidden scrollbar interactions closing dialogs

### DIFF
--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -24,10 +24,8 @@ const StyledOverlay = React.forwardRef<
   />
 ));
 
-type ContentRef = React.ElementRef<typeof DialogPrimitive.Content>;
-
 const StyledContent = React.forwardRef<
-  ContentRef,
+  React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >((props, forwardedRef) => {
   const scrollBarDetectRef = React.useRef<HTMLDivElement | null>(null);

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -27,69 +27,54 @@ const StyledOverlay = React.forwardRef<
 const StyledContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->((props, forwardedRef) => {
-  const scrollBarDetectRef = React.useRef<HTMLDivElement | null>(null);
+>((props, forwardedRef) => (
+  <DialogPrimitive.Content
+    ref={forwardedRef}
+    data-h2-font-family="base(sans)"
+    data-h2-max-width="base(48rem)"
+    data-h2-margin="base(x3, auto)"
+    data-h2-position="base(relative)"
+    data-h2-width="base(90vw)"
+    style={{
+      zIndex: 9999,
+    }}
+    {...props}
+    onPointerDownOutside={(event) => {
+      const target = event.target as HTMLElement;
 
-  return (
-    <>
-      <DialogPrimitive.Content
-        ref={forwardedRef}
-        data-h2-font-family="base(sans)"
-        data-h2-max-width="base(48rem)"
-        data-h2-margin="base(x3, auto)"
-        data-h2-position="base(relative)"
-        data-h2-width="base(90vw)"
-        style={{
-          zIndex: 9999,
-        }}
-        {...props}
-        onPointerDownOutside={(event) => {
-          const target = event.target as HTMLElement;
+      /**
+       * Roughly determine if the user is attempting to interact
+       * with a hidden scrollbar.
+       *
+       * Note: 16 is a rough estimate of the width of these scrollbars
+       * it is not entirely accurate since they change based on your operating system.
+       * This may create a small dead zone of 1-3px where clicking the overlay will not
+       * close the dialog. This is a trade off to allow users to scroll without a wheel.
+       *
+       * `targetIsScrollbar`: Checks to see if the click ocurred within 16px
+       * edge of the screen
+       *
+       * `targetIsScrollable`: Checks to see if the visible height of the container
+       * exceeds the total scroll height
+       *
+       * `scrollWidth`: If this is 0, the scrollbar is likely not there or hidden
+       *
+       */
+      // Note: 16 is a rough estimate of scrollbar width, this is not exact!
+      const targetIsScrollbar =
+        target.clientWidth - event.detail.originalEvent.clientX < 16;
+      const targetIsScrollable = target.clientHeight - target.scrollHeight < 0;
+      const scrollWidth = target.offsetWidth - target.clientWidth;
 
-          /**
-           * Roughly determine if the user is attempting to interact
-           * with a hidden scrollbar.
-           *
-           * Note: 16 is a rough estimate of the width of these scrollbars
-           * it is not entirely accurate since they change based on your operating system.
-           * This may create a small dead zone of 1-3px where clicking the overlay will not
-           * close the dialog. This is a trade off to allow users to scroll without a wheel.
-           *
-           * `targetIsScrollbar`: Checks to see if the click ocurred within 16px
-           * edge of the screen
-           *
-           * `targetIsScrollable`: Checks to see if the visible height of the container
-           * exceeds the total scroll height
-           *
-           * `scrollWidth`: If this is 0, the scrollbar is likely not there or hidden
-           *
-           */
-          // Note: 16 is a rough estimate of scrollbar width, this is not exact!
-          const targetIsScrollbar =
-            target.clientWidth - event.detail.originalEvent.clientX < 16;
-          const targetIsScrollable =
-            target.clientHeight - target.scrollHeight < 0;
-          const scrollWidth = target.offsetWidth - target.clientWidth;
+      if (targetIsScrollbar && targetIsScrollable && !scrollWidth) {
+        event.preventDefault();
+        return;
+      }
 
-          if (targetIsScrollbar && targetIsScrollable && !scrollWidth) {
-            event.preventDefault();
-            return;
-          }
-
-          props.onPointerDownOutside?.(event);
-        }}
-      />
-      <div
-        ref={scrollBarDetectRef}
-        data-h2-height="base(100px)"
-        data-h2-position="base(absolute)"
-        data-h2-overflow="base(scroll)"
-        data-h2-top="base(-9999px)"
-        data-h2-width="base(100px)"
-      />
-    </>
-  );
-});
+      props.onPointerDownOutside?.(event);
+    }}
+  />
+));
 
 const StyledClose = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Close>,

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -17,30 +17,81 @@ const StyledOverlay = React.forwardRef<
     data-h2-position="base(fixed)"
     data-h2-background-color="base(black.light.9)"
     data-h2-location="base(0)"
-    data-h2-overflow="base(visible auto)"
+    data-h2-overflow="base(auto)"
     style={{ placeItems: "center", zIndex: 9998 }}
     ref={forwardedRef}
     {...props}
   />
 ));
 
+type ContentRef = React.ElementRef<typeof DialogPrimitive.Content>;
+
 const StyledContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
+  ContentRef,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->((props, forwardedRef) => (
-  <DialogPrimitive.Content
-    data-h2-font-family="base(sans)"
-    data-h2-max-width="base(48rem)"
-    data-h2-margin="base(x3, auto)"
-    data-h2-position="base(relative)"
-    data-h2-width="base(90vw)"
-    style={{
-      zIndex: 9999,
-    }}
-    ref={forwardedRef}
-    {...props}
-  />
-));
+>((props, forwardedRef) => {
+  const scrollBarDetectRef = React.useRef<HTMLDivElement | null>(null);
+
+  return (
+    <>
+      <DialogPrimitive.Content
+        ref={forwardedRef}
+        data-h2-font-family="base(sans)"
+        data-h2-max-width="base(48rem)"
+        data-h2-margin="base(x3, auto)"
+        data-h2-position="base(relative)"
+        data-h2-width="base(90vw)"
+        style={{
+          zIndex: 9999,
+        }}
+        {...props}
+        onPointerDownOutside={(event) => {
+          const target = event.target as HTMLElement;
+
+          /**
+           * Roughly determine if the user is attempting to interact
+           * with a hidden scrollbar.
+           *
+           * Note: 16 is a rough estimate of the width of these scrollbars
+           * it is not entirely accurate since they change based on your operating system.
+           * This may create a small dead zone of 1-3px where clicking the overlay will not
+           * close the dialog. This is a trade off to allow users to scroll without a wheel.
+           *
+           * `targetIsScrollbar`: Checks to see if the click ocurred within 16px
+           * edge of the screen
+           *
+           * `targetIsScrollable`: Checks to see if the visible height of the container
+           * exceeds the total scroll height
+           *
+           * `scrollWidth`: If this is 0, the scrollbar is likely not there or hidden
+           *
+           */
+          // Note: 16 is a rough estimate of scrollbar width, this is not exact!
+          const targetIsScrollbar =
+            target.clientWidth - event.detail.originalEvent.clientX < 16;
+          const targetIsScrollable =
+            target.clientHeight - target.scrollHeight < 0;
+          const scrollWidth = target.offsetWidth - target.clientWidth;
+
+          if (targetIsScrollbar && targetIsScrollable && !scrollWidth) {
+            event.preventDefault();
+            return;
+          }
+
+          props.onPointerDownOutside?.(event);
+        }}
+      />
+      <div
+        ref={scrollBarDetectRef}
+        data-h2-height="base(100px)"
+        data-h2-position="base(absolute)"
+        data-h2-overflow="base(scroll)"
+        data-h2-top="base(-9999px)"
+        data-h2-width="base(100px)"
+      />
+    </>
+  );
+});
 
 const StyledClose = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Close>,


### PR DESCRIPTION
🤖 Resolves #8472 

## 👋 Introduction

Fixes a bug where interacting with hidden scrollbars was closing any open, scrollable dialogs.

## 🕵️ Details

This is an issue with hidden scrollbars specifically. They overlay ontop of content but allow the events to pass through them as to not interfere with the underlying content. The issue was, we have a full screen overlay that closes dialogs on the pointer down event.

This does some basic checks to attempt to determine if the click may have been inteneded to be a scroll click. If we think it may have been, we prevent the close event from firing.

> [!WARNING]
> This may result in a deadzone of up to 16px on the right of the overlay that will not close the dialog. I tested this on Windows and MacOS in a few browsers and the most I could see of a dead zone was about 1-2px. Do we think this trade off is worth it? (I do 😅 )

## 🧪 Testing

> [!NOTE]
> You may want to test with both always visible and hidden scrollbars.

1. Build `npm run dev`
2. Navigate to a long dialog (Indigenous identity is a good one!)
3. Try to scroll with the scroll bar and confirm it works as expected
4. Try to close the dialog by clicking as close as possible to the scrollbar as possible
5. If it does not close, gradually move away, attempting to close it to determine how large the dead zone (if any) is
6. Open a non-scrollable dialog
7. Repeat step 5 but with the edge of the screen


## 📸 Screenshot


https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/8fe0c91d-9a07-469b-8783-7178126faf88

