### PR TITLE
[Feature] Accessibility testing in Playwright

### DIFF
--- a/apps/playwright/fixtures/index.ts
+++ b/apps/playwright/fixtures/index.ts
@@ -43,9 +43,9 @@ export const test = base.extend<AppFixtures>({
     await context.close();
   },
 
-  makeAxeBuilder: async ({ page }, use, testInfo) => {
+  makeAxeBuilder: async ({ appPage }, use) => {
     const makeAxeBuilder = () =>
-      new AxeBuilder({ page }).withTags([
+      new AxeBuilder({ page: appPage.page }).withTags([
         "wcag21a",
         "wcag21a",
         "wcag2a",

--- a/apps/playwright/fixtures/index.ts
+++ b/apps/playwright/fixtures/index.ts
@@ -1,4 +1,4 @@
-import { Page, test as base } from "@playwright/test";
+import { test as base } from "@playwright/test";
 
 import auth from "~/constants/auth";
 

--- a/apps/playwright/fixtures/index.ts
+++ b/apps/playwright/fixtures/index.ts
@@ -1,10 +1,11 @@
-import { test as base } from "@playwright/test";
+import { Page, test as base } from "@playwright/test";
 
 import auth from "~/constants/auth";
 
 import { AppPage } from "./AppPage";
 import { AdminPage } from "./AdminPage";
 import { ApplicantPage } from "./ApplicantPage";
+import AxeBuilder from "@axe-core/playwright";
 
 type AppFixtures = {
   // Base unauthenticated page
@@ -13,6 +14,8 @@ type AppFixtures = {
   adminPage: AdminPage;
   // Authenticated as applicant page
   applicantPage: ApplicantPage;
+  // Axe test builder
+  makeAxeBuilder: () => AxeBuilder;
 };
 
 // Extend base text with our fixtures
@@ -38,6 +41,18 @@ export const test = base.extend<AppFixtures>({
     const admin = new ApplicantPage(await context.newPage());
     await use(admin);
     await context.close();
+  },
+
+  makeAxeBuilder: async ({ page }, use, testInfo) => {
+    const makeAxeBuilder = () =>
+      new AxeBuilder({ page }).withTags([
+        "wcag21a",
+        "wcag21a",
+        "wcag2a",
+        "wcag2aa",
+      ]);
+
+    await use(makeAxeBuilder);
   },
 });
 export { expect } from "@playwright/test";

--- a/apps/playwright/package.json
+++ b/apps/playwright/package.json
@@ -17,7 +17,11 @@
     "@gc-digital-talent/graphql": "*",
     "@playwright/test": "^1.41.2",
     "@types/node": "^20.11.20",
+    "axe-core": "^4.8.4",
     "dotenv": "^16.4.5",
     "eslint-plugin-playwright": "^1.3.0"
+  },
+  "dependencies": {
+    "@axe-core/playwright": "^4.8.5"
   }
 }

--- a/apps/playwright/tests/admin/accessibility.spec.ts
+++ b/apps/playwright/tests/admin/accessibility.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "~/fixtures";
+import { loginBySub } from "~/utils/auth";
+
+test.describe("Admin accessibility", () => {
+  test("Dashboard", async ({ page, makeAxeBuilder }) => {
+    await loginBySub(page, "admin@test.com");
+    await page.goto("/en/admin");
+
+    const accessibilityScanResults = await makeAxeBuilder().analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});

--- a/apps/playwright/tests/admin/accessibility.spec.ts
+++ b/apps/playwright/tests/admin/accessibility.spec.ts
@@ -2,9 +2,10 @@ import { expect, test } from "~/fixtures";
 import { loginBySub } from "~/utils/auth";
 
 test.describe("Admin accessibility", () => {
-  test("Dashboard", async ({ page, makeAxeBuilder }) => {
-    await loginBySub(page, "admin@test.com");
-    await page.goto("/en/admin");
+  test("Dashboard", async ({ appPage, makeAxeBuilder }) => {
+    await loginBySub(appPage.page, "admin@test.com");
+    await appPage.page.goto("/en/admin");
+    await appPage.waitForGraphqlResponse("AdminDashboard_Query");
 
     const accessibilityScanResults = await makeAxeBuilder().analyze();
     expect(accessibilityScanResults.violations).toEqual([]);

--- a/apps/playwright/tests/admin/accessibility.spec.ts
+++ b/apps/playwright/tests/admin/accessibility.spec.ts
@@ -4,7 +4,7 @@ import { loginBySub } from "~/utils/auth";
 test.describe("Admin accessibility", () => {
   test("Dashboard", async ({ appPage, makeAxeBuilder }) => {
     await loginBySub(appPage.page, "admin@test.com");
-    await appPage.page.goto("/en/admin");
+    await appPage.page.goto("/en/admin/dashboard");
     await appPage.waitForGraphqlResponse("AdminDashboard_Query");
 
     const accessibilityScanResults = await makeAxeBuilder().analyze();

--- a/apps/playwright/utils/axe.ts
+++ b/apps/playwright/utils/axe.ts
@@ -1,0 +1,20 @@
+import { TestInfo } from "@playwright/test";
+import { AxeResults } from "axe-core";
+
+/**
+ * Attach all results to a test
+ *
+ * Primarily used to debug or see inconclusive items.
+ *
+ * @param results
+ * @param testInfo
+ */
+export const attachResults = async (
+  results: AxeResults,
+  testInfo: TestInfo,
+) => {
+  await testInfo.attach("accessibility-scan-results", {
+    body: JSON.stringify(results, null, 2),
+    contentType: "application/json",
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,12 +63,16 @@
       "name": "@gc-digital-talent/playwright",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "@axe-core/playwright": "^4.8.5"
+      },
       "devDependencies": {
         "@gc-digital-talent/date-helpers": "*",
         "@gc-digital-talent/env": "*",
         "@gc-digital-talent/graphql": "*",
         "@playwright/test": "^1.41.2",
         "@types/node": "^20.11.20",
+        "axe-core": "^4.8.4",
         "dotenv": "^16.4.5",
         "eslint-plugin-playwright": "^1.3.0"
       }
@@ -375,6 +379,17 @@
       },
       "bin": {
         "x-default-browser": "bin/x-default-browser.js"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.8.5.tgz",
+      "integrity": "sha512-GFdXXAEn9uk0Vyzgl2eEP+VwvgGzas0YSnacoJ/0U237G83zWZ1PhbP/RDymm0cqevoA+xRjMo+ONzh9Q711nw==",
+      "dependencies": {
+        "axe-core": "~4.8.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -13363,7 +13378,6 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.4.tgz",
       "integrity": "sha512-CZLSKisu/bhJ2awW4kJndluz2HLZYIHh5Uy1+ZwDRkJi69811xgIXXfdU9HSLX0Th+ILrHj8qfL/5wzamsFtQg==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -23885,7 +23899,6 @@
       "version": "1.41.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
       "integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
-      "dev": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -30053,6 +30066,14 @@
         "default-browser-id": "3.0.0"
       }
     },
+    "@axe-core/playwright": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.8.5.tgz",
+      "integrity": "sha512-GFdXXAEn9uk0Vyzgl2eEP+VwvgGzas0YSnacoJ/0U237G83zWZ1PhbP/RDymm0cqevoA+xRjMo+ONzh9Q711nw==",
+      "requires": {
+        "axe-core": "~4.8.4"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.23.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
@@ -32148,11 +32169,13 @@
     "@gc-digital-talent/playwright": {
       "version": "file:apps/playwright",
       "requires": {
+        "@axe-core/playwright": "^4.8.5",
         "@gc-digital-talent/date-helpers": "*",
         "@gc-digital-talent/env": "*",
         "@gc-digital-talent/graphql": "*",
         "@playwright/test": "^1.41.2",
         "@types/node": "^20.11.20",
+        "axe-core": "^4.8.4",
         "dotenv": "^16.4.5",
         "eslint-plugin-playwright": "^1.3.0"
       }
@@ -39235,8 +39258,7 @@
     "axe-core": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.4.tgz",
-      "integrity": "sha512-CZLSKisu/bhJ2awW4kJndluz2HLZYIHh5Uy1+ZwDRkJi69811xgIXXfdU9HSLX0Th+ILrHj8qfL/5wzamsFtQg==",
-      "dev": true
+      "integrity": "sha512-CZLSKisu/bhJ2awW4kJndluz2HLZYIHh5Uy1+ZwDRkJi69811xgIXXfdU9HSLX0Th+ILrHj8qfL/5wzamsFtQg=="
     },
     "axobject-query": {
       "version": "3.2.1",
@@ -46146,8 +46168,7 @@
     "playwright-core": {
       "version": "1.41.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
-      "integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
-      "dev": true
+      "integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA=="
     },
     "polished": {
       "version": "4.2.2",


### PR DESCRIPTION
🤖 Resolves #7670 

## 👋 Introduction

Solves the spike with testing accessibility without `jest-axe` by using `@axe-core/playwright`.

## 🕵️ Details

While component testing in Playwright is [still experimental](https://playwright.dev/docs/test-components), you can test full pages. The benefit of this is, we can interact with the app and test at different stages. Meaning, we could navigate to a page, open a dialog and run a test. This would catch violations that could be hiding behind not being mounted.

I still think `jest-axe` is a decent solution if we only use it on small, isolated components. I think we should probably move forward with this pattern for more complex testing and avoid doing any `jest-axe` testing inside of the `apps/**` folders. 

If we keep `jest-axe` to components in `packages/**` the speed should be less of an issue.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build the app `npm run build`
2. Run `npm run e2e:playwright -- -- -- accessibility.spec.ts`
3. Confirm it passes
4. Maybe force an error
5. Re-run command in step 2
6. Confirm it fails
7. View report to see violations

### ❓ How to force an error

You can edit the `LinkWell` component. 

- Add `data-h2-background-color="base(black)"` to the `Well`
- Add `data-h2-color="base(black.light)"` to the `Heading` inside the `Well`

## 📸 Screenshot

![Screenshot 2024-02-27 161534](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/9e1fb78d-6a39-43be-a1e9-5f4a8e89279e)

![Screenshot 2024-02-28 121235](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/ffbad4ee-f154-4ade-86a6-52c116d17d93)

