### PR TITLE
[Feature] Add notes field to assessment results

### DIFF
--- a/api/app/Models/AssessmentResult.php
+++ b/api/app/Models/AssessmentResult.php
@@ -19,7 +19,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $other_justification_notes
  * @property string $assessment_decision_level
  * @property string $skill_decision_notes
- * @property string $notes
+ * @property string $assessment_notes
  * @property Illuminate\Support\Carbon $created_at
  * @property Illuminate\Support\Carbon $updated_at
  */

--- a/api/app/Models/AssessmentResult.php
+++ b/api/app/Models/AssessmentResult.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $other_justification_notes
  * @property string $assessment_decision_level
  * @property string $skill_decision_notes
+ * @property string $notes
  * @property Illuminate\Support\Carbon $created_at
  * @property Illuminate\Support\Carbon $updated_at
  */

--- a/api/database/factories/AssessmentResultFactory.php
+++ b/api/database/factories/AssessmentResultFactory.php
@@ -47,7 +47,7 @@ class AssessmentResultFactory extends Factory
             'skill_decision_notes' => $assessmentResultType === AssessmentResultType::SKILL->name &&
                 $assessmentDecision === AssessmentDecision::SUCCESSFUL->name ?
                 $this->faker->paragraph() : null,
-            'notes' => $this->faker->paragraphs(3, true),
+            'assessment_notes' => $this->faker->paragraphs(3, true),
         ];
     }
 

--- a/api/database/factories/AssessmentResultFactory.php
+++ b/api/database/factories/AssessmentResultFactory.php
@@ -47,6 +47,7 @@ class AssessmentResultFactory extends Factory
             'skill_decision_notes' => $assessmentResultType === AssessmentResultType::SKILL->name &&
                 $assessmentDecision === AssessmentDecision::SUCCESSFUL->name ?
                 $this->faker->paragraph() : null,
+            'notes' => $this->faker->paragraphs(3, true),
         ];
     }
 

--- a/api/database/migrations/2024_01_04_144452_add_notes_column_assessment_results_table.php
+++ b/api/database/migrations/2024_01_04_144452_add_notes_column_assessment_results_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('assessment_results', function (Blueprint $table) {
+            $table->text('notes')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('assessment_results', function (Blueprint $table) {
+            $table->dropColumn('notes');
+        });
+    }
+};

--- a/api/database/migrations/2024_01_04_144452_add_notes_column_assessment_results_table.php
+++ b/api/database/migrations/2024_01_04_144452_add_notes_column_assessment_results_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('assessment_results', function (Blueprint $table) {
-            $table->text('notes')->nullable()->default(null);
+            $table->text('assessment_notes')->nullable()->default(null);
         });
     }
 
@@ -22,7 +22,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('assessment_results', function (Blueprint $table) {
-            $table->dropColumn('notes');
+            $table->dropColumn('assessment_notes');
         });
     }
 };

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -236,7 +236,7 @@ type AssessmentResult {
   assessmentDecisionLevel: AssessmentDecisionLevel
     @rename(attribute: "assessment_decision_level")
   skillDecisionNotes: String @rename(attribute: "skill_decision_notes")
-  notes: String @rename(attribute: "notes")
+  assessmentNotes: String @rename(attribute: "assessment_notes")
 }
 
 type PoolSkill {
@@ -1394,7 +1394,7 @@ input CreateAssessmentResultInput
   assessmentDecisionLevel: AssessmentDecisionLevel
     @rename(attribute: "assessment_decision_level")
   skillDecisionNotes: String @rename(attribute: "skill_decision_notes")
-  notes: String
+  assessmentNotes: String @rename(attribute: "assessment_notes")
 }
 
 input UpdateAssessmentResultInput
@@ -1412,7 +1412,7 @@ input UpdateAssessmentResultInput
   assessmentDecisionLevel: AssessmentDecisionLevel
     @rename(attribute: "assessment_decision_level")
   skillDecisionNotes: String @rename(attribute: "skill_decision_notes")
-  notes: String
+  assessmentNotes: String @rename(attribute: "assessment_notes")
 }
 
 input PoolSkillBelongsToMany {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -236,6 +236,7 @@ type AssessmentResult {
   assessmentDecisionLevel: AssessmentDecisionLevel
     @rename(attribute: "assessment_decision_level")
   skillDecisionNotes: String @rename(attribute: "skill_decision_notes")
+  notes: String @rename(attribute: "notes")
 }
 
 type PoolSkill {
@@ -1393,6 +1394,7 @@ input CreateAssessmentResultInput
   assessmentDecisionLevel: AssessmentDecisionLevel
     @rename(attribute: "assessment_decision_level")
   skillDecisionNotes: String @rename(attribute: "skill_decision_notes")
+  notes: String
 }
 
 input UpdateAssessmentResultInput
@@ -1410,6 +1412,7 @@ input UpdateAssessmentResultInput
   assessmentDecisionLevel: AssessmentDecisionLevel
     @rename(attribute: "assessment_decision_level")
   skillDecisionNotes: String @rename(attribute: "skill_decision_notes")
+  notes: String
 }
 
 input PoolSkillBelongsToMany {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -337,7 +337,7 @@ type AssessmentResult {
   otherJustificationNotes: String
   assessmentDecisionLevel: AssessmentDecisionLevel
   skillDecisionNotes: String
-  notes: String
+  assessmentNotes: String
 }
 
 type PoolSkill {
@@ -1197,7 +1197,7 @@ input CreateAssessmentResultInput {
   otherJustificationNotes: String
   assessmentDecisionLevel: AssessmentDecisionLevel
   skillDecisionNotes: String
-  notes: String
+  assessmentNotes: String
 }
 
 input UpdateAssessmentResultInput {
@@ -1208,7 +1208,7 @@ input UpdateAssessmentResultInput {
   otherJustificationNotes: String
   assessmentDecisionLevel: AssessmentDecisionLevel
   skillDecisionNotes: String
-  notes: String
+  assessmentNotes: String
 }
 
 input PoolSkillBelongsToMany {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -337,6 +337,7 @@ type AssessmentResult {
   otherJustificationNotes: String
   assessmentDecisionLevel: AssessmentDecisionLevel
   skillDecisionNotes: String
+  notes: String
 }
 
 type PoolSkill {
@@ -1196,6 +1197,7 @@ input CreateAssessmentResultInput {
   otherJustificationNotes: String
   assessmentDecisionLevel: AssessmentDecisionLevel
   skillDecisionNotes: String
+  notes: String
 }
 
 input UpdateAssessmentResultInput {
@@ -1206,6 +1208,7 @@ input UpdateAssessmentResultInput {
   otherJustificationNotes: String
   assessmentDecisionLevel: AssessmentDecisionLevel
   skillDecisionNotes: String
+  notes: String
 }
 
 input PoolSkillBelongsToMany {

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.stories.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.stories.tsx
@@ -89,7 +89,7 @@ WithInitialValues.args = {
     assessmentDecisionLevel: AssessmentDecisionLevel.AboveAndBeyondRequired,
     skillDecisionNotes:
       "This applicant went above and beyond our expectations.",
-    notes: undefined,
+    assessmentNotes: undefined,
     otherJustificationNotes: undefined,
   },
 };

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.stories.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.stories.tsx
@@ -89,7 +89,7 @@ WithInitialValues.args = {
     assessmentDecisionLevel: AssessmentDecisionLevel.AboveAndBeyondRequired,
     skillDecisionNotes:
       "This applicant went above and beyond our expectations.",
-    notesForThisAssessment: undefined,
+    notes: undefined,
     otherJustificationNotes: undefined,
   },
 };

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -292,7 +292,7 @@ export const ScreeningDecisionDialog = ({
     justifications: null,
     otherJustificationNotes: null,
     skillDecisionNotes: null,
-    notesForThisAssessment: null,
+    notes: null,
   };
 
   return (

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -292,7 +292,7 @@ export const ScreeningDecisionDialog = ({
     justifications: null,
     otherJustificationNotes: null,
     skillDecisionNotes: null,
-    notes: null,
+    assessmentNotes: null,
   };
 
   return (

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialogForm.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialogForm.tsx
@@ -24,7 +24,7 @@ type FormNames =
   | "assessmentDecisionLevel"
   | "otherJustificationNotes"
   | "skillDecisionNotes"
-  | "notes"
+  | "assessmentNotes"
   | `justifications.${number}`;
 
 interface ScreeningDecisionDialogFormProps {
@@ -133,11 +133,11 @@ const ScreeningDecisionDialogForm = ({
       {dialogType === "GENERIC" && (
         <div data-h2-margin-bottom="base(x1)">
           <TextArea
-            id="notes"
-            name="notes"
+            id="assessmentNotes"
+            name="assessmentNotes"
             rows={TEXT_AREA_ROWS}
             wordLimit={TEXT_AREA_MAX_WORDS}
-            label={labels.notes}
+            label={labels.assessmentNotes}
             rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
         </div>

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialogForm.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialogForm.tsx
@@ -24,7 +24,7 @@ type FormNames =
   | "assessmentDecisionLevel"
   | "otherJustificationNotes"
   | "skillDecisionNotes"
-  | "notesForThisAssessment"
+  | "notes"
   | `justifications.${number}`;
 
 interface ScreeningDecisionDialogFormProps {
@@ -133,11 +133,11 @@ const ScreeningDecisionDialogForm = ({
       {dialogType === "GENERIC" && (
         <div data-h2-margin-bottom="base(x1)">
           <TextArea
-            id="notesForThisAssessment"
-            name="notesForThisAssessment"
+            id="notes"
+            name="notes"
             rows={TEXT_AREA_ROWS}
             wordLimit={TEXT_AREA_MAX_WORDS}
-            label={labels.notesForThisAssessment}
+            label={labels.notes}
             rules={{ required: intl.formatMessage(errorMessages.required) }}
           />
         </div>

--- a/apps/web/src/components/ScreeningDecisions/useLabels.ts
+++ b/apps/web/src/components/ScreeningDecisions/useLabels.ts
@@ -28,7 +28,7 @@ const getLabels = (intl: IntlShape) => {
       description:
         "Label for demonstrated notes text area in the screening decision dialog.",
     }),
-    notesForThisAssessment: intl.formatMessage({
+    notes: intl.formatMessage({
       defaultMessage: "Notes for this assessment",
       id: "vHDpXX",
       description:

--- a/apps/web/src/components/ScreeningDecisions/useLabels.ts
+++ b/apps/web/src/components/ScreeningDecisions/useLabels.ts
@@ -28,7 +28,7 @@ const getLabels = (intl: IntlShape) => {
       description:
         "Label for demonstrated notes text area in the screening decision dialog.",
     }),
-    notes: intl.formatMessage({
+    assessmentNotes: intl.formatMessage({
       defaultMessage: "Notes for this assessment",
       id: "vHDpXX",
       description:

--- a/apps/web/src/components/ScreeningDecisions/utils.ts
+++ b/apps/web/src/components/ScreeningDecisions/utils.ts
@@ -24,7 +24,7 @@ export type FormValues = {
   assessmentDecisionLevel: AssessmentResult["assessmentDecisionLevel"];
   otherJustificationNotes: AssessmentResult["otherJustificationNotes"];
   skillDecisionNotes: AssessmentResult["skillDecisionNotes"];
-  notesForThisAssessment?: Maybe<string>; // TODO: This field will be added to backend on #8729
+  notes?: Maybe<string>;
 };
 
 export type FormValuesToApiCreateInputArgs = {
@@ -81,6 +81,7 @@ export function convertFormValuesToApiUpdateInput({
     justifications,
     otherJustificationNotes,
     skillDecisionNotes,
+    notes,
   } = formValues;
   return {
     id: assessmentResultId,
@@ -92,6 +93,7 @@ export function convertFormValuesToApiUpdateInput({
       : justifications && [justifications],
     otherJustificationNotes,
     skillDecisionNotes,
+    notes,
   };
 }
 

--- a/apps/web/src/components/ScreeningDecisions/utils.ts
+++ b/apps/web/src/components/ScreeningDecisions/utils.ts
@@ -24,7 +24,7 @@ export type FormValues = {
   assessmentDecisionLevel: AssessmentResult["assessmentDecisionLevel"];
   otherJustificationNotes: AssessmentResult["otherJustificationNotes"];
   skillDecisionNotes: AssessmentResult["skillDecisionNotes"];
-  notes?: Maybe<string>;
+  assessmentNotes?: Maybe<string>;
 };
 
 export type FormValuesToApiCreateInputArgs = {
@@ -81,7 +81,7 @@ export function convertFormValuesToApiUpdateInput({
     justifications,
     otherJustificationNotes,
     skillDecisionNotes,
-    notes,
+    assessmentNotes,
   } = formValues;
   return {
     id: assessmentResultId,
@@ -93,7 +93,7 @@ export function convertFormValuesToApiUpdateInput({
       : justifications && [justifications],
     otherJustificationNotes,
     skillDecisionNotes,
-    notes,
+    assessmentNotes,
   };
 }
 


### PR DESCRIPTION
🤖 Resolves #8729 

## 👋 Introduction

Adds the notes test column to the assessment results table and dialog form.

## 🧪 Testing

1. Refresh API `docker-compose run --rm maintenance bash refresh_api.sh`
2. Build `npm run dev`
3. Run storybook `npm run storybook:web`
4. Navigagte to the "AssessmentDescisionDialog -> Generic" story
5. Fill out some notes
6. Submit
7. Confirm they appear in the action data
8. Seed the database `docker-compose exec -w /home/site/wwwroot/api webserver sh -c "php artisan migrate:fresh --seed"`
9. Open the database and find an assessment result with notes (or insert one) and copy the pool candidate ID
10. Navigate to `/graphiql`
11. Run a query for the notes using the pool candidate ID copied in step 9
12. Confirm it shows up in the result

```graphql
query AssessmentResults{
  poolCandidate(id: "poolCandidateId") {
    id
    assessmentResults {
      assessmentNotes
    }
  }
}
```