### PR TITLE
[Feature] Add status badge to candidate page header

### DIFF
--- a/apps/web/src/components/AssessmentStepTracker/ResultsDetails.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/ResultsDetails.tsx
@@ -4,11 +4,12 @@ import { useIntl } from "react-intl";
 import { Board } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 import Counter from "@gc-digital-talent/ui/src/components/Button/Counter";
+import { AssessmentStep, AssessmentStepType } from "@gc-digital-talent/graphql";
 
-import { AssessmentStep, AssessmentStepType } from "~/api/generated";
 import { NullableDecision } from "~/utils/assessmentResults";
+import { ResultDecisionCounts } from "~/utils/poolCandidate";
 
-import { getDecisionInfo, decisionOrder, ResultDecisionCounts } from "./utils";
+import { getDecisionInfo, decisionOrder } from "./utils";
 
 interface StatusCountProps {
   counter: number;

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -10,17 +10,19 @@ import {
   PoolCandidate,
   ArmedForcesStatus,
   AssessmentDecision,
-  AssessmentResult,
   Maybe,
-  PoolSkillType,
   AssessmentStep,
-  AssessmentStepType,
-  AssessmentResultType,
 } from "@gc-digital-talent/graphql";
-import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
+import { notEmpty } from "@gc-digital-talent/helpers";
 
 import { NO_DECISION, NullableDecision } from "~/utils/assessmentResults";
 import poolCandidateMessages from "~/messages/poolCandidateMessages";
+import {
+  ResultDecisionCounts,
+  determineCandidateStatusPerStep,
+  determineCurrentStepPerCandidate,
+  getDecisionCountForEachStep,
+} from "~/utils/poolCandidate";
 
 export type CandidateAssessmentResult = {
   poolCandidate: PoolCandidate;
@@ -106,24 +108,6 @@ export const getDecisionInfo = (
   };
 };
 
-export type ResultDecisionCounts = Record<NullableDecision, number>;
-
-export const sumDecisionTypes = (results: NullableDecision[]) => {
-  const stepAccumulation: ResultDecisionCounts = {
-    [NO_DECISION]: 0,
-    [AssessmentDecision.Hold]: 0,
-    [AssessmentDecision.Successful]: 0,
-    [AssessmentDecision.Unsuccessful]: 0,
-  };
-
-  return results.reduce((accumulator: ResultDecisionCounts, result) => {
-    return {
-      ...accumulator,
-      [result]: accumulator[result] + 1,
-    };
-  }, stepAccumulation);
-};
-
 export const decisionOrder: NullableDecision[] = [
   NO_DECISION,
   AssessmentDecision.Successful,
@@ -198,196 +182,6 @@ export const sortResultsAndAddOrdinal = (
       compareFirstNames(resultA, resultB)
     );
   });
-};
-
-const getResultsDecision = (
-  step: AssessmentStep,
-  results?: AssessmentResult[],
-): NullableDecision => {
-  if (!results) return NO_DECISION;
-  let hasFailure: boolean = false;
-  let hasOnHold: boolean = false;
-  let hasToAssess: boolean = false;
-
-  const stepResults = results.filter((result) => {
-    return result.assessmentStep?.id === step.id;
-  });
-
-  if (stepResults.length === 0) {
-    hasToAssess = true;
-  }
-
-  const requiredSkillAssessments = step.poolSkills?.filter(
-    (poolSkill) => poolSkill?.type === PoolSkillType.Essential,
-  );
-
-  requiredSkillAssessments?.forEach((skillAssessment) => {
-    const assessmentResults = stepResults.filter((result) => {
-      return result.poolSkill?.id === skillAssessment?.id;
-    });
-
-    if (assessmentResults.length === 0) {
-      hasToAssess = true;
-      return;
-    }
-
-    assessmentResults.forEach((assessmentResult) => {
-      switch (assessmentResult.assessmentDecision) {
-        case null:
-          hasToAssess = true;
-          break;
-        case AssessmentDecision.Hold:
-          hasOnHold = true;
-          break;
-        case AssessmentDecision.Unsuccessful:
-          hasFailure = true;
-          break;
-        default:
-      }
-    });
-  });
-
-  // Check for Education requirement if this is an ApplicationScreening step
-  if (step.type === AssessmentStepType.ApplicationScreening) {
-    const educationResults = stepResults.filter(
-      (result) =>
-        result.assessmentResultType === AssessmentResultType.Education,
-    );
-    if (educationResults.length === 0) {
-      hasToAssess = true;
-    }
-    educationResults.forEach((result) => {
-      // Any "to assess" should be marked
-      if (result.assessmentDecision === null) {
-        hasToAssess = true;
-      }
-      switch (result.assessmentDecision) {
-        case null:
-          hasToAssess = true;
-          break;
-        case AssessmentDecision.Hold:
-          hasOnHold = true;
-          break;
-        case AssessmentDecision.Unsuccessful:
-          hasFailure = true;
-          break;
-        default:
-      }
-    });
-  }
-
-  if (hasFailure) {
-    return AssessmentDecision.Unsuccessful;
-  }
-  if (hasToAssess) {
-    return NO_DECISION;
-  }
-  if (hasOnHold) {
-    return AssessmentDecision.Hold;
-  }
-
-  return AssessmentDecision.Successful;
-};
-
-type PoolCandidateId = string;
-type AssessmentStepId = string;
-
-export const determineCandidateStatusPerStep = (
-  poolCandidates: PoolCandidate[],
-  steps: AssessmentStep[],
-): Map<PoolCandidateId, Map<AssessmentStepId, NullableDecision>> => {
-  return poolCandidates.reduce((candidateToResults, candidate) => {
-    const assessmentToResult = steps.reduce((map, step) => {
-      return map.set(
-        step.id,
-        getResultsDecision(step, unpackMaybes(candidate.assessmentResults)),
-      );
-    }, new Map<AssessmentStepId, NullableDecision>());
-    candidateToResults.set(candidate.id, assessmentToResult);
-    return candidateToResults;
-  }, new Map<PoolCandidateId, Map<AssessmentStepId, NullableDecision>>());
-};
-
-/**
- * Returns the "current step" a candidate should appear at in the assessment tracker.
- * A candidate should appear in all columns less than or equal to its current step.
- * A value of null means that a candidate has passed all steps.
- * @param assessmentToResult
- * @param assessmentOrdering
- * @returns
- */
-const determineCurrentStep = (
-  assessmentToResult: Map<AssessmentStepId, NullableDecision>,
-  assessmentOrdering: string[],
-): number | null => {
-  for (let index = 0; index < assessmentOrdering.length; index += 1) {
-    const assessmentStepId = assessmentOrdering[index];
-    const result = assessmentToResult.get(assessmentStepId);
-    if (result === AssessmentDecision.Unsuccessful || result === NO_DECISION) {
-      return index;
-    }
-  }
-  return null;
-};
-
-export const determineCurrentStepPerCandidate = (
-  candidateToResults: Map<
-    PoolCandidateId,
-    Map<AssessmentStepId, NullableDecision>
-  >,
-  assessmentSteps: AssessmentStep[],
-): Map<PoolCandidateId, number | null> => {
-  const orderedStepIds = assessmentSteps
-    .sort((stepA, stepB) => {
-      return (stepA.sortOrder ?? Number.MAX_SAFE_INTEGER) >
-        (stepB.sortOrder ?? Number.MAX_SAFE_INTEGER)
-        ? 1
-        : -1;
-    })
-    .map((step) => step.id);
-
-  const candidateToCurrentStep = new Map<PoolCandidateId, number | null>();
-  candidateToResults.forEach((assessmentToResult, candidateId) => {
-    candidateToCurrentStep.set(
-      candidateId,
-      determineCurrentStep(assessmentToResult, orderedStepIds),
-    );
-  });
-  return candidateToCurrentStep;
-};
-
-export const getDecisionCountForEachStep = (
-  assessmentSteps: AssessmentStep[],
-  candidateToResults: Map<
-    PoolCandidateId,
-    Map<AssessmentStepId, NullableDecision>
-  >,
-  candidateToCurrentStep: Map<PoolCandidateId, number | null>,
-): Map<AssessmentStepId, ResultDecisionCounts> => {
-  const orderedSteps = sortBy(assessmentSteps, (step) => step.sortOrder);
-  const decisionCountMap = new Map<AssessmentStepId, ResultDecisionCounts>();
-  for (let index = 0; index < orderedSteps.length; index += 1) {
-    const stepId = orderedSteps[index].id;
-    const poolCandidateIds = Array.from(candidateToCurrentStep.keys());
-    const decisionsForCurrentStep = poolCandidateIds
-      .filter((candidateId) => {
-        // A candidate's result should be counted for its current step and any previous steps
-        // A null step indicates the candidate has successfully passed all assessment steps and should be counted in all of them
-        const candidateStep = candidateToCurrentStep.get(candidateId) ?? null;
-        return candidateStep === null || candidateStep >= index;
-      })
-      // For all the filtered-in candidates, get their result for this step and put them together in an array.
-      .reduce(
-        (decisions: Array<NullableDecision | undefined>, candidateId) => [
-          ...decisions,
-          candidateToResults.get(candidateId)?.get(stepId),
-        ],
-        [],
-      )
-      .filter(notEmpty);
-    decisionCountMap.set(stepId, sumDecisionTypes(decisionsForCurrentStep));
-  }
-  return decisionCountMap;
 };
 
 type StepWithGroupedCandidates = {

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -12,7 +12,7 @@ import {
   getProvinceOrTerritory,
 } from "@gc-digital-talent/i18n";
 import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
-import { Color, Pill, Spoiler } from "@gc-digital-talent/ui";
+import { Pill, Spoiler } from "@gc-digital-talent/ui";
 import {
   graphql,
   CandidateExpiryFilter,
@@ -37,10 +37,7 @@ import {
 import useRoutes from "~/hooks/useRoutes";
 import { getFullNameLabel } from "~/utils/nameUtils";
 import {
-  isDisqualifiedStatus,
-  isQualifiedStatus,
-  isRemovedStatus,
-  isToAssessStatus,
+  getFinalDecisionPillColor,
   statusToFinalDecision,
   statusToJobPlacement,
 } from "~/utils/poolCandidate";
@@ -221,28 +218,6 @@ export const currentLocationAccessor = (
       ? getProvinceOrTerritory(province as string)
       : commonMessages.notFound,
   )}`;
-
-const getFinalDecisionPillColor = (
-  status?: Maybe<PoolCandidateStatus>,
-): Color => {
-  if (isToAssessStatus(status)) {
-    return "warning";
-  }
-
-  if (isDisqualifiedStatus(status)) {
-    return "error";
-  }
-
-  if (isRemovedStatus(status)) {
-    return "black";
-  }
-
-  if (isQualifiedStatus(status)) {
-    return "success";
-  }
-
-  return "white";
-};
 
 export const finalDecisionCell = (
   intl: IntlShape,

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5207,6 +5207,10 @@
     "defaultMessage": "Modifiez vos options concernant la diversité, l’équité et l’inclusion",
     "description": "Link text to edit diversity, equity and inclusion information on profile."
   },
+  "RiGj9w": {
+    "defaultMessage": "Étape {currentStep}",
+    "description": "Label for the candidates current assessment step"
+  },
   "RjYGPw": {
     "defaultMessage": "Chercher une compétence",
     "description": "Label for the skill library table search input"

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
@@ -183,9 +183,11 @@ const PoolCandidate_SnapshotQuery = graphql(/* GraphQL */ `
         assessmentResultType
         assessmentStep {
           id
+          type
         }
         poolSkill {
           id
+          type
           skill {
             id
             key

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
@@ -16,10 +16,10 @@ import {
   CardBasic,
   Button,
   Link,
-  Chip,
+  Pill,
 } from "@gc-digital-talent/ui";
 import { commonMessages } from "@gc-digital-talent/i18n";
-import { notEmpty } from "@gc-digital-talent/helpers";
+import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import {
   User,
   Scalars,
@@ -35,6 +35,7 @@ import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import PoolStatusTable from "~/components/PoolStatusTable/PoolStatusTable";
 import AdminHero from "~/components/Hero/AdminHero";
+import { getCandidateStatusPill } from "~/utils/poolCandidate";
 
 import CareerTimelineSection from "./components/CareerTimelineSection/CareerTimelineSection";
 import ApplicationInformation from "./components/ApplicationInformation/ApplicationInformation";
@@ -161,12 +162,28 @@ const PoolCandidate_SnapshotQuery = graphql(/* GraphQL */ `
             fr
           }
         }
+        assessmentSteps {
+          id
+          title {
+            en
+            fr
+          }
+          type
+          sortOrder
+          poolSkills {
+            id
+            type
+          }
+        }
         ...ApplicationInformation_PoolFragment
       }
       assessmentResults {
         id
         assessmentDecision
         assessmentResultType
+        assessmentStep {
+          id
+        }
         poolSkill {
           id
           skill {
@@ -222,6 +239,11 @@ export const ViewPoolCandidate = ({
   const parsedSnapshot: Maybe<User> = JSON.parse(poolCandidate.profileSnapshot);
   const snapshotUserPropertyExists = !!parsedSnapshot;
   const showRichSnapshot = snapshotUserPropertyExists && preferRichView;
+  const statusPill = getCandidateStatusPill(
+    poolCandidate,
+    unpackMaybes(poolCandidate.pool.assessmentSteps),
+    intl,
+  );
 
   const sections: Record<string, SectionContent> = {
     statusForm: {
@@ -456,29 +478,33 @@ export const ViewPoolCandidate = ({
       data-h2-align-items="base(center)"
       data-h2-gap="base(x.5)"
     >
+      <Pill
+        mode="outline"
+        color={statusPill.color}
+        icon={statusPill.icon}
+        data-h2-font-weight="base(700)"
+      >
+        {statusPill.label}
+      </Pill>
       {poolCandidate.user.hasPriorityEntitlement ||
       poolCandidate.user.priorityWeight === 10 ? (
-        <Chip
-          color="black"
-          mode="outline"
-          label={intl.formatMessage({
+        <Pill color="black" mode="outline">
+          {intl.formatMessage({
             defaultMessage: "Priority",
             id: "xGMcBO",
             description: "Label for priority chip on view candidate page",
           })}
-        />
+        </Pill>
       ) : null}
       {poolCandidate.user.armedForcesStatus === ArmedForcesStatus.Veteran ||
       poolCandidate.user.priorityWeight === 20 ? (
-        <Chip
-          color="black"
-          mode="outline"
-          label={intl.formatMessage({
+        <Pill color="black" mode="outline">
+          {intl.formatMessage({
             defaultMessage: "Veteran",
             id: "16iCWc",
             description: "Label for veteran chip on view candidate page",
           })}
-        />
+        </Pill>
       ) : null}
     </div>
   );

--- a/apps/web/src/utils/poolCandidate.ts
+++ b/apps/web/src/utils/poolCandidate.ts
@@ -1,5 +1,8 @@
 import { IntlShape } from "react-intl";
 import isPast from "date-fns/isPast";
+import React from "react";
+import sortBy from "lodash/sortBy";
+import ExclamationTriangleIcon from "@heroicons/react/20/solid/ExclamationTriangleIcon";
 
 import {
   formatDate,
@@ -10,6 +13,17 @@ import {
   commonMessages,
   getPoolCandidateStatus,
 } from "@gc-digital-talent/i18n";
+import { Color, IconType } from "@gc-digital-talent/ui";
+import {
+  AssessmentDecision,
+  AssessmentResult,
+  AssessmentResultType,
+  AssessmentStep,
+  AssessmentStepType,
+  PoolCandidate,
+  PoolSkillType,
+} from "@gc-digital-talent/graphql";
+import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 
 import { Maybe, PoolCandidateStatus, PublishingGroup } from "~/api/generated";
 import poolCandidateMessages from "~/messages/poolCandidateMessages";
@@ -23,6 +37,7 @@ import {
 } from "~/constants/poolCandidate";
 
 import { isOngoingPublishingGroup } from "./poolUtils";
+import { NO_DECISION, NullableDecision } from "./assessmentResults";
 
 export const isDisqualifiedStatus = (
   status: Maybe<PoolCandidateStatus> | undefined,
@@ -97,6 +112,235 @@ export const formatSubmittedAt = (
     : "";
 };
 
+const getResultsDecision = (
+  step: AssessmentStep,
+  results?: AssessmentResult[],
+): NullableDecision => {
+  if (!results) return NO_DECISION;
+  let hasFailure: boolean = false;
+  let hasOnHold: boolean = false;
+  let hasToAssess: boolean = false;
+
+  const stepResults = results.filter((result) => {
+    return result.assessmentStep?.id === step.id;
+  });
+
+  if (stepResults.length === 0) {
+    hasToAssess = true;
+  }
+
+  const requiredSkillAssessments = step.poolSkills?.filter(
+    (poolSkill) => poolSkill?.type === PoolSkillType.Essential,
+  );
+
+  requiredSkillAssessments?.forEach((skillAssessment) => {
+    const assessmentResults = stepResults.filter((result) => {
+      return result.poolSkill?.id === skillAssessment?.id;
+    });
+
+    if (assessmentResults.length === 0) {
+      hasToAssess = true;
+      return;
+    }
+
+    assessmentResults.forEach((assessmentResult) => {
+      switch (assessmentResult.assessmentDecision) {
+        case null:
+          hasToAssess = true;
+          break;
+        case AssessmentDecision.Hold:
+          hasOnHold = true;
+          break;
+        case AssessmentDecision.Unsuccessful:
+          hasFailure = true;
+          break;
+        default:
+      }
+    });
+  });
+
+  // Check for Education requirement if this is an ApplicationScreening step
+  if (step.type === AssessmentStepType.ApplicationScreening) {
+    const educationResults = stepResults.filter(
+      (result) =>
+        result.assessmentResultType === AssessmentResultType.Education,
+    );
+    if (educationResults.length === 0) {
+      hasToAssess = true;
+    }
+    educationResults.forEach((result) => {
+      // Any "to assess" should be marked
+      if (result.assessmentDecision === null) {
+        hasToAssess = true;
+      }
+      switch (result.assessmentDecision) {
+        case null:
+          hasToAssess = true;
+          break;
+        case AssessmentDecision.Hold:
+          hasOnHold = true;
+          break;
+        case AssessmentDecision.Unsuccessful:
+          hasFailure = true;
+          break;
+        default:
+      }
+    });
+  }
+
+  if (hasFailure) {
+    return AssessmentDecision.Unsuccessful;
+  }
+  if (hasToAssess) {
+    return NO_DECISION;
+  }
+  if (hasOnHold) {
+    return AssessmentDecision.Hold;
+  }
+
+  return AssessmentDecision.Successful;
+};
+
+export type ResultDecisionCounts = Record<NullableDecision, number>;
+export type PoolCandidateId = string;
+export type AssessmentStepId = string;
+
+export const sumDecisionTypes = (results: NullableDecision[]) => {
+  const stepAccumulation: ResultDecisionCounts = {
+    [NO_DECISION]: 0,
+    [AssessmentDecision.Hold]: 0,
+    [AssessmentDecision.Successful]: 0,
+    [AssessmentDecision.Unsuccessful]: 0,
+  };
+
+  return results.reduce((accumulator: ResultDecisionCounts, result) => {
+    return {
+      ...accumulator,
+      [result]: accumulator[result] + 1,
+    };
+  }, stepAccumulation);
+};
+
+export const determineCandidateStatusPerStep = (
+  poolCandidates: PoolCandidate[],
+  steps: AssessmentStep[],
+): Map<PoolCandidateId, Map<AssessmentStepId, NullableDecision>> => {
+  return poolCandidates.reduce((candidateToResults, candidate) => {
+    const assessmentToResult = steps.reduce((map, step) => {
+      return map.set(
+        step.id,
+        getResultsDecision(step, unpackMaybes(candidate.assessmentResults)),
+      );
+    }, new Map<AssessmentStepId, NullableDecision>());
+    candidateToResults.set(candidate.id, assessmentToResult);
+    return candidateToResults;
+  }, new Map<PoolCandidateId, Map<AssessmentStepId, NullableDecision>>());
+};
+
+export const getDecisionCountForEachStep = (
+  assessmentSteps: AssessmentStep[],
+  candidateToResults: Map<
+    PoolCandidateId,
+    Map<AssessmentStepId, NullableDecision>
+  >,
+  candidateToCurrentStep: Map<PoolCandidateId, number | null>,
+): Map<AssessmentStepId, ResultDecisionCounts> => {
+  const orderedSteps = sortBy(assessmentSteps, (step) => step.sortOrder);
+  const decisionCountMap = new Map<AssessmentStepId, ResultDecisionCounts>();
+  for (let index = 0; index < orderedSteps.length; index += 1) {
+    const stepId = orderedSteps[index].id;
+    const poolCandidateIds = Array.from(candidateToCurrentStep.keys());
+    const decisionsForCurrentStep = poolCandidateIds
+      .filter((candidateId) => {
+        // A candidate's result should be counted for its current step and any previous steps
+        // A null step indicates the candidate has successfully passed all assessment steps and should be counted in all of them
+        const candidateStep = candidateToCurrentStep.get(candidateId) ?? null;
+        return candidateStep === null || candidateStep >= index;
+      })
+      // For all the filtered-in candidates, get their result for this step and put them together in an array.
+      .reduce(
+        (decisions: Array<NullableDecision | undefined>, candidateId) => [
+          ...decisions,
+          candidateToResults.get(candidateId)?.get(stepId),
+        ],
+        [],
+      )
+      .filter(notEmpty);
+    decisionCountMap.set(stepId, sumDecisionTypes(decisionsForCurrentStep));
+  }
+  return decisionCountMap;
+};
+
+/**
+ * Returns the "current step" a candidate should appear at in the assessment tracker.
+ * A candidate should appear in all columns less than or equal to its current step.
+ * A value of null means that a candidate has passed all steps.
+ * @param assessmentToResult
+ * @param assessmentOrdering
+ * @returns
+ */
+const determineCurrentStep = (
+  assessmentToResult: Map<AssessmentStepId, NullableDecision>,
+  assessmentOrdering: string[],
+): number | null => {
+  for (let index = 0; index < assessmentOrdering.length; index += 1) {
+    const assessmentStepId = assessmentOrdering[index];
+    const result = assessmentToResult.get(assessmentStepId);
+    if (result === AssessmentDecision.Unsuccessful || result === NO_DECISION) {
+      return index;
+    }
+  }
+  return null;
+};
+
+export const determineCurrentStepPerCandidate = (
+  candidateToResults: Map<
+    PoolCandidateId,
+    Map<AssessmentStepId, NullableDecision>
+  >,
+  assessmentSteps: AssessmentStep[],
+): Map<PoolCandidateId, number | null> => {
+  const orderedStepIds = assessmentSteps
+    .sort((stepA, stepB) => {
+      return (stepA.sortOrder ?? Number.MAX_SAFE_INTEGER) >
+        (stepB.sortOrder ?? Number.MAX_SAFE_INTEGER)
+        ? 1
+        : -1;
+    })
+    .map((step) => step.id);
+
+  const candidateToCurrentStep = new Map<PoolCandidateId, number | null>();
+  candidateToResults.forEach((assessmentToResult, candidateId) => {
+    candidateToCurrentStep.set(
+      candidateId,
+      determineCurrentStep(assessmentToResult, orderedStepIds),
+    );
+  });
+  return candidateToCurrentStep;
+};
+
+export const getFinalDecisionPillColor = (
+  status?: Maybe<PoolCandidateStatus>,
+): Color => {
+  if (isToAssessStatus(status)) {
+    return "warning";
+  }
+
+  if (isDisqualifiedStatus(status)) {
+    return "error";
+  }
+
+  if (isRemovedStatus(status)) {
+    return "black";
+  }
+
+  if (isQualifiedStatus(status)) {
+    return "success";
+  }
+
+  return "white";
+};
+
 export const statusToFinalDecision = (status?: Maybe<PoolCandidateStatus>) => {
   if (isToAssessStatus(status)) {
     return poolCandidateMessages.toAssess;
@@ -129,4 +373,53 @@ export const statusToJobPlacement = (status?: Maybe<PoolCandidateStatus>) => {
   }
 
   return commonMessages.notAvailable;
+};
+
+type StatusPill = {
+  color: Color;
+  label: React.ReactNode;
+  icon?: IconType;
+};
+
+export const getCandidateStatusPill = (
+  candidate: PoolCandidate,
+  steps: AssessmentStep[],
+  intl: IntlShape,
+): StatusPill => {
+  const isToAssess = isToAssessStatus(candidate.status);
+  let suffix = "";
+  let icon;
+
+  if (isToAssess) {
+    const orderedSteps = sortBy(steps, (step) => step.sortOrder);
+    const candidateResults = determineCandidateStatusPerStep(
+      [candidate],
+      orderedSteps,
+    );
+    const candidateCurrentSteps = determineCurrentStepPerCandidate(
+      candidateResults,
+      steps,
+    );
+    const currentStep = candidateCurrentSteps.get(candidate.id) ?? 0;
+
+    icon = ExclamationTriangleIcon;
+    suffix =
+      intl.formatMessage(commonMessages.dividingColon) +
+      intl.formatMessage(
+        {
+          defaultMessage: "Step {currentStep}",
+          id: "RiGj9w",
+          description: "Label for the candidates current assessment step",
+        },
+        {
+          currentStep: currentStep + 1,
+        },
+      );
+  }
+
+  return {
+    label: intl.formatMessage(statusToFinalDecision(candidate.status)) + suffix,
+    color: getFinalDecisionPillColor(candidate.status),
+    icon,
+  };
 };


### PR DESCRIPTION
🤖 Resolves #9131 

## 👋 Introduction

Adds a badge to the header of a pool candidate showing the "final decision" from the candidate table with some additional detail. If the user has the "to assess" status, it adds the current step from the assessment step tracker and an icon.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure you have `FEATURE_RECORD_OF_DECISION=true` in your `.env` file
2. Build `npm run dev`
3. Login as admin and navigate to `/admin/pool-candidates`
4. Click on the "view" link for candidates with different final decisions
5. Confirm the badge matches the descision
6. Confirm "to assess" has the triangle icon along with the current step

## 📸 Screenshot

![Screenshot 2024-01-30 115458](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/0dfe34b4-779e-49bf-b7f3-f52f40295da2)
