### PR TITLE
[Style] Update hold status colour

### DIFF
--- a/apps/web/src/components/AssessmentStepTracker/Filters.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/Filters.tsx
@@ -103,7 +103,7 @@ const Filters = ({
                 name={AssessmentDecision.Hold}
                 id={AssessmentDecision.Hold}
                 label={intl.formatMessage(poolCandidateMessages.onHold)}
-                color="warning"
+                color="secondary"
                 hideLabel
                 icon={{
                   default: PauseCircleIcon,

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -54,7 +54,7 @@ export const getDecisionInfo = (
     return {
       icon: PauseCircleIcon,
       colorStyle: {
-        "data-h2-color": "base(warning)",
+        "data-h2-color": "base(secondary)",
       },
       name: intl.formatMessage(poolCandidateMessages.onHold),
     };


### PR DESCRIPTION
🤖 Resolves #9236 

## 👋 Introduction

Updates the "hold for assessment" status colour to "secondary" to differentiate it more from the "to assess" status.

## 🕵️ Details

PR mentions the table as well, but that is getting done in a different PR.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login as admin
3. Navigate to a pools "Screening and assessment" page
4. Confirm the "hold for assessment" status colours are using the secondary (teal, blue?) colours

## 📸 Screenshot

![Screenshot 2024-02-13 130202](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/922e0a4c-6f92-4770-b329-3554bc314074)
