### PR TITLE
[Fix] Bump jwt library

### DIFF
--- a/api/composer.lock
+++ b/api/composer.lock
@@ -7393,23 +7393,23 @@
         },
         {
             "name": "web-token/jwt-core",
-            "version": "3.2.8",
+            "version": "3.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/web-token/jwt-core.git",
-                "reference": "2bc6e99a60910d0f495682acd8b23d3eef9865a3"
+                "reference": "2b7277a4837230cf2982a1484643a978d505eae3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/web-token/jwt-core/zipball/2bc6e99a60910d0f495682acd8b23d3eef9865a3",
-                "reference": "2bc6e99a60910d0f495682acd8b23d3eef9865a3",
+                "url": "https://api.github.com/repos/web-token/jwt-core/zipball/2b7277a4837230cf2982a1484643a978d505eae3",
+                "reference": "2b7277a4837230cf2982a1484643a978d505eae3",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.9|^0.10|^0.11",
+                "brick/math": "^0.9|^0.10|^0.11|^0.12",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "paragonie/constant_time_encoding": "^2.4",
+                "paragonie/constant_time_encoding": "^2.6",
                 "php": ">=8.1",
                 "spomky-labs/pki-framework": "^1.0"
             },
@@ -7457,7 +7457,7 @@
                 "symfony"
             ],
             "support": {
-                "source": "https://github.com/web-token/jwt-core/tree/3.2.8"
+                "source": "https://github.com/web-token/jwt-core/tree/3.2.9"
             },
             "funding": [
                 {
@@ -7465,7 +7465,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2023-08-23T09:49:09+00:00"
+            "time": "2024-01-04T15:42:08+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -9601,5 +9601,5 @@
     "platform-overrides": {
         "php": "8.2.9"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/api/programmatic-types.graphql
+++ b/api/programmatic-types.graphql
@@ -472,6 +472,7 @@ enum PoolCandidateSearchStatus {
   IN_PROGRESS
   WAITING
   DONE
+  DONE_NO_CANDIDATES
 }
 
 enum PoolCandidateSearchPositionType {
@@ -735,7 +736,7 @@ enum AssessmentResultType {
 }
 
 enum AssessmentDecision {
-  NOT_SURE
+  HOLD
   SUCCESSFUL
   UNSUCCESSFUL
 }

--- a/api/schema-directives.graphql
+++ b/api/schema-directives.graphql
@@ -966,6 +966,13 @@ The arguments are a map from directive names to namespaces.
 """
 directive @namespace repeatable on FIELD_DEFINITION | OBJECT
 
+# Directive class: Nuwave\Lighthouse\Schema\Directives\NamespacedDirective
+"""
+Provides a no-op field resolver that allows nesting of queries and mutations.
+Useful to implement [namespacing by separation of concerns](https://www.apollographql.com/docs/technotes/TN0012-namespacing-by-separation-of-concern).
+"""
+directive @namespaced on FIELD_DEFINITION
+
 # Directive class: Nuwave\Lighthouse\Schema\Directives\NeqDirective
 """
 Use the client given value to add a not-equal conditional to a database query.
@@ -1447,9 +1454,241 @@ Any constant literal value: https://graphql.github.io/graphql-spec/draft/#sec-In
 """
 scalar CanArgs
 
+# Directive class: Nuwave\Lighthouse\Auth\CanFindDirective
+"""
+Any constant literal value: https://graphql.github.io/graphql-spec/draft/#sec-Input-Values
+"""
+scalar CanArgs
+
+enum CanAction {
+    """
+    Pass exception to the client.
+    """
+    EXCEPTION_PASS
+
+    """
+    Throw generic "not authorized" exception to conceal the real error.
+    """
+    EXCEPTION_NOT_AUTHORIZED
+
+    """
+    Return the value specified in `value` argument to conceal the real error.
+    """
+    RETURN_VALUE
+}
+
+"""
+Check a Laravel Policy to ensure the current user is authorized to access a field.
+
+Query for specific model instances to check the policy against, using primary key(s) from specified argument.
+"""
+directive @canFind(
+  """
+  The ability to check permissions for.
+  """
+  ability: String!
+
+  """
+  Pass along the client given input data as arguments to `Gate::check`.
+  """
+  injectArgs: Boolean! = false
+
+  """
+  Statically defined arguments that are passed to `Gate::check`.
+
+  You may pass arbitrary GraphQL literals,
+  e.g.: [1, 2, 3] or { foo: "bar" }
+  """
+  args: CanArgs
+
+  """
+  Action to do if the user is not authorized.
+  """
+  action: CanAction! = EXCEPTION_PASS
+
+  """
+  Value to return if the user is not authorized and `action` is `RETURN_VALUE`.
+  """
+  returnValue: CanArgs
+
+  """
+  Specify the name of the field argument that contains its primary key(s).
+
+  You may pass the string in dot notation to use nested inputs.
+  """
+  find: String!
+
+  """
+  Should the query fail when the models of `find` were not found?
+  """
+  findOrFail: Boolean! = true
+
+  """
+  Apply scopes to the underlying query.
+  """
+  scopes: [String!]
+) repeatable on FIELD_DEFINITION
+
+# Directive class: Nuwave\Lighthouse\Auth\CanModelDirective
+"""
+Check a Laravel Policy to ensure the current user is authorized to access a field.
+
+Check the policy against the root model.
+"""
+directive @canModel(
+  """
+  The ability to check permissions for.
+  """
+  ability: String!
+
+  """
+  Pass along the client given input data as arguments to `Gate::check`.
+  """
+  injectArgs: Boolean! = false
+
+  """
+  Statically defined arguments that are passed to `Gate::check`.
+
+  You may pass arbitrary GraphQL literals,
+  e.g.: [1, 2, 3] or { foo: "bar" }
+  """
+  args: CanArgs
+
+  """
+  Action to do if the user is not authorized.
+  """
+  action: CanAction! = EXCEPTION_PASS
+
+  """
+  Value to return if the user is not authorized and `action` is `RETURN_VALUE`.
+  """
+  returnValue: CanArgs
+
+  """
+  The model name to check against.
+  """
+  model: String
+
+) repeatable on FIELD_DEFINITION
+
+# Directive class: Nuwave\Lighthouse\Auth\CanQueryDirective
+"""
+Check a Laravel Policy to ensure the current user is authorized to access a field.
+
+Query for specific model instances to check the policy against, using arguments
+with directives that add constraints to the query builder, such as `@eq`.
+"""
+directive @canQuery(
+  """
+  The ability to check permissions for.
+  """
+  ability: String!
+
+  """
+  Pass along the client given input data as arguments to `Gate::check`.
+  """
+  injectArgs: Boolean! = false
+
+  """
+  Statically defined arguments that are passed to `Gate::check`.
+
+  You may pass arbitrary GraphQL literals,
+  e.g.: [1, 2, 3] or { foo: "bar" }
+  """
+  args: CanArgs
+
+  """
+  Action to do if the user is not authorized.
+  """
+  action: CanAction! = EXCEPTION_PASS
+
+  """
+  Value to return if the user is not authorized and `action` is `RETURN_VALUE`.
+  """
+  returnValue: CanArgs
+
+  """
+  Apply scopes to the underlying query.
+  """
+  scopes: [String!]
+) repeatable on FIELD_DEFINITION
+
+# Directive class: Nuwave\Lighthouse\Auth\CanResolvedDirective
+"""
+Check a Laravel Policy to ensure the current user is authorized to access a field.
+
+Check the policy against the model instances returned by the field resolver.
+Only use this if the field does not mutate data, it is run before checking.
+"""
+directive @canResolved(
+  """
+  The ability to check permissions for.
+  """
+  ability: String!
+
+  """
+  Pass along the client given input data as arguments to `Gate::check`.
+  """
+  injectArgs: Boolean! = false
+
+  """
+  Statically defined arguments that are passed to `Gate::check`.
+
+  You may pass arbitrary GraphQL literals,
+  e.g.: [1, 2, 3] or { foo: "bar" }
+  """
+  args: CanArgs
+
+  """
+  Action to do if the user is not authorized.
+  """
+  action: CanAction! = EXCEPTION_PASS
+
+  """
+  Value to return if the user is not authorized and `action` is `RETURN_VALUE`.
+  """
+  returnValue: CanArgs
+) repeatable on FIELD_DEFINITION
+
+# Directive class: Nuwave\Lighthouse\Auth\CanRootDirective
+"""
+Check a Laravel Policy to ensure the current user is authorized to access a field.
+
+Check the policy against the root object.
+"""
+directive @canRoot(
+  """
+  The ability to check permissions for.
+  """
+  ability: String!
+
+  """
+  Pass along the client given input data as arguments to `Gate::check`.
+  """
+  injectArgs: Boolean! = false
+
+  """
+  Statically defined arguments that are passed to `Gate::check`.
+
+  You may pass arbitrary GraphQL literals,
+  e.g.: [1, 2, 3] or { foo: "bar" }
+  """
+  args: CanArgs
+
+  """
+  Action to do if the user is not authorized.
+  """
+  action: CanAction! = EXCEPTION_PASS
+
+  """
+  Value to return if the user is not authorized and `action` is `RETURN_VALUE`.
+  """
+  returnValue: CanArgs
+) repeatable on FIELD_DEFINITION
+
 # Directive class: Nuwave\Lighthouse\Auth\GuardDirective
 """
-Run authentication through one or more guards.
+Run authentication through one or more guards from `config/auth.php`.
 
 This is run per field and may allow unauthenticated
 users to still receive partial results.

--- a/api/tests/Unit/resources/README.md
+++ b/api/tests/Unit/resources/README.md
@@ -1,4 +1,4 @@
-They keys in this folder are only used for automated testing. They do not need to be protected and can be safely checked into version control.  The certificate is a self-signed x509 certificate for including in the jwks file.
+They keys in this folder are only used for automated testing. They do not need to be protected and can be safely checked into version control. The certificate is a self-signed x509 certificate for including in the jwks file.
 
 To generate more, use the following command:
 `openssl req -x509 -newkey rsa:4096 -keyout key1.pem -out key1-cert.pem -sha256 -days 99999 -nodes -subj '/CN=localhost'`
@@ -7,3 +7,6 @@ This can be done in the maintenance container.
 The key modulus "n" must be Base64urlUInt-encoded, not regular Base64 encoded.
 https://www.rfc-editor.org/rfc/rfc7518#section-6.3.1.1
 https://stackoverflow.com/a/34285088
+
+Base64url Encoding must have trailing '=' characters omitted.
+See appendix C of https://www.rfc-editor.org/rfc/rfc7515.txt

--- a/api/tests/Unit/resources/jwks.json
+++ b/api/tests/Unit/resources/jwks.json
@@ -1,20 +1,22 @@
 {
-  "keys" : [ {
-      "kty" : "RSA",
-      "use" : "sig",
-      "kid" : "key1",
-      "n"   : "zW0RhzZzEYnnrhkdHTsq-lrXbHwdMiwi8rfownC-xPX8Y-qtL2_fWRDJjZLg099TrGOmgPxl_Pe3U1mFPD-GbKZvBpvYOqrJNSd6FnMO3DSCt2FWDN1sar7KEvEGBEUpNUt8ztyZLYM9yTZYLyxFHWKOXhfb7NHRUht3YfYdBq5O8CJ5jhuwrhaqjb_QQZYuXoteR4NwA_AOMbhVcgyCdDamYNMRlapENlDtAyhoodnhJBpwIcactXYRHpJhD5svlBJYiZN-pOnYCmXIsIWjMGDxp1TzCP7gRPJMKk5eo7EYCNtRSQPwCFE4QVogPUvjAnbVJgjJ5TXQds9bT9h55_hJ6_Arw1dNVrPzO6bVf_ktIM05P9UX10Q_evZtWeSwHjOBrNTbU0T8dw1dyUz7w9DIJYhcf-EZz80oCTtNa3B-sl_b7cahc2MY9-XbOKIOirHcivYdHt49cq7MAHyqFPzyHehPoVSvlbCUWu5DagpGAbPJ1j9PBlBVHRqTpoZWs3XKWab7a0NTeT_5MjxozlwioI1HxyiTJmiyMNamTBRFunaGN3aMMkU3tnADUfS-22rtiVqy8t6I67hgsWKkwHaM9Fc2sUI_XW_Hoh2lvc8mB8Sn0xgqMThcPOFxxRLut7O42l2itzHK58e2amKD_A-Be7G8ZWdeJFj51dnHus0=",
-      "e"   : "AQAB",
-      "exp" : 2147483647,
-      "alg" : "RS256"
-  },
-  {
-      "kty" : "RSA",
-      "use" : "sig",
-      "kid" : "key2",
-      "n"   : "1Xg99scnMiFwFBgzgVGv49K7G1-b0v_wh002OUH6s3N7FXrlzruFxNi0tQt9FgWayBdDw8zMRhVWPle8g95t1pyIPTxIxVveYhcb0YFk503y66peNMgUIaqCBHCzp4evESHFfoZUZXEcsIeMCmYnUjPL8y4T-ag0T_YDMFwdaKwhp7SV-FkFdL45kJ-q5uMVdUi3auOh_eNDe-ZAQ-giCOQVo6zxqSf5XdVO3ax1uetPrjauDqEoTPlhEh7ObMBSt0nZKPHWq36oHFjv8JzJH8auPrIa_WFklsU_zVfkH4ycG7JSoPiPL0a5bdE1ZiXI20uynTYbMSEy5KI3zYeqIhhymIdm9KzwjyZdeRuxqis0HYIV2rjQc7xCCgE-H_6khwfyTlDCD-j31O8JE2euKSAfKYNPqPh6HXsnos3Pttv8Xc_0xgtjb0Fycenbw81RQjz3D4hsp9tv2w40b8pBvmAoqb3GZ791yR8VlMzlPb0RPt-2_2Cl_t74nbm-X74zDrHiuRlhHokDzTDyiVX5scPYtraPyiVhS0b891qjhD5QZ_qz5w2ZVFXsTDhx4hhjoV4rP8oPpMpX5fsPZWRLgYYOsvQhck1hHUmqgz3SY2RzBgRrNt1HOYrA6zN3xUO_aHfdxkHjzBRtroRhMrEZ2ggImPyp8erI-7vbS342jl0=",
-      "e"   : "AQAB",
-      "exp" : 2147483647,
-      "alg" : "RS256"
-  }]
+  "keys": [
+    {
+      "kty": "RSA",
+      "use": "sig",
+      "kid": "key1",
+      "n": "zW0RhzZzEYnnrhkdHTsq-lrXbHwdMiwi8rfownC-xPX8Y-qtL2_fWRDJjZLg099TrGOmgPxl_Pe3U1mFPD-GbKZvBpvYOqrJNSd6FnMO3DSCt2FWDN1sar7KEvEGBEUpNUt8ztyZLYM9yTZYLyxFHWKOXhfb7NHRUht3YfYdBq5O8CJ5jhuwrhaqjb_QQZYuXoteR4NwA_AOMbhVcgyCdDamYNMRlapENlDtAyhoodnhJBpwIcactXYRHpJhD5svlBJYiZN-pOnYCmXIsIWjMGDxp1TzCP7gRPJMKk5eo7EYCNtRSQPwCFE4QVogPUvjAnbVJgjJ5TXQds9bT9h55_hJ6_Arw1dNVrPzO6bVf_ktIM05P9UX10Q_evZtWeSwHjOBrNTbU0T8dw1dyUz7w9DIJYhcf-EZz80oCTtNa3B-sl_b7cahc2MY9-XbOKIOirHcivYdHt49cq7MAHyqFPzyHehPoVSvlbCUWu5DagpGAbPJ1j9PBlBVHRqTpoZWs3XKWab7a0NTeT_5MjxozlwioI1HxyiTJmiyMNamTBRFunaGN3aMMkU3tnADUfS-22rtiVqy8t6I67hgsWKkwHaM9Fc2sUI_XW_Hoh2lvc8mB8Sn0xgqMThcPOFxxRLut7O42l2itzHK58e2amKD_A-Be7G8ZWdeJFj51dnHus0",
+      "e": "AQAB",
+      "exp": 2147483647,
+      "alg": "RS256"
+    },
+    {
+      "kty": "RSA",
+      "use": "sig",
+      "kid": "key2",
+      "n": "1Xg99scnMiFwFBgzgVGv49K7G1-b0v_wh002OUH6s3N7FXrlzruFxNi0tQt9FgWayBdDw8zMRhVWPle8g95t1pyIPTxIxVveYhcb0YFk503y66peNMgUIaqCBHCzp4evESHFfoZUZXEcsIeMCmYnUjPL8y4T-ag0T_YDMFwdaKwhp7SV-FkFdL45kJ-q5uMVdUi3auOh_eNDe-ZAQ-giCOQVo6zxqSf5XdVO3ax1uetPrjauDqEoTPlhEh7ObMBSt0nZKPHWq36oHFjv8JzJH8auPrIa_WFklsU_zVfkH4ycG7JSoPiPL0a5bdE1ZiXI20uynTYbMSEy5KI3zYeqIhhymIdm9KzwjyZdeRuxqis0HYIV2rjQc7xCCgE-H_6khwfyTlDCD-j31O8JE2euKSAfKYNPqPh6HXsnos3Pttv8Xc_0xgtjb0Fycenbw81RQjz3D4hsp9tv2w40b8pBvmAoqb3GZ791yR8VlMzlPb0RPt-2_2Cl_t74nbm-X74zDrHiuRlhHokDzTDyiVX5scPYtraPyiVhS0b891qjhD5QZ_qz5w2ZVFXsTDhx4hhjoV4rP8oPpMpX5fsPZWRLgYYOsvQhck1hHUmqgz3SY2RzBgRrNt1HOYrA6zN3xUO_aHfdxkHjzBRtroRhMrEZ2ggImPyp8erI-7vbS342jl0",
+      "e": "AQAB",
+      "exp": 2147483647,
+      "alg": "RS256"
+    }
+  ]
 }


### PR DESCRIPTION
🤖 Resolves #9006 

## 👋 Introduction

This branch bumps our jwt dependency and fixes a flaw in our fake data used for testing.

## 🕵️ Details

It seems like the base64 encoding used in JWT is not supposed to have any padding '=' characters.  I removed the padding in our fake endpoint and all tests are passing.  See "Base64url Encoding" in section 2 of [https://www.rfc-editor.org/rfc/rfc7515.txt](https://www.rfc-editor.org/rfc/rfc7515.txt).

When I manually ran the composer update there were some unrelated updates applied to the graphql files.

## 🧪 Testing

> [!TIP]
> There was some linting happening.  I recommend viewing the diffs with whitespace changes hidden.

- Rebuild with Sign In Canada configured.
- Ensure you can login, refresh, and logout.
- Ensure phpunit tests pass.