### PR TITLE
[Bug] Resolve intermittent failure of `KeywordSearchTest`

### DIFF
--- a/api/tests/Feature/KeywordSearchTest.php
+++ b/api/tests/Feature/KeywordSearchTest.php
@@ -434,6 +434,8 @@ class KeywordSearchTest extends TestCase
             'organization' => 'CDS',
             'start_date' => '2020-01-01',
             'end_date' => '2021-01-01',
+            'division' => 'division',
+            'details' => 'details',
         ]);
 
         // sync the same skill to all 3 work experiences


### PR DESCRIPTION
🤖 Resolves #9067

## 👋 Introduction

Make the test pass reliably. 

## 🕵️ Details

User 3 would sometimes in their generated experience have the word "user" appear, like in the division field. So I resolved this by constraining division and details to specific values. 

## 🧪 Testing

1. Run the test file a bunch of times
2. I was able to replicate the bug locally before attempting to fix it, occurred maybe 1 in 10 to 15 runs maybe

Sample snippet

`for i in {1..50}; do docker-compose exec -w /home/site/wwwroot/api webserver sh -c "./vendor/bin/phpunit ./tests/Feature/KeywordSearchTest.php"; done`

