### PR TITLE
[Debt] Removes legacy table of contents heading css

### DIFF
--- a/packages/ui/src/components/TableOfContents/Heading.tsx
+++ b/packages/ui/src/components/TableOfContents/Heading.tsx
@@ -3,8 +3,6 @@ import React, { HTMLAttributes } from "react";
 import Heading, { type HeadingLevel } from "../Heading";
 import { IconType, Color } from "../../types";
 
-import "./heading.css";
-
 export interface HeadingProps {
   as?: HeadingLevel;
   size?: HeadingLevel;

--- a/packages/ui/src/components/TableOfContents/heading.css
+++ b/packages/ui/src/components/TableOfContents/heading.css
@@ -1,3 +1,0 @@
-.toc-heading__icon {
-  flex-shrink: 0;
-}


### PR DESCRIPTION
🤖 Resolves #9594.

## 👋 Introduction

This PR removes legacy table of contents heading css.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Search codebase for references to `packages/ui/src/components/TableOfContents/heading.css` file
2. Verify none exist
3. Search codebase for references to `toc-heading__icon` css class
4. Verify none exist