### PR TITLE
[Fix] Add null states for no assessment plan

### DIFF
--- a/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
+++ b/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
@@ -24,6 +24,7 @@ import { Well } from "@gc-digital-talent/ui";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import adminMessages from "~/messages/adminMessages";
 import { getOrderedSteps } from "~/utils/poolCandidate";
+import processMessages from "~/messages/processMessages";
 
 import cells from "../Table/cells";
 import { buildColumn, columnHeader, columnStatus } from "./utils";
@@ -49,14 +50,7 @@ const AssessmentResultsTable = ({
   if (!assessmentSteps.length) {
     return (
       <Well>
-        <p>
-          {intl.formatMessage({
-            defaultMessage: "This process does not have an assessment plan.",
-            id: "jz53Y9",
-            description:
-              "Message for when an applicants process does not have an assessment plan",
-          })}
-        </p>
+        <p>{intl.formatMessage(processMessages.noAssessmentPlan)}</p>
       </Well>
     );
   }

--- a/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
+++ b/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
@@ -19,6 +19,7 @@ import {
   PoolSkillType,
 } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { Well } from "@gc-digital-talent/ui";
 
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import adminMessages from "~/messages/adminMessages";
@@ -44,6 +45,21 @@ const AssessmentResultsTable = ({
   const assessmentSteps: Array<AssessmentStep> = unpackMaybes(
     poolCandidate?.pool?.assessmentSteps,
   );
+
+  if (!assessmentSteps.length) {
+    return (
+      <Well>
+        <p>
+          {intl.formatMessage({
+            defaultMessage: "This process does not have an assessment plan.",
+            id: "jz53Y9",
+            description:
+              "Message for when an applicants process does not have an assessment plan",
+          })}
+        </p>
+      </Well>
+    );
+  }
 
   // Get pool skills from pool
   const poolSkills: Array<PoolSkill> = unpackMaybes(

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
@@ -12,6 +12,7 @@ import { AssessmentStep, Pool } from "@gc-digital-talent/graphql";
 
 import applicationMessages from "~/messages/applicationMessages";
 import useRoutes from "~/hooks/useRoutes";
+import processMessages from "~/messages/processMessages";
 
 import ResultsDetails from "./ResultsDetails";
 import AssessmentResults from "./AssessmentResults";
@@ -87,22 +88,11 @@ const AssessmentStepTracker = ({ pool }: AssessmentStepTrackerProps) => {
       ) : (
         <Well>
           <p>
-            {intl.formatMessage(
-              {
-                defaultMessage:
-                  "This process does not have an assessment plan. You can view your candidates on the <a>Talent placement</a> page.",
-                id: "C42d2P",
-                description:
-                  "Message displayed when a process has no assessment plan",
-              },
-              {
-                a: (chunks: React.ReactNode) =>
-                  talentPlacementLink(
-                    chunks,
-                    paths.poolCandidateTable(pool.id),
-                  ),
-              },
-            )}
+            {intl.formatMessage(processMessages.noAssessmentPlan)}{" "}
+            {intl.formatMessage(processMessages.viewTalentPlacement, {
+              a: (chunks: React.ReactNode) =>
+                talentPlacementLink(chunks, paths.poolCandidateTable(pool.id)),
+            })}
           </p>
         </Well>
       )}

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { IntlShape, useIntl } from "react-intl";
 
-import { Board } from "@gc-digital-talent/ui";
+import { Board, Link, Well } from "@gc-digital-talent/ui";
 import {
   commonMessages,
   getAssessmentStepType,
@@ -11,6 +11,7 @@ import { unpackMaybes } from "@gc-digital-talent/helpers";
 import { AssessmentStep, Pool } from "@gc-digital-talent/graphql";
 
 import applicationMessages from "~/messages/applicationMessages";
+import useRoutes from "~/hooks/useRoutes";
 
 import ResultsDetails from "./ResultsDetails";
 import AssessmentResults from "./AssessmentResults";
@@ -22,6 +23,9 @@ import {
 } from "./utils";
 import Filters from "./Filters";
 
+const talentPlacementLink = (chunks: React.ReactNode, href: string) => (
+  <Link href={href}>{chunks}</Link>
+);
 export interface AssessmentStepTrackerProps {
   pool: Pool;
 }
@@ -40,6 +44,7 @@ const generateStepName = (step: AssessmentStep, intl: IntlShape): string => {
 
 const AssessmentStepTracker = ({ pool }: AssessmentStepTrackerProps) => {
   const intl = useIntl();
+  const paths = useRoutes();
   const [filters, setFilters] = React.useState<ResultFilters>(defaultFilters);
   const steps = unpackMaybes(pool.assessmentSteps);
   const candidates = unpackMaybes(pool.poolCandidates);
@@ -49,35 +54,58 @@ const AssessmentStepTracker = ({ pool }: AssessmentStepTrackerProps) => {
   return (
     <>
       <Filters onFiltersChange={setFilters} />
-      <Board.Root>
-        {filteredSteps.map(({ step, resultCounts, results }, index) => {
-          const stepName = generateStepName(step, intl);
-          const stepNumber = intl.formatMessage(
-            applicationMessages.numberedStep,
-            {
-              stepOrdinal: index + 1,
-            },
-          );
+      {steps.length ? (
+        <Board.Root>
+          {filteredSteps.map(({ step, resultCounts, results }, index) => {
+            const stepName = generateStepName(step, intl);
+            const stepNumber = intl.formatMessage(
+              applicationMessages.numberedStep,
+              {
+                stepOrdinal: index + 1,
+              },
+            );
 
-          return (
-            <Board.Column key={step.id}>
-              <Board.ColumnHeader prefix={stepNumber}>
-                {stepName}
-              </Board.ColumnHeader>
-              <ResultsDetails {...{ resultCounts, step }} />
-              <AssessmentResults
-                stepType={step.type}
-                stepName={
-                  stepNumber +
-                  intl.formatMessage(commonMessages.dividingColon) +
-                  stepName
-                }
-                {...{ results }}
-              />
-            </Board.Column>
-          );
-        })}
-      </Board.Root>
+            return (
+              <Board.Column key={step.id}>
+                <Board.ColumnHeader prefix={stepNumber}>
+                  {stepName}
+                </Board.ColumnHeader>
+                <ResultsDetails {...{ resultCounts, step }} />
+                <AssessmentResults
+                  stepType={step.type}
+                  stepName={
+                    stepNumber +
+                    intl.formatMessage(commonMessages.dividingColon) +
+                    stepName
+                  }
+                  {...{ results }}
+                />
+              </Board.Column>
+            );
+          })}
+        </Board.Root>
+      ) : (
+        <Well>
+          <p>
+            {intl.formatMessage(
+              {
+                defaultMessage:
+                  "This process does not have an assessment plan. You can view your candidates on the <a>Talent placement</a> page.",
+                id: "C42d2P",
+                description:
+                  "Message displayed when a process has no assessment plan",
+              },
+              {
+                a: (chunks: React.ReactNode) =>
+                  talentPlacementLink(
+                    chunks,
+                    paths.poolCandidateTable(pool.id),
+                  ),
+              },
+            )}
+          </p>
+        </Well>
+      )}
     </>
   );
 };

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2543,10 +2543,6 @@
     "defaultMessage": "Version",
     "description": "Label for the specific version number of the site"
   },
-  "C42d2P": {
-    "defaultMessage": "This process does not have an assessment plan. You can view your candidates on the <a>Talent placement</a> page.Ce processus n'a pas de plan d'évaluation. Vous pouvez visualiser vos candidat(e)s sur la page <a>Placement de talents</a>.",
-    "description": "Message displayed when a process has no assessment plan"
-  },
   "C43ZgD": {
     "defaultMessage": "La plupart des offres d’emploi ne nécessiteront pas de note spéciale. Cette section est réservée à des circonstances particulières. Cette note spéciale peut notamment servir à indiquer si un processus peut être utilisé pour embaucher dans plusieurs classifications ou non et si le processus est limité aux candidatures d’un groupe visé par l’équité en matière d’emploi spécifique.",
     "description": "Describes the 'special note' section of a process' advertisement."
@@ -8758,10 +8754,6 @@
     "defaultMessage": "Ce que nous pouvons faire pour vous",
     "description": "Heading for the manager opportunities"
   },
-  "jz53Y9": {
-    "defaultMessage": "Ce processus n'a pas de plan d'évaluation.",
-    "description": "Message for when an applicants process does not have an assessment plan"
-  },
   "k1uZ7o": {
     "defaultMessage": "Une cote de fiabilité valide",
     "description": "Item 3 in the candidate list in the 'Indigenous talent ready for IT apprenticeships' section"
@@ -9185,6 +9177,10 @@
   "mVqKm+": {
     "defaultMessage": "2. <strong>Balayez le code QR</strong> ou <strong>saisissez votre code secret</strong> au moyen de votre application d’authentification à deux facteurs.",
     "description": "Text for second sign up -> mfa step."
+  },
+  "mYnQH4": {
+    "defaultMessage": "Ce processus n'a pas de plan d'évaluation.",
+    "description": "A process has no assessment plan"
   },
   "mYuXWF": {
     "defaultMessage": "utilisateurs_{date}.csv",
@@ -10325,6 +10321,10 @@
   "tgGPyx": {
     "defaultMessage": "Le questionnaire rempli doit être soumis au moment où un contrat de services numériques (y compris la commande d’un instrument contractuel établi) est soumis aux autorités ministérielles chargées de l’approvisionnement aux fins de traitement.",
     "description": "Paragraph three of the _requirements_ section of the _digital services contracting questionnaire_"
+  },
+  "tgtpgb": {
+    "defaultMessage": "Vous pouvez visualiser vos candidat(e)s sur la page <a>Placement de talents</a>.",
+    "description": "Message to direct users to the talent placement page"
   },
   "thgFzS": {
     "defaultMessage": "Télécharger le guide sur la mise en œuvre pour les gestionnaires (texte clair)",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2543,6 +2543,10 @@
     "defaultMessage": "Version",
     "description": "Label for the specific version number of the site"
   },
+  "C42d2P": {
+    "defaultMessage": "This process does not have an assessment plan. You can view your candidates on the <a>Talent placement</a> page.Ce processus n'a pas de plan d'évaluation. Vous pouvez visualiser vos candidat(e)s sur la page <a>Placement de talents</a>.",
+    "description": "Message displayed when a process has no assessment plan"
+  },
   "C43ZgD": {
     "defaultMessage": "La plupart des offres d’emploi ne nécessiteront pas de note spéciale. Cette section est réservée à des circonstances particulières. Cette note spéciale peut notamment servir à indiquer si un processus peut être utilisé pour embaucher dans plusieurs classifications ou non et si le processus est limité aux candidatures d’un groupe visé par l’équité en matière d’emploi spécifique.",
     "description": "Describes the 'special note' section of a process' advertisement."
@@ -8753,6 +8757,10 @@
   "jz/FoH": {
     "defaultMessage": "Ce que nous pouvons faire pour vous",
     "description": "Heading for the manager opportunities"
+  },
+  "jz53Y9": {
+    "defaultMessage": "Ce processus n'a pas de plan d'évaluation.",
+    "description": "Message for when an applicants process does not have an assessment plan"
   },
   "k1uZ7o": {
     "defaultMessage": "Une cote de fiabilité valide",

--- a/apps/web/src/messages/processMessages.ts
+++ b/apps/web/src/messages/processMessages.ts
@@ -126,6 +126,17 @@ const messages = defineMessages({
     id: "PnWNZn",
     description: "Title of general questions",
   },
+  noAssessmentPlan: {
+    defaultMessage: "This process does not have an assessment plan.",
+    id: "mYnQH4",
+    description: "A process has no assessment plan",
+  },
+  viewTalentPlacement: {
+    defaultMessage:
+      "You can view your candidates on the <a>Talent placement</a> page.",
+    id: "tgtpgb",
+    description: "Message to direct users to the talent placement page",
+  },
 });
 
 export default messages;


### PR DESCRIPTION
🤖 Resolves #9516 

## 👋 Introduction

Adds a null state for the step tracker and pool candidate pages when their associated process has no assessment plan.

## 🧪 Testing

1. Build `npm run dev`
2. Remove all assessment steps from a pool in the database
3. Login as admin `admin@test.com`
4. Navigate to the pool from page 2's screening and assessment sectioon
5. Confirm the null message appears and link goes to the proper talent placement page
6. Navigate to a candidate from the talent placement page
7. Confirm the null message appears under the assessment section for that candidate

## 📸 Screenshot

![Screenshot 2024-02-29 122058](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/eedbce50-d3ff-4b90-ba87-e18273ff9487)
![Screenshot 2024-02-29 122102](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/a5424578-ae8b-4f54-a9a5-0ca429f9bd2c)
