### PR TITLE
[Debt] Consolidate `Separator` implementation

### DIFF
--- a/apps/web/src/components/ExperienceCard/ExperienceCard.tsx
+++ b/apps/web/src/components/ExperienceCard/ExperienceCard.tsx
@@ -253,12 +253,7 @@ const ExperienceCard = ({
             </Button>
           </Collapsible.Trigger>
           <Collapsible.Content data-h2-padding-left="base(x1.5)">
-            <Separator
-              orientation="horizontal"
-              decorative
-              data-h2-background-color="base(gray)"
-              data-h2-margin="base(x1 0)"
-            />
+            <Separator space="sm" />
             {isAwardExperience(experience) && (
               <AwardContent
                 experience={experience}
@@ -284,14 +279,7 @@ const ExperienceCard = ({
               />
             )}
             {/** Personal type has no custom content so separator is redundant */}
-            {!isPersonalExperience(experience) && (
-              <Separator
-                orientation="horizontal"
-                decorative
-                data-h2-background-color="base(gray)"
-                data-h2-margin="base(x1 0)"
-              />
-            )}
+            {!isPersonalExperience(experience) && <Separator space="sm" />}
             <ContentSection
               title={experienceLabels.details}
               headingLevel={headingLevel}
@@ -301,12 +289,7 @@ const ExperienceCard = ({
             </ContentSection>
             {showSkills && !singleSkill && (
               <>
-                <Separator
-                  orientation="horizontal"
-                  decorative
-                  data-h2-background-color="base(gray)"
-                  data-h2-margin="base(x1 0)"
-                />
+                <Separator space="sm" />
                 <ContentSection
                   headingLevel={headingLevel}
                   title={intl.formatMessage({

--- a/apps/web/src/components/ProcessCard/ProcessCard.tsx
+++ b/apps/web/src/components/ProcessCard/ProcessCard.tsx
@@ -28,12 +28,7 @@ const Header = (props: DivProps) => (
 
 const Footer = (props: DivProps) => (
   <>
-    <Separator
-      orientation="horizontal"
-      decorative
-      data-h2-background-color="base(gray)"
-      data-h2-margin="base(x1 0)"
-    />
+    <Separator space="sm" />
     <div
       data-h2-display="base(flex)"
       data-h2-flex-direction="base(column) p-tablet(row)"

--- a/apps/web/src/components/Profile/components/DiversityEquityInclusion/Display.tsx
+++ b/apps/web/src/components/Profile/components/DiversityEquityInclusion/Display.tsx
@@ -77,12 +77,7 @@ const Display = ({
           </li>
         )}
       </ul>
-      <Separator
-        orientation="horizontal"
-        data-h2-background-color="base:all(gray.lighter)"
-        data-h2-margin="base(x1, 0)"
-        decorative
-      />
+      <Separator space="sm" />
       <p>
         {intl.formatMessage({
           defaultMessage:

--- a/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.tsx
+++ b/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.tsx
@@ -240,9 +240,6 @@ const QualifiedRecruitmentCard = ({
         </Collapsible.Content>
       </Collapsible.Root>
       <Separator
-        orientation="horizontal"
-        decorative
-        data-h2-background-color="base(gray)"
         data-h2-width="base(calc(100% + x2))"
         data-h2-margin="base(x1 -x1 x.5 -x1)"
       />

--- a/apps/web/src/components/SkillBrowser/SkillSelection.tsx
+++ b/apps/web/src/components/SkillBrowser/SkillSelection.tsx
@@ -230,12 +230,7 @@ const SkillSelection = ({
           </Button>
         </Collapsible.Trigger>
         <Collapsible.Content data-h2-padding-left="base(x1.5)">
-          <Separator
-            orientation="horizontal"
-            decorative
-            data-h2-background-color="base(gray.lighter)"
-            data-h2-margin="base(x1 0)"
-          />
+          <Separator space="sm" />
           <p data-h2-margin-bottom="base(x.5)">
             {intl.formatMessage({
               defaultMessage:

--- a/apps/web/src/components/SkillRankCard/SkillRankCard.tsx
+++ b/apps/web/src/components/SkillRankCard/SkillRankCard.tsx
@@ -60,11 +60,7 @@ const SkillRankCard = ({
         )}
       </div>
       <p>{description}</p>
-      <Separator
-        orientation="horizontal"
-        data-h2-background-color="base(gray.lighter)"
-        data-h2-margin="base(x1 0)"
-      />
+      <Separator space="sm" />
       {userSkills.length ? (
         <ul data-h2-margin="base(0)" data-h2-padding-left="base(x.75)">
           {userSkills.map((userSkill) => (

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/components/AddExperienceForm.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/components/AddExperienceForm.tsx
@@ -159,12 +159,7 @@ const AddExperienceForm = ({ applicationId }: AddExperienceFormProps) => {
         />
         <ExperienceDetails />
         <TasksAndResponsibilities />
-        <Separator
-          orientation="horizontal"
-          decorative
-          data-h2-background="base(gray)"
-          data-h2-margin="base(x2, 0)"
-        />
+        <Separator />
         <div
           data-h2-display="base(flex)"
           data-h2-gap="base(x1)"

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/components/ExperienceEditForm.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/components/ExperienceEditForm.tsx
@@ -143,12 +143,7 @@ const EditExperienceForm = ({
         <ErrorSummary experienceType={experienceType} />
         <ExperienceDetails experienceType={experienceType} />
         <TasksAndResponsibilities experienceType={experienceType} />
-        <Separator
-          orientation="horizontal"
-          decorative
-          data-h2-background="base(gray)"
-          data-h2-margin="base(x2, 0)"
-        />
+        <Separator />
         <div
           data-h2-display="base(flex)"
           data-h2-gap="base(x1)"

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineIntroductionPage/ApplicationCareerTimelineIntroductionPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineIntroductionPage/ApplicationCareerTimelineIntroductionPage.tsx
@@ -99,12 +99,7 @@ const ApplicationCareerTimelineIntroduction = ({
             "Application step to begin working on career timeline, paragraph three",
         })}
       </p>
-      <Separator
-        orientation="horizontal"
-        data-h2-background-color="base(gray)"
-        data-h2-margin="base(x2, 0)"
-        decorative
-      />
+      <Separator />
       <div
         data-h2-display="base(flex)"
         data-h2-gap="base(x1)"

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
@@ -402,12 +402,7 @@ export const ApplicationCareerTimeline = ({
             }}
           />
 
-          <Separator
-            orientation="horizontal"
-            decorative
-            data-h2-background="base(gray)"
-            data-h2-margin="base(x2, 0)"
-          />
+          <Separator />
           <div
             data-h2-display="base(flex)"
             data-h2-gap="base(x1)"

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
@@ -365,12 +365,7 @@ const ApplicationEducation = ({
             previousStepPath={previousStep}
             classificationGroup={classificationGroup}
           />
-          <Separator
-            orientation="horizontal"
-            decorative
-            data-h2-background="base(gray)"
-            data-h2-margin="base(x2, 0, x2, 0)"
-          />
+          <Separator />
           <div
             data-h2-display="base(flex)"
             data-h2-gap="base(x1)"

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
@@ -135,12 +135,7 @@ export const ApplicationProfile = ({
       <div data-h2-margin="base(x2, 0, 0, 0)">
         <LanguageProfile {...sectionProps} application={application} />
       </div>
-      <Separator
-        orientation="horizontal"
-        data-h2-background-color="base(gray)"
-        data-h2-margin="base(x2, 0)"
-        decorative
-      />
+      <Separator />
       <StepNavigation
         application={application}
         user={user}

--- a/apps/web/src/pages/Applications/ApplicationQuestionsIntroductionPage/ApplicationQuestionsIntroductionPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsIntroductionPage/ApplicationQuestionsIntroductionPage.tsx
@@ -118,12 +118,7 @@ const ApplicationQuestionsIntroduction = ({
         </>
       )}
 
-      <Separator
-        orientation="horizontal"
-        data-h2-background-color="base(gray)"
-        data-h2-margin="base(x2, 0)"
-        decorative
-      />
+      <Separator />
       <div
         data-h2-display="base(flex)"
         data-h2-gap="base(x1)"

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/components/FormActions.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/components/FormActions.tsx
@@ -21,12 +21,7 @@ const FormActions = ({ disabled = false }: FormActionsProps) => {
 
   return (
     <>
-      <Separator
-        orientation="horizontal"
-        decorative
-        data-h2-background="base(gray)"
-        data-h2-margin="base(x2, 0)"
-      />
+      <Separator />
       <div
         data-h2-display="base(flex)"
         data-h2-gap="base(x1)"

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/ApplicationSelfDeclarationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/ApplicationSelfDeclarationPage.tsx
@@ -335,12 +335,7 @@ export const ApplicationSelfDeclaration = ({
               </>
             )}
           </div>
-          <Separator
-            orientation="horizontal"
-            decorative
-            data-h2-background-color="base(gray)"
-            data-h2-margin="base(x2, 0)"
-          />
+          <Separator />
           <HelpLink />
           <p data-h2-font-weight="base(700)" data-h2-margin="base(x1, 0)">
             {intl.formatMessage(

--- a/apps/web/src/pages/Applications/ApplicationSkillsIntroductionPage/ApplicationSkillsIntroductionPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsIntroductionPage/ApplicationSkillsIntroductionPage.tsx
@@ -88,12 +88,7 @@ const ApplicationSkillsIntroduction = ({
             "Application step for skill requirements, introduction, description, paragraph two",
         })}
       </p>
-      <Separator
-        orientation="horizontal"
-        decorative
-        data-h2-background="base(gray)"
-        data-h2-margin="base(x2, 0)"
-      />
+      <Separator />
       <div
         data-h2-display="base(flex)"
         data-h2-gap="base(x1)"

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -325,12 +325,7 @@ export const ApplicationSkills = ({
       ) : null}
       <FormProvider {...methods}>
         <form onSubmit={methods.handleSubmit(handleSubmit)}>
-          <Separator
-            orientation="horizontal"
-            decorative
-            data-h2-background="base(gray)"
-            data-h2-margin="base(x2, 0)"
-          />
+          <Separator />
           {/* -x.25 removes stray gap from flex layout */}
           <div data-h2-margin="base(-x.25 0 x1 0)">
             <Input

--- a/apps/web/src/pages/Applications/ApplicationWelcomePage/ApplicationWelcomePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationWelcomePage/ApplicationWelcomePage.tsx
@@ -151,12 +151,7 @@ const ApplicationWelcome = ({ application }: ApplicationPageProps) => {
             "Description of the application process and the next step",
         })}
       </p>
-      <Separator
-        orientation="horizontal"
-        data-h2-background-color="base(gray)"
-        data-h2-margin="base(x2, 0)"
-        decorative
-      />
+      <Separator />
       <div
         data-h2-display="base(flex)"
         data-h2-gap="base(x1)"

--- a/apps/web/src/pages/Applications/StepDisabledPage/StepDisabledPage.tsx
+++ b/apps/web/src/pages/Applications/StepDisabledPage/StepDisabledPage.tsx
@@ -23,12 +23,7 @@ const StepDisabledPage = ({ returnUrl }: { returnUrl: string | undefined }) => {
           description: "Application step skipped page details",
         })}
       </p>
-      <Separator
-        orientation="horizontal"
-        data-h2-background-color="base(gray.lighter)"
-        data-h2-margin="base(x2, 0)"
-        decorative
-      />
+      <Separator />
       {returnUrl ? (
         <Link href={returnUrl} color="primary" mode="solid">
           {intl.formatMessage({

--- a/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
+++ b/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
@@ -5,7 +5,7 @@ import SparklesIcon from "@heroicons/react/24/outline/SparklesIcon";
 import ArrowLeftOnRectangleIcon from "@heroicons/react/24/outline/ArrowLeftOnRectangleIcon";
 import InformationCircleIcon from "@heroicons/react/24/outline/InformationCircleIcon";
 
-import { Accordion, Heading, Link } from "@gc-digital-talent/ui";
+import { Accordion, Heading, Link, Separator } from "@gc-digital-talent/ui";
 import { useApiRoutes } from "@gc-digital-talent/auth";
 import { getLocale } from "@gc-digital-talent/i18n";
 import { useTheme } from "@gc-digital-talent/theme";
@@ -397,12 +397,7 @@ const SignInPage = () => {
               </p>
             </>
           )}
-          <hr
-            data-h2-margin="base(x2, 0)"
-            data-h2-border="base(none)"
-            data-h2-height="base(1px)"
-            data-h2-background-color="base(gray)"
-          />
+          <Separator />
           <div
             data-h2-display="base(flex)"
             data-h2-flex-direction="base(row)"

--- a/apps/web/src/pages/Auth/SignUpPage/SignUpPage.tsx
+++ b/apps/web/src/pages/Auth/SignUpPage/SignUpPage.tsx
@@ -4,7 +4,7 @@ import { useSearchParams } from "react-router-dom";
 import InformationCircleIcon from "@heroicons/react/24/outline/InformationCircleIcon";
 import MapIcon from "@heroicons/react/24/outline/MapIcon";
 
-import { Accordion, Heading, Link } from "@gc-digital-talent/ui";
+import { Accordion, Heading, Link, Separator } from "@gc-digital-talent/ui";
 import { useApiRoutes } from "@gc-digital-talent/auth";
 import { getLocale } from "@gc-digital-talent/i18n";
 import { useTheme } from "@gc-digital-talent/theme";
@@ -550,12 +550,7 @@ const SignUpPage = () => {
               </p>
             </>
           )}
-          <hr
-            data-h2-margin="base(x2, 0)"
-            data-h2-border="base(none)"
-            data-h2-height="base(1px)"
-            data-h2-background-color="base(gray)"
-          />
+          <Separator />
           <div
             data-h2-display="base(flex)"
             data-h2-flex-direction="base(column) l-tablet(row)"

--- a/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/fieldsSets/PersonnelRequirementFieldset.tsx
+++ b/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/fieldsSets/PersonnelRequirementFieldset.tsx
@@ -248,7 +248,7 @@ const PersonnelRequirementFieldset = ({
                   )}
                 </Button>
               </div>
-              <Separator space="sm" />
+              <Separator space="xs" />
             </div>
           </div>
         );

--- a/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/fieldsSets/PersonnelRequirementFieldset.tsx
+++ b/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/fieldsSets/PersonnelRequirementFieldset.tsx
@@ -248,12 +248,7 @@ const PersonnelRequirementFieldset = ({
                   )}
                 </Button>
               </div>
-              <Separator
-                orientation="horizontal"
-                decorative
-                data-h2-background-color="base(gray.lighter)"
-                data-h2-margin="base(x.5 0)"
-              />
+              <Separator space="sm" />
             </div>
           </div>
         );

--- a/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/sections/PreambleSection.tsx
+++ b/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/sections/PreambleSection.tsx
@@ -309,12 +309,7 @@ const PreambleSection = () => {
               </Button>
             </Collapsible.Trigger>
             <Collapsible.Content data-h2-padding-left="base(x1.5)">
-              <Separator
-                orientation="horizontal"
-                decorative
-                data-h2-background-color="base(gray.lighter)"
-                data-h2-margin="base(x1 0)"
-              />
+              <Separator space="sm" />
               <p>
                 {intl.formatMessage({
                   defaultMessage:

--- a/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/sections/QuestionnaireSection.tsx
+++ b/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/sections/QuestionnaireSection.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useIntl } from "react-intl";
 import ListBulletIcon from "@heroicons/react/24/outline/ListBulletIcon";
 
-import { Heading, TableOfContents } from "@gc-digital-talent/ui";
+import { Heading, Separator, TableOfContents } from "@gc-digital-talent/ui";
 import { Submit } from "@gc-digital-talent/forms";
 import { Department, Skill } from "@gc-digital-talent/graphql";
 
@@ -47,12 +47,7 @@ const QuestionnaireSection = ({
       <TechnologicalChangeSection />
       <OperationsConsiderationsSection />
       <TalentSourcingDecisionSection />
-      <hr
-        data-h2-margin-top="base(x2)"
-        data-h2-border="base(none)"
-        data-h2-height="base(1px)"
-        data-h2-background-color="base(gray)"
-      />
+      <Separator />
       <Submit data-h2-margin-top="base(x2)" isSubmitting={isSubmitting} />
     </TableOfContents.Section>
   );

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -657,10 +657,7 @@ export const ViewPoolCandidate = ({
                 },
               )}
             </p>
-            <Separator
-              data-h2-background-color="base(black.lightest)"
-              data-h2-margin="base(x1, 0, x1, 0)"
-            />
+            <Separator space="sm" />
             {parsedSnapshot && (
               <div
                 data-h2-container="base(center, large, 0)"
@@ -775,10 +772,7 @@ export const ViewPoolCandidate = ({
                     {sections.statusForm.title}
                   </TableOfContents.Heading>
                   <ApplicationStatusForm candidateQuery={poolCandidate} />
-                  <Separator
-                    data-h2-background-color="base(black.lightest)"
-                    data-h2-margin="base(x1, 0, 0, 0)"
-                  />
+                  <Separator space="sm" />
                 </TableOfContents.Section>
                 <TableOfContents.Section id={sections.poolInformation.id}>
                   <TableOfContents.Heading
@@ -789,10 +783,7 @@ export const ViewPoolCandidate = ({
                     {sections.poolInformation.title}
                   </TableOfContents.Heading>
                   <PoolStatusTable user={poolCandidate.user} pools={pools} />
-                  <Separator
-                    data-h2-background-color="base(black.lightest)"
-                    data-h2-margin="base(x1, 0, 0, 0)"
-                  />
+                  <Separator data-h2-margin="base(x1, 0, 0, 0)" />
                 </TableOfContents.Section>
                 {mainContent}
               </TableOfContents.Content>

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationInformation/SkillDisplay.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationInformation/SkillDisplay.tsx
@@ -29,12 +29,7 @@ const SkillExperiences = ({ skill, experiences }: SkillExperiencesProps) => {
           {getLocalizedName(skill.description, intl)}
         </p>
       )}
-      <Separator
-        data-h2-margin="base(x1 0)"
-        data-h2-background-color="base(tertiary)"
-        orientation="horizontal"
-        decorative
-      />
+      <Separator data-h2-background-color="base(tertiary)" space="sm" />
       {skillExperiences.length ? (
         <div
           data-h2-display="base(flex)"

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
@@ -88,12 +88,7 @@ export const AssessmentPlanBuilder = ({
           </Pill>
         </Heading>
         <p data-h2-margin="base(x1 0)">{intl.formatMessage(pageSubtitle)}</p>
-        <Separator
-          orientation="horizontal"
-          decorative
-          data-h2-background-color="base(gray)"
-          data-h2-margin="base(x2, 0, x1, 0)"
-        />
+        <Separator data-h2-margin="base(x2, 0, x1, 0)" />
         <Sidebar.Wrapper>
           <Sidebar.Sidebar>
             <div data-h2-margin-top="base(x1.5)">
@@ -106,12 +101,7 @@ export const AssessmentPlanBuilder = ({
           <Sidebar.Content>
             <OrganizeSection pool={pool} pageIsLoading={pageIsLoading} />
             <SkillSummarySection pool={pool} />
-            <Separator
-              orientation="horizontal"
-              decorative
-              data-h2-background-color="base(gray)"
-              data-h2-margin="base(x3 0)"
-            />
+            <Separator space="lg" />
             <div
               data-h2-display="base(flex)"
               data-h2-gap="base(x.5, x1)"

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/SkillsQuickSummary.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/SkillsQuickSummary.tsx
@@ -104,12 +104,7 @@ const SkillsQuickSummary = ({
             />
           );
         })}
-        <Separator
-          orientation="horizontal"
-          decorative
-          data-h2-background-color="base(gray)"
-          data-h2-margin="base(x1, 0, x1, 0)"
-        />
+        <Separator space="sm" />
 
         <ScrollToLink to={PAGE_SECTION_ID.SKILL_SUMMARY}>
           {intl.formatMessage({

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/DataRow.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/DataRow.tsx
@@ -16,14 +16,7 @@ const DataRow = ({
   hideSeparator = false,
 }: DataRowProps) => (
   <>
-    {!hideSeparator && (
-      <Separator
-        orientation="horizontal"
-        decorative
-        data-h2-background-color="base(gray)"
-        data-h2-margin="base(x1, 0)"
-      />
-    )}
+    {!hideSeparator && <Separator space="sm" />}
     <div
       data-h2-display="base(flex)"
       data-h2-flex-direction="base(column) p-tablet(row)"

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -348,12 +348,7 @@ export const ExperienceForm = ({
                     skills={skills}
                   />
                 </TableOfContents.Section>
-                <Separator
-                  orientation="horizontal"
-                  decorative
-                  data-h2-background="base(gray)"
-                  data-h2-margin="base(x3, 0)"
-                />
+                <Separator space="lg" />
                 {edit ? (
                   <div
                     data-h2-display="base(flex)"

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplicationsCard.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplicationsCard.tsx
@@ -139,9 +139,6 @@ const TrackApplicationsCard = ({
         </div>
       </div>
       <Separator
-        orientation="horizontal"
-        decorative
-        data-h2-background-color="base(gray)"
         data-h2-width="base(calc(100% + x2))"
         data-h2-margin="base(x1 -x1 x.5 -x1)"
       />

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -14,7 +14,7 @@ import {
   enumToOptions,
   objectsToSortedOptions,
 } from "@gc-digital-talent/forms";
-import { Heading, Link, Pending } from "@gc-digital-talent/ui";
+import { Heading, Link, Pending, Separator } from "@gc-digital-talent/ui";
 import { errorMessages, getSearchRequestReason } from "@gc-digital-talent/i18n";
 import { notEmpty } from "@gc-digital-talent/helpers";
 import { toast } from "@gc-digital-talent/toast";
@@ -516,12 +516,7 @@ export const RequestForm = ({
             filters={applicantFilterInputToType}
             selectedClassifications={selectedClassifications}
           />
-          <hr
-            data-h2-height="base(1px)"
-            data-h2-border="base(none)"
-            data-h2-background="base(gray)"
-            data-h2-margin="base(x1, 0, x2, 0)"
-          />
+          <Separator />
           <p data-h2-font-weight="base(700)" data-h2-margin-bottom="base(x1)">
             {intl.formatMessage(
               {

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/NoResults.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/NoResults.tsx
@@ -54,11 +54,7 @@ const NoResults = () => {
         })}
       </p>
 
-      <Separator
-        orientation="horizontal"
-        data-h2-margin="base(x1 0)"
-        data-h2-background-color="base(gray.lighter)"
-      />
+      <Separator space="sm" />
 
       <Button
         color="secondary"

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -151,12 +151,7 @@ export const SearchForm = ({
               />
             </div>
           </div>
-          <Separator
-            decorative
-            orientation="horizontal"
-            data-h2-margin="base(x2, 0)"
-            data-h2-background-color="base(gray)"
-          />
+          <Separator />
           <Heading level="h3" size="h4" id="results">
             {intl.formatMessage(
               {

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
@@ -123,12 +123,7 @@ const SearchResultCard = ({ candidateCount, pool }: SearchResultCardProps) => {
             ))
           : null}
       </p>
-      <Separator
-        orientation="horizontal"
-        decorative
-        data-h2-background-color="base(gray)"
-        data-h2-margin="base(x1 0)"
-      />
+      <Separator space="sm" />
       <div
         data-h2-display="base(flex)"
         data-h2-flex-direction="base(row)"

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
@@ -449,7 +449,7 @@ export const ViewSearchRequest = ({
                 reason ? intl.formatMessage(getSearchRequestReason(reason)) : ""
               }
             />
-            <Separator space="sm" />
+            <Separator space="sm" data-h2-margin-top="base(0)" />
             <SearchRequestFilters filters={abstractFilter} />
             <div
               data-h2-padding="base(x1, 0, 0, 0)"

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
@@ -449,11 +449,7 @@ export const ViewSearchRequest = ({
                 reason ? intl.formatMessage(getSearchRequestReason(reason)) : ""
               }
             />
-            <Separator
-              orientation="horizontal"
-              data-h2-background-color="base(black.2)"
-              data-h2-margin-bottom="base(x1)"
-            />
+            <Separator space="sm" />
             <SearchRequestFilters filters={abstractFilter} />
             <div
               data-h2-padding="base(x1, 0, 0, 0)"

--- a/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
+++ b/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
@@ -334,13 +334,7 @@ const UpdateSkillShowcase = ({
                         </Repeater.Fieldset>
                       ))}
                     </Repeater.Root>
-
-                    <Separator
-                      orientation="horizontal"
-                      decorative
-                      data-h2-margin="base(x2, 0, x2, 0)"
-                      data-h2-background-color="base(gray)"
-                    />
+                    <Separator />
                     <div
                       data-h2-display="base(flex)"
                       data-h2-gap="base(x.5, x1)"

--- a/apps/web/src/pages/Teams/ViewTeamPage/ViewTeamPage.tsx
+++ b/apps/web/src/pages/Teams/ViewTeamPage/ViewTeamPage.tsx
@@ -34,13 +34,7 @@ export const ViewTeamContent = ({ team }: ViewTeamContentProps) => {
     <>
       <SEO title={pageTitle} />
       <ViewTeam team={team} />
-      <Separator
-        decorative
-        data-h2-margin="base(x2, 0, 0, 0)"
-        data-h2-height="base(1px)"
-        data-h2-background-color="base(black.2)"
-        data-h2-border="base(none)"
-      />
+      <Separator data-h2-margin="base(x2, 0, 0, 0)" />
     </>
   );
 };

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -210,7 +210,7 @@ module.exports = {
         message: "Please use WebP as the image format.",
       },
     ],
-    "react/forbid-elements": [1, { forbid: ["a"] }],
+    "react/forbid-elements": [1, { forbid: ["a", "hr"] }],
     "no-restricted-syntax": [
       "error",
       {

--- a/packages/forms/src/components/Combobox/Input.tsx
+++ b/packages/forms/src/components/Combobox/Input.tsx
@@ -144,7 +144,7 @@ const Toggle = React.forwardRef<HTMLButtonElement, ToggleProps>(
 
 const Separator = () => (
   <span data-h2-padding="base(x.25 0)">
-    <SeparatorPrimitive />
+    <SeparatorPrimitive orientation="vertical" space="none" decorative />
   </span>
 );
 

--- a/packages/forms/src/components/Combobox/Input.tsx
+++ b/packages/forms/src/components/Combobox/Input.tsx
@@ -144,11 +144,7 @@ const Toggle = React.forwardRef<HTMLButtonElement, ToggleProps>(
 
 const Separator = () => (
   <span data-h2-padding="base(x.25 0)">
-    <SeparatorPrimitive
-      data-h2-background-color="base(gray)"
-      orientation="vertical"
-      decorative
-    />
+    <SeparatorPrimitive />
   </span>
 );
 

--- a/packages/ui/src/components/Alert/Alert.tsx
+++ b/packages/ui/src/components/Alert/Alert.tsx
@@ -183,11 +183,7 @@ interface AlertFooterProps {
 
 const Footer = ({ children }: AlertFooterProps) => (
   <>
-    <Separator
-      orientation="horizontal"
-      data-h2-margin="base(x1, 0)"
-      data-h2-background-color="base(gray)"
-    />
+    <Separator space="sm" />
     {children}
   </>
 );

--- a/packages/ui/src/components/AlertDialog/AlertDialog.tsx
+++ b/packages/ui/src/components/AlertDialog/AlertDialog.tsx
@@ -4,6 +4,8 @@
 import React from "react";
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
+import Separator from "../Separator";
+
 const StyledOverlay = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
@@ -121,12 +123,7 @@ interface AlertDialogFooterProps {
 
 const Footer = ({ children }: AlertDialogFooterProps) => (
   <div data-h2-padding="base(x1 0 0 0)">
-    <hr
-      data-h2-border="base(none)"
-      data-h2-height="base(1px)"
-      data-h2-background="base(black.2)"
-      data-h2-margin="base(0 0 x1 0)"
-    />
+    <Separator space="none" data-h2-margin-bottom="base(x1)" />
     <div
       data-h2-align-items="base(center)"
       data-h2-display="base(flex)"

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -8,6 +8,8 @@ import { useIntl } from "react-intl";
 
 import { uiMessages } from "@gc-digital-talent/i18n";
 
+import Separator from "../Separator";
+
 const StyledOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
@@ -209,12 +211,7 @@ interface DialogFooterProps extends React.HTMLProps<HTMLDivElement> {
 
 const Footer = ({ children, ...rest }: DialogFooterProps) => (
   <div data-h2-margin="base(x1 0 0 0)">
-    <hr
-      data-h2-border="base(none)"
-      data-h2-height="base(1px)"
-      data-h2-background="base(black.2)"
-      data-h2-margin="base(0 0 x1 0)"
-    />
+    <Separator space="none" data-h2-margin-bottom="base(x1)" />
     <div
       data-h2-align-items="base(center)"
       data-h2-display="base(flex)"

--- a/packages/ui/src/components/Separator/Separator.tsx
+++ b/packages/ui/src/components/Separator/Separator.tsx
@@ -26,13 +26,22 @@ const Separator = React.forwardRef<
     let spaceStyles: Record<string, string> = {};
     if (space !== "none") {
       if (space === "sm") {
-        spaceStyles = { "data-h2-margin": "base(x1 0)" };
+        spaceStyles =
+          orientation === "vertical"
+            ? { "data-h2-margin": "base(0 x1)" }
+            : { "data-h2-margin": "base(x1 0)" };
       }
       if (space === "md") {
-        spaceStyles = { "data-h2-margin": "base(x2 0)" };
+        spaceStyles =
+          orientation === "vertical"
+            ? { "data-h2-margin": "base(0 x2)" }
+            : { "data-h2-margin": "base(x2 0)" };
       }
       if (space === "lg") {
-        spaceStyles = { "data-h2-margin": "base(x3 0)" };
+        spaceStyles =
+          orientation === "vertical"
+            ? { "data-h2-margin": "base(x3 0)" }
+            : { "data-h2-margin": "base(x3 0)" };
       }
     }
     return (

--- a/packages/ui/src/components/Separator/Separator.tsx
+++ b/packages/ui/src/components/Separator/Separator.tsx
@@ -4,7 +4,7 @@ import * as SeparatorPrimitive from "@radix-ui/react-separator";
 type SeparatorProps = React.ComponentPropsWithoutRef<
   typeof SeparatorPrimitive.Root
 > & {
-  space?: "none" | "sm" | "md" | "lg";
+  space?: "none" | "xs" | "sm" | "md" | "lg";
 } & Omit<
     React.DetailedHTMLProps<React.HTMLAttributes<HTMLHRElement>, HTMLHRElement>,
     "ref"
@@ -25,6 +25,13 @@ const Separator = React.forwardRef<
   ) => {
     let spaceStyles: Record<string, string> = {};
     if (space !== "none") {
+      if (space === "xs") {
+        spaceStyles =
+          orientation === "vertical"
+            ? { "data-h2-margin": "base(0 x.5)" }
+            : { "data-h2-margin": "base(x.5 0)" };
+      }
+
       if (space === "sm") {
         spaceStyles =
           orientation === "vertical"

--- a/packages/ui/src/components/Separator/Separator.tsx
+++ b/packages/ui/src/components/Separator/Separator.tsx
@@ -18,33 +18,39 @@ type SeparatorProps = React.ComponentPropsWithoutRef<
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,
   SeparatorProps
->(({ space = "sm", ...rest }, forwardedRef) => {
-  let spaceStyles: Record<string, string> = {};
-  if (space !== "none") {
-    if (space === "sm") {
-      spaceStyles = { "data-h2-margin": "base(x1)" };
+>(
+  (
+    { space = "md", orientation = "horizontal", decorative = true, ...rest },
+    forwardedRef,
+  ) => {
+    let spaceStyles: Record<string, string> = {};
+    if (space !== "none") {
+      if (space === "sm") {
+        spaceStyles = { "data-h2-margin": "base(x1)" };
+      }
+      if (space === "md") {
+        spaceStyles = { "data-h2-margin": "base(x2)" };
+      }
+      if (space === "lg") {
+        spaceStyles = { "data-h2-margin": "base(x3)" };
+      }
     }
-    if (space === "md") {
-      spaceStyles = { "data-h2-margin": "base(x2)" };
-    }
-    if (space === "lg") {
-      spaceStyles = { "data-h2-margin": "base(x3)" };
-    }
-  }
-  return (
-    <SeparatorPrimitive.Root
-      ref={forwardedRef}
-      data-h2-height="
+    return (
+      <SeparatorPrimitive.Root
+        ref={forwardedRef}
+        {...{ orientation, decorative }}
+        data-h2-height="
       base:selectors[[data-orientation='vertical']](100%)
       base:selectors[[data-orientation='horizontal']](1px)"
-      data-h2-width="
+        data-h2-width="
       base:selectors[[data-orientation='vertical']](1px)
       base:selectors[[data-orientation='horizontal']](100%)"
-      data-h2-background-color="base(gray)"
-      {...spaceStyles}
-      {...rest}
-    />
-  );
-});
+        data-h2-background-color="base(gray)"
+        {...spaceStyles}
+        {...rest}
+      />
+    );
+  },
+);
 
 export default Separator;

--- a/packages/ui/src/components/Separator/Separator.tsx
+++ b/packages/ui/src/components/Separator/Separator.tsx
@@ -26,13 +26,13 @@ const Separator = React.forwardRef<
     let spaceStyles: Record<string, string> = {};
     if (space !== "none") {
       if (space === "sm") {
-        spaceStyles = { "data-h2-margin": "base(x1)" };
+        spaceStyles = { "data-h2-margin": "base(x1 0)" };
       }
       if (space === "md") {
-        spaceStyles = { "data-h2-margin": "base(x2)" };
+        spaceStyles = { "data-h2-margin": "base(x2 0)" };
       }
       if (space === "lg") {
-        spaceStyles = { "data-h2-margin": "base(x3)" };
+        spaceStyles = { "data-h2-margin": "base(x3 0)" };
       }
     }
     return (

--- a/packages/ui/src/components/Separator/Separator.tsx
+++ b/packages/ui/src/components/Separator/Separator.tsx
@@ -1,6 +1,15 @@
 import React from "react";
 import * as SeparatorPrimitive from "@radix-ui/react-separator";
 
+type SeparatorProps = React.ComponentPropsWithoutRef<
+  typeof SeparatorPrimitive.Root
+> & {
+  space?: "none" | "sm" | "md" | "lg";
+} & Omit<
+    React.DetailedHTMLProps<React.HTMLAttributes<HTMLHRElement>, HTMLHRElement>,
+    "ref"
+  >;
+
 /**
  * @name Separator
  * @desc Visually or semantically separates content.
@@ -8,18 +17,34 @@ import * as SeparatorPrimitive from "@radix-ui/react-separator";
  */
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
->((props, forwardedRef) => (
-  <SeparatorPrimitive.Root
-    data-h2-height="
+  SeparatorProps
+>(({ space = "sm", ...rest }, forwardedRef) => {
+  let spaceStyles: Record<string, string> = {};
+  if (space !== "none") {
+    if (space === "sm") {
+      spaceStyles = { "data-h2-margin": "base(x1)" };
+    }
+    if (space === "md") {
+      spaceStyles = { "data-h2-margin": "base(x2)" };
+    }
+    if (space === "lg") {
+      spaceStyles = { "data-h2-margin": "base(x3)" };
+    }
+  }
+  return (
+    <SeparatorPrimitive.Root
+      ref={forwardedRef}
+      data-h2-height="
       base:selectors[[data-orientation='vertical']](100%)
       base:selectors[[data-orientation='horizontal']](1px)"
-    data-h2-width="
+      data-h2-width="
       base:selectors[[data-orientation='vertical']](1px)
       base:selectors[[data-orientation='horizontal']](100%)"
-    ref={forwardedRef}
-    {...props}
-  />
-));
+      data-h2-background-color="base(gray)"
+      {...spaceStyles}
+      {...rest}
+    />
+  );
+});
 
 export default Separator;


### PR DESCRIPTION
🤖 Resolves #8554 

## 👋 Introduction

Updates the `Separator` component to make it consistent and reduce the amount of boilerplate.

## 🕵️ Details

We almost always use the following props so they have been added as defaults with the addition of a new `space` prop.

- `data-h2-margin="base(x2 0)"`
- `data-h2-background-color="base(gray)"`
- `orientation="horizontal"`
- `decorative`

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build the app `npm run dev`
2. Check some of the spots this component is used
3. Confirm it still looks okay
4. Check chromatic
