### PR TITLE
[Feature] Basic filters for `AssessmentStepTracker`

### DIFF
--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.test.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.test.tsx
@@ -282,7 +282,7 @@ describe("AssessmentStepTracker", () => {
       groupedResults,
     );
 
-    // Five item should be removed (unassessed candidate)
+    // Five item should be removed (successful candidates)
     expect(noSuccessfulResults.length).toEqual(testCandidates.length - 5);
     expect(noSuccessfulResults).not.toEqual(
       expect.arrayContaining([
@@ -300,7 +300,7 @@ describe("AssessmentStepTracker", () => {
       groupedResults,
     );
 
-    // Five item should be removed (unassessed candidate)
+    // Five item should be removed (unsuccessful candidate)
     expect(noUnsuccessfulResults.length).toEqual(testCandidates.length - 1);
     expect(noUnsuccessfulResults).not.toEqual(
       expect.arrayContaining([
@@ -318,9 +318,29 @@ describe("AssessmentStepTracker", () => {
       groupedResults,
     );
 
-    // Five item should be removed (unassessed candidate)
+    // Five item should be removed (on hold candidate)
     expect(noHoldResults.length).toEqual(testCandidates.length - 1);
     expect(noHoldResults).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          decision: AssessmentDecision.Hold,
+        }),
+      ]),
+    );
+
+    //
+    const [{ results: noHoldOrSuccessResults }] = filterResults(
+      {
+        ...defaultFilters,
+        [AssessmentDecision.Hold]: false,
+        [AssessmentDecision.Successful]: false,
+      },
+      groupedResults,
+    );
+
+    // Fix items should be removed (successful + on hold candidate)
+    expect(noHoldOrSuccessResults.length).toEqual(testCandidates.length - 6);
+    expect(noHoldOrSuccessResults).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           decision: AssessmentDecision.Hold,

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
@@ -14,8 +14,9 @@ import {
   ResultFilters,
   filterResults,
   groupPoolCandidatesByStep,
+  defaultFilters,
 } from "./utils";
-import Filters, { initialValues } from "./Filters";
+import Filters from "./Filters";
 
 export interface AssessmentStepTrackerProps {
   pool: Pool;
@@ -23,7 +24,7 @@ export interface AssessmentStepTrackerProps {
 
 const AssessmentStepTracker = ({ pool }: AssessmentStepTrackerProps) => {
   const intl = useIntl();
-  const [filters, setFilters] = React.useState<ResultFilters>(initialValues);
+  const [filters, setFilters] = React.useState<ResultFilters>(defaultFilters);
   const steps = unpackMaybes(pool.assessmentSteps);
   const candidates = unpackMaybes(pool.poolCandidates);
   const groupedSteps = groupPoolCandidatesByStep(steps, candidates);

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
@@ -4,13 +4,18 @@ import { useIntl } from "react-intl";
 import { Board } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { Pool } from "@gc-digital-talent/graphql";
 
-import { Pool } from "~/api/generated";
 import applicationMessages from "~/messages/applicationMessages";
 
 import ResultsDetails from "./ResultsDetails";
 import AssessmentResults from "./AssessmentResults";
-import { groupPoolCandidatesByStep } from "./utils";
+import {
+  ResultFilters,
+  filterResults,
+  groupPoolCandidatesByStep,
+} from "./utils";
+import Filters, { initialValues } from "./Filters";
 
 export interface AssessmentStepTrackerProps {
   pool: Pool;
@@ -18,26 +23,34 @@ export interface AssessmentStepTrackerProps {
 
 const AssessmentStepTracker = ({ pool }: AssessmentStepTrackerProps) => {
   const intl = useIntl();
+  const [filters, setFilters] = React.useState<ResultFilters>(initialValues);
   const steps = unpackMaybes(pool.assessmentSteps);
   const candidates = unpackMaybes(pool.poolCandidates);
   const groupedSteps = groupPoolCandidatesByStep(steps, candidates);
 
+  const filteredSteps = React.useMemo(() => {
+    return filterResults(filters, groupedSteps);
+  }, [groupedSteps, filters]);
+
   return (
-    <Board.Root>
-      {groupedSteps.map(({ step, resultCounts, results }, index) => (
-        <Board.Column key={step.id}>
-          <Board.ColumnHeader
-            prefix={intl.formatMessage(applicationMessages.numberedStep, {
-              stepOrdinal: index + 1,
-            })}
-          >
-            {getLocalizedName(step.title, intl)}
-          </Board.ColumnHeader>
-          <ResultsDetails {...{ resultCounts, step }} />
-          <AssessmentResults stepType={step.type} {...{ results }} />
-        </Board.Column>
-      ))}
-    </Board.Root>
+    <>
+      <Filters onFiltersChange={setFilters} />
+      <Board.Root>
+        {filteredSteps.map(({ step, resultCounts, results }, index) => (
+          <Board.Column key={step.id}>
+            <Board.ColumnHeader
+              prefix={intl.formatMessage(applicationMessages.numberedStep, {
+                stepOrdinal: index + 1,
+              })}
+            >
+              {getLocalizedName(step.title, intl)}
+            </Board.ColumnHeader>
+            <ResultsDetails {...{ resultCounts, step }} />
+            <AssessmentResults stepType={step.type} {...{ results }} />
+          </Board.Column>
+        ))}
+      </Board.Root>
+    </>
   );
 };
 

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
@@ -28,10 +28,7 @@ const AssessmentStepTracker = ({ pool }: AssessmentStepTrackerProps) => {
   const steps = unpackMaybes(pool.assessmentSteps);
   const candidates = unpackMaybes(pool.poolCandidates);
   const groupedSteps = groupPoolCandidatesByStep(steps, candidates);
-
-  const filteredSteps = React.useMemo(() => {
-    return filterResults(filters, groupedSteps);
-  }, [groupedSteps, filters]);
+  const filteredSteps = filterResults(filters, groupedSteps);
 
   return (
     <>

--- a/apps/web/src/components/AssessmentStepTracker/Filters.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/Filters.tsx
@@ -12,15 +12,9 @@ import { Field, Input, SwitchInput } from "@gc-digital-talent/forms";
 import { NO_DECISION } from "~/utils/assessmentResults";
 import poolCandidateMessages from "~/messages/poolCandidateMessages";
 
-export type FormValues = {
-  query: string;
-  [NO_DECISION]: boolean;
-  [AssessmentDecision.Successful]: boolean;
-  [AssessmentDecision.Hold]: boolean;
-  [AssessmentDecision.Unsuccessful]: boolean;
-};
+import { ResultFilters } from "./utils";
 
-export const initialValues: FormValues = {
+export const initialValues: ResultFilters = {
   query: "",
   [NO_DECISION]: true,
   [AssessmentDecision.Successful]: true,
@@ -29,8 +23,8 @@ export const initialValues: FormValues = {
 };
 
 interface FiltersProps {
-  defaultValues?: FormValues;
-  onFiltersChange: (newFilters: FormValues) => void;
+  defaultValues?: ResultFilters;
+  onFiltersChange: (newFilters: ResultFilters) => void;
 }
 
 const Filters = ({
@@ -38,7 +32,7 @@ const Filters = ({
   defaultValues = initialValues,
 }: FiltersProps) => {
   const intl = useIntl();
-  const methods = useForm<FormValues>({
+  const methods = useForm<ResultFilters>({
     defaultValues: {
       ...initialValues,
       ...defaultValues,

--- a/apps/web/src/components/AssessmentStepTracker/Filters.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/Filters.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { useForm, FormProvider } from "react-hook-form";
+import { useIntl } from "react-intl";
+import ExclamationCircleIcon from "@heroicons/react/20/solid/ExclamationCircleIcon";
+import CheckCircleIcon from "@heroicons/react/20/solid/CheckCircleIcon";
+import PauseCircleIcon from "@heroicons/react/20/solid/PauseCircleIcon";
+import XCircleIcon from "@heroicons/react/20/solid/XCircleIcon";
+
+import { AssessmentDecision } from "@gc-digital-talent/graphql";
+import { Field, Input, SwitchInput } from "@gc-digital-talent/forms";
+
+import { NO_DECISION } from "~/utils/assessmentResults";
+import poolCandidateMessages from "~/messages/poolCandidateMessages";
+
+export type FormValues = {
+  query: string;
+  [NO_DECISION]: boolean;
+  [AssessmentDecision.Successful]: boolean;
+  [AssessmentDecision.Hold]: boolean;
+  [AssessmentDecision.Unsuccessful]: boolean;
+};
+
+export const initialValues: FormValues = {
+  query: "",
+  [NO_DECISION]: true,
+  [AssessmentDecision.Successful]: true,
+  [AssessmentDecision.Hold]: true,
+  [AssessmentDecision.Unsuccessful]: true,
+};
+
+interface FiltersProps {
+  defaultValues?: FormValues;
+  onFiltersChange: (newFilters: FormValues) => void;
+}
+
+const Filters = ({
+  onFiltersChange,
+  defaultValues = initialValues,
+}: FiltersProps) => {
+  const intl = useIntl();
+  const methods = useForm<FormValues>({
+    defaultValues: {
+      ...initialValues,
+      ...defaultValues,
+    },
+    mode: "onChange",
+  });
+  const { watch, handleSubmit } = methods;
+
+  React.useEffect(() => {
+    const subscription = watch((newValues) => {
+      onFiltersChange({
+        ...initialValues,
+        ...newValues,
+      });
+    });
+
+    return () => subscription.unsubscribe();
+  }, [watch, handleSubmit, onFiltersChange]);
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={methods.handleSubmit(onFiltersChange)}>
+        <div
+          data-h2-display="base(flex)"
+          data-h2-align-items="base(flex-end)"
+          data-h2-gap="base(x.5)"
+          data-h2-margin-bottom="base(x.5)"
+        >
+          <Input
+            name="query"
+            id="query"
+            type="text"
+            label={intl.formatMessage({
+              defaultMessage: "Filter candidates by name",
+              id: "ZAcxSx",
+              description: "Label for candidate search input",
+            })}
+          />
+          <Field.Fieldset>
+            <Field.Legend>
+              {intl.formatMessage({
+                defaultMessage: "Filter candidates by status",
+                id: "QsILUL",
+                description:
+                  "Legend for filtering candidates by assessment decisions",
+              })}
+            </Field.Legend>
+            <Field.BoundingBox
+              data-h2-border-color="base(gray) base:focus-visible(focus)"
+              data-h2-flex-direction="base(row)"
+              data-h2-gap="base(x.25)"
+              // To match input off by 0.01px
+              data-h2-padding="base(x.4)"
+            >
+              <SwitchInput
+                name={NO_DECISION}
+                id={NO_DECISION}
+                label={intl.formatMessage(poolCandidateMessages.toAssess)}
+                color="warning"
+                hideLabel
+                icon={{
+                  default: ExclamationCircleIcon,
+                }}
+              />
+              <SwitchInput
+                name={AssessmentDecision.Successful}
+                id={AssessmentDecision.Successful}
+                label={intl.formatMessage(poolCandidateMessages.successful)}
+                color="success"
+                hideLabel
+                icon={{
+                  default: CheckCircleIcon,
+                }}
+              />
+              <SwitchInput
+                name={AssessmentDecision.Hold}
+                id={AssessmentDecision.Hold}
+                label={intl.formatMessage(poolCandidateMessages.onHold)}
+                color="warning"
+                hideLabel
+                icon={{
+                  default: PauseCircleIcon,
+                }}
+              />
+              <SwitchInput
+                name={AssessmentDecision.Unsuccessful}
+                id={AssessmentDecision.Unsuccessful}
+                label={intl.formatMessage(poolCandidateMessages.unsuccessful)}
+                color="error"
+                hideLabel
+                icon={{
+                  default: XCircleIcon,
+                }}
+              />
+            </Field.BoundingBox>
+          </Field.Fieldset>
+        </div>
+      </form>
+    </FormProvider>
+  );
+};
+
+export default Filters;

--- a/apps/web/src/components/AssessmentStepTracker/Filters.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/Filters.tsx
@@ -12,15 +12,7 @@ import { Field, Input, SwitchInput } from "@gc-digital-talent/forms";
 import { NO_DECISION } from "~/utils/assessmentResults";
 import poolCandidateMessages from "~/messages/poolCandidateMessages";
 
-import { ResultFilters } from "./utils";
-
-export const initialValues: ResultFilters = {
-  query: "",
-  [NO_DECISION]: true,
-  [AssessmentDecision.Successful]: true,
-  [AssessmentDecision.Hold]: true,
-  [AssessmentDecision.Unsuccessful]: true,
-};
+import { ResultFilters, defaultFilters } from "./utils";
 
 interface FiltersProps {
   defaultValues?: ResultFilters;
@@ -29,12 +21,12 @@ interface FiltersProps {
 
 const Filters = ({
   onFiltersChange,
-  defaultValues = initialValues,
+  defaultValues = defaultFilters,
 }: FiltersProps) => {
   const intl = useIntl();
   const methods = useForm<ResultFilters>({
     defaultValues: {
-      ...initialValues,
+      ...defaultFilters,
       ...defaultValues,
     },
     mode: "onChange",
@@ -44,7 +36,7 @@ const Filters = ({
   React.useEffect(() => {
     const subscription = watch((newValues) => {
       onFiltersChange({
-        ...initialValues,
+        ...defaultFilters,
         ...newValues,
       });
     });

--- a/apps/web/src/components/AssessmentStepTracker/testData.ts
+++ b/apps/web/src/components/AssessmentStepTracker/testData.ts
@@ -20,7 +20,7 @@ faker.seed(0);
 
 const fakePool = fakePools(1)[0];
 const fakePoolAssessmentSteps = fakeAssessmentSteps(2);
-const fakeCandidates = fakePoolCandidates(6);
+const fakeCandidates = fakePoolCandidates(8);
 
 const requiredAssessment = {
   ...fakePoolAssessmentSteps[0],
@@ -124,6 +124,32 @@ export const firstByName: PoolCandidate = {
     armedForcesStatus: ArmedForcesStatus.NonCaf,
   },
 };
+export const secondLastByStatus: PoolCandidate = {
+  ...fakeCandidates[6],
+  id: "second-last-by-status",
+  isBookmarked: false,
+  assessmentResults: [getAssessmentResult(AssessmentDecision.Hold)],
+  user: {
+    id: faker.string.uuid(),
+    firstName: "on",
+    lastName: "hold",
+    hasPriorityEntitlement: false,
+    armedForcesStatus: ArmedForcesStatus.NonCaf,
+  },
+};
+export const lastByStatus: PoolCandidate = {
+  ...fakeCandidates[7],
+  id: "last-by-status",
+  isBookmarked: false,
+  assessmentResults: [getAssessmentResult(AssessmentDecision.Unsuccessful)],
+  user: {
+    id: faker.string.uuid(),
+    firstName: "not",
+    lastName: "successful",
+    hasPriorityEntitlement: false,
+    armedForcesStatus: ArmedForcesStatus.NonCaf,
+  },
+};
 
 export const testCandidates = [
   priorityEntitlementCandidate,
@@ -132,6 +158,8 @@ export const testCandidates = [
   unassessedCandidate,
   lastByFirstName,
   firstByName,
+  lastByStatus,
+  secondLastByStatus,
 ];
 
 // eslint-disable-next-line import/prefer-default-export

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -54,12 +54,7 @@ export const getDecisionInfo = (
       colorStyle: {
         "data-h2-color": "base(warning)",
       },
-      name: intl.formatMessage({
-        defaultMessage: "On hold",
-        id: "qA8+f5",
-        description:
-          "Message displayed when candidate was unsuccessful but put on hold",
-      }),
+      name: intl.formatMessage(poolCandidateMessages.onHold),
     };
   }
 
@@ -70,18 +65,8 @@ export const getDecisionInfo = (
         "data-h2-color": "base(error)",
       },
       name: isApplicationStep
-        ? intl.formatMessage({
-            defaultMessage: "Screened out",
-            id: "3xCX4b",
-            description:
-              "Message displayed when candidate has been screened out at a specific assessment step",
-          })
-        : intl.formatMessage({
-            defaultMessage: "Unsuccessful",
-            id: "TIAla1",
-            description:
-              "Message displayed when candidate has not passed an assessment step",
-          }),
+        ? intl.formatMessage(poolCandidateMessages.screenedOut)
+        : intl.formatMessage(poolCandidateMessages.unsuccessful),
     };
   }
 
@@ -91,18 +76,8 @@ export const getDecisionInfo = (
       "data-h2-color": "base(success)",
     },
     name: isApplicationStep
-      ? intl.formatMessage({
-          defaultMessage: "Screened in",
-          id: "3W/NbE",
-          description:
-            "Message displayed when candidate has been screened in at a specific assessment step",
-        })
-      : intl.formatMessage({
-          defaultMessage: "Successful",
-          id: "Whq2Xl",
-          description:
-            "Message displayed when candidate has successfully passed an assessment step",
-        }),
+      ? intl.formatMessage(poolCandidateMessages.screenedIn)
+      : intl.formatMessage(poolCandidateMessages.successful),
   };
 };
 

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -459,25 +459,7 @@ export const filterResults = (
           }
         }
 
-        let available: boolean = true;
-        switch (decision) {
-          case NO_DECISION:
-            available = !!filters[NO_DECISION];
-            break;
-          case AssessmentDecision.Hold:
-            available = !!filters[AssessmentDecision.Hold];
-            break;
-          case AssessmentDecision.Successful:
-            available = !!filters[AssessmentDecision.Successful];
-            break;
-          case AssessmentDecision.Unsuccessful:
-            available = !!filters[AssessmentDecision.Unsuccessful];
-            break;
-          default:
-            break;
-        }
-
-        return available;
+        return filters[decision];
       },
     );
 

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -443,10 +443,6 @@ export const defaultFilters: ResultFilters = {
   [AssessmentDecision.Unsuccessful]: true,
 };
 
-const statusIsAvailable = (filter?: boolean) => {
-  return typeof filter !== "undefined" && filter;
-};
-
 export const filterResults = (
   filters: ResultFilters,
   steps: StepWithGroupedCandidates[],
@@ -466,20 +462,16 @@ export const filterResults = (
         let available: boolean = true;
         switch (decision) {
           case NO_DECISION:
-            available = statusIsAvailable(filters[NO_DECISION]);
+            available = !!filters[NO_DECISION];
             break;
           case AssessmentDecision.Hold:
-            available = statusIsAvailable(filters[AssessmentDecision.Hold]);
+            available = !!filters[AssessmentDecision.Hold];
             break;
           case AssessmentDecision.Successful:
-            available = statusIsAvailable(
-              filters[AssessmentDecision.Successful],
-            );
+            available = !!filters[AssessmentDecision.Successful];
             break;
           case AssessmentDecision.Unsuccessful:
-            available = statusIsAvailable(
-              filters[AssessmentDecision.Unsuccessful],
-            );
+            available = !!filters[AssessmentDecision.Unsuccessful];
             break;
           default:
             break;

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -435,6 +435,14 @@ export type ResultFilters = {
   [AssessmentDecision.Unsuccessful]: boolean;
 };
 
+export const defaultFilters: ResultFilters = {
+  query: "",
+  [NO_DECISION]: true,
+  [AssessmentDecision.Successful]: true,
+  [AssessmentDecision.Hold]: true,
+  [AssessmentDecision.Unsuccessful]: true,
+};
+
 const statusIsAvailable = (filter?: boolean) => {
   return typeof filter !== "undefined" && filter;
 };

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5047,6 +5047,10 @@
     "defaultMessage": "Ces renseignements seront utilisés sous une forme anonyme à des fins statistiques.",
     "description": "Explanation on how employment equity information will be used, item three"
   },
+  "QsILUL": {
+    "defaultMessage": "Filtrer les candidats par ordre de statut",
+    "description": "Legend for filtering candidates by assessment decisions"
+  },
   "QsWizb": {
     "defaultMessage": "<strong>Vous n’avez pas de compte CléGC?</strong> <a>Créez-en un</a>.",
     "description": "Instruction on what to do if user does not have a GCKey"
@@ -6542,6 +6546,10 @@
   "ZA20CY": {
     "defaultMessage": "Tous les cadres n’ont pas eu l’occasion de gérer leurs propres processus de recrutement. Si ce domaine éveille votre intérêt, pensez à acquérir de l’expérience en participant de manière volontaire à une équipe interministérielle responsable du déroulement du processus sur la plateforme.",
     "description": "Text displayed for gaining hiring experience"
+  },
+  "ZAcxSx": {
+    "defaultMessage": "Filtrer les candidats par ordre de nom",
+    "description": "Label for candidate search input"
   },
   "ZAeStR": {
     "defaultMessage": "Compétences à améliorer",

--- a/apps/web/src/messages/poolCandidateMessages.ts
+++ b/apps/web/src/messages/poolCandidateMessages.ts
@@ -55,6 +55,36 @@ const messages = defineMessages({
     description:
       "Messaged displayed when a user is qualified but has yet to be placed",
   },
+  successful: {
+    defaultMessage: "Successful",
+    id: "Whq2Xl",
+    description:
+      "Message displayed when candidate has successfully passed an assessment step",
+  },
+  screenedIn: {
+    defaultMessage: "Screened in",
+    id: "3W/NbE",
+    description:
+      "Message displayed when candidate has been screened in at a specific assessment step",
+  },
+  unsuccessful: {
+    defaultMessage: "Unsuccessful",
+    id: "TIAla1",
+    description:
+      "Message displayed when candidate has not passed an assessment step",
+  },
+  screenedOut: {
+    defaultMessage: "Screened out",
+    id: "3xCX4b",
+    description:
+      "Message displayed when candidate has been screened out at a specific assessment step",
+  },
+  onHold: {
+    defaultMessage: "On hold",
+    id: "qA8+f5",
+    description:
+      "Message displayed when candidate was unsuccessful but put on hold",
+  },
 });
 
 export default messages;

--- a/packages/jest-helpers/src/index.ts
+++ b/packages/jest-helpers/src/index.ts
@@ -1,6 +1,7 @@
 import "./mocks/drag";
 import "./mocks/clipboard";
 import "./mocks/matchMedia";
+import "./mocks/resizeObserver";
 
 import Providers from "./components/Providers";
 import axeTest from "./utils/axe";

--- a/packages/jest-helpers/src/mocks/resizeObserver.ts
+++ b/packages/jest-helpers/src/mocks/resizeObserver.ts
@@ -1,0 +1,17 @@
+/* eslint-disable class-methods-use-this */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+class ResizeObserverMock {
+  observe() {
+    // Pass
+  }
+
+  unobserve() {
+    // Pass
+  }
+
+  disconnect() {
+    // Pass
+  }
+}
+
+(globalThis as any).ResizeObserver = ResizeObserverMock;


### PR DESCRIPTION
🤖 Resolves #9016 

## 👋 Introduction

Adds some basic filters for the `AssessmentStepTracker` component.

- Candidate name search
- Status (decision) toggles

## 🕵️ Details

The test I wrote only test one filter at a time. Would it be worth it to try some combinations of filters? 🤔 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Open storybook `npm run storybook:web`
3. Navigate to the "Assessment Step Tracker" story
4. Play around with the filters
5. Confirm they act as you expect

## 📸 Screenshot

![Screenshot 2024-01-31 143341](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/d64f360a-81fd-4471-8ae5-93410095c8bb)
