### PR TITLE
[Style] Update `Tab` styling

### DIFF
--- a/packages/ui/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { ComponentStory, ComponentMeta } from "@storybook/react";
+import type { StoryFn } from "@storybook/react";
 
 import TabsDocs from "./Tabs.docs.mdx";
 import Tabs from "./Tabs";
@@ -12,25 +12,54 @@ export default {
       page: TabsDocs,
     },
   },
-} as ComponentMeta<typeof Tabs.Root>;
+};
 
-const Template: ComponentStory<typeof Tabs.Root> = (args) => (
-  <Tabs.Root {...args}>
-    <Tabs.List aria-label="Tabs Nav">
-      <Tabs.Trigger value="one">One</Tabs.Trigger>
-      <Tabs.Trigger value="two">Two</Tabs.Trigger>
-      <Tabs.Trigger value="three">Three</Tabs.Trigger>
-    </Tabs.List>
-    <Tabs.Content value="one">
-      <p>One</p>
-    </Tabs.Content>
-    <Tabs.Content value="two">
-      <p>Two</p>
-    </Tabs.Content>
-    <Tabs.Content value="three">
-      <p>Three</p>
-    </Tabs.Content>
-  </Tabs.Root>
+const themes: Array<string> = ["light", "dark"];
+
+const Template: StoryFn<typeof Tabs.Root> = (args) => (
+  <div>
+    {themes.map((theme) => (
+      <div
+        key={theme}
+        data-h2={theme}
+        data-h2-max-width="base(100%)"
+        data-h2-display="base(grid)"
+        data-h2-grid-template-columns="l-tablet(1fr 1fr)"
+      >
+        <div
+          data-h2-margin="base(-1rem)"
+          data-h2-background="base(background)"
+          data-h2-padding="base(x1 0)"
+          data-h2-max-width="base(100%)"
+        >
+          <Tabs.Root {...args}>
+            <Tabs.List aria-label="Tabs Nav">
+              <Tabs.Trigger value="one">One</Tabs.Trigger>
+              <Tabs.Trigger value="two">Two</Tabs.Trigger>
+              <Tabs.Trigger value="three">Three</Tabs.Trigger>
+              <Tabs.Trigger value="four">Four</Tabs.Trigger>
+              <Tabs.Trigger value="five">Five</Tabs.Trigger>
+            </Tabs.List>
+            <Tabs.Content value="one">
+              <p>One</p>
+            </Tabs.Content>
+            <Tabs.Content value="two">
+              <p>Two</p>
+            </Tabs.Content>
+            <Tabs.Content value="three">
+              <p>Three</p>
+            </Tabs.Content>
+            <Tabs.Content value="four">
+              <p>Four</p>
+            </Tabs.Content>
+            <Tabs.Content value="five">
+              <p>Five</p>
+            </Tabs.Content>
+          </Tabs.Root>
+        </div>
+      </div>
+    ))}
+  </div>
 );
 
 export const Default = Template.bind({});

--- a/packages/ui/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.stories.tsx
@@ -19,15 +19,8 @@ const themes: Array<string> = ["light", "dark"];
 const Template: StoryFn<typeof Tabs.Root> = (args) => (
   <div>
     {themes.map((theme) => (
-      <div
-        key={theme}
-        data-h2={theme}
-        data-h2-max-width="base(100%)"
-        data-h2-display="base(grid)"
-        data-h2-grid-template-columns="l-tablet(1fr 1fr)"
-      >
+      <div key={theme} data-h2={theme}>
         <div
-          data-h2-margin="base(-1rem)"
           data-h2-background="base(background)"
           data-h2-padding="base(x1 0)"
           data-h2-max-width="base(100%)"

--- a/packages/ui/src/components/Tabs/Tabs.test.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.test.tsx
@@ -37,7 +37,7 @@ const renderTabs = ({ ...rest }: TabsRootPrimitivePropsWithoutRef) => {
 
 describe("Tabs", () => {
   const user = userEvent.setup();
-  window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  window.HTMLElement.prototype.scrollTo = jest.fn();
 
   it("should not have accessibility errors when closed", async () => {
     const { container } = renderTabs({});

--- a/packages/ui/src/components/Tabs/Tabs.test.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.test.tsx
@@ -10,6 +10,10 @@ import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";
 
 import Tabs from ".";
 
+// Mock scroll into view func
+const scrollIntoViewMock = jest.fn();
+Element.prototype.scrollIntoView = scrollIntoViewMock();
+
 type TabsRootPrimitivePropsWithoutRef = React.ComponentPropsWithoutRef<
   typeof Tabs.Root
 >;

--- a/packages/ui/src/components/Tabs/Tabs.test.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.test.tsx
@@ -10,10 +10,6 @@ import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";
 
 import Tabs from ".";
 
-// Mock scroll into view func
-const scrollIntoViewMock = jest.fn();
-Element.prototype.scrollIntoView = scrollIntoViewMock();
-
 type TabsRootPrimitivePropsWithoutRef = React.ComponentPropsWithoutRef<
   typeof Tabs.Root
 >;
@@ -41,6 +37,7 @@ const renderTabs = ({ ...rest }: TabsRootPrimitivePropsWithoutRef) => {
 
 describe("Tabs", () => {
   const user = userEvent.setup();
+  window.HTMLElement.prototype.scrollIntoView = jest.fn();
 
   it("should not have accessibility errors when closed", async () => {
     const { container } = renderTabs({});

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -20,57 +20,73 @@ const List = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
 >(({ children, ...rest }, forwardedRef) => (
   <TabsPrimitive.List
-    ata-h2-max-width="base(100%)"
-    data-h2-overflow-x="base(scroll)"
+    data-h2-max-width="base(100%)"
+    data-h2-display="base(flex)"
+    data-h2-gap="base(x.25)"
+    data-h2-overflow="base(auto visible)"
+    data-h2-width="base(100%)"
+    data-h2-padding="base(0 x1)"
+    data-h2-z-index="base(1)"
+    data-h2-overflow-x="base(auto)"
+    data-h2-overscroll-behavior-x="base(contain)"
+    data-h2-scroll-snap-align="base(start)"
+    data-h2-scroll-snap-type="base(x mandatory)"
+    data-h2-scrollbar-width="base:hover(none)"
     ref={forwardedRef}
     {...rest}
   >
-    <div
-      data-h2-display="base(flex)"
-      data-h2-gap="base(x.25)"
-      data-h2-overflow="base(auto visible)"
-      data-h2-width="base(100%)"
-      data-h2-padding="base(0 x1)"
-      data-h2-z-index="base(1)"
-    >
-      {children}
-    </div>
+    {children}
   </TabsPrimitive.List>
 ));
 
 const Trigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ children, ...rest }, forwardedRef) => (
-  <TabsPrimitive.Trigger
-    className="Tabs__Trigger"
-    data-h2-background-color="base(background)"
-    data-h2-border="base(thin solid background.darker)"
-    data-h2-border-top-color="
+>(({ children, ...rest }, forwardedRef) => {
+  const handleFocus: React.FocusEventHandler<HTMLButtonElement> = (event) => {
+    event.currentTarget.scrollIntoView({
+      block: "center",
+    });
+  };
+
+  return (
+    <TabsPrimitive.Trigger
+      className="Tabs__Trigger"
+      onFocus={handleFocus}
+      data-h2-background-color="base(background)"
+      data-h2-border="base(thin solid background.darker)"
+      data-h2-border-top-color="
       base:selectors[[data-state='active'] > span](primary)
       base:focus-visible:children[span](focus)
     "
-    data-h2-border-bottom-color="base:selectors[[data-state='active']](transparent)"
-    data-h2-display="base(inline-flex)"
-    data-h2-margin-top="base(x.25) base:hover(0)"
-    data-h2-padding="base(0)"
-    data-h2-outline="base(none)"
-    data-h2-radius="base(rounded rounded 0 0)"
-    data-h2-text-decoration="base:selectors[[data-state='inactive'] > span](underline)"
-    data-h2-position="base(relative)"
-    data-h2-z-index="base(1)"
-    ref={forwardedRef}
-    {...rest}
-  >
-    <span
-      data-h2-border-top="base(x.25 solid background.darker)"
-      data-h2-display="base(block)"
-      data-h2-padding="base(x.5 x.75)"
+      data-h2-border-bottom-color="base:selectors[[data-state='active']](transparent)"
+      data-h2-color="
+      base(black)
+      base:selectors[[data-state='active']](primary.darker)
+    "
+      data-h2-display="base(inline-flex)"
+      data-h2-font-weight="base:selectors[[data-state='active']](700)"
+      data-h2-margin-top="base(x.25) base:hover(0)"
+      data-h2-padding="base(0)"
+      data-h2-outline="base(none)"
+      data-h2-radius="base(rounded rounded 0 0)"
+      data-h2-text-decoration="base:selectors[[data-state='inactive']](underline)"
+      data-h2-position="base(relative)"
+      data-h2-z-index="base(1)"
+      ref={forwardedRef}
+      {...rest}
     >
-      {children}
-    </span>
-  </TabsPrimitive.Trigger>
-));
+      <span
+        data-h2-border-top="base(x.25 solid background.darker)"
+        data-h2-display="base(block)"
+        data-h2-radius="base(s s 0 0)"
+        data-h2-padding="base(x.5 x.75)"
+      >
+        {children}
+      </span>
+    </TabsPrimitive.Trigger>
+  );
+});
 
 const Content = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
@@ -79,9 +95,11 @@ const Content = React.forwardRef<
   <TabsPrimitive.Content
     ref={forwardedRef}
     data-h2-border-top="base(thin solid background.darker)"
+    data-h2-color="base(black)"
     data-h2-margin-top="base(-1px)"
-    data-h2-padding="base(x1)"
     data-h2-max-width="base(100%)"
+    data-h2-outline="base(none)"
+    data-h2-padding="base(x1)"
     {...props}
   />
 ));

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -20,6 +20,7 @@ const List = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
 >(({ children, ...rest }, forwardedRef) => (
   <TabsPrimitive.List
+    className="Tabs__List"
     data-h2-max-width="base(100%)"
     data-h2-display="base(flex)"
     data-h2-gap="base(x.25)"
@@ -43,10 +44,24 @@ const Trigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
 >(({ children, ...rest }, forwardedRef) => {
+  /**
+   * Scroll to the list item when it is in view.
+   *
+   * This allows us to have the currently focused item appear
+   * in the list when it has been focused for keyboard-only users.
+   *
+   * @param event
+   */
   const handleFocus: React.FocusEventHandler<HTMLButtonElement> = (event) => {
-    event.currentTarget.scrollIntoView({
-      block: "center",
-    });
+    const { currentTarget } = event;
+    const list = currentTarget.closest(".Tabs__List");
+    const currentScroll = list?.scrollLeft ?? 0;
+    const totalWidth = list?.scrollWidth ?? 0;
+
+    const offset = currentTarget.offsetLeft;
+    const scrollTo = offset + currentScroll - totalWidth / 2;
+
+    list?.scrollTo({ left: scrollTo });
   };
 
   return (

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -8,40 +8,68 @@ const Root = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>
 >((props, forwardedRef) => (
-  <TabsPrimitive.Root ref={forwardedRef} {...props} />
+  <TabsPrimitive.Root
+    ref={forwardedRef}
+    data-h2-max-width="base(100%)"
+    {...props}
+  />
 ));
 
 const List = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->((props, forwardedRef) => (
-  <TabsPrimitive.List ref={forwardedRef} {...props} />
+>(({ children, ...rest }, forwardedRef) => (
+  <TabsPrimitive.List
+    ata-h2-max-width="base(100%)"
+    data-h2-overflow-x="base(scroll)"
+    ref={forwardedRef}
+    {...rest}
+  >
+    <div
+      data-h2-display="base(flex)"
+      data-h2-gap="base(x.25)"
+      data-h2-overflow="base(auto visible)"
+      data-h2-width="base(100%)"
+      data-h2-padding="base(0 x1)"
+      data-h2-z-index="base(1)"
+    >
+      {children}
+    </div>
+  </TabsPrimitive.List>
 ));
 
 const Trigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->((props, forwardedRef) => (
+>(({ children, ...rest }, forwardedRef) => (
   <TabsPrimitive.Trigger
     className="Tabs__Trigger"
-    data-h2-background-color="base(white)"
-    data-h2-border="base(1px solid gray)"
-    data-h2-border-top="
-      base:selectors[[data-state='inactive']](x.5 solid gray)
-      base:selectors[[data-state='active']](x.5 solid primary)
-      base:selectors[[data-state='inactive']]:hover(x.5 solid gray.dark)
-      base:selectors[[data-state='active']]:hover(x.5 solid primary.dark)"
-    data-h2-border-bottom="base:selectors[[data-state='active']](1px solid white)"
-    data-h2-cursor="base(pointer)"
-    data-h2-padding="base(x.5, x1)"
-    data-h2-margin="base(0, x.5, 0, 0)"
+    data-h2-background-color="base(background)"
+    data-h2-border="base(thin solid background.darker)"
+    data-h2-border-top-color="
+      base:selectors[[data-state='active'] > span](primary)
+      base:focus-visible:children[span](focus)
+    "
+    data-h2-border-bottom-color="base:selectors[[data-state='active']](transparent)"
+    data-h2-display="base(inline-flex)"
+    data-h2-margin-top="base(x.25) base:hover(0)"
+    data-h2-padding="base(0)"
+    data-h2-outline="base(none)"
+    data-h2-radius="base(rounded rounded 0 0)"
+    data-h2-text-decoration="base:selectors[[data-state='inactive'] > span](underline)"
     data-h2-position="base(relative)"
-    data-h2-location="base(1px, auto, auto, auto)"
-    data-h2-radius="base(s, s, 0, 0)"
-    data-h2-transition="base(border 100ms ease)"
+    data-h2-z-index="base(1)"
     ref={forwardedRef}
-    {...props}
-  />
+    {...rest}
+  >
+    <span
+      data-h2-border-top="base(x.25 solid background.darker)"
+      data-h2-display="base(block)"
+      data-h2-padding="base(x.5 x.75)"
+    >
+      {children}
+    </span>
+  </TabsPrimitive.Trigger>
 ));
 
 const Content = React.forwardRef<
@@ -49,11 +77,11 @@ const Content = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
 >((props, forwardedRef) => (
   <TabsPrimitive.Content
-    data-h2-background-color="base(white)"
-    data-h2-border="base(1px solid gray)"
-    data-h2-radius="base(0, s, s, s)"
-    data-h2-padding="base(x1, x.75)"
     ref={forwardedRef}
+    data-h2-border-top="base(thin solid background.darker)"
+    data-h2-margin-top="base(-1px)"
+    data-h2-padding="base(x1)"
+    data-h2-max-width="base(100%)"
     {...props}
   />
 ));


### PR DESCRIPTION
🤖 Resolves #8582 

## 👋 Introduction

Updates the tab styles for mobile and dark mode.

## 🧪 Testing

1. Run storybook `npm run storybook:design-system`
2. Navigate to the "Tabs" story
3. Confirm it matches the mockup
4. Confirm tabs work on mobile

## 📸 Screenshot
<img width="505" alt="image" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/34dcc439-d2c2-4ebc-be78-a8b47e1bfe80">

