### PR TITLE
[Fix] Renders `appliedWorkListMessages`

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationEducationPage/utils.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/utils.tsx
@@ -258,11 +258,11 @@ export const getEducationRequirementOptions = (
               }),
           contentBelow: (
             <>
-              <p>
+              <p data-h2-margin="base(0, 0, x.5, 0)">
                 {intl.formatMessage(applicationMessages.appliedWorkExperience)}
               </p>
               <ul>
-                {Object.values(appliedWorkListMessages).map((value) => (
+                {appliedWorkListMessages(isIAP).map((value) => (
                   <li key={uniqueId()} data-h2-margin="base(0, 0, x.25, 0)">
                     {intl.formatMessage(value)}
                   </li>


### PR DESCRIPTION
🤖 Resolves #9227.

## 👋 Introduction

This PR renders `appliedWorkListMessages` that had previously been mistakenly un-rendered in #8474.

## 🎩 Acknowledgement
@esizer for his 🦅  👀.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/applications/:application-id/education`
2. Observe **On-the-job learning** and other relevant list items are rendered

## 📸 Screenshots

### Non-IAP
<img width="1143" alt="Screen Shot 2024-02-14 at 15 06 28" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/3b1c5ac7-b1fb-4321-9c94-0a8be75290ba">

### IAP
<img width="1139" alt="Screen Shot 2024-02-14 at 15 13 38" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/caa5b337-83a5-4f97-bd2e-39f896c5c479">
