### PR TITLE
[Bug] Filter out already disqualified candidates in processes

### DIFF
--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.test.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.test.tsx
@@ -10,7 +10,10 @@ import userEvent from "@testing-library/user-event";
 
 import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
 import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
-import { AssessmentDecision } from "@gc-digital-talent/graphql";
+import {
+  AssessmentDecision,
+  PoolCandidateStatus,
+} from "@gc-digital-talent/graphql";
 
 import { NO_DECISION } from "~/utils/assessmentResults";
 
@@ -22,10 +25,12 @@ import {
   sortResultsAndAddOrdinal,
   filterResults,
   ResultFilters,
+  filterAlreadyDisqualified,
 } from "./utils";
 import {
   armedForcesCandidate,
   bookmarkedCandidate,
+  filterDisqualifiedTestData,
   firstByName,
   lastByFirstName,
   lastByStatus,
@@ -368,5 +373,18 @@ describe("AssessmentStepTracker", () => {
         }),
       ]),
     );
+  });
+
+  it("should filter out candidates disqualified before RoD", () => {
+    // test array with a length of three, of which one should be filtered out the first with ScreenedOutApplication
+    const candidates = filterDisqualifiedTestData;
+    expect(candidates.length).toEqual(3);
+    const filteredCandidates = filterAlreadyDisqualified(candidates);
+    expect(filteredCandidates.length).toEqual(2);
+    const attemptToFindFilteredCandidate = filteredCandidates.filter(
+      (candidate) =>
+        candidate.status === PoolCandidateStatus.ScreenedOutApplication,
+    );
+    expect(attemptToFindFilteredCandidate.length).toEqual(0);
   });
 });

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
@@ -21,6 +21,7 @@ import {
   filterResults,
   groupPoolCandidatesByStep,
   defaultFilters,
+  filterAlreadyDisqualified,
 } from "./utils";
 import Filters from "./Filters";
 
@@ -49,7 +50,9 @@ const AssessmentStepTracker = ({ pool }: AssessmentStepTrackerProps) => {
   const [filters, setFilters] = React.useState<ResultFilters>(defaultFilters);
   const steps = unpackMaybes(pool.assessmentSteps);
   const candidates = unpackMaybes(pool.poolCandidates);
-  const groupedSteps = groupPoolCandidatesByStep(steps, candidates);
+  // to handle partially completed processes, filter out candidates assessed and disqualified pre-RoD
+  const filteredCandidates = filterAlreadyDisqualified(candidates);
+  const groupedSteps = groupPoolCandidatesByStep(steps, filteredCandidates);
   const filteredSteps = filterResults(filters, groupedSteps);
 
   return (

--- a/apps/web/src/components/AssessmentStepTracker/testData.ts
+++ b/apps/web/src/components/AssessmentStepTracker/testData.ts
@@ -13,6 +13,7 @@ import {
   AssessmentStepType,
   Pool,
   PoolCandidate,
+  PoolCandidateStatus,
   PoolSkillType,
 } from "@gc-digital-talent/graphql";
 
@@ -178,3 +179,24 @@ export const poolWithAssessmentSteps: Pool = {
   ],
   poolCandidates: testCandidates,
 };
+
+export const filterDisqualifiedTestData: PoolCandidate[] = [
+  {
+    ...fakeCandidates[0],
+    user: fakeCandidates[0].user,
+    status: PoolCandidateStatus.ScreenedOutApplication,
+    assessmentResults: [],
+  },
+  {
+    ...fakeCandidates[1],
+    user: fakeCandidates[1].user,
+    status: PoolCandidateStatus.NewApplication,
+    assessmentResults: [],
+  },
+  {
+    ...fakeCandidates[2],
+    user: fakeCandidates[2].user,
+    status: PoolCandidateStatus.ScreenedOutAssessment,
+    assessmentResults: [{ id: "123" }],
+  },
+];

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -23,6 +23,7 @@ import {
   determineCandidateStatusPerStep,
   determineCurrentStepPerCandidate,
   getDecisionCountForEachStep,
+  isDisqualifiedStatus,
 } from "~/utils/poolCandidate";
 
 export type CandidateAssessmentResult = {
@@ -268,4 +269,19 @@ export const filterResults = (
       results: filteredResults,
     };
   });
+};
+
+// filter out candidates who are disqualified AND have an empty assessment results collection
+export const filterAlreadyDisqualified = (
+  candidates: PoolCandidate[],
+): PoolCandidate[] => {
+  const filteredResult = candidates.filter(
+    (candidate) =>
+      !(
+        isDisqualifiedStatus(candidate.status) &&
+        (candidate.assessmentResults ? candidate.assessmentResults : [])
+          .length === 0
+      ),
+  );
+  return filteredResult;
 };

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -12,7 +12,6 @@ import {
   AssessmentDecision,
   Maybe,
   AssessmentStep,
-  PoolCandidateStatus,
 } from "@gc-digital-talent/graphql";
 import { notEmpty } from "@gc-digital-talent/helpers";
 import { commonMessages } from "@gc-digital-talent/i18n";
@@ -24,6 +23,8 @@ import {
   determineCandidateStatusPerStep,
   determineCurrentStepPerCandidate,
   getDecisionCountForEachStep,
+  isDisqualifiedStatus,
+  isRemovedStatus,
 } from "~/utils/poolCandidate";
 
 export type CandidateAssessmentResult = {
@@ -271,18 +272,6 @@ export const filterResults = (
   });
 };
 
-const consideredDisqualifiedStatuses = [
-  PoolCandidateStatus.ScreenedOutApplication,
-  PoolCandidateStatus.ScreenedOutAssessment,
-  PoolCandidateStatus.ScreenedOutNotInterested,
-  PoolCandidateStatus.ScreenedOutNotResponsive,
-];
-
-const isConsideredDisqualifiedStatus = (
-  status: Maybe<PoolCandidateStatus> | undefined,
-): boolean =>
-  status ? consideredDisqualifiedStatuses.includes(status) : false;
-
 // filter out candidates who are disqualified AND have an empty assessment results collection
 export const filterAlreadyDisqualified = (
   candidates: PoolCandidate[],
@@ -290,7 +279,8 @@ export const filterAlreadyDisqualified = (
   const filteredResult = candidates.filter(
     (candidate) =>
       !(
-        isConsideredDisqualifiedStatus(candidate.status) &&
+        (isDisqualifiedStatus(candidate.status) ||
+          isRemovedStatus(candidate.status)) &&
         (candidate.assessmentResults ? candidate.assessmentResults : [])
           .length === 0
       ),

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -12,6 +12,7 @@ import {
   AssessmentDecision,
   Maybe,
   AssessmentStep,
+  PoolCandidateStatus,
 } from "@gc-digital-talent/graphql";
 import { notEmpty } from "@gc-digital-talent/helpers";
 import { commonMessages } from "@gc-digital-talent/i18n";
@@ -23,7 +24,6 @@ import {
   determineCandidateStatusPerStep,
   determineCurrentStepPerCandidate,
   getDecisionCountForEachStep,
-  isDisqualifiedStatus,
 } from "~/utils/poolCandidate";
 
 export type CandidateAssessmentResult = {
@@ -271,6 +271,18 @@ export const filterResults = (
   });
 };
 
+const consideredDisqualifiedStatuses = [
+  PoolCandidateStatus.ScreenedOutApplication,
+  PoolCandidateStatus.ScreenedOutAssessment,
+  PoolCandidateStatus.ScreenedOutNotInterested,
+  PoolCandidateStatus.ScreenedOutNotResponsive,
+];
+
+const isConsideredDisqualifiedStatus = (
+  status: Maybe<PoolCandidateStatus> | undefined,
+): boolean =>
+  status ? consideredDisqualifiedStatuses.includes(status) : false;
+
 // filter out candidates who are disqualified AND have an empty assessment results collection
 export const filterAlreadyDisqualified = (
   candidates: PoolCandidate[],
@@ -278,7 +290,7 @@ export const filterAlreadyDisqualified = (
   const filteredResult = candidates.filter(
     (candidate) =>
       !(
-        isDisqualifiedStatus(candidate.status) &&
+        isConsideredDisqualifiedStatus(candidate.status) &&
         (candidate.assessmentResults ? candidate.assessmentResults : [])
           .length === 0
       ),

--- a/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
+++ b/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
@@ -19,6 +19,7 @@ const ScreeningAndEvaluation_AssessmentResultFragment = graphql(/* GraphQL */ `
     poolCandidates {
       id
       isBookmarked
+      status
       pool {
         id
       }


### PR DESCRIPTION
🤖 Resolves #9789

## 👋 Introduction

Filter out candidates that were already disqualified prior to RoD
I think I got the gist of what the goal was? 😅 

## 🧪 Testing

1. Add a candidate to a process, disqualify them, then ensure they are missing from Screening and assessment
2. Must have no assessment results 

## 📸 Screenshot

Pool candidate

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/51a74749-b65a-4621-ac61-971646e305a8)

Present

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/1d5adf1e-80d7-4703-b4fb-adc5a35cf2ae)

Missing

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/cb8048d4-af99-4585-8f7b-102270f848de)
