### PR TITLE
[Feature] Update dependabot types merge group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,7 @@ updates:
           - "patch"
       types:
         patterns:
-          - "@types*"
+          - "@types/*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
🤖 Resolves #9750.

## 👋 Introduction

This PR updates dependabot's types merge group so that it only includes TypeScript `@types` packages.

## 🎩 Acknowledgement

@esizer for the [solution](https://github.com/GCTC-NTGC/gc-digital-talent/issues/9750#:~:text=add%20a%20slash%20before%20the%20asterisk%20here%20to%20make%20it%20slightly%20more%20specific).

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. 🤞 it works on dependabot thursday! 🤷