### PR TITLE
[Copy] Assessment plan condense copy

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7570,10 +7570,6 @@
     "defaultMessage": "Sélection des compétences",
     "description": "Title for the skill filters on search page."
   },
-  "eGNxdM": {
-    "defaultMessage": "Plan d'évaluation",
-    "description": "Title for card for actions related to a process' assessment plan"
-  },
   "eIxShU": {
     "defaultMessage": "IT-04: Conseiller principal ou Gestionnaire",
     "description": "IT-04 classification label including titles"
@@ -7811,7 +7807,7 @@
     "description": "Heading for sign and submit section of application review page."
   },
   "fkYYe3": {
-    "defaultMessage": "Plan d’évaluation",
+    "defaultMessage": "Plan d'évaluation",
     "description": "Title for the assessment plan builder"
   },
   "fpdcE/": {

--- a/apps/web/src/messages/adminMessages.ts
+++ b/apps/web/src/messages/adminMessages.ts
@@ -125,6 +125,11 @@ const messages = defineMessages({
     description:
       "Alert message displayed when a user attempts to print without selecting items first",
   },
+  assessmentPlan: {
+    defaultMessage: "Assessment plan",
+    id: "fkYYe3",
+    description: "Title for the assessment plan builder",
+  },
 });
 
 export default messages;

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
@@ -34,16 +34,13 @@ import SEO from "~/components/SEO/SEO";
 import { routeErrorMessages } from "~/hooks/useErrorMessages";
 import { getAssessmentPlanStatus } from "~/validators/pool/assessmentPlan";
 import { getPoolCompletenessBadge } from "~/utils/poolUtils";
+import messages from "~/messages/adminMessages";
 
 import OrganizeSection from "./components/OrganizeSection";
 import SkillSummarySection from "./components/SkillSummarySection";
 import SkillsQuickSummary from "./components/SkillsQuickSummary";
 
-const pageTitle = defineMessage({
-  defaultMessage: "Assessment plan",
-  id: "fkYYe3",
-  description: "Title for the assessment plan builder",
-});
+const pageTitle = defineMessage(messages.assessmentPlan);
 
 const pageSubtitle = defineMessage({
   defaultMessage:

--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -30,6 +30,7 @@ import {
 import { checkRole } from "~/utils/teamUtils";
 import usePoolMutations from "~/hooks/usePoolMutations";
 import { getAssessmentPlanStatus } from "~/validators/pool/assessmentPlan";
+import messages from "~/messages/adminMessages";
 
 import SubmitForPublishingDialog from "./components/SubmitForPublishingDialog";
 import DuplicateProcessDialog from "./components/DuplicateProcessDialog";
@@ -197,12 +198,7 @@ export const ViewPool = ({
           <ProcessCard.Root>
             <ProcessCard.Header>
               <Heading level="h3" size="h6" data-h2-margin="base(0)">
-                {intl.formatMessage({
-                  defaultMessage: "Assessment plan",
-                  id: "eGNxdM",
-                  description:
-                    "Title for card for actions related to a process' assessment plan",
-                })}
+                {intl.formatMessage(messages.assessmentPlan)}
               </Heading>
               {recordOfDecisionFlag && (
                 <Pill

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -42,6 +42,7 @@ import {
   SimpleClassification,
   SimplePool,
 } from "~/types/pool";
+import messages from "~/messages/adminMessages";
 
 import { wrapAbbr } from "./nameUtils";
 
@@ -318,11 +319,7 @@ export const useAdminPoolPages = (intl: IntlShape, pool: Pick<Pool, "id">) => {
         [
           "plan",
           {
-            title: intl.formatMessage({
-              defaultMessage: "Assessment plan",
-              id: "fkYYe3",
-              description: "Title for the assessment plan builder",
-            }),
+            title: intl.formatMessage(messages.assessmentPlan),
             link: {
               url: paths.assessmentPlanBuilder(pool.id),
             },
@@ -349,11 +346,7 @@ export const useAdminPoolPages = (intl: IntlShape, pool: Pick<Pool, "id">) => {
               },
               {
                 url: paths.assessmentPlanBuilder(pool.id),
-                label: intl.formatMessage({
-                  defaultMessage: "Assessment plan",
-                  id: "fkYYe3",
-                  description: "Title for the assessment plan builder",
-                }),
+                label: intl.formatMessage(messages.assessmentPlan),
               },
             ],
           },


### PR DESCRIPTION
🤖 Resolves #9389 

## 👋 Introduction

Condense instances of "Assessment plan"

## 🧪 Testing

1. Build and navigate to places with the string in question, for example, `/fr/admin/pools/:id/plan`
2. Observe 

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/20491e5b-8a6d-44b2-9849-f7c510cfee5c)

