### PR TITLE
[Bug] Sort options alphabetically by default

### DIFF
--- a/packages/forms/src/components/Combobox/Combobox.tsx
+++ b/packages/forms/src/components/Combobox/Combobox.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useIntl } from "react-intl";
 import { Controller, FieldError, useFormContext } from "react-hook-form";
 import isArray from "lodash/isArray";
@@ -21,6 +21,7 @@ import {
 import { BaseProps } from "./types";
 import Single from "./Single";
 import Multi from "./Multi";
+import { alphaSortOptions } from "../../utils";
 
 export type ComboboxProps = Omit<HTMLInputProps, "ref"> &
   CommonInputProps & {
@@ -40,6 +41,8 @@ export type ComboboxProps = Omit<HTMLInputProps, "ref"> &
     total?: BaseProps["total"];
     /** Optional: Accept multiple values (must be array type in form values) */
     isMulti?: boolean;
+    /** Determine if it should sort options in alphanumeric ascending order */
+    doNotSort?: boolean;
   };
 
 const Combobox = ({
@@ -58,6 +61,7 @@ const Combobox = ({
   fetching = false,
   isExternalSearch = false,
   isMulti = false,
+  doNotSort = false,
 }: ComboboxProps) => {
   const intl = useIntl();
   const {
@@ -122,6 +126,9 @@ const Combobox = ({
     return value.length <= maxValue || getErrorMessage(rules.max);
   };
 
+  const optionsModified = useMemo(() => {
+    return doNotSort ? options : alphaSortOptions(options);
+  }, [doNotSort, options]);
   return (
     <Field.Wrapper>
       <Controller
@@ -145,14 +152,22 @@ const Combobox = ({
               onSelectedChange={(items) => {
                 setValue(name, items?.map((item) => item.value));
               }}
-              value={getMultiDefaultValue(options, defaultValue, currentValue)}
+              value={getMultiDefaultValue(
+                optionsModified,
+                defaultValue,
+                currentValue,
+              )}
               {...sharedProps}
             />
           ) : (
             <Single
               onInputChange={onSearch}
               onSelectedChange={(item) => setValue(name, item?.value)}
-              value={getSingleDefaultValue(options, defaultValue, currentValue)}
+              value={getSingleDefaultValue(
+                optionsModified,
+                defaultValue,
+                currentValue,
+              )}
               {...sharedProps}
             />
           )

--- a/packages/forms/src/formUtils.test.ts
+++ b/packages/forms/src/formUtils.test.ts
@@ -6,6 +6,7 @@ import {
   matchStringCaseDiacriticInsensitive,
   enumToOptions,
   countNumberOfWords,
+  alphaSort,
 } from "./utils";
 
 describe("string matching tests", () => {
@@ -109,4 +110,93 @@ describe("countNumberOfWords tests", () => {
     numOfWords = countNumberOfWords(textWithBoth);
     expect(numOfWords).toEqual(7);
   });
+});
+
+test("should sort array of strings alphabetically", () => {
+  // alphabetical handling of capitalization
+  let sortedList = ["Aa", "Bb", "Cc", "Dd", "Ee", "Ff"];
+
+  let unsortedList = ["Dd", "Ee", "Aa", "Bb", "Ff", "Cc"];
+
+  let modifiedList = alphaSort(unsortedList);
+  expect(modifiedList).toStrictEqual(sortedList);
+
+  // handling of French accented characters
+  sortedList = ["à", "ä", "Ç", "é", "É", "ü"];
+
+  unsortedList = ["Ç", "à", "é", "ü", "É", "ä"];
+
+  modifiedList = alphaSort(unsortedList, "fr");
+  expect(modifiedList).toStrictEqual(sortedList);
+
+  // handling of non-alphanumeric characters
+  // Non-alphanumeric sort order: _-,;:!?.'"()@*/\&#%`^<>|~$ (https://support.google.com/drive/thread/150638299?hl=en&msgid=150657957)
+  sortedList = [
+    "_",
+    "-",
+    ",",
+    ";",
+    ":",
+    "!",
+    "?",
+    ".",
+    "@",
+    "*",
+    "&",
+    "#",
+    "%",
+    "~",
+    "$",
+  ];
+
+  unsortedList = [
+    "_",
+    ";",
+    ":",
+    "$",
+    "?",
+    "!",
+    "~",
+    ",",
+    "-",
+    "@",
+    "*",
+    "%",
+    ".",
+    "#",
+    "&",
+  ];
+
+  modifiedList = alphaSort(unsortedList);
+  expect(modifiedList).toStrictEqual(sortedList);
+
+  // handling all edge cases together
+  sortedList = [
+    ".NET Programming",
+    "~alpha",
+    "azure",
+    "C#",
+    "C++",
+    "Database Design & Data Administration",
+    "F# or Visual Basic",
+    "integrity",
+    "python",
+    "React",
+  ];
+
+  unsortedList = [
+    "React",
+    "azure",
+    ".NET Programming",
+    "integrity",
+    "~alpha",
+    "C#",
+    "F# or Visual Basic",
+    "python",
+    "Database Design & Data Administration",
+    "C++",
+  ];
+
+  modifiedList = alphaSort(unsortedList);
+  expect(modifiedList).toStrictEqual(sortedList);
 });

--- a/packages/forms/src/utils.ts
+++ b/packages/forms/src/utils.ts
@@ -10,11 +10,12 @@ import {
   Scalars,
   WorkRegion,
 } from "@gc-digital-talent/graphql";
-import { commonMessages, getLocale } from "@gc-digital-talent/i18n";
+import { Locales, commonMessages, getLocale } from "@gc-digital-talent/i18n";
 import { getId, unpackMaybes } from "@gc-digital-talent/helpers";
 import { defaultLogger } from "@gc-digital-talent/logger";
 
 import { Node } from "./components/RichTextInput/types";
+import { Option } from "./components/Combobox/types";
 /**
  * Filters out empty data from data response, and returns list of ids.
  * @param data
@@ -255,4 +256,14 @@ export function flattenErrors(
   }
 
   return errorNames;
+}
+
+export function alphaSort(list: string[], locale?: Locales): string[] {
+  return list.sort(Intl.Collator(locale).compare);
+}
+
+export function alphaSortOptions(list: Option[], locale?: Locales): Option[] {
+  return list.sort((a, b) =>
+    Intl.Collator(locale).compare(String(a.label), String(b.label)),
+  );
 }


### PR DESCRIPTION
🤖 Resolves #9023 

## 👋 Introduction

- Adds default alphabetical sorting to the Combox component.
- Adds prop to turn off sorting if need be.

Question: The Select component has a house build sortingOptions function. I found that [Intl.Collator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator) works well so there's no need to reinvent the wheel. Should I replace `sortOptions` with `alphaSortOptions`?

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run `npm run build`
2. Login as `admin@test.com`
3. Go to any combobox across site and ensure it is sorted alphabetically. For example, the talent requests filters `http://localhost:8000/en/admin/talent-requests`.

## 📸 Screenshot

![Screenshot 2024-01-23 103328](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/0936fdda-dcf5-4ab8-87ad-dd97c2e41c32)
