### PR TITLE
[Bug] Don't output endpoint response

### DIFF
--- a/api/app/Http/Controllers/SupportController.php
+++ b/api/app/Http/Controllers/SupportController.php
@@ -45,13 +45,13 @@ class SupportController extends Controller
             );
         if ($response->status() == 201) { // status code 201 = created.
             return response([
-                'serviceResponse' => $response->json(),
+                'serviceResponse' => 'success',
             ], 200);
         } else {
             Log::error('Error when trying to create a ticket: '.$response->getBody(true));
 
             return response([
-                'serviceResponse' => $response->json(),
+                'serviceResponse' => 'error',
             ], 500);
         }
     }


### PR DESCRIPTION
🤖 Resolves #9036 

## 👋 Introduction

No longer outputting the endpoint response into the API, just a simple success/error. 
Error toasting and logging of errors already present. 

## 🧪 Testing

1. Not sure, does it need to be pushed to dev vertical?
2. Messages appear instead of json

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/b9ab5082-b498-46ac-a345-57e5a3e31eed)



