### PR TITLE
[Debt] Implements `useBreadcrumbs` hook broadly

### DIFF
--- a/apps/web/src/components/Layout/Layout.tsx
+++ b/apps/web/src/components/Layout/Layout.tsx
@@ -45,11 +45,7 @@ const Layout = () => {
 
   let menuItems = [
     <MenuLink key="home" to={paths.home()} end>
-      {intl.formatMessage({
-        defaultMessage: "Home",
-        id: "G1RNXj",
-        description: "Link to the Homepage in the nav menu.",
-      })}
+      {intl.formatMessage(navigationMessages.home)}
     </MenuLink>,
     <MenuLink key="search" to={paths.search()}>
       {intl.formatMessage(navigationMessages.findTalent)}

--- a/apps/web/src/hooks/useBreadcrumbs.ts
+++ b/apps/web/src/hooks/useBreadcrumbs.ts
@@ -7,16 +7,17 @@ import useRoutes from "./useRoutes";
 
 type Crumbs = BreadcrumbsProps["crumbs"];
 
-const useBreadcrumbs = (crumbs: Crumbs) => {
+const useBreadcrumbs = (crumbs: Crumbs, isAdmin?: boolean) => {
   const intl = useIntl();
   const paths = useRoutes();
   const [searchParams] = useSearchParams();
 
   const iapPersonality = searchParams.get("personality") === "iap";
+  const homePath = isAdmin ? paths.adminDashboard : paths.home();
 
   return [
     {
-      url: !iapPersonality ? paths.home() : paths.iap(),
+      url: !iapPersonality ? homePath : paths.iap(),
       label: intl.formatMessage({
         defaultMessage: "Home",
         id: "EBmWyo",

--- a/apps/web/src/hooks/useBreadcrumbs.ts
+++ b/apps/web/src/hooks/useBreadcrumbs.ts
@@ -7,7 +7,12 @@ import useRoutes from "./useRoutes";
 
 type Crumbs = BreadcrumbsProps["crumbs"];
 
-const useBreadcrumbs = (crumbs: Crumbs, isAdmin?: boolean) => {
+type useBreadcrumbsProps = {
+  crumbs: Crumbs;
+  isAdmin?: boolean;
+};
+
+const useBreadcrumbs = ({ crumbs, isAdmin }: useBreadcrumbsProps) => {
   const intl = useIntl();
   const paths = useRoutes();
   const [searchParams] = useSearchParams();

--- a/apps/web/src/hooks/useBreadcrumbs.ts
+++ b/apps/web/src/hooks/useBreadcrumbs.ts
@@ -13,7 +13,7 @@ const useBreadcrumbs = (crumbs: Crumbs, isAdmin?: boolean) => {
   const [searchParams] = useSearchParams();
 
   const iapPersonality = searchParams.get("personality") === "iap";
-  const homePath = isAdmin ? paths.adminDashboard : paths.home();
+  const homePath = isAdmin ? paths.adminDashboard() : paths.home();
 
   return [
     {

--- a/apps/web/src/hooks/useBreadcrumbs.ts
+++ b/apps/web/src/hooks/useBreadcrumbs.ts
@@ -2,6 +2,7 @@ import { useIntl } from "react-intl";
 import { useSearchParams } from "react-router-dom";
 
 import type { BreadcrumbsProps } from "@gc-digital-talent/ui";
+import { navigationMessages } from "@gc-digital-talent/i18n";
 
 import useRoutes from "./useRoutes";
 
@@ -23,11 +24,7 @@ const useBreadcrumbs = ({ crumbs, isAdmin }: useBreadcrumbsProps) => {
   return [
     {
       url: !iapPersonality ? homePath : paths.iap(),
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
+      label: intl.formatMessage(navigationMessages.home),
     },
     ...crumbs,
   ];

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2839,10 +2839,6 @@
     "defaultMessage": "Aidez les gestionnaires à comprendre vos occasions potentielles d’apprentissage de compétences comportementales.",
     "description": "Page description for the improve behavioural skills page"
   },
-  "EBmWyo": {
-    "defaultMessage": "Accueil",
-    "description": "Link text for the home link in breadcrumbs."
-  },
   "EGNLD7": {
     "defaultMessage": "Durée de l’emploi",
     "description": "Label for pool advertisement employment length"
@@ -3142,10 +3138,6 @@
   "G1OWMo": {
     "defaultMessage": "Vous pouvez ajouter des expériences lorsque vous <link>créez une nouvelle expérience de parcours professionnel à l’étape précédente.</link>",
     "description": "Secondary alert message informing user to add experience in application education page."
-  },
-  "G1RNXj": {
-    "defaultMessage": "Accueil",
-    "description": "Link to the Homepage in the nav menu."
   },
   "G1jegJ": {
     "defaultMessage": "Veuillez remplir toutes les zones obligatoires avant de continuer",

--- a/apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.tsx
+++ b/apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.tsx
@@ -252,12 +252,14 @@ const AccessibilityStatementPage = () => {
     },
   ];
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: pageTitle,
-      url: paths.accessibility(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: pageTitle,
+        url: paths.accessibility(),
+      },
+    ],
+  });
 
   return (
     <>

--- a/apps/web/src/pages/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/apps/web/src/pages/AnnouncementsPage/AnnouncementsPage.tsx
@@ -13,6 +13,7 @@ import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import AdminHero from "~/components/Hero/AdminHero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import SitewideAnnouncementSection from "./SitewideAnnouncementSection";
 
@@ -95,20 +96,15 @@ const AnnouncementsPage = () => {
     );
   };
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: formattedPageTitle,
-      url: routes.announcements(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: formattedPageTitle,
+        url: routes.announcements(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   return (
     <>

--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -85,17 +85,19 @@ const ApplicationPageWrapper = ({ query }: ApplicationPageWrapperProps) => {
   const followingStep =
     currentStepIndex < steps.length - 1 ? steps[currentStepIndex + 1] : null;
 
-  const crumbs = useBreadcrumbs([
-    {
-      url: paths.browsePools(),
-      label: intl.formatMessage(navigationMessages.browseJobs),
-    },
-    {
-      url: paths.pool(application.pool.id),
-      label: title.html,
-    },
-    ...currentCrumbs,
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        url: paths.browsePools(),
+        label: intl.formatMessage(navigationMessages.browseJobs),
+      },
+      {
+        url: paths.pool(application.pool.id),
+        label: title.html,
+      },
+      ...currentCrumbs,
+    ],
+  });
 
   const userIsOnDisabledPage = isOnDisabledPage(
     currentPage?.link.url,

--- a/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
+++ b/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
@@ -49,12 +49,14 @@ const SignInPage = () => {
     description: "Page title for the sign in page for applicant profiles",
   });
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: pageTitle,
-      url: paths.login(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: pageTitle,
+        url: paths.login(),
+      },
+    ],
+  });
 
   useEffect(() => {
     if (iapMode && themeKey !== "iap") {

--- a/apps/web/src/pages/Auth/SignUpPage/SignUpPage.tsx
+++ b/apps/web/src/pages/Auth/SignUpPage/SignUpPage.tsx
@@ -56,12 +56,14 @@ const SignUpPage = () => {
     description: "Page title for the registration page for applicant profiles",
   });
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: pageTitle,
-      url: paths.register(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: pageTitle,
+        url: paths.register(),
+      },
+    ],
+  });
 
   useEffect(() => {
     if (iapMode && themeKey !== "iap") {

--- a/apps/web/src/pages/Auth/SignedOutPage/SignedOutPage.tsx
+++ b/apps/web/src/pages/Auth/SignedOutPage/SignedOutPage.tsx
@@ -29,12 +29,14 @@ const SignedOutPage = () => {
     description: "Title for the page users land on after successful logout.",
   });
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: pageTitle,
-      url: paths.loggedOut(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: pageTitle,
+        url: paths.loggedOut(),
+      },
+    ],
+  });
 
   return (
     <>

--- a/apps/web/src/pages/Auth/UserDeletedPage/UserDeletedPage.tsx
+++ b/apps/web/src/pages/Auth/UserDeletedPage/UserDeletedPage.tsx
@@ -21,12 +21,14 @@ const UserDeletedPage = () => {
       "Title for the page users land on if their account was deleted.",
   });
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: pageTitle,
-      url: paths.userDeleted(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: pageTitle,
+        url: paths.userDeleted(),
+      },
+    ],
+  });
 
   const inlineLink = (chunks: React.ReactNode) => (
     <Link

--- a/apps/web/src/pages/Classifications/CreateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/CreateClassificationPage.tsx
@@ -16,6 +16,7 @@ import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWr
 import { pageTitle as indexClassificationPageTitle } from "~/pages/Classifications/IndexClassificationPage";
 import AdminHero from "~/components/Hero/AdminHero";
 import adminMessages from "~/messages/adminMessages";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 type FormValues = CreateClassificationInput;
 interface CreateClassificationFormProps {
@@ -210,29 +211,24 @@ const CreateClassification = () => {
       return Promise.reject(result.error);
     });
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: intl.formatMessage(indexClassificationPageTitle),
-      url: routes.classificationTable(),
-    },
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Create<hidden> classification</hidden>",
-        id: "E8BMJW",
-        description:
-          "Breadcrumb title for the create classification page link.",
-      }),
-      url: routes.classificationCreate(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(indexClassificationPageTitle),
+        url: routes.classificationTable(),
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Create<hidden> classification</hidden>",
+          id: "E8BMJW",
+          description:
+            "Breadcrumb title for the create classification page link.",
+        }),
+        url: routes.classificationCreate(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   const pageTitle = intl.formatMessage({
     defaultMessage: "Create classification",

--- a/apps/web/src/pages/Classifications/IndexClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/IndexClassificationPage.tsx
@@ -9,6 +9,7 @@ import SEO from "~/components/SEO/SEO";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRoutes from "~/hooks/useRoutes";
 import AdminHero from "~/components/Hero/AdminHero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import ClassificationTableApi from "./components/ClassificationTable";
 
@@ -26,20 +27,15 @@ export const IndexClassificationPage = () => {
 
   const formattedPageTitle = intl.formatMessage(pageTitle);
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: formattedPageTitle,
-      url: routes.classificationTable(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: formattedPageTitle,
+        url: routes.classificationTable(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   return (
     <>

--- a/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
@@ -28,6 +28,7 @@ import { pageTitle as indexClassificationPageTitle } from "~/pages/Classificatio
 import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminHero from "~/components/Hero/AdminHero";
 import adminMessages from "~/messages/adminMessages";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 type FormValues = UpdateClassificationInput;
 interface UpdateClassificationFormProps {
@@ -263,33 +264,28 @@ const UpdateClassification = () => {
       return Promise.reject(result.error);
     });
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: intl.formatMessage(indexClassificationPageTitle),
-      url: routes.classificationTable(),
-    },
-    ...(classificationId
-      ? [
-          {
-            label: intl.formatMessage({
-              defaultMessage: "Edit<hidden> classification</hidden>",
-              id: "ow4z7W",
-              description:
-                "Breadcrumb title for the edit classification page link.",
-            }),
-            url: routes.classificationUpdate(classificationId),
-          },
-        ]
-      : []),
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(indexClassificationPageTitle),
+        url: routes.classificationTable(),
+      },
+      ...(classificationId
+        ? [
+            {
+              label: intl.formatMessage({
+                defaultMessage: "Edit<hidden> classification</hidden>",
+                id: "ow4z7W",
+                description:
+                  "Breadcrumb title for the edit classification page link.",
+              }),
+              url: routes.classificationUpdate(classificationId),
+            },
+          ]
+        : []),
+    ],
+    isAdmin: true,
+  });
 
   const pageTitle = intl.formatMessage({
     defaultMessage: "Update classification",

--- a/apps/web/src/pages/Departments/CreateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/CreateDepartmentPage.tsx
@@ -15,6 +15,7 @@ import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWr
 import { pageTitle as indexDepartmentPageTitle } from "~/pages/Departments/IndexDepartmentPage";
 import AdminHero from "~/components/Hero/AdminHero";
 import adminMessages from "~/messages/adminMessages";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 type FormValues = CreateDepartmentInput;
 
@@ -138,28 +139,23 @@ const CreateDepartmentPage = () => {
       return Promise.reject(result.error);
     });
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: intl.formatMessage(indexDepartmentPageTitle),
-      url: routes.departmentTable(),
-    },
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Create<hidden> department</hidden>",
-        id: "1XaX86",
-        description: "Breadcrumb title for the create department page link.",
-      }),
-      url: routes.departmentCreate(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(indexDepartmentPageTitle),
+        url: routes.departmentTable(),
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Create<hidden> department</hidden>",
+          id: "1XaX86",
+          description: "Breadcrumb title for the create department page link.",
+        }),
+        url: routes.departmentCreate(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   const pageTitle = intl.formatMessage({
     defaultMessage: "Create department",

--- a/apps/web/src/pages/Departments/IndexDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/IndexDepartmentPage.tsx
@@ -9,6 +9,7 @@ import SEO from "~/components/SEO/SEO";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRoutes from "~/hooks/useRoutes";
 import AdminHero from "~/components/Hero/AdminHero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import DepartmentTableApi from "./components/DepartmentTable";
 
@@ -25,20 +26,15 @@ export const DepartmentPage = () => {
   const routes = useRoutes();
   const formattedPageTitle = intl.formatMessage(pageTitle);
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: formattedPageTitle,
-      url: routes.departmentTable(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: formattedPageTitle,
+        url: routes.departmentTable(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   return (
     <>

--- a/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
@@ -23,6 +23,7 @@ import { pageTitle as indexDepartmentPageTitle } from "~/pages/Departments/Index
 import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminHero from "~/components/Hero/AdminHero";
 import adminMessages from "~/messages/adminMessages";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 type FormValues = UpdateDepartmentInput;
 
@@ -186,33 +187,28 @@ const UpdateDepartmentPage = () => {
       return Promise.reject(result.error);
     });
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: intl.formatMessage(indexDepartmentPageTitle),
-      url: routes.departmentTable(),
-    },
-    ...(departmentId
-      ? [
-          {
-            label: intl.formatMessage({
-              defaultMessage: "Edit<hidden> department</hidden>",
-              id: "FYIbdJ",
-              description:
-                "Breadcrumb title for the edit department page link.",
-            }),
-            url: routes.departmentUpdate(departmentId),
-          },
-        ]
-      : []),
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(indexDepartmentPageTitle),
+        url: routes.departmentTable(),
+      },
+      ...(departmentId
+        ? [
+            {
+              label: intl.formatMessage({
+                defaultMessage: "Edit<hidden> department</hidden>",
+                id: "FYIbdJ",
+                description:
+                  "Breadcrumb title for the edit department page link.",
+              }),
+              url: routes.departmentUpdate(departmentId),
+            },
+          ]
+        : []),
+    ],
+    isAdmin: true,
+  });
 
   const pageTitle = intl.formatMessage({
     defaultMessage: "Edit department",

--- a/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/DigitalServicesContractingQuestionnairePage.tsx
+++ b/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/DigitalServicesContractingQuestionnairePage.tsx
@@ -59,16 +59,18 @@ export const DigitalServicesContractingQuestionnaire = ({
   const localeState = useLocale();
   const paths = useRoutes();
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: intl.formatMessage(directiveHomePageTitle),
-      url: paths.directive(),
-    },
-    {
-      label: intl.formatMessage(pageTitle),
-      url: paths.digitalServicesContractingQuestionnaire(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(directiveHomePageTitle),
+        url: paths.directive(),
+      },
+      {
+        label: intl.formatMessage(pageTitle),
+        url: paths.digitalServicesContractingQuestionnaire(),
+      },
+    ],
+  });
 
   const labels = useLabels();
 

--- a/apps/web/src/pages/DirectivePage/DirectivePage.tsx
+++ b/apps/web/src/pages/DirectivePage/DirectivePage.tsx
@@ -61,12 +61,14 @@ const DirectivePage = () => {
   const paths = useRoutes();
   const { directiveForms: directiveFormsFlag } = useFeatureFlags();
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: intl.formatMessage(pageTitle),
-      url: paths.directive(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(pageTitle),
+        url: paths.directive(),
+      },
+    ],
+  });
 
   const directiveUrl =
     locale === "en"

--- a/apps/web/src/pages/PoolCandidates/AllPoolCandidatesPage/AllPoolCandidatesPage.tsx
+++ b/apps/web/src/pages/PoolCandidates/AllPoolCandidatesPage/AllPoolCandidatesPage.tsx
@@ -14,6 +14,7 @@ import PoolCandidatesTable from "~/components/PoolCandidatesTable/PoolCandidates
 import SEO from "~/components/SEO/SEO";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import AdminHero from "~/components/Hero/AdminHero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 export const pageTitle: MessageDescriptor = defineMessage({
   defaultMessage: "Candidate search",
@@ -29,24 +30,19 @@ export const AllPoolCandidatesPage = () => {
 
   const formattedPageTitle = intl.formatMessage(pageTitle);
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Candidates",
-        id: "zzf16k",
-        description: "Breadcrumb for the All Candidates page",
-      }),
-      url: routes.poolCandidates(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Candidates",
+          id: "zzf16k",
+          description: "Breadcrumb for the All Candidates page",
+        }),
+        url: routes.poolCandidates(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   return (
     <>

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/RODViewPoolCandidatePage.tsx
@@ -43,6 +43,7 @@ import { getFullNameLabel } from "~/utils/nameUtils";
 import AssessmentResultsTable from "~/components/AssessmentResultsTable/AssessmentResultsTable";
 import ChangeDateDialog from "~/pages/Users/UserInformationPage/components/ChangeDateDialog";
 import ChangeStatusDialog from "~/pages/Users/UserInformationPage/components/ChangeStatusDialog";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import CareerTimelineSection from "./components/CareerTimelineSection/CareerTimelineSection";
 import ApplicationInformation from "./components/ApplicationInformation/ApplicationInformation";
@@ -728,32 +729,27 @@ export const ViewPoolCandidate = ({
     intl,
   );
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: paths.adminDashboard(),
-    },
-    {
-      label: intl.formatMessage(indexPoolPageTitle),
-      url: paths.poolTable(),
-    },
-    {
-      label: getFullPoolTitleLabel(intl, poolCandidate.pool),
-      url: paths.poolView(poolCandidate.pool.id),
-    },
-    {
-      label: intl.formatMessage(screeningAndAssessmentTitle),
-      url: paths.screeningAndEvaluation(poolCandidate.pool.id),
-    },
-    {
-      label: candidateName,
-      url: paths.poolCandidateApplication(poolCandidate.id),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(indexPoolPageTitle),
+        url: paths.poolTable(),
+      },
+      {
+        label: getFullPoolTitleLabel(intl, poolCandidate.pool),
+        url: paths.poolView(poolCandidate.pool.id),
+      },
+      {
+        label: intl.formatMessage(screeningAndAssessmentTitle),
+        url: paths.screeningAndEvaluation(poolCandidate.pool.id),
+      },
+      {
+        label: candidateName,
+        url: paths.poolCandidateApplication(poolCandidate.id),
+      },
+    ],
+    isAdmin: true,
+  });
 
   return (
     <>

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
@@ -35,6 +35,7 @@ import { routeErrorMessages } from "~/hooks/useErrorMessages";
 import { getAssessmentPlanStatus } from "~/validators/pool/assessmentPlan";
 import { getPoolCompletenessBadge } from "~/utils/poolUtils";
 import messages from "~/messages/adminMessages";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import OrganizeSection from "./components/OrganizeSection";
 import SkillSummarySection from "./components/SkillSummarySection";
@@ -231,28 +232,23 @@ export const AssessmentPlanBuilderPage = () => {
 
   // Note: Should technically be in subNav of layout?
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: intl.formatMessage(indexPoolPageTitle),
-      url: routes.poolTable(),
-    },
-    {
-      label: getLocalizedName(queryData?.pool?.name, intl),
-      url: routes.poolView(poolId),
-    },
-    {
-      label: intl.formatMessage(pageTitle),
-      url: routes.assessmentPlanBuilder(poolId),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(indexPoolPageTitle),
+        url: routes.poolTable(),
+      },
+      {
+        label: getLocalizedName(queryData?.pool?.name, intl),
+        url: routes.poolView(poolId),
+      },
+      {
+        label: intl.formatMessage(pageTitle),
+        url: routes.assessmentPlanBuilder(poolId),
+      },
+    ],
+    isAdmin: true,
+  });
 
   // RequireAuth in router can't check team roles
   const authorizedToSeeThePage: boolean =

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
@@ -28,14 +28,12 @@ import {
 
 import useRoutes from "~/hooks/useRoutes";
 import useRequiredParams from "~/hooks/useRequiredParams";
-import { pageTitle as indexPoolPageTitle } from "~/pages/Pools/IndexPoolPage/IndexPoolPage";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import SEO from "~/components/SEO/SEO";
 import { routeErrorMessages } from "~/hooks/useErrorMessages";
 import { getAssessmentPlanStatus } from "~/validators/pool/assessmentPlan";
 import { getPoolCompletenessBadge } from "~/utils/poolUtils";
 import messages from "~/messages/adminMessages";
-import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import OrganizeSection from "./components/OrganizeSection";
 import SkillSummarySection from "./components/SkillSummarySection";
@@ -205,7 +203,6 @@ const AssessmentPlanBuilderPage_Query = graphql(/* GraphQL */ `
 export const AssessmentPlanBuilderPage = () => {
   const intl = useIntl();
   const { poolId } = useRequiredParams<RouteParams>("poolId");
-  const routes = useRoutes();
   const authorization = useAuthorization();
 
   const notFoundMessage = intl.formatMessage(

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
@@ -230,26 +230,6 @@ export const AssessmentPlanBuilderPage = () => {
       variables: { poolId },
     });
 
-  // Note: Should technically be in subNav of layout?
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const navigationCrumbs = useBreadcrumbs({
-    crumbs: [
-      {
-        label: intl.formatMessage(indexPoolPageTitle),
-        url: routes.poolTable(),
-      },
-      {
-        label: getLocalizedName(queryData?.pool?.name, intl),
-        url: routes.poolView(poolId),
-      },
-      {
-        label: intl.formatMessage(pageTitle),
-        url: routes.assessmentPlanBuilder(poolId),
-      },
-    ],
-    isAdmin: true,
-  });
-
   // RequireAuth in router can't check team roles
   const authorizedToSeeThePage: boolean =
     authorization.roleAssignments?.some(

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
@@ -152,12 +152,14 @@ export const BrowsePools = () => {
 
   const title = intl.formatMessage(navigationMessages.browseJobs);
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: title,
-      url: paths.browsePools(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: title,
+        url: paths.browsePools(),
+      },
+    ],
+  });
 
   const activeRecruitmentPools = pools.filter(
     (p) =>

--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -28,6 +28,7 @@ import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import { pageTitle as indexPoolPageTitle } from "~/pages/Pools/IndexPoolPage/IndexPoolPage";
 import AdminHero from "~/components/Hero/AdminHero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 type FormValues = {
   classification: string[];
@@ -263,28 +264,23 @@ const CreatePoolPage = () => {
       return Promise.reject(result.error);
     });
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: intl.formatMessage(indexPoolPageTitle),
-      url: routes.poolTable(),
-    },
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Create new pool",
-        id: "OgeWgx",
-        description: "Breadcrumb title for the create new pool page link.",
-      }),
-      url: routes.poolCreate(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(indexPoolPageTitle),
+        url: routes.poolTable(),
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Create new pool",
+          id: "OgeWgx",
+          description: "Breadcrumb title for the create new pool page link.",
+        }),
+        url: routes.poolCreate(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   const pageTitle = intl.formatMessage({
     defaultMessage: "Create pool",

--- a/apps/web/src/pages/Pools/IndexPoolPage/IndexPoolPage.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/IndexPoolPage.tsx
@@ -9,6 +9,7 @@ import useRoutes from "~/hooks/useRoutes";
 import SEO from "~/components/SEO/SEO";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import AdminHero from "~/components/Hero/AdminHero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import PoolTableApi from "./components/PoolTable";
 
@@ -26,20 +27,15 @@ export const PoolPage = () => {
 
   const formattedPageTitle = intl.formatMessage(pageTitle);
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: formattedPageTitle,
-      url: routes.poolTable(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: formattedPageTitle,
+        url: routes.poolTable(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   return (
     <>

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -237,16 +237,18 @@ export const PoolPoster = ({
     canApply,
   };
 
-  const links = useBreadcrumbs([
-    {
-      label: intl.formatMessage(navigationMessages.browseJobs),
-      url: paths.browsePools(),
-    },
-    {
-      label: poolTitle,
-      url: paths.pool(pool.id),
-    },
-  ]);
+  const links = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(navigationMessages.browseJobs),
+        url: paths.browsePools(),
+      },
+      {
+        label: poolTitle,
+        url: paths.pool(pool.id),
+      },
+    ],
+  });
 
   const sections: Record<string, SectionContent> = {
     employmentDetails: {

--- a/apps/web/src/pages/PrivacyPolicy/PrivacyPolicy.tsx
+++ b/apps/web/src/pages/PrivacyPolicy/PrivacyPolicy.tsx
@@ -108,12 +108,14 @@ const PrivacyPolicy = () => {
     description: "Sub title for the websites privacy policy",
   });
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: pageTitle,
-      url: paths.privacyPolicy(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: pageTitle,
+        url: paths.privacyPolicy(),
+      },
+    ],
+  });
 
   return (
     <>

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
@@ -18,6 +18,7 @@ import Hero from "~/components/Hero/Hero";
 import useRoutes from "~/hooks/useRoutes";
 import { wrapAbbr } from "~/utils/nameUtils";
 import { Application } from "~/utils/applicationUtils";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import { PAGE_SECTION_ID, titles } from "../constants";
 import CareerTimelineSection from "./CareerTimelineSection";
@@ -52,15 +53,7 @@ const CareerTimelineAndRecruitment = ({
   const intl = useIntl();
   const paths = useRoutes();
 
-  const crumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: paths.home(),
-    },
+  const crumbs = useBreadcrumbs([
     {
       label: intl.formatMessage(navigationMessages.profileAndApplications),
       url: paths.profileAndApplications(),
@@ -69,7 +62,7 @@ const CareerTimelineAndRecruitment = ({
       label: intl.formatMessage(titles.careerTimelineAndRecruitment),
       url: paths.careerTimelineAndRecruitment(userId),
     },
-  ];
+  ]);
 
   const pageTitle = intl.formatMessage(titles.careerTimelineAndRecruitment);
 

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
@@ -53,16 +53,18 @@ const CareerTimelineAndRecruitment = ({
   const intl = useIntl();
   const paths = useRoutes();
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: intl.formatMessage(navigationMessages.profileAndApplications),
-      url: paths.profileAndApplications(),
-    },
-    {
-      label: intl.formatMessage(titles.careerTimelineAndRecruitment),
-      url: paths.careerTimelineAndRecruitment(userId),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(navigationMessages.profileAndApplications),
+        url: paths.profileAndApplications(),
+      },
+      {
+        label: intl.formatMessage(titles.careerTimelineAndRecruitment),
+        url: paths.careerTimelineAndRecruitment(userId),
+      },
+    ],
+  });
 
   const pageTitle = intl.formatMessage(titles.careerTimelineAndRecruitment);
 

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -209,34 +209,37 @@ export const ExperienceForm = ({
     }
   }, [isSubmitSuccessful, reset, action, setFocus, setValue]);
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: intl.formatMessage(navigationMessages.profileAndApplications),
-      url: paths.profileAndApplications(),
-    },
-    {
-      label: intl.formatMessage(
-        navigationMessages.careerTimelineAndRecruitment,
-      ),
-      url: returnPath,
-    },
-    {
-      label: experience
-        ? intl.formatMessage({
-            defaultMessage: "Edit experience",
-            id: "zsUuN9",
-            description: "Title for edit experience page",
-          })
-        : intl.formatMessage({
-            defaultMessage: "Add Experience",
-            id: "mJ1HE4",
-            description: "Display text for add experience form in breadcrumbs",
-          }),
-      url: experience
-        ? paths.editExperience(userId, experienceType, experience.id)
-        : "#",
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(navigationMessages.profileAndApplications),
+        url: paths.profileAndApplications(),
+      },
+      {
+        label: intl.formatMessage(
+          navigationMessages.careerTimelineAndRecruitment,
+        ),
+        url: returnPath,
+      },
+      {
+        label: experience
+          ? intl.formatMessage({
+              defaultMessage: "Edit experience",
+              id: "zsUuN9",
+              description: "Title for edit experience page",
+            })
+          : intl.formatMessage({
+              defaultMessage: "Add Experience",
+              id: "mJ1HE4",
+              description:
+                "Display text for add experience form in breadcrumbs",
+            }),
+        url: experience
+          ? paths.editExperience(userId, experienceType, experience.id)
+          : "#",
+      },
+    ],
+  });
 
   const pageTitle: string = experience
     ? intl.formatMessage({

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -47,6 +47,7 @@ import {
   formValuesToSubmitData,
   queryResultToDefaultValues,
 } from "~/utils/experienceUtils";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import ExperienceSkills from "./components/ExperienceSkills";
 
@@ -208,15 +209,7 @@ export const ExperienceForm = ({
     }
   }, [isSubmitSuccessful, reset, action, setFocus, setValue]);
 
-  const crumbs: { label: string | React.ReactNode; url: string }[] = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: paths.home(),
-    },
+  const crumbs = useBreadcrumbs([
     {
       label: intl.formatMessage(navigationMessages.profileAndApplications),
       url: paths.profileAndApplications(),
@@ -243,7 +236,7 @@ export const ExperienceForm = ({
         ? paths.editExperience(userId, experienceType, experience.id)
         : "#",
     },
-  ];
+  ]);
 
   const pageTitle: string = experience
     ? intl.formatMessage({

--- a/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
@@ -96,16 +96,18 @@ export const ProfileForm = ({ user }: ProfilePageProps) => {
     description: "applicant dashboard card title for profile card",
   });
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: intl.formatMessage(navigationMessages.profileAndApplications),
-      url: paths.profileAndApplications(),
-    },
-    {
-      label: pageTitle,
-      url: paths.profile(user.id),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(navigationMessages.profileAndApplications),
+        url: paths.profileAndApplications(),
+      },
+      {
+        label: pageTitle,
+        url: paths.profile(user.id),
+      },
+    ],
+  });
 
   const [{ fetching: isUpdating }, executeUpdateMutation] = useMutation(
     ProfileUpdateUser_Mutation,

--- a/apps/web/src/pages/SearchRequests/IndexSearchRequestPage/IndexSearchRequestPage.tsx
+++ b/apps/web/src/pages/SearchRequests/IndexSearchRequestPage/IndexSearchRequestPage.tsx
@@ -10,6 +10,7 @@ import SearchRequestTable from "~/components/SearchRequestTable/SearchRequestTab
 import useRoutes from "~/hooks/useRoutes";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import AdminHero from "~/components/Hero/AdminHero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 export const pageTitle: MessageDescriptor = defineMessage({
   defaultMessage: "Talent requests",
@@ -25,20 +26,15 @@ export const IndexSearchRequestPage = () => {
 
   const formattedPageTitle = intl.formatMessage(pageTitle);
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: formattedPageTitle,
-      url: routes.searchRequestTable(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: formattedPageTitle,
+        url: routes.searchRequestTable(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   return (
     <>

--- a/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
@@ -36,24 +36,26 @@ const RequestConfirmationPage = () => {
   const { requestId } =
     useRequiredParams<RequestConfirmationParams>("requestId");
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Search for talent",
-        id: "weLwJA",
-        description: "Link text for the search page breadcrumb",
-      }),
-      url: paths.search(),
-    },
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Request submitted",
-        id: "0zo274",
-        description: "Link text for request confirmation breadcrumb",
-      }),
-      url: paths.requestConfirmation(requestId),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Search for talent",
+          id: "weLwJA",
+          description: "Link text for the search page breadcrumb",
+        }),
+        url: paths.search(),
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Request submitted",
+          id: "0zo274",
+          description: "Link text for request confirmation breadcrumb",
+        }),
+        url: paths.requestConfirmation(requestId),
+      },
+    ],
+  });
 
   const pageTitle = intl.formatMessage({
     defaultMessage: "Successful request",

--- a/apps/web/src/pages/SearchRequests/SearchPage/SearchPage.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/SearchPage.tsx
@@ -20,12 +20,14 @@ const SearchPage = () => {
     description: "Title displayed on hero for Search and Request pages.",
   });
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: title,
-      url: paths.search(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: title,
+        url: paths.search(),
+      },
+    ],
+  });
 
   return (
     <>

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
@@ -33,6 +33,7 @@ import FilterBlock from "~/components/SearchRequestFilters/FilterBlock";
 import AdminHero from "~/components/Hero/AdminHero";
 import SEO from "~/components/SEO/SEO";
 import { pageTitle as indexSearchRequestPageTitle } from "~/pages/SearchRequests/IndexSearchRequestPage/IndexSearchRequestPage";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import SingleSearchRequestTableApi from "./SearchRequestCandidatesTable";
 import UpdateSearchRequest from "./UpdateSearchRequest";
@@ -363,24 +364,19 @@ export const ViewSearchRequest = ({
     reason,
   } = searchRequest;
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: intl.formatMessage(indexSearchRequestPageTitle),
-      url: routes.searchRequestTable(),
-    },
-    {
-      label: `${fullName} - ${getLocalizedName(department?.name, intl)}`,
-      url: routes.searchRequestView(id),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(indexSearchRequestPageTitle),
+        url: routes.searchRequestTable(),
+      },
+      {
+        label: `${fullName} - ${getLocalizedName(department?.name, intl)}`,
+        url: routes.searchRequestView(id),
+      },
+    ],
+    isAdmin: true,
+  });
 
   const pageTitle = intl.formatMessage({
     defaultMessage: "Request",

--- a/apps/web/src/pages/SkillFamilies/CreateSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/CreateSkillFamilyPage.tsx
@@ -23,6 +23,7 @@ import useRoutes from "~/hooks/useRoutes";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import adminMessages from "~/messages/adminMessages";
 import AdminHero from "~/components/Hero/AdminHero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 type Option<V> = { value: V; label: string };
 
@@ -257,28 +258,24 @@ const CreateSkillFamilyPage = () => {
       return Promise.reject(result.error);
     });
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: intl.formatMessage(adminMessages.skillFamilies),
-      url: routes.skillFamilyTable(),
-    },
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Create<hidden> skill family</hidden>",
-        id: "PQXvrU",
-        description: "Breadcrumb title for the create skill family page link.",
-      }),
-      url: routes.skillFamilyCreate(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(adminMessages.skillFamilies),
+        url: routes.skillFamilyTable(),
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Create<hidden> skill family</hidden>",
+          id: "PQXvrU",
+          description:
+            "Breadcrumb title for the create skill family page link.",
+        }),
+        url: routes.skillFamilyCreate(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   const pageTitle = intl.formatMessage({
     defaultMessage: "Create skill family",

--- a/apps/web/src/pages/SkillFamilies/IndexSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/IndexSkillFamilyPage.tsx
@@ -9,6 +9,7 @@ import AdminHero from "~/components/Hero/AdminHero";
 import SEO from "~/components/SEO/SEO";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRoutes from "~/hooks/useRoutes";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import SkillFamilyTableApi from "./components/SkillFamilyTable";
 
@@ -26,20 +27,23 @@ const IndexSkillFamilyPage = () => {
 
   const formattedPageTitle = intl.formatMessage(pageTitle);
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: formattedPageTitle,
-      url: routes.skillFamilyTable(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Home",
+          id: "EBmWyo",
+          description: "Link text for the home link in breadcrumbs.",
+        }),
+        url: routes.adminDashboard(),
+      },
+      {
+        label: formattedPageTitle,
+        url: routes.skillFamilyTable(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   return (
     <>

--- a/apps/web/src/pages/SkillFamilies/IndexSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/IndexSkillFamilyPage.tsx
@@ -30,14 +30,6 @@ const IndexSkillFamilyPage = () => {
   const navigationCrumbs = useBreadcrumbs({
     crumbs: [
       {
-        label: intl.formatMessage({
-          defaultMessage: "Home",
-          id: "EBmWyo",
-          description: "Link text for the home link in breadcrumbs.",
-        }),
-        url: routes.adminDashboard(),
-      },
-      {
         label: formattedPageTitle,
         url: routes.skillFamilyTable(),
       },

--- a/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
@@ -36,6 +36,7 @@ import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import adminMessages from "~/messages/adminMessages";
 import AdminHero from "~/components/Hero/AdminHero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 type Option<V> = { value: V; label: string };
 
@@ -295,33 +296,28 @@ const UpdateSkillFamilyPage = () => {
       return Promise.reject(result.error);
     });
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: intl.formatMessage(adminMessages.skillFamilies),
-      url: routes.skillFamilyTable(),
-    },
-    ...(skillFamilyId
-      ? [
-          {
-            label: intl.formatMessage({
-              defaultMessage: "Edit<hidden> skill family</hidden>",
-              id: "5SKmte",
-              description:
-                "Breadcrumb title for the edit skill family page link.",
-            }),
-            url: routes.skillFamilyUpdate(skillFamilyId),
-          },
-        ]
-      : []),
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(adminMessages.skillFamilies),
+        url: routes.skillFamilyTable(),
+      },
+      ...(skillFamilyId
+        ? [
+            {
+              label: intl.formatMessage({
+                defaultMessage: "Edit<hidden> skill family</hidden>",
+                id: "5SKmte",
+                description:
+                  "Breadcrumb title for the edit skill family page link.",
+              }),
+              url: routes.skillFamilyUpdate(skillFamilyId),
+            },
+          ]
+        : []),
+    ],
+    isAdmin: true,
+  });
 
   const pageTitle = intl.formatMessage({
     defaultMessage: "Edit skill family",

--- a/apps/web/src/pages/Skills/CreateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/CreateSkillPage.tsx
@@ -36,6 +36,7 @@ import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWr
 import adminMessages from "~/messages/adminMessages";
 import { parseKeywords } from "~/utils/skillUtils";
 import AdminHero from "~/components/Hero/AdminHero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 type Option<V> = { value: V; label: string };
 
@@ -348,28 +349,23 @@ const CreateSkillPage = () => {
       return Promise.reject(result.error);
     });
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: intl.formatMessage(adminMessages.skills),
-      url: routes.skillTable(),
-    },
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Create<hidden> skill</hidden>",
-        id: "9QxHnD",
-        description: "Breadcrumb title for the create skill page link.",
-      }),
-      url: routes.skillCreate(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(adminMessages.skills),
+        url: routes.skillTable(),
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Create<hidden> skill</hidden>",
+          id: "9QxHnD",
+          description: "Breadcrumb title for the create skill page link.",
+        }),
+        url: routes.skillCreate(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   const pageTitle = intl.formatMessage({
     defaultMessage: "Create skill",

--- a/apps/web/src/pages/Skills/ImproveBehaviouralSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/ImproveBehaviouralSkillsPage.tsx
@@ -10,6 +10,7 @@ import { navigationMessages } from "@gc-digital-talent/i18n";
 import { Skill, SkillCategory, UserSkill } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import UpdateSkillShowcase, {
   FormValues,
@@ -50,15 +51,7 @@ const ImproveBehaviouralSkills = ({
     id: "6+TjHb",
   });
 
-  const crumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: paths.home(),
-    },
+  const crumbs = useBreadcrumbs([
     {
       label: intl.formatMessage(navigationMessages.profileAndApplications),
       url: paths.profileAndApplications(),
@@ -71,7 +64,7 @@ const ImproveBehaviouralSkills = ({
       label: pageTitle,
       url: paths.improveBehaviouralSkills(),
     },
-  ];
+  ]);
 
   const pageDescription = intl.formatMessage({
     defaultMessage:

--- a/apps/web/src/pages/Skills/ImproveBehaviouralSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/ImproveBehaviouralSkillsPage.tsx
@@ -51,20 +51,22 @@ const ImproveBehaviouralSkills = ({
     id: "6+TjHb",
   });
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: intl.formatMessage(navigationMessages.profileAndApplications),
-      url: paths.profileAndApplications(),
-    },
-    {
-      label: intl.formatMessage(navigationMessages.skillShowcase),
-      url: paths.skillShowcase(),
-    },
-    {
-      label: pageTitle,
-      url: paths.improveBehaviouralSkills(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(navigationMessages.profileAndApplications),
+        url: paths.profileAndApplications(),
+      },
+      {
+        label: intl.formatMessage(navigationMessages.skillShowcase),
+        url: paths.skillShowcase(),
+      },
+      {
+        label: pageTitle,
+        url: paths.improveBehaviouralSkills(),
+      },
+    ],
+  });
 
   const pageDescription = intl.formatMessage({
     defaultMessage:

--- a/apps/web/src/pages/Skills/ImproveTechnicalSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/ImproveTechnicalSkillsPage.tsx
@@ -49,20 +49,22 @@ const ImproveTechnicalSkills = ({
     id: "aIMh6f",
   });
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: intl.formatMessage(navigationMessages.profileAndApplications),
-      url: paths.profileAndApplications(),
-    },
-    {
-      label: intl.formatMessage(navigationMessages.skillShowcase),
-      url: paths.skillShowcase(),
-    },
-    {
-      label: pageTitle,
-      url: paths.improveTechnicalSkills(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(navigationMessages.profileAndApplications),
+        url: paths.profileAndApplications(),
+      },
+      {
+        label: intl.formatMessage(navigationMessages.skillShowcase),
+        url: paths.skillShowcase(),
+      },
+      {
+        label: pageTitle,
+        url: paths.improveTechnicalSkills(),
+      },
+    ],
+  });
 
   const pageDescription = intl.formatMessage({
     defaultMessage:

--- a/apps/web/src/pages/Skills/ImproveTechnicalSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/ImproveTechnicalSkillsPage.tsx
@@ -10,6 +10,7 @@ import { navigationMessages } from "@gc-digital-talent/i18n";
 import { Skill, SkillCategory, UserSkill } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import UpdateSkillShowcase, {
   FormValues,
@@ -48,15 +49,7 @@ const ImproveTechnicalSkills = ({
     id: "aIMh6f",
   });
 
-  const crumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: paths.home(),
-    },
+  const crumbs = useBreadcrumbs([
     {
       label: intl.formatMessage(navigationMessages.profileAndApplications),
       url: paths.profileAndApplications(),
@@ -69,7 +62,7 @@ const ImproveTechnicalSkills = ({
       label: pageTitle,
       url: paths.improveTechnicalSkills(),
     },
-  ];
+  ]);
 
   const pageDescription = intl.formatMessage({
     defaultMessage:

--- a/apps/web/src/pages/Skills/IndexSkillPage.tsx
+++ b/apps/web/src/pages/Skills/IndexSkillPage.tsx
@@ -8,6 +8,7 @@ import { IconType } from "@gc-digital-talent/ui";
 import SEO from "~/components/SEO/SEO";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRoutes from "~/hooks/useRoutes";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import SkillTableApi from "./components/SkillTable";
 import AdminHero from "../../components/Hero/AdminHero";
@@ -26,20 +27,15 @@ export const IndexSkillPage = () => {
 
   const formattedPageTitle = intl.formatMessage(pageTitle);
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: formattedPageTitle,
-      url: routes.skillTable(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: formattedPageTitle,
+        url: routes.skillTable(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   return (
     <>

--- a/apps/web/src/pages/Skills/SkillLibraryPage.tsx
+++ b/apps/web/src/pages/Skills/SkillLibraryPage.tsx
@@ -12,6 +12,7 @@ import { Skill, UserSkill } from "@gc-digital-talent/graphql";
 import SEO from "~/components/SEO/SEO";
 import Hero from "~/components/Hero/Hero";
 import useRoutes from "~/hooks/useRoutes";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import SkillLibraryTable from "./components/SkillLibraryTable";
 import { UserSkills_Query } from "./operations";
@@ -46,15 +47,7 @@ const SkillLibrary = ({ userSkills, skills }: SkillLibraryProps) => {
     },
   };
 
-  const crumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: paths.home(),
-    },
+  const crumbs = useBreadcrumbs([
     {
       label: intl.formatMessage(navigationMessages.profileAndApplications),
       url: paths.profileAndApplications(),
@@ -63,7 +56,7 @@ const SkillLibrary = ({ userSkills, skills }: SkillLibraryProps) => {
       label: intl.formatMessage(navigationMessages.skillLibrary),
       url: paths.skillLibrary(),
     },
-  ];
+  ]);
 
   const pageTitle = intl.formatMessage(navigationMessages.skillLibrary);
 

--- a/apps/web/src/pages/Skills/SkillLibraryPage.tsx
+++ b/apps/web/src/pages/Skills/SkillLibraryPage.tsx
@@ -47,16 +47,18 @@ const SkillLibrary = ({ userSkills, skills }: SkillLibraryProps) => {
     },
   };
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: intl.formatMessage(navigationMessages.profileAndApplications),
-      url: paths.profileAndApplications(),
-    },
-    {
-      label: intl.formatMessage(navigationMessages.skillLibrary),
-      url: paths.skillLibrary(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(navigationMessages.profileAndApplications),
+        url: paths.profileAndApplications(),
+      },
+      {
+        label: intl.formatMessage(navigationMessages.skillLibrary),
+        url: paths.skillLibrary(),
+      },
+    ],
+  });
 
   const pageTitle = intl.formatMessage(navigationMessages.skillLibrary);
 

--- a/apps/web/src/pages/Skills/SkillPage.tsx
+++ b/apps/web/src/pages/Skills/SkillPage.tsx
@@ -33,12 +33,14 @@ export const SkillPage = () => {
   const formattedPageTitle = intl.formatMessage(pageTitle);
   const formattedPageSubtitle = intl.formatMessage(pageSubtitle);
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: formattedPageTitle,
-      url: routes.skills(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: formattedPageTitle,
+        url: routes.skills(),
+      },
+    ],
+  });
 
   return (
     <>

--- a/apps/web/src/pages/Skills/SkillShowcasePage.tsx
+++ b/apps/web/src/pages/Skills/SkillShowcasePage.tsx
@@ -97,20 +97,22 @@ export const SkillShowcase = ({
     description: "Subtitle for the skill showcase page",
   });
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: intl.formatMessage(navigationMessages.profileAndApplications),
-      url: paths.profileAndApplications(),
-    },
-    {
-      label: intl.formatMessage(navigationMessages.skillLibrary),
-      url: paths.skillLibrary(),
-    },
-    {
-      label: pageTitle,
-      url: paths.skillShowcase(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(navigationMessages.profileAndApplications),
+        url: paths.profileAndApplications(),
+      },
+      {
+        label: intl.formatMessage(navigationMessages.skillLibrary),
+        url: paths.skillLibrary(),
+      },
+      {
+        label: pageTitle,
+        url: paths.skillShowcase(),
+      },
+    ],
+  });
 
   const sections: PageSections = {
     topSkills: {

--- a/apps/web/src/pages/Skills/TopBehaviouralSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/TopBehaviouralSkillsPage.tsx
@@ -49,20 +49,22 @@ const TopBehaviouralSkills = ({
     id: "6IitrN",
   });
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: intl.formatMessage(navigationMessages.profileAndApplications),
-      url: paths.profileAndApplications(),
-    },
-    {
-      label: intl.formatMessage(navigationMessages.skillShowcase),
-      url: paths.skillShowcase(),
-    },
-    {
-      label: pageTitle,
-      url: paths.topBehaviouralSkills(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(navigationMessages.profileAndApplications),
+        url: paths.profileAndApplications(),
+      },
+      {
+        label: intl.formatMessage(navigationMessages.skillShowcase),
+        url: paths.skillShowcase(),
+      },
+      {
+        label: pageTitle,
+        url: paths.topBehaviouralSkills(),
+      },
+    ],
+  });
 
   const pageDescription = intl.formatMessage({
     defaultMessage:

--- a/apps/web/src/pages/Skills/TopBehaviouralSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/TopBehaviouralSkillsPage.tsx
@@ -10,6 +10,7 @@ import { navigationMessages } from "@gc-digital-talent/i18n";
 import { Skill, SkillCategory, UserSkill } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import UpdateSkillShowcase, {
   FormValues,
@@ -48,15 +49,7 @@ const TopBehaviouralSkills = ({
     id: "6IitrN",
   });
 
-  const crumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: paths.home(),
-    },
+  const crumbs = useBreadcrumbs([
     {
       label: intl.formatMessage(navigationMessages.profileAndApplications),
       url: paths.profileAndApplications(),
@@ -69,7 +62,7 @@ const TopBehaviouralSkills = ({
       label: pageTitle,
       url: paths.topBehaviouralSkills(),
     },
-  ];
+  ]);
 
   const pageDescription = intl.formatMessage({
     defaultMessage:

--- a/apps/web/src/pages/Skills/TopTechnicalSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/TopTechnicalSkillsPage.tsx
@@ -43,24 +43,26 @@ const TopTechnicalSkills = ({
 
   const pageId = "top-technical-skills";
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: intl.formatMessage(navigationMessages.profileAndApplications),
-      url: paths.profileAndApplications(),
-    },
-    {
-      label: intl.formatMessage(navigationMessages.skillShowcase),
-      url: paths.skillShowcase(),
-    },
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Top 10 technical skills",
-        id: "Aymigb",
-        description: "Title for the top 10 technical skills page",
-      }),
-      url: paths.topTechnicalSkills(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(navigationMessages.profileAndApplications),
+        url: paths.profileAndApplications(),
+      },
+      {
+        label: intl.formatMessage(navigationMessages.skillShowcase),
+        url: paths.skillShowcase(),
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Top 10 technical skills",
+          id: "Aymigb",
+          description: "Title for the top 10 technical skills page",
+        }),
+        url: paths.topTechnicalSkills(),
+      },
+    ],
+  });
 
   const pageTitle = intl.formatMessage({
     defaultMessage: "Your top 10 technical skills",

--- a/apps/web/src/pages/Skills/TopTechnicalSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/TopTechnicalSkillsPage.tsx
@@ -10,6 +10,7 @@ import { navigationMessages } from "@gc-digital-talent/i18n";
 import { Skill, SkillCategory, UserSkill } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import UpdateSkillShowcase, {
   FormValues,
@@ -42,15 +43,7 @@ const TopTechnicalSkills = ({
 
   const pageId = "top-technical-skills";
 
-  const crumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: paths.home(),
-    },
+  const crumbs = useBreadcrumbs([
     {
       label: intl.formatMessage(navigationMessages.profileAndApplications),
       url: paths.profileAndApplications(),
@@ -67,7 +60,7 @@ const TopTechnicalSkills = ({
       }),
       url: paths.topTechnicalSkills(),
     },
-  ];
+  ]);
 
   const pageTitle = intl.formatMessage({
     defaultMessage: "Your top 10 technical skills",

--- a/apps/web/src/pages/Skills/UpdateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateSkillPage.tsx
@@ -41,6 +41,7 @@ import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWr
 import adminMessages from "~/messages/adminMessages";
 import { parseKeywords } from "~/utils/skillUtils";
 import AdminHero from "~/components/Hero/AdminHero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 type Option<V> = { value: V; label: string };
 
@@ -377,32 +378,27 @@ export const UpdateSkill = () => {
       return Promise.reject(result.error);
     });
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: intl.formatMessage(adminMessages.skills),
-      url: routes.skillTable(),
-    },
-    ...(skillId
-      ? [
-          {
-            label: intl.formatMessage({
-              defaultMessage: "Edit<hidden> skill</hidden>",
-              id: "M2LfhH",
-              description: "Breadcrumb title for the edit skill page link.",
-            }),
-            url: routes.skillUpdate(skillId),
-          },
-        ]
-      : []),
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(adminMessages.skills),
+        url: routes.skillTable(),
+      },
+      ...(skillId
+        ? [
+            {
+              label: intl.formatMessage({
+                defaultMessage: "Edit<hidden> skill</hidden>",
+                id: "M2LfhH",
+                description: "Breadcrumb title for the edit skill page link.",
+              }),
+              url: routes.skillUpdate(skillId),
+            },
+          ]
+        : []),
+    ],
+    isAdmin: true,
+  });
 
   const pageTitle = intl.formatMessage({
     defaultMessage: "Edit skill",

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -222,29 +222,31 @@ export const UpdateUserSkillForm = ({
       );
   };
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: intl.formatMessage(navigationMessages.profileAndApplications),
-      url: paths.profileAndApplications(),
-    },
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(navigationMessages.profileAndApplications),
+        url: paths.profileAndApplications(),
+      },
 
-    {
-      label: intl.formatMessage(navigationMessages.skillLibrary),
-      url: paths.skillLibrary(),
-    },
-    ...(fromShowcase
-      ? [
-          {
-            label: intl.formatMessage(navigationMessages.skillShowcase),
-            url: paths.skillShowcase(),
-          },
-        ]
-      : []),
-    {
-      label: skillName,
-      url: paths.editUserSkill(skill.id),
-    },
-  ]);
+      {
+        label: intl.formatMessage(navigationMessages.skillLibrary),
+        url: paths.skillLibrary(),
+      },
+      ...(fromShowcase
+        ? [
+            {
+              label: intl.formatMessage(navigationMessages.skillShowcase),
+              url: paths.skillShowcase(),
+            },
+          ]
+        : []),
+      {
+        label: skillName,
+        url: paths.editUserSkill(skill.id),
+      },
+    ],
+  });
 
   const sections: PageSections = {
     skillLevel: {

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -41,6 +41,7 @@ import ExperienceCard from "~/components/ExperienceCard/ExperienceCard";
 import ExperienceSkillFormDialog from "~/components/ExperienceSkillFormDialog/ExperienceSkillFormDialog";
 import useRoutes from "~/hooks/useRoutes";
 import useRequiredParams from "~/hooks/useRequiredParams";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import {
   CreateUserSkill_Mutation,
@@ -221,15 +222,7 @@ export const UpdateUserSkillForm = ({
       );
   };
 
-  const crumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: paths.home(),
-    },
+  const crumbs = useBreadcrumbs([
     {
       label: intl.formatMessage(navigationMessages.profileAndApplications),
       url: paths.profileAndApplications(),
@@ -251,7 +244,7 @@ export const UpdateUserSkillForm = ({
       label: skillName,
       url: paths.editUserSkill(skill.id),
     },
-  ];
+  ]);
 
   const sections: PageSections = {
     skillLevel: {

--- a/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
+++ b/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
@@ -9,6 +9,7 @@ import {
   ButtonLinkMode,
   CardRepeater,
   Link,
+  BreadcrumbsProps,
 } from "@gc-digital-talent/ui";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 import { commonMessages } from "@gc-digital-talent/i18n";
@@ -39,7 +40,7 @@ interface UpdateSkillShowcaseProps {
   allUserSkills: UserSkill[];
   initialData: FormValues;
   maxItems: number;
-  crumbs: { label: string; url: string }[];
+  crumbs: BreadcrumbsProps["crumbs"];
   pageInfo: {
     id: string;
     title: string;

--- a/apps/web/src/pages/SupportPage/SupportPage.tsx
+++ b/apps/web/src/pages/SupportPage/SupportPage.tsx
@@ -30,12 +30,14 @@ export const SupportPage = () => {
     description: "Page title for the Support page",
   });
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: title,
-      url: paths.support(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: title,
+        url: paths.support(),
+      },
+    ],
+  });
 
   return (
     <>

--- a/apps/web/src/pages/Teams/CreateTeamPage/CreateTeamPage.tsx
+++ b/apps/web/src/pages/Teams/CreateTeamPage/CreateTeamPage.tsx
@@ -11,6 +11,7 @@ import useRoutes from "~/hooks/useRoutes";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import { pageTitle as indexTeamPageTitle } from "~/pages/Teams/IndexTeamPage/IndexTeamPage";
 import AdminHero from "~/components/Hero/AdminHero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import CreateTeamForm from "./components/CreateTeamForm";
 
@@ -69,28 +70,23 @@ const CreateTeamPage = () => {
     });
   };
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: intl.formatMessage(indexTeamPageTitle),
-      url: routes.teamTable(),
-    },
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Create<hidden> team</hidden>",
-        id: "o7SM7j",
-        description: "Breadcrumb title for the create team page link.",
-      }),
-      url: routes.teamCreate(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(indexTeamPageTitle),
+        url: routes.teamTable(),
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Create<hidden> team</hidden>",
+          id: "o7SM7j",
+          description: "Breadcrumb title for the create team page link.",
+        }),
+        url: routes.teamCreate(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   return (
     <>

--- a/apps/web/src/pages/Teams/IndexTeamPage/IndexTeamPage.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/IndexTeamPage.tsx
@@ -9,6 +9,7 @@ import useRoutes from "~/hooks/useRoutes";
 import SEO from "~/components/SEO/SEO";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import AdminHero from "~/components/Hero/AdminHero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import TeamTableApi from "./components/TeamTable/TeamTable";
 
@@ -26,20 +27,15 @@ const IndexTeamPage = () => {
 
   const formattedPageTitle = intl.formatMessage(pageTitle);
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: formattedPageTitle,
-      url: routes.teamTable(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: formattedPageTitle,
+        url: routes.teamTable(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   return (
     <>

--- a/apps/web/src/pages/TermsAndConditions/TermsAndConditions.tsx
+++ b/apps/web/src/pages/TermsAndConditions/TermsAndConditions.tsx
@@ -223,12 +223,14 @@ const TermsAndConditions = () => {
     },
   };
 
-  const crumbs = useBreadcrumbs([
-    {
-      label: pageTitle,
-      url: paths.accessibility(),
-    },
-  ]);
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: pageTitle,
+        url: paths.accessibility(),
+      },
+    ],
+  });
 
   const comments = [
     intl.formatMessage({

--- a/apps/web/src/pages/Users/IndexUserPage/IndexUserPage.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/IndexUserPage.tsx
@@ -9,6 +9,7 @@ import SEO from "~/components/SEO/SEO";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import useRoutes from "~/hooks/useRoutes";
 import AdminHero from "~/components/Hero/AdminHero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import UserTable from "./components/UserTable";
 
@@ -26,20 +27,15 @@ export const IndexUserPage = () => {
 
   const formattedPageTitle = intl.formatMessage(pageTitle);
 
-  const navigationCrumbs = [
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Home",
-        id: "EBmWyo",
-        description: "Link text for the home link in breadcrumbs.",
-      }),
-      url: routes.adminDashboard(),
-    },
-    {
-      label: formattedPageTitle,
-      url: routes.userTable(),
-    },
-  ];
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: formattedPageTitle,
+        url: routes.userTable(),
+      },
+    ],
+    isAdmin: true,
+  });
 
   return (
     <>

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -13,6 +13,7 @@ import {
   getLocalizedName,
   getPoolStatus,
   getPoolStream,
+  navigationMessages,
 } from "@gc-digital-talent/i18n";
 import { ROLE_NAME, RoleName } from "@gc-digital-talent/auth";
 import { notEmpty } from "@gc-digital-talent/helpers";
@@ -287,11 +288,7 @@ export const useAdminPoolPages = (intl: IntlShape, pool: Pick<Pool, "id">) => {
             crumbs: [
               {
                 url: paths.adminDashboard(),
-                label: intl.formatMessage({
-                  defaultMessage: "Home",
-                  id: "G1RNXj",
-                  description: "Link to the Homepage in the nav menu.",
-                }),
+                label: intl.formatMessage(navigationMessages.home),
               },
               {
                 url: paths.poolTable(),
@@ -327,11 +324,7 @@ export const useAdminPoolPages = (intl: IntlShape, pool: Pick<Pool, "id">) => {
             crumbs: [
               {
                 url: paths.adminDashboard(),
-                label: intl.formatMessage({
-                  defaultMessage: "Home",
-                  id: "G1RNXj",
-                  description: "Link to the Homepage in the nav menu.",
-                }),
+                label: intl.formatMessage(navigationMessages.home),
               },
               {
                 url: paths.poolTable(),
@@ -416,11 +409,7 @@ export const useAdminPoolPages = (intl: IntlShape, pool: Pick<Pool, "id">) => {
             crumbs: [
               {
                 url: paths.adminDashboard(),
-                label: intl.formatMessage({
-                  defaultMessage: "Home",
-                  id: "G1RNXj",
-                  description: "Link to the Homepage in the nav menu.",
-                }),
+                label: intl.formatMessage(navigationMessages.home),
               },
               {
                 url: paths.poolTable(),

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -931,6 +931,10 @@
     "defaultMessage": "Fiabilité ou plus élevée",
     "description": "Reliability security clearance"
   },
+  "Ro+gP0": {
+    "defaultMessage": "Accueil",
+    "description": "Name of Home page"
+  },
   "Rwh/Ld": {
     "defaultMessage": "Indéterminé",
     "description": "Simple indeterminate selection for government employee type."

--- a/packages/i18n/src/messages/navigationMessages.ts
+++ b/packages/i18n/src/messages/navigationMessages.ts
@@ -76,6 +76,11 @@ const navigationMessages = defineMessages({
     id: "gBoG9M",
     description: "Name of Profile and applications page",
   },
+  home: {
+    defaultMessage: "Home",
+    id: "Ro+gP0",
+    description: "Name of Home page",
+  },
 });
 
 export default navigationMessages;


### PR DESCRIPTION
🤖 Resolves #9764.

## 👋 Introduction

This PR implements the `useBreadcrumbs` hook on all breadcrumbs and adds the `isAdmin` prop so it can be used on admin pages, where possible. It also consolidates the **Home** string to avoid potential diverging translations.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Verify breadcrumbs do not include **Home** within crumbs array in `useBreadcrumbs` object
2. Verify breadcrumbs appear as they did before and link to the proper page