### PR TITLE
Fix request responder note permission

### DIFF
--- a/api/app/Policies/AssessmentResultPolicy.php
+++ b/api/app/Policies/AssessmentResultPolicy.php
@@ -12,7 +12,7 @@ class AssessmentResultPolicy
     use HandlesAuthorization;
 
     /**
-     * Determine whether the user can view
+     * NOTE: the logic for PoolCandidatePolicy->viewAssessmentResults should be kept in sync with this function.
      *
      * @return \Illuminate\Auth\Access\Response|bool
      */

--- a/api/app/Policies/PoolCandidatePolicy.php
+++ b/api/app/Policies/PoolCandidatePolicy.php
@@ -91,8 +91,8 @@ class PoolCandidatePolicy
                     || $user->isAbleTo('update-team-applicationStatus', $candidatePoolTeam))
         ) {
             if ($request && array_key_exists('notes', $request)
-                && !$user->isAbleTo('update-any-applicationNotes')
-                && !$user->isAbleTo('update-team-applicationNotes', $candidatePoolTeam)) {
+                && ! $user->isAbleTo('update-any-applicationNotes')
+                && ! $user->isAbleTo('update-team-applicationNotes', $candidatePoolTeam)) {
                 return false;
             }
 
@@ -201,6 +201,7 @@ class PoolCandidatePolicy
             return true;
         }
         $poolCandidate->loadMissing('pool.team');
+
         return $user->isAbleTo('view-team-applicationStatus', $poolCandidate->pool->team);
     }
 
@@ -210,6 +211,7 @@ class PoolCandidatePolicy
             return true;
         }
         $poolCandidate->loadMissing('pool.team');
+
         return $user->isAbleTo('update-team-applicationStatus', $poolCandidate->pool->team);
     }
 
@@ -219,6 +221,7 @@ class PoolCandidatePolicy
             return true;
         }
         $poolCandidate->loadMissing('pool.team');
+
         return $user->isAbleTo('view-team-applicationNotes', $poolCandidate->pool->team);
     }
 
@@ -228,6 +231,7 @@ class PoolCandidatePolicy
             return true;
         }
         $poolCandidate->loadMissing('pool.team');
+
         return $user->isAbleTo('update-team-applicationNotes', $poolCandidate->pool->team);
     }
 
@@ -235,8 +239,6 @@ class PoolCandidatePolicy
      * NOTE: this logic must be kept up to date with AssessmentResultPolicy->view, but may be used
      *       to check for permission to view all of a candidate's results with one function call, where convenient.
      *
-     * @param User $user
-     * @param PoolCandidate $poolCandidate
      * @return void
      */
     public function viewAssessmentResults(User $user, PoolCandidate $poolCandidate)
@@ -245,6 +247,7 @@ class PoolCandidatePolicy
             return true;
         }
         $poolCandidate->loadMissing('pool.team');
+
         return $user->isAbleTo('view-team-assessmentResult', $poolCandidate->pool->team);
     }
 }

--- a/api/app/Policies/PoolCandidatePolicy.php
+++ b/api/app/Policies/PoolCandidatePolicy.php
@@ -90,7 +90,7 @@ class PoolCandidatePolicy
         if (! $isDraft && ($user->isAbleTo('update-any-applicationStatus')
                     || $user->isAbleTo('update-team-applicationStatus', $candidatePoolTeam))
         ) {
-            if ($request['notes']
+            if (array_key_exists('notes', $request)
                 && !$user->isAbleTo('update-any-applicationNotes')
                 && !$user->isAbleTo('update-team-applicationNotes', $candidatePoolTeam)) {
                 return false;

--- a/api/app/Policies/PoolCandidatePolicy.php
+++ b/api/app/Policies/PoolCandidatePolicy.php
@@ -82,7 +82,7 @@ class PoolCandidatePolicy
      *
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function updateAsAdmin(User $user, PoolCandidate $poolCandidate, $request)
+    public function updateAsAdmin(User $user, PoolCandidate $poolCandidate, $request = null)
     {
         $poolCandidate->loadMissing('pool.team');
         $candidatePoolTeam = $poolCandidate->pool->team;
@@ -90,7 +90,7 @@ class PoolCandidatePolicy
         if (! $isDraft && ($user->isAbleTo('update-any-applicationStatus')
                     || $user->isAbleTo('update-team-applicationStatus', $candidatePoolTeam))
         ) {
-            if (array_key_exists('notes', $request)
+            if ($request && array_key_exists('notes', $request)
                 && !$user->isAbleTo('update-any-applicationNotes')
                 && !$user->isAbleTo('update-team-applicationNotes', $candidatePoolTeam)) {
                 return false;

--- a/api/app/Policies/PoolCandidatePolicy.php
+++ b/api/app/Policies/PoolCandidatePolicy.php
@@ -230,4 +230,21 @@ class PoolCandidatePolicy
         $poolCandidate->loadMissing('pool.team');
         return $user->isAbleTo('update-team-applicationNotes', $poolCandidate->pool->team);
     }
+
+    /**
+     * NOTE: this logic must be kept up to date with AssessmentResultPolicy->view, but may be used
+     *       to check for permission to view all of a candidate's results with one function call, where convenient.
+     *
+     * @param User $user
+     * @param PoolCandidate $poolCandidate
+     * @return void
+     */
+    public function viewAssessmentResults(User $user, PoolCandidate $poolCandidate)
+    {
+        if ($user->isAbleTo('view-any-assessmentResult')) {
+            return true;
+        }
+        $poolCandidate->loadMissing('pool.team');
+        return $user->isAbleTo('view-team-assessmentResult', $poolCandidate->pool->team);
+    }
 }

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -293,10 +293,6 @@ return [
             'fr' => 'Suspendre ou débloquer sa propre candidature présentée',
         ],
 
-        'view-own-applicationNotes' => [
-            'en' => 'View the notes associated with my own Applications',
-            'fr' => 'Consulter les notes associés avec mes propres candidatures',
-        ],
         'view-team-applicationNotes' => [
             'en' => 'View the notes of Applications submitted to this Team\'s Pools',
             'fr' => 'Consulter les notes des candidatures soumises aux bassins de cette équipe.',

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -439,19 +439,19 @@ return [
 
         'view-any-assessmentPlan' => [
             'en' => 'View the assessment plan (assessment steps) for any pool.',
-            'fr' => 'Consulter le plan d\'évaluation (étapes de l\'évaluation) pour n\'importe quel bassin.'
+            'fr' => 'Consulter le plan d\'évaluation (étapes de l\'évaluation) pour n\'importe quel bassin.',
         ],
         'view-team-assessmentPlan' => [
             'en' => 'View the assessment plan (assessment steps) for pools run by your team only.',
-            'fr' => 'Consultez le plan d\'évaluation (étapes de l\'évaluation) pour les pools gérés par votre équipe uniquement.'
+            'fr' => 'Consultez le plan d\'évaluation (étapes de l\'évaluation) pour les pools gérés par votre équipe uniquement.',
         ],
         'update-any-assessmentPlan' => [
             'en' => 'Edit the assessment plan (assessment steps) for any pool.',
-            'fr' => 'Modifier le plan d\'évaluation (étapes de l\'évaluation) pour n\'importe quel bassin.'
+            'fr' => 'Modifier le plan d\'évaluation (étapes de l\'évaluation) pour n\'importe quel bassin.',
         ],
         'update-team-assessmentPlan' => [
             'en' => 'Edit the assessment plan (assessment steps) for pools run by your team only.',
-            'fr' => 'Modifier le plan d\'évaluation (étapes de l\'évaluation) pour les pools gérés par votre équipe uniquement.'
+            'fr' => 'Modifier le plan d\'évaluation (étapes de l\'évaluation) pour les pools gérés par votre équipe uniquement.',
         ],
 
         'view-any-assessmentResult' => [
@@ -663,7 +663,7 @@ return [
             ],
             'applicationStatus' => [
                 'own' => ['view'],
-            ]
+            ],
         ],
 
         'pool_operator' => [
@@ -695,7 +695,7 @@ return [
                 'team' => ['view'],
             ],
             'assessmentPlan' => [
-                'team' => ['view', 'update']
+                'team' => ['view', 'update'],
             ],
             'assessmentResult' => [
                 'team' => ['view', 'update'],
@@ -719,7 +719,7 @@ return [
                 'any' => ['view'],
             ],
             'assessmentPlan' => [
-                'any' => ['view']
+                'any' => ['view'],
             ],
             'assessmentResult' => [
                 'any' => ['view'],
@@ -744,7 +744,7 @@ return [
             ],
             'assessmentPlan' => [
                 'any' => ['view'],
-            ]
+            ],
         ],
 
         'platform_admin' => [

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -714,7 +714,7 @@ return [
                 'any' => ['view', 'update'],
             ],
             'applicationNotes' => [
-                'team' => ['view', 'update'],
+                'any' => ['view', 'update'],
             ],
             'searchRequest' => [
                 'any' => ['view', 'update', 'delete'],

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -70,6 +70,7 @@ return [
         'application' => 'application',
         'submittedApplication' => 'submittedApplication',
         'draftApplication' => 'draftApplication',
+        'applicationNotes' => 'applicationNotes',
         'applicationStatus' => 'applicationStatus',
         'applicantCount' => 'applicantCount',
         'searchRequest' => 'searchRequest',
@@ -79,6 +80,7 @@ return [
         'directiveForm' => 'directiveForm',
         'applicantProfile' => 'applicantProfile',
         'teamRole' => 'teamRole',
+        'assessmentPlan' => 'assessmentPlan',
         'assessmentResult' => 'assessmentResult',
     ],
 
@@ -278,14 +280,6 @@ return [
             'en' => 'Submit my own Application',
             'fr' => 'Soumettre ma propre candidature',
         ],
-        'update-team-applicationStatus' => [
-            'en' => 'Update the status of Applications submitted to this Team\'s Pools',
-            'fr' => 'Mettre à jour le statut des demandes soumises aux bassins de cette équipe.',
-        ],
-        'update-any-applicationStatus' => [
-            'en' => 'Update the status of any submitted Applications',
-            'fr' => 'Mettre à jour le statut des demandes soumises aux bassins de cette équipe.',
-        ],
         'delete-own-draftApplication' => [
             'en' => 'Delete Own Draft Application',
             'fr' => 'Supprimer sa propre candidature provisoire',
@@ -297,6 +291,48 @@ return [
         'suspend-own-submittedApplication' => [
             'en' => 'Suspend or un-suspend Own Submitted Application',
             'fr' => 'Suspendre ou débloquer sa propre candidature présentée',
+        ],
+
+        'view-own-applicationNotes' => [
+            'en' => 'View the notes associated with my own Applications',
+            'fr' => 'Consulter les notes associés avec mes propres candidatures',
+        ],
+        'view-team-applicationNotes' => [
+            'en' => 'View the notes of Applications submitted to this Team\'s Pools',
+            'fr' => 'Consulter les notes des candidatures soumises aux bassins de cette équipe.',
+        ],
+        'view-any-applicationNotes' => [
+            'en' => 'View the notes of any submitted Application',
+            'fr' => 'Consulter les notes de n\'importe quel candidature soumise',
+        ],
+        'update-team-applicationNotes' => [
+            'en' => 'Update the notes of Applications submitted to this Team\'s Pools',
+            'fr' => 'Mettre à jour les notes des demandes soumises aux bassins de cette équipe.',
+        ],
+        'update-any-applicationNotes' => [
+            'en' => 'Update the notes of any submitted Applications',
+            'fr' => 'Mettre à jour les notes des demandes soumises aux bassins de cette équipe.',
+        ],
+
+        'view-own-applicationStatus' => [
+            'en' => 'View the status of my own Applications',
+            'fr' => 'Consulter le statut de mes propres candidatures',
+        ],
+        'view-team-applicationStatus' => [
+            'en' => 'View the status of Applications submitted to this Team\'s Pools',
+            'fr' => 'Consulter le statut des candidatures soumises aux bassins de cette équipe.',
+        ],
+        'view-any-applicationStatus' => [
+            'en' => 'View the status of any submitted Application',
+            'fr' => 'Consulter le statut de n\'importe quel candidature soumise',
+        ],
+        'update-team-applicationStatus' => [
+            'en' => 'Update the status of Applications submitted to this Team\'s Pools',
+            'fr' => 'Mettre à jour le statut des demandes soumises aux bassins de cette équipe.',
+        ],
+        'update-any-applicationStatus' => [
+            'en' => 'Update the status of any submitted Applications',
+            'fr' => 'Mettre à jour le statut des demandes soumises aux bassins de cette équipe.',
         ],
 
         'create-any-application' => [
@@ -403,6 +439,23 @@ return [
         'delete-any-directiveForm' => [
             'en' => 'Delete any directive form',
             'fr' => 'Supprimer tout formulaire de directive',
+        ],
+
+        'view-any-assessmentPlan' => [
+            'en' => 'View the assessment plan (assessment steps) for any pool.',
+            'fr' => 'Consulter le plan d\'évaluation (étapes de l\'évaluation) pour n\'importe quel bassin.'
+        ],
+        'view-team-assessmentPlan' => [
+            'en' => 'View the assessment plan (assessment steps) for pools run by your team only.',
+            'fr' => 'Consultez le plan d\'évaluation (étapes de l\'évaluation) pour les pools gérés par votre équipe uniquement.'
+        ],
+        'update-any-assessmentPlan' => [
+            'en' => 'Edit the assessment plan (assessment steps) for any pool.',
+            'fr' => 'Modifier le plan d\'évaluation (étapes de l\'évaluation) pour n\'importe quel bassin.'
+        ],
+        'update-team-assessmentPlan' => [
+            'en' => 'Edit the assessment plan (assessment steps) for pools run by your team only.',
+            'fr' => 'Modifier le plan d\'évaluation (étapes de l\'évaluation) pour les pools gérés par votre équipe uniquement.'
         ],
 
         'view-any-assessmentResult' => [
@@ -612,6 +665,9 @@ return [
             'submittedApplication' => [
                 'own' => ['archive', 'suspend'],
             ],
+            'applicationStatus' => [
+                'own' => ['view'],
+            ]
         ],
 
         'pool_operator' => [
@@ -628,7 +684,10 @@ return [
                 'team' => ['view'],
             ],
             'applicationStatus' => [
-                'team' => ['update'],
+                'team' => ['view', 'update'],
+            ],
+            'applicationNotes' => [
+                'team' => ['view', 'update'],
             ],
             'teamMembers' => [
                 'team' => ['view'],
@@ -638,6 +697,9 @@ return [
             ],
             'applicantProfile' => [
                 'team' => ['view'],
+            ],
+            'assessmentPlan' => [
+                'team' => ['view', 'update']
             ],
             'assessmentResult' => [
                 'team' => ['view', 'update'],
@@ -649,13 +711,19 @@ return [
                 'any' => ['view'],
             ],
             'applicationStatus' => [
-                'any' => ['update'],
+                'any' => ['view', 'update'],
+            ],
+            'applicationNotes' => [
+                'team' => ['view', 'update'],
             ],
             'searchRequest' => [
                 'any' => ['view', 'update', 'delete'],
             ],
             'user' => [
                 'any' => ['view'],
+            ],
+            'assessmentPlan' => [
+                'any' => ['view']
             ],
             'assessmentResult' => [
                 'any' => ['view'],
@@ -678,6 +746,9 @@ return [
             'teamRole' => [
                 'any' => ['assign'],
             ],
+            'assessmentPlan' => [
+                'any' => ['view'],
+            ]
         ],
 
         'platform_admin' => [

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -657,6 +657,9 @@ return [
             'user' => [
                 'any' => ['view'],
             ],
+            'assessmentResult' => [
+                'any' => ['view'],
+            ],
         ],
 
         'community_manager' => [

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -57,7 +57,7 @@ class UserFactory extends Factory
         return [
             'first_name' => $this->faker->firstName(),
             'last_name' => $this->faker->lastName(),
-            'email' => $this->faker->firstName() . '_' . $this->faker->unique()->safeEmail(),
+            'email' => $this->faker->firstName().'_'.$this->faker->unique()->safeEmail(),
             'sub' => $this->faker->boolean(75) ? $this->faker->unique()->uuid() : null,
             'telephone' => $this->faker->e164PhoneNumber(),
             'preferred_lang' => $this->faker->randomElement(Language::cases())->value,

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -57,7 +57,7 @@ class UserFactory extends Factory
         return [
             'first_name' => $this->faker->firstName(),
             'last_name' => $this->faker->lastName(),
-            'email' => $this->faker->unique()->safeEmail(),
+            'email' => $this->faker->firstName() . '_' . $this->faker->unique()->safeEmail(),
             'sub' => $this->faker->boolean(75) ? $this->faker->unique()->uuid() : null,
             'telephone' => $this->faker->e164PhoneNumber(),
             'preferred_lang' => $this->faker->randomElement(Language::cases())->value,

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1535,11 +1535,19 @@ type Mutation {
   updatePoolCandidateAsAdmin(
     id: ID!
     poolCandidate: UpdatePoolCandidateAsAdminInput! @spread
-  ): PoolCandidate @update @guard @can(ability: "updateAsAdmin", find: "id")
+  ): PoolCandidate
+    @update
+    @guard
+    @can(ability: "updateAsAdmin", find: "id", injectArgs: true)
   # Return a boolean to prevent automatically updating the client's cache
   togglePoolCandidateBookmark(id: ID!): Boolean
     @guard
-    @can(ability: "updateAsAdmin", find: "id", model: "poolCandidate")
+    @can(
+      ability: "updateAsAdmin"
+      find: "id"
+      model: "poolCandidate"
+      injectArgs: true
+    )
   deletePoolCandidate(id: ID! @whereKey): PoolCandidate
     @delete
     @guard

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -256,16 +256,20 @@ type PoolCandidate {
   # Expiry date for this candidate being in the pool.
   expiryDate: Date @rename(attribute: "expiry_date")
 
-  status: PoolCandidateStatus @rename(attribute: "pool_candidate_status")
-  statusWeight: Int @rename(attribute: "status_weight")
-  notes: String @canOnParent(ability: "viewAssessmentResults")
+  status: PoolCandidateStatus
+    @rename(attribute: "pool_candidate_status")
+    @canOnParent(ability: "viewStatus")
+  statusWeight: Int
+    @rename(attribute: "status_weight")
+    @canOnParent(ability: "viewStatus")
+  notes: String @canOnParent(ability: "viewNotes")
   archivedAt: DateTime @rename(attribute: "archived_at")
   submittedAt: DateTime @rename(attribute: "submitted_at")
   suspendedAt: DateTime @rename(attribute: "suspended_at")
   deletedDate: DateTime @rename(attribute: "deleted_at")
   isBookmarked: Boolean
     @rename(attribute: "is_bookmarked")
-    @canOnParent(ability: "viewAssessmentResults")
+    @canOnParent(ability: "viewNotes")
 
   profileSnapshot: JSON @rename(attribute: "profile_snapshot")
   signature: String

--- a/api/tests/Feature/PoolCandidateTest.php
+++ b/api/tests/Feature/PoolCandidateTest.php
@@ -493,8 +493,6 @@ class PoolCandidateTest extends TestCase
 
     /**
      * Status access permissions are similar to notes, except a candidate can see their own status
-     *
-     * @return void
      */
     public function testStatusAccess(): void
     {

--- a/api/tests/Feature/PoolCandidateTest.php
+++ b/api/tests/Feature/PoolCandidateTest.php
@@ -449,6 +449,17 @@ class PoolCandidateTest extends TestCase
                 ],
             ]);
 
+        // Assert request responder can view notes
+        $this->actingAs($this->requestResponderUser, 'api')
+            ->graphQL($notesQuery, ['id' => $candidate->id])
+            ->assertJson([
+                'data' => [
+                    'poolCandidate' => [
+                        'notes' => $candidate->notes,
+                    ],
+                ],
+            ]);
+
         // Assert admin can view notes
         $this->actingAs($this->adminUser, 'api')
             ->graphQL($notesQuery, ['id' => $candidate->id])
@@ -460,7 +471,7 @@ class PoolCandidateTest extends TestCase
                 ],
             ]);
 
-        // Assert applicant can query candidate
+        // Assert applicant can query candidate, but not access notes
         $this->actingAs($this->applicantUser, 'api')
             ->graphQL($basicQuery, ['id' => $candidate->id])
             ->assertJson([
@@ -470,9 +481,7 @@ class PoolCandidateTest extends TestCase
                     ],
                 ],
             ]);
-
-        // Assert request responder cannot query candidate notes
-        $this->actingAs($this->requestResponderUser, 'api')
+        $this->actingAs($this->applicantUser, 'api')
             ->graphQL($notesQuery, ['id' => $candidate->id])
             ->assertGraphQLErrorMessage('This action is unauthorized.');
 
@@ -480,10 +489,79 @@ class PoolCandidateTest extends TestCase
         $this->actingAs($this->unAssociatedTeamUser, 'api')
             ->graphQL($notesQuery, ['id' => $candidate->id])
             ->assertGraphQLErrorMessage('This action is unauthorized.');
+    }
 
-        // Assert applicant cannot query candidate notes
+    /**
+     * Status access permissions are similar to notes, except a candidate can see their own status
+     *
+     * @return void
+     */
+    public function testStatusAccess(): void
+    {
+        $candidate = PoolCandidate::factory()->create([
+            'pool_candidate_status' => PoolCandidateStatus::NEW_APPLICATION->name,
+            'submitted_at' => config('constants.past_date'),
+            'expiry_date' => config('constants.far_future_date'),
+            'pool_id' => $this->pool->id,
+            'user_id' => $this->applicantUser->id,
+        ]);
+
+        $statusQuery = /** @lang GraphQL */
+        '
+            query poolCandidate($id: UUID!) {
+                poolCandidate(id: $id) {
+                    status
+                }
+            }
+         ';
+
+        // Assert team member can view status
+        $this->actingAs($this->teamUser, 'api')
+            ->graphQL($statusQuery, ['id' => $candidate->id])
+            ->assertJson([
+                'data' => [
+                    'poolCandidate' => [
+                        'status' => $candidate->pool_candidate_status,
+                    ],
+                ],
+            ]);
+
+        // Assert request responder can view status
+        $this->actingAs($this->requestResponderUser, 'api')
+            ->graphQL($statusQuery, ['id' => $candidate->id])
+            ->assertJson([
+                'data' => [
+                    'poolCandidate' => [
+                        'status' => $candidate->pool_candidate_status,
+                    ],
+                ],
+            ]);
+
+        // Assert admin can view status
+        $this->actingAs($this->adminUser, 'api')
+            ->graphQL($statusQuery, ['id' => $candidate->id])
+            ->assertJson([
+                'data' => [
+                    'poolCandidate' => [
+                        'status' => $candidate->pool_candidate_status,
+                    ],
+                ],
+            ]);
+
+        // Assert applicant can access status
         $this->actingAs($this->applicantUser, 'api')
-            ->graphQL($notesQuery, ['id' => $candidate->id])
+            ->graphQL($statusQuery, ['id' => $candidate->id])
+            ->assertJson([
+                'data' => [
+                    'poolCandidate' => [
+                        'status' => $candidate->pool_candidate_status,
+                    ],
+                ],
+            ]);
+
+        // Assert an unassociated pool operator cannot query candidate status
+        $this->actingAs($this->unAssociatedTeamUser, 'api')
+            ->graphQL($statusQuery, ['id' => $candidate->id])
             ->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 }

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -112,6 +112,7 @@ class RolePermissionTest extends TestCase
         $this->assertTrue($this->user->hasRole('applicant'));
         $this->assertTrue($this->user->isAbleTo([
             'view-own-application',
+            'view-own-applicationStatus',
             'submit-own-application',
             'create-own-draftApplication',
             'delete-own-draftApplication',
@@ -143,11 +144,16 @@ class RolePermissionTest extends TestCase
             'update-team-poolClosingDate',
             'delete-team-draftPool',
             'view-team-submittedApplication',
+            'view-team-applicationStatus',
             'update-team-applicationStatus',
+            'view-team-applicationNotes',
+            'update-team-applicationNotes',
             'view-team-teamMembers',
             'view-team-applicantProfile',
             'view-team-assessmentResult',
             'update-team-assessmentResult',
+            'view-team-assessmentPlan',
+            'update-team-assessmentPlan'
         ];
 
         $this->assertTrue($this->user->hasRole('pool_operator', $this->ownedTeam));
@@ -171,9 +177,15 @@ class RolePermissionTest extends TestCase
 
         $permissionsToCheck = [
             'view-any-submittedApplication',
+            'view-any-applicationStatus',
+            'update-any-applicationStatus',
+            'view-any-applicationNotes',
+            'update-any-applicationNotes',
             'view-any-searchRequest',
             'update-any-searchRequest',
             'delete-any-searchRequest',
+            'view-any-assessmentPlan',
+            'view-any-assessmentResult'
         ];
 
         $this->assertTrue($this->user->hasRole('request_responder'));

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -153,7 +153,7 @@ class RolePermissionTest extends TestCase
             'view-team-assessmentResult',
             'update-team-assessmentResult',
             'view-team-assessmentPlan',
-            'update-team-assessmentPlan'
+            'update-team-assessmentPlan',
         ];
 
         $this->assertTrue($this->user->hasRole('pool_operator', $this->ownedTeam));
@@ -185,7 +185,7 @@ class RolePermissionTest extends TestCase
             'update-any-searchRequest',
             'delete-any-searchRequest',
             'view-any-assessmentPlan',
-            'view-any-assessmentResult'
+            'view-any-assessmentResult',
         ];
 
         $this->assertTrue($this->user->hasRole('request_responder'));

--- a/api/tests/Unit/PoolCandidatePolicyTest.php
+++ b/api/tests/Unit/PoolCandidatePolicyTest.php
@@ -26,6 +26,8 @@ class PoolCandidatePolicyTest extends TestCase
 
     protected $requestResponderUser;
 
+    protected $communityManagerUser;
+
     protected $adminUser;
 
     protected $team;
@@ -71,6 +73,13 @@ class PoolCandidatePolicyTest extends TestCase
             ->create([
                 'email' => 'request-responder-user@test.com',
                 'sub' => 'request-responder-user@test.com',
+            ]);
+
+        $this->communityManagerUser = User::factory()
+            ->asCommunityManager()
+            ->create([
+                'email' => 'community-manager-user@test.com',
+                'sub' => 'community-manager-user@test.com',
             ]);
 
         $this->adminUser = User::factory()
@@ -120,6 +129,7 @@ class PoolCandidatePolicyTest extends TestCase
         $this->assertFalse($this->candidateUser->can('viewAny', PoolCandidate::class));
         $this->assertFalse($this->poolOperatorUser->can('viewAny', PoolCandidate::class));
         $this->assertFalse($this->requestResponderUser->can('viewAny', PoolCandidate::class));
+        $this->assertFalse($this->communityManagerUser->can('viewAny', PoolCandidate::class));
         $this->assertFalse($this->adminUser->can('viewAny', PoolCandidate::class));
     }
 
@@ -139,6 +149,7 @@ class PoolCandidatePolicyTest extends TestCase
         $this->assertFalse($this->applicantUser->can('view', $this->poolCandidate));
         $this->assertFalse($this->poolOperatorUser->can('view', $this->poolCandidate));
         $this->assertFalse($this->requestResponderUser->can('view', $this->poolCandidate));
+        $this->assertFalse($this->communityManagerUser->can('view', $this->poolCandidate));
         $this->assertFalse($this->adminUser->can('view', $this->poolCandidate));
     }
 
@@ -159,6 +170,7 @@ class PoolCandidatePolicyTest extends TestCase
         $this->assertTrue($this->requestResponderUser->can('view', $this->poolCandidate));
 
         $this->assertFalse($this->adminUser->can('view', $this->poolCandidate));
+        $this->assertFalse($this->communityManagerUser->can('view', $this->poolCandidate));
         $this->assertFalse($this->guestUser->can('view', $this->poolCandidate));
         $this->assertFalse($this->applicantUser->can('view', $this->poolCandidate));
         // Pool operator cannot view submitted applications not in their teams pool
@@ -178,6 +190,7 @@ class PoolCandidatePolicyTest extends TestCase
         $this->assertFalse($this->guestUser->can('createDraft', PoolCandidate::class));
         $this->assertFalse($this->poolOperatorUser->can('createDraft', PoolCandidate::class));
         $this->assertFalse($this->requestResponderUser->can('createDraft', PoolCandidate::class));
+        $this->assertFalse($this->communityManagerUser->can('createDraft', PoolCandidate::class));
         $this->assertFalse($this->adminUser->can('createDraft', PoolCandidate::class));
     }
 
@@ -195,6 +208,7 @@ class PoolCandidatePolicyTest extends TestCase
         $this->assertFalse($this->applicantUser->can('create', PoolCandidate::class));
         $this->assertFalse($this->poolOperatorUser->can('create', PoolCandidate::class));
         $this->assertFalse($this->requestResponderUser->can('create', PoolCandidate::class));
+        $this->assertFalse($this->communityManagerUser->can('create', PoolCandidate::class));
     }
 
     /**
@@ -214,6 +228,7 @@ class PoolCandidatePolicyTest extends TestCase
         $this->assertFalse($this->guestUser->can('updateAsAdmin', $this->poolCandidate));
         $this->assertFalse($this->candidateUser->can('updateAsAdmin', $this->poolCandidate));
         $this->assertFalse($this->applicantUser->can('updateAsAdmin', $this->poolCandidate));
+        $this->assertFalse($this->communityManagerUser->can('updateAsAdmin', $this->poolCandidate));
         $this->assertFalse($this->adminUser->can('updateAsAdmin', $this->poolCandidate));
 
         // make candidate draft
@@ -225,6 +240,7 @@ class PoolCandidatePolicyTest extends TestCase
         $this->assertFalse($this->candidateUser->can('updateAsAdmin', $this->poolCandidate));
         $this->assertFalse($this->applicantUser->can('updateAsAdmin', $this->poolCandidate));
         $this->assertFalse($this->requestResponderUser->can('updateAsAdmin', $this->poolCandidate));
+        $this->assertFalse($this->communityManagerUser->can('updateAsAdmin', $this->poolCandidate));
         $this->assertFalse($this->adminUser->can('updateAsAdmin', $this->poolCandidate));
     }
 
@@ -245,6 +261,7 @@ class PoolCandidatePolicyTest extends TestCase
         $this->assertFalse($this->candidateUser->can('update', $this->poolCandidate));
         $this->assertFalse($this->applicantUser->can('update', $this->poolCandidate));
         $this->assertFalse($this->requestResponderUser->can('update', $this->poolCandidate));
+        $this->assertFalse($this->communityManagerUser->can('update', $this->poolCandidate));
         $this->assertFalse($this->adminUser->can('update', $this->poolCandidate));
 
         // make candidate draft
@@ -256,6 +273,7 @@ class PoolCandidatePolicyTest extends TestCase
         $this->assertTrue($this->candidateUser->can('update', $this->poolCandidate));
         $this->assertFalse($this->applicantUser->can('update', $this->poolCandidate));
         $this->assertFalse($this->requestResponderUser->can('update', $this->poolCandidate));
+        $this->assertFalse($this->communityManagerUser->can('update', $this->poolCandidate));
         $this->assertFalse($this->adminUser->can('update', $this->poolCandidate));
     }
 
@@ -272,6 +290,7 @@ class PoolCandidatePolicyTest extends TestCase
         $this->assertFalse($this->applicantUser->can('submit', $this->poolCandidate));
         $this->assertFalse($this->poolOperatorUser->can('submit', $this->poolCandidate));
         $this->assertFalse($this->requestResponderUser->can('submit', $this->poolCandidate));
+        $this->assertFalse($this->communityManagerUser->can('submit', $this->poolCandidate));
         $this->assertFalse($this->adminUser->can('submit', $this->poolCandidate));
     }
 
@@ -288,6 +307,7 @@ class PoolCandidatePolicyTest extends TestCase
         $this->assertFalse($this->applicantUser->can('archive', $this->poolCandidate));
         $this->assertFalse($this->poolOperatorUser->can('archive', $this->poolCandidate));
         $this->assertFalse($this->requestResponderUser->can('archive', $this->poolCandidate));
+        $this->assertFalse($this->communityManagerUser->can('archive', $this->poolCandidate));
         $this->assertFalse($this->adminUser->can('archive', $this->poolCandidate));
     }
 
@@ -304,6 +324,7 @@ class PoolCandidatePolicyTest extends TestCase
         $this->assertFalse($this->applicantUser->can('delete', $this->poolCandidate));
         $this->assertFalse($this->poolOperatorUser->can('delete', $this->poolCandidate));
         $this->assertFalse($this->requestResponderUser->can('delete', $this->poolCandidate));
+        $this->assertFalse($this->communityManagerUser->can('delete', $this->poolCandidate));
         $this->assertFalse($this->adminUser->can('delete', $this->poolCandidate));
     }
 
@@ -320,6 +341,7 @@ class PoolCandidatePolicyTest extends TestCase
         $this->assertFalse($this->applicantUser->can('suspend', $this->poolCandidate));
         $this->assertFalse($this->poolOperatorUser->can('suspend', $this->poolCandidate));
         $this->assertFalse($this->requestResponderUser->can('suspend', $this->poolCandidate));
+        $this->assertFalse($this->communityManagerUser->can('suspend', $this->poolCandidate));
         $this->assertFalse($this->adminUser->can('suspend', $this->poolCandidate));
     }
 
@@ -335,6 +357,7 @@ class PoolCandidatePolicyTest extends TestCase
         $this->assertTrue($this->applicantUser->can('count', $this->poolCandidate));
         $this->assertTrue($this->poolOperatorUser->can('count', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('count', $this->poolCandidate));
+        $this->assertTrue($this->communityManagerUser->can('count', $this->poolCandidate));
         $this->assertTrue($this->adminUser->can('count', $this->poolCandidate));
     }
 }

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -1542,6 +1542,7 @@ const createRoute = (
                         <RequireAuth
                           roles={[
                             ROLE_NAME.PoolOperator,
+                            ROLE_NAME.CommunityManager,
                             ROLE_NAME.PlatformAdmin,
                           ]}
                           loginPath={loginPath}

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
@@ -210,8 +210,11 @@ export const AssessmentPlanBuilderPage = () => {
   const authorizedToSeeThePage: boolean =
     authorization.roleAssignments?.some(
       (authorizedRoleAssignment) =>
-        authorizedRoleAssignment.role?.name === ROLE_NAME.PoolOperator &&
-        authorizedRoleAssignment.team?.name === queryData?.pool?.team?.name,
+        (authorizedRoleAssignment.role?.name === ROLE_NAME.PoolOperator &&
+          authorizedRoleAssignment.team?.name ===
+            queryData?.pool?.team?.name) ||
+        authorizedRoleAssignment.role?.name === ROLE_NAME.CommunityManager ||
+        authorizedRoleAssignment.role?.name === ROLE_NAME.PlatformAdmin,
     ) ?? false;
 
   // figure out what content should be displayed


### PR DESCRIPTION
🤖 Resolves #9044

## 👋 Introduction

Make sure the permissions are correct so that users with a single admin permission (ie RequestResponder or PoolOperator) can see the pools and PoolCandidates they should be able to.

## 🕵️ Details

For those among us who are against the proliferation of permissions, I apologize! I added any/team + view/update permissions specific to applicationNotes, applicationStatus, assessmentPlan, and assessmentResult, because I realized the cross section of who can do what with each of those resources differes _slightly_ across roles.

The [roles and permissions](https://docs.google.com/spreadsheets/d/1RC7wufxwjLEvaEunHsfZfOzBefg218dvvzkDwKSiQjI/edit#gid=428263758) spreadsheet has been updated as well.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

0. Run `php artisan db:seed --class=RolePermissionSeeder`
1. Log in as request@test.com
2. Go to the pool candidates page
3. Go to an individual pool candidate (application) page
4. Try to change the notes and status of an application
5. Log in as pool@test.com and repeat steps 2-4

## 🚚 Deployment

Run `php artisan db:seed --class=RolePermissionSeeder`