### PR TITLE
[Bug] Resolve duplicate `UserSkill` in skill library

### DIFF
--- a/apps/web/src/pages/Skills/components/SkillLibraryTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillLibraryTable.tsx
@@ -83,6 +83,11 @@ const SkillLibraryTable = ({
     ? getTechnicalSkillLevel
     : getBehaviouralSkillLevel;
 
+  const userSkillSkillIds = data.map((usrSkill) => usrSkill.skill.id);
+  const unclaimedSkills = allSkills.filter(
+    (skill) => !userSkillSkillIds.includes(skill.id),
+  );
+
   const columns = [
     columnHelper.accessor((row) => getLocalizedName(row.skill.name, intl), {
       id: "name",
@@ -152,7 +157,7 @@ const SkillLibraryTable = ({
           <SkillBrowserDialog
             context="library"
             showCategory={false}
-            skills={allSkills}
+            skills={unclaimedSkills}
             onSave={async (value) => {
               executeCreateMutation({
                 userId: userAuthInfo?.id,


### PR DESCRIPTION
🤖 Resolves #8535

## 👋 Introduction

Prevent seeing the error toast. 

## 🕵️ Details

Just filtering out claimed skills before loading them into the browser dialog. 

## 🧪 Testing

1. Navigate to `/en/applicant/profile-and-applications/skills`
2. Observe claimed skills not accessible from the skill browser
3. Claim a skill, it should no longer be addable 

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/528c7cff-2a53-4ac9-9c26-fdca4c4fa17d)

