### PR TITLE
[Fix] `notes` column sorting on Pool candidates table

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -298,7 +298,6 @@ export function transformSortStateToOrderByClause(
   const columnMap = new Map<string, string>([
     ["dateReceived", "submitted_at"],
     ["candidacyStatus", "suspended_at"],
-    ["candidacyStatus", "suspended_at"],
     ["finalDecision", "status"],
     ["jobPlacement", "status"],
     ["candidateName", "FIRST_NAME"],

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -308,6 +308,7 @@ export function transformSortStateToOrderByClause(
     ["skillCount", "skill_count"],
     ["priority", "PRIORITY_WEIGHT"],
     ["status", "status_weight"],
+    ["notes", "notes"],
   ]);
 
   const sortingRule = sortingRules?.find((rule) => {
@@ -317,7 +318,9 @@ export function transformSortStateToOrderByClause(
 
   if (
     sortingRule &&
-    ["dateReceived", "candidacyStatus", "status"].includes(sortingRule.id)
+    ["dateReceived", "candidacyStatus", "status", "notes"].includes(
+      sortingRule.id,
+    )
   ) {
     const columnName = columnMap.get(sortingRule.id);
     return {


### PR DESCRIPTION
🤖 Resolves #9218.

## 👋 Introduction

This PR fixes sorting for the `notes` column on the Pool candidates table.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Log in as an admin
2. Go to "candidate search" (/admin/pool-candidates)
3. Sort by **Notes** column (ensure at least a few candidates have notes)
4. Verify alphanumeric sorting occurs