### PR TITLE
[Debt] camelCase PHP functions

### DIFF
--- a/api/tests/Feature/ClassificationTest.php
+++ b/api/tests/Feature/ClassificationTest.php
@@ -68,7 +68,7 @@ class ClassificationTest extends TestCase
      *
      * @return void
      */
-    public function test_view_any_classification()
+    public function testViewAnyClassification()
     {
         $this->actingAs($this->baseUser, 'api')
             ->graphQL('query { classifications { id } }')
@@ -80,7 +80,7 @@ class ClassificationTest extends TestCase
      *
      * @return void
      */
-    public function test_view_classification()
+    public function testViewClassification()
     {
 
         $variables = ['id' => $this->uuid];
@@ -105,7 +105,7 @@ class ClassificationTest extends TestCase
      *
      * @return void
      */
-    public function test_update_classification()
+    public function testUpdateClassification()
     {
 
         $variables = [
@@ -146,7 +146,7 @@ class ClassificationTest extends TestCase
      *
      * @return void
      */
-    public function test_create_classification()
+    public function testCreateClassification()
     {
         $variables = [
             'classification' => [
@@ -187,7 +187,7 @@ class ClassificationTest extends TestCase
      *
      * @return void
      */
-    public function test_delete_classification()
+    public function testDeleteClassification()
     {
         $variables = ['id' => $this->toBeDeletedUUID];
 

--- a/api/tests/Feature/DepartmentTest.php
+++ b/api/tests/Feature/DepartmentTest.php
@@ -60,7 +60,7 @@ class DepartmentTest extends TestCase
      *
      * @return void
      */
-    public function test_view_any_department()
+    public function testViewAnyDepartment()
     {
         $this->actingAs($this->baseUser, 'api')
             ->graphQL('query { departments { id } }')
@@ -72,7 +72,7 @@ class DepartmentTest extends TestCase
      *
      * @return void
      */
-    public function test_view_department()
+    public function testViewDepartment()
     {
 
         $variables = ['id' => $this->department->id];
@@ -97,7 +97,7 @@ class DepartmentTest extends TestCase
      *
      * @return void
      */
-    public function test_update_department()
+    public function testUpdateDepartment()
     {
 
         $variables = [
@@ -138,7 +138,7 @@ class DepartmentTest extends TestCase
      *
      * @return void
      */
-    public function test_create_department()
+    public function testCreateDepartment()
     {
         $variables = [
             'department' => [
@@ -178,7 +178,7 @@ class DepartmentTest extends TestCase
      *
      * @return void
      */
-    public function test_delete_department()
+    public function testDeleteDepartment()
     {
         $variables = ['id' => $this->toBeDeleted->id];
 

--- a/api/tests/Feature/GenericJobTitleTest.php
+++ b/api/tests/Feature/GenericJobTitleTest.php
@@ -61,7 +61,7 @@ class GenericJobTitleTest extends TestCase
      *
      * @return void
      */
-    public function test_view_any_generic_job_title()
+    public function testViewAnyGenericJobTitle()
     {
         $this->actingAs($this->baseUser, 'api')
             ->graphQL('query { genericJobTitles { id } }')
@@ -73,7 +73,7 @@ class GenericJobTitleTest extends TestCase
      *
      * @return void
      */
-    public function test_view_generic_job_title()
+    public function testViewGenericJobTitle()
     {
 
         $variables = ['id' => $this->genericJobTitle->id];

--- a/api/tests/Feature/NotifyTest.php
+++ b/api/tests/Feature/NotifyTest.php
@@ -43,7 +43,7 @@ class NotifyTest extends TestCase
      *
      * @return void
      */
-    public function test_email()
+    public function testEmail()
     {
         $this->checkKey('notify.templates.test_email', 'Email template not found.');
 
@@ -61,7 +61,7 @@ class NotifyTest extends TestCase
      *
      * @return void
      */
-    public function test_sms()
+    public function testSms()
     {
         $this->checkKey('notify.templates.test_sms', 'Email template not found.');
 
@@ -79,7 +79,7 @@ class NotifyTest extends TestCase
      *
      * @return void
      */
-    public function test_bulk_sms()
+    public function testBulkSms()
     {
         $this->markTestSkipped('Prevent hitting the server.');
 
@@ -119,7 +119,7 @@ class NotifyTest extends TestCase
      *
      * @return void
      */
-    public function test_bulk_email()
+    public function testBulkEmail()
     {
         $this->markTestSkipped('Prevent hitting the server.');
 

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -44,7 +44,7 @@ class RolePermissionTest extends TestCase
      *
      * @return void
      */
-    public function test_guest_role()
+    public function testGuestRole()
     {
         $guestRole = Role::where('name', 'guest')->sole();
         $this->user->addRole($guestRole);
@@ -73,7 +73,7 @@ class RolePermissionTest extends TestCase
      *
      * @return void
      */
-    public function test_base_user_role()
+    public function testBaseUserRole()
     {
         $baseUserRole = Role::where('name', 'base_user')->sole();
         $this->user->addRole($baseUserRole);
@@ -104,7 +104,7 @@ class RolePermissionTest extends TestCase
      *
      * @return void
      */
-    public function test_applicant_role()
+    public function testApplicantRole()
     {
         $applicantRole = Role::where('name', 'applicant')->sole();
         $this->user->addRole($applicantRole);
@@ -128,7 +128,7 @@ class RolePermissionTest extends TestCase
      *
      * @return void
      */
-    public function test_pool_operator_role()
+    public function testPoolOperatorRole()
     {
         $poolOperatorRole = Role::where('name', 'pool_operator')->sole();
         $this->user->addRole(
@@ -164,7 +164,7 @@ class RolePermissionTest extends TestCase
      *
      * @return void
      */
-    public function test_request_responder_role()
+    public function testRequestResponderRole()
     {
         $requestResponderRole = Role::where('name', 'request_responder')->sole();
         $this->user->addRole($requestResponderRole);
@@ -188,7 +188,7 @@ class RolePermissionTest extends TestCase
      *
      * @return void
      */
-    public function test_platform_admin_role()
+    public function testPlatformAdminRole()
     {
         $superAdminRole = Role::where('name', 'platform_admin')->sole();
         $this->user->addRole($superAdminRole);
@@ -235,7 +235,7 @@ class RolePermissionTest extends TestCase
      *
      * @return void
      */
-    public function test_community_manager_role()
+    public function testCommunityManagerRole()
     {
         $communityManager = Role::where('name', 'community_manager')->sole();
         $this->user->addRole($communityManager);
@@ -262,7 +262,7 @@ class RolePermissionTest extends TestCase
      *
      * @return void
      */
-    public function test_strict_team_check()
+    public function testStrictTeamCheck()
     {
         $poolOperatorRole = Role::where('name', 'pool_operator')->sole();
         $this->user->addRole(

--- a/api/tests/Feature/SkillFamilyTest.php
+++ b/api/tests/Feature/SkillFamilyTest.php
@@ -61,7 +61,7 @@ class SkillFamilyTest extends TestCase
      *
      * @return void
      */
-    public function test_view_any_skill_family()
+    public function testViewAnySkillFamily()
     {
         $this->graphQL('query { skillFamilies { id } }')
             ->assertJsonFragment(['id' => $this->uuid]);
@@ -72,7 +72,7 @@ class SkillFamilyTest extends TestCase
      *
      * @return void
      */
-    public function test_view_skill_family()
+    public function testViewSkillFamily()
     {
 
         $variables = ['id' => $this->uuid];
@@ -96,7 +96,7 @@ class SkillFamilyTest extends TestCase
      *
      * @return void
      */
-    public function test_update_skill_family()
+    public function testUpdateSkillFamily()
     {
 
         $variables = [
@@ -137,7 +137,7 @@ class SkillFamilyTest extends TestCase
      *
      * @return void
      */
-    public function test_create_skill_family()
+    public function testCreateSkillFamily()
     {
         $variables = [
             'skillFamily' => [

--- a/api/tests/Feature/SkillTest.php
+++ b/api/tests/Feature/SkillTest.php
@@ -67,7 +67,7 @@ class SkillTest extends TestCase
      *
      * @return void
      */
-    public function test_view_any_skill()
+    public function testViewAnySkill()
     {
         $this->graphQL('query { skills { id } }')
             ->assertJsonFragment(['id' => $this->uuid]);
@@ -78,7 +78,7 @@ class SkillTest extends TestCase
      *
      * @return void
      */
-    public function test_view_skill()
+    public function testViewSkill()
     {
 
         $variables = ['id' => $this->uuid];
@@ -102,7 +102,7 @@ class SkillTest extends TestCase
      *
      * @return void
      */
-    public function test_update_skill()
+    public function testUpdateSkill()
     {
         $variables = [
             'id' => $this->uuid,
@@ -142,7 +142,7 @@ class SkillTest extends TestCase
      *
      * @return void
      */
-    public function test_create_skill()
+    public function testCreateSkill()
     {
         $variables = [
             'skill' => [
@@ -184,7 +184,7 @@ class SkillTest extends TestCase
      *
      * @return void
      */
-    public function test_create_non_unique_skill_key()
+    public function testCreateNonUniqueSkillKey()
     {
         $variables = [
             'skill' => [


### PR DESCRIPTION
🤖 Resolves #8479

## 👋 Introduction

Rename PHP functions to camelCase notation wherever they are not. 

## 🕵️ Details

Couldn't find them in anywhere but the unit test files 

## 🧪 Testing

1. Tests pass
2. No more underscore methods 


