### PR TITLE
[Fix] Add missing permission to platform admin

### DIFF
--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -806,6 +806,9 @@ return [
             'directiveForm' => [
                 'any' => ['create', 'view', 'update', 'delete'],
             ],
+            'assessmentPlan' => [
+                'any' => ['view'],
+            ],
             'assessmentResult' => [
                 'any' => ['view'],
             ],


### PR DESCRIPTION
🤖 Resolves #9428 

## 👋 Introduction

Adds the `view-any-assessmentPlan` to the platform admin role. It also updates our file for tracking permissions.

## 🕵️ Details

The noted permission is now required to view the pool page but was only given to community managers. So, if you had the platform admin role but not the community manager role, you could no longer view pools.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Re-run role permission seeder `php artisan db:seed --class=RolePermissionSeeder`
2. Login as admin `admin@test.com`
3. Find a user and give them only the following roles
  - Base user
  - Applicant
  - Request Responder
  - Platform admin
4. Copy their sub
5. Logout
6. Login with the sub of the user copied in step 4
7. Navigate to a process information page `/admin/pools/{poolId}`
8. Confirm it works with no errors

## 📸 Screenshot

Add a screenshot (if possible).

## 🚚 Deployment

1. Run the `RolePermissionSeeder`