### PR TITLE
[Bug] Fix inline link styling

### DIFF
--- a/packages/ui/src/components/ButtonLinkContent/ButtonLinkContent.tsx
+++ b/packages/ui/src/components/ButtonLinkContent/ButtonLinkContent.tsx
@@ -111,6 +111,17 @@ const ButtonLinkContent = ({
       "data-h2-margin-top": "base(-x.2)",
     };
   }
+  let contentDisplay = {
+    "data-h2-display": "base(block) base:children[>*](inline-block)",
+    "data-h2-vertical-align": "base:children[>*](middle)",
+  };
+  if (mode === "text") {
+    contentDisplay = {
+      "data-h2-display":
+        "base(inline) base:children[>svg, .counter](inline-block)",
+      "data-h2-vertical-align": "base:children[>svg, .counter](middle)",
+    };
+  }
   if (!newTab && !icon && !utilityIcon)
     return (
       <span {...textSize} data-h2-text-decoration="base(underline)">
@@ -170,11 +181,7 @@ const ButtonLinkContent = ({
     );
   }
   return (
-    <span
-      data-h2-display="base(flex)"
-      data-h2-align-items="base(center)"
-      {...rest}
-    >
+    <span {...contentDisplay} {...rest}>
       {Icon && (
         <Icon data-h2-margin-right="base(x.25)" {...iconSize} {...iconMargin} />
       )}


### PR DESCRIPTION
🤖 Resolves #9028 

## 👋 Introduction

- Reverts back to previous styling on ButtonLinkContent. 
- The issue was caused when trying to line up icons with longer text on l-width screen. However, the formatted messages containing a link seems to be effected which was missed in review.

## 🧪 Testing
1. Build app `npm run build`
2. Login as `admin@test.com`
3. Ensure links across site are lined up correctly (Specifically formattedMessage containing links). One example, is the education requirement step during application process.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/fa4b3d8c-3618-4c26-afbd-8e3f493efa7f)
