### PR TITLE
[Fix] Bookmark column to support `null`

### DIFF
--- a/api/database/factories/PoolCandidateFactory.php
+++ b/api/database/factories/PoolCandidateFactory.php
@@ -51,7 +51,7 @@ class PoolCandidateFactory extends Factory
                 $this->faker->numberBetween(0, count(ApplicationStep::cases()) - 1)
             ),
             'education_requirement_option' => $this->faker->randomElement(EducationRequirementOption::cases())->name,
-            'is_bookmarked' => $this->faker->boolean(10),
+            'is_bookmarked' => $this->faker->optional(.8)->boolean(10),
         ];
     }
 

--- a/api/database/migrations/2023_12_05_210313_add_bookmarked_column_to_pool_candidates.php
+++ b/api/database/migrations/2023_12_05_210313_add_bookmarked_column_to_pool_candidates.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('pool_candidates', function (Blueprint $table) {
-            $table->boolean('is_bookmarked');
+            $table->boolean('is_bookmarked')->nullable()->default(null);
         });
     }
 


### PR DESCRIPTION
🤖 Resolves #8977 

## 👋 Introduction

Without a default value/nullable the bookmark column was causing issues for existing rows. This updates the migration to make it nullable with null as a default value. As well, it makes the field optional in the factory so we can simulate this locally as well.

## 🕵️ Details

I wasn't sure if we had already ran this migration but the AC mentioned updating the migration instead of creating a new one. If we have and it would be safer to create a new migration, let me know and I can fix that.

## 🧪 Testing

```graphql
  mutation ToggleBookmark_Mutation($id: ID!) {
    togglePoolCandidateBookmark(id: $id)
  }
```

1. Run migrations `docker-compose exec -w /home/site/wwwroot/api webserver sh -c "php artisan migrate"`
2. Navigate to `/graphiql`
3. Attempt to bookmark a candidate
4. Confirm there is no error
5. Confirm the new value is in the database
6. Seed new data `docker-compose exec -w /home/site/wwwroot/api webserver sh -c "php artisan migrate:fresh --seed"`
7. Confirm there are a mix of `null`, `true`, `false` bookmarked candidates
8. Toggle the bookmark on a candidate with `null` from `null` to `true` from the `grappql` mutation
9. Confirm it works as expected
10. Repeat steps 8-9 between `true` and `false`
