### PR TITLE
[Fix] Assessment table initial update

### DIFF
--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
@@ -3,7 +3,7 @@ import { defineMessage, useIntl } from "react-intl";
 import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
 import HandRaisedIcon from "@heroicons/react/24/outline/HandRaisedIcon";
 import ExclamationTriangleIcon from "@heroicons/react/24/outline/ExclamationTriangleIcon";
-import { useQuery } from "urql";
+import { OperationContext, useQuery } from "urql";
 
 import {
   NotFound,
@@ -923,6 +923,10 @@ export const ViewPoolCandidate = ({
   );
 };
 
+const context: Partial<OperationContext> = {
+  additionalTypenames: ["AssessmentResult"],
+};
+
 type RouteParams = {
   poolId: Scalars["ID"]["output"];
   poolCandidateId: Scalars["ID"]["output"];
@@ -933,6 +937,7 @@ export const RODViewPoolCandidatePage = () => {
   const { poolCandidateId } = useRequiredParams<RouteParams>("poolCandidateId");
   const [{ data, fetching, error }] = useQuery({
     query: PoolCandidate_SnapshotQuery,
+    context,
     variables: { poolCandidateId },
   });
 


### PR DESCRIPTION
🤖 Resolves #9527 

## 👋 Introduction

Adds additional typnames to the query context so `urql` knows to update its cache. 

## 🕵️ Details

While this does close the dialog it technically is not a complete solution to #9526 since it only closes because of a re-render.

## 🧪 Testing

1. Build `npm run dev`
2. Login as `admin@test.com`
3. Navigate to a pool candidate who has no assessments
4. Assess a skill
5. Confirm the table updates automatically
