### PR TITLE
[Fix] Increase max page size for `PoolCandidatesTable`

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -595,7 +595,7 @@ const PoolCandidatesTable = ({
       pagination={{
         internal: false,
         total: data?.poolCandidatesPaginated?.paginatorInfo.total,
-        pageSizes: [10, 20, 50],
+        pageSizes: [10, 20, 50, 100, 500],
         onPaginationChange: ({ pageIndex, pageSize }: PaginationState) => {
           handlePaginationStateChange({ pageIndex, pageSize });
         },


### PR DESCRIPTION
🤖 Resolves #8591 

## 👋 Introduction

Fixes a regression in the page size for the pool candidates table after the refactor.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/admin/pool-candidates`
3. Confirm you can increase page size to 500

## 📸 Screenshot

![Screenshot 2023-11-23 164426](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/a5f77381-9080-4a7a-a72d-4b512e009e3a)