### PR TITLE
[Fix] Error summary second focus

### DIFF
--- a/apps/web/src/components/ExperienceFormFields/ErrorSummary.tsx
+++ b/apps/web/src/components/ExperienceFormFields/ErrorSummary.tsx
@@ -3,6 +3,7 @@ import { useFormContext, useWatch } from "react-hook-form";
 import { useIntl } from "react-intl";
 
 import { ErrorSummary as ErrorSummaryAlert } from "@gc-digital-talent/forms";
+import { flattenErrors } from "@gc-digital-talent/forms/src/utils";
 
 import { getExperienceFormLabels } from "~/utils/experienceUtils";
 import { ExperienceType } from "~/types/experience";
@@ -22,6 +23,7 @@ const ErrorSummary = ({ experienceType }: ErrorSummaryProps) => {
   const {
     formState: { errors, isSubmitting },
   } = useFormContext();
+  const flatErrors = flattenErrors(errors);
 
   React.useEffect(() => {
     // After during submit, if there are errors, focus the summary
@@ -31,10 +33,15 @@ const ErrorSummary = ({ experienceType }: ErrorSummaryProps) => {
   }, [isSubmitting, errors]);
 
   React.useEffect(() => {
-    if (errorSummaryRef.current) {
+    if (
+      showErrorSummary &&
+      errorSummaryRef.current &&
+      isSubmitting &&
+      flatErrors.length > 0
+    ) {
       errorSummaryRef.current.focus();
     }
-  }, [showErrorSummary, errorSummaryRef]);
+  }, [showErrorSummary, flatErrors, isSubmitting]);
 
   return (
     <ErrorSummaryAlert

--- a/packages/forms/src/components/BasicForm.tsx
+++ b/packages/forms/src/components/BasicForm.tsx
@@ -17,6 +17,7 @@ import {
 
 import ErrorSummary from "./ErrorSummary";
 import UnsavedChanges from "./UnsavedChanges";
+import { flattenErrors } from "../utils";
 
 export type FieldLabels = Record<string, React.ReactNode>;
 
@@ -75,19 +76,20 @@ function BasicForm<TFieldValues extends FieldValues>({
     reset,
     formState: { isDirty, errors, isSubmitting },
   } = methods;
+  const flatErrors = flattenErrors(errors);
 
   React.useEffect(() => {
     // After during submit, if there are errors, focus the summary
-    if (errors && isSubmitting) {
+    if (flatErrors.length > 0) {
       setShowErrorSummary(true);
     }
-  }, [isSubmitting, errors]);
+  }, [isSubmitting, flatErrors]);
 
   React.useEffect(() => {
-    if (errorSummaryRef.current) {
+    if (errorSummaryRef.current && flatErrors && isSubmitting) {
       errorSummaryRef.current.focus();
     }
-  }, [showErrorSummary, errorSummaryRef]);
+  }, [flatErrors, isSubmitting]);
 
   const handleSubmit = async (data: TFieldValues) => {
     // Reset form to clear dirty values


### PR DESCRIPTION
🤖 Resolves #8846 

## 👋 Introduction

Fixes the focus of an error summary on a second attempt to submit.

## 🕵️ Details

The values we were using the effect dependencies array were not primitives. This meant the callback was never re-fired. This updates it to use the flattened array of input IDs which is primitive. This allows the callback to be called when it updates meaning we can focus the summary every time errors change on submit.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to a basic form that has labels (profile forms work well here)
3. Submit with errors, confirming the summary gets focus
4. Fix on error or introduce more
5. Re submit, confirming the summary is once again focused
6. Navigate to the experience form
7. Repeat steps 3-5

