### PR TITLE
[Fix] Hide truncated text when "read more" open

### DIFF
--- a/packages/ui/src/components/Spoiler/Spoiler.tsx
+++ b/packages/ui/src/components/Spoiler/Spoiler.tsx
@@ -27,7 +27,10 @@ const Spoiler = ({ linkSuffix, text, characterCount = 32 }: SpoilerProps) => {
         data-h2-align-items="base(center)"
         data-h2-gap="base(0 x.25)"
       >
-        <div>{truncated}&hellip;</div>
+        <div>
+          {!isOpen && <>{truncated}&hellip;</>}
+          <Collapsible.Content>{text}</Collapsible.Content>
+        </div>
         <Collapsible.Trigger asChild>
           <Button mode="inline" color="black" data-h2-flex-shrink="base(0)">
             {!isOpen
@@ -40,7 +43,6 @@ const Spoiler = ({ linkSuffix, text, characterCount = 32 }: SpoilerProps) => {
           </Button>
         </Collapsible.Trigger>
       </div>
-      <Collapsible.Content>{text}</Collapsible.Content>
     </Collapsible.Root>
   );
 };


### PR DESCRIPTION
🤖 Resolves #9541 

## 👋 Introduction

Fixes an issue where both the full and truncated text was appearing on the "Read more" section of the search request table "notes" column.

## 🧪 Testing

1. Build the app `npm run dev`
2. Navigate to the search requests table (`/admin/talent-requests`)
3. Enable the "notes" column
4. Activate the "read more" button on one of the rows
5. Confirm that the truncated version of the text no longer appears

## 📸 Screenshot

### Closed

![Screenshot 2024-02-29 165833](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/02c77bbe-3165-4af1-bb3a-3f52a56e8e7a)

### Open

![Screenshot 2024-02-29 165830](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/c4198814-bcc3-428e-a925-623aee59e255)
