### PR TITLE
[Fix] Prevent combobox auto focus

### DIFF
--- a/packages/forms/src/components/Combobox/Multi.tsx
+++ b/packages/forms/src/components/Combobox/Multi.tsx
@@ -35,9 +35,12 @@ const Multi = ({
 }: MultiProps) => {
   const intl = useIntl();
   const [inputValue, setInputValue] = React.useState<string>("");
-  const [available, setAvailable] = React.useState<Option[]>([]);
+  const [available, setAvailable] = React.useState<Option[]>(options);
   const inputRef = React.useRef<HTMLInputElement | null>(null);
-  const items = isExternalSearch ? options : available;
+  const items = React.useMemo(
+    () => (isExternalSearch ? options : available),
+    [available, isExternalSearch, options],
+  );
 
   const handleInputChanged = (newQuery?: string) => {
     const query = newQuery ?? "";

--- a/packages/forms/src/components/Combobox/Single.tsx
+++ b/packages/forms/src/components/Combobox/Single.tsx
@@ -30,7 +30,10 @@ const Single = ({
 }: SingleProps) => {
   const [available, setAvailable] = React.useState<Option[]>(options);
   const inputRef = React.useRef<HTMLInputElement | null>(null);
-  const items = isExternalSearch ? options : available;
+  const items = React.useMemo(
+    () => (isExternalSearch ? options : available),
+    [available, isExternalSearch, options],
+  );
 
   const {
     isOpen,
@@ -75,10 +78,6 @@ const Single = ({
     selectItem(null);
     inputRef?.current?.focus();
   };
-
-  React.useEffect(() => {
-    setAvailable(options);
-  }, [options]);
 
   return (
     <>

--- a/packages/forms/src/components/Combobox/Single.tsx
+++ b/packages/forms/src/components/Combobox/Single.tsx
@@ -79,6 +79,10 @@ const Single = ({
     inputRef?.current?.focus();
   };
 
+  React.useEffect(() => {
+    setAvailable(options);
+  }, [options]);
+
   return (
     <>
       <Field.Label {...getLabelProps()} required={isRequired}>


### PR DESCRIPTION
🤖 Resolves #9598 

## 👋 Introduction

Fixes an issue where the comobox input was receiving focus when it mounted.

## 🕵️ Details

We were using a `useEffect` to sync the options with the items passed in. The issue was, we initially set the options to an empty array so it was unnecessarily re-rendering on mount and getting focus. I'm still not sure why it was receiving focus on re-render but this solves that issue along with making the component more stable by avoiding that initial re-render.

To do this, we set the available options in the default state instead of the empty array. Then, we rely on `useMemo` to keep the items a bit more stable. Now, the `useEffect` does not detect an initial change in options so does not fire and cause unnecessary re-renders.

## 🧪 Testing

1. Build `npm run dev`
2. Navigate to any combobox (pool candidates filter dialog works well for this)
3. Confirm that no combobox receives focus immediately

### ◀️  Regression Test 

1. Navigate to a skill browser
2. Select a family
3. Open the skills combobox menu
4. Confirm the available options matches the items in the selected skill family
5. Repeat steps 2-4 with different families
