### PR TITLE
[Bug] Pagination on filter changes

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -277,6 +277,7 @@ const PoolCandidatesTable = ({
   const filterRef = React.useRef<PoolCandidateSearchInput | undefined>(
     initialFilters,
   );
+
   const [paginationState, setPaginationState] = React.useState<PaginationState>(
     initialState.paginationState
       ? {
@@ -325,6 +326,10 @@ const PoolCandidatesTable = ({
   };
 
   const handleFilterSubmit: SubmitHandler<FormValues> = (data) => {
+    setPaginationState((previous) => ({
+      ...previous,
+      pageIndex: 0,
+    }));
     const transformedData: PoolCandidateSearchInput =
       transformFormValuesToFilterState(data);
 
@@ -789,6 +794,8 @@ const PoolCandidatesTable = ({
       }}
       pagination={{
         internal: false,
+        initialState: INITIAL_STATE.paginationState,
+        state: paginationState,
         total: data?.poolCandidatesPaginated?.paginatorInfo.total,
         pageSizes: [10, 20, 50, 100, 500],
         onPaginationChange: ({ pageIndex, pageSize }: PaginationState) => {

--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -186,6 +186,10 @@ const SearchRequestTable = ({ title }: SearchRequestTableProps) => {
     useState<PoolCandidateSearchRequestInput>(initialFilters);
 
   const handleFilterSubmit: SubmitHandler<FormValues> = (data) => {
+    setPaginationState((previous) => ({
+      ...previous,
+      pageIndex: 0,
+    }));
     const transformedData = transformFormValuesToSearchRequestFilterInput(data);
     setFilterState(transformedData);
     if (!isEqual(transformedData, filterRef.current)) {
@@ -376,6 +380,8 @@ const SearchRequestTable = ({ title }: SearchRequestTableProps) => {
       }}
       pagination={{
         internal: false,
+        initialState: INITIAL_STATE.paginationState,
+        state: paginationState,
         total: data?.poolCandidateSearchRequestsPaginated.paginatorInfo.total,
         pageSizes: [10, 20, 50],
         onPaginationChange: ({ pageIndex, pageSize }: PaginationState) => {

--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -212,13 +212,20 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
       const initialPageIndex =
         pagination?.initialState?.pageIndex ??
         INITIAL_STATE.paginationState.pageIndex;
-      if (paginationState.pageIndex === initialPageIndex) {
+
+      let currentPageIndex: number = paginationState.pageIndex;
+      if (
+        !pagination?.internal &&
+        typeof pagination?.state?.pageIndex !== "undefined"
+      ) {
+        const externalPageIndex = pagination.state.pageIndex - 1;
+        currentPageIndex = externalPageIndex < 0 ? 0 : externalPageIndex;
+      }
+
+      if (currentPageIndex === initialPageIndex) {
         newParams.delete(SEARCH_PARAM_KEY.PAGE);
       } else {
-        newParams.set(
-          SEARCH_PARAM_KEY.PAGE,
-          String(paginationState.pageIndex + 1),
-        );
+        newParams.set(SEARCH_PARAM_KEY.PAGE, String(currentPageIndex + 1));
       }
 
       const initialSearchState =
@@ -270,6 +277,8 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
     sort?.initialState,
     hiddenColumnIds,
     search?.initialState,
+    pagination?.internal,
+    pagination?.state,
     pagination?.initialState?.pageSize,
     pagination?.initialState?.pageIndex,
     urlSync,

--- a/apps/web/src/components/Table/ResponsiveTable/TablePagination.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/TablePagination.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { Table } from "@tanstack/react-table";
+import { PaginationState, Table } from "@tanstack/react-table";
 
 import Pagination from "~/components/Pagination";
 
@@ -45,7 +45,22 @@ const TablePagination = <T,>({
     }
   };
 
-  const tablePaginationState = table.getState().pagination;
+  let currentPageIndex: number = 0;
+  if (
+    !pagination?.internal &&
+    typeof pagination?.state?.pageIndex !== "undefined"
+  ) {
+    const externalPageIndex = pagination.state.pageIndex - 1;
+    currentPageIndex = externalPageIndex < 0 ? 0 : externalPageIndex;
+  }
+
+  const tablePaginationState: PaginationState =
+    !pagination.internal && pagination.state
+      ? {
+          pageIndex: currentPageIndex,
+          pageSize: pagination.state.pageSize,
+        }
+      : table.getState().pagination;
 
   return (
     <Pagination

--- a/apps/web/src/components/Table/ResponsiveTable/types.ts
+++ b/apps/web/src/components/Table/ResponsiveTable/types.ts
@@ -129,6 +129,8 @@ export type PaginationDef = {
   onPaginationChange?: (newPagination: PaginationState) => void;
   /** Initial pagination state */
   initialState?: PaginationState;
+  /** Pagination state */
+  state?: PaginationState;
   /** Total number of pages */
   total?: number;
   /** Available page sizes */

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -139,6 +139,10 @@ const UserTable = ({ title }: UserTableProps) => {
   };
 
   const handleFilterSubmit: SubmitHandler<FormValues> = (data) => {
+    setPaginationState((previous) => ({
+      ...previous,
+      pageIndex: 0,
+    }));
     const transformedData = transformFormValuesToUserFilterInput(data);
     setFilterState(transformedData);
     if (!isEqual(transformedData, filterRef.current)) {
@@ -359,6 +363,8 @@ const UserTable = ({ title }: UserTableProps) => {
       }}
       pagination={{
         internal: false,
+        initialState: INITIAL_STATE.paginationState,
+        state: paginationState,
         total: data?.usersPaginated?.paginatorInfo.total,
         pageSizes: [10, 20, 50],
         onPaginationChange: ({ pageIndex, pageSize }: PaginationState) => {


### PR DESCRIPTION
🤖 Resolves #9312 

## 👋 Introduction

- Thanks to @esizer for the help 🥇 
- Adds external state to ResponsiveTable
- Adds fix to all api tables: PoolCandidatesTable, UserTable, SearchRequestTable

## 🧪 Testing

1. Log is as admin
2. Go to a PoolCandidate/UserTable/SearchRequestTable 
3. Add some filters which decrease the number of results (and the number of pages) but still have some results.
4. Reset the filters
5. Go to the last page of the table
6. Add the same filters from before
7. Table appears on first page with correct number of rows
