### PR TITLE
[Feature] Hides Remove candidate button

### DIFF
--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
@@ -599,19 +599,23 @@ export const ViewPoolCandidate = ({
                   poolCandidate?.assessmentResults?.filter(notEmpty) ?? []
                 }
               />
-              <Button
-                icon={HandRaisedIcon}
-                type="button"
-                color="primary"
-                mode="inline"
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Remove candidate",
-                  id: "Aixzmb",
-                  description:
-                    "Button label for remove candidate on view pool candidate page",
-                })}
-              </Button>
+              {/* TODO: Add "Remove" and "Re-instate" dialogs to Pool Candidate
+              page (#9198) */}
+              {false && (
+                <Button
+                  icon={HandRaisedIcon}
+                  type="button"
+                  color="primary"
+                  mode="inline"
+                >
+                  {intl.formatMessage({
+                    defaultMessage: "Remove candidate",
+                    id: "Aixzmb",
+                    description:
+                      "Button label for remove candidate on view pool candidate page",
+                  })}
+                </Button>
+              )}
               <NotesDialog
                 poolCandidateId={poolCandidate.id}
                 notes={poolCandidate.notes}


### PR DESCRIPTION
🤖 Resolves #9317.

## 👋 Introduction

This PR hides Remove candidate button until it is ready to be implemented in https://github.com/GCTC-NTGC/gc-digital-talent/issues/9198.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate to`/admin/candidates/:candidate-id/application`
3. Verify there is no **Remove candidate** button

## 📸 Screenshot
<img width="1050" alt="Screen Shot 2024-02-14 at 12 03 40" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/9e0d3aa0-3a10-4b7c-a4a3-0f0337df8be8">
