### PR TITLE
[Bug] Fix assessment step dialog

### DIFF
--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -296,7 +296,9 @@ export const ScreeningDecisionDialog = ({
         ? getAssessmentStepType(assessmentStep?.type)
         : commonMessages.notApplicable,
     ),
-    customTitle: getLocalizedName(assessmentStep?.title, intl),
+    customTitle: assessmentStep.title
+      ? getLocalizedName(assessmentStep?.title, intl)
+      : "",
     candidateName: poolCandidate.user.firstName,
     skillName: getLocalizedName(skill?.name, intl),
     skillLevel,

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -163,10 +163,6 @@
     "defaultMessage": "Vue {name} <hidden>{hiddenLabel}</hidden>",
     "description": "Title displayed for the View Item column."
   },
-  "/+cTZi": {
-    "defaultMessage": "Anglais – Titre de l’évaluation facultative",
-    "description": "Label for 'English assessment title' input on the assessment details dialog"
-  },
   "/+naWC": {
     "defaultMessage": "À évaluer",
     "description": "Message displayed when candidate has yet to be assessed at a specific assessment step"
@@ -4583,10 +4579,6 @@
     "defaultMessage": "Réduire toutes les sections<hidden> de l’information sur la demande</hidden>",
     "description": "Button text to close all application information accordions"
   },
-  "OoZjap": {
-    "defaultMessage": "Français – Titre de l’évaluation facultative",
-    "description": "Label for 'French assessment title' input on the assessment details dialog"
-  },
   "OpKC2i": {
     "defaultMessage": "Exceptions relatives au lieu de travail",
     "description": "Work location exceptions label"
@@ -8222,6 +8214,10 @@
     "defaultMessage": "La présente section vous permet, <strong>de façon facultative,</strong> d’ajouter jusqu’à 3 questions d’ordre général qui seront posées aux candidats dans le cadre du processus de demande. Veuillez prendre note que celles-ci ne <strong>sont pas des questions de filtrage</strong>. Des questions de filtrage seront ajoutées une fois que vous aurez façonné votre plan d’évaluation.",
     "description": "Helper message indicating what general questions are and how they differ from screening questions"
   },
+  "iFbBSU": {
+    "defaultMessage": "Titre de l’évaluation (Anglais)",
+    "description": "Label for 'English assessment title' input on the assessment details dialog"
+  },
   "iGXXjP": {
     "defaultMessage": "Téléchargez la trousse du gestionnaire",
     "description": "Call to action to download the manager's package"
@@ -8769,6 +8765,10 @@
   "lPuC3S": {
     "defaultMessage": "Commentaires et échanges",
     "description": "Heading for comments and interaction section"
+  },
+  "lSHDBh": {
+    "defaultMessage": "Titre de l’évaluation (Français)",
+    "description": "Label for 'French assessment title' input on the assessment details dialog"
   },
   "lVb1hs": {
     "defaultMessage": "Au moins une question est requise dans le cadre de cette évaluation. Veuillez l’ajouter ici.",

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialogLabels.ts
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialogLabels.ts
@@ -8,14 +8,14 @@ const labels = defineMessages({
       "Label for 'Type of assessment' input on the assessment details dialog",
   },
   assessmentTitleEn: {
-    defaultMessage: "English - Optional assessment title",
-    id: "/+cTZi",
+    defaultMessage: "Assessment title (English)",
+    id: "iFbBSU",
     description:
       "Label for 'English assessment title' input on the assessment details dialog",
   },
   assessmentTitleFr: {
-    defaultMessage: "French - Optional assessment title",
-    id: "OoZjap",
+    defaultMessage: "Assessment title (French)",
+    id: "lSHDBh",
     description:
       "Label for 'French assessment title' input on the assessment details dialog",
   },


### PR DESCRIPTION
🤖 Resolves #9758 

## 👋 Introduction

- Fixes the screening decision dialog custom title.
- Fixes the assessment dialog optional title labels.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Login as admin `admin@test.com`
2. Go to processes and find a process with no custom title and ensure "N/A" doesn't show up if no custom title exists. (You might need to create a process to verify this or manipulate the data in the DB)
3. Also, go to the Assessment plan page and open the assessment plan dialog by clicking "Add a new assessment". Ensure the custom title labels are correct.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/dfd91369-df76-4aac-882a-974c75d593b0)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/def6bd62-4ce9-4400-84f4-d23d5e0bb3f2)
