### PR TITLE
[Fix] Preferred lang sort on pool candidates table

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -308,8 +308,6 @@ export function transformSortStateToOrderByClause(
     ["candidateName", "FIRST_NAME"],
     ["email", "EMAIL"],
     ["preferredLang", "PREFERRED_LANG"],
-    ["preferredLang", "PREFERRED_LANGUAGE_FOR_INTERVIEW"],
-    ["preferredLang", "PREFERRED_LANGUAGE_FOR_EXAM"],
     ["currentLocation", "CURRENT_CITY"],
     ["skillCount", "skill_count"],
     ["priority", "PRIORITY_WEIGHT"],


### PR DESCRIPTION
🤖 Resolves #9298 

## 👋 Introduction

Fixes and issue where we were sorting the pool candidates table language field on the wrong database column.

## 🕵️ Details

We have multiple items in the column name map for `preferredLang`. The last item was being used which was not intended. This just removes the incorrect items in the map so the proper column name is used.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login as admin`admin@test.com`
3. Navigate to `/admin/pool-candidates`
4. Sort by the "Preferred communication language" column
5. Confirm the sorting is happening as expected

## 📸 Screenshot

![Screenshot 2024-03-04 082143](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/322cc618-3eb1-4efc-93f1-9240e88fbb40)
![Screenshot 2024-03-04 082148](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/b278705a-d9eb-4da5-bcfc-aaa04433b713)
