### PR TITLE
[Debt] Refactors `specialErrorExchange` options

### DIFF
--- a/packages/client/src/exchanges/specialErrorExchange.ts
+++ b/packages/client/src/exchanges/specialErrorExchange.ts
@@ -5,13 +5,8 @@ import { IntlShape } from "react-intl";
 import { toast } from "@gc-digital-talent/toast";
 import { errorMessages } from "@gc-digital-talent/i18n";
 
-/** Input parameters for the specialErrorExchange. */
-export interface SpecialErrorExchangeOptions {
-  intl: IntlShape;
-}
-
 // A custom exchange that watches for special errors that are meaningful to us and need special handling.
-const specialErrorExchange = ({ intl }: SpecialErrorExchangeOptions) => {
+const specialErrorExchange = ({ intl }: { intl: IntlShape }) => {
   const exchange: Exchange =
     ({ forward }) =>
     (ops$) =>


### PR DESCRIPTION
🤖 Resolves #9708.

## 👋 Introduction

This PR refactors `specialErrorExchange` options out of an interface.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Verify application works as before
2. Verify no unused exports in `specialErrorExchange.ts`
3. Verify that single property interface removed for `specialErrorExchange`