### PR TITLE
Replace "pool" and "recruitment" with "process" where appropriate

### DIFF
--- a/apps/e2e/cypress/e2e/admin/pools.cy.ts
+++ b/apps/e2e/cypress/e2e/admin/pools.cy.ts
@@ -114,12 +114,12 @@ describe("Pools", () => {
 
     cy.wait("@gqlPoolTableQuery");
 
-    cy.findByRole("link", { name: /create pool/i }).click();
+    cy.findByRole("link", { name: /create process/i }).click();
 
     cy.wait("@gqlCreatePoolPageQuery");
 
     // Ensure we got to the correct page
-    cy.findByRole("heading", { name: /create pool/i })
+    cy.findByRole("heading", { name: /create process/i })
       .should("exist")
       .and("be.visible");
 
@@ -148,9 +148,9 @@ describe("Pools", () => {
     });
 
     // Submit form
-    cy.findByRole("button", { name: /create new pool/i }).click();
+    cy.findByRole("button", { name: /create new process/i }).click();
     cy.wait("@gqlCreatePoolMutation");
-    cy.expectToast(/pool created successfully/i);
+    cy.expectToast(/process created successfully/i);
 
     // Ensure we got to the correct page
     cy.findByText("Digital Community Management")
@@ -328,6 +328,6 @@ describe("Pools", () => {
 
     cy.wait("@gqlDeletePoolMutation");
 
-    cy.expectToast(/pool deleted successfully/i);
+    cy.expectToast(/process deleted successfully/i);
   });
 });

--- a/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.tsx
+++ b/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.tsx
@@ -138,16 +138,14 @@ const QualifiedRecruitmentCard = ({
               <span>
                 {isOpen
                   ? intl.formatMessage({
-                      defaultMessage:
-                        "Hide this recruitment's skill assessments",
-                      id: "+h7iQH",
+                      defaultMessage: "Hide this process's skill assessments",
+                      id: "JeAzDb",
                       description:
                         "Button text to hide a miscellaneous qualified recruitment's skill assessments",
                     })
                   : intl.formatMessage({
-                      defaultMessage:
-                        "Show this recruitment's skill assessments",
-                      id: "BFewIk",
+                      defaultMessage: "Show this process's skill assessments",
+                      id: "7Iv/YA",
                       description:
                         "Button text to show a miscellaneous qualified recruitment's skill assessments",
                     })}
@@ -289,14 +287,14 @@ const QualifiedRecruitmentCard = ({
           >
             {linkCopied
               ? intl.formatMessage({
-                  defaultMessage: "Recruitment ID copied",
-                  id: "5HJIwt",
+                  defaultMessage: "Process ID copied",
+                  id: "QNmxIN",
                   description:
                     "Button text to indicate that a specific qualified recruitment's ID has been copied",
                 })
               : intl.formatMessage({
-                  defaultMessage: "Copy recruitment ID",
-                  id: "iO72f+",
+                  defaultMessage: "Copy process ID",
+                  id: "IW+wmC",
                   description:
                     "Button text to copy a specific qualified recruitment's ID",
                 })}

--- a/apps/web/src/components/RecruitmentAvailabilityDialog/RecruitmentAvailabilityDialog.tsx
+++ b/apps/web/src/components/RecruitmentAvailabilityDialog/RecruitmentAvailabilityDialog.tsx
@@ -150,7 +150,7 @@ const RecruitmentAvailabilityDialog = ({
               <p data-h2-margin-bottom="base(x1)">
                 {intl.formatMessage({
                   defaultMessage:
-                    "If you've recently taken a job or simply no longer want to be considered for opportunities, you can disable your availability in this recruitment process. <strong>This will <emphasize>not</emphasize> remove you from the recruitment</strong> itself and you can always re-enable your availability if you change your mind.",
+                    "If you've recently taken a job or simply no longer want to be considered for opportunities, you can disable your availability in this recruitment process. <strong>This will <emphasize>not</emphasize> remove you from the process</strong> itself and you can always re-enable your availability if you change your mind.",
                   id: "3AwFyW",
                   description:
                     "Text describing what it means to disable your availability and that you can reverse the decision",

--- a/apps/web/src/hooks/usePoolMutations.ts
+++ b/apps/web/src/hooks/usePoolMutations.ts
@@ -263,8 +263,8 @@ const usePoolMutations = (returnPath?: string) => {
           navigateBack();
           toast.success(
             intl.formatMessage({
-              defaultMessage: "Pool deleted successfully!",
-              id: "93AuFS",
+              defaultMessage: "Process deleted successfully!",
+              id: "LVQu1R",
               description: "Message displayed to user after pool is deleted",
             }),
           );
@@ -296,8 +296,8 @@ const usePoolMutations = (returnPath?: string) => {
           navigateBack();
           toast.success(
             intl.formatMessage({
-              defaultMessage: "Pool archived successfully!",
-              id: "jft3KM",
+              defaultMessage: "Process archived successfully!",
+              id: "s3JBjM",
               description: "Message displayed to user after pool is archived",
             }),
           );
@@ -330,8 +330,8 @@ const usePoolMutations = (returnPath?: string) => {
           toast.success(
             intl.formatMessage({
               defaultMessage:
-                "Success: This pool has been duplicated successfully.",
-              id: "vlyq02",
+                "Success: This process has been duplicated successfully.",
+              id: "MwWYDJ",
               description: "Message displayed to user after pool is deleted",
             }),
           );

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -111,8 +111,8 @@
     "defaultMessage": "Modifier ces renseignements<hidden> pour {title}</hidden>",
     "description": "Text label for button to edit employment equity category in profile."
   },
-  "+h7iQH": {
-    "defaultMessage": "Masquer les évaluations des compétences de ce recrutement",
+  "JeAzDb": {
+    "defaultMessage": "Masquer les évaluations des compétences de ce processus",
     "description": "Button text to hide a miscellaneous qualified recruitment's skill assessments"
   },
   "+hRCVl": {
@@ -1303,8 +1303,8 @@
     "defaultMessage": "Les ressources contractuelles devraient commencer à travailler en",
     "description": "Label for _contract start timeframe_ fieldset in the _digital services contracting questionnaire_"
   },
-  "5HJIwt": {
-    "defaultMessage": "Identifiant de recrutement copié",
+  "QNmxIN": {
+    "defaultMessage": "Identifiant de processus copié",
     "description": "Button text to indicate that a specific qualified recruitment's ID has been copied"
   },
   "5LWxHq": {
@@ -2315,8 +2315,8 @@
     "defaultMessage": "« Minorité visible réfère au fait qu'une personne est ou non une minorité visible, tel que défini dans la Loi sur l'équité en matière d'emploi. Dans le cadre de la Loi sur l'équité en matière d'emploi, les minorités visibles sont définies comme « les personnes, autres que les Autochtones, qui ne sont pas de race blanche ou qui n'ont pas la peau blanche ». La population des minorités visibles est principalement composée des groupes suivants : Sud-Asiatique, Chinois, Noir, Philippin, Arabe, Latino-Américain, Asiatique du Sud-Est, Asiatique occidental, Coréen et Japonais. »",
     "description": "Definition of Visible minority from the StatsCan 'Visible minority of person' page."
   },
-  "BFewIk": {
-    "defaultMessage": "Afficher les évaluations des compétences de ce recrutement",
+  "7Iv/YA": {
+    "defaultMessage": "Afficher les évaluations des compétences de ce processus",
     "description": "Button text to show a miscellaneous qualified recruitment's skill assessments"
   },
   "BFvwdM": {
@@ -3863,8 +3863,8 @@
     "defaultMessage": "Fiabilité",
     "description": "Reliability screening level"
   },
-  "KLEaLQ": {
-    "defaultMessage": "Recrutements",
+  "aAIZbC": {
+    "defaultMessage": "Processus",
     "description": "Link to the Pools page in the nav menu."
   },
   "KS1jGw": {
@@ -8222,8 +8222,8 @@
     "defaultMessage": "Facultatives",
     "description": "Label for an optional skill"
   },
-  "iO72f+": {
-    "defaultMessage": "Copier l’identifiant de recrutement",
+  "IW+wmC": {
+    "defaultMessage": "Copier l’identifiant du processus",
     "description": "Button text to copy a specific qualified recruitment's ID"
   },
   "iPuAKE": {
@@ -8594,8 +8594,8 @@
     "defaultMessage": "Échec de la mise à jour des notes pour le candidat dans le {poolName}",
     "description": "Toast notification for failed update of candidates notes in specified pool"
   },
-  "kZs3Nk": {
-    "defaultMessage": "Autres recrutements",
+  "n+/HPL": {
+    "defaultMessage": "Autres processus",
     "description": "Heading for table of a users other applications and recruitments"
   },
   "kbMB6R": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -267,9 +267,9 @@
     "defaultMessage": "Vous aurez besoin d’une application d’authentification.",
     "description": "Subtitle for a section explaining mfa apps"
   },
-  "/Y7x+s": {
-    "defaultMessage": "Créer un bassin",
-    "description": "Heading displayed above the Create Pool form."
+  "wP9+aN": {
+    "defaultMessage": "Créer un processus",
+    "description": "Heading displayed above the Create process form."
   },
   "/YaoWc": {
     "defaultMessage": "Vos principales compétences",
@@ -475,8 +475,8 @@
     "defaultMessage": "Placement de talents",
     "description": "Title for candidates tab for a process"
   },
-  "0a8nPa": {
-    "defaultMessage": "Ce tableau présente une liste de tous les candidats à ce bassin.",
+  "Evn5Mo": {
+    "defaultMessage": "Ce tableau présente une liste de tous les candidats à ce processus.",
     "description": "Descriptive text about the list of pool candidates in the admin portal."
   },
   "0aU6BD": {
@@ -1915,8 +1915,8 @@
     "defaultMessage": "Statut de citoyenneté :",
     "description": "Citizenship status label"
   },
-  "93AuFS": {
-    "defaultMessage": "Bassin supprimé!",
+  "LVQu1R": {
+    "defaultMessage": "Processus supprimé!",
     "description": "Message displayed to user after pool is deleted"
   },
   "93zCaS": {
@@ -2151,8 +2151,8 @@
     "defaultMessage": "Ajouter une nouvelle expérience",
     "description": "A link to add a new experience to your career timeline"
   },
-  "ARL2Tz": {
-    "defaultMessage": "Au moyen de la liste des compétences fournie dans l’annonce du bassin de candidats, sélectionnez les compétences que vous prévoyez évaluer au moyen de cette méthode d’évaluation.",
+  "ylpxzO": {
+    "defaultMessage": "Au moyen de la liste des compétences du processus de recrutement, sélectionnez les compétences que vous prévoyez évaluer au moyen de cette méthode d’évaluation.",
     "description": "description of 'skill selection' section of the 'assessment details' dialog"
   },
   "ASYJlr": {
@@ -2967,8 +2967,8 @@
     "defaultMessage": "Prolonger la date de clôture",
     "description": "Title to extend a process"
   },
-  "F46Sel": {
-    "defaultMessage": "Cette section sert à définir les évaluations qui seront utilisées dans le cadre de votre processus d’évaluation. Vous pouvez également changer l’ordre dans lequel vous prévoyez effectuer ces évaluations. Les seules exceptions sont les évaluations de “présélection des candidatures” et de “questions de présélection (au moment de la candidature)” qui constitueront toujours la première et la deuxième étape pour toute annonce du bassin de candidats.",
+  "0Arzgj": {
+    "defaultMessage": "Cette section sert à définir les évaluations qui seront utilisées dans le cadre de votre processus d’évaluation. Vous pouvez également changer l’ordre dans lequel vous prévoyez effectuer ces évaluations. Les seules exceptions sont les évaluations de “présélection des candidatures” et de “questions de présélection (au moment de la candidature)” qui constitueront toujours la première et la deuxième étape pour tout processus d’évaluation.",
     "description": "introduction to the organize section in the assessment plan builder"
   },
   "F4RHJu": {
@@ -5387,8 +5387,8 @@
     "defaultMessage": "Étant donné que les plateformes de médias sociaux sont gérées par des tiers fournisseurs de services, elles n’ont pas à être conformes aux normes du gouvernement du Canada en matière d’accessibilité du Web.",
     "description": "Paragraph for comments and interaction section"
   },
-  "TLl20s": {
-    "defaultMessage": "Créer un nouveau bassin",
+  "Odhwqn": {
+    "defaultMessage": "Créer un nouveau processus",
     "description": "Label displayed on submit button for new pool form."
   },
   "TN9ndX": {
@@ -5886,8 +5886,8 @@
     "defaultMessage": "Étape de l’évaluation sauvegardée avec succès!",
     "description": "Success message displayed after unlinking an experience to a skill"
   },
-  "W2qRX5": {
-    "defaultMessage": "Erreur : Échec de la création du bassin",
+  "ruHk5N": {
+    "defaultMessage": "Erreur : Échec de la création du processus de recrutement",
     "description": "Message displayed to pool after pool fails to get created."
   },
   "W3KFtQ": {
@@ -8486,8 +8486,8 @@
     "defaultMessage": "Vous êtes sur le point de procéder à la mise à jour des rôles de l’utilisateur suivant : <strong>{userDisplayName}</strong>",
     "description": "Lead in text for the add role to user form."
   },
-  "jft3KM": {
-    "defaultMessage": "Le bassin a été archivé avec succès!",
+  "s3JBjM": {
+    "defaultMessage": "Le processus a été archivé avec succès!",
     "description": "Message affiché à l'utilisateur après l'archivage du bassin"
   },
   "jiJ8qo": {
@@ -9994,8 +9994,8 @@
     "defaultMessage": "<strong>Cheminement en gestion</strong> : Chefs d'équipe de la <abbreviation>TI</abbreviation> (<abbreviation>TI-03</abbreviation>) sont chargés de superviser le travail et les équipes de projet pour les services et les opérations de la <abbreviation>TI</abbreviation> dans leur domaine d'expertise afin de soutenir la prestation de services aux clients et aux intervenants. Les chefs d'équipe de la <abbreviation>TI</abbreviation> se trouvent dans tous les volets de travail.",
     "description": "IT-03 team lead path description"
   },
-  "t0OrQA": {
-    "defaultMessage": "Survol de l’ensemble des compétences et des évaluations prévues pour ce bassin de candidats.",
+  "S/R0ne": {
+    "defaultMessage": "Survol de l’ensemble des compétences et des évaluations prévues pour ce processus.",
     "description": "introduction to the skill summary section in the assessment plan builder"
   },
   "t28EG0": {
@@ -10350,8 +10350,8 @@
     "defaultMessage": "Se connecter à l’aide de CléGC",
     "description": "Page title for the sign in page for applicant profiles"
   },
-  "vlyq02": {
-    "defaultMessage": "Réussite : Vous avez réussi à dupliquer ce bassin.",
+  "MwWYDJ": {
+    "defaultMessage": "Réussite : Vous avez réussi à dupliquer ce processus.",
     "description": "Message displayed to user after pool is deleted"
   },
   "vyyfX6": {
@@ -10470,8 +10470,8 @@
     "defaultMessage": "1 à 5",
     "description": "Contract FTE range between one and five"
   },
-  "wZ91g+": {
-    "defaultMessage": "Création du bassin réussie!",
+  "/UxJBZ": {
+    "defaultMessage": "Création du processus de recrutement réussie!",
     "description": "Message displayed to user after pool is created successfully."
   },
   "weLwJA": {
@@ -11026,8 +11026,8 @@
     "defaultMessage": "Téléchargez la trousse du gestionnaire pour plus de renseignements et contactez l’équipe pour lancer le processus.",
     "description": "Paragraph 1 for the 'How to begin hiring an apprentice' section"
   },
-  "zwYuly": {
-    "defaultMessage": "Créer un bassin",
+  "AsxUp5": {
+    "defaultMessage": "Créer un processus",
     "description": "Page title for the pool creation page"
   },
   "zxLL3N": {

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
@@ -176,8 +176,8 @@ export const IndexPoolCandidatePage = () => {
         <p data-h2-margin="base(x1, 0)">
           {intl.formatMessage({
             defaultMessage:
-              "This table shows a list of all applicants to this pool.",
-            id: "0a8nPa",
+              "This table shows a list of all applicants to this process.",
+            id: "Evn5Mo",
             description:
               "Descriptive text about the list of pool candidates in the admin portal.",
           })}

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
@@ -650,8 +650,8 @@ export const ViewPoolCandidate = ({
             <Accordion.Item value="otherRecruitments">
               <Accordion.Trigger>
                 {intl.formatMessage({
-                  defaultMessage: "Other recruitments",
-                  id: "kZs3Nk",
+                  defaultMessage: "Other processes",
+                  id: "n+/HPL",
                   description:
                     "Heading for table of a users other applications and recruitments",
                 })}

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -304,8 +304,8 @@ export const ViewPoolCandidate = ({
               <Accordion.Item value="otherRecruitments">
                 <Accordion.Trigger>
                   {intl.formatMessage({
-                    defaultMessage: "Other recruitments",
-                    id: "kZs3Nk",
+                    defaultMessage: "Other processes",
+                    id: "n+/HPL",
                     description:
                       "Heading for table of a users other applications and recruitments",
                   })}

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialog.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialog.tsx
@@ -641,8 +641,8 @@ const AssessmentDetailsDialog = ({
                   <div data-h2-margin-top="base(x.25)">
                     {intl.formatMessage({
                       defaultMessage:
-                        "Using the list of skills from the pool advertisement, select the skills you are planning to assess using this evaluation method. ",
-                      id: "ARL2Tz",
+                        "Using the list of skills from the recruitment process, select the skills you are planning to assess using this evaluation method. ",
+                      id: "ylpxzO",
                       description:
                         "description of 'skill selection' section of the 'assessment details' dialog",
                     })}

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/OrganizeSection.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/OrganizeSection.tsx
@@ -179,8 +179,8 @@ const OrganizeSection = ({
       <p data-h2-margin="base(x1, 0)">
         {intl.formatMessage({
           defaultMessage:
-            "Use this section to define which assessments will be used as part of your assessment process. You can also change the order in which you plan to perform these evaluations. The only exceptions are the “Application screening” and the “Screening questions (at the time of application)” assessments which will always be the first and second steps in any pool advertisement.",
-          id: "F46Sel",
+            "Use this section to define which assessments will be used as part of your assessment process. You can also change the order in which you plan to perform these evaluations. The only exceptions are the “Application screening” and the “Screening questions (at the time of application)” assessments which will always be the first and second steps in any assessment process.",
+          id: "0Arzgj",
           description:
             "introduction to the organize section in the assessment plan builder",
         })}

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/SkillSummarySection.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/SkillSummarySection.tsx
@@ -33,8 +33,8 @@ const SkillSummarySection = ({ pool }: SkillSummarySectionProps) => {
       <p data-h2-margin="base(x1, 0)">
         {intl.formatMessage({
           defaultMessage:
-            "Overview of all skills and assessments planned for this pool.",
-          id: "t0OrQA",
+            "Overview of all skills and assessments planned for this process.",
+          id: "S/R0ne",
           description:
             "introduction to the skill summary section in the assessment plan builder",
         })}

--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -70,8 +70,8 @@ export const CreatePoolForm = ({
           navigate(paths.poolUpdate(result.id));
           toast.success(
             intl.formatMessage({
-              defaultMessage: "Pool created successfully!",
-              id: "wZ91g+",
+              defaultMessage: "Recruitment process created successfully!",
+              id: "/UxJBZ",
               description:
                 "Message displayed to user after pool is created successfully.",
             }),
@@ -81,8 +81,8 @@ export const CreatePoolForm = ({
       .catch(() => {
         toast.error(
           intl.formatMessage({
-            defaultMessage: "Error: creating pool failed",
-            id: "W2qRX5",
+            defaultMessage: "Error: creating recruitment process failed",
+            id: "ruHk5N",
             description:
               "Message displayed to pool after pool fails to get created.",
           }),
@@ -159,8 +159,8 @@ export const CreatePoolForm = ({
               <Submit
                 color="secondary"
                 text={intl.formatMessage({
-                  defaultMessage: "Create new pool",
-                  id: "TLl20s",
+                  defaultMessage: "Create new process",
+                  id: "Odhwqn",
                   description:
                     "Label displayed on submit button for new pool form.",
                 })}
@@ -263,6 +263,12 @@ const CreatePoolPage = () => {
       return Promise.reject(result.error);
     });
 
+  const pageTitle = intl.formatMessage({
+    defaultMessage: "Create process",
+    id: "AsxUp5",
+    description: "Page title for the pool creation page",
+  });
+
   const navigationCrumbs = [
     {
       label: intl.formatMessage({
@@ -277,20 +283,10 @@ const CreatePoolPage = () => {
       url: routes.poolTable(),
     },
     {
-      label: intl.formatMessage({
-        defaultMessage: "Create new pool",
-        id: "OgeWgx",
-        description: "Breadcrumb title for the create new pool page link.",
-      }),
+      label: pageTitle,
       url: routes.poolCreate(),
     },
   ];
-
-  const pageTitle = intl.formatMessage({
-    defaultMessage: "Create pool",
-    id: "zwYuly",
-    description: "Page title for the pool creation page",
-  });
 
   return (
     <>

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -231,9 +231,9 @@ export const PoolTable = ({ pools, title }: PoolTableProps) => {
         linkProps: {
           href: paths.poolCreate(),
           label: intl.formatMessage({
-            defaultMessage: "Create Pool",
-            id: "/Y7x+s",
-            description: "Heading displayed above the Create Pool form.",
+            defaultMessage: "Create process",
+            id: "wP9+aN",
+            description: "Heading displayed above the Create process form.",
           }),
         },
       }}

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -296,8 +296,8 @@ export const useAdminPoolPages = (intl: IntlShape, pool: Pick<Pool, "id">) => {
               {
                 url: paths.poolTable(),
                 label: intl.formatMessage({
-                  defaultMessage: "Recruitments",
-                  id: "KLEaLQ",
+                  defaultMessage: "Processes",
+                  id: "aAIZbC",
                   description: "Link to the Pools page in the nav menu.",
                 }),
               },
@@ -336,8 +336,8 @@ export const useAdminPoolPages = (intl: IntlShape, pool: Pick<Pool, "id">) => {
               {
                 url: paths.poolTable(),
                 label: intl.formatMessage({
-                  defaultMessage: "Recruitments",
-                  id: "KLEaLQ",
+                  defaultMessage: "Processes",
+                  id: "aAIZbC",
                   description: "Link to the Pools page in the nav menu.",
                 }),
               },
@@ -425,8 +425,8 @@ export const useAdminPoolPages = (intl: IntlShape, pool: Pick<Pool, "id">) => {
               {
                 url: paths.poolTable(),
                 label: intl.formatMessage({
-                  defaultMessage: "Recruitments",
-                  id: "KLEaLQ",
+                  defaultMessage: "Processes",
+                  id: "aAIZbC",
                   description: "Link to the Pools page in the nav menu.",
                 }),
               },


### PR DESCRIPTION
🤖 Resolves #9643

## 👋 Introduction

I made the change to the breadcrumbs which @Jerryescandon initially required.

Additionally, I looked through other uses of the word "Recruitment" and the instances of "Pool" which @mnigh [found](https://github.com/GCTC-NTGC/gc-digital-talent/issues/9643#issuecomment-1981399371), and tried to use my judgement following @Jerryescandon's [advice](https://github.com/GCTC-NTGC/gc-digital-talent/issues/9643#issuecomment-1981481988) to replace with the word "process" (or "recruitment process") where appropriate.
