### PR TITLE
[Bug] Use snapshot for screening dialog

### DIFF
--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -18,6 +18,7 @@ import {
   PoolSkillType,
   Skill,
   UpdateAssessmentResultInput,
+  User,
   graphql,
 } from "@gc-digital-talent/graphql";
 import {
@@ -314,6 +315,11 @@ export const ScreeningDecisionDialog = ({
   const skill = poolSkill?.skill ? poolSkill.skill : undefined;
   const skillLevel = getSkillLevelMessage(poolSkill, intl);
 
+  const parsedSnapshot: Maybe<User> = JSON.parse(poolCandidate.profileSnapshot);
+  const snapshotCandidate = parsedSnapshot?.poolCandidates
+    ?.filter(notEmpty)
+    .find(({ id }) => id === poolCandidate.id);
+
   const headers = useHeaders({
     type: dialogType,
     title: intl.formatMessage(
@@ -322,7 +328,7 @@ export const ScreeningDecisionDialog = ({
         : commonMessages.notApplicable,
     ),
     customTitle: getLocalizedName(assessmentStep?.title, intl, true),
-    candidateName: poolCandidate.user.firstName,
+    candidateName: parsedSnapshot?.firstName,
     skillName: getLocalizedName(skill?.name, intl),
     skillLevel,
   });
@@ -330,9 +336,10 @@ export const ScreeningDecisionDialog = ({
 
   const experiences =
     dialogType === "EDUCATION"
-      ? poolCandidate.educationRequirementExperiences?.filter(notEmpty) || []
+      ? snapshotCandidate?.educationRequirementExperiences?.filter(notEmpty) ||
+        []
       : getExperienceSkills(
-          poolCandidate.user.experiences?.filter(notEmpty) || [],
+          parsedSnapshot?.experiences?.filter(notEmpty) || [],
           skill,
         );
 
@@ -346,7 +353,7 @@ export const ScreeningDecisionDialog = ({
     classificationGroup,
     isIAPPool(poolCandidate.pool),
   ).find(
-    (option) => option.value === poolCandidate.educationRequirementOption,
+    (option) => option.value === snapshotCandidate?.educationRequirementOption,
   )?.label;
 
   const defaultValues: FormValues = {

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -206,13 +206,14 @@ const AssessmentStepTypeSection = ({
 const ScreeningQuestions = ({
   poolCandidate,
 }: {
-  poolCandidate: PoolCandidate;
+  poolCandidate: PoolCandidate | undefined;
 }) => {
   const intl = useIntl();
-  const screeningQuestions =
-    poolCandidate.pool.screeningQuestions?.filter(notEmpty) || [];
   const screeningQuestionResponses =
-    poolCandidate.screeningQuestionResponses?.filter(notEmpty) || [];
+    poolCandidate?.screeningQuestionResponses?.filter(notEmpty) || [];
+  const screeningQuestions = screeningQuestionResponses
+    .map((response) => response.screeningQuestion)
+    .filter(notEmpty);
 
   if (screeningQuestions.length === 0)
     return (
@@ -443,7 +444,7 @@ export const ScreeningDecisionDialog = ({
               type={dialogType}
             />
             {dialogType === "SCREENING_QUESTIONS" ? (
-              <ScreeningQuestions poolCandidate={poolCandidate} />
+              <ScreeningQuestions poolCandidate={snapshotCandidate} />
             ) : (
               <SupportingEvidence experiences={experiences} skill={skill} />
             )}


### PR DESCRIPTION
🤖 Resolves #9812 

## 👋 Introduction

Rectify the dialog component to pull data to render out of the snapshot. Also noticed the screening question responses ought to do that too. 
Just recycled code from elsewhere for the most part ♻️ 

## 🧪 Testing

1. Submit an application
2. Retroactively update stuff, it should not be reflected in the dialog

## 📸 Screenshot

Dialog view

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/3fc9559d-9901-4b80-aecd-58bb273e7735)

Updated experience

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/5f34ec29-e4d9-43f3-9cbe-7300d8ff7097)

Screening questions still rendered

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/95644372-3f86-4555-84d6-846db683d36d)

