### PR TITLE
[Feature] Allow overriding feature flags in cypress

### DIFF
--- a/apps/e2e/cypress.d.ts
+++ b/apps/e2e/cypress.d.ts
@@ -55,6 +55,13 @@ declare global {
        * @example cy.logout()
        */
       graphqlRequest<T extends Object>(body: Object): Promise<T>;
+      /**
+       * Override specific feature flags.
+       * Note: Should be used in `before*`
+       * @param {Object} flags - Feature flags you want to override.
+       * @example cy.overrideFeatureFlags({FEATURE_FLAG: false})
+       */
+      overrideFeatureFlags(flags: Object): void;
 
       /**
        * ======================================

--- a/apps/e2e/cypress/support/e2e.ts
+++ b/apps/e2e/cypress/support/e2e.ts
@@ -19,6 +19,7 @@ import "./applicationCommands";
 import "./classificationCommands";
 import "./commands";
 import "./departmentCommands";
+import "./featureFlagCommands";
 import "./genericJobTitleCommands";
 import "./poolCommands";
 import "./searchRequestCommands";

--- a/apps/e2e/cypress/support/featureFlagCommands.ts
+++ b/apps/e2e/cypress/support/featureFlagCommands.ts
@@ -1,0 +1,21 @@
+import * as dotenv from "dotenv";
+
+dotenv.config({ path: "../web/.env" });
+
+const overrideFeatureFlags = (flags: Object) => {
+  const env = {
+    ...process.env,
+    ...flags,
+  };
+
+  let map = `const data = new Map();`;
+  Object.keys(env).forEach((key) => {
+    map = `data.set(${key}, ${env[key]});`;
+  });
+
+  return `${map} window.__SERVER_CONFIG__ = data`;
+};
+
+Cypress.Commands.add("overrideFeatureFlags", (flags) => {
+  cy.intercept("GET", "/config.js", overrideFeatureFlags(flags));
+});

--- a/apps/e2e/cypress/support/featureFlagCommands.ts
+++ b/apps/e2e/cypress/support/featureFlagCommands.ts
@@ -10,7 +10,7 @@ const overrideFeatureFlags = (flags: Object) => {
 
   let map = `const data = new Map();`;
   Object.keys(env).forEach((key) => {
-    map = `data.set(${key}, ${env[key]});`;
+    map = `${map} data.set(${key}, ${env[key]});`;
   });
 
   return `${map} window.__SERVER_CONFIG__ = data`;

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -20,6 +20,7 @@
     "cypress": "^13.6.1",
     "cypress-axe": "^1.5.0",
     "cypress-terminal-report": "^5.3.9",
+    "dotenv": "^16.3.1",
     "eslint-plugin-cypress": "^2.15.1",
     "prettier": "^3.1.0",
     "tsconfig": "*",

--- a/documentation/environment-variables.md
+++ b/documentation/environment-variables.md
@@ -20,3 +20,33 @@ For deployment in production, there needs to be a way to change variables in the
 
 To check what variables have been set in the app, open the console of your browser and enter:
 `window.__SERVER_CONFIG__`
+
+#### End-to-End Testing
+
+Since run-time variables are used to maintain the current feature set and can be changed, tests should be run against both versions of a specific feature set. In order to do this, the "feature flags" must be overridden in the test specifications.
+
+When writing test specifications, run-time variables can be modified for the entire spec, or specific tests using the `cy.overrideFeatureFlags(flags: Object): void` command.
+
+##### Override for entire spec
+
+```tsx
+describe("Override for all tests", () => {
+  beforeEach(() => {
+    cy.overrideFeatureFlags({ FEATURE_FLAG: null });
+  });
+});
+```
+
+##### Override for specific test
+
+```tsx
+describe("Override for specific test", () => {
+  it("Is overridden", () => {
+    cy.overrideFeatureFlags({ FEATURE_FLAG: null }); // Must be called before visiting a page
+    cy.visit("/");
+  });
+  it("Is default", () => {
+    cy.visit("/");
+  });
+});
+```

--- a/documentation/environment-variables.md
+++ b/documentation/environment-variables.md
@@ -23,9 +23,9 @@ To check what variables have been set in the app, open the console of your brows
 
 #### End-to-End Testing
 
-Since run-time variables are used to maintain the current feature set and can be changed, tests should be run against both versions of a specific feature set. In order to do this, the "feature flags" must be overridden in the test specifications.
+Since run-time variables are used to maintain the current feature set and can be changed, tests should be run against both versions of a specific feature set. In order to do this, the feature flags must be overridden in the test specifications.
 
-When writing test specifications, run-time variables can be modified for the entire spec, or specific tests using the `cy.overrideFeatureFlags(flags: Object): void` command.
+When writing test specifications, run-time variables can be modified for the entire spec, or for specific tests using the `cy.overrideFeatureFlags(flags: Object): void` command.
 
 ##### Override for entire spec
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "cypress": "^13.6.1",
         "cypress-axe": "^1.5.0",
         "cypress-terminal-report": "^5.3.9",
+        "dotenv": "^16.3.1",
         "eslint-plugin-cypress": "^2.15.1",
         "prettier": "^3.1.0",
         "tsconfig": "*",
@@ -14198,7 +14199,8 @@
     },
     "node_modules/dotenv": {
       "version": "16.3.1",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
       "engines": {
         "node": ">=12"
       },
@@ -29582,6 +29584,7 @@
         "cypress": "^13.6.1",
         "cypress-axe": "^1.5.0",
         "cypress-terminal-report": "^5.3.9",
+        "dotenv": "^16.3.1",
         "eslint-plugin-cypress": "^2.15.1",
         "prettier": "^3.1.0",
         "tsconfig": "*",
@@ -37274,7 +37277,9 @@
       }
     },
     "dotenv": {
-      "version": "16.3.1"
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
     },
     "dotenv-expand": {
       "version": "10.0.0",


### PR DESCRIPTION
🤖 Resolves #4227 

## 👋 Introduction

This adds a command that allows us to override our feature flags.

> [!NOTE]
> I was able to get a working example so I posted this PR. Though, I imagine there are other ways of accomplishing this and it does not need to result in a merge.

## 🕵️ Details

The approach taken is to intercept and override the `config.js` file on our server. We do this by:

1. Reading the `.env` file in `apps/web`.
2. Spreading any overridden flags (written as an object)
3. Then, we loop over it using the [`Map.prototype.set`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set) method to create the new config
4. Then, we return the new, custom `config.js` file

## 🛠️ Usage

It is pretty easy to do this, but, similar to aliasing requests, it matters where you use it. It is best to call this _before_ you visit a specific page.

```ts
// Override for all tests in a spec
describe("Override for all assertions", () => {
  beforeEach(() => {
    cy.overrideFeatureFlags({ FEATURE_FLAG: null });
  });
});

// Override for a specific assertion
describe("Override for specific assertions", () => {
  it("Is overridden", () => {
    cy.overrideFeatureFlags({ FEATURE_FLAG: null });
    cy.visit("/");
  });
  it("Is is default", () => {
    cy.visit("/");
  });
});
```

## 🧪 Testing

> [!TIP]
> I found using the `FEATURE_RECORD_OF_DECISION` on the `pool-candidates.cy.ts` is very noticeable to see it working.

### All asserations

1. Open a test you know is using a feature flag
2. Add the override to `beforeEach`
3. Confirm all assertions read the new value properly

### Specific assertion

1. Open a test you know is using a feature flag
2. Add the override to the top of a specific assertion
3. Confirm only that assertion uses the value
