### PR TITLE
[Fix] Heading level for education requirements

### DIFF
--- a/apps/web/src/components/EducationRequirements/EducationRequirements.tsx
+++ b/apps/web/src/components/EducationRequirements/EducationRequirements.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { Link, Heading } from "@gc-digital-talent/ui";
+import { Link, Heading, HeadingLevel } from "@gc-digital-talent/ui";
 import { getLocale } from "@gc-digital-talent/i18n";
 
 import applicationMessages from "~/messages/applicationMessages";
@@ -78,11 +78,13 @@ const Or = (props: React.HTMLProps<HTMLDivElement>) => {
 interface EducationRequirementsProps {
   isIAP: boolean;
   classificationGroup?: ClassificationGroup;
+  headingAs?: HeadingLevel;
 }
 
 const EducationRequirements = ({
   classificationGroup,
   isIAP,
+  headingAs = "h3",
 }: EducationRequirementsProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -104,7 +106,11 @@ const EducationRequirements = ({
       return (
         <Wrapper data-h2-grid-template-columns="base(1fr) l-tablet(1fr 1fr 1fr)">
           <Card>
-            <Heading level="h4" size="h6" data-h2-margin="base(0 0 x.5 0)">
+            <Heading
+              level={headingAs}
+              size="h6"
+              data-h2-margin="base(0 0 x.5 0)"
+            >
               {intl.formatMessage({
                 defaultMessage: "Professional designation",
                 id: "KqEyqD",
@@ -120,7 +126,11 @@ const EducationRequirements = ({
           </Card>
           <Or data-h2-left="l-tablet(33%)" />
           <Card>
-            <Heading level="h4" size="h6" data-h2-margin="base(0 0 x.5 0)">
+            <Heading
+              level={headingAs}
+              size="h6"
+              data-h2-margin="base(0 0 x.5 0)"
+            >
               {intl.formatMessage({
                 defaultMessage: "Applied work experience",
                 id: "dwYJOo",
@@ -136,7 +146,11 @@ const EducationRequirements = ({
           </Card>
           <Or data-h2-left="l-tablet(67%)" />
           <Card>
-            <Heading level="h4" size="h6" data-h2-margin="base(0 0 x.5 0)">
+            <Heading
+              level={headingAs}
+              size="h6"
+              data-h2-margin="base(0 0 x.5 0)"
+            >
               {intl.formatMessage({
                 defaultMessage: "Graduation with degree",
                 id: "ijg+sm",
@@ -165,7 +179,11 @@ const EducationRequirements = ({
       return (
         <Wrapper>
           <Card>
-            <Heading level="h4" size="h6" data-h2-margin="base(0 0 x.5 0)">
+            <Heading
+              level={headingAs}
+              size="h6"
+              data-h2-margin="base(0 0 x.5 0)"
+            >
               {intl.formatMessage({
                 defaultMessage: "Applied work experience",
                 id: "dwYJOo",
@@ -179,7 +197,11 @@ const EducationRequirements = ({
           </Card>
           <Or />
           <Card>
-            <Heading level="h4" size="h6" data-h2-margin="base(0 0 x.5 0)">
+            <Heading
+              level={headingAs}
+              size="h6"
+              data-h2-margin="base(0 0 x.5 0)"
+            >
               {intl.formatMessage(applicationMessages.secondarySchoolHeading)}
             </Heading>
             <Text>
@@ -194,7 +216,7 @@ const EducationRequirements = ({
       return (
         <Wrapper>
           <Card>
-            <Heading level="h4" size="h6" data-h2-margin-top="base(0)">
+            <Heading level={headingAs} size="h6" data-h2-margin-top="base(0)">
               {intl.formatMessage(
                 applicationMessages.educationRequirementECJustEducationHeading,
               )}
@@ -207,7 +229,7 @@ const EducationRequirements = ({
           </Card>
           <Or />
           <Card>
-            <Heading level="h4" size="h6" data-h2-margin-top="base(0)">
+            <Heading level={headingAs} size="h6" data-h2-margin-top="base(0)">
               {intl.formatMessage(
                 applicationMessages.educationRequirementECEducationPlusHeading,
               )}
@@ -224,7 +246,11 @@ const EducationRequirements = ({
       return (
         <Wrapper>
           <Card>
-            <Heading level="h4" size="h6" data-h2-margin="base(0 0 x.5 0)">
+            <Heading
+              level={headingAs}
+              size="h6"
+              data-h2-margin="base(0 0 x.5 0)"
+            >
               {intl.formatMessage({
                 defaultMessage: "Applied work experience",
                 id: "dwYJOo",
@@ -250,7 +276,11 @@ const EducationRequirements = ({
           </Card>
           <Or />
           <Card>
-            <Heading level="h4" size="h6" data-h2-margin="base(0 0 x.5 0)">
+            <Heading
+              level={headingAs}
+              size="h6"
+              data-h2-margin="base(0 0 x.5 0)"
+            >
               {isIAP
                 ? intl.formatMessage({
                     defaultMessage: "High school diploma or GED",


### PR DESCRIPTION
🤖 Resolves #9381 

## 👋 Introduction

Adjusts the heading level for education requirements to use the appropriate semantic rank.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login as admin
3. Navigate to the edit pool page
4. Confirm the education requirements headings are one level more than the section heading
5. Navigate to a pool advertisement page
6. Confirm the education requirements headings are one level more than the section heading
