### PR TITLE
[Copy] Removes view copy from several table cells

### DIFF
--- a/apps/e2e/cypress/e2e/admin/pool-candidate.cy.ts
+++ b/apps/e2e/cypress/e2e/admin/pool-candidate.cy.ts
@@ -121,10 +121,13 @@ describe("Pool Candidates", () => {
       .should("exist")
       .click();
     cy.wait("@gqlCandidatesTableCandidatesPaginated_QueryQuery");
-
-    cy.findAllByRole("link", { name: /view(.+)application/i })
-      .eq(0)
-      .click();
+    cy.get<User>("@testUser").then((testUser) => {
+      cy.findAllByRole("link", {
+        name: new RegExp(testUser.firstName + " " + testUser.lastName, "i"),
+      })
+        .eq(0)
+        .click();
+    });
 
     cy.wait("@gqlViewPoolCandidatesPageQuery");
 
@@ -232,9 +235,13 @@ describe("Pool Candidates", () => {
       .click();
     cy.wait("@gqlCandidatesTableCandidatesPaginated_QueryQuery");
 
-    cy.findAllByRole("link", { name: /view(.+)application/i })
-      .eq(0)
-      .click();
+    cy.get<User>("@testUser").then((testUser) => {
+      cy.findAllByRole("link", {
+        name: new RegExp(testUser.firstName + " " + testUser.lastName, "i"),
+      })
+        .eq(0)
+        .click();
+    });
 
     cy.wait("@gqlViewPoolCandidatesPageQuery");
 

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -128,24 +128,9 @@ export const candidateNameCell = (
     intl,
   );
   return (
-    <span data-h2-font-weight="base(700)">
-      {cells.view(
-        paths.poolCandidateApplication(candidate.id),
-        candidateName,
-        undefined,
-        intl.formatMessage(
-          {
-            defaultMessage: "View {name}'s application",
-            id: "mzGMZC",
-            description:
-              "Link text to view a candidates application for assistive technologies",
-          },
-          {
-            name: candidateName,
-          },
-        ),
-      )}
-    </span>
+    <Link href={paths.poolCandidateApplication(candidate.id)}>
+      {candidateName}
+    </Link>
   );
 };
 

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -55,7 +55,6 @@ import {
 import { getFullPoolTitleLabel } from "~/utils/poolUtils";
 import processMessages from "~/messages/processMessages";
 
-import cells from "../Table/cells";
 import { FormValues } from "./types";
 import tableMessages from "./tableMessages";
 import CandidateBookmark from "../CandidateBookmark/CandidateBookmark";

--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.test.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.test.tsx
@@ -57,9 +57,7 @@ describe("SearchRequestsTable", () => {
     renderSearchRequestsTable();
 
     // Assert table filled with values and the result of requests[0] is present
-    expect(
-      screen.getAllByText(`View ${requestOne.jobTitle ?? ""}`),
-    ).toBeTruthy();
+    expect(screen.getAllByText(`${requestOne.jobTitle ?? ""}`)).toBeTruthy();
     expect(
       screen.getAllByText(requestOne.department?.name.en ?? ""),
     ).toBeTruthy();

--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -32,6 +32,7 @@ import {
   classificationAccessor,
   classificationsCell,
   detailsCell,
+  jobTitleCell,
   notesCell,
   statusCell,
 } from "./components/helpers";
@@ -203,8 +204,8 @@ const SearchRequestTable = ({ title }: SearchRequestTableProps) => {
       meta: {
         isRowTitle: true,
       },
-      cell: ({ row: { original: searchRequest }, getValue }) =>
-        cells.view(paths.searchRequestView(searchRequest.id), getValue() || ""),
+      cell: ({ row: { original: searchRequest } }) =>
+        jobTitleCell(searchRequest, paths),
     }),
     columnHelper.accessor(
       (row) =>

--- a/apps/web/src/components/SearchRequestTable/components/helpers.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/helpers.tsx
@@ -16,6 +16,8 @@ import {
   Scalars,
 } from "@gc-digital-talent/graphql";
 
+import useRoutes from "~/hooks/useRoutes";
+
 export function classificationAccessor(
   classifications: Maybe<Maybe<Classification>[]> | undefined,
 ) {
@@ -64,6 +66,17 @@ export function dateCell(
     </span>
   ) : null;
 }
+
+export const jobTitleCell = (
+  searchRequest: PoolCandidateSearchRequest,
+  paths: ReturnType<typeof useRoutes>,
+) => {
+  return (
+    <Link href={paths.searchRequestView(searchRequest.id)}>
+      {searchRequest.jobTitle}
+    </Link>
+  );
+};
 
 export const notesCell = (
   searchRequest: PoolCandidateSearchRequest,

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9218,10 +9218,6 @@
     "defaultMessage": "Ce formulaire vous permet d’ajouter une nouvelle expérience à votre parcours professionnel. Commencez par sélectionner le type d’expérience que vous souhaitez ajouter. Si vous avez besoin de plus d’informations sur ce qu’un certain type d’expérience peut inclure, agrandissez les informations ci-dessous pour voir des exemples.",
     "description": "Instructions on how to add an experience to your career timeline"
   },
-  "mzGMZC": {
-    "defaultMessage": "Consulter la demande de {name}",
-    "description": "Link text to view a candidates application for assistive technologies"
-  },
   "n+tkit": {
     "defaultMessage": "Aller à la première page ",
     "description": "Label for first page button in pagination nav"


### PR DESCRIPTION
🤖 Resolves #9331.

## 👋 Introduction

This PR removes the word view from several table cells.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to Candidate Search table `/admin/pool-candidates` (Candidate name)
2. Verify View copy does not exist
3. Navigate to Pool Candidates table `/admin/pools/:id/pool-candidates` (Candidate name)
4. Verify View copy does not exist
5. Navigate to Talent Request table `/admin/talent-requests` (Job title)
6. Verify View copy does not exist
7. Navigate to Request Candidate Results table `/admin/talent-requests/:id` (Candidate name)
8. Verify View copy does not exist

## 📸 Screenshots
<img width="1428" alt="Screen Shot 2024-02-20 at 10 58 42" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/60944548-76c0-4961-9019-3ae1e3bf759d">
<img width="1430" alt="Screen Shot 2024-02-20 at 10 58 13" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/440c9302-c7ac-424a-825c-d3de469dad18">
<img width="1425" alt="Screen Shot 2024-02-20 at 10 58 05" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/a1c332a1-2fa5-4c06-a169-6814514c3e61">
<img width="1420" alt="Screen Shot 2024-02-20 at 10 57 57" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/618298df-4eac-4e5b-a451-e26863217ccf">

