### PR TITLE
[Feature] Assessment step tracker null states

### DIFF
--- a/apps/web/src/components/AssessmentStepTracker/AssessmentResults.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentResults.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { Board, Link } from "@gc-digital-talent/ui";
+import { Board, Link, Well } from "@gc-digital-talent/ui";
 import {
   Maybe,
   Scalars,
@@ -152,12 +152,13 @@ const AssessmentResults = ({
   stepType,
   stepName,
 }: AssessmentResultsProps) => {
+  const intl = useIntl();
   const sortedResults = sortResultsAndAddOrdinal(results);
   const candidateIds = sortedResults.map((result) => result.poolCandidate.id);
   const isApplicationStep =
     stepType === AssessmentStepType.ApplicationScreening;
 
-  return (
+  return sortedResults.length ? (
     <Board.List>
       {sortedResults.map((result) => (
         <AssessmentResult
@@ -169,6 +170,17 @@ const AssessmentResults = ({
         />
       ))}
     </Board.List>
+  ) : (
+    <Well fontSize="caption" data-h2-margin="base(x.25)">
+      <p>
+        {intl.formatMessage({
+          defaultMessage: "There are no candidate results in this step.",
+          id: "BCBPYT",
+          description:
+            "Message displayed when no candidates are being assessed in a step",
+        })}
+      </p>
+    </Well>
   );
 };
 

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
@@ -71,7 +71,7 @@ const AssessmentStepTracker = ({ pool }: AssessmentStepTrackerProps) => {
                 <Board.ColumnHeader prefix={stepNumber}>
                   {stepName}
                 </Board.ColumnHeader>
-                <ResultsDetails {...{ resultCounts, step }} />
+                <ResultsDetails {...{ resultCounts, step, filters }} />
                 <AssessmentResults
                   stepType={step.type}
                   stepName={

--- a/apps/web/src/components/AssessmentStepTracker/ResultsDetails.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/ResultsDetails.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { Board } from "@gc-digital-talent/ui";
+import { Board, Well } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 import Counter from "@gc-digital-talent/ui/src/components/Button/Counter";
 import { AssessmentStep, AssessmentStepType } from "@gc-digital-talent/graphql";
@@ -9,7 +9,7 @@ import { AssessmentStep, AssessmentStepType } from "@gc-digital-talent/graphql";
 import { NullableDecision } from "~/utils/assessmentResults";
 import { ResultDecisionCounts } from "~/utils/poolCandidate";
 
-import { getDecisionInfo, decisionOrder } from "./utils";
+import { getDecisionInfo, decisionOrder, ResultFilters } from "./utils";
 
 interface StatusCountProps {
   counter: number;
@@ -70,9 +70,14 @@ const StatusCount = ({
 interface ResultsDetailsProps {
   step: AssessmentStep;
   resultCounts?: ResultDecisionCounts;
+  filters?: ResultFilters;
 }
 
-const ResultsDetails = ({ step, resultCounts }: ResultsDetailsProps) => {
+const ResultsDetails = ({
+  step,
+  resultCounts,
+  filters,
+}: ResultsDetailsProps) => {
   const [isOpen, setIsOpen] = React.useState<boolean>(true);
   const intl = useIntl();
   const stepTitle = getLocalizedName(step.title, intl);
@@ -84,6 +89,8 @@ const ResultsDetails = ({ step, resultCounts }: ResultsDetailsProps) => {
     },
     0,
   );
+
+  const decisions = decisionOrder.filter((decision) => !!filters?.[decision]);
 
   return (
     <Board.Info
@@ -115,14 +122,26 @@ const ResultsDetails = ({ step, resultCounts }: ResultsDetailsProps) => {
       }
     >
       <div data-h2-display="base(flex)" data-h2-flex-direction="base(column)">
-        {decisionOrder.map((decision) => (
-          <StatusCount
-            key={decision}
-            decision={decision}
-            counter={resultCounts ? resultCounts[decision] : 0}
-            isApplicationStep={isApplicationStep}
-          />
-        ))}
+        {decisions.length ? (
+          decisions.map((decision) => (
+            <StatusCount
+              key={decision}
+              decision={decision}
+              counter={resultCounts ? resultCounts[decision] : 0}
+              isApplicationStep={isApplicationStep}
+            />
+          ))
+        ) : (
+          <Well fontSize="caption">
+            <p>
+              {intl.formatMessage({
+                defaultMessage: "There are no selected statuses.",
+                id: "NJUJl0",
+                description: "Message displayed when no statuses are shown",
+              })}
+            </p>
+          </Well>
+        )}
       </div>
     </Board.Info>
   );


### PR DESCRIPTION
🤖 Resolves #9609 

## 👋 Introduction

Adds null states to the assessment step tracker column  list and distribution summary.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to a pools screening and assessment page
3. Turn off all filters
4. Confirm the null states appear as expected

## 📸 Screenshot

![Screenshot 2024-03-04 123849](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/c7086c17-8f0c-4b3f-8263-5a8835779606)
