### PR TITLE
[Copy] Changes case of Reconciliation to lowercase

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -423,10 +423,6 @@
     "defaultMessage": "Familles de compétences",
     "description": "Title for skill families"
   },
-  "0Ew2uu": {
-    "defaultMessage": "Directement lié à l’avancement de la réconciliation, le programme a été conçu par, pour et avec les Premières Nations, les Inuit et les Métis.",
-    "description": "Paragraph 2 of the 'About the program' section"
-  },
   "0H0CLx": {
     "defaultMessage": "Accordé à",
     "description": "Label displayed on Award form for awarded to input"
@@ -1278,6 +1274,10 @@
   "56WpMU": {
     "defaultMessage": "Laissez les préférences de votre navigateur dicter le thème du site Web.",
     "description": "Button text to set no theme mode"
+  },
+  "56jSOM": {
+    "defaultMessage": "Ensemble, nous sommes en mesure de tirer parti de la diversité des expériences et des idées que les personnes autochtones apportent à la fonction publique et de contribuer à la réconciliation au Canada.",
+    "description": "Hero subtitle for IAP manager homepage"
   },
   "5A0a7w": {
     "defaultMessage": "Modifiez la liste des questions de sélection",
@@ -8258,6 +8258,10 @@
     "defaultMessage": "Compétences requises :",
     "description": "Label for pool advertisement's required skills"
   },
+  "iSbtcK": {
+    "defaultMessage": "Directement lié à l’avancement de la réconciliation, le programme a été conçu par, pour et avec les Premières Nations, les Inuit et les Métis.",
+    "description": "Paragraph 2 of the 'About the program' section"
+  },
   "iUAe/2": {
     "defaultMessage": "Langues",
     "description": "Label for language ability field"
@@ -9061,10 +9065,6 @@
   "mtFK6A": {
     "defaultMessage": "Courriel :",
     "description": "Email label and colon"
-  },
-  "mtLAap": {
-    "defaultMessage": "Ensemble, nous sommes en mesure de tirer parti de la diversité des expériences et des idées que les personnes autochtones apportent à la fonction publique et de contribuer à la réconciliation au Canada.",
-    "description": "Hero subtitle for IAP manager homepage"
   },
   "muduUA": {
     "defaultMessage": "Vous avez acquis de l’expérience en faisant partie d’une communauté ou en lui donnant en retour? Les gens acquièrent des compétences à partir d’un large éventail d’expériences, comme le bénévolat ou la participation à des organisations sans but lucratif, à des communautés autochtones ou à des collaborations virtuelles. Il peut s’agir d’aider lors d’événements et de cérémonies, de faire le disc-jockey au mariage d’un ami, de jouer et de faire de la diffusion en continu.",

--- a/apps/web/src/pages/Home/IAPManagerHomePage/IAPManagerHomePage.tsx
+++ b/apps/web/src/pages/Home/IAPManagerHomePage/IAPManagerHomePage.tsx
@@ -135,8 +135,8 @@ export const IAPManagerHomePage = () => {
             <p data-h2-font-size="base(h5)">
               {intl.formatMessage({
                 defaultMessage:
-                  "Together we can address barriers to Reconciliation, diversity and inclusion",
-                id: "mtLAap",
+                  "Together we can address barriers to reconciliation, diversity and inclusion",
+                id: "56jSOM",
                 description: "Hero subtitle for IAP manager homepage",
               })}
             </p>
@@ -272,8 +272,8 @@ export const IAPManagerHomePage = () => {
                   <p data-h2-margin="base(x1, 0)">
                     {intl.formatMessage({
                       defaultMessage:
-                        "Linked directly to the advancement of Reconciliation, the program was designed by, for, and with First Nations, Inuit, and Métis peoples.",
-                      id: "0Ew2uu",
+                        "Linked directly to the advancement of reconciliation, the program was designed by, for, and with First Nations, Inuit, and Métis peoples.",
+                      id: "iSbtcK",
                       description:
                         "Paragraph 2 of the 'About the program' section",
                     })}


### PR DESCRIPTION
🤖 Resolves #9231.

## 👋 Introduction

This PR changes the word **reconciliation** to lowercase in English on the IAP Manager Homepage.

## 🕵️ Details

No changes to the French copy as it is already lowercase.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate to `/indigenous-it-apprentice/hire`
3. Verify Reconciliation copy is lowercase

## 📸 Screenshots

<img width="846" alt="Screen Shot 2024-02-12 at 12 14 59" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/048123ac-361b-4583-9542-b6adaebbec60">

<img width="869" alt="Screen Shot 2024-02-12 at 12 15 09" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/0343321e-5054-4e58-8650-8fcc3247f888">