### PR TITLE
[Fix] Update position of skill error

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -322,27 +322,30 @@ export const ApplicationSkills = ({
       ) : null}
       <FormProvider {...methods}>
         <form onSubmit={methods.handleSubmit(handleSubmit)}>
-          <Input
-            id="skillsMissingExperiences"
-            name="skillsMissingExperiences"
-            label=""
-            type="number"
-            hidden
-            rules={{
-              max: {
-                value: 0,
-                message: intl.formatMessage(
-                  apiMessages.MISSING_ESSENTIAL_SKILLS,
-                ),
-              },
-            }}
-          />
           <Separator
             orientation="horizontal"
             decorative
             data-h2-background="base(gray)"
             data-h2-margin="base(x2, 0)"
           />
+          {/* -x.25 removes stray gap from flex layout */}
+          <div data-h2-margin="base(-x.25 0 x1 0)">
+            <Input
+              id="skillsMissingExperiences"
+              name="skillsMissingExperiences"
+              label=""
+              type="number"
+              hidden
+              rules={{
+                max: {
+                  value: 0,
+                  message: intl.formatMessage(
+                    apiMessages.MISSING_ESSENTIAL_SKILLS,
+                  ),
+                },
+              }}
+            />
+          </div>
           <div
             data-h2-display="base(flex)"
             data-h2-gap="base(x1)"


### PR DESCRIPTION
🤖 Resolves #9027 

## 👋 Introduction

Moves the error message for skill requirements on the application so that it no longer appears to be associated with the optional skills.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login and an applicant `applicant@test.com`
3. Start an application
4. Continue through the process until the "Skill requirements" page
5. Force an error
6. Scroll to the bottom and confirm the error message appears below the `Separator`

## 📸 Screenshot

![Screenshot 2024-02-01 081541](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/28eec32c-37ea-489e-983a-cdf971a6a329)
