### PR TITLE
[Fix] French typo in word process

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2756,7 +2756,7 @@
     "description": "Text to confirm the process to be extend"
   },
   "DqM+mu": {
-    "defaultMessage": "Erreur : Le désarchivage du proccesus a échoué",
+    "defaultMessage": "Erreur : Le désarchivage du processus a échoué",
     "description": "Message displayed to user after pool fails to get un-archived."
   },
   "Dqsq+M": {


### PR DESCRIPTION
🤖 Resolves #9869.

## 👋 Introduction

This PR fixes a French typo introduced in #9759. Sorry @tristan-orourke, I lied, [the process is not complete](https://github.com/GCTC-NTGC/gc-digital-talent/pull/9759#pullrequestreview-1949113375) 😓. 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Do a French spell check on the word `processus`
2. Verify no instances of `proccesus` in codebase