### PR TITLE
[Fix] Remove Dependabot `versioning-strategy`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
       interval: "weekly"
       day: "thursday"
     open-pull-requests-limit: 50
-    versioning-strategy: lockfile-only
     groups:
       storybook:
         patterns:


### PR DESCRIPTION
🤖 Resolves #9847.

## 👋 Introduction

Update Dependabot to remove `versioning-strategy`.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. 🤞 