### PR TITLE
Show status as "To assess" when pool has no AssessmentSteps

### DIFF
--- a/apps/web/src/utils/poolCandidate.ts
+++ b/apps/web/src/utils/poolCandidate.ts
@@ -432,6 +432,14 @@ const computeInAssessmentStatusPill = (
   steps: AssessmentStep[],
   intl: IntlShape,
 ): StatusPill => {
+  if (steps.length === 0) {
+    // This escape hatch mostly applies to Pools created before Record of Decision.
+    return {
+      label: intl.formatMessage(poolCandidateMessages.toAssess),
+      color: "warning",
+    };
+  }
+
   const orderedSteps = sortBy(steps, (step) => step.sortOrder);
   const candidateResults = determineCandidateStatusPerStep(
     [candidate],


### PR DESCRIPTION
🤖 Resolves #9525

## 👋 Introduction

If a Pool has no assessment steps, candidates in assessment should show "To assess" in Final Decision column, not "Qualified: Pending decision".

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

1. Log in as admin
2. Go to a published pool with candidates and no assessment steps (can be seeded or set up manually)
3. Turn on Record of Decision feature flag
4. Set a candidate to New Application status
5. Candidate's status pill should read "To assess", not "Qualified: Pending decision"
