### PR TITLE
[Debt] Removes `FEATURE_EXECUTIVE_TEASER` flag

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -12,7 +12,6 @@ FEATURE_SKILL_LIBRARY=true
 #FEATURE_STATUS_NOTIFICATIONS=true  // not yet implemented on the client side
 FEATURE_DIRECTIVE_FORMS=true
 FEATURE_RECORD_OF_DECISION=true
-FEATURE_EXECUTIVE_TEASER=true
 
 # Logging - enable by setting the logging level. Eight severity levels from rfc5424.
 LOG_CONSOLE_LEVEL="debug"

--- a/apps/web/public/config.ejs
+++ b/apps/web/public/config.ejs
@@ -16,7 +16,6 @@ const data = new Map([
     ["FEATURE_SKILL_LIBRARY", filterUnusable("$FEATURE_SKILL_LIBRARY") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_SKILL_LIBRARY %>"],
     ["FEATURE_DIRECTIVE_FORMS", filterUnusable("$FEATURE_DIRECTIVE_FORMS") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_DIRECTIVE_FORMS %>"],
     ["FEATURE_RECORD_OF_DECISION", filterUnusable("$FEATURE_RECORD_OF_DECISION") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_RECORD_OF_DECISION %>"],
-    ["FEATURE_EXECUTIVE_TEASER", filterUnusable("$FEATURE_EXECUTIVE_TEASER") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_EXECUTIVE_TEASER %>"],
 
     // Azure application insights not used in dev
     ["APPLICATIONINSIGHTS_CONNECTION_STRING", filterUnusable("$APPLICATIONINSIGHTS_CONNECTION_STRING")],

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1071,10 +1071,6 @@
     "defaultMessage": "Rejeté(e)",
     "description": "Message displayed when candidate has been screened out at a specific assessment step"
   },
-  "3yg5j7": {
-    "defaultMessage": "Notre premier processus exécutif (EX) pour un poste EX-03 sera publié sur la plateforme des talents numériques du GC en novembre 2023. Gardez l’œil ouvert pour une possibilité d’emploi où vous pourrez soumettre votre candidature pour devenir un leader du numérique au sein du gouvernement.",
-    "description": "Text describing upcoming executive opportunities instructing users to create a profile when anonymous"
-  },
   "404R1N": {
     "defaultMessage": "Ce programme a été pour moi une occasion de changer ma vie et je vois <b>un meilleur avenir</b>.",
     "description": "testimonial number one"
@@ -7242,10 +7238,6 @@
   "dE2WB1": {
     "defaultMessage": "Équité en matière d’emploi ({equityFiltersActive})",
     "description": "Employment equity with a number in parentheses"
-  },
-  "dFCH1c": {
-    "defaultMessage": "Processus exécutif à venir sous peu",
-    "description": "Heading for the teaser of executive processes"
   },
   "dGgEAz": {
     "defaultMessage": "La sauvegarde des étapes d’évaluation ont été sauvegardées!",

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
@@ -5,7 +5,6 @@ import { CardFlat, Flourish, Pending } from "@gc-digital-talent/ui";
 import { useTheme } from "@gc-digital-talent/theme";
 import { useAuthentication } from "@gc-digital-talent/auth";
 import { nowUTCDateTime } from "@gc-digital-talent/date-helpers";
-import { useFeatureFlags } from "@gc-digital-talent/env";
 
 import SEO from "~/components/SEO/SEO";
 import Hero from "~/components/Hero";
@@ -46,7 +45,6 @@ export const BrowsePools = ({ pools }: BrowsePoolsProps) => {
   const intl = useIntl();
   const { loggedIn } = useAuthentication();
   const paths = useRoutes();
-  const { executiveTeaser } = useFeatureFlags();
 
   const title = intl.formatMessage({
     defaultMessage: "Browse jobs",
@@ -136,72 +134,49 @@ export const BrowsePools = ({ pools }: BrowsePoolsProps) => {
           <div>
             <ActiveRecruitmentSection pools={activeRecruitmentPools} />
           </div>
-          {executiveTeaser && (
-            <CallToActionCard
-              heading={intl.formatMessage({
-                defaultMessage: "Executive (EX) process coming soon",
-                id: "dFCH1c",
-                description: "Heading for the teaser of executive processes",
-              })}
-              link={profileLink}
-              data-h2-margin="base(x1, 0, 0, 0)"
-            >
-              <p>
-                {intl.formatMessage({
-                  defaultMessage:
-                    "Our first executive (EX) process for an EX-03 position will be published on the GC Digital Talent platform in November 2023. Check this space for an opportunity to submit your candidacy to be a digital leader in government.",
-                  id: "3yg5j7",
-                  description:
-                    "Text describing upcoming executive opportunities instructing users to create a profile when anonymous",
-                })}
-              </p>
-            </CallToActionCard>
-          )}
           {ongoingRecruitmentPools.length > 0 && (
             <div>
               <OngoingRecruitmentSection pools={ongoingRecruitmentPools} />
             </div>
           )}
-          {!executiveTeaser && (
-            <CallToActionCard
-              heading={
-                areOpportunitiesShowing
-                  ? intl.formatMessage({
-                      defaultMessage: "More opportunities are coming soon!",
-                      id: "g+JcDC",
-                      description:
-                        "Heading for message about upcoming opportunities",
-                    })
-                  : intl.formatMessage({
-                      defaultMessage:
-                        "No opportunities are available right now, but more are coming soon!",
-                      id: "xHjgXz",
-                      description:
-                        "Text displayed when there are no pool advertisements to display",
-                    })
-              }
-              link={profileLink}
-              data-h2-margin="base(x1, 0, 0, 0)"
-            >
-              <p>
-                {loggedIn
-                  ? intl.formatMessage({
-                      defaultMessage:
-                        "We're posting new opportunities all the time. By keeping your profile up to date, you'll be able to submit applications lightning fast when the time comes.",
-                      id: "9SZDCq",
-                      description:
-                        "Text describing upcoming opportunities instructing users to update a profile when signed in",
-                    })
-                  : intl.formatMessage({
-                      defaultMessage:
-                        "We're posting new opportunities all the time. By starting your profile now, you'll be able to submit applications lightning fast when the time comes.",
-                      id: "3sbLPV",
-                      description:
-                        "Text describing upcoming opportunities instructing users to create a profile when anonymous",
-                    })}
-              </p>
-            </CallToActionCard>
-          )}
+          <CallToActionCard
+            heading={
+              areOpportunitiesShowing
+                ? intl.formatMessage({
+                    defaultMessage: "More opportunities are coming soon!",
+                    id: "g+JcDC",
+                    description:
+                      "Heading for message about upcoming opportunities",
+                  })
+                : intl.formatMessage({
+                    defaultMessage:
+                      "No opportunities are available right now, but more are coming soon!",
+                    id: "xHjgXz",
+                    description:
+                      "Text displayed when there are no pool advertisements to display",
+                  })
+            }
+            link={profileLink}
+            data-h2-margin="base(x1, 0, 0, 0)"
+          >
+            <p>
+              {loggedIn
+                ? intl.formatMessage({
+                    defaultMessage:
+                      "We're posting new opportunities all the time. By keeping your profile up to date, you'll be able to submit applications lightning fast when the time comes.",
+                    id: "9SZDCq",
+                    description:
+                      "Text describing upcoming opportunities instructing users to update a profile when signed in",
+                  })
+                : intl.formatMessage({
+                    defaultMessage:
+                      "We're posting new opportunities all the time. By starting your profile now, you'll be able to submit applications lightning fast when the time comes.",
+                    id: "3sbLPV",
+                    description:
+                      "Text describing upcoming opportunities instructing users to create a profile when anonymous",
+                  })}
+            </p>
+          </CallToActionCard>
         </div>
         <img
           alt=""


### PR DESCRIPTION
🤖 Resolves #8293.

## 👋 Introduction

This PR removes the executive teaser section from the browse pools page along with its associated strings in French and the feature flag that it uses for conditional rendering.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate to `/browse/pools`
3. Confirm the absence of a `CallToActionCard` that includes the copy **Executive (EX) process coming soon**

## 🚚 Deployment

Add any additional details that are required for deploying the application.

> [!IMPORTANT]  
> Remove `FEATURE_EXECUTIVE_TEASER` from IaC