### PR TITLE
[Bug] Duplicate `experience_user_skill_unique`

### DIFF
--- a/apps/web/src/pages/Profile/ExperienceFormPage/components/ExperienceSkills.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/components/ExperienceSkills.tsx
@@ -49,6 +49,13 @@ const ExperienceSkills = ({
     }
   };
 
+  const watchedSkillIds = watchedSkills.map(
+    (watchedSkill) => watchedSkill.skillId,
+  );
+  const unclaimedSkills = skills.filter(
+    (skill) => !watchedSkillIds.includes(skill.id),
+  );
+
   const handleRemoveSkill = (id: string) => {
     const index = watchedSkills.findIndex(
       (field: FormSkill) => field.skillId === id,
@@ -175,7 +182,7 @@ const ExperienceSkills = ({
                 }),
               }}
               context="experience"
-              skills={skills}
+              skills={unclaimedSkills}
               onSave={handleAddSkill}
             />
           </div>

--- a/apps/web/src/pages/Profile/ExperienceFormPage/components/ExperienceSkills.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/components/ExperienceSkills.tsx
@@ -49,9 +49,9 @@ const ExperienceSkills = ({
     }
   };
 
-  const watchedSkillIds = watchedSkills.map(
-    (watchedSkill) => watchedSkill.skillId,
-  );
+  const watchedSkillIds = watchedSkills
+    ? watchedSkills.map((watchedSkill) => watchedSkill.skillId)
+    : [];
   const unclaimedSkills = skills.filter(
     (skill) => !watchedSkillIds.includes(skill.id),
   );


### PR DESCRIPTION
🤖 Resolves #8778

## 👋 Introduction

Find and resolve the constraint violation

## 🕵️ Details

Given the production environment has limited ways to edit the skill-userskill-experience grouping, where to look was narrowed. 
Setting skill-library to false and exploring I could not replicate the matter except for in one method, attempting to sync the same skill twice in one edit.
The soft deletion and restore seemed without issue to me. 

Solved then by preventing you from selecting the same skill multiple times. 

## 🧪 Testing

1. Set skill library to false
2. Be unable to replicate a duplication error from the career timeline

## 📸 Screenshot

Off main

Pick the same skill twice

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/a9405608-7e93-424c-934e-ef833d77fb5f)

Observe console error

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/658a1c18-e081-4987-b9ae-3cf3afaa64f9)

Update fails

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/0edaa675-c946-4d2f-b494-8e0823fbc2c6)





