### PR TITLE
[Copy] Consolidates Any language string

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
@@ -288,11 +288,7 @@ const PoolCandidateFilterDialog = ({
             id="languageAbility"
             name="languageAbility"
             enableNull
-            nullSelection={intl.formatMessage({
-              defaultMessage: "Any language",
-              id: "qp68Mh",
-              description: "Option label for allowing any language",
-            })}
+            nullSelection={intl.formatMessage(commonMessages.anyLanguage)}
             label={intl.formatMessage({
               defaultMessage: "Languages",
               id: "iUAe/2",

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -142,11 +142,7 @@ const ApplicantFilters = ({
     );
   const languageAbility: string = applicantFilter?.languageAbility
     ? intl.formatMessage(getLanguageAbility(applicantFilter?.languageAbility))
-    : intl.formatMessage({
-        defaultMessage: "Any language",
-        id: "/jDW4V",
-        description: "Label for the any language option",
-      });
+    : intl.formatMessage(commonMessages.anyLanguage);
 
   const workLocationIds: string[] =
     (applicantFilter?.locationPreferences as string[]) ?? [];
@@ -401,11 +397,7 @@ const SearchRequestFilters = ({
     ? intl.formatMessage(
         getLanguageAbility(poolCandidateFilter?.languageAbility),
       )
-    : intl.formatMessage({
-        defaultMessage: "Any language",
-        id: "/jDW4V",
-        description: "Label for the any language option",
-      });
+    : intl.formatMessage(commonMessages.anyLanguage);
 
   return (
     <section data-h2-radius="base(s)">

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -339,10 +339,6 @@
     "defaultMessage": "Avez-vous un droit de priorité?",
     "description": "Priority Entitlement Status in Government Info Form"
   },
-  "/jDW4V": {
-    "defaultMessage": "N’importe quelle langue",
-    "description": "Label for the any language option"
-  },
   "/ldR5A": {
     "defaultMessage": "{count, plural, =0 {0 expériences} =1 {1 expérience} other {# expériences}}",
     "description": "Number of experiences linked to a skill"
@@ -9865,10 +9861,6 @@
   "qn77WI": {
     "defaultMessage": "Équipe, groupe ou division",
     "description": "Label displayed on Work Experience form for team/group/division input"
-  },
-  "qp68Mh": {
-    "defaultMessage": "Toute langue",
-    "description": "Option label for allowing any language"
   },
   "qqkQ/h": {
     "defaultMessage": "Décision finale relative à l’évaluation",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6675,7 +6675,7 @@
     "description": "Label for the team members table search input"
   },
   "YyHN1i": {
-    "defaultMessage": "Toute langue (anglais ou français)",
+    "defaultMessage": "N'importe quelle langue (français ou anglais)",
     "description": "No preference for language ability - will accept English or French"
   },
   "Z+JxTc": {

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserFilterDialog.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserFilterDialog.tsx
@@ -5,6 +5,7 @@ import { OperationContext, useQuery } from "urql";
 import {
   EmploymentDuration,
   OperationalRequirementV2,
+  commonMessages,
   getEmploymentDuration,
   getLanguageAbility,
   getLocalizedName,
@@ -141,11 +142,7 @@ const UserFilterDialog = ({
             id="languageAbility"
             name="languageAbility"
             enableNull
-            nullSelection={intl.formatMessage({
-              defaultMessage: "Any language",
-              id: "qp68Mh",
-              description: "Option label for allowing any language",
-            })}
+            nullSelection={intl.formatMessage(commonMessages.anyLanguage)}
             label={intl.formatMessage({
               defaultMessage: "Languages",
               id: "iUAe/2",

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1783,6 +1783,10 @@
     "defaultMessage": "Veuillez sélectionner les Premières Nations qui détiennent le statut ou les Premières Nations qui ne détiennent pas le statut.",
     "description": "Error message that the user has selected both status and non-status first nations."
   },
+  "sotCgD": {
+    "defaultMessage": "N'importe quelle langue",
+    "description": "Any language"
+  },
   "spP+Tz": {
     "defaultMessage": "Nunavut",
     "description": "Nunavut selection for province or territory input"

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -205,6 +205,11 @@ const commonMessages = defineMessages({
     id: "GLRLYT",
     description: "A decision has not been made",
   },
+  anyLanguage: {
+    defaultMessage: "Any language",
+    id: "sotCgD",
+    description: "Any language",
+  },
 });
 
 export default commonMessages;


### PR DESCRIPTION
🤖 Resolves #9393.

## 👋 Introduction

This PR consolidates **Any language** string to use a single source of truth and places the word _français_ first for the translation of **Any language (English or French)** to follow the logo standard where the current language is always first in the order.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Search codebase for string Any language
2. Verify there is once source of truth

## 📸 Screenshot
<img width="730" alt="Screen Shot 2024-02-26 at 12 46 58" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/531168ac-5f26-4acb-b76c-89af60c12f1b">