### PR TITLE
[Bug] Add team name subtitle to pool layout

### DIFF
--- a/apps/e2e/cypress/e2e/admin/pools.cy.ts
+++ b/apps/e2e/cypress/e2e/admin/pools.cy.ts
@@ -139,6 +139,10 @@ describe("Pools", () => {
       .should("exist")
       .and("be.visible");
 
+    cy.findByText("Digital Community Management")
+      .should("exist")
+      .and("be.visible");
+
     cy.findByRole("button", { name: /edit pool name/i }).click();
 
     // Update the classification field

--- a/apps/web/src/pages/Pools/PoolLayout.tsx
+++ b/apps/web/src/pages/Pools/PoolLayout.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { Outlet } from "react-router-dom";
 
 import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
+import { getLocalizedName } from "@gc-digital-talent/i18n";
 
 import SEO from "~/components/SEO/SEO";
 import useCurrentPage from "~/hooks/useCurrentPage";
@@ -13,7 +14,7 @@ import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminHero from "~/components/Hero/AdminHero";
 
 interface PoolHeaderProps {
-  pool: Pick<Pool, "id" | "classifications" | "stream" | "name">;
+  pool: Pick<Pool, "id" | "classifications" | "stream" | "name" | "team">;
 }
 
 const PoolHeader = ({ pool }: PoolHeaderProps) => {
@@ -23,13 +24,16 @@ const PoolHeader = ({ pool }: PoolHeaderProps) => {
 
   const poolTitle = getFullPoolTitleLabel(intl, pool);
   const currentPage = useCurrentPage<PageNavKeys>(pages);
+  const subtitle = pool.team
+    ? getLocalizedName(pool.team?.displayName, intl)
+    : currentPage?.subtitle;
 
   return (
     <>
       <SEO title={currentPage?.title} />
       <AdminHero
         title={poolTitle}
-        subtitle={currentPage?.subtitle}
+        subtitle={subtitle}
         nav={{
           mode: "subNav",
           items: Array.from(pages.values()).map((page) => ({

--- a/apps/web/src/pages/Pools/poolOperations.graphql
+++ b/apps/web/src/pages/Pools/poolOperations.graphql
@@ -53,6 +53,14 @@ query GetBasicPoolInfo($poolId: UUID!) {
       group
       level
     }
+    team {
+      id
+      name
+      displayName {
+        en
+        fr
+      }
+    }
   }
 }
 


### PR DESCRIPTION
🤖 Resolves #8307 

## 👋 Introduction

- Add team name subtitle to pool layout.

## 🧪 Testing

1. Login as `admin@test.com`
2. Go to all "pool" pages and ensure team name shows up. 
- `http://localhost:8000/en/admin/pools/1e390f8d-e2b5-402f-8b7d-3594798c7433`
- http://localhost:8000/en/admin/pools/1e390f8d-e2b5-402f-8b7d-3594798c7433/edit
- http://localhost:8000/en/admin/pools/1e390f8d-e2b5-402f-8b7d-3594798c7433/screening
- http://localhost:8000/en/admin/pools/1e390f8d-e2b5-402f-8b7d-3594798c7433/pool-candidates

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/49f61e25-cd1d-4904-85c0-5f977350d7c6)
