### PR TITLE
[Debt] Integrate text search into builder

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -127,10 +127,6 @@ class User extends Model implements Authenticatable, LaratrustUser
         'updated_at',
     ];
 
-    protected static $nonNullableColumns = [
-        'id',
-    ];
-
     protected $keyType = 'string';
 
     protected $casts = [


### PR DESCRIPTION
🤖 Resolves #9071 

## 👋 Introduction

This branch removes the Scout search, which is not really made to be integrated into query builder, and uses regular query builder commands for text search.  I tried to essentially replicate the query that Scout was building.  Scout is still being used to maintain the indexes, though.

## 🕵️ Details

Does it perform better?  A little better, maybe.  I seeded 10,000 users into my database and the updated query returns in about 800ms while the old query returns in about 1,000.

## 🧪 Testing

- [ ] Users table general search works as before
- [ ] Pool candidates table general search works as before
- [ ] Searches perform at least as well as before