### PR TITLE
[Fix] Returns string instead of an array in `AuthServiceProvider`

### DIFF
--- a/api/app/Providers/AuthServiceProvider.php
+++ b/api/app/Providers/AuthServiceProvider.php
@@ -88,7 +88,7 @@ class AuthServiceProvider extends ServiceProvider
                 foreach ($e->violations() as $violationError) {
                     array_push($violations, $violationError->getMessage());
                 }
-                throw new AuthenticationException('Authorization token not valid: '.$violations, 'invalid_token');
+                throw new AuthenticationException('Authorization token not valid: '.implode(',', $violations), 'invalid_token');
             } catch (Throwable $e) {
                 throw new AuthenticationException('Error while validating authorization token: '.$e->getMessage(), 'token_validation');
             }


### PR DESCRIPTION
🤖 Resolves #8722.

## 👋 Introduction

This PR fixes a case where an array was trying to be sent to a string in `AuthServiceProvider`.

## 🕵️ Details

This change happened as part of #6547 when `Log::notice` was replaced with `AuthenticationException`. `Log::notice` accepts an array as an argument but `AuthenticationException` does not: https://github.com/GCTC-NTGC/gc-digital-talent/pull/6547/commits/f312838a786d9f1a40391cda480f0dc886ee84d0#diff-43896043b9f0d9bf8ee8679ffca9a195c2e149cb9db46e7d1d5ada0a1b47721eL83-R91

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Use 🧠 logic (I have no idea how to trigger the auth exception locally 😟)