### PR TITLE
[Debt] Migrate terms and conditions and privacy policy pages

### DIFF
--- a/apps/web/src/components/Footer/Footer.tsx
+++ b/apps/web/src/components/Footer/Footer.tsx
@@ -34,7 +34,7 @@ const Footer = ({ width }: FooterProps) => {
       }),
     },
     {
-      href: `/${intl.locale}/privacy-notice`,
+      href: `/${intl.locale}/privacy-policy`,
       external: true,
       children: intl.formatMessage({
         defaultMessage: "Privacy Policy",

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -62,6 +62,22 @@ const SupportPage = React.lazy(() =>
       ),
   ),
 );
+const TermsAndConditions = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsSupportPage" */ "../pages/TermsAndConditions/TermsAndConditions"
+      ),
+  ),
+);
+const PrivacyPolicy = React.lazy(() =>
+  lazyRetry(
+    () =>
+      import(
+        /* webpackChunkName: "tsSupportPage" */ "../pages/PrivacyPolicy/PrivacyPolicy"
+      ),
+  ),
+);
 const AccessibilityPage = React.lazy(() =>
   lazyRetry(
     () =>
@@ -769,6 +785,14 @@ const createRoute = (
             {
               path: "support",
               element: <SupportPage />,
+            },
+            {
+              path: "terms-and-conditions",
+              element: <TermsAndConditions />,
+            },
+            {
+              path: "privacy-policy",
+              element: <PrivacyPolicy />,
             },
             {
               path: "accessibility-statement",

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -53,6 +53,8 @@ const getRoutes = (lang: Locales) => {
     loggedOut: () => path.join(baseUrl, "logged-out"),
     userDeleted: () => path.join(baseUrl, "user-deleted"),
     createAccount: () => path.join(baseUrl, "create-account"),
+    termsAndConditions: () => path.join(baseUrl, "terms-and-conditions"),
+    privacyPolicy: () => path.join(baseUrl, "privacy-policy"),
     accessibility: () => path.join(baseUrl, "accessibility-statement"),
     manager: () => path.join(baseUrl, "manager"),
     executive: () => path.join(baseUrl, "executive"),

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -131,6 +131,10 @@
     "defaultMessage": "Cette compétence requise doit être associée à au moins une expérience au cours de votre parcours professionnel.",
     "description": "Message that appears when a required skill has no experiences linked to it"
   },
+  "+lxGIT": {
+    "defaultMessage": "Suivre, « aimer » et s’abonner",
+    "description": "Heading for following section"
+  },
   "+mCsoW": {
     "defaultMessage": "Demande d’état mise à jour!",
     "description": "Message displayed to user after the request status is successfully updated."
@@ -715,6 +719,10 @@
     "defaultMessage": "Une fois que vous avez terminé votre parcours professionnel et que vous êtes satisfait(e) des expériences que vous avez ajoutées, vous les utiliserez dans les étapes suivantes pour nous aider à mieux comprendre en quoi vous répondez aux exigences en matière de compétences pour cette possibilité.",
     "description": "Application step to begin working on career timeline, paragraph three"
   },
+  "1e84jV": {
+    "defaultMessage": "Les visiteurs doivent également savoir que l’information offerte par les sites autres que ceux du gouvernement du Canada, accessibles à l’aide des liens de ce site Web, n’est pas assujettie à la <privacyActLink>Loi sur la protection des renseignements personnels</privacyActLink> ni à la <langActLink>Loi sur les langues officielles</langActLink> et pourrait ne pas être accessible aux personnes handicapées. Il est probable que l’information offerte ne soit disponible que dans les langues employées dans les sites en question. En ce qui a trait aux renseignements personnels, nous invitons les visiteurs à consulter les politiques de ces sites Web non gouvernementaux en matière de protection des renseignements personnels avant de fournir leurs renseignements personnels.",
+    "description": "Paragraph two describing linking to gov section"
+  },
   "1fMzyo": {
     "defaultMessage": "Afficher les candidatures antérieures ({applicationCount})",
     "description": "Heading for past applications accordion on profile and applications."
@@ -1243,6 +1251,10 @@
     "defaultMessage": "Révisez votre candidature et envoyez-la!",
     "description": "Subtitle for the application review page."
   },
+  "4jMHwL": {
+    "defaultMessage": "Le gouvernement du Canada est déterminé à observer une norme d’accessibilité élevée conformément à la <accessibilityLink>Norme sur l’accessibilité des sites Web</accessibilityLink> et la <optimizeLink>Norme sur l’optimisation des sites Web et des applications pour appareils mobiles</optimizeLink>. Communiquez avec nous si vous éprouvez des difficultés à utiliser nos pages Web, nos applications ou nos applications mobiles axées sur l’appareil, ou si vous désirez obtenir des documents en médias substituts comme le caractère ordinaire, le Braille ou un autre format approprié.",
+    "description": "Paragraph describing accessibility commitment section"
+  },
   "4l+jIq": {
     "defaultMessage": "Pour toute question ou préoccupation concernant le questionnaire, veuillez contacter <link>Talents numériques du GC</link> pour obtenir de plus amples renseignements.",
     "description": "Paragraph four of the _instructions_ section of the _digital services contracting questionnaire_"
@@ -1611,6 +1623,10 @@
     "defaultMessage": "notes pour {name}",
     "description": "Link text suffix to read more notes for a search request"
   },
+  "6f2bWo": {
+    "defaultMessage": "Contenu et fréquence",
+    "description": "Heading for content and frequency section"
+  },
   "6l9YH+": {
     "defaultMessage": "Les demandeurs doivent répondre aux exigences suivantes :",
     "description": "Heading for the applicant requirements dialog"
@@ -1646,6 +1662,10 @@
   "6wCHq2": {
     "defaultMessage": "Activez le mode sombre",
     "description": "Button text to set theme mode to dark"
+  },
+  "6yxxP6": {
+    "defaultMessage": "Le gouvernement du Canada se réserve le droit de signaler les utilisateurs et/ou leurs commentaires et contributions à des tiers fournisseurs de services de médias sociaux, afin de prévenir ou de supprimer l’affichage de contenu qui ne respecte pas cet avis ou les modalités de service ou d’utilisation des tiers fournisseurs de plateformes de médias sociaux.",
+    "description": "Paragraph of comments and interactions sections"
   },
   "7+GPYf": {
     "defaultMessage": "Des évaluations avec de réels utilisateurs",
@@ -1754,6 +1774,10 @@
   "7b0U9u": {
     "defaultMessage": "Lorsque les responsables du recrutement ont des besoins en personnel informatique et que des postes se libèrent, les candidats qui répondent aux qualifications de ce processus peuvent être contactés pour une évaluation plus approfondie. Cela signifie que divers responsables peuvent vous contacter au sujet d'occasions précises.",
     "description": "Description of pool recruitment, paragraph two"
+  },
+  "7ejG4K": {
+    "defaultMessage": "Vous avez le droit d’accéder à vos renseignements personnels, de les corriger et de les protéger en vertu de la Loi sur la protection des renseignements personnels et de déposer une plainte auprès du Commissariat à la protection de la vie privée du Canada quant à la façon dont vos renseignements personnels sont traités.",
+    "description": "Paragraph for privacy policy page"
   },
   "7fJqJP": {
     "defaultMessage": "Si vous êtes membre d'un ou de plusieurs de ces groupes visés par l'équité en matière d'emploi et que vous ne souhaitez pas vous auto-identifier sur cette plateforme, vous n'êtes pas dans l'obligation de le faire.",
@@ -1887,6 +1911,10 @@
     "defaultMessage": "<strong>Je possède un diplôme d’études secondaires ou l’équivalent (p. ex., formation Générale). </strong>",
     "description": "Radio group option for education requirement filter in IAP application education form."
   },
+  "8L9eJ3": {
+    "defaultMessage": "Le gouvernement du Canada ne se prononcera pas sur des questions de partisanerie ou de politique, et il ne répondra pas aux questions qui contreviennent aux règles énoncées dans cet avis.",
+    "description": "Paragraph for comments and interaction section"
+  },
   "8M/lmC": {
     "defaultMessage": "N'oubliez pas que pour vous reconnecter, vous devrez utiliser votre nom d’utilisateur et votre mot de passe CléGC. Nous espérons vous voir bientôt!",
     "description": "Message displayed to a user after signing out"
@@ -1926,6 +1954,10 @@
   "8YKsal": {
     "defaultMessage": "Apprenez comment les dates limites des demandes fonctionnent.",
     "description": "Info button label for pool application deadline details."
+  },
+  "8ZIao3": {
+    "defaultMessage": "remplissez le <questionsLink>formulaire pour questions et commentaires</questionsLink>",
+    "description": "Commercial reproduction list item"
   },
   "8bJgxK": {
     "defaultMessage": "Français - Votre travail",
@@ -2010,6 +2042,10 @@
   "9Aa5c0": {
     "defaultMessage": "Notes - {poolName}",
     "description": "Label for the notes field for a specific pool"
+  },
+  "9CAhAX": {
+    "defaultMessage": "Accessibilité des plateformes de médias sociaux",
+    "description": "Heading for comments and interaction section"
   },
   "9DCx2n": {
     "defaultMessage": "Peut accepter une combinaison d’expérience de travail et d’études",
@@ -2138,6 +2174,10 @@
   "9yGJ6k": {
     "defaultMessage": "Description",
     "description": "Title displayed for the skill table Description column."
+  },
+  "9zhqQf": {
+    "defaultMessage": "Établissement d’hyperliens vers des sites Web autres que ceux du gouvernement du Canada",
+    "description": "Title for the linkink to gov section"
   },
   "A+4huJ": {
     "defaultMessage": "Mettre à jour ou supprimer une expérience dans votre chronologie de carrière",
@@ -2386,6 +2426,10 @@
   "B9dbbl": {
     "defaultMessage": "Lorsque vous liez une expérience, essayez de répondre à au moins l’une de ces questions :",
     "description": "Lead-in text for the list of skill experience questions"
+  },
+  "BA5yoE": {
+    "defaultMessage": "À moins d’avis contraire, il est interdit de reproduire le contenu de ce site, en totalité ou en partie, à des fins de diffusion commerciale sans avoir obtenu au préalable la permission écrite de l’administrateur du droit d’auteur. Si vous souhaitez obtenir les droits de reproduction du contenu du gouvernement du Canada du présent site à des fins commerciales, écrivez aux :",
+    "description": "Commercial reproduction list description in ownership and usage section"
   },
   "BDo1aH": {
     "defaultMessage": "Ministère",
@@ -2895,6 +2939,10 @@
     "defaultMessage": "Mise en œuvre de 573 entretiens personnalisés de gestion et d’accompagnement de carrière avec des candidats à l’emploi et des cadres au cours de l’exercice financier de 2022-2023.",
     "description": "Description of digital community support"
   },
+  "Dsa/aH": {
+    "defaultMessage": "Propriété et utilisation du contenu offert dans ce site",
+    "description": "Title for the ownership and usage section."
+  },
   "DspBFX": {
     "defaultMessage": "Changer la date",
     "description": "Command to change a date"
@@ -3106,6 +3154,10 @@
   "FA+cJX": {
     "defaultMessage": "Supprimer",
     "description": "Button to delete the pool in the delete pool dialog"
+  },
+  "FAEU2d": {
+    "defaultMessage": "Droit d’auteur",
+    "description": "Heading for comments and interaction section"
   },
   "FAOzjP": {
     "defaultMessage": "Portée :",
@@ -3363,6 +3415,10 @@
     "defaultMessage": "Ministère mis à jour avec succès!",
     "description": "Message displayed to user after department is updated successfully."
   },
+  "GTqXN1": {
+    "defaultMessage": "constituent une violation de cet avis de quelque autre manière que ce soit",
+    "description": "Comments or contributions list item"
+  },
   "GVeb32": {
     "defaultMessage": "Mi'kmaw",
     "description": "Name of Mi'kmaw language"
@@ -3458,6 +3514,10 @@
   "H1wLfA": {
     "defaultMessage": "Sélectionnez une province ou un territoire",
     "description": "Placeholder displayed on the About Me form province or territory field."
+  },
+  "H2l4rG": {
+    "defaultMessage": "Les renseignements que vous fournissez peuvent également être utilisés à des fins statistiques et de recherche, et ils peuvent être communiqués à la<publicServiceLink>Direction des enquêtes de la Commission de la fonction publique</publicServiceLink> au besoin.",
+    "description": "Paragraph for privacy policy page"
   },
   "H3Za3e": {
     "defaultMessage": "Enregistrer et aller sur mon profil",
@@ -3582,6 +3642,10 @@
   "I/fGUN": {
     "defaultMessage": "Analyste (<abbreviation>TI-02</abbreviation>)",
     "description": "Title for the 'IT-02 Analyst' classification"
+  },
+  "I2CtZJ": {
+    "defaultMessage": "Les commentaires ou les contributions seront supprimés s’ils :",
+    "description": "Comments or contributions list title"
   },
   "I5q1n6": {
     "defaultMessage": "Soumettre aux fins de publication",
@@ -3710,6 +3774,10 @@
   "IjBtl5": {
     "defaultMessage": "Le transfert de connaissances de l’entrepreneur à l’unité de travail du gouvernement a-t-il été intégré au contrat?",
     "description": "Label for _knowledge transfer in contract_ fieldset in the _digital services contracting questionnaire_"
+  },
+  "Ijz5oe": {
+    "defaultMessage": "Le fait de ne pas fournir de renseignements personnels vous rendra inadmissible aux postes d'emploi associées à cet outil.",
+    "description": "Paragraph for privacy policy page"
   },
   "Ilot3b": {
     "defaultMessage": "Que se passe-t-il après lorsqu’une personne achève le programme de 24 mois?",
@@ -3898,6 +3966,10 @@
   "JxVREd": {
     "defaultMessage": "Familles",
     "description": "Label displayed on the skill form families field."
+  },
+  "Jz7jAF": {
+    "defaultMessage": "Les hyperliens menant à des sites Web qui ne sont pas gérés par le gouvernement du Canada, y compris ceux qui mènent à nos comptes de médias sociaux, sont offerts uniquement par commodité aux visiteurs de notre site Web. Nous n’assumons aucune responsabilité quant à la précision, l’actualité ou la fiabilité du contenu de ces sites. Le gouvernement du Canada n’offre aucune garantie à cet égard, n’assume aucune responsabilité concernant l’information obtenue au moyen de ces liens et n’approuve ni ces sites, ni leur contenu.",
+    "description": "Paragraph describing linking to gov section"
   },
   "K+F5H7": {
     "defaultMessage": "Lieux de travail",
@@ -4123,6 +4195,10 @@
     "defaultMessage": "Ajoutez votre expérience personnelle",
     "description": "Button text to add a personal experience to the profile"
   },
+  "L7Pe9h": {
+    "defaultMessage": "Liens vers d’autres sites Web et des annonces",
+    "description": "Heading for link to others section"
+  },
   "L7PqXn": {
     "defaultMessage": "Décrivez comment vous avez utilisé cette compétence",
     "description": "Label for skill experience details input"
@@ -4154,6 +4230,10 @@
   "LBU5dT": {
     "defaultMessage": "Se renseigner sur la CléGC et trouver des liens vers les renseignements sur le compte.",
     "description": "Introductory text displayed in sign in and authentication accordion."
+  },
+  "LDrXbc": {
+    "defaultMessage": "contiennent des renseignements protégés ou classifiés du gouvernement du Canada",
+    "description": "Comments or contributions list item"
   },
   "LEVK8x": {
     "defaultMessage": "Erreur : Échec de la mise à jour de la classification",
@@ -4259,6 +4339,10 @@
     "defaultMessage": "Commencez <hidden> à entrer vos renseignements personnels et vos coordonnées </hidden>",
     "description": "Call to action to begin editing personal and contact information"
   },
+  "Lt7tcM": {
+    "defaultMessage": "Les comptes de médias sociaux du gouvernement du Canada sont une autre façon d’échanger avec les Canadiens et les Canadiennes, et de diffuser le contenu publié sur son site Web. Ces comptes facilitent l’accès à l’information et aux services du gouvernement du Canada, et donnent l’occasion aux intervenants d’interagir dans un environnement informatif et respectueux.",
+    "description": "Paragraph for content and frequency section"
+  },
   "Lu5ppY": {
     "defaultMessage": "Tout sélectionner",
     "description": "Label for the checkbox to select all rows in a table"
@@ -4310,6 +4394,10 @@
   "MDjwSO": {
     "defaultMessage": "Titre précis (français)",
     "description": "Label for a pool advertisements specific French title"
+  },
+  "MLrQQy": {
+    "defaultMessage": "Emploi de fichiers situés sur des serveurs autres que ceux du gouvernement du Canada ",
+    "description": "Title for the using files section"
   },
   "MMtY88": {
     "defaultMessage": "Non démontrée (en attente d’une évaluation plus poussée)",
@@ -4591,6 +4679,10 @@
     "defaultMessage": "Aller à la page suivante ",
     "description": "Aria label for next page button in pagination nav"
   },
+  "O7Lkda": {
+    "defaultMessage": "Descriptive subtitle explaining tasks on the page.",
+    "description": "Subtitle for the terms and conditions page."
+  },
   "O8U5Sz": {
     "defaultMessage": "Utilisateur ajouté avec succès",
     "description": "Toast for successful add user to pool on view-user page"
@@ -4851,6 +4943,10 @@
     "defaultMessage": "Notes sur les demandes",
     "description": "Label displayed on the search request form request notes field."
   },
+  "PerY/b": {
+    "defaultMessage": "Reproduction non commerciale",
+    "description": "Non commercial reproduction list in ownership and usage section"
+  },
   "PhrOLp": {
     "defaultMessage": "Courriel de la personne-ressource",
     "description": "Label for the French team display name input"
@@ -4959,6 +5055,10 @@
     "defaultMessage": "Numéro de ministère",
     "description": "Title displayed for the Department table Department # column."
   },
+  "QQXvOh": {
+    "defaultMessage": "Notre engagement à l’égard de l’accessibilité",
+    "description": "Title for the accessibility commitment section."
+  },
   "QRI/bf": {
     "defaultMessage": "Modifier votre expérience",
     "description": "Page title for the application career timeline edit experience page"
@@ -5038,6 +5138,10 @@
   "QmMm7V": {
     "defaultMessage": "Dupliquer et consulter la nouvelle affiche d’emploi",
     "description": "Button text to duplicate a job poster"
+  },
+  "QnfjbI": {
+    "defaultMessage": "constituent de l’usurpation d’identité, de la publicité ou un pourriel",
+    "description": "Comments or contributions list item"
   },
   "QodYZE": {
     "defaultMessage": "Créer une nouvelle affiche de poste à partir de zéro",
@@ -5222,6 +5326,10 @@
   "Rm4SuQ": {
     "defaultMessage": "Sélectionnez un bassin",
     "description": "Placeholder displayed on the pool field of the add user to pool dialog."
+  },
+  "RmcS7J": {
+    "defaultMessage": "Les comptes de médias sociaux ne sont pas des sites Web du gouvernement du Canada : ils constituent seulement un moyen de manifester la présence du gouvernement du Canada sur les plateformes des tiers fournisseurs de services.",
+    "description": "Paragraph for comments and interaction section"
   },
   "Rn3HMc": {
     "defaultMessage": "Profil linguistique",
@@ -5471,6 +5579,10 @@
     "defaultMessage": "Télécharger le guide sur la mise en œuvre pour les agents d’approvisionnement (PDF)",
     "description": "Aria label for download guidance for procurement officers pdf link."
   },
+  "TKONR6": {
+    "defaultMessage": "Étant donné que les plateformes de médias sociaux sont gérées par des tiers fournisseurs de services, elles n’ont pas à être conformes aux normes du gouvernement du Canada en matière d’accessibilité du Web.",
+    "description": "Paragraph for comments and interaction section"
+  },
   "TLl20s": {
     "defaultMessage": "Créer un nouveau bassin",
     "description": "Label displayed on submit button for new pool form."
@@ -5478,6 +5590,10 @@
   "TN9ndX": {
     "defaultMessage": "Tentez d’utiliser un autre terme ou une autre recherche pour la compétence, en vous servant du bouton \"Ajouter une nouvelle compétence\" fourni à cet effet.",
     "description": "Message displayed when no skills match a users filters"
+  },
+  "TPw/0u": {
+    "defaultMessage": "sont menaçants, violents, intimidants ou harcelants",
+    "description": "Comments or contributions list item"
   },
   "TQt+3L": {
     "defaultMessage": "Enregistrer et retourner",
@@ -5558,6 +5674,10 @@
   "Tp7hml": {
     "defaultMessage": "Des représentants du service à la clientèle sont disponibles pour vous aider par téléphone toute l'année, 24 heures sur 24, 7 jours sur 7.",
     "description": "GCKey answer for who to contact about GCKey, contact availability"
+  },
+  "Tq0ZKw": {
+    "defaultMessage": "Votre interaction avec le gouvernement du Canada sur les médias sociaux est en partie régie par les modalités de services ou d’utilisation des tiers fournisseurs de plateformes de médias sociaux concernés, ainsi que par les modalités présentées ci-dessous. Le gouvernement du Canada n’a aucun contrôle sur les modalités de service ou d’utilisation des fournisseurs de plateformes de médias sociaux, d’où l’importance pour vous d’en prendre connaissance.",
+    "description": "Paragraph describing social media section"
   },
   "TrbPjE": {
     "defaultMessage": "Vous êtes sur le point de désarchiver ce processus : {poolName}",
@@ -5703,6 +5823,9 @@
     "defaultMessage": "Pouvez-vous supprimer l'authentification à deux facteurs de mon compte afin que je puisse le réinitialiser?",
     "description": "GCKey question for ability to remove two-factor authentication"
   },
+  "UnAF+3": {
+    "defaultMessage": "À moins d’avis contraire, vous pouvez reproduire le contenu en totalité ou en partie à des fins non commerciales, dans tout format, sans frais ni autre permission, à condition :"
+  },
   "UoZLL/": {
     "defaultMessage": "La <chrcLink>Commission canadienne des droits de la personne</chrcLink> (CCDP) traite les plaintes en matière de discrimination en vertu de la <chraLink>Loi canadienne sur les droits de la personne</chraLink>.",
     "description": "Description of complaints to the Canadian Human Rights Commission"
@@ -5738,6 +5861,10 @@
   "Uzx5dR": {
     "defaultMessage": "Vous ne voyez pas de processus de recrutement actif correspondant à vos compétences ? Pas de problème, nous voulons toujours avoir de vos nouvelles.",
     "description": "summary for section with ongoing pool advertisements"
+  },
+  "V0jG33": {
+    "defaultMessage": "Protection des renseignements personnels",
+    "description": "Heading for comments and interaction section"
   },
   "V1DqDX": {
     "defaultMessage": "Compétences requises :",
@@ -5798,6 +5925,10 @@
   "VHhOb/": {
     "defaultMessage": "Le programme est une initiative du gouvernement du Canada, qui est conçue spécifiquement pour les Premières Nations, les Inuits et les Métis. Il s’agit d’un chemin vers l’emploi au sein de la fonction publique fédérale pour les Autochtones qui sont passionnés de technologies de l’information (TI). Nous misons sur cette passion ainsi que sur votre potentiel pour grandir et réussir dans ce domaine.",
     "description": "Description of how the hiring platform assesses candidates for IAP."
+  },
+  "VIZAgj": {
+    "defaultMessage": "Étant donné que les plateformes de médias sociaux et leurs serveurs sont gérés par un tiers, les comptes de médias sociaux sont sujets à des interruptions de service qui échappent au contrôle du gouvernement du Canada. Le gouvernement du Canada n’assume donc aucune responsabilité en cas de non-disponibilité des plateformes.",
+    "description": "Paragraph for content and frequency section"
   },
   "VJYI6K": {
     "defaultMessage": "Équipe {teamId} non trouvée.",
@@ -5935,6 +6066,10 @@
     "defaultMessage": "Membres de l’équipe",
     "description": "Title for the list of team members page"
   },
+  "Vz719J": {
+    "defaultMessage": "Learn more about how GC Digital Talent handles user privacy.",
+    "description": "Sub title for the websites privacy policy"
+  },
   "W+Lub4": {
     "defaultMessage": "Est équivalent en termes de durée par rapport aux exigences du diplôme",
     "description": "Text for education accepted information context in screening decision dialog"
@@ -6062,6 +6197,10 @@
   "Whq2Xl": {
     "defaultMessage": "Réussi",
     "description": "Message displayed when candidate has successfully passed an assessment step"
+  },
+  "WhtOLT": {
+    "defaultMessage": "de préciser qu’il s’agit d’une reproduction de la version disponible au [adresse URL de l’emplacement du document original]",
+    "description": "Non commercial reproduction list item"
   },
   "Wi4tia": {
     "defaultMessage": "Nos développeurs prêtent une attention particulière aux éléments suivants : ",
@@ -6207,6 +6346,10 @@
     "defaultMessage": "Finances",
     "description": "Label for _finance_ option in _authorities involved_ fieldset in the _digital services contracting questionnaire_"
   },
+  "XYF/1P": {
+    "defaultMessage": "Les renseignements personnels recueillis par le truchement de Talents numériques du GC sont décrits dans le fichier de <personalInfoLink>renseignements personnels du Nuage de talents (SCT PPU 095)</personalInfoLink>.",
+    "description": "Paragraph for privacy policy page"
+  },
   "XaYhX3": {
     "defaultMessage": "Créer une nouvelle équipe à partir de zéro",
     "description": "Descriptive text for the create team page in the admin portal."
@@ -6218,6 +6361,10 @@
   "Xdmhoo": {
     "defaultMessage": "Ce volet comprend la gestion de l’infrastructure des réseaux, des ordinateurs centraux, des serveurs et du stockage, la fourniture d’un soutien de la <abbreviation>TI</abbreviation> et les relations avec les clients et fournisseurs.",
     "description": "Title for the 'infrastructure operations' IT work stream"
+  },
+  "Xe39xZ": {
+    "defaultMessage": "ne respectent pas les lois fédérales, provinciales ou territoriales du Canada",
+    "description": "Comments or contributions list item"
   },
   "Xe90FW": {
     "defaultMessage": "Ne suis-je pas un membre d’un groupe autochtone?",
@@ -6306,6 +6453,10 @@
   "Y3rbFp": {
     "defaultMessage": "Visitez votre démonstration",
     "description": "Link text to the skill showcase page."
+  },
+  "Y5Z216": {
+    "defaultMessage": "d’indiquer le titre complet du contenu reproduit, ainsi que son auteur (s’il y a lieu)",
+    "description": "Non commercial reproduction list item"
   },
   "Y6X4Ok": {
     "defaultMessage": "Communication générale",
@@ -7095,6 +7246,10 @@
     "defaultMessage": "Sélectionnez l’option qui représente le mieux votre raison pour soumettre la présente demande de talent",
     "description": "Legend for the options related to the reason for submitting a request."
   },
+  "cYNDhP": {
+    "defaultMessage": "Énoncé de confidentialité",
+    "description": "Title for the websites privacy policy"
+  },
   "cYq1Dp": {
     "defaultMessage": "Les apprentis qui participent au programme disent que ça « change une vie », que ça représente « une occasion d’avoir une meilleure vie grâce à la technologie » et qu’« il n’y a aucun obstacle à la réussite de ce programme ».",
     "description": "Third paragraph about the program"
@@ -7147,9 +7302,17 @@
     "defaultMessage": "Réponse à la question {number}",
     "description": "Label for answer to specific question field"
   },
+  "clzYpT": {
+    "defaultMessage": "Le gouvernement du Canada se réserve le droit de supprimer des commentaires et des contributions, et de bloquer des utilisateurs en fonction des critères ci-dessous:",
+    "description": "Paragraph for comments and interaction section"
+  },
   "crzWxb": {
     "defaultMessage": "Ouvrir le menu",
     "description": "Text label for header button that opens side menu."
+  },
+  "cx7pV4": {
+    "defaultMessage": "Bon nombre de plateformes de médias sociaux offrent plusieurs choix de langues et donnent des instructions pour définir des préférences. Le gouvernement du Canada respecte la <langActLink>Loi sur les langues officielles</langActLink> et est déterminé à prendre les moyens nécessaires pour que son information soit disponible en français et en anglais et pour que la qualité soit égale dans les deux versions.",
+    "description": "Paragraph for comments and interaction section"
   },
   "czThVC": {
     "defaultMessage": "Fournissez quelques détails normalisés au sujet de votre expérience pour aider les gestionnaires à mieux comprendre le rôle qu’elle a joué dans votre cheminement de carrière.",
@@ -7291,6 +7454,10 @@
     "defaultMessage": "Ces renseignements seront communiqués aux gestionnaires d'embauche.",
     "description": "Explanation on how employment equity information will be used, item one"
   },
+  "diSBjl": {
+    "defaultMessage": "Langues officielles",
+    "description": "Heading for comments and interaction section"
+  },
   "dj8GiH": {
     "defaultMessage": "Détails sur le candidat",
     "description": "Page title for the individual user page"
@@ -7343,6 +7510,10 @@
     "defaultMessage": "Nous utilisons ce filtre pour apparier les candidats qui expriment de l’intérêt pour un niveau de classification, ou certains salaires prévus dans ces classifications.",
     "description": "Message describing the classification filter of the search form."
   },
+  "dxwgXw": {
+    "defaultMessage": "communiquent des messages racistes, haineux, sexistes, homophobes ou diffamatoires, ou contiennent du matériel obscène ou pornographique ou y font allusion",
+    "description": "Comments or contributions list item"
+  },
   "e+xir3": {
     "defaultMessage": "Autres exigences",
     "description": "Signpost title for _work requirement description_ textbox in the _digital services contracting questionnaire_"
@@ -7354,6 +7525,10 @@
   "e0QYLO": {
     "defaultMessage": "Montrez aux gestionnaires les 10 compétences techniques qui représentent le mieux votre expertise et vos compétences. Vous pouvez modifier cette vitrine à tout moment et vous êtes libre de mettre les compétences dans l’ordre qui vous convient. Les compétences que vous ajoutez à la vitrine qui ne sont pas déjà dans votre bibliothèque seront ajoutées automatiquement.",
     "description": "Page description for the top technical skills page"
+  },
+  "e1JW62": {
+    "defaultMessage": "Les renseignements personnels recueillis par l’entremise de Talents numériques du GC sont utilisés aux fins des activités de dotation, de recrutement et la mobilité interne des talents au sein des institutions fédérales, conformément au <justiceLaws7Link>paragraphe 7(1)</justiceLaws7Link> de la Loi sur la gestion des finances publiques, aux paragraphes <justiceLaws15Link>15(1)</justiceLaws15Link>, <justiceLaws29Link>29</justiceLaws29Link> et <justiceLaws30Link>30 (1), (2), and (3)</justiceLaws30Link> de la Loi sur l’emploi dans la fonction publique et de l’article 5 de la Loi sur l’équité en matière d’emploi.",
+    "description": "Paragraph for privacy policy page"
   },
   "e2qUId": {
     "defaultMessage": "Processus exécuté par {team} à {departments}",
@@ -7707,6 +7882,10 @@
     "defaultMessage": "Adresse de courriel personnelle",
     "description": "Label for email field"
   },
+  "g2We9g": {
+    "defaultMessage": "Une partie du contenu de ce site pourrait faire l’objet du droit d’auteur d’une tierce partie. Lorsque des informations sont produites et que le gouvernement du Canada n’est pas le détenteur des droits d’auteur, le contenu est protégé par la <copyrightLink>Loi sur le droit d’auteur</copyrightLink> et des ententes internationales. Les détails relatifs au droit d’auteur figurent sur les pages pertinentes.",
+    "description": "Commercial reproduction list description in ownership and usage section"
+  },
   "g5JeNf": {
     "defaultMessage": "Poursuivre ma demande",
     "description": "Link text to continue an existing, draft application"
@@ -7766,6 +7945,10 @@
   "gLHr9Y": {
     "defaultMessage": "La clôture automatique de ce bassin est programmés pour le :",
     "description": "Third paragraph for publish pool dialog"
+  },
+  "gMaDG/": {
+    "defaultMessage": "Reproduction commerciale",
+    "description": "Commercial reproduction list in ownership and usage section"
   },
   "gN5gy5": {
     "defaultMessage": "Groupe et niveau de départ",
@@ -8095,6 +8278,10 @@
     "defaultMessage": "Ministères et organismes",
     "description": "Link text for all departments page"
   },
+  "hyBNpJ": {
+    "defaultMessage": "Les comptes de médias sociaux peuvent comporter des liens ou des annonces liés à des sites Web échappant au contrôle du gouvernement du Canada. Ces liens sont fournis aux utilisateurs uniquement par souci de commodité. Le gouvernement du Canada n’assume aucune responsabilité à l’égard de l’information obtenue au moyen de ces liens ou de ces annonces, pas plus qu’il ne cautionne ces sites et leur contenu..",
+    "description": "Paragraph for link to others section"
+  },
   "hyJz3G": {
     "defaultMessage": "À propos du programme",
     "description": "Program information section title"
@@ -8311,6 +8498,10 @@
     "defaultMessage": "10 millions de dollars à 15 millions de dollars",
     "description": "Contract value range between ten-million and fifteen-million"
   },
+  "issrI6": {
+    "defaultMessage": "Avis concernant l’image de marque",
+    "description": "Title for the trademark notice section."
+  },
   "iuve97": {
     "defaultMessage": "Modifier le statut",
     "description": "Confirmation button for change status dialog"
@@ -8354,6 +8545,10 @@
   "j7nWu/": {
     "defaultMessage": "Vous avez réussi à mettre à jour vos compétences!",
     "description": "Message displayed to users when saving skills is successful."
+  },
+  "j8DE64": {
+    "defaultMessage": "Présentation d’un contenu dans les deux langues officielles du Canada",
+    "description": "Title for the providing content section"
   },
   "j9m5qA": {
     "defaultMessage": "Date de réception",
@@ -8715,6 +8910,10 @@
     "defaultMessage": "Créer un compte",
     "description": "Page title for the account creation page"
   },
+  "lPuC3S": {
+    "defaultMessage": "Commentaires et échanges",
+    "description": "Heading for comments and interaction section"
+  },
   "lTkp5g": {
     "defaultMessage": "Sauvegarder les questions filtres",
     "description": "Text on a button to save the pool screening questions"
@@ -8738,6 +8937,10 @@
   "laGCzG": {
     "defaultMessage": "Conditions d’emploi/Exigences opérationnelles",
     "description": "Heading for operational requirements section of the search form."
+  },
+  "laYGvQ": {
+    "defaultMessage": "de faire preuve de diligence raisonnable quant à l'exactitude du contenu reproduit",
+    "description": "Non commercial reproduction list item"
   },
   "lb7SoP": {
     "defaultMessage": "Anglais - Votre travail",
@@ -8914,6 +9117,10 @@
   "mSUVuL": {
     "defaultMessage": "RH",
     "description": "Label for _hr_ option in _authorities involved_ fieldset in the _digital services contracting questionnaire_"
+  },
+  "mSdBi1": {
+    "defaultMessage": "La décision du gouvernement du Canada de « suivre », « d'aimer » ou de « s'abonner » à un autre compte de médias sociaux ne signifie pas qu'il approuve ce compte, cette voie de communication, cette page ou ce site, et il en est de même pour le partage (retransmission, republication ou lien) de contenu provenant d'un autre utilisateur.",
+    "description": "Paragraph for following section"
   },
   "mTsq+x": {
     "defaultMessage": "Sélectionnez un rôle",
@@ -9143,6 +9350,10 @@
     "defaultMessage": "Statut mis à jour avec succès",
     "description": "Toast for successful status update on view-user page"
   },
+  "nZ8ZLR": {
+    "defaultMessage": "sont rédigés dans une autre langue que le français ou l’anglais",
+    "description": "Comments or contributions list item"
+  },
   "nZT/WM": {
     "defaultMessage": "Type de poste",
     "description": "Label for an opportunity's position type."
@@ -9202,6 +9413,10 @@
   "nx5fZY": {
     "defaultMessage": "En postulant à un bassin de talents sur la plateforme, vous acceptez de recevoir des notifications sur les possibilités d’emploi potentielles qui y sont liées. Vous pouvez gérer ces notifications à l’aide des <strong>mesures de contrôle de disponibilité</strong>, ou en consultant les <link>processus de recrutement actuels sur votre parcours professionnel</link>.",
     "description": "Description for managing recruitment availability."
+  },
+  "nxAw/X": {
+    "defaultMessage": "Cet avis a été préparé pour expliquer la façon dont le gouvernement du Canada interagit avec le public sur les plateformes de médias sociaux.",
+    "description": "Paragraph describing social media section"
   },
   "nxsvto": {
     "defaultMessage": "Date d'archivage",
@@ -9410,6 +9625,10 @@
   "p8+wKq": {
     "defaultMessage": "Questions de sélection",
     "description": "Title of screening questions"
+  },
+  "p8o9cO": {
+    "defaultMessage": "Le contenu de ce site Web a été produit ou rassemblé afin d’offrir aux Canadiens l’accès aux renseignements concernant les programmes et les services offerts par le gouvernement du Canada. Vous pouvez l’utiliser et le reproduire des façons suivantes :",
+    "description": "Paragraph describing ownership and usage section"
   },
   "pB5bOl": {
     "defaultMessage": "Hors du Canada et des États-Unis",
@@ -9671,6 +9890,10 @@
     "defaultMessage": "Vous avez atteint le nombre maximum (3) de questions filtres par poste annoncé.",
     "description": "Message displayed when a user adds the maximum number of questions"
   },
+  "qsI2b1": {
+    "defaultMessage": "Services Web de Canada.ca 200 Promenade du Portage Gatineau (Québec) Canada K1A 0J9, ou",
+    "description": "Commercial reproduction list item"
+  },
   "qsuIJa": {
     "defaultMessage": "Déterminer et coordonner les occasions de formation et d’amélioration des compétences à l’échelle du gouvernement",
     "description": "An OCIO role in the _supporting the community_ section of the _digital services contracting questionnaire_"
@@ -9842,6 +10065,10 @@
   "s9unRt": {
     "defaultMessage": "Heures supplémentaires à court terme",
     "description": "Overtime on short notice personnel other requirement"
+  },
+  "sB7wVn": {
+    "defaultMessage": "L’information publiée par le gouvernement du Canada est assujettie à la <copyrightLink>Loi sur le droit d’auteur</copyrightLink>.",
+    "description": "Paragraph for comments and interaction section"
   },
   "sBksyQ": {
     "defaultMessage": "Supprimer",
@@ -10095,6 +10322,10 @@
     "defaultMessage": "l’amélioration de l'accessibilité des couleurs",
     "description": "List item two, things designers consider for accessibility"
   },
+  "tZsKb7": {
+    "defaultMessage": "Échanger avec nous sur les médias sociaux",
+    "description": "Title for the social media section."
+  },
   "tgGPyx": {
     "defaultMessage": "Le questionnaire rempli doit être soumis au moment où un contrat de services numériques (y compris la commande d’un instrument contractuel établi) est soumis aux autorités ministérielles chargées de l’approvisionnement aux fins de traitement.",
     "description": "Paragraph three of the _requirements_ section of the _digital services contracting questionnaire_"
@@ -10142,6 +10373,10 @@
   "tuXnJB": {
     "defaultMessage": "Rôles individuels",
     "description": "Label for the input to add roles to a user"
+  },
+  "tvQYG5": {
+    "defaultMessage": "Avis",
+    "description": "Title for the websites terms and conditions"
   },
   "txq9ha": {
     "defaultMessage": "50 000 $ à 1 million de dollars",
@@ -10551,6 +10786,14 @@
     "defaultMessage": "N’a pas réussi(e) au cours de l’évaluation",
     "description": "Unsuccessful during assessment option"
   },
+  "wsNG8a": {
+    "defaultMessage": "La <langActLink>Loi sur les langues officielles</langActLink>, le <langRegulationsLink>Règlement sur les langues officielles – communications avec le public et prestation des services</langRegulationsLink> et les exigences des politiques du Conseil du Trésor prévoient les circonstances où nous employons le français et l’anglais dans la prestation des services au public. S’il n’y a pas d’obligation d’offrir le contenu dans les deux langues officielles, celui-ci pourrait être offert uniquement dans une des langues officielles. L’information offerte par des entités non assujetties à la <langActLink>Loi sur les langues officielles</langActLink> est diffusée que dans la langue dans laquelle elle est fournie. Toute information dans une langue autre que l’anglais ou le français est offerte seulement à titre gracieux aux visiteurs de notre site Web.",
+    "description": "Paragraph describing providing content section"
+  },
+  "wvxZxx": {
+    "defaultMessage": "portent atteinte à la propriété intellectuelle ou à un droit de propriété",
+    "description": "Comments or contributions list item"
+  },
   "ww+trY": {
     "defaultMessage": "Ces informations permettent aux candidats de savoir à quoi s’attendre après avoir postulé : examens supplémentaires, rencontres directes avec les gestionnaires, délais éventuels.",
     "description": "Describes the 'what to expect after applying' section of a process' advertisement."
@@ -10582,6 +10825,10 @@
   "x45gSl": {
     "defaultMessage": "Un membre de l'équipe du Bureau des initiatives autochtones communiquera avec vous sous peu.",
     "description": "Paragraph 5 of a manager's email for apprenticeship"
+  },
+  "x4HViJ": {
+    "defaultMessage": "encouragent ou incitent toute activité illégale ou criminelle",
+    "description": "Comments or contributions list item"
   },
   "x6saT3": {
     "defaultMessage": "Avant de vous amener à votre profil, nous devons recueillir les renseignements nécessaires pour compléter la configuration de votre compte.",
@@ -10767,6 +11014,10 @@
     "defaultMessage": "Création du ministère réussie!",
     "description": "Message displayed to user after department is created successfully."
   },
+  "yGwPBd": {
+    "defaultMessage": "Afin d’améliorer la fonctionnalité des sites Web du gouvernement du Canada, certains fichiers (tels que les bibliothèques à code source ouvert, les images et les scripts) peuvent être téléchargés automatiquement vers votre navigateur à l’aide d’un serveur tiers ou d’un réseau de diffusion de contenu de confiance. La diffusion de ces fichiers vise à offrir une expérience utilisateur transparente en diminuant les temps de réponse et en évitant le téléchargement de ces fichiers par chaque visiteur. Le cas échéant, les énoncés de protection des renseignements personnels traitant spécifiquement de ces fichiers se trouvent dans notre <privacyPolicyLink>Avis de confidentialité</privacyPolicyLink>.",
+    "description": "Paragraph describing using files section"
+  },
   "yGy+to": {
     "defaultMessage": "Aller à la page précédente ",
     "description": "Aria label for previous page button in pagination nav"
@@ -10903,9 +11154,17 @@
     "defaultMessage": "Mise à jour réussie de l’amélioration des compétences techniques",
     "description": "Success message displayed after updating improve technical skills"
   },
+  "z6omvn": {
+    "defaultMessage": "ne respectent pas les principes de la Charte canadienne des droits et libertés, Loi constitutionnelle de 1982",
+    "description": "Comments or contributions list item"
+  },
   "z7FpHz": {
     "defaultMessage": "Vous pouvez commencer par formuler une demande dans le cadre d’un processus de recrutement ciblé ou en cours.",
     "description": "Message to user when no qualified recruitments have been attached to profile, paragraph two."
+  },
+  "z8b14H": {
+    "defaultMessage": "contiennent des renseignements personnels",
+    "description": "Comments or contributions list item"
   },
   "zACLaV": {
     "defaultMessage": "Position dans le groupe requis non autorisée en raison d’une restriction de classification",
@@ -10951,6 +11210,10 @@
     "defaultMessage": "À partir d’ici, vous pouvez modifier cette expérience. N’oubliez pas, les expériences de travail devraient miser sur une description d’expériences vécues dans le cadre de postes à temps partiel, à plein temps, d’emplois autonomes, de bourses, de postes bénévoles, et de stages.",
     "description": "Description for editing an experience."
   },
+  "zMa59V": {
+    "defaultMessage": "Veuillez ne pas fournir des renseignements personnels supplémentaires qui ne sont pas requis à cette fin.",
+    "description": "Paragraph for privacy policy page"
+  },
   "zXkLL2": {
     "defaultMessage": "Non démontrée (supprimée du processus)",
     "description": "Option for assessment decision when candidate has unsuccessful assessment and been removed from the process."
@@ -10958,6 +11221,14 @@
   "zXzQhc": {
     "defaultMessage": "Si vous ne savez pas si ce questionnaire est nécessaire pour un type de contrat spécifique, veuillez communiquer avec nous, à <link>GCTalentGC@tbs-sct.gc.ca</link>, pour obtenir de plus amples renseignements.",
     "description": "Paragraph three of the _examples of contracts_ section of the _digital services contracting questionnaire_"
+  },
+  "zbmWLG": {
+    "defaultMessage": "Le gouvernement du Canada lira les commentaires et participera aux discussions, au besoin. Vos commentaires et vos contributions doivent être pertinents et respectueux.",
+    "description": "Paragraph for comments and interaction section"
+  },
+  "zcr51k": {
+    "defaultMessage": "La reproduction des symboles officiels du gouvernement du Canada, y compris le mot-symbole « Canada », les armoiries du Canada et le symbole du drapeau, à des fins commerciales ou non commerciales, est interdite sans <trademarkLink>autorisation écrite</trademarkLink> au préalable.",
+    "description": "Paragraph describing trademark notice section"
   },
   "zdeoxH": {
     "defaultMessage": "Diplôme d’études secondaires",

--- a/apps/web/src/pages/PrivacyPolicy/PrivacyPolicy.test.tsx
+++ b/apps/web/src/pages/PrivacyPolicy/PrivacyPolicy.test.tsx
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment jsdom
+ */
+import "@testing-library/jest-dom";
+import React from "react";
+
+import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";
+
+import PrivacyPolicy from "./PrivacyPolicy";
+
+const renderPrivacyPolicy = () => {
+  return renderWithProviders(<PrivacyPolicy />);
+};
+
+describe("PrivacyPolicy", () => {
+  it("should have no accessibility errors", async () => {
+    const { container } = renderPrivacyPolicy();
+    await axeTest(container);
+  });
+});

--- a/apps/web/src/pages/PrivacyPolicy/PrivacyPolicy.tsx
+++ b/apps/web/src/pages/PrivacyPolicy/PrivacyPolicy.tsx
@@ -1,0 +1,220 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { Link, TableOfContents } from "@gc-digital-talent/ui";
+import { getLocale } from "@gc-digital-talent/i18n";
+
+import Hero from "~/components/Hero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
+import useRoutes from "~/hooks/useRoutes";
+
+const PrivacyPolicy = () => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
+  const paths = useRoutes();
+
+  const justiceLaws7Link = (chunks: React.ReactNode) => (
+    <Link
+      newTab
+      external
+      href={
+        locale === "en"
+          ? "https://laws-lois.justice.gc.ca/eng/acts/F-11/section-7.html"
+          : "https://laws-lois.justice.gc.ca/fra/lois/f-11/section-7.html"
+      }
+    >
+      {chunks}
+    </Link>
+  );
+  const justiceLaws15Link = (chunks: React.ReactNode) => (
+    <Link
+      newTab
+      external
+      href={
+        locale === "en"
+          ? "https://laws-lois.justice.gc.ca/eng/acts/P-33.01/section-15.html"
+          : "https://laws-lois.justice.gc.ca/fra/lois/P-33.01/section-15.html"
+      }
+    >
+      {chunks}
+    </Link>
+  );
+  const justiceLaws29Link = (chunks: React.ReactNode) => (
+    <Link
+      newTab
+      external
+      href={
+        locale === "en"
+          ? "https://laws-lois.justice.gc.ca/eng/acts/P-33.01/section-29.html"
+          : "https://laws-lois.justice.gc.ca/fra/lois/P-33.01/section-29.html"
+      }
+    >
+      {chunks}
+    </Link>
+  );
+
+  const justiceLaws30Link = (chunks: React.ReactNode) => (
+    <Link
+      newTab
+      external
+      href={
+        locale === "en"
+          ? "https://laws-lois.justice.gc.ca/eng/acts/P-33.01/section-30.html"
+          : "https://laws-lois.justice.gc.ca/fra/lois/p-33.01/section-30.html"
+      }
+    >
+      {chunks}
+    </Link>
+  );
+
+  const publicServiceLink = (chunks: React.ReactNode) => (
+    <Link
+      newTab
+      external
+      href={
+        locale === "en"
+          ? "https://www.canada.ca/en/public-service-commission/services/oversight-activities/investigations.html"
+          : "https://www.canada.ca/fr/commission-fonction-publique/services/activites-surveillance/enquetes.html"
+      }
+    >
+      {chunks}
+    </Link>
+  );
+
+  const personalInfoLink = (chunks: React.ReactNode) => (
+    <Link
+      newTab
+      external
+      href={
+        locale === "en"
+          ? "https://www.canada.ca/en/treasury-board-secretariat/corporate/transparency/treasury-board-secretariat-sources-federal-government-employee-information-info-source.html"
+          : "https://www.canada.ca/fr/secretariat-conseil-tresor/organisation/transparence/secretariat-conseil-tresor-sources-renseignements-gouvernement-federal-fonctionnaires-federaux-info-source.html"
+      }
+    >
+      {chunks}
+    </Link>
+  );
+
+  const id = "privacy";
+  const pageTitle = intl.formatMessage({
+    defaultMessage: "Privacy policy",
+    id: "cYNDhP",
+    description: "Title for the websites privacy policy",
+  });
+
+  const subtitle = intl.formatMessage({
+    defaultMessage:
+      "Learn more about how GC Digital Talent handles user privacy.",
+    id: "Vz719J",
+    description: "Sub title for the websites privacy policy",
+  });
+
+  const crumbs = useBreadcrumbs([
+    {
+      label: pageTitle,
+      url: paths.privacyPolicy(),
+    },
+  ]);
+
+  return (
+    <>
+      <Hero title={pageTitle} subtitle={subtitle} crumbs={crumbs} />
+      <div data-h2-container="base(center, large, x1) p-tablet(center, large, x2)">
+        <TableOfContents.Wrapper data-h2-margin-top="base(x3)">
+          <TableOfContents.Navigation>
+            <TableOfContents.List>
+              <TableOfContents.ListItem key={id}>
+                <TableOfContents.AnchorLink id={id}>
+                  {pageTitle}
+                </TableOfContents.AnchorLink>
+              </TableOfContents.ListItem>
+            </TableOfContents.List>
+          </TableOfContents.Navigation>
+          <TableOfContents.Content>
+            <TableOfContents.Section id={id}>
+              <TableOfContents.Heading
+                size="h3"
+                data-h2-margin="base(0, 0, x1, 0)"
+              >
+                {pageTitle}
+              </TableOfContents.Heading>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "Personal information collected through GC Digital Talent is used for staffing, external recruitment, and internal talent mobility within federal institutions pursuant to <justiceLaws7Link>section 7(1)</justiceLaws7Link> of the Financial Administration Act, <justiceLaws15Link>section 15(1)</justiceLaws15Link>, <justiceLaws29Link>section 29</justiceLaws29Link> and <justiceLaws30Link>30 (1), (2), and (3)</justiceLaws30Link> of the Public Service Employment Act and section 5 of the Employment Equity Act.",
+                    id: "e1JW62",
+                    description: "Paragraph for privacy policy page",
+                  },
+                  {
+                    justiceLaws7Link,
+                    justiceLaws15Link,
+                    justiceLaws29Link,
+                    justiceLaws30Link,
+                  },
+                )}
+              </p>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "Please do not provide additional personal information which is not required for this purpose.",
+                  id: "zMa59V",
+                  description: "Paragraph for privacy policy page",
+                })}
+              </p>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "  The information you provide may also be used for statistical and research purposes, and may be disclosed to the <publicServiceLink>Public Service Commission Investigation Directorate</publicServiceLink> when necessary.",
+                    id: "H2l4rG",
+                    description: "Paragraph for privacy policy page",
+                  },
+                  {
+                    publicServiceLink,
+                  },
+                )}
+              </p>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "Failure to provide personal information will result in your ineligibility for employment opportunities associated with this tool.",
+                  id: "Ijz5oe",
+                  description: "Paragraph for privacy policy page",
+                })}
+              </p>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "You have the right to the correction of, the access to, and protection of your personal information under the Privacy Act and the right to complain to the Privacy Commissioner of Canada about the handling of your personal information.",
+                  id: "7ejG4K",
+                  description: "Paragraph for privacy policy page",
+                })}
+              </p>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "Personal information collected through GC Digital Talent is described by the <personalInfoLink>Talent Cloud Personal Information Bank (TBS PPU 095).</personalInfoLink>",
+                    id: "XYF/1P",
+                    description: "Paragraph for privacy policy page",
+                  },
+                  {
+                    personalInfoLink,
+                  },
+                )}
+              </p>
+            </TableOfContents.Section>
+          </TableOfContents.Content>
+        </TableOfContents.Wrapper>
+      </div>
+      <div
+        data-h2-background-image="base(main-linear)"
+        data-h2-display="base(block)"
+        data-h2-height="base(x1)"
+      />
+    </>
+  );
+};
+
+export default PrivacyPolicy;

--- a/apps/web/src/pages/TermsAndConditions/TermsAndConditions.test.tsx
+++ b/apps/web/src/pages/TermsAndConditions/TermsAndConditions.test.tsx
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment jsdom
+ */
+import "@testing-library/jest-dom";
+import React from "react";
+
+import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";
+
+import TermsAndConditions from "./TermsAndConditions";
+
+const renderTermsAndConditions = () => {
+  return renderWithProviders(<TermsAndConditions />);
+};
+
+describe("TermsAndConditions", () => {
+  it("should have no accessibility errors", async () => {
+    const { container } = renderTermsAndConditions();
+    await axeTest(container);
+  });
+});

--- a/apps/web/src/pages/TermsAndConditions/TermsAndConditions.tsx
+++ b/apps/web/src/pages/TermsAndConditions/TermsAndConditions.tsx
@@ -1,0 +1,795 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import uniqueId from "lodash/uniqueId";
+
+import { Heading, Link, TableOfContents } from "@gc-digital-talent/ui";
+import { getLocale } from "@gc-digital-talent/i18n";
+
+import Hero from "~/components/Hero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
+import useRoutes from "~/hooks/useRoutes";
+import heroImg from "~/assets/img/accessibility-statement-header.webp";
+
+import comments from "./utils";
+
+export type SectionKey =
+  | "usingFiles"
+  | "providingContent"
+  | "linkingToGov"
+  | "ownershipAndUsage"
+  | "trademarkNotice"
+  | "accessibilityCommitment"
+  | "socialMedia";
+
+type Section = {
+  id: string;
+  title: React.ReactNode;
+};
+
+const TermsAndConditions = () => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
+  const paths = useRoutes();
+
+  const privacyPolicyLink = (chunks: React.ReactNode) => (
+    <Link href={paths.privacyPolicy()}>{chunks}</Link>
+  );
+
+  const langActLink = (chunks: React.ReactNode) => (
+    <Link
+      newTab
+      external
+      href={
+        locale === "en"
+          ? "https://laws-lois.justice.gc.ca/eng/acts/O-3.01/"
+          : "https://laws-lois.justice.gc.ca/fra/lois/o-3.01/"
+      }
+    >
+      {chunks}
+    </Link>
+  );
+
+  const langRegulationsLink = (chunks: React.ReactNode) => (
+    <Link
+      newTab
+      external
+      href={
+        locale === "en"
+          ? "https://laws.justice.gc.ca/eng/regulations/SOR-92-48/index.html"
+          : "https://laws.justice.gc.ca/fra/reglements/DORS-92-48/index.html"
+      }
+    >
+      {chunks}
+    </Link>
+  );
+
+  const privacyActLink = (chunks: React.ReactNode) => (
+    <Link
+      newTab
+      external
+      href={
+        locale === "en"
+          ? "https://laws-lois.justice.gc.ca/eng/acts/P-21/index.html"
+          : "https://laws-lois.justice.gc.ca/fra/lois/p-21/index.html"
+      }
+    >
+      {chunks}
+    </Link>
+  );
+
+  const questionsLink = (chunks: React.ReactNode) => (
+    <Link
+      newTab
+      external
+      href={
+        locale === "en"
+          ? "https://www.canada.ca/en/contact/questions.html"
+          : "https://www.canada.ca/fr/contact/questions.html"
+      }
+    >
+      {chunks}
+    </Link>
+  );
+
+  const copyrightLink = (chunks: React.ReactNode) => (
+    <Link
+      newTab
+      external
+      href={
+        locale === "en"
+          ? "https://laws-lois.justice.gc.ca/eng/acts/C-42/index.html"
+          : "https://laws-lois.justice.gc.ca/fra/lois/c-42/index.html"
+      }
+    >
+      {chunks}
+    </Link>
+  );
+
+  const trademarkLink = (chunks: React.ReactNode) => (
+    <Link
+      newTab
+      external
+      href={
+        locale === "en"
+          ? "https://www.canada.ca/en/treasury-board-secretariat/topics/government-communications/federal-identity-requirements/legal-protection-official-symbols-government-canada.html"
+          : "https://www.canada.ca/fr/secretariat-conseil-tresor/sujets/communications-gouvernementales/exigences-image-marque/protection-juridique-symboles-officiels-gouvernement-canada.html"
+      }
+    >
+      {chunks}
+    </Link>
+  );
+
+  const accessibilityLink = (chunks: React.ReactNode) => (
+    <Link
+      newTab
+      external
+      href={
+        locale === "en"
+          ? "https://www.tbs-sct.canada.ca/pol/doc-eng.aspx?id=23601"
+          : "https://www.tbs-sct.canada.ca/pol/doc-fra.aspx?id=23601"
+      }
+    >
+      {chunks}
+    </Link>
+  );
+
+  const optimizeLink = (chunks: React.ReactNode) => (
+    <Link
+      newTab
+      external
+      href={
+        locale === "en"
+          ? "https://www.tbs-sct.canada.ca/pol/doc-eng.aspx?id=27088"
+          : "https://www.tbs-sct.canada.ca/pol/doc-fra.aspx?id=27088"
+      }
+    >
+      {chunks}
+    </Link>
+  );
+
+  const pageTitle = intl.formatMessage({
+    defaultMessage: "Terms and conditions",
+    id: "tvQYG5",
+    description: "Title for the websites terms and conditions",
+  });
+
+  const sections: Record<SectionKey, Section> = {
+    usingFiles: {
+      id: "using-files",
+      title: intl.formatMessage({
+        defaultMessage:
+          "Using files located on non-Government of Canada servers",
+        id: "MLrQQy",
+        description: "Title for the using files section",
+      }),
+    },
+    providingContent: {
+      id: "providing-content",
+      title: intl.formatMessage({
+        defaultMessage: "Providing content in Canada’s official languages",
+        id: "j8DE64",
+        description: "Title for the providing content section",
+      }),
+    },
+    linkingToGov: {
+      id: "linking-to-gov",
+      title: intl.formatMessage({
+        defaultMessage: "Linking to non-Government of Canada websites",
+        id: "9zhqQf",
+        description: "Title for the linkink to gov section",
+      }),
+    },
+    ownershipAndUsage: {
+      id: "ownership-and-usage",
+      title: intl.formatMessage({
+        defaultMessage: "Ownership and usage of content provided on this site",
+        id: "Dsa/aH",
+        description: "Title for the ownership and usage section.",
+      }),
+    },
+    trademarkNotice: {
+      id: "trademark-notice",
+      title: intl.formatMessage({
+        defaultMessage: "Trademark notice",
+        id: "issrI6",
+        description: "Title for the trademark notice section.",
+      }),
+    },
+    accessibilityCommitment: {
+      id: "accessibility-commitment",
+      title: intl.formatMessage({
+        defaultMessage: "Our commitment to accessibility",
+        id: "QQXvOh",
+        description: "Title for the accessibility commitment section.",
+      }),
+    },
+    socialMedia: {
+      id: "social-media",
+      title: intl.formatMessage({
+        defaultMessage: "Interacting with us on social media",
+        id: "tZsKb7",
+        description: "Title for the social media section.",
+      }),
+    },
+  };
+
+  const crumbs = useBreadcrumbs([
+    {
+      label: pageTitle,
+      url: paths.accessibility(),
+    },
+  ]);
+
+  return (
+    <>
+      <Hero
+        imgPath={heroImg}
+        title={pageTitle}
+        subtitle={intl.formatMessage({
+          defaultMessage: "Descriptive subtitle explaining tasks on the page.",
+          id: "O7Lkda",
+          description: "Subtitle for the terms and conditions page.",
+        })}
+        crumbs={crumbs}
+      />
+      <div data-h2-container="base(center, large, x1) p-tablet(center, large, x2)">
+        <TableOfContents.Wrapper data-h2-margin-top="base(x3)">
+          <TableOfContents.Navigation>
+            <TableOfContents.List>
+              {Object.values(sections).map((section) => (
+                <TableOfContents.ListItem key={section.id}>
+                  <TableOfContents.AnchorLink id={section.id}>
+                    {section.title}
+                  </TableOfContents.AnchorLink>
+                </TableOfContents.ListItem>
+              ))}
+            </TableOfContents.List>
+          </TableOfContents.Navigation>
+          <TableOfContents.Content>
+            <TableOfContents.Section id={sections.usingFiles.id}>
+              <TableOfContents.Heading
+                size="h3"
+                data-h2-margin="base(0, 0, x1, 0)"
+              >
+                {sections.usingFiles.title}
+              </TableOfContents.Heading>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "To improve the functionality of Government of Canada websites, certain files (such as open source libraries, images and scripts) may be delivered automatically to your browser via a trusted third-party server or content delivery network. The delivery of these files is intended to provide a seamless user experience by speeding response times and avoiding the need for each visitor to download these files. Where applicable, specific privacy statements covering these files are included in our <privacyPolicyLink>Privacy policy</privacyPolicyLink>.",
+                    id: "yGwPBd",
+                    description: "Paragraph describing using files section",
+                  },
+                  {
+                    privacyPolicyLink,
+                  },
+                )}
+              </p>
+            </TableOfContents.Section>
+            <TableOfContents.Section id={sections.providingContent.id}>
+              <TableOfContents.Heading
+                size="h3"
+                data-h2-margin="base(x3, 0, x1, 0)"
+              >
+                {sections.providingContent.title}
+              </TableOfContents.Heading>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage(
+                  {
+                    id: "wsNG8a",
+                    defaultMessage:
+                      "The <langActLink>Official Languages Act</langActLink>, the <langRegulationsLink>Official Languages (Communications with and Services to the Public) Regulations</langRegulationsLink> and Treasury Board policy requirements establish when we use both English and French to provide services to or communicate with members of the public. When there is no obligation to provide information in both official languages, content may be available in one official language only. Information provided by organizations not subject to the <langActLink>Official Languages Act</langActLink> is in the language(s) provided. Information provided in a language other than English or French is only for the convenience of our visitors.",
+                    description:
+                      "Paragraph describing providing content section",
+                  },
+                  {
+                    langActLink,
+                    langRegulationsLink,
+                  },
+                )}
+              </p>
+            </TableOfContents.Section>
+            <TableOfContents.Section id={sections.linkingToGov.id}>
+              <TableOfContents.Heading
+                size="h3"
+                data-h2-margin="base(x3, 0, x1, 0)"
+              >
+                {sections.linkingToGov.title}
+              </TableOfContents.Heading>
+              <p data-h2-margin="base(x.5, 0)">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "Links to websites not under the control of the Government of Canada, including those to our social media accounts, are provided solely for the convenience of our website visitors. We are not responsible for the accuracy, currency or reliability of the content of such websites. The Government of Canada does not offer any guarantee in that regard and is not responsible for the information found through these links, and does not endorse the sites and their content.",
+                  id: "Jz7jAF",
+                  description: "Paragraph describing linking to gov section",
+                })}
+              </p>
+              <p data-h2-margin="base(x.5, 0)">
+                {intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "Visitors should also be aware that information offered by non-Government of Canada sites to which this website links is not subject to the <privacyActLink>Privacy Act</privacyActLink> or the <langActLink>Official Languages Act</langActLink> and may not be accessible to persons with disabilities. The information offered may be available only in the language(s) used by the sites in question. With respect to privacy, visitors should research the privacy policies of these non-government websites before providing personal information.",
+                    id: "1e84jV",
+                    description:
+                      "Paragraph two describing linking to gov section",
+                  },
+                  {
+                    privacyActLink,
+                    langActLink,
+                  },
+                )}
+              </p>
+            </TableOfContents.Section>
+            <TableOfContents.Section id={sections.ownershipAndUsage.id}>
+              <TableOfContents.Heading
+                size="h3"
+                data-h2-margin="base(x3, 0, x1, 0)"
+              >
+                {sections.ownershipAndUsage.title}
+              </TableOfContents.Heading>
+              <p data-h2-margin="base(x.5, 0)">
+                {intl.formatMessage({
+                  id: "p8o9cO",
+                  defaultMessage:
+                    "Materials on this website were produced and/or compiled for the purpose of providing Canadians with access to information about the programs and services offered by the Government of Canada. You may use and reproduce the materials as follows:",
+                  description:
+                    "Paragraph describing ownership and usage section",
+                })}
+              </p>
+              <ul>
+                <li>
+                  <p data-h2-font-weight="base(bold)">
+                    {intl.formatMessage({
+                      defaultMessage: "Non-commercial reproduction",
+                      id: "PerY/b",
+                      description:
+                        "Non commercial reproduction list in ownership and usage section",
+                    })}
+                  </p>
+                  <p data-h2-margin="base(x.5, 0)">
+                    {intl.formatMessage({
+                      defaultMessage:
+                        "Unless otherwise specified you may reproduce the materials in whole or in part for non-commercial purposes, and in any format, without charge or further permission, provided you do the following:",
+                      id: "UnAF+3",
+                      description:
+                        "Non commercial reproduction list description in ownership and usage section",
+                    })}
+                  </p>
+                  <ul
+                    data-h2-list-style="base(disc)"
+                    data-h2-margin="base:children[> li](x.25, 0, 0, 0)"
+                  >
+                    <li>
+                      {intl.formatMessage({
+                        defaultMessage:
+                          "exercise due diligence in ensuring the accuracy of the materials reproduced",
+                        id: "laYGvQ",
+                        description: "Non commercial reproduction list item",
+                      })}
+                    </li>
+                    <li>
+                      {intl.formatMessage({
+                        defaultMessage:
+                          "indicate both the complete title of the materials reproduced, as well as the author (where available)",
+                        id: "Y5Z216",
+                        description: "Non commercial reproduction list item",
+                      })}
+                    </li>
+                    <li>
+                      {intl.formatMessage({
+                        defaultMessage:
+                          "indicate that the reproduction is a copy of the version available at [URL where original document is available]",
+                        id: "WhtOLT",
+                        description: "Non commercial reproduction list item",
+                      })}
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <p
+                    data-h2-margin="base(x.5, 0)"
+                    data-h2-font-weight="base(bold)"
+                  >
+                    {intl.formatMessage({
+                      defaultMessage: "Commercial reproduction",
+                      id: "gMaDG/",
+                      description:
+                        "Commercial reproduction list in ownership and usage section",
+                    })}
+                  </p>
+                  <p data-h2-margin="base(x.5, 0)">
+                    {intl.formatMessage({
+                      defaultMessage:
+                        "Unless otherwise specified, you may not reproduce materials on this site, in whole or in part, for the purposes of commercial redistribution without prior written permission from the copyright administrator. To obtain permission to reproduce Government of Canada materials on this site for commercial purposes, contact:",
+                      id: "BA5yoE",
+                      description:
+                        "Commercial reproduction list description in ownership and usage section",
+                    })}
+                  </p>
+                  <ul
+                    data-h2-list-style="base(disc)"
+                    data-h2-margin="base:children[> li](x.25, 0, 0, 0)"
+                  >
+                    <li>
+                      {intl.formatMessage({
+                        defaultMessage:
+                          "Canada.ca Web Services 200 Promenade du Portage Gatineau, QC K1A 0J9 Canada, or",
+                        id: "qsI2b1",
+                        description: "Commercial reproduction list item",
+                      })}
+                    </li>
+                    <li>
+                      {intl.formatMessage(
+                        {
+                          defaultMessage:
+                            "complete the <questionsLink>Questions and comments form</questionsLink>",
+                          id: "8ZIao3",
+                          description: "Commercial reproduction list item",
+                        },
+                        {
+                          questionsLink,
+                        },
+                      )}
+                    </li>
+                  </ul>
+                  <p data-h2-margin-top="base(x.5)">
+                    {intl.formatMessage(
+                      {
+                        defaultMessage:
+                          "Some of the content on this site may be subject to the copyright of another party. Where information has been produced or copyright is not held by the Government of Canada, the materials are protected under the <copyrightLink>Copyright Act</copyrightLink>, and international agreements. Details concerning copyright ownership are indicated on the relevant page(s).",
+                        id: "g2We9g",
+                        description:
+                          "Commercial reproduction list description in ownership and usage section",
+                      },
+                      {
+                        copyrightLink,
+                      },
+                    )}
+                  </p>
+                </li>
+              </ul>
+            </TableOfContents.Section>
+            <TableOfContents.Section id={sections.trademarkNotice.id}>
+              <TableOfContents.Heading
+                size="h3"
+                data-h2-margin="base(x3, 0, x1, 0)"
+              >
+                {sections.trademarkNotice.title}
+              </TableOfContents.Heading>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage(
+                  {
+                    id: "zcr51k",
+                    defaultMessage:
+                      "The official symbols of the Government of Canada, including the Canada wordmark, the Arms of Canada, and the flag symbol may not be reproduced, whether for commercial or non-commercial purposes, without prior <trademarkLink>written authorization</trademarkLink>.",
+                    description:
+                      "Paragraph describing trademark notice section",
+                  },
+                  {
+                    trademarkLink,
+                  },
+                )}
+              </p>
+            </TableOfContents.Section>
+            <TableOfContents.Section id={sections.accessibilityCommitment.id}>
+              <TableOfContents.Heading
+                size="h3"
+                data-h2-margin="base(x3, 0, x1, 0)"
+              >
+                {sections.accessibilityCommitment.title}
+              </TableOfContents.Heading>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage(
+                  {
+                    id: "4jMHwL",
+                    defaultMessage:
+                      "The Government of Canada is committed to achieving a high standard of accessibility as defined in the <accessibilityLink>Standard on Web Accessibility</accessibilityLink> and the <optimizeLink>Standard on Optimizing Websites and Applications for Mobile Devices</optimizeLink>. In the event of difficulty using our web pages, applications or device-based mobile applications, contact us for assistance or to obtain alternative formats such as regular print, Braille or another appropriate format.",
+                    description:
+                      "Paragraph describing accessibility commitment section",
+                  },
+                  {
+                    accessibilityLink,
+                    optimizeLink,
+                  },
+                )}
+              </p>
+            </TableOfContents.Section>
+            <TableOfContents.Section id={sections.socialMedia.id}>
+              <TableOfContents.Heading
+                size="h3"
+                data-h2-margin="base(x3, 0, x1, 0)"
+              >
+                {sections.socialMedia.title}
+              </TableOfContents.Heading>
+              <p data-h2-margin="base(x1 0)">
+                {intl.formatMessage({
+                  id: "nxAw/X",
+                  defaultMessage:
+                    "This notice has been written to explain how the Government of Canada interacts with the public on social media platforms.",
+                  description: "Paragraph describing social media section",
+                })}
+              </p>
+              <p data-h2-margin-bottom="base(x3)">
+                {intl.formatMessage({
+                  id: "Tq0ZKw",
+                  defaultMessage:
+                    "Your engagement with the Government of Canada via social media is in part governed by the Terms of Service/Use of the relevant third-party social media platform providers, as well as the following Terms and Conditions. The Government of Canada has no control over the social media platform providers’ Terms of Service/Use, but you are strongly encouraged to read them in addition to those that follow.",
+                  description: "Paragraph describing social media section",
+                })}
+              </p>
+              <div
+                data-h2-display="base(flex)"
+                data-h2-flex-direction="base(column)"
+                data-h2-gap="base(x3)"
+              >
+                <div>
+                  <Heading
+                    level="h3"
+                    size="h4"
+                    color="black"
+                    data-h2-font-weight="base(bold)"
+                    data-h2-margin-bottom="base(x1)"
+                  >
+                    {intl.formatMessage({
+                      id: "6f2bWo",
+                      defaultMessage: "Content and frequency",
+                      description: "Heading for content and frequency section",
+                    })}
+                  </Heading>
+                  <p>
+                    {intl.formatMessage({
+                      id: "Lt7tcM",
+                      defaultMessage:
+                        "The Government of Canada uses social media accounts as an alternative method of interacting with Canadians and of sharing the content posted on its website, facilitating access to Government of Canada information and services, and providing stakeholders with an opportunity to interact in an informative and respectful environment.",
+                      description:
+                        "Paragraph for content and frequency section",
+                    })}
+                  </p>
+                  <p>
+                    {intl.formatMessage({
+                      id: "VIZAgj",
+                      defaultMessage:
+                        "Because social media platforms and their computer servers are managed by a third party, social media accounts are subject to downtime that may be out of the Government of Canada’s control. The government accepts no responsibility for platforms becoming unresponsive or unavailable.",
+                      description:
+                        "Paragraph for content and frequency section",
+                    })}
+                  </p>
+                </div>
+                <div>
+                  <Heading
+                    level="h3"
+                    size="h4"
+                    color="black"
+                    data-h2-font-weight="base(bold)"
+                    data-h2-margin-bottom="base(x1)"
+                  >
+                    {intl.formatMessage({
+                      id: "L7Pe9h",
+                      defaultMessage: "Links to other websites and ads",
+                      description: "Heading for link to others section",
+                    })}
+                  </Heading>
+                  <p>
+                    {intl.formatMessage({
+                      id: "hyBNpJ",
+                      defaultMessage:
+                        "Social media accounts may post or display links or ads for websites that are not under the control of the government of Canada. These links are provided solely for the convenience of users. The government is not responsible for the information found through these links or ads; neither does it endorse the sites or their content.",
+                      description: "Paragraph for link to others section",
+                    })}
+                  </p>
+                </div>
+                <div>
+                  <Heading
+                    level="h3"
+                    size="h4"
+                    color="black"
+                    data-h2-font-weight="base(bold)"
+                    data-h2-margin-bottom="base(x1)"
+                  >
+                    {intl.formatMessage({
+                      id: "+lxGIT",
+                      defaultMessage: "Following, “liking” and subscribing",
+                      description: "Heading for following section",
+                    })}
+                  </Heading>
+                  <p>
+                    {intl.formatMessage({
+                      id: "mSdBi1",
+                      defaultMessage:
+                        "The Government of Canada’s decision to follow, “like” or subscribe to another social media account does not imply an endorsement of that account, channel, page or site, and neither does sharing (re-tweeting, reposting or linking to) content from another user.",
+                      description: "Paragraph for following section",
+                    })}
+                  </p>
+                </div>
+                <div>
+                  <Heading
+                    level="h3"
+                    size="h4"
+                    color="black"
+                    data-h2-font-weight="base(bold)"
+                    data-h2-margin-bottom="base(x1)"
+                  >
+                    {intl.formatMessage({
+                      id: "lPuC3S",
+                      defaultMessage: "Comments and interaction",
+                      description:
+                        "Heading for comments and interaction section",
+                    })}
+                  </Heading>
+                  <p data-h2-margin-bottom="base(x.5)">
+                    {intl.formatMessage({
+                      id: "zbmWLG",
+                      defaultMessage:
+                        "The Government of Canada will read comments and participate in discussions when appropriate. Your comments and contributions must be relevant and respectful.",
+                      description:
+                        "Paragraph for comments and interaction section",
+                    })}
+                  </p>
+                  <p data-h2-margin-bottom="base(x.5)">
+                    {intl.formatMessage({
+                      id: "8L9eJ3",
+                      defaultMessage:
+                        "The Government of Canada will not engage in partisan or political issues or respond to questions that violate these Terms and Conditions.",
+                      description:
+                        "Paragraph for comments and interaction section",
+                    })}
+                  </p>
+                  <p data-h2-margin-bottom="base(x.5)">
+                    {intl.formatMessage({
+                      id: "clzYpT",
+                      defaultMessage:
+                        "The Government of Canada reserves the right to remove comments and contributions, and to block users based on the following criteria:",
+                      description:
+                        "Paragraph for comments and interaction section",
+                    })}
+                  </p>
+                  <p data-h2-margin-bottom="base(x.5)">
+                    {intl.formatMessage({
+                      id: "I2CtZJ",
+                      defaultMessage: "The comments or contributions:",
+                      description: "Comments or contributions list title",
+                    })}
+                  </p>
+                  <ul>
+                    {Object.values(comments).map((comment) => (
+                      <li key={uniqueId()} data-h2-margin-bottom="base(x.25)">
+                        {comment.defaultMessage}
+                      </li>
+                    ))}
+                  </ul>
+                  <p data-h2-margin-top="base(x.5)">
+                    {intl.formatMessage({
+                      id: "6yxxP6",
+                      defaultMessage:
+                        "The Government of Canada reserves the right to report users and/or their comments and contributions to third-party social media service providers to - prevent or remove the posting of content that is contrary to these Terms and Conditions, or to the Terms of Service/Use of the third-party social media platform.",
+                      description:
+                        "Paragraph of comments and interactions sections",
+                    })}
+                  </p>
+                </div>
+                <div>
+                  <Heading
+                    level="h3"
+                    size="h4"
+                    color="black"
+                    data-h2-font-weight="base(bold)"
+                    data-h2-margin-bottom="base(x1)"
+                  >
+                    {intl.formatMessage({
+                      id: "9CAhAX",
+                      defaultMessage: "Accessibility of social media platforms",
+                      description:
+                        "Heading for comments and interaction section",
+                    })}
+                  </Heading>
+                  <p>
+                    {intl.formatMessage({
+                      id: "TKONR6",
+                      defaultMessage:
+                        "Social media platforms are third-party service providers and are not bound by Government of Canada standards for web accessibility.",
+                      description:
+                        "Paragraph for comments and interaction section",
+                    })}
+                  </p>
+                </div>
+                <div>
+                  <Heading
+                    level="h3"
+                    size="h4"
+                    color="black"
+                    data-h2-font-weight="base(bold)"
+                    data-h2-margin-bottom="base(x1)"
+                  >
+                    {intl.formatMessage({
+                      id: "FAEU2d",
+                      defaultMessage: "Copyright",
+                      description:
+                        "Heading for comments and interaction section",
+                    })}
+                  </Heading>
+                  <p>
+                    {intl.formatMessage(
+                      {
+                        id: "sB7wVn",
+                        defaultMessage:
+                          "Information posted by the Government of Canada is subject to the <copyrightLink>Copyright Act</copyrightLink>.",
+                        description:
+                          "Paragraph for comments and interaction section",
+                      },
+                      {
+                        copyrightLink,
+                      },
+                    )}
+                  </p>
+                </div>
+                <div>
+                  <Heading
+                    level="h3"
+                    size="h4"
+                    color="black"
+                    data-h2-font-weight="base(bold)"
+                    data-h2-margin-bottom="base(x1)"
+                  >
+                    {intl.formatMessage({
+                      id: "V0jG33",
+                      defaultMessage: "Privacy",
+                      description:
+                        "Heading for comments and interaction section",
+                    })}
+                  </Heading>
+                  <p>
+                    {intl.formatMessage({
+                      id: "RmcS7J",
+                      defaultMessage:
+                        "Social media accounts are not Government of Canada websites and represent only their presence on third-party service providers.",
+                      description:
+                        "Paragraph for comments and interaction section",
+                    })}
+                  </p>
+                </div>
+                <div>
+                  <Heading
+                    level="h3"
+                    size="h4"
+                    color="black"
+                    data-h2-font-weight="base(bold)"
+                    data-h2-margin-bottom="base(x1)"
+                  >
+                    {intl.formatMessage({
+                      id: "diSBjl",
+                      defaultMessage: "Official languages",
+                      description:
+                        "Heading for comments and interaction section",
+                    })}
+                  </Heading>
+                  <p>
+                    {intl.formatMessage(
+                      {
+                        id: "cx7pV4",
+                        defaultMessage:
+                          "Many social media platforms have multiple language options and provide instructions on how to set your preferences. The Government of Canada respects the <langActLink>Official Languages Act</langActLink> and is committed to ensuring that our information is available in both French and English and that both versions are of equal quality.",
+                        description:
+                          "Paragraph for comments and interaction section",
+                      },
+                      {
+                        langActLink,
+                      },
+                    )}
+                  </p>
+                </div>
+              </div>
+            </TableOfContents.Section>
+          </TableOfContents.Content>
+        </TableOfContents.Wrapper>
+      </div>
+      <div
+        data-h2-background-image="base(main-linear)"
+        data-h2-display="base(block)"
+        data-h2-height="base(x1)"
+      />
+    </>
+  );
+};
+
+export default TermsAndConditions;

--- a/apps/web/src/pages/TermsAndConditions/utils.tsx
+++ b/apps/web/src/pages/TermsAndConditions/utils.tsx
@@ -1,0 +1,65 @@
+import { defineMessages } from "react-intl";
+
+const comments = defineMessages({
+  personalInfo: {
+    defaultMessage: "include personal information",
+    id: "z8b14H",
+    description: "Comments or contributions list item",
+  },
+  protectedInfo: {
+    id: "LDrXbc",
+    defaultMessage:
+      "include protected or classified information of the Government of Canada",
+    description: "Comments or contributions list item",
+  },
+  propertyRights: {
+    id: "wvxZxx",
+    defaultMessage: "infringe upon intellectual property or proprietary rights",
+    description: "Comments or contributions list item",
+  },
+  canadianCharter: {
+    id: "z6omvn",
+    defaultMessage:
+      "are contrary to the principles of the Canadian Charter of Rights and Freedoms, Constitution Act, 1982",
+    description: "Comments or contributions list item",
+  },
+  hateful: {
+    id: "dxwgXw",
+    defaultMessage:
+      "are racist, hateful, sexist, homophobic or defamatory, or contain or refer to any obscenity or pornography",
+    description: "Comments or contributions list item",
+  },
+  threatening: {
+    id: "TPw/0u",
+    defaultMessage: "are threatening, violent, intimidating or harassing",
+    description: "Comments or contributions list item",
+  },
+  lawsOfCanada: {
+    id: "Xe39xZ",
+    defaultMessage:
+      "are contrary to any federal, provincial or territorial laws of Canada",
+    description: "Comments or contributions list item",
+  },
+  impersonation: {
+    id: "QnfjbI",
+    defaultMessage: "constitute impersonation, advertising or spam",
+    description: "Comments or contributions list item",
+  },
+  criminalActivity: {
+    id: "x4HViJ",
+    defaultMessage: "encourage or incite any criminal activity",
+    description: "Comments or contributions list item",
+  },
+  otherLang: {
+    id: "nZ8ZLR",
+    defaultMessage: "are written in a language other than English or French",
+    description: "Comments or contributions list item",
+  },
+  violateNotice: {
+    id: "GTqXN1",
+    defaultMessage: "otherwise violate this notice",
+    description: "Comments or contributions list item",
+  },
+});
+
+export default comments;

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -189,6 +189,16 @@ server {
         rewrite "^(?:/[a-z]{2})?/support(/.*|$)" /apps/web/dist/index.html break;
     }
 
+    # rewrite possible lang prefix then "support" to apps/web index.html
+    location ~ "^(?:/[a-z]{2})?/terms-and-conditions(/.*|$)" {
+        rewrite "^(?:/[a-z]{2})?/terms-and-conditions(/.*|$)" /apps/web/dist/index.html break;
+    }
+
+    # rewrite possible lang prefix then "support" to apps/web index.html
+    location ~ "^(?:/[a-z]{2})?/privacy-policy(/.*|$)" {
+        rewrite "^(?:/[a-z]{2})?/privacy-policy(/.*|$)" /apps/web/dist/index.html break;
+    }
+
     # rewrite possible lang prefix then "accessibility-statement" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/accessibility-statement(/.*|$)" {
           add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -208,6 +208,16 @@ server {
         rewrite "^(?:/[a-z]{2})?/support(/.*|$)" /apps/web/dist/index.html break;
     }
 
+    # rewrite possible lang prefix then "support" to apps/web index.html
+    location ~ "^(?:/[a-z]{2})?/terms-and-conditions(/.*|$)" {
+        rewrite "^(?:/[a-z]{2})?/terms-and-conditions(/.*|$)" /apps/web/dist/index.html break;
+    }
+
+    # rewrite possible lang prefix then "support" to apps/web index.html
+    location ~ "^(?:/[a-z]{2})?/privacy-policy(/.*|$)" {
+        rewrite "^(?:/[a-z]{2})?/privacy-policy(/.*|$)" /apps/web/dist/index.html break;
+    }
+
     # rewrite possible lang prefix then "accessibility-statement" to apps/web index.html
     location ~ "^(?:/[a-z]{2})?/accessibility-statement(/.*|$)" {
         rewrite "^(?:/[a-z]{2})?/accessibility-statement(/.*|$)" /apps/web/dist/index.html break;


### PR DESCRIPTION
🤖 Resolves #8549 

## 👋 Introduction

- Moves the terms and conditions page off talent cloud report to the main app
- Moves the privacy policy page off talent cloud report to the main app
- Note: Privacy notice is getting renamed to Privacy policy.

## 🕵️ Details

You'll need to reload nginx to apply the new route additions: 
![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/449546f9-e723-4abe-ad61-7abe3f3ed62c)

Or you can enter the container and execute the command there:
1. Enter exec:  `docker exec -it gc-digital-talent-webserver-1 bash`
2. Reload nginx: `nginx -s reload`
3. Exit exec: `exit`

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Go to terms and conditions page and ensure copy and links are correct
2. Go to privacy policy page and ensure copy and links are correct
