### PR TITLE
[Bug] Location exemptions set to text column

### DIFF
--- a/api/database/migrations/2024_01_08_203349_location_exemption_to_text.php
+++ b/api/database/migrations/2024_01_08_203349_location_exemption_to_text.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->text('location_exemptions')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('location_exemptions')->change();
+        });
+    }
+};


### PR DESCRIPTION
🤖 Resolves #8837

## 👋 Introduction

Migrate the column to type text. 

## 🧪 Testing

1. Migrate forward and back successfully 
2. Location exemptions not destroyed
3. Can fill out exemptions on your profile with many more characters now

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/79be4b26-cd31-445a-bc4e-91b151854de8)


