### PR TITLE
[Copy] Update screening question translation

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9052,7 +9052,7 @@
     "description": "Heading for working language ability section of the search form."
   },
   "p8+wKq": {
-    "defaultMessage": "Questions relatives à la sélection préliminaire",
+    "defaultMessage": "Questions de sélection",
     "description": "Title of screening questions"
   },
   "pB5bOl": {


### PR DESCRIPTION
🤖 Resolves #8521 

## 👋 Introduction

This updates the translation of "Screening questions" to a more succinct message _Questions de sélection_.

## 🕵️ Details

The consolidation happened in #8899 but it seems we used the longer version. DCM and the copy writers have requested the shorter _Questions de sélection_.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to a page that mentions screening questions
3. Change to French language
4. Confirm the copy reads _Questions de sélection_

## 📸 Screenshot

![Screenshot 2024-01-03 153336](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/97617a03-0573-4200-bd59-68cc689c91a8)
