### PR TITLE
[Fix] Combox clear button resets options

### DIFF
--- a/packages/forms/src/components/Combobox/Multi.tsx
+++ b/packages/forms/src/components/Combobox/Multi.tsx
@@ -193,8 +193,7 @@ const Multi = ({
   }, [options]);
 
   const handleClear = () => {
-    setInputValue("");
-    onInputChange?.("");
+    handleInputChanged("");
     inputRef?.current?.focus();
   };
 


### PR DESCRIPTION
🤖 Resolves #9239 

## 👋 Introduction

Fixes the clear button on the mutli combobox to also reset the options in the dropdown.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to `/search`
3. Type in the skill combobox
4. Click the "X" to clear
5. Without typing, open the dropdown
6. Confirm the options were reset
