### PR TITLE
[Feature] Updates support email

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 # Security
 
-Do not post security vulnerabilities to our public repository. Security vulnerabilities should be reported by email to <gctalent-talentgc@support-soutien.gc.ca>.
+Do not post security vulnerabilities to our public repository. Security vulnerabilities should be reported by email to <support-soutien@talent.canada.ca>.

--- a/apps/web/src/constants/talentSearchConstants.ts
+++ b/apps/web/src/constants/talentSearchConstants.ts
@@ -1,5 +1,5 @@
 export const TALENTSEARCH_SUPPORT_EMAIL =
   (process.env.TALENTSEARCH_SUPPORT_EMAIL as string) ??
-  "gctalent-talentgc@support-soutien.gc.ca";
+  "support-soutien@talent.canada.ca";
 export const API_SUPPORT_ENDPOINT =
   (process.env.API_SUPPORT_ENDPOINT as string) ?? "/api/support/tickets";

--- a/apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.tsx
+++ b/apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.tsx
@@ -9,6 +9,7 @@ import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import useRoutes from "~/hooks/useRoutes";
 import { wrapAbbr } from "~/utils/nameUtils";
 import heroImg from "~/assets/img/accessibility-statement-header.webp";
+import { TALENTSEARCH_SUPPORT_EMAIL } from "~/constants/talentSearchConstants";
 
 const digitalStandardsLink = (locale: Locales, chunks: React.ReactNode) => (
   <Link
@@ -502,11 +503,8 @@ const AccessibilityStatementPage = () => {
                 })}
               </p>
               <p data-h2-margin="base(x.5, 0)">
-                <Link
-                  external
-                  href="mailto:gctalent-talentgc@support-soutien.gc.ca"
-                >
-                  gctalent-talentgc@support-soutien.gc.ca
+                <Link external href={`mailto:${TALENTSEARCH_SUPPORT_EMAIL}`}>
+                  {TALENTSEARCH_SUPPORT_EMAIL}
                 </Link>
               </p>
               <p data-h2-margin="base(x.5, 0)">


### PR DESCRIPTION
🤖 Resolves #8674.

## 👋 Introduction

This PR updates `AccessbilityStatementPage` to reference the `TALENTSEARCH_SUPPORT_EMAIL` constant which itself gets its value from an identically named environment variable called `TALENTSEARCH_SUPPORT_EMAIL`. It also updates the fallback value for the TALENTSEARCH_SUPPORT_EMAIL constant to be [support-soutien@talent.canada.ca](mailto:support-soutien@talent.canada.ca) and updates a reference to the support email in the security policy file.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Update `TALENTSEARCH_SUPPORT_EMAIL` environment variable in `apps/web/.env` to `support-soutien@talent.canada.ca`
2. `npm run build`
3. Navigate to `/accessibility-statement`
4. Confirm email address rendered in feedback and contact information section is support-soutien@talent.canada.ca

## 🚚 Deployment

Add any additional details that are required for deploying the application.

> [!IMPORTANT]  
> Update `TALENTSEARCH_SUPPORT_EMAIL` in UAT, DEV, and PROD from `gctalent-talentgc@support-soutien.gc.ca` to `support-soutien@talent.canada.ca`