### PR TITLE
[Fix] Table date sort

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -509,12 +509,19 @@ const PoolCandidatesTable = ({
       },
     ),
     columnHelper.accessor(
-      ({ poolCandidate: { submittedAt } }) => accessors.date(submittedAt, intl),
+      ({ poolCandidate: { submittedAt } }) => accessors.date(submittedAt),
       {
         id: "dateReceived",
         enableColumnFilter: false,
         header: intl.formatMessage(tableMessages.dateReceived),
         sortingFn: "datetime",
+        cell: ({
+          row: {
+            original: {
+              poolCandidate: { submittedAt },
+            },
+          },
+        }) => cells.date(submittedAt, intl),
       },
     ),
   ] as ColumnDef<PoolCandidateWithSkillCount>[];

--- a/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
+++ b/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
@@ -166,7 +166,7 @@ const PoolStatusTable = ({ user, pools }: UserInformationProps) => {
         }),
       },
     ),
-    columnHelper.accessor((row) => accessors.date(row.expiryDate, intl), {
+    columnHelper.accessor((row) => accessors.date(row.expiryDate), {
       id: "expiryDate",
       enableHiding: false,
       sortingFn: "datetime",

--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -235,16 +235,21 @@ const SearchRequestTable = ({ title }: SearchRequestTableProps) => {
         statusCell(searchRequest.status, intl),
     }),
     columnHelper.accessor(
-      ({ requestedDate }) => accessors.date(requestedDate, intl),
+      ({ requestedDate }) => accessors.date(requestedDate),
       {
         id: "requestedDate",
+        enableColumnFilter: false,
         header: intl.formatMessage({
           defaultMessage: "Date Received",
           id: "r2gD/4",
           description:
             "Title displayed on the search request table requested date column.",
         }),
-        enableColumnFilter: false,
+        cell: ({
+          row: {
+            original: { requestedDate },
+          },
+        }) => cells.date(requestedDate, intl),
       },
     ),
     columnHelper.accessor("adminNotes", {

--- a/apps/web/src/components/Table/accessors.tsx
+++ b/apps/web/src/components/Table/accessors.tsx
@@ -1,20 +1,11 @@
-import { IntlShape } from "react-intl";
-
-import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
+import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 
 import { Maybe, Scalars } from "~/api/generated";
 
 function dateAccessor(
   value: Maybe<Scalars["DateTime"]> | undefined,
-  intl: IntlShape,
-): string {
-  return value
-    ? formatDate({
-        date: parseDateTimeUtc(value),
-        formatString: "PPP p",
-        intl,
-      })
-    : "";
+): Date | null {
+  return value ? parseDateTimeUtc(value) : null;
 }
 
 export default {

--- a/apps/web/src/components/Table/cells.tsx
+++ b/apps/web/src/components/Table/cells.tsx
@@ -1,6 +1,9 @@
 import React from "react";
+import { IntlShape } from "react-intl";
 
 import { Link } from "@gc-digital-talent/ui";
+import { Scalars } from "@gc-digital-talent/graphql";
+import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 
 import { Maybe } from "~/api/generated";
 
@@ -71,6 +74,19 @@ function phoneCell(telephone?: Maybe<string>) {
   );
 }
 
+function dateCell(
+  value: Maybe<Scalars["DateTime"]["output"]> | undefined,
+  intl: IntlShape,
+): string {
+  return value
+    ? formatDate({
+        date: parseDateTimeUtc(value),
+        formatString: "PPP p",
+        intl,
+      })
+    : "";
+}
+
 export default {
   actions: actionsCell,
   edit: editCell,
@@ -79,4 +95,5 @@ export default {
   jsx: jsxCell,
   email: emailCell,
   phone: phoneCell,
+  date: dateCell,
 };

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -169,32 +169,36 @@ export const PoolTable = ({ pools, title }: PoolTableProps) => {
           getLocalizedName(pool.name, intl),
         ),
     }),
-    columnHelper.accessor(
-      ({ createdDate }) => accessors.date(createdDate, intl),
-      {
-        id: "createdDate",
-        enableColumnFilter: false,
-        sortingFn: "datetime",
-        header: intl.formatMessage({
-          defaultMessage: "Created",
-          id: "zAqJMe",
-          description: "Title displayed on the Pool table Date Created column",
-        }),
-      },
-    ),
-    columnHelper.accessor(
-      ({ updatedDate }) => accessors.date(updatedDate, intl),
-      {
-        id: "updatedDate",
-        enableColumnFilter: false,
-        sortingFn: "datetime",
-        header: intl.formatMessage({
-          defaultMessage: "Updated",
-          id: "R2sSy9",
-          description: "Title displayed for the User table Date Updated column",
-        }),
-      },
-    ),
+    columnHelper.accessor(({ createdDate }) => accessors.date(createdDate), {
+      id: "createdDate",
+      enableColumnFilter: false,
+      sortingFn: "datetime",
+      header: intl.formatMessage({
+        defaultMessage: "Created",
+        id: "zAqJMe",
+        description: "Title displayed on the Pool table Date Created column",
+      }),
+      cell: ({
+        row: {
+          original: { createdDate },
+        },
+      }) => cells.date(createdDate, intl),
+    }),
+    columnHelper.accessor(({ updatedDate }) => accessors.date(updatedDate), {
+      id: "updatedDate",
+      enableColumnFilter: false,
+      sortingFn: "datetime",
+      header: intl.formatMessage({
+        defaultMessage: "Updated",
+        id: "R2sSy9",
+        description: "Title displayed for the User table Date Updated column",
+      }),
+      cell: ({
+        row: {
+          original: { updatedDate },
+        },
+      }) => cells.date(updatedDate, intl),
+    }),
   ] as ColumnDef<Pool>[];
 
   const data = pools.filter(notEmpty);

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -216,30 +216,34 @@ const UserTable = ({ title }: UserTableProps) => {
           getFullNameLabel(user.firstName, user.lastName, intl),
         ),
     }),
-    columnHelper.accessor(
-      ({ createdDate }) => accessors.date(createdDate, intl),
-      {
-        id: "createdDate",
-        enableColumnFilter: false,
-        header: intl.formatMessage({
-          defaultMessage: "Created",
-          id: "zAqJMe",
-          description: "Title displayed on the Pool table Date Created column",
-        }),
-      },
-    ),
-    columnHelper.accessor(
-      ({ updatedDate }) => accessors.date(updatedDate, intl),
-      {
-        id: "updatedDate",
-        enableColumnFilter: false,
-        header: intl.formatMessage({
-          defaultMessage: "Updated",
-          id: "R2sSy9",
-          description: "Title displayed for the User table Date Updated column",
-        }),
-      },
-    ),
+    columnHelper.accessor(({ createdDate }) => accessors.date(createdDate), {
+      id: "createdDate",
+      enableColumnFilter: false,
+      header: intl.formatMessage({
+        defaultMessage: "Created",
+        id: "zAqJMe",
+        description: "Title displayed on the Pool table Date Created column",
+      }),
+      cell: ({
+        row: {
+          original: { createdDate },
+        },
+      }) => cells.date(createdDate, intl),
+    }),
+    columnHelper.accessor(({ updatedDate }) => accessors.date(updatedDate), {
+      id: "updatedDate",
+      enableColumnFilter: false,
+      header: intl.formatMessage({
+        defaultMessage: "Updated",
+        id: "R2sSy9",
+        description: "Title displayed for the User table Date Updated column",
+      }),
+      cell: ({
+        row: {
+          original: { updatedDate },
+        },
+      }) => cells.date(updatedDate, intl),
+    }),
   ] as ColumnDef<User>[];
 
   const [{ data, fetching }] = useAllUsersPaginatedQuery({


### PR DESCRIPTION
🤖 Resolves #8838 

## 👋 Introduction

Fixes the issue with tables not sorting date columns properly.

## 🕵️ Details

We had the `accessor` and `cells` mixed up 😅 . This updates it so the accessor returns a `Date` and adds a `cell` to handle the formatting of said date.

> [!NOTE]
> We have been sorting the `PoolTable`  by `ceatedDate` so I was hesitant to change this. Do we still want to be changing this to `updatedDate`.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to tables in the admin
3. Sort any date columns
4. Confirm they are sorted properly

## 📸 Screenshot

![Screenshot 2023-12-19 124640](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/ae4a8036-6170-4d27-83a1-2eaa6074809c)
