### PR TITLE
[Fix] Prevent unauthorized users from accessing pool candidate notes

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -257,7 +257,7 @@ type PoolCandidate {
 
   status: PoolCandidateStatus @rename(attribute: "pool_candidate_status")
   statusWeight: Int @rename(attribute: "status_weight")
-  notes: String
+  notes: String @canOnParent(ability: "viewAssessmentResults")
   archivedAt: DateTime @rename(attribute: "archived_at")
   submittedAt: DateTime @rename(attribute: "submitted_at")
   suspendedAt: DateTime @rename(attribute: "suspended_at")


### PR DESCRIPTION
🤖 Resolves #8808 

## 👋 Introduction

This adds the `@canOnParent` directive to the notes field on the `PoolCandidate` model in our GraphQL schema. It uses the `viewAssessmentResults` permission allowing access to only:

- Pool operator (who is part of the team that owns the pool)
- Platform admin

## 🕵️ Details

I hope the test I wrote is good enough, it basically checks that we get the notes field for the users who should see it as well as a auth error on those that cannot. I'm hoping it is not over-testing but I wanted to cover all the possibilities 🤷‍♀️ 

## 🧪 Testing

```graphql
query MyInfo {
  poolCandidate(id: "{id}") {
    id
    notes
  }
}
```

1. Login as an applicant `applicant@test.com`
2. Submit an application
3. Logout and log back in as an admin `admin@test.com`
4. Navigate to the application you just submitted and add some notes to it
5. Make sure to copy the ID for use in the following steps
6. Logout
7. Set the default auth user to applicant `AUTH_DEFAULT_USER=applicant@test.com` in `api/.env`
8. Navigate to `http://localhost:8000/graphiql`
9. Attempt to run the query noted previously replace `{id}` with the ID copied in step 5
10. Confirm you get an unauthorized error
11. Update the default auth user to `admin@test.com` from step 5
12. Re-run the query from step 8
13. Confirm you get the notes with no errors
