### PR TITLE
[Fix] Step tracker search case insensitve

### DIFF
--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -247,8 +247,9 @@ export const filterResults = (
         if (filters.query) {
           const fullName = [user.firstName, user.lastName]
             .filter(notEmpty)
-            .join(" ");
-          if (!fullName.includes(filters.query)) {
+            .join(" ")
+            .toLowerCase();
+          if (!fullName.includes(filters.query.toLowerCase())) {
             return false;
           }
         }


### PR DESCRIPTION
🤖 Resolves #9241 

## 👋 Introduction

Fixes the search on the step tracker to be case insensitve

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run storybook `npm run storybook:web`
2. Navigate to the "Assessment Step Tracker" story
3. Use the search typing in queries that do not match the case of results
4. Confirm they appear in the results regardless of case

## 📸 Screenshot

![Screenshot 2024-02-07 160407](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/de661e27-3b8e-4a04-9853-760fbd27fd73)
