### PR TITLE
[Tooling] `Makefile` for common scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ down:
 	docker-compose down
 
 setup:
-	$(DOCKER_RUN) bash setup.sh
+	$(DOCKER_RUN) setup.sh
 
 refresh:
 	$(DOCKER_RUN) refresh_all.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: up down setup clean-modules refresh refresh-frontend refresh-api seed-fresh migrate artisan
+
+DOCKER_RUN=docker-compose run --rm maintenance bash
+DOCKER_EXEC=docker-compose exec -w /home/site/wwwroot/api webserver sh -c
+
+up:
+	docker-compose up --build --detach
+
+down:
+	docker-compose down
+
+setup:
+	$(DOCKER_RUN) bash setup.sh
+
+refresh:
+	$(DOCKER_RUN) refresh_all.sh
+
+clean-modules:
+	find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +
+
+refresh-frontend:
+	$(DOCKER_RUN) refresh_frontend.sh
+
+refresh-api:
+	$(DOCKER_RUN) refresh_api.sh
+
+seed-fresh:
+	$(DOCKER_EXEC) "php artisan migrate:fresh --seed"
+
+migrate:
+	$(DOCKER_EXEC) "php artisan migrate"
+
+artisan:
+	$(DOCKER_EXEC) "php artisan $(CMD)"
+


### PR DESCRIPTION
🤖 Resolves #9886 

## 👋 Introduction

Not sure if anyone would find this useful but I use this to run some common commands so I don't need to go looking for them all the time.

## 🕵️ Details

If you have [make](https://www.gnu.org/software/make/manual/make.html) installed you can run the following commands:

- `make up`: Start docker compose in detach mode
- `make down`: Shutdown docker-compose
- `make setup`: Runs the `setup.sh` script
- `make refresh`: Runs the `refresh_all.sh` script
- `make refresh-frontend`: Runs the `refresh_frontend.sh` script
- `make refresh-api`: Runs the `refresh_api.sh` script
- `make clean-modules`: Deletes all `node_modules` directories
- `make seed-fresh`: Refreshes the database with new data
- `make migrate`: Runs new db migrations
- `make artisan CMD="some artisan command"`: Run artisan inside the webserver eg.
    - `make artisan CMD="make:migration new_table"`

## 🧪 Testing

1. Test our the commands list in the details section
2. Confirm they work
