### PR TITLE
[Copy] Update title of add skill dialog on edit pool page

### DIFF
--- a/apps/web/src/components/SkillBrowser/types.ts
+++ b/apps/web/src/components/SkillBrowser/types.ts
@@ -7,6 +7,7 @@ import {
 } from "@gc-digital-talent/graphql";
 
 export type SkillBrowserDialogContext =
+  | "pool"
   | "experience"
   | "library"
   | "showcase"

--- a/apps/web/src/components/SkillBrowser/utils.ts
+++ b/apps/web/src/components/SkillBrowser/utils.ts
@@ -85,8 +85,8 @@ export const getSkillBrowserDialogMessages: GetSkillBrowserDialogMessages = ({
       }),
       title: intl.formatMessage({
         defaultMessage: "Add a skill to this process",
-        id: "+/ie0/",
-        description: "Title for the find a skill dialog within an experience",
+        id: "Z4iL1M",
+        description: "Title for the find a skill dialog within a pool",
       }),
       subtitle: null,
     };

--- a/apps/web/src/components/SkillBrowser/utils.ts
+++ b/apps/web/src/components/SkillBrowser/utils.ts
@@ -75,6 +75,23 @@ export const getSkillBrowserDialogMessages: GetSkillBrowserDialogMessages = ({
       ),
   };
 
+  if (context === "pool") {
+    return {
+      ...defaults,
+      trigger: intl.formatMessage({
+        defaultMessage: "Add a skill",
+        id: "mS15HC",
+        description: "Button text to open the skill dialog and add a skill",
+      }),
+      title: intl.formatMessage({
+        defaultMessage: "Add a skill to this process",
+        id: "+/ie0/",
+        description: "Title for the find a skill dialog within an experience",
+      }),
+      subtitle: null,
+    };
+  }
+
   if (context === "experience") {
     return {
       ...defaults,

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6447,6 +6447,10 @@
     "defaultMessage": "<hidden>Change language to </hidden>English",
     "description": "Title for the language toggle link."
   },
+  "Z4iL1M": {
+    "defaultMessage": "Ajouter une compétence à ce processus",
+    "description": "Title for the find a skill dialog within a pool"
+  },
   "Z8hEuY": {
     "defaultMessage": "Modifiez cette section",
     "description": "Default edit link text for application review page"

--- a/apps/web/src/pages/Pools/EditPoolPage/components/SkillTable.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/SkillTable.tsx
@@ -108,7 +108,7 @@ const SkillTable = ({
           ? {
               component: (
                 <SkillBrowserDialog
-                  context="experience"
+                  context="pool"
                   showCategory={false}
                   skills={availableSkills}
                   onSave={async (value) => {


### PR DESCRIPTION
🤖 Resolves #8398

## 👋 Introduction

Changes the title of the add skill dialog on the edit pool page.

## 🧪 Testing

1. Navigate to `/admin/pools`
2. Select "edit" on a draft pool
3. Scroll to the essential skills section and select to "Add a skill"
4. Confirm the dialog title is "Add a skill to this process"
5. Scroll to the asset skills section and select to "Add a skill"
6. Confirm the dialog title is "Add a skill to this process"

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/49166751/a69d9415-abac-41b7-9fd1-411edbfb21e7)
