### PR TITLE
[Feature] Add breadcrumbs to ROD application page

### DIFF
--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useIntl } from "react-intl";
+import { defineMessage, useIntl } from "react-intl";
 import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
 import HandRaisedIcon from "@heroicons/react/24/outline/HandRaisedIcon";
 import ArrowRightCircleIcon from "@heroicons/react/24/solid/ArrowRightCircleIcon";
@@ -36,12 +36,21 @@ import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWr
 import PoolStatusTable from "~/components/PoolStatusTable/PoolStatusTable";
 import AdminHero from "~/components/Hero/AdminHero";
 import { getCandidateStatusPill } from "~/utils/poolCandidate";
+import { getFullPoolTitleLabel } from "~/utils/poolUtils";
+import { pageTitle as indexPoolPageTitle } from "~/pages/Pools/IndexPoolPage/IndexPoolPage";
 
 import CareerTimelineSection from "./components/CareerTimelineSection/CareerTimelineSection";
 import ApplicationInformation from "./components/ApplicationInformation/ApplicationInformation";
 import ProfileDetails from "./components/ProfileDetails/ProfileDetails";
 import NotesDialog from "./components/MoreActions/NotesDialog";
 import FinalDecisionDialog from "./components/MoreActions/FinalDecisionDialog";
+import { getFullNameLabel } from "../../../utils/nameUtils";
+
+const screeningAndAssessmentTitle = defineMessage({
+  defaultMessage: "Screening and assessment",
+  id: "R8Naqm",
+  description: "Heading for the information of an application",
+});
 
 const PoolCandidate_SnapshotQuery = graphql(/* GraphQL */ `
   query PoolCandidateSnapshot($poolCandidateId: UUID!) {
@@ -511,11 +520,45 @@ export const ViewPoolCandidate = ({
     </div>
   );
 
+  const candidateName = getFullNameLabel(
+    poolCandidate.user.firstName,
+    poolCandidate.user.lastName,
+    intl,
+  );
+
+  const navigationCrumbs = [
+    {
+      label: intl.formatMessage({
+        defaultMessage: "Home",
+        id: "EBmWyo",
+        description: "Link text for the home link in breadcrumbs.",
+      }),
+      url: paths.adminDashboard(),
+    },
+    {
+      label: intl.formatMessage(indexPoolPageTitle),
+      url: paths.poolTable(),
+    },
+    {
+      label: getFullPoolTitleLabel(intl, poolCandidate.pool),
+      url: paths.poolView(poolCandidate.pool.id),
+    },
+    {
+      label: intl.formatMessage(screeningAndAssessmentTitle),
+      url: paths.screeningAndEvaluation(poolCandidate.pool.id),
+    },
+    {
+      label: candidateName,
+      url: paths.poolCandidateApplication(poolCandidate.id),
+    },
+  ];
+
   return (
     <>
       <AdminHero
-        title={`${poolCandidate.user.firstName} ${poolCandidate.user.lastName}`}
+        title={candidateName}
         contentRight={pills}
+        nav={{ mode: "crumbs", items: navigationCrumbs }}
       >
         <ProfileDetails user={poolCandidate.user} />
       </AdminHero>
@@ -626,11 +669,7 @@ export const ViewPoolCandidate = ({
                 color="quaternary"
                 data-h2-margin="base(x.75, 0, x1, 0)"
               >
-                {intl.formatMessage({
-                  defaultMessage: "Screening and assessment",
-                  id: "R8Naqm",
-                  description: "Heading for the information of an application",
-                })}
+                {intl.formatMessage(screeningAndAssessmentTitle)}
               </Heading>
               <div>Coming soon!</div>
             </div>

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
@@ -38,13 +38,13 @@ import AdminHero from "~/components/Hero/AdminHero";
 import { getCandidateStatusPill } from "~/utils/poolCandidate";
 import { getFullPoolTitleLabel } from "~/utils/poolUtils";
 import { pageTitle as indexPoolPageTitle } from "~/pages/Pools/IndexPoolPage/IndexPoolPage";
+import { getFullNameLabel } from "~/utils/nameUtils";
 
 import CareerTimelineSection from "./components/CareerTimelineSection/CareerTimelineSection";
 import ApplicationInformation from "./components/ApplicationInformation/ApplicationInformation";
 import ProfileDetails from "./components/ProfileDetails/ProfileDetails";
 import NotesDialog from "./components/MoreActions/NotesDialog";
 import FinalDecisionDialog from "./components/MoreActions/FinalDecisionDialog";
-import { getFullNameLabel } from "../../../utils/nameUtils";
 
 const screeningAndAssessmentTitle = defineMessage({
   defaultMessage: "Screening and assessment",


### PR DESCRIPTION
🤖 Resolves #9199 

## 👋 Introduction

Adds the following breadcrumbs to the ROD admin pool candidate page.

Home > Processes > {poolName} > Screening and Assessment > {candidateName}

## 🕵️ Details

"Processes" was used in favour of "Recruitments". It seems like we were planning on using "Recruitments" at an earlier stage but decided upon "Processes" instead so the ticket was out of date.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login as admin
3. Navigate to `/admin/pool-candidates`
4. Click on the view link for a candidate
5. Confirm the breadcrumbs appear with the appropriate links and labels

## 📸 Screenshot

![Screenshot 2024-02-05 133718](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/44f07686-2883-4f2c-96d5-90dddc2bb692)
