### PR TITLE
[Fix] Updates active matching logic for admin nav item

### DIFF
--- a/apps/web/src/components/Layout/AdminLayout/AdminLayout.tsx
+++ b/apps/web/src/components/Layout/AdminLayout/AdminLayout.tsx
@@ -266,7 +266,11 @@ const AdminLayout = () => {
               </SideMenuItem>
             )}
             {checkRole([ROLE_NAME.PlatformAdmin], roleAssignments) && (
-              <SideMenuItem href={paths.skillTable()} icon={indexSkillPageIcon}>
+              <SideMenuItem
+                href={paths.skillTable()}
+                icon={indexSkillPageIcon}
+                end
+              >
                 {intl.formatMessage(indexSkillPageTitle)}
               </SideMenuItem>
             )}


### PR DESCRIPTION
🤖 Resolves #9195.

## 👋 Introduction

This PR updates `active` matching logic for the **Skills** admin nav item.

> [!NOTE]  
> Although this fixes active for `/admin/settings/skills`, `/admin/settings/skills/:skill-id/edit` and `/admin/settings/skills/create` will not match because of the way the paths are set up. Not sure there is a way to fix those without changing their paths.

## Acknowledgment
@esizer: https://github.com/GCTC-NTGC/gc-digital-talent/issues/9195#issuecomment-1924661000

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate to `/admin/settings/skills/families`
3. Verify that only **Skill Families** is active in nav
4. Navigate to `/admin/settings/skills/`
2. Verify that only **Skills** is active in nav

## 📸 Screenshot

<img width="1049" alt="Screen Shot 2024-02-12 at 12 41 54" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/85760ffd-0b90-43a6-bd69-76b82ca37c20">
