### PR TITLE
[Copy] Changes Apprenez-en advantage to Apprenez-en davantage

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2988,7 +2988,7 @@
     "description": "Link text for editing a users top behavioural skills"
   },
   "EYPaLh": {
-    "defaultMessage": "Vous avez obtenu un diplôme à l’extérieur du Canada? <foreignDegreeLink>Apprenez-en advantage sur les équivalences pour les diplômes étrangers.</foreignDegreeLink>",
+    "defaultMessage": "Vous avez obtenu un diplôme à l’extérieur du Canada? <foreignDegreeLink>Apprenez-en davantage sur les équivalences pour les diplômes étrangers.</foreignDegreeLink>",
     "description": "External link message for the EX graduation with degree requirement."
   },
   "EdUZaX": {
@@ -7748,7 +7748,7 @@
     "description": "Label for _official language requirement_ fieldset in the _digital services contracting questionnaire_"
   },
   "gZaILA": {
-    "defaultMessage": "Apprenez-en advantage sur la <directiveLink>Directive sur les talents numériques</directiveLink>.",
+    "defaultMessage": "Apprenez-en davantage sur la <directiveLink>Directive sur les talents numériques</directiveLink>.",
     "description": "Link to more information on the directive."
   },
   "gbquTr": {


### PR DESCRIPTION
🤖 Resolves #8583.

## 👋 Introduction

This PR changes _Apprenez-en advantage_ to _Apprenez-en davantage_ in French.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/fr/search/request`
2. Observe **Apprenez-en davantage...** copy
3. Navigate to `/fr/applications/:application-id/education` (pool must have `EX` classification group)
4. Observe **Apprenez-en davantage...** copy

## 📸 Screenshots

![Screen Shot 2023-11-23 at 14 52 45](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/7ccb9231-d8c1-4a1d-a2a2-933f7a7eed3a)

![Screen Shot 2023-11-23 at 14 50 42](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/5f0e9893-f44f-4e77-bd4e-4c7324e8132d)

