### PR TITLE
[Bug] Have filtered total display for client side table

### DIFF
--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -295,6 +295,16 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
       ? nullSearchMessage
       : nullMessage;
 
+  // manipulate pagination object prop as needed
+  // adjust total for client side only, to be post filtering
+  let paginationAdjusted: PaginationDef | undefined = pagination;
+  if (paginationAdjusted?.internal) {
+    paginationAdjusted = {
+      ...paginationAdjusted,
+      total: table.getFilteredRowModel().rows.length,
+    };
+  }
+
   return (
     <>
       <Table.Controls add={add}>
@@ -360,8 +370,8 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
               />
             )}
           </Table.Wrapper>
-          {pagination && (
-            <TablePagination table={table} pagination={pagination} />
+          {paginationAdjusted && (
+            <TablePagination table={table} pagination={paginationAdjusted} />
           )}
         </div>
       )}


### PR DESCRIPTION
🤖 Resolves #9061

## 👋 Introduction

Have the total displayed for client side tables be the result after filters were applied. 
Probed around and found a method to use and a place to plug it in. 

## 🧪 Testing

1. Ensure API-driven tables unaffected
2. Client side table pagination updated, counts in sync with filtering

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/06d58d02-43fd-49e5-96fc-4ec59be15ee4)


