### PR TITLE
[Fix] Employment equity filters

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -662,7 +662,7 @@ class User extends Model implements Authenticatable, LaratrustUser
         $query->where(function ($query) use ($equityVars) {
             foreach ($equityVars as $index => $equityInstance) {
                 if ($equityInstance === 'is_indigenous') {
-                    $query->whereJsonLength('indigenous_communities', '>', 0);
+                    $query->orWhereJsonLength('indigenous_communities', '>', 0);
                 } else {
                     $query->orWhere($equityVars[$index], true);
                 }

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
@@ -46,23 +46,7 @@ import FilterDialog, {
 } from "../FilterDialog/FilterDialog";
 import adminMessages from "../../messages/adminMessages";
 import { getFullPoolTitleLabel } from "../../utils/poolUtils";
-
-export type FormValues = {
-  languageAbility: string;
-  classifications: string[];
-  stream: string[];
-  operationalRequirement: string[];
-  workRegion: string[];
-  equity: string[];
-  poolCandidateStatus: string[];
-  priorityWeight: string[];
-  pools: string[];
-  skills: string[];
-  expiryStatus: string;
-  suspendedStatus: string;
-  publishingGroups: string[];
-  govEmployee: string;
-};
+import { FormValues } from "./types";
 
 const context: Partial<OperationContext> = {
   additionalTypenames: ["Skill", "SkillFamily"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -25,9 +25,6 @@ import {
   useGetSelectedPoolCandidatesQuery,
   Pool,
   Maybe,
-  CandidateExpiryFilter,
-  CandidateSuspendedFilter,
-  PoolStream,
   PoolCandidateWithSkillCount,
   useGetSkillsQuery,
   PublishingGroup,
@@ -37,14 +34,6 @@ import {
   INITIAL_STATE,
   SEARCH_PARAM_KEY,
 } from "~/components/Table/ResponsiveTable/constants";
-import {
-  stringToEnumCandidateExpiry,
-  stringToEnumCandidateSuspended,
-  stringToEnumLanguage,
-  stringToEnumLocation,
-  stringToEnumOperational,
-  stringToEnumPoolCandidateStatus,
-} from "~/utils/userUtils";
 import cells from "~/components/Table/cells";
 import adminMessages from "~/messages/adminMessages";
 import UserProfilePrintButton from "~/pages/Users/AdminUserProfilePage/components/UserProfilePrintButton";
@@ -64,64 +53,18 @@ import {
   notesCell,
   priorityCell,
   statusCell,
+  transformFormValuesToFilterState,
+  transformPoolCandidateSearchInputToFormValues,
   transformSortStateToOrderByClause,
   viewPoolCandidateCell,
 } from "./helpers";
 import { rowSelectCell } from "../Table/ResponsiveTable/RowSelection";
 import { normalizedText } from "../Table/sortingFns";
 import accessors from "../Table/accessors";
-import PoolCandidateFilterDialog, {
-  FormValues,
-} from "./PoolCandidateFilterDialog";
+import PoolCandidateFilterDialog from "./PoolCandidateFilterDialog";
+import { FormValues } from "./types";
 
 const columnHelper = createColumnHelper<PoolCandidateWithSkillCount>();
-
-function transformPoolCandidateSearchInputToFormValues(
-  input: PoolCandidateSearchInput | undefined,
-): FormValues {
-  return {
-    publishingGroups: input?.publishingGroups?.filter(notEmpty) ?? [],
-    classifications:
-      input?.applicantFilter?.qualifiedClassifications
-        ?.filter(notEmpty)
-        .map((c) => `${c.group}-${c.level}`) ?? [],
-    stream: input?.applicantFilter?.qualifiedStreams?.filter(notEmpty) ?? [],
-    languageAbility: input?.applicantFilter?.languageAbility ?? "",
-    workRegion:
-      input?.applicantFilter?.locationPreferences?.filter(notEmpty) ?? [],
-    operationalRequirement:
-      input?.applicantFilter?.operationalRequirements?.filter(notEmpty) ?? [],
-    equity: input?.applicantFilter?.equity
-      ? [
-          ...(input.applicantFilter.equity.hasDisability
-            ? ["hasDisability"]
-            : []),
-          ...(input.applicantFilter.equity.isIndigenous
-            ? ["isIndigenous"]
-            : []),
-          ...(input.applicantFilter.equity.isVisibleMinority
-            ? ["isVisibleMinority"]
-            : []),
-          ...(input.applicantFilter.equity.isWoman ? ["isWoman"] : []),
-        ]
-      : [],
-    pools:
-      input?.applicantFilter?.pools
-        ?.filter(notEmpty)
-        .map((poolFilter) => poolFilter.id) ?? [],
-    skills:
-      input?.applicantFilter?.skills?.filter(notEmpty).map((s) => s.id) ?? [],
-    priorityWeight: input?.priorityWeight?.map((pw) => String(pw)) ?? [],
-    poolCandidateStatus: input?.poolCandidateStatus?.filter(notEmpty) ?? [],
-    expiryStatus: input?.expiryStatus
-      ? input.expiryStatus
-      : CandidateExpiryFilter.Active,
-    suspendedStatus: input?.suspendedStatus
-      ? input.suspendedStatus
-      : CandidateSuspendedFilter.Active,
-    govEmployee: input?.isGovEmployee ? "true" : "",
-  };
-}
 
 const defaultState = {
   ...INITIAL_STATE,
@@ -216,58 +159,8 @@ const PoolCandidatesTable = ({
   };
 
   const handleFilterSubmit: SubmitHandler<FormValues> = (data) => {
-    const transformedData: PoolCandidateSearchInput = {
-      applicantFilter: {
-        languageAbility: data.languageAbility
-          ? stringToEnumLanguage(data.languageAbility)
-          : undefined,
-        qualifiedClassifications: data.classifications.map((classification) => {
-          const splitString = classification.split("-");
-          return { group: splitString[0], level: Number(splitString[1]) };
-        }),
-        qualifiedStreams: data.stream as PoolStream[],
-        operationalRequirements: data.operationalRequirement
-          .map((requirement) => {
-            return stringToEnumOperational(requirement);
-          })
-          .filter(notEmpty),
-        locationPreferences: data.workRegion
-          .map((region) => {
-            return stringToEnumLocation(region);
-          })
-          .filter(notEmpty),
-        equity: {
-          ...(data.equity.includes("isWoman") && { isWoman: true }),
-          ...(data.equity.includes("hasDisability") && { hasDisability: true }),
-          ...(data.equity.includes("isIndigenous") && { isIndigenous: true }),
-          ...(data.equity.includes("isVisibleMinority") && {
-            isVisibleMinority: true,
-          }),
-        },
-        pools: data.pools.map((id) => {
-          return { id };
-        }),
-        skills: data.skills.map((id) => {
-          return { id };
-        }),
-      },
-      poolCandidateStatus: data.poolCandidateStatus
-        .map((status) => {
-          return stringToEnumPoolCandidateStatus(status);
-        })
-        .filter(notEmpty),
-      priorityWeight: data.priorityWeight.map((priority) => {
-        return Number(priority);
-      }),
-      expiryStatus: data.expiryStatus
-        ? stringToEnumCandidateExpiry(data.expiryStatus)
-        : undefined,
-      suspendedStatus: data.suspendedStatus
-        ? stringToEnumCandidateSuspended(data.suspendedStatus)
-        : undefined,
-      isGovEmployee: data.govEmployee ? true : undefined, // massage from FormValue type to PoolCandidateSearchInput
-      publishingGroups: data.publishingGroups as PublishingGroup[],
-    };
+    const transformedData: PoolCandidateSearchInput =
+      transformFormValuesToFilterState(data);
 
     setFilterState(transformedData);
     if (!isEqual(transformedData, filterRef.current)) {

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -12,6 +12,12 @@ import {
 } from "@gc-digital-talent/i18n";
 import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 import { Spoiler } from "@gc-digital-talent/ui";
+import {
+  CandidateExpiryFilter,
+  PoolStream,
+  PublishingGroup,
+} from "@gc-digital-talent/graphql";
+import { notEmpty } from "@gc-digital-talent/helpers";
 
 import {
   OrderByRelationWithColumnAggregateFunction,
@@ -29,6 +35,15 @@ import useRoutes from "~/hooks/useRoutes";
 import { getFullNameLabel } from "~/utils/nameUtils";
 
 import cells from "../Table/cells";
+import { FormValues } from "./types";
+import {
+  stringToEnumCandidateExpiry,
+  stringToEnumCandidateSuspended,
+  stringToEnumLanguage,
+  stringToEnumLocation,
+  stringToEnumOperational,
+  stringToEnumPoolCandidateStatus,
+} from "../../utils/userUtils";
 
 export const statusCell = (
   status: PoolCandidateStatus | null | undefined,
@@ -336,5 +351,109 @@ export function transformSortStateToOrderByClause(
     column: "submitted_at",
     order: SortOrder.Asc,
     user: undefined,
+  };
+}
+
+export function transformPoolCandidateSearchInputToFormValues(
+  input: PoolCandidateSearchInput | undefined,
+): FormValues {
+  return {
+    publishingGroups: input?.publishingGroups?.filter(notEmpty) ?? [],
+    classifications:
+      input?.applicantFilter?.qualifiedClassifications
+        ?.filter(notEmpty)
+        .map((c) => `${c.group}-${c.level}`) ?? [],
+    stream: input?.applicantFilter?.qualifiedStreams?.filter(notEmpty) ?? [],
+    languageAbility: input?.applicantFilter?.languageAbility ?? "",
+    workRegion:
+      input?.applicantFilter?.locationPreferences?.filter(notEmpty) ?? [],
+    operationalRequirement:
+      input?.applicantFilter?.operationalRequirements?.filter(notEmpty) ?? [],
+    equity: input?.applicantFilter?.equity
+      ? [
+          ...(input.applicantFilter.equity.hasDisability
+            ? ["hasDisability"]
+            : []),
+          ...(input.applicantFilter.equity.isIndigenous
+            ? ["isIndigenous"]
+            : []),
+          ...(input.applicantFilter.equity.isVisibleMinority
+            ? ["isVisibleMinority"]
+            : []),
+          ...(input.applicantFilter.equity.isWoman ? ["isWoman"] : []),
+        ]
+      : [],
+    pools:
+      input?.applicantFilter?.pools
+        ?.filter(notEmpty)
+        .map((poolFilter) => poolFilter.id) ?? [],
+    skills:
+      input?.applicantFilter?.skills?.filter(notEmpty).map((s) => s.id) ?? [],
+    priorityWeight: input?.priorityWeight?.map((pw) => String(pw)) ?? [],
+    poolCandidateStatus: input?.poolCandidateStatus?.filter(notEmpty) ?? [],
+    expiryStatus: input?.expiryStatus
+      ? input.expiryStatus
+      : CandidateExpiryFilter.Active,
+    suspendedStatus: input?.suspendedStatus
+      ? input.suspendedStatus
+      : CandidateSuspendedFilter.Active,
+    govEmployee: input?.isGovEmployee ? "true" : "",
+  };
+}
+
+export function transformFormValuesToFilterState(
+  data: FormValues,
+): PoolCandidateSearchInput {
+  return {
+    applicantFilter: {
+      languageAbility: data.languageAbility
+        ? stringToEnumLanguage(data.languageAbility)
+        : undefined,
+      qualifiedClassifications: data.classifications.map((classification) => {
+        const splitString = classification.split("-");
+        return { group: splitString[0], level: Number(splitString[1]) };
+      }),
+      qualifiedStreams: data.stream as PoolStream[],
+      operationalRequirements: data.operationalRequirement
+        .map((requirement) => {
+          return stringToEnumOperational(requirement);
+        })
+        .filter(notEmpty),
+      locationPreferences: data.workRegion
+        .map((region) => {
+          return stringToEnumLocation(region);
+        })
+        .filter(notEmpty),
+      equity: {
+        ...(data.equity.includes("isWoman") && { isWoman: true }),
+        ...(data.equity.includes("hasDisability") && { hasDisability: true }),
+        ...(data.equity.includes("isIndigenous") && { isIndigenous: true }),
+        ...(data.equity.includes("isVisibleMinority") && {
+          isVisibleMinority: true,
+        }),
+      },
+      pools: data.pools.map((id) => {
+        return { id };
+      }),
+      skills: data.skills.map((id) => {
+        return { id };
+      }),
+    },
+    poolCandidateStatus: data.poolCandidateStatus
+      .map((status) => {
+        return stringToEnumPoolCandidateStatus(status);
+      })
+      .filter(notEmpty),
+    priorityWeight: data.priorityWeight.map((priority) => {
+      return Number(priority);
+    }),
+    expiryStatus: data.expiryStatus
+      ? stringToEnumCandidateExpiry(data.expiryStatus)
+      : undefined,
+    suspendedStatus: data.suspendedStatus
+      ? stringToEnumCandidateSuspended(data.suspendedStatus)
+      : undefined,
+    isGovEmployee: data.govEmployee ? true : undefined, // massage from FormValue type to PoolCandidateSearchInput
+    publishingGroups: data.publishingGroups as PublishingGroup[],
   };
 }

--- a/apps/web/src/components/PoolCandidatesTable/poolCandidateHelpers.test.ts
+++ b/apps/web/src/components/PoolCandidatesTable/poolCandidateHelpers.test.ts
@@ -1,0 +1,113 @@
+import {
+  CandidateExpiryFilter,
+  CandidateSuspendedFilter,
+} from "@gc-digital-talent/graphql";
+
+import { transformFormValuesToFilterState } from "./helpers";
+import { FormValues } from "./types";
+
+const defaultFormValues: FormValues = {
+  publishingGroups: [],
+  classifications: [],
+  stream: [],
+  languageAbility: "",
+  workRegion: [],
+  operationalRequirement: [],
+  equity: [],
+  pools: [],
+  skills: [],
+  priorityWeight: [],
+  poolCandidateStatus: [],
+  expiryStatus: CandidateExpiryFilter.Active,
+  suspendedStatus: CandidateSuspendedFilter.Active,
+  govEmployee: "",
+};
+
+describe("Transform form values to filter state", () => {
+  test("Single equity item", () => {
+    const hasDisabilityFilters = transformFormValuesToFilterState({
+      ...defaultFormValues,
+      equity: ["hasDisability"],
+    });
+
+    expect(hasDisabilityFilters).toEqual(
+      expect.objectContaining({
+        applicantFilter: expect.objectContaining({
+          equity: { hasDisability: true },
+        }),
+      }),
+    );
+
+    const isWomanFilters = transformFormValuesToFilterState({
+      ...defaultFormValues,
+      equity: ["isWoman"],
+    });
+
+    expect(isWomanFilters).toEqual(
+      expect.objectContaining({
+        applicantFilter: expect.objectContaining({
+          equity: { isWoman: true },
+        }),
+      }),
+    );
+
+    const isVisibleMinorityFilters = transformFormValuesToFilterState({
+      ...defaultFormValues,
+      equity: ["isVisibleMinority"],
+    });
+
+    expect(isVisibleMinorityFilters).toEqual(
+      expect.objectContaining({
+        applicantFilter: expect.objectContaining({
+          equity: { isVisibleMinority: true },
+        }),
+      }),
+    );
+
+    const isIndigenousFilters = transformFormValuesToFilterState({
+      ...defaultFormValues,
+      equity: ["isIndigenous"],
+    });
+
+    expect(isIndigenousFilters).toEqual(
+      expect.objectContaining({
+        applicantFilter: expect.objectContaining({
+          equity: { isIndigenous: true },
+        }),
+      }),
+    );
+  });
+
+  test("Multiple equity filters", () => {
+    const multipleEquityFilters = transformFormValuesToFilterState({
+      ...defaultFormValues,
+      equity: ["hasDisability", "isIndigenous"],
+    });
+
+    expect(multipleEquityFilters).toEqual(
+      expect.objectContaining({
+        applicantFilter: expect.objectContaining({
+          equity: { hasDisability: true, isIndigenous: true },
+        }),
+      }),
+    );
+
+    const allEquityFilters = transformFormValuesToFilterState({
+      ...defaultFormValues,
+      equity: ["hasDisability", "isIndigenous", "isWoman", "isVisibleMinority"],
+    });
+
+    expect(allEquityFilters).toEqual(
+      expect.objectContaining({
+        applicantFilter: expect.objectContaining({
+          equity: {
+            hasDisability: true,
+            isIndigenous: true,
+            isWoman: true,
+            isVisibleMinority: true,
+          },
+        }),
+      }),
+    );
+  });
+});

--- a/apps/web/src/components/PoolCandidatesTable/types.ts
+++ b/apps/web/src/components/PoolCandidatesTable/types.ts
@@ -1,0 +1,16 @@
+export type FormValues = {
+  languageAbility: string;
+  classifications: string[];
+  stream: string[];
+  operationalRequirement: string[];
+  workRegion: string[];
+  equity: string[];
+  poolCandidateStatus: string[];
+  priorityWeight: string[];
+  pools: string[];
+  skills: string[];
+  expiryStatus: string;
+  suspendedStatus: string;
+  publishingGroups: string[];
+  govEmployee: string;
+};


### PR DESCRIPTION
🤖 Resolves #9010

## 👋 Introduction

Fixes the union (OR) function of our employment equity filters.

## 🕵️ Details

For the `isIndigenous` filter, we were using a `whereJsonLength`. Which means, when you included this filter with any of the others, it was looking for Indigenous and other equity groups. This has been updated to a `orWhereJsonLength` to treat them all like OR statements.

> [!NOTE]
> The functions we needed to do jest tests for were inside the component so this also needed to extract those out so they could actually be tested.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Confirm jest and PHP unit tests make sense and are passing
2. Build `npm run dev`
3. Navigate to `/admin/pool-candidates`
4. Open the filter dialog
5. Update the equity filter with different combinations and single selections
6. Confirm the users that appear have the expected equity declarations
