### PR TITLE
[Feature] Adds IT-05 to `classificationsAvailableForSearch`

### DIFF
--- a/apps/web/src/constants/classificationsAvailableForSearch.ts
+++ b/apps/web/src/constants/classificationsAvailableForSearch.ts
@@ -19,6 +19,10 @@ export default (): Pick<Classification, "group" | "level">[] => {
       level: 4,
     },
     {
+      group: "IT",
+      level: 5,
+    },
+    {
       group: "PM",
       level: 1,
     },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1104,7 +1104,7 @@
     "description": "First paragraph for publish pool dialog"
   },
   "46pgKa": {
-    "defaultMessage": "PM-04: Analyste",
+    "defaultMessage": "PM-04 : Analyste",
     "description": "PM-04 classification label including titles"
   },
   "491LrZ": {
@@ -3192,7 +3192,7 @@
     "description": "Aria label for download guidance for managers pdf link."
   },
   "Fe9Cje": {
-    "defaultMessage": "IT-01: Technicien(ne)",
+    "defaultMessage": "IT-01 : Technicien(ne)",
     "description": "IT-01 classification label including titles"
   },
   "FffxNt": {
@@ -4044,7 +4044,7 @@
     "description": "Bilingual advanced personnel language"
   },
   "Kf7cYc": {
-    "defaultMessage": "PM-03: Agent(e)",
+    "defaultMessage": "PM-03 : Agent(e)",
     "description": "PM-03 classification label including titles"
   },
   "Kg8PlJ": {
@@ -5184,7 +5184,7 @@
     "description": "GCKey question for when user does not have recovery codes"
   },
   "RHTrvR": {
-    "defaultMessage": "IT-03: Conseiller technique ou Chef d'équipe",
+    "defaultMessage": "IT-03 : Conseiller technique ou Chef d'équipe",
     "description": "IT-03 classification label including titles"
   },
   "RIi/3q": {
@@ -5192,7 +5192,7 @@
     "description": "Title for Contact us action"
   },
   "RJtGM5": {
-    "defaultMessage": "PM-02: Analyste subalterne",
+    "defaultMessage": "PM-02 : Analyste subalterne",
     "description": "PM-02 classification label including titles"
   },
   "RNI+IH": {
@@ -6227,7 +6227,7 @@
     "description": "Title for the additional comments block in the search request filters"
   },
   "WsR0FB": {
-    "defaultMessage": "IT-02: Analyste",
+    "defaultMessage": "IT-02 : Analyste",
     "description": "IT-02 classification label including titles"
   },
   "WuMMRK": {
@@ -7599,7 +7599,7 @@
     "description": "Title for the skill filters on search page."
   },
   "eIxShU": {
-    "defaultMessage": "IT-04: Conseiller principal ou Gestionnaire",
+    "defaultMessage": "IT-04 : Conseiller principal ou Gestionnaire",
     "description": "IT-04 classification label including titles"
   },
   "eKPE3F": {
@@ -8791,7 +8791,7 @@
     "description": "Message displayed to users when they attempt to quit the profile form with unsaved changes"
   },
   "kfPc04": {
-    "defaultMessage": "PM-01: Agent(e) subalterne",
+    "defaultMessage": "PM-01 : Agent(e) subalterne",
     "description": "PM-01 classification label including titles"
   },
   "kfjmTt": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9870,6 +9870,10 @@
     "defaultMessage": "Déterminer et coordonner les occasions de formation et d’amélioration des compétences à l’échelle du gouvernement",
     "description": "An OCIO role in the _supporting the community_ section of the _digital services contracting questionnaire_"
   },
+  "qt8lB2": {
+    "defaultMessage": "IT-05 : Directeur",
+    "description": "IT-05 classification label including titles"
+  },
   "qtCt+G": {
     "defaultMessage": "Aller à la dernière page ",
     "description": "Label for last page button in pagination nav"
@@ -11181,6 +11185,10 @@
   "zXzQhc": {
     "defaultMessage": "Si vous ne savez pas si ce questionnaire est nécessaire pour un type de contrat spécifique, veuillez communiquer avec nous, à <link>GCTalentGC@tbs-sct.gc.ca</link>, pour obtenir de plus amples renseignements.",
     "description": "Paragraph three of the _examples of contracts_ section of the _digital services contracting questionnaire_"
+  },
+  "zbiumT": {
+    "defaultMessage": "Directeur I T 5",
+    "description": "IT-05 classification aria label including titles"
   },
   "zbmWLG": {
     "defaultMessage": "Le gouvernement du Canada lira les commentaires et participera aux discussions, au besoin. Vos commentaires et vos contributions doivent être pertinents et respectueux.",

--- a/apps/web/src/pages/SearchRequests/SearchPage/labels.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/labels.ts
@@ -22,6 +22,11 @@ export const classificationLabels: Record<string, MessageDescriptor> =
       id: "eIxShU",
       description: "IT-04 classification label including titles",
     },
+    "IT-05": {
+      defaultMessage: "IT-05: Director",
+      id: "qt8lB2",
+      description: "IT-05 classification label including titles",
+    },
     "PM-01": {
       defaultMessage: "PM-01: Junior Officer",
       id: "kfPc04",
@@ -65,6 +70,11 @@ export const classificationAriaLabels: Record<string, MessageDescriptor> =
       defaultMessage: "Senior Advisor or Manager I T 4",
       id: "jAPSUd",
       description: "IT-04 classification aria label including titles",
+    },
+    "IT-05": {
+      defaultMessage: "Director I T 5",
+      id: "zbiumT",
+      description: "IT-05 classification aria label including titles",
     },
     "PM-01": {
       defaultMessage: "Junior Officer P M 1",


### PR DESCRIPTION
🤖 Resolves #9477.

## 👋 Introduction

This PR adds IT-05 to `classificationsAvailableForSearch`. It also [adds a space after the colon in all of the classifications labels in French](https://github.com/GCTC-NTGC/gc-digital-talent/pull/9479/commits/26497342fe3a1d7dc40c9c217a4903ba6781f8e8) for consistency.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate to `/search`
3. Select `Classification filter`
4. Verify **IT-05** is an option

## 📸 Screenshots

<img width="777" alt="Screen Shot 2024-02-22 at 14 10 12" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/b6d9b3c3-625b-4d9b-b52d-91fb7d53103a">

<img width="780" alt="Screen Shot 2024-02-22 at 14 20 57" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/23adaf72-e68e-4b41-a1c7-e6256f3a2ba1">