### PR TITLE
[Fix] `isIndigenous` `EmploymentEquitySection` logic

### DIFF
--- a/apps/web/src/pages/Users/UserInformationPage/components/EmploymentEquitySection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/EmploymentEquitySection.tsx
@@ -25,7 +25,7 @@ const EmploymentEquitySection = ({ user }: BasicUserInformationProps) => {
           description:
             "Text on view-user page that the user isn't part of any employment equity groups",
         })}
-      {!isIndigenous && (
+      {isIndigenous && (
         <div data-h2-padding="base(x.125, 0)">
           <CheckIcon style={{ width: "1rem" }} />
           {"  "}


### PR DESCRIPTION
🤖 Resolves #8825.

## 👋 Introduction

This PR fixes the conditional logic for `isIndigenous` in `EmploymentEquitySection`.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Log in as a platform admin
2. In the users table, find a user who has claimed membership in an indigenous community and one who has not (you can do this on your own profile, for simplicity)
3. Compare the Employment Equity blocks on the User Information and User Profile pages