### PR TITLE
[Fix] Changes meta URL to production value

### DIFF
--- a/apps/web/webpack.base.js
+++ b/apps/web/webpack.base.js
@@ -6,16 +6,18 @@ require("dotenv").config({ path: "./.env" });
 
 const basePath = path.resolve(__dirname);
 
-const appUrl = process.env.APP_URL ?? "http://localhost:8000";
+const appUrl = process.env.APP_URL ?? "https://talent.canada.ca";
 
 const meta = {
-  title: process.env.APP_TITLE ?? "GC Digital Talent | Talents numériques du GC",
+  title:
+    process.env.APP_TITLE ?? "GC Digital Talent | Talents numériques du GC",
   description:
-    process.env.APP_DESCRIPTION ?? "Recruitment platform for digital jobs in the Government of Canada. Plateforme de recrutement pour les emplois numériques au gouvernement du Canada.",
+    process.env.APP_DESCRIPTION ??
+    "Recruitment platform for digital jobs in the Government of Canada. Plateforme de recrutement pour les emplois numériques au gouvernement du Canada.",
   url: appUrl,
   domain: process.env.APP_DOMAIN ?? "talent.canada.ca",
   image: `${appUrl}/images/digital-talent/banner.jpg`,
-}
+};
 
 module.exports = merge(base(basePath, meta), {
   entry: {

--- a/apps/web/webpack.base.js
+++ b/apps/web/webpack.base.js
@@ -6,7 +6,7 @@ require("dotenv").config({ path: "./.env" });
 
 const basePath = path.resolve(__dirname);
 
-const appUrl = process.env.APP_URL ?? "https://talent.canada.ca";
+const appUrl = "https://talent.canada.ca";
 
 const meta = {
   title:


### PR DESCRIPTION
🤖 Resolves #9134.

## 👋 Introduction

This PR changes meta URL to production value so that social sharing works in production.

> [!NOTE]  
> This fix should be temporary as these values should be able to changed for testing. 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Inspect page
2. Verify `property="og:url"` value is https://talent.canada.ca/images/digital-talent/banner.jpg


## 📸 Screenshot
<img width="851" alt="Screen Shot 2024-02-05 at 11 48 05" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/1e2a85bb-bed2-4600-b894-ea834311cb8a">

