### PR TITLE
[Copy] Adds `alt` copy in `crg`, `crk`, `mic`, `ojw` to IAP homepage

### DIFF
--- a/apps/web/src/lang/crg.json
+++ b/apps/web/src/lang/crg.json
@@ -362,5 +362,41 @@
   "oMpO+C": {
     "defaultMessage": "IT Nakachistowin Paminikaywin poor Indigene Li moond",
     "description": "Title tag for IT Apprenticeship Program for Indigenous Peoples site"
+  },
+  "71+GZq": {
+    "defaultMessage": "Aen bonch di Indigene li moond nipuwaywak avek kaw-shoopayhakikawtayw aen tawnboor.",
+    "description": "Indigenous Apprenticeship hero image text alternative"
+  },
+  "cErFoy": {
+    "defaultMessage": "Indigene li faem kawkishkam en zhilay di kwaroon bleu kiko ashtaywa awtist jeufarawn lee zipang.",
+    "description": "Indigenous Apprenticeship woman smiling image text alternative"
+  },
+  "0D8Efk": {
+    "defaultMessage": "Deu lee'd plem mamouwi tankoupitaywa.",
+    "description": "Indigenous Apprenticeship feathers image text alternative"
+  },
+  "XDgkwV": {
+    "defaultMessage": "Indigene l'om atoushkaydaw li computer.",
+    "description": "Indigenous Apprenticeship man on computer image text alternative"
+  },
+  "aPLL9Z": {
+    "defaultMessage": "Aen Michif fasoon lee gawn avek awn floeree lee rasaed.",
+    "description": "Indigenous Apprenticeship gloves image text alternative"
+  },
+  "X6+rc1": {
+    "defaultMessage": "Indigene li faem pawhpuwinawkoushlw, kishkam li shakwalaw en swetur pi lee leunet.",
+    "description": "Indigenous Apprenticeship applicant image text alternative"
+  },
+  "IIZNzj": {
+    "defaultMessage": "Ulu, aen Niskimoo awpacihchikan kaw-awpachista oushci aen Niskimoo lee faem.",
+    "description": "Indigenous Apprenticeship ulu image text alternative"
+  },
+  "9VPBwR": {
+    "defaultMessage": "Koumaen Aen mawl li dawnsoer kounja itouwuhk kawkishkam.",
+    "description": "Indigenous Apprenticeship lower back image text alternative"
+  },
+  "dY3Qr4": {
+    "defaultMessage": "Indigene la faem kawkishkam li roozh la shmeezh katahkounihk li computer.",
+    "description": "Indigenous Apprenticeship woman on laptop image text alternative"
   }
 }

--- a/apps/web/src/lang/crk.json
+++ b/apps/web/src/lang/crk.json
@@ -362,5 +362,41 @@
   "oMpO+C": {
     "defaultMessage": "IT Kiskinwahamâkan Pimipayihtâwin kiki Nêhiyawak",
     "description": "Title tag for IT Apprenticeship Program for Indigenous Peoples site"
+  },
+  "71+GZq": {
+    "defaultMessage": "ôki nâpêwak wîcikâpawêstawêwak mihko-mistikwaskwa.",
+    "description": "Indigenous Apprenticeship hero image text alternative"
+  },
+  "cErFoy": {
+    "defaultMessage": "awa iskwêw postiskam miskotâkay êkwa mîcêt sakâskahikanisa ê-akomwêyit.",
+    "description": "Indigenous Apprenticeship woman smiling image text alternative"
+  },
+  "0D8Efk": {
+    "defaultMessage": "nîswâpisiwak mihkwanak.",
+    "description": "Indigenous Apprenticeship feathers image text alternative"
+  },
+  "XDgkwV": {
+    "defaultMessage": "nêhiyaw atoskêw mamâhtâwi-âpacihcikanihk.",
+    "description": "Indigenous Apprenticeship man on computer image text alternative"
+  },
+  "aPLL9Z": {
+    "defaultMessage": "âpihtawikosisân astisak wâpakwaniyak mîkistahikâsiwak.",
+    "description": "Indigenous Apprenticeship gloves image text alternative"
+  },
+  "X6+rc1": {
+    "defaultMessage": "awa iskwêw pahpisiw, postiskam osâwipakwayân êkwa miskîsikohkâna.",
+    "description": "Indigenous Apprenticeship applicant image text alternative"
+  },
+  "IIZNzj": {
+    "defaultMessage": "wâwêyiwâwi-môhkomân, ayaskîmow âpacihcikanis ohci ayaskîmow-iskwêwak.",
+    "description": "Indigenous Apprenticeship ulu image text alternative"
+  },
+  "9VPBwR": {
+    "defaultMessage": "opwâtisimow postiskam opwâtayiwinisa.",
+    "description": "Indigenous Apprenticeship lower back image text alternative"
+  },
+  "dY3Qr4": {
+    "defaultMessage": "iskwêw postiskam mihkwasâkay ê-atoskêt mamâhtâwi-âpacihcikanisihk.",
+    "description": "Indigenous Apprenticeship woman on laptop image text alternative"
   }
 }

--- a/apps/web/src/lang/mic.json
+++ b/apps/web/src/lang/mic.json
@@ -362,5 +362,41 @@
   "oMpO+C": {
     "defaultMessage": "IT Apprenticeship Program wjit L’nu’k",
     "description": "Title tag for IT Apprenticeship Program for Indigenous Peoples site"
+  },
+  "71+GZq": {
+    "defaultMessage": "L’nuk alpukuwltiji’k aqq alatu’tij amalamuk pepkwjetemaqn.",
+    "description": "Indigenous Apprenticeship hero image text alternative"
+  },
+  "cErFoy": {
+    "defaultMessage": "L’nuk E’pitji’k naskuwatijik pitu’kn toqo naspulti’jik milamusultiji’k pin’ji’jk.",
+    "description": "Indigenous Apprenticeship woman smiling image text alternative"
+  },
+  "0D8Efk": {
+    "defaultMessage": "Toqpiliji'k ta'pusiji'k pikunk",
+    "description": "Indigenous Apprenticeship feathers image text alternative"
+  },
+  "XDgkwV": {
+    "defaultMessage": "L’nu Ji’nm etl-lukwet computerik’tuk.",
+    "description": "Indigenous Apprenticeship man on computer image text alternative"
+  },
+  "aPLL9Z": {
+    "defaultMessage": "Métise’k piljaqn’k toqo wasuweke’ wikasiji’k.",
+    "description": "Indigenous Apprenticeship gloves image text alternative"
+  },
+  "X6+rc1": {
+    "defaultMessage": "L’nuskwe’j welitutk, nasku’atl tupkwanamu’ksitl a’su’n, aqq maw pukikwe’l naski’kil aqq weskwikwtu’tk.",
+    "description": "Indigenous Apprenticeship applicant image text alternative"
+  },
+  "IIZNzj": {
+    "defaultMessage": "Ulu, na Inuitaq ewketu’tij e’pitjik.",
+    "description": "Indigenous Apprenticeship ulu image text alternative"
+  },
+  "9VPBwR": {
+    "defaultMessage": "Ji’nm amalka’t naski’k l’nuey regalia.",
+    "description": "Indigenous Apprenticeship lower back image text alternative"
+  },
+  "dY3Qr4": {
+    "defaultMessage": "L’nu e’pit naski’k mekwe’k a’tlai aqq etl-lukwet laptopiktuk.",
+    "description": "Indigenous Apprenticeship woman on laptop image text alternative"
   }
 }

--- a/apps/web/src/lang/ojw.json
+++ b/apps/web/src/lang/ojw.json
@@ -362,5 +362,41 @@
   "oMpO+C": {
     "defaultMessage": "Anishinaabe Gikinoo’amaadiwin Izhichigewin ogowe Anishinaabeg",
     "description": "Title tag for IT Apprenticeship Program for Indigenous Peoples site"
+  },
+  "71+GZq": {
+    "defaultMessage": "Oko-gaabawiwag dewe’iganensa’ dakonaawaad.",
+    "description": "Indigenous Apprenticeship hero image text alternative"
+  },
+  "cErFoy": {
+    "defaultMessage": "Anishinaabekweg ogigishkaanaawaan maamaagwegino’ biinsikawaaganan bebakaan zaagaakono’a ogigishkawaawaa’.",
+    "description": "Indigenous Apprenticeship woman smiling image text alternative"
+  },
+  "0D8Efk": {
+    "defaultMessage": "Niizhopizowag miigwanag.",
+    "description": "Indigenous Apprenticeship feathers image text alternative"
+  },
+  "XDgkwV": {
+    "defaultMessage": "Anishinaabe Inini odanokaadaan aazhawaatebii’iganaabik.",
+    "description": "Indigenous Apprenticeship man on computer image text alternative"
+  },
+  "aPLL9Z": {
+    "defaultMessage": "Wiisaakodewinini ominjikaawana’ waabigwaniiwigwaazowa’.",
+    "description": "Indigenous Apprenticeship gloves image text alternative"
+  },
+  "X6+rc1": {
+    "defaultMessage": "Anishinaabekwe zhoomiingweni, ozaawegadini ozhiibiigishkaawayaan gaye oshkiinzhigoke.",
+    "description": "Indigenous Apprenticeship applicant image text alternative"
+  },
+  "IIZNzj": {
+    "defaultMessage": "Ulu, Eshkiime aabajichigan odaabajitoon Eshkiikwe.",
+    "description": "Indigenous Apprenticeship ulu image text alternative"
+  },
+  "9VPBwR": {
+    "defaultMessage": "Inini bwaazhiiwikonaye.",
+    "description": "Indigenous Apprenticeship lower back image text alternative"
+  },
+  "dY3Qr4": {
+    "defaultMessage": "Anishinaabekwe ogigishkaan misko-bagiwiyaan anokaadang aazhawaatebii’iganaabik.",
+    "description": "Indigenous Apprenticeship woman on laptop image text alternative"
   }
 }

--- a/apps/web/src/pages/Home/IAPHomePage/Home.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.tsx
@@ -91,17 +91,13 @@ export const Home = ({ latestPool }: HomeProps) => {
             data-h2-width="base(100%)"
             data-h2-order="base(2)"
             src={iapHeroImg}
-            alt={
-              locale
-                ? ""
-                : intl.formatMessage({
-                    defaultMessage:
-                      "Group of Indigenous people standing with a painted hand drum.",
-                    id: "71+GZq",
-                    description:
-                      "Indigenous Apprenticeship hero image text alternative",
-                  })
-            }
+            alt={intl.formatMessage({
+              defaultMessage:
+                "Group of Indigenous people standing with a painted hand drum.",
+              id: "71+GZq",
+              description:
+                "Indigenous Apprenticeship hero image text alternative",
+            })}
           />
           <div
             data-h2-background="base(linear-gradient(#46032c, #46032c 90%, transparent)) p-tablet(linear-gradient(#46032c, #46032c 60%, transparent)) l-tablet(linear-gradient(#46032c, #46032c 30%, transparent)) laptop(transparent)"
@@ -211,17 +207,13 @@ export const Home = ({ latestPool }: HomeProps) => {
                       />
                       <img
                         src={womanSmiling}
-                        alt={
-                          locale
-                            ? ""
-                            : intl.formatMessage({
-                                defaultMessage:
-                                  "Indigenous woman wearing a jean jacket which contains several different pins.",
-                                id: "cErFoy",
-                                description:
-                                  "Indigenous Apprenticeship woman smiling image text alternative",
-                              })
-                        }
+                        alt={intl.formatMessage({
+                          defaultMessage:
+                            "Indigenous woman wearing a jean jacket which contains several different pins.",
+                          id: "cErFoy",
+                          description:
+                            "Indigenous Apprenticeship woman smiling image text alternative",
+                        })}
                         data-h2-min-height="base(60vh) p-tablet(initial)"
                         data-h2-height="p-tablet(100%)"
                         data-h2-width="p-tablet(100%)"
@@ -232,16 +224,12 @@ export const Home = ({ latestPool }: HomeProps) => {
                       />
                       <img
                         src={feathers}
-                        alt={
-                          locale
-                            ? ""
-                            : intl.formatMessage({
-                                defaultMessage: "Two feathers tied together.",
-                                id: "0D8Efk",
-                                description:
-                                  "Indigenous Apprenticeship feathers image text alternative",
-                              })
-                        }
+                        alt={intl.formatMessage({
+                          defaultMessage: "Two feathers tied together.",
+                          id: "0D8Efk",
+                          description:
+                            "Indigenous Apprenticeship feathers image text alternative",
+                        })}
                         data-h2-position="base(absolute)"
                         data-h2-width="base(150%)"
                         data-h2-location="base(auto, -15%, 0, auto)"
@@ -323,17 +311,12 @@ export const Home = ({ latestPool }: HomeProps) => {
                     />
                     <img
                       src={manOnComputer}
-                      alt={
-                        locale
-                          ? ""
-                          : intl.formatMessage({
-                              defaultMessage:
-                                "Indigenous man working at a computer.",
-                              id: "XDgkwV",
-                              description:
-                                "Indigenous Apprenticeship man on computer image text alternative",
-                            })
-                      }
+                      alt={intl.formatMessage({
+                        defaultMessage: "Indigenous man working at a computer.",
+                        id: "XDgkwV",
+                        description:
+                          "Indigenous Apprenticeship man on computer image text alternative",
+                      })}
                       data-h2-min-height="base(60vh) p-tablet(initial)"
                       data-h2-height="p-tablet(100%)"
                       data-h2-width="p-tablet(100%)"
@@ -344,17 +327,13 @@ export const Home = ({ latestPool }: HomeProps) => {
                     />
                     <img
                       src={gloves}
-                      alt={
-                        locale
-                          ? ""
-                          : intl.formatMessage({
-                              defaultMessage:
-                                "Métis style gloves with floral beading.",
-                              id: "aPLL9Z",
-                              description:
-                                "Indigenous Apprenticeship gloves image text alternative",
-                            })
-                      }
+                      alt={intl.formatMessage({
+                        defaultMessage:
+                          "Métis style gloves with floral beading.",
+                        id: "aPLL9Z",
+                        description:
+                          "Indigenous Apprenticeship gloves image text alternative",
+                      })}
                       data-h2-position="base(absolute)"
                       data-h2-width="base(140%)"
                       data-h2-location="base(auto, -x4, -x5, auto) l-tablet(auto, -x8, -x9, auto)"
@@ -438,17 +417,13 @@ export const Home = ({ latestPool }: HomeProps) => {
                     />
                     <img
                       src={applicant}
-                      alt={
-                        locale
-                          ? ""
-                          : intl.formatMessage({
-                              defaultMessage:
-                                "Indigenous woman smiling, wearing a brown sweater and glasses.",
-                              id: "X6+rc1",
-                              description:
-                                "Indigenous Apprenticeship applicant image text alternative",
-                            })
-                      }
+                      alt={intl.formatMessage({
+                        defaultMessage:
+                          "Indigenous woman smiling, wearing a brown sweater and glasses.",
+                        id: "X6+rc1",
+                        description:
+                          "Indigenous Apprenticeship applicant image text alternative",
+                      })}
                       data-h2-min-height="base(60vh) p-tablet(initial)"
                       data-h2-height="p-tablet(100%)"
                       data-h2-width="p-tablet(100%)"
@@ -459,17 +434,13 @@ export const Home = ({ latestPool }: HomeProps) => {
                     />
                     <img
                       src={ulu}
-                      alt={
-                        locale
-                          ? ""
-                          : intl.formatMessage({
-                              defaultMessage:
-                                "Ulu, an Inuit tool used by Inuit women.",
-                              id: "IIZNzj",
-                              description:
-                                "Indigenous Apprenticeship ulu image text alternative",
-                            })
-                      }
+                      alt={intl.formatMessage({
+                        defaultMessage:
+                          "Ulu, an Inuit tool used by Inuit women.",
+                        id: "IIZNzj",
+                        description:
+                          "Indigenous Apprenticeship ulu image text alternative",
+                      })}
                       data-h2-display="base(block) p-tablet(none)"
                       data-h2-position="base(absolute)"
                       data-h2-width="base(x20)"
@@ -583,17 +554,12 @@ export const Home = ({ latestPool }: HomeProps) => {
                 <div data-h2-position="base(relative)">
                   <img
                     src={lowerBack}
-                    alt={
-                      locale
-                        ? ""
-                        : intl.formatMessage({
-                            defaultMessage:
-                              "Male Traditional dancer in regalia.",
-                            id: "9VPBwR",
-                            description:
-                              "Indigenous Apprenticeship lower back image text alternative",
-                          })
-                    }
+                    alt={intl.formatMessage({
+                      defaultMessage: "Male Traditional dancer in regalia.",
+                      id: "9VPBwR",
+                      description:
+                        "Indigenous Apprenticeship lower back image text alternative",
+                    })}
                     style={{
                       position: "absolute",
                       inset: "0",
@@ -995,17 +961,13 @@ export const Home = ({ latestPool }: HomeProps) => {
                         data-h2-position="p-tablet(absolute)"
                         data-h2-location="p-tablet(auto, -x2, -x3, auto) l-tablet(auto, -x3, -x5, auto)"
                         src={indigenousWoman}
-                        alt={
-                          locale
-                            ? ""
-                            : intl.formatMessage({
-                                defaultMessage:
-                                  "Indigenous woman wearing a red shirt working on a laptop.",
-                                id: "dY3Qr4",
-                                description:
-                                  "Indigenous Apprenticeship woman on laptop image text alternative",
-                              })
-                        }
+                        alt={intl.formatMessage({
+                          defaultMessage:
+                            "Indigenous woman wearing a red shirt working on a laptop.",
+                          id: "dY3Qr4",
+                          description:
+                            "Indigenous Apprenticeship woman on laptop image text alternative",
+                        })}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
🤖 Resolves #8604.

## 👋 Introduction

This PR adds `alt` copy in `crg`, `crk`, `mic`, `ojw` to the IAP homepage.

## 🕵️ Details

> [!IMPORTANT]
> Some of the strings that were returned from translation were translated before the decision was made in https://github.com/GCTC-NTGC/gc-digital-talent/pull/8033 not to use some of these strings at all (6.alt text(background image): talking stick; 7.alt text: open quote mark; 8.alt text: closed quote mark; 9b (background image): Traditional Métis sash).

For reference with IDs, I have created [en.json](https://github.com/GCTC-NTGC/gc-digital-talent/files/13491206/en.json) for reference for the English versions of the 9 strings.

[This PR](https://github.com/GCTC-NTGC/gc-digital-talent/pull/8295) actually actually did not render the `alt` values when the locale was unset. That has been fixed in 1e4fb02eb4df0220f656a6d9a01606fa77d2cb66.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate to `/indigenous-it-apprentice`
3. Verify `alt` values exist for all 9 strings added
4. Repeat steps 2 and 3 for `fr`, `crg`, `crk`, `mic`, `ojw`

## 📸 Screenshots

### EN example
![Screen Shot 2023-11-28 at 12 12 14](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/dc057efc-e29a-4be0-8214-e82ccaa17e4d)

### CRG example
![Screen Shot 2023-11-28 at 12 15 40](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/d2853ac2-bf93-4d3a-b067-85a4d2360380)
