### PR TITLE
[Bug] Add character limits to inputs for experience forms

### DIFF
--- a/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
@@ -34,7 +34,15 @@ const AwardFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.awardTitle}
             name="awardTitle"
             type="text"
-            rules={{ required: intl.formatMessage(errorMessages.required) }}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+              maxLength: {
+                message: intl.formatMessage(errorMessages.overCharacterLimit, {
+                  value: 256,
+                }),
+                value: 255,
+              },
+            }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
@@ -68,7 +76,15 @@ const AwardFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.issuedBy}
             name="issuedBy"
             type="text"
-            rules={{ required: intl.formatMessage(errorMessages.required) }}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+              maxLength: {
+                message: intl.formatMessage(errorMessages.overCharacterLimit, {
+                  value: 256,
+                }),
+                value: 255,
+              },
+            }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">

--- a/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
@@ -30,7 +30,15 @@ const CommunityFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.role}
             name="role"
             type="text"
-            rules={{ required: intl.formatMessage(errorMessages.required) }}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+              maxLength: {
+                message: intl.formatMessage(errorMessages.overCharacterLimit, {
+                  value: 256,
+                }),
+                value: 255,
+              },
+            }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
@@ -53,7 +61,15 @@ const CommunityFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.organization}
             name="organization"
             type="text"
-            rules={{ required: intl.formatMessage(errorMessages.required) }}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+              maxLength: {
+                message: intl.formatMessage(errorMessages.overCharacterLimit, {
+                  value: 256,
+                }),
+                value: 255,
+              },
+            }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
@@ -62,7 +78,15 @@ const CommunityFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.project}
             name="project"
             type="text"
-            rules={{ required: intl.formatMessage(errorMessages.required) }}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+              maxLength: {
+                message: intl.formatMessage(errorMessages.overCharacterLimit, {
+                  value: 256,
+                }),
+                value: 255,
+              },
+            }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">

--- a/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
@@ -80,7 +80,15 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.areaOfStudy}
             name="areaOfStudy"
             type="text"
-            rules={{ required: intl.formatMessage(errorMessages.required) }}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+              maxLength: {
+                message: intl.formatMessage(errorMessages.overCharacterLimit, {
+                  value: 256,
+                }),
+                value: 255,
+              },
+            }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
@@ -89,7 +97,15 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.institution}
             name="institution"
             type="text"
-            rules={{ required: intl.formatMessage(errorMessages.required) }}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+              maxLength: {
+                message: intl.formatMessage(errorMessages.overCharacterLimit, {
+                  value: 256,
+                }),
+                value: 255,
+              },
+            }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
@@ -124,6 +140,14 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.thesisTitle}
             name="thesisTitle"
             type="text"
+            rules={{
+              maxLength: {
+                message: intl.formatMessage(errorMessages.overCharacterLimit, {
+                  value: 256,
+                }),
+                value: 255,
+              },
+            }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">

--- a/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
@@ -45,7 +45,15 @@ const PersonalFields = ({ labels }: SubExperienceFormProps) => {
         label={labels.experienceTitle}
         name="experienceTitle"
         type="text"
-        rules={{ required: intl.formatMessage(errorMessages.required) }}
+        rules={{
+          required: intl.formatMessage(errorMessages.required),
+          maxLength: {
+            message: intl.formatMessage(errorMessages.overCharacterLimit, {
+              value: 256,
+            }),
+            value: 255,
+          },
+        }}
       />
       <TextArea
         id="experienceDescription"

--- a/apps/web/src/components/ExperienceFormFields/WorkFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields.tsx
@@ -30,7 +30,15 @@ const WorkFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.role}
             name="role"
             type="text"
-            rules={{ required: intl.formatMessage(errorMessages.required) }}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+              maxLength: {
+                message: intl.formatMessage(errorMessages.overCharacterLimit, {
+                  value: 256,
+                }),
+                value: 255,
+              },
+            }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
@@ -53,11 +61,32 @@ const WorkFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.organization}
             name="organization"
             type="text"
-            rules={{ required: intl.formatMessage(errorMessages.required) }}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+              maxLength: {
+                message: intl.formatMessage(errorMessages.overCharacterLimit, {
+                  value: 256,
+                }),
+                value: 255,
+              },
+            }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-          <Input id="team" label={labels.team} name="team" type="text" />
+          <Input
+            id="team"
+            label={labels.team}
+            name="team"
+            type="text"
+            rules={{
+              maxLength: {
+                message: intl.formatMessage(errorMessages.overCharacterLimit, {
+                  value: 256,
+                }),
+                value: 255,
+              },
+            }}
+          />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
           <DateInput

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/components/ExperienceEditForm.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/components/ExperienceEditForm.tsx
@@ -73,7 +73,16 @@ const EditExperienceForm = ({
     if (executeMutation) {
       executeMutation(args)
         .then((res) => {
-          if (res.data) {
+          if (res.error) {
+            toast.error(
+              intl.formatMessage({
+                defaultMessage: "Error: updating experience failed",
+                id: "WyKJsK",
+                description:
+                  "Message displayed to user after experience fails to be updated.",
+              }),
+            );
+          } else {
             toast.success(
               intl.formatMessage({
                 defaultMessage: "Successfully updated experience!",

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -142,7 +142,9 @@ export const ExperienceForm = ({
   };
 
   const handleMutationResponse = (res: ExperienceMutationResponse) => {
-    if (res.data) {
+    if (res.error) {
+      handleError();
+    } else {
       handleSuccess();
     }
   };

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -479,6 +479,10 @@
     "defaultMessage": "Être disponible, disposé(e) et apte à travailler par quarts.",
     "description": "The operational requirement described as shift work."
   },
+  "GiYTD4": {
+    "defaultMessage": "Ce champ doit contenir moins de {value} caractères.",
+    "description": "Error Message displayed when the user passes some given character or letter limit."
+  },
   "Glb1Te": {
     "defaultMessage": "Diriger",
     "description": "The technical skill level for lead"

--- a/packages/i18n/src/messages/errorMessages.ts
+++ b/packages/i18n/src/messages/errorMessages.ts
@@ -47,6 +47,12 @@ const errorMessages = defineMessages({
     description:
       "Error Message displayed on word counter when user passes the limit.",
   },
+  overCharacterLimit: {
+    defaultMessage: "This field must have less than {value} characters.",
+    id: "GiYTD4",
+    description:
+      "Error Message displayed when the user passes some given character or letter limit.",
+  },
   unknownErrorRequestErrorTitle: {
     defaultMessage: "Sorry, we encountered an error.",
     id: "edeLyW",


### PR DESCRIPTION
🤖 Resolves #8725

## 👋 Introduction

Uses `maxLength` rules for inputs, as well as correct toasting/action on errored updates. 

## 🕵️ Details

Elected to check if an error is returned in the response object, given the nested data object contains 10 possibles keys (5 experiences x 2 mutation types) the truthy check wasn't working right so I thought it would be easier to assert on `res.error` instead. 

## 🧪 Testing

1. Head to career timeline and the experiences section of the application flow
2. Check you cannot trigger the value too long error for VARCHAR database error
3. Check failed operations do not return a success toast

A suggestion to check the third option. Open an experience, then open and soft-delete it in adminer, then attempt to update it in app. 
Generate strings of a certain character count with https://loremipsum360.com/

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/3ecac8c2-1e37-420d-9345-5c6d8d5e2b92)


