### PR TITLE
[Fix] Add description fields to create team form

### DIFF
--- a/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamForm.tsx
+++ b/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamForm.tsx
@@ -24,15 +24,17 @@ type FormValues = {
   displayName?: Maybe<LocalizedStringInput>;
   contactEmail?: Maybe<Scalars["Email"]["output"]>;
   departments?: Array<Scalars["UUID"]["output"]>;
+  description?: Maybe<LocalizedStringInput>;
 };
 
 const formValuesToSubmitData = (data: FormValues): CreateTeamInput => {
-  const { displayName, contactEmail, departments } = data;
+  const { displayName, contactEmail, departments, description } = data;
   return {
     displayName,
     contactEmail,
     name: kebabCase(displayName?.en || ""),
     departments: { sync: departments },
+    description,
   };
 };
 
@@ -76,12 +78,7 @@ const CreateTeamForm = ({ departments, onSubmit }: CreateTeamFormProps) => {
 
   return (
     <BasicForm onSubmit={handleSubmit}>
-      <div
-        data-h2-flex-grid="base(center, x1, x1)"
-        data-h2-margin-bottom="base(x1)"
-      >
-        <CreateTeamFormFields departments={departments} />
-      </div>
+      <CreateTeamFormFields departments={departments} />
       <div
         data-h2-display="base(flex)"
         data-h2-gap="base(x1)"

--- a/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamFormFields.tsx
+++ b/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamFormFields.tsx
@@ -3,12 +3,15 @@ import { useIntl } from "react-intl";
 import { useFormContext } from "react-hook-form";
 import kebabCase from "lodash/kebabCase";
 
-import { Input, Combobox } from "@gc-digital-talent/forms";
+import { Input, Combobox, TextArea } from "@gc-digital-talent/forms";
 import { errorMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import { notEmpty } from "@gc-digital-talent/helpers";
 import { Maybe, Department } from "@gc-digital-talent/graphql";
 
 import adminMessages from "~/messages/adminMessages";
+
+const TEXT_AREA_ROWS = 4;
+const TEXT_AREA_MAX_WORDS = 200;
 
 interface CreateTeamFormFieldsProps {
   departments?: Maybe<Array<Maybe<Omit<Department, "teams">>>>;
@@ -33,7 +36,10 @@ const CreateTeamFormFields = ({ departments }: CreateTeamFormFieldsProps) => {
   };
 
   return (
-    <>
+    <div
+      data-h2-flex-grid="base(center, x1, x1)"
+      data-h2-margin-bottom="base(x1)"
+    >
       <div data-h2-flex-item="base(1/2)">
         <Input
           type="text"
@@ -98,7 +104,39 @@ const CreateTeamFormFields = ({ departments }: CreateTeamFormFieldsProps) => {
           }}
         />
       </div>
-    </>
+      <div data-h2-flex-item="base(1/2)">
+        <TextArea
+          id="description_en"
+          name="description.en"
+          rows={TEXT_AREA_ROWS}
+          wordLimit={TEXT_AREA_MAX_WORDS}
+          label={intl.formatMessage({
+            defaultMessage: "Team's short description (English)",
+            id: "sSGgnI",
+            description: "Label for team description in English language",
+          })}
+          rules={{
+            required: intl.formatMessage(errorMessages.required),
+          }}
+        />
+      </div>
+      <div data-h2-flex-item="base(1/2)">
+        <TextArea
+          id="description_fr"
+          name="description.fr"
+          rows={TEXT_AREA_ROWS}
+          wordLimit={TEXT_AREA_MAX_WORDS}
+          label={intl.formatMessage({
+            defaultMessage: "Team's short description (French)",
+            id: "RSkJQR",
+            description: "Label for team description in French language",
+          })}
+          rules={{
+            required: intl.formatMessage(errorMessages.required),
+          }}
+        />
+      </div>
+    </div>
   );
 };
 

--- a/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.tsx
+++ b/apps/web/src/pages/Teams/UpdateTeamPage/components/UpdateTeamForm.tsx
@@ -5,14 +5,8 @@ import { SubmitHandler } from "react-hook-form";
 import omit from "lodash/omit";
 import kebabCase from "lodash/kebabCase";
 
-import {
-  BasicForm,
-  Submit,
-  TextArea,
-  unpackIds,
-} from "@gc-digital-talent/forms";
+import { BasicForm, Submit, unpackIds } from "@gc-digital-talent/forms";
 import { toast } from "@gc-digital-talent/toast";
-import { errorMessages } from "@gc-digital-talent/i18n";
 import { Link } from "@gc-digital-talent/ui";
 import {
   Scalars,
@@ -27,9 +21,6 @@ import {
 import useRoutes from "~/hooks/useRoutes";
 
 import CreateTeamFormFields from "../../CreateTeamPage/components/CreateTeamFormFields";
-
-const TEXT_AREA_ROWS = 4;
-const TEXT_AREA_MAX_WORDS = 200;
 
 type FormValues = {
   displayName?: Maybe<LocalizedStringInput>;
@@ -109,41 +100,8 @@ const UpdateTeamForm = ({
         defaultValues: dataToFormValues(team),
       }}
     >
-      <div data-h2-flex-grid="base(center, x1, x1)">
-        <CreateTeamFormFields departments={departments} />
-        <div data-h2-flex-item="base(1/2)">
-          <TextArea
-            id="description_en"
-            name="description.en"
-            rows={TEXT_AREA_ROWS}
-            wordLimit={TEXT_AREA_MAX_WORDS}
-            label={intl.formatMessage({
-              defaultMessage: "Team's short description (English)",
-              id: "sSGgnI",
-              description: "Label for team description in English language",
-            })}
-            rules={{
-              required: intl.formatMessage(errorMessages.required),
-            }}
-          />
-        </div>
-        <div data-h2-flex-item="base(1/2)">
-          <TextArea
-            id="description_fr"
-            name="description.fr"
-            rows={TEXT_AREA_ROWS}
-            wordLimit={TEXT_AREA_MAX_WORDS}
-            label={intl.formatMessage({
-              defaultMessage: "Team's short description (French)",
-              id: "RSkJQR",
-              description: "Label for team description in French language",
-            })}
-            rules={{
-              required: intl.formatMessage(errorMessages.required),
-            }}
-          />
-        </div>
-      </div>
+      <CreateTeamFormFields departments={departments} />
+
       <div
         data-h2-display="base(flex)"
         data-h2-gap="base(x1)"


### PR DESCRIPTION
🤖 Resolves #9411 

## 👋 Introduction

Adds the description fields to the create team form.

## 🕵️ Details

These were set to be required on the edit page so even though they are marked as optional in the API I kept the required. Hopefully that is intended.

## 🧪 Testing

1. Build `npm run dev`
2. Login as admin `admin@test.com`
3. Navigate to the create team page `/admin/teams/create`
4. Ensure the description fields exist
5. Fill out the form and submit it
6. Confirm that the descriptions are saved

## 📸 Screenshot

![Screenshot 2024-03-01 082929](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/0207e40b-f080-4b15-be63-e92ce968e758)
