### PR TITLE
[Debt] Update assessment step tracker initial state

### DIFF
--- a/apps/web/src/components/AssessmentStepTracker/ResultsDetails.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/ResultsDetails.tsx
@@ -78,7 +78,7 @@ const ResultsDetails = ({
   resultCounts,
   filters,
 }: ResultsDetailsProps) => {
-  const [isOpen, setIsOpen] = React.useState<boolean>(true);
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const intl = useIntl();
   const stepTitle = getLocalizedName(step.title, intl);
   const isApplicationStep =

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -233,9 +233,9 @@ export type ResultFilters = {
 export const defaultFilters: ResultFilters = {
   query: "",
   [NO_DECISION]: true,
-  [AssessmentDecision.Successful]: true,
-  [AssessmentDecision.Hold]: true,
-  [AssessmentDecision.Unsuccessful]: true,
+  [AssessmentDecision.Successful]: false,
+  [AssessmentDecision.Hold]: false,
+  [AssessmentDecision.Unsuccessful]: false,
 };
 
 export const filterResults = (


### PR DESCRIPTION
🤖 Resolves #9610 

## 👋 Introduction

Changes the initial state of the step tracker to only show "to assess" status and hide the distribution summary.

## 🧪 Testing

1. Build `npm run dev`
2. Login as admin `admin@test.com`
3. Navigate to a process screening and assessment page
4. Confirm that only the  "to assess" filter is enabled
5. Confirm the distribution is collapsed

## 📸 Screenshot

![Screenshot 2024-03-05 123831](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/6cb176cb-1521-4278-a8fc-3f2eb75ea8ac)
