### PR TITLE
[Bug] Update tab active + focused styles

### DIFF
--- a/packages/ui/src/components/Tabs/utils.ts
+++ b/packages/ui/src/components/Tabs/utils.ts
@@ -39,6 +39,7 @@ export const commonTabStyles = {
     "data-h2-color": `
       base(black)
       base:children[a:focus-visible](black)
+      base:focus-visible:children[span](black)
       base:selectors[[data-state='active']](primary.darker)
     `,
     "data-h2-margin-top": "base(x.25) base:hover(0)",

--- a/packages/ui/src/components/Tabs/utils.ts
+++ b/packages/ui/src/components/Tabs/utils.ts
@@ -38,8 +38,8 @@ export const commonTabStyles = {
     `,
     "data-h2-color": `
       base(black)
+      base:focus-visible(black)
       base:children[a:focus-visible](black)
-      base:focus-visible:children[span](black)
       base:selectors[[data-state='active']](primary.darker)
     `,
     "data-h2-margin-top": "base(x.25) base:hover(0)",

--- a/packages/ui/src/components/Tabs/utils.ts
+++ b/packages/ui/src/components/Tabs/utils.ts
@@ -38,7 +38,8 @@ export const commonTabStyles = {
     `,
     "data-h2-color": `
       base(black)
-      base:selectors[[data-state='active']](black.darker)
+      base:children[a:focus-visible](black)
+      base:selectors[[data-state='active']](primary.darker)
     `,
     "data-h2-margin-top": "base(x.25) base:hover(0)",
     "data-h2-outline": "base(none) base:children[a](none)",

--- a/packages/ui/src/components/Tabs/utils.ts
+++ b/packages/ui/src/components/Tabs/utils.ts
@@ -38,7 +38,7 @@ export const commonTabStyles = {
     `,
     "data-h2-color": `
       base(black)
-      base:selectors[[data-state='active']](primary.darker)
+      base:selectors[[data-state='active']](black.darker)
     `,
     "data-h2-margin-top": "base(x.25) base:hover(0)",
     "data-h2-outline": "base(none) base:children[a](none)",


### PR DESCRIPTION
🤖 Resolves #8785 

## 👋 Introduction

- Updates tab active + focused font color to black
![290341557-404d0b3f-e5c0-4a6f-8b6a-992c686eddf2](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/c46c19b2-1eb4-40cc-99a7-75ae85b2bf0a)

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build app `npm run build`
2. Login as `admin@test.com`
3. Go to pools table and select a pool
4. Click and tab through TabNav
5. Ensure all states matches the states in the image above

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/5f283cb2-a6bb-4710-8f14-287261730ee0)