### PR TITLE
[Bug] Handle missing `where` in `CountPoolCandidatesByPool`

### DIFF
--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -13,7 +13,7 @@ final class CountPoolCandidatesByPool
      */
     public function __invoke($_, array $args)
     {
-        $filters = $args['where'];
+        $filters = ! empty($args['where']) ? $args['where'] : [];
 
         // query counts pool candidate rows, so start on that model
         $queryBuilder = PoolCandidate::query();

--- a/api/tests/Feature/CountPoolCandidatesByPoolTest.php
+++ b/api/tests/Feature/CountPoolCandidatesByPoolTest.php
@@ -87,6 +87,30 @@ class CountPoolCandidatesByPoolTest extends TestCase
         $user = User::factory()->create([]);
         PoolCandidate::factory()->create($this->poolCandidateData($pool, $user));
 
+        // no input
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+            query ($where: ApplicantFilterInput) {
+                countPoolCandidatesByPool(where: $where) {
+                  pool { id }
+                  candidateCount
+                }
+              }
+            ',
+            []
+        )->assertSimilarJson([
+            'data' => [
+                'countPoolCandidatesByPool' => [
+                    [
+                        'pool' => ['id' => $pool->id],
+                        'candidateCount' => 1,
+                    ],
+                ],
+            ],
+        ]);
+
+        // empty array input for where
         $this->graphQL(
             /** @lang GraphQL */
             '


### PR DESCRIPTION
🤖 Resolves #9674 

## 👋 Introduction

Define the variable `filters` such that it handles the input not being present. 

## 🧪 Testing

1. Test query below
2. Tests succeed

```
query count {
  countPoolCandidatesByPool(where: null) {
    pool {
      id
      name {
        en
      }
    }
    candidateCount
  }
}
```

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/93662262-47fd-4334-85b7-34de030aa7f0)



