### PR TITLE
[Debt] Removes the dark mode feature flag

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -18,7 +18,6 @@ OAUTH_LOGOUT_URI="http://localhost:8000/oxauth/endsession"
 #FEATURE_STATUS_NOTIFICATIONS=true  // not yet implemented on the client side
 FEATURE_DIRECTIVE_FORMS=true
 FEATURE_RECORD_OF_DECISION=true
-FEATURE_DARK_MODE=true
 
 # Logging - enable by setting the logging level. Eight severity levels from rfc5424.
 LOG_CONSOLE_LEVEL="debug"

--- a/apps/web/public/config.ejs
+++ b/apps/web/public/config.ejs
@@ -16,7 +16,6 @@ const data = new Map([
     // Feature flags
     ["FEATURE_DIRECTIVE_FORMS", filterUnusable("$FEATURE_DIRECTIVE_FORMS") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_DIRECTIVE_FORMS %>"],
     ["FEATURE_RECORD_OF_DECISION", filterUnusable("$FEATURE_RECORD_OF_DECISION") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_RECORD_OF_DECISION %>"],
-    ["FEATURE_DARK_MODE", filterUnusable("$FEATURE_DARK_MODE") ?? "<%= htmlWebpackPlugin.options.environment.FEATURE_DARK_MODE %>"],
 
     // Azure application insights not used in dev
     ["APPLICATIONINSIGHTS_CONNECTION_STRING", filterUnusable("$APPLICATIONINSIGHTS_CONNECTION_STRING")],

--- a/apps/web/src/components/Header/Header.tsx
+++ b/apps/web/src/components/Header/Header.tsx
@@ -8,7 +8,6 @@ import {
   oppositeLocale,
   useLocale,
 } from "@gc-digital-talent/i18n";
-import { useFeatureFlags } from "@gc-digital-talent/env";
 
 import { GocLogoEn, GocLogoFr, GocLogoWhiteEn, GocLogoWhiteFr } from "../Svg";
 import ThemeSwitcher from "../ThemeSwitcher/ThemeSwitcher";
@@ -20,7 +19,6 @@ interface HeaderProps {
 const Header = ({ width }: HeaderProps) => {
   const intl = useIntl();
   const { locale } = useLocale();
-  const { darkMode } = useFeatureFlags();
 
   const location = useLocation();
   const changeToLang = oppositeLocale(locale);
@@ -93,11 +91,9 @@ const Header = ({ width }: HeaderProps) => {
             data-h2-justify-content="base(center) p-tablet(flex-end)"
             data-h2-text-align="base(center) p-tablet(left)"
           >
-            {darkMode && (
-              <div>
-                <ThemeSwitcher />
-              </div>
-            )}
+            <div>
+              <ThemeSwitcher />
+            </div>
             <div>
               <a
                 data-h2-background-color="base:focus-visible(focus)"

--- a/packages/env/src/utils.ts
+++ b/packages/env/src/utils.ts
@@ -41,7 +41,6 @@ export const checkFeatureFlag = (name: string): boolean => {
 export const getFeatureFlags = () => ({
   directiveForms: checkFeatureFlag("FEATURE_DIRECTIVE_FORMS"),
   recordOfDecision: checkFeatureFlag("FEATURE_RECORD_OF_DECISION"),
-  darkMode: checkFeatureFlag("FEATURE_DARK_MODE"),
 });
 
 export type FeatureFlags = ReturnType<typeof getFeatureFlags>;

--- a/packages/theme/src/components/ThemeProvider.tsx
+++ b/packages/theme/src/components/ThemeProvider.tsx
@@ -70,7 +70,6 @@ const ThemeProvider = ({
   override,
   themeSelector,
 }: ThemeProviderProps) => {
-  const { darkMode } = useFeatureFlags();
   const [theme, setTheme] = useLocalStorage<Theme>(
     "theme",
     getDefaultTheme(override),
@@ -111,9 +110,6 @@ const ThemeProvider = ({
 
     if (computedMode && key) {
       themeString = `${key} ${computedMode}`;
-      if (!darkMode) {
-        themeString = key;
-      }
     } else if (key) {
       themeString = key;
     } else if (mode) {
@@ -129,7 +125,7 @@ const ThemeProvider = ({
         item.dataset.h2 = themeString;
       }
     });
-  }, [computedMode, darkMode, key, mode, themeSelector]);
+  }, [computedMode, key, mode, themeSelector]);
 
   const testDark = React.useCallback(() => {
     const isSet = mode && mode !== "pref";

--- a/packages/theme/src/components/ThemeProvider.tsx
+++ b/packages/theme/src/components/ThemeProvider.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import { useLocalStorage } from "@gc-digital-talent/storage";
-import { useFeatureFlags } from "@gc-digital-talent/env";
 
 import {
   ThemeMode,


### PR DESCRIPTION
🤖 Resolves #9291 

## 👋 Introduction

Dark mode has been deployed now as a beta so we no longer need the feature flag.

## 🧪 Testing

1. Confirm no more instances of `FEATURE_DARK_MODE` and `darkMode`
2. Confirm app still builds and light/dark mode are working as expected

## 🚚 Deployment

Remove `FEATURE_DARK_MODE` env var.
