### PR TITLE
[Fix] Validator logic for past `closingDate`

### DIFF
--- a/apps/web/src/validators/process/closingDate.ts
+++ b/apps/web/src/validators/process/closingDate.ts
@@ -1,7 +1,10 @@
+import isPast from "date-fns/isPast";
+
 import { Pool } from "@gc-digital-talent/graphql";
+import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 
 // Only one field to check here
 // eslint-disable-next-line import/prefer-default-export
 export function hasEmptyRequiredFields({ closingDate }: Pool): boolean {
-  return !closingDate;
+  return !closingDate || isPast(parseDateTimeUtc(closingDate));
 }


### PR DESCRIPTION
🤖 Resolves #4179.

## 👋 Introduction

This PR adds validator logic for when a `closingDate` is in the past so that the correct indicator status is shown for the section that is no longer "complete".

> [!NOTE]
> The copy for the "null" state should possibly be changed, including the action that prompt the user to "Get started", to include a message that is more generic or include a message for the state where a closing date value is in the past, but this seems out of scope for this issue and would also (possibly) change the way the other non "form" sections behave.

https://github.com/GCTC-NTGC/gc-digital-talent/blob/8c765ade8d25cf1974d400da3a71954e31fcfaac/apps/web/src/pages/Pools/EditPoolPage/components/ClosingDateSection/ClosingDateSection.tsx#L125-L132

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Create a pool
2. Complete all of the required fields in the **Advertisement information** "forms"
3. Edit the `closing_date` value in the database for the newly created pool to be in the past
4. Navigate to newly created pool `/admin/pools/:pool-id/edit#closing-date`
5. Observe table of contents status indicator is "incomplete" for **Closing date**

## 📸 Screenshot

![Screen Shot 2023-12-04 at 14 33 54](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/7ef3f82d-34a9-430b-845b-11794ac19308)