### PR TITLE
[Bug] Exception thrown on id token check

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -83,6 +83,12 @@ class AuthController extends Controller
         $config = $this->fastSigner;
 
         assert($config instanceof Configuration);
+
+        throw_unless(
+            $idToken && is_string($idToken),
+            new InvalidArgumentException('id token is a '.gettype($idToken))
+        );
+
         $token = $config->parser()->parse($idToken);
         assert($token instanceof UnencryptedToken);
 

--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Services\OpenIdBearerTokenService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Lcobucci\JWT\Configuration;
@@ -80,14 +81,13 @@ class AuthController extends Controller
         // pull token out of the response as json -> lcobucci parser, no key verification is being done here however
         $idToken = $response->json('id_token');
 
+        if (! ($idToken && is_string($idToken))) {
+            Log::debug((string) $response->body());
+            throw new InvalidArgumentException('id token is a '.gettype($idToken));
+        }
+
         $config = $this->fastSigner;
-
         assert($config instanceof Configuration);
-
-        throw_unless(
-            $idToken && is_string($idToken),
-            new InvalidArgumentException('id token is a '.gettype($idToken))
-        );
 
         $token = $config->parser()->parse($idToken);
         assert($token instanceof UnencryptedToken);


### PR DESCRIPTION
🤖 Resolves #8723 

## 👋 Introduction

Check the id token is a string, if it isn't throw an exception. 

## 🧪 Testing

Not entirely sure of the best way, an idea below

1. Set id token variable to a different type, like an integer value, right before the `throw_unless()` on `$idToken`
2. Attempt logging in, observe exception message 


