### PR TITLE
[Copy] Rename candidates tab for a process

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -497,7 +497,7 @@
   },
   "0YpfAG": {
     "defaultMessage": "Placement de talents",
-    "description": "Title for a process's candidates tab"
+    "description": "Title for candidates tab for a process"
   },
   "0a8nPa": {
     "defaultMessage": "Ce tableau présente une liste de tous les candidats à ce bassin.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -495,6 +495,10 @@
     "defaultMessage": "Embauché (Temporaire)",
     "description": "Status for an application that has been hired with a casual contract"
   },
+  "0YpfAG": {
+    "defaultMessage": "Placement de talents",
+    "description": "Title for a process's candidates tab"
+  },
   "0a8nPa": {
     "defaultMessage": "Ce tableau présente une liste de tous les candidats à ce bassin.",
     "description": "Descriptive text about the list of pool candidates in the admin portal."

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -267,9 +267,9 @@ export const useAdminPoolPages = (intl: IntlShape, pool: Pick<Pool, "id">) => {
             link: {
               url: paths.poolCandidateTable(pool.id),
               label: intl.formatMessage({
-                defaultMessage: "View Candidates",
-                id: "Rl+0Er",
-                description: "Title for the edit pool page",
+                defaultMessage: "Talent placement",
+                id: "ohRBJ3",
+                description: "Title for a process's candidates tab",
               }),
             },
           },

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -268,8 +268,8 @@ export const useAdminPoolPages = (intl: IntlShape, pool: Pick<Pool, "id">) => {
               url: paths.poolCandidateTable(pool.id),
               label: intl.formatMessage({
                 defaultMessage: "Talent placement",
-                id: "ohRBJ3",
-                description: "Title for a process's candidates tab",
+                id: "0YpfAG",
+                description: "Title for candidates tab for a process",
               }),
             },
           },


### PR DESCRIPTION
🤖 Resolves #9235

## 👋 Introduction

Changes the copy to "Talent placement". 

## 🧪 Testing

1. With RoD on navigate to `/en/admin/pools/:id/pool-candidates`
2. Observe tabs

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/a5a256cb-4835-4e1e-9804-7c6752abe9da)

