### PR TITLE
[Feature] Add new fields to Pool model

### DIFF
--- a/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
+++ b/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
@@ -65,6 +65,10 @@ final class PoolIsCompleteValidator extends Validator
             'advertisement_location.fr' => ['string', 'nullable', 'required_if:is_remote,false', 'required_with:advertisement_location.en'],
             'special_note.en' => ['required_with:special_note.fr', 'string'],
             'special_note.fr' => ['required_with:special_note.en', 'string'],
+            'about_us.en' => ['required_with:about_us.fr', 'string'],
+            'about_us.fr' => ['required_with:about_us.en', 'string'],
+            'what_to_expect_admission.en' => ['required_with:what_to_expect_admission.fr', 'string'],
+            'what_to_expect_admission.fr' => ['required_with:what_to_expect_admission.en', 'string'],
             'publishing_group' => ['required', Rule::in(array_column(PublishingGroup::cases(), 'name'))],
         ];
     }

--- a/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
+++ b/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
@@ -65,10 +65,10 @@ final class PoolIsCompleteValidator extends Validator
             'advertisement_location.fr' => ['string', 'nullable', 'required_if:is_remote,false', 'required_with:advertisement_location.en'],
             'special_note.en' => ['required_with:special_note.fr', 'string'],
             'special_note.fr' => ['required_with:special_note.en', 'string'],
-            'about_us.en' => ['required_with:about_us.fr', 'string'],
-            'about_us.fr' => ['required_with:about_us.en', 'string'],
-            'what_to_expect_admission.en' => ['required_with:what_to_expect_admission.fr', 'string'],
-            'what_to_expect_admission.fr' => ['required_with:what_to_expect_admission.en', 'string'],
+            'about_us.en' => ['required_with:about_us.fr', 'string', 'nullable'],
+            'about_us.fr' => ['required_with:about_us.en', 'string', 'nullable'],
+            'what_to_expect_admission.en' => ['required_with:what_to_expect_admission.fr', 'string', 'nullable'],
+            'what_to_expect_admission.fr' => ['required_with:what_to_expect_admission.en', 'string', 'nullable'],
             'publishing_group' => ['required', Rule::in(array_column(PublishingGroup::cases(), 'name'))],
         ];
     }

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -30,6 +30,8 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property array $key_tasks
  * @property array $your_impact
  * @property array $what_to_expect
+ * @property array $what_to_expect_admission
+ * @property array $about_us
  * @property array $advertisement_location
  * @property array $special_note
  * @property string $security_clearance
@@ -66,6 +68,8 @@ class Pool extends Model
         'your_impact' => 'array',
         'what_to_expect' => 'array',
         'special_note' => 'array',
+        'what_to_expect_admission' => 'array',
+        'about_us' => 'array',
         'closing_date' => 'datetime',
         'published_at' => 'datetime',
         'is_remote' => 'boolean',

--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -147,6 +147,8 @@ class PoolFactory extends Factory
                 'key_tasks' => ['en' => $this->faker->paragraph().' EN', 'fr' => $this->faker->paragraph().' FR'],
                 'your_impact' => ['en' => $this->faker->paragraph().' EN', 'fr' => $this->faker->paragraph().' FR'],
                 'what_to_expect' => ['en' => $this->faker->paragraph().' EN', 'fr' => $this->faker->paragraph().' FR'],
+                'what_to_expect_admission' => ['en' => $this->faker->paragraph().' EN', 'fr' => $this->faker->paragraph().' FR'],
+                'about_us' => ['en' => $this->faker->paragraph().' EN', 'fr' => $this->faker->paragraph().' FR'],
                 'security_clearance' => $this->faker->randomElement(array_column(SecurityStatus::cases(), 'name')),
                 'advertisement_language' => $this->faker->randomElement(array_column(PoolLanguage::cases(), 'name')),
                 'advertisement_location' => ! $isRemote ? ['en' => $this->faker->country(), 'fr' => $this->faker->country()] : null,

--- a/api/database/migrations/2024_03_11_175506_add_about_us_post_admission_columns_pools_table.php
+++ b/api/database/migrations/2024_03_11_175506_add_about_us_post_admission_columns_pools_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+
+        Schema::table('pools', function (Blueprint $table) {
+            $table->jsonb('what_to_expect_admission')->nullable()->default(json_encode(['en' => '', 'fr' => '']));
+            $table->jsonb('about_us')->nullable()->default(json_encode(['en' => '', 'fr' => '']));
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pools', function (Blueprint $table) {
+            $table->dropColumn('what_to_expect_admission');
+            $table->dropColumn('about_us');
+        });
+    }
+};

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -185,6 +185,9 @@ type Pool {
   yourImpact: LocalizedString @rename(attribute: "your_impact")
   whatToExpect: LocalizedString @rename(attribute: "what_to_expect")
   specialNote: LocalizedString @rename(attribute: "special_note")
+  whatToExpectAdmission: LocalizedString
+    @rename(attribute: "what_to_expect_admission")
+  aboutUs: LocalizedString @rename(attribute: "about_us")
   isRemote: Boolean @rename(attribute: "is_remote")
   location: LocalizedString @rename(attribute: "advertisement_location")
   securityClearance: SecurityStatus @rename(attribute: "security_clearance")
@@ -1399,6 +1402,11 @@ input UpdatePoolInput {
   whatToExpect: LocalizedStringInput @rename(attribute: "what_to_expect")
   # Special note
   specialNote: LocalizedStringInput @rename(attribute: "special_note")
+  # What to expect after admission
+  whatToExpectAdmission: LocalizedStringInput
+    @rename(attribute: "what_to_expect_admission")
+  # About us (team, department, etc.)
+  aboutUs: LocalizedStringInput @rename(attribute: "about_us")
   # Other requirements
   language: PoolLanguage @rename(attribute: "advertisement_language")
   securityClearance: SecurityStatus @rename(attribute: "security_clearance")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -307,6 +307,8 @@ type Pool {
   yourImpact: LocalizedString
   whatToExpect: LocalizedString
   specialNote: LocalizedString
+  whatToExpectAdmission: LocalizedString
+  aboutUs: LocalizedString
   isRemote: Boolean
   location: LocalizedString
   securityClearance: SecurityStatus
@@ -1212,6 +1214,8 @@ input UpdatePoolInput {
   keyTasks: LocalizedStringInput
   whatToExpect: LocalizedStringInput
   specialNote: LocalizedStringInput
+  whatToExpectAdmission: LocalizedStringInput
+  aboutUs: LocalizedStringInput
   language: PoolLanguage
   securityClearance: SecurityStatus
   location: LocalizedStringInput

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -867,6 +867,10 @@
     "defaultMessage": "Numéro de processus",
     "description": "Label for a process number"
   },
+  "2quQuW": {
+    "defaultMessage": "À propos de nous (français)",
+    "description": "Label for a process' French about us"
+  },
   "2wzOfY": {
     "defaultMessage": "Exécuter un processus de recrutement",
     "description": "Heading for the contact section to run a recruitment process"
@@ -3779,6 +3783,10 @@
     "defaultMessage": "Familles",
     "description": "Label displayed on the skill form families field."
   },
+  "Jz0oC2": {
+    "defaultMessage": "À propos de nous (anglais)",
+    "description": "Label for a process' English about us"
+  },
   "Jz7jAF": {
     "defaultMessage": "Les hyperliens menant à des sites Web qui ne sont pas gérés par le gouvernement du Canada, y compris ceux qui mènent à nos comptes de médias sociaux, sont offerts uniquement par commodité aux visiteurs de notre site Web. Nous n’assumons aucune responsabilité quant à la précision, l’actualité ou la fiabilité du contenu de ces sites. Le gouvernement du Canada n’offre aucune garantie à cet égard, n’assume aucune responsabilité concernant l’information obtenue au moyen de ces liens et n’approuve ni ces sites, ni leur contenu.",
     "description": "Paragraph describing linking to gov section"
@@ -4075,6 +4083,10 @@
     "defaultMessage": "Citoyenneté :",
     "description": "label for citizenship status"
   },
+  "LTpCFL": {
+    "defaultMessage": "À propos de nous",
+    "description": "Title for about us section on a pool advertisement."
+  },
   "LWtWs1": {
     "defaultMessage": "Scolarité",
     "description": "Experience requirement, formal education."
@@ -4170,6 +4182,10 @@
   "MCFcrj": {
     "defaultMessage": "Un groupe diversifié de personnes, représentant toutes les races, tous les genres et toutes les origines, réunies dans l'unité. Tout le monde est le bienvenu ici!",
     "description": "Hero image alt text."
+  },
+  "ME4sNt": {
+    "defaultMessage": "Sauvegarder « À propos de nous »",
+    "description": "Text on a button to save the pool about us"
   },
   "MHZ1CD": {
     "defaultMessage": "Titre (Anglais)",
@@ -4775,6 +4791,10 @@
     "defaultMessage": "Description (français)",
     "description": "Label displayed on the create a skill family form description (French) field."
   },
+  "Q2uL2b": {
+    "defaultMessage": "Cette question aide les candidats à comprendre ce que signifie le fait dans un bassin \"pool\" de recrutement, et ce à quoi ils pourraient s’attendre en tant que candidats qui se qualifient.",
+    "description": "Describes the 'what to expect after admission' section of a process' advertisement."
+  },
   "Q3adCp": {
     "defaultMessage": "Modifier le plan d’évaluation",
     "description": "Link text to edit a specific pool assessment"
@@ -4974,6 +4994,10 @@
   "QzU2SL": {
     "defaultMessage": "Veuillez remplir toute l’information relative à l'annonce avant de la publier.",
     "description": "Error message displayed when user attempts to publish an incomplete advertisement"
+  },
+  "R+6vfG": {
+    "defaultMessage": "Cette annonce n’exige pas d’une section « À propos de nous ».",
+    "description": "Message displayed when there is no about us for a process advertisement."
   },
   "R/z71a": {
     "defaultMessage": "Information sur la demande",
@@ -5638,6 +5662,10 @@
     "defaultMessage": "Voici une liste des utilisateurs actifs ainsi que certains de leurs renseignements.",
     "description": "Descriptive text about the list of users in the admin portal."
   },
+  "Uwtkv6": {
+    "defaultMessage": "Ce à quoi s’attendre après l’admission",
+    "description": "Title for the what to expect post admission section"
+  },
   "UxF291": {
     "defaultMessage": "Nom de famille",
     "description": "Label displayed for the last name field in create account form."
@@ -6069,6 +6097,10 @@
   "Wwb8Lb": {
     "defaultMessage": "Sélecteur de mode de couleur du thème",
     "description": "Label for the group of buttons to change the current colour mode"
+  },
+  "Wy6aeg": {
+    "defaultMessage": "À propos de nous",
+    "description": "Sub title for the pool about us section"
   },
   "WyKJsK": {
     "defaultMessage": "Erreur : échec de la mise à jour de l'expérience",
@@ -7146,6 +7178,10 @@
     "defaultMessage": "Ouvrir le menu",
     "description": "Text label for header button that opens side menu."
   },
+  "cweZUH": {
+    "defaultMessage": "Cette section <strong>facultative</strong> vous permet de fournir un context additionnel pour le ministère, la direction ou l’équipe qui embauchera grâce à ce processus.",
+    "description": "Describes the 'about us' section of a process' advertisement."
+  },
   "cx7pV4": {
     "defaultMessage": "Bon nombre de plateformes de médias sociaux offrent plusieurs choix de langues et donnent des instructions pour définir des préférences. Le gouvernement du Canada respecte la <langActLink>Loi sur les langues officielles</langActLink> et est déterminé à prendre les moyens nécessaires pour que son information soit disponible en français et en anglais et pour que la qualité soit égale dans les deux versions.",
     "description": "Paragraph for comments and interaction section"
@@ -8101,6 +8137,10 @@
   "hvG6bH": {
     "defaultMessage": "Exécuter des processus de recrutement pangouvernementaux pour les talents numériques",
     "description": "An OCIO role in the _supporting the community_ section of the _digital services contracting questionnaire_"
+  },
+  "hwVlzN": {
+    "defaultMessage": "\"À quoi devrais-je m’attendre si je réussis ce processus?\"",
+    "description": "Button text to toggle the accordion for what to expect after admission"
   },
   "hxaIWa": {
     "defaultMessage": "Ministères et organismes",

--- a/apps/web/src/messages/processMessages.ts
+++ b/apps/web/src/messages/processMessages.ts
@@ -111,6 +111,16 @@ const messages = defineMessages({
     id: "g7RC9u",
     description: "Label for a process' French special note",
   },
+  aboutUsEn: {
+    defaultMessage: "About us (English)",
+    id: "Jz0oC2",
+    description: "Label for a process' English about us",
+  },
+  aboutUsFr: {
+    defaultMessage: "About us (French)",
+    id: "2quQuW",
+    description: "Label for a process' French about us",
+  },
   screeningQuestions: {
     defaultMessage: "Screening questions",
     id: "p8+wKq",

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.test.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.test.tsx
@@ -63,12 +63,40 @@ describe("EditPoolPage", () => {
     );
 
     await user.click(
-      screen.getByRole("button", { name: /edit what to expect/i }),
+      screen.getByRole("button", {
+        name: /edit what to expect post-application/i,
+      }),
     );
     await user.click(
-      screen.getByRole("button", { name: /save what to expect/i }),
+      screen.getByRole("button", {
+        name: /save what to expect/i,
+      }),
     );
 
-    expect(handleSave).toHaveBeenCalledTimes(7);
+    await user.click(
+      screen.getByRole("button", {
+        name: /edit what to expect post-admission/i,
+      }),
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /save what to expect/i,
+      }),
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /edit about us/i,
+      }),
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /save about us/i,
+      }),
+    );
+
+    expect(handleSave).toHaveBeenCalledTimes(9);
   });
 });

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -71,6 +71,9 @@ import { PoolSkillMutationsType, SectionKey } from "./types";
 import AboutUsSection, {
   AboutUsSubmitData,
 } from "./components/AboutUsSection/AboutUsSection";
+import WhatToExpectAdmissionSection, {
+  WhatToExpectAdmissionSubmitData,
+} from "./components/WhatToExpectAdmissionSection/WhatToExpectAdmissionSection";
 
 export type PoolSubmitData =
   | ClosingDateSubmitData
@@ -79,6 +82,7 @@ export type PoolSubmitData =
   | WorkTasksSubmitData
   | YourImpactSubmitData
   | WhatToExpectSubmitData
+  | WhatToExpectAdmissionSubmitData
   | SpecialNoteSubmitData
   | AboutUsSubmitData
   | GeneralQuestionsSubmitData;
@@ -517,6 +521,11 @@ export const EditPoolForm = ({
                       <WhatToExpectSection
                         pool={pool}
                         sectionMetadata={sectionMetadata.whatToExpect}
+                        onSave={onSave}
+                      />
+                      <WhatToExpectAdmissionSection
+                        pool={pool}
+                        sectionMetadata={sectionMetadata.whatToExpectAdmission}
                         onSave={onSave}
                       />
                     </div>

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -68,6 +68,9 @@ import WhatToExpectSection, {
 } from "./components/WhatToExpectSection/WhatToExpectSection";
 import EditPoolContext from "./components/EditPoolContext";
 import { PoolSkillMutationsType, SectionKey } from "./types";
+import AboutUsSection, {
+  AboutUsSubmitData,
+} from "./components/AboutUsSection/AboutUsSection";
 
 export type PoolSubmitData =
   | ClosingDateSubmitData
@@ -77,6 +80,7 @@ export type PoolSubmitData =
   | YourImpactSubmitData
   | WhatToExpectSubmitData
   | SpecialNoteSubmitData
+  | AboutUsSubmitData
   | GeneralQuestionsSubmitData;
 
 export interface EditPoolFormProps {
@@ -253,6 +257,16 @@ export const EditPoolForm = ({
       }),
       inList: false,
     },
+    aboutUs: {
+      id: "about-us",
+      hasError: false, // Optional section
+      title: intl.formatMessage({
+        defaultMessage: "About us",
+        id: "Wy6aeg",
+        description: "Sub title for the pool about us section",
+      }),
+      inList: false,
+    },
     commonQuestions: {
       id: "common-questions",
       hasError: false, // Add understanding classification (#8831) validation here
@@ -278,6 +292,16 @@ export const EditPoolForm = ({
         defaultMessage: "What to expect post-application",
         id: "U0MY+6",
         description: "Title for the what to expect section",
+      }),
+      inList: false,
+    },
+    whatToExpectAdmission: {
+      id: "what-to-expect-admission",
+      hasError: false,
+      title: intl.formatMessage({
+        defaultMessage: "What to expect post-admission",
+        id: "Uwtkv6",
+        description: "Title for the what to expect post admission section",
       }),
       inList: false,
     },
@@ -455,6 +479,11 @@ export const EditPoolForm = ({
                         sectionMetadata={sectionMetadata.workTasks}
                         onSave={onSave}
                       />
+                      <AboutUsSection
+                        pool={pool}
+                        sectionMetadata={sectionMetadata.aboutUs}
+                        onSave={onSave}
+                      />
                     </div>
                   </TableOfContents.Section>
                 </div>
@@ -555,6 +584,14 @@ const EditPoolPage_Query = graphql(/* GraphQL */ `
         fr
       }
       specialNote {
+        en
+        fr
+      }
+      aboutUs {
+        en
+        fr
+      }
+      whatToExpectAdmission {
         en
         fr
       }

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -36,6 +36,8 @@ import { hasEmptyRequiredFields as keyTasksError } from "~/validators/process/ke
 import { hasEmptyRequiredFields as coreRequirementsError } from "~/validators/process/coreRequirements";
 import { hasEmptyRequiredFields as essentialSkillsError } from "~/validators/process/essentialSkills";
 import { hasEmptyRequiredFields as nonessentialSkillsError } from "~/validators/process/nonEssentialSkills";
+import { hasOneEmptyField as aboutUsError } from "~/validators/process/aboutUs";
+import { hasOneEmptyField as whatToExpectAdmissionError } from "~/validators/process/whatToExpectAdmission";
 import usePoolMutations from "~/hooks/usePoolMutations";
 import { hasAllEmptyFields as specialNoteIsNull } from "~/validators/process/specialNote";
 
@@ -120,7 +122,8 @@ export const EditPoolForm = ({
   const basicInfoHasError = poolNameError(pool) || closingDateError(pool);
   const skillRequirementsHasError =
     essentialSkillsError(pool) || nonessentialSkillsError(pool);
-  const aboutRoleHasError = yourImpactError(pool) || keyTasksError(pool);
+  const aboutRoleHasError =
+    yourImpactError(pool) || keyTasksError(pool) || aboutUsError(pool);
   const sectionMetadata: Record<SectionKey, EditPoolSectionMetadata> = {
     basicInfo: {
       id: "basic-info",
@@ -273,7 +276,7 @@ export const EditPoolForm = ({
     },
     commonQuestions: {
       id: "common-questions",
-      hasError: false, // Add understanding classification (#8831) validation here
+      hasError: whatToExpectAdmissionError(pool), // Add understanding classification (#8831) validation here
       title: intl.formatMessage({
         defaultMessage: "Common questions",
         id: "RahVQS",

--- a/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/AboutUsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/AboutUsSection.tsx
@@ -16,6 +16,7 @@ import {
 import { hasAllEmptyFields } from "~/validators/process/aboutUs";
 import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
+import processMessages from "~/messages/processMessages";
 
 import { useEditPoolContext } from "../EditPoolContext";
 import { SectionProps } from "../../types";
@@ -80,8 +81,8 @@ const AboutUsSection = ({
 
   const subtitle = intl.formatMessage({
     defaultMessage:
-      "Most job advertisements will not require a about us. This section is for special circumstances only. Examples of this special note include identifying if a process may be used to hire in multiple classifications or if the process is limited to application from a specific equity group.",
-    id: "9Us5Hy",
+      "This <strong>optional</strong> section allows you to provide further context for the department, branch, or team that will be hiring from this process.",
+    id: "cweZUH",
     description:
       "Describes the 'about us' section of a process' advertisement.",
   });
@@ -95,8 +96,8 @@ const AboutUsSection = ({
       <ToggleSection.Header
         Icon={icon.icon}
         color={icon.color}
-        level="h2"
-        size="h3"
+        level="h3"
+        size="h4"
         toggle={
           <ToggleForm.LabelledTrigger
             disabled={formDisabled}
@@ -125,13 +126,8 @@ const AboutUsSection = ({
                 data-h2-margin="base(x1, 0)"
               >
                 <RichTextInput
-                  id="whatToExpectEn"
-                  label={intl.formatMessage({
-                    defaultMessage: "English - about us for this process",
-                    id: "1gtR6U",
-                    description:
-                      "Label for the English - about us for this process textarea on edit pool page.",
-                  })}
+                  id="aboutUsEn"
+                  label={intl.formatMessage(processMessages.aboutUsEn)}
                   name="aboutUsEn"
                   {...(!formDisabled && {
                     wordLimit: TEXT_AREA_MAX_WORDS_EN,
@@ -139,13 +135,8 @@ const AboutUsSection = ({
                   readOnly={formDisabled}
                 />
                 <RichTextInput
-                  id="whatToExpectFr"
-                  label={intl.formatMessage({
-                    defaultMessage: "French - about us for this process",
-                    id: "Ll7GHg",
-                    description:
-                      "Label for the French - about us for this process textarea in the edit pool page.",
-                  })}
+                  id="aboutUsFr"
+                  label={intl.formatMessage(processMessages.aboutUsFr)}
                   name="aboutUsFr"
                   {...(!formDisabled && {
                     wordLimit: TEXT_AREA_MAX_WORDS_FR,

--- a/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/AboutUsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/AboutUsSection.tsx
@@ -1,0 +1,185 @@
+import * as React from "react";
+import { useIntl } from "react-intl";
+import { FormProvider, useForm } from "react-hook-form";
+import NewspaperIcon from "@heroicons/react/24/outline/NewspaperIcon";
+
+import { Button, ToggleSection } from "@gc-digital-talent/ui";
+import { RichTextInput, Submit } from "@gc-digital-talent/forms";
+import { commonMessages, formMessages } from "@gc-digital-talent/i18n";
+import {
+  PoolStatus,
+  LocalizedString,
+  Pool,
+  UpdatePoolInput,
+} from "@gc-digital-talent/graphql";
+
+import { hasAllEmptyFields } from "~/validators/process/aboutUs";
+import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
+import ToggleForm from "~/components/ToggleForm/ToggleForm";
+
+import { useEditPoolContext } from "../EditPoolContext";
+import { SectionProps } from "../../types";
+import Display from "./Display";
+import ActionWrapper from "../ActionWrapper";
+
+type FormValues = {
+  aboutUsEn?: LocalizedString["en"];
+  aboutUsFr?: LocalizedString["fr"];
+};
+
+export type AboutUsSubmitData = Pick<UpdatePoolInput, "aboutUs">;
+
+type AboutUsSectionProps = SectionProps<AboutUsSubmitData>;
+
+const TEXT_AREA_MAX_WORDS_EN = 100;
+const TEXT_AREA_MAX_WORDS_FR = TEXT_AREA_MAX_WORDS_EN + 30;
+
+const AboutUsSection = ({
+  pool,
+  sectionMetadata,
+  onSave,
+}: AboutUsSectionProps): JSX.Element => {
+  const intl = useIntl();
+  const isNull = hasAllEmptyFields(pool);
+  const { isSubmitting } = useEditPoolContext();
+  const { isEditing, setIsEditing, icon } = useToggleSectionInfo({
+    isNull,
+    emptyRequired: false, // Not a required field
+    fallbackIcon: NewspaperIcon,
+    optional: true,
+  });
+
+  const dataToFormValues = (initialData: Pool): FormValues => ({
+    aboutUsEn: initialData.specialNote?.en ?? "",
+    aboutUsFr: initialData.specialNote?.fr ?? "",
+  });
+
+  const methods = useForm<FormValues>({
+    defaultValues: dataToFormValues(pool),
+  });
+  const { handleSubmit } = methods;
+
+  const handleSave = async (formValues: FormValues) => {
+    return onSave({
+      aboutUs: {
+        en: formValues.aboutUsEn ?? "",
+        fr: formValues.aboutUsFr ?? "",
+      },
+    })
+      .then(() => {
+        methods.reset(formValues, {
+          keepDirty: false,
+        });
+        setIsEditing(false);
+      })
+      .catch(() => methods.reset(formValues));
+  };
+
+  // disabled unless status is draft
+  const formDisabled = pool.status !== PoolStatus.Draft;
+
+  const subtitle = intl.formatMessage({
+    defaultMessage:
+      "Most job advertisements will not require a about us. This section is for special circumstances only. Examples of this special note include identifying if a process may be used to hire in multiple classifications or if the process is limited to application from a specific equity group.",
+    id: "9Us5Hy",
+    description:
+      "Describes the 'about us' section of a process' advertisement.",
+  });
+
+  return (
+    <ToggleSection.Root
+      id={`${sectionMetadata.id}-form`}
+      open={isEditing}
+      onOpenChange={setIsEditing}
+    >
+      <ToggleSection.Header
+        Icon={icon.icon}
+        color={icon.color}
+        level="h2"
+        size="h3"
+        toggle={
+          <ToggleForm.LabelledTrigger
+            disabled={formDisabled}
+            sectionTitle={sectionMetadata.title}
+          />
+        }
+      >
+        {sectionMetadata.title}
+      </ToggleSection.Header>
+      <p>{subtitle}</p>
+      <ToggleSection.Content>
+        <ToggleSection.InitialContent>
+          {isNull ? (
+            <ToggleForm.NullDisplay optional />
+          ) : (
+            <Display pool={pool} />
+          )}
+        </ToggleSection.InitialContent>
+        <ToggleSection.OpenContent>
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(handleSave)}>
+              <div
+                data-h2-display="base(grid)"
+                data-h2-gap="base(x1)"
+                data-h2-grid-template-columns="l-tablet(repeat(2, 1fr))"
+                data-h2-margin="base(x1, 0)"
+              >
+                <RichTextInput
+                  id="whatToExpectEn"
+                  label={intl.formatMessage({
+                    defaultMessage: "English - about us for this process",
+                    id: "1gtR6U",
+                    description:
+                      "Label for the English - about us for this process textarea on edit pool page.",
+                  })}
+                  name="aboutUsEn"
+                  {...(!formDisabled && {
+                    wordLimit: TEXT_AREA_MAX_WORDS_EN,
+                  })}
+                  readOnly={formDisabled}
+                />
+                <RichTextInput
+                  id="whatToExpectFr"
+                  label={intl.formatMessage({
+                    defaultMessage: "French - about us for this process",
+                    id: "Ll7GHg",
+                    description:
+                      "Label for the French - about us for this process textarea in the edit pool page.",
+                  })}
+                  name="aboutUsFr"
+                  {...(!formDisabled && {
+                    wordLimit: TEXT_AREA_MAX_WORDS_FR,
+                  })}
+                  readOnly={formDisabled}
+                />
+              </div>
+
+              <ActionWrapper>
+                {!formDisabled && (
+                  <Submit
+                    text={intl.formatMessage(formMessages.saveChanges)}
+                    aria-label={intl.formatMessage({
+                      defaultMessage: "Save about us",
+                      id: "ME4sNt",
+                      description: "Text on a button to save the pool about us",
+                    })}
+                    color="secondary"
+                    mode="solid"
+                    isSubmitting={isSubmitting}
+                  />
+                )}
+                <ToggleSection.Close>
+                  <Button mode="inline" type="button" color="quaternary">
+                    {intl.formatMessage(commonMessages.cancel)}
+                  </Button>
+                </ToggleSection.Close>
+              </ActionWrapper>
+            </form>
+          </FormProvider>
+        </ToggleSection.OpenContent>
+      </ToggleSection.Content>
+    </ToggleSection.Root>
+  );
+};
+
+export default AboutUsSection;

--- a/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/AboutUsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/AboutUsSection.tsx
@@ -13,7 +13,10 @@ import {
   UpdatePoolInput,
 } from "@gc-digital-talent/graphql";
 
-import { hasAllEmptyFields } from "~/validators/process/aboutUs";
+import {
+  hasAllEmptyFields,
+  hasOneEmptyField,
+} from "~/validators/process/aboutUs";
 import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
 import processMessages from "~/messages/processMessages";
@@ -45,7 +48,7 @@ const AboutUsSection = ({
   const { isSubmitting } = useEditPoolContext();
   const { isEditing, setIsEditing, icon } = useToggleSectionInfo({
     isNull,
-    emptyRequired: false, // Not a required field
+    emptyRequired: hasOneEmptyField(pool), // Not a required field
     fallbackIcon: NewspaperIcon,
     optional: true,
   });

--- a/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/AboutUsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/AboutUsSection.tsx
@@ -51,8 +51,8 @@ const AboutUsSection = ({
   });
 
   const dataToFormValues = (initialData: Pool): FormValues => ({
-    aboutUsEn: initialData.specialNote?.en ?? "",
-    aboutUsFr: initialData.specialNote?.fr ?? "",
+    aboutUsEn: initialData.aboutUs?.en ?? "",
+    aboutUsFr: initialData.aboutUs?.fr ?? "",
   });
 
   const methods = useForm<FormValues>({

--- a/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/AboutUsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/AboutUsSection.tsx
@@ -98,6 +98,7 @@ const AboutUsSection = ({
         color={icon.color}
         level="h3"
         size="h4"
+        data-h2-font-weight="base(700)"
         toggle={
           <ToggleForm.LabelledTrigger
             disabled={formDisabled}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/Display.tsx
@@ -9,7 +9,7 @@ import ToggleForm from "~/components/ToggleForm/ToggleForm";
 import processMessages from "~/messages/processMessages";
 
 import { DisplayProps } from "../../types";
-import { hasAllEmptyFields } from "../../../../../validators/process/aboutUs";
+import { hasAllEmptyFields } from "~/validators/process/aboutUs";
 
 const Display = ({ pool, subtitle }: DisplayProps) => {
   const intl = useIntl();

--- a/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/Display.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { commonMessages } from "@gc-digital-talent/i18n";
+import { Well } from "@gc-digital-talent/ui";
+import { RichTextRenderer, htmlToRichTextJSON } from "@gc-digital-talent/forms";
+
+import ToggleForm from "~/components/ToggleForm/ToggleForm";
+import processMessages from "~/messages/processMessages";
+
+import { DisplayProps } from "../../types";
+import { hasAllEmptyFields } from "../../../../../validators/process/aboutUs";
+
+const Display = ({ pool, subtitle }: DisplayProps) => {
+  const intl = useIntl();
+  const notProvided = intl.formatMessage(commonMessages.notProvided);
+  const isNull = hasAllEmptyFields(pool);
+  const { aboutUs } = pool;
+
+  return (
+    <>
+      {subtitle && <p data-h2-margin-bottom="base(x1)">{subtitle}</p>}
+      {!isNull ? (
+        <div
+          data-h2-display="base(grid)"
+          data-h2-gap="base(x1)"
+          data-h2-grid-template-columns="p-tablet(repeat(2, 1fr))"
+        >
+          <ToggleForm.FieldDisplay
+            hasError={!aboutUs?.en}
+            label={intl.formatMessage(processMessages.aboutUsEn)}
+          >
+            {aboutUs?.en ? (
+              <RichTextRenderer node={htmlToRichTextJSON(aboutUs?.en)} />
+            ) : (
+              notProvided
+            )}
+          </ToggleForm.FieldDisplay>
+          <ToggleForm.FieldDisplay
+            hasError={!aboutUs?.fr}
+            label={intl.formatMessage(processMessages.aboutUsFr)}
+          >
+            {aboutUs?.fr ? (
+              <RichTextRenderer node={htmlToRichTextJSON(aboutUs?.fr)} />
+            ) : (
+              notProvided
+            )}
+          </ToggleForm.FieldDisplay>
+        </div>
+      ) : (
+        <Well>
+          {intl.formatMessage({
+            defaultMessage: "This advertisement does not require about us.",
+            id: "R+6vfG",
+            description:
+              "Message displayed when there is no about us for a process advertisement.",
+          })}
+        </Well>
+      )}
+    </>
+  );
+};
+
+export default Display;

--- a/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/Display.tsx
@@ -7,9 +7,9 @@ import { RichTextRenderer, htmlToRichTextJSON } from "@gc-digital-talent/forms";
 
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
 import processMessages from "~/messages/processMessages";
+import { hasAllEmptyFields } from "~/validators/process/aboutUs";
 
 import { DisplayProps } from "../../types";
-import { hasAllEmptyFields } from "~/validators/process/aboutUs";
 
 const Display = ({ pool, subtitle }: DisplayProps) => {
   const intl = useIntl();

--- a/apps/web/src/pages/Pools/EditPoolPage/components/WhatToExpectAdmissionSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/WhatToExpectAdmissionSection/Display.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { commonMessages } from "@gc-digital-talent/i18n";
+import { RichTextRenderer, htmlToRichTextJSON } from "@gc-digital-talent/forms";
+
+import ToggleForm from "~/components/ToggleForm/ToggleForm";
+import processMessages from "~/messages/processMessages";
+
+import { DisplayProps } from "../../types";
+
+const Display = ({ pool, subtitle }: DisplayProps) => {
+  const intl = useIntl();
+  const notProvided = intl.formatMessage(commonMessages.notProvided);
+  const { whatToExpectAdmission } = pool;
+
+  return (
+    <>
+      {subtitle && <p data-h2-margin-bottom="base(x1)">{subtitle}</p>}
+      <div
+        data-h2-display="base(grid)"
+        data-h2-gap="base(x1)"
+        data-h2-grid-template-columns="p-tablet(repeat(2, 1fr))"
+      >
+        <ToggleForm.FieldDisplay
+          hasError={!whatToExpectAdmission?.en}
+          label={intl.formatMessage(processMessages.whatToExpectEn)}
+        >
+          {whatToExpectAdmission?.en ? (
+            <RichTextRenderer
+              node={htmlToRichTextJSON(whatToExpectAdmission?.en)}
+            />
+          ) : (
+            notProvided
+          )}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          hasError={!whatToExpectAdmission?.fr}
+          label={intl.formatMessage(processMessages.whatToExpectFr)}
+        >
+          {whatToExpectAdmission?.fr ? (
+            <RichTextRenderer
+              node={htmlToRichTextJSON(whatToExpectAdmission?.fr)}
+            />
+          ) : (
+            notProvided
+          )}
+        </ToggleForm.FieldDisplay>
+      </div>
+    </>
+  );
+};
+
+export default Display;

--- a/apps/web/src/pages/Pools/EditPoolPage/components/WhatToExpectAdmissionSection/WhatToExpectAdmissionSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/WhatToExpectAdmissionSection/WhatToExpectAdmissionSection.tsx
@@ -1,0 +1,182 @@
+import * as React from "react";
+import { useIntl } from "react-intl";
+import { FormProvider, useForm } from "react-hook-form";
+import QuestionMarkCircleIcon from "@heroicons/react/24/outline/QuestionMarkCircleIcon";
+
+import { Button, ToggleSection } from "@gc-digital-talent/ui";
+import { RichTextInput, Submit } from "@gc-digital-talent/forms";
+import { commonMessages, formMessages } from "@gc-digital-talent/i18n";
+import {
+  PoolStatus,
+  LocalizedString,
+  Pool,
+  UpdatePoolInput,
+} from "@gc-digital-talent/graphql";
+
+import { hasAllEmptyFields } from "~/validators/process/whatToExpectAdmission";
+import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
+import ToggleForm from "~/components/ToggleForm/ToggleForm";
+
+import { useEditPoolContext } from "../EditPoolContext";
+import { SectionProps } from "../../types";
+import Display from "./Display";
+import ActionWrapper from "../ActionWrapper";
+
+type FormValues = {
+  whatToExpectAdmissionEn?: LocalizedString["en"];
+  whatToExpectAdmissionFr?: LocalizedString["fr"];
+};
+
+export type WhatToExpectAdmissionSubmitData = Pick<
+  UpdatePoolInput,
+  "whatToExpectAdmission"
+>;
+
+type WhatToExpectAdmissionSectionProps =
+  SectionProps<WhatToExpectAdmissionSubmitData>;
+
+const TEXT_AREA_MAX_WORDS_EN = 200;
+const TEXT_AREA_MAX_WORDS_FR = TEXT_AREA_MAX_WORDS_EN + 100;
+
+const WhatToExpectAdmissionSection = ({
+  pool,
+  sectionMetadata,
+  onSave,
+}: WhatToExpectAdmissionSectionProps): JSX.Element => {
+  const intl = useIntl();
+  const isNull = hasAllEmptyFields(pool);
+  const { isSubmitting } = useEditPoolContext();
+  const { isEditing, setIsEditing, icon } = useToggleSectionInfo({
+    isNull,
+    emptyRequired: false,
+    fallbackIcon: QuestionMarkCircleIcon,
+    optional: true,
+  });
+
+  const dataToFormValues = (initialData: Pool): FormValues => ({
+    whatToExpectAdmissionEn: initialData.whatToExpect?.en ?? "",
+    whatToExpectAdmissionFr: initialData.whatToExpect?.fr ?? "",
+  });
+
+  const methods = useForm<FormValues>({
+    defaultValues: dataToFormValues(pool),
+  });
+  const { handleSubmit } = methods;
+
+  const handleSave = async (formValues: FormValues) => {
+    return onSave({
+      whatToExpectAdmission: {
+        en: formValues.whatToExpectAdmissionEn,
+        fr: formValues.whatToExpectAdmissionFr,
+      },
+    })
+      .then(() => {
+        methods.reset(formValues, {
+          keepDirty: false,
+        });
+        setIsEditing(false);
+      })
+      .catch(() => methods.reset(formValues));
+  };
+
+  // disabled unless status is draft
+  const formDisabled = pool.status !== PoolStatus.Draft;
+
+  const subtitle = intl.formatMessage({
+    defaultMessage:
+      "This information lets applicants know what they can expect after they apply, such as further exams, meeting with managers directly and possible timelines.",
+    id: "ww+trY",
+    description:
+      "Describes the 'what to expect after applying' section of a process' advertisement.",
+  });
+
+  return (
+    <ToggleSection.Root
+      id={`${sectionMetadata.id}-form`}
+      open={isEditing}
+      onOpenChange={setIsEditing}
+    >
+      <ToggleSection.Header
+        Icon={icon.icon}
+        color={icon.color}
+        level="h3"
+        size="h4"
+        toggle={
+          <ToggleForm.LabelledTrigger
+            disabled={formDisabled}
+            sectionTitle={sectionMetadata.title}
+          />
+        }
+        data-h2-font-weight="base(bold)"
+      >
+        {sectionMetadata.title}
+      </ToggleSection.Header>
+      <p>{subtitle}</p>
+      <ToggleSection.Content>
+        <ToggleSection.InitialContent>
+          {isNull ? <ToggleForm.NullDisplay /> : <Display pool={pool} />}
+        </ToggleSection.InitialContent>
+        <ToggleSection.OpenContent>
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(handleSave)}>
+              <div
+                data-h2-display="base(grid)"
+                data-h2-gap="base(x1)"
+                data-h2-grid-template-columns="l-tablet(repeat(2, 1fr))"
+              >
+                <RichTextInput
+                  id="whatToExpectAdmissionEn"
+                  label={intl.formatMessage({
+                    defaultMessage: "English - What to expect",
+                    id: "o7OKLq",
+                    description:
+                      "Label for the English - What to expect textarea in the edit pool page.",
+                  })}
+                  name="whatToExpectAdmissionEn"
+                  {...(!formDisabled && { wordLimit: TEXT_AREA_MAX_WORDS_EN })}
+                  readOnly={formDisabled}
+                />
+                <RichTextInput
+                  id="whatToExpectAdmissionFr"
+                  label={intl.formatMessage({
+                    defaultMessage: "French - What to expect",
+                    id: "zDHOiY",
+                    description:
+                      "Label for the French - What to expect textarea in the edit pool page.",
+                  })}
+                  name="whatToExpectAdmissionFr"
+                  {...(!formDisabled && { wordLimit: TEXT_AREA_MAX_WORDS_FR })}
+                  readOnly={formDisabled}
+                />
+              </div>
+
+              <ActionWrapper>
+                {!formDisabled && (
+                  <Submit
+                    text={intl.formatMessage(formMessages.saveChanges)}
+                    aria-label={intl.formatMessage({
+                      defaultMessage: "Save what to expect",
+                      id: "wimmA1",
+                      description:
+                        "Text on a button to save the pool what to expect",
+                    })}
+                    color="secondary"
+                    mode="solid"
+                    isSubmitting={isSubmitting}
+                  />
+                )}
+                <ToggleSection.Close>
+                  <Button mode="inline" type="button" color="quaternary">
+                    {intl.formatMessage(commonMessages.cancel)}
+                  </Button>
+                </ToggleSection.Close>
+              </ActionWrapper>
+            </form>
+          </FormProvider>
+        </ToggleSection.OpenContent>
+      </ToggleSection.Content>
+    </ToggleSection.Root>
+  );
+};
+
+export default WhatToExpectAdmissionSection;

--- a/apps/web/src/pages/Pools/EditPoolPage/components/WhatToExpectAdmissionSection/WhatToExpectAdmissionSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/WhatToExpectAdmissionSection/WhatToExpectAdmissionSection.tsx
@@ -54,8 +54,8 @@ const WhatToExpectAdmissionSection = ({
   });
 
   const dataToFormValues = (initialData: Pool): FormValues => ({
-    whatToExpectAdmissionEn: initialData.whatToExpect?.en ?? "",
-    whatToExpectAdmissionFr: initialData.whatToExpect?.fr ?? "",
+    whatToExpectAdmissionEn: initialData.whatToExpectAdmission?.en ?? "",
+    whatToExpectAdmissionFr: initialData.whatToExpectAdmission?.fr ?? "",
   });
 
   const methods = useForm<FormValues>({
@@ -84,10 +84,10 @@ const WhatToExpectAdmissionSection = ({
 
   const subtitle = intl.formatMessage({
     defaultMessage:
-      "This information lets applicants know what they can expect after they apply, such as further exams, meeting with managers directly and possible timelines.",
-    id: "ww+trY",
+      "This question helps applicants understand what it means to be in a recruitment “pool” and what they should expect as qualified candidates.",
+    id: "e+nzX5",
     description:
-      "Describes the 'what to expect after applying' section of a process' advertisement.",
+      "Describes the 'what to expect after admission' section of a process' advertisement.",
   });
 
   return (

--- a/apps/web/src/pages/Pools/EditPoolPage/components/WhatToExpectAdmissionSection/WhatToExpectAdmissionSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/WhatToExpectAdmissionSection/WhatToExpectAdmissionSection.tsx
@@ -13,7 +13,10 @@ import {
   UpdatePoolInput,
 } from "@gc-digital-talent/graphql";
 
-import { hasAllEmptyFields } from "~/validators/process/whatToExpectAdmission";
+import {
+  hasAllEmptyFields,
+  hasOneEmptyField,
+} from "~/validators/process/whatToExpectAdmission";
 import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
 
@@ -48,7 +51,7 @@ const WhatToExpectAdmissionSection = ({
   const { isSubmitting } = useEditPoolContext();
   const { isEditing, setIsEditing, icon } = useToggleSectionInfo({
     isNull,
-    emptyRequired: false,
+    emptyRequired: hasOneEmptyField(pool),
     fallbackIcon: QuestionMarkCircleIcon,
     optional: true,
   });

--- a/apps/web/src/pages/Pools/EditPoolPage/components/WhatToExpectAdmissionSection/WhatToExpectAdmissionSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/WhatToExpectAdmissionSection/WhatToExpectAdmissionSection.tsx
@@ -84,8 +84,8 @@ const WhatToExpectAdmissionSection = ({
 
   const subtitle = intl.formatMessage({
     defaultMessage:
-      "This question helps applicants understand what it means to be in a recruitment “pool” and what they should expect as qualified candidates.",
-    id: "e+nzX5",
+      'This question helps applicants understand what it means to be in a recruitment "pool" and what they should expect as qualified candidates.',
+    id: "Q2uL2b",
     description:
       "Describes the 'what to expect after admission' section of a process' advertisement.",
   });

--- a/apps/web/src/pages/Pools/EditPoolPage/types.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/types.ts
@@ -32,8 +32,10 @@ export type SectionKey =
   | "aboutRole"
   | "yourImpact"
   | "workTasks"
+  | "aboutUs"
   | "commonQuestions"
   | "whatToExpect"
+  | "whatToExpectAdmission"
   | "generalQuestions";
 
 export type PoolSkillMutationsType = {

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -113,7 +113,7 @@ const moreInfoAccordions = {
   dei: "diversity-equity-inclusion",
   accommodations: "accommodations",
   whatToExpectApply: "what-to-expect-apply",
-  whatToExpectIfSuccessful: "what-to-expect-success",
+  whatToExpectAdmission: "what-to-expect-admission",
 };
 
 interface PoolAdvertisementProps {
@@ -161,6 +161,9 @@ export const PoolPoster = ({
 
   const showSpecialNote = !!(pool.specialNote && pool.specialNote[locale]);
   const showWhatToExpect = !!(pool.whatToExpect && pool.whatToExpect[locale]);
+  const showWhatToExpectAdmission = !!(
+    pool.whatToExpectAdmission && pool.whatToExpectAdmission[locale]
+  );
 
   const opportunityLength = pool.opportunityLength
     ? intl.formatMessage(getPoolOpportunityLength(pool.opportunityLength))
@@ -822,6 +825,28 @@ export const PoolPoster = ({
                   />
                 </>
               )}
+              {pool.aboutUs && (
+                <>
+                  <Heading
+                    level="h3"
+                    size="h4"
+                    data-h2-font-weight="base(700)"
+                    data-h2-margin-bottom="base(x1)"
+                  >
+                    {intl.formatMessage({
+                      defaultMessage: "About us",
+                      id: "LTpCFL",
+                      description:
+                        "Title for about us section on a pool advertisement.",
+                    })}
+                  </Heading>
+                  <RichTextRenderer
+                    node={htmlToRichTextJSON(
+                      getLocalizedName(pool.aboutUs, intl),
+                    )}
+                  />
+                </>
+              )}
               {pool.keyTasks && (
                 <>
                   <Heading
@@ -1018,6 +1043,28 @@ export const PoolPoster = ({
                     </Accordion.Content>
                   </Accordion.Item>
                 )}
+                {showWhatToExpectAdmission && (
+                  <Accordion.Item
+                    value={moreInfoAccordions.whatToExpectAdmission}
+                  >
+                    <Accordion.Trigger as="h3">
+                      {intl.formatMessage({
+                        defaultMessage:
+                          '"What should I expect if I\'m successful in the process?"',
+                        id: "hwVlzN",
+                        description:
+                          "Button text to toggle the accordion for what to expect after admission",
+                      })}
+                    </Accordion.Trigger>
+                    <Accordion.Content>
+                      <RichTextRenderer
+                        node={htmlToRichTextJSON(
+                          getLocalizedName(pool.whatToExpectAdmission, intl),
+                        )}
+                      />
+                    </Accordion.Content>
+                  </Accordion.Item>
+                )}
               </Accordion.Root>
             </TableOfContents.Section>
             <TableOfContents.Section id={sections.startAnApplication.id}>
@@ -1142,6 +1189,14 @@ const PoolAdvertisementPage_Query = graphql(/* GraphQL */ `
         fr
       }
       specialNote {
+        en
+        fr
+      }
+      whatToExpectAdmission {
+        en
+        fr
+      }
+      aboutUs {
         en
         fr
       }

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -159,6 +159,7 @@ export const PoolPoster = ({
       })
     : getLocalizedName(pool.location, intl);
 
+  const showAboutUs = !!(pool.aboutUs && pool.aboutUs[locale]);
   const showSpecialNote = !!(pool.specialNote && pool.specialNote[locale]);
   const showWhatToExpect = !!(pool.whatToExpect && pool.whatToExpect[locale]);
   const showWhatToExpectAdmission = !!(
@@ -825,28 +826,6 @@ export const PoolPoster = ({
                   />
                 </>
               )}
-              {pool.aboutUs && (
-                <>
-                  <Heading
-                    level="h3"
-                    size="h4"
-                    data-h2-font-weight="base(700)"
-                    data-h2-margin-bottom="base(x1)"
-                  >
-                    {intl.formatMessage({
-                      defaultMessage: "About us",
-                      id: "LTpCFL",
-                      description:
-                        "Title for about us section on a pool advertisement.",
-                    })}
-                  </Heading>
-                  <RichTextRenderer
-                    node={htmlToRichTextJSON(
-                      getLocalizedName(pool.aboutUs, intl),
-                    )}
-                  />
-                </>
-              )}
               {pool.keyTasks && (
                 <>
                   <Heading
@@ -865,6 +844,28 @@ export const PoolPoster = ({
                   <RichTextRenderer
                     node={htmlToRichTextJSON(
                       getLocalizedName(pool.keyTasks, intl),
+                    )}
+                  />
+                </>
+              )}
+              {showAboutUs && (
+                <>
+                  <Heading
+                    level="h3"
+                    size="h4"
+                    data-h2-font-weight="base(700)"
+                    data-h2-margin-bottom="base(x1)"
+                  >
+                    {intl.formatMessage({
+                      defaultMessage: "About us",
+                      id: "LTpCFL",
+                      description:
+                        "Title for about us section on a pool advertisement.",
+                    })}
+                  </Heading>
+                  <RichTextRenderer
+                    node={htmlToRichTextJSON(
+                      getLocalizedName(pool.aboutUs, intl),
                     )}
                   />
                 </>

--- a/apps/web/src/validators/process/aboutUs.ts
+++ b/apps/web/src/validators/process/aboutUs.ts
@@ -1,0 +1,9 @@
+import { Pool } from "@gc-digital-talent/graphql";
+
+export function hasAllEmptyFields({ aboutUs }: Pool): boolean {
+  return !!(!aboutUs?.en && !aboutUs?.fr);
+}
+
+export function hasEmptyRequiredFields({ aboutUs }: Pool): boolean {
+  return !!(!aboutUs?.en || !aboutUs?.fr);
+}

--- a/apps/web/src/validators/process/aboutUs.ts
+++ b/apps/web/src/validators/process/aboutUs.ts
@@ -7,3 +7,7 @@ export function hasAllEmptyFields({ aboutUs }: Pool): boolean {
 export function hasEmptyRequiredFields({ aboutUs }: Pool): boolean {
   return !!(!aboutUs?.en || !aboutUs?.fr);
 }
+
+export function hasOneEmptyField({ aboutUs }: Pool): boolean {
+  return !!(aboutUs?.en && !aboutUs?.fr) || !!(aboutUs?.fr && !aboutUs.en);
+}

--- a/apps/web/src/validators/process/whatToExpectAdmission.ts
+++ b/apps/web/src/validators/process/whatToExpectAdmission.ts
@@ -5,3 +5,10 @@ import { Pool } from "@gc-digital-talent/graphql";
 export function hasAllEmptyFields({ whatToExpectAdmission }: Pool): boolean {
   return !!(!whatToExpectAdmission?.en && !whatToExpectAdmission?.fr);
 }
+
+export function hasOneEmptyField({ whatToExpectAdmission }: Pool): boolean {
+  return (
+    !!(whatToExpectAdmission?.en && !whatToExpectAdmission?.fr) ||
+    !!(whatToExpectAdmission?.fr && !whatToExpectAdmission.en)
+  );
+}

--- a/apps/web/src/validators/process/whatToExpectAdmission.ts
+++ b/apps/web/src/validators/process/whatToExpectAdmission.ts
@@ -1,0 +1,7 @@
+import { Pool } from "@gc-digital-talent/graphql";
+
+// Note: Field is optional so we only validate for null state
+// eslint-disable-next-line import/prefer-default-export
+export function hasAllEmptyFields({ whatToExpectAdmission }: Pool): boolean {
+  return !!(!whatToExpectAdmission?.en && !whatToExpectAdmission?.fr);
+}

--- a/packages/forms/src/components/RichTextInput/ControlledInput.tsx
+++ b/packages/forms/src/components/RichTextInput/ControlledInput.tsx
@@ -86,7 +86,7 @@ const ControlledInput = ({
       <div data-h2-color="base(black)">
         <EditorContent {...{ content, editor }} />
       </div>
-      <Footer {...{ editor, wordLimit, name }} />
+      <Footer {...{ wordLimit, name }} />
     </div>
   );
 };

--- a/packages/forms/src/components/RichTextInput/Footer.tsx
+++ b/packages/forms/src/components/RichTextInput/Footer.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Editor } from "@tiptap/react";
 
 import WordCounter from "../WordCounter";
 

--- a/packages/forms/src/components/RichTextInput/Footer.tsx
+++ b/packages/forms/src/components/RichTextInput/Footer.tsx
@@ -6,19 +6,14 @@ import WordCounter from "../WordCounter";
 interface FooterProps {
   name: string;
   wordLimit?: number;
-  editor: Editor | null;
 }
 
-const Footer = ({ wordLimit, name, editor }: FooterProps) => {
+const Footer = ({ wordLimit, name }: FooterProps) => {
   if (!wordLimit) return null;
 
   return (
     <div data-h2-text-align="base(right)">
-      <WordCounter
-        name={name}
-        wordLimit={wordLimit}
-        currentCount={editor?.storage.characterCount.words()}
-      />
+      <WordCounter name={name} wordLimit={wordLimit} />
     </div>
   );
 };


### PR DESCRIPTION
🤖 Resolves #8829 

## 👋 Introduction

Adds two new fields ("what to expect post admission" and "about us") to the pool model.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Migrate `php artisan migrate`
2. Build app `npm run dev`
3. Login as admin `admin@test.com`
4. Create a pool
5. Confirm the new sections exist
6. Confirm they save and load data properly
7. Confirm they appear on the advertisement page as expected

## 📸 Screenshot

![Screenshot 2024-03-11 162600](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/b1b1a23c-90a6-4ee1-8266-ed6ca33623a6)
![Screenshot 2024-03-11 162603](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/8c266580-98ff-4769-a422-9bec137ad460)
![Screenshot 2024-03-11 162608](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/f1e9961d-5c34-4a8a-9687-8388b553e478)
![Screenshot 2024-03-11 162646](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/610ef6c8-c90f-49a8-aad1-1d8480fa98c8)
![Screenshot 2024-03-11 162700](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/8515faf5-9a1c-4f2f-af7d-9c8345ba550c)
![Screenshot 2024-03-11 162711](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/e7492b8f-b714-4dfa-983e-b3f8e0192026)
