### PR TITLE
[Bug] Pool candidates table filter dialog and results out of sync

### DIFF
--- a/apps/web/src/pages/PoolCandidates/AllPoolCandidatesPage/AllPoolCandidatesPage.tsx
+++ b/apps/web/src/pages/PoolCandidates/AllPoolCandidatesPage/AllPoolCandidatesPage.tsx
@@ -8,6 +8,10 @@ import SEO from "~/components/SEO/SEO";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import adminMessages from "~/messages/adminMessages";
 import PageHeader from "~/components/PageHeader";
+import {
+  CandidateExpiryFilter,
+  CandidateSuspendedFilter,
+} from "~/api/generated";
 
 export const AllPoolCandidatesPage = () => {
   const intl = useIntl();
@@ -38,7 +42,13 @@ export const AllPoolCandidatesPage = () => {
     <AdminContentWrapper crumbs={navigationCrumbs}>
       <SEO title={pageTitle} />
       <PageHeader icon={IdentificationIcon}>{pageTitle}</PageHeader>
-      <PoolCandidatesTable title={pageTitle} />
+      <PoolCandidatesTable
+        title={pageTitle}
+        initialFilterInput={{
+          suspendedStatus: CandidateSuspendedFilter.Active,
+          expiryStatus: CandidateExpiryFilter.Active,
+        }}
+      />
     </AdminContentWrapper>
   );
 };

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
@@ -4,7 +4,12 @@ import { useIntl } from "react-intl";
 import { Pending } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 
-import { Scalars, useGetPoolQuery } from "~/api/generated";
+import {
+  CandidateExpiryFilter,
+  CandidateSuspendedFilter,
+  Scalars,
+  useGetPoolQuery,
+} from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
 import PoolCandidatesTable from "~/components/PoolCandidatesTable/PoolCandidatesTable";
 import SEO from "~/components/SEO/SEO";
@@ -80,6 +85,8 @@ export const IndexPoolCandidatePage = () => {
         <PoolCandidatesTable
           initialFilterInput={{
             applicantFilter: { pools: [{ id: poolId || "" }] },
+            suspendedStatus: CandidateSuspendedFilter.Active,
+            expiryStatus: CandidateExpiryFilter.Active,
           }}
           currentPool={data?.pool}
           title={pageTitle}

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -14,6 +14,8 @@ import {
   ClassificationFilterInput,
   PoolCandidateSearchInput,
   PoolCandidateStatus,
+  CandidateSuspendedFilter,
+  CandidateExpiryFilter,
 } from "~/api/generated";
 import PoolCandidatesTable from "~/components/PoolCandidatesTable/PoolCandidatesTable";
 import adminMessages from "~/messages/adminMessages";
@@ -112,7 +114,15 @@ const SingleSearchRequestTableApi = ({
 
   return (
     <PoolCandidatesTable
-      initialFilterInput={isLegacyFilter ? undefined : applicantFilterInput}
+      initialFilterInput={
+        isLegacyFilter
+          ? undefined
+          : {
+              ...applicantFilterInput,
+              suspendedStatus: CandidateSuspendedFilter.Active, // add default filters
+              expiryStatus: CandidateExpiryFilter.Active,
+            }
+      }
       title={intl.formatMessage(adminMessages.poolsCandidates)}
     />
   );


### PR DESCRIPTION
🤖 Resolves #8755  

## 👋 Introduction

Solve the discrepancy between the dialog and what actually happens filter-wise. 

## 🕵️ Details

The fallback condition in `transformPoolCandidateSearchInputToFormValues` checks in the desired state and this appears in the filter dialog, however, this is after filtering occurs and is not the earliest point in the flow of page/API. 

Fallback 

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/aa14008c-802b-4d25-87f8-aa702c4a3961)

Adjusted by having the desired defaults fed in at the earliest state, the component props. 
Noticed this presented an issue for view candidates for a pool, but as well as the all candidates, and view search request pages.

## 🧪 Testing

1. Navigate to the view candidates page for a pool, observe the filter dialog and the submitted API operation
2. Repeat for all candidates table
3. Repeat for viewing a single search request
4. Ensure filter submits works as normal for all three

## 📸 Screenshot

View candidates

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/0bfbc65b-1712-4cb0-9f36-d88386aa7ae1)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/1912fc2d-e187-49d8-999f-4ed68b33e456)

All candidates

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/9db88bb2-4fc8-4a91-ad17-3111bf95530a)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/a8a2e8ca-011c-4d2f-bc50-dbc8e12aabfa)

For requests, adding onto fetched filters

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/68da56c7-9d56-4e7d-8c22-e3c7b2e3b01e)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/eceffd29-fe6c-4559-b3e3-dccc653bcdca)






