### PR TITLE
[Fix] User input in team members add dialog

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -690,6 +690,20 @@ class User extends Model implements Authenticatable, LaratrustUser
         return $query;
     }
 
+    public static function scopePublicProfileSearch(Builder $query, ?string $search): Builder
+    {
+        if ($search) {
+            $query->where(function ($query) use ($search) {
+                self::scopeName($query, $search);
+                $query->orWhere(function ($query) use ($search) {
+                    self::scopeEmail($query, $search);
+                });
+            });
+        }
+
+        return $query;
+    }
+
     public static function scopeName(Builder $query, ?string $name): Builder
     {
         if ($name) {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -713,7 +713,11 @@ type Query {
     orderBy: [OrderByClause!] @orderBy
   ): [UserPublicProfile]!
     @orderBy(column: "created_at", direction: DESC)
-    @paginate(defaultCount: 10, maxCount: 1000, scopes: ["authorizedToView"])
+    @paginate(
+      defaultCount: 10
+      maxCount: 1000
+      scopes: ["authorizedToViewBasicInfo"]
+    )
     @guard
     @can(ability: "viewBasicInfo", model: "User")
   # countApplicants returns the number of candidates matching its filters, and requires no special permissions.

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -614,6 +614,13 @@ input UserFilterInput {
   trashed: Trashed @trashed
 }
 
+input UserPublicProfileFilterInput {
+  telephone: String @scope
+  email: String @scope
+  name: String @scope
+  generalSearch: [String] @scope
+}
+
 # Changes to this input will require some manual updates to api/app/GraphQL/Queries/CountPoolCandidatesByPool.php since it doesn't use the directives for automatic resolution
 input ApplicantFilterInput {
   equity: EquitySelectionsInput @scope
@@ -703,6 +710,14 @@ type Query {
     @deprecated(
       reason: "We should avoid non-paginated queries when we know a query will return thousands of values. In this case, we must write an alternative first!"
     )
+  userPublicProfilesPaginated(
+    where: UserPublicProfileFilterInput
+    orderBy: [OrderByClause!] @orderBy
+  ): [UserPublicProfile]!
+    @orderBy(column: "created_at", direction: DESC)
+    @paginate(defaultCount: 10, maxCount: 1000)
+    @guard
+    @can(ability: "viewBasicInfo", model: "User")
   # countApplicants returns the number of candidates matching its filters, and requires no special permissions.
   countApplicants(where: ApplicantFilterInput): Int!
     @count(model: "User", scopes: ["inITPublishingGroup"])

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -712,10 +712,11 @@ type Query {
     )
   userPublicProfilesPaginated(
     where: UserPublicProfileFilterInput
+    excludeIds: [ID!] @notIn(key: "id")
     orderBy: [OrderByClause!] @orderBy
   ): [UserPublicProfile]!
     @orderBy(column: "created_at", direction: DESC)
-    @paginate(defaultCount: 10, maxCount: 1000)
+    @paginate(defaultCount: 10, maxCount: 1000, scopes: ["authorizedToView"])
     @guard
     @can(ability: "viewBasicInfo", model: "User")
   # countApplicants returns the number of candidates matching its filters, and requires no special permissions.

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -615,10 +615,7 @@ input UserFilterInput {
 }
 
 input UserPublicProfileFilterInput {
-  telephone: String @scope
-  email: String @scope
-  name: String @scope
-  generalSearch: [String] @scope
+  publicProfileSearch: String @scope
 }
 
 # Changes to this input will require some manual updates to api/app/GraphQL/Queries/CountPoolCandidatesByPool.php since it doesn't use the directives for automatic resolution

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -700,13 +700,6 @@ type Query {
     @deprecated(
       reason: "applicants is deprecated. Use usersPaginated instead. Remove in #7652."
     )
-  userPublicProfiles: [UserPublicProfile]!
-    @all
-    @guard
-    @can(ability: "viewBasicInfo", model: "User")
-    @deprecated(
-      reason: "We should avoid non-paginated queries when we know a query will return thousands of values. In this case, we must write an alternative first!"
-    )
   userPublicProfilesPaginated(
     where: UserPublicProfileFilterInput
     excludeIds: [ID!] @notIn(key: "id")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -670,10 +670,7 @@ input UserFilterInput {
 }
 
 input UserPublicProfileFilterInput {
-  telephone: String
-  email: String
-  name: String
-  generalSearch: [String]
+  publicProfileSearch: String
 }
 
 input ApplicantFilterInput {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -12,7 +12,6 @@ type Query {
     trashed: Trashed
   ): [User]! @deprecated(reason: "users is deprecated. Use usersPaginated instead. Remove in #7660.")
   applicants(includeIds: [ID]!): [User]! @deprecated(reason: "applicants is deprecated. Use usersPaginated instead. Remove in #7652.")
-  userPublicProfiles: [UserPublicProfile]! @deprecated(reason: "We should avoid non-paginated queries when we know a query will return thousands of values. In this case, we must write an alternative first!")
   countApplicants(where: ApplicantFilterInput): Int!
   pool(id: UUID!): Pool
   publishedPools(closingAfter: DateTime, publishingGroup: PublishingGroup): [Pool!]!

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -50,6 +50,7 @@ type Query {
   ): UserPaginator!
   userPublicProfilesPaginated(
     where: UserPublicProfileFilterInput
+    excludeIds: [ID!]
     orderBy: [OrderByClause!]
 
     "Limits number of fetched items. Maximum allowed value: 1000."

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -48,6 +48,16 @@ type Query {
     "The offset from which items are returned."
     page: Int
   ): UserPaginator!
+  userPublicProfilesPaginated(
+    where: UserPublicProfileFilterInput
+    orderBy: [OrderByClause!]
+
+    "Limits number of fetched items. Maximum allowed value: 1000."
+    first: Int! = 10
+
+    "The offset from which items are returned."
+    page: Int
+  ): UserPublicProfilePaginator!
   poolCandidatesPaginated(
     where: PoolCandidateSearchInput
     orderBy: [QueryPoolCandidatesPaginatedOrderByRelationOrderByClause!]
@@ -656,6 +666,13 @@ input UserFilterInput {
   generalSearch: [String]
   roles: [ID]
   trashed: Trashed
+}
+
+input UserPublicProfileFilterInput {
+  telephone: String
+  email: String
+  name: String
+  generalSearch: [String]
 }
 
 input ApplicantFilterInput {
@@ -1613,6 +1630,15 @@ type UserPaginator {
 
   "A list of User items."
   data: [User!]!
+}
+
+"A paginated list of UserPublicProfile items."
+type UserPublicProfilePaginator {
+  "Pagination information about the list of items."
+  paginatorInfo: PaginatorInfo!
+
+  "A list of UserPublicProfile items."
+  data: [UserPublicProfile!]!
 }
 
 "A paginated list of PoolCandidateWithSkillCount items."

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/AddTeamMemberDialog.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/AddTeamMemberDialog.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
+import debounce from "lodash/debounce";
 import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
 
 import { Dialog, Button } from "@gc-digital-talent/ui";
@@ -35,7 +36,10 @@ const AddTeamMemberDialog = ({
 }: // onSave,
 AddTeamMemberDialogProps) => {
   const intl = useIntl();
-  const { users, fetching: usersFetching } = useAvailableUsers(members);
+  const [query, setQuery] = React.useState<string>("");
+  const { users, fetching: usersFetching } = useAvailableUsers(members, {
+    generalSearch: query ? query.split(",") : undefined,
+  });
   const { roles, fetching: rolesFetching } = useAvailableRoles();
   const [, executeMutation] = useUpdateUserTeamRolesMutation();
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
@@ -91,6 +95,10 @@ AddTeamMemberDialogProps) => {
       });
   };
 
+  const handleDebouncedSearch = debounce((newQuery: string) => {
+    setQuery(newQuery);
+  }, 300);
+
   const roleOptions = getTeamBasedRoleOptions(roles, intl);
   const userOptions = users?.map((user) => ({
     value: user.id,
@@ -138,6 +146,8 @@ AddTeamMemberDialogProps) => {
                   id="userId"
                   name="userId"
                   fetching={usersFetching}
+                  isExternalSearch
+                  onSearch={handleDebouncedSearch}
                   rules={{
                     required: intl.formatMessage(errorMessages.required),
                   }}

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/AddTeamMemberDialog.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/AddTeamMemberDialog.tsx
@@ -37,8 +37,12 @@ const AddTeamMemberDialog = ({
 AddTeamMemberDialogProps) => {
   const intl = useIntl();
   const [query, setQuery] = React.useState<string>("");
-  const { users, fetching: usersFetching } = useAvailableUsers(members, {
-    generalSearch: query ? query.split(",") : undefined,
+  const {
+    users,
+    total,
+    fetching: usersFetching,
+  } = useAvailableUsers(members, {
+    publicProfileSearch: query || undefined,
   });
   const { roles, fetching: rolesFetching } = useAvailableRoles();
   const [, executeMutation] = useUpdateUserTeamRolesMutation();
@@ -148,6 +152,7 @@ AddTeamMemberDialogProps) => {
                   fetching={usersFetching}
                   isExternalSearch
                   onSearch={handleDebouncedSearch}
+                  total={total}
                   rules={{
                     required: intl.formatMessage(errorMessages.required),
                   }}

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/useAvailableUsers.ts
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/useAvailableUsers.ts
@@ -31,8 +31,6 @@ const TeamMembers_AvailableUsersQuery = graphql(/* GraphQL */ `
         email
       }
       paginatorInfo {
-        lastPage
-        currentPage
         total
       }
     }
@@ -41,6 +39,7 @@ const TeamMembers_AvailableUsersQuery = graphql(/* GraphQL */ `
 
 type UseAvailableUsersReturn = {
   users: UserPublicProfile[];
+  total: number;
   fetching: boolean;
 };
 
@@ -59,9 +58,12 @@ const useAvailableUsers = (
   });
 
   const users = unpackMaybes(data?.userPublicProfilesPaginated.data);
+  const total =
+    data?.userPublicProfilesPaginated.paginatorInfo?.total ?? users.length;
 
   return {
     users,
+    total,
     fetching,
   };
 };

--- a/apps/web/src/pages/Teams/TeamMembersPage/components/useAvailableUsers.ts
+++ b/apps/web/src/pages/Teams/TeamMembersPage/components/useAvailableUsers.ts
@@ -1,18 +1,40 @@
 import { useQuery } from "urql";
-import React from "react";
 
-import { UserPublicProfile, graphql } from "@gc-digital-talent/graphql";
-import { notEmpty } from "@gc-digital-talent/helpers";
+import {
+  UserPublicProfile,
+  UserPublicProfileFilterInput,
+  graphql,
+} from "@gc-digital-talent/graphql";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 import { TeamMember } from "~/utils/teamUtils";
 
 const TeamMembers_AvailableUsersQuery = graphql(/* GraphQL */ `
-  query TeamMembers_AvailableUsers {
-    userPublicProfiles {
-      id
-      firstName
-      lastName
-      email
+  query TeamMembers_AvailableUsers(
+    $where: UserPublicProfileFilterInput
+    $excludeIds: [ID!]
+    $first: Int
+    $page: Int
+    $orderBy: [OrderByClause!]
+  ) {
+    userPublicProfilesPaginated(
+      where: $where
+      first: $first
+      page: $page
+      excludeIds: $excludeIds
+      orderBy: $orderBy
+    ) {
+      data {
+        id
+        firstName
+        lastName
+        email
+      }
+      paginatorInfo {
+        lastPage
+        currentPage
+        total
+      }
     }
   }
 `);
@@ -22,20 +44,21 @@ type UseAvailableUsersReturn = {
   fetching: boolean;
 };
 
-const useAvailableUsers = (members: TeamMember[]): UseAvailableUsersReturn => {
+const useAvailableUsers = (
+  members: TeamMember[],
+  where?: UserPublicProfileFilterInput,
+): UseAvailableUsersReturn => {
+  const excludeIds = members.map((member) => member.id);
   const [{ data, fetching }] = useQuery({
     query: TeamMembers_AvailableUsersQuery,
+    variables: {
+      first: 100,
+      excludeIds,
+      where,
+    },
   });
 
-  const users: UserPublicProfile[] = React.useMemo(
-    () =>
-      data?.userPublicProfiles
-        .filter(
-          (user) => !members?.find((teamUser) => teamUser.id === user?.id),
-        )
-        ?.filter(notEmpty) ?? [],
-    [data?.userPublicProfiles, members],
-  );
+  const users = unpackMaybes(data?.userPublicProfilesPaginated.data);
 
   return {
     users,

--- a/apps/web/src/pages/Teams/teamsOperations.graphql
+++ b/apps/web/src/pages/Teams/teamsOperations.graphql
@@ -175,15 +175,6 @@ mutation CreateTeam($team: CreateTeamInput!) {
   }
 }
 
-query AllUsersNames {
-  userPublicProfiles {
-    id
-    firstName
-    lastName
-    email
-  }
-}
-
 mutation UpdateUserTeamRoles($teamRoleAssignments: UpdateUserTeamRolesInput!) {
   updateUserTeamRoles(teamRoleAssignments: $teamRoleAssignments) {
     roleAssignments {


### PR DESCRIPTION
🤖 Resolves #9064 

## 👋 Introduction

Applies a fix to the users team member dialog crashing by using a paginated query.

## 🕵️ Details

This adds a new `userPublisProfilesPaginated` query that uses a limited search scope (`publicProfileSearch`) that only searches available fields on the public profile.

It also adds an `excludeIds` option so we return the proper page number (`100`) when filtering out existing team members.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login as admin@test.com
3. Navigate to `/admin/teams`
4. Click on a team name
5. Navigate to the "View team members" tab
6. Active the "Add new member" dialog
7. Focus the "Manager name" field
8. Confirm it opens with only 100 results
9. Search for a user
10. Confirm search returns expected results
11. Confirm saving the form still adds the user

## 📸 Screenshot

![Screenshot 2024-02-09 104755](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/801253db-cda3-49af-be77-017627751961)