### PR TITLE
[Bug] Associate ScreeningDecisionDialog skill levels with pool's

### DIFF
--- a/apps/web/src/components/AssessmentResultsTable/testData.ts
+++ b/apps/web/src/components/AssessmentResultsTable/testData.ts
@@ -19,6 +19,7 @@ import {
   PoolSkill,
   PoolSkillType,
   Skill,
+  SkillLevel,
 } from "@gc-digital-talent/graphql";
 
 faker.seed(0);
@@ -31,6 +32,7 @@ const essentialPoolSkills: PoolSkill[] =
     return {
       id: faker.string.uuid(),
       type: PoolSkillType.Essential,
+      requiredLevel: SkillLevel.Beginner,
       skill: {
         ...fakeSkills(1)[0],
         id: faker.string.uuid(),
@@ -47,6 +49,7 @@ const nonEssentialPoolSkills: PoolSkill[] =
     return {
       id: faker.string.uuid(),
       type: PoolSkillType.Nonessential,
+      requiredLevel: SkillLevel.Beginner,
       skill: {
         ...fakeSkills(1)[0],
         id: faker.string.uuid(),

--- a/apps/web/src/components/ScreeningDecisions/useHeaders.ts
+++ b/apps/web/src/components/ScreeningDecisions/useHeaders.ts
@@ -19,8 +19,8 @@ const getHeaders = (intl: IntlShape, args: Args) => {
     args;
   const reviewAndRecord = intl.formatMessage(
     {
-      defaultMessage: `Review and record {candidateName}'s results on "{skillName} at the "{skillLevel}" level.`,
-      id: "YGE5XN",
+      defaultMessage: `Review and record {candidateName}'s results on "{skillName}" at the "{skillLevel}" level.`,
+      id: "e1mxkv",
       description:
         "Subtitle for education requirement screening decision dialog.",
     },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6474,10 +6474,6 @@
     "defaultMessage": "Apprendre comment décrire le mieux possible votre expérience d’une compétence",
     "description": "Button text to open accordion describing skill experience"
   },
-  "YGE5XN": {
-    "defaultMessage": "Examiner et consigner les résultats de {candidateName} concernant \"{skillName} au \"{skillLevel}\" niveau.",
-    "description": "Subtitle for education requirement screening decision dialog."
-  },
   "YGM/D5": {
     "defaultMessage": "Le programme dure 24 mois et les apprentis ont accès à un soutien pendant leur période de participation au programme.",
     "description": "Learn more dialog question two paragraph one"
@@ -7521,6 +7517,10 @@
   "e1JW62": {
     "defaultMessage": "Les renseignements personnels recueillis par l’entremise de Talents numériques du GC sont utilisés aux fins des activités de dotation, de recrutement et la mobilité interne des talents au sein des institutions fédérales, conformément au <justiceLaws7Link>paragraphe 7(1)</justiceLaws7Link> de la Loi sur la gestion des finances publiques, aux paragraphes <justiceLaws15Link>15(1)</justiceLaws15Link>, <justiceLaws29Link>29</justiceLaws29Link> et <justiceLaws30Link>30 (1), (2), and (3)</justiceLaws30Link> de la Loi sur l’emploi dans la fonction publique et de l’article 5 de la Loi sur l’équité en matière d’emploi.",
     "description": "Paragraph for privacy policy page"
+  },
+  "e1mxkv": {
+    "defaultMessage": "Examiner et consigner les résultats de {candidateName} concernant \"{skillName}\" au \"{skillLevel}\" niveau.",
+    "description": "Subtitle for education requirement screening decision dialog."
   },
   "e2qUId": {
     "defaultMessage": "Processus exécuté par {team} à {departments}",

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
@@ -328,6 +328,7 @@ const PoolCandidate_SnapshotQuery = graphql(/* GraphQL */ `
         poolSkills {
           id
           type
+          requiredLevel
           skill {
             name {
               en
@@ -398,6 +399,7 @@ const PoolCandidate_SnapshotQuery = graphql(/* GraphQL */ `
         poolSkill {
           id
           type
+          requiredLevel
           skill {
             id
             key

--- a/packages/fake-data/src/fakePoolSkills.ts
+++ b/packages/fake-data/src/fakePoolSkills.ts
@@ -1,6 +1,11 @@
 import { faker } from "@faker-js/faker";
 
-import { PoolSkillType, PoolSkill, Skill } from "@gc-digital-talent/graphql";
+import {
+  PoolSkillType,
+  PoolSkill,
+  Skill,
+  SkillLevel,
+} from "@gc-digital-talent/graphql";
 
 import fakeSkills from "./fakeSkills";
 
@@ -9,6 +14,9 @@ const generatePoolSkill = (): PoolSkill => {
     id: faker.string.uuid(),
     type: faker.helpers.arrayElement<PoolSkillType>(
       Object.values(PoolSkillType),
+    ),
+    requiredLevel: faker.helpers.arrayElement<SkillLevel>(
+      Object.values(SkillLevel),
     ),
     skill: faker.helpers.arrayElement<Skill>(fakeSkills(1)),
   };

--- a/packages/fake-data/src/fakePools.ts
+++ b/packages/fake-data/src/fakePools.ts
@@ -22,6 +22,7 @@ import {
   AssessmentStepType,
   PoolSkillType,
   PoolSkill,
+  SkillLevel,
 } from "@gc-digital-talent/graphql";
 
 import fakeScreeningQuestions from "./fakeScreeningQuestions";
@@ -61,6 +62,9 @@ const generatePool = (
       return {
         id: faker.string.uuid(),
         skill,
+        requiredLevel: faker.helpers.arrayElement<SkillLevel>(
+          Object.values(SkillLevel),
+        ),
         type: PoolSkillType.Essential,
       };
     }),
@@ -68,6 +72,9 @@ const generatePool = (
       return {
         id: faker.string.uuid(),
         skill,
+        requiredLevel: faker.helpers.arrayElement<SkillLevel>(
+          Object.values(SkillLevel),
+        ),
         type: PoolSkillType.Nonessential,
       };
     }),


### PR DESCRIPTION
🤖 Resolves #9524 

## 👋 Introduction

Have the screening dialogs draw their skill level from the pool itself and not from the user.

## 🧪 Testing

1. Setup pool with poster, assessments, and a candidate
2. Go to screening dialog and observe skill level, should match the pool's skill level

## 📸 Screenshot

Dialog view

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/777b50d5-fdf8-4d29-9f43-e526a191f1a6)

Matches poster

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/80ceeec2-8400-4158-a2ec-6b1171ca46f6)

Storybook dialog

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/537379db-2977-4c48-ac95-339da3ea161e)





