### PR TITLE
[Fix] In library skill count

### DIFF
--- a/apps/web/src/components/SkillBrowser/utils.ts
+++ b/apps/web/src/components/SkillBrowser/utils.ts
@@ -363,6 +363,14 @@ export const getFamilyOptions = (
   category?: SkillCategory | "all",
   inLibrary?: Skill[],
 ): Option[] => {
+  const filteredSkills =
+    category !== "all"
+      ? skills.filter((skill) => skill.category === category)
+      : skills;
+  const filteredLibrary = inLibrary?.filter((librarySkill) =>
+    skills.some((skill) => skill.id === librarySkill.id),
+  );
+
   let familyOptions = [
     {
       value: "all",
@@ -375,14 +383,14 @@ export const getFamilyOptions = (
         {
           count:
             category && category !== "all"
-              ? getSkillCategorySkillCount(skills, category)
+              ? filteredSkills.length
               : skills.length,
         },
       ),
     },
   ];
 
-  if (inLibrary) {
+  if (filteredLibrary) {
     familyOptions = [
       ...familyOptions,
       {
@@ -395,7 +403,7 @@ export const getFamilyOptions = (
               "Label for filtering skills by ones already added to the users library",
           },
           {
-            count: inLibrary.length,
+            count: filteredLibrary.length,
           },
         ),
       },


### PR DESCRIPTION
🤖 Resolves #9602 

## 👋 Introduction

Fixes the skill count for "in library" skills when being filtered by category.

## 🕵️ Details

This applies a second filter when the category is selected to only get those skills in the users library and the category to more accurately reflect the number of skills that will be avilable.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. navigate to a skill showcase
3. Click the add a new item button
4. Confirm the number of library skills in the family select matches those available in the combobox

## 📸 Screenshot

![Screenshot 2024-03-04 081222](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/c655bd6d-c294-490a-973f-4eb2c312c02d)
![Screenshot 2024-03-04 081232](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/8ca80ca9-8660-4709-9765-2182e4f7be94)
