### PR TITLE
[Feature] Add better email error

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2668,7 +2668,7 @@
     "description": "Note for when an assessment was unsuccessful but put on hold"
   },
   "DOn3Hm": {
-    "defaultMessage": "Adresse courriel non valide. Essayez de nouveau ou envoyez un courriel, o <anchorTag>{emailAddress}</anchorTag>.",
+    "defaultMessage": "Adresse courriel non valide. Essayez de nouveau ou envoyez un courriel à <anchorTag>{emailAddress}</anchorTag>.",
     "description": "Support form toast message error"
   },
   "DPfJ30": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2667,6 +2667,10 @@
     "defaultMessage": "Non démontré suffisamment dans le cadre de la présente méthode d’évaluation – faire passer à de plus amples mises à l’essai. (Ne s’applique qu’aux occasions où les points sont cumulatifs à l’échelle des méthodes d’évaluation. Ne s’applique pas dans les cas où les candidats doivent répondre à certains critères essentiels à chaque étape).",
     "description": "Note for when an assessment was unsuccessful but put on hold"
   },
+  "DOn3Hm": {
+    "defaultMessage": "Adresse courriel non valide. Essayez de nouveau ou envoyez un courriel, o <anchorTag>{emailAddress}</anchorTag>.",
+    "description": "Support form toast message error"
+  },
   "DPfJ30": {
     "defaultMessage": "La compétence <strong>sera associée aux expériences auxquelles elle était précédemment associée.</strong>",
     "description": "Notice that re-adding a skill will re-add it to any linked experiences"

--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
@@ -2,7 +2,7 @@
 // Note: Disable camelcase since variables are being used by API
 import * as React from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
-import { MessageDescriptor, useIntl } from "react-intl";
+import { defineMessage, useIntl } from "react-intl";
 import { useLocation } from "react-router-dom";
 import { useQuery } from "urql";
 
@@ -292,23 +292,23 @@ const SupportFormApi = () => {
     logger.error(`Failed to submit ticket: ${JSON.stringify(responseBody)}`);
 
     // default error message if we don't recognize the error
-    let errorMessage: MessageDescriptor = {
+    let errorMessage = defineMessage({
       defaultMessage:
         "Sorry, something went wrong. Please email <anchorTag>{emailAddress}</anchorTag> and mention this error code: {errorCode}.",
       id: "rNVDaA",
       description: "Support form toast message error",
-    };
+    });
 
     if (
       responseBody?.serviceResponse === "error" &&
       responseBody?.errorDetail === "invalid_email"
     ) {
-      errorMessage = {
+      errorMessage = defineMessage({
         defaultMessage:
           "Invalid email address. Try again or send an email to <anchorTag>{emailAddress}</anchorTag>.",
-        id: "rNVDaA",
+        id: "DOn3Hm",
         description: "Support form toast message error",
-      };
+      });
     }
 
     toast.error(

--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
@@ -263,6 +263,19 @@ const SupportFormUser_Query = graphql(/* GraphQL */ `
   }
 `);
 
+const defaultErrorMessage = defineMessage({
+  defaultMessage:
+    "Sorry, something went wrong. Please email <anchorTag>{emailAddress}</anchorTag> and mention this error code: {errorCode}.",
+  id: "rNVDaA",
+  description: "Support form toast message error",
+});
+const emailErrorMessage = defineMessage({
+  defaultMessage:
+    "Invalid email address. Try again or send an email to <anchorTag>{emailAddress}</anchorTag>.",
+  id: "DOn3Hm",
+  description: "Support form toast message error",
+});
+
 const SupportFormApi = () => {
   const intl = useIntl();
   const logger = useLogger();
@@ -292,23 +305,13 @@ const SupportFormApi = () => {
     logger.error(`Failed to submit ticket: ${JSON.stringify(responseBody)}`);
 
     // default error message if we don't recognize the error
-    let errorMessage = defineMessage({
-      defaultMessage:
-        "Sorry, something went wrong. Please email <anchorTag>{emailAddress}</anchorTag> and mention this error code: {errorCode}.",
-      id: "rNVDaA",
-      description: "Support form toast message error",
-    });
+    let errorMessage = defaultErrorMessage;
 
     if (
       responseBody?.serviceResponse === "error" &&
       responseBody?.errorDetail === "invalid_email"
     ) {
-      errorMessage = defineMessage({
-        defaultMessage:
-          "Invalid email address. Try again or send an email to <anchorTag>{emailAddress}</anchorTag>.",
-        id: "DOn3Hm",
-        description: "Support form toast message error",
-      });
+      errorMessage = emailErrorMessage;
     }
 
     toast.error(


### PR DESCRIPTION
🤖 Resolves #9733

## 👋 Introduction

This branch adds a better error to the support page when an "invalid email" code is being returned by Freshdesk.  I ran the suggested error message past Marc and got a "looks good".

## 🧪 Testing

1. Set up your environment for Freshdesk (either set up a junk account or copy the values from prod).

- [ ] An invalid email address triggers the new error message.
- [ ] Any other error (like bad API key) triggers the existing default error message.
- [ ] A successful ticket submission triggers the existing success toast.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/36b06c5a-2412-4b86-a517-1cf391b88e5b)