### PR TITLE
[Bug] Missing error summary for application questions

### DIFF
--- a/apps/playwright/tests/applicant/application.spec.ts
+++ b/apps/playwright/tests/applicant/application.spec.ts
@@ -233,7 +233,7 @@ test.describe("Application", () => {
     await application.saveAndContinue();
     await expect(
       application.page.getByText(/this field is required/i),
-    ).toBeVisible();
+    ).toHaveCount(2);
     await application.answerQuestion(1);
     await application.saveAndContinue();
 

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
@@ -114,9 +114,19 @@ const ApplicationQuestions = ({ application }: ApplicationPageProps) => {
       });
   };
 
+  const errorLabels = {
+    "generalAnswers.*.answer": intl.formatMessage(
+      processMessages.generalQuestions,
+    ),
+    "screeningAnswers.*.answer": intl.formatMessage(
+      processMessages.screeningQuestions,
+    ),
+  };
+
   return (
     <BasicForm
       onSubmit={handleSubmit}
+      labels={errorLabels}
       options={{
         defaultValues: dataToFormValues(
           screeningQuestions,


### PR DESCRIPTION
🤖 Resolves #9716 

## 👋 Introduction

Get the missing error summary to appear again.
Was missing needed labels prop, with a bunch of trial and error I got something to pass in 😛 

## 🧪 Testing

1. Start an application and reach the questions page
2. Attempt to submit incomplete 

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/65a2c43e-497e-4249-8ec4-dbec8741a609)



