### PR TITLE
[Accessibility] Update required validation with more explicit error message

### DIFF
--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -607,6 +607,10 @@
     "defaultMessage": "Région de Québec (excluant Gatineau)",
     "description": "The work region of Canada described as Quebec."
   },
+  "JqjYZq": {
+    "defaultMessage": "Ce champ est obligatoire. Veuillez inscrire une valeur.",
+    "description": "Error message that this field must filled for the form to be valid."
+  },
   "K/npC7": {
     "defaultMessage": "Pour les besoins à venir (la classification ou le financement n’a pas encore été mis(e) en place",
     "description": "Option for searching candidates for an upcoming staffing need"
@@ -618,10 +622,6 @@
   "K9SPL+": {
     "defaultMessage": "À un stade initial de développement",
     "description": "The behavioural skill level for beginner"
-  },
-  "KC/sxi": {
-    "defaultMessage": "Ce champ est obligatoire.",
-    "description": "Error message that this field must filled for the form to be valid."
   },
   "KGX4bI": {
     "defaultMessage": "{count, plural, =0 { <strong>0</strong> résultats équivalents} =1 {<strong>1</strong> résultats équivalents} other {<strong>#</strong> résultats équivalents}} de {total, plural, =0 {<strong>0</strong> options disponibles} =1 {<strong>1</strong> option disponible} other {<strong>#</strong> options disponibles}}",

--- a/packages/i18n/src/messages/errorMessages.ts
+++ b/packages/i18n/src/messages/errorMessages.ts
@@ -8,8 +8,8 @@ const errorMessages = defineMessages({
     //
     // This was the case despite indications that feeding it ReactNode as a message should work:
     // https://github.com/react-hook-form/react-hook-form/discussions/8401#discussioncomment-2819633
-    defaultMessage: "This field is required.",
-    id: "KC/sxi",
+    defaultMessage: "This field is required. Please enter a value.",
+    id: "JqjYZq",
     description:
       "Error message that this field must filled for the form to be valid.",
   },


### PR DESCRIPTION
🤖 Resolves #8851 

## 👋 Introduction

- Updates the required validation with more explicit error message.

From:
EN: {Label}: This field is required.
FR: {Label}: Ce champ est obligatoire.

To: 
EN: {Label}: This field is required. Please enter a value.
FR: {Label}: Ce champ est obligatoire. Veuillez inscrire une valeur.

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing
1. Cause a required error message to pop up and ensure correct copy shows up.

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/5fb14d80-b579-4aa6-894f-4361e429c4ca)

