### PR TITLE
[Feature] Remove locked sorting for RoD

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -338,7 +338,12 @@ const PoolCandidatesTable = ({
       ),
       page: paginationState.pageIndex,
       first: paginationState.pageSize,
-      sortingInput: getSortOrder(sortState, filterState, doNotUseBookmark),
+      sortingInput: getSortOrder(
+        sortState,
+        filterState,
+        doNotUseBookmark,
+        recordOfDecision,
+      ),
     },
   });
 

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -481,9 +481,7 @@ const PoolCandidatesTable = ({
             },
           },
         }) => finalDecisionCell(intl, status),
-        meta: {
-          sortingLocked: true,
-        },
+        enableSorting: false,
       },
     ),
     columnHelper.accessor(
@@ -501,9 +499,7 @@ const PoolCandidatesTable = ({
             },
           },
         }) => jobPlacementCell(intl, status),
-        meta: {
-          sortingLocked: true,
-        },
+        enableSorting: false,
       },
     ),
     columnHelper.accessor(

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -439,7 +439,7 @@ const PoolCandidatesTable = ({
           },
         }) => statusCell(poolCandidate.status, intl),
         meta: {
-          sortingLocked: true,
+          sortingLocked: !recordOfDecision,
           hideMobileHeader: true,
         },
       },
@@ -462,7 +462,7 @@ const PoolCandidatesTable = ({
           },
         }) => priorityCell(user.priorityWeight, intl),
         meta: {
-          sortingLocked: true,
+          sortingLocked: !recordOfDecision,
         },
       },
     ),

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -346,12 +346,15 @@ export function transformSortStateToOrderByClause(
     };
   }
   // input cannot be optional for QueryPoolCandidatesPaginatedOrderByRelationOrderByClause
-  // default tertiary sort is submitted_at,
+  // default final sort is column candidateName,
 
   return {
-    column: "submitted_at",
+    column: undefined,
     order: SortOrder.Asc,
-    user: undefined,
+    user: {
+      aggregate: OrderByRelationWithColumnAggregateFunction.Max,
+      column: "FIRST_NAME" as QueryPoolCandidatesPaginatedOrderByUserColumn,
+    },
   };
 }
 

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -359,20 +359,25 @@ export function getSortOrder(
   sortingRules?: SortingState,
   filterState?: PoolCandidateSearchInput,
   doNotUseBookmark?: boolean,
+  recordDecisionActive?: boolean,
 ): QueryPoolCandidatesPaginatedOrderByRelationOrderByClause[] {
   return [
     ...(doNotUseBookmark
       ? []
       : [{ column: "is_bookmarked", order: SortOrder.Desc }]),
-    { column: "status_weight", order: SortOrder.Asc },
-    {
-      user: {
-        aggregate: OrderByRelationWithColumnAggregateFunction.Max,
-        column:
-          "PRIORITY_WEIGHT" as QueryPoolCandidatesPaginatedOrderByUserColumn,
-      },
-      order: SortOrder.Asc,
-    },
+    ...(recordDecisionActive
+      ? []
+      : [
+          { column: "status_weight", order: SortOrder.Asc },
+          {
+            user: {
+              aggregate: OrderByRelationWithColumnAggregateFunction.Max,
+              column:
+                "PRIORITY_WEIGHT" as QueryPoolCandidatesPaginatedOrderByUserColumn,
+            },
+            order: SortOrder.Asc,
+          },
+        ]),
     transformSortStateToOrderByClause(sortingRules, filterState),
   ];
 }

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -297,6 +297,8 @@ export function transformSortStateToOrderByClause(
     ["preferredLang", "PREFERRED_LANGUAGE_FOR_EXAM"],
     ["currentLocation", "CURRENT_CITY"],
     ["skillCount", "skill_count"],
+    ["priority", "PRIORITY_WEIGHT"],
+    ["status", "status_weight"],
   ]);
 
   const sortingRule = sortingRules?.find((rule) => {
@@ -306,7 +308,7 @@ export function transformSortStateToOrderByClause(
 
   if (
     sortingRule &&
-    ["dateReceived", "candidacyStatus"].includes(sortingRule.id)
+    ["dateReceived", "candidacyStatus", "status"].includes(sortingRule.id)
   ) {
     const columnName = columnMap.get(sortingRule.id);
     return {
@@ -318,9 +320,13 @@ export function transformSortStateToOrderByClause(
 
   if (
     sortingRule &&
-    ["candidateName", "email", "preferredLang", "currentLocation"].includes(
-      sortingRule.id,
-    )
+    [
+      "candidateName",
+      "email",
+      "preferredLang",
+      "currentLocation",
+      "priority",
+    ].includes(sortingRule.id)
   ) {
     const columnName = columnMap.get(sortingRule.id);
     return {


### PR DESCRIPTION
🤖 Resolves #9224

## 👋 Introduction

If RoD is active, default sort is less multi-layered, can sort by more columns. 
Final default sort is now alphabetical always. 

## 🧪 Testing

RoD OFF

1. Default final sort is alphabetical
2. Otherwise, unchanged

RoD ON

1. Default final sort is alphabetical
2. Priority and status no longer fed in by default
3. Can sort by priority and status columns now

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/ec8ca8a0-a3f5-471a-b19c-e98bc1a33ff6)



