### PR TITLE
[Feature] Add Playwright

### DIFF
--- a/apps/playwright/.eslintrc.js
+++ b/apps/playwright/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  root: true,
+  extends: ["plugin:playwright/recommended"],
+  ignorePatterns: ["tsconfig.json"]
+};

--- a/apps/playwright/.gitignore
+++ b/apps/playwright/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+.auth

--- a/apps/playwright/constants/auth.ts
+++ b/apps/playwright/constants/auth.ts
@@ -1,0 +1,7 @@
+export default {
+  SERVER_ROOT: "/oxauth",
+  STATE: {
+    ADMIN: ".auth/admin.json",
+    APPLICANT: ".auth/applicant.json",
+  },
+};

--- a/apps/playwright/fixtures/AdminPage.ts
+++ b/apps/playwright/fixtures/AdminPage.ts
@@ -31,12 +31,15 @@ export class AdminPage extends AppPage {
     const roleIds = allRoles
       .filter((role) => roles.includes(role.name))
       .map((role) => role.id);
-    return this.graphqlRequest(Test_UpdateUserRolesMutationDocument, {
-      userId,
-      roleAssignmentsInput: {
-        attach: {
-          roles: roleIds,
-          team,
+
+    await this.graphqlRequest(Test_UpdateUserRolesMutationDocument, {
+      updateUserRolesInput: {
+        userId,
+        roleAssignmentsInput: {
+          attach: {
+            roles: roleIds,
+            team,
+          },
         },
       },
     });

--- a/apps/playwright/fixtures/AdminPage.ts
+++ b/apps/playwright/fixtures/AdminPage.ts
@@ -1,0 +1,13 @@
+import { type Page } from "@playwright/test";
+import { AppPage } from "./AppPage";
+
+/**
+ * Admin Page
+ *
+ * Page containing an admin user context from global setup
+ */
+export class AdminPage extends AppPage {
+  constructor(page: Page) {
+    super(page);
+  }
+}

--- a/apps/playwright/fixtures/AppPage.ts
+++ b/apps/playwright/fixtures/AppPage.ts
@@ -1,13 +1,15 @@
 import { type Page } from "@playwright/test";
 
+import { Test_MeQueryDocument } from "~/utils/user";
+
+/**
+ * App Page
+ *
+ * Common functionality, extended by other pages
+ */
 export class AppPage {
   constructor(public readonly page: Page) {}
 
-  /**
-   * Go to the homepage
-   *
-   * Common operation on all pages
-   */
   async gotoHome() {
     await this.page.goto("/");
   }
@@ -54,5 +56,11 @@ export class AppPage {
 
       return isGraphql && isOperation;
     });
+  }
+
+  async getMe() {
+    const res = await this.graphqlRequest(Test_MeQueryDocument);
+
+    return res.me;
   }
 }

--- a/apps/playwright/fixtures/AppPage.ts
+++ b/apps/playwright/fixtures/AppPage.ts
@@ -1,0 +1,49 @@
+import { type Page } from "@playwright/test";
+
+export class AppPage {
+  constructor(public readonly page: Page) {}
+
+  /**
+   * GraphQL Request
+   *
+   * Make a GraphQL request using the current page context
+   *
+   * @param query
+   * @param variables
+   * @returns
+   */
+  async graphqlRequest(query: string, variables?: Record<string, unknown>) {
+    const res = await this.page.request.post("/graphql", {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      data: {
+        query,
+        variables,
+      },
+    });
+
+    const json = await res.json();
+
+    return json.data;
+  }
+
+  /**
+   * Wait for as specific GraphQL Response by operation name
+
+   * @param operationName
+   */
+  async waitForGraphqlResponse(operationName: string) {
+    await this.page.waitForResponse(async (resp) => {
+      let isOperation: boolean = false;
+      const isGraphql = await resp.url().includes("/graphql");
+
+      if (isGraphql) {
+        const body = await resp.text();
+        isOperation = body.includes(operationName);
+      }
+
+      return isGraphql && isOperation;
+    });
+  }
+}

--- a/apps/playwright/fixtures/AppPage.ts
+++ b/apps/playwright/fixtures/AppPage.ts
@@ -4,6 +4,15 @@ export class AppPage {
   constructor(public readonly page: Page) {}
 
   /**
+   * Go to the homepage
+   *
+   * Common operation on all pages
+   */
+  async gotoHome() {
+    await this.page.goto("/");
+  }
+
+  /**
    * GraphQL Request
    *
    * Make a GraphQL request using the current page context

--- a/apps/playwright/fixtures/AppPage.ts
+++ b/apps/playwright/fixtures/AppPage.ts
@@ -10,8 +10,8 @@ import { Test_MeQueryDocument } from "~/utils/user";
 export class AppPage {
   constructor(public readonly page: Page) {}
 
-  async gotoHome() {
-    await this.page.goto("/");
+  async gotoHome(locale: "en" | "fr" = "en") {
+    await this.page.goto(`${locale}`);
   }
 
   /**
@@ -46,15 +46,12 @@ export class AppPage {
    */
   async waitForGraphqlResponse(operationName: string) {
     await this.page.waitForResponse(async (resp) => {
-      let isOperation: boolean = false;
-      const isGraphql = await resp.url().includes("/graphql");
-
-      if (isGraphql) {
-        const body = await resp.text();
-        isOperation = body.includes(operationName);
+      if (await resp.url()?.includes("/graphql")) {
+        const reqJson = await resp.request()?.postDataJSON();
+        return reqJson.operationName === operationName;
       }
 
-      return isGraphql && isOperation;
+      return false;
     });
   }
 

--- a/apps/playwright/fixtures/ApplicantPage.ts
+++ b/apps/playwright/fixtures/ApplicantPage.ts
@@ -1,0 +1,13 @@
+import { type Page } from "@playwright/test";
+import { AppPage } from "./AppPage";
+
+/**
+ * Applicant Page
+ *
+ * Page containing an applicant user context from global setup
+ */
+export class ApplicantPage extends AppPage {
+  constructor(public readonly page: Page) {
+    super(page);
+  }
+}

--- a/apps/playwright/fixtures/ApplicationPage.ts
+++ b/apps/playwright/fixtures/ApplicationPage.ts
@@ -1,0 +1,111 @@
+import { type Page } from "@playwright/test";
+
+import { AppPage } from "./AppPage";
+
+/**
+ * Application Page
+ *
+ * Page containing a utilities to interact with applications
+ */
+export class ApplicationPage extends AppPage {
+  public readonly poolId: string;
+
+  constructor(page: Page, poolId: string) {
+    super(page);
+
+    this.poolId = poolId;
+  }
+
+  /** Start application */
+  async create() {
+    await this.page.goto("/en/browse/pools");
+    await this.waitForGraphqlResponse("browsePools");
+
+    await this.page.locator(`a[href*="${this.poolId}"]`).click();
+    await this.waitForGraphqlResponse("getPool");
+
+    await this.page
+      .getByRole("link", { name: /apply for this process/i })
+      .first()
+      .click();
+  }
+
+  async saveAndContinue() {
+    await this.page.getByRole("button", { name: /save and continue/i }).click();
+  }
+
+  async addExperience() {
+    await this.page
+      .getByRole("combobox", { name: /experience type/i })
+      .selectOption({ label: "Education and certificates" });
+
+    await this.page
+      .getByRole("combobox", { name: /type of education/i })
+      .selectOption({ label: "Certification" });
+
+    await this.page
+      .getByRole("textbox", { name: /area of study/i })
+      .fill("QA Testing");
+
+    await this.page
+      .getByRole("textbox", { name: /institution/i })
+      .fill("Playwright University");
+
+    const startDate = await this.page.getByRole("group", {
+      name: /start date/i,
+    });
+
+    await startDate.getByRole("spinbutton", { name: /year/i }).fill("2001");
+    await startDate
+      .getByRole("combobox", { name: /month/i })
+      .selectOption("01");
+
+    const endDate = await this.page.getByRole("group", {
+      name: /end date/i,
+    });
+
+    await endDate.getByRole("spinbutton", { name: /year/i }).fill("2001");
+    await endDate.getByRole("combobox", { name: /month/i }).selectOption("02");
+
+    await this.page
+      .getByRole("combobox", { name: /status/i })
+      .selectOption({ label: "Successful Completion (Credential Awarded)" });
+
+    await this.page
+      .getByRole("textbox", { name: /additional details/i })
+      .fill("Mastering Playwright");
+
+    await this.page.getByRole("button", { name: /save and go back/i }).click();
+    await this.waitForGraphqlResponse("CreateEducationExperience");
+  }
+
+  async connectExperience(experienceName: string) {
+    await this.page
+      .getByRole("combobox", { name: /select an experience/i })
+      .selectOption({ label: experienceName });
+
+    await this.page
+      .getByRole("textbox", { name: /describe how you used this skill/i })
+      .fill("Riveting justification.");
+
+    await this.page
+      .getByRole("button", { name: /add this experience/i })
+      .click();
+  }
+
+  async answerQuestion(question: number) {
+    await this.page
+      .getByRole("textbox", {
+        name: new RegExp(`answer to question ${question}`, "i"),
+      })
+      .fill(`Definitely not getting screened out response ${question}.`);
+  }
+
+  async submit() {
+    this.page
+      .getByRole("textbox", { name: /your full name/i })
+      .fill("Signature");
+
+    this.page.getByRole("button", { name: /submit my application/i }).click();
+  }
+}

--- a/apps/playwright/fixtures/PoolPage.ts
+++ b/apps/playwright/fixtures/PoolPage.ts
@@ -1,0 +1,58 @@
+import { type Page } from "@playwright/test";
+
+import {
+  CreatePoolInput,
+  Pool,
+  UpdatePoolInput,
+} from "@gc-digital-talent/graphql";
+
+import {
+  Test_CreatePoolMutationDocument,
+  Test_PublishPoolMutationDocument,
+  Test_UpdatePoolMutationDocument,
+} from "~/utils/pools";
+import { GraphQLResponse } from "~/utils/graphql";
+
+import { AppPage } from "./AppPage";
+
+/**
+ * Pool Page
+ *
+ * Page containing an admin user context from global setup
+ */
+export class PoolPage extends AppPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async gotoIndex() {
+    await this.page.goto("/admin/pools");
+  }
+
+  async createPool(
+    userId: string,
+    teamId: string,
+    pool: CreatePoolInput,
+  ): Promise<Pool> {
+    return this.graphqlRequest(Test_CreatePoolMutationDocument, {
+      userId,
+      teamId,
+      pool,
+    }).then((res: GraphQLResponse<"createPool", Pool>) => res.createPool);
+  }
+
+  async updatePool(poolId: string, pool: UpdatePoolInput): Promise<Pool> {
+    return this.graphqlRequest(Test_UpdatePoolMutationDocument, {
+      poolId,
+      pool,
+    }).then((res: GraphQLResponse<"updatePool", Pool>) => {
+      return res.updatePool;
+    });
+  }
+
+  async publishPool(poolId: string): Promise<Pool> {
+    return this.graphqlRequest(Test_PublishPoolMutationDocument, {
+      id: poolId,
+    }).then((res: GraphQLResponse<"publishPool", Pool>) => res.publishPool);
+  }
+}

--- a/apps/playwright/fixtures/PoolPage.ts
+++ b/apps/playwright/fixtures/PoolPage.ts
@@ -18,7 +18,7 @@ import { AppPage } from "./AppPage";
 /**
  * Pool Page
  *
- * Page containing an admin user context from global setup
+ * Page containing utilities for interacting with pools
  */
 export class PoolPage extends AppPage {
   constructor(page: Page) {

--- a/apps/playwright/fixtures/index.ts
+++ b/apps/playwright/fixtures/index.ts
@@ -1,0 +1,43 @@
+import { test as base } from "@playwright/test";
+
+import auth from "~/constants/auth";
+
+import { AppPage } from "./AppPage";
+import { AdminPage } from "./AdminPage";
+import { ApplicantPage } from "./ApplicantPage";
+
+type AppFixtures = {
+  // Base unauthenticated page
+  appPage: AppPage;
+  // Authenticated as admin page
+  adminPage: AdminPage;
+  // Authenticated as applicant page
+  applicantPage: ApplicantPage;
+};
+
+// Extend base text with our fixtures
+export const test = base.extend<AppFixtures>({
+  appPage: async ({ page }, use) => {
+    const app = new AppPage(page);
+    await use(app);
+  },
+
+  adminPage: async ({ browser }, use) => {
+    const context = await browser.newContext({
+      storageState: auth.STATE.ADMIN,
+    });
+    const admin = new AdminPage(await context.newPage());
+    await use(admin);
+    await context.close();
+  },
+
+  applicantPage: async ({ browser }, use) => {
+    const context = await browser.newContext({
+      storageState: auth.STATE.APPLICANT,
+    });
+    const admin = new ApplicantPage(await context.newPage());
+    await use(admin);
+    await context.close();
+  },
+});
+export { expect } from "@playwright/test";

--- a/apps/playwright/global.setup.ts
+++ b/apps/playwright/global.setup.ts
@@ -1,0 +1,14 @@
+import { Page, test as setup } from "@playwright/test";
+
+import auth from "~/constants/auth";
+import { loginByEmail } from "~/utils/auth";
+
+setup("authenticate as admin", async ({ page }) => {
+  loginByEmail(page, "admin@test.com");
+  await page.context().storageState({ path: auth.STATE.ADMIN });
+});
+
+setup("authenticate as admin", async ({ page }) => {
+  loginByEmail(page, "applicant@test.com");
+  await page.context().storageState({ path: auth.STATE.APPLICANT });
+});

--- a/apps/playwright/global.setup.ts
+++ b/apps/playwright/global.setup.ts
@@ -4,11 +4,11 @@ import auth from "~/constants/auth";
 import { loginByEmail } from "~/utils/auth";
 
 setup("authenticate as admin", async ({ page }) => {
-  loginByEmail(page, "admin@test.com");
+  await loginByEmail(page, "admin@test.com");
   await page.context().storageState({ path: auth.STATE.ADMIN });
 });
 
-setup("authenticate as admin", async ({ page }) => {
-  loginByEmail(page, "applicant@test.com");
+setup("authenticate as applicant", async ({ page }) => {
+  await loginByEmail(page, "applicant@test.com");
   await page.context().storageState({ path: auth.STATE.APPLICANT });
 });

--- a/apps/playwright/global.setup.ts
+++ b/apps/playwright/global.setup.ts
@@ -1,14 +1,14 @@
 import { Page, test as setup } from "@playwright/test";
 
 import auth from "~/constants/auth";
-import { loginByEmail } from "~/utils/auth";
+import { loginBySub } from "~/utils/auth";
 
 setup("authenticate as admin", async ({ page }) => {
-  await loginByEmail(page, "admin@test.com");
+  await loginBySub(page, "admin@test.com");
   await page.context().storageState({ path: auth.STATE.ADMIN });
 });
 
 setup("authenticate as applicant", async ({ page }) => {
-  await loginByEmail(page, "applicant@test.com");
+  await loginBySub(page, "applicant@test.com");
   await page.context().storageState({ path: auth.STATE.APPLICANT });
 });

--- a/apps/playwright/package.json
+++ b/apps/playwright/package.json
@@ -5,9 +5,10 @@
   "main": "index.js",
   "license": "ISC",
   "scripts": {
-    "e2e:playwright": "npx playwright test"
+    "e2e:playwright": "npx playwright test application.spec.ts"
   },
   "devDependencies": {
+    "@gc-digital-talent/date-helpers": "*",
     "@gc-digital-talent/graphql": "*",
     "@playwright/test": "^1.40.1",
     "@types/node": "^20.10.5",

--- a/apps/playwright/package.json
+++ b/apps/playwright/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@gc-digital-talent/playwright",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "license": "ISC",
+  "scripts": {
+    "e2e:playwright": "npx playwright test"
+  },
+  "devDependencies": {
+    "@gc-digital-talent/graphql": "*",
+    "@playwright/test": "^1.40.1",
+    "@types/node": "^20.10.5",
+    "eslint-plugin-playwright": "^0.20.0"
+  }
+}

--- a/apps/playwright/package.json
+++ b/apps/playwright/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "license": "ISC",
   "scripts": {
-    "e2e:playwright": "npx playwright test application.spec.ts"
+    "e2e:playwright": "npx playwright test"
   },
   "devDependencies": {
     "@gc-digital-talent/date-helpers": "*",

--- a/apps/playwright/playwright.config.ts
+++ b/apps/playwright/playwright.config.ts
@@ -34,7 +34,8 @@ export default defineConfig({
   projects: [
     {
       name: "setup",
-      testMatch: /..\/global.setup\.ts/,
+      testDir: ".",
+      testMatch: /global.setup\.ts/,
     },
 
     {

--- a/apps/playwright/playwright.config.ts
+++ b/apps/playwright/playwright.config.ts
@@ -1,0 +1,85 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./tests",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: "http://localhost:8000",
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "setup",
+      testMatch: /..\/global.setup\.ts/,
+    },
+
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+      dependencies: ["setup"],
+    },
+
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+      dependencies: ["setup"],
+    },
+
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+      dependencies: ["setup"],
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/apps/playwright/tests/admin/auth.spec.ts
+++ b/apps/playwright/tests/admin/auth.spec.ts
@@ -1,53 +1,166 @@
 import { Page } from "@playwright/test";
 
 import { test, expect } from "~/fixtures";
-import auth from "../../constants/auth";
+import auth from "~/constants/auth";
+import { getAuthCookies, getAuthTokens, AuthCookies } from "~/utils/auth";
 
-const onLoginInfoPage = async (page: Page) => {
-  await page.waitForURL("**/login-info*");
-  await expect(page.url()).toContain("/en/login-info");
-};
+function expectAuthCookies(cookies: AuthCookies) {
+  expect(cookies).toEqual(
+    expect.objectContaining({
+      apiSession: expect.objectContaining({ name: "api_session" }),
+      xsrf: expect.objectContaining({ name: "XSRF-TOKEN" }),
+    }),
+  );
+}
 
-test.describe("Auth flows (development)", () => {
-  test.describe("Anonymous user", () => {
-    test("redirects restricted pages to sign in", async ({ browser }) => {
-      const pages = [
-        "/en/admin/dashboard",
-        "/en/admin/talent-requests",
-        "/en/admin/users",
-        "/en/admin/settings/classifications",
-        "/en/admin/pools",
-        "/en/admin/settings/departments",
-        "/en/admin/settings/skills",
-        "/en/admin/settings/skills/families",
-      ];
+const restrictedPaths = [
+  "/en/admin/dashboard",
+  "/en/admin/talent-requests",
+  "/en/admin/users",
+  "/en/admin/settings/classifications",
+  "/en/admin/pools",
+  "/en/admin/settings/departments",
+  "/en/admin/settings/skills",
+  "/en/admin/settings/skills/families",
+];
 
+test.describe("Anonymous user", () => {
+  test("Redirects restricted pages to sign in", async ({ browser }) => {
+    await Promise.all(
+      restrictedPaths.map(async (restrictedPath) => {
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        await page.goto(restrictedPath);
+        await page.waitForURL("**/login-info*");
+        await expect(page.url()).toContain("/en/login-info");
+      }),
+    );
+  });
+
+  test("Redirects app login page to auth login page", async ({ page }) => {
+    await page.goto("/login");
+    await page.waitForURL(`**${auth.SERVER_ROOT}/authorize*`);
+    await expect(page.url()).toContain(auth.SERVER_ROOT + "/authorize");
+  });
+
+  test("Does not have tokens", async ({ appPage }) => {
+    await appPage.gotoHome();
+    const tokens = await getAuthTokens(appPage.page);
+
+    expect(tokens.idToken).toBeNull();
+    expect(tokens.accessToken).toBeNull();
+    expect(tokens.refreshToken).toBeNull();
+  });
+
+  test("Does not have cookies", async ({ appPage }) => {
+    await appPage.gotoHome();
+    const { apiSession, xsrf } = await getAuthCookies(appPage.page);
+
+    expect(apiSession).toBeUndefined();
+    expect(xsrf).toBeUndefined();
+  });
+
+  test("Sets cookies on login redirect", async ({ request, page }) => {
+    let cookies = await getAuthCookies(page);
+
+    expect(cookies.apiSession).toBeUndefined();
+    expect(cookies.xsrf).toBeUndefined();
+
+    await page.goto("/login");
+    cookies = await getAuthCookies(page);
+    expectAuthCookies(cookies);
+  });
+});
+
+test.describe("Authenticated", () => {
+  test("Has tokens", async ({ applicantPage }) => {
+    await applicantPage.gotoHome();
+    const tokens = await getAuthTokens(applicantPage.page);
+
+    expect(tokens).toEqual(
+      expect.objectContaining({
+        idToken: expect.any(String),
+        accessToken: expect.any(String),
+        refreshToken: expect.any(String),
+      }),
+    );
+  });
+
+  test("Has cookies", async ({ applicantPage }) => {
+    await applicantPage.gotoHome();
+    const cookies = await getAuthCookies(applicantPage.page);
+
+    expectAuthCookies(cookies);
+  });
+
+  test("Can logout", async ({ applicantPage }) => {
+    await applicantPage.gotoHome();
+    await applicantPage.page.getByRole("button", { name: /sign out/i }).click();
+    const logoutDialog = await applicantPage.page.getByRole("alertdialog", {
+      name: /sign out/i,
+    });
+
+    await logoutDialog.getByRole("button", { name: /sign out/i }).click();
+    await applicantPage.page.waitForLoadState("networkidle");
+    await applicantPage.page.waitForURL("**/logged-out");
+
+    const tokens = await getAuthTokens(applicantPage.page);
+
+    expect(tokens.idToken).toBeNull();
+    expect(tokens.accessToken).toBeNull();
+    expect(tokens.refreshToken).toBeNull();
+
+    await expect(
+      applicantPage.page.getByRole("link", { name: /sign in/i }),
+    ).toBeVisible();
+  });
+
+  test.describe("Admin user", () => {
+    test("Can access restricted paths", async ({ adminPage }) => {
       await Promise.all(
-        pages.map(async (restrictedPath) => {
-          const context = await browser.newContext();
+        restrictedPaths.map(async (restrictedPath) => {
+          const context = await adminPage.page.context();
           const page = await context.newPage();
           await page.goto(restrictedPath);
-          await onLoginInfoPage(page);
+          await expect(page.url()).toContain(restrictedPath);
+          await expect(
+            page.getByRole("heading", {
+              name: "Sorry, you are not authorized to view this page.",
+            }),
+          ).not.toBeVisible();
         }),
       );
     });
-
-    test("redirects app login page to auth login page", async ({ page }) => {
-      await page.goto("/login");
-      await page.waitForURL(`**${auth.SERVER_ROOT}/authorize*`);
-      await expect(page.url()).toContain(auth.SERVER_ROOT + "/authorize");
-    });
   });
 
-  test.describe("Login", () => {
-    test("succeeds for an existing admin user", async ({ adminPage }) => {
-      await adminPage.page.goto("/admin");
-      await adminPage.waitForGraphqlResponse("myAuth");
-      await expect(
-        adminPage.page.getByRole("heading", {
-          name: /welcome back, admin test/i,
+  test.describe("Applicant user", () => {
+    test("Cannot access restricted paths", async ({ applicantPage }) => {
+      await Promise.all(
+        restrictedPaths.map(async (restrictedPath) => {
+          const context = await applicantPage.page.context();
+          const page = await context.newPage();
+          await page.goto(restrictedPath);
+          await expect(page.url()).toContain(restrictedPath);
+          await page.waitForLoadState("networkidle");
+          await expect(
+            page.getByRole("heading", {
+              name: "Sorry, you are not authorized to view this page.",
+            }),
+          ).toBeVisible();
         }),
-      ).toBeVisible();
+      );
     });
+  });
+});
+
+test.describe("Login", () => {
+  test("succeeds for an existing admin user", async ({ adminPage }) => {
+    await adminPage.page.goto("/admin");
+    await adminPage.waitForGraphqlResponse("myAuth");
+    await expect(
+      adminPage.page.getByRole("heading", {
+        name: /welcome back, admin test/i,
+      }),
+    ).toBeVisible();
   });
 });

--- a/apps/playwright/tests/admin/auth.spec.ts
+++ b/apps/playwright/tests/admin/auth.spec.ts
@@ -102,7 +102,7 @@ test.describe("Authenticated", () => {
 
     await logoutDialog.getByRole("button", { name: /sign out/i }).click();
     await applicantPage.page.waitForLoadState("networkidle");
-    await applicantPage.page.waitForURL("**/logged-out");
+    await applicantPage.page.waitForURL("**/en/logged-out");
 
     const tokens = await getAuthTokens(applicantPage.page);
 
@@ -122,7 +122,6 @@ test.describe("Authenticated", () => {
           const context = await adminPage.page.context();
           const page = await context.newPage();
           await page.goto(restrictedPath);
-          await expect(page.url()).toContain(restrictedPath);
           await expect(
             page.getByRole("heading", {
               name: "Sorry, you are not authorized to view this page.",
@@ -140,7 +139,6 @@ test.describe("Authenticated", () => {
           const context = await applicantPage.page.context();
           const page = await context.newPage();
           await page.goto(restrictedPath);
-          await expect(page.url()).toContain(restrictedPath);
           await page.waitForLoadState("networkidle");
           await expect(
             page.getByRole("heading", {
@@ -156,7 +154,7 @@ test.describe("Authenticated", () => {
 test.describe("Login", () => {
   test("succeeds for an existing admin user", async ({ adminPage }) => {
     await adminPage.page.goto("/admin");
-    await adminPage.waitForGraphqlResponse("myAuth");
+    await adminPage.waitForGraphqlResponse("AdminDashboard_Query");
     await expect(
       adminPage.page.getByRole("heading", {
         name: /welcome back, admin test/i,

--- a/apps/playwright/tests/admin/auth.spec.ts
+++ b/apps/playwright/tests/admin/auth.spec.ts
@@ -1,0 +1,53 @@
+import { Page } from "@playwright/test";
+
+import { test, expect } from "~/fixtures";
+import auth from "../../constants/auth";
+
+const onLoginInfoPage = async (page: Page) => {
+  await page.waitForURL("**/login-info*");
+  await expect(page.url()).toContain("/en/login-info");
+};
+
+test.describe("Auth flows (development)", () => {
+  test.describe("Anonymous user", () => {
+    test("redirects restricted pages to sign in", async ({ browser }) => {
+      const pages = [
+        "/en/admin/dashboard",
+        "/en/admin/talent-requests",
+        "/en/admin/users",
+        "/en/admin/settings/classifications",
+        "/en/admin/pools",
+        "/en/admin/settings/departments",
+        "/en/admin/settings/skills",
+        "/en/admin/settings/skills/families",
+      ];
+
+      await Promise.all(
+        pages.map(async (restrictedPath) => {
+          const context = await browser.newContext();
+          const page = await context.newPage();
+          await page.goto(restrictedPath);
+          await onLoginInfoPage(page);
+        }),
+      );
+    });
+
+    test("redirects app login page to auth login page", async ({ page }) => {
+      await page.goto("/login");
+      await page.waitForURL(`**${auth.SERVER_ROOT}/authorize*`);
+      await expect(page.url()).toContain(auth.SERVER_ROOT + "/authorize");
+    });
+  });
+
+  test.describe("Login", () => {
+    test("succeeds for an existing admin user", async ({ adminPage }) => {
+      await adminPage.page.goto("/admin");
+      await adminPage.waitForGraphqlResponse("myAuth");
+      await expect(
+        adminPage.page.getByRole("heading", {
+          name: /welcome back, admin test/i,
+        }),
+      ).toBeVisible();
+    });
+  });
+});

--- a/apps/playwright/tests/applicant/application.spec.ts
+++ b/apps/playwright/tests/applicant/application.spec.ts
@@ -1,0 +1,119 @@
+import {
+  ArmedForcesStatus,
+  CitizenshipStatus,
+  Pool,
+  PoolLanguage,
+  PoolStream,
+  PositionDuration,
+  ProvinceOrTerritory,
+  PublishingGroup,
+  SecurityStatus,
+  Skill,
+  SkillCategory,
+  User,
+  WorkRegion,
+} from "@gc-digital-talent/graphql";
+import { FAR_FUTURE_DATE } from "@gc-digital-talent/date-helpers";
+
+import { test } from "~/fixtures";
+import { getSkills } from "~/utils/skills";
+import { getDCM } from "~/utils/team";
+import { getClassifications } from "~/utils/classification";
+import { loginByEmail } from "~/utils/auth";
+import { PoolPage } from "~/fixtures/PoolPage";
+
+test.describe("Application", () => {
+  const uniqueTestId = Date.now().valueOf();
+  let pool: Pool;
+  let user: User;
+
+  test.beforeAll(async ({ adminPage }) => {
+    const poolPage = new PoolPage(adminPage.page);
+    const skills = await getSkills();
+    await adminPage
+      .createUser({
+        email: `cypress.user.${uniqueTestId}@example.org`,
+        sub: `cypress.sub.${uniqueTestId}`,
+        currentProvince: ProvinceOrTerritory.Ontario,
+        currentCity: "Test City",
+        telephone: "+10123456789",
+        armedForcesStatus: ArmedForcesStatus.NonCaf,
+        citizenship: CitizenshipStatus.Citizen,
+        lookingForEnglish: true,
+        isGovEmployee: false,
+        hasPriorityEntitlement: false,
+        locationPreferences: [WorkRegion.Ontario],
+        positionDuration: [PositionDuration.Permanent],
+      })
+      .then(async (u) => {
+        user = u;
+        await adminPage.addRolesToUser(u.id, [
+          "guest",
+          "base_user",
+          "applicant",
+        ]);
+
+        const team = await getDCM();
+        const classifications = await getClassifications();
+
+        await poolPage
+          .createPool(user.id, team.id, {
+            classifications: {
+              sync: [classifications[0].id],
+            },
+          })
+          .then(async (p) => {
+            pool = p;
+            await poolPage
+              .updatePool(p.id, {
+                name: {
+                  en: "Cypress Test Pool EN",
+                  fr: "Cypress Test Pool FR",
+                },
+                stream: PoolStream.BusinessAdvisoryServices,
+                closingDate: `${FAR_FUTURE_DATE} 00:00:00`,
+                yourImpact: {
+                  en: "test impact EN",
+                  fr: "test impact FR",
+                },
+                keyTasks: { en: "key task EN", fr: "key task FR" },
+                essentialSkills: {
+                  sync: [
+                    skills.find(
+                      (skill) => skill.category === SkillCategory.Technical,
+                    ).id,
+                  ],
+                },
+                language: PoolLanguage.Various,
+                securityClearance: SecurityStatus.Secret,
+                location: {
+                  en: "test location EN",
+                  fr: "test location FR",
+                },
+                isRemote: true,
+                publishingGroup: PublishingGroup.ItJobs,
+                screeningQuestions: {
+                  create: [
+                    {
+                      question: { en: "Question EN", fr: "Question FR" },
+                      sortOrder: 1,
+                    },
+                  ],
+                },
+              })
+              .then(async (pool) => {
+                await poolPage.publishPool(pool.id);
+              });
+          });
+      });
+  });
+
+  test("Can submit application", async ({ appPage }) => {
+    await loginByEmail(appPage.page, user.email);
+
+    await appPage.page.goto("/en/browse/pools");
+    await appPage.waitForGraphqlResponse("publishedPools");
+
+    await appPage.page.locator(`a[href*="${pool.id}"]`).click();
+  });
+});

--- a/apps/playwright/tests/applicant/application.spec.ts
+++ b/apps/playwright/tests/applicant/application.spec.ts
@@ -1,3 +1,4 @@
+import { Page } from "@playwright/test";
 import {
   ArmedForcesStatus,
   CitizenshipStatus,
@@ -8,32 +9,43 @@ import {
   ProvinceOrTerritory,
   PublishingGroup,
   SecurityStatus,
-  Skill,
   SkillCategory,
   User,
   WorkRegion,
 } from "@gc-digital-talent/graphql";
 import { FAR_FUTURE_DATE } from "@gc-digital-talent/date-helpers";
 
-import { test } from "~/fixtures";
+import { test, expect } from "~/fixtures";
 import { getSkills } from "~/utils/skills";
 import { getDCM } from "~/utils/team";
 import { getClassifications } from "~/utils/classification";
-import { loginByEmail } from "~/utils/auth";
+import { loginBySub } from "~/utils/auth";
 import { PoolPage } from "~/fixtures/PoolPage";
+import { ApplicationPage } from "~/fixtures/ApplicationPage";
 
 test.describe("Application", () => {
   const uniqueTestId = Date.now().valueOf();
+  const sub = `playwright.sub.${uniqueTestId}`;
   let pool: Pool;
   let user: User;
+
+  async function expectOnStep(page: Page, step: number) {
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`step ${step} of 7`, "i") }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByText(/uh oh, it looks like you jumped ahead!/i),
+    ).not.toBeVisible();
+  }
 
   test.beforeAll(async ({ adminPage }) => {
     const poolPage = new PoolPage(adminPage.page);
     const skills = await getSkills();
     await adminPage
       .createUser({
-        email: `cypress.user.${uniqueTestId}@example.org`,
-        sub: `cypress.sub.${uniqueTestId}`,
+        email: `${sub}@example.org`,
+        sub,
         currentProvince: ProvinceOrTerritory.Ontario,
         currentCity: "Test City",
         telephone: "+10123456789",
@@ -67,8 +79,8 @@ test.describe("Application", () => {
             await poolPage
               .updatePool(p.id, {
                 name: {
-                  en: "Cypress Test Pool EN",
-                  fr: "Cypress Test Pool FR",
+                  en: "Playwright Test Pool EN",
+                  fr: "Playwright Test Pool FR",
                 },
                 stream: PoolStream.BusinessAdvisoryServices,
                 closingDate: `${FAR_FUTURE_DATE} 00:00:00`,
@@ -109,11 +121,167 @@ test.describe("Application", () => {
   });
 
   test("Can submit application", async ({ appPage }) => {
-    await loginByEmail(appPage.page, user.email);
+    const application = new ApplicationPage(appPage.page, pool.id);
+    await loginBySub(application.page, sub);
 
-    await appPage.page.goto("/en/browse/pools");
-    await appPage.waitForGraphqlResponse("publishedPools");
+    await application.create();
 
-    await appPage.page.locator(`a[href*="${pool.id}"]`).click();
+    // Welcome page - step one
+    await expectOnStep(application.page, 1);
+    await application.page.getByRole("button", { name: /let's go/i }).click();
+    //await application.waitForGraphqlResponse("Application");
+
+    // Review profile page - step two
+    await expectOnStep(application.page, 2);
+    await application.saveAndContinue();
+    await application.waitForGraphqlResponse("Application");
+
+    // Review career timeline page - step three
+    await expectOnStep(application.page, 3);
+
+    // Attempt skipping to review
+    const currentUrl = await application.page.url();
+    const hackedUrl = currentUrl.replace(
+      "career-timeline/introduction",
+      "review",
+    );
+    await application.page.goto(hackedUrl);
+    await expect(
+      application.page.getByText(/uh oh, it looks like you jumped ahead!/i),
+    ).toBeVisible();
+    await application.page
+      .getByRole("link", { name: /return to the last step i was working on/i })
+      .click();
+    await expectOnStep(application.page, 3);
+    await expect(
+      application.page.getByRole("heading", {
+        name: /create your career timeline/i,
+      }),
+    ).toBeVisible();
+    // can't skip with the stepper
+    await expect(
+      application.page.getByRole("link", { name: /review and submit/i }),
+    ).toBeDisabled();
+
+    // Quit trying to skip and continue step three honestly
+    await expect(
+      application.page.getByText(
+        /you don’t have any career timeline experiences yet./i,
+      ),
+    ).toBeVisible();
+    await application.saveAndContinue();
+    // Expect error when no experiences added
+    await expect(application.page.getByRole("alert")).toContainText(
+      /please add at least one experience/i,
+    );
+
+    // Add an experience
+    await application.page
+      .getByRole("link", { name: /add a new experience/i })
+      .click();
+    await expect(application.page.url()).toContain("/career-timeline/add");
+    await application.addExperience();
+    await expect(application.page.getByRole("alert")).toContainText(
+      /successfully added experience!/i,
+    );
+    await expect(
+      application.page.getByText("1 education and certificate experience"),
+    ).toBeVisible();
+    await application.saveAndContinue();
+    await application.waitForGraphqlResponse("Application");
+
+    // Education experience page - step four
+    await expectOnStep(application.page, 4);
+    await application.saveAndContinue();
+    await expect(
+      application.page.getByText(/this field is required/i),
+    ).toBeVisible();
+    await application.page
+      .getByRole("radio", { name: /i meet the 2-year post-secondary option/i })
+      .click();
+    await application.page
+      .getByRole("checkbox", { name: /qa testing at playwright university/i })
+      .click();
+    await application.saveAndContinue();
+
+    // Skills requirement page - step five
+    await expectOnStep(application.page, 5);
+    await application.page
+      .getByRole("link", { name: /let's get to it/i })
+      .click();
+    await expect(
+      application.page.getByText(
+        /this required skill must have at least 1 career timeline experience associated with it/i,
+      ),
+    ).toBeVisible();
+    await application.saveAndContinue();
+    await expect(
+      application.page.getByText(
+        /please connect at least one career timeline experience to each required technical skill/i,
+      ),
+    ).toBeVisible();
+    await application.page
+      .getByRole("button", { name: /connect a career timeline experience/i })
+      .first()
+      .click();
+    await application.connectExperience("QA Testing at Playwright University");
+    await await expect(
+      application.page.getByText(
+        /please connect at least one career timeline experience to each required technical skill and ensure each skill has details about how you used it/i,
+      ),
+    ).not.toBeVisible();
+    await application.saveAndContinue();
+
+    // Screening questions page - step six
+    await expectOnStep(application.page, 6);
+    await application.page.getByRole("link", { name: /i'm ready/i }).click();
+    await application.saveAndContinue();
+    await expect(
+      application.page.getByText(/this field is required/i),
+    ).toBeVisible();
+    await application.answerQuestion(1);
+    await application.saveAndContinue();
+
+    // Review page - step seven
+    await expectOnStep(application.page, 7);
+    // Screening question response
+    await expect(
+      application.page.getByText(
+        /definitely not getting screened out response 1/i,
+      ),
+    ).toBeVisible();
+    // Experience is present 3 times
+    await expect(
+      application.page.getByText(/qa testing at playwright university/i).nth(2),
+    ).toBeVisible();
+    // No error/warning messages
+    await expect(
+      application.page.getByText(
+        /it looks like you haven't added any experiences/i,
+      ),
+    ).not.toBeVisible();
+    await expect(
+      application.page.getByText(
+        /it looks like you haven't selected an education requirement/i,
+      ),
+    ).not.toBeVisible();
+    await expect(
+      application.page.getByText(
+        /it looks like you haven't answered any screening questions/i,
+      ),
+    ).not.toBeVisible();
+
+    await application.submit();
+    await application.waitForGraphqlResponse("Application");
+    await expect(
+      application.page.getByRole("heading", {
+        name: /we successfully received your application/i,
+      }),
+    ).toBeVisible();
+    await expect(
+      application.page.getByRole("link", {
+        name: /visit your Profile and applications page/i,
+      }),
+    ).toBeVisible();
   });
 });

--- a/apps/playwright/tsconfig.json
+++ b/apps/playwright/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"]
+    }
+  }
+}

--- a/apps/playwright/utils/auth.ts
+++ b/apps/playwright/utils/auth.ts
@@ -1,7 +1,6 @@
 import { Page } from "@playwright/test";
 
 export async function loginByEmail(page: Page, email: string) {
-  // Perform authentication steps. Replace these actions with your own.
   await page.goto("/login-info");
   await page
     .getByRole("link", { name: /continue to gckey and sign in/i })
@@ -9,9 +8,5 @@ export async function loginByEmail(page: Page, email: string) {
     .click();
   await page.getByPlaceholder("Enter any user/subject").fill(email);
   await page.getByRole("button", { name: /sign-in/i }).click();
-  // Wait until the page receives the cookies.
-  //
-  // Sometimes login flow sets cookies in the process of several redirects.
-  // Wait for the final URL to ensure that the cookies are actually set.
   await page.waitForURL("**/applicant/profile-and-applications");
 }

--- a/apps/playwright/utils/auth.ts
+++ b/apps/playwright/utils/auth.ts
@@ -3,21 +3,21 @@ import { Cookie, Page } from "@playwright/test";
 import { graphqlRequest } from "./graphql";
 
 /**
- * Login by email
+ * Login by sub
  *
  * Logs a user into the application
  * through the UI.
  *
  * @param {Page} page
- * @param {String} email
+ * @param {String} sub
  */
-export async function loginByEmail(page: Page, email: string) {
+export async function loginBySub(page: Page, sub: string) {
   await page.goto("/login-info");
   await page
     .getByRole("link", { name: /continue to gckey and sign in/i })
     .first()
     .click();
-  await page.getByPlaceholder("Enter any user/subject").fill(email);
+  await page.getByPlaceholder("Enter any user/subject").fill(sub);
   await page.getByRole("button", { name: /sign-in/i }).click();
   await page.waitForURL("**/applicant/profile-and-applications");
 }
@@ -98,5 +98,26 @@ export const Test_UpdateUserRolesMutationDocument = /* GraphQL */ `
   mutation Test_UpdateUserRoles($updateUserRolesInput: UpdateUserRolesInput!) {
     updateUserRoles(updateUserRolesInput: $updateUserRolesInput) {
       id
+      roleAssignments {
+        id
+        role {
+          id
+          name
+          isTeamBased
+          displayName {
+            en
+            fr
+          }
+        }
+        team {
+          id
+          name
+          displayName {
+            en
+            fr
+          }
+        }
+      }
     }
+  }
 `;

--- a/apps/playwright/utils/auth.ts
+++ b/apps/playwright/utils/auth.ts
@@ -1,4 +1,4 @@
-import { Page } from "@playwright/test";
+import { Cookie, Page } from "@playwright/test";
 
 export async function loginByEmail(page: Page, email: string) {
   await page.goto("/login-info");
@@ -9,4 +9,37 @@ export async function loginByEmail(page: Page, email: string) {
   await page.getByPlaceholder("Enter any user/subject").fill(email);
   await page.getByRole("button", { name: /sign-in/i }).click();
   await page.waitForURL("**/applicant/profile-and-applications");
+}
+
+export type AuthCookies = {
+  apiSession?: Cookie;
+  xsrf?: Cookie;
+};
+
+export async function getAuthCookies(page: Page): Promise<AuthCookies> {
+  const cookies = await page.context().cookies();
+
+  const apiSession = cookies.find((cookie) => cookie.name === "api_session");
+  const xsrf = cookies.find((cookie) => cookie.name === "XSRF-TOKEN");
+
+  return {
+    apiSession,
+    xsrf,
+  };
+}
+
+export type AuthTokens = {
+  idToken?: string;
+  accessToken?: string;
+  refreshToken?: string;
+};
+
+export async function getAuthTokens(page: Page): Promise<AuthTokens> {
+  const tokens = await page.evaluate(() => ({
+    idToken: localStorage.getItem("id_token"),
+    accessToken: localStorage.getItem("access_token"),
+    refreshToken: localStorage.getItem("refresh_token"),
+  }));
+
+  return tokens;
 }

--- a/apps/playwright/utils/auth.ts
+++ b/apps/playwright/utils/auth.ts
@@ -1,5 +1,16 @@
+import { Role } from "@gc-digital-talent/graphql";
 import { Cookie, Page } from "@playwright/test";
+import { graphqlRequest } from "./graphql";
 
+/**
+ * Login by email
+ *
+ * Logs a user into the application
+ * through the UI.
+ *
+ * @param {Page} page
+ * @param {String} email
+ */
 export async function loginByEmail(page: Page, email: string) {
   await page.goto("/login-info");
   await page
@@ -16,6 +27,15 @@ export type AuthCookies = {
   xsrf?: Cookie;
 };
 
+/**
+ * Get Auth Cookies
+ *
+ * Attempt to get the auth cookies
+ * from the current page context.
+ *
+ * @param page
+ * @returns {Promise<AuthCookies>}
+ */
 export async function getAuthCookies(page: Page): Promise<AuthCookies> {
   const cookies = await page.context().cookies();
 
@@ -34,6 +54,15 @@ export type AuthTokens = {
   refreshToken?: string;
 };
 
+/**
+ * Get Auth Tokens
+ *
+ * Attempt to get the auth tokens from the
+ * current page context local storage.
+ *
+ * @param page
+ * @returns {Promise<AuthTokens>}
+ */
 export async function getAuthTokens(page: Page): Promise<AuthTokens> {
   const tokens = await page.evaluate(() => ({
     idToken: localStorage.getItem("id_token"),
@@ -43,3 +72,31 @@ export async function getAuthTokens(page: Page): Promise<AuthTokens> {
 
   return tokens;
 }
+
+export const Test_RolesQueryDocument = /* GraphQL */ `
+  query Test_Roles {
+    roles {
+      id
+      name
+    }
+  }
+`;
+
+/**
+ * Get Roles
+ *
+ * Get all the roles directly from
+ * the API.
+ */
+export async function getRoles(): Promise<Role[]> {
+  const res = await graphqlRequest(Test_RolesQueryDocument);
+
+  return res.roles;
+}
+
+export const Test_UpdateUserRolesMutationDocument = /* GraphQL */ `
+  mutation Test_UpdateUserRoles($updateUserRolesInput: UpdateUserRolesInput!) {
+    updateUserRoles(updateUserRolesInput: $updateUserRolesInput) {
+      id
+    }
+`;

--- a/apps/playwright/utils/auth.ts
+++ b/apps/playwright/utils/auth.ts
@@ -1,0 +1,17 @@
+import { Page } from "@playwright/test";
+
+export async function loginByEmail(page: Page, email: string) {
+  // Perform authentication steps. Replace these actions with your own.
+  await page.goto("/login-info");
+  await page
+    .getByRole("link", { name: /continue to gckey and sign in/i })
+    .first()
+    .click();
+  await page.getByPlaceholder("Enter any user/subject").fill(email);
+  await page.getByRole("button", { name: /sign-in/i }).click();
+  // Wait until the page receives the cookies.
+  //
+  // Sometimes login flow sets cookies in the process of several redirects.
+  // Wait for the final URL to ensure that the cookies are actually set.
+  await page.waitForURL("**/applicant/profile-and-applications");
+}

--- a/apps/playwright/utils/classification.ts
+++ b/apps/playwright/utils/classification.ts
@@ -1,0 +1,25 @@
+import { Classification } from "@gc-digital-talent/graphql";
+
+import { graphqlRequest } from "./graphql";
+
+export const Test_ClassificationsQueryDocument = /* GraphQL */ `
+  query Test_Classifications {
+    classifications {
+      id
+      group
+      level
+    }
+  }
+`;
+
+/**
+ * Get Classifications
+ *
+ * Get all the classifications directly from
+ * the API.
+ */
+export async function getClassifications(): Promise<Classification[]> {
+  const res = await graphqlRequest(Test_ClassificationsQueryDocument);
+
+  return res.classifications;
+}

--- a/apps/playwright/utils/graphql.ts
+++ b/apps/playwright/utils/graphql.ts
@@ -1,0 +1,28 @@
+import { request } from "@playwright/test";
+import auth from "~/constants/auth";
+
+export async function graphqlRequest(
+  query: string,
+  variables?: Record<string, unknown>,
+  storageState?: string,
+) {
+  const apiContext = await request.newContext({
+    baseURL: "http://localhost:8000/graphql",
+    storageState: storageState ?? auth.STATE.ADMIN,
+  });
+
+  const res = await apiContext.fetch("/graphql", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    data: {
+      query,
+      variables,
+    },
+  });
+
+  const json = await res.json();
+
+  return json.data;
+}

--- a/apps/playwright/utils/graphql.ts
+++ b/apps/playwright/utils/graphql.ts
@@ -1,6 +1,16 @@
 import { request } from "@playwright/test";
 import auth from "~/constants/auth";
 
+export type GraphQLResponse<K extends string, T> = {
+  [k in K]: T;
+};
+
+/**
+ * GraphQL Request
+ *
+ * Make a GraphQL request using the
+ * admin auth state by default.
+ */
 export async function graphqlRequest(
   query: string,
   variables?: Record<string, unknown>,

--- a/apps/playwright/utils/pools.ts
+++ b/apps/playwright/utils/pools.ts
@@ -1,0 +1,32 @@
+export const Test_CreatePoolMutationDocument = /* GraphQL */ `
+  mutation Test_CreatePool(
+    $userId: ID!
+    $teamId: ID!
+    $pool: CreatePoolInput!
+  ) {
+    createPool(userId: $userId, teamId: $teamId, pool: $pool) {
+      id
+      name {
+        en
+        fr
+      }
+    }
+  }
+`;
+
+export const Test_UpdatePoolMutationDocument = /* GraphQL */ `
+  mutation Test_UpdatePool($poolId: ID!, $pool: UpdatePoolInput!) {
+    updatePool(id: $poolId, pool: $pool) {
+      id
+    }
+  }
+`;
+
+export const Test_PublishPoolMutationDocument = /* GraphQL */ `
+  mutation Test_PublishPool($id: ID!) {
+    publishPool(id: $id) {
+      id
+      publishedAt
+    }
+  }
+`;

--- a/apps/playwright/utils/skills.ts
+++ b/apps/playwright/utils/skills.ts
@@ -1,0 +1,19 @@
+import { Skill } from "@gc-digital-talent/graphql";
+import { graphqlRequest } from "./graphql";
+
+export const getSkills = async (): Promise<Skill[]> => {
+  const res = await graphqlRequest(/* GraphQL */ `
+    query Skills {
+      skills {
+        id
+        key
+        name {
+          en
+          fr
+        }
+      }
+    }
+  `);
+
+  return res.skills;
+};

--- a/apps/playwright/utils/skills.ts
+++ b/apps/playwright/utils/skills.ts
@@ -1,12 +1,19 @@
 import { Skill } from "@gc-digital-talent/graphql";
 import { graphqlRequest } from "./graphql";
 
+/**
+ * Get Skills
+ *
+ * Get all the skills directly from
+ * the API.
+ */
 export const getSkills = async (): Promise<Skill[]> => {
   const res = await graphqlRequest(/* GraphQL */ `
     query Skills {
       skills {
         id
         key
+        category
         name {
           en
           fr

--- a/apps/playwright/utils/team.ts
+++ b/apps/playwright/utils/team.ts
@@ -1,0 +1,32 @@
+import { Team } from "@gc-digital-talent/graphql";
+
+import { graphqlRequest } from "./graphql";
+
+export const Test_TeamsQueryDocument = /* GraphQL */ `
+  query Test_Teams {
+    teams {
+      id
+      name
+      displayName {
+        en
+        fr
+      }
+    }
+  }
+`;
+
+/**
+ * Get DCM
+ *
+ * Get all the DCM team directly from
+ * the API.
+ */
+export async function getDCM(): Promise<Team> {
+  const res = await graphqlRequest(Test_TeamsQueryDocument);
+
+  const dcm = res.teams.find(
+    (team) => team.name === "digital-community-management",
+  );
+
+  return dcm;
+}

--- a/apps/playwright/utils/user.ts
+++ b/apps/playwright/utils/user.ts
@@ -1,0 +1,58 @@
+export const defaultUser = {
+  // required
+  firstName: "Cypress",
+  lastName: "User",
+  preferredLang: "EN",
+  preferredLanguageForInterview: "EN",
+  preferredLanguageForExam: "EN",
+
+  // optional
+  telephone: undefined,
+  email: undefined,
+  currentProvince: undefined,
+  currentCity: undefined,
+  lookingForEnglish: undefined,
+  lookingForFrench: undefined,
+  lookingForBilingual: undefined,
+  bilingualEvaluation: undefined,
+  comprehensionLevel: undefined,
+  writtenLevel: undefined,
+  verbalLevel: undefined,
+  estimatedLanguageAbility: undefined,
+  isGovEmployee: undefined,
+  hasPriorityEntitlement: undefined,
+  priorityNumber: undefined,
+  department: undefined,
+  currentClassification: undefined,
+  isWoman: undefined,
+  hasDisability: undefined,
+  isVisibleMinority: undefined,
+  hasDiploma: undefined,
+  locationPreferences: undefined,
+  locationExemptions: undefined,
+  acceptedOperationalRequirements: undefined,
+  positionDuration: undefined,
+};
+
+export const Test_CreateUserMutationDocument = /* GraphQL */ `
+  mutation Test_CreateUser($user: CreateUserInput!) {
+    createUser(user: $user) {
+      id
+      firstName
+      lastName
+      email
+      authInfo {
+        id
+        sub
+      }
+    }
+  }
+`;
+
+export const Test_MeQueryDocument = /* GraphQL */ `
+  query Test_Me {
+    me {
+      id
+    }
+  }
+`;

--- a/apps/playwright/utils/user.ts
+++ b/apps/playwright/utils/user.ts
@@ -1,6 +1,6 @@
 export const defaultUser = {
   // required
-  firstName: "Cypress",
+  firstName: "Playwright",
   lastName: "User",
   preferredLang: "EN",
   preferredLanguageForInterview: "EN",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,17 @@
         "node": ">=4.2.0"
       }
     },
+    "apps/playwright": {
+      "name": "@gc-digital-talent/playwright",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@gc-digital-talent/graphql": "*",
+        "@playwright/test": "^1.40.1",
+        "@types/node": "^20.10.5",
+        "eslint-plugin-playwright": "^0.20.0"
+      }
+    },
     "apps/web": {
       "name": "@gc-digital-talent/web",
       "version": "1.0.0",
@@ -3232,6 +3243,10 @@
       "resolved": "packages/logger",
       "link": true
     },
+    "node_modules/@gc-digital-talent/playwright": {
+      "resolved": "apps/playwright",
+      "link": true
+    },
     "node_modules/@gc-digital-talent/storage": {
       "resolved": "packages/storage",
       "link": true
@@ -5813,6 +5828,53 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
+      "integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.40.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
+      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.40.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.11",
@@ -15819,6 +15881,51 @@
         "eslint": ">=5.16.0"
       }
     },
+    "node_modules/eslint-plugin-playwright": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.20.0.tgz",
+      "integrity": "sha512-JWTSwUyPPipSOm6AK8z78bQXtKRCykvhSGUewcmZuxstSZ5oGsykW2JaRXJQ2IIfzKJToCBeKD2ISc8Li8qVEQ==",
+      "dev": true,
+      "dependencies": {
+        "globals": "^13.23.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7",
+        "eslint-plugin-jest": ">=25"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-playwright/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-playwright/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.0.tgz",
@@ -21950,6 +22057,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/polished": {
@@ -30232,6 +30351,15 @@
         "typescript": "^5.3.3"
       }
     },
+    "@gc-digital-talent/playwright": {
+      "version": "file:apps/playwright",
+      "requires": {
+        "@gc-digital-talent/graphql": "*",
+        "@playwright/test": "^1.40.1",
+        "@types/node": "^20.10.5",
+        "eslint-plugin-playwright": "^0.20.0"
+      }
+    },
     "@gc-digital-talent/storage": {
       "version": "file:packages/storage",
       "requires": {
@@ -32221,6 +32349,34 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
           "dev": true
+        }
+      }
+    },
+    "@playwright/test": {
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
+      "integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.40.1"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        },
+        "playwright": {
+          "version": "1.40.1",
+          "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
+          "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
+          "dev": true,
+          "requires": {
+            "fsevents": "2.3.2",
+            "playwright-core": "1.40.1"
+          }
         }
       }
     },
@@ -38819,6 +38975,32 @@
         "semver": "^6.1.0"
       }
     },
+    "eslint-plugin-playwright": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.20.0.tgz",
+      "integrity": "sha512-JWTSwUyPPipSOm6AK8z78bQXtKRCykvhSGUewcmZuxstSZ5oGsykW2JaRXJQ2IIfzKJToCBeKD2ISc8Li8qVEQ==",
+      "dev": true,
+      "requires": {
+        "globals": "^13.23.0"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "13.24.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+          "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-prettier": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.0.tgz",
@@ -42771,6 +42953,12 @@
       "requires": {
         "find-up": "^5.0.0"
       }
+    },
+    "playwright-core": {
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
+      "dev": true
     },
     "polished": {
       "version": "4.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@gc-digital-talent/date-helpers": "*",
         "@gc-digital-talent/graphql": "*",
         "@playwright/test": "^1.40.1",
         "@types/node": "^20.10.5",
@@ -30354,6 +30355,7 @@
     "@gc-digital-talent/playwright": {
       "version": "file:apps/playwright",
       "requires": {
+        "@gc-digital-talent/date-helpers": "*",
         "@gc-digital-talent/graphql": "*",
         "@playwright/test": "^1.40.1",
         "@types/node": "^20.10.5",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "watch": "turbo run watch --concurrency=30",
     "watch:project": "turbo run watch",
     "e2e": "npm run e2e --workspace=@gc-digital-talent/e2e",
+    "e2e:playwright": "npm run e2e:playwright --workspace=@gc-digital-talent/playwright",
     "e2e:open": "npm run e2e:open",
     "e2e:run:all": "npm run e2e:run:all --workspace=@gc-digital-talent/e2e",
     "e2e:run:inspect": "npm run e2e:run:inspect --workspace=@gc-digital-talent/e2e",

--- a/turbo.json
+++ b/turbo.json
@@ -97,6 +97,7 @@
     },
     "e2e": {},
     "e2e:open": {},
+    "e2e:playwright": {},
     "e2e:run": {},
     "e2e:run:all": {
       "dependsOn": ["^e2e:run:all"]


### PR DESCRIPTION
🤖 Resolves #8809 

## 👋 Introduction

This is an example of [Playwright](https://playwright.dev/) implementation.

## 🕵️ Details

> [!NOTE]
> Unsure if this will get merged but it demonstrates how we could effectively implement playwright. I could take it further if the team is interested.

First off, this was very enjoyable and imo, much easier to work with and understand than Cypress. I'm going tot take my time to try and explain what is going on here but if you are reviewing and have questions, feel free to reach out.

### Async/Await

One of my largest gripes with Cypress is that it tries hard to hide async functionality from you. Playwright is different in that it embraces it and feels far less like magic. Instead of just assuming a navigation is waited on, Playwright makes you add `await` before to be explicit. 

### Fixtures

REF: https://playwright.dev/docs/test-fixtures

One of the largest changes was the idea of fixtures. In Cypress, we were just using them as static json. In Playwright, they are classes that encapsulates the current environment and functionality. So, in our setup we create an `adminPage` and `applicantPage` fixture that has that user logged in and isolated to that fixture. This means, we no longer need to keep logging in and out to do different things. As well, since these are just classes, you can add methods for common functionality for that user/page and extend them!

```ts
test("something", async ({ adminPage, applicantPage }) => {
  // This user can go to admin
  await adminPage.page.goto("/admin");

  // This user cannot (no need to logout/login)
  await applicantPage.page.goto("/admin");
});
```

### Projects

REF: https://playwright.dev/docs/test-projects

I'm not sure if cypress has this concept but it is neat. When you run `npx playwright test` it runs all projects at once in parallel. So we are testing chromium, firefox and webkit all that once with no extra work.

### Debugging

I never had any luck debugging tests in cypress but found playwright just worked. If you run `npx playwright test --debug` it opens the ui and a debugger console allowing you to step through your tests like a normal debugger. This made finding issues with my tests much easier.

## 🧪 Testing

> [!NOTE]
> I only added a single script and opted to pass flags for now since this was more exploratory (sorry 😅 ). We can add easier to run commands for ui and debugging if we decide we want to move forward.

1. Install `npm run install`
2. Build `bpm run build`
3. Run tests in headless `npm run e2e:playwright`
4. Confirm it works
5. Try out the ui `npm run e2e:playwright -- -- --ui`
6. Confirm it works
7. Try out the debug mode `npm run e2e:playwright -- -- --debug`

## 📸 Screenshot

![Screenshot 2023-12-29 153319](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/8e390b99-beb0-4bf3-a2b8-0f928cbab12b)
