### PR TITLE
[Debt] Add non-nullable marker to query `poolCandidates`

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -692,7 +692,7 @@ type Query {
     @find
     @guard
     @can(ability: "view", query: true)
-  poolCandidates(includeIds: [ID] @in(key: "id")): [PoolCandidate]!
+  poolCandidates(includeIds: [ID]! @in(key: "id")): [PoolCandidate]!
     @all(scopes: ["notDraft"])
     @guard
     @can(ability: "view", resolved: true)

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -18,7 +18,7 @@ type Query {
   publishedPools(closingAfter: DateTime, publishingGroup: PublishingGroup): [Pool!]!
   pools: [Pool]!
   poolCandidate(id: UUID!): PoolCandidate
-  poolCandidates(includeIds: [ID]): [PoolCandidate]! @deprecated(reason: "poolCandidates is deprecated. Use poolCandidatesPaginated instead. Remove in #7656.")
+  poolCandidates(includeIds: [ID]!): [PoolCandidate]! @deprecated(reason: "poolCandidates is deprecated. Use poolCandidatesPaginated instead. Remove in #7656.")
   countPoolCandidatesByPool(where: ApplicantFilterInput): [CandidateSearchPoolResult!]!
   classification(id: UUID!): Classification
   classifications: [Classification]!

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/poolCandidatesOperations.graphql
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/poolCandidatesOperations.graphql
@@ -447,7 +447,7 @@ query getPoolCandidate($id: UUID!) {
   }
 }
 
-query GetSelectedPoolCandidates($ids: [ID]) {
+query GetSelectedPoolCandidates($ids: [ID]!) {
   poolCandidates(includeIds: $ids) {
     ...selectedPoolCandidates
   }


### PR DESCRIPTION
🤖 Resolves #8820 

## 👋 Introduction

Adds the marker to require a non-null input (array of something). 

## 🧪 Testing

1. Build unaffected
2. Can exercise the pool candidates table and nothing changed



