### PR TITLE
[Fix] "All skills" skill count in family select

### DIFF
--- a/apps/web/src/components/SkillBrowser/utils.ts
+++ b/apps/web/src/components/SkillBrowser/utils.ts
@@ -360,11 +360,6 @@ export const getFamilyOptions = (
   category?: SkillCategory | "all",
   inLibrary?: Skill[],
 ): Option[] => {
-  console.log({
-    full: skills.length,
-    category,
-    categoryLen: category ? getSkillCategorySkillCount(skills, category) : 0,
-  });
   let familyOptions = [
     {
       value: "all",

--- a/apps/web/src/components/SkillBrowser/utils.ts
+++ b/apps/web/src/components/SkillBrowser/utils.ts
@@ -299,7 +299,7 @@ export const getSkillFamilySkillCount = (
 
 export const getSkillCategorySkillCount = (
   skills: Skill[],
-  category: SkillCategory,
+  category: SkillCategory | "all",
 ): number => {
   const skillsByCategory = skills.filter(
     (skill) => skill.category === category,
@@ -357,9 +357,14 @@ export const getCategoryOptions = (
 export const getFamilyOptions = (
   skills: Skill[],
   intl: IntlShape,
-  category?: SkillCategory,
+  category?: SkillCategory | "all",
   inLibrary?: Skill[],
 ): Option[] => {
+  console.log({
+    full: skills.length,
+    category,
+    categoryLen: category ? getSkillCategorySkillCount(skills, category) : 0,
+  });
   let familyOptions = [
     {
       value: "all",
@@ -370,9 +375,10 @@ export const getFamilyOptions = (
           description: "Label for removing the skill family filter",
         },
         {
-          count: category
-            ? getSkillCategorySkillCount(skills, category)
-            : skills.length,
+          count:
+            category && category !== "all"
+              ? getSkillCategorySkillCount(skills, category)
+              : skills.length,
         },
       ),
     },


### PR DESCRIPTION
🤖 Resolves #8844 

## 👋 Introduction

Fixes the count being `0` when the "All categories" option is selected in the skill browser.

## 🕵️ Details

Not sure why typescript didn't catch this but it was because we passed in `"all"` as a skill category which caused the filter to occur. But, since "all" is not a category, it always showed `0`. 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/users/{userId}/personal-information/career-timeline/create`
3. Click the "Add a skill" button to invoke the dialog
4. Select "All categories" in the category dropdown
5. Confirm the "All skills" option in the skill family select indicates the full skill count
6. Select a different category
7. Confirm the "All skills" option in the skill family select indicates the same skill count as the category
8. Repeat steps 6-7 with the other category

## 📸 Screenshot

![Screenshot 2023-12-21 130602](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/db7a6d1a-3c25-4a50-a42a-4ffbbbf70722)
