### PR TITLE
Dark mode: Forms edition

### DIFF
--- a/packages/forms/src/components/CardOptionGroup/CardOptionGroup.stories.tsx
+++ b/packages/forms/src/components/CardOptionGroup/CardOptionGroup.stories.tsx
@@ -37,7 +37,7 @@ const TemplateCardOptionGroup: StoryFn<typeof CardOptionGroup> = (args) => {
         <div
           data-h2={theme}
           data-h2-background="base(background)"
-          data-h2-padding="base(x1)"
+          data-h2-padding="base(x2)"
           key={theme}
         >
           <Form onSubmit={action("Submit Form")}>

--- a/packages/forms/src/components/CardOptionGroup/CardOptionGroup.tsx
+++ b/packages/forms/src/components/CardOptionGroup/CardOptionGroup.tsx
@@ -147,7 +147,11 @@ const CardOptionGroup = ({
         data-h2-flex-direction="base(column)"
         data-h2-gap="base(x.25)"
       >
-        <Field.Legend required={!!rules.required} data-h2-color="base(black)">
+        <Field.Legend
+          required={!!rules.required}
+          data-h2-color="base(black)"
+          data-h2-margin-bottom="base(x.25)"
+        >
           {legend}
         </Field.Legend>
         {items.map(
@@ -192,6 +196,7 @@ const CardOptionGroup = ({
                   htmlFor={id}
                   data-h2-cursor="base(pointer)"
                   data-h2-color="base(black)"
+                  data-h2-font-size="base(body)"
                 >
                   <Icon data-h2-height="base(x1)" data-h2-width="base(x1)" />
                   <span>{label}</span>

--- a/packages/forms/src/components/CheckButton/CheckButton.stories.tsx
+++ b/packages/forms/src/components/CheckButton/CheckButton.stories.tsx
@@ -6,11 +6,13 @@ import CheckButton from "./CheckButton";
 
 export default {
   component: CheckButton,
-  title: "Components/Check Button",
+  title: "Form/Check Button",
   args: {
     label: "Check button label",
   },
 } as Meta;
+
+const themes = ["light", "dark"];
 
 const Template: Story<{ label: string }> = (args) => {
   const [isChecked, setChecked] = React.useState<boolean>(false);
@@ -24,59 +26,75 @@ const Template: Story<{ label: string }> = (args) => {
 
   return (
     <div
-      data-h2-display="base(flex)"
-      data-h2-justify-content="base(space-around)"
-      data-h2-margin="base(-x1)"
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(100%)"
     >
-      <div
-        data-h2-display="base(flex)"
-        data-h2-flex-direction="base(column)"
-        data-h2-align-items="base(center)"
-        data-h2-padding="base(x1)"
-      >
-        <span>Not Checked</span>
-        <CheckButton
-          checked={false}
-          onToggle={() => action("clicked not checked")}
-          label="Not Checked"
-        />
-      </div>
-      <div
-        data-h2-display="base(flex)"
-        data-h2-flex-direction="base(column)"
-        data-h2-align-items="base(center)"
-        data-h2-padding="base(x1)"
-      >
-        <span>Checked</span>
-        <CheckButton
-          checked
-          onToggle={() => action("clicked checked")}
-          label="Checked"
-        />
-      </div>
-      <div
-        data-h2-display="base(flex)"
-        data-h2-flex-direction="base(column)"
-        data-h2-align-items="base(center)"
-        data-h2-padding="base(x1)"
-      >
-        <span>Indeterminate</span>
-        <CheckButton
-          checked={false}
-          indeterminate
-          onToggle={() => action("clicked indeterminate")}
-          label="Indeterminate"
-        />
-      </div>
-      <div
-        data-h2-display="base(flex)"
-        data-h2-flex-direction="base(column)"
-        data-h2-align-items="base(center)"
-        data-h2-padding="base(x1)"
-      >
-        <span>Controlled</span>
-        <CheckButton checked={isChecked} onToggle={handleCheck} label={label} />
-      </div>
+      {themes.map((theme) => (
+        <div data-h2={theme} key={theme}>
+          <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+            <div
+              data-h2-display="base(flex)"
+              data-h2-justify-content="base(space-around)"
+              data-h2-margin="base(-x1)"
+              data-h2-color="base(black)"
+            >
+              <div
+                data-h2-display="base(flex)"
+                data-h2-flex-direction="base(column)"
+                data-h2-align-items="base(center)"
+                data-h2-padding="base(x1)"
+              >
+                <span>Not Checked</span>
+                <CheckButton
+                  checked={false}
+                  onToggle={() => action("clicked not checked")}
+                  label="Not Checked"
+                />
+              </div>
+              <div
+                data-h2-display="base(flex)"
+                data-h2-flex-direction="base(column)"
+                data-h2-align-items="base(center)"
+                data-h2-padding="base(x1)"
+              >
+                <span>Checked</span>
+                <CheckButton
+                  checked
+                  onToggle={() => action("clicked checked")}
+                  label="Checked"
+                />
+              </div>
+              <div
+                data-h2-display="base(flex)"
+                data-h2-flex-direction="base(column)"
+                data-h2-align-items="base(center)"
+                data-h2-padding="base(x1)"
+              >
+                <span>Indeterminate</span>
+                <CheckButton
+                  checked={false}
+                  indeterminate
+                  onToggle={() => action("clicked indeterminate")}
+                  label="Indeterminate"
+                />
+              </div>
+              <div
+                data-h2-display="base(flex)"
+                data-h2-flex-direction="base(column)"
+                data-h2-align-items="base(center)"
+                data-h2-padding="base(x1)"
+              >
+                <span>Controlled</span>
+                <CheckButton
+                  checked={isChecked}
+                  onToggle={handleCheck}
+                  label={label}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      ))}
     </div>
   );
 };

--- a/packages/forms/src/components/CheckButton/CheckButton.tsx
+++ b/packages/forms/src/components/CheckButton/CheckButton.tsx
@@ -19,9 +19,10 @@ const borderMap = {
 
 const colorMap = {
   black: {
-    "data-h2-color": "base(black)",
+    "data-h2-color": "base(black) base:dark:hover(white)",
     "data-h2-background-color":
-      "base(transparent) base:hover(primary.light.25)",
+      "base(transparent) base:all:hover(primary.lightest)",
+    "data-h2-border-color": "base:dark:children[span]:hover(white)",
   },
   white: {
     "data-h2-color": "base(gray.light)",

--- a/packages/forms/src/components/CheckButton/check-button.css
+++ b/packages/forms/src/components/CheckButton/check-button.css
@@ -1,7 +1,6 @@
 .check-button {
   border: none;
   cursor: pointer;
-  transition: background-color 150ms ease-in;
 }
 
 .check-button__inner {

--- a/packages/forms/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/forms/src/components/Checkbox/Checkbox.stories.tsx
@@ -15,32 +15,26 @@ export default {
   title: "Form/Checkbox",
 } as Meta;
 
+const themes = ["light", "dark"];
+
 const TemplateCheckbox: Story<CheckboxProps> = (args) => {
   return (
     <div
       data-h2-display="base(grid)"
       data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
     >
-      <div data-h2="light">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form onSubmit={action("Submit Form")}>
-            <Checkbox {...args} />
-            <p data-h2-margin-top="base(x1)">
-              <Submit />
-            </p>
-          </Form>
+      {themes.map((theme) => (
+        <div data-h2={theme} key={theme}>
+          <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+            <Form onSubmit={action("Submit Form")}>
+              <Checkbox {...args} />
+              <p data-h2-margin-top="base(x1)">
+                <Submit />
+              </p>
+            </Form>
+          </div>
         </div>
-      </div>
-      <div data-h2="dark">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form onSubmit={action("Submit Form")}>
-            <Checkbox {...args} />
-            <p data-h2-margin-top="base(x1)">
-              <Submit />
-            </p>
-          </Form>
-        </div>
-      </div>
+      ))}
     </div>
   );
 };

--- a/packages/forms/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/forms/src/components/Checkbox/Checkbox.stories.tsx
@@ -17,12 +17,31 @@ export default {
 
 const TemplateCheckbox: Story<CheckboxProps> = (args) => {
   return (
-    <Form onSubmit={action("Submit Form")}>
-      <Checkbox {...args} />
-      <p data-h2-margin-top="base(x1)">
-        <Submit />
-      </p>
-    </Form>
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
+    >
+      <div data-h2="light">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form onSubmit={action("Submit Form")}>
+            <Checkbox {...args} />
+            <p data-h2-margin-top="base(x1)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
+      <div data-h2="dark">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form onSubmit={action("Submit Form")}>
+            <Checkbox {...args} />
+            <p data-h2-margin-top="base(x1)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
+    </div>
   );
 };
 
@@ -48,7 +67,9 @@ CheckboxWithBoundingBox.args = {
 CheckboxElementLabel.args = {
   id: "Red Selection",
   name: "Red Selection",
-  label: <span data-h2-background-color="base(error)">Red Selection</span>,
+  label: (
+    <span data-h2-background-color="base(error.lighter)">Red Selection</span>
+  ),
 };
 
 LongTextCheckbox.args = {

--- a/packages/forms/src/components/Checkbox/Checkbox.tsx
+++ b/packages/forms/src/components/Checkbox/Checkbox.tsx
@@ -75,7 +75,12 @@ const Checkbox = ({
               {...register(name, rules)}
               {...rest}
             />
-            <span data-h2-margin-top="base(-x.125)">{label}</span>
+            <span
+              data-h2-font-size="base(body)"
+              data-h2-margin-top="base(-x.125)"
+            >
+              {label}
+            </span>
             {!asFieldset && !inCheckList && (
               <Field.Required required={!!rules.required} />
             )}

--- a/packages/forms/src/components/Checklist/Checklist.stories.tsx
+++ b/packages/forms/src/components/Checklist/Checklist.stories.tsx
@@ -13,12 +13,31 @@ export default {
 
 const TemplateChecklist: StoryFn<typeof Checklist> = (args) => {
   return (
-    <Form onSubmit={action("Submit Form")}>
-      <Checklist {...args} />
-      <p data-h2-margin-top="base(x1)">
-        <Submit />
-      </p>
-    </Form>
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(50% 50%)"
+    >
+      <div data-h2="light">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form onSubmit={action("Submit Form")}>
+            <Checklist {...args} />
+            <p data-h2-margin-top="base(x1)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
+      <div data-h2="dark">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form onSubmit={action("Submit Form")}>
+            <Checklist {...args} />
+            <p data-h2-margin-top="base(x1)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
+    </div>
   );
 };
 
@@ -62,10 +81,7 @@ ChecklistOfLabelElements.args = {
     {
       value: "one",
       label: (
-        <span
-          data-h2-background-color="base(error)"
-          data-h2-color="base(white)"
-        >
+        <span data-h2-background-color="base(error.lighter)">
           Red Selection
         </span>
       ),

--- a/packages/forms/src/components/Checklist/Checklist.stories.tsx
+++ b/packages/forms/src/components/Checklist/Checklist.stories.tsx
@@ -11,32 +11,26 @@ export default {
   title: "Form/Checklist",
 };
 
+const themes = ["light", "dark"];
+
 const TemplateChecklist: StoryFn<typeof Checklist> = (args) => {
   return (
     <div
       data-h2-display="base(grid)"
-      data-h2-grid-template-columns="base(50% 50%)"
+      data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
     >
-      <div data-h2="light">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form onSubmit={action("Submit Form")}>
-            <Checklist {...args} />
-            <p data-h2-margin-top="base(x1)">
-              <Submit />
-            </p>
-          </Form>
+      {themes.map((theme) => (
+        <div data-h2={theme} key={theme}>
+          <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+            <Form onSubmit={action("Submit Form")}>
+              <Checklist {...args} />
+              <p data-h2-margin-top="base(x1)">
+                <Submit />
+              </p>
+            </Form>
+          </div>
         </div>
-      </div>
-      <div data-h2="dark">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form onSubmit={action("Submit Form")}>
-            <Checklist {...args} />
-            <p data-h2-margin-top="base(x1)">
-              <Submit />
-            </p>
-          </Form>
-        </div>
-      </div>
+      ))}
     </div>
   );
 };

--- a/packages/forms/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/forms/src/components/Combobox/Combobox.stories.tsx
@@ -68,20 +68,47 @@ const Template: StoryFn<ComboboxType> = (args) => {
     : undefined;
 
   return (
-    <BasicForm
-      onSubmit={action("onSubmit")}
-      options={{ defaultValues: { skill: defaultValue ?? "" } }}
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(50% 50%)"
     >
-      <Combobox
-        {...rest}
-        onSearch={debouncedSearch}
-        fetching={isSearching}
-        options={mockSearch ? filteredOptions : options}
-      />
-      <p data-h2-margin-top="base(x1)">
-        <Submit />
-      </p>
-    </BasicForm>
+      <div data-h2="light">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <BasicForm
+            onSubmit={action("onSubmit")}
+            options={{ defaultValues: { skill: defaultValue ?? "" } }}
+          >
+            <Combobox
+              {...rest}
+              onSearch={debouncedSearch}
+              fetching={isSearching}
+              options={mockSearch ? filteredOptions : options}
+            />
+            <p data-h2-margin-top="base(x1)">
+              <Submit />
+            </p>
+          </BasicForm>
+        </div>
+      </div>
+      <div data-h2="dark">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <BasicForm
+            onSubmit={action("onSubmit")}
+            options={{ defaultValues: { skill: defaultValue ?? "" } }}
+          >
+            <Combobox
+              {...rest}
+              onSearch={debouncedSearch}
+              fetching={isSearching}
+              options={mockSearch ? filteredOptions : options}
+            />
+            <p data-h2-margin-top="base(x1)">
+              <Submit />
+            </p>
+          </BasicForm>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/packages/forms/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/forms/src/components/Combobox/Combobox.stories.tsx
@@ -39,6 +39,8 @@ export default {
   title: "Form/Combobox",
 };
 
+const themes = ["light", "dark"];
+
 const Template: StoryFn<ComboboxType> = (args) => {
   const { mockSearch, defaultValue, options, fetching, ...rest } = args;
   const [isSearching, setIsSearching] = React.useState<boolean>(
@@ -70,44 +72,28 @@ const Template: StoryFn<ComboboxType> = (args) => {
   return (
     <div
       data-h2-display="base(grid)"
-      data-h2-grid-template-columns="base(50% 50%)"
+      data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
     >
-      <div data-h2="light">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <BasicForm
-            onSubmit={action("onSubmit")}
-            options={{ defaultValues: { skill: defaultValue ?? "" } }}
-          >
-            <Combobox
-              {...rest}
-              onSearch={debouncedSearch}
-              fetching={isSearching}
-              options={mockSearch ? filteredOptions : options}
-            />
-            <p data-h2-margin-top="base(x1)">
-              <Submit />
-            </p>
-          </BasicForm>
+      {themes.map((theme) => (
+        <div data-h2={theme} key={theme}>
+          <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+            <BasicForm
+              onSubmit={action("onSubmit")}
+              options={{ defaultValues: { skill: defaultValue ?? "" } }}
+            >
+              <Combobox
+                {...rest}
+                onSearch={debouncedSearch}
+                fetching={isSearching}
+                options={mockSearch ? filteredOptions : options}
+              />
+              <p data-h2-margin-top="base(x1)">
+                <Submit />
+              </p>
+            </BasicForm>
+          </div>
         </div>
-      </div>
-      <div data-h2="dark">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <BasicForm
-            onSubmit={action("onSubmit")}
-            options={{ defaultValues: { skill: defaultValue ?? "" } }}
-          >
-            <Combobox
-              {...rest}
-              onSearch={debouncedSearch}
-              fetching={isSearching}
-              options={mockSearch ? filteredOptions : options}
-            />
-            <p data-h2-margin-top="base(x1)">
-              <Submit />
-            </p>
-          </BasicForm>
-        </div>
-      </div>
+      ))}
     </div>
   );
 };

--- a/packages/forms/src/components/Combobox/Input.tsx
+++ b/packages/forms/src/components/Combobox/Input.tsx
@@ -45,7 +45,7 @@ const Wrapper = React.forwardRef<HTMLDivElement, DivHTMLProps>(
       data-h2-flex-grow="base(1)"
       data-h2-width="base(100%)"
       data-h2-position="base(relative)"
-      data-h2-margin="base(x.125, 0)"
+      data-h2-margin="base(0, 0, x.125, 0)"
       {...props}
     />
   ),
@@ -145,7 +145,7 @@ const Toggle = React.forwardRef<HTMLButtonElement, ToggleProps>(
 const Separator = () => (
   <span data-h2-padding="base(x.25 0)">
     <SeparatorPrimitive
-      data-h2-background-color="base(black.lightest)"
+      data-h2-background-color="base(gray)"
       orientation="vertical"
       decorative
     />

--- a/packages/forms/src/components/Combobox/Multi.tsx
+++ b/packages/forms/src/components/Combobox/Multi.tsx
@@ -302,8 +302,8 @@ const Multi = ({
               type="button"
               mode="inline"
               color="black"
+              fontSize="caption"
               onClick={handleReset}
-              data-h2-font-size="base(caption)"
               data-h2-font-weight="base(400)"
             >
               {intl.formatMessage(formMessages.clearSelectedCombobox)}

--- a/packages/forms/src/components/DateInput/ControlledInput.tsx
+++ b/packages/forms/src/components/DateInput/ControlledInput.tsx
@@ -35,6 +35,7 @@ const ControlledInput = ({
 }: ControlledInputProps) => {
   const intl = useIntl();
   const inputStyles = useCommonInputStyles();
+  const selectStyles = useCommonInputStyles("select");
   const { year, month, day } = splitSegments(
     defaultValues ? defaultValues[name] : undefined,
   );
@@ -108,10 +109,10 @@ const ControlledInput = ({
             onChange={handleMonthChange}
             defaultValue={month || ""}
             data-h2-width="base(100%)"
-            {...inputStyles}
+            {...selectStyles}
             {...stateStyles}
           >
-            <option value="">
+            <option data-h2-color="base(gray.dark)" value="">
               {intl.formatMessage(dateMessages.selectAMonth)}
             </option>
             {months.map((monthName, index) => (

--- a/packages/forms/src/components/DateInput/DateInput.stories.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.stories.tsx
@@ -46,6 +46,8 @@ export default {
   },
 };
 
+const themes = ["light", "dark"];
+
 type DateInputArgs = typeof DateInput;
 type DefaultValueDateInputArgs = DateInputArgs & {
   defaultValue?: string;
@@ -56,48 +58,30 @@ const Template: StoryFn<DefaultValueDateInputArgs> = (args) => {
   return (
     <div
       data-h2-display="base(grid)"
-      data-h2-grid-template-columns="base(50% 50%)"
+      data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
     >
-      <div data-h2="light">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form
-            options={{
-              mode: "onSubmit",
-              defaultValues: defaultValue
-                ? {
-                    [rest.name]: defaultValue,
-                  }
-                : undefined,
-            }}
-            onSubmit={(data) => action("Submit Form")(data)}
-          >
-            <DateInput {...rest} />
-            <p data-h2-margin-top="base(x1)">
-              <Submit />
-            </p>
-          </Form>
+      {themes.map((theme) => (
+        <div data-h2={theme} key={theme}>
+          <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+            <Form
+              options={{
+                mode: "onSubmit",
+                defaultValues: defaultValue
+                  ? {
+                      [rest.name]: defaultValue,
+                    }
+                  : undefined,
+              }}
+              onSubmit={(data) => action("Submit Form")(data)}
+            >
+              <DateInput {...rest} />
+              <p data-h2-margin-top="base(x1)">
+                <Submit />
+              </p>
+            </Form>
+          </div>
         </div>
-      </div>
-      <div data-h2="dark">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form
-            options={{
-              mode: "onSubmit",
-              defaultValues: defaultValue
-                ? {
-                    [rest.name]: defaultValue,
-                  }
-                : undefined,
-            }}
-            onSubmit={(data) => action("Submit Form")(data)}
-          >
-            <DateInput {...rest} />
-            <p data-h2-margin-top="base(x1)">
-              <Submit />
-            </p>
-          </Form>
-        </div>
-      </div>
+      ))}
     </div>
   );
 };
@@ -166,34 +150,23 @@ const ValidationDependantTemplate: StoryFn<DateInputArgs> = (args) => {
   return (
     <div
       data-h2-display="base(grid)"
-      data-h2-grid-template-columns="base(50% 50%)"
+      data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
     >
-      <div data-h2="light">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form
-            options={{ mode: "onSubmit" }}
-            onSubmit={(data) => action("Submit Form")(data)}
-          >
-            <ValidationDependantInputs {...args} />
-            <p data-h2-margin="base(x1, 0, 0, 0)">
-              <Submit />
-            </p>
-          </Form>
+      {themes.map((theme) => (
+        <div data-h2={theme} key={theme}>
+          <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+            <Form
+              options={{ mode: "onSubmit" }}
+              onSubmit={(data) => action("Submit Form")(data)}
+            >
+              <ValidationDependantInputs {...args} />
+              <p data-h2-margin="base(x1, 0, 0, 0)">
+                <Submit />
+              </p>
+            </Form>
+          </div>
         </div>
-      </div>
-      <div data-h2="dark">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form
-            options={{ mode: "onSubmit" }}
-            onSubmit={(data) => action("Submit Form")(data)}
-          >
-            <ValidationDependantInputs {...args} />
-            <p data-h2-margin="base(x1, 0, 0, 0)">
-              <Submit />
-            </p>
-          </Form>
-        </div>
-      </div>
+      ))}
     </div>
   );
 };
@@ -221,36 +194,24 @@ const RenderDependantTemplate: StoryFn<DateInputArgs> = (args) => {
   return (
     <div
       data-h2-display="base(grid)"
-      data-h2-grid-template-columns="base(50% 50%)"
+      data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
     >
-      <div data-h2="light">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form
-            options={{ mode: "onSubmit" }}
-            onSubmit={(data) => action("Submit Form")(data)}
-          >
-            <DateInput name={name} {...rest} />
-            <RenderDependantInput name={name} />
-            <p data-h2-margin="base(x1, 0, 0, 0)">
-              <Submit />
-            </p>
-          </Form>
+      {themes.map((theme) => (
+        <div data-h2={theme} key={theme}>
+          <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+            <Form
+              options={{ mode: "onSubmit" }}
+              onSubmit={(data) => action("Submit Form")(data)}
+            >
+              <DateInput name={name} {...rest} />
+              <RenderDependantInput name={name} />
+              <p data-h2-margin="base(x1, 0, 0, 0)">
+                <Submit />
+              </p>
+            </Form>
+          </div>
         </div>
-      </div>
-      <div data-h2="dark">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form
-            options={{ mode: "onSubmit" }}
-            onSubmit={(data) => action("Submit Form")(data)}
-          >
-            <DateInput name={name} {...rest} />
-            <RenderDependantInput name={name} />
-            <p data-h2-margin="base(x1, 0, 0, 0)">
-              <Submit />
-            </p>
-          </Form>
-        </div>
-      </div>
+      ))}
     </div>
   );
 };
@@ -281,60 +242,36 @@ const AsyncTemplate: StoryFn<AsyncArgs> = (args) => {
   return (
     <div
       data-h2-display="base(grid)"
-      data-h2-grid-template-columns="base(50% 50%)"
+      data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
     >
-      <div data-h2="light">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Pending fetching={fetching}>
-            <Form
-              options={{
-                mode: "onSubmit",
-                defaultValues: {
-                  [rest.name]: pool?.closingDate
-                    ? formatDate({
-                        date: parseISO(pool?.closingDate),
-                        formatString: DATE_FORMAT_STRING,
-                        intl,
-                      })
-                    : undefined,
-                },
-              }}
-              onSubmit={(data) => action("Submit Form")(data)}
-            >
-              <DateInput {...rest} />
-              <p data-h2-margin="base(x1, 0, 0, 0)">
-                <Submit />
-              </p>
-            </Form>
-          </Pending>
+      {themes.map((theme) => (
+        <div data-h2={theme} key={theme}>
+          <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+            <Pending fetching={fetching}>
+              <Form
+                options={{
+                  mode: "onSubmit",
+                  defaultValues: {
+                    [rest.name]: pool?.closingDate
+                      ? formatDate({
+                          date: parseISO(pool?.closingDate),
+                          formatString: DATE_FORMAT_STRING,
+                          intl,
+                        })
+                      : undefined,
+                  },
+                }}
+                onSubmit={(data) => action("Submit Form")(data)}
+              >
+                <DateInput {...rest} />
+                <p data-h2-margin="base(x1, 0, 0, 0)">
+                  <Submit />
+                </p>
+              </Form>
+            </Pending>
+          </div>
         </div>
-      </div>
-      <div data-h2="dark">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Pending fetching={fetching}>
-            <Form
-              options={{
-                mode: "onSubmit",
-                defaultValues: {
-                  [rest.name]: pool?.closingDate
-                    ? formatDate({
-                        date: parseISO(pool?.closingDate),
-                        formatString: DATE_FORMAT_STRING,
-                        intl,
-                      })
-                    : undefined,
-                },
-              }}
-              onSubmit={(data) => action("Submit Form")(data)}
-            >
-              <DateInput {...rest} />
-              <p data-h2-margin="base(x1, 0, 0, 0)">
-                <Submit />
-              </p>
-            </Form>
-          </Pending>
-        </div>
-      </div>
+      ))}
     </div>
   );
 };

--- a/packages/forms/src/components/DateInput/DateInput.stories.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.stories.tsx
@@ -54,22 +54,51 @@ type DefaultValueDateInputArgs = DateInputArgs & {
 const Template: StoryFn<DefaultValueDateInputArgs> = (args) => {
   const { defaultValue, ...rest } = args;
   return (
-    <Form
-      options={{
-        mode: "onSubmit",
-        defaultValues: defaultValue
-          ? {
-              [rest.name]: defaultValue,
-            }
-          : undefined,
-      }}
-      onSubmit={(data) => action("Submit Form")(data)}
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(50% 50%)"
     >
-      <DateInput {...rest} />
-      <p data-h2-margin-top="base(x1)">
-        <Submit />
-      </p>
-    </Form>
+      <div data-h2="light">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form
+            options={{
+              mode: "onSubmit",
+              defaultValues: defaultValue
+                ? {
+                    [rest.name]: defaultValue,
+                  }
+                : undefined,
+            }}
+            onSubmit={(data) => action("Submit Form")(data)}
+          >
+            <DateInput {...rest} />
+            <p data-h2-margin-top="base(x1)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
+      <div data-h2="dark">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form
+            options={{
+              mode: "onSubmit",
+              defaultValues: defaultValue
+                ? {
+                    [rest.name]: defaultValue,
+                  }
+                : undefined,
+            }}
+            onSubmit={(data) => action("Submit Form")(data)}
+          >
+            <DateInput {...rest} />
+            <p data-h2-margin-top="base(x1)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
+    </div>
   );
 };
 
@@ -135,13 +164,37 @@ const ValidationDependantInputs = ({
 
 const ValidationDependantTemplate: StoryFn<DateInputArgs> = (args) => {
   return (
-    <Form
-      options={{ mode: "onSubmit" }}
-      onSubmit={(data) => action("Submit Form")(data)}
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(50% 50%)"
     >
-      <ValidationDependantInputs {...args} />
-      <Submit />
-    </Form>
+      <div data-h2="light">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form
+            options={{ mode: "onSubmit" }}
+            onSubmit={(data) => action("Submit Form")(data)}
+          >
+            <ValidationDependantInputs {...args} />
+            <p data-h2-margin="base(x1, 0, 0, 0)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
+      <div data-h2="dark">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form
+            options={{ mode: "onSubmit" }}
+            onSubmit={(data) => action("Submit Form")(data)}
+          >
+            <ValidationDependantInputs {...args} />
+            <p data-h2-margin="base(x1, 0, 0, 0)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
+    </div>
   );
 };
 
@@ -157,7 +210,7 @@ const RenderDependantInput = ({ name }: Pick<DateInputProps, "name">) => {
   return inputDate && isAfter(new Date(), inputDate) ? (
     <Input type="text" id="signature" name="signature" label="Signature" />
   ) : (
-    <p data-h2-margin="base(x1, 0)">
+    <p data-h2-color="base(black)" data-h2-margin="base(x1, 0)">
       Please select a date in the past to continue.
     </p>
   );
@@ -166,14 +219,39 @@ const RenderDependantInput = ({ name }: Pick<DateInputProps, "name">) => {
 const RenderDependantTemplate: StoryFn<DateInputArgs> = (args) => {
   const { name, ...rest } = args;
   return (
-    <Form
-      options={{ mode: "onSubmit" }}
-      onSubmit={(data) => action("Submit Form")(data)}
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(50% 50%)"
     >
-      <DateInput name={name} {...rest} />
-      <RenderDependantInput name={name} />
-      <Submit />
-    </Form>
+      <div data-h2="light">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form
+            options={{ mode: "onSubmit" }}
+            onSubmit={(data) => action("Submit Form")(data)}
+          >
+            <DateInput name={name} {...rest} />
+            <RenderDependantInput name={name} />
+            <p data-h2-margin="base(x1, 0, 0, 0)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
+      <div data-h2="dark">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form
+            options={{ mode: "onSubmit" }}
+            onSubmit={(data) => action("Submit Form")(data)}
+          >
+            <DateInput name={name} {...rest} />
+            <RenderDependantInput name={name} />
+            <p data-h2-margin="base(x1, 0, 0, 0)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
+    </div>
   );
 };
 
@@ -201,26 +279,63 @@ const AsyncTemplate: StoryFn<AsyncArgs> = (args) => {
   }, [mockQuery]);
 
   return (
-    <Pending fetching={fetching}>
-      <Form
-        options={{
-          mode: "onSubmit",
-          defaultValues: {
-            [rest.name]: pool?.closingDate
-              ? formatDate({
-                  date: parseISO(pool?.closingDate),
-                  formatString: DATE_FORMAT_STRING,
-                  intl,
-                })
-              : undefined,
-          },
-        }}
-        onSubmit={(data) => action("Submit Form")(data)}
-      >
-        <DateInput {...rest} />
-        <Submit />
-      </Form>
-    </Pending>
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(50% 50%)"
+    >
+      <div data-h2="light">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Pending fetching={fetching}>
+            <Form
+              options={{
+                mode: "onSubmit",
+                defaultValues: {
+                  [rest.name]: pool?.closingDate
+                    ? formatDate({
+                        date: parseISO(pool?.closingDate),
+                        formatString: DATE_FORMAT_STRING,
+                        intl,
+                      })
+                    : undefined,
+                },
+              }}
+              onSubmit={(data) => action("Submit Form")(data)}
+            >
+              <DateInput {...rest} />
+              <p data-h2-margin="base(x1, 0, 0, 0)">
+                <Submit />
+              </p>
+            </Form>
+          </Pending>
+        </div>
+      </div>
+      <div data-h2="dark">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Pending fetching={fetching}>
+            <Form
+              options={{
+                mode: "onSubmit",
+                defaultValues: {
+                  [rest.name]: pool?.closingDate
+                    ? formatDate({
+                        date: parseISO(pool?.closingDate),
+                        formatString: DATE_FORMAT_STRING,
+                        intl,
+                      })
+                    : undefined,
+                },
+              }}
+              onSubmit={(data) => action("Submit Form")(data)}
+            >
+              <DateInput {...rest} />
+              <p data-h2-margin="base(x1, 0, 0, 0)">
+                <Submit />
+              </p>
+            </Form>
+          </Pending>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/packages/forms/src/components/Field/BoundingBox.tsx
+++ b/packages/forms/src/components/Field/BoundingBox.tsx
@@ -26,7 +26,7 @@ const BoundingBox = ({ flat, ...rest }: BoundingBoxProps) => {
             "data-h2-padding": "base(0)",
           }
         : {
-            "data-h2-background": "base(white) base:dark(black.light)",
+            "data-h2-background": "base(foreground)",
           })}
       {...rest}
     />

--- a/packages/forms/src/components/Field/Label.tsx
+++ b/packages/forms/src/components/Field/Label.tsx
@@ -11,7 +11,12 @@ export type LabelProps = React.DetailedHTMLProps<
 
 const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
   ({ required, children, ...props }, forwardedRef) => (
-    <label ref={forwardedRef} data-h2-font-size="base(caption)" {...props}>
+    <label
+      ref={forwardedRef}
+      data-h2-color="base(black)"
+      data-h2-font-size="base(caption)"
+      {...props}
+    >
       {children}
       <Required required={required} />
     </label>

--- a/packages/forms/src/components/Field/Legend.tsx
+++ b/packages/forms/src/components/Field/Legend.tsx
@@ -10,7 +10,11 @@ export type LegendProps = React.DetailedHTMLProps<
 };
 
 const Legend = ({ required, children, ...props }: LegendProps) => (
-  <legend data-h2-font-size="base(caption)" {...props}>
+  <legend
+    data-h2-color="base(black)"
+    data-h2-font-size="base(caption)"
+    {...props}
+  >
     {children}
     <Required required={required} />
   </legend>

--- a/packages/forms/src/components/Input/Input.stories.tsx
+++ b/packages/forms/src/components/Input/Input.stories.tsx
@@ -11,22 +11,10 @@ import type { InputProps } from ".";
 export default {
   component: Input,
   title: "Form/Input",
-  args: {
-    maxWidth: "20rem",
-  },
-  argTypes: {
-    maxWidth: {
-      name: "Max Width",
-      type: { name: "string", required: true },
-      control: {
-        type: "text",
-      },
-    },
-  },
 } as Meta;
 
-const TemplateInput: Story<InputProps & { maxWidth: string }> = (args) => {
-  const { maxWidth, ...rest } = args;
+const TemplateInput: Story<InputProps> = (args) => {
+  const { ...rest } = args;
   return (
     <div
       data-h2-display="base(grid)"

--- a/packages/forms/src/components/Input/Input.stories.tsx
+++ b/packages/forms/src/components/Input/Input.stories.tsx
@@ -13,33 +13,27 @@ export default {
   title: "Form/Input",
 } as Meta;
 
+const themes = ["light", "dark"];
+
 const TemplateInput: Story<InputProps> = (args) => {
   const { ...rest } = args;
   return (
     <div
       data-h2-display="base(grid)"
-      data-h2-grid-template-columns="base(50% 50%)"
+      data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
     >
-      <div data-h2="light">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form onSubmit={action("Submit Form")}>
-            <Input {...rest} />
-            <p data-h2-margin-top="base(x1)">
-              <Submit />
-            </p>
-          </Form>
+      {themes.map((theme) => (
+        <div data-h2={theme} key={theme}>
+          <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+            <Form onSubmit={action("Submit Form")}>
+              <Input {...rest} />
+              <p data-h2-margin-top="base(x1)">
+                <Submit />
+              </p>
+            </Form>
+          </div>
         </div>
-      </div>
-      <div data-h2="dark">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form onSubmit={action("Submit Form")}>
-            <Input {...rest} />
-            <p data-h2-margin-top="base(x1)">
-              <Submit />
-            </p>
-          </Form>
-        </div>
-      </div>
+      ))}
     </div>
   );
 };

--- a/packages/forms/src/components/Input/Input.stories.tsx
+++ b/packages/forms/src/components/Input/Input.stories.tsx
@@ -28,13 +28,30 @@ export default {
 const TemplateInput: Story<InputProps & { maxWidth: string }> = (args) => {
   const { maxWidth, ...rest } = args;
   return (
-    <div style={{ maxWidth }}>
-      <Form onSubmit={action("Submit Form")}>
-        <Input {...rest} />
-        <p data-h2-margin-top="base(x1)">
-          <Submit />
-        </p>
-      </Form>
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(50% 50%)"
+    >
+      <div data-h2="light">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form onSubmit={action("Submit Form")}>
+            <Input {...rest} />
+            <p data-h2-margin-top="base(x1)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
+      <div data-h2="dark">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form onSubmit={action("Submit Form")}>
+            <Input {...rest} />
+            <p data-h2-margin-top="base(x1)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
     </div>
   );
 };

--- a/packages/forms/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/forms/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -17,7 +17,7 @@ const TemplateRadioGroup: StoryFn<typeof RadioGroup> = (args) => {
   return (
     <div
       data-h2-display="base(grid)"
-      data-h2-grid-template-columns="base(50% 50%)"
+      data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
     >
       <div data-h2="light">
         <div data-h2-background="base(background)" data-h2-padding="base(x2)">

--- a/packages/forms/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/forms/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -13,32 +13,26 @@ export default {
   title: "Form/RadioGroup",
 };
 
+const themes = ["light", "dark"];
+
 const TemplateRadioGroup: StoryFn<typeof RadioGroup> = (args) => {
   return (
     <div
       data-h2-display="base(grid)"
       data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
     >
-      <div data-h2="light">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form onSubmit={action("Submit Form")}>
-            <RadioGroup {...args} />
-            <p data-h2-margin-top="base(x1)">
-              <Submit />
-            </p>
-          </Form>
+      {themes.map((theme) => (
+        <div data-h2={theme} key={theme}>
+          <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+            <Form onSubmit={action("Submit Form")}>
+              <RadioGroup {...args} />
+              <p data-h2-margin-top="base(x1)">
+                <Submit />
+              </p>
+            </Form>
+          </div>
         </div>
-      </div>
-      <div data-h2="dark">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form onSubmit={action("Submit Form")}>
-            <RadioGroup {...args} />
-            <p data-h2-margin-top="base(x1)">
-              <Submit />
-            </p>
-          </Form>
-        </div>
-      </div>
+      ))}
     </div>
   );
 };

--- a/packages/forms/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/forms/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -15,12 +15,31 @@ export default {
 
 const TemplateRadioGroup: StoryFn<typeof RadioGroup> = (args) => {
   return (
-    <Form onSubmit={action("Submit Form")}>
-      <RadioGroup {...args} />
-      <p data-h2-margin-top="base(x1)">
-        <Submit />
-      </p>
-    </Form>
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(50% 50%)"
+    >
+      <div data-h2="light">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form onSubmit={action("Submit Form")}>
+            <RadioGroup {...args} />
+            <p data-h2-margin-top="base(x1)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
+      <div data-h2="dark">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form onSubmit={action("Submit Form")}>
+            <RadioGroup {...args} />
+            <p data-h2-margin-top="base(x1)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
+    </div>
   );
 };
 
@@ -63,7 +82,11 @@ RadioGroupOfElements.args = {
   items: [
     {
       value: "one",
-      label: <span data-h2-background-color="base(error)">Red Selection</span>,
+      label: (
+        <span data-h2-background-color="base(error.lighter)">
+          Red Selection
+        </span>
+      ),
     },
     {
       value: "two",

--- a/packages/forms/src/components/Repeater/ActionButton.tsx
+++ b/packages/forms/src/components/Repeater/ActionButton.tsx
@@ -43,7 +43,7 @@ const ActionButton = React.forwardRef<HTMLButtonElement, ActionButtonProps>(
         {...(disabled
           ? {
               disabled: true,
-              "data-h2-color": "base(black.lightest)",
+              "data-h2-color": "base(gray.dark) base:dark(gray)",
               "data-h2-background-color": "base(foreground)",
             }
           : {

--- a/packages/forms/src/components/Repeater/Repeater.stories.tsx
+++ b/packages/forms/src/components/Repeater/Repeater.stories.tsx
@@ -40,6 +40,8 @@ const defaultArgs = {
   addText: "Add screening question",
 };
 
+const themes = ["light", "dark"];
+
 const Fields = (props: Omit<StoryProps, "defaultValues">) => {
   const intl = useIntl();
   const {
@@ -63,69 +65,80 @@ const Fields = (props: Omit<StoryProps, "defaultValues">) => {
   const canAdd = maxItems ? fields.length < maxItems : true;
 
   return (
-    <Repeater.Root
-      {...rootProps}
-      name={name}
-      trackUnsaved
-      addButtonProps={{
-        disabled: !canAdd,
-      }}
-      onAdd={() => {
-        const newValues = {
-          en: "",
-          fr: "",
-        };
-        append(newValues);
-        action("add")(newValues);
-      }}
-      maxItems={maxItems}
-      total={fields.length}
-      showApproachingLimit
-      showUnsavedChanges
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
     >
-      {fields.map((item, index) => (
-        <Repeater.Fieldset
-          key={item.id}
-          index={index}
-          name={name}
-          total={fields.length}
-          onMove={move}
-          onRemove={remove}
-          legend={`Screening Question ${index + 1}`}
-          hideLegend={hideLegend}
-          hideIndex={hideIndex}
-          onEdit={() => {
-            action("edit")("Opens edit form dialog.");
-          }}
-          moveDisabledIndexes={moveDisabledIndexes}
-          editDisabled={!!editDisabledIndexes?.includes(index)}
-          removeDisabled={!!removeDisabledIndexes?.includes(index)}
-        >
-          <div
-            data-h2-display="base(grid)"
-            data-h2-grid-template-columns="base(1fr 1fr)"
-            data-h2-gap="base(x.5)"
-          >
-            <TextArea
-              id={`${name}.${index}.en`}
-              name={`${name}.${index}.en`}
-              label="Question (EN)"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
+      {themes.map((theme) => (
+        <div data-h2={theme} key={theme}>
+          <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+            <Repeater.Root
+              {...rootProps}
+              name={name}
+              trackUnsaved
+              addButtonProps={{
+                disabled: !canAdd,
               }}
-            />
-            <TextArea
-              id={`${name}.${index}.fr`}
-              name={`${name}.${index}.fr`}
-              label="Question (FR)"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
+              onAdd={() => {
+                const newValues = {
+                  en: "",
+                  fr: "",
+                };
+                append(newValues);
+                action("add")(newValues);
               }}
-            />
+              maxItems={maxItems}
+              total={fields.length}
+              showApproachingLimit
+              showUnsavedChanges
+            >
+              {fields.map((item, index) => (
+                <Repeater.Fieldset
+                  key={item.id}
+                  index={index}
+                  name={name}
+                  total={fields.length}
+                  onMove={move}
+                  onRemove={remove}
+                  legend={`Screening Question ${index + 1}`}
+                  hideLegend={hideLegend}
+                  hideIndex={hideIndex}
+                  onEdit={() => {
+                    action("edit")("Opens edit form dialog.");
+                  }}
+                  moveDisabledIndexes={moveDisabledIndexes}
+                  editDisabled={!!editDisabledIndexes?.includes(index)}
+                  removeDisabled={!!removeDisabledIndexes?.includes(index)}
+                >
+                  <div
+                    data-h2-display="base(grid)"
+                    data-h2-grid-template-columns="base(1fr 1fr)"
+                    data-h2-gap="base(x.5)"
+                  >
+                    <TextArea
+                      id={`${name}.${index}.en`}
+                      name={`${name}.${index}.en`}
+                      label="Question (EN)"
+                      rules={{
+                        required: intl.formatMessage(errorMessages.required),
+                      }}
+                    />
+                    <TextArea
+                      id={`${name}.${index}.fr`}
+                      name={`${name}.${index}.fr`}
+                      label="Question (FR)"
+                      rules={{
+                        required: intl.formatMessage(errorMessages.required),
+                      }}
+                    />
+                  </div>
+                </Repeater.Fieldset>
+              ))}
+            </Repeater.Root>
           </div>
-        </Repeater.Fieldset>
+        </div>
       ))}
-    </Repeater.Root>
+    </div>
   );
 };
 

--- a/packages/forms/src/components/Repeater/Repeater.tsx
+++ b/packages/forms/src/components/Repeater/Repeater.tsx
@@ -146,7 +146,7 @@ const Fieldset = ({
 
   // replaces a button when it should be disabled.
   const disabledIcon = (
-    <span aria-hidden data-h2-width="base(x.75)">
+    <span data-h2-color="base(gray)" aria-hidden data-h2-width="base(x.75)">
       &bull;
     </span>
   );
@@ -356,7 +356,7 @@ const Fieldset = ({
                     role="presentation"
                     data-h2-margin="base(0, 0, x.5, 0)"
                     data-h2-color="base(inherit)"
-                    data-h2-font-weight="base(800)"
+                    data-h2-font-weight="base(700)"
                   >
                     {legend}
                   </p>
@@ -487,8 +487,9 @@ const Root = ({
       )}
       {total === 0 && (
         <Well
-          data-h2-margin-bottom="base(x1)"
+          data-h2-margin-bottom="base(x.5)"
           data-h2-text-align="base(center)"
+          data-h2-color="base(black)"
         >
           {customNullMessage ?? (
             <>
@@ -527,8 +528,9 @@ const Root = ({
       {total === maxItems && maxItemsMessage && <Well>{maxItemsMessage}</Well>}
       {hasUnsavedChanges ? (
         <Well
-          data-h2-margin-bottom="base(x1)"
+          data-h2-margin-bottom="base(x.5)"
           data-h2-text-align="base(center)"
+          data-h2-color="base(black)"
         >
           {intl.formatMessage(formMessages.repeaterUnsavedChanges)}
         </Well>

--- a/packages/forms/src/components/RichTextInput/ControlledInput.tsx
+++ b/packages/forms/src/components/RichTextInput/ControlledInput.tsx
@@ -83,7 +83,9 @@ const ControlledInput = ({
   return (
     <div>
       <MenuBar {...{ editor }} />
-      <EditorContent {...{ content, editor }} />
+      <div data-h2-color="base(black)">
+        <EditorContent {...{ content, editor }} />
+      </div>
       <Footer {...{ editor, wordLimit, name }} />
     </div>
   );

--- a/packages/forms/src/components/RichTextInput/MenuBar.tsx
+++ b/packages/forms/src/components/RichTextInput/MenuBar.tsx
@@ -20,14 +20,17 @@ const MenuBar = ({ editor }: MenuBarProps) => {
 
   return (
     <div
-      data-h2-background="base(background.darkest)"
-      data-h2-padding="base(x.25)"
+      data-h2-background="base:all(black)"
+      data-h2-padding="base(x.25, x.5, x.5, x.5)"
       data-h2-display="base(flex)"
-      data-h2-gap="base(x.25)"
+      data-h2-gap="base(x.5)"
       data-h2-radius="base(rounded rounded 0 0)"
       data-h2-justify-content="base(space-between)"
+      data-h2-border-top="base(1px solid gray)"
+      data-h2-border-right="base(1px solid gray)"
+      data-h2-border-left="base(1px solid gray)"
     >
-      <div data-h2-display="base(flex)" data-h2-gap="base(x.25)">
+      <div data-h2-display="base(flex)" data-h2-gap="base(x.5)">
         <MenuButton
           active={editor?.isActive("bulletList") ?? false}
           onClick={() => editor?.chain().focus().toggleBulletList().run()}
@@ -38,7 +41,7 @@ const MenuBar = ({ editor }: MenuBarProps) => {
         </MenuButton>
         <LinkDialog editor={editor} />
       </div>
-      <div data-h2-display="base(flex)" data-h2-gap="base(x.25)">
+      <div data-h2-display="base(flex)" data-h2-gap="base(x.5)">
         <MenuButton
           onClick={() => editor?.chain().focus().undo().run()}
           disabled={readOnly || !editor?.can().undo()}

--- a/packages/forms/src/components/RichTextInput/MenuButton.tsx
+++ b/packages/forms/src/components/RichTextInput/MenuButton.tsx
@@ -12,14 +12,13 @@ type MenuButtonProps = {
 };
 
 const MenuButton = React.forwardRef<HTMLButtonElement, MenuButtonProps>(
-  ({ active, ...rest }, ref) => (
+  ({ ...rest }, ref) => (
     <Button
       ref={ref}
-      mode="solid"
+      mode="text"
       type="button"
-      color={active ? "white" : "black"}
-      data-h2-padding="base(x.125 x.25)"
-      data-h2-font-size="base(caption)"
+      color="whiteFixed"
+      fontSize="caption"
       {...rest}
     />
   ),

--- a/packages/forms/src/components/RichTextInput/RichTextInput.stories.tsx
+++ b/packages/forms/src/components/RichTextInput/RichTextInput.stories.tsx
@@ -35,41 +35,59 @@ type DefaultValueRichTextInputArgs = RichTextInputArgs & {
   defaultValue?: string;
 };
 
+const themes = ["light", "dark"];
+
 const Template: StoryFn<DefaultValueRichTextInputArgs> = (args) => {
   const { defaultValue, ...rest } = args;
   const [output, setOutput] = React.useState<string>(
     defaultValue ? String(defaultValue) : "",
   );
   return (
-    <>
-      <Form
-        options={{
-          mode: "onSubmit",
-          defaultValues: defaultValue
-            ? {
-                [rest.name]: defaultValue,
-              }
-            : undefined,
-        }}
-        onSubmit={(data) => {
-          action("Submit Form")(data);
-          setOutput(String(data.richText));
-        }}
-      >
-        <RichTextInput {...rest} />
-        <p data-h2-margin-top="base(x1)">
-          <Submit />
-        </p>
-      </Form>
-      <Heading>Preview</Heading>
-      <div
-        data-h2-radius="base(s)"
-        data-h2-border="base(thin solid black)"
-        data-h2-padding="base(0 x1)"
-      >
-        <RichTextRenderer node={htmlToRichTextJSON(output)} />
-      </div>
-    </>
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
+    >
+      {themes.map((theme) => (
+        <div data-h2={theme} key={theme}>
+          <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+            <Form
+              options={{
+                mode: "onSubmit",
+                defaultValues: defaultValue
+                  ? {
+                      [rest.name]: defaultValue,
+                    }
+                  : undefined,
+              }}
+              onSubmit={(data) => {
+                action("Submit Form")(data);
+                setOutput(String(data.richText));
+              }}
+            >
+              <RichTextInput {...rest} />
+              <p data-h2-margin="base(x1, 0)">
+                <Submit />
+              </p>
+            </Form>
+            <Heading
+              size="h6"
+              data-h2-color="base(black)"
+              data-h2-font-weight="base(700)"
+            >
+              Preview
+            </Heading>
+            <div
+              data-h2-radius="base(s)"
+              data-h2-padding="base(x1)"
+              data-h2-shadow="base(larger)"
+              data-h2-background-color="base(foreground)"
+            >
+              <RichTextRenderer node={htmlToRichTextJSON(output)} />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
   );
 };
 

--- a/packages/forms/src/components/RichTextInput/RichTextRenderer.tsx
+++ b/packages/forms/src/components/RichTextInput/RichTextRenderer.tsx
@@ -10,7 +10,12 @@ const NoNode: NodeRenderer = ({ children }) => {
 };
 
 const DocNode: NodeRenderer = ({ children }) => (
-  <div data-h2-margin="base:children[>p](x1 0)">{children}</div>
+  <div
+    data-h2-color="base(black)"
+    data-h2-margin="base:children[>p:not(:first-child)](x.5, 0, 0, 0)"
+  >
+    {children}
+  </div>
 );
 
 const TextNode: NodeRenderer = ({ node }) => {

--- a/packages/forms/src/components/Select/Select.stories.tsx
+++ b/packages/forms/src/components/Select/Select.stories.tsx
@@ -25,6 +25,8 @@ export default {
   },
 };
 
+const themes = ["light", "dark"];
+
 const Template: StoryFn<SelectProps> = (args) => {
   const intl = useIntl();
   const departments = fakeDepartments();
@@ -35,34 +37,23 @@ const Template: StoryFn<SelectProps> = (args) => {
   return (
     <div
       data-h2-display="base(grid)"
-      data-h2-grid-template-columns="base(50% 50%)"
+      data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
     >
-      <div data-h2="light">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form
-            onSubmit={action("Submit Form")}
-            options={{ defaultValues: { groups: "" } }}
-          >
-            <Select {...args} options={departmentOptions} />
-            <p data-h2-margin-top="base(x1)">
-              <Submit />
-            </p>
-          </Form>
+      {themes.map((theme) => (
+        <div data-h2={theme} key={theme}>
+          <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+            <Form
+              onSubmit={action("Submit Form")}
+              options={{ defaultValues: { groups: "" } }}
+            >
+              <Select {...args} options={departmentOptions} />
+              <p data-h2-margin-top="base(x1)">
+                <Submit />
+              </p>
+            </Form>
+          </div>
         </div>
-      </div>
-      <div data-h2="dark">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form
-            onSubmit={action("Submit Form")}
-            options={{ defaultValues: { groups: "" } }}
-          >
-            <Select {...args} options={departmentOptions} />
-            <p data-h2-margin-top="base(x1)">
-              <Submit />
-            </p>
-          </Form>
-        </div>
-      </div>
+      ))}
     </div>
   );
 };
@@ -111,38 +102,25 @@ const TemplateGroups: StoryFn<SelectProps> = (args) => {
   return (
     <div
       data-h2-display="base(grid)"
-      data-h2-grid-template-columns="base(50% 50%)"
+      data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
     >
-      <div data-h2="light">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form
-            onSubmit={action("Submit Form")}
-            options={{ defaultValues: { groups: "" } }}
-          >
-            <div>
-              <Select {...args} options={groupOptions} />
-              <p data-h2-margin-top="base(x1)">
-                <Submit />
-              </p>
-            </div>
-          </Form>
+      {themes.map((theme) => (
+        <div data-h2={theme} key={theme}>
+          <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+            <Form
+              onSubmit={action("Submit Form")}
+              options={{ defaultValues: { groups: "" } }}
+            >
+              <div>
+                <Select {...args} options={groupOptions} />
+                <p data-h2-margin-top="base(x1)">
+                  <Submit />
+                </p>
+              </div>
+            </Form>
+          </div>
         </div>
-      </div>
-      <div data-h2="dark">
-        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
-          <Form
-            onSubmit={action("Submit Form")}
-            options={{ defaultValues: { groups: "" } }}
-          >
-            <div>
-              <Select {...args} options={groupOptions} />
-              <p data-h2-margin-top="base(x1)">
-                <Submit />
-              </p>
-            </div>
-          </Form>
-        </div>
-      </div>
+      ))}
     </div>
   );
 };

--- a/packages/forms/src/components/Select/Select.stories.tsx
+++ b/packages/forms/src/components/Select/Select.stories.tsx
@@ -33,15 +33,37 @@ const Template: StoryFn<SelectProps> = (args) => {
     label: getLocalizedName(name, intl) || "",
   }));
   return (
-    <Form
-      onSubmit={action("Submit Form")}
-      options={{ defaultValues: { groups: "" } }}
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(50% 50%)"
     >
-      <Select {...args} options={departmentOptions} />
-      <p data-h2-margin-top="base(x1)">
-        <Submit />
-      </p>
-    </Form>
+      <div data-h2="light">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form
+            onSubmit={action("Submit Form")}
+            options={{ defaultValues: { groups: "" } }}
+          >
+            <Select {...args} options={departmentOptions} />
+            <p data-h2-margin-top="base(x1)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
+      <div data-h2="dark">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form
+            onSubmit={action("Submit Form")}
+            options={{ defaultValues: { groups: "" } }}
+          >
+            <Select {...args} options={departmentOptions} />
+            <p data-h2-margin-top="base(x1)">
+              <Submit />
+            </p>
+          </Form>
+        </div>
+      </div>
+    </div>
   );
 };
 
@@ -87,15 +109,41 @@ const TemplateGroups: StoryFn<SelectProps> = (args) => {
   }));
 
   return (
-    <Form
-      onSubmit={action("Submit Form")}
-      options={{ defaultValues: { groups: "" } }}
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(50% 50%)"
     >
-      <div>
-        <Select {...args} options={groupOptions} />
-        <Submit />
+      <div data-h2="light">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form
+            onSubmit={action("Submit Form")}
+            options={{ defaultValues: { groups: "" } }}
+          >
+            <div>
+              <Select {...args} options={groupOptions} />
+              <p data-h2-margin-top="base(x1)">
+                <Submit />
+              </p>
+            </div>
+          </Form>
+        </div>
       </div>
-    </Form>
+      <div data-h2="dark">
+        <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+          <Form
+            onSubmit={action("Submit Form")}
+            options={{ defaultValues: { groups: "" } }}
+          >
+            <div>
+              <Select {...args} options={groupOptions} />
+              <p data-h2-margin-top="base(x1)">
+                <Submit />
+              </p>
+            </div>
+          </Form>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/packages/forms/src/components/Select/Select.tsx
+++ b/packages/forms/src/components/Select/Select.tsx
@@ -93,7 +93,7 @@ const Select = ({
   } = useFormContext();
   // To grab errors in nested objects we need to use lodash's get helper.
   const error = get(errors, name)?.message as FieldError;
-  const baseStyles = useCommonInputStyles();
+  const baseStyles = useCommonInputStyles("select");
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
   const fieldState = useFieldState(id, !trackUnsaved);
   const isUnsaved = fieldState === "dirty" && trackUnsaved;
@@ -128,7 +128,7 @@ const Select = ({
         {...register(name, rules)}
         {...rest}
       >
-        <option value="" disabled>
+        <option data-h2-color="base(gray.dark)" value="" disabled>
           {nullSelection}
         </option>
         {optionsModified.map((option) =>

--- a/packages/forms/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/forms/src/components/TextArea/TextArea.stories.tsx
@@ -15,31 +15,32 @@ export default {
     id: "description",
     name: "description",
     label: "Description",
-    maxWidth: "20rem",
-  },
-  argTypes: {
-    maxWidth: {
-      name: "Max Width",
-      type: { name: "string", required: true },
-      control: {
-        type: "text",
-      },
-    },
   },
 };
+
+const themes = ["light", "dark"];
 
 const TemplateTextArea: StoryFn<TextAreaProps & { maxWidth: string }> = (
   args,
 ) => {
-  const { maxWidth, ...rest } = args;
+  const { ...rest } = args;
   return (
-    <div style={{ maxWidth }}>
-      <Form onSubmit={action("Submit Form")}>
-        <TextArea {...rest} />
-        <p data-h2-margin-top="base(x1)">
-          <Submit />
-        </p>
-      </Form>
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="base(100%) l-tablet(50% 50%)"
+    >
+      {themes.map((theme) => (
+        <div data-h2={theme} key={theme}>
+          <div data-h2-background="base(background)" data-h2-padding="base(x2)">
+            <Form onSubmit={action("Submit Form")}>
+              <TextArea {...rest} />
+              <p data-h2-margin-top="base(x1)">
+                <Submit />
+              </p>
+            </Form>
+          </div>
+        </div>
+      ))}
     </div>
   );
 };

--- a/packages/forms/src/hooks/useCommonInputStyles.ts
+++ b/packages/forms/src/hooks/useCommonInputStyles.ts
@@ -10,6 +10,7 @@ const useCommonInputStyles: UseCommonInputStyles = () => {
     "data-h2-outline-offset": "base(2px)",
     "data-h2-padding": "base(x.5)",
     "data-h2-radius": "base(rounded)",
+    "data-h2-color": "base(black)",
   };
 };
 

--- a/packages/forms/src/hooks/useCommonInputStyles.ts
+++ b/packages/forms/src/hooks/useCommonInputStyles.ts
@@ -3,7 +3,7 @@ import { StyleRecord } from "../types";
 type UseCommonInputStyles = (type?: string) => StyleRecord;
 
 const useCommonInputStyles: UseCommonInputStyles = (type) => {
-  let defaults = {
+  const defaults = {
     "data-h2-border-style": "base(solid)",
     "data-h2-border-width": "base(1px)",
     "data-h2-outline": "base(none) base:focus-visible(2px solid focus)",
@@ -16,10 +16,11 @@ const useCommonInputStyles: UseCommonInputStyles = (type) => {
   if (type === "select") {
     selectIcon = {
       "data-h2-appearance": "base(none)",
-      "data-h2-background-image": `base(url("data:image/svg+xml;utf8,<svg fill='black' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>")) base:dark(url("data:image/svg+xml;utf8,<svg fill='white' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>"))`,
+      "data-h2-background-image": `base(url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='rgba(86, 86, 90, 1)'><path stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/></svg>")) base:dark(url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='rgba(191, 191, 191, 1)'><path stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/></svg>"))`,
       "data-h2-background-repeat": "base(no-repeat)",
-      "data-h2-background-position-x": "base(98%)",
-      "data-h2-background-position-y": "base(x.5)",
+      "data-h2-background-position-x": "base(calc(100% - .75rem))",
+      "data-h2-background-position-y": "base(x.7)",
+      "data-h2-background-size": "base(1rem)",
     };
   }
   return { ...defaults, ...selectIcon };

--- a/packages/forms/src/hooks/useCommonInputStyles.ts
+++ b/packages/forms/src/hooks/useCommonInputStyles.ts
@@ -1,17 +1,28 @@
 import { StyleRecord } from "../types";
 
-type UseCommonInputStyles = () => StyleRecord;
+type UseCommonInputStyles = (type?: string) => StyleRecord;
 
-const useCommonInputStyles: UseCommonInputStyles = () => {
-  return {
+const useCommonInputStyles: UseCommonInputStyles = (type) => {
+  let defaults = {
     "data-h2-border-style": "base(solid)",
     "data-h2-border-width": "base(1px)",
     "data-h2-outline": "base(none) base:focus-visible(2px solid focus)",
     "data-h2-outline-offset": "base(2px)",
-    "data-h2-padding": "base(x.5)",
     "data-h2-radius": "base(rounded)",
     "data-h2-color": "base(black)",
+    "data-h2-padding": "base(x.5)",
   };
+  let selectIcon = {};
+  if (type === "select") {
+    selectIcon = {
+      "data-h2-appearance": "base(none)",
+      "data-h2-background-image": `base(url("data:image/svg+xml;utf8,<svg fill='black' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>")) base:dark(url("data:image/svg+xml;utf8,<svg fill='white' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>"))`,
+      "data-h2-background-repeat": "base(no-repeat)",
+      "data-h2-background-position-x": "base(98%)",
+      "data-h2-background-position-y": "base(x.5)",
+    };
+  }
+  return { ...defaults, ...selectIcon };
 };
 
 export default useCommonInputStyles;

--- a/packages/forms/src/styles.ts
+++ b/packages/forms/src/styles.ts
@@ -6,8 +6,8 @@ const fieldStateStyles: Record<FieldState, Record<string, string>> = {
     "data-h2-border-color": "base(gray) base:focus-visible(focus)",
   },
   invalid: {
-    "data-h2-border-color": "base(error.darker) base:focus-visible(focus)",
     "data-h2-background-color": "base(error.lightest)",
+    "data-h2-border-color": "base(error.darker) base:focus-visible(focus)",
   },
   dirty: {
     "data-h2-background-color": "base(foreground)",

--- a/packages/ui/src/components/ButtonLinkContent/ButtonLinkContent.tsx
+++ b/packages/ui/src/components/ButtonLinkContent/ButtonLinkContent.tsx
@@ -106,7 +106,7 @@ const ButtonLinkContent = ({
   let iconMargin = {
     "data-h2-margin-top": "base(0)",
   };
-  if (mode === "text") {
+  if (mode === "text" && fontSize !== "caption") {
     iconMargin = {
       "data-h2-margin-top": "base(-x.2)",
     };

--- a/packages/ui/src/utils/button/getButtonFontColor.ts
+++ b/packages/ui/src/utils/button/getButtonFontColor.ts
@@ -226,6 +226,16 @@ const getFontColor: ButtonFontColor = ({ mode, color, disabled }) => {
             base:focus-visible:children[.counter](focus)`,
         };
       }
+      if (color === "whiteFixed") {
+        return {
+          "data-h2-color": `
+            base:all(gray.light)
+            base:all:focus-visible(black)
+
+            base:children[.counter](black)
+            base:focus-visible:children[.counter](focus)`,
+        };
+      }
       return {
         "data-h2-color": `
           base(gray.darker)


### PR DESCRIPTION
![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/6960386/e26b7346-7079-40c7-a821-6e8768c8acfa)

## ✨ Summary

This PR focuses on updating the UI components under `forms` to ensure they have working dark mode styles. It also includes updates to their stories where relevant.

```[tasklist]
### ✅ Requirements
- [ ] All UI components in the `forms` directory show dark mode stories in Storybook
- [ ] All UI components in the `forms` directory have appropriate contrast in dark mode
- [ ] Things look prettier
``` 

## 🔎 Details

While most of the changes in this PR focused on dark mode styles, there were also a few other fixes related to inputs that were addressed:
* `Select` now matches the look of `Combobox` and provides a consistent experience across browsers
* `Select` now matches the height of other inputs
* `Checkbox` and `Checklist` now have the appropriate label sizes to match `RadioGroup`
* `RichText` got some style upgrades