### PR TITLE
[Tooling] Add artisan command to null expiry dates

### DIFF
--- a/api/app/Console/Commands/RemoveExpiryDates.php
+++ b/api/app/Console/Commands/RemoveExpiryDates.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\PoolCandidateStatus;
+use App\Models\PoolCandidate;
+use Illuminate\Console\Command;
+
+class RemoveExpiryDates extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:wipe-expiryDates';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Null expiry dates for non-qualified pool candidates';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        PoolCandidate::WhereIn('pool_candidate_status', [
+            PoolCandidateStatus::DRAFT->name,
+            PoolCandidateStatus::DRAFT_EXPIRED->name,
+            PoolCandidateStatus::NEW_APPLICATION->name,
+            PoolCandidateStatus::SCREENED_IN->name,
+            PoolCandidateStatus::APPLICATION_REVIEW->name,
+            PoolCandidateStatus::UNDER_ASSESSMENT->name,
+            PoolCandidateStatus::SCREENED_OUT_APPLICATION->name,
+            PoolCandidateStatus::SCREENED_OUT_ASSESSMENT->name,
+            PoolCandidateStatus::SCREENED_OUT_NOT_INTERESTED->name,
+            PoolCandidateStatus::SCREENED_OUT_NOT_RESPONSIVE->name,
+        ])
+            ->whereNotNull('expiry_date')
+            ->update(['expiry_date' => null]);
+
+        return Command::SUCCESS;
+    }
+}

--- a/api/app/Console/Commands/RemoveExpiryDates.php
+++ b/api/app/Console/Commands/RemoveExpiryDates.php
@@ -27,7 +27,7 @@ class RemoveExpiryDates extends Command
      */
     public function handle()
     {
-        PoolCandidate::WhereIn('pool_candidate_status', [
+        $modelsUpdatedCount = PoolCandidate::WhereIn('pool_candidate_status', [
             PoolCandidateStatus::DRAFT->name,
             PoolCandidateStatus::DRAFT_EXPIRED->name,
             PoolCandidateStatus::NEW_APPLICATION->name,
@@ -41,6 +41,8 @@ class RemoveExpiryDates extends Command
         ])
             ->whereNotNull('expiry_date')
             ->update(['expiry_date' => null]);
+
+        $this->info("$modelsUpdatedCount models updated");
 
         return Command::SUCCESS;
     }


### PR DESCRIPTION
🤖 Resolves #9136 

## 👋 Introduction

Add artisan command to null out expiry dates for pool candidates with certain statuses. 

## 🧪 Testing

1. Seed fresh
2. Run command
3. Observe candidates in database by updated at, the specified status ones should have been updated

`php artisan app:wipe-expiryDates`

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/eaa18e23-6ba3-48d5-8c69-6f868b500094)

## 🚚 Deployment

Run

`php artisan app:wipe-expiryDates`
