### PR TITLE
[Tooling] make slow query logging into single line

### DIFF
--- a/api/app/Http/Middleware/SlowQueryLoggerMiddleware.php
+++ b/api/app/Http/Middleware/SlowQueryLoggerMiddleware.php
@@ -31,10 +31,13 @@ class SlowQueryLoggerMiddleware
         $result = $next($request);
         $end = hrtime(true);
         $elapsedSeconds = ($end - $start) / 1000000000;
-        $requestData = $request->json()->all();
 
         if ($elapsedSeconds > 5) {
-            $logMessage = 'Slow query, '.$elapsedSeconds.', '.($requestData['operationName'] ? $requestData['operationName'] : 'Unnamed operation').', '.request()->headers->get('referer').', '.($requestData['query'] ? json_encode($requestData['query']) : 'No query found');
+            $requestData = $request->json()->all();
+            $referer = request()->headers->get('referer');
+            $operationName = $requestData['operationName'] ?? 'Unnamed Operation';
+            $query = $requestData['query'] ?? 'No query found'; 
+            $logMessage = 'Slow Query, '.$elapsedSeconds.', '.$operationName.', '.$referer.', '.json_encode($query);
             $this->logger->info($logMessage);
         }
 

--- a/api/app/Http/Middleware/SlowQueryLoggerMiddleware.php
+++ b/api/app/Http/Middleware/SlowQueryLoggerMiddleware.php
@@ -36,7 +36,7 @@ class SlowQueryLoggerMiddleware
             $requestData = $request->json()->all();
             $referer = request()->headers->get('referer');
             $operationName = $requestData['operationName'] ?? 'Unnamed Operation';
-            $query = $requestData['query'] ?? 'No query found'; 
+            $query = $requestData['query'] ?? 'No query found';
             $logMessage = 'Slow Query, '.$elapsedSeconds.', '.$operationName.', '.$referer.', '.json_encode($query);
             $this->logger->info($logMessage);
         }

--- a/api/app/Http/Middleware/SlowQueryLoggerMiddleware.php
+++ b/api/app/Http/Middleware/SlowQueryLoggerMiddleware.php
@@ -31,15 +31,14 @@ class SlowQueryLoggerMiddleware
         $result = $next($request);
         $end = hrtime(true);
         $elapsedSeconds = ($end - $start) / 1000000000;
+        $requestData = $request->json()->all();
+        $referer = request()->headers->get('referer');
+        $operationName = $requestData['operationName'] ?? 'Unnamed Operation';
+        $query = $requestData['query'] ?? 'No query found'; // just in case
 
         if ($elapsedSeconds > 5) {
-            $this->logger->info(
-                'Slow query',
-                [
-                    'request' => $request->json()->all(),
-                    'elapsed_seconds' => $elapsedSeconds,
-                ]
-            );
+            $logMessage = 'Slow Query, '.$elapsedSeconds.', '.$operationName.', '.$referer.', '.json_encode($query);
+            $this->logger->info($logMessage);
         }
 
         return $result;

--- a/api/app/Http/Middleware/SlowQueryLoggerMiddleware.php
+++ b/api/app/Http/Middleware/SlowQueryLoggerMiddleware.php
@@ -32,12 +32,9 @@ class SlowQueryLoggerMiddleware
         $end = hrtime(true);
         $elapsedSeconds = ($end - $start) / 1000000000;
         $requestData = $request->json()->all();
-        $referer = request()->headers->get('referer');
-        $operationName = $requestData['operationName'] ?? 'Unnamed Operation';
-        $query = $requestData['query'] ?? 'No query found'; // just in case
 
         if ($elapsedSeconds > 5) {
-            $logMessage = 'Slow Query, '.$elapsedSeconds.', '.$operationName.', '.$referer.', '.json_encode($query);
+            $logMessage = 'Slow query, '.$elapsedSeconds.', '.($requestData['operationName'] ? $requestData['operationName'] : 'Unnamed operation').', '.request()->headers->get('referer').', '.($requestData['query'] ? json_encode($requestData['query']) : 'No query found');
             $this->logger->info($logMessage);
         }
 


### PR DESCRIPTION
🤖 Resolves #9704 

## 👋 Introduction
This PR formats slow query logging into single line

## 🧪 Testing


1. Open up laravel.log file
2. Go to Admin Dashboard and do any extensive operation like opening up Candidate Search page
3. Observe the log 

## 📸 Screenshot
```
[2024-03-19 14:42:03] local.INFO: Slow Query, 10.3536912, AdminDashboard_Query, http://localhost:8000/en/admin/dashboard, "query AdminDashboard_Query {\n  me {\n    id\n    firstName\n    lastName\n    __typename\n  }\n}"  

```

