### PR TITLE
[Bug] Retrying call to auth endpoint

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -83,7 +83,7 @@ class AuthController extends Controller
             'redirect_uri' => config('oauth.redirect_uri'),
             'code' => $request->code,
         ])->throw(function (Response $response, RequestException $e) {
-            Log::debug('Failed to get a response from POSTing to the token URI');
+            Log::error('Failed to get a response from POSTing to the token URI');
             Log::debug((string) $response->getBody());
         });
 

--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -83,7 +83,8 @@ class AuthController extends Controller
             'redirect_uri' => config('oauth.redirect_uri'),
             'code' => $request->code,
         ])->throw(function (Response $response, RequestException $e) {
-            Log::debug($response->json());
+            Log::debug('Failed to get a response from POSTing to the token URI');
+            Log::debug((string) $response->getBody());
         });
 
         // decode id_token stage


### PR DESCRIPTION
🤖 Resolves #8777 

## 👋 Introduction

Add retrying and a logging line to the auth callback function, the client request method. 

## 🕵️ Details

Attempted to just follow documentation for implementation, not 100% on things. 

https://laravel.com/docs/10.x/http-client

## 🧪 Testing

1. Can login successfully
2. ?

