### PR TITLE
[Copy] Changes IAP program launch year to 2024

### DIFF
--- a/apps/web/src/lang/crg.json
+++ b/apps/web/src/lang/crg.json
@@ -323,8 +323,8 @@
     "defaultMessage": "Ihtakoun trwaw ispray la bonch di Indigene Li moond didawn aen Zhawn'd Kenadaw Constitution. Kakwaychimikawin chi-kayshchinahoohk tawnima Indigene la bonch(s) itouwuhk li moond kiya shawpou Indigene Li moond Kinish<softHyphen></softHyphen>taway<softHyphen></softHyphen>nikashoon Ay-ishchikataywin.",
     "description": "How it works, step 1 content paragraph 2"
   },
-  "0i34ZZ": {
-    "defaultMessage": "Itayimoowin chi-mawchistahk Paminikaywin weeput ishpee 2023.",
+  "utLdbN": {
+    "defaultMessage": "Itayimoowin chi-mawchistahk Paminikaywin weeput ishpee 2024.",
     "description": "Talent portal strategy item 4 content"
   },
   "gj0bQO": {

--- a/apps/web/src/lang/crk.json
+++ b/apps/web/src/lang/crk.json
@@ -323,8 +323,8 @@
     "defaultMessage": "nisto iyinito-ayisiniwak ayāwak itastēw Canadian Constitution. Kika-kakwēcimikawin awīna kiya anita Indigenous Peoples Self-Declaration Form",
     "description": "How it works, step 1 content paragraph 2"
   },
-  "0i34ZZ": {
-    "defaultMessage": "nantaw ka machihtawak wîpac ispayiki 2023.",
+  "utLdbN": {
+    "defaultMessage": "nantaw ka machihtawak wîpac ispayiki 2024.",
     "description": "Talent portal strategy item 4 content"
   },
   "gj0bQO": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -491,10 +491,6 @@
     "defaultMessage": "{experienceCount, plural, =0 {0 expérience en matière d’éducation et de certificats} =1 {1 expérience en matière d’éducation et de certificats} other {# expériences en matière d’éducation et de certificats}}",
     "description": "list a number of education experiences"
   },
-  "0i34ZZ": {
-    "defaultMessage": "Vise à lancer le programme au début de 2023.",
-    "description": "Talent portal strategy item 4 content"
-  },
   "0jV7Rn": {
     "defaultMessage": "Complet",
     "description": "Simplified status label for a complete process advertisement or assessment"
@@ -10273,6 +10269,10 @@
   "usb0gM": {
     "defaultMessage": "Bien que le libellé de ces catégories ait besoin d'être mis à jour, le gouvernement du Canada utilisera parfois ces catégories lors de l'embauche afin de s'assurer qu'il respecte les objectifs de l'équité en matière d'emploi.",
     "description": "Description of how the Government of Canada uses employment equity categories in hiring."
+  },
+  "utLdbN": {
+    "defaultMessage": "Vise à lancer le programme au début de 2024.",
+    "description": "Talent portal strategy item 4 content"
   },
   "utl6O/": {
     "defaultMessage": "Gérer le recrutement {title}",

--- a/apps/web/src/lang/mic.json
+++ b/apps/web/src/lang/mic.json
@@ -323,8 +323,8 @@
     "defaultMessage": "Etekl ne’siskl distinct groups wjit l’nu’k ta’n etek Kanata Constitution. Ki’l pipanimuksitis wjit tluwen teken L’nu’k eymu’tijik ta’n ki’l tley via l’nu’k majuinu’k Self-Declaration wi’katikn.",
     "description": "How it works, step 1 content paragraph 2"
   },
-  "0i34ZZ": {
-    "defaultMessage": "Jinu'kwalsi kisi tuwa'tn wula program ta'n poqjiaq 2023.",
+  "utLdbN": {
+    "defaultMessage": "Jinu'kwalsi kisi tuwa'tn wula program ta'n poqjiaq 2024.",
     "description": "Talent portal strategy item 4 content"
   },
   "gj0bQO": {

--- a/apps/web/src/lang/ojw.json
+++ b/apps/web/src/lang/ojw.json
@@ -323,8 +323,8 @@
     "defaultMessage": "Niswewaanigiziwag Anishinaabeg omaa Zhaaganaashiiwakiing. Gigagwejimigoo aandi wenjiiyan gaye ayaawiyan",
     "description": "How it works, step 1 content paragraph 2"
   },
-  "0i34ZZ": {
-    "defaultMessage": "Giga-maajitoomin anokiiwin ani-ziigwang 2023.",
+  "utLdbN": {
+    "defaultMessage": "Giga-maajitoomin anokiiwin ani-ziigwang 2024.",
     "description": "Talent portal strategy item 4 content"
   },
   "gj0bQO": {

--- a/apps/web/src/pages/Home/IAPHomePage/Home.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.tsx
@@ -891,8 +891,8 @@ export const Home = ({ query }: HomeProps) => {
                   <p>
                     {intl.formatMessage({
                       defaultMessage:
-                        "Aim to launch the program in the early half of 2023.",
-                      id: "0i34ZZ",
+                        "Aim to launch the program in the early half of 2024.",
+                      id: "utLdbN",
                       description: "Talent portal strategy item 4 content",
                     })}
                   </p>


### PR DESCRIPTION
🤖 Resolves #9700.

## 👋 Introduction

This PR changes the IAP program launch year to 2024.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `npm run build`
2. Navigate to `/en/indigenous-it-apprentice/`
3. Search for **2024**
4. Verify full sentence is **Aim to launch the program in the early half of 2024.**
5. Switch to each of `crg`, `crk`, `mic`, `ojw`, `fr` languages
6. Search for **2024**
7. Verify sentence contains **2024**

## 📸 Screenshots

<img width="497" alt="Screen Shot 2024-03-08 at 10 22 34" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/d4e1fe52-f109-4db8-9fe9-0e9ca834aa5d">
<img width="502" alt="Screen Shot 2024-03-08 at 10 22 13" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/73ededde-55a8-4577-aa9a-b63048189b05">
<img width="503" alt="Screen Shot 2024-03-08 at 10 23 32" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/3648849a-7ed9-46ce-99bf-02d9518f5484">
<img width="499" alt="Screen Shot 2024-03-08 at 10 23 17" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/31f42257-64c8-43fe-98e7-0ac49b4a3834">
<img width="490" alt="Screen Shot 2024-03-08 at 10 23 03" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/508cb3a9-47f9-4487-b850-e12dc72b117b">
<img width="500" alt="Screen Shot 2024-03-08 at 10 22 50" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/359dcd3f-1b7a-48cd-965e-15cfd6d1d269">