### PR TITLE
[Fix] Label logic for `getDecisionInfo`

### DIFF
--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -51,10 +51,10 @@ export const getDecisionInfo = (
               "Message displayed when candidate has been screened out at a specific assessment step",
           })
         : intl.formatMessage({
-            defaultMessage: "Successful",
-            id: "Whq2Xl",
+            defaultMessage: "Unsuccessful",
+            id: "TIAla1",
             description:
-              "Message displayed when candidate has successfully passed an assessment step",
+              "Message displayed when candidate has not passed an assessment step",
           }),
     };
   }
@@ -72,10 +72,10 @@ export const getDecisionInfo = (
             "Message displayed when candidate has been screened in at a specific assessment step",
         })
       : intl.formatMessage({
-          defaultMessage: "Unsuccessful",
-          id: "TIAla1",
+          defaultMessage: "Successful",
+          id: "Whq2Xl",
           description:
-            "Message displayed when candidate has not passed an assessment step",
+            "Message displayed when candidate has successfully passed an assessment step",
         }),
   };
 };


### PR DESCRIPTION
🤖 Resolves #8620.

## 👋 Introduction

This PR fixes the label logic for `getDecisionInfo` when rendering the totals for **Unsuccessful** or **Successful**.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run storybook`
2. Navigate to `http://localhost:6006/?path=/story/components-assessment-step-tracker--with-candidates`
3. Observe count for **Unsuccessful** or **Successful** for each column
4. Ensure each count matches number of candidates in column

## 📸 Screenshot

![Screen Shot 2023-11-30 at 12 05 46](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/7960d357-4943-4c8b-b5d8-a7ef668896f9)

