### PR TITLE
[Fix] Date input error summary links

### DIFF
--- a/packages/forms/src/components/DateInput/DateInput.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.tsx
@@ -107,7 +107,7 @@ const DateInput = ({
 
   return (
     <Field.Wrapper>
-      <Field.Fieldset aria-describedby={ariaDescribedBy} {...rest}>
+      <Field.Fieldset id={id} aria-describedby={ariaDescribedBy} {...rest}>
         <Field.Legend
           required={required}
           data-h2-font-size="base(copy)"


### PR DESCRIPTION
🤖 Resolves #8537 

## 👋 Introduction

This adds the `id` to the date input fieldset so they can be properly targeted by anchor links.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/directive-on-digital-talent/digital-services-contracting-questionnaire`
3. Submit the form with errors (specifically for date fields)
4. Click on the link for the date field in the summary
5. Confirmit scrolls to the fieldset and focuses the first element