### PR TITLE
[Bug] Update countApplicants query base scopes

### DIFF
--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -2,7 +2,6 @@
 
 namespace App\GraphQL\Queries;
 
-use App\Enums\CandidateExpiryFilter;
 use App\Models\PoolCandidate;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;

--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -33,9 +33,6 @@ final class CountPoolCandidatesByPool
         // available candidates scope (scope CANDIDATE_STATUS_QUALIFIED_AVAILABLE or CANDIDATE_STATUS_PLACED_CASUAL)
         PoolCandidate::scopeAvailable($queryBuilder);
 
-        // expiry status filter (filter active pool candidates)
-        PoolCandidate::scopeExpiryStatus($queryBuilder, CandidateExpiryFilter::ACTIVE->name);
-
         // Only display IT candidates
         PoolCandidate::scopeInITPublishingGroup($queryBuilder);
 

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -452,6 +452,9 @@ class PoolCandidate extends Model
             ->where(function ($query) {
                 $query->where('suspended_at', '>=', Carbon::now())
                     ->orWhereNull('suspended_at');
+            })
+            ->where(function ($query) {
+                self::scopeExpiryStatus($query, CandidateExpiryFilter::ACTIVE->name);
             });
 
         return $query;

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -6,7 +6,6 @@ use App\Enums\CandidateExpiryFilter;
 use App\Enums\CandidateSuspendedFilter;
 use App\Enums\LanguageAbility;
 use App\Enums\PoolCandidateStatus;
-use App\Enums\PublishingGroup;
 use Carbon\Carbon;
 use Illuminate\Auth\Authenticatable as AuthenticatableTrait;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -595,15 +594,13 @@ class User extends Model implements Authenticatable, LaratrustUser
 
     /**
      * Return users who have an available PoolCandidate in at least one IT pool.
-     *
-     * @param Builder $query
-     * @return Builder
      */
     public static function scopeAvailableInITPool(Builder $query): Builder
     {
         return $query->whereHas('poolCandidates', function ($innerQueryBuilder) {
             PoolCandidate::scopeAvailable($innerQueryBuilder);
             PoolCandidate::scopeInITPublishingGroup($innerQueryBuilder);
+
             return $innerQueryBuilder;
         });
     }

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -595,7 +595,7 @@ class User extends Model implements Authenticatable, LaratrustUser
     /**
      * Return users who have an available PoolCandidate in at least one IT pool.
      */
-    public static function scopeAvailableInITPool(Builder $query): Builder
+    public static function scopeAvailableInITPublishingGroup(Builder $query): Builder
     {
         return $query->whereHas('poolCandidates', function ($innerQueryBuilder) {
             PoolCandidate::scopeAvailable($innerQueryBuilder);

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -594,22 +594,18 @@ class User extends Model implements Authenticatable, LaratrustUser
     }
 
     /**
-     * Scope is IT
+     * Return users who have an available PoolCandidate in at least one IT pool.
      *
-     * Restrict a query by pool candidates that are for pools
-     * containing IT specific publishing groups
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query  The existing query being built
-     * @return \Illuminate\Database\Eloquent\Builder The resulting query
+     * @param Builder $query
+     * @return Builder
      */
-    public static function scopeInITPublishingGroup(Builder $query)
+    public static function scopeAvailableInITPool(Builder $query): Builder
     {
-        $query = self::scopePublishingGroups($query, [
-            PublishingGroup::IT_JOBS_ONGOING->name,
-            PublishingGroup::IT_JOBS->name,
-        ]);
-
-        return $query;
+        return $query->whereHas('poolCandidates', function ($innerQueryBuilder) {
+            PoolCandidate::scopeAvailable($innerQueryBuilder);
+            PoolCandidate::scopeInITPublishingGroup($innerQueryBuilder);
+            return $innerQueryBuilder;
+        });
     }
 
     public static function scopeHasDiploma(Builder $query, ?bool $hasDiploma): Builder

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -684,7 +684,7 @@ type Query {
     )
   # countApplicants returns the number of candidates matching its filters, and requires no special permissions.
   countApplicants(where: ApplicantFilterInput): Int!
-    @count(model: "User", scopes: ["availableInITPool"])
+    @count(model: "User", scopes: ["availableInITPublishingGroup"])
   pool(id: UUID! @eq): Pool @find @can(ability: "view", query: true)
   publishedPools(
     closingAfter: DateTime @where(key: "closing_date", operator: ">")

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -684,7 +684,7 @@ type Query {
     )
   # countApplicants returns the number of candidates matching its filters, and requires no special permissions.
   countApplicants(where: ApplicantFilterInput): Int!
-    @count(model: "User", scopes: ["inITPublishingGroup"])
+    @count(model: "User", scopes: ["availableInITPool"])
   pool(id: UUID! @eq): Pool @find @can(ability: "view", query: true)
   publishedPools(
     closingAfter: DateTime @where(key: "closing_date", operator: ">")


### PR DESCRIPTION
🤖 Resolves #9160

## 👋 Introduction

Updates the base scopes for the countApplicants query to match the countPoolCandidatesByPool query.

## 🕵️ Details

The steps to reproduce in the issue will still return a different number of candidates due to candidates in archived pools. The base query includes those pools but the search page does not.

## 🧪 Testing

The easiest way to test this is probably just ensuring the tests match desired behavior and all pass. Removing any archived pools from your environment should also cause the steps to reproduce in the issue to pass.