### PR TITLE
[Debt] Merge skill library tables

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1343,10 +1343,6 @@
     "defaultMessage": "Mes renseignements sur l'équité en matière d'emploi :",
     "description": "Label preceding what groups the user identifies as part of, followed by a colon"
   },
-  "5Z/SAX": {
-    "defaultMessage": "Les compétences techniques désignent les connaissances et les capacités techniques associées à des postes ou des rôles précis au sein de l’organisation. Les compétences techniques sont habituellement acquises dans le cadre d’une formation ou d’une expérience de travail particulières où la personne met en application ses connaissances et compétences.",
-    "description": "Definition of technical skills"
-  },
   "5bdLGy": {
     "defaultMessage": "Ce que nous pouvons faire pour vous",
     "description": "Heading for the executive opportunities"
@@ -1530,10 +1526,6 @@
   "6cEYtp": {
     "defaultMessage": "la cybersécurité;",
     "description": "An example in the _examples of contracts_ section of the _digital services contracting questionnaire_"
-  },
-  "6cFJ2w": {
-    "defaultMessage": "Cette section vous permet de gérer toutes les compétences techniques associées à votre profil, vos expériences et vos réalisations. Cliquez sur le nom d’une compétence pour obtenir une description détaillée.",
-    "description": "Description on how to use technical skills"
   },
   "6eCvv1": {
     "defaultMessage": "Postes bilingues (français et anglais)",
@@ -2451,10 +2443,6 @@
     "defaultMessage": "Établissement d’un bassin de talents numériques",
     "description": "Heading for the directives digital talent and sourcing component"
   },
-  "C1wuXs": {
-    "defaultMessage": "Cette section vous permet de gérer toutes les compétences comportementales associées à votre profil, vos expériences et vos réalisations. Cliquez sur le nom d’une compétence pour obtenir une description détaillée.",
-    "description": "Description on how to use behavioural skills"
-  },
   "C3fUwm": {
     "defaultMessage": "Version",
     "description": "Label for the specific version number of the site"
@@ -2763,6 +2751,10 @@
     "defaultMessage": "Plus élevé que 100",
     "description": "Contract FTE range greater than one-hundred"
   },
+  "Di1aEV": {
+    "defaultMessage": "Cette section vous permet de gérer toutes les compétences qui sont liées à votre profil, et votre démonstration des compétences. Sélectionnez le titre d’une compétences pour gérer de plus amples détails, y compris les détails ayant trait à votre niveau et à vos expériences de carrière connexes.",
+    "description": "Description on how to use behavioural skills"
+  },
   "DlBusi": {
     "defaultMessage": "Nom de famille",
     "description": "CSV Header, Last Name column"
@@ -2882,10 +2874,6 @@
   "EPF4Ac": {
     "defaultMessage": "Le processus de demande repose sur la collecte et l’examen des renseignements de manière linéaire. Par conséquent, il n’est pas encore possible de passer à cette étape. La dernière étape sur laquelle vous travailliez est mise en surbrillance dans la zone des étapes de la page, ou vous pouvez utiliser le bouton fourni pour y accéder directement.",
     "description": "Application step skipped page details"
-  },
-  "ERDq0Q": {
-    "defaultMessage": "Ajouter, modifier ou gérer des compétences comportementales et techniques dans votre profil.",
-    "description": "Page description for the skill library page"
   },
   "ETrCOq": {
     "defaultMessage": "Statut du candidat",
@@ -4311,6 +4299,10 @@
     "defaultMessage": "Chercher un nouveau membre à partir de la liste des gestionnaires approuvés.",
     "description": "Help text for user field on the add member to team form"
   },
+  "Mz7sON": {
+    "defaultMessage": "Gérez vos compétences",
+    "description": "Title for editing a users skills"
+  },
   "N/Vcp3": {
     "defaultMessage": "Ce à quoi vous pouvez vous attendre",
     "description": "Heading for the section about user expectations for their request"
@@ -4430,6 +4422,10 @@
   "NkZeS1": {
     "defaultMessage": "Talents numériques du GC s'associe au service de justificatifs du gouvernement du Canada, CléGC, pour vous donner accès à votre compte à l'aide d'une seule combinaison de nom d'utilisateur et de mot de passe. Vous pouvez gérer les données connexes sur le site Web de CléGC, et elles s'afficheront automatiquement ici lorsque vous accéderez à votre compte.",
     "description": "Description of how we use GCKey for authentication."
+  },
+  "NlYIHM": {
+    "defaultMessage": "Ajoutez, modifiez, et gérez les compétences de votre profil.",
+    "description": "Page description for the skill library page"
   },
   "NuT+Rx": {
     "defaultMessage": "Procéder à la mise à jour du sujet",
@@ -4999,10 +4995,6 @@
     "defaultMessage": "Révisé",
     "description": "Title displayed for the User table Date Updated column"
   },
-  "R4Z9FQ": {
-    "defaultMessage": "Les compétences comportementales désignent les principales qualités interpersonnelles et personnelles nécessaires pour occuper des emplois précis au sein de l’organisation. Ces compétences se rapportent généralement à la façon dont une personne agit, communique et interagit avec les autres.",
-    "description": "Definition of behavioural skills"
-  },
   "R5eNu/": {
     "defaultMessage": "Y aura-t-il un besoin continu pour les connaissances dans l’unité de travail pour laquelle l’entrepreneur est engagé?",
     "description": "Label for _ongoing need for knowledge_ fieldset in the _digital services contracting questionnaire_"
@@ -5138,10 +5130,6 @@
   "RiGj9w": {
     "defaultMessage": "Étape {currentStep}",
     "description": "Label for the candidates current assessment step"
-  },
-  "RjYGPw": {
-    "defaultMessage": "Chercher une compétence",
-    "description": "Label for the skill library table search input"
   },
   "Rk1i9Q": {
     "defaultMessage": "Ce programme élimine l’un des principaux obstacles à l’emploi en valorisant le potentiel d’une personne plutôt que son niveau de scolarité. Ce faisant, cette initiative contribue à combler les écarts en matière d’éducation, d’emploi et d’économie auxquelles sont confrontées les personnes autochtones du Canada.",
@@ -6841,6 +6829,10 @@
   "b8mC0r": {
     "defaultMessage": "La Directive n'introduit pas d'étapes de la procédure supplémentaires pour les responsables de l'approvisionnement, mais il existe des exigences en matière d'établissement de rapports liés à l'approvisionnement qui incombent aux responsables de l'initiative sur le numérique. Ces ressources sont conçues pour aider les responsables de l'approvisionnement à soutenir leurs clients lorsqu'ils achètent des services numériques (p. ex., des talents numériques, produits liés à la TI, à la gestion de l'information, etc.)",
     "description": "Body message for digital initiative procurement section."
+  },
+  "bBIZ3a": {
+    "defaultMessage": "Recherchez vos compétences",
+    "description": "Label for the skill library table search input"
   },
   "bBz/OJ": {
     "defaultMessage": "les résultats d’évaluation d’acceptation par les utilisateurs",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3007,10 +3007,6 @@
     "defaultMessage": "Vous êtes sur le point de publier l'annonce de ce processus : {poolName}",
     "description": "Text to confirm the process to be published"
   },
-  "FEK54g": {
-    "defaultMessage": "Bibliothèque des compétences techniques",
-    "description": "Title for technical skill library section"
-  },
   "FFD16/": {
     "defaultMessage": "Supprimer la candidature",
     "description": "Title for the modal that appears when a user attempts to delete an application"
@@ -10865,10 +10861,6 @@
   "yzgwjd": {
     "defaultMessage": "Province ou territoire",
     "description": "Label for current province or territory field"
-  },
-  "yzqnvb": {
-    "defaultMessage": "Bibliothèque des compétences comportementales",
-    "description": "Title for behavioural skill library section"
   },
   "z/J4uL": {
     "defaultMessage": "Statut de l’employé :",

--- a/apps/web/src/pages/Skills/SkillLibraryPage.tsx
+++ b/apps/web/src/pages/Skills/SkillLibraryPage.tsx
@@ -102,7 +102,7 @@ const SkillLibrary = ({ userSkills, skills }: SkillLibraryProps) => {
               >
                 {sections.manage.title}
               </TableOfContents.Heading>
-              <p data-h2-margin="base(x.5, 0)">
+              <p data-h2-margin="base(x1, 0)">
                 {intl.formatMessage({
                   defaultMessage:
                     "This section allows you to manage all the skills linked to your profile, experiences, and showcase. Select a skill's name to manage further details including your level and related career experiences.",

--- a/apps/web/src/pages/Skills/SkillLibraryPage.tsx
+++ b/apps/web/src/pages/Skills/SkillLibraryPage.tsx
@@ -1,19 +1,17 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import GlobeAmericasIcon from "@heroicons/react/24/outline/GlobeAmericasIcon";
-import CpuChipIcon from "@heroicons/react/24/outline/CpuChipIcon";
 import { OperationContext, useQuery } from "urql";
 import ChartPieIcon from "@heroicons/react/24/outline/ChartPieIcon";
+import BoltIcon from "@heroicons/react/24/outline/BoltIcon";
 
 import { TableOfContents, Pending, Link } from "@gc-digital-talent/ui";
-import { notEmpty } from "@gc-digital-talent/helpers/src/utils/util";
+import { unpackMaybes } from "@gc-digital-talent/helpers/src/utils/util";
 import { navigationMessages } from "@gc-digital-talent/i18n";
-import { Skill, SkillCategory, UserSkill } from "@gc-digital-talent/graphql";
+import { Skill, UserSkill } from "@gc-digital-talent/graphql";
 
 import SEO from "~/components/SEO/SEO";
 import Hero from "~/components/Hero/Hero";
 import useRoutes from "~/hooks/useRoutes";
-import { categorizeSkill, categorizeUserSkill } from "~/utils/skillUtils";
 
 import SkillLibraryTable from "./components/SkillLibraryTable";
 import { UserSkills_Query } from "./operations";
@@ -33,24 +31,13 @@ const SkillLibrary = ({ userSkills, skills }: SkillLibraryProps) => {
   const intl = useIntl();
   const paths = useRoutes();
 
-  const categorizedUserSkills = categorizeUserSkill(userSkills);
-  const categorizedSkills = categorizeSkill(skills);
-
   const sections: PageSections = {
-    behavioural: {
-      id: "behavioural",
+    manage: {
+      id: "manage",
       title: intl.formatMessage({
-        defaultMessage: "Behavioural skill library",
-        id: "yzqnvb",
-        description: "Title for behavioural skill library section",
-      }),
-    },
-    technical: {
-      id: "technical",
-      title: intl.formatMessage({
-        defaultMessage: "Technical skill library",
-        id: "FEK54g",
-        description: "Title for technical skill library section",
+        defaultMessage: "Manage your skills",
+        id: "Mz7sON",
+        description: "Title for editing a users skills",
       }),
     },
     showcase: {
@@ -81,10 +68,9 @@ const SkillLibrary = ({ userSkills, skills }: SkillLibraryProps) => {
   const pageTitle = intl.formatMessage(navigationMessages.skillLibrary);
 
   const pageDescription = intl.formatMessage({
-    defaultMessage:
-      "Add, edit, and manage behavioural and technical skills on your profile.",
+    defaultMessage: "Add, edit, and manage the skills on your profile.",
     description: "Page description for the skill library page",
-    id: "ERDq0Q",
+    id: "NlYIHM",
   });
 
   return (
@@ -96,13 +82,8 @@ const SkillLibrary = ({ userSkills, skills }: SkillLibraryProps) => {
           <TableOfContents.Navigation>
             <TableOfContents.List>
               <TableOfContents.ListItem>
-                <TableOfContents.AnchorLink id={sections.behavioural.id}>
-                  {sections.behavioural.title}
-                </TableOfContents.AnchorLink>
-              </TableOfContents.ListItem>
-              <TableOfContents.ListItem>
-                <TableOfContents.AnchorLink id={sections.technical.id}>
-                  {sections.technical.title}
+                <TableOfContents.AnchorLink id={sections.manage.id}>
+                  {sections.manage.title}
                 </TableOfContents.AnchorLink>
               </TableOfContents.ListItem>
               <TableOfContents.ListItem>
@@ -113,65 +94,26 @@ const SkillLibrary = ({ userSkills, skills }: SkillLibraryProps) => {
             </TableOfContents.List>
           </TableOfContents.Navigation>
           <TableOfContents.Content>
-            <TableOfContents.Section id={sections.behavioural.id}>
+            <TableOfContents.Section id={sections.manage.id}>
               <TableOfContents.Heading
-                icon={GlobeAmericasIcon}
+                icon={BoltIcon}
                 color="primary"
                 data-h2-margin="base(0, 0, x1, 0)"
               >
-                {sections.behavioural.title}
+                {sections.manage.title}
               </TableOfContents.Heading>
               <p data-h2-margin="base(x.5, 0)">
                 {intl.formatMessage({
                   defaultMessage:
-                    "This section allows you to manage all the behavioural skills linked to your profile, experiences, and showcase. Click on a skill's name to view further details.",
-                  id: "C1wuXs",
+                    "This section allows you to manage all the skills linked to your profile, experiences, and showcase. Select a skill's name to manage further details including your level and related career experiences.",
+                  id: "Di1aEV",
                   description: "Description on how to use behavioural skills",
                 })}
               </p>
-              <p data-h2-margin="base(x.5, 0, x1, 0)">
-                {intl.formatMessage({
-                  defaultMessage:
-                    "Behavioural skills refer to the key interpersonal and personal attributes that are necessary for specific jobs across the organization. These competencies generally refer to the way a person acts, communicates and interacts with others.",
-                  id: "R4Z9FQ",
-                  description: "Definition of behavioural skills",
-                })}
-              </p>
               <SkillLibraryTable
-                caption={sections.behavioural.title}
-                data={categorizedUserSkills[SkillCategory.Behavioural] ?? []}
-                allSkills={categorizedSkills[SkillCategory.Behavioural] ?? []}
-              />
-            </TableOfContents.Section>
-            <TableOfContents.Section id={sections.technical.id}>
-              <TableOfContents.Heading
-                icon={CpuChipIcon}
-                color="secondary"
-                data-h2-margin-top="base(x3)"
-              >
-                {sections.technical.title}
-              </TableOfContents.Heading>
-              <p data-h2-margin="base(x.5, 0)">
-                {intl.formatMessage({
-                  defaultMessage:
-                    "This section allows you to manage all the technical skills linked to your profile, experiences, and showcase. Click on a skill's name to view further details.",
-                  id: "6cFJ2w",
-                  description: "Description on how to use technical skills",
-                })}
-              </p>
-              <p data-h2-margin="base(x.5, 0, x1, 0)">
-                {intl.formatMessage({
-                  defaultMessage:
-                    "Technical skills refer to the technical knowledge and abilities that are relevant to specific jobs or roles across the organization. Technical skills are usually acquired through specific learning or work experience in applying the knowledge and skill.",
-                  id: "5Z/SAX",
-                  description: "Definition of technical skills",
-                })}
-              </p>
-              <SkillLibraryTable
-                isTechnical
-                caption={sections.technical.title}
-                data={categorizedUserSkills[SkillCategory.Technical] ?? []}
-                allSkills={categorizedSkills[SkillCategory.Technical] ?? []}
+                caption={sections.manage.title}
+                data={userSkills}
+                allSkills={skills}
               />
             </TableOfContents.Section>
             <TableOfContents.Section id={sections.showcase.id}>
@@ -215,12 +157,12 @@ const SkillLibraryPage = () => {
     context,
   });
 
-  const userSkills = data?.me?.userSkills?.filter(notEmpty);
-  const skills = data?.skills.filter(notEmpty);
+  const userSkills = unpackMaybes(data?.me?.userSkills);
+  const skills = unpackMaybes(data?.skills);
 
   return (
     <Pending fetching={fetching} error={error}>
-      <SkillLibrary userSkills={userSkills ?? []} skills={skills ?? []} />
+      <SkillLibrary userSkills={userSkills} skills={skills} />
     </Pending>
   );
 };

--- a/apps/web/src/pages/Skills/components/SkillLibraryTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillLibraryTable.tsx
@@ -15,7 +15,12 @@ import {
 } from "@gc-digital-talent/i18n";
 import { Link } from "@gc-digital-talent/ui";
 import { useAuthorization } from "@gc-digital-talent/auth";
-import { Skill, SkillLevel, UserSkill } from "@gc-digital-talent/graphql";
+import {
+  Skill,
+  SkillCategory,
+  SkillLevel,
+  UserSkill,
+} from "@gc-digital-talent/graphql";
 
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import { normalizedText } from "~/components/Table/sortingFns";
@@ -63,23 +68,17 @@ interface SkillLibraryTableProps {
   caption: string;
   data: UserSkill[];
   allSkills: Skill[];
-  isTechnical?: boolean;
 }
 
 const SkillLibraryTable = ({
   caption,
   data,
   allSkills,
-  isTechnical = false,
 }: SkillLibraryTableProps) => {
   const intl = useIntl();
   const paths = useRoutes();
   const { userAuthInfo } = useAuthorization();
   const [, executeCreateMutation] = useMutation(CreateUserSkill_Mutation);
-
-  const levelGetter = isTechnical
-    ? getTechnicalSkillLevel
-    : getBehaviouralSkillLevel;
 
   const userSkillSkillIds = data.map((usrSkill) => usrSkill.skill.id);
   const unclaimedSkills = allSkills.filter(
@@ -134,10 +133,19 @@ const SkillLibraryTable = ({
       }),
       cell: ({
         row: {
-          original: { skillLevel },
+          original: {
+            skillLevel,
+            skill: { category },
+          },
         },
       }: UserSkillCell) =>
-        skillLevel ? intl.formatMessage(levelGetter(skillLevel)) : null,
+        skillLevel
+          ? intl.formatMessage(
+              category === SkillCategory.Technical
+                ? getTechnicalSkillLevel(skillLevel)
+                : getBehaviouralSkillLevel(skillLevel),
+            )
+          : null,
       enableHiding: false,
       enableColumnFilter: false,
       sortingFn: skillLevelSort,

--- a/apps/web/src/pages/Skills/components/SkillLibraryTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillLibraryTable.tsx
@@ -171,8 +171,8 @@ const SkillLibraryTable = ({
       }}
       search={{
         label: intl.formatMessage({
-          defaultMessage: "Search for a skill",
-          id: "RjYGPw",
+          defaultMessage: "Search your skills",
+          id: "bBIZ3a",
           description: "Label for the skill library table search input",
         }),
         internal: true,


### PR DESCRIPTION
🤖 Resolves #9624 

## 👋 Introduction

Merges the separate technical and behavioral skill tables on the skill library page.

## 🧪 Testing

1. Build `npm run dev`
2. Login as applicant `applicant@test.com`
3. Navigate to the skill library
4. Confirm there is now only one table
5. Confirm the copy and layout match [the mockup ](https://www.figma.com/file/FhRhwczL8JI6JC8eVFlWOm/Skill-library?type=design&node-id=383-16577&mode=design&t=KkN8J2lX1u1JvsOe-0)
6. Confirm the add dialog shows all skills
7. Confirm the level matches the category of skill in the table

## 📸 Screenshot

![localhost_8000_en_applicant_profile-and-applications_skills (1)](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/5d4eefb8-2944-47f8-9d65-ae65477599b0)
