### PR TITLE
[Fix] Table landmark uniqueness

### DIFF
--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -327,8 +327,11 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
       {hasNoData || hasNoVisibleRows ? (
         <NullMessage {...(nullStateMessage ? { ...nullStateMessage } : {})} />
       ) : (
-        <div aria-labelledby={captionId}>
-          <Table.Wrapper data-h2-position="base(relative)">
+        <>
+          <Table.Wrapper
+            data-h2-position="base(relative)"
+            aria-labelledby={captionId}
+          >
             <Table.Table>
               <Table.Caption id={captionId}>{caption}</Table.Caption>
               <Table.Head>
@@ -371,9 +374,13 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
             )}
           </Table.Wrapper>
           {paginationAdjusted && (
-            <TablePagination table={table} pagination={paginationAdjusted} />
+            <TablePagination
+              table={table}
+              pagination={paginationAdjusted}
+              label={caption?.toString() ?? ""}
+            />
           )}
-        </div>
+        </>
       )}
     </>
   );

--- a/apps/web/src/components/Table/ResponsiveTable/TablePagination.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/TablePagination.tsx
@@ -7,11 +7,13 @@ import Pagination from "~/components/Pagination";
 import { PaginationDef } from "./types";
 
 interface TablePaginationProps<T> {
+  label: string;
   pagination: PaginationDef;
   table: Table<T>;
 }
 
 const TablePagination = <T,>({
+  label,
   pagination,
   table,
 }: TablePaginationProps<T>) => {
@@ -49,11 +51,14 @@ const TablePagination = <T,>({
     <Pagination
       data-h2-margin-top="base(x1) l-tablet(x.5)"
       color="black"
-      ariaLabel={intl.formatMessage({
-        defaultMessage: "Page navigation",
-        description: "Label for the table pagination",
-        id: "N3sUUc",
-      })}
+      ariaLabel={intl.formatMessage(
+        {
+          defaultMessage: "{label} page navigation",
+          description: "Label for the table pagination",
+          id: "RRlKyW",
+        },
+        { label },
+      )}
       currentPage={tablePaginationState.pageIndex + 1}
       pageSize={tablePaginationState.pageSize}
       pageSizes={pagination.pageSizes}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5155,6 +5155,10 @@
     "defaultMessage": "Rétablir les filtres",
     "description": "Button text to reset table filters to the default values"
   },
+  "RRlKyW": {
+    "defaultMessage": "{label} navigation de page",
+    "description": "Label for the table pagination"
+  },
   "RSkJQR": {
     "defaultMessage": "Brève description de l'équipe (en français)",
     "description": "Label for team description in French language"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4399,10 +4399,6 @@
     "defaultMessage": "Ce à quoi vous pouvez vous attendre",
     "description": "Heading for the section about user expectations for their request"
   },
-  "N3sUUc": {
-    "defaultMessage": "Navigation dans la page",
-    "description": "Label for the table pagination"
-  },
   "N3uD4m": {
     "defaultMessage": "Mes équipes",
     "description": "Link text for current users teams page"


### PR DESCRIPTION
🤖 Resolves #9379 

## 👋 Introduction

Updates the the base table component to ensure landmarks are unique. 

## 🕵️ Details

We had an issue where we had a `div` with `role="region"` but applied the `aria-labelledby` attribute to the parent node instead. As well, the pagination had a hardcoded "Page navigation" label, we have prefixed it with the caption to make these unique.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login as an applicant
3. Navigate to the skill library
4. Inspect the table accessibility tree
5. Confirm all landmarks (region, table, nav) have unique names across the tables
