### PR TITLE
[Debt] Handle logging for tokens better

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -6,7 +6,6 @@ use App\Services\OpenIdBearerTokenService;
 use Exception;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Http;
@@ -74,19 +73,21 @@ class AuthController extends Controller
             new InvalidArgumentException('Invalid session state')
         );
 
-        $response = Http::retry(3, 500, function (Exception $exception, PendingRequest $request) {
+        $response = Http::retry(times: 3, sleepMilliseconds: 500, when: function (Exception $exception, PendingRequest $request) {
             return $exception instanceof ConnectionException;
-        })->asForm()->post(config('oauth.token_uri'), [
+        }, throw: false)->asForm()->post(config('oauth.token_uri'), [
             'grant_type' => 'authorization_code',
             'client_id' => config('oauth.client_id'),
             'client_secret' => config('oauth.client_secret'),
             'redirect_uri' => config('oauth.redirect_uri'),
             'code' => $request->code,
-        ])->throw(function (Response $response, RequestException $e) {
-            Log::error('Failed to get a response from POSTing to the token URI');
+        ]);
+        if ($response->failed()) {
+            Log::error('Failed when POSTing to the token URI in authCallback');
             Log::debug((string) $response->getBody());
-        });
 
+            return response('Failed to get token', 400);
+        }
         // decode id_token stage
         // pull token out of the response as json -> lcobucci parser, no key verification is being done here however
         $idToken = $response->json('id_token');


### PR DESCRIPTION
🤖 Resolves #9147

## 👋 Introduction

This branch turns off exception throwing when requesting a token and instead manually checks for a failed response.  This allows us to do clearer logging.

## 🧪 Testing

1. Configure your environment to use the Sign In Canada test server.
2. Break the code so that the authcallback token request to fail.  This is an easy way to do it:
![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/b8d4c3ef-fec0-4ef9-84aa-bba974335ee7)
3. Try to log in.

Optional:
Set 
```
APP_ENV=production
APP_DEBUG=false
```
so you can see what the users will see.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/398c2357-767f-4ce8-9460-34167a2448b5)
![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/b2963045-bfb5-4278-bcf4-064fc7772e6b)
