### PR TITLE
[Fix] Stabilize `urlSync` for `ResponsiveTable`

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -542,6 +542,7 @@ const PoolCandidatesTable = ({
         initialState: defaultState.sortState,
       }}
       filter={{
+        initialState: initialFilterInput,
         state: filterRef.current,
         component: (
           <PoolCandidateTableFilterDialog

--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -241,7 +241,11 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
         }
       }
 
-      if (empty(filter?.state) || isEmpty(filter?.state)) {
+      if (
+        empty(filter?.state) ||
+        isEmpty(filter?.state) ||
+        isEqual(filter?.initialState, filter?.state)
+      ) {
         newParams.delete(SEARCH_PARAM_KEY.FILTERS);
       } else {
         newParams.set(SEARCH_PARAM_KEY.FILTERS, JSON.stringify(filter?.state));
@@ -270,6 +274,7 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
     pagination?.initialState?.pageIndex,
     urlSync,
     filter?.state,
+    filter?.initialState,
   ]);
 
   React.useEffect(() => {

--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -166,108 +166,95 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
   } = table.getState();
 
   React.useEffect(() => {
-    let searchState: SearchState = {
-      term: String(globalFilterState),
-    };
-    if (columnFilterState.length) {
-      searchState = {
-        term: String(columnFilterState[0].value),
-        type: columnFilterState[0].id,
-      };
-    }
-
-    const newHiddenIds = Object.keys(columnVisibilityState)
-      .map((colId) => (columnVisibilityState[colId] ? undefined : colId))
-      .filter(notEmpty);
-
     if (urlSync) {
-      setSearchParams(
-        (previous) => {
-          const newParams = new URLSearchParams(previous);
+      const currentParams = new URLSearchParams(window.location.search);
+      const newParams = new URLSearchParams(window.location.search);
 
-          const initialSortState =
-            sort?.initialState ?? INITIAL_STATE.sortState;
-          if (
-            isEqual(sortingState, initialSortState) ||
-            isEmpty(sortingState)
-          ) {
-            newParams.delete(SEARCH_PARAM_KEY.SORT_RULE);
-          } else {
-            newParams.set(
-              SEARCH_PARAM_KEY.SORT_RULE,
-              JSON.stringify(sortingState),
-            );
-          }
+      let searchState: SearchState = {
+        term: String(globalFilterState),
+      };
+      if (columnFilterState.length) {
+        searchState = {
+          term: String(columnFilterState[0].value),
+          type: columnFilterState[0].id,
+        };
+      }
 
-          if (isEqual(hiddenColumnIds, newHiddenIds) || isEmpty(sortingState)) {
-            newParams.delete(SEARCH_PARAM_KEY.HIDDEN_COLUMNS);
-          } else {
-            newParams.set(
-              SEARCH_PARAM_KEY.HIDDEN_COLUMNS,
-              newHiddenIds.join(","),
-            );
-          }
+      const newHiddenIds = Object.keys(columnVisibilityState)
+        .map((colId) => (columnVisibilityState[colId] ? undefined : colId))
+        .filter(notEmpty);
 
-          const initialPageSize =
-            pagination?.initialState?.pageSize ??
-            INITIAL_STATE.paginationState.pageSize;
-          if (paginationState.pageSize === initialPageSize) {
-            newParams.delete(SEARCH_PARAM_KEY.PAGE_SIZE);
-          } else {
-            newParams.set(
-              SEARCH_PARAM_KEY.PAGE_SIZE,
-              String(paginationState.pageSize),
-            );
-          }
+      const initialSortState = sort?.initialState ?? INITIAL_STATE.sortState;
+      if (isEqual(sortingState, initialSortState) || isEmpty(sortingState)) {
+        newParams.delete(SEARCH_PARAM_KEY.SORT_RULE);
+      } else {
+        newParams.set(SEARCH_PARAM_KEY.SORT_RULE, JSON.stringify(sortingState));
+      }
 
-          const initialPageIndex =
-            pagination?.initialState?.pageIndex ??
-            INITIAL_STATE.paginationState.pageIndex;
-          if (paginationState.pageIndex === initialPageIndex) {
-            newParams.delete(SEARCH_PARAM_KEY.PAGE);
-          } else {
-            newParams.set(
-              SEARCH_PARAM_KEY.PAGE,
-              String(paginationState.pageIndex + 1),
-            );
-          }
+      if (isEqual(hiddenColumnIds, newHiddenIds) || isEmpty(sortingState)) {
+        newParams.delete(SEARCH_PARAM_KEY.HIDDEN_COLUMNS);
+      } else {
+        newParams.set(SEARCH_PARAM_KEY.HIDDEN_COLUMNS, newHiddenIds.join(","));
+      }
 
-          const initialSearchState =
-            search?.initialState ?? INITIAL_STATE.searchState;
-          if (isEqual(initialSearchState, searchState)) {
-            newParams.delete(SEARCH_PARAM_KEY.SEARCH_COLUMN);
-            newParams.delete(SEARCH_PARAM_KEY.SEARCH_TERM);
-          } else if (columnFilterState.length > 0) {
-            newParams.set(
-              SEARCH_PARAM_KEY.SEARCH_COLUMN,
-              columnFilterState[0].id,
-            );
-            newParams.set(
-              SEARCH_PARAM_KEY.SEARCH_TERM,
-              String(columnFilterState[0].value),
-            );
-          } else {
-            newParams.delete(SEARCH_PARAM_KEY.SEARCH_COLUMN);
-            if (globalFilterState) {
-              newParams.set(SEARCH_PARAM_KEY.SEARCH_TERM, globalFilterState);
-            } else {
-              newParams.delete(SEARCH_PARAM_KEY.SEARCH_TERM);
-            }
-          }
+      const initialPageSize =
+        pagination?.initialState?.pageSize ??
+        INITIAL_STATE.paginationState.pageSize;
+      if (paginationState.pageSize === initialPageSize) {
+        newParams.delete(SEARCH_PARAM_KEY.PAGE_SIZE);
+      } else {
+        newParams.set(
+          SEARCH_PARAM_KEY.PAGE_SIZE,
+          String(paginationState.pageSize),
+        );
+      }
 
-          if (empty(filter?.state) || isEmpty(filter?.state)) {
-            newParams.delete(SEARCH_PARAM_KEY.FILTERS);
-          } else {
-            newParams.set(
-              SEARCH_PARAM_KEY.FILTERS,
-              JSON.stringify(filter?.state),
-            );
-          }
+      const initialPageIndex =
+        pagination?.initialState?.pageIndex ??
+        INITIAL_STATE.paginationState.pageIndex;
+      if (paginationState.pageIndex === initialPageIndex) {
+        newParams.delete(SEARCH_PARAM_KEY.PAGE);
+      } else {
+        newParams.set(
+          SEARCH_PARAM_KEY.PAGE,
+          String(paginationState.pageIndex + 1),
+        );
+      }
 
-          return newParams;
-        },
-        { replace: true },
-      );
+      const initialSearchState =
+        search?.initialState ?? INITIAL_STATE.searchState;
+      if (isEqual(initialSearchState, searchState)) {
+        newParams.delete(SEARCH_PARAM_KEY.SEARCH_COLUMN);
+        newParams.delete(SEARCH_PARAM_KEY.SEARCH_TERM);
+      } else if (columnFilterState.length > 0) {
+        newParams.set(SEARCH_PARAM_KEY.SEARCH_COLUMN, columnFilterState[0].id);
+        newParams.set(
+          SEARCH_PARAM_KEY.SEARCH_TERM,
+          String(columnFilterState[0].value),
+        );
+      } else {
+        newParams.delete(SEARCH_PARAM_KEY.SEARCH_COLUMN);
+        if (globalFilterState) {
+          newParams.set(SEARCH_PARAM_KEY.SEARCH_TERM, globalFilterState);
+        } else {
+          newParams.delete(SEARCH_PARAM_KEY.SEARCH_TERM);
+        }
+      }
+
+      if (empty(filter?.state) || isEmpty(filter?.state)) {
+        newParams.delete(SEARCH_PARAM_KEY.FILTERS);
+      } else {
+        newParams.set(SEARCH_PARAM_KEY.FILTERS, JSON.stringify(filter?.state));
+      }
+
+      if (
+        !isEqual(
+          Object.fromEntries(currentParams),
+          Object.fromEntries(newParams),
+        )
+      ) {
+        setSearchParams(newParams, { replace: true });
+      }
     }
   }, [
     sortingState,

--- a/apps/web/src/components/Table/ResponsiveTable/types.ts
+++ b/apps/web/src/components/Table/ResponsiveTable/types.ts
@@ -70,6 +70,7 @@ export type SortDef = {
 };
 
 export type FilterDef<TFilterState = object> = {
+  initialState?: TFilterState;
   state?: TFilterState;
   component: React.ReactNode;
 };


### PR DESCRIPTION
🤖 Resolves #8597 

## 👋 Introduction

Fixes a bug that caused infinite re-renders when using `urlSync` on pages that need to read from url params. This also prevents the URL from updating with default filters.

## 🕵️ Details

It seems that the `setSearchParams` updater does not work like the default `setState` update in react. Using the updater, it causes a navigation regardless if there are any new params.

We fixed this by checking to see if the new params are different than our current params before setting them.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/admin/pools`
3. Click on "View candidates" for any row
4. Confirm the page is not infinitely re-rendering
5. Confirm the URL state sync still works
