### PR TITLE
Automate blocking issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/♻️-debt-refactor.md
+++ b/.github/ISSUE_TEMPLATE/♻️-debt-refactor.md
@@ -28,3 +28,12 @@ A set of assumptions which, when tested, verify that the debt was addressed and 
 
 - [ ] Criteria 1
 - [ ] Criteria 2
+
+## 🛑 Blockers
+
+Issues which must be completed before this one.
+
+```[tasklist]
+### Blocked By
+- [ ] ticket number
+```

--- a/.github/ISSUE_TEMPLATE/✨-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/✨-feature-request.md
@@ -40,3 +40,12 @@ A set of assumptions which, when tested, verify that the feature was properly im
 
 - [ ] Criteria 1
 - [ ] Criteria 2
+
+## 🛑 Blockers
+
+Issues which must be completed before this one.
+
+```[tasklist]
+### Blocked By
+- [ ] ticket number
+```

--- a/.github/ISSUE_TEMPLATE/🛠️-tooling.md
+++ b/.github/ISSUE_TEMPLATE/🛠️-tooling.md
@@ -24,3 +24,12 @@ A set of assumptions which, when tested, verify that the debt tooling was proper
 
 - [ ] Criteria 1
 - [ ] Criteria 2
+
+## 🛑 Blockers
+
+Issues which must be completed before this one.
+
+```[tasklist]
+### Blocked By
+- [ ] ticket number
+```

--- a/.github/ISSUE_TEMPLATE/🧪-tests.md
+++ b/.github/ISSUE_TEMPLATE/🧪-tests.md
@@ -24,3 +24,12 @@ A set of assumptions which, when tested, verify that the debt tests were properl
 
 - [ ] Criteria 1
 - [ ] Criteria 2
+
+## 🛑 Blockers
+
+Issues which must be completed before this one.
+
+```[tasklist]
+### Blocked By
+- [ ] ticket number
+```

--- a/.github/workflows/blocking-issues.yml
+++ b/.github/workflows/blocking-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Checks for blocking issues
 
     steps:
-      - uses: tristan-orourke/blocking-issues@v1.0
+      - uses: tristan-orourke/blocking-issues@v1.1
         with:
           # Optional: Choose an existing label to use instead of creating a new one.
           # If the label cannot be found, the default one will be created and used.

--- a/.github/workflows/blocking-issues.yml
+++ b/.github/workflows/blocking-issues.yml
@@ -1,0 +1,20 @@
+name: Blocking Issues
+
+on:
+  issues:
+    types: [opened, edited, deleted, transferred, closed, reopened]
+  pull_request_target:
+    types: [opened, edited, closed, reopened]
+
+jobs:
+  blocking_issues:
+    runs-on: ubuntu-latest
+    name: Checks for blocking issues
+
+    steps:
+      - uses: tristan-orourke/blocking-issues@v1.0
+        with:
+          # Optional: Choose an existing label to use instead of creating a new one.
+          # If the label cannot be found, the default one will be created and used.
+          # The default is: "blocked" (black).
+          use-label: "blocked: dependencies"


### PR DESCRIPTION
🤖 Resolves `none`

## 👋 Introduction

One of the best features of Zenhub (compared to Github Projects) was a better way to indicate blocked or blocking issues. This is an attempt to improve the experience slightly on Github Projects. 

It makes use of a github Action which can automatically add a "blocked" label to tickets, and remove it when the blocking issues are closed. The original Action was https://github.com/Levi-Lesches/blocking-issues. I forked it in order to modify it slightly -  blockers are now defined in a tasklist, allowing us to leverage `tracks` and `tracked by` fields at the same time.

## 🕵️ Details

To indicate blockers, create a tasklist with the title "Blocked By", like so:

````
```[tasklist]
### Blocked By
- [ ] #1111
- [x] #2222
- [ ] #3333
```
````
If any of the blocking tickets are open, the `blocking-issues` workflow will automatically add the `blocked: dependencies` label, When all the issues are closed, it will remove the label! It does this by running every time an issue is edited or closed.

At the same time, I've edited dev issue templates to include the Blocked By tasklist, though in most cases we will likely delete it.

## 🧪 Testing

I'm not sure how to test an action like this without merging it :/

## PS

Somehow I managed to accidentally commit this to the main branch! I reverted it there, and so this PR reverts the reversions... 😩 