### PR TITLE
[Feature] Theme mode switcher

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -17,6 +17,7 @@ OAUTH_LOGOUT_URI="http://localhost:8000/oxauth/endsession"
 #FEATURE_STATUS_NOTIFICATIONS=true  // not yet implemented on the client side
 FEATURE_DIRECTIVE_FORMS=true
 FEATURE_RECORD_OF_DECISION=true
+FEATURE_DARK_MODE=true
 
 # Logging - enable by setting the logging level. Eight severity levels from rfc5424.
 LOG_CONSOLE_LEVEL="debug"

--- a/apps/web/public/config.ejs
+++ b/apps/web/public/config.ejs
@@ -15,6 +15,7 @@ const data = new Map([
     // Feature flags
     ["FEATURE_DIRECTIVE_FORMS", filterUnusable("$FEATURE_DIRECTIVE_FORMS") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_DIRECTIVE_FORMS %>"],
     ["FEATURE_RECORD_OF_DECISION", filterUnusable("$FEATURE_RECORD_OF_DECISION") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_RECORD_OF_DECISION %>"],
+    ["FEATURE_DARK_MODE", filterUnusable("$FEATURE_DARK_MODE") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_DARK_MODE %>"],
 
     // Azure application insights not used in dev
     ["APPLICATIONINSIGHTS_CONNECTION_STRING", filterUnusable("$APPLICATIONINSIGHTS_CONNECTION_STRING")],

--- a/apps/web/src/components/Header/Header.tsx
+++ b/apps/web/src/components/Header/Header.tsx
@@ -10,6 +10,7 @@ import {
 } from "@gc-digital-talent/i18n";
 
 import { GocLogoEn, GocLogoFr, GocLogoWhiteEn, GocLogoWhiteFr } from "../Svg";
+import ThemeSwitcher from "../ThemeSwitcher/ThemeSwitcher";
 
 interface HeaderProps {
   width?: string;
@@ -90,7 +91,9 @@ const Header = ({ width }: HeaderProps) => {
             data-h2-justify-content="base(center) p-tablet(flex-end)"
             data-h2-text-align="base(center) p-tablet(left)"
           >
-            <div>{/* <ThemeSwitcher / > */}</div>
+            <div>
+              <ThemeSwitcher />
+            </div>
             <div>
               <a
                 data-h2-background-color="base:focus-visible(focus)"

--- a/apps/web/src/components/Header/Header.tsx
+++ b/apps/web/src/components/Header/Header.tsx
@@ -8,6 +8,7 @@ import {
   oppositeLocale,
   useLocale,
 } from "@gc-digital-talent/i18n";
+import { useFeatureFlags } from "@gc-digital-talent/env";
 
 import { GocLogoEn, GocLogoFr, GocLogoWhiteEn, GocLogoWhiteFr } from "../Svg";
 import ThemeSwitcher from "../ThemeSwitcher/ThemeSwitcher";
@@ -19,6 +20,7 @@ interface HeaderProps {
 const Header = ({ width }: HeaderProps) => {
   const intl = useIntl();
   const { locale } = useLocale();
+  const { darkMode } = useFeatureFlags();
 
   const location = useLocation();
   const changeToLang = oppositeLocale(locale);
@@ -91,9 +93,11 @@ const Header = ({ width }: HeaderProps) => {
             data-h2-justify-content="base(center) p-tablet(flex-end)"
             data-h2-text-align="base(center) p-tablet(left)"
           >
-            <div>
-              <ThemeSwitcher />
-            </div>
+            {darkMode && (
+              <div>
+                <ThemeSwitcher />
+              </div>
+            )}
             <div>
               <a
                 data-h2-background-color="base:focus-visible(focus)"

--- a/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.test.tsx
+++ b/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.test.tsx
@@ -23,11 +23,6 @@ describe("ThemeSwitcher", () => {
   jest.spyOn(Object.getPrototypeOf(window.localStorage), "setItem");
   Object.setPrototypeOf(window.localStorage.setItem, jest.fn());
 
-  it("should have no accessibility errors", async () => {
-    const { container } = renderThemeSwitcher();
-    await axeTest(container);
-  });
-
   it("should change theme to light mode", async () => {
     renderThemeSwitcher();
     fireEvent.click(

--- a/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.test.tsx
+++ b/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.test.tsx
@@ -5,7 +5,7 @@ import "@testing-library/jest-dom";
 import React from "react";
 import { screen, fireEvent } from "@testing-library/react";
 
-import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";
+import { renderWithProviders } from "@gc-digital-talent/jest-helpers";
 import { ThemeProvider } from "@gc-digital-talent/theme";
 
 import ThemeSwitcher from "./ThemeSwitcher";

--- a/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.tsx
@@ -7,6 +7,24 @@ import MoonIcon from "@heroicons/react/24/solid/MoonIcon";
 import { ToggleGroup } from "@gc-digital-talent/ui";
 import { useTheme } from "@gc-digital-talent/theme";
 
+const Beta = () => {
+  const intl = useIntl();
+
+  return (
+    <span
+      data-h2-font-size="base(caption)"
+      data-h2-font-weight="base(700)"
+      data-h2-text-transform="base(uppercase)"
+    >
+      {intl.formatMessage({
+        defaultMessage: "Beta",
+        id: "RTR3mh",
+        description: "Label to indicate a feature is in beta",
+      })}
+    </span>
+  );
+};
+
 const ThemeSwitcher = () => {
   const intl = useIntl();
   const { setMode, fullMode } = useTheme();
@@ -25,6 +43,7 @@ const ThemeSwitcher = () => {
       value={fullMode}
       onValueChange={setMode}
       aria-label={groupLabel}
+      label={<Beta />}
     >
       <ToggleGroup.Item
         value="pref"

--- a/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.tsx
@@ -5,11 +5,11 @@ import SunIcon from "@heroicons/react/24/solid/SunIcon";
 import MoonIcon from "@heroicons/react/24/solid/MoonIcon";
 
 import { ToggleGroup } from "@gc-digital-talent/ui";
-import { useTheme, ThemeMode } from "@gc-digital-talent/theme";
+import { useTheme } from "@gc-digital-talent/theme";
 
 const ThemeSwitcher = () => {
   const intl = useIntl();
-  const { mode, setMode, isPref } = useTheme();
+  const { setMode, fullMode } = useTheme();
 
   const groupLabel = intl.formatMessage({
     defaultMessage: "Theme colour mode switcher",
@@ -22,10 +22,8 @@ const ThemeSwitcher = () => {
     <ToggleGroup.Root
       type="single"
       color="secondary"
-      value={isPref ? "pref" : mode}
-      onValueChange={(newMode: string) =>
-        setMode((newMode as ThemeMode) || "pref")
-      }
+      value={fullMode}
+      onValueChange={setMode}
       aria-label={groupLabel}
     >
       <ToggleGroup.Item

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5203,6 +5203,10 @@
     "defaultMessage": "Bref résumé des compétences",
     "description": "Title for skills quick summary sidebar"
   },
+  "RTR3mh": {
+    "defaultMessage": "Bêta",
+    "description": "Label to indicate a feature is in beta"
+  },
   "RTf/0v": {
     "defaultMessage": "L’utilisateur perdra tous les rôles suivants au sein de l’équipe : ",
     "description": "Text notifying user which role will be removed from the user"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29092,6 +29092,7 @@
       "version": "1.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
+        "@gc-digital-talent/env": "*",
         "@gc-digital-talent/storage": "*"
       },
       "devDependencies": {
@@ -31522,6 +31523,7 @@
     "@gc-digital-talent/theme": {
       "version": "file:packages/theme",
       "requires": {
+        "@gc-digital-talent/env": "*",
         "@gc-digital-talent/storage": "*",
         "@swc/core": "^1.3.106",
         "@types/react": "^18.2.48",

--- a/packages/env/src/utils.ts
+++ b/packages/env/src/utils.ts
@@ -41,6 +41,7 @@ export const checkFeatureFlag = (name: string): boolean => {
 export const getFeatureFlags = () => ({
   directiveForms: checkFeatureFlag("FEATURE_DIRECTIVE_FORMS"),
   recordOfDecision: checkFeatureFlag("FEATURE_RECORD_OF_DECISION"),
+  darkMode: checkFeatureFlag("FEATURE_DARK_MODE"),
 });
 
 export type FeatureFlags = ReturnType<typeof getFeatureFlags>;

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -21,6 +21,7 @@
     "preset": "jest-presets/jest/node"
   },
   "dependencies": {
+    "@gc-digital-talent/env": "*",
     "@gc-digital-talent/storage": "*"
   },
   "devDependencies": {

--- a/packages/theme/src/components/ThemeProvider.tsx
+++ b/packages/theme/src/components/ThemeProvider.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { useLocalStorage } from "@gc-digital-talent/storage";
+import { useFeatureFlags } from "@gc-digital-talent/env";
 
 import {
   ThemeMode,
@@ -69,6 +70,7 @@ const ThemeProvider = ({
   override,
   themeSelector,
 }: ThemeProviderProps) => {
+  const { darkMode } = useFeatureFlags();
   const [theme, setTheme] = useLocalStorage<Theme>(
     "theme",
     getDefaultTheme(override),
@@ -109,6 +111,9 @@ const ThemeProvider = ({
 
     if (computedMode && key) {
       themeString = `${key} ${computedMode}`;
+      if (!darkMode) {
+        themeString = key;
+      }
     } else if (key) {
       themeString = key;
     } else if (mode) {

--- a/packages/theme/src/components/ThemeProvider.tsx
+++ b/packages/theme/src/components/ThemeProvider.tsx
@@ -13,7 +13,12 @@ import {
 } from "../types";
 
 export interface ThemeState {
+  /** Full mode stores three values to determine the current setting */
   fullMode: ThemeMode;
+  /**
+   * Mode omits "pref" and is used by hydrogen that only supports light/dark
+   * where pref will fallback to one based on users `prefers-color-scheme`
+   * */
   mode: Omit<ThemeMode, "pref">;
   key: ThemeKey;
   isPref: boolean;

--- a/packages/theme/src/components/ThemeProvider.tsx
+++ b/packages/theme/src/components/ThemeProvider.tsx
@@ -129,7 +129,7 @@ const ThemeProvider = ({
         item.dataset.h2 = themeString;
       }
     });
-  }, [computedMode, key, mode, themeSelector]);
+  }, [computedMode, darkMode, key, mode, themeSelector]);
 
   const testDark = React.useCallback(() => {
     const isSet = mode && mode !== "pref";

--- a/packages/theme/src/components/ThemeProvider.tsx
+++ b/packages/theme/src/components/ThemeProvider.tsx
@@ -69,20 +69,12 @@ const ThemeProvider = ({
     getDefaultTheme(override),
   );
   const { key, mode } = theme;
-
-  const computedMode = React.useMemo(() => {
-    const prefersDark = window.matchMedia(
-      "(prefers-color-scheme: dark)",
-    ).matches;
-    const isSetLight = localStorage.theme === "light";
-
-    let themeMode: ThemeMode = mode;
-    if (mode === "pref") {
-      themeMode = prefersDark && !isSetLight ? "dark" : "light";
-    }
-
-    return themeMode;
-  }, [mode]);
+  let computedMode: ThemeMode = mode;
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const isSetLight = localStorage.theme === "light";
+  if (mode === "pref") {
+    computedMode = prefersDark && !isSetLight ? "dark" : "light";
+  }
 
   const setKey = React.useCallback(
     (newKey: ThemeKey) => {

--- a/packages/ui/src/components/ToggleGroup/ToggleGroup.stories.tsx
+++ b/packages/ui/src/components/ToggleGroup/ToggleGroup.stories.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 import type { StoryFn, Meta } from "@storybook/react";
-import AcademicCapIcon from "@heroicons/react/24/outline/AcademicCapIcon";
-import BanknotesIcon from "@heroicons/react/24/outline/BanknotesIcon";
-import UserIcon from "@heroicons/react/24/outline/UserIcon";
+import AcademicCapIcon from "@heroicons/react/20/solid/AcademicCapIcon";
+import BanknotesIcon from "@heroicons/react/20/solid/BanknotesIcon";
+import UserIcon from "@heroicons/react/20/solid/UserIcon";
 
 import ToggleGroupDocs from "./ToggleGroup.docs.mdx";
 import ToggleGroup from "./ToggleGroup";
 
 export default {
   component: ToggleGroup.Root,
-  title: "Components/ToggleGroup",
+  title: "Components/Toggle Group",
   args: {
     type: "single",
   },
@@ -28,48 +28,8 @@ export default {
 
 const AllTemplate: StoryFn<typeof ToggleGroup.Root> = (args) => {
   return (
-    <div
-      data-h2-display="base(flex)"
-      data-h2-flex-direction="base(column)"
-      data-h2-gap="base(x1, 0)"
-      data-h2-align-items="base(center)"
-    >
+    <div data-h2-padding="base(x2)">
       <ToggleGroup.Root {...args}>
-        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
-        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
-        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
-      </ToggleGroup.Root>
-      <ToggleGroup.Root {...args} color="primary.dark">
-        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
-        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
-        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
-      </ToggleGroup.Root>
-      <ToggleGroup.Root {...args} color="secondary">
-        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
-        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
-        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
-      </ToggleGroup.Root>
-      <ToggleGroup.Root {...args} color="tertiary">
-        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
-        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
-        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
-      </ToggleGroup.Root>
-      <ToggleGroup.Root {...args} color="quaternary">
-        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
-        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
-        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
-      </ToggleGroup.Root>
-      <ToggleGroup.Root {...args} color="quinary">
-        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
-        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
-        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
-      </ToggleGroup.Root>
-      <ToggleGroup.Root {...args} color="black">
-        <ToggleGroup.Item value="one">One</ToggleGroup.Item>
-        <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
-        <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
-      </ToggleGroup.Root>
-      <ToggleGroup.Root {...args} color="white">
         <ToggleGroup.Item value="one">One</ToggleGroup.Item>
         <ToggleGroup.Item value="two">Two</ToggleGroup.Item>
         <ToggleGroup.Item value="three">Three</ToggleGroup.Item>
@@ -81,7 +41,11 @@ const AllTemplate: StoryFn<typeof ToggleGroup.Root> = (args) => {
 const Template: StoryFn<typeof ToggleGroup.Root> = (args) => {
   const { children, ...rest } = args;
 
-  return <ToggleGroup.Root {...rest}>{children}</ToggleGroup.Root>;
+  return (
+    <div data-h2-padding="base(x2)">
+      <ToggleGroup.Root {...rest}>{children}</ToggleGroup.Root>
+    </div>
+  );
 };
 
 export const Single = AllTemplate.bind({});
@@ -113,6 +77,12 @@ export const WithTwoOptions = Template.bind({});
 WithTwoOptions.args = {
   type: "single",
   children: <TwoOptionsChildren />,
+};
+
+export const WithPrefix = AllTemplate.bind({});
+WithPrefix.args = {
+  type: "single",
+  label: <span>Prefix</span>,
 };
 
 export const WithIcons = Template.bind({});

--- a/packages/ui/src/components/ToggleGroup/ToggleGroup.test.tsx
+++ b/packages/ui/src/components/ToggleGroup/ToggleGroup.test.tsx
@@ -9,10 +9,9 @@ import userEvent from "@testing-library/user-event";
 import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";
 
 import ToggleGroup from "./ToggleGroup";
-import type { ToggleGroupProps } from "./ToggleGroup";
 
 const renderToggleGroup = (
-  props: React.ComponentPropsWithoutRef<ToggleGroupProps>,
+  props: React.ComponentPropsWithoutRef<typeof ToggleGroup.Root>,
 ) => {
   return renderWithProviders(
     <ToggleGroup.Root {...props}>

--- a/packages/ui/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/packages/ui/src/components/ToggleGroup/ToggleGroup.tsx
@@ -4,106 +4,62 @@
 import React from "react";
 import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
 
-type Color =
-  | "primary"
-  | "primary.dark"
-  | "secondary"
-  | "tertiary"
-  | "quaternary"
-  | "quinary"
-  | "white"
-  | "black";
-
-const colorMap: Record<Color, Record<string, string>> = {
-  primary: {
-    "data-h2-background-color": "base(primary)",
-    "data-h2-color":
-      "base:children[>*](white) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
-  },
-  "primary.dark": {
-    "data-h2-background-color": "base(primary.dark)",
-    "data-h2-color":
-      "base:children[>*](white) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
-  },
-  secondary: {
-    "data-h2-background-color": "base(secondary) base:dark(secondary.lighter)",
-    "data-h2-color":
-      "base:children[>*](black) base:dark:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](black)",
-  },
-  tertiary: {
-    "data-h2-background-color": "base(tertiary)",
-    "data-h2-color":
-      "base:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
-  },
-  quaternary: {
-    "data-h2-background-color": "base(quaternary)",
-    "data-h2-color":
-      "base:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
-  },
-  quinary: {
-    "data-h2-background-color": "base(quinary)",
-    "data-h2-color":
-      "base:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
-  },
-  white: {
-    "data-h2-background-color": "base(white) base:dark(black.lighter)",
-    "data-h2-color":
-      "base:children[>*](black) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
-  },
-  black: {
-    "data-h2-background-color": "base(black) base:dark(black.lighter)",
-    "data-h2-color":
-      "base:children[>*](white) base:children[>[data-state='on']](black) base:dark:children[>[data-state='on']](white)",
-  },
-};
-
 const Item = React.forwardRef<
   React.ElementRef<typeof ToggleGroupPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item>
 >((props, forwardedRef) => (
   <ToggleGroupPrimitive.Item
     data-h2-align-items="base(center)"
-    data-h2-background-color="
-      base(transparent)
-      base:selectors[[data-state='on']](white)
-      base:dark:selectors[[data-state='on']](black)
-      base:hover(white.15)
-      base:dark:hover(black.15)
-      base:focus-visible(focus)
-      base:dark:selectors[[data-state='on']]:focus-visible(focus)"
     data-h2-cursor="base:hover(pointer)"
     data-h2-display="base(flex)"
     data-h2-line-height="base(1)"
     data-h2-outline="base(none)"
-    data-h2-padding="base(x.25, x.5)"
+    data-h2-padding="base(x.25)"
     data-h2-radius="base(m)"
-    data-h2-text-decoration="base:selectors[[data-state='off']](underline)"
-    data-h2-width="base:children[svg](var(--h2-font-size-copy))"
+    data-h2-width="base:children[svg](x1)"
     ref={forwardedRef}
     {...props}
   />
 ));
 
-type ToggleGroupType = typeof ToggleGroupPrimitive.Root;
-export interface ToggleGroupProps extends ToggleGroupType {
-  color?: Color;
-}
+export type RootProps = React.ComponentPropsWithoutRef<
+  typeof ToggleGroupPrimitive.Root
+> & {
+  label?: React.ReactNode;
+};
 
 const Root = React.forwardRef<
-  React.ElementRef<ToggleGroupType>,
-  React.ComponentPropsWithoutRef<ToggleGroupProps>
->(({ color = "primary", ...rest }, forwardedRef) => {
+  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+  RootProps
+>(({ label, children, ...rest }, forwardedRef) => {
   return (
     <ToggleGroupPrimitive.Root
-      className={`ToggleGroup ToggleGroup--${color}`}
-      {...colorMap[color as Color]}
+      data-h2-align-items="base(center)"
+      data-h2-background-color="
+        base(background)
+        base:children[button](background.dark)
+        base:children[button:hover](background.darkest)
+        base:children[button:focus-visible](focus)
+        base:children[button[data-state='on']](quaternary)
+        base:dark:children[button[data-state='on']](quaternary.light)
+      "
+      data-h2-color="
+        base(black) base:children[button](black)
+        base:children[button:hover](white)
+        base:children[button:focus-visible]:all(black)
+        base:all:children[button[data-state='on']](black)
+      "
+      data-h2-border="base(1px solid background.darker)"
       data-h2-display="base(inline-flex)"
       data-h2-padding="base(x.25)"
       data-h2-radius="base(m)"
       data-h2-gap="base(0, x.25)"
       ref={forwardedRef}
       {...rest}
-    />
+    >
+      {label && <div>{label}</div>}
+      {children}
+    </ToggleGroupPrimitive.Root>
   );
 });
 

--- a/packages/ui/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/packages/ui/src/components/ToggleGroup/ToggleGroup.tsx
@@ -16,7 +16,7 @@ const Item = React.forwardRef<
     data-h2-outline="base(none)"
     data-h2-padding="base(x.25)"
     data-h2-radius="base(m)"
-    data-h2-width="base:children[svg](x1)"
+    data-h2-width="base:children[svg](x.75)"
     ref={forwardedRef}
     {...props}
   />
@@ -36,18 +36,21 @@ const Root = React.forwardRef<
     <ToggleGroupPrimitive.Root
       data-h2-align-items="base(center)"
       data-h2-background-color="
-        base(background)
+        base(foreground) base:dark(white)
         base:children[button](background.dark)
         base:children[button:hover](background.darkest)
         base:children[button:focus-visible](focus)
-        base:children[button[data-state='on']](quaternary)
-        base:dark:children[button[data-state='on']](quaternary.light)
+        base:all:children[button[data-state='on']](quaternary.light)
       "
       data-h2-color="
-        base(black) base:children[button](black)
+        base(black)
+        base:children[button](black)
+        base:iap:children[button](black)
         base:children[button:hover](white)
-        base:children[button:focus-visible]:all(black)
+        base:all:children[button:focus-visible](black)
         base:all:children[button[data-state='on']](black)
+        base:iap:all:children[button[data-state='on']](white)
+        base:iap:children[button:hover[data-state='on']](white)
       "
       data-h2-border="base(1px solid background.darker)"
       data-h2-display="base(inline-flex)"


### PR DESCRIPTION
🤖 Resolves #4033 

## 👋 Introduction

Adds the theme switcher to the header with the beta label.

## 🕵️ Details

This also includes some changes to the base `ToggleGroup` component, removing the option to change the colour.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> [!TIP]
> If you don't want to change your system settings and just emulate it, here is how you do that you can follow [this guide](https://devtoolstips.org/tips/en/emulate-color-schemes/) for each browser.


1. Build `npm run dev`
2. Navigate to home page
3. Confirm the switcher appears and matches [the mockup](https://www.figma.com/file/guHeIIh8dqFVCks310Wv0G/Style-library?type=design&node-id=11-4115&mode=design&t=PUAWqgbAuvjPXtIT-0)
4. Confirm it starts of the first option
5. Change modes confirming it updates the theme
6. Refresh the page confirming your settings persist
7. Change back to the first option (preference)
8. Change your `prefers-color-scheme`
9. Confirm the page updates to reflect your settings
10. Repeat steps 3-9 on the IAP

## 📸 Screenshot

![Screenshot 2024-02-06 123757](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/055715ec-4b29-401c-b8d2-3187139477c4)
![Screenshot 2024-02-06 123801](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/f731f453-3463-4d72-8961-8051c8854bc8)
![Screenshot 2024-02-06 123805](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/8ee5b28e-d77a-48d1-98b5-396f5055c5bb)
![Screenshot 2024-02-06 123809](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/c1ebb84b-8876-4ac1-8848-b2eaf05a9f43)
