### PR TITLE
[Fix] Display skills for print

### DIFF
--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationInformation/ApplicationInformation.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationInformation/ApplicationInformation.tsx
@@ -88,7 +88,7 @@ const ApplicationInformation = ({
             <ApplicationPrintButton
               mode="inline"
               color="secondary"
-              pool={application.pool}
+              pool={pool}
               user={snapshot}
             />
           )}

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationPrintButton/SkillWithExperiences.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationPrintButton/SkillWithExperiences.tsx
@@ -226,14 +226,14 @@ const SkillWithExperiences = ({
     );
   };
 
+  const description = getLocalizedName(skill.description, intl, true);
+
   return (
     <PageSection>
       <p data-h2-font-weight="base(700)">
         {getLocalizedName(skill.name, intl)}
       </p>
-      <p>
-        {skill.description ? getLocalizedName(skill.description, intl) : ""}
-      </p>
+      {description && <p>{description}</p>}
       <ul>
         {skillExperiences.map((experience) => {
           return (


### PR DESCRIPTION
🤖 Resolves #8768 

## 👋 Introduction

This fixes an issue where skills were missing from the application print document when the record of desicison flag was set to true.

> [!NOTE]
> While working on this, I noticed we were renders "N/A" when a skill description did not exist. This looked broken to me so I opted to just not render it. Hope that is okay 😅 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Make sure you have `FEATURE_RECORD_OF_DECISION=true` in your `.env`
2. Build `npm run dev`
3. Navigate to an application that consists of skills (some seeded data does not)
4. Click on the "Print application" button
5. Confirm the proper skills appear in the print document

## 📸 Screenshot

![Screenshot 2023-12-12 134029](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/e60f0ff2-bfa6-4174-998f-1c4af987ff65)
