### PR TITLE
[Debt] Add default max length to `Input`

### DIFF
--- a/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
@@ -34,15 +34,7 @@ const AwardFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.awardTitle}
             name="awardTitle"
             type="text"
-            rules={{
-              required: intl.formatMessage(errorMessages.required),
-              maxLength: {
-                message: intl.formatMessage(errorMessages.overCharacterLimit, {
-                  value: 256,
-                }),
-                value: 255,
-              },
-            }}
+            rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
@@ -76,15 +68,7 @@ const AwardFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.issuedBy}
             name="issuedBy"
             type="text"
-            rules={{
-              required: intl.formatMessage(errorMessages.required),
-              maxLength: {
-                message: intl.formatMessage(errorMessages.overCharacterLimit, {
-                  value: 256,
-                }),
-                value: 255,
-              },
-            }}
+            rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">

--- a/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
@@ -30,15 +30,7 @@ const CommunityFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.role}
             name="role"
             type="text"
-            rules={{
-              required: intl.formatMessage(errorMessages.required),
-              maxLength: {
-                message: intl.formatMessage(errorMessages.overCharacterLimit, {
-                  value: 256,
-                }),
-                value: 255,
-              },
-            }}
+            rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
@@ -61,15 +53,7 @@ const CommunityFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.organization}
             name="organization"
             type="text"
-            rules={{
-              required: intl.formatMessage(errorMessages.required),
-              maxLength: {
-                message: intl.formatMessage(errorMessages.overCharacterLimit, {
-                  value: 256,
-                }),
-                value: 255,
-              },
-            }}
+            rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
@@ -78,15 +62,7 @@ const CommunityFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.project}
             name="project"
             type="text"
-            rules={{
-              required: intl.formatMessage(errorMessages.required),
-              maxLength: {
-                message: intl.formatMessage(errorMessages.overCharacterLimit, {
-                  value: 256,
-                }),
-                value: 255,
-              },
-            }}
+            rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">

--- a/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
@@ -80,15 +80,7 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.areaOfStudy}
             name="areaOfStudy"
             type="text"
-            rules={{
-              required: intl.formatMessage(errorMessages.required),
-              maxLength: {
-                message: intl.formatMessage(errorMessages.overCharacterLimit, {
-                  value: 256,
-                }),
-                value: 255,
-              },
-            }}
+            rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
@@ -97,15 +89,7 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.institution}
             name="institution"
             type="text"
-            rules={{
-              required: intl.formatMessage(errorMessages.required),
-              maxLength: {
-                message: intl.formatMessage(errorMessages.overCharacterLimit, {
-                  value: 256,
-                }),
-                value: 255,
-              },
-            }}
+            rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
@@ -140,14 +124,7 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.thesisTitle}
             name="thesisTitle"
             type="text"
-            rules={{
-              maxLength: {
-                message: intl.formatMessage(errorMessages.overCharacterLimit, {
-                  value: 256,
-                }),
-                value: 255,
-              },
-            }}
+            rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">

--- a/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
@@ -124,7 +124,6 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.thesisTitle}
             name="thesisTitle"
             type="text"
-            rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">

--- a/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
@@ -45,15 +45,7 @@ const PersonalFields = ({ labels }: SubExperienceFormProps) => {
         label={labels.experienceTitle}
         name="experienceTitle"
         type="text"
-        rules={{
-          required: intl.formatMessage(errorMessages.required),
-          maxLength: {
-            message: intl.formatMessage(errorMessages.overCharacterLimit, {
-              value: 256,
-            }),
-            value: 255,
-          },
-        }}
+        rules={{ required: intl.formatMessage(errorMessages.required) }}
       />
       <TextArea
         id="experienceDescription"

--- a/apps/web/src/components/ExperienceFormFields/WorkFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields.tsx
@@ -57,13 +57,7 @@ const WorkFields = ({ labels }: SubExperienceFormProps) => {
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
-          <Input
-            id="team"
-            label={labels.team}
-            name="team"
-            type="text"
-            rules={{ required: intl.formatMessage(errorMessages.required) }}
-          />
+          <Input id="team" label={labels.team} name="team" type="text" />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
           <DateInput

--- a/apps/web/src/components/ExperienceFormFields/WorkFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields.tsx
@@ -30,15 +30,7 @@ const WorkFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.role}
             name="role"
             type="text"
-            rules={{
-              required: intl.formatMessage(errorMessages.required),
-              maxLength: {
-                message: intl.formatMessage(errorMessages.overCharacterLimit, {
-                  value: 256,
-                }),
-                value: 255,
-              },
-            }}
+            rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
@@ -61,15 +53,7 @@ const WorkFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.organization}
             name="organization"
             type="text"
-            rules={{
-              required: intl.formatMessage(errorMessages.required),
-              maxLength: {
-                message: intl.formatMessage(errorMessages.overCharacterLimit, {
-                  value: 256,
-                }),
-                value: 255,
-              },
-            }}
+            rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
@@ -78,14 +62,7 @@ const WorkFields = ({ labels }: SubExperienceFormProps) => {
             label={labels.team}
             name="team"
             type="text"
-            rules={{
-              maxLength: {
-                message: intl.formatMessage(errorMessages.overCharacterLimit, {
-                  value: 256,
-                }),
-                value: 255,
-              },
-            }}
+            rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">

--- a/packages/forms/src/components/Input/Input.tsx
+++ b/packages/forms/src/components/Input/Input.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 import get from "lodash/get";
 import { FieldError, useFormContext } from "react-hook-form";
+import { useIntl } from "react-intl";
+
+import { errorMessages } from "@gc-digital-talent/i18n";
 
 import Field from "../Field";
 import { CommonInputProps, HTMLInputProps } from "../../types";
@@ -31,6 +34,7 @@ const Input = ({
   trackUnsaved = true,
   ...rest
 }: InputProps) => {
+  const intl = useIntl();
   const {
     register,
     setValue,
@@ -75,6 +79,12 @@ const Input = ({
         {...baseStyles}
         {...stateStyles}
         {...register(name, {
+          maxLength: {
+            message: intl.formatMessage(errorMessages.overCharacterLimit, {
+              value: 256,
+            }),
+            value: 255,
+          },
           ...rules,
           onBlur: normalizeInput,
         })}


### PR DESCRIPTION
🤖 Resolves #8841 

## 👋 Introduction

Adds a default max length to the `<Input />` component.

## 🕵️ Details

The `<Input />` almost always maps to a `varchar(255)` in the database so setting this default max length seemed most logical. It can still be override using the `rules` prop where appropriate. 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to any form with an normal text, number, email, telephone, password or search input on it
3. Add more than 255 characters to the fields
4. Attempt to submit the form
5. Confirm you get the character limit error message
