### PR TITLE
[Feature] Anonymous application print

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5803,6 +5803,10 @@
     "defaultMessage": "Participation de la collectivité",
     "description": "Title for community experience section"
   },
+  "UzbDEi": {
+    "defaultMessage": "Imprimer le profil au complet",
+    "description": "Button label for print full user profile"
+  },
   "Uzx5dR": {
     "defaultMessage": "Vous ne voyez pas de processus de recrutement actif correspondant à vos compétences ? Pas de problème, nous voulons toujours avoir de vos nouvelles.",
     "description": "summary for section with ongoing pool advertisements"
@@ -6394,6 +6398,10 @@
   "Y0WLp5": {
     "defaultMessage": "Sélectionnez un groupe des publications",
     "description": "Placeholder for publishing group field"
+  },
+  "Y2PPGY": {
+    "defaultMessage": "Imprimer le profil sans les coordonnées",
+    "description": "Button label for print user anonymous profile"
   },
   "Y2ULHN": {
     "defaultMessage": "Associer une expérience",

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationPrintButton/ApplicationPrintButton.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationPrintButton/ApplicationPrintButton.tsx
@@ -1,9 +1,15 @@
 import React, { useRef } from "react";
-import { useIntl } from "react-intl";
+import { defineMessage, useIntl } from "react-intl";
 import { useReactToPrint } from "react-to-print";
 import PrinterIcon from "@heroicons/react/20/solid/PrinterIcon";
+import ChevronDownIcon from "@heroicons/react/20/solid/ChevronDownIcon";
 
-import { Button, ButtonLinkMode, Color } from "@gc-digital-talent/ui";
+import {
+  Button,
+  ButtonLinkMode,
+  Color,
+  DropdownMenu,
+} from "@gc-digital-talent/ui";
 import { FragmentType, User } from "@gc-digital-talent/graphql";
 
 import printStyles from "~/styles/printStyles";
@@ -11,6 +17,12 @@ import printStyles from "~/styles/printStyles";
 import ApplicationPrintDocument, {
   ApplicationPrintDocument_PoolFragment,
 } from "./ApplicationPrintDocument";
+
+const documentTitle = defineMessage({
+  defaultMessage: "Application snapshot",
+  id: "ipsXat",
+  description: "Document title for printing a user's application snapshot.",
+});
 
 interface ApplicationPrintButtonProps {
   user: User;
@@ -27,35 +39,67 @@ const ApplicationPrintButton = ({
 }: ApplicationPrintButtonProps) => {
   const intl = useIntl();
 
-  const componentRef = useRef(null);
-  const handlePrint = useReactToPrint({
-    content: () => componentRef.current,
+  const commonArgs = {
     pageStyle: printStyles,
-    documentTitle: intl.formatMessage({
-      defaultMessage: "Application snapshot",
-      id: "ipsXat",
-      description: "Document title for printing a user's application snapshot.",
-    }),
+    documentTitle: intl.formatMessage(documentTitle),
+  };
+
+  const anonymousComponentRef = useRef(null);
+  const handleAnonymousPrint = useReactToPrint({
+    content: () => anonymousComponentRef.current,
+    ...commonArgs,
+  });
+
+  const fullComponentRef = useRef(null);
+  const handleFullPrint = useReactToPrint({
+    content: () => fullComponentRef.current,
+    ...commonArgs,
   });
 
   return (
     <>
-      <Button
-        color={color}
-        mode={mode}
-        onClick={handlePrint}
-        icon={PrinterIcon}
-      >
-        {intl.formatMessage({
-          defaultMessage: "Print application",
-          id: "0pDCvX",
-          description: "Print application",
-        })}
-      </Button>
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>
+          <Button
+            color={color}
+            mode={mode}
+            utilityIcon={ChevronDownIcon}
+            icon={PrinterIcon}
+          >
+            {intl.formatMessage({
+              defaultMessage: "Print application",
+              id: "0pDCvX",
+              description: "Print application",
+            })}
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="end" collisionPadding={2}>
+          <DropdownMenu.Item onSelect={handleFullPrint}>
+            {intl.formatMessage({
+              defaultMessage: "Print with all information",
+              id: "qN+dwB",
+              description: "Button label for print user profile.",
+            })}
+          </DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={handleAnonymousPrint}>
+            {intl.formatMessage({
+              defaultMessage: "Print without contact information",
+              id: "c795MO",
+              description: "Button label for print user anonymous profile.",
+            })}
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+      <ApplicationPrintDocument
+        anonymous
+        user={user}
+        poolQuery={pool}
+        ref={anonymousComponentRef}
+      />
       <ApplicationPrintDocument
         user={user}
         poolQuery={pool}
-        ref={componentRef}
+        ref={fullComponentRef}
       />
     </>
   );

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationPrintButton/ApplicationPrintButton.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationPrintButton/ApplicationPrintButton.tsx
@@ -17,11 +17,18 @@ import printStyles from "~/styles/printStyles";
 import ApplicationPrintDocument, {
   ApplicationPrintDocument_PoolFragment,
 } from "./ApplicationPrintDocument";
+import ProfileDocument from "../../../../../components/ProfileDocument/ProfileDocument";
 
 const documentTitle = defineMessage({
   defaultMessage: "Application snapshot",
   id: "ipsXat",
   description: "Document title for printing a user's application snapshot.",
+});
+
+const printApplication = defineMessage({
+  defaultMessage: "Print application",
+  id: "0pDCvX",
+  description: "Print application",
 });
 
 interface ApplicationPrintButtonProps {
@@ -44,15 +51,21 @@ const ApplicationPrintButton = ({
     documentTitle: intl.formatMessage(documentTitle),
   };
 
-  const anonymousComponentRef = useRef(null);
-  const handleAnonymousPrint = useReactToPrint({
-    content: () => anonymousComponentRef.current,
+  const applicationRef = useRef(null);
+  const handleApplicationPrint = useReactToPrint({
+    content: () => applicationRef.current,
     ...commonArgs,
   });
 
-  const fullComponentRef = useRef(null);
+  const fullProfileRef = useRef(null);
   const handleFullPrint = useReactToPrint({
-    content: () => fullComponentRef.current,
+    content: () => fullProfileRef.current,
+    ...commonArgs,
+  });
+
+  const anonymousProfileRef = useRef(null);
+  const handleAnonymousPrint = useReactToPrint({
+    content: () => anonymousProfileRef.current,
     ...commonArgs,
   });
 
@@ -66,41 +79,36 @@ const ApplicationPrintButton = ({
             utilityIcon={ChevronDownIcon}
             icon={PrinterIcon}
           >
-            {intl.formatMessage({
-              defaultMessage: "Print application",
-              id: "0pDCvX",
-              description: "Print application",
-            })}
+            {intl.formatMessage(printApplication)}
           </Button>
         </DropdownMenu.Trigger>
         <DropdownMenu.Content align="end" collisionPadding={2}>
+          <DropdownMenu.Item onSelect={handleApplicationPrint}>
+            {intl.formatMessage(printApplication)}
+          </DropdownMenu.Item>
           <DropdownMenu.Item onSelect={handleFullPrint}>
             {intl.formatMessage({
-              defaultMessage: "Print with all information",
-              id: "qN+dwB",
-              description: "Button label for print user profile.",
+              defaultMessage: "Print full profile",
+              id: "UzbDEi",
+              description: "Button label for print full user profile",
             })}
           </DropdownMenu.Item>
           <DropdownMenu.Item onSelect={handleAnonymousPrint}>
             {intl.formatMessage({
-              defaultMessage: "Print without contact information",
-              id: "c795MO",
-              description: "Button label for print user anonymous profile.",
+              defaultMessage: "Print profile without contact information",
+              id: "Y2PPGY",
+              description: "Button label for print user anonymous profile",
             })}
           </DropdownMenu.Item>
         </DropdownMenu.Content>
       </DropdownMenu.Root>
       <ApplicationPrintDocument
-        anonymous
         user={user}
         poolQuery={pool}
-        ref={anonymousComponentRef}
+        ref={applicationRef}
       />
-      <ApplicationPrintDocument
-        user={user}
-        poolQuery={pool}
-        ref={fullComponentRef}
-      />
+      <ProfileDocument results={[user]} ref={fullProfileRef} />
+      <ProfileDocument anonymous results={[user]} ref={anonymousProfileRef} />
     </>
   );
 };

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationPrintButton/ApplicationPrintDocument.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationPrintButton/ApplicationPrintDocument.tsx
@@ -55,6 +55,7 @@ import EducationRequirementExperience from "./EducationRequirementExperience";
 interface ApplicationPrintDocumentProps {
   user: User;
   poolQuery: FragmentType<typeof ApplicationPrintDocument_PoolFragment>;
+  anonymous?: boolean;
 }
 
 const PageSection = ({ children }: { children: React.ReactNode }) => (
@@ -94,7 +95,7 @@ export const ApplicationPrintDocument_PoolFragment = graphql(/* GraphQL */ `
 const ApplicationPrintDocument = React.forwardRef<
   HTMLDivElement,
   ApplicationPrintDocumentProps
->(({ user, poolQuery }, ref) => {
+>(({ user, poolQuery, anonymous }, ref) => {
   const intl = useIntl();
   const locale = getLocale(intl);
 
@@ -202,7 +203,17 @@ const ApplicationPrintDocument = React.forwardRef<
               })}
             </Heading>
             <Heading level="h2" data-h2-font-weight="base(700)">
-              <>{getFullNameLabel(user.firstName, user.lastName, intl)}</>
+              {anonymous ? (
+                <>
+                  {getFullNameLabel(
+                    user.firstName,
+                    user.lastName ? `${user.lastName?.slice(0, 1)}.` : null,
+                    intl,
+                  )}
+                </>
+              ) : (
+                <>{getFullNameLabel(user.firstName, user.lastName, intl)}</>
+              )}
             </Heading>
             {relevantPoolCandidate && (
               <>
@@ -351,80 +362,83 @@ const ApplicationPrintDocument = React.forwardRef<
                   "Profile and applications card title for profile card",
               })}
             </Heading>
-            <PageSection>
-              <Heading level="h3" data-h2-font-weight="base(700)">
-                {intl.formatMessage({
-                  defaultMessage: "Contact information",
-                  id: "XqF3wS",
-                  description: "Profile section title for contact information",
-                })}
-              </Heading>
-              {user.email && (
-                <p>
-                  {intl.formatMessage(commonMessages.email)}
-                  {intl.formatMessage(commonMessages.dividingColon)}
-                  {user.email}
-                </p>
-              )}
-              {user.telephone && (
-                <p>
-                  {intl.formatMessage(commonMessages.telephone)}
-                  {intl.formatMessage(commonMessages.dividingColon)}
-                  {user.telephone}
-                </p>
-              )}
-              {user.currentCity && user.currentProvince && (
-                <p>
+            {!anonymous && (
+              <PageSection>
+                <Heading level="h3" data-h2-font-weight="base(700)">
                   {intl.formatMessage({
-                    defaultMessage: "City",
-                    id: "QjO3Y0",
-                    description: "Label for city and province/territory",
+                    defaultMessage: "Contact information",
+                    id: "XqF3wS",
+                    description:
+                      "Profile section title for contact information",
                   })}
-                  {intl.formatMessage(commonMessages.dividingColon)}
-                  {user.currentCity},{" "}
-                  {intl.formatMessage(
-                    getProvinceOrTerritory(user.currentProvince),
-                  )}
-                </p>
-              )}
-              {user.preferredLang && (
-                <p>
-                  {intl.formatMessage({
-                    defaultMessage: "Communication language",
-                    id: "BzKGyK",
-                    description: "Label for communication language",
-                  })}
-                  {intl.formatMessage(commonMessages.dividingColon)}
-                  {intl.formatMessage(getLanguage(user.preferredLang))}
-                </p>
-              )}
-              {user.preferredLanguageForInterview && (
-                <p>
-                  {intl.formatMessage({
-                    defaultMessage: "Spoken interview language",
-                    id: "HUy0EA",
-                    description: "Label for spoken interview language",
-                  })}
-                  {intl.formatMessage(commonMessages.dividingColon)}
-                  {intl.formatMessage(
-                    getLanguage(user.preferredLanguageForInterview),
-                  )}
-                </p>
-              )}
-              {user.preferredLanguageForExam && (
-                <p>
-                  {intl.formatMessage({
-                    defaultMessage: "Written exam language",
-                    id: "Yh1Y7Z",
-                    description: "Label for written exam language",
-                  })}
-                  {intl.formatMessage(commonMessages.dividingColon)}
-                  {intl.formatMessage(
-                    getLanguage(user.preferredLanguageForExam),
-                  )}
-                </p>
-              )}
-            </PageSection>
+                </Heading>
+                {user.email && (
+                  <p>
+                    {intl.formatMessage(commonMessages.email)}
+                    {intl.formatMessage(commonMessages.dividingColon)}
+                    {user.email}
+                  </p>
+                )}
+                {user.telephone && (
+                  <p>
+                    {intl.formatMessage(commonMessages.telephone)}
+                    {intl.formatMessage(commonMessages.dividingColon)}
+                    {user.telephone}
+                  </p>
+                )}
+                {user.currentCity && user.currentProvince && (
+                  <p>
+                    {intl.formatMessage({
+                      defaultMessage: "City",
+                      id: "QjO3Y0",
+                      description: "Label for city and province/territory",
+                    })}
+                    {intl.formatMessage(commonMessages.dividingColon)}
+                    {user.currentCity},{" "}
+                    {intl.formatMessage(
+                      getProvinceOrTerritory(user.currentProvince),
+                    )}
+                  </p>
+                )}
+                {user.preferredLang && (
+                  <p>
+                    {intl.formatMessage({
+                      defaultMessage: "Communication language",
+                      id: "BzKGyK",
+                      description: "Label for communication language",
+                    })}
+                    {intl.formatMessage(commonMessages.dividingColon)}
+                    {intl.formatMessage(getLanguage(user.preferredLang))}
+                  </p>
+                )}
+                {user.preferredLanguageForInterview && (
+                  <p>
+                    {intl.formatMessage({
+                      defaultMessage: "Spoken interview language",
+                      id: "HUy0EA",
+                      description: "Label for spoken interview language",
+                    })}
+                    {intl.formatMessage(commonMessages.dividingColon)}
+                    {intl.formatMessage(
+                      getLanguage(user.preferredLanguageForInterview),
+                    )}
+                  </p>
+                )}
+                {user.preferredLanguageForExam && (
+                  <p>
+                    {intl.formatMessage({
+                      defaultMessage: "Written exam language",
+                      id: "Yh1Y7Z",
+                      description: "Label for written exam language",
+                    })}
+                    {intl.formatMessage(commonMessages.dividingColon)}
+                    {intl.formatMessage(
+                      getLanguage(user.preferredLanguageForExam),
+                    )}
+                  </p>
+                )}
+              </PageSection>
+            )}
             <PageSection>
               <Heading level="h4" data-h2-font-weight="base(700)">
                 {intl.formatMessage(commonMessages.status)}

--- a/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
+++ b/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
@@ -10,7 +10,7 @@ import AdminAboutUserSection from "~/components/AdminAboutUserSection/AdminAbout
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRequiredParams from "~/hooks/useRequiredParams";
 
-import UserProfilePrintButton from "./components/UserProfilePrintButton";
+import SingleUserProfilePrintButton from "./components/SingleUserProfilePrintButton";
 
 interface AdminUserProfileProps {
   user: User;
@@ -23,7 +23,11 @@ export const AdminUserProfile = ({ user }: AdminUserProfileProps) => {
         data-h2-container="base(center, large, x1) p-tablet(center, large, x2)"
         data-h2-text-align="base(right)"
       >
-        <UserProfilePrintButton users={[user]} color="primary" mode="solid" />
+        <SingleUserProfilePrintButton
+          users={[user]}
+          color="primary"
+          mode="solid"
+        />
       </div>
       <UserProfile
         user={user}

--- a/apps/web/src/pages/Users/AdminUserProfilePage/components/SingleUserProfilePrintButton.tsx
+++ b/apps/web/src/pages/Users/AdminUserProfilePage/components/SingleUserProfilePrintButton.tsx
@@ -1,0 +1,94 @@
+import React, { useRef } from "react";
+import { defineMessage, useIntl } from "react-intl";
+import { useReactToPrint } from "react-to-print";
+import PrinterIcon from "@heroicons/react/20/solid/PrinterIcon";
+import ChevronDownIcon from "@heroicons/react/20/solid/ChevronDownIcon";
+
+import {
+  Button,
+  ButtonLinkMode,
+  Color,
+  DropdownMenu,
+} from "@gc-digital-talent/ui";
+import { User } from "@gc-digital-talent/graphql";
+
+import printStyles from "~/styles/printStyles";
+import ProfileDocument from "~/components/ProfileDocument/ProfileDocument";
+
+const documentTitle = defineMessage({
+  defaultMessage: "Candidate profile",
+  id: "mVmrEn",
+  description: "Document title for printing User profile",
+});
+
+interface SingleUserProfilePrintButtonProps {
+  users: User[];
+  color: Color;
+  mode: ButtonLinkMode;
+}
+
+const SingleUserProfilePrintButton = ({
+  users,
+  color,
+  mode,
+}: SingleUserProfilePrintButtonProps) => {
+  const intl = useIntl();
+
+  const commonArgs = {
+    pageStyle: printStyles,
+    documentTitle: intl.formatMessage(documentTitle),
+  };
+
+  const anonymousComponentRef = useRef(null);
+  const handleAnonymousPrint = useReactToPrint({
+    content: () => anonymousComponentRef.current,
+    ...commonArgs,
+  });
+
+  const fullComponentRef = useRef(null);
+  const handleFullPrint = useReactToPrint({
+    content: () => fullComponentRef.current,
+    ...commonArgs,
+  });
+
+  return (
+    <>
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>
+          <Button
+            color={color}
+            mode={mode}
+            utilityIcon={ChevronDownIcon}
+            icon={PrinterIcon}
+          >
+            {intl.formatMessage({
+              defaultMessage: "Print profile",
+              id: "Yr0nVZ",
+              description: "Text label for button to print items in a table",
+            })}
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="end" collisionPadding={2}>
+          <DropdownMenu.Item onSelect={handleFullPrint}>
+            {intl.formatMessage({
+              defaultMessage: "Print with all information",
+              id: "qN+dwB",
+              description: "Button label for print user profile.",
+            })}
+          </DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={handleAnonymousPrint}>
+            {intl.formatMessage({
+              defaultMessage: "Print without contact information",
+              id: "c795MO",
+              description: "Button label for print user anonymous profile.",
+            })}
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+      <ProfileDocument anonymous results={users} ref={anonymousComponentRef} />
+      <ProfileDocument results={users} ref={fullComponentRef} />
+    </>
+  );
+};
+
+export default SingleUserProfilePrintButton;


### PR DESCRIPTION
🤖 Resolves #9201 

## 👋 Introduction

Adds a dropdown allowing users to choose either a full or anonymous application print document.

## 🕵️ Details

During developing this, I noticed that the "Print profile" button (where I got the code for this) does not properly print an redacted profile when on the "User profile" page. So, this had to use a different approach of two documents and two handlers. 

I created a ticket (https://github.com/GCTC-NTGC/gc-digital-talent/issues/9209) to look into this in hopes that someone has a better solution. Or at least fix the existing user profile print.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login as admin
3. Navigate to `/admin/pool-candidates`
4. View an application for a user
5. Active the "Print application" dropdown
6. Select "Print without contact information"
7. Confirm  the user's last name is only the first letter and no contact information section exists
8. Repeat steps 5-6 but selecting "Print with all information"
9. Confirm the full users name is displayed along with a contact information section
10. Update `apps/web/.env` file setting `FEATURE_RECORD_OF_DECISION=false`
11. Repeat steps 1-9

## 📸 Screenshot

### ROD Enabled

![Screenshot 2024-02-05 143855](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/0733be74-528b-4760-9bca-3041076c0f1d)

### ROD Disabled

![Screenshot 2024-02-05 145029](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/949cf03b-dc87-4e40-b03c-8833dc2d206c)
