### PR TITLE
[Fix] Revert cookie setting

### DIFF
--- a/api/config/session.php
+++ b/api/config/session.php
@@ -195,8 +195,10 @@ return [
     |
     | Supported: "lax", "strict", "none", null
     |
+    | GC Talent Note: strict cookies will break login session state from a provider in a different origin.
+    |
     */
 
-    'same_site' => env('SESSION_SAME_SITE_COOKIE', 'strict'),
+    'same_site' => env('SESSION_SAME_SITE_COOKIE', 'lax'),
 
 ];


### PR DESCRIPTION
🤖 Resolves #9791

## 👋 Introduction

This branch reverts the Laravel cookies setting back to lax to allow SIC logins to continue working.

## 🧪 Testing

1. Configure your environment to use SIC-Test
2. Try to log in and log out.