### PR TITLE
[Spike] User generated files from local storage

### DIFF
--- a/api/app/Console/Commands/PruneUserGeneratedFiles.php
+++ b/api/app/Console/Commands/PruneUserGeneratedFiles.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+
+class PruneUserGeneratedFiles extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:prune-user-generated-files';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Prune old user generated files';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $now = Carbon::now();
+        $disk = Storage::disk('userGenerated');
+        $allDirectories = $disk->allDirectories();
+        $directoryCount = count($allDirectories);
+        $this->info("Checking $directoryCount directories.");
+        foreach ($allDirectories as $directory) {
+            $allFiles = $disk->allFiles($directory);
+            $fileCount = count($allFiles);
+            $this->info("Checking directory $directory with $fileCount files.");
+            foreach ($allFiles as $file) {
+                $lastModified = Carbon::createFromTimestamp($disk->lastModified($file));
+                $hoursOld = $now->diffInHours($lastModified);
+                $shouldDelete = $hoursOld > 12;
+                $this->info("$file - $lastModified - $shouldDelete");
+                //if ($shouldDelete) $disk->delete($file);
+            }
+        }
+    }
+}

--- a/api/app/GraphQL/Mutations/MakeAFile.php
+++ b/api/app/GraphQL/Mutations/MakeAFile.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Illuminate\Validation\UnauthorizedException;
+
+final class MakeAFile
+{
+    /**
+     * Closes the pool by setting the archived_at to now().
+     *
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $userId = Auth::id();
+
+        throw_unless(is_string($userId), UnauthorizedException::class);
+
+        $response = Http::get('https://loremflickr.com/640/360');
+
+        $newFilename = ((string) Str::orderedUuid()).'.jpg'; // https://stackoverflow.com/a/50535499
+
+        Storage::disk('userGenerated')->put($userId.'/'.$newFilename, $response->body());
+
+        return $newFilename;
+    }
+}

--- a/api/app/Http/Controllers/UserGeneratedFilesController.php
+++ b/api/app/Http/Controllers/UserGeneratedFilesController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+class UserGeneratedFilesController extends Controller
+{
+    /*
+    curl http://localhost:8000/api/user-generated-files/Synthesis_NASA_data_Vis_720p_YouTube.mp4  \
+     -O \
+     -H "Authorization: Bearer {accessToken}"
+   */
+
+    public function getFile(string $fileName)
+    {
+        // https://laravel.com/docs/10.x/authentication#accessing-specific-guard-instances
+        $userId = Auth::guard('api')->id();
+        throw_unless(is_string($userId), UnauthorizedHttpException::class);
+
+        $filePath = $userId.'/'.$fileName;
+        throw_unless(Storage::disk('userGenerated')->exists($filePath), NotFoundHttpException::class);
+
+        switch (strtolower(pathinfo($filePath)['extension'])) {
+            case 'jpg':
+                $contentType = ['Content-Type' => 'image/jpeg'];
+                break;
+            case 'mp4':
+                $contentType = ['Content-Type' => 'video/mpeg'];
+                break;
+        }
+
+        /* unbuffered response */
+        // return response()->streamDownload(function () use ($filePath) {
+        //     echo Storage::disk('userGenerated')->get($filePath);
+        // }, $fileName, $contentType);
+
+        /* buffered response */
+        return response()->streamDownload(function () use ($filePath) {
+            $handle = Storage::disk('userGenerated')->readStream($filePath);
+            while (! feof($handle)) {
+                $buffer = fread($handle, 4096);
+                if (! is_bool($buffer)) {
+                    echo $buffer;
+                }
+            }
+            fclose($handle);
+        }, $fileName, $contentType);
+
+    }
+}

--- a/api/config/filesystems.php
+++ b/api/config/filesystems.php
@@ -35,6 +35,11 @@ return [
             'root' => storage_path('app'),
         ],
 
+        'userGenerated' => [
+            'driver' => 'local',
+            'root' => storage_path('app').'/user-generated',
+        ],
+
         // A somewhat hacky solution to enable deploying the app in a read-only directory
         'tmp' => [
             'driver' => 'local',

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1881,6 +1881,8 @@ type Mutation {
   updateSitewideAnnouncement(
     sitewideAnnouncementInput: SitewideAnnouncementInput! @spread
   ): SitewideAnnouncement @guard
+
+  makeAFile: String @guard
 }
 
 #import directiveForms.graphql

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\SupportController;
+use App\Http\Controllers\UserGeneratedFilesController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -16,3 +17,10 @@ use Illuminate\Support\Facades\Route;
 Route::prefix('support')->controller(SupportController::class)->group(function () {
     Route::post('/tickets', 'createTicket');
 });
+
+Route::prefix('user-generated-files')
+    ->controller(UserGeneratedFilesController::class)->group(function () {
+        Route::get('/{fileName}', 'getFile')
+        // api/config/auth.php
+            ->middleware('auth:api');
+    });

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -152,6 +152,7 @@ type Mutation {
   updateAssessmentResult(updateAssessmentResult: UpdateAssessmentResultInput!): AssessmentResult
   deleteAssessmentResult(id: UUID!): AssessmentResult
   updateSitewideAnnouncement(sitewideAnnouncementInput: SitewideAnnouncementInput!): SitewideAnnouncement
+  makeAFile: String
   createDigitalContractingQuestionnaire(digitalContractingQuestionnaire: DigitalContractingQuestionnaireInput!): DigitalContractingQuestionnaire
   updateDigitalContractingQuestionnaire(id: UUID!, digitalContractingQuestionnaire: DigitalContractingQuestionnaireInput!): DigitalContractingQuestionnaire
   deleteDigitalContractingQuestionnaire(id: UUID!): DigitalContractingQuestionnaire


### PR DESCRIPTION
🤖 Related to (but does not close) #8852 

> [!Warning]
> This PR should not be merged.  It is a proof of concept, not production-ready code.

## 👋 Introduction

This branch provides a sample solution to serving user generated files from the web server's local storage.

Pros:
- Fairly simple code.
- No extra infrastructure to set up.
- Can hook into Laravel auth.

Cons:
- Possible to fill up our storage.
- Files (probably?) lost when app service recycled.
- Ties up a PHP-FPM worker during download.
- (Probably?) not comparatively fast.

## 🕵️ Details

You can simulate the operation of a graphql response resulting in a file by running:
```graphql
mutation MyMutation {
  makeAFile
}
```
In reality, this just downloads an image from a lorem generator.  You must be logged in to do this.  It will save the file in a directory with your user ID.  The files go into a custom `api/storage/app/user-generated` directory locally but would probably go into '/tmp' somewhere in the app service.

To download the file you can use your browser, a tool like Postman, or utility like curl.  You must send the authorization header for the same user that made the file.

```bash
curl http://localhost:8000/api/user-generated-files/Synthesis_NASA_data_Vis_720p_YouTube.mp4  \
  -O \
  -H "Authorization: Bearer {accessToken}"
```

An alternative to enforcing a logged in user in the controller would be to provide a [signed URL](https://laravel.com/docs/10.x/urls#signed-urls) when generating the file.  This would then be shareable by the user.  You would still need to stream the file download through the controller, though.

To clean up old files, I added an Artisan command that would be run periodically, either manually or by a scheduler.
```bash
php artisan app:prune-user-generated-files
```
It's set to delete after 12 hours and the actual delete is commented out right now.  You can see a "1" on the rows that would be deleted.

## 🧪 Testing

- [ ] When authenticated you can make a file.
- [ ] When not authenticated you cannot make a file.
- [ ] When authenticated with the same user you can get the file.
- [ ] When authenticated as a different user you cannot get the file.
- [ ] When not authenticated  you cannot get the file.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/c2e1f089-f3b9-443f-8713-7cb885cbb550)
