### PR TITLE
[Copy] Translated error messages for (un-)archiving pools

### DIFF
--- a/api/app/GraphQL/Mutations/ArchivePool.php
+++ b/api/app/GraphQL/Mutations/ArchivePool.php
@@ -18,7 +18,7 @@ final class ArchivePool
     {
         $pool = Pool::find($args['id']);
         if ($pool->getStatusAttribute() !== PoolStatus::CLOSED->name) {
-            throw ValidationException::withMessages(['You cannot archive a pool unless it is in the closed status.']);
+            throw ValidationException::withMessages(['ArchivePoolInvalidStatus']);
         }
         $pool->update(['archived_at' => Carbon::now()]);
 

--- a/api/app/GraphQL/Mutations/UnarchivePool.php
+++ b/api/app/GraphQL/Mutations/UnarchivePool.php
@@ -17,7 +17,7 @@ final class UnarchivePool
     {
         $pool = Pool::find($args['id']);
         if ($pool->getStatusAttribute() !== PoolStatus::ARCHIVED->name) {
-            throw ValidationException::withMessages(['You cannot un-archive a pool unless it is in the archived status.']);
+            throw ValidationException::withMessages(['UnarchivePoolInvalidStatus']);
         }
         $pool->update(['archived_at' => null]);
 

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -511,7 +511,7 @@ class PoolTest extends TestCase
                 'id' => $pool->id,
             ]
         )
-            ->assertGraphQLErrorMessage('You cannot archive a pool unless it is in the closed status.');
+            ->assertGraphQLErrorMessage('ArchivePoolInvalidStatus');
     }
 
     public function testCanUnarchiveArchived(): void
@@ -551,7 +551,7 @@ class PoolTest extends TestCase
                 'id' => $pool->id,
             ]
         )
-            ->assertGraphQLErrorMessage('You cannot un-archive a pool unless it is in the archived status.');
+            ->assertGraphQLErrorMessage('UnarchivePoolInvalidStatus');
     }
 
     public function testCannotPublishWithDeletedSkill(): void

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -271,6 +271,10 @@
     "defaultMessage": "La demande a déjà été soumise.",
     "description": "Error message that the given application is already submitted."
   },
+  "7D58wn": {
+    "defaultMessage": "Vous ne pouvez pas archiver un bassin à moins que le statut indique qu'il soit fermé.",
+    "description": "Error message when attempting to archive a pool with an invalid status."
+  },
   "7Gg5er": {
     "defaultMessage": "Déplacements selon les besoins",
     "description": "The operational requirement described as travel as required. (short-form for limited space)"
@@ -1254,6 +1258,10 @@
   "hd7hdn": {
     "defaultMessage": "avertissement",
     "description": "Message for the warning status"
+  },
+  "hpBnAk": {
+    "defaultMessage": "Vous ne pouvez pas désarchiver un bassin à moins que son statut indique qu'il soit archivé.",
+    "description": "Error message when attempting to un-archive a pool with an invalid status."
   },
   "i3Jl6C": {
     "defaultMessage": " : ",

--- a/packages/i18n/src/messages/apiMessages.ts
+++ b/packages/i18n/src/messages/apiMessages.ts
@@ -147,6 +147,22 @@ export const apiMessages: { [key: string]: MessageDescriptor } = defineMessages(
         "Error message that the pool closing date isn't in the future.",
     },
 
+    // pool archiving
+    ArchivePoolInvalidStatus: {
+      defaultMessage:
+        "You cannot archive a pool unless it is in the closed status.",
+      id: "7D58wn",
+      description:
+        "Error message when attempting to archive a pool with an invalid status.",
+    },
+    UnarchivePoolInvalidStatus: {
+      defaultMessage:
+        "You cannot un-archive a pool unless it is in the archived status.",
+      id: "hpBnAk",
+      description:
+        "Error message when attempting to un-archive a pool with an invalid status.",
+    },
+
     // pool publishing validation
     EnglishWorkTasksRequired: {
       defaultMessage: "You are missing a required field: English - Your work",


### PR DESCRIPTION
🤖 Resolves #8533

## 👋 Introduction

Adds translations for the api error messages when archiving/un-archiving pools.

## 🧪 Testing

1. First make the buttons appear for invalid pools by changing the `===` to `!==` in the following lines of code
https://github.com/GCTC-NTGC/gc-digital-talent/blob/ab0700f7c8b9dfec7f980e3badee19188078d6c0/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx#L375
https://github.com/GCTC-NTGC/gc-digital-talent/blob/ab0700f7c8b9dfec7f980e3badee19188078d6c0/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx#L381
2. Navigate to `/admin/pools`
3. Engage the title link for a Draft or Published pool
4. Engage **Archive process** button (appears as a link)
5. Engage **Archive process** button in the dialog
6. Observe error message
7. Engage **Un-archive process** button (appears as a link)
8. Engage **Un-archive process** button in the dialog
9. Observe error message
