### PR TITLE
Allow for override of Input maxLength. Extend maxLength for Pool location fields.

### DIFF
--- a/apps/web/src/pages/Pools/EditPoolPage/components/CoreRequirementsSection/CoreRequirementsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/CoreRequirementsSection/CoreRequirementsSection.tsx
@@ -164,6 +164,7 @@ const CoreRequirementsSection = ({
                           "Label for a pool advertisements specific English Location",
                       })}
                       disabled={formDisabled}
+                      maxLength={1023}
                     />
                     <Input
                       id="specificLocationFr"
@@ -176,6 +177,7 @@ const CoreRequirementsSection = ({
                           "Label for a pool advertisements specific French Location",
                       })}
                       disabled={formDisabled}
+                      maxLength={1023}
                     />
                   </>
                 ) : undefined}

--- a/packages/forms/src/components/Input/Input.tsx
+++ b/packages/forms/src/components/Input/Input.tsx
@@ -19,6 +19,7 @@ export type InputProps = HTMLInputProps &
     type: "text" | "number" | "email" | "tel" | "password" | "search";
     // Whether to trim leading/ending whitespace upon blurring of an input, default on
     whitespaceTrim?: boolean;
+    maxLength?: number;
   };
 
 const Input = ({
@@ -32,6 +33,7 @@ const Input = ({
   "aria-describedby": describedBy,
   whitespaceTrim = true,
   trackUnsaved = true,
+  maxLength = 255,
   ...rest
 }: InputProps) => {
   const intl = useIntl();
@@ -81,9 +83,9 @@ const Input = ({
         {...register(name, {
           maxLength: {
             message: intl.formatMessage(errorMessages.overCharacterLimit, {
-              value: 256,
+              value: maxLength + 1,
             }),
-            value: 255,
+            value: maxLength,
           },
           ...rules,
           onBlur: normalizeInput,


### PR DESCRIPTION
🤖 Resolves #9631

## 👋 Introduction

Recruitment team needs to publish a job which requires an in-office presence but has offices in many cities across the country, and they don't all fit into 256 characters.  (They require three-hundred-something characters.) A rich-text field may be the better way to go, but here's a quick fix for now.

## 🕵️ Details

Allows for overriding the maxLength rule on our Input component.

## 🧪 Testing

1. Log in as an admin
2. Edit a draft poster
3. edit Core Requirements
4. set location to Specific Location
5. Add add lest 400 characters of text to Specific Location (English) and Specific Location (French) fields.
6. Make sure you can save the poster
7. Make sure you can publish the poster
8. Make sure the location text appears correctly on the published poster.
