### PR TITLE
[Debt] Load mode specific images only

### DIFF
--- a/apps/web/src/components/FlourishContainer/FlourishContainer.tsx
+++ b/apps/web/src/components/FlourishContainer/FlourishContainer.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { useTheme } from "@gc-digital-talent/theme";
+
 import desktopGraphicsLight2 from "~/assets/img/Desktop_Graphics_light_2.webp";
 import desktopGraphicsLight3 from "~/assets/img/Desktop_Graphics_light_3.webp";
 import desktopGraphicsDark2 from "~/assets/img/Desktop_Graphics_dark_2.webp";
@@ -20,22 +22,22 @@ const FlourishContainer = ({
   show = ["top", "bottom"],
   size = "lg",
   skew = true,
-}: FlourishContainerProps) => (
-  <div data-h2-layer="base(3, relative)">
-    <div
-      data-h2-background="base(background)"
-      data-h2-height="base(100%)"
-      data-h2-width="base(100%)"
-      data-h2-position="base(absolute)"
-      {...(skew && {
-        "data-h2-transform": "base(skewY(-3deg))",
-      })}
-      data-h2-overflow="base(hidden)"
-    >
-      {show.includes("top") && (
-        <>
+}: FlourishContainerProps) => {
+  const { mode } = useTheme();
+  return (
+    <div data-h2-layer="base(3, relative)">
+      <div
+        data-h2-background="base(background)"
+        data-h2-height="base(100%)"
+        data-h2-width="base(100%)"
+        data-h2-position="base(absolute)"
+        {...(skew && {
+          "data-h2-transform": "base(skewY(-3deg))",
+        })}
+        data-h2-overflow="base(hidden)"
+      >
+        {show.includes("top") && (
           <img
-            data-h2-display="base(block) base:dark(none)"
             data-h2-position="base(absolute)"
             data-h2-location="base(0, 0, auto, auto)"
             data-h2-transform="base(skew(3deg))"
@@ -49,33 +51,12 @@ const FlourishContainer = ({
                   "data-h2-height": "base(auto) p-tablet(20%)",
                   "data-h2-width": "base(60%) p-tablet(auto)",
                 })}
-            src={desktopGraphicsLight2}
+            src={mode === "dark" ? desktopGraphicsDark2 : desktopGraphicsLight2}
             alt=""
           />
+        )}
+        {show.includes("bottom") && (
           <img
-            data-h2-display="base(none) base:dark(block)"
-            data-h2-position="base(absolute)"
-            data-h2-location="base(0, 0, auto, auto)"
-            data-h2-transform="base(skew(3deg))"
-            data-h2-max-width="base(initial)"
-            {...(size === "lg"
-              ? {
-                  "data-h2-height": "base(auto) p-tablet(50%)",
-                  "data-h2-width": "base(150%) p-tablet(auto)",
-                }
-              : {
-                  "data-h2-height": "base(auto) p-tablet(20%)",
-                  "data-h2-width": "base(60%) p-tablet(auto)",
-                })}
-            src={desktopGraphicsDark2}
-            alt=""
-          />
-        </>
-      )}
-      {show.includes("bottom") && (
-        <>
-          <img
-            data-h2-display="base(block) base:dark(none)"
             data-h2-position="base(absolute)"
             data-h2-location="base(auto, auto, 0, 0)"
             data-h2-transform="base(skew(3deg))"
@@ -89,39 +70,21 @@ const FlourishContainer = ({
                   "data-h2-height": "base(auto) desktop(30%)",
                   "data-h2-width": "base(45%) p-tablet(32%) desktop(auto)",
                 })}
-            src={desktopGraphicsLight3}
+            src={mode === "dark" ? desktopGraphicsDark3 : desktopGraphicsLight3}
             alt=""
           />
-          <img
-            data-h2-display="base(none) base:dark(block)"
-            data-h2-position="base(absolute)"
-            data-h2-location="base(auto, auto, 0, 0)"
-            data-h2-transform="base(skew(3deg))"
-            data-h2-max-width="base(initial)"
-            {...(size === "lg"
-              ? {
-                  "data-h2-height": "base(auto) desktop(90%)",
-                  "data-h2-width": "base(150%) p-tablet(100%) desktop(auto)",
-                }
-              : {
-                  "data-h2-height": "base(auto) desktop(30%)",
-                  "data-h2-width": "base(45%) p-tablet(32%) desktop(auto)",
-                })}
-            src={desktopGraphicsDark3}
-            alt=""
-          />
-        </>
-      )}
-    </div>
-    <div
-      data-h2-position="base(relative)"
-      data-h2-container="base(center, large, x1) p-tablet(center, large, x2)"
-    >
-      <div data-h2-padding="base(x3, 0) p-tablet(x5, 0, x4, 0) l-tablet(x7, 0, x6, 0)">
-        {children}
+        )}
+      </div>
+      <div
+        data-h2-position="base(relative)"
+        data-h2-container="base(center, large, x1) p-tablet(center, large, x2)"
+      >
+        <div data-h2-padding="base(x3, 0) p-tablet(x5, 0, x4, 0) l-tablet(x7, 0, x6, 0)">
+          {children}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default FlourishContainer;

--- a/apps/web/src/components/Instructions/InstructionStep.tsx
+++ b/apps/web/src/components/Instructions/InstructionStep.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import ArrowRightCircleIcon from "@heroicons/react/24/solid/ArrowRightCircleIcon";
 import ArrowDownCircleIcon from "@heroicons/react/24/solid/ArrowDownCircleIcon";
 
+import { useTheme } from "@gc-digital-talent/theme";
+
 export interface InstructionStepProps {
   image: string;
   imageDark?: string;
@@ -15,25 +17,8 @@ export const InstructionStep = ({
   includeArrow = true,
   children,
 }: InstructionStepProps) => {
-  let lightImage;
-  let darkImage;
-
-  if (image) {
-    lightImage = <img data-h2-display="base(block)" src={image} alt="" />;
-  }
-
-  if (imageDark) {
-    lightImage = (
-      <img data-h2-display="base(block) base:dark(none)" src={image} alt="" />
-    );
-    darkImage = (
-      <img
-        data-h2-display="base(none) base:dark(block)"
-        src={imageDark}
-        alt=""
-      />
-    );
-  }
+  const { mode } = useTheme();
+  const imgSrc = mode === "dark" && imageDark ? imageDark : image;
 
   return (
     <li
@@ -42,8 +27,7 @@ export const InstructionStep = ({
       data-h2-flex-item="base(1of1) p-tablet(1of4)"
     >
       <div data-h2-display="base(flex)" data-h2-flex-direction="base(row)">
-        {lightImage}
-        {darkImage}
+        <img src={imgSrc} alt="" />
         {includeArrow && (
           <ArrowRightCircleIcon
             data-h2-display="base(none) p-tablet(block)"

--- a/apps/web/src/components/SkewedContainer/SkewedContainer.tsx
+++ b/apps/web/src/components/SkewedContainer/SkewedContainer.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { useTheme } from "@gc-digital-talent/theme";
+
 import desktopGraphicsLight1 from "~/assets/img/Desktop_Graphics_light_1.webp";
 import desktopGraphicsDark1 from "~/assets/img/Desktop_Graphics_dark_1.webp";
 
@@ -7,55 +9,46 @@ interface SkewedContainerProps {
   children: React.ReactNode;
 }
 
-const SkewedContainer = ({ children }: SkewedContainerProps) => (
-  <div data-h2-margin="base(-3%, 0, 0, 0)" data-h2-layer="base(2, relative)">
-    <div
-      data-h2-height="base(100%)"
-      data-h2-width="base(100%)"
-      data-h2-background-color="base(background)"
-      data-h2-position="base(absolute)"
-      data-h2-transform="base(skewY(-3deg))"
-      data-h2-overflow="base(hidden)"
-    >
-      <img
-        data-h2-display="base(block) base:dark(none)"
-        data-h2-position="base(absolute)"
-        data-h2-location="base(0, 0, auto, auto)"
-        data-h2-transform="base(translate(32%, -52%) skew(3deg)) l-tablet(translate(0, 0) skew(3deg))"
-        data-h2-height="base(auto)"
-        data-h2-width="base(250%) l-tablet(40%)"
-        data-h2-max-width="base(initial)"
-        src={desktopGraphicsLight1}
-        alt=""
-      />
-      <img
-        data-h2-display="base(none) base:dark(block)"
-        data-h2-position="base(absolute)"
-        data-h2-location="base(0, 0, auto, auto)"
-        data-h2-transform="base(translate(32%, -52%) skew(3deg)) l-tablet(translate(0, 0) skew(3deg))"
-        data-h2-height="base(auto)"
-        data-h2-width="base(250%) l-tablet(40%)"
-        data-h2-max-width="base(initial)"
-        src={desktopGraphicsDark1}
-        alt=""
-      />
+const SkewedContainer = ({ children }: SkewedContainerProps) => {
+  const { mode } = useTheme();
+  return (
+    <div data-h2-margin="base(-3%, 0, 0, 0)" data-h2-layer="base(2, relative)">
       <div
-        data-h2-background="base(main-linear)"
-        data-h2-location="base(0, 0, auto, 0)"
-        data-h2-display="base(block)"
-        data-h2-height="base(x1)"
+        data-h2-height="base(100%)"
+        data-h2-width="base(100%)"
+        data-h2-background-color="base(background)"
         data-h2-position="base(absolute)"
-      />
-    </div>
-    <div
-      data-h2-position="base(relative)"
-      data-h2-container="base(center, large, x1) p-tablet(center, large, x2)"
-    >
-      <div data-h2-padding="base(x3, 0) p-tablet(x5, 0, x4, 0) l-tablet(x7, 0, x6, 0)">
-        {children}
+        data-h2-transform="base(skewY(-3deg))"
+        data-h2-overflow="base(hidden)"
+      >
+        <img
+          data-h2-position="base(absolute)"
+          data-h2-location="base(0, 0, auto, auto)"
+          data-h2-transform="base(translate(32%, -52%) skew(3deg)) l-tablet(translate(0, 0) skew(3deg))"
+          data-h2-height="base(auto)"
+          data-h2-width="base(250%) l-tablet(40%)"
+          data-h2-max-width="base(initial)"
+          src={mode === "dark" ? desktopGraphicsDark1 : desktopGraphicsLight1}
+          alt=""
+        />
+        <div
+          data-h2-background="base(main-linear)"
+          data-h2-location="base(0, 0, auto, 0)"
+          data-h2-display="base(block)"
+          data-h2-height="base(x1)"
+          data-h2-position="base(absolute)"
+        />
+      </div>
+      <div
+        data-h2-position="base(relative)"
+        data-h2-container="base(center, large, x1) p-tablet(center, large, x2)"
+      >
+        <div data-h2-padding="base(x3, 0) p-tablet(x5, 0, x4, 0) l-tablet(x7, 0, x6, 0)">
+          {children}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default SkewedContainer;


### PR DESCRIPTION
🤖 Resolves #6166 

## 👋 Introduction

Updates images that have light/dark mode specific versions to only load the one for the active mode.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to pages that have mode specific images
    - Home
    - Sign in/Sign out
    - Error page
    - Browse pools
    - Support
3. Confirm there are no duplicate images for light/dark mode
4. Confirm the proper image loads
