### PR TITLE
[Fix] Moves `skills/families` to `skill-families`

### DIFF
--- a/apps/e2e/cypress/e2e/admin/auth.cy.ts
+++ b/apps/e2e/cypress/e2e/admin/auth.cy.ts
@@ -36,7 +36,7 @@ describe("Auth flows (development)", () => {
         "/en/admin/pools",
         "/en/admin/settings/departments",
         "/en/admin/settings/skills",
-        "/en/admin/settings/skills-families",
+        "/en/admin/settings/skill-families",
       ].forEach((restrictedPath) => {
         cy.visit(restrictedPath);
         onLoginInfoPage();
@@ -193,7 +193,7 @@ describe("Auth flows (development)", () => {
         "/en/admin/pools",
         "/en/admin/settings/departments",
         "/en/admin/settings/skills",
-        "/en/admin/settings/skills-families",
+        "/en/admin/settings/skill-families",
       ].forEach((restrictedPath) => {
         cy.visit(restrictedPath);
         cy.contains("not authorized");

--- a/apps/e2e/cypress/e2e/admin/auth.cy.ts
+++ b/apps/e2e/cypress/e2e/admin/auth.cy.ts
@@ -36,7 +36,7 @@ describe("Auth flows (development)", () => {
         "/en/admin/pools",
         "/en/admin/settings/departments",
         "/en/admin/settings/skills",
-        "/en/admin/settings/skills/families",
+        "/en/admin/settings/skills-families",
       ].forEach((restrictedPath) => {
         cy.visit(restrictedPath);
         onLoginInfoPage();
@@ -193,7 +193,7 @@ describe("Auth flows (development)", () => {
         "/en/admin/pools",
         "/en/admin/settings/departments",
         "/en/admin/settings/skills",
-        "/en/admin/settings/skills/families",
+        "/en/admin/settings/skills-families",
       ].forEach((restrictedPath) => {
         cy.visit(restrictedPath);
         cy.contains("not authorized");

--- a/apps/web/src/components/Layout/AdminLayout/AdminLayout.tsx
+++ b/apps/web/src/components/Layout/AdminLayout/AdminLayout.tsx
@@ -266,11 +266,7 @@ const AdminLayout = () => {
               </SideMenuItem>
             )}
             {checkRole([ROLE_NAME.PlatformAdmin], roleAssignments) && (
-              <SideMenuItem
-                href={paths.skillTable()}
-                icon={indexSkillPageIcon}
-                end
-              >
+              <SideMenuItem href={paths.skillTable()} icon={indexSkillPageIcon}>
                 {intl.formatMessage(indexSkillPageTitle)}
               </SideMenuItem>
             )}

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -1780,46 +1780,46 @@ const createRoute = (
                         },
                       ],
                     },
+                  ],
+                },
+                {
+                  path: "skill-families",
+                  children: [
                     {
-                      path: "families",
+                      index: true,
+                      element: (
+                        <RequireAuth
+                          roles={[ROLE_NAME.PlatformAdmin]}
+                          loginPath={loginPath}
+                        >
+                          <IndexSkillFamilyPage />
+                        </RequireAuth>
+                      ),
+                    },
+                    {
+                      path: "create",
+                      element: (
+                        <RequireAuth
+                          roles={[ROLE_NAME.PlatformAdmin]}
+                          loginPath={loginPath}
+                        >
+                          <CreateSkillFamilyPage />
+                        </RequireAuth>
+                      ),
+                    },
+                    {
+                      path: ":skillFamilyId",
                       children: [
                         {
-                          index: true,
+                          path: "edit",
                           element: (
                             <RequireAuth
                               roles={[ROLE_NAME.PlatformAdmin]}
                               loginPath={loginPath}
                             >
-                              <IndexSkillFamilyPage />
+                              <UpdateSkillFamilyPage />
                             </RequireAuth>
                           ),
-                        },
-                        {
-                          path: "create",
-                          element: (
-                            <RequireAuth
-                              roles={[ROLE_NAME.PlatformAdmin]}
-                              loginPath={loginPath}
-                            >
-                              <CreateSkillFamilyPage />
-                            </RequireAuth>
-                          ),
-                        },
-                        {
-                          path: ":skillFamilyId",
-                          children: [
-                            {
-                              path: "edit",
-                              element: (
-                                <RequireAuth
-                                  roles={[ROLE_NAME.PlatformAdmin]}
-                                  loginPath={loginPath}
-                                >
-                                  <UpdateSkillFamilyPage />
-                                </RequireAuth>
-                              ),
-                            },
-                          ],
                         },
                       ],
                     },

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -136,19 +136,11 @@ const getRoutes = (lang: Locales) => {
       path.join(adminUrl, "settings", "skills", skillId, "edit"),
 
     // Admin - Skill Families
-    skillFamilyTable: () =>
-      path.join(adminUrl, "settings", "skills", "families"),
+    skillFamilyTable: () => path.join(adminUrl, "settings", "skill-families"),
     skillFamilyCreate: () =>
-      path.join(adminUrl, "settings", "skills", "families", "create"),
+      path.join(adminUrl, "settings", "skill-families", "create"),
     skillFamilyUpdate: (skillFamilyId: string) =>
-      path.join(
-        adminUrl,
-        "settings",
-        "skills",
-        "families",
-        skillFamilyId,
-        "edit",
-      ),
+      path.join(adminUrl, "settings", "skill-families", skillFamilyId, "edit"),
 
     // Admin - Departments
     departmentTable: () => path.join(adminUrl, "settings", "departments"),


### PR DESCRIPTION
🤖 Resolves #9319.

## 👋 Introduction

This PR moves `skills/families` to `skill-families` and fixes the active menu issue for skill families and associated pages.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/admin/settings/skill-families`
2. Verify navigation item for Skill Families is active
3. Navigate to `/admin/settings/skill-families/create`
4. Verify navigation item for Skill Families is active
5. Navigate to `/admin/settings/skill-families/:skill-family-id/edit`
6. Verify navigation item for Skill Families is active

