### PR TITLE
[a11y] Increase touch target for checkbox/radio buttons

### DIFF
--- a/apps/web/src/components/UserSkillFormFields/UserSkillFormFields.tsx
+++ b/apps/web/src/components/UserSkillFormFields/UserSkillFormFields.tsx
@@ -37,13 +37,7 @@ const UserSkillFormFields = ({
     value: skillLevel,
     label: <strong>{intl.formatMessage(levelGetter(skillLevel))}</strong>,
     contentBelow: (
-      <p
-        data-h2-margin="base(x.15, 0, x.5, x1)"
-        data-h2-color="base(black.light)"
-        data-h2-font-size="base(caption)"
-      >
-        {intl.formatMessage(levelDefinitionGetter(skillLevel))}
-      </p>
+      <p>{intl.formatMessage(levelDefinitionGetter(skillLevel))}</p>
     ),
   }));
 

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/utils.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/utils.tsx
@@ -113,17 +113,11 @@ export const getEducationRequirementOptions = (
               "Radio group option for education requirement filter in application education form.",
           }),
           contentBelow: (
-            <div data-h2-margin="base(x.15, 0, x.5, x1)">
-              <p>
-                {intl.formatMessage(
-                  applicationMessages.professionalDesignation,
-                  {
-                    link: (msg: React.ReactNode) =>
-                      eligibilityLink(msg, locale),
-                  },
-                )}
-              </p>
-            </div>
+            <p>
+              {intl.formatMessage(applicationMessages.professionalDesignation, {
+                link: (msg: React.ReactNode) => eligibilityLink(msg, locale),
+              })}
+            </p>
           ),
         },
         {
@@ -136,13 +130,11 @@ export const getEducationRequirementOptions = (
               "Radio group option for education requirement filter in application education form.",
           }),
           contentBelow: (
-            <div data-h2-margin="base(x.15, 0, x.5, x1)">
-              <p>
-                {intl.formatMessage(applicationMessages.appliedWorkExpEXGroup, {
-                  link: (msg: React.ReactNode) => acceptableLink(msg, locale),
-                })}
-              </p>
-            </div>
+            <p>
+              {intl.formatMessage(applicationMessages.appliedWorkExpEXGroup, {
+                link: (msg: React.ReactNode) => acceptableLink(msg, locale),
+              })}
+            </p>
           ),
         },
         {
@@ -155,7 +147,7 @@ export const getEducationRequirementOptions = (
               "Radio group option for education requirement filter in application education form.",
           }),
           contentBelow: (
-            <div data-h2-margin="base(x.15, 0, x.15, x1)">
+            <>
               <p>
                 {intl.formatMessage(applicationMessages.graduationWithDegree, {
                   degreeLink: (msg: React.ReactNode) => degreeLink(msg, locale),
@@ -169,7 +161,7 @@ export const getEducationRequirementOptions = (
                     foreignDegreeLink(msg, locale),
                 })}
               </p>
-            </div>
+            </>
           ),
         },
       ];
@@ -185,11 +177,9 @@ export const getEducationRequirementOptions = (
               "Radio group option for education requirement filter in application education form.",
           }),
           contentBelow: (
-            <div data-h2-margin="base(x.15, 0, x.5, x1)">
-              <p>
-                {intl.formatMessage(applicationMessages.appliedWorkExpPMGroup)}
-              </p>
-            </div>
+            <p>
+              {intl.formatMessage(applicationMessages.appliedWorkExpPMGroup)}
+            </p>
           ),
         },
         {
@@ -202,13 +192,11 @@ export const getEducationRequirementOptions = (
               "Radio group option for education requirement filter in application education form.",
           }),
           contentBelow: (
-            <div data-h2-margin="base(x.15, 0, x.15, x1)">
-              <p>
-                {intl.formatMessage(
-                  applicationMessages.secondarySchoolDescription,
-                )}
-              </p>
-            </div>
+            <p>
+              {intl.formatMessage(
+                applicationMessages.secondarySchoolDescription,
+              )}
+            </p>
           ),
         },
       ];
@@ -232,7 +220,7 @@ export const getEducationRequirementOptions = (
                   "Radio group option for education requirement filter in application education form.",
               }),
           contentBelow: (
-            <div data-h2-margin="base(x.15, 0, x.5, x1)">
+            <>
               <p>
                 {intl.formatMessage(applicationMessages.appliedWorkExperience)}
               </p>
@@ -243,7 +231,7 @@ export const getEducationRequirementOptions = (
                   </li>
                 ))}
               </ul>
-            </div>
+            </>
           ),
         },
         {
@@ -264,25 +252,23 @@ export const getEducationRequirementOptions = (
                   "Radio group option for education requirement filter in application education form.",
               }),
           contentBelow: (
-            <div data-h2-margin="base(x.15, 0, x.15, x1)">
-              <p>
-                {isIAP
-                  ? intl.formatMessage({
-                      defaultMessage:
-                        "Successful completion of a standard high school diploma or GED equivalent.",
-                      id: "nIJlba",
-                      description:
-                        "Message under radio button in IAP application education page.",
-                    })
-                  : intl.formatMessage(
-                      applicationMessages.postSecondaryEducation,
-                      {
-                        link: (msg: React.ReactNode) =>
-                          qualityStandardsLink(msg, locale),
-                      },
-                    )}
-              </p>
-            </div>
+            <p>
+              {isIAP
+                ? intl.formatMessage({
+                    defaultMessage:
+                      "Successful completion of a standard high school diploma or GED equivalent.",
+                    id: "nIJlba",
+                    description:
+                      "Message under radio button in IAP application education page.",
+                  })
+                : intl.formatMessage(
+                    applicationMessages.postSecondaryEducation,
+                    {
+                      link: (msg: React.ReactNode) =>
+                        qualityStandardsLink(msg, locale),
+                    },
+                  )}
+            </p>
           ),
         },
       ];

--- a/packages/forms/src/components/CheckButton/CheckButton.tsx
+++ b/packages/forms/src/components/CheckButton/CheckButton.tsx
@@ -74,10 +74,15 @@ const CheckButton = ({
       <span
         className="check-button__inner"
         data-h2-padding="base(x.125)"
+        data-h2-radius="base(input)"
         data-h2-background-color="base(foreground)"
         {...borderMap[color]}
       >
-        <Icon className="check-button__icon" data-h2-display="base(block)" />
+        <Icon
+          className="check-button__icon"
+          data-h2-display="base(block)"
+          data-h2-stroke-width="base(3)"
+        />
       </span>
     </button>
   );

--- a/packages/forms/src/components/Checkbox/Checkbox.tsx
+++ b/packages/forms/src/components/Checkbox/Checkbox.tsx
@@ -66,6 +66,7 @@ const Checkbox = ({
         )}
         <BoundingBox {...(asFieldset ? stateStyles : {})}>
           <Field.Label
+            data-h2-cursor="base(pointer)"
             data-h2-display="base(flex)"
             data-h2-align-items="base(flex-start)"
             data-h2-gap="base(x.25)"

--- a/packages/forms/src/components/Checkbox/Checkbox.tsx
+++ b/packages/forms/src/components/Checkbox/Checkbox.tsx
@@ -6,6 +6,7 @@ import Field from "../Field";
 import type { CommonInputProps, HTMLInputProps } from "../../types";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
+import getCheckboxRadioStyles from "../../utils/getCheckboxRadioStyles";
 
 export type CheckboxProps = HTMLInputProps &
   CommonInputProps & {
@@ -36,6 +37,7 @@ const Checkbox = ({
     register,
     formState: { errors },
   } = useFormContext();
+  const baseStyles = getCheckboxRadioStyles();
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
   // To grab errors in nested objects we need to use lodash's get helper.
   const error = get(errors, name)?.message as FieldError;
@@ -73,23 +75,10 @@ const Checkbox = ({
               aria-describedby={ariaDescribedBy}
               aria-required={!!rules.required && !inCheckList}
               aria-invalid={!!error}
-              data-h2-appearance="base(none)"
-              data-h2-background-color="base(white) base:focus-visible(focus) base:selectors[::before](primary) base:dark:selectors[::before](primary.light) base:all:selectors[:focus-visible::before](black)"
-              data-h2-border="base(thin solid black.light)"
               data-h2-clip-path="base:selectors[::before](polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%))"
-              data-h2-color="base(currentColor)"
-              data-h2-content="base:selectors[::before]('')"
-              data-h2-display="base(grid)"
-              data-h2-flex-shrink="base(0)"
-              data-h2-place-content="base(center)"
-              data-h2-height="base(x.9) base:selectors[::before](x.5)"
-              data-h2-line-height="base(x1)"
-              data-h2-margin="base(x.1 0 0 0)"
               data-h2-radius="base(input)"
-              data-h2-transform="base:selectors[::before](scale(0)) base:selectors[:checked::before](scale(1))"
-              data-h2-transition="base:selectors[::before](120ms transform ease-in-out)"
-              data-h2-width="base(x.9) base:selectors[::before](x.5)"
               {...register(name, rules)}
+              {...baseStyles}
               {...rest}
             />
             <span data-h2-font-size="base(body)">{label}</span>

--- a/packages/forms/src/components/Checkbox/Checkbox.tsx
+++ b/packages/forms/src/components/Checkbox/Checkbox.tsx
@@ -67,6 +67,9 @@ const Checkbox = ({
             data-h2-display="base(flex)"
             data-h2-align-items="base(flex-start)"
             data-h2-gap="base(x.25)"
+            {...(inCheckList && {
+              "data-h2-padding": "base(x.25 x.5)",
+            })}
           >
             <input
               id={id}

--- a/packages/forms/src/components/Checkbox/Checkbox.tsx
+++ b/packages/forms/src/components/Checkbox/Checkbox.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import get from "lodash/get";
 import { FieldError, useFormContext } from "react-hook-form";
+import { useReducedMotion } from "framer-motion";
 
 import Field from "../Field";
 import type { CommonInputProps, HTMLInputProps } from "../../types";
@@ -37,7 +38,8 @@ const Checkbox = ({
     register,
     formState: { errors },
   } = useFormContext();
-  const baseStyles = getCheckboxRadioStyles();
+  const shouldReduceMotion = useReducedMotion();
+  const baseStyles = getCheckboxRadioStyles(shouldReduceMotion);
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
   // To grab errors in nested objects we need to use lodash's get helper.
   const error = get(errors, name)?.message as FieldError;

--- a/packages/forms/src/components/Checkbox/Checkbox.tsx
+++ b/packages/forms/src/components/Checkbox/Checkbox.tsx
@@ -80,11 +80,18 @@ const Checkbox = ({
               aria-invalid={!!error}
               data-h2-clip-path="base:selectors[::before](polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%))"
               data-h2-radius="base(input)"
+              data-h2-vertical-align="base(middle)"
               {...register(name, rules)}
               {...baseStyles}
               {...rest}
             />
-            <span data-h2-font-size="base(body)">{label}</span>
+            <span
+              data-h2-font-size="base(body)"
+              data-h2-vertical-align="base(middle)"
+              data-h2-line-height="base(x1)"
+            >
+              {label}
+            </span>
             {!asFieldset && !inCheckList && (
               <Field.Required required={!!rules.required} />
             )}

--- a/packages/forms/src/components/Checkbox/Checkbox.tsx
+++ b/packages/forms/src/components/Checkbox/Checkbox.tsx
@@ -69,10 +69,26 @@ const Checkbox = ({
             <input
               id={id}
               type="checkbox"
+              className="Input--Checkbox"
               aria-describedby={ariaDescribedBy}
               aria-required={!!rules.required && !inCheckList}
               aria-invalid={!!error}
-              data-h2-margin-top="base(x.26)"
+              data-h2-appearance="base(none)"
+              data-h2-background-color="base(white) base:focus-visible(focus) base:selectors[::before](primary) base:dark:selectors[::before](primary.light) base:all:selectors[:focus-visible::before](black)"
+              data-h2-border="base(thin solid black.light)"
+              data-h2-clip-path="base:selectors[::before](polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%))"
+              data-h2-color="base(currentColor)"
+              data-h2-content="base:selectors[::before]('')"
+              data-h2-display="base(grid)"
+              data-h2-flex-shrink="base(0)"
+              data-h2-place-content="base(center)"
+              data-h2-height="base(x.9) base:selectors[::before](x.5)"
+              data-h2-line-height="base(x1)"
+              data-h2-margin="base(x.1 0 0 0)"
+              data-h2-radius="base(input)"
+              data-h2-transform="base:selectors[::before](scale(0)) base:selectors[:checked::before](scale(1))"
+              data-h2-transition="base:selectors[::before](120ms transform ease-in-out)"
+              data-h2-width="base(x.9) base:selectors[::before](x.5)"
               {...register(name, rules)}
               {...rest}
             />

--- a/packages/forms/src/components/Checklist/Checklist.tsx
+++ b/packages/forms/src/components/Checklist/Checklist.tsx
@@ -69,7 +69,11 @@ const Checklist = ({
         {...rest}
       >
         <Field.Legend required={!!rules.required}>{legend}</Field.Legend>
-        <Field.BoundingBox {...{ ...baseStyles, ...stateStyles }}>
+        <Field.BoundingBox
+          {...{ ...baseStyles, ...stateStyles }}
+          data-h2-gap="base(0)"
+          data-h2-padding="base(x.25 0)"
+        >
           {items.map(({ value, label }) => {
             const id = `${idPrefix}-${value}`;
             return (

--- a/packages/forms/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/forms/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { StoryFn } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
+import { faker } from "@faker-js/faker";
 
 import { VIEWPORT } from "@gc-digital-talent/storybook-helpers";
 
 import Form from "../BasicForm";
 import Submit from "../Submit";
 import RadioGroup from "./RadioGroup";
+
+faker.seed(0);
 
 export default {
   component: RadioGroup,
@@ -122,4 +125,13 @@ LongLegendRadioGroup.args = {
   ...BasicRadioGroup.args,
   legend:
     "This is a super, super long title which will wrap around to a second line at some point. Fusce lacinia sollicitudin nulla, sit amet semper metus mattis id. Suspendisse nisl enim, bibendum sed sem eget, porttitor ultrices metus.",
+};
+
+export const ContentBelowRadioGroup = TemplateRadioGroup.bind({});
+ContentBelowRadioGroup.args = {
+  ...BasicRadioGroup.args,
+  items: BasicRadioGroup.args.items?.map((item) => ({
+    ...item,
+    contentBelow: faker.lorem.lines(6),
+  })),
 };

--- a/packages/forms/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/forms/src/components/RadioGroup/RadioGroup.tsx
@@ -132,6 +132,7 @@ const RadioGroup = ({
                 >
                   <Field.Label
                     key={value}
+                    data-h2-cursor="base(pointer)"
                     data-h2-font-size="base(copy)"
                     data-h2-display="base(flex)"
                     data-h2-align-items="base(flex-start)"

--- a/packages/forms/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/forms/src/components/RadioGroup/RadioGroup.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import get from "lodash/get";
 import { FieldError, useFormContext } from "react-hook-form";
+import { useReducedMotion } from "framer-motion";
 
 import Field from "../Field";
 import type { CommonInputProps, HTMLFieldsetProps } from "../../types";
@@ -87,7 +88,8 @@ const RadioGroup = ({
   // To grab errors in nested objects we need to use lodash's get helper.
   const error = get(errors, name)?.message as FieldError;
   const baseStyles = useInputStyles();
-  const baseRadioStyles = getCheckboxRadioStyles();
+  const shouldReduceMotion = useReducedMotion();
+  const baseRadioStyles = getCheckboxRadioStyles(shouldReduceMotion);
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
   const fieldState = useFieldState(name, !trackUnsaved);
   const isUnsaved = fieldState === "dirty" && trackUnsaved;

--- a/packages/forms/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/forms/src/components/RadioGroup/RadioGroup.tsx
@@ -111,7 +111,10 @@ const RadioGroup = ({
         {...rest}
       >
         <Field.Legend required={!!rules.required}>{legend}</Field.Legend>
-        <Field.BoundingBox {...{ ...baseStyles, ...stateStyles }}>
+        <Field.BoundingBox
+          {...{ ...baseStyles, ...stateStyles }}
+          data-h2-padding="base(x.25 0)"
+        >
           <div
             data-h2-display="base(grid)"
             data-h2-gap="base(x.25)"
@@ -130,7 +133,7 @@ const RadioGroup = ({
                     data-h2-font-size="base(copy)"
                     data-h2-display="base(flex)"
                     data-h2-align-items="base(flex-start)"
-                    data-h2-gap="base(0 x.25)"
+                    data-h2-padding="base(x.25 x.5)"
                   >
                     <input
                       id={id}

--- a/packages/forms/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/forms/src/components/RadioGroup/RadioGroup.tsx
@@ -8,6 +8,7 @@ import useFieldState from "../../hooks/useFieldState";
 import useInputStyles from "../../hooks/useInputStyles";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
+import getCheckboxRadioStyles from "../../utils/getCheckboxRadioStyles";
 
 export type Radio = {
   value: string | number;
@@ -86,6 +87,7 @@ const RadioGroup = ({
   // To grab errors in nested objects we need to use lodash's get helper.
   const error = get(errors, name)?.message as FieldError;
   const baseStyles = useInputStyles();
+  const baseRadioStyles = getCheckboxRadioStyles();
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
   const fieldState = useFieldState(name, !trackUnsaved);
   const isUnsaved = fieldState === "dirty" && trackUnsaved;
@@ -137,7 +139,8 @@ const RadioGroup = ({
                       type="radio"
                       disabled={disabled}
                       defaultChecked={defaultSelected === value}
-                      data-h2-margin-top="base(x.26)"
+                      data-h2-radius="base(l) base:selectors[::before](l)"
+                      {...baseRadioStyles}
                       {...(contentBelow && {
                         "aria-describedby": `${id}-content-below`,
                       })}

--- a/packages/forms/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/forms/src/components/RadioGroup/RadioGroup.tsx
@@ -144,15 +144,29 @@ const RadioGroup = ({
                       disabled={disabled}
                       defaultChecked={defaultSelected === value}
                       data-h2-radius="base(l) base:selectors[::before](l)"
+                      data-h2-vertical-align="base(middle)"
                       {...baseRadioStyles}
                       {...(contentBelow && {
                         "aria-describedby": `${id}-content-below`,
                       })}
                     />
-                    <span data-h2-font-size="base(body)">{label}</span>
+                    <span
+                      data-h2-font-size="base(body)"
+                      data-h2-vertical-align="base(middle)"
+                      data-h2-line-height="base(x1)"
+                    >
+                      {label}
+                    </span>
                   </Field.Label>
                   {contentBelow && (
-                    <div id={`${id}-content-below`}>{contentBelow}</div>
+                    <div
+                      id={`${id}-content-below`}
+                      data-h2-padding-left="base(x1.7)"
+                      data-h2-color="base(black.light)"
+                      data-h2-font-size="base(caption)"
+                    >
+                      {contentBelow}
+                    </div>
                   )}
                 </div>
               );

--- a/packages/forms/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/forms/src/components/RadioGroup/RadioGroup.tsx
@@ -117,7 +117,7 @@ const RadioGroup = ({
         >
           <div
             data-h2-display="base(grid)"
-            data-h2-gap="base(x.25)"
+            data-h2-gap="base(0 x.25)"
             {...columnStyles}
           >
             {items.map(({ value, label, contentBelow }) => {
@@ -134,6 +134,7 @@ const RadioGroup = ({
                     data-h2-display="base(flex)"
                     data-h2-align-items="base(flex-start)"
                     data-h2-padding="base(x.25 x.5)"
+                    data-h2-gap="base(x.25)"
                   >
                     <input
                       id={id}

--- a/packages/forms/src/utils/getCheckboxRadioStyles.ts
+++ b/packages/forms/src/utils/getCheckboxRadioStyles.ts
@@ -1,0 +1,20 @@
+const getCheckboxRadioStyles = () => ({
+  "data-h2-appearance": "base(none)",
+  "data-h2-background-color":
+    "base(white) base:focus-visible(focus) base:selectors[::before](primary) base:dark:selectors[::before](primary.light) base:all:selectors[:focus-visible::before](black)",
+  "data-h2-border": "base(thin solid black.light)",
+  "data-h2-color": "base(currentColor)",
+  "data-h2-content": "base:selectors[::before]('')",
+  "data-h2-display": "base(grid)",
+  "data-h2-flex-shrink": "base(0)",
+  "data-h2-place-content": "base(center)",
+  "data-h2-height": "base(x.9) base:selectors[::before](x.5)",
+  "data-h2-line-height": "base(x1)",
+  "data-h2-margin": "base(x.1 0 0 0)",
+  "data-h2-transform":
+    "base:selectors[::before](scale(0)) base:selectors[:checked::before](scale(1))",
+  "data-h2-transition": "base:selectors[::before](120ms transform ease-in-out)",
+  "data-h2-width": "base(x.9) base:selectors[::before](x.5)",
+});
+
+export default getCheckboxRadioStyles;

--- a/packages/forms/src/utils/getCheckboxRadioStyles.ts
+++ b/packages/forms/src/utils/getCheckboxRadioStyles.ts
@@ -1,4 +1,4 @@
-const getCheckboxRadioStyles = () => ({
+const getCheckboxRadioStyles = (shouldReduceMotion: boolean | null) => ({
   "data-h2-appearance": "base(none)",
   "data-h2-background-color":
     "base(white) base:focus-visible(focus) base:selectors[::before](primary) base:dark:selectors[::before](primary.light) base:all:selectors[:focus-visible::before](black)",
@@ -13,7 +13,10 @@ const getCheckboxRadioStyles = () => ({
   "data-h2-margin": "base(0)",
   "data-h2-transform":
     "base:selectors[::before](scale(0)) base:selectors[:checked::before](scale(1))",
-  "data-h2-transition": "base:selectors[::before](120ms transform ease-in-out)",
+  ...(!shouldReduceMotion && {
+    "data-h2-transition":
+      "base:selectors[::before](120ms transform ease-in-out)",
+  }),
   "data-h2-width": "base(x1) base:selectors[::before](x.5)",
 });
 

--- a/packages/forms/src/utils/getCheckboxRadioStyles.ts
+++ b/packages/forms/src/utils/getCheckboxRadioStyles.ts
@@ -8,13 +8,13 @@ const getCheckboxRadioStyles = () => ({
   "data-h2-display": "base(grid)",
   "data-h2-flex-shrink": "base(0)",
   "data-h2-place-content": "base(center)",
-  "data-h2-height": "base(x.9) base:selectors[::before](x.5)",
+  "data-h2-height": "base(x1) base:selectors[::before](x.5)",
   "data-h2-line-height": "base(x1)",
-  "data-h2-margin": "base(x.1 0 0 0)",
+  "data-h2-margin": "base(0)",
   "data-h2-transform":
     "base:selectors[::before](scale(0)) base:selectors[:checked::before](scale(1))",
   "data-h2-transition": "base:selectors[::before](120ms transform ease-in-out)",
-  "data-h2-width": "base(x.9) base:selectors[::before](x.5)",
+  "data-h2-width": "base(x1) base:selectors[::before](x.5)",
 });
 
 export default getCheckboxRadioStyles;


### PR DESCRIPTION
🤖 Resolves #8965 

## 👋 Introduction

Increases the total touch target of checkboxes and radio buttons. Also, improves the styling to better match our current design system.

## 🧪 Testing

>[!NOTE]
> This was tested in safari and working as expected.

1. Build `npm run dev`
2. Navigate to a form or, start storybook
3. Ensure the touch target is expanded in check lists and radio groups
4. Ensure they still function as expected

## 📸 Screenshot

![Screenshot 2024-01-10 113838](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/15f939a8-b802-4be8-ae32-380a352b94fa)
![Screenshot 2024-01-10 114044](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/7aa70cd6-20b3-4f9b-81fb-c5e36405463e)
