### PR TITLE
[Fix] "X" button clears multi combobox input

### DIFF
--- a/packages/forms/src/components/Combobox/Multi.tsx
+++ b/packages/forms/src/components/Combobox/Multi.tsx
@@ -193,9 +193,8 @@ const Multi = ({
   }, [options]);
 
   const handleClear = () => {
-    if (onInputChange) {
-      onInputChange("");
-    }
+    setInputValue("");
+    onInputChange?.("");
     inputRef?.current?.focus();
   };
 


### PR DESCRIPTION
🤖 Resolves #9060 

## 👋 Introduction

Fixes an issue where the input was not empty after activating the clear action.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to the search talent page `/search`
3. Scroll down to the "Skills selection" section
4. Select a family to display the skill picker
5. Type something into the text input
6. Active the "X" button in the input
7. Confirm the input is emptied and focused
