### PR TITLE
[Fix] Team role assignment user query

### DIFF
--- a/api/app/Models/RoleAssignment.php
+++ b/api/app/Models/RoleAssignment.php
@@ -34,6 +34,11 @@ class RoleAssignment extends Model
 
     public function user(): MorphTo
     {
-        return $this->morphTo('user')->select(['id']);
+        return $this->morphTo('user')->select([
+            'id',
+            'first_name',
+            'last_name',
+            'email',
+        ]);
     }
 }


### PR DESCRIPTION
🤖 Resolves #9512. 

## 👋 Introduction

Fixes an issue where only `id` was available on the `Team.roleAssignments.user` query.

## 🕵️ Details

We had the relationship there but were only selecting `id` so that was the only data that could be returned. This adds the other remaining fields to the select statement so they can be returned in the response.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Login as admin
2. /admin/teams/{teamId}/members
3. Confirm you see the user name (first and last) as well as email

## 📸 Screenshot

![Screenshot 2024-02-27 122038](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/976fbbed-e33e-4262-8cb0-65bee0e5aaf1)
