### PR TITLE
[Fix] Expose decision table heading icons to a11y tree

### DIFF
--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/components/AssessmentSummary.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/components/AssessmentSummary.tsx
@@ -47,6 +47,7 @@ const TableHeader = ({ tableTitle }: { tableTitle: string }): JSX.Element => {
           data-h2-margin="base(0, x.5, 0, 0)"
           data-h2-padding="base(x.25 0)"
           data-h2-color="base(success)"
+          aria-hidden="false"
           aria-label={intl.formatMessage({
             defaultMessage: "Demonstrated",
             id: "5wKh/o",
@@ -63,6 +64,7 @@ const TableHeader = ({ tableTitle }: { tableTitle: string }): JSX.Element => {
           data-h2-margin="base(0, x.5, 0, 0)"
           data-h2-padding="base(x.25 0)"
           data-h2-color="base(error)"
+          aria-hidden="false"
           aria-label={intl.formatMessage({
             defaultMessage: "Not demonstrated (Remove from process)",
             id: "zXkLL2",
@@ -79,6 +81,7 @@ const TableHeader = ({ tableTitle }: { tableTitle: string }): JSX.Element => {
           data-h2-margin="base(0, x.5, 0, 0)"
           data-h2-padding="base(x.25 0)"
           data-h2-color="base(warning)"
+          aria-hidden="false"
           aria-label={intl.formatMessage({
             defaultMessage: "Not demonstrated (Hold for further assessment)",
             id: "MMtY88",


### PR DESCRIPTION
🤖 Resolves #9380 

## 👋 Introduction

Adds `aria-hidden=false` to the icons in the decision dialog so they can be programmatically determined by the accessibility tree.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Make sure you have the ROD feature flag enabled
2. Build `npm run dev`
3. Navigate to an application
4. Open the "Record final decision" dialog
5. Confirm the icon headers have a programmatically determined name in the accessibility tree

## 📸 Screenshot

![Screenshot 2024-02-20 083458](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/a9e68ac6-fd20-49e5-958b-6d66ed6ee28e)
