### PR TITLE
[Fix] Log users out of all tabs

### DIFF
--- a/apps/e2e/cypress/e2e/api/login-logout.cy.ts
+++ b/apps/e2e/cypress/e2e/api/login-logout.cy.ts
@@ -360,7 +360,7 @@ describe("Login and logout", () => {
 
     // Logout appears to affect all logged in tabs
     // Bug in app prevents this test from completing: #9188
-    it.skip("will affect all tabs when logged out", () => {
+    it("will affect all tabs when logged out", () => {
       cy.loginBySubject(testUserSubject);
       cy.visit("/en/applicant/profile-and-applications");
 
@@ -373,13 +373,6 @@ describe("Login and logout", () => {
       // simulate logged out in a different tab
       cy.clearLocalStorage("access_token");
       cy.clearLocalStorage("refresh_token");
-
-      // not important, just need an API request to occur
-      cy.findByRole("navigation", { name: "Personal information" }).within(
-        () => {
-          cy.findByRole("link", { name: "Personal information" }).click();
-        },
-      );
 
       // forcibly logged out
       cy.findByRole("heading", {

--- a/packages/auth/src/components/AuthenticationContainer.tsx
+++ b/packages/auth/src/components/AuthenticationContainer.tsx
@@ -132,6 +132,21 @@ const AuthenticationContainer = ({
     }
   }
 
+  // Logout if the access token is removed in another way other than
+  // the user logging out manually
+  useEffect(() => {
+    const logoutOnAccessTokenRemoved = (event: StorageEvent) => {
+      if (event.key === ACCESS_TOKEN && event.newValue === null) {
+        window.location.href = logoutRedirectUri;
+      }
+    };
+
+    window.addEventListener("storage", logoutOnAccessTokenRemoved);
+
+    return () =>
+      window.removeEventListener("storage", logoutOnAccessTokenRemoved);
+  });
+
   // We have saved it in local storage , then clear query parameters.
   useEffect(() => {
     if (newTokens?.accessToken) {

--- a/packages/auth/src/hooks/useLogoutChannel.ts
+++ b/packages/auth/src/hooks/useLogoutChannel.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useRef } from "react";
+
+const LOGOUT_MESSAGE = "LOGOUT";
+let singleChannel: BroadcastChannel;
+
+/**
+ * Create a single broadcast channel
+ * to emit logout message to all tabs
+ *
+ * @returns
+ */
+const getChannel = () => {
+  if (!singleChannel) {
+    singleChannel = new BroadcastChannel("logoutChannel");
+  }
+
+  return singleChannel;
+};
+
+const useLogoutChannel = (onLogout: () => void) => {
+  const channel = getChannel();
+  // Prevents channel from being closed/reopened
+  const isSubscribed = useRef(false);
+
+  useEffect(() => {
+    if (!isSubscribed.current) {
+      channel.onmessage = (event) => {
+        if (event.data === LOGOUT_MESSAGE) {
+          onLogout();
+        }
+      };
+    }
+
+    return () => {
+      if (isSubscribed.current) {
+        channel.close();
+        isSubscribed.current = false;
+      }
+    };
+    // We only want this to run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const postLogoutMessage = useCallback(() => {
+    channel?.postMessage(LOGOUT_MESSAGE);
+  }, [channel]);
+
+  return {
+    postLogoutMessage,
+  };
+};
+
+export default useLogoutChannel;


### PR DESCRIPTION
🤖 Resolves #9188 

## 👋 Introduction

This updates our auth container to log users out of all active tabs at once.

## 🕵️ Details

This uses two different ways to accomplish it.

1. Broadcast channel affects all tabs and posts a message to tell other tabs to logout
2. An effect that watches for the access token to be set to null and logging out when doing so

### Broadcast channel

This is the common way of completing this task. On mount of the auth container, it creates a broadcast channel singleton. When the user is logged out, it sends a logout message to all tabs. Then, the tabs redirect when that specific message is received. 

### Storage effect

This method is not entirely necessary but since we cannot test multiple tabs in Cypress we need to manually remove the access token. This does actually have a use case though, if the access token is removed by any method outside of `logoutAndRefreshPage` (unlikely but possible) this will also log the user out of other tabs.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login
3. Open a new tab
4. Logout of either tab
5. Confirm the other tab is automatically logged out
6. Repeat steps 2 and 3
7. Open local storage of one tab
8. Delete the access token
9. Confirm other tab is logged out 
