### PR TITLE
[Feature] Education options for EC group

### DIFF
--- a/api/database/seeders/ClassificationSeeder.php
+++ b/api/database/seeders/ClassificationSeeder.php
@@ -26,6 +26,11 @@ class ClassificationSeeder extends Seeder
             'group' => 'PM',
             'name' => ['en' => 'Programme Administration', 'fr' => 'Administration des programmes'],
         ];
+        // https://www.tbs-sct.canada.ca/agreements-conventions/view-visualiser-eng.aspx?id=4
+        $ecGroup = [
+            'group' => 'EC',
+            'name' => ['en' => 'Economics and Social Science Services', 'fr' => 'économique et services de sciences sociales'],
+        ];
 
         $classifications = [
             // IT classifications 01-05.
@@ -108,6 +113,71 @@ class ClassificationSeeder extends Seeder
                     'level' => 5,
                     'min_salary' => 67981,
                     'max_salary' => 73495,
+                ]
+            ),
+            // https://www.tbs-sct.canada.ca/agreements-conventions/view-visualiser-eng.aspx?id=4#tocxx338387
+            array_merge(
+                $ecGroup,
+                [
+                    'level' => 1,
+                    'min_salary' => 59978,
+                    'max_salary' => 69725,
+                ]
+            ),
+            array_merge(
+                $ecGroup,
+                [
+                    'level' => 2,
+                    'min_salary' => 67102,
+                    'max_salary' => 76933,
+                ]
+            ),
+            array_merge(
+                $ecGroup,
+                [
+                    'level' => 3,
+                    'min_salary' => 74116,
+                    'max_salary' => 83863,
+                ]
+            ),
+            array_merge(
+                $ecGroup,
+                [
+                    'level' => 4,
+                    'min_salary' => 80005,
+                    'max_salary' => 92587,
+                ]
+            ),
+            array_merge(
+                $ecGroup,
+                [
+                    'level' => 5,
+                    'min_salary' => 95653,
+                    'max_salary' => 110096,
+                ]
+            ),
+            array_merge(
+                $ecGroup,
+                [
+                    'level' => 6,
+                    'min_salary' => 108068,
+                    'max_salary' => 125332,
+                ]
+            ),
+            array_merge(
+                $ecGroup,
+                [
+                    'level' => 7,
+                    'min_salary' => 122103,
+                    'max_salary' => 140177,
+                ]
+            ),
+            array_merge(
+                $ecGroup,
+                [
+                    'level' => 8,
+                    'min_salary' => 132754,
+                    'max_salary' => 151729,
                 ]
             ),
         ];

--- a/apps/web/src/components/EducationRequirements/EducationRequirements.tsx
+++ b/apps/web/src/components/EducationRequirements/EducationRequirements.tsx
@@ -191,6 +191,36 @@ const EducationRequirements = ({
           </Card>
         </Wrapper>
       );
+    case "EC":
+      return (
+        <Wrapper>
+          <Card>
+            <Heading level="h4" size="h6" data-h2-margin-top="base(0)">
+              {intl.formatMessage(
+                applicationMessages.educationRequirementECJustEducationHeading,
+              )}
+            </Heading>
+            <Text>
+              {intl.formatMessage(
+                applicationMessages.educationRequirementECJustEducationDescription,
+              )}
+            </Text>
+          </Card>
+          <Or />
+          <Card>
+            <Heading level="h4" size="h6" data-h2-margin-top="base(0)">
+              {intl.formatMessage(
+                applicationMessages.educationRequirementECEducationPlusHeading,
+              )}
+            </Heading>
+            <Text>
+              {intl.formatMessage(
+                applicationMessages.educationRequirementECEducationPlusDescription,
+              )}
+            </Text>
+          </Card>
+        </Wrapper>
+      );
     default:
       return (
         <Wrapper>

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3471,6 +3471,10 @@
     "defaultMessage": "Créer une équipe ",
     "description": "Link text to create a new team in the admin portal"
   },
+  "GurdF+": {
+    "defaultMessage": "Un grade d’un établissement d’enseignement postsecondaire reconnu avec spécialisation acceptable en économie, en sociologie ou en statistique.",
+    "description": "Description for the `just education` option for EC education requirements"
+  },
   "H+83NU": {
     "defaultMessage": "Vous avez des questions? <link>Contactez-nous</link>.",
     "description": "Fourth paragraph for pool deadlines dialog"
@@ -3654,6 +3658,10 @@
   "IEkhMc": {
     "defaultMessage": "Prénom",
     "description": "Label displayed for the first name field in create account form."
+  },
+  "IEp0sR": {
+    "defaultMessage": "Un grade est quand même requis. Cependant, la spécialisation en économie, en sociologie ou en statistique peut également être formée d’un agencement acceptable d’études, de formation ou d’expérience.",
+    "description": "Description for the `other education with specialization` option for EC education requirements"
   },
   "IFGKCz": {
     "defaultMessage": "Supprimer",
@@ -4878,6 +4886,10 @@
   "Pasf+O": {
     "defaultMessage": "Les mises à jour de votre profil après l’envoi de votre candidature ne se refléteront pas dans votre dossier de candidature.",
     "description": "List item note 2 for the application review page."
+  },
+  "PbLJnr": {
+    "defaultMessage": "Grade en économie, en sociologie ou en statistique",
+    "description": "Heading for the `just education` option for EC education requirements"
   },
   "PdE7yp": {
     "defaultMessage": "Archiver ce bassin",
@@ -6114,6 +6126,10 @@
   "WSo3Y/": {
     "defaultMessage": "Le commissaire à l’accessibilité est responsable de faire appliquer la <acaLink>Loi canadienne sur l’accessibilité</acaLink> et le <acrLink>Règlement canadien sur l’accessibilité</acrLink> dans la fonction publique fédérale. Le commissaire traitera également certaines <complaintsLink>plaintes en matière d’accessibilité</complaintsLink>. Le commissaire à l’accessibilité est membre de la Commission canadienne des droits de la personne.",
     "description": "Text describing accessibility commissioner"
+  },
+  "WT+5to": {
+    "defaultMessage": "Autre grade avec spécialisation",
+    "description": "Heading for the `other education with specialization` option for EC education requirements"
   },
   "WVTDgX": {
     "defaultMessage": "Bienvenue à Talents numériques du GC",

--- a/apps/web/src/messages/applicationMessages.ts
+++ b/apps/web/src/messages/applicationMessages.ts
@@ -135,6 +135,32 @@ const messages = defineMessages({
     description:
       "External link message for the EX graduation with degree requirement.",
   },
+  educationRequirementECJustEducationHeading: {
+    defaultMessage: "Degree in economics, sociology or statistics",
+    id: "PbLJnr",
+    description:
+      "Heading for the `just education` option for EC education requirements",
+  },
+  educationRequirementECJustEducationDescription: {
+    defaultMessage:
+      "Graduation with a degree from a recognized post-secondary institution with acceptable specialization in economics, sociology or statistics.",
+    id: "GurdF+",
+    description:
+      "Description for the `just education` option for EC education requirements",
+  },
+  educationRequirementECEducationPlusHeading: {
+    defaultMessage: "Other degree with specialization",
+    id: "WT+5to",
+    description:
+      "Heading for the `other education with specialization` option for EC education requirements",
+  },
+  educationRequirementECEducationPlusDescription: {
+    defaultMessage:
+      "A degree is still required. However, the specialization in economics, sociology, or statistics may also be obtained through an acceptable combination of education, training, or experience.",
+    id: "IEp0sR",
+    description:
+      "Description for the `other education with specialization` option for EC education requirements",
+  },
 });
 
 export default messages;

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
@@ -359,6 +359,7 @@ const ApplicationEducation = ({
             experiences={experiences}
             watchEducationRequirement={watchEducationRequirement}
             previousStepPath={previousStep}
+            classificationGroup={classificationGroup}
           />
           <Separator
             orientation="horizontal"

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/LinkCareerTimeline.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/LinkCareerTimeline.tsx
@@ -17,6 +17,7 @@ import {
   isPersonalExperience,
   isWorkExperience,
 } from "~/utils/experienceUtils";
+import { ClassificationGroup } from "~/utils/poolUtils";
 
 const essentialExperienceMessages = defineMessages({
   computerScience: {
@@ -70,12 +71,14 @@ interface LinkCareerTimelineProps {
   experiences: Experience[];
   watchEducationRequirement: EducationRequirementOption;
   previousStepPath: string;
+  classificationGroup?: ClassificationGroup;
 }
 
 const LinkCareerTimeline = ({
   experiences,
   watchEducationRequirement,
   previousStepPath,
+  classificationGroup,
 }: LinkCareerTimelineProps) => {
   const intl = useIntl();
   const previousStepLink = (chunks: React.ReactNode) => (
@@ -168,27 +171,34 @@ const LinkCareerTimeline = ({
   );
 
   const checkListSection = (): React.ReactNode => {
+    // decide whether to show the "select experiences in" helper list
+    const showEssentialExperienceMessage: boolean =
+      classificationGroup !== "EC";
     switch (watchEducationRequirement) {
       // If "I meet the applied work experience" option is selected, checkboxes are displayed for every experience.
       case EducationRequirementOption.AppliedWork:
       case EducationRequirementOption.ProfessionalDesignation:
         return (
           <>
-            <p data-h2-margin="base(0, 0, x.5, 0)">
-              {intl.formatMessage({
-                defaultMessage: "Please select experiences in:",
-                id: "6Q1N7Z",
-                description:
-                  "Message before skills list in application education page.",
-              })}
-            </p>
-            <ul data-h2-margin="base(0, 0, x1, 0)">
-              {Object.values(essentialExperienceMessages).map((value) => (
-                <li key={uniqueId()} data-h2-margin="base(0, 0, x.25, 0)">
-                  {intl.formatMessage(value)}
-                </li>
-              ))}
-            </ul>
+            {showEssentialExperienceMessage && (
+              <>
+                <p data-h2-margin="base(0, 0, x.5, 0)">
+                  {intl.formatMessage({
+                    defaultMessage: "Please select experiences in:",
+                    id: "6Q1N7Z",
+                    description:
+                      "Message before skills list in application education page.",
+                  })}
+                </p>
+                <ul data-h2-margin="base(0, 0, x1, 0)">
+                  {Object.values(essentialExperienceMessages).map((value) => (
+                    <li key={uniqueId()} data-h2-margin="base(0, 0, x.25, 0)">
+                      {intl.formatMessage(value)}
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
             {experienceItems.allExperiences.length === 0 ? (
               <Well>
                 <p

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/utils.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/utils.tsx
@@ -101,6 +101,43 @@ export const getEducationRequirementOptions = (
   isIAP = false,
 ): Radio[] => {
   switch (classificationGroup) {
+    case "EC":
+      return [
+        {
+          value: EducationRequirementOption.Education,
+          label: (
+            <strong>
+              {intl.formatMessage(
+                applicationMessages.educationRequirementECJustEducationHeading,
+              )}
+            </strong>
+          ),
+          contentBelow: (
+            <p>
+              {intl.formatMessage(
+                applicationMessages.educationRequirementECJustEducationDescription,
+              )}
+            </p>
+          ),
+        },
+        {
+          value: EducationRequirementOption.AppliedWork,
+          label: (
+            <strong>
+              {intl.formatMessage(
+                applicationMessages.educationRequirementECEducationPlusHeading,
+              )}
+            </strong>
+          ),
+          contentBelow: (
+            <p>
+              {intl.formatMessage(
+                applicationMessages.educationRequirementECEducationPlusDescription,
+              )}
+            </p>
+          ),
+        },
+      ];
     case "EX":
       return [
         {

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -332,7 +332,7 @@ export const isOngoingPublishingGroup = (
 ): boolean =>
   publishingGroup ? ONGOING_PUBLISHING_GROUPS.includes(publishingGroup) : false;
 
-export type ClassificationGroup = "AS" | "EX" | "PM" | "IT";
+export type ClassificationGroup = "AS" | "EX" | "PM" | "IT" | "EC";
 
 export function getClassificationGroup(
   pool: Maybe<Pool>,


### PR DESCRIPTION
🤖 Resolves #9219

## 👋 Introduction

This branch adds the education options for the EC classification group.

## 🧪 Testing

1. Can create a pool for the EC group
2. Can see a pool advertisement for the EC group
3. Can apply to a pool for the EC group
4. Can review an application for the eC group

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/f76ccc83-10c6-4608-ac2c-6aaf539a7ba9)

## 🚚 Deployment

Might need to add the EC classifications in prod.  Can use the admin interface for that.  Or run the seeder if it is confirmed accurate.