### PR TITLE
[Debt] Reduce `framer-motion` initial bundle

### DIFF
--- a/apps/web/src/components/Context/ContextProvider.tsx
+++ b/apps/web/src/components/Context/ContextProvider.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { HelmetProvider } from "react-helmet-async";
-import { MotionConfig } from "framer-motion";
+import { MotionConfig, LazyMotion } from "framer-motion";
 
 import { AppInsightsProvider } from "@gc-digital-talent/app-insights";
 import {
@@ -18,6 +18,8 @@ import { Announcer } from "@gc-digital-talent/ui";
 import { ThemeProvider } from "@gc-digital-talent/theme";
 import Toast from "@gc-digital-talent/toast";
 
+const loadFeatures = () =>
+  import("./motion-features").then((res) => res.default);
 interface ContextContainerProps {
   messages: Messages;
   children: React.ReactNode;
@@ -34,9 +36,11 @@ const ContextContainer = ({ messages, children }: ContextContainerProps) => (
               <ClientProvider>
                 <AppInsightsProvider>
                   <AuthorizationProvider>
-                    <MotionConfig reducedMotion="user">
-                      <Announcer>{children}</Announcer>
-                    </MotionConfig>
+                    <LazyMotion features={loadFeatures}>
+                      <MotionConfig reducedMotion="user">
+                        <Announcer>{children}</Announcer>
+                      </MotionConfig>
+                    </LazyMotion>
                   </AuthorizationProvider>
                 </AppInsightsProvider>
               </ClientProvider>

--- a/apps/web/src/components/Context/motion-features.ts
+++ b/apps/web/src/components/Context/motion-features.ts
@@ -1,0 +1,3 @@
+import { domAnimation } from "framer-motion";
+
+export default domAnimation;

--- a/apps/web/src/components/SpinnerIcon/SpinnerIcon.tsx
+++ b/apps/web/src/components/SpinnerIcon/SpinnerIcon.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { motion, useReducedMotion } from "framer-motion";
+import { m, useReducedMotion } from "framer-motion";
 import ArrowPathIcon from "@heroicons/react/20/solid/ArrowPathIcon";
 
 import { IconProps } from "@gc-digital-talent/ui";
@@ -8,7 +8,7 @@ const SpinnerIcon = (props: IconProps) => {
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <motion.span
+    <m.span
       data-h2-display="base(inline-flex)"
       data-h2-margin-right="base(x.25)"
       {...(!shouldReduceMotion && {
@@ -24,7 +24,7 @@ const SpinnerIcon = (props: IconProps) => {
       })}
     >
       <ArrowPathIcon {...props} data-h2-margin-right="base(0)" />
-    </motion.span>
+    </m.span>
   );
 };
 

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunityIcon.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclaration/CommunityIcon.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, m } from "framer-motion";
 import { useFormContext } from "react-hook-form";
 
 import firstNationsOn from "~/assets/img/first-nations-true.webp";
@@ -68,22 +68,17 @@ const CommunityIcon = ({ community, values }: CommunityIconProps) => {
       >
         <AnimatePresence>
           {isOn ? (
-            <motion.img
-              {...styles}
-              alt=""
-              key={`${community}-true`}
-              src={iconOn}
-            />
+            <m.img {...styles} alt="" key={`${community}-true`} src={iconOn} />
           ) : (
             <>
-              <motion.img
+              <m.img
                 {...styles}
                 data-h2-display="base(block) base:dark(none)"
                 alt=""
                 key={`${community}-false`}
                 src={iconOff}
               />
-              <motion.img
+              <m.img
                 {...styles}
                 data-h2-display="base(none) base:dark(block)"
                 alt=""

--- a/apps/web/src/pages/Home/IAPHomePage/Home.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import orderBy from "lodash/orderBy";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "urql";
@@ -73,10 +73,10 @@ export const Home = ({ query }: HomeProps) => {
   const latestPool = getFragment(IAPHome_PoolFragment, query);
   /**
    * Language swapping is a little rough here,
-   * motion.div adds a fade to smooth things out a bit
+   * m.div adds a fade to smooth things out a bit
    */
   return (
-    <motion.div
+    <m.div
       data-h2-background="base(white) base:dark(background)"
       data-h2-overflow="base(hidden visible)"
       initial={{ opacity: 0 }}
@@ -993,7 +993,7 @@ export const Home = ({ query }: HomeProps) => {
           </div>
         </div>
       </div>
-    </motion.div>
+    </m.div>
   );
 };
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,12 +2,10 @@
   "name": "@gc-digital-talent/ui",
   "license": "AGPL-3.0",
   "version": "1.0.0",
-  "main": "./dist/index.js",
+  "main": "./src/index.tsx",
   "types": "./dist/index.d.ts",
   "sideEffects": [
-    "**/*.css"
-  ],
-  "files": [
+    "**/*.css",
     "dist/**"
   ],
   "scripts": {

--- a/packages/ui/src/components/CardRepeater/Card.tsx
+++ b/packages/ui/src/components/CardRepeater/Card.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { motion, useReducedMotion } from "framer-motion";
+import { m, useReducedMotion } from "framer-motion";
 import { useIntl } from "react-intl";
 import ArrowDownIcon from "@heroicons/react/20/solid/ArrowDownIcon";
 import ArrowUpIcon from "@heroicons/react/20/solid/ArrowUpIcon";
@@ -115,7 +115,7 @@ const Card = ({ index, edit, remove, error, onMove, children }: CardProps) => {
   }
 
   return (
-    <motion.li
+    <m.li
       layout
       transition={
         shouldReduceMotion
@@ -215,7 +215,7 @@ const Card = ({ index, edit, remove, error, onMove, children }: CardProps) => {
         </Actions>
       </div>
       {children}
-    </motion.li>
+    </m.li>
   );
 };
 

--- a/packages/ui/src/components/Loading/Loading.tsx
+++ b/packages/ui/src/components/Loading/Loading.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { motion, useReducedMotion } from "framer-motion";
+import { m, useReducedMotion } from "framer-motion";
 
 export interface LoadingProps extends React.HTMLProps<HTMLDivElement> {
   inline?: boolean;
@@ -68,7 +68,7 @@ const Loading = ({
       <div {...inlineWrapper[inline === true ? "inline" : "none"]}>
         <span data-h2-display="base(inline-block)">
           <span data-h2-visually-hidden="base(invisible)">{children}</span>
-          <motion.span
+          <m.span
             data-h2-display="base(block)"
             data-h2-height="base(x1)"
             data-h2-width="base(x1)"

--- a/packages/ui/src/components/SideMenu/SideMenu.tsx
+++ b/packages/ui/src/components/SideMenu/SideMenu.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import FocusLock from "react-focus-lock";
 import { RemoveScroll } from "react-remove-scroll";
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { m, AnimatePresence, useReducedMotion } from "framer-motion";
 
 import { useIsSmallScreen } from "@gc-digital-talent/helpers";
 
@@ -77,7 +77,7 @@ const SideMenu = ({
     >
       <AnimatePresence>
         {showMenu ? (
-          <motion.div
+          <m.div
             data-h2-flex-item="base(content)"
             data-h2-position="base(fixed) p-tablet(static)"
             data-h2-location="base(0, auto, auto, auto) p-tablet(auto)"
@@ -149,12 +149,12 @@ const SideMenu = ({
                 </RemoveScroll>
               </FocusLock>
             </div>
-          </motion.div>
+          </m.div>
         ) : null}
       </AnimatePresence>
       <AnimatePresence>
         {showOverlay && (
-          <motion.div
+          <m.div
             data-h2-position="base(fixed)"
             data-h2-location="base(0, 0, 0, 0)"
             data-h2-background-color="base(black)"

--- a/packages/ui/src/components/SideMenu/SideMenuCategory.tsx
+++ b/packages/ui/src/components/SideMenu/SideMenuCategory.tsx
@@ -1,5 +1,5 @@
 import React, { Children } from "react";
-import { motion, useReducedMotion } from "framer-motion";
+import { m, useReducedMotion } from "framer-motion";
 
 import { useSideMenuContext } from "./SideMenuProvider";
 
@@ -51,7 +51,7 @@ const SideMenuCategory = ({ title, children }: SideMenuCategoryProps) => {
         data-h2-padding-bottom="base(x.15)"
         data-h2-height="base(x1)"
       >
-        <motion.span
+        <m.span
           data-h2-display="base(flex)"
           transition={transitionConfig}
           animate={
@@ -66,7 +66,7 @@ const SideMenuCategory = ({ title, children }: SideMenuCategoryProps) => {
           >
             {title}
           </span>
-        </motion.span>
+        </m.span>
       </div>
 
       {children}

--- a/packages/ui/src/components/SideMenu/SideMenuItem.tsx
+++ b/packages/ui/src/components/SideMenu/SideMenuItem.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { motion, useReducedMotion } from "framer-motion";
+import { m, useReducedMotion } from "framer-motion";
 import { NavLink, NavLinkProps, useNavigate } from "react-router-dom";
 
 import { sanitizeUrl, useIsSmallScreen } from "@gc-digital-talent/helpers";
@@ -21,7 +21,7 @@ const SideMenuItemChildren = ({ icon, children }: SideMenuItemChildProps) => {
   const transitionConfig = { duration: shouldReduceMotion ? 0 : undefined };
 
   return (
-    <motion.span
+    <m.span
       data-h2-display="base(grid)"
       data-h2-grid-template-columns="base(x1 1fr)"
       transition={transitionConfig}
@@ -44,7 +44,7 @@ const SideMenuItemChildren = ({ icon, children }: SideMenuItemChildProps) => {
           />
         ) : null}
       </span>
-      <motion.span
+      <m.span
         transition={transitionConfig}
         animate={
           ctx?.open
@@ -64,8 +64,8 @@ const SideMenuItemChildren = ({ icon, children }: SideMenuItemChildProps) => {
         >
           {children}
         </span>
-      </motion.span>
-    </motion.span>
+      </m.span>
+    </m.span>
   );
 };
 


### PR DESCRIPTION
🤖 Resolves #8404 

## 👋 Introduction

Reduces the initial bundle size of `framer-motion` by lazy loading the animations.

## 🕵️ Details

At first, this was causing an increased bundle size. After investigation, it turns out this was because we had `ui` setup to be an external package. Meaning, it was actually getting bundled twice (once in `apps/web` and again in `packages/ui` and using different contexts.

Since we don't actually need `ui` to be an external package and are not publishing it, I converted it to an internal package. Which means, it only gets bundled once in the app and uses the same context 🎉 

## 📉 Results

### Before

![308590517-4b6319aa-3667-4336-a742-6d979e0121b1](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/7931cc9f-d312-40df-9200-8e9f2b136850)
![308590367-31321a35-d58b-42fb-b9b6-050c9e937f59](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/ae3acef4-1579-4bae-80cd-b3048119099c)

### After

![Screenshot 2024-02-28 134456](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/b2e18462-cc21-43cd-8d01-b62d7d1ee342)
![Screenshot 2024-02-28 134611](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/e1c9dd49-536c-4477-923b-d3e92f5b194f)


## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build app `npm run build`
2. Confirm animations are working still
3. Confirm the bundle size is lower than on main