### PR TITLE
[Fix] Career timeline self reference

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1059,6 +1059,10 @@
     "defaultMessage": "Je suis actuellement actif dans ces études",
     "description": "Label displayed on Education Experience form for current education input"
   },
+  "49MghK": {
+    "defaultMessage": "La présente section ressemble à votre cv traditionnel. Il s’agit de l’endroit où vous pouvez décrire vos expériences, au travail, à l’école et dans la vie. Vous pourrez réutiliser ces informations pour chaque candidature que vous soumettrez sur la plateforme, ce qui accélérera le processus et garantira que vos informations sont toujours à jour.",
+    "description": "Descriptive paragraph for the Manage your career timeline section of the career timeline and recruitment page."
+  },
   "49UIne": {
     "defaultMessage": "Apprenti en TI du Gouvernement du Canada",
     "description": "author of testimonial number one"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -10323,10 +10323,6 @@
     "defaultMessage": "Consultez notre nouveau Portail de données sur les talents numériques pour connaître des tendances, des pistes de réflexion et des idées afin de renforcer vos propres stratégies de planification des talents et de recrutement.",
     "description": "Description for the digital talent data portal"
   },
-  "xXEhNq": {
-    "defaultMessage": "Cette section est semblable à votre cv traditionnel, et elle décrit vos expérience à travers votre vie professionnelle, scolaire et personnelle. Vous pourrez vous servir de cette information dans chaque demande que vous soumettez sur la plateforme, accélérant ainsi le processus et veillant à ce que votre information soit toujours à jour.",
-    "description": "Descriptive paragraph for the Manage your career timeline section of the career timeline and recruitment page."
-  },
   "xXwUGs": {
     "defaultMessage": "Directive sur les talents numériques",
     "description": "Title for the digital talent directive page"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6979,10 +6979,6 @@
     "defaultMessage": "Langue de communication préférée",
     "description": "CSV Header, Preferred Communication Language column"
   },
-  "dAGii/": {
-    "defaultMessage": "Cette section est similaire à votre parcours professionnel traditionnel et décrit vos expériences au travail, à l’école et dans la vie. Vous pourrez réutiliser ces informations pour chaque candidature que vous soumettrez sur la plateforme, ce qui accélérera le processus et garantira que vos informations sont toujours à jour.",
-    "description": "Descriptive paragraph for the Manage your career timeline section of the career timeline and recruitment page."
-  },
   "dAopan": {
     "defaultMessage": "l’optimisation des résultats de la recherche en matière de l'expérience utilisateur",
     "description": "List item four, things designers consider for accessibility"
@@ -10326,6 +10322,10 @@
   "xQfIcL": {
     "defaultMessage": "Consultez notre nouveau Portail de données sur les talents numériques pour connaître des tendances, des pistes de réflexion et des idées afin de renforcer vos propres stratégies de planification des talents et de recrutement.",
     "description": "Description for the digital talent data portal"
+  },
+  "xXEhNq": {
+    "defaultMessage": "Cette section est semblable à votre cv traditionnel, et elle décrit vos expérience à travers votre vie professionnelle, scolaire et personnelle. Vous pourrez vous servir de cette information dans chaque demande que vous soumettez sur la plateforme, accélérant ainsi le processus et veillant à ce que votre information soit toujours à jour.",
+    "description": "Descriptive paragraph for the Manage your career timeline section of the career timeline and recruitment page."
   },
   "xXwUGs": {
     "defaultMessage": "Directive sur les talents numériques",

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
@@ -137,8 +137,8 @@ const CareerTimelineAndRecruitment = ({
               <p>
                 {intl.formatMessage({
                   defaultMessage:
-                    "This section is similar to your traditional resume and describes your experiences across work, school, and life. You’ll be able to reuse this information on each application you submit on the platform, speeding up the process and ensuring that your information is always up-to-date.",
-                  id: "xXEhNq",
+                    "This section is similar to your traditional resume. This is where you can describe your experiences across work, school, and life.",
+                  id: "jH6Fsj",
                   description:
                     "Descriptive paragraph for the Manage your career timeline section of the career timeline and recruitment page.",
                 })}

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
@@ -137,8 +137,8 @@ const CareerTimelineAndRecruitment = ({
               <p>
                 {intl.formatMessage({
                   defaultMessage:
-                    "This section is similar to your traditional career timeline and describes your experiences across work, school, and life. You’ll be able to reuse this information on each application you submit on the platform, speeding up the process and ensuring that your information is always up-to-date.",
-                  id: "dAGii/",
+                    "This section is similar to your traditional resume and describes your experiences across work, school, and life. You’ll be able to reuse this information on each application you submit on the platform, speeding up the process and ensuring that your information is always up-to-date.",
+                  id: "xXEhNq",
                   description:
                     "Descriptive paragraph for the Manage your career timeline section of the career timeline and recruitment page.",
                 })}

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
@@ -137,8 +137,8 @@ const CareerTimelineAndRecruitment = ({
               <p>
                 {intl.formatMessage({
                   defaultMessage:
-                    "This section is similar to your traditional resume. This is where you can describe your experiences across work, school, and life.",
-                  id: "jH6Fsj",
+                    "This section is similar to your traditional resume. This is where you can describe your experiences across work, school, and life. You'll be able to reuse this information on each application you submit on the platform, speeding up the process and ensuring that your information is always up-to-date.",
+                  id: "49MghK",
                   description:
                     "Descriptive paragraph for the Manage your career timeline section of the career timeline and recruitment page.",
                 })}


### PR DESCRIPTION
🤖 Resolves #7936 

## 👋 Introduction

Fixes a place on the career timeline page where we were self referencing "career timeline" in the description of what it was.

## 🕵️ Details

Tested with JAWS, NVDA, Narrator and it read it as a noun properly.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login as an applicant
3. Navigate to `/users/{userId}/personal-information/career-timeline`
4. Confirm the first paragraph uses "resume" and not "career timeline"
5. **Bonus** Try it out with some screen readers and confirm the term "resume" is read out properly

