### PR TITLE
[Bug] Skill browser sorting of skills

### DIFF
--- a/apps/web/src/components/SkillBrowser/SkillBrowser.tsx
+++ b/apps/web/src/components/SkillBrowser/SkillBrowser.tsx
@@ -67,8 +67,17 @@ const SkillBrowser = ({
   }, [skills, category, intl]);
 
   const filteredSkills = React.useMemo(() => {
-    return getFilteredSkills({ skills, family, category });
-  }, [category, family, skills]);
+    return getFilteredSkills({ skills, family, category }).sort(
+      (skillA, skillB) => {
+        const a = normalizeString(getLocalizedName(skillA.name, intl));
+        const b = normalizeString(getLocalizedName(skillB.name, intl));
+
+        if (a === b) return 0;
+
+        return a > b ? 1 : -1;
+      },
+    );
+  }, [category, family, skills, intl]);
 
   React.useEffect(() => {
     resetField("skill");

--- a/apps/web/src/components/SkillBrowser/SkillSelection.tsx
+++ b/apps/web/src/components/SkillBrowser/SkillSelection.tsx
@@ -13,6 +13,7 @@ import {
 } from "@gc-digital-talent/ui";
 import { Combobox, Field, Select } from "@gc-digital-talent/forms";
 import { errorMessages, getLocalizedName } from "@gc-digital-talent/i18n";
+import { normalizeString } from "@gc-digital-talent/helpers";
 
 import { Skill } from "~/api/generated";
 import useRoutes from "~/hooks/useRoutes";
@@ -62,12 +63,30 @@ const SkillSelection = ({
   const [category, family, skill] = watch(["category", "family", "skill"]);
 
   const filteredFamilies = React.useMemo(() => {
-    return getFilteredFamilies({ skills, category });
-  }, [skills, category]);
+    return getFilteredFamilies({ skills, category }).sort(
+      (familyA, familyB) => {
+        const a = normalizeString(getLocalizedName(familyA.name, intl));
+        const b = normalizeString(getLocalizedName(familyB.name, intl));
+
+        if (a === b) return 0;
+
+        return a > b ? 1 : -1;
+      },
+    );
+  }, [skills, category, intl]);
 
   const filteredSkills = React.useMemo(() => {
-    return getFilteredSkills({ skills, family, inLibrary, category });
-  }, [category, family, inLibrary, skills]);
+    return getFilteredSkills({ skills, family, inLibrary, category }).sort(
+      (skillA, skillB) => {
+        const a = normalizeString(getLocalizedName(skillA.name, intl));
+        const b = normalizeString(getLocalizedName(skillB.name, intl));
+
+        if (a === b) return 0;
+
+        return a > b ? 1 : -1;
+      },
+    );
+  }, [category, family, inLibrary, skills, intl]);
 
   const selectedSkill = React.useMemo(() => {
     return skill


### PR DESCRIPTION
🤖 Resolves #8895

## 👋 Introduction

Resolves the bug with sorting of skills. 

## 🕵️ Details

A sort that well sorts as expected but also handles French special characters was added in the inline selector, I used it in more places. As I also noticed skill families wasn't sorted either. 

## 🧪 Testing

1. Observe skills, skill families being sorted correctly in English and French
2. Inline selector exists on the find talent page, dialog variant like in the issue found on editing experiences

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/25a52941-4850-4ffe-a3d8-857266daf7d5)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/0410a315-4ad8-4582-b6ca-1f600ecf3467)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/e9c4ca20-c565-4e9c-bb20-fe1adf842994)


