### PR TITLE
[Feature] Have more admin tables utilize `state.from` 

### DIFF
--- a/apps/web/src/components/Table/ResponsiveTable/Table.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/Table.tsx
@@ -219,6 +219,7 @@ const AddAction = ({ add }: AddActionProps) => (
           mode="solid"
           href={add.linkProps.href}
           block
+          state={{ from: add.linkProps.from ?? null }}
         >
           {add.linkProps.label}
         </Link>

--- a/apps/web/src/components/Table/ResponsiveTable/types.ts
+++ b/apps/web/src/components/Table/ResponsiveTable/types.ts
@@ -78,6 +78,7 @@ export type FilterDef<TFilterState = object> = {
 export type AddLinkProps = {
   label: React.ReactNode;
   href: string;
+  from?: string;
 };
 
 export type AddDef = {

--- a/apps/web/src/pages/Classifications/CreateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/CreateClassificationPage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import upperCase from "lodash/upperCase";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
@@ -33,6 +33,9 @@ export const CreateClassificationForm = ({
   const { handleSubmit, watch } = methods;
   const watchMinSalary = watch("minSalary");
 
+  const { state } = useLocation();
+  const navigateTo = state?.from ?? paths.classificationTable();
+
   const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
     const classification: FormValues = {
       ...data,
@@ -43,7 +46,7 @@ export const CreateClassificationForm = ({
     };
     return handleCreateClassification(classification)
       .then(() => {
-        navigate(paths.classificationTable());
+        navigate(navigateTo);
         toast.success(
           intl.formatMessage({
             defaultMessage: "Classification created successfully!",

--- a/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import pick from "lodash/pick";
 import upperCase from "lodash/upperCase";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
@@ -45,6 +45,9 @@ export const UpdateClassificationForm = ({
   const { handleSubmit, watch } = methods;
   const watchMinSalary = watch("minSalary");
 
+  const { state } = useLocation();
+  const navigateTo = state?.from ?? paths.classificationTable();
+
   const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
     const classification: FormValues = {
       name: {
@@ -57,7 +60,7 @@ export const UpdateClassificationForm = ({
     };
     return handleUpdateClassification(initialClassification.id, classification)
       .then(() => {
-        navigate(paths.classificationTable());
+        navigate(navigateTo);
         toast.success(
           intl.formatMessage({
             defaultMessage: "Classification updated successfully!",

--- a/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
+++ b/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { useIntl } from "react-intl";
 import { OperationContext } from "urql";
+import { useLocation } from "react-router-dom";
 
 import { notEmpty } from "@gc-digital-talent/helpers";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
@@ -106,6 +107,9 @@ export const ClassificationTable = ({
 
   const data = classifications.filter(notEmpty);
 
+  const { pathname, search, hash } = useLocation();
+  const currentUrl = `${pathname}${search}${hash}`;
+
   return (
     <Table<Classification>
       caption={title}
@@ -137,6 +141,7 @@ export const ClassificationTable = ({
             description:
               "Heading displayed above the Create Classification form.",
           }),
+          from: currentUrl,
         },
       }}
     />

--- a/apps/web/src/pages/Departments/CreateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/CreateDepartmentPage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
 
@@ -35,13 +35,16 @@ export const CreateDepartmentForm = ({
   const methods = useForm<FormValues>();
   const { handleSubmit } = methods;
 
+  const { state } = useLocation();
+  const navigateTo = state?.from ?? paths.departmentTable();
+
   const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
     return handleCreateDepartment({
       departmentNumber: Number(data.departmentNumber),
       name: data.name,
     })
       .then(() => {
-        navigate(paths.departmentTable());
+        navigate(navigateTo);
         toast.success(
           intl.formatMessage({
             defaultMessage: "Department created successfully!",

--- a/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
 import pick from "lodash/pick";
@@ -48,13 +48,16 @@ export const UpdateDepartmentForm = ({
   });
   const { handleSubmit } = methods;
 
+  const { state } = useLocation();
+  const navigateTo = state?.from ?? paths.departmentTable();
+
   const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
     return handleUpdateDepartment(initialDepartment.id, {
       departmentNumber: Number(data.departmentNumber),
       name: data.name,
     })
       .then(() => {
-        navigate(paths.departmentTable());
+        navigate(navigateTo);
         toast.success(
           intl.formatMessage({
             defaultMessage: "Department updated successfully!",

--- a/apps/web/src/pages/Departments/components/DepartmentTable.tsx
+++ b/apps/web/src/pages/Departments/components/DepartmentTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { useIntl } from "react-intl";
+import { useLocation } from "react-router-dom";
 
 import { notEmpty } from "@gc-digital-talent/helpers";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
@@ -60,6 +61,9 @@ export const DepartmentTable = ({
 
   const data = departments.filter(notEmpty);
 
+  const { pathname, search, hash } = useLocation();
+  const currentUrl = `${pathname}${search}${hash}`;
+
   return (
     <Table<Department>
       data={data}
@@ -89,6 +93,7 @@ export const DepartmentTable = ({
             id: "ZbpbD6",
             description: "Heading displayed above the Create Department form.",
           }),
+          from: currentUrl,
         },
       }}
     />

--- a/apps/web/src/pages/Departments/components/DepartmentTable.tsx
+++ b/apps/web/src/pages/Departments/components/DepartmentTable.tsx
@@ -30,7 +30,7 @@ export const DepartmentTable = ({
   const columns = [
     columnHelper.accessor("departmentNumber", {
       id: "departmentNumber",
-      filterFn: "equals",
+      filterFn: "weakEquals",
       header: intl.formatMessage({
         defaultMessage: "Department #",
         id: "QOvS1b",

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/UpdateSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/UpdateSearchRequest.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
+import { useLocation } from "react-router-dom";
 
 import { Heading, Link } from "@gc-digital-talent/ui";
 import {
@@ -124,6 +125,9 @@ export const UpdateSearchRequestForm = ({
       });
   };
 
+  const { state } = useLocation();
+  const navigateTo = state?.from ?? paths.searchRequestTable();
+
   return (
     <div>
       <div
@@ -245,7 +249,7 @@ export const UpdateSearchRequestForm = ({
         </FormProvider>
       </div>
       <div data-h2-margin="base(0, 0, x1, 0)">
-        <Link href={paths.searchRequestTable()} mode="inline" color="secondary">
+        <Link href={navigateTo} mode="inline" color="secondary">
           {intl.formatMessage({
             defaultMessage: "Back to requests",
             id: "O8nHiQ",

--- a/apps/web/src/pages/SkillFamilies/CreateSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/CreateSkillFamilyPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useIntl } from "react-intl";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import sortBy from "lodash/sortBy";
@@ -72,10 +72,13 @@ export const CreateSkillFamilyForm = ({
     },
   });
 
+  const { state } = useLocation();
+  const navigateTo = state?.from ?? paths.skillFamilyTable();
+
   const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
     return handleCreateSkillFamily(formValuesToSubmitData(data))
       .then(() => {
-        navigate(paths.skillFamilyTable());
+        navigate(navigateTo);
         toast.success(
           intl.formatMessage({
             defaultMessage: "Skill family created successfully!",

--- a/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useIntl } from "react-intl";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import pick from "lodash/pick";
@@ -91,13 +91,16 @@ export const UpdateSkillFamilyForm = ({
   });
   const { handleSubmit } = methods;
 
+  const { state } = useLocation();
+  const navigateTo = state?.from ?? paths.skillFamilyTable();
+
   const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
     return handleUpdateSkillFamily(
       initialSkillFamily.id,
       formValuesToSubmitData(data),
     )
       .then(() => {
-        navigate(paths.skillFamilyTable());
+        navigate(navigateTo);
         toast.success(
           intl.formatMessage({
             defaultMessage: "Skill family updated successfully!",

--- a/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
+++ b/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { useIntl } from "react-intl";
+import { useLocation } from "react-router-dom";
 
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 import { notEmpty } from "@gc-digital-talent/helpers";
@@ -75,6 +76,9 @@ export const SkillFamilyTable = ({
 
   const data = skillFamilies.filter(notEmpty);
 
+  const { pathname, search, hash } = useLocation();
+  const currentUrl = `${pathname}${search}${hash}`;
+
   return (
     <Table<SkillFamily>
       caption={title}
@@ -106,6 +110,7 @@ export const SkillFamilyTable = ({
             description:
               "Heading displayed above the Create Skill Family form.",
           }),
+          from: currentUrl,
         },
       }}
     />

--- a/apps/web/src/pages/Skills/CreateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/CreateSkillPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useIntl } from "react-intl";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import sortBy from "lodash/sortBy";
@@ -87,10 +87,13 @@ export const CreateSkillForm = ({
     },
   });
 
+  const { state } = useLocation();
+  const navigateTo = state?.from ?? paths.skillTable();
+
   const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
     return handleCreateSkill(formValuesToSubmitData(data))
       .then(() => {
-        navigate(paths.skillTable());
+        navigate(navigateTo);
         toast.success(
           intl.formatMessage({
             defaultMessage: "Skill created successfully!",

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { useIntl } from "react-intl";
 import { OperationContext } from "urql";
+import { useLocation } from "react-router-dom";
 
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 import { notEmpty } from "@gc-digital-talent/helpers";
@@ -96,6 +97,9 @@ export const SkillTable = ({ skills, title }: SkillTableProps) => {
 
   const data = skills.filter(notEmpty);
 
+  const { pathname, search, hash } = useLocation();
+  const currentUrl = `${pathname}${search}${hash}`;
+
   return (
     <Table<Skill>
       caption={title}
@@ -127,6 +131,7 @@ export const SkillTable = ({ skills, title }: SkillTableProps) => {
             id: "lFrPv1",
             description: "Heading displayed above the Create Skill form.",
           }),
+          from: currentUrl,
         },
       }}
     />

--- a/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamForm.tsx
+++ b/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamForm.tsx
@@ -87,7 +87,7 @@ const CreateTeamForm = ({ departments, onSubmit }: CreateTeamFormProps) => {
         data-h2-gap="base(x1)"
         data-h2-align-items="base(center)"
       >
-        <Link mode="inline" href={paths.teamTable()}>
+        <Link mode="inline" href={navigateTo}>
           {intl.formatMessage({
             defaultMessage: "Cancel and go back to teams",
             id: "i0IT1I",

--- a/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamForm.tsx
+++ b/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamForm.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { SubmitHandler } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useIntl } from "react-intl";
 import kebabCase from "lodash/kebabCase";
 
@@ -48,10 +48,13 @@ const CreateTeamForm = ({ departments, onSubmit }: CreateTeamFormProps) => {
   const paths = useRoutes();
   const navigate = useNavigate();
 
+  const { state } = useLocation();
+  const navigateTo = state?.from ?? paths.teamTable();
+
   const handleSubmit: SubmitHandler<FormValues> = async (data) => {
     return onSubmit(formValuesToSubmitData(data))
       .then(() => {
-        navigate(paths.teamTable());
+        navigate(navigateTo);
         toast.success(
           intl.formatMessage({
             defaultMessage: "Team updated successfully!",

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
@@ -42,6 +42,10 @@ export const TeamTable = ({
 }: TeamTableProps) => {
   const intl = useIntl();
   const paths = useRoutes();
+
+  const { pathname, search, hash } = useLocation();
+  const currentUrl = `${pathname}${search}${hash}`;
+
   const columns = [
     columnHelper.display({
       id: "actions",
@@ -66,7 +70,7 @@ export const TeamTable = ({
         description: "Title displayed for the teams table team column.",
       }),
       cell: ({ row: { original: team }, getValue }) =>
-        viewCell(paths.teamView(team.id), getValue(), intl),
+        viewCell(paths.teamView(team.id), getValue(), intl, currentUrl),
       meta: {
         isRowTitle: true,
       },
@@ -107,9 +111,6 @@ export const TeamTable = ({
   ] as ColumnDef<Team>[];
 
   const data = teams.filter(notEmpty);
-
-  const { pathname, search, hash } = useLocation();
-  const currentUrl = `${pathname}${search}${hash}`;
 
   return (
     <Table<Team>

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { useIntl } from "react-intl";
+import { useLocation } from "react-router-dom";
 
 import { Pending } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
@@ -107,6 +108,9 @@ export const TeamTable = ({
 
   const data = teams.filter(notEmpty);
 
+  const { pathname, search, hash } = useLocation();
+  const currentUrl = `${pathname}${search}${hash}`;
+
   return (
     <Table<Team>
       caption={title}
@@ -137,6 +141,7 @@ export const TeamTable = ({
             id: "GtrrJ3",
             description: "Link text to create a new team in the admin portal",
           }),
+          from: currentUrl,
         },
       }}
     />

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/helpers.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/helpers.tsx
@@ -8,9 +8,14 @@ import { notEmpty } from "@gc-digital-talent/helpers";
 
 import { MyRoleTeam } from "./types";
 
-export function viewCell(url: string, label: Maybe<string>, intl: IntlShape) {
+export function viewCell(
+  url: string,
+  label: Maybe<string>,
+  intl: IntlShape,
+  currentUrl?: string,
+) {
   return (
-    <Link href={url} color="black">
+    <Link href={url} color="black" state={{ from: currentUrl ?? null }}>
       {label ||
         intl.formatMessage({
           defaultMessage: "No name provided",

--- a/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.tsx
+++ b/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.tsx
@@ -149,7 +149,7 @@ const UpdateTeamForm = ({
         data-h2-gap="base(x1)"
         data-h2-align-items="base(center)"
       >
-        <Link mode="inline" href={paths.teamTable()}>
+        <Link mode="inline" href={navigateTo}>
           {intl.formatMessage({
             defaultMessage: "Cancel and go back to teams",
             id: "i0IT1I",

--- a/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.tsx
+++ b/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { SubmitHandler } from "react-hook-form";
 import omit from "lodash/omit";
 import kebabCase from "lodash/kebabCase";
@@ -76,10 +76,13 @@ const UpdateTeamForm = ({
   const paths = useRoutes();
   const navigate = useNavigate();
 
+  const { state } = useLocation();
+  const navigateTo = state?.from ?? paths.teamTable();
+
   const handleSubmit: SubmitHandler<FormValues> = async (data) => {
     return onSubmit(team.id, formValuesToSubmitData(data))
       .then(() => {
-        navigate(paths.teamTable());
+        navigate(navigateTo);
         toast.success(
           intl.formatMessage({
             defaultMessage: "Team updated successfully!",

--- a/apps/web/src/pages/Teams/ViewTeamPage/ViewTeamPage.tsx
+++ b/apps/web/src/pages/Teams/ViewTeamPage/ViewTeamPage.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
+import { useLocation } from "react-router-dom";
 
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import { Pending, NotFound, Link, Separator } from "@gc-digital-talent/ui";
@@ -76,6 +77,9 @@ const ViewTeamPage = () => {
       : []),
   ];
 
+  const { state } = useLocation();
+  const navigateTo = state?.from ?? routes.teamTable();
+
   return (
     <AdminContentWrapper crumbs={navigationCrumbs}>
       <Pending fetching={fetching} error={error}>
@@ -99,7 +103,7 @@ const ViewTeamPage = () => {
         )}
       </Pending>
       <p data-h2-margin="base(x2, 0, 0, 0)">
-        <Link mode="solid" color="secondary" href={routes.teamTable()}>
+        <Link mode="solid" color="secondary" href={navigateTo}>
           {intl.formatMessage({
             defaultMessage: "Back to teams",
             id: "LocjmN",

--- a/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useIntl } from "react-intl";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { OperationContext } from "urql";
@@ -90,10 +90,13 @@ export const UpdateUserForm = ({
   });
   const { handleSubmit } = methods;
 
+  const { state } = useLocation();
+  const navigateTo = state?.from ?? paths.userTable();
+
   const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
     await handleUpdateUser(initialUser.id, formValuesToSubmitData(data))
       .then(() => {
-        navigate(paths.userTable());
+        navigate(navigateTo);
         toast.success(
           intl.formatMessage({
             defaultMessage: "User updated successfully!",


### PR DESCRIPTION
🤖 Resolves #8345 

## 👋 Introduction

Implements the state solution of #8342 in more places. 

## 🕵️ Details

For the most part just finding places to copy paste. 

## 🧪 Testing

1. Go to effected tables, adjust the filters to change the URL then test the submit and return
2. Effected tables include classifications, departments, teams, skills, skill families, users, and requests
3. Submit and return, as well as go back buttons

## 📸 ~Screenshot~ Recordings

https://recordit.co/Orl9vqFytJ

https://recordit.co/CQf17DDn6u