### PR TITLE
[Bug] Default table message

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -749,6 +749,12 @@ const PoolCandidatesTable = ({
         onChange: (newState: SearchState) => {
           handleSearchStateChange(newState);
         },
+        overrideAllTableMsg: intl.formatMessage({
+          defaultMessage: "Full Profile",
+          id: "rN333X",
+          description:
+            "Text in table search form column dropdown when no column is selected.",
+        }),
       }}
       sort={{
         internal: false,

--- a/apps/web/src/components/Table/ResponsiveTable/SearchForm.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/SearchForm.tsx
@@ -27,6 +27,7 @@ const SearchForm = <T,>({
   label,
   id,
   inputProps,
+  overrideAllTableMsg,
 }: SearchFormProps<T>) => {
   const intl = useIntl();
   const searchRef = React.useRef<HTMLInputElement | null>(null);
@@ -104,12 +105,14 @@ const SearchForm = <T,>({
     });
   };
 
-  const allTableMsg = intl.formatMessage({
-    defaultMessage: "Full Profile",
-    id: "rN333X",
+  const defaultAllTableMsg = intl.formatMessage({
+    defaultMessage: "Entire table",
+    id: "z59tbA",
     description:
-      "Text in table search form column dropdown when no column is selected.",
+      "Default text in table search form column dropdown when no column is selected",
   });
+
+  const allTableMsg = overrideAllTableMsg ?? defaultAllTableMsg;
 
   return (
     <div data-h2-width="base(100%) l-tablet(auto)">

--- a/apps/web/src/components/Table/ResponsiveTable/types.ts
+++ b/apps/web/src/components/Table/ResponsiveTable/types.ts
@@ -49,6 +49,8 @@ export interface SearchFormProps<TData extends RowData> {
   id: React.HTMLAttributes<HTMLInputElement>["id"];
   /** Additional props forwarded to the search input */
   inputProps?: Omit<React.HTMLProps<HTMLInputElement>, "aria-label" | "id">;
+  /** Override default allTable message */
+  overrideAllTableMsg?: string;
 }
 
 type SearchDefFormProps<T> = Omit<

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -11082,6 +11082,10 @@
     "defaultMessage": "Vous pouvez ajouter des points en vous servant du bouton \"Ajouter une nouvelle question \" ayant été fourni à cet effet.",
     "description": "Instructions on how to add a question when there are none"
   },
+  "z59tbA": {
+    "defaultMessage": "Tout le tableau",
+    "description": "Default text in table search form column dropdown when no column is selected"
+  },
   "z5YYOk": {
     "defaultMessage": "Veuillez préciser l’instrument",
     "description": "Label for _instrument type other_ fieldset in the _digital services contracting questionnaire_"

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -425,6 +425,12 @@ const UserTable = ({ title }: UserTableProps) => {
         onChange: ({ term, type }: SearchState) => {
           handleSearchStateChange({ term, type });
         },
+        overrideAllTableMsg: intl.formatMessage({
+          defaultMessage: "Full Profile",
+          id: "rN333X",
+          description:
+            "Text in table search form column dropdown when no column is selected.",
+        }),
       }}
       sort={{
         internal: false,


### PR DESCRIPTION
🤖 Resolves #9517 

## 👋 Introduction

Sets default message for the table search to "Entire table" with the option to pass in an override. 

## 🧪 Testing

1. Navigate to users and pool candidates table and observe search dropdown unchanged
2. Other tables had their search dropdowns changed

## 📸 Screenshot

Unchanged

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/c6dbca1d-9810-4cd7-8104-481396754ca8)

Changed

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/b1af7bae-ab25-4c69-a03c-7097f9f37afb)
