### PR TITLE
Visual updates to SearchResultCard

### DIFF
--- a/apps/e2e/cypress/e2e/talentsearch/search-workflows.cy.ts
+++ b/apps/e2e/cypress/e2e/talentsearch/search-workflows.cy.ts
@@ -49,7 +49,7 @@ describe("Talent Search Workflow Tests", () => {
       cy.findByRole("article", {
         name: `Cypress Test Pool EN 1 ${uniqueTestId} (I T 1 Business Line Advisory Services)`,
       }).within(() => {
-        cy.contains("There is approximately 1 matching candidate in this pool");
+        cy.contains("1 approximate match");
 
         cy.findByRole("button", { name: /Request candidates/i })
           .should("exist")

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7467,10 +7467,6 @@
     "defaultMessage": "Compétences essentielles",
     "description": "Shorter version of the title for the pool essential skills"
   },
-  "eeWkWi": {
-    "defaultMessage": "{totalCandidateCount, plural, =0 {Résultats : <testId>{totalCandidateCount}</testId> candidats correspondants à vos critères} =1 {Résultats : <testId>{totalCandidateCount}</testId> candidat correspondant à vos critères} other {Résultats : <testId>{totalCandidateCount}</testId> candidats correspondants à vos critères}}",
-    "description": "Heading for total matching candidates in results section of search page."
-  },
   "eeyR6R": {
     "defaultMessage": "étiqueter et compléter les jeux de données fournis, le cas échéant, pour l’établissement de rapports",
     "description": "Context example for _work requirement description_ textbox in the _digital services contracting questionnaire_"
@@ -8338,6 +8334,10 @@
   "j12uou": {
     "defaultMessage": "un nouveau système technologique, logiciel ou matériel d’une nature fondamentalement différente de ceux utilisés précédemment;",
     "description": "technological change factor - new technological system"
+  },
+  "j2qiFb": {
+    "defaultMessage": "Résultats: { totalCandidateCount, plural, =0 {<testId><b>{totalCandidateCount}</b></testId> candidats correspondants} =1 {<testId><b>{totalCandidateCount}</b></testId> candidats correspondants} other {<testId><b>{totalCandidateCount}</b></testId> candidats correspondants à l'échelle } } de { numPools, plural, =0 {<b>{numPools}</b> bassins} =1 {<b>{numPools}</b> bassins} other {<b>{numPools}</b> bassins} }",
+    "description": "Heading for total matching candidates across a certain number of pools in results section of search page."
   },
   "j3OROA": {
     "defaultMessage": "Les techniciens (<abbreviation>TI-01</abbreviation>) fournissent un soutien technique pour l'élaboration, la mise en œuvre, l'intégration et la maintenance de la prestation de services aux clients et aux intervenants",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3419,6 +3419,10 @@
     "defaultMessage": "Rôles des membres",
     "description": "Title displayed for the role table display roles column"
   },
+  "Gki8Ex": {
+    "defaultMessage": "{candidateCount, plural, one {<testId>{candidateCount}</testId> concordance approximative} other {<testId>{candidateCount}</testId> concordances approximatives} }",
+    "description": "Message for total estimated matching candidates in pool"
+  },
   "GplLic": {
     "defaultMessage": "Identifiant",
     "description": "Title for unique ID of a resource"
@@ -3831,13 +3835,13 @@
     "defaultMessage": "Le gouvernement du Canada offre parfois des possibilités de formation. Cette section vous permet de mettre en évidence <strong>jusqu’à 5 compétences techniques</strong> que vous souhaitez apprendre ou perfectionner",
     "description": "Description of a users technical skills to be improved"
   },
-  "JZk4NZ": {
-    "defaultMessage": "{candidateCount, plural, one {Il y a environ <strong><testId>{candidateCount}</testId></strong> candidat qui répond à vos critères dans ce bassin.} other {Il y a environ <strong><testId>{candidateCount}</testId></strong> candidats qui répondent à vos critères dans ce bassin.}}",
-    "description": "Message for total estimated matching candidates in pool"
-  },
   "JamdKo": {
     "defaultMessage": "Premières Nations non inscrites",
     "description": "The indigenous community for non-status First Nations"
+  },
+  "JbHieN": {
+    "defaultMessage": "Demander pour les candidats du bassin {poolName}",
+    "description": "Button link message on search page that takes user to the request form."
   },
   "Jdlnz6": {
     "defaultMessage": "ᓀᐦᐃᔭᐍᐏᐣ nēhiyawēwin (Cris des Plaines)",

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -160,35 +160,25 @@ export const SearchForm = ({
           <Heading level="h3" size="h4" id="results">
             {intl.formatMessage(
               {
-                defaultMessage: `{totalCandidateCount, plural,
-                  =0 {Results: <testId><styledCount>{totalCandidateCount}</styledCount></testId> matching candidates}
-                  =1 {Results: <testId><styledCount>{totalCandidateCount}</styledCount></testId> matching candidate}
-                  other {Results: <testId><styledCount>{totalCandidateCount}</styledCount></testId> matching candidates}
-                }`,
-                id: "noxThS",
+                defaultMessage: `Results:
+                    { totalCandidateCount, plural,
+                      =0 {<testId><b>{totalCandidateCount}</b></testId> matching candidates}
+                      =1 {<testId><b>{totalCandidateCount}</b></testId> matching candidate}
+                      other {<testId><b>{totalCandidateCount}</b></testId> matching candidates} }
+                    across
+                    { numPools, plural,
+                      =0 {<b>{numPools}</b> pools}
+                      =1 {<b>{numPools}</b> pool}
+                      other {<b>{numPools}</b> pools} }`,
+                id: "j2qiFb",
                 description:
-                  "Heading for total matching candidates in results section of search page.",
+                  "Heading for total matching candidates across a certain number of pools in results section of search page.",
               },
               {
                 testId,
-                styledCount,
+                b: styledCount,
                 totalCandidateCount: candidateCount,
-              },
-            )}
-            {intl.formatMessage(
-              {
-                defaultMessage: `{numPools, plural,
-                  =0 { across <styledCount>{numPools}</styledCount> pools}
-                  =1 { across <styledCount>{numPools}</styledCount> pool}
-                  other { across <styledCount>{numPools}</styledCount> pools}
-                }`,
-                id: "T/8qWO",
-                description:
-                  "Heading for total matching pools in results section of search page.",
-              },
-              {
-                styledCount,
-                numPools: results?.length || 0,
+                numPools: results?.length ?? 0,
               },
             )}
           </Heading>

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -30,6 +30,12 @@ const testId = (chunks: React.ReactNode) => (
   <span data-testid="candidateCount">{chunks}</span>
 );
 
+const styledCount = (chunks: React.ReactNode) => (
+  <span data-h2-font-weight="base(700)" data-h2-color="base(secondary.dark)">
+    {chunks}
+  </span>
+);
+
 interface SearchFormProps {
   pools: Pool[];
   classifications: Classification[];
@@ -155,17 +161,34 @@ export const SearchForm = ({
             {intl.formatMessage(
               {
                 defaultMessage: `{totalCandidateCount, plural,
-                  =0 {Results: <testId>{totalCandidateCount}</testId> matching candidates}
-                  =1 {Results: <testId>{totalCandidateCount}</testId> matching candidate}
-                  other {Results: <testId>{totalCandidateCount}</testId> matching candidates}
+                  =0 {Results: <testId><styledCount>{totalCandidateCount}</styledCount></testId> matching candidates}
+                  =1 {Results: <testId><styledCount>{totalCandidateCount}</styledCount></testId> matching candidate}
+                  other {Results: <testId><styledCount>{totalCandidateCount}</styledCount></testId> matching candidates}
                 }`,
-                id: "eeWkWi",
+                id: "noxThS",
                 description:
                   "Heading for total matching candidates in results section of search page.",
               },
               {
                 testId,
+                styledCount,
                 totalCandidateCount: candidateCount,
+              },
+            )}
+            {intl.formatMessage(
+              {
+                defaultMessage: `{numPools, plural,
+                  =0 { across <styledCount>{numPools}</styledCount> pools}
+                  =1 { across <styledCount>{numPools}</styledCount> pool}
+                  other { across <styledCount>{numPools}</styledCount> pools}
+                }`,
+                id: "T/8qWO",
+                description:
+                  "Heading for total matching pools in results section of search page.",
+              },
+              {
+                styledCount,
+                numPools: results?.length || 0,
               },
             )}
           </Heading>

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useIntl } from "react-intl";
 import { useFormContext } from "react-hook-form";
 
-import { Button, Link, Pill } from "@gc-digital-talent/ui";
+import { Button, Link, Separator } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 import { notEmpty } from "@gc-digital-talent/helpers";
 
@@ -45,33 +45,59 @@ const SearchResultCard = ({ candidateCount, pool }: SearchResultCardProps) => {
       >
         {getFullPoolTitleHtml(intl, pool)}
       </p>
-      <p data-h2-margin="base(x.5, 0, x1, 0)">
-        {intl.formatMessage(
-          {
-            defaultMessage: "Process run by {team} at {departments}",
-            id: "e2qUId",
-            description: "Team and department of pool",
-          },
-          {
-            team: pool?.team
-              ? getLocalizedName(pool.team.displayName, intl)
-              : intl.formatMessage({
-                  defaultMessage: "Digital Community Management Team",
-                  id: "S82O61",
-                  description: "Default team for pool",
-                }),
-            departments: departments
-              ? departments.join(", ")
-              : intl.formatMessage({
-                  defaultMessage: "Treasury Board of Canada Secretariat",
-                  id: "SZ2DsZ",
-                  description: "Default department for pool",
-                }),
-          },
-        )}
-        .
+      <p
+        data-h2-margin="base(x.5, 0, x1, 0)"
+        data-h2-display="base(flex)"
+        data-h2-gap="base(0, x.5)"
+      >
+        <span>
+          {intl.formatMessage(
+            {
+              defaultMessage: "Process run by {team} at {departments}",
+              id: "e2qUId",
+              description: "Team and department of pool",
+            },
+            {
+              team: pool?.team
+                ? getLocalizedName(pool.team.displayName, intl)
+                : intl.formatMessage({
+                    defaultMessage: "Digital Community Management Team",
+                    id: "S82O61",
+                    description: "Default team for pool",
+                  }),
+              departments: departments
+                ? departments.join(", ")
+                : intl.formatMessage({
+                    defaultMessage: "Treasury Board of Canada Secretariat",
+                    id: "SZ2DsZ",
+                    description: "Default department for pool",
+                  }),
+            },
+          )}
+        </span>
+        <span aria-hidden>&bull;</span>
+        <span
+          data-h2-font-weight="base(700)"
+          data-h2-color="base(secondary.darker)"
+        >
+          {intl.formatMessage(
+            {
+              defaultMessage: `{candidateCount, plural,
+                one {<testId>{candidateCount}</testId> approximate match}
+                other {<testId>{candidateCount}</testId> approximate matches}
+              }`,
+              id: "Gki8Ex",
+              description:
+                "Message for total estimated matching candidates in pool",
+            },
+            {
+              testId,
+              candidateCount,
+            },
+          )}
+        </span>
       </p>
-      <p data-h2-margin="base(x1, 0, x.25, 0)" data-h2-font-weight="base(700)">
+      <p data-h2-margin="base(x1, 0, x.25, 0)">
         {intl.formatMessage({
           defaultMessage:
             "These essential skills were assessed during the process:",
@@ -83,35 +109,26 @@ const SearchResultCard = ({ candidateCount, pool }: SearchResultCardProps) => {
       <p
         data-h2-display="base(flex)"
         data-h2-flex-wrap="base(wrap)"
-        data-h2-gap="base(x.125)"
+        data-h2-gap="base(0, x.5)"
+        data-h2-font-size="base(caption)"
       >
         {pool?.essentialSkills && pool?.essentialSkills.length > 0
-          ? pool.essentialSkills.map((skill) => (
-              <span key={skill.id}>
-                <Pill key={skill.id} color="secondary" mode="outline">
+          ? pool.essentialSkills.map((skill, index) => (
+              <>
+                {index !== 0 && <span aria-hidden>&bull;</span>}
+                <span key={skill.id}>
                   {getLocalizedName(skill?.name, intl)}
-                </Pill>
-              </span>
+                </span>
+              </>
             ))
           : null}
       </p>
-      <p data-h2-margin="base(x1, 0)">
-        {intl.formatMessage(
-          {
-            defaultMessage: `{candidateCount, plural,
-              one {There is approximately <strong><testId>{candidateCount}</testId></strong> matching candidate in this pool.}
-              other {There are approximately <strong><testId>{candidateCount}</testId></strong> matching candidates in this pool.}
-            }`,
-            id: "JZk4NZ",
-            description:
-              "Message for total estimated matching candidates in pool",
-          },
-          {
-            testId,
-            candidateCount,
-          },
-        )}
-      </p>
+      <Separator
+        orientation="horizontal"
+        decorative
+        data-h2-background-color="base(gray)"
+        data-h2-margin="base(x1 0)"
+      />
       <div
         data-h2-display="base(flex)"
         data-h2-flex-direction="base(row)"
@@ -123,6 +140,7 @@ const SearchResultCard = ({ candidateCount, pool }: SearchResultCardProps) => {
         <Button
           color="secondary"
           type="submit"
+          mode="inline"
           {...poolSubmitProps}
           value={pool.id}
           onClick={() => {
@@ -130,12 +148,15 @@ const SearchResultCard = ({ candidateCount, pool }: SearchResultCardProps) => {
             setValue("count", candidateCount);
           }}
         >
-          {intl.formatMessage({
-            defaultMessage: "Request candidates",
-            id: "3BfvIy",
-            description:
-              "Button link message on search page that takes user to the request form.",
-          })}
+          {intl.formatMessage(
+            {
+              defaultMessage: "Request candidates from {poolName}",
+              id: "JbHieN",
+              description:
+                "Button link message on search page that takes user to the request form.",
+            },
+            { poolName: getLocalizedName(pool.name, intl) },
+          )}
         </Button>
         <Link
           mode="inline"

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
@@ -116,7 +116,7 @@ const SearchResultCard = ({ candidateCount, pool }: SearchResultCardProps) => {
           ? pool.essentialSkills.map((skill, index) => (
               <React.Fragment key={skill.id}>
                 {index !== 0 && <span aria-hidden>&bull;</span>}
-                <span key={skill.id}>
+                <span key={skill.id} data-h2-color="base(black.light)">
                   {getLocalizedName(skill?.name, intl)}
                 </span>
               </React.Fragment>

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
@@ -114,12 +114,12 @@ const SearchResultCard = ({ candidateCount, pool }: SearchResultCardProps) => {
       >
         {pool?.essentialSkills && pool?.essentialSkills.length > 0
           ? pool.essentialSkills.map((skill, index) => (
-              <>
+              <React.Fragment key={skill.id}>
                 {index !== 0 && <span aria-hidden>&bull;</span>}
                 <span key={skill.id}>
                   {getLocalizedName(skill?.name, intl)}
                 </span>
-              </>
+              </React.Fragment>
             ))
           : null}
       </p>


### PR DESCRIPTION
🤖 Resolves #9089

## 👋 Introduction

Applies some visual updates to the SearchResultCard.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run `npm run dev`
2. Navigate to the search page `/en/search`
3. Verify the SearchResultCards appear as expected
4. Verify functionality is unchanged

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/49166751/5cd6b0b5-6a66-4f00-938d-f804db132e1b)