### PR TITLE
[Fix] Admin table filter dialog count and clearing

### DIFF
--- a/apps/web/src/components/FilterDialog/FilterDialog.tsx
+++ b/apps/web/src/components/FilterDialog/FilterDialog.tsx
@@ -15,17 +15,17 @@ import { notEmpty } from "@gc-digital-talent/helpers";
 // Used by specific dialogs
 export type CommonFilterDialogProps<TFieldValues extends FieldValues> = {
   onSubmit: SubmitHandler<TFieldValues>;
-  /** Defaults values, including from URL */
-  routeValues?: Partial<TFieldValues>;
-  /** Initial values to reset the form to, not including URL, */
-  initialValues: TFieldValues;
+  /** When the user resets filters they will return to these values. If initialValues is empty, resetValues is used to initialize the filters. */
+  resetValues: TFieldValues;
+  /** If initialValues is set, it will override resetValues when the filter form is first initialized. */
+  initialValues?: Partial<TFieldValues>;
 };
 
 type FilterDialogProps<TFieldValues extends FieldValues> = {
   onSubmit: CommonFilterDialogProps<TFieldValues>["onSubmit"];
   options?: UseFormProps<TFieldValues, unknown>;
   // Values to reset to (removing URL state)
-  initialValues: CommonFilterDialogProps<TFieldValues>["initialValues"];
+  resetValues: CommonFilterDialogProps<TFieldValues>["resetValues"];
   defaultOpen?: boolean;
   children: React.ReactNode;
 };
@@ -34,7 +34,7 @@ const FilterDialog = <TFieldValues extends FieldValues>({
   onSubmit,
   options,
   children,
-  initialValues,
+  resetValues,
   defaultOpen = false,
 }: FilterDialogProps<TFieldValues>) => {
   const [isOpen, setIsOpen] = React.useState<boolean>(defaultOpen);
@@ -69,8 +69,8 @@ const FilterDialog = <TFieldValues extends FieldValues>({
 
   // Reset form and submit
   const handleClear = async () => {
-    reset(initialValues);
-    setActiveFilters(initialValues);
+    reset(resetValues);
+    setActiveFilters(resetValues);
     await methods.handleSubmit(onSubmit)();
     setIsOpen(false);
   };

--- a/apps/web/src/components/FilterDialog/FilterDialog.tsx
+++ b/apps/web/src/components/FilterDialog/FilterDialog.tsx
@@ -16,7 +16,7 @@ import { notEmpty } from "@gc-digital-talent/helpers";
 export type CommonFilterDialogProps<TFieldValues extends FieldValues> = {
   onSubmit: SubmitHandler<TFieldValues>;
   /** Defaults values, including from URL */
-  defaultValues?: Partial<TFieldValues>;
+  routeValues?: Partial<TFieldValues>;
   /** Initial values to reset the form to, not including URL, */
   initialValues: TFieldValues;
 };

--- a/apps/web/src/components/FilterDialog/FilterDialog.tsx
+++ b/apps/web/src/components/FilterDialog/FilterDialog.tsx
@@ -72,7 +72,10 @@ const FilterDialog = <TFieldValues extends FieldValues>({
   // Reset the form with no submission on close
   const handleOpenChange = (newOpen: boolean) => {
     if (!newOpen) {
-      reset();
+      reset((currentValues) => ({
+        ...currentValues,
+        ...activeFilters,
+      }));
     }
 
     setIsOpen(newOpen);

--- a/apps/web/src/components/FilterDialog/FilterDialog.tsx
+++ b/apps/web/src/components/FilterDialog/FilterDialog.tsx
@@ -6,6 +6,7 @@ import {
   SubmitHandler,
   UseFormProps,
   useForm,
+  DefaultValues,
 } from "react-hook-form";
 import AdjustmentsVerticalIcon from "@heroicons/react/20/solid/AdjustmentsVerticalIcon";
 
@@ -39,10 +40,13 @@ const FilterDialog = <TFieldValues extends FieldValues>({
 }: FilterDialogProps<TFieldValues>) => {
   const [isOpen, setIsOpen] = React.useState<boolean>(defaultOpen);
   const intl = useIntl();
+  const defaultValues =
+    options?.defaultValues ??
+    (resetValues as DefaultValues<TFieldValues> | undefined);
   const methods = useForm({
     mode: "onSubmit",
     ...options,
-    defaultValues: options?.defaultValues,
+    defaultValues,
   });
   const {
     reset,

--- a/apps/web/src/components/FilterDialog/FilterDialog.tsx
+++ b/apps/web/src/components/FilterDialog/FilterDialog.tsx
@@ -61,27 +61,8 @@ const FilterDialog = <TFieldValues extends FieldValues>({
     setIsOpen(false);
   };
 
-  /**
-   * Clear the form, including default values
-   *
-   * Unfortunately, `react-hook-form` does not support clearing the form.
-   * This gets the current state and sets them to empty values then uses
-   * the reset to "clear" the form.
-   *
-   * Note: This is disabled for now until we decide if we really want to do this
-   *
-   * REF: https://github.com/orgs/react-hook-form/discussions/7589
-   *
-   */
+  // Reset form and submit
   const handleClear = async () => {
-    // const currentValues = getValues();
-    // const emptyValues: TFieldValues = Object.keys(currentValues).reduce(
-    //   (accumulator, k) => {
-    //     const currentValue = currentValues[k];
-    //     return { ...accumulator, [k]: Array.isArray(currentValue) ? [] : "" };
-    //   },
-    //   currentValues,
-    // );
     reset();
     setActiveFilters(defaultActiveFilters);
     await methods.handleSubmit(onSubmit)();
@@ -143,9 +124,10 @@ const FilterDialog = <TFieldValues extends FieldValues>({
                   onClick={handleClear}
                 >
                   {intl.formatMessage({
-                    description: "Clear button within the search filter dialog",
-                    defaultMessage: "Clear filters",
-                    id: "uC0YPE",
+                    description:
+                      "Button text to reset table filters to the default values",
+                    defaultMessage: "Reset filters",
+                    id: "ROfrit",
                   })}
                 </Button>
                 <Button type="submit" color="primary" disabled={isSubmitting}>

--- a/apps/web/src/components/FilterDialog/FilterDialog.tsx
+++ b/apps/web/src/components/FilterDialog/FilterDialog.tsx
@@ -15,12 +15,17 @@ import { notEmpty } from "@gc-digital-talent/helpers";
 // Used by specific dialogs
 export type CommonFilterDialogProps<TFieldValues extends FieldValues> = {
   onSubmit: SubmitHandler<TFieldValues>;
+  /** Defaults values, including from URL */
   defaultValues?: Partial<TFieldValues>;
+  /** Initial values to reset the form to, not including URL, */
+  initialValues: TFieldValues;
 };
 
 type FilterDialogProps<TFieldValues extends FieldValues> = {
   onSubmit: CommonFilterDialogProps<TFieldValues>["onSubmit"];
   options?: UseFormProps<TFieldValues, unknown>;
+  // Values to reset to (removing URL state)
+  initialValues: CommonFilterDialogProps<TFieldValues>["initialValues"];
   defaultOpen?: boolean;
   children: React.ReactNode;
 };
@@ -29,6 +34,7 @@ const FilterDialog = <TFieldValues extends FieldValues>({
   onSubmit,
   options,
   children,
+  initialValues,
   defaultOpen = false,
 }: FilterDialogProps<TFieldValues>) => {
   const [isOpen, setIsOpen] = React.useState<boolean>(defaultOpen);
@@ -43,9 +49,9 @@ const FilterDialog = <TFieldValues extends FieldValues>({
     formState: { isSubmitting },
   } = methods;
   // Spreading removes the `ReadOnly` type
-  const defaultActiveFilters = { ...options?.defaultValues };
-  const [activeFilters, setActiveFilters] =
-    React.useState<Partial<TFieldValues>>(defaultActiveFilters);
+  const [activeFilters, setActiveFilters] = React.useState<
+    Partial<TFieldValues>
+  >({ ...options?.defaultValues });
   const filterCount = Object.values(activeFilters ?? {}).filter((value) => {
     if (Array.isArray(value)) {
       return value.length > 0;
@@ -63,8 +69,8 @@ const FilterDialog = <TFieldValues extends FieldValues>({
 
   // Reset form and submit
   const handleClear = async () => {
-    reset();
-    setActiveFilters(defaultActiveFilters);
+    reset(initialValues);
+    setActiveFilters(initialValues);
     await methods.handleSubmit(onSubmit)();
     setIsOpen(false);
   };

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
@@ -71,7 +71,7 @@ type PoolCandidateFilterDialogProps = CommonFilterDialogProps<FormValues>;
 
 const PoolCandidateFilterDialog = ({
   onSubmit,
-  routeValues,
+  resetValues,
   initialValues,
 }: PoolCandidateFilterDialogProps) => {
   const intl = useIntl();
@@ -89,8 +89,8 @@ const PoolCandidateFilterDialog = ({
 
   return (
     <FilterDialog<FormValues>
-      options={{ defaultValues: routeValues }}
-      {...{ initialValues, onSubmit }}
+      options={{ defaultValues: initialValues }}
+      {...{ resetValues, onSubmit }}
     >
       <div
         data-h2-display="base(grid)"

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
@@ -71,7 +71,7 @@ type PoolCandidateFilterDialogProps = CommonFilterDialogProps<FormValues>;
 
 const PoolCandidateFilterDialog = ({
   onSubmit,
-  defaultValues,
+  routeValues,
   initialValues,
 }: PoolCandidateFilterDialogProps) => {
   const intl = useIntl();
@@ -89,7 +89,7 @@ const PoolCandidateFilterDialog = ({
 
   return (
     <FilterDialog<FormValues>
-      options={{ defaultValues }}
+      options={{ defaultValues: routeValues }}
       {...{ initialValues, onSubmit }}
     >
       <div

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
@@ -72,6 +72,7 @@ type PoolCandidateFilterDialogProps = CommonFilterDialogProps<FormValues>;
 const PoolCandidateFilterDialog = ({
   onSubmit,
   defaultValues,
+  initialValues,
 }: PoolCandidateFilterDialogProps) => {
   const intl = useIntl();
 
@@ -87,7 +88,10 @@ const PoolCandidateFilterDialog = ({
   });
 
   return (
-    <FilterDialog<FormValues> onSubmit={onSubmit} options={{ defaultValues }}>
+    <FilterDialog<FormValues>
+      options={{ defaultValues }}
+      {...{ initialValues, onSubmit }}
+    >
       <div
         data-h2-display="base(grid)"
         data-h2-gap="base(x1)"

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -548,6 +548,9 @@ const PoolCandidatesTable = ({
         component: (
           <PoolCandidateFilterDialog
             onSubmit={handleFilterSubmit}
+            initialValues={transformPoolCandidateSearchInputToFormValues(
+              initialFilterInput,
+            )}
             defaultValues={transformPoolCandidateSearchInputToFormValues(
               initialFilters,
             )}

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -548,10 +548,10 @@ const PoolCandidatesTable = ({
         component: (
           <PoolCandidateFilterDialog
             onSubmit={handleFilterSubmit}
-            initialValues={transformPoolCandidateSearchInputToFormValues(
+            resetValues={transformPoolCandidateSearchInputToFormValues(
               initialFilterInput,
             )}
-            routeValues={transformPoolCandidateSearchInputToFormValues(
+            initialValues={transformPoolCandidateSearchInputToFormValues(
               initialFilters,
             )}
           />

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -551,7 +551,7 @@ const PoolCandidatesTable = ({
             initialValues={transformPoolCandidateSearchInputToFormValues(
               initialFilterInput,
             )}
-            defaultValues={transformPoolCandidateSearchInputToFormValues(
+            routeValues={transformPoolCandidateSearchInputToFormValues(
               initialFilters,
             )}
           />

--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -348,8 +348,8 @@ const SearchRequestTable = ({ title }: SearchRequestTableProps) => {
           <SearchRequestFilterDialog
             onSubmit={handleFilterSubmit}
             // Required for reset
-            initialValues={transformSearchRequestFilterInputToFormValues({})}
-            routeValues={transformSearchRequestFilterInputToFormValues(
+            resetValues={transformSearchRequestFilterInputToFormValues({})}
+            initialValues={transformSearchRequestFilterInputToFormValues(
               initialFilters,
             )}
           />

--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -347,6 +347,8 @@ const SearchRequestTable = ({ title }: SearchRequestTableProps) => {
         component: (
           <SearchRequestFilterDialog
             onSubmit={handleFilterSubmit}
+            // Required for reset
+            initialValues={transformSearchRequestFilterInputToFormValues({})}
             defaultValues={transformSearchRequestFilterInputToFormValues(
               initialFilters,
             )}

--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -349,7 +349,7 @@ const SearchRequestTable = ({ title }: SearchRequestTableProps) => {
             onSubmit={handleFilterSubmit}
             // Required for reset
             initialValues={transformSearchRequestFilterInputToFormValues({})}
-            defaultValues={transformSearchRequestFilterInputToFormValues(
+            routeValues={transformSearchRequestFilterInputToFormValues(
               initialFilters,
             )}
           />

--- a/apps/web/src/components/SearchRequestTable/components/SearchRequestFilterDialog.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/SearchRequestFilterDialog.tsx
@@ -31,7 +31,7 @@ type SearchRequestFilterDialogProps = CommonFilterDialogProps<FormValues>;
 
 const SearchRequestFilterDialog = ({
   onSubmit,
-  routeValues,
+  resetValues,
   initialValues,
 }: SearchRequestFilterDialogProps) => {
   const intl = useIntl();
@@ -43,8 +43,8 @@ const SearchRequestFilterDialog = ({
 
   return (
     <FilterDialog<FormValues>
-      {...{ onSubmit, initialValues }}
-      options={{ defaultValues: routeValues }}
+      {...{ onSubmit, resetValues }}
+      options={{ defaultValues: initialValues }}
     >
       <div
         data-h2-display="base(grid)"

--- a/apps/web/src/components/SearchRequestTable/components/SearchRequestFilterDialog.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/SearchRequestFilterDialog.tsx
@@ -31,7 +31,7 @@ type SearchRequestFilterDialogProps = CommonFilterDialogProps<FormValues>;
 
 const SearchRequestFilterDialog = ({
   onSubmit,
-  defaultValues,
+  routeValues,
   initialValues,
 }: SearchRequestFilterDialogProps) => {
   const intl = useIntl();
@@ -44,7 +44,7 @@ const SearchRequestFilterDialog = ({
   return (
     <FilterDialog<FormValues>
       {...{ onSubmit, initialValues }}
-      options={{ defaultValues }}
+      options={{ defaultValues: routeValues }}
     >
       <div
         data-h2-display="base(grid)"

--- a/apps/web/src/components/SearchRequestTable/components/SearchRequestFilterDialog.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/SearchRequestFilterDialog.tsx
@@ -32,6 +32,7 @@ type SearchRequestFilterDialogProps = CommonFilterDialogProps<FormValues>;
 const SearchRequestFilterDialog = ({
   onSubmit,
   defaultValues,
+  initialValues,
 }: SearchRequestFilterDialogProps) => {
   const intl = useIntl();
 
@@ -41,7 +42,10 @@ const SearchRequestFilterDialog = ({
   const classifications = unpackMaybes(data?.classifications);
 
   return (
-    <FilterDialog<FormValues> onSubmit={onSubmit} options={{ defaultValues }}>
+    <FilterDialog<FormValues>
+      {...{ onSubmit, initialValues }}
+      options={{ defaultValues }}
+    >
       <div
         data-h2-display="base(grid)"
         data-h2-grid-template-columns="p-tablet(repeat(2, 1fr))"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5151,6 +5151,10 @@
     "defaultMessage": "Compétences sélectionnées ({skillCount})",
     "description": "Skills selected and then a number in parentheses"
   },
+  "ROfrit": {
+    "defaultMessage": "Rétablir les filtres",
+    "description": "Button text to reset table filters to the default values"
+  },
   "RSx3Ni": {
     "defaultMessage": "Bref résumé des compétences",
     "description": "Title for skills quick summary sidebar"
@@ -10282,10 +10286,6 @@
   "uBmoxQ": {
     "defaultMessage": "Rôle",
     "description": "Title displayed for the role table display name column"
-  },
-  "uC0YPE": {
-    "defaultMessage": "Effacer les filtres",
-    "description": "Clear button within the search filter dialog"
   },
   "uD7QTb": {
     "defaultMessage": "Il appartient aux gestionnaires de gérer l’élaboration et la prestation de services et (ou) d’opérations de <abbreviation>TI</abbreviation> par l’entremise de chefs d’équipe subalternes, de conseillers techniques et d’équipes de projet.",

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserFilterDialog.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserFilterDialog.tsx
@@ -56,7 +56,7 @@ type UserFilterDialogProps = CommonFilterDialogProps<FormValues>;
 
 const UserFilterDialog = ({
   onSubmit,
-  routeValues,
+  resetValues,
   initialValues,
 }: UserFilterDialogProps) => {
   const intl = useIntl();
@@ -69,8 +69,8 @@ const UserFilterDialog = ({
 
   return (
     <FilterDialog<FormValues>
-      options={{ defaultValues: routeValues }}
-      {...{ onSubmit, initialValues }}
+      options={{ defaultValues: initialValues }}
+      {...{ onSubmit, resetValues }}
     >
       <div
         data-h2-display="base(grid)"

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserFilterDialog.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserFilterDialog.tsx
@@ -56,7 +56,7 @@ type UserFilterDialogProps = CommonFilterDialogProps<FormValues>;
 
 const UserFilterDialog = ({
   onSubmit,
-  defaultValues,
+  routeValues,
   initialValues,
 }: UserFilterDialogProps) => {
   const intl = useIntl();
@@ -69,7 +69,7 @@ const UserFilterDialog = ({
 
   return (
     <FilterDialog<FormValues>
-      options={{ defaultValues }}
+      options={{ defaultValues: routeValues }}
       {...{ onSubmit, initialValues }}
     >
       <div

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserFilterDialog.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserFilterDialog.tsx
@@ -57,6 +57,7 @@ type UserFilterDialogProps = CommonFilterDialogProps<FormValues>;
 const UserFilterDialog = ({
   onSubmit,
   defaultValues,
+  initialValues,
 }: UserFilterDialogProps) => {
   const intl = useIntl();
 
@@ -67,7 +68,10 @@ const UserFilterDialog = ({
   const roles = unpackMaybes(data?.roles);
 
   return (
-    <FilterDialog<FormValues> onSubmit={onSubmit} options={{ defaultValues }}>
+    <FilterDialog<FormValues>
+      options={{ defaultValues }}
+      {...{ onSubmit, initialValues }}
+    >
       <div
         data-h2-display="base(grid)"
         data-h2-gap="base(x1)"

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -384,10 +384,10 @@ const UserTable = ({ title }: UserTableProps) => {
         component: (
           <UserFilterDialog
             onSubmit={handleFilterSubmit}
-            initialValues={transformUserFilterInputToFormValues(
+            resetValues={transformUserFilterInputToFormValues(
               defaultState.filters,
             )}
-            routeValues={transformUserFilterInputToFormValues(initialFilters)}
+            initialValues={transformUserFilterInputToFormValues(initialFilters)}
           />
         ),
       }}

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -384,6 +384,9 @@ const UserTable = ({ title }: UserTableProps) => {
         component: (
           <UserFilterDialog
             onSubmit={handleFilterSubmit}
+            initialValues={transformUserFilterInputToFormValues(
+              defaultState.filters,
+            )}
             defaultValues={transformUserFilterInputToFormValues(initialFilters)}
           />
         ),

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -387,7 +387,7 @@ const UserTable = ({ title }: UserTableProps) => {
             initialValues={transformUserFilterInputToFormValues(
               defaultState.filters,
             )}
-            defaultValues={transformUserFilterInputToFormValues(initialFilters)}
+            routeValues={transformUserFilterInputToFormValues(initialFilters)}
           />
         ),
       }}


### PR DESCRIPTION
🤖 Resolves #8776 

## 👋 Introduction

This fixes the filter count for the dialog to only display the number of filters actually in use.

## 🕵️ Details

### Clear functionality

It appears as though the functionality we want on the clear button is not easily possible. This includes a solution but has been disabled while we revisit it. While it does clear the filters, we are unsure if this is actually what we want based on how we actually use the filters.

The odd stuff comes up when we indiscriminately clear filters, it affects the UI in an unexpected way. This is most notable on radio buttons where the true "empty" value is not empty. 

The current ideas are:

1. Force devs to pass in the expected "empty" value for specific inputs so the generic form is aware of them
2. Override the value for things like radio buttons to be an empty string (this will required revisiting the transforms)
3. Keep the existing functionality and just rename the button to reflect it (ie. "Reset filters")

#### Answer

REF: https://github.com/GCTC-NTGC/gc-digital-talent/issues/8776#issuecomment-1854523405

It seems we opted to maintain existing functionality (option 3) and just update the button text to better represent the function. Please be aware of this when testing.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to a table that includes the dialog
3. Apply some filters and submit
5. Confirm the number updates as expected
6. Open the dialog and use the "reset filters"
7. Confirm the number resets to the initial value
8. Open the dialog and set some filters
9. Close the dialog without submitting (X or <kbd>esc</kbd>)
10. Confirm the number remains constant 