### PR TITLE
Date fields limit equality check to active fields

### DIFF
--- a/packages/forms/src/components/DateInput/DateInput.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.tsx
@@ -6,7 +6,9 @@ import get from "lodash/get";
 import omit from "lodash/omit";
 import isAfter from "date-fns/isAfter";
 import isBefore from "date-fns/isBefore";
-import isEqual from "date-fns/isEqual";
+import isSameDay from "date-fns/isSameDay";
+import isSameMonth from "date-fns/isSameMonth";
+import isSameYear from "date-fns/isSameYear";
 import isValid from "date-fns/isValid";
 import { FieldError, useFormContext, Controller } from "react-hook-form";
 
@@ -80,6 +82,22 @@ const DateInput = ({
     );
   };
 
+  // Check for equality only within the scope of available fields
+  const isRelativelyEqual = (dateA: Date | number, dateB: Date | number) => {
+    if (show.includes(DATE_SEGMENT.Year)) {
+      if (show.includes(DATE_SEGMENT.Month)) {
+        if (show.includes(DATE_SEGMENT.Day)) {
+          return isSameDay(dateA, dateB);
+        }
+        return isSameMonth(dateA, dateB);
+      }
+      return isSameYear(dateA, dateB);
+    }
+
+    // What is this input actually for?
+    return false;
+  };
+
   const isAfterMin = (value: string) => {
     if (!rules.min) {
       return true;
@@ -92,7 +110,7 @@ const DateInput = ({
     const minDate = formDateStringToDate(rules.min.value);
     return (
       isAfter(currentDate, minDate) ||
-      isEqual(currentDate, minDate) ||
+      isRelativelyEqual(currentDate, minDate) ||
       rules.min.message
     );
   };
@@ -109,7 +127,7 @@ const DateInput = ({
     const maxDate = formDateStringToDate(rules.max.value);
     return (
       isBefore(currentDate, maxDate) ||
-      isEqual(currentDate, maxDate) ||
+      isRelativelyEqual(currentDate, maxDate) ||
       rules.max.message
     );
   };


### PR DESCRIPTION
🤖 Resolves #9063 

## 👋 Introduction

Updates the DateInput field to check equality based on the used fields.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login as an applicant
3. Navigate to the career timeline page `/en/users/{id}/personal-information/career-timeline`
4. Select to edit an experience with no end date
5. Set an end date before the start date
6. Confirm error message appears on submit
7. Set an end date at the same time as the start date
8. Confirm form successfully submits
9. Manually change the date field to include day and repeat steps 4-8
10. Manually change the date field to only the year and repeat steps 4-8