### PR TITLE
[Fix] Errant new records in CSV download

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/poolCandidateCsv.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/poolCandidateCsv.tsx
@@ -28,6 +28,7 @@ import {
   getExperienceTitles,
   getScreeningQuestionResponses,
   getIndigenousCommunities,
+  sanitizeCSVString,
 } from "~/utils/csvUtils";
 import { PoolCandidate, PositionDuration, Pool } from "~/api/generated";
 import adminMessages from "~/messages/adminMessages";
@@ -61,13 +62,13 @@ export const getPoolCandidateCsvData = (
         priority: user.priorityWeight
           ? intl.formatMessage(getPoolCandidatePriorities(user.priorityWeight))
           : "",
-        notes: notes || "",
+        notes: sanitizeCSVString(notes),
         dateReceived: submittedAt || "",
         expiryDate: expiryDate || "",
         archivedAt: archivedAt || "",
-        firstName: user.firstName || "",
-        lastName: user.lastName || "",
-        email: user.email || "",
+        firstName: sanitizeCSVString(user.firstName),
+        lastName: sanitizeCSVString(user.lastName),
+        email: sanitizeCSVString(user.email),
         preferredCommunicationLanguage: user.preferredLang
           ? intl.formatMessage(getLanguage(user.preferredLang as string))
           : "",
@@ -116,7 +117,7 @@ export const getPoolCandidateCsvData = (
           : "",
         isGovEmployee: yesOrNo(user.isGovEmployee, intl),
         hasPriorityEntitlement: yesOrNo(user.hasPriorityEntitlement, intl),
-        priorityNumber: user.priorityNumber || "",
+        priorityNumber: sanitizeCSVString(user.priorityNumber),
         department: getLocalizedName(user.department?.name, intl, true),
         govEmployeeType: user.govEmployeeType
           ? employeeTypeToString(user.govEmployeeType, intl)
@@ -128,7 +129,7 @@ export const getPoolCandidateCsvData = (
           user.locationPreferences,
           intl,
         ),
-        locationExemptions: user.locationExemptions || "",
+        locationExemptions: sanitizeCSVString(user.locationExemptions),
         wouldAcceptTemporary: yesOrNo(
           user.positionDuration?.includes(PositionDuration.Temporary),
           intl,

--- a/apps/web/src/pages/Users/IndexUserPage/components/userCsv.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/userCsv.tsx
@@ -17,6 +17,7 @@ import {
   getLocationPreference,
   getLookingForLanguage,
   getOperationalRequirements,
+  sanitizeCSVString,
   yesOrNo,
 } from "~/utils/csvUtils";
 import { User, PositionDuration } from "~/api/generated";
@@ -55,8 +56,8 @@ export const getUserCsvData = (users: User[], intl: IntlShape) => {
       hasDisability,
       experiences,
     }) => ({
-      firstName: firstName || "",
-      lastName: lastName || "",
+      firstName: sanitizeCSVString(firstName),
+      lastName: sanitizeCSVString(lastName),
       armedForcesStatus: armedForcesStatus
         ? intl.formatMessage(getArmedForcesStatusesAdmin(armedForcesStatus))
         : "",
@@ -86,8 +87,8 @@ export const getUserCsvData = (users: User[], intl: IntlShape) => {
         : "",
       isGovEmployee: yesOrNo(isGovEmployee, intl),
       hasPriorityEntitlement: yesOrNo(hasPriorityEntitlement, intl),
-      priorityNumber: priorityNumber || "",
-      department: department?.name[locale] || "",
+      priorityNumber: sanitizeCSVString(priorityNumber),
+      department: sanitizeCSVString(department?.name[locale]),
       govEmployeeType: govEmployeeType
         ? employeeTypeToString(govEmployeeType, intl)
         : "",
@@ -95,7 +96,7 @@ export const getUserCsvData = (users: User[], intl: IntlShape) => {
         ? `${currentClassification.group}-${currentClassification.level}`
         : "",
       locationPreferences: getLocationPreference(locationPreferences, intl),
-      locationExemptions: locationExemptions || "",
+      locationExemptions: sanitizeCSVString(locationExemptions),
       wouldAcceptTemporary: yesOrNo(
         positionDuration?.includes(PositionDuration.Temporary),
         intl,

--- a/apps/web/src/utils/csvUtils.tsx
+++ b/apps/web/src/utils/csvUtils.tsx
@@ -35,6 +35,20 @@ import {
 import experienceMessages from "~/messages/experienceMessages";
 
 /**
+ * Sanitize a string for use in a CSV
+ *
+ * - Replaces '"' with '""' for proper double quotes
+ * - Removes new lines (\r\n) that create new rows
+ *
+ * @param value
+ * @returns string
+ */
+export const sanitizeCSVString = (value?: Maybe<string>) => {
+  if (!value) return "";
+  return value.replace(/"/g, "").replace(/(\r\n|\n|\r)/gm, "");
+};
+
+/**
  * Converts a possible boolean
  * to yes or no string
  *
@@ -78,9 +92,7 @@ const listOrEmptyString = (value: string[] | undefined) => {
  * @returns string                      Comma separated list or empty
  */
 const sanitizeJustifications = (values: string[] | undefined) => {
-  const sanitizedList = values
-    ? values.map((v) => v.replace(/"/g, '""')) // escape double quotes
-    : "";
+  const sanitizedList = values ? values.map((v) => sanitizeCSVString(v)) : "";
   return sanitizedList ? insertBetween("\n\n", sanitizedList).join("") : "";
 };
 
@@ -372,7 +384,7 @@ export const getExperienceTitles = (
     ?.filter(notEmpty)
     .map((experience) => getExperienceName(experience, intl));
 
-  return titles?.join(", ") || "";
+  return sanitizeCSVString(titles?.join(", "));
 };
 
 /**
@@ -389,7 +401,7 @@ export const getScreeningQuestionResponses = (
     data = {
       ...data,
       // Note: API sends Maybe with everything, but this should never be null or undefined
-      [screeningQuestion?.id || id]: answer ?? "",
+      [screeningQuestion?.id || id]: sanitizeCSVString(answer),
     };
   });
 

--- a/packages/ui/src/components/Link/DownloadCsv.tsx
+++ b/packages/ui/src/components/Link/DownloadCsv.tsx
@@ -40,6 +40,7 @@ const DownloadCsv = ({
       data-h2-cursor="base(pointer)"
       {...getButtonStyles({ mode, color, block, disabled })}
       {...rest}
+      wrapColumnChar='"'
       disabled={disabled}
       columns={headers}
       datas={data}


### PR DESCRIPTION
🤖 Resolves #9018 

## 👋 Introduction

Applies some basic sanitization to strings used in CSV downloads to avoid accidently creating new records.

## 🕵️ Details

We had some sanitization on experience details but other user created data was not being sanitized properly. The data containing double quotes and line breaks were leading to CSV interpreting them as new columns and rows, breaking the CSV.

In order to fix this we have:

- Sanitized user created strings by 
  - replacing " with "" (way of escaping in CSVs) which was leading to new columns
  - removing line breaks `\r\n` which was leading to new rows (records)
  - added a column wrapper character (") which wraps each column of data to avoid accidental new columns

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login as admin
3. Navigate to `/admin/pool-candidates`
4. Edit some candidates adding double quote (") and line breaks into their records (notes is an easy field to accomplish this)
5. Navigate back to the table
6. Select those users
7. Activate "Download CSV"
8. Open the CSV and confirm the data is clean and rendered properly in any spreadsheet software
    - Preferably test with Microsoft Excel since that is likely the main software used by admins
