### PR TITLE
[Fix] Announce admin pool page navigations

### DIFF
--- a/apps/web/src/pages/Pools/PoolLayout.tsx
+++ b/apps/web/src/pages/Pools/PoolLayout.tsx
@@ -3,7 +3,12 @@ import { useIntl } from "react-intl";
 import { Outlet } from "react-router-dom";
 import { useQuery } from "urql";
 
-import { Pending, Chip, ThrowNotFound } from "@gc-digital-talent/ui";
+import {
+  Pending,
+  Chip,
+  ThrowNotFound,
+  useAnnouncer,
+} from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 import { graphql, Pool } from "@gc-digital-talent/graphql";
 
@@ -25,6 +30,7 @@ interface PoolHeaderProps {
 
 const PoolHeader = ({ pool }: PoolHeaderProps) => {
   const intl = useIntl();
+  const { announce } = useAnnouncer();
 
   const pages = useAdminPoolPages(intl, pool);
 
@@ -36,6 +42,12 @@ const PoolHeader = ({ pool }: PoolHeaderProps) => {
 
   const advertisementStatus = getAdvertisementStatus(pool);
   const advertisementBadge = getPoolCompletenessBadge(advertisementStatus);
+
+  React.useEffect(() => {
+    if (currentPage?.title) {
+      announce(currentPage?.title);
+    }
+  }, [announce, currentPage?.title, intl]);
 
   return (
     <>


### PR DESCRIPTION
🤖 Resolves #9728 

## 👋 Introduction

Fixes an issue where pool page navigations were not being announced to screen readers.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `npm run dev`
2. Login as admin `admin@test.com
3. Start a screen reader
4. Navigate to a pool in the admin
5. Change tabs
6. Confirm page title is being announced after the page change
