### PR TITLE
[Urgent] add posters with executive publishing group  to browse pools page

### DIFF
--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.test.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.test.tsx
@@ -37,6 +37,12 @@ const publishedExecJobsPool: Pool = {
   status: PoolStatus.Published,
 };
 
+const publishedIAPJobsPool: Pool = {
+  id: "publishedIAPJobsPool",
+  publishingGroup: PublishingGroup.Iap,
+  status: PoolStatus.Published,
+};
+
 describe("BrowsePoolsPage", () => {
   function renderBrowsePoolsPage({
     pools,
@@ -98,23 +104,27 @@ describe("BrowsePoolsPage", () => {
     );
   });
 
-  it("should only show IT jobs", async () => {
+  it("should only show IT and Executive jobs", async () => {
     renderBrowsePoolsPage({
-      pools: [publishedItJobsPool, publishedExecJobsPool],
+      pools: [publishedItJobsPool, publishedExecJobsPool, publishedIAPJobsPool],
     });
 
     const links = screen.queryAllByRole("link", {
       name: /Apply to this recruitment/i,
     });
 
-    expect(links).toHaveLength(1);
+    expect(links).toHaveLength(2);
     expect(links[0]).toHaveAttribute(
       "href",
       expect.stringContaining(publishedItJobsPool.id),
     );
-    expect(links[0]).not.toHaveAttribute(
+    expect(links[1]).toHaveAttribute(
       "href",
       expect.stringContaining(publishedExecJobsPool.id),
+    );
+    expect(links[0] && links[1]).not.toHaveAttribute(
+      "href",
+      expect.stringContaining(publishedIAPJobsPool.id),
     );
   });
 });

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
@@ -64,7 +64,8 @@ export const BrowsePools = ({ pools }: BrowsePoolsProps) => {
   const activeRecruitmentPools = pools.filter(
     (p) =>
       p.status === PoolStatus.Published && // list jobs which have the PUBLISHED PoolStatus
-      p.publishingGroup === PublishingGroup.ItJobs, // and which are meant to be published on the IT Jobs page
+      (p.publishingGroup === PublishingGroup.ItJobs ||
+        p.publishingGroup === PublishingGroup.ExecutiveJobs), // and which are meant to be published on the IT Jobs page
   );
 
   const ongoingRecruitmentPools = pools.filter(

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
@@ -65,7 +65,7 @@ export const BrowsePools = ({ pools }: BrowsePoolsProps) => {
     (p) =>
       p.status === PoolStatus.Published && // list jobs which have the PUBLISHED PoolStatus
       (p.publishingGroup === PublishingGroup.ItJobs ||
-        p.publishingGroup === PublishingGroup.ExecutiveJobs), // and which are meant to be published on the IT Jobs page
+        p.publishingGroup === PublishingGroup.ExecutiveJobs),
   );
 
   const ongoingRecruitmentPools = pools.filter(


### PR DESCRIPTION
🤖 Resolves {#8607}

## 👋 Introduction

Describe what this PR is solving.

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Create a Pool with Executive Stream and Executive Publishing group 
2. Publish it 
3. Go to browse pools page and see the pool card exists for the same 
4. go to en/executive page and see the pool card exists there as well 
5. Click on the pool card to open up the job poster and verify you get the proper education requirement section as well 


## 📸 Screenshot

