### PR TITLE
[Copy] Updates date modified string

### DIFF
--- a/apps/web/src/components/Footer/Footer.tsx
+++ b/apps/web/src/components/Footer/Footer.tsx
@@ -112,10 +112,10 @@ const Footer = ({ width }: FooterProps) => {
                 <span>
                   {intl.formatMessage(
                     {
-                      defaultMessage: "Date Modified: {modifiedDate}",
-                      id: "Fc/i3e",
+                      defaultMessage: "Date modified: {modifiedDate}",
+                      id: "Jkg004",
                       description:
-                        "Header for the sites last date modification found in the footer.",
+                        "Header for the date of the last modification of the site",
                     },
                     {
                       modifiedDate: new Date(

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3215,10 +3215,6 @@
     "defaultMessage": "Vous êtes sur le point d'archiver ce bassin :",
     "description": "First paragraph for archive pool dialog"
   },
-  "Fc/i3e": {
-    "defaultMessage": "Modification de la date : {modifiedDate}",
-    "description": "Header for the sites last date modification found in the footer."
-  },
   "FckGRB": {
     "defaultMessage": "Songez à ajouter des renseignements à ces compétences représentant un atout :",
     "description": "Text that appears when a user is missing optional skills on their profile"
@@ -3882,6 +3878,10 @@
   "JjTGYe": {
     "defaultMessage": "Vous êtes sur le point de modifier la date d'expiration pour cet utilisateur :",
     "description": "First section of text on the change candidate expiry date dialog"
+  },
+  "Jkg004": {
+    "defaultMessage": "Date de modification : {modifiedDate}",
+    "description": "Header for the date of the last modification of the site"
   },
   "Jp/oeD": {
     "defaultMessage": "2. Créez un nom d’utilisateur et un mot de passe. N’oubliez pas d’ <strong>enregistrer votre nom d’utilisateur</strong> à part de votre <strong>adresse de courriel</strong>.",


### PR DESCRIPTION
🤖 Resolves #8670.

## 👋 Introduction

This PR updates the **Date modified** string to be sentence case to follow the site's existing copy style and corrects the **Date modified** string in French to the termium approved version _Date de modification_.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate to any page of the application
3. Confirm footer copy **Date modified** string is sentence case
4. Switch to French
5. Confirm footer copy _Date de modification_ string exists

## 📸 Screenshot

![Screen Shot 2023-12-07 at 12 00 23](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/edde9ef1-76b5-4e94-adac-1c5c6842c79c)

