### PR TITLE
[Fix] Set admin theme on layout

### DIFF
--- a/apps/web/src/components/Layout/AdminLayout/AdminLayout.tsx
+++ b/apps/web/src/components/Layout/AdminLayout/AdminLayout.tsx
@@ -21,6 +21,7 @@ import Footer from "~/components/Footer/Footer";
 import Header from "~/components/Header/Header";
 import SEO, { Favicon } from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
+import useLayoutTheme from "~/hooks/useLayoutTheme";
 import { checkRole } from "~/utils/teamUtils";
 import {
   pageTitle as indexPoolPageTitle,
@@ -104,6 +105,7 @@ const AdminLayout = () => {
   const intl = useIntl();
   const { locale } = useLocale();
   const paths = useRoutes();
+  useLayoutTheme("default");
   const isSmallScreen = useIsSmallScreen();
   const { roleAssignments } = useAuthorization();
 


### PR DESCRIPTION
🤖 Resolves #9309 

## 👋 Introduction

Fixes an issue where navigating to admin from IAP did not switch theme back.

## 🧪 Testing

1. Build `npm run dev`
2. Navigate to `/indigenous-it-apprentice`
3. Navigate directly to `/admin` with no intermediary step (must use the address bar, not links)
4. Confirm the theme switches back to the default colours
