### PR TITLE
[Dep] Bump `react-toastify`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14523,8 +14523,9 @@
       }
     },
     "node_modules/clsx": {
-      "version": "1.2.1",
-      "license": "MIT",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
       "engines": {
         "node": ">=6"
       }
@@ -25433,10 +25434,11 @@
       }
     },
     "node_modules/react-toastify": {
-      "version": "9.1.3",
-      "license": "MIT",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.4.tgz",
+      "integrity": "sha512-etR3RgueY8pe88SA67wLm8rJmL1h+CLqUGHuAoNsseW35oTGJEri6eBTyaXnFKNQ80v/eO10hBYLgz036XRGgA==",
       "dependencies": {
-        "clsx": "^1.1.1"
+        "clsx": "^2.1.0"
       },
       "peerDependencies": {
         "react": ">=16",
@@ -29783,7 +29785,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@heroicons/react": "^2.1.1",
-        "react-toastify": "^9.1.3"
+        "react-toastify": "^10.0.4"
       },
       "devDependencies": {
         "@faker-js/faker": "^8.4.1",
@@ -32240,7 +32242,7 @@
         "eslint": "^8.57.0",
         "eslint-config-custom": "*",
         "react": "^18.2.0",
-        "react-toastify": "^9.1.3",
+        "react-toastify": "^10.0.4",
         "tsconfig": "*",
         "tsup": "^8.0.2",
         "typescript": "^5.3.3"
@@ -39981,7 +39983,9 @@
       }
     },
     "clsx": {
-      "version": "1.2.1"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg=="
     },
     "co": {
       "version": "4.6.0",
@@ -47177,9 +47181,11 @@
       "requires": {}
     },
     "react-toastify": {
-      "version": "9.1.3",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.4.tgz",
+      "integrity": "sha512-etR3RgueY8pe88SA67wLm8rJmL1h+CLqUGHuAoNsseW35oTGJEri6eBTyaXnFKNQ80v/eO10hBYLgz036XRGgA==",
       "requires": {
-        "clsx": "^1.1.1"
+        "clsx": "^2.1.0"
       }
     },
     "read": {

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.1.1",
-    "react-toastify": "^9.1.3"
+    "react-toastify": "^10.0.4"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",

--- a/packages/toast/src/components/Toast/Toast.tsx
+++ b/packages/toast/src/components/Toast/Toast.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {
   ToastContainer,
   Slide,
-  CloseButtonProps,
+  CloseButton as ReactToastifyCloseButton,
   ToastContainerProps,
 } from "react-toastify";
 import XCircleIcon from "@heroicons/react/24/solid/XCircleIcon";
@@ -11,6 +11,10 @@ import closeButtonStyles from "./styles";
 
 import "react-toastify/dist/ReactToastify.minimal.css";
 import "./toast.css";
+
+type CloseButtonProps = React.ComponentPropsWithoutRef<
+  typeof ReactToastifyCloseButton
+>;
 
 const CloseButton = ({ type, closeToast, ariaLabel }: CloseButtonProps) => (
   <button


### PR DESCRIPTION
🤖 Resolves #9126 

## 👋 Introduction

Bumps `react-toastify` to latest version and fixes breaking change.

## 🕵️ Details

Looks like they no longer exported the props for `CloseButton` so this has been updated to just use `React.ComponentPropsWithoutRef` generic.

## 🧪 Testing

1. Install new dep `npm i`
2. Build `npm run dev`
3. Trigger a toast and confirm it works
4. Manually close the toast and confirm it works
