### PR TITLE
Switch to name getter rather than description

### DIFF
--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -36,6 +36,7 @@ import {
   getLocale,
   getLocalizedName,
   getSkillLevelDefinition,
+  getSkillLevelName,
 } from "@gc-digital-talent/i18n";
 import { toast } from "@gc-digital-talent/toast";
 import {
@@ -66,10 +67,7 @@ const getSkillLevelMessage = (
   let skillLevel = "";
   if (poolSkill?.requiredLevel && poolSkill.skill) {
     skillLevel = intl.formatMessage(
-      getSkillLevelDefinition(
-        poolSkill.requiredLevel,
-        poolSkill.skill.category,
-      ),
+      getSkillLevelName(poolSkill.requiredLevel, poolSkill.skill.category),
     );
   } else skillLevel = intl.formatMessage(commonMessages.notFound);
 


### PR DESCRIPTION
🤖 Resolves #9778 

## 👋 Introduction

One place was just using the wrong getter, a quick fix

## 🧪 Testing

1. Open assessment dialog for a candidate and observe

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/e1e77d45-b6a3-4187-adc1-7de2e1910681)

