### PR TITLE
[Debt] Removes `user.isIndigenous` GraphQL field

### DIFF
--- a/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
@@ -49,7 +49,6 @@ query getProfile($userId: UUID!) {
     }
     isWoman
     hasDisability
-    isIndigenous
     indigenousCommunities
     indigenousDeclarationSignature
     isVisibleMinority

--- a/api/app/Http/Resources/UserResource.php
+++ b/api/app/Http/Resources/UserResource.php
@@ -79,7 +79,6 @@ class UserResource extends JsonResource
             'currentClassification' => (new ClassificationResource($this->currentClassification)),
             'isWoman' => $this->is_woman,
             'hasDisability' => $this->has_disability,
-            'isIndigenous' => $this->is_indigenous,
             'isVisibleMinority' => $this->is_visible_minority,
             'indigenousCommunities' => $this->indigenous_communities,
             'indigenousDeclarationSignature' => $this->indigenous_declaration_signature,

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -4,7 +4,6 @@ namespace App\Models;
 
 use App\Enums\CandidateExpiryFilter;
 use App\Enums\CandidateSuspendedFilter;
-use App\Enums\IndigenousCommunity;
 use App\Enums\LanguageAbility;
 use App\Enums\PoolCandidateStatus;
 use App\Enums\PublishingGroup;

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -605,11 +605,13 @@ class User extends Model implements Authenticatable, LaratrustUser
             array_push($equityVars, 'is_visible_minority');
         }
 
-        // 3 fields are booleans, one is a jsonb field, isIndigenous = LEGACY_IS_INDIGENOUS
+        // 3 fields are booleans, one is a jsonb field
         $query->where(function ($query) use ($equityVars) {
             foreach ($equityVars as $index => $equityInstance) {
                 if ($equityInstance === 'is_indigenous') {
-                    $query->orWhereJsonContains('indigenous_communities', IndigenousCommunity::LEGACY_IS_INDIGENOUS->name);
+                    foreach (array_column(IndigenousCommunity::cases(), 'name') as $indigenousOption) {
+                        $query->orWhereJsonContains('indigenous_communities', $indigenousOption);
+                    }
                 } else {
                     $query->orWhere($equityVars[$index], true);
                 }

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -588,8 +588,8 @@ class User extends Model implements Authenticatable, LaratrustUser
             return $query;
         }
 
-        // OR filter - first find out how many booleans are true, create array of all true equity bools
-        // equity object has 4 keys with associated bools
+        // OR filter - first find out how many booleans are true, create array of all true equity booleans
+        // equity object has 4 keys with associated booleans
         $equityVars = [];
         if (array_key_exists('is_woman', $equity) && $equity['is_woman']) {
             array_push($equityVars, 'is_woman');

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -693,22 +693,6 @@ class User extends Model implements Authenticatable, LaratrustUser
         return $query;
     }
 
-    /* accessor to maintain functionality of to be deprecated isIndigenous field */
-    public function getIsIndigenousAttribute()
-    {
-        $indigenousCommunities = $this->indigenous_communities;
-
-        if ($indigenousCommunities && in_array(IndigenousCommunity::LEGACY_IS_INDIGENOUS->name, $indigenousCommunities)) {
-            return true;
-        }
-
-        if (gettype($indigenousCommunities) == 'array') {
-            return false; // case for when the array exists but lacks the legacy value which would reverse to is_indigenous = false, or is empty
-        }
-
-        return null; // if indigenousCommunities is null then so is isIndigenous
-    }
-
     // Prepares the parameters for Laratrust and then calls the function to modify the roles
     private function callRolesFunction($rolesInput, $functionName)
     {

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -609,9 +609,7 @@ class User extends Model implements Authenticatable, LaratrustUser
         $query->where(function ($query) use ($equityVars) {
             foreach ($equityVars as $index => $equityInstance) {
                 if ($equityInstance === 'is_indigenous') {
-                    foreach (array_column(IndigenousCommunity::cases(), 'name') as $indigenousOption) {
-                        $query->orWhereJsonContains('indigenous_communities', $indigenousOption);
-                    }
+                    $query->whereJsonLength('indigenous_communities', '>', 0);
                 } else {
                     $query->orWhere($equityVars[$index], true);
                 }

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -117,7 +117,6 @@ class UserFactory extends Factory
             'priority_number' => $hasPriorityEntitlement ? $this->faker->word() : null,
             'indigenous_declaration_signature' => $isDeclared ? $this->faker->firstName() : null,
             'indigenous_communities' => $isDeclared ? [$this->faker->randomElement(IndigenousCommunity::cases())->name] : [],
-            // mirroring migration where isIndigenous = false maps to []
         ];
     }
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -78,11 +78,6 @@ type User {
   # Employment equity
   isWoman: Boolean @rename(attribute: "is_woman")
   hasDisability: Boolean @rename(attribute: "has_disability")
-  isIndigenous: Boolean
-    @rename(attribute: "is_indigenous")
-    @deprecated(
-      reason: "isIndigenous is deprecated. Use indigenousCommunities instead. Remove in #7662."
-    )
   isVisibleMinority: Boolean @rename(attribute: "is_visible_minority")
   indigenousCommunities: [IndigenousCommunity]
     @rename(attribute: "indigenous_communities")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -217,7 +217,6 @@ type User {
   priorityNumber: String
   isWoman: Boolean
   hasDisability: Boolean
-  isIndigenous: Boolean @deprecated(reason: "isIndigenous is deprecated. Use indigenousCommunities instead. Remove in #7662.")
   isVisibleMinority: Boolean
   indigenousCommunities: [IndigenousCommunity]
   indigenousDeclarationSignature: String

--- a/api/tests/Feature/ApplicantFilterTest.php
+++ b/api/tests/Feature/ApplicantFilterTest.php
@@ -389,7 +389,7 @@ class ApplicantFilterTest extends TestCase
             [
                 'has_diploma' => $candidate->user->has_diploma,
                 'has_disability' => $candidate->user->has_disability,
-                'is_indigenous' => $candidate->user->is_indigenous,
+                'is_indigenous' => ! empty($candidate->user->indigenous_communities),
                 'is_visible_minority' => $candidate->user->is_visible_minority,
                 'is_woman' => $candidate->user->is_woman,
                 'position_duration' => $candidate->user->position_duration,

--- a/api/tests/Feature/ApplicantTest.php
+++ b/api/tests/Feature/ApplicantTest.php
@@ -136,7 +136,7 @@ class ApplicantTest extends TestCase
             'user_id' => User::factory([
                 'is_woman' => true,
                 'has_disability' => false,
-                'indigenous_communities' => [IndigenousCommunity::OTHER->name], // will not be filtered for
+                'indigenous_communities' => [IndigenousCommunity::STATUS_FIRST_NATIONS->name],
                 'is_visible_minority' => false,
             ]),
         ]);
@@ -146,9 +146,57 @@ class ApplicantTest extends TestCase
             'expiry_date' => config('constants.far_future_date'),
             'pool_candidate_status' => PoolCandidateStatus::QUALIFIED_AVAILABLE->name,
             'user_id' => User::factory([
-                'is_woman' => true,
+                'is_woman' => false,
                 'has_disability' => true,
-                'indigenous_communities' => [IndigenousCommunity::LEGACY_IS_INDIGENOUS->name], // will be filtered for
+                'indigenous_communities' => [IndigenousCommunity::NON_STATUS_FIRST_NATIONS->name],
+                'is_visible_minority' => false,
+            ]),
+        ]);
+
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'expiry_date' => config('constants.far_future_date'),
+            'pool_candidate_status' => PoolCandidateStatus::QUALIFIED_AVAILABLE->name,
+            'user_id' => User::factory([
+                'is_woman' => false,
+                'has_disability' => false,
+                'indigenous_communities' => [IndigenousCommunity::INUIT->name],
+                'is_visible_minority' => false,
+            ]),
+        ]);
+
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'expiry_date' => config('constants.far_future_date'),
+            'pool_candidate_status' => PoolCandidateStatus::QUALIFIED_AVAILABLE->name,
+            'user_id' => User::factory([
+                'is_woman' => false,
+                'has_disability' => false,
+                'indigenous_communities' => [IndigenousCommunity::METIS->name],
+                'is_visible_minority' => false,
+            ]),
+        ]);
+
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'expiry_date' => config('constants.far_future_date'),
+            'pool_candidate_status' => PoolCandidateStatus::QUALIFIED_AVAILABLE->name,
+            'user_id' => User::factory([
+                'is_woman' => false,
+                'has_disability' => false,
+                'indigenous_communities' => [IndigenousCommunity::OTHER->name],
+                'is_visible_minority' => false,
+            ]),
+        ]);
+
+        PoolCandidate::factory()->create([
+            'pool_id' => $pool1['id'],
+            'expiry_date' => config('constants.far_future_date'),
+            'pool_candidate_status' => PoolCandidateStatus::QUALIFIED_AVAILABLE->name,
+            'user_id' => User::factory([
+                'is_woman' => false,
+                'has_disability' => false,
+                'indigenous_communities' => [IndigenousCommunity::LEGACY_IS_INDIGENOUS->name],
                 'is_visible_minority' => false,
             ]),
         ]);
@@ -170,7 +218,7 @@ class ApplicantTest extends TestCase
             ]
         )->assertJson([
             'data' => [
-                'countApplicants' => 5,
+                'countApplicants' => 9,
             ],
         ]);
 
@@ -197,11 +245,11 @@ class ApplicantTest extends TestCase
             ]
         )->assertJson([
             'data' => [
-                'countApplicants' => 5,
+                'countApplicants' => 9,
             ],
         ]);
 
-        // Assert query will OR filter the equity
+        // Assert query if isWoman OR hasDisability is true
         $this->graphQL(
             /** @lang GraphQL */
             '
@@ -226,7 +274,7 @@ class ApplicantTest extends TestCase
             ],
         ]);
 
-        // Assert query will correctly filter for LEGACY_IS_INDIGENOUS
+        // Assert query will correctly filter for any indigenous community
         $this->graphQL(
             /** @lang GraphQL */
             '
@@ -246,7 +294,7 @@ class ApplicantTest extends TestCase
             ]
         )->assertJson([
             'data' => [
-                'countApplicants' => 1,
+                'countApplicants' => 6,
             ],
         ]);
     }

--- a/apps/e2e/cypress/support/userCommands.ts
+++ b/apps/e2e/cypress/support/userCommands.ts
@@ -41,7 +41,6 @@ const defaultUser = {
   currentClassification: undefined,
   isWoman: undefined,
   hasDisability: undefined,
-  isIndigenous: undefined,
   isVisibleMinority: undefined,
   hasDiploma: undefined,
   locationPreferences: undefined,

--- a/apps/web/src/components/UserProfile/UserProfile.stories.tsx
+++ b/apps/web/src/components/UserProfile/UserProfile.stories.tsx
@@ -77,7 +77,6 @@ UserProfileNull.args = {
   currentClassification: null,
   isWoman: null,
   hasDisability: null,
-  isIndigenous: null,
   indigenousCommunities: null,
   isVisibleMinority: null,
   hasDiploma: null,

--- a/apps/web/src/pages/Applications/applicationOperations.graphql
+++ b/apps/web/src/pages/Applications/applicationOperations.graphql
@@ -134,7 +134,6 @@ query GetApplication($id: UUID!) {
       }
       isWoman
       hasDisability
-      isIndigenous
       indigenousCommunities
       indigenousDeclarationSignature
       isVisibleMinority

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/poolCandidatesOperations.graphql
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/poolCandidatesOperations.graphql
@@ -53,7 +53,6 @@ fragment poolCandidateTable on PoolCandidate {
 
     # Employment equity
     isWoman
-    isIndigenous
     isVisibleMinority
     hasDisability
     indigenousCommunities
@@ -254,7 +253,6 @@ fragment selectedPoolCandidates on PoolCandidate {
     positionDuration
     acceptedOperationalRequirements
     isWoman
-    isIndigenous
     indigenousCommunities
     indigenousDeclarationSignature
     isVisibleMinority
@@ -564,7 +562,6 @@ query getCandidateProfile($id: UUID!) {
       positionDuration
       acceptedOperationalRequirements
       isWoman
-      isIndigenous
       indigenousCommunities
       indigenousDeclarationSignature
       isVisibleMinority

--- a/apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql
+++ b/apps/web/src/pages/Profile/ProfilePage/profileOperations.graphql
@@ -49,7 +49,6 @@ query getMe {
     }
     isWoman
     hasDisability
-    isIndigenous
     indigenousCommunities
     indigenousDeclarationSignature
     isVisibleMinority

--- a/apps/web/src/pages/ProfileAndApplicationsPage/applicantOperations.graphql
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/applicantOperations.graphql
@@ -96,7 +96,6 @@ query ApplicantInformation {
     }
     isWoman
     hasDisability
-    isIndigenous
     indigenousCommunities
     indigenousDeclarationSignature
     indigenousCommunities

--- a/apps/web/src/pages/Users/UserInformationPage/components/EmploymentEquitySection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/EmploymentEquitySection.tsx
@@ -3,15 +3,18 @@ import { useIntl } from "react-intl";
 import CheckIcon from "@heroicons/react/24/outline/CheckIcon";
 
 import { Well } from "@gc-digital-talent/ui";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 import { BasicUserInformationProps } from "../types";
 
 const EmploymentEquitySection = ({ user }: BasicUserInformationProps) => {
   const intl = useIntl();
 
+  const isIndigenous = unpackMaybes(user.indigenousCommunities)?.length > 0;
+
   return (
     <Well>
-      {!user.isIndigenous &&
+      {!isIndigenous &&
         !user.hasDisability &&
         !user.isVisibleMinority &&
         !user.isWoman &&
@@ -22,7 +25,7 @@ const EmploymentEquitySection = ({ user }: BasicUserInformationProps) => {
           description:
             "Text on view-user page that the user isn't part of any employment equity groups",
         })}
-      {user.isIndigenous && (
+      {!isIndigenous && (
         <div data-h2-padding="base(x.125, 0)">
           <CheckIcon style={{ width: "1rem" }} />
           {"  "}

--- a/apps/web/src/pages/Users/userOperations.graphql
+++ b/apps/web/src/pages/Users/userOperations.graphql
@@ -349,7 +349,6 @@ query GetViewUserData($id: UUID!) {
     locationExemptions
     positionDuration
     acceptedOperationalRequirements
-    isIndigenous
     indigenousCommunities
     indigenousDeclarationSignature
     hasDisability
@@ -571,7 +570,6 @@ query selectedUsers($ids: [ID]!) {
     positionDuration
     acceptedOperationalRequirements
     isWoman
-    isIndigenous
     indigenousCommunities
     indigenousDeclarationSignature
     isVisibleMinority

--- a/packages/fake-data/src/fakeUsers.ts
+++ b/packages/fake-data/src/fakeUsers.ts
@@ -126,7 +126,6 @@ const generateUser = (
     // Employment Equity
     isWoman: faker.datatype.boolean(),
     hasDisability: faker.datatype.boolean(),
-    isIndigenous: faker.datatype.boolean(),
     isVisibleMinority: faker.datatype.boolean(),
     indigenousCommunities: faker.helpers.arrayElements<IndigenousCommunity>([
       IndigenousCommunity.StatusFirstNations,


### PR DESCRIPTION
🤖 Resolves #7662.

## 👋 Introduction

This PR removes the deprecated `user.isIndigenous` GraphQL field.

## 🎩 Acknowlegments
@esizer for going down the 🐰 🕳️. 

### 🕵️ Details

> [!NOTE]  
> There were a few fixes out of the original scope of this issue but are important fixes that are directly related to the `isIndigenous` field.

- [Fix scopeEquity query for indigenous_communities](https://github.com/GCTC-NTGC/gc-digital-talent/commit/663e73d8a1c2fd8c9d5f8a8b829f08ca1bf2577e): had limited any search requests to **only** `LEGACY_IS_INDIGENOUS`
- [Fix isIndigenous reference](https://github.com/GCTC-NTGC/gc-digital-talent/commit/8e5fa65007dd06b5096ddb8072cf99e597eb5993): had limited rendering to **only** `LEGACY_IS_INDIGENOUS`

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure no references to `user.isIndigenous` GraphQL field
