### PR TITLE
Enable hiding of status column if Record of Decision flag is true

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -426,7 +426,7 @@ const PoolCandidatesTable = ({
       {
         id: "status",
         header: intl.formatMessage(tableMessages.status),
-        enableHiding: false,
+        enableHiding: !recordOfDecision, // After record of decision is turned on, we can remove this property entirely (it defaults to true)
         cell: ({
           row: {
             original: { poolCandidate },

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -426,7 +426,7 @@ const PoolCandidatesTable = ({
       {
         id: "status",
         header: intl.formatMessage(tableMessages.status),
-        enableHiding: !recordOfDecision, // After record of decision is turned on, we can remove this property entirely (it defaults to true)
+        enableHiding: recordOfDecision, // After record of decision is turned on, we can remove this property entirely (it defaults to true)
         cell: ({
           row: {
             original: { poolCandidate },


### PR DESCRIPTION
🤖 Resolves #9221

## 👋 Introduction

Status column wasn't able to be shown on the Pool Candidates table with Record of Decision flag on.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. With Record of Decision flag OFF, status column is shown on the Pool Candidates table and locked, cannot be hidden
2. Turn Record of Decision flag ON and rebuild
3. Refresh Pool Candidates table page
4. Status column is hidden, but can be shown.
