### PR TITLE
[Fix] Prevent `PoolCandidate` authorized to view scope error

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -675,8 +675,12 @@ class PoolCandidate extends Model
      */
     public function scopeAuthorizedToView(Builder $query)
     {
-        $userId = Auth::user()->id;
-        $user = User::find($userId);
+        $authUser = Auth::user();
+        if (! $authUser) {
+            return $query->where('id', null);
+        }
+
+        $user = User::find($authUser->id);
         if (! $user->isAbleTo('view-any-application')) {
             $query->where(function (Builder $query) use ($user) {
                 if ($user->isAbleTo('view-any-submittedApplication')) {

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -675,7 +675,9 @@ class PoolCandidate extends Model
      */
     public function scopeAuthorizedToView(Builder $query)
     {
-        $user = User::find(Auth::id());
+        /** @var \App\Models\User */
+        $user = Auth::user();
+
         if (! $user) {
             return $query->where('id', null);
         }

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -675,12 +675,11 @@ class PoolCandidate extends Model
      */
     public function scopeAuthorizedToView(Builder $query)
     {
-        $authUser = Auth::user();
-        if (! $authUser) {
+        $user = User::find(Auth::id());
+        if (! $user) {
             return $query->where('id', null);
         }
 
-        $user = User::find($authUser->id);
         if (! $user->isAbleTo('view-any-application')) {
             $query->where(function (Builder $query) use ($user) {
                 if ($user->isAbleTo('view-any-submittedApplication')) {

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -871,6 +871,7 @@ class User extends Model implements Authenticatable, LaratrustUser
 
     public function scopeAuthorizedToView(Builder $query)
     {
+        /** @var \App\Models\User */
         $user = Auth::user();
 
         if (! $user) {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -173,6 +173,7 @@ type Pool {
   poolCandidates: [PoolCandidate]
     @hasMany(relation: "publishedPoolCandidates", scopes: ["authorizedToView"])
     @can(ability: "view", resolved: true)
+    @guard
   keyTasks: LocalizedString @rename(attribute: "key_tasks")
   yourImpact: LocalizedString @rename(attribute: "your_impact")
   whatToExpect: LocalizedString @rename(attribute: "what_to_expect")


### PR DESCRIPTION
🤖 Resolves #9153 

## 👋 Introduction

This adds better protection to the `Pool.poolCandidates` field in our schema.

## 🕵️ Details

As far as Peter and I could tell, this was happening during our auth flakiness the other week(?). What was happening was, authenticated users were accessing the `Pool.poolCandidates` field in some weird time when they were not authenticated.

Since our `pools` query is not guarded, they could access that.  But we did not have a `@guard` directive on the `poolCandidates` field. The `@can` should have saw no user and rejected it but for some reason, the scope is evaluated first here 🤷‍♀️ .

So, this did two things:

- Added a `@guard` to `Pool.poolCandidates` (we only want authenticated users accessing this anyway)
- Did a quick check in the scope to make sure a user exists just in case (this is a little odd but extra careful)

## 🧪 Testing

```graphql
query {
  pools {
    id
    poolCandidates {
      id
    }
  }
}
```

1. Ensure you have no default auth user in the `api/.env` file
2. Navigate to `/graphiql`
3. Run the provided quiery
4. Confirm you get "unauthenticated" error
5. Remove the poolCandidates field from the query
6. Confirm you can still get pools

## 📸 Screenshot

![Screenshot 2024-02-01 131303](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/527893cd-442b-4051-a323-0c667066590d)
