### PR TITLE
[Debt] Renames `TrackApplicationsCard` to `ApplicationCard`

### DIFF
--- a/apps/web/src/components/Profile/components/AccountAndPrivacy/AccountAndPrivacy.tsx
+++ b/apps/web/src/components/Profile/components/AccountAndPrivacy/AccountAndPrivacy.tsx
@@ -7,7 +7,7 @@ import { unpackMaybes } from "@gc-digital-talent/helpers";
 import { PoolCandidateStatus } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
-import TrackApplicationsCard from "~/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplicationsCard";
+import ApplicationCard from "~/pages/ProfileAndApplicationsPage/components/TrackApplications/ApplicationCard";
 
 import { SectionProps } from "../../types";
 import { getSectionTitle } from "../../utils";
@@ -177,7 +177,7 @@ const AccountAndPrivacy = ({ user, pool }: SectionProps) => {
             </p>
             {activeApplications.length > 0 ? (
               activeApplications.map((application) => (
-                <TrackApplicationsCard
+                <ApplicationCard
                   key={application.id}
                   application={application}
                 />

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/ApplicationCard.stories.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/ApplicationCard.stories.tsx
@@ -7,10 +7,10 @@ import { PoolCandidateStatus } from "@gc-digital-talent/graphql";
 
 import { isExpired } from "~/utils/poolCandidate";
 
-import TrackApplicationsCard from "./TrackApplicationsCard";
+import ApplicationCard from "./ApplicationCard";
 
-type Story = ComponentStory<typeof TrackApplicationsCard>;
-type Meta = ComponentMeta<typeof TrackApplicationsCard>;
+type Story = ComponentStory<typeof ApplicationCard>;
+type Meta = ComponentMeta<typeof ApplicationCard>;
 
 const mockApplications = fakePoolCandidates(20);
 
@@ -32,8 +32,8 @@ const expiredApplications = fakePoolCandidates(5).map((application) => ({
 const applications = [...activeApplications, ...expiredApplications];
 
 export default {
-  component: TrackApplicationsCard,
-  title: "Components/Track Applications Card",
+  component: ApplicationCard,
+  title: "Components/Application Card",
 } as Meta;
 
 const Template: Story = () => {
@@ -53,7 +53,7 @@ const Template: Story = () => {
                 "(EXPIRED)"}
               {application.status}
             </h2>
-            <TrackApplicationsCard application={application} />
+            <ApplicationCard application={application} />
           </div>
         ))}
       </div>

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/ApplicationCard.test.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/ApplicationCard.test.tsx
@@ -17,9 +17,7 @@ import { PoolCandidateStatus } from "@gc-digital-talent/graphql";
 
 import { PAGE_SECTION_ID } from "~/pages/Profile/CareerTimelineAndRecruitmentPage/constants";
 
-import TrackApplicationsCard, {
-  TrackApplicationsCardProps,
-} from "./TrackApplicationsCard";
+import ApplicationCard, { ApplicationCardProps } from "./ApplicationCard";
 
 const mockApplication = fakePoolCandidates()[0];
 
@@ -34,14 +32,14 @@ const mockClient = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any;
 
-const renderCard = (props: TrackApplicationsCardProps) =>
+const renderCard = (props: ApplicationCardProps) =>
   renderWithProviders(
     <GraphqlProvider value={mockClient}>
-      <TrackApplicationsCard {...props} />
+      <ApplicationCard {...props} />
     </GraphqlProvider>,
   );
 
-describe("TrackApplicationsCard", () => {
+describe("ApplicationCard", () => {
   it("should have no accessibility errors", async () => {
     const { container } = renderCard(defaultProps);
     await axeTest(container);

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/ApplicationCard.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/ApplicationCard.tsx
@@ -26,17 +26,17 @@ type Application = Omit<
   "user" | "educationRequirementExperiences"
 >;
 
-export interface TrackApplicationsCardProps {
+export interface ApplicationCardProps {
   application: Application;
   headingLevel?: HeadingProps["level"];
   onDelete: DeleteActionProps["onDelete"];
 }
 
-const TrackApplicationsCard = ({
+const ApplicationCard = ({
   application,
   headingLevel = "h2",
   onDelete,
-}: TrackApplicationsCardProps) => {
+}: ApplicationCardProps) => {
   const intl = useIntl();
 
   // Conditionals for card actions
@@ -179,24 +179,20 @@ const TrackApplicationsCard = ({
   );
 };
 
-const TrackApplicationsCardDelete_Mutation = graphql(/* GraphQL */ `
-  mutation TrackApplicationsCardDelete($id: ID!) {
+const ApplicationCardDelete_Mutation = graphql(/* GraphQL */ `
+  mutation ApplicationCardDelete($id: ID!) {
     deleteApplication(id: $id) {
       id
     }
   }
 `);
 
-interface TrackApplicationsCardApiProps {
+interface ApplicationCardApiProps {
   application: Application;
 }
 
-const TrackApplicationsCardApi = ({
-  application,
-}: TrackApplicationsCardApiProps) => {
-  const [, executeDeleteMutation] = useMutation(
-    TrackApplicationsCardDelete_Mutation,
-  );
+const ApplicationCardApi = ({ application }: ApplicationCardApiProps) => {
+  const [, executeDeleteMutation] = useMutation(ApplicationCardDelete_Mutation);
   const intl = useIntl();
 
   const deleteApplication = () => {
@@ -217,11 +213,8 @@ const TrackApplicationsCardApi = ({
   };
 
   return (
-    <TrackApplicationsCard
-      application={application}
-      onDelete={deleteApplication}
-    />
+    <ApplicationCard application={application} onDelete={deleteApplication} />
   );
 };
 
-export default TrackApplicationsCardApi;
+export default ApplicationCardApi;

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplications.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/TrackApplications/TrackApplications.tsx
@@ -11,7 +11,7 @@ import useRoutes from "~/hooks/useRoutes";
 import { isApplicationInProgress, notRemoved } from "~/utils/applicationUtils";
 import { PAGE_SECTION_ID as CAREER_TIMELINE_AND_RECRUITMENTS_PAGE_SECTION_ID } from "~/pages/Profile/CareerTimelineAndRecruitmentPage/constants";
 
-import TrackApplicationsCard from "./TrackApplicationsCard";
+import ApplicationCard from "./ApplicationCard";
 
 function buildLink(href: string, chunks: React.ReactNode): React.ReactElement {
   return <Link href={href}>{chunks}</Link>;
@@ -142,7 +142,7 @@ const TrackApplications = ({
             <Accordion.Content>
               {inProgressApplications.length > 0 ? (
                 inProgressApplications.map((activeRecruitment) => (
-                  <TrackApplicationsCard
+                  <ApplicationCard
                     key={activeRecruitment.id}
                     application={activeRecruitment}
                   />
@@ -215,7 +215,7 @@ const TrackApplications = ({
             <Accordion.Content>
               {pastApplications.length > 0 ? (
                 pastApplications.map((pastApplication) => (
-                  <TrackApplicationsCard
+                  <ApplicationCard
                     key={pastApplication.id}
                     application={pastApplication}
                   />


### PR DESCRIPTION
🤖 Resolves #9498.

## 👋 Introduction

This PR renames `TrackApplicationsCard` to `ApplicationCard` to reflect what it is: a card with application data.

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate to **Track your applications** section of `/applicant/profile-and-applications`
3. Verify application cards render as they did before
4. `npm run storybook:web`
5. Navigate to http://localhost:6006/?path=/story/components-application-card--application-cards
6. Verify **Application Cards** story renders as it did before