### PR TITLE
Improve a type used in cypress tests

### DIFF
--- a/apps/e2e/cypress.d.ts
+++ b/apps/e2e/cypress.d.ts
@@ -58,10 +58,10 @@ declare global {
       /**
        * Override specific feature flags.
        * Note: Should be used in `before*`
-       * @param {Object} flags - Feature flags you want to override.
+       * @param {Record<string, boolean | null>} flags - Feature flags you want to override.
        * @example cy.overrideFeatureFlags({FEATURE_FLAG: false})
        */
-      overrideFeatureFlags(flags: Object): void;
+      overrideFeatureFlags(flags: Record<string, boolean | null>): void;
 
       /**
        * ======================================

--- a/documentation/environment-variables.md
+++ b/documentation/environment-variables.md
@@ -25,7 +25,7 @@ To check what variables have been set in the app, open the console of your brows
 
 Since run-time variables are used to maintain the current feature set and can be changed, tests should be run against both versions of a specific feature set. In order to do this, the feature flags must be overridden in the test specifications.
 
-When writing test specifications, run-time variables can be modified for the entire spec, or for specific tests using the `cy.overrideFeatureFlags(flags: Object): void` command.
+When writing test specifications, run-time variables can be modified for the entire spec, or for specific tests using the `cy.overrideFeatureFlags(flags)` command.
 
 ##### Override for entire spec
 


### PR DESCRIPTION
🤖 Resolves #8780

## 👋 Introduction

Just improves a type which was left overly general as an oversight.

## 🧪 Testing

1. make sure the cypress tests still run and pass.
