### PR TITLE
[Fix] Fix the blank white error on the support page

### DIFF
--- a/api/app/Http/Controllers/SupportController.php
+++ b/api/app/Http/Controllers/SupportController.php
@@ -4,15 +4,18 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 class SupportController extends Controller
 {
     public function createTicket(Request $request)
     {
         if (! config('freshdesk.api.tickets_endpoint') || ! config('freshdesk.api.key')) {
+            Log::error('Attempted to create a ticket with missing config values.');
+
             return response([
                 'apiResponse' => 'Missing parameters',
-            ], 422);
+            ], 500);
         }
         $parameters = [
             'description' => $request->input('description'),
@@ -45,9 +48,11 @@ class SupportController extends Controller
                 'serviceResponse' => $response->json(),
             ], 200);
         } else {
+            Log::error('Error when trying to create a ticket: '.$response->getBody(true));
+
             return response([
                 'serviceResponse' => $response->json(),
-            ], 400);
+            ], 500);
         }
     }
 }

--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
@@ -7,12 +7,9 @@ import { useLocation } from "react-router-dom";
 
 import { toast } from "@gc-digital-talent/toast";
 import { Input, Submit, TextArea, Select } from "@gc-digital-talent/forms";
-import {
-  errorMessages,
-  apiMessages,
-  uiMessages,
-} from "@gc-digital-talent/i18n";
-import { Heading, Pending, Button, Link } from "@gc-digital-talent/ui";
+import { errorMessages, uiMessages } from "@gc-digital-talent/i18n";
+import { Heading, Pending, Button } from "@gc-digital-talent/ui";
+import { useLogger } from "@gc-digital-talent/logger";
 
 import { getFullNameLabel } from "~/utils/nameUtils";
 import { useGetMeQuery, User } from "~/api/generated";
@@ -42,9 +39,9 @@ interface SupportFormSuccessProps {
 }
 
 const anchorTag = (chunks: React.ReactNode) => (
-  <Link external href={`mailto:${TALENTSEARCH_SUPPORT_EMAIL}`}>
-    {chunks}
-  </Link>
+  // Toast is not within the IntlProvider, can't use Link component.
+  // eslint-disable-next-line react/forbid-elements
+  <a href={`mailto:${TALENTSEARCH_SUPPORT_EMAIL}`}>{chunks}</a>
 );
 
 const SupportFormSuccess = ({ onFormToggle }: SupportFormSuccessProps) => {
@@ -112,6 +109,7 @@ const SupportForm = ({
 }: SupportFormProps) => {
   const intl = useIntl();
   const location = useLocation();
+  const logger = useLogger();
   const previousUrl = location?.state?.referrer ?? document?.referrer ?? "";
   const methods = useForm<FormValues>({
     defaultValues: {
@@ -126,9 +124,41 @@ const SupportForm = ({
   const { handleSubmit } = methods;
 
   const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
-    return handleCreateTicket(data).then(() => {
+    try {
+      await handleCreateTicket(data);
+      toast.success(
+        intl.formatMessage({
+          defaultMessage: "Ticket created successfully!",
+          id: "jHuiRm",
+          description: "Support form toast message success",
+        }),
+      );
       onFormToggle(false);
-    });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : intl.formatMessage(errorMessages.unknown);
+      logger.error(`Exception during ticket submission: ${errorMessage}`);
+      toast.error(
+        <>
+          {intl.formatMessage(
+            {
+              defaultMessage:
+                "Sorry, something went wrong. Please email <anchorTag>{emailAddress}</anchorTag> and mention this error code: {errorCode}.",
+              id: "rNVDaA",
+              description: "Support form toast message error",
+            },
+            {
+              anchorTag,
+              emailAddress: TALENTSEARCH_SUPPORT_EMAIL,
+              errorCode: errorMessage,
+            },
+          )}
+        </>,
+        { autoClose: 20000 },
+      );
+    }
   };
   return showSupportForm ? (
     <section>
@@ -256,57 +286,25 @@ const SupportForm = ({
 };
 
 const SupportFormApi = () => {
-  const intl = useIntl();
-  const handleCreateTicket = (data: FormValues) =>
-    fetch(API_SUPPORT_ENDPOINT, {
+  const logger = useLogger();
+  const handleCreateTicket = async (data: FormValues) => {
+    const response = await fetch(API_SUPPORT_ENDPOINT, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(data),
-    }).then((response) => {
-      if (response.status === 200) {
-        // status code 201 = created.
-        toast.success(
-          intl.formatMessage({
-            defaultMessage: "Ticket created successfully!",
-            id: "jHuiRm",
-            description: "Support form toast message success",
-          }),
-        );
-        return Promise.resolve(response.status);
-      }
-      if (response.status === 422) {
-        // status code 422 = missing params.
-        toast.error(intl.formatMessage(errorMessages.unknown));
-        return Promise.reject(response.status);
-      }
-      if (response.status === 429) {
-        toast.error(<>{intl.formatMessage(apiMessages.RATE_LIMIT)}</>, {
-          autoClose: 20000,
-        });
-        return Promise.reject(response.status);
-      }
-      toast.error(
-        <>
-          {intl.formatMessage(
-            {
-              defaultMessage:
-                "Sorry, something went wrong. Please email <anchorTag>{emailAddress}</anchorTag> and mention this error code: {errorCode}.",
-              id: "rNVDaA",
-              description: "Support form toast message error",
-            },
-            {
-              anchorTag,
-              emailAddress: TALENTSEARCH_SUPPORT_EMAIL,
-              errorCode: response.status,
-            },
-          )}
-        </>,
-        { autoClose: 20000 },
-      );
-      return Promise.reject(response.status);
     });
+    if (response.ok) {
+      logger.info("Ticket successfully submitted");
+      return;
+    }
+
+    logger.error(
+      `Failed to submit ticket: ${response.status} - ${response.statusText}`,
+    );
+    throw new Error(`${response.status} - ${response.statusText}`);
+  };
 
   const [{ data, fetching, error }] = useGetMeQuery();
   const [showSupportForm, setShowSupportForm] = React.useState(true);

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -13,7 +13,6 @@
   ],
   "scripts": {
     "build": "env NODE_ENV=production tsup",
-    "build:intl-cli": "npm run build",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsup",
     "watch": "tsup --watch",


### PR DESCRIPTION
🤖 Resolves #8897 

## 👋 Introduction

This branch fixes the crash to a blank white screen on the support page.

## 🕵️ Details

The culprit of the app crash was that our toasts are not in the intl provider and our error message used the Link component which calls an intl function.  For a quick fix, I changed it a regular `a` tag.  I opened  #9037 for a more thorough review.

There was a desire to ensure that an email address was always displayed for errors.  So I removed the two other error messages in favour of the single generic one with the email.  I did a bit of refactoring on the submit handler to use `await` to make it easier to read, too.

There was also a desire for better logging around failed ticket creation so I added that as well.  I changed the response code to 500 which makes more sense, I think, and will make it more noticeable in analytics.

I noticed a security concern that I logged in #9036.

There was a small fix to a turbo bug I rolled in, too.  It was a duplicate script shortcut preventing running `check-intl` in the maintenance container.

## 🧪 Testing

- [ ] With Freshdesk configured correctly
  - [ ] Tickets go through with a success toast.
  - [ ] The form toggles to the success message
- [ ] With Freshdesk configured incorrectly
  - [ ] An error toast with an email address is always displayed
  - [ ] A detailed error message is logged server side
  - [ ] The form doesn't toggle or navigate

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/fa0adcf0-62c9-42ac-b41e-7531fb4130c6)