### PR TITLE
[Tooling] Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
       storybook:
         patterns:
           - "@storybook*"
+          - "storybook*"
         update-types:
           - "major"
           - "minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,32 @@ updates:
       interval: "weekly"
       day: "thursday"
     open-pull-requests-limit: 50
+    groups:
+      storybook:
+        patterns:
+          - "@storybook*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+      graphql-codegen:
+        patterns:
+          - "@graphql-codegen*"
+        update-types:
+          - "minor"
+          - "patch"
+      tiptap:
+        patterns:
+          - "@tiptap*"
+        update-types:
+          - "minor"
+          - "patch"
+      types:
+        patterns:
+          - "@types*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # This ignores all updates to tc-report, since it's now served as a static website.
   #


### PR DESCRIPTION
🤖 Resolves #9474 

## 👋 Introduction

Add merge groups.
Not sure how to confirm it works? Other than merge and wait until there are enough dependencies to update then trigger it.

Storybook, graphql, tiptap, and types were what I picked as they have multiples. Storybook I allowed major since that would probably have to be merged together anyway for it to not break. 

## 🧪 Testing

1. ?
