### PR TITLE
[Feature] New all pools request button

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2915,6 +2915,10 @@
     "defaultMessage": "Type d'employé",
     "description": "CSV Header, Employee Type column"
   },
+  "DxNuJ9": {
+    "defaultMessage": "Demander à recevoir des candidats de tous les bassins",
+    "description": "Button text to submit search request for candidates across all pools"
+  },
   "DxqFM1": {
     "defaultMessage": "Masquer plus de renseignements sur les types d’expériences que vous pouvez ajouter à votre chronologie de carrière",
     "description": "Button text to close accordion describing skill experience"
@@ -8634,6 +8638,10 @@
   "l/jGX9": {
     "defaultMessage": "J'envisagerais d'accepter un emploi qui :",
     "description": "Label for what conditions a user will accept, followed by a colon"
+  },
+  "l1f8zy": {
+    "defaultMessage": "Ou demander à recevoir des candidats par ordre de bassin",
+    "description": "Lead-in text to list of pools managers can request candidates from"
   },
   "l62TJM": {
     "defaultMessage": "Disponibilité",

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -144,7 +144,7 @@ export const RequestForm = ({
       positionType: positionTypeMassaged,
       reason: values.reason,
       additionalComments: values.additionalComments,
-      wasEmpty: candidateCount === 0,
+      wasEmpty: candidateCount === 0 && !state.allPools,
       applicantFilter: {
         create: {
           positionDuration:

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -74,14 +74,7 @@ export const SearchForm = ({
   }, [classifications, pools, watch]);
 
   const handleSubmit = (values: FormValues) => {
-    let poolIds: { id: string }[] = [];
-    if (values.pool) {
-      if (Array.isArray(values.pool)) {
-        poolIds = values.pool.map((id) => ({ id }));
-      } else {
-        poolIds = [{ id: values.pool }];
-      }
-    }
+    const poolIds = values.pool ? [{ id: values.pool }] : [];
     const selectedPool = pools.find((pool) => pool.id === values.pool);
 
     navigate(paths.request(), {
@@ -98,8 +91,6 @@ export const SearchForm = ({
       },
     });
   };
-
-  const resultPools = unpackMaybes(results?.map((result) => result.pool.id));
 
   return (
     <div
@@ -184,10 +175,10 @@ export const SearchForm = ({
               color="primary"
               type="submit"
               {...poolSubmitProps}
-              value={resultPools}
+              value=""
               onClick={() => {
                 setValue("allPools", true);
-                setValue("pool", resultPools);
+                setValue("pool", "");
                 setValue("count", candidateCount);
               }}
             >

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -90,6 +90,7 @@ export const SearchForm = ({
           ...applicantFilter,
           pools: poolIds,
         },
+        allPools: values.allPools,
         candidateCount: values.count,
         selectedClassifications: selectedPool
           ? selectedPool.classifications?.filter(notEmpty)
@@ -185,6 +186,7 @@ export const SearchForm = ({
               {...poolSubmitProps}
               value={resultPools}
               onClick={() => {
+                setValue("allPools", true);
                 setValue("pool", resultPools);
                 setValue("count", candidateCount);
               }}

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -170,54 +170,57 @@ export const SearchForm = ({
             )}
           </Heading>
           <SearchFilterAdvice filters={applicantFilter} />
-          <p data-h2-margin="base(x1, 0)">
-            <Button
-              color="primary"
-              type="submit"
-              {...poolSubmitProps}
-              value=""
-              onClick={() => {
-                setValue("allPools", true);
-                setValue("pool", "");
-                setValue("count", candidateCount);
-              }}
-            >
-              {intl.formatMessage({
-                defaultMessage: "Request candidates from all pools",
-                id: "DxNuJ9",
-                description:
-                  "Button text to submit search request for candidates across all pools",
-              })}
-            </Button>
-          </p>
-          <p
-            data-h2-font-size="base(h4)"
-            data-h2-margin="base(x1.5, 0, x.25, 0)"
-          >
-            {intl.formatMessage({
-              defaultMessage: "Or request candidates by pool",
-              id: "l1f8zy",
-              description:
-                "Lead-in text to list of pools managers can request candidates from",
-            })}
-            {intl.formatMessage(commonMessages.dividingColon)}
-          </p>
-          <div
-            data-h2-display="base(flex)"
-            data-h2-flex-direction="base(column)"
-          >
-            {results?.length && candidateCount > 0 ? (
-              results.map(({ pool, candidateCount: resultsCount }) => (
-                <SearchResultCard
-                  key={pool.id}
-                  candidateCount={resultsCount}
-                  pool={pool}
-                />
-              ))
-            ) : (
-              <NoResults />
-            )}
-          </div>
+
+          {results?.length && candidateCount > 0 ? (
+            <>
+              <p data-h2-margin="base(x1, 0)">
+                <Button
+                  color="primary"
+                  type="submit"
+                  {...poolSubmitProps}
+                  value=""
+                  onClick={() => {
+                    setValue("allPools", true);
+                    setValue("pool", "");
+                    setValue("count", candidateCount);
+                  }}
+                >
+                  {intl.formatMessage({
+                    defaultMessage: "Request candidates from all pools",
+                    id: "DxNuJ9",
+                    description:
+                      "Button text to submit search request for candidates across all pools",
+                  })}
+                </Button>
+              </p>
+              <p
+                data-h2-font-size="base(h4)"
+                data-h2-margin="base(x1.5, 0, x.25, 0)"
+              >
+                {intl.formatMessage({
+                  defaultMessage: "Or request candidates by pool",
+                  id: "l1f8zy",
+                  description:
+                    "Lead-in text to list of pools managers can request candidates from",
+                })}
+                {intl.formatMessage(commonMessages.dividingColon)}
+              </p>
+              <div
+                data-h2-display="base(flex)"
+                data-h2-flex-direction="base(column)"
+              >
+                {results.map(({ pool, candidateCount: resultsCount }) => (
+                  <SearchResultCard
+                    key={pool.id}
+                    candidateCount={resultsCount}
+                    pool={pool}
+                  />
+                ))}
+              </div>
+            </>
+          ) : (
+            <NoResults />
+          )}
         </form>
       </FormProvider>
     </div>

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -4,7 +4,7 @@ import { useIntl } from "react-intl";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "urql";
 
-import { Heading, Pending, Separator } from "@gc-digital-talent/ui";
+import { Button, Heading, Pending, Separator } from "@gc-digital-talent/ui";
 import { unpackMaybes, notEmpty } from "@gc-digital-talent/helpers";
 import {
   graphql,
@@ -13,6 +13,7 @@ import {
   ApplicantFilterInput,
   Skill,
 } from "@gc-digital-talent/graphql";
+import { commonMessages } from "@gc-digital-talent/i18n";
 
 import { FormValues } from "~/types/searchRequest";
 import useRoutes from "~/hooks/useRoutes";
@@ -56,7 +57,8 @@ export const SearchForm = ({
     mode: "onSubmit",
     reValidateMode: "onBlur",
   });
-  const { watch } = methods;
+  const { watch, register, setValue } = methods;
+  const poolSubmitProps = register("pool");
 
   React.useEffect(() => {
     const subscription = watch((newValues) => {
@@ -72,7 +74,14 @@ export const SearchForm = ({
   }, [classifications, pools, watch]);
 
   const handleSubmit = (values: FormValues) => {
-    const poolIds = values.pool ? [{ id: values.pool }] : [];
+    let poolIds: { id: string }[] = [];
+    if (values.pool) {
+      if (Array.isArray(values.pool)) {
+        poolIds = values.pool.map((id) => ({ id }));
+      } else {
+        poolIds = [{ id: values.pool }];
+      }
+    }
     const selectedPool = pools.find((pool) => pool.id === values.pool);
 
     navigate(paths.request(), {
@@ -88,6 +97,8 @@ export const SearchForm = ({
       },
     });
   };
+
+  const resultPools = unpackMaybes(results?.map((result) => result.pool.id));
 
   return (
     <div
@@ -167,6 +178,37 @@ export const SearchForm = ({
             )}
           </Heading>
           <SearchFilterAdvice filters={applicantFilter} />
+          <p data-h2-margin="base(x1, 0)">
+            <Button
+              color="primary"
+              type="submit"
+              {...poolSubmitProps}
+              value={resultPools}
+              onClick={() => {
+                setValue("pool", resultPools);
+                setValue("count", candidateCount);
+              }}
+            >
+              {intl.formatMessage({
+                defaultMessage: "Request candidates from all pools",
+                id: "DxNuJ9",
+                description:
+                  "Button text to submit search request for candidates across all pools",
+              })}
+            </Button>
+          </p>
+          <p
+            data-h2-font-size="base(h4)"
+            data-h2-margin="base(x1.5, 0, x.25, 0)"
+          >
+            {intl.formatMessage({
+              defaultMessage: "Or request candidates by pool",
+              id: "l1f8zy",
+              description:
+                "Lead-in text to list of pools managers can request candidates from",
+            })}
+            {intl.formatMessage(commonMessages.dividingColon)}
+          </p>
           <div
             data-h2-display="base(flex)"
             data-h2-flex-direction="base(column)"

--- a/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
@@ -170,6 +170,7 @@ export const dataToFormValues = (
     employmentDuration: data.positionDuration
       ? positionDurationToEmploymentDuration(data.positionDuration)
       : "",
+    allPools: false,
   };
 };
 

--- a/apps/web/src/types/searchRequest.ts
+++ b/apps/web/src/types/searchRequest.ts
@@ -27,6 +27,7 @@ export type FormValues = Pick<
   pool?: Scalars["ID"] | Scalars["ID"][];
   selectedClassifications?: Classification[];
   count?: number;
+  allPools?: boolean; // Prevent `was_empty` when requesting all pools
 };
 
 export type LocationState = BrowserHistoryState | null;
@@ -36,4 +37,5 @@ export type BrowserHistoryState = {
   candidateCount: number;
   initialValues?: FormValues;
   selectedClassifications?: SimpleClassification[];
+  allPools?: boolean;
 };

--- a/apps/web/src/types/searchRequest.ts
+++ b/apps/web/src/types/searchRequest.ts
@@ -24,7 +24,7 @@ export type FormValues = Pick<
   educationRequirement: "has_diploma" | "no_diploma";
   poolCandidates?: UserPoolFilterInput;
   pools?: SimplePool[];
-  pool?: Scalars["ID"];
+  pool?: Scalars["ID"] | Scalars["ID"][];
   selectedClassifications?: Classification[];
   count?: number;
 };

--- a/apps/web/src/types/searchRequest.ts
+++ b/apps/web/src/types/searchRequest.ts
@@ -24,7 +24,7 @@ export type FormValues = Pick<
   educationRequirement: "has_diploma" | "no_diploma";
   poolCandidates?: UserPoolFilterInput;
   pools?: SimplePool[];
-  pool?: Scalars["ID"] | Scalars["ID"][];
+  pool?: Scalars["ID"];
   selectedClassifications?: Classification[];
   count?: number;
   allPools?: boolean; // Prevent `was_empty` when requesting all pools


### PR DESCRIPTION
🤖 Resolves #9075 

## 👋 Introduction

Adds a new button to the search page that allows users to request candidates from all pools.

## 🕵️ Details

This button always appears, regardless of how many pools/candidates are returned by the search in order to be forward thinking (candidates may appear in results in the future).

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

### Setup

1. Build the application `npm run dev`
2. Login as admin
3. Create two pools with the same classification and stream
4. Add _different_ users to both pools, setting their status to "Qualified available"

### Multiple Pools

1. Run a search request that has overlap between the two pools so they appear
2. Submit the request using the new button
3. Navigate to that request in the admin interface
4. Confirm it shows up with candidates and the `was_empty` column is `false`

### Empty

1. Run a new search request that results in no candidates
2. Submit the request using the new button
3. Navigate to that request in the admin interface
4. Confirm it shows up with candidates and the `was_empty` column is `false`

## 📸 Screenshot

![Screenshot 2024-01-25 124258](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/cd6393ea-df3f-484c-9e7d-07173cf7c69b)
