### PR TITLE
[Fix] Improve UUID enforcement on URL params

### DIFF
--- a/apps/web/src/hooks/useRequiredParams.ts
+++ b/apps/web/src/hooks/useRequiredParams.ts
@@ -81,13 +81,12 @@ const useRequiredParams = <
         newParams = { ...newParams, [key]: param }; // param must be a string if assertParam didn't throw an error.
       }
     } catch (err) {
-      throw new Response(
-        message ?? intl.formatMessage(commonMessages.notFound),
-        {
-          status: 404,
-          statusText: "Not Found",
-        },
-      );
+      const errorMessage =
+        message ?? intl.formatMessage(commonMessages.notFound);
+      throw new Response(errorMessage, {
+        status: 404,
+        statusText: errorMessage,
+      });
     }
 
     return newParams;

--- a/apps/web/src/hooks/useRequiredParams.ts
+++ b/apps/web/src/hooks/useRequiredParams.ts
@@ -70,7 +70,6 @@ const useRequiredParams = <
   nonEmptyParams = keyArray.reduce((reducedParams, key) => {
     const param: string | undefined = params[String(key)];
     let newParams = { ...reducedParams };
-    console.log(isUUID(param ?? ""));
     assertParam(param, enforceUUID, logger);
 
     if (key) {

--- a/apps/web/src/hooks/useRequiredParams.ts
+++ b/apps/web/src/hooks/useRequiredParams.ts
@@ -10,7 +10,7 @@ import { notEmpty } from "@gc-digital-talent/helpers";
 import invariant from "~/utils/invariant";
 
 export const uuidRegEx =
-  /[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}/;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 export const isUUID = (str: string): boolean => {
   return !!str.match(uuidRegEx);
@@ -70,6 +70,7 @@ const useRequiredParams = <
   nonEmptyParams = keyArray.reduce((reducedParams, key) => {
     const param: string | undefined = params[String(key)];
     let newParams = { ...reducedParams };
+    console.log(isUUID(param ?? ""));
     assertParam(param, enforceUUID, logger);
 
     if (key) {


### PR DESCRIPTION
🤖 Resolves #8724 

## 👋 Introduction

This solves an issue where malformed UUIDs in the URL were not throwing errors.

## 🕵️ Details

> [!NOTE]
> A big thanks to @petertgiles for helping play detective and getting to the root of the issue! 🙇‍♀️ 🕵️ 

We encountered an error in our logs where malformed UUIDs were making it to the API. With the help of @petertgiles we were able to determine it was attempting to retrieve a Pool with a specific ID, but there was a stray `]` at the end of the string. Reviewing our code, this did not seem to be a dev error.

Further testing, I found that if you added any extra data to the start or end of a UUID in the URL, it was not being caught by our `useRequiredParams` hook even when the `enforceUUID` option was set to true. Digging deeper, I noticed the regex was only checking to see if the string contained a UUID. So, you could change data inside the UUID to see the proper error, but adding data to the beginning or end caused the `CoercionError` since no error was thrown on the client and the malformed UUID was getting to the server😬 

So, this updates that regex to enforce start (`^`) and end (`$`) points on the string so we are now asserting the entire string is equal to a UUID rather than if it contains a UUID.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to any page that has a UUID in the URL and sent to the API
3. Add anything to the start of the string
4. Confirm you get the pug error page and not a blank page with `GraphQL` error
5. Confirm the graphql request was not sent
6. Confirm the laravel log does not contain a `CoercionError`
7. Repeat steps 3-6 but add the data to the end of the UUID
