### PR TITLE
[Bug] Screening dialog handle null education requirement

### DIFF
--- a/api/database/factories/PoolCandidateFactory.php
+++ b/api/database/factories/PoolCandidateFactory.php
@@ -111,8 +111,9 @@ class PoolCandidateFactory extends Factory
                 ]);
             }
 
-            if ($poolCandidate->education_requirement_option ===
-            EducationRequirementOption::EDUCATION->name || EducationRequirementOption::PROFESSIONAL_DESIGNATION->name) {
+            // attach either a work or education experience to a pool candidate to meet minimum criteria
+            if ($poolCandidate->education_requirement_option === EducationRequirementOption::EDUCATION->name ||
+            $poolCandidate->education_requirement_option === EducationRequirementOption::PROFESSIONAL_DESIGNATION->name) {
                 //Ensure user has at least one education experience
                 $experience = EducationExperience::factory()->create([
                     'user_id' => $poolCandidate->user_id,

--- a/api/database/factories/PoolCandidateFactory.php
+++ b/api/database/factories/PoolCandidateFactory.php
@@ -49,9 +49,8 @@ class PoolCandidateFactory extends Factory
             'submitted_steps' => array_slice(
                 array_column(ApplicationStep::cases(), 'name'),
                 0,
-                $this->faker->numberBetween(0, count(ApplicationStep::cases()) - 1)
+                $this->faker->numberBetween(0, count(ApplicationStep::cases()) - 2)
             ),
-            'education_requirement_option' => $this->faker->randomElement(EducationRequirementOption::cases())->name,
             'is_bookmarked' => $this->faker->boolean(10),
         ];
     }
@@ -71,6 +70,7 @@ class PoolCandidateFactory extends Factory
                 $poolCandidate->update([
                     'submitted_at' => $submittedDate,
                     'signature' => $fakeSignature,
+                    'submitted_steps' => array_column(ApplicationStep::cases(), 'name'),
                 ]);
             }
 
@@ -98,7 +98,21 @@ class PoolCandidateFactory extends Factory
                 }
             }
 
-            if ($poolCandidate->education_requirement_option === EducationRequirementOption::EDUCATION->name) {
+            // set education requirement option, influenced by classification of pool
+            $classificationOne = $poolCandidate->pool->classifications()->first()->group;
+            if ($classificationOne === 'EX') {
+                $poolCandidate->update([
+                    'education_requirement_option' => EducationRequirementOption::PROFESSIONAL_DESIGNATION->name,
+                ]);
+            } else {
+                $requirementOption = $this->faker->boolean() ? EducationRequirementOption::APPLIED_WORK->name : EducationRequirementOption::EDUCATION->name;
+                $poolCandidate->update([
+                    'education_requirement_option' => $requirementOption,
+                ]);
+            }
+
+            if ($poolCandidate->education_requirement_option ===
+            EducationRequirementOption::EDUCATION->name || EducationRequirementOption::PROFESSIONAL_DESIGNATION->name) {
                 //Ensure user has at least one education experience
                 $experience = EducationExperience::factory()->create([
                     'user_id' => $poolCandidate->user_id,

--- a/api/database/seeders/UserRandomSeeder.php
+++ b/api/database/seeders/UserRandomSeeder.php
@@ -2,16 +2,13 @@
 
 namespace Database\Seeders;
 
-use App\Enums\EducationRequirementOption;
 use App\Enums\SkillLevel;
 use App\Enums\WhenSkillUsed;
 use App\Models\AwardExperience;
-use App\Models\EducationExperience;
 use App\Models\Pool;
 use App\Models\PoolCandidate;
 use App\Models\User;
 use App\Models\UserSkill;
-use App\Models\WorkExperience;
 use Faker\Generator;
 use Illuminate\Container\Container;
 use Illuminate\Database\Seeder;
@@ -136,26 +133,6 @@ class UserRandomSeeder extends Seeder
                 }
             })
             ->create();
-
-        // attach either a work or education experience to a pool candidate to meet minimum criteria
-        PoolCandidate::all()->load('user')->each(function ($poolCandidate) {
-            $educationRequirementOption = $poolCandidate->education_requirement_option;
-            $user = $poolCandidate->user;
-
-            if ($educationRequirementOption === EducationRequirementOption::EDUCATION->name) {
-                //Ensure user has at least one education experience
-                $experience = EducationExperience::factory()->create([
-                    'user_id' => $user->id,
-                ]);
-                $poolCandidate->educationRequirementEducationExperiences()->sync([$experience->id]);
-            } elseif ($educationRequirementOption === EducationRequirementOption::APPLIED_WORK->name) {
-                //Ensure user has at least one work experience
-                $experience = WorkExperience::factory()->create([
-                    'user_id' => $user->id,
-                ]);
-                $poolCandidate->educationRequirementWorkExperiences()->sync([$experience->id]);
-            }
-        });
     }
 
     private function seedPoolCandidate(User $user, Pool $pool)

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -100,12 +100,21 @@ const AssessmentStepTypeSection = ({
                 "Header for selected requirement option in education requirement screening decision dialog.",
             })}
           </p>
-          <Well
-            data-h2-margin-bottom="base(x1)"
-            data-h2-text-align="base(left)"
-          >
-            {educationRequirementOption}
-          </Well>
+          {educationRequirementOption ? (
+            <Well
+              data-h2-margin-bottom="base(x1)"
+              data-h2-text-align="base(left)"
+            >
+              {educationRequirementOption}
+            </Well>
+          ) : (
+            <p
+              data-h2-margin-bottom="base(x.5)"
+              data-h2-margin-left="base(x.25)"
+            >
+              {intl.formatMessage(commonMessages.notFound)}
+            </p>
+          )}
         </div>
       );
     default:
@@ -237,18 +246,22 @@ const SupportingEvidence = ({
             "Header for supporting evidence section in screening decision dialog.",
         })}
       </p>
-      {experiences.length
-        ? experiences.map((experience) => (
-            <div data-h2-margin-bottom="base(x.5)" key={experience.id}>
-              <ExperienceCard
-                experience={experience}
-                headingLevel={contentHeadingLevel}
-                showEdit={false}
-                showSkills={skill}
-              />
-            </div>
-          ))
-        : null}
+      {experiences.length ? (
+        experiences.map((experience) => (
+          <div data-h2-margin-bottom="base(x.5)" key={experience.id}>
+            <ExperienceCard
+              experience={experience}
+              headingLevel={contentHeadingLevel}
+              showEdit={false}
+              showSkills={skill}
+            />
+          </div>
+        ))
+      ) : (
+        <p data-h2-margin-bottom="base(x.5)" data-h2-margin-left="base(x.25)">
+          {intl.formatMessage(commonMessages.notFound)}
+        </p>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
🤖 Resolves #9730

## 👋 Introduction

The referenced is not skill-related but actually the education form of the dialog, so falsy handling added.
Tweaked seeding a bit as it was throwing me for a loop a first. 

## 🧪 Testing

1. Normal assessment view for education unchanged
2. Empty education view has null handling 

## 📸 Screenshot

Normal 

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/90545b0e-a2a7-4515-8958-e0a00850599a)

Falsy

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/8917958b-d9d6-4eea-b3b0-bc07f48c5a21)

Easy way to add applications with empty education

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/961bf972-7b4d-4b5f-beb2-6d1aed2df30e)

French for reference to compare against image in issue

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/b5fa0f94-7ca3-4cfe-a2a9-94d9c32d02af)



