### PR TITLE
[Feature] Add prev/next/back links to pool candidate page

### DIFF
--- a/apps/web/src/components/AssessmentStepTracker/AssessmentResults.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentResults.tsx
@@ -142,7 +142,7 @@ interface AssessmentResultsProps {
 
 const AssessmentResults = ({ results, stepType }: AssessmentResultsProps) => {
   const sortedResults = sortResultsAndAddOrdinal(results);
-  const candidateIds = results.map((result) => result.poolCandidate.id);
+  const candidateIds = sortedResults.map((result) => result.poolCandidate.id);
   const isApplicationStep =
     stepType === AssessmentStepType.ApplicationScreening;
 

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentResults.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentResults.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useIntl } from "react-intl";
 
 import { Board, Link } from "@gc-digital-talent/ui";
-import { Maybe } from "@gc-digital-talent/graphql";
+import { Maybe, Scalars } from "@gc-digital-talent/graphql";
 
 import { ArmedForcesStatus, AssessmentStepType } from "~/api/generated";
 import { getFullNameLabel } from "~/utils/nameUtils";
@@ -54,11 +54,13 @@ const Priority = ({ type }: PriorityProps) => {
 interface AssessmentResultProps {
   result: CandidateAssessmentResult & { ordinal: number };
   isApplicationStep: boolean;
+  candidateIds: Scalars["UUID"]["output"][];
 }
 
 const AssessmentResult = ({
   result,
   isApplicationStep,
+  candidateIds,
 }: AssessmentResultProps) => {
   const intl = useIntl();
   const paths = useRoutes();
@@ -105,6 +107,7 @@ const AssessmentResult = ({
             mode="text"
             color="black"
             href={paths.poolCandidateApplication(result.poolCandidate.id)}
+            state={{ candidateIds }}
           >
             {result.ordinal}.{" "}
             {getFullNameLabel(
@@ -139,6 +142,7 @@ interface AssessmentResultsProps {
 
 const AssessmentResults = ({ results, stepType }: AssessmentResultsProps) => {
   const sortedResults = sortResultsAndAddOrdinal(results);
+  const candidateIds = results.map((result) => result.poolCandidate.id);
   const isApplicationStep =
     stepType === AssessmentStepType.ApplicationScreening;
 
@@ -146,6 +150,7 @@ const AssessmentResults = ({ results, stepType }: AssessmentResultsProps) => {
     <Board.List>
       {sortedResults.map((result) => (
         <AssessmentResult
+          candidateIds={candidateIds}
           key={result.poolCandidate.id}
           result={{ ...result }}
           isApplicationStep={isApplicationStep}

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentResults.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentResults.tsx
@@ -54,6 +54,7 @@ const Priority = ({ type }: PriorityProps) => {
 interface AssessmentResultProps {
   result: CandidateAssessmentResult & { ordinal: number };
   isApplicationStep: boolean;
+  stepName: string;
   candidateIds: Scalars["UUID"]["output"][];
 }
 
@@ -61,6 +62,7 @@ const AssessmentResult = ({
   result,
   isApplicationStep,
   candidateIds,
+  stepName,
 }: AssessmentResultProps) => {
   const intl = useIntl();
   const paths = useRoutes();
@@ -107,7 +109,7 @@ const AssessmentResult = ({
             mode="text"
             color="black"
             href={paths.poolCandidateApplication(result.poolCandidate.id)}
-            state={{ candidateIds }}
+            state={{ candidateIds, stepName }}
           >
             {result.ordinal}.{" "}
             {getFullNameLabel(
@@ -138,9 +140,14 @@ const AssessmentResult = ({
 interface AssessmentResultsProps {
   results: CandidateAssessmentResult[];
   stepType?: Maybe<AssessmentStepType>;
+  stepName: string;
 }
 
-const AssessmentResults = ({ results, stepType }: AssessmentResultsProps) => {
+const AssessmentResults = ({
+  results,
+  stepType,
+  stepName,
+}: AssessmentResultsProps) => {
   const sortedResults = sortResultsAndAddOrdinal(results);
   const candidateIds = sortedResults.map((result) => result.poolCandidate.id);
   const isApplicationStep =
@@ -153,6 +160,7 @@ const AssessmentResults = ({ results, stepType }: AssessmentResultsProps) => {
           candidateIds={candidateIds}
           key={result.poolCandidate.id}
           result={{ ...result }}
+          stepName={stepName}
           isApplicationStep={isApplicationStep}
         />
       ))}

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useIntl } from "react-intl";
 
 import { Board } from "@gc-digital-talent/ui";
-import { getLocalizedName } from "@gc-digital-talent/i18n";
+import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 import { Pool } from "@gc-digital-talent/graphql";
 
@@ -34,19 +34,33 @@ const AssessmentStepTracker = ({ pool }: AssessmentStepTrackerProps) => {
     <>
       <Filters onFiltersChange={setFilters} />
       <Board.Root>
-        {filteredSteps.map(({ step, resultCounts, results }, index) => (
-          <Board.Column key={step.id}>
-            <Board.ColumnHeader
-              prefix={intl.formatMessage(applicationMessages.numberedStep, {
-                stepOrdinal: index + 1,
-              })}
-            >
-              {getLocalizedName(step.title, intl)}
-            </Board.ColumnHeader>
-            <ResultsDetails {...{ resultCounts, step }} />
-            <AssessmentResults stepType={step.type} {...{ results }} />
-          </Board.Column>
-        ))}
+        {filteredSteps.map(({ step, resultCounts, results }, index) => {
+          const stepName = getLocalizedName(step.title, intl);
+          const stepNumber = intl.formatMessage(
+            applicationMessages.numberedStep,
+            {
+              stepOrdinal: index + 1,
+            },
+          );
+
+          return (
+            <Board.Column key={step.id}>
+              <Board.ColumnHeader prefix={stepNumber}>
+                {stepName}
+              </Board.ColumnHeader>
+              <ResultsDetails {...{ resultCounts, step }} />
+              <AssessmentResults
+                stepType={step.type}
+                stepName={
+                  stepNumber +
+                  intl.formatMessage(commonMessages.dividingColon) +
+                  stepName
+                }
+                {...{ results }}
+              />
+            </Board.Column>
+          );
+        })}
       </Board.Root>
     </>
   );

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7974,10 +7974,6 @@
     "defaultMessage": "Talents numériques du <abbreviation>GC</abbreviation> n’est qu’une des nombreuses initiatives menées par le bureau de la dirigeante principale de l’information du Canada (BDPI). Apprenez-en davantage sur le rôle du BDPI au sein du gouvernement du Canada. Consultez l’Ambition numérique du Canada 2022 pour connaître la direction future du BDPI.",
     "description": "Description of the Office of the Chief Information Officer"
   },
-  "mNYw+h": {
-    "defaultMessage": "Filtrage en cours",
-    "description": "Label for currently screening section on view pool candidate page"
-  },
   "h8AdRp": {
     "defaultMessage": "Vous ne pouvez pas récupérer vos informations de connexion, mais vous pouvez contacter votre <helpLink>Bureau d'aide</helpLink> qui vous aidera à récupérer votre compte.",
     "description": "GCKey answer for when user does not have recovery codes"
@@ -8877,6 +8873,10 @@
   "mNNgEF": {
     "defaultMessage": "Êtes-vous sûr(e) de vouloir vous déconnecter?",
     "description": "Question displayed when authenticated user lands on /logged-out."
+  },
+  "mNYw+h": {
+    "defaultMessage": "Filtrage en cours",
+    "description": "Label for currently screening section on view pool candidate page"
   },
   "mNfi9b": {
     "defaultMessage": "Sélectionnez le lieu géographique où le travail doit être effectué.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9030,6 +9030,10 @@
     "defaultMessage": "Posez une question",
     "description": "Support form subject field question option label"
   },
+  "mt4AkL": {
+    "defaultMessage": "Candidat(e) precedent(e)",
+    "description": "Link label to view previous candidate on view pool candidate page"
+  },
   "mtFK6A": {
     "defaultMessage": "Courriel :",
     "description": "Email label and colon"
@@ -10721,6 +10725,10 @@
   "y+r+ej": {
     "defaultMessage": "Groupe et niveau",
     "description": "Title displayed on the search request table group and level column."
+  },
+  "y1uo+J": {
+    "defaultMessage": "Prochain(e) candidat(e)",
+    "description": "Link label to view next candidate on view pool candidate page"
   },
   "y2Rl/m": {
     "defaultMessage": "Étapes relatives à l’application",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9126,6 +9126,10 @@
     "defaultMessage": "Compétence linguistique estimée",
     "description": "CSV Header, Estimated Language Ability column"
   },
+  "nUokX9": {
+    "defaultMessage": "Retourner au suivi des évaluations",
+    "description": "Link label to return to assessment tracker"
+  },
   "nWZiWr": {
     "defaultMessage": "Obtention réussie d’un diplôme d’études secondaires ou un équivalent du GED.",
     "description": "Education requirement (IT Apprenticeship Program for Indigenous Peoples)"
@@ -10657,6 +10661,10 @@
   "xdojyj": {
     "defaultMessage": "Politique et rétroaction",
     "description": "Label for the policy, conditions and feedback navigation"
+  },
+  "xfHjyy": {
+    "defaultMessage": "Passer au candidat précédent",
+    "description": "Link label to view previous candidate on view pool candidate page"
   },
   "xff04x": {
     "defaultMessage": "J'aimerais que ma candidature soit prise en compte pour des postes en français.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9302,10 +9302,6 @@
     "defaultMessage": "Consulter les possibilités offertes pour commencer à remplir une candidature.",
     "description": "Additional text displayed in the applications in progress section when empty."
   },
-  "oTNbp0": {
-    "defaultMessage": "Passer au prochain candidat",
-    "description": "Link label to view next candidate on view pool candidate page"
-  },
   "oTs24h": {
     "defaultMessage": "Concurrence (appel d’offres ouvert/appel d’offres sélectif/traditionnel)",
     "description": "Competitive contract solicitation procedure"
@@ -10661,10 +10657,6 @@
   "xdojyj": {
     "defaultMessage": "Politique et rétroaction",
     "description": "Label for the policy, conditions and feedback navigation"
-  },
-  "xfHjyy": {
-    "defaultMessage": "Passer au candidat précédent",
-    "description": "Link label to view previous candidate on view pool candidate page"
   },
   "xff04x": {
     "defaultMessage": "J'aimerais que ma candidature soit prise en compte pour des postes en français.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7974,8 +7974,8 @@
     "defaultMessage": "Talents numériques du <abbreviation>GC</abbreviation> n’est qu’une des nombreuses initiatives menées par le bureau de la dirigeante principale de l’information du Canada (BDPI). Apprenez-en davantage sur le rôle du BDPI au sein du gouvernement du Canada. Consultez l’Ambition numérique du Canada 2022 pour connaître la direction future du BDPI.",
     "description": "Description of the Office of the Chief Information Officer"
   },
-  "h7l8Sd": {
-    "defaultMessage": "Filtrage en cours :",
+  "mNYw+h": {
+    "defaultMessage": "Filtrage en cours",
     "description": "Label for currently screening section on view pool candidate page"
   },
   "h8AdRp": {

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
@@ -637,15 +637,6 @@ export const ViewPoolCandidate = ({
               data-h2-align-items="base(flex-start)"
               data-h2-gap="base(x.5)"
             >
-              <p data-h2-font-weight="base(700)">
-                {intl.formatMessage({
-                  defaultMessage: "Currently screening:",
-                  id: "h7l8Sd",
-                  description:
-                    "Label for currently screening section on view pool candidate page",
-                })}
-              </p>
-              <p>Step 1: Screening Application (Replace with fetched value)</p>
               <CandidateNavigation
                 candidateId={poolCandidate.id}
                 poolId={poolCandidate.pool.id}

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { defineMessage, useIntl } from "react-intl";
 import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
 import HandRaisedIcon from "@heroicons/react/24/outline/HandRaisedIcon";
-import ArrowRightCircleIcon from "@heroicons/react/24/solid/ArrowRightCircleIcon";
 import ExclamationTriangleIcon from "@heroicons/react/24/outline/ExclamationTriangleIcon";
 import { useQuery } from "urql";
 
@@ -45,6 +44,7 @@ import ApplicationInformation from "./components/ApplicationInformation/Applicat
 import ProfileDetails from "./components/ProfileDetails/ProfileDetails";
 import NotesDialog from "./components/MoreActions/NotesDialog";
 import FinalDecisionDialog from "./components/MoreActions/FinalDecisionDialog";
+import CandidateNavigation from "./components/CandidateNavigation/CandidateNavigation";
 
 const screeningAndAssessmentTitle = defineMessage({
   defaultMessage: "Screening and assessment",
@@ -646,20 +646,10 @@ export const ViewPoolCandidate = ({
                 })}
               </p>
               <p>Step 1: Screening Application (Replace with fetched value)</p>
-              <Link
-                href="#replace-with-link"
-                icon={ArrowRightCircleIcon}
-                type="button"
-                color="primary"
-                mode="inline"
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Go to next candidate",
-                  id: "oTNbp0",
-                  description:
-                    "Link label to view next candidate on view pool candidate page",
-                })}
-              </Link>
+              <CandidateNavigation
+                candidateId={poolCandidate.id}
+                poolId={poolCandidate.pool.id}
+              />
             </div>
           </Sidebar.Sidebar>
           <Sidebar.Content>

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/CandidateNavigation.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/CandidateNavigation.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import ArrowLeftCircleIcon from "@heroicons/react/20/solid/ArrowLeftCircleIcon";
+import ArrowRightCircleIcon from "@heroicons/react/20/solid/ArrowRightCircleIcon";
+
+import { Link, LinkProps } from "@gc-digital-talent/ui";
+
+import useRoutes from "~/hooks/useRoutes";
+
+import usePoolCandidateNavigation from "./usePoolCandidateNavigation";
+
+interface CandidateNavigationProps {
+  candidateId: string;
+  poolId: string;
+}
+
+const CandidateNavigation = ({
+  candidateId,
+  poolId,
+}: CandidateNavigationProps) => {
+  const intl = useIntl();
+  const paths = useRoutes();
+  const candidateNavigation = usePoolCandidateNavigation(candidateId);
+  if (!candidateNavigation) return null;
+  const { nextCandidate, previousCandidate, lastCandidate, candidateIds } =
+    candidateNavigation;
+
+  const commonLinkProps: LinkProps = {
+    color: "primary",
+    mode: "inline",
+    state: { candidateIds },
+  };
+
+  return (
+    <div
+      data-h2-display="base(flex)"
+      data-h2-flex-direction="base(column)"
+      data-h2-gap="base(x.5 0)"
+    >
+      {nextCandidate && (
+        <Link
+          href={paths.poolCandidateApplication(nextCandidate)}
+          icon={ArrowRightCircleIcon}
+          {...commonLinkProps}
+        >
+          {intl.formatMessage({
+            defaultMessage: "Go to next candidate",
+            id: "oTNbp0",
+            description:
+              "Link label to view next candidate on view pool candidate page",
+          })}
+        </Link>
+      )}
+      {previousCandidate && (
+        <Link
+          href={paths.poolCandidateApplication(previousCandidate)}
+          icon={ArrowLeftCircleIcon}
+          {...commonLinkProps}
+        >
+          {intl.formatMessage({
+            defaultMessage: "Go to previous candidate",
+            id: "xfHjyy",
+            description:
+              "Link label to view previous candidate on view pool candidate page",
+          })}
+        </Link>
+      )}
+      {lastCandidate && (
+        <Link
+          href={paths.screeningAndEvaluation(poolId)}
+          icon={ArrowLeftCircleIcon}
+          {...commonLinkProps}
+        >
+          {intl.formatMessage({
+            defaultMessage: "Back to assessments tracker",
+            id: "nUokX9",
+            description: "Link label to return to assessment tracker",
+          })}
+        </Link>
+      )}
+    </div>
+  );
+};
+
+export default CandidateNavigation;

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/CandidateNavigation.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/CandidateNavigation.tsx
@@ -44,8 +44,8 @@ const CandidateNavigation = ({
           {...commonLinkProps}
         >
           {intl.formatMessage({
-            defaultMessage: "Go to next candidate",
-            id: "oTNbp0",
+            defaultMessage: "Next candidate",
+            id: "y1uo+J",
             description:
               "Link label to view next candidate on view pool candidate page",
           })}
@@ -58,8 +58,8 @@ const CandidateNavigation = ({
           {...commonLinkProps}
         >
           {intl.formatMessage({
-            defaultMessage: "Go to previous candidate",
-            id: "xfHjyy",
+            defaultMessage: "Previous candidate",
+            id: "mt4AkL",
             description:
               "Link label to view previous candidate on view pool candidate page",
           })}

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/CandidateNavigation.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/CandidateNavigation.tsx
@@ -4,6 +4,7 @@ import ArrowLeftCircleIcon from "@heroicons/react/20/solid/ArrowLeftCircleIcon";
 import ArrowRightCircleIcon from "@heroicons/react/20/solid/ArrowRightCircleIcon";
 
 import { Link, LinkProps } from "@gc-digital-talent/ui";
+import { commonMessages } from "@gc-digital-talent/i18n";
 
 import useRoutes from "~/hooks/useRoutes";
 
@@ -22,13 +23,18 @@ const CandidateNavigation = ({
   const paths = useRoutes();
   const candidateNavigation = usePoolCandidateNavigation(candidateId);
   if (!candidateNavigation) return null;
-  const { nextCandidate, previousCandidate, lastCandidate, candidateIds } =
-    candidateNavigation;
+  const {
+    nextCandidate,
+    previousCandidate,
+    lastCandidate,
+    candidateIds,
+    stepName,
+  } = candidateNavigation;
 
   const commonLinkProps: LinkProps = {
     color: "primary",
     mode: "inline",
-    state: { candidateIds },
+    state: { candidateIds, stepName },
   };
 
   return (
@@ -37,6 +43,19 @@ const CandidateNavigation = ({
       data-h2-flex-direction="base(column)"
       data-h2-gap="base(x.5 0)"
     >
+      {stepName && (
+        <div>
+          <p data-h2-font-weight="base(700)" data-h2-margin-bottom="base(x.25)">
+            {intl.formatMessage({
+              defaultMessage: "Currently screening",
+              id: "mNYw+h",
+              description:
+                "Label for currently screening section on view pool candidate page",
+            }) + intl.formatMessage(commonMessages.dividingColon)}
+          </p>
+          <p>{stepName}</p>
+        </div>
+      )}
       {nextCandidate && (
         <Link
           href={paths.poolCandidateApplication(nextCandidate)}

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/usePoolCandidateNavigation.ts
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/usePoolCandidateNavigation.ts
@@ -1,0 +1,44 @@
+import { useLocation } from "react-router-dom";
+
+type CandidateLocation = {
+  state?: {
+    candidateIds?: string[];
+  };
+};
+
+type UsePoolCandidateNavigationReturn = {
+  candidateIds?: string[];
+  previousCandidate?: string;
+  nextCandidate?: string;
+  lastCandidate?: boolean;
+} | null;
+
+const usePoolCandidateNavigation = (
+  candidateId: string,
+): UsePoolCandidateNavigationReturn => {
+  const { state }: CandidateLocation = useLocation();
+  if (!state?.candidateIds || !candidateId) return null;
+  const { candidateIds } = state;
+
+  const currentIndex = candidateIds.findIndex((id) => id === candidateId);
+  if (currentIndex < 0) return null;
+
+  const nextCandidate = candidateIds[currentIndex + 1];
+  const previousCandidate = candidateIds[currentIndex - 1];
+
+  if (currentIndex === 0) {
+    return { nextCandidate, candidateIds };
+  }
+
+  if (currentIndex === candidateIds.length - 1) {
+    return {
+      previousCandidate,
+      candidateIds,
+      lastCandidate: true,
+    };
+  }
+
+  return { previousCandidate, nextCandidate, candidateIds };
+};
+
+export default usePoolCandidateNavigation;

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/usePoolCandidateNavigation.ts
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/usePoolCandidateNavigation.ts
@@ -3,11 +3,13 @@ import { useLocation } from "react-router-dom";
 type CandidateLocation = {
   state?: {
     candidateIds?: string[];
+    stepName?: string;
   };
 };
 
 type UsePoolCandidateNavigationReturn = {
   candidateIds?: string[];
+  stepName?: string;
   previousCandidate?: string;
   nextCandidate?: string;
   lastCandidate?: boolean;
@@ -18,7 +20,7 @@ const usePoolCandidateNavigation = (
 ): UsePoolCandidateNavigationReturn => {
   const { state }: CandidateLocation = useLocation();
   if (!state?.candidateIds || !candidateId) return null;
-  const { candidateIds } = state;
+  const { candidateIds, stepName } = state;
 
   const currentIndex = candidateIds.findIndex((id) => id === candidateId);
   if (currentIndex < 0) return null;
@@ -27,7 +29,7 @@ const usePoolCandidateNavigation = (
   const previousCandidate = candidateIds[currentIndex - 1];
 
   if (currentIndex === 0) {
-    return { nextCandidate, candidateIds };
+    return { nextCandidate, candidateIds, stepName };
   }
 
   if (currentIndex === candidateIds.length - 1) {
@@ -35,10 +37,11 @@ const usePoolCandidateNavigation = (
       previousCandidate,
       candidateIds,
       lastCandidate: true,
+      stepName,
     };
   }
 
-  return { previousCandidate, nextCandidate, candidateIds };
+  return { previousCandidate, nextCandidate, candidateIds, stepName };
 };
 
 export default usePoolCandidateNavigation;


### PR DESCRIPTION
🤖 Resolves #9017 

## 👋 Introduction

This adds the prev/next/back links to the candidate page when navigating from the assessment tracker.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login as `admin@test.com`
3. Navigate to a pool's screening and assessment page 
4. Take note of the order candidates appear in a column
5. Click on one
6. Confirm the next/previous links appear
7. Step through confirming that the links navigate to the expected candidate
8. Navigate to the start of the column (first candidate)
9. Confirm the previous link does not appear
10. Navigate to the last candidate
11. Confirm the next link does not appear
12. Confirm that the return to assessment tracker link appears
13. Navigate to the pool candidate from anywhere but the assessment tracker
    - or, empty cache and hard reload
14. Confirm the navigation does not exist

## 📸 Screenshot

### First candidate
![Screenshot 2024-02-09 135610](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/692d479f-eceb-4b73-9fd0-b35b968bf8c8)

### Middle of the List
![Screenshot 2024-02-09 135341](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/c1fd8534-1d7f-46b8-b84e-db5923029db5)

### Last candidate
![Screenshot 2024-02-09 135355](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/eef35dbe-a0ea-4bf0-ae34-a6449287753c)
