### PR TITLE
[Fix] Display of skill accordion subtitle

### DIFF
--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SkillAccordion.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SkillAccordion.tsx
@@ -92,26 +92,17 @@ const SkillAccordion = ({ poolSkill, required }: SkillAccordionProps) => {
         });
 
   const accordionSubtitle = (
-    <ul
+    <span
       data-h2-color="base(black.light)"
       data-h2-font-size="base(caption)"
-      data-h2-padding-left="base(0)"
       data-h2-margin-top="base(x.5)"
+      data-h2-display="base(flex)"
+      data-h2-gap="base(x.5)"
     >
-      (
-      <React.Fragment key={poolSkill.skill.name.en}>
-        <li data-h2-padding-left="base(0)" data-h2-display="base(inline)">
-          {skillLevelItem}
-        </li>
-        <span data-h2-margin="base(0 x.5)" aria-hidden>
-          •
-        </span>
-        <li data-h2-padding-left="base(0)" data-h2-display="base(inline)">
-          {screeningTime}
-        </li>
-      </React.Fragment>
-      )
-    </ul>
+      <span>{skillLevelItem}</span>
+      <span>&bull;</span>
+      <span>{screeningTime}</span>
+    </span>
   );
 
   return (

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SkillAccordion.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SkillAccordion.tsx
@@ -93,14 +93,16 @@ const SkillAccordion = ({ poolSkill, required }: SkillAccordionProps) => {
 
   const accordionSubtitle = (
     <span
+      data-h2-align-items="base(flex-start) p-tablet(center)"
       data-h2-color="base(black.light)"
       data-h2-font-size="base(caption)"
       data-h2-margin-top="base(x.5)"
       data-h2-display="base(flex)"
+      data-h2-flex-direction="base(column) p-tablet(row)"
       data-h2-gap="base(x.5)"
     >
       <span>{skillLevelItem}</span>
-      <span>&bull;</span>
+      <span data-h2-display="base(none) p-tablet(inline)">&bull;</span>
       <span>{screeningTime}</span>
     </span>
   );


### PR DESCRIPTION
🤖 Resolves #9672 

## 👋 Introduction

Fixes the display of the skill accordion subtitle by removing the parentheses and replacing the list with `span` tags.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Navigate to a job poster
3. Confirm the parentheses are no longer present in the subtitle
4. Confirm the list has been replaced by spans

## 📸 Screenshot

![Screenshot 2024-03-07 115744](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/ab5c7f29-ce46-4604-9a03-6286b0124a33)
