### PR TITLE
[Feature] Create nav component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5943,6 +5943,69 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-navigation-menu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.1.4.tgz",
+      "integrity": "sha512-Cc+seCS3PmWmjI51ufGG7zp1cAAIRqHVw7C9LOA2TZ+R4hG6rDvHcTqIsEEFLmZO3zNVH72jOOE7kKNy8W+RtA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz",
+      "integrity": "sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-escape-keydown": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.1.2.tgz",
@@ -6474,7 +6537,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz",
       "integrity": "sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.3"
@@ -27161,6 +27223,7 @@
         "@radix-ui/react-collapsible": "^1.0.3",
         "@radix-ui/react-dialog": "^1.0.3",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
+        "@radix-ui/react-navigation-menu": "^1.1.4",
         "@radix-ui/react-scroll-area": "^1.0.5",
         "@radix-ui/react-separator": "^1.0.2",
         "@radix-ui/react-slot": "^1.0.2",
@@ -29571,6 +29634,7 @@
         "@radix-ui/react-collapsible": "^1.0.3",
         "@radix-ui/react-dialog": "^1.0.3",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
+        "@radix-ui/react-navigation-menu": "*",
         "@radix-ui/react-scroll-area": "^1.0.5",
         "@radix-ui/react-separator": "^1.0.2",
         "@radix-ui/react-slot": "^1.0.2",
@@ -31460,6 +31524,43 @@
         }
       }
     },
+    "@radix-ui/react-navigation-menu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.1.4.tgz",
+      "integrity": "sha512-Cc+seCS3PmWmjI51ufGG7zp1cAAIRqHVw7C9LOA2TZ+R4hG6rDvHcTqIsEEFLmZO3zNVH72jOOE7kKNy8W+RtA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3"
+      },
+      "dependencies": {
+        "@radix-ui/react-dismissable-layer": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz",
+          "integrity": "sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/primitive": "1.0.1",
+            "@radix-ui/react-compose-refs": "1.0.1",
+            "@radix-ui/react-primitive": "1.0.3",
+            "@radix-ui/react-use-callback-ref": "1.0.1",
+            "@radix-ui/react-use-escape-keydown": "1.0.3"
+          }
+        }
+      }
+    },
     "@radix-ui/react-popper": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.1.2.tgz",
@@ -31712,7 +31813,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz",
       "integrity": "sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.3"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.3",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
+    "@radix-ui/react-navigation-menu": "^1.1.4",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-separator": "^1.0.2",
     "@radix-ui/react-slot": "^1.0.2",

--- a/packages/ui/src/components/Tabs/NavTabs.stories.tsx
+++ b/packages/ui/src/components/Tabs/NavTabs.stories.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import type { StoryFn } from "@storybook/react";
+
+import NavTabs from "./NavTabs";
+
+export default {
+  component: NavTabs.Root,
+  title: "Components/Nav Tabs",
+};
+
+const themes: Array<string> = ["light", "dark"];
+
+const Template: StoryFn<typeof NavTabs.Root> = (args) => (
+  <div>
+    {themes.map((theme) => (
+      <div key={theme} data-h2={theme}>
+        <div
+          data-h2-background="base(background)"
+          data-h2-padding="base(x1 0)"
+          data-h2-max-width="base(100%)"
+        >
+          <NavTabs.Root {...args}>
+            <NavTabs.List aria-label="Sub navigation">
+              <NavTabs.Item>
+                <NavTabs.Link href="/one">One</NavTabs.Link>
+              </NavTabs.Item>
+              <NavTabs.Item>
+                <NavTabs.Link href="/two">Two</NavTabs.Link>
+              </NavTabs.Item>
+              <NavTabs.Item>
+                <NavTabs.Link href="/three">Three</NavTabs.Link>
+              </NavTabs.Item>
+              <NavTabs.Item>
+                <NavTabs.Link href="/four">Four</NavTabs.Link>
+              </NavTabs.Item>
+              <NavTabs.Item>
+                <NavTabs.Link href="/five">Five</NavTabs.Link>
+              </NavTabs.Item>
+            </NavTabs.List>
+          </NavTabs.Root>
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+export const Default = Template.bind({});
+Default.parameters = {
+  defaultPath: {
+    path: "/:index",
+    initialEntries: [`/one`],
+  },
+};

--- a/packages/ui/src/components/Tabs/NavTabs.stories.tsx
+++ b/packages/ui/src/components/Tabs/NavTabs.stories.tsx
@@ -19,8 +19,8 @@ const Template: StoryFn<typeof NavTabs.Root> = (args) => (
           data-h2-padding="base(x1 0)"
           data-h2-max-width="base(100%)"
         >
-          <NavTabs.Root {...args}>
-            <NavTabs.List aria-label="Sub navigation">
+          <NavTabs.Root {...args} aria-label={`${theme} sub nav`}>
+            <NavTabs.List>
               <NavTabs.Item>
                 <NavTabs.Link href="/one">One</NavTabs.Link>
               </NavTabs.Item>

--- a/packages/ui/src/components/Tabs/NavTabs.tsx
+++ b/packages/ui/src/components/Tabs/NavTabs.tsx
@@ -1,0 +1,115 @@
+/**
+ * This is different from tabs in that
+ * it contains a `nav` element with `a` tags
+ * and applies the appropriate `aria` attributes
+ *
+ * Documentation: https://www.radix-ui.com/docs/primitives/components/navigation-menu
+ */
+import React from "react";
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
+import { Link as RouterLink, useLocation } from "react-router-dom";
+
+import { commonTabStyles, handleTabFocus } from "./utils";
+
+const Root = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root>
+>((props, forwardedRef) => (
+  <div {...commonTabStyles.root}>
+    <NavigationMenuPrimitive.Root ref={forwardedRef} {...props} />
+    <div {...commonTabStyles.contentDivide} />
+  </div>
+));
+
+const List = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List>
+>(({ children, ...rest }, forwardedRef) => (
+  <NavigationMenuPrimitive.List
+    ref={forwardedRef}
+    className="Tabs__List Tabs__List--nav"
+    {...commonTabStyles.list}
+    {...rest}
+  >
+    {children}
+  </NavigationMenuPrimitive.List>
+));
+
+const Item = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Item>
+>((props, forwardedRef) => (
+  <NavigationMenuPrimitive.Item
+    ref={forwardedRef}
+    {...commonTabStyles.triggerHover}
+    {...props}
+  />
+));
+
+type LinkProps = React.ComponentPropsWithoutRef<
+  typeof NavigationMenuPrimitive.Link
+> & {
+  href: string;
+};
+
+const Link = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Link>,
+  LinkProps
+>(({ children, href, ...rest }, forwardedRef) => {
+  const { pathname } = useLocation();
+
+  const isActive = pathname === href;
+  return (
+    <NavigationMenuPrimitive.Link
+      ref={forwardedRef}
+      active={isActive}
+      asChild
+      {...rest}
+    >
+      <RouterLink
+        to={href}
+        onFocus={handleTabFocus}
+        {...(isActive && {
+          "data-state": "active", // Needed for active styles (mirrors tabs)
+        })}
+        {...commonTabStyles.trigger}
+      >
+        <span {...commonTabStyles.triggerInner}>{children}</span>
+      </RouterLink>
+    </NavigationMenuPrimitive.Link>
+  );
+});
+
+/**
+ * @name NavTabs
+ * @desc A collection of links for navigating websites.
+ * @see [Documentation](https://www.radix-ui.com/docs/primitives/components/navigation-menu)
+ */
+const NavTabs = {
+  /**
+   * @name Root
+   * @desc An item in the group.
+   * @see [Documentation](https://www.radix-ui.com/docs/primitives/components/navigation-menu#root)
+   */
+  Root,
+  /**
+   * @name List
+   * @desc Contains the top level menu items.
+   * @see [Documentation](https://www.radix-ui.com/docs/primitives/components/navigation-menu#list)
+   */
+  List,
+  /**
+   * @name Item
+   * @desc A top level menu item, contains a link or trigger with content combination.
+   * @see [Documentation](https://www.radix-ui.com/docs/primitives/components/navigation-menu#item)
+   */
+  Item,
+  /**
+   * @name Link
+   * @desc A navigational link.
+   * @see [Documentation](https://www.radix-ui.com/docs/primitives/components/navigation-menu#link)
+   */
+  Link,
+};
+
+export default NavTabs;

--- a/packages/ui/src/components/Tabs/NavTabs.tsx
+++ b/packages/ui/src/components/Tabs/NavTabs.tsx
@@ -41,7 +41,7 @@ const Item = React.forwardRef<
 >((props, forwardedRef) => (
   <NavigationMenuPrimitive.Item
     ref={forwardedRef}
-    {...commonTabStyles.triggerHover}
+    {...commonTabStyles.trigger}
     {...props}
   />
 ));
@@ -57,8 +57,19 @@ const Link = React.forwardRef<
   LinkProps
 >(({ children, href, ...rest }, forwardedRef) => {
   const { pathname } = useLocation();
+  const linkRef = React.useRef<HTMLAnchorElement>(null);
 
   const isActive = pathname === href;
+
+  React.useEffect(() => {
+    if (linkRef.current) {
+      linkRef.current.parentElement?.setAttribute(
+        "data-state",
+        isActive ? "active" : "inactive",
+      );
+    }
+  }, [isActive]);
+
   return (
     <NavigationMenuPrimitive.Link
       ref={forwardedRef}
@@ -68,13 +79,14 @@ const Link = React.forwardRef<
     >
       <RouterLink
         to={href}
+        ref={linkRef}
         onFocus={handleTabFocus}
         {...(isActive && {
           "data-state": "active", // Needed for active styles (mirrors tabs)
         })}
-        {...commonTabStyles.trigger}
+        {...commonTabStyles.triggerInner}
       >
-        <span {...commonTabStyles.triggerInner}>{children}</span>
+        {children}
       </RouterLink>
     </NavigationMenuPrimitive.Link>
   );

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -35,7 +35,6 @@ const Trigger = React.forwardRef<
     className="Tabs__Trigger"
     onFocus={handleTabFocus}
     {...commonTabStyles.trigger}
-    {...commonTabStyles.triggerHover}
     ref={forwardedRef}
     {...rest}
   >

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -4,15 +4,13 @@
 import React from "react";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 
+import { commonTabStyles, handleTabFocus } from "./utils";
+
 const Root = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>
 >((props, forwardedRef) => (
-  <TabsPrimitive.Root
-    ref={forwardedRef}
-    data-h2-max-width="base(100%)"
-    {...props}
-  />
+  <TabsPrimitive.Root ref={forwardedRef} {...commonTabStyles.root} {...props} />
 ));
 
 const List = React.forwardRef<
@@ -20,20 +18,9 @@ const List = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
 >(({ children, ...rest }, forwardedRef) => (
   <TabsPrimitive.List
-    className="Tabs__List"
-    data-h2-max-width="base(100%)"
-    data-h2-display="base(flex)"
-    data-h2-gap="base(x.25)"
-    data-h2-overflow="base(auto visible)"
-    data-h2-width="base(100%)"
-    data-h2-padding="base(0 x1)"
-    data-h2-z-index="base(1)"
-    data-h2-overflow-x="base(auto)"
-    data-h2-overscroll-behavior-x="base(contain)"
-    data-h2-scroll-snap-align="base(start)"
-    data-h2-scroll-snap-type="base(x mandatory)"
-    data-h2-scrollbar-width="base:hover(none)"
     ref={forwardedRef}
+    className="Tabs__List"
+    {...commonTabStyles.list}
     {...rest}
   >
     {children}
@@ -43,65 +30,18 @@ const List = React.forwardRef<
 const Trigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ children, ...rest }, forwardedRef) => {
-  /**
-   * Scroll to the list item when it is in view.
-   *
-   * This allows us to have the currently focused item appear
-   * in the list when it has been focused for keyboard-only users.
-   *
-   * @param event
-   */
-  const handleFocus: React.FocusEventHandler<HTMLButtonElement> = (event) => {
-    const { currentTarget } = event;
-    const list = currentTarget.closest(".Tabs__List");
-    const currentScroll = list?.scrollLeft ?? 0;
-    const totalWidth = list?.scrollWidth ?? 0;
-
-    const offset = currentTarget.offsetLeft;
-    const scrollTo = offset + currentScroll - totalWidth / 2;
-
-    list?.scrollTo({ left: scrollTo });
-  };
-
-  return (
-    <TabsPrimitive.Trigger
-      className="Tabs__Trigger"
-      onFocus={handleFocus}
-      data-h2-background-color="base(background)"
-      data-h2-border="base(thin solid background.darker)"
-      data-h2-border-top-color="
-      base:selectors[[data-state='active'] > span](primary)
-      base:focus-visible:children[span](focus)
-    "
-      data-h2-border-bottom-color="base:selectors[[data-state='active']](transparent)"
-      data-h2-color="
-      base(black)
-      base:selectors[[data-state='active']](primary.darker)
-    "
-      data-h2-display="base(inline-flex)"
-      data-h2-font-weight="base:selectors[[data-state='active']](700)"
-      data-h2-margin-top="base(x.25) base:hover(0)"
-      data-h2-padding="base(0)"
-      data-h2-outline="base(none)"
-      data-h2-radius="base(rounded rounded 0 0)"
-      data-h2-text-decoration="base:selectors[[data-state='inactive']](underline)"
-      data-h2-position="base(relative)"
-      data-h2-z-index="base(1)"
-      ref={forwardedRef}
-      {...rest}
-    >
-      <span
-        data-h2-border-top="base(x.25 solid background.darker)"
-        data-h2-display="base(block)"
-        data-h2-radius="base(s s 0 0)"
-        data-h2-padding="base(x.5 x.75)"
-      >
-        {children}
-      </span>
-    </TabsPrimitive.Trigger>
-  );
-});
+>(({ children, ...rest }, forwardedRef) => (
+  <TabsPrimitive.Trigger
+    className="Tabs__Trigger"
+    onFocus={handleTabFocus}
+    {...commonTabStyles.trigger}
+    {...commonTabStyles.triggerHover}
+    ref={forwardedRef}
+    {...rest}
+  >
+    <span {...commonTabStyles.triggerInner}>{children}</span>
+  </TabsPrimitive.Trigger>
+));
 
 const Content = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
@@ -109,12 +49,7 @@ const Content = React.forwardRef<
 >((props, forwardedRef) => (
   <TabsPrimitive.Content
     ref={forwardedRef}
-    data-h2-border-top="base(thin solid background.darker)"
-    data-h2-color="base(black)"
-    data-h2-margin-top="base(-1px)"
-    data-h2-max-width="base(100%)"
-    data-h2-outline="base(none)"
-    data-h2-padding="base(x1)"
+    {...commonTabStyles.contentDivide}
     {...props}
   />
 ));
@@ -128,7 +63,7 @@ const Tabs = {
   /**
    * @name Root
    * @desc An item in the group.
-   * @see [Documentation](https://www.radix-ui.com/docs/primitives/components/toggle-group#item)
+   * @see [Documentation](https://www.radix-ui.com/docs/primitives/components/tabs#root)
    */
   Root,
   /**

--- a/packages/ui/src/components/Tabs/utils.ts
+++ b/packages/ui/src/components/Tabs/utils.ts
@@ -25,7 +25,7 @@ export const commonTabStyles = {
       "base:selectors[[data-state='active']](transparent)",
     "data-h2-font-weight": "base:selectors[[data-state='active']](700)",
     "data-h2-text-decoration":
-      "base:selectors[[data-state='inactive']](underline)",
+      "base:selectors[[data-state='inactive']](underline) base:selectors[[data-state='active'] > a](none)",
     "data-h2-border-top-color": `
       base:selectors[[data-state='active'] > span](primary)
       base:selectors[[data-state='active'] > a](primary)

--- a/packages/ui/src/components/Tabs/utils.ts
+++ b/packages/ui/src/components/Tabs/utils.ts
@@ -1,0 +1,87 @@
+export const commonTabStyles = {
+  root: {
+    "data-h2-max-width": "base(100%)",
+  },
+  list: {
+    "data-h2-list-style": "base(none)",
+    "data-h2-display": "base(flex)",
+    "data-h2-max-width": "base(100%)",
+    "data-h2-gap": "base(x.25)",
+    "data-h2-overflow": "base(auto visible)",
+    "data-h2-width": "base(100%)",
+    "data-h2-padding": "base(0 x1)",
+    "data-h2-z-index": "base(1)",
+    "data-h2-overflow-x": "base(auto)",
+    "data-h2-overscroll-behavior-x": "base(contain)",
+    "data-h2-scroll-snap-align": "base(start)",
+    "data-h2-scroll-snap-type": "base(x mandatory)",
+    "data-h2-scrollbar-width": "base:hover(none)",
+  },
+  trigger: {
+    "data-h2-background-color": "base(background)",
+    "data-h2-display": "base(inline-flex)",
+    "data-h2-padding": "base(0)",
+    "data-h2-outline": "base(none)",
+    "data-h2-radius": "base(rounded rounded 0 0)",
+    "data-h2-border-bottom-color":
+      "base:selectors[[data-state='active']](transparent)",
+    "data-h2-font-weight": "base:selectors[[data-state='active']](700)",
+    "data-h2-text-decoration":
+      "base:selectors[[data-state='inactive']](underline)",
+    "data-h2-border-top-color": `
+      base:selectors[[data-state='active'] > span](primary)
+      base:focus-visible:children[span](focus)
+    `,
+    "data-h2-color": `
+      base(black)
+      base:selectors[[data-state='active']](primary.darker)
+    `,
+  },
+  triggerHover: {
+    "data-h2-background-color": "base(background)",
+    "data-h2-radius": "base(rounded rounded 0 0)",
+    "data-h2-border": "base(thin solid background.darker)",
+    "data-h2-margin-top": "base(x.25) base:hover(0)",
+    "data-h2-position": "base(relative)",
+    "data-h2-z-index": "base(1)",
+  },
+  triggerInner: {
+    "data-h2-border-top": "base(x.25 solid background.darker)",
+    "data-h2-display": "base(block)",
+    "data-h2-radius": "base(s s 0 0)",
+    "data-h2-padding": "base(x.5 x.75)",
+  },
+  contentDivide: {
+    "data-h2-border-top": "base(thin solid background.darker)",
+    "data-h2-color": "base(black)",
+    "data-h2-margin-top": "base(-1px)",
+    "data-h2-max-width": "base(100%)",
+    "data-h2-outline": "base(none)",
+    "data-h2-padding": "base(x1)",
+  },
+};
+
+/**
+ * Scroll to the list item when it is in view.
+ *
+ * This allows us to have the currently focused item appear
+ * in the list when it has been focused for keyboard-only users.
+ *
+ * @param event
+ */
+export const handleTabFocus: React.FocusEventHandler<HTMLElement> = (event) => {
+  let target: HTMLElement = event.currentTarget;
+  const list = target.closest(".Tabs__List");
+  // Target could be in list.
+  // If so, we need to use the parent list item to calculate offset
+  if (list?.nodeName === "UL" && target?.parentElement?.nodeName === "LI") {
+    target = target.parentElement;
+  }
+  const currentScroll = list?.scrollLeft ?? 0;
+  const totalWidth = list?.scrollWidth ?? 0;
+
+  const offset = target.offsetLeft;
+  const scrollTo = offset + currentScroll - totalWidth / 2;
+
+  list?.scrollTo({ left: scrollTo });
+};

--- a/packages/ui/src/components/Tabs/utils.ts
+++ b/packages/ui/src/components/Tabs/utils.ts
@@ -7,10 +7,10 @@ export const commonTabStyles = {
     "data-h2-display": "base(flex)",
     "data-h2-max-width": "base(100%)",
     "data-h2-gap": "base(x.25)",
-    "data-h2-overflow": "base(auto visible)",
     "data-h2-width": "base(100%)",
     "data-h2-padding": "base(0 x1)",
-    "data-h2-z-index": "base(1)",
+    "data-h2-z-index": "base(2)",
+    "data-h2-overflow-y": "base(visible)",
     "data-h2-overflow-x": "base(auto)",
     "data-h2-overscroll-behavior-x": "base(contain)",
     "data-h2-scroll-snap-align": "base(start)",
@@ -19,10 +19,8 @@ export const commonTabStyles = {
   },
   trigger: {
     "data-h2-background-color": "base(background)",
+    "data-h2-border": "base(thin solid background.darker)",
     "data-h2-display": "base(inline-flex)",
-    "data-h2-padding": "base(0)",
-    "data-h2-outline": "base(none)",
-    "data-h2-radius": "base(rounded rounded 0 0)",
     "data-h2-border-bottom-color":
       "base:selectors[[data-state='active']](transparent)",
     "data-h2-font-weight": "base:selectors[[data-state='active']](700)",
@@ -30,19 +28,19 @@ export const commonTabStyles = {
       "base:selectors[[data-state='inactive']](underline)",
     "data-h2-border-top-color": `
       base:selectors[[data-state='active'] > span](primary)
+      base:selectors[[data-state='active'] > a](primary)
       base:focus-visible:children[span](focus)
+      base:children[a:focus-visible](focus)
     `,
     "data-h2-color": `
       base(black)
       base:selectors[[data-state='active']](primary.darker)
     `,
-  },
-  triggerHover: {
-    "data-h2-background-color": "base(background)",
-    "data-h2-radius": "base(rounded rounded 0 0)",
-    "data-h2-border": "base(thin solid background.darker)",
     "data-h2-margin-top": "base(x.25) base:hover(0)",
+    "data-h2-outline": "base(none) base:children[a](none)",
+    "data-h2-padding": "base(0)",
     "data-h2-position": "base(relative)",
+    "data-h2-radius": "base(rounded rounded 0 0)",
     "data-h2-z-index": "base(1)",
   },
   triggerInner: {

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -42,6 +42,7 @@ import Link, {
   type MenuLinkProps,
 } from "./components/Link";
 import Loading, { type LoadingProps } from "./components/Loading";
+import NavTabs from "./components/Tabs/NavTabs";
 import NotFound, { ThrowNotFound } from "./components/NotFound";
 import Pending, { type PendingProps } from "./components/Pending";
 import Pill, {
@@ -147,6 +148,7 @@ export {
   DownloadCsv,
   ScrollToLink,
   MenuLink,
+  NavTabs,
   Loading,
   Pending,
   NotFound,


### PR DESCRIPTION
🤖 Resolves #8612 

## 👋 Introduction

Creates a new `NavTabs` component, reusing styles from the existing `Tabs` component. 

## 🕵️ Details

I ended up using [`@radix-ui/react-navigation-menu`](https://www.radix-ui.com/primitives/docs/components/navigation-menu) since it had a lot of nice keyboard controls and other accessibility features built in. We are only using a portion of the functionality, but now that it is installed, if we like we can also use the dropdown menus as well in the future.

## 🛠️ Usage

```tsx
import { NavTabs } from "@gc-digital-talent/ui";

const PageHeader = () => {
  
  return (
    <NavTabs.Root {...args} aria-label="Some page navigation">
      <NavTabs.List>
        <NavTabs.Item>
          <NavTabs.Link href="/one">One</NavTabs.Link>
        </NavTabs.Item>
        <NavTabs.Item>
          <NavTabs.Link href="/two">Two</NavTabs.Link>
        </NavTabs.Item>
      </NavTabs.List>
    </NavTabs.Root>
  );
}
```

## 🧪 Testing

> [!TIP]
> When testing, you can also test the [keyboard shortcuts](https://www.radix-ui.com/primitives/docs/components/navigation-menu#accessibility) 😄 

1. Install new deps `npm i`
2. Run storybook `npm run storybook:design-system`
3. Navigate to the "Nav Tabs" story
4. Confirm they match the `Tabs` component and [mock up](https://www.figma.com/file/guHeIIh8dqFVCks310Wv0G/Style-library?type=design&node-id=914-23922&mode=design&t=H1N6B6g30qErGhCI-0)

## 📸 Screenshot

![Screenshot 2023-12-11 084728](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/8e1a9c28-d2fb-410b-a80e-97e8011e2b9b)

