### PR TITLE
[Fix] Update skill showcase without refresh

### DIFF
--- a/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
+++ b/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
@@ -81,7 +81,7 @@ const UpdateSkillShowcase = ({
     defaultValues: initialSkills,
   });
   const { control, watch, formState } = methods;
-  const { remove, move, fields } = useFieldArray({
+  const { remove, move, fields, append } = useFieldArray({
     control,
     name: "userSkills",
   });
@@ -134,6 +134,9 @@ const UpdateSkillShowcase = ({
         .then((res) => {
           handleSuccess();
           if (res.data?.updateUserSkill?.skill.id) {
+            append({
+              skill: res.data.updateUserSkill.skill.id,
+            });
             // having claimed a user skill in the modal and the mutation successful, update the ranking
             onAddition(
               existingSkillsRankingFiltered,
@@ -154,6 +157,9 @@ const UpdateSkillShowcase = ({
         .then((res) => {
           handleSuccess();
           if (res.data?.createUserSkill?.skill.id) {
+            append({
+              skill: res.data.createUserSkill.skill.id,
+            });
             onAddition(
               existingSkillsRankingFiltered,
               res.data.createUserSkill.skill.id,

--- a/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
+++ b/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
@@ -136,6 +136,7 @@ const UpdateSkillShowcase = ({
           if (res.data?.updateUserSkill?.skill.id) {
             append({
               skill: res.data.updateUserSkill.skill.id,
+              skillLevel: res.data.updateUserSkill.skillLevel ?? undefined,
             });
             // having claimed a user skill in the modal and the mutation successful, update the ranking
             onAddition(
@@ -159,6 +160,7 @@ const UpdateSkillShowcase = ({
           if (res.data?.createUserSkill?.skill.id) {
             append({
               skill: res.data.createUserSkill.skill.id,
+              skillLevel: res.data.createUserSkill.skillLevel ?? undefined,
             });
             onAddition(
               existingSkillsRankingFiltered,


### PR DESCRIPTION
🤖 Resolves #8814 

## 👋 Introduction

Quick (not great) fix for for the skills showcase pages not updating without a full page refresh.

## 🕵️ Details

This uses the `useFieldArray` function `append` to add the skill after the mutation is successful. It is a little janky but works for our purposes until we can revisit the functionality for this type of repeatable item.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login as an applicant and navigate to a skill showcase `/applicant/profile-and-applications/skills/showcase/*`
3. Add a skill in your library
4. Confirm it is added to the list without a refresh
5. Add a skill not in your library
6. Confirm it is added to the list without a refresh
7. Change the order
8. Save and confirm the expected values were saved

