### PR TITLE
[Feature] Hide pool filter on specific pool candidate page

### DIFF
--- a/apps/web/src/components/FilterDialog/FilterDialog.tsx
+++ b/apps/web/src/components/FilterDialog/FilterDialog.tsx
@@ -29,6 +29,8 @@ type FilterDialogProps<TFieldValues extends FieldValues> = {
   resetValues: CommonFilterDialogProps<TFieldValues>["resetValues"];
   defaultOpen?: boolean;
   children: React.ReactNode;
+  /** Modify the filter count in the button (most commonly used for hidden filters) */
+  modifyFilterCount?: number;
 };
 
 const FilterDialog = <TFieldValues extends FieldValues>({
@@ -36,6 +38,7 @@ const FilterDialog = <TFieldValues extends FieldValues>({
   options,
   children,
   resetValues,
+  modifyFilterCount,
   defaultOpen = false,
 }: FilterDialogProps<TFieldValues>) => {
   const [isOpen, setIsOpen] = React.useState<boolean>(defaultOpen);
@@ -99,7 +102,7 @@ const FilterDialog = <TFieldValues extends FieldValues>({
           type="button"
           icon={AdjustmentsVerticalIcon}
           {...(filterCount > 0 && {
-            counter: filterCount,
+            counter: filterCount + (modifyFilterCount ?? 0),
           })}
         >
           {intl.formatMessage({

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
@@ -6,6 +6,7 @@ import {
   Checkbox,
   Checklist,
   Combobox,
+  HiddenInput,
   RadioGroup,
   Select,
   enumToOptions,
@@ -67,12 +68,15 @@ const context: Partial<OperationContext> = {
   requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
 };
 
-type PoolCandidateFilterDialogProps = CommonFilterDialogProps<FormValues>;
+type PoolCandidateFilterDialogProps = CommonFilterDialogProps<FormValues> & {
+  hidePoolFilter?: boolean;
+};
 
 const PoolCandidateFilterDialog = ({
   onSubmit,
   resetValues,
   initialValues,
+  hidePoolFilter,
 }: PoolCandidateFilterDialogProps) => {
   const intl = useIntl();
 
@@ -90,6 +94,10 @@ const PoolCandidateFilterDialog = ({
   return (
     <FilterDialog<FormValues>
       options={{ defaultValues: initialValues }}
+      // Remove hidden pools filter from count
+      {...(hidePoolFilter && {
+        modifyFilterCount: -1,
+      })}
       {...{ resetValues, onSubmit }}
     >
       <div
@@ -97,19 +105,24 @@ const PoolCandidateFilterDialog = ({
         data-h2-gap="base(x1)"
         data-h2-grid-template-columns="p-tablet(repeat(2, 1fr)) p-tablet(repeat(3, 1fr))"
       >
-        <div data-h2-grid-column="l-tablet(span 3)">
-          <Combobox
-            id="pools"
-            name="pools"
-            {...{ fetching }}
-            isMulti
-            label={intl.formatMessage(adminMessages.pools)}
-            options={pools.map((pool) => ({
-              value: pool.id,
-              label: getFullPoolTitleLabel(intl, pool),
-            }))}
-          />
-        </div>
+        {hidePoolFilter ? (
+          <HiddenInput name="pools" />
+        ) : (
+          <div data-h2-grid-column="l-tablet(span 3)">
+            <Combobox
+              id="pools"
+              name="pools"
+              {...{ fetching }}
+              isMulti
+              label={intl.formatMessage(adminMessages.pools)}
+              options={pools.map((pool) => ({
+                value: pool.id,
+                label: getFullPoolTitleLabel(intl, pool),
+              }))}
+            />
+          </div>
+        )}
+
         <Checklist
           idPrefix="publishingGroups"
           name="publishingGroups"

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -148,10 +148,12 @@ const PoolCandidatesTable = ({
   initialFilterInput,
   currentPool,
   title,
+  hidePoolFilter,
 }: {
   initialFilterInput?: PoolCandidateSearchInput;
   currentPool?: Maybe<Pick<Pool, "essentialSkills" | "nonessentialSkills">>;
   title: string;
+  hidePoolFilter?: boolean;
 }) => {
   const intl = useIntl();
   const paths = useRoutes();
@@ -554,6 +556,7 @@ const PoolCandidatesTable = ({
         state: filterRef.current,
         component: (
           <PoolCandidateFilterDialog
+            {...{ hidePoolFilter }}
             onSubmit={handleFilterSubmit}
             resetValues={transformPoolCandidateSearchInputToFormValues(
               initialFilterInput,

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
@@ -45,6 +45,7 @@ export const IndexPoolCandidatePage = () => {
           })}
         </p>
         <PoolCandidatesTable
+          hidePoolFilter
           initialFilterInput={{
             applicantFilter: { pools: [{ id: poolId || "" }] },
             suspendedStatus: CandidateSuspendedFilter.Active,

--- a/packages/forms/src/components/HiddenInput/HiddenInput.tsx
+++ b/packages/forms/src/components/HiddenInput/HiddenInput.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { useFormContext } from "react-hook-form";
+
+export type HiddenInputProps = {
+  name: string;
+};
+
+const HiddenInput = ({ name }: HiddenInputProps) => {
+  const { register } = useFormContext();
+
+  return <input type="hidden" {...register(name)} />;
+};
+
+export default HiddenInput;

--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -18,6 +18,9 @@ import Field, {
   RequiredProps,
   WrapperProps,
 } from "./components/Field";
+import HiddenInput, {
+  type HiddenInputProps,
+} from "./components/HiddenInput/HiddenInput";
 import Input, { type InputProps } from "./components/Input";
 import RadioGroup, {
   type RadioGroupProps,
@@ -62,6 +65,7 @@ export {
   Checklist,
   Combobox,
   Field,
+  HiddenInput,
   Input,
   Repeater,
   RadioGroup,
@@ -87,6 +91,7 @@ export type {
   CheckButtonProps,
   ChecklistProps,
   ComboboxProps,
+  HiddenInputProps,
   InputProps,
   Radio,
   RadioGroupProps,


### PR DESCRIPTION
🤖 Resolves #5321 

## 👋 Introduction

Hides the pool filter when on the "view candidates" page for a specific pool.

## 🕵️ Details

Since the admin is within the specific context of a pool, it does not make sense to allow them to filter by different pools. We also now has the "all pool candidates" page that allows this. So, we are hiding this filter. In order to do this a few things were done:

- Added a hidden input component that is registered with `react-hook-form`
- Allow modifying the filter count on the filter dialog button so we can omit hidden filters from the count
   - Used addition here to make it clear what is happening. I currently can't think of a reason why we would want to increase the number right now but seeing  a negative integer makes more sense to me 🤷‍♀️ 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login as an admin
3. Navigate to `/admin/pool-candidates`
4. Filter by a specific pool
5. Confirm the filter count is correct
6. Make note of the candidates who appear and how many
7. Navigate to `/admin/pools`
8. Find the pool you filtered by in step 4
9. Click "View candidates" in that row
10. Confirm the table candidates matches the one from step 6
11. Confirm the filter count matches the **visible** filters
12. Confirm filters and count function as expected still

## 📸 Screenshot

![Screenshot 2024-01-03 112820](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/38ee84ef-d208-4c86-bbe2-c4a02502e4b9)
