### PR TITLE
[Bug] Step title fallback for assessment board

### DIFF
--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
@@ -1,10 +1,14 @@
 import React from "react";
-import { useIntl } from "react-intl";
+import { IntlShape, useIntl } from "react-intl";
 
 import { Board } from "@gc-digital-talent/ui";
-import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  getAssessmentStepType,
+  getLocalizedName,
+} from "@gc-digital-talent/i18n";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
-import { Pool } from "@gc-digital-talent/graphql";
+import { AssessmentStep, Pool } from "@gc-digital-talent/graphql";
 
 import applicationMessages from "~/messages/applicationMessages";
 
@@ -22,6 +26,18 @@ export interface AssessmentStepTrackerProps {
   pool: Pool;
 }
 
+const generateStepName = (step: AssessmentStep, intl: IntlShape): string => {
+  // check if title exists in LocalizedString object, then return empty string if not for a truthy check
+  const titleLocalized = getLocalizedName(step.title, intl, true);
+  if (titleLocalized) {
+    return titleLocalized;
+  }
+  if (step.type) {
+    return intl.formatMessage(getAssessmentStepType(step.type));
+  }
+  return intl.formatMessage(commonMessages.notAvailable);
+};
+
 const AssessmentStepTracker = ({ pool }: AssessmentStepTrackerProps) => {
   const intl = useIntl();
   const [filters, setFilters] = React.useState<ResultFilters>(defaultFilters);
@@ -35,7 +51,7 @@ const AssessmentStepTracker = ({ pool }: AssessmentStepTrackerProps) => {
       <Filters onFiltersChange={setFilters} />
       <Board.Root>
         {filteredSteps.map(({ step, resultCounts, results }, index) => {
-          const stepName = getLocalizedName(step.title, intl);
+          const stepName = generateStepName(step, intl);
           const stepNumber = intl.formatMessage(
             applicationMessages.numberedStep,
             {


### PR DESCRIPTION
🤖 Resolves #9432

## 👋 Introduction

Fallback to step type first, then as a last resort render the not available/applicable. 

## 🧪 Testing

1. Navigate to the screening and assessment board for various pools
2. Should not see "N/A"

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/7fb7fc7c-1805-4939-9a83-d113a36a14c5)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/85e4570b-403d-43eb-acdc-b791b6b5de38)

