### PR TITLE
[Debt] Removes `poolCandidateFilters` GraphQL query

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -741,14 +741,6 @@ type Query {
   classifications: [Classification]! @all @can(ability: "viewAny")
   department(id: UUID! @eq): Department @find @can(ability: "view")
   departments: [Department]! @all @can(ability: "viewAny")
-  poolCandidateFilters: [PoolCandidateFilter]!
-    @all
-    @guard
-    @can(ability: "viewAny", model: "PoolCandidateSearchRequest")
-    @throttle(name: "graphql")
-    @deprecated(
-      reason: "poolCandidateFilters is deprecated. Use poolCandidateSearchRequest.poolCandidateFilter instead. Remove in #7658."
-    )
   applicantFilters: [ApplicantFilter]!
     @all
     @guard

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -24,7 +24,6 @@ type Query {
   classifications: [Classification]!
   department(id: UUID!): Department
   departments: [Department]!
-  poolCandidateFilters: [PoolCandidateFilter]! @deprecated(reason: "poolCandidateFilters is deprecated. Use poolCandidateSearchRequest.poolCandidateFilter instead. Remove in #7658.")
   applicantFilters: [ApplicantFilter]! @deprecated(reason: "applicantFilters is deprecated. Use poolCandidateSearchRequest.applicantFilter instead. Remove in #7654.")
   poolCandidateSearchRequest(id: ID!): PoolCandidateSearchRequest
   skillFamily(id: UUID!): SkillFamily


### PR DESCRIPTION
🤖 Resolves #7658.

## 👋 Introduction

This PR removes the unused `poolCandidateFilters` GraphQL query.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure no references to `poolCandidateFilters` in codebase