### PR TITLE
[Fix] Updates refresh endpoint response type to json

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -136,6 +136,6 @@ class AuthController extends Controller
                 'refresh_token' => $refreshToken,
             ]);
 
-        return response($response);
+        return response($response)->header('Content-Type', 'application/json');
     }
 }


### PR DESCRIPTION
🤖 Resolves #9148.

## 👋 Introduction

This PR changes the response type to JSON for the refresh endpoint.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `http://localhost:8000/refresh?refresh_token=test`
2. Observe **Content-type** value is **application/json**

## 📸 Screenshot
<img width="560" alt="Screen Shot 2024-02-01 at 11 56 55" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/a8ee5c18-b5db-490f-a908-db827606fd12">

