### PR TITLE
[Debt] Add retries and env variable for auth provider

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -55,6 +55,7 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 
 OAUTH_REDIRECT_URI="http://localhost:8000/auth-callback"
 OAUTH_POST_LOGIN_REDIRECT="http://localhost:8000/talent/profile"
+OAUTH_REQUEST_RETRIES=3
 
 # Setting this value fakes a login for local development.
 # DEVELOPMENT ONLY. DO NOT ENABLE IN PRODUCTION.

--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -5,9 +5,7 @@ namespace App\Http\Controllers;
 use App\Services\OpenIdBearerTokenService;
 use Exception;
 use Illuminate\Http\Client\ConnectionException;
-use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -73,7 +71,7 @@ class AuthController extends Controller
             new InvalidArgumentException('Invalid session state')
         );
 
-        $response = Http::retry(times: 3, sleepMilliseconds: 500, when: function (Exception $exception, PendingRequest $request) {
+        $response = Http::retry(times: config('oauth.request_retries'), sleepMilliseconds: 500, when: function (Exception $exception) {
             return $exception instanceof ConnectionException;
         }, throw: false)->asForm()->post(config('oauth.token_uri'), [
             'grant_type' => 'authorization_code',
@@ -129,13 +127,22 @@ class AuthController extends Controller
     public function refresh(Request $request)
     {
         $refreshToken = $request->query('refresh_token');
-        $response = Http::asForm()
+        $response =
+        Http::retry(times: config('oauth.request_retries'), sleepMilliseconds: 500, when: function (Exception $exception) {
+            return $exception instanceof ConnectionException;
+        }, throw: false)->asForm()
             ->post(config('oauth.token_uri'), [
                 'grant_type' => 'refresh_token',
                 'client_id' => config('oauth.client_id'),
                 'client_secret' => config('oauth.client_secret'),
                 'refresh_token' => $refreshToken,
             ]);
+        if ($response->failed()) {
+            Log::error('Failed when POSTing to the token URI in refresh');
+            Log::debug((string) $response->getBody());
+
+            return response('Failed to get token', 400);
+        }
 
         return response($response)->header('Content-Type', 'application/json');
     }

--- a/api/app/Services/OpenIdBearerTokenService.php
+++ b/api/app/Services/OpenIdBearerTokenService.php
@@ -4,8 +4,10 @@ namespace App\Services;
 
 use DateInterval;
 use Exception;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\UnauthorizedException;
 // We're using two JWT management libraries here (Jose & Lcobucci), which each
 // offer different functionality related to constraints and JWKS.
@@ -57,7 +59,17 @@ class OpenIdBearerTokenService
     private function getConfigProperty(string $propertyName): string
     {
         $jsonString = Cache::remember('openid_config_json_string', 60, function () { // only get content every minute
-            return Http::get($this->configUri)->body();
+            $response = Http::retry(times: config('oauth.request_retries'), sleepMilliseconds: 500, when: function (Exception $exception) {
+                return $exception instanceof ConnectionException;
+            }, throw: false)->get($this->configUri);
+
+            if ($response->failed()) {
+                Log::error('Failed when GETting the OpenID configuration in getConfigProperty');
+                Log::debug((string) $response->getBody());
+                throw new Exception('Failed to get config');
+            }
+
+            return $response->body();
         });
 
         $obj = json_decode($jsonString);
@@ -78,7 +90,17 @@ class OpenIdBearerTokenService
 
         $jwks_uri = $this->getConfigProperty('jwks_uri');
         $jsonString = Cache::remember('jwks_json_string', 60, function () use ($jwks_uri) { // only get jwks content every minute
-            return Http::get($jwks_uri)->body();
+            $response = Http::retry(times: config('oauth.request_retries'), sleepMilliseconds: 500, when: function (Exception $exception) {
+                return $exception instanceof ConnectionException;
+            }, throw: false)->get($jwks_uri);
+
+            if ($response->failed()) {
+                Log::error('Failed when GETting the JWKS in getConfiguration');
+                Log::debug((string) $response->getBody());
+                throw new Exception('Failed to get config');
+            }
+
+            return $response->body();
         });
 
         // Uses web-token/jwt-core to generate public key from "e" and "n" in JWKS.
@@ -119,25 +141,26 @@ class OpenIdBearerTokenService
     // call the introspection endpoint to check if the OP considers the access token still valid
     public function verifyJwtWithIntrospection(string $accessToken)
     {
-        $cacheKey = 'introspection_token_'.$accessToken;
-
-        if (Cache::has($cacheKey)) {
-            // use cached access token status if available
-            $isTokenActive = Cache::get($cacheKey);
-        } else {
+        // cache for a few seconds in case of multiple API calls for a page load
+        $isTokenActive = Cache::remember('introspection_token_'.$accessToken, 3, function () use ($accessToken) {
             // make api call to introspect endpoint
             $introspectionUri = $this->getConfigProperty('introspection_endpoint');
-            $introspectionResponse = Http::asForm()
+            $response = Http::retry(times: config('oauth.request_retries'), sleepMilliseconds: 500, when: function (Exception $exception) {
+                return $exception instanceof ConnectionException;
+            }, throw: false)->asForm()
                 ->withToken($accessToken)
                 ->post($introspectionUri, [
                     'token' => $accessToken,
                 ]);
 
-            $isTokenActive = boolval($introspectionResponse->json('active'));
-            if ($isTokenActive) {
-                Cache::put($cacheKey, $isTokenActive, 3); // cache for a few seconds in case of multiple API calls for a page load
+            if ($response->failed()) {
+                Log::error('Failed when POSTing the introspection endpoint in verifyJwtWithIntrospection');
+                Log::debug((string) $response->getBody());
+                throw new Exception('Failed to get config');
             }
-        }
+
+            return boolval($response->json('active'));
+        });
 
         if (! $isTokenActive) {
             throw new UnauthorizedException('Access token is not active', 401);

--- a/api/config/oauth.php
+++ b/api/config/oauth.php
@@ -85,4 +85,9 @@ return [
      * Where is the user redirected to after login if it is not in the login request.
      */
     'post_login_redirect' => env('OAUTH_POST_LOGIN_REDIRECT'),
+
+    /**
+     * How many times should requests to the OAUTH server be retried when there are errors
+     */
+    'request_retries' => env('OAUTH_REQUEST_RETRIES', 3),
 ];


### PR DESCRIPTION
🤖 Resolves #9130

## 👋 Introduction

This branch adds retries to all the calls from our backend to our auth provider.  It gets the number of retries from a new env variable.

## 🕵️ Details

I don't know how to trigger HttpExceptions for testing.  :cry:  If someone can figure it out, I'd love to hear it. I guess we can just test that the "happy path" still works well.

## 🧪 Testing

1. Refresh your .env file.
2. Set yourself up with SIC Test
3. Auth actions work fine:
  - [ ] log in
  - [ ] refresh
  - [ ] log out 

## 🚚 Deployment

- Add new env variable OAUTH_REQUEST_RETRIES with value "3".