### PR TITLE
[Fix] Update user skill return path

### DIFF
--- a/apps/web/src/components/SkillRankCard/SkillRankListItem.tsx
+++ b/apps/web/src/components/SkillRankCard/SkillRankListItem.tsx
@@ -19,10 +19,12 @@ interface SkillLinkProps {
 
 const SkillLink = ({ id, children }: SkillLinkProps) => {
   const paths = useRoutes();
+  const searchParams = new URLSearchParams();
+  searchParams.set("from", "showcase");
 
   return (
     <Link
-      href={paths.editUserSkill(id ?? "")}
+      href={`${paths.editUserSkill(id ?? "")}?${searchParams.toString()}`}
       mode="text"
       color="black"
       data-h2-text-align="base(left)"
@@ -35,6 +37,7 @@ const SkillLink = ({ id, children }: SkillLinkProps) => {
 interface SkillRankListItemProps {
   userSkill: UserSkill;
   editable?: boolean;
+  from?: string;
 }
 
 const SkillRankListItem = ({

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -229,15 +229,19 @@ export const UpdateUserSkillForm = ({
       label: intl.formatMessage(navigationMessages.profileAndApplications),
       url: paths.profileAndApplications(),
     },
-    fromShowcase
-      ? {
-          label: intl.formatMessage(navigationMessages.skillShowcase),
-          url: paths.skillShowcase(),
-        }
-      : {
-          label: intl.formatMessage(navigationMessages.skillLibrary),
-          url: paths.skillLibrary(),
-        },
+
+    {
+      label: intl.formatMessage(navigationMessages.skillLibrary),
+      url: paths.skillLibrary(),
+    },
+    ...(fromShowcase
+      ? [
+          {
+            label: intl.formatMessage(navigationMessages.skillShowcase),
+            url: paths.skillShowcase(),
+          },
+        ]
+      : []),
     {
       label: skillName,
       url: paths.editUserSkill(skill.id),

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useIntl } from "react-intl";
 import LightBulbIcon from "@heroicons/react/24/outline/LightBulbIcon";
 import BookmarkSquareIcon from "@heroicons/react/24/outline/BookmarkSquareIcon";
@@ -120,11 +120,17 @@ export const UpdateUserSkillForm = ({
   const intl = useIntl();
   const paths = useRoutes();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const skillName = getLocalizedName(skill.name, intl);
   const skillDescription = getLocalizedName(skill.description, intl);
   const hasUserSkill = notEmpty(userSkill);
   const isTechnical = skill.category === SkillCategory.Technical;
   const linkedExperiences = userSkill?.experiences?.filter(notEmpty);
+  const from = searchParams.get("from");
+  const fromShowcase = from && from === "showcase";
+  const returnPath = fromShowcase
+    ? paths.skillShowcase()
+    : paths.skillLibrary();
 
   const availableExperiences = experiences.filter(
     (exp) =>
@@ -150,7 +156,7 @@ export const UpdateUserSkillForm = ({
           description: "Message displayed when a user updates a skill",
         }),
     );
-    navigate(paths.skillLibrary());
+    navigate(returnPath);
   };
 
   const handleError = (msg?: React.ReactNode) => {
@@ -223,10 +229,15 @@ export const UpdateUserSkillForm = ({
       label: intl.formatMessage(navigationMessages.profileAndApplications),
       url: paths.profileAndApplications(),
     },
-    {
-      label: intl.formatMessage(navigationMessages.skillLibrary),
-      url: paths.skillLibrary(),
-    },
+    fromShowcase
+      ? {
+          label: intl.formatMessage(navigationMessages.skillShowcase),
+          url: paths.skillShowcase(),
+        }
+      : {
+          label: intl.formatMessage(navigationMessages.skillLibrary),
+          url: paths.skillLibrary(),
+        },
     {
       label: skillName,
       url: paths.editUserSkill(skill.id),


### PR DESCRIPTION
🤖 Resolves #9062 

## 👋 Introduction

This updates the update user skill page to return to the skill showcase when that is where the user came from. In addition, the breadcrumbs were not accurate so have been updated to also indicate that the skill showcase is included when coming from there.

## 🕵️ Details

It seems that the user can only get here from the library or showcase. So, instead of using a path I simply used "showcase" so we can update the return path and breadcrumbs based on that.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login as an applicant
3. Navigate to your skill showcase `/applicant/profile-and-applications/skills/showcase`
4. If a skill does not exist yet, add one
5. Click on a skill title to edit it
6. Confirm the a `?from=showcase` appears in the URL
7. Confirm the breadcrumbs appear as expected
8. Save the form
9. Confirm you are returned to the showcase and not library
10. Navigate to the skill library `/applicant/profile-and-applications/skills`
11. Click on a skill to edit it
12. Save the form
13. Confirm you are returned to the library

