### PR TITLE
[Fix] Skills page crumbs

### DIFF
--- a/apps/web/src/pages/Skills/SkillPage.tsx
+++ b/apps/web/src/pages/Skills/SkillPage.tsx
@@ -39,7 +39,7 @@ export const SkillPage = () => {
         id: "EBmWyo",
         description: "Link text for the home link in breadcrumbs.",
       }),
-      url: routes.adminDashboard(),
+      url: routes.home(),
     },
     {
       label: formattedPageTitle,

--- a/apps/web/src/pages/Skills/SkillPage.tsx
+++ b/apps/web/src/pages/Skills/SkillPage.tsx
@@ -9,6 +9,7 @@ import Hero from "~/components/Hero";
 import { INITIAL_STATE } from "~/components/Table/ResponsiveTable/constants";
 import adminMessages from "~/messages/adminMessages";
 import skillBrowserMessages from "~/components/SkillBrowser/messages";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import SkillTableApi from "./components/SkillTable";
 
@@ -32,20 +33,12 @@ export const SkillPage = () => {
   const formattedPageTitle = intl.formatMessage(pageTitle);
   const formattedPageSubtitle = intl.formatMessage(pageSubtitle);
 
-  const crumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.home(),
-    },
+  const crumbs = useBreadcrumbs([
     {
       label: formattedPageTitle,
       url: routes.skills(),
     },
-  ];
+  ]);
 
   return (
     <>


### PR DESCRIPTION
🤖 Resolves #9763.

## 👋 Introduction

This PR fixes the **Home** breadcrumb link to lead to home route. It also makes use of the `useBreadcrumb` hook.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/skills`
2. Click Home breadcrumb link
3. Page that loads is `/`