### PR TITLE
[Feature] Generate candidate profiles

### DIFF
--- a/api/app/Generators/CandidateProfileDoc.php
+++ b/api/app/Generators/CandidateProfileDoc.php
@@ -3,25 +3,33 @@
 namespace App\Generators;
 
 use App\Models\PoolCandidate;
+use App\Models\User;
 use Exception;
 
 class CandidateProfileDoc extends DocGenerator
 {
 
     protected array $ids;
+    protected string $lang = "en";
+    protected bool $anonymous;
 
-    public function __construct(array $ids)
+    public function __construct(array $ids, ?string $lang = "en", ?bool $anonymous = false)
     {
         $this->ids = $ids;
+        $this->lang = $lang;
+        $this->anonymous = $anonymous;
 
         parent::__construct();
     }
 
     public function generate()
     {
-        $candidates = PoolCandidate::with(
-            'user'
-        )
+        $candidates = PoolCandidate::with([
+            'user' => [
+                'department',
+                'currentClassification'
+            ]
+        ])
             ->whereIn('id', $this->ids)
             ->get();
 
@@ -29,15 +37,64 @@ class CandidateProfileDoc extends DocGenerator
             throw new Exception("No candidates found.");
         }
 
+        $this->doc->addTitle("Applicant snapshot");
 
-        $this->doc->addTitle("Applicant snapshot", 1);
-
-        foreach($candidates as $candidate) {
+        $candidates->each(function ($candidate) {
             $section = $this->doc->addSection();
 
-            $section->addTitle($candidate->user->getFullName(), 2);
+            $section->addTitle($candidate->user->getFullName($this->anonymous), 1);
+
+            $section->addTitle('General information', 2);
+
+            $this->addSubTitle($section, 'Contact Information');
+            $this->addLabelText($section, 'Email', $candidate->user->email);
+            $this->addLabelText($section, 'Phone', $candidate->user->telephone);
+            $this->addLabelText($section, 'City', $candidate->user->getLocation());
+            $this->addLabelText($section, 'Communication language', $candidate->user->getLanguage("preferred_lang"));
+            $this->addLabelText($section, 'Spoken interview language', $candidate->user->getLanguage("preferred_language_for_interview"));
+            $this->addLabelText($section, 'Written exam language', $candidate->user->getLanguage("preferred_language_for_exam"));
+            $this->addLabelText($section, 'Member of CAF', $candidate->user->getArmedForcesStatus());
+            $this->addLabelText($section, 'Citizenship', $candidate->user->getCitizenship());
+
+            $this->addSubTitle($section, 'Language information');
+            $this->addLabelText($section, 'Interested in', $candidate->user->getLookingForLanguage());
+            $this->addLabelText($section, 'Completed an official GoC evaluation', $candidate->user->getBilingualEvaluation());
+            $this->addLabelText($section, 'Second language level (Comprehension, Written, Verbal)', $candidate->user->getSecondLanguageEvaluation());
+
+            $this->addSubTitle($section, 'Government information');
+            $this->addLabelText($section, 'Government of Canada employee', $candidate->user->is_gov_employee ? "Yes" : "No");
+            if($candidate->user->is_gov_employee) {
+                $department = $candidate->user->department()->first();
+                $this->addLabelText($section, 'Department', $department->name[$this->lang] ?? "");
+                $this->addLabelText($section, 'Employee type', $candidate->user->getGovEmployeeType());
+                $this->addLabelText($section, 'Classification', $candidate->user->getClassification());
+            }
+            $this->addLabelText($section, 'Priority entitlement', $candidate->user->has_priority_entitlement ? "Yes" : "No");
+
+            $this->addSubTitle($section, 'Work location');
+            $this->addLabelText($section, 'Work location',
+                $candidate->user->location_preferences ? implode(', ', $candidate->user->location_preferences) : "");
+            $this->addLabelText($section, 'Location exemptions', $candidate->user->location_exemptions);
+
+            $this->addSubTitle($section, 'Diversity, equity, inclusion');
+
+            $indigenousCommunities = $candidate->user->getIndigenousCommunities();
+            if($indigenousCommunities) {
+                foreach($indigenousCommunities as $community) {
+                    $section->addListItem($community);
+                }
+            }
+            if($candidate->user->is_woman) {
+                $section->addListItem("Woman");
+            }
+            if($candidate->user->is_visible_minority) {
+                $section->addListItem("Visible minority");
+            }
+            if($candidate->user->has_disability) {
+                $section->addListItem("Person with a disability");
+            }
 
             $section->addPageBreak();
-        }
+        });
     }
 }

--- a/api/app/Generators/CandidateProfileDoc.php
+++ b/api/app/Generators/CandidateProfileDoc.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Generators;
+
+use App\Models\PoolCandidate;
+use Exception;
+
+class CandidateProfileDoc extends DocGenerator
+{
+
+    protected array $ids;
+
+    public function __construct(array $ids)
+    {
+        $this->ids = $ids;
+
+        parent::__construct();
+    }
+
+    public function generate()
+    {
+        $candidates = PoolCandidate::with(
+            'user'
+        )
+            ->whereIn('id', $this->ids)
+            ->get();
+
+        if(empty($candidates)){
+            throw new Exception("No candidates found.");
+        }
+
+
+        $this->doc->addTitle("Applicant snapshot", 1);
+
+        foreach($candidates as $candidate) {
+            $section = $this->doc->addSection();
+
+            $section->addTitle($candidate->user->getFullName(), 2);
+
+            $section->addPageBreak();
+        }
+    }
+}

--- a/api/app/Generators/DocGenerator.php
+++ b/api/app/Generators/DocGenerator.php
@@ -5,10 +5,12 @@ namespace App\Generators;
 use Illuminate\Support\Facades\Storage;
 use \PhpOffice\PhpWord\PhpWord;
 use \PhpOffice\PhpWord\IOFactory;
+use \PhpOffice\PhpWord\Element;
 
 abstract class DocGenerator {
 
     protected PhpWord $doc;
+    protected array $strong;
 
     public function __construct()
     {
@@ -18,6 +20,8 @@ abstract class DocGenerator {
         $this->doc->addTitleStyle(2, ['size' => 18, 'bold' => true]);
         $this->doc->addTitleStyle(3, ['size' => 15, 'bold' => true]);
         $this->doc->addTitleStyle(4, ['size' => 13, 'bold' => true]);
+
+        $this->strong = ['bold' => true];
     }
 
     abstract function generate();
@@ -33,4 +37,18 @@ abstract class DocGenerator {
 
         return $writer->save($path);
     }
+
+    protected function addSubTitle(Element\Section $section, string $text, ?int $rank = 3)
+    {
+        $section->addTextBreak(2);
+        $section->addTitle($text, $rank);
+    }
+
+    protected function addLabelText(Element\Section $section, string $label, string $text)
+    {
+        $run = $section->addTextRun();
+        $run->addText($label.': ', $this->strong);
+        $run->addText($text);
+    }
+
 }

--- a/api/app/Generators/DocGenerator.php
+++ b/api/app/Generators/DocGenerator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Generators;
+
+use Illuminate\Support\Facades\Storage;
+use \PhpOffice\PhpWord\PhpWord;
+use \PhpOffice\PhpWord\IOFactory;
+
+abstract class DocGenerator {
+
+    protected PhpWord $doc;
+
+    public function __construct()
+    {
+        $this->doc = new PhpWord();
+
+        $this->doc->addTitleStyle(1, ['size' => 22, 'bold' => true]);
+        $this->doc->addTitleStyle(2, ['size' => 18, 'bold' => true]);
+        $this->doc->addTitleStyle(3, ['size' => 15, 'bold' => true]);
+        $this->doc->addTitleStyle(4, ['size' => 13, 'bold' => true]);
+    }
+
+    abstract function generate();
+
+    public function write(string $fileName)
+    {
+       /** @var \Illuminate\Filesystem\FilesystemManager */
+        $disk = Storage::disk('generated');
+
+        $path = $disk->path($fileName);
+
+        $writer = IOFactory::createWriter($this->doc);
+
+        return $writer->save($path);
+    }
+}

--- a/api/app/Generators/DocGenerator.php
+++ b/api/app/Generators/DocGenerator.php
@@ -16,10 +16,10 @@ abstract class DocGenerator {
     {
         $this->doc = new PhpWord();
 
-        $this->doc->addTitleStyle(1, ['size' => 22, 'bold' => true]);
-        $this->doc->addTitleStyle(2, ['size' => 18, 'bold' => true]);
-        $this->doc->addTitleStyle(3, ['size' => 15, 'bold' => true]);
-        $this->doc->addTitleStyle(4, ['size' => 13, 'bold' => true]);
+        $this->doc->addTitleStyle(1, ['size' => 22, 'bold' => true], ['spaceBefore' => 240, 'spaceAfter' => 120]);
+        $this->doc->addTitleStyle(2, ['size' => 18, 'bold' => true], ['spaceBefore' => 240, 'spaceAfter' => 120]);
+        $this->doc->addTitleStyle(3, ['size' => 15, 'bold' => true], ['spaceBefore' => 240, 'spaceAfter' => 120]);
+        $this->doc->addTitleStyle(4, ['size' => 13, 'bold' => true],    ['spaceBefore' => 240, 'spaceAfter' => 120]);
 
         $this->strong = ['bold' => true];
     }
@@ -40,7 +40,6 @@ abstract class DocGenerator {
 
     protected function addSubTitle(Element\Section $section, string $text, ?int $rank = 3)
     {
-        $section->addTextBreak(2);
         $section->addTitle($text, $rank);
     }
 

--- a/api/app/Models/AwardExperience.php
+++ b/api/app/Models/AwardExperience.php
@@ -32,4 +32,14 @@ class AwardExperience extends Experience
     protected $casts = [
         'awarded_date' => 'date',
     ];
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getExperienceType(): string
+    {
+        return 'award';
+    }
 }

--- a/api/app/Models/CommunityExperience.php
+++ b/api/app/Models/CommunityExperience.php
@@ -33,4 +33,14 @@ class CommunityExperience extends Experience
         'start_date' => 'date',
         'end_date' => 'date',
     ];
+
+    public function getTitle(): string
+    {
+        return sprintf("%s at %s", $this->title, $this->organization);
+    }
+
+    public function getExperienceType(): string
+    {
+        return 'community';
+    }
 }

--- a/api/app/Models/EducationExperience.php
+++ b/api/app/Models/EducationExperience.php
@@ -35,4 +35,14 @@ class EducationExperience extends Experience
         'start_date' => 'date',
         'end_date' => 'date',
     ];
+
+    public function getTitle(): string
+    {
+        return sprintf("%s at %s", $this->area_of_study, $this->institution);
+    }
+
+    public function getExperienceType(): string
+    {
+        return 'education';
+    }
 }

--- a/api/app/Models/Experience.php
+++ b/api/app/Models/Experience.php
@@ -25,6 +25,9 @@ abstract class Experience extends Model
 
     protected $keyType = 'string';
 
+    abstract public function getTitle(): string;
+    abstract public function getExperienceType(): string;
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class)
@@ -166,5 +169,12 @@ abstract class Experience extends Model
                 $user->searchable();
             }
         });
+    }
+
+    public function getDateRange(): string
+    {
+        $start = $this->start_date->format('M Y');
+        $end = $this->end_date ? $this->end_date->format('M Y') : 'Present';
+        return "$start - $end";
     }
 }

--- a/api/app/Models/PersonalExperience.php
+++ b/api/app/Models/PersonalExperience.php
@@ -32,4 +32,14 @@ class PersonalExperience extends Experience
         'start_date' => 'date',
         'end_date' => 'date',
     ];
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getExperienceType(): string
+    {
+        return 'personal';
+    }
 }

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -308,6 +308,19 @@ class User extends Model implements Authenticatable, LaratrustUser
         $this->searchable();
     }
 
+    public function getFullName()
+    {
+        if($this->first_name && $this->last_name) {
+            return $this->first_name . " " . $this->last_name;
+        } else if($this->first_name) {
+            return $this->first_name;
+        } else if ($this->last_name) {
+            return $this->last_name;
+        }
+
+        return "";
+    }
+
     // getIsProfileCompleteAttribute function is correspondent to isProfileComplete attribute in graphql schema
     public function getIsProfileCompleteAttribute(): bool
     {

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -234,7 +234,7 @@ class User extends Model implements Authenticatable, LaratrustUser
     public function department(): BelongsTo
     {
         return $this->belongsTo(Department::class, 'department')
-            ->select(['id', 'name']);
+            ->select(['id', 'name', 'department_number']);
     }
 
     public function currentClassification(): BelongsTo
@@ -462,7 +462,8 @@ class User extends Model implements Authenticatable, LaratrustUser
                 IndigenousCommunity::STATUS_FIRST_NATIONS->name => "Status First Nations",
                 IndigenousCommunity::INUIT->name => "Inuk (Inuit)",
                 IndigenousCommunity::METIS->name => "Métis",
-                IndigenousCommunity::OTHER->name => "Other"
+                IndigenousCommunity::OTHER->name => "Other",
+                default => "Unknown"
             };
         }, $this->indigenous_communities);
     }

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -2,8 +2,13 @@
 
 namespace App\Models;
 
+use App\Enums\ArmedForcesStatus;
+use App\Enums\BilingualEvaluation;
 use App\Enums\CandidateExpiryFilter;
 use App\Enums\CandidateSuspendedFilter;
+use App\Enums\CitizenshipStatus;
+use App\Enums\GovEmployeeType;
+use App\Enums\IndigenousCommunity;
 use App\Enums\LanguageAbility;
 use App\Enums\PoolCandidateStatus;
 use App\Traits\EnrichedNotifiable;
@@ -228,7 +233,8 @@ class User extends Model implements Authenticatable, LaratrustUser
 
     public function department(): BelongsTo
     {
-        return $this->belongsTo(Department::class, 'department');
+        return $this->belongsTo(Department::class, 'department')
+            ->select(['id', 'name']);
     }
 
     public function currentClassification(): BelongsTo
@@ -308,17 +314,157 @@ class User extends Model implements Authenticatable, LaratrustUser
         $this->searchable();
     }
 
-    public function getFullName()
+    public function getFullName(?bool $anonymous = false)
     {
-        if($this->first_name && $this->last_name) {
-            return $this->first_name . " " . $this->last_name;
+        $lastName = $this->last_name;
+        if($anonymous && $lastName) {
+            $lastName = substr($lastName, 0, 1);
+        }
+
+        if($this->first_name && $lastName) {
+            return $this->first_name . " " . $lastName;
         } else if($this->first_name) {
             return $this->first_name;
-        } else if ($this->last_name) {
-            return $this->last_name;
+        } else if ($lastName) {
+            return $lastName;
         }
 
         return "";
+    }
+
+    public function getLocation()
+    {
+        if($this->current_city && $this->current_province) {
+            return $this->current_city.", ".$this->current_province;
+        } else if($this->current_city) {
+            return $this->current_city;
+        } else if ($this->current_province) {
+            return $this->current_province;
+        }
+
+        return "";
+    }
+
+    public function getLanguage(string $key)
+    {
+        $code = $this->$key;
+        if($code !== 'en' && $code !== 'fr') {
+            return "";
+        }
+
+        return $code === "en" ? "English" : "French";
+    }
+
+    public function getArmedForcesStatus()
+    {
+        switch($this->armed_forces_status) {
+            case ArmedForcesStatus::MEMBER->name:
+                return 'Member';
+            case ArmedForcesStatus::VETERAN->name:
+                return 'Veteran';
+            default:
+                return 'Not in the CAF';
+        }
+    }
+
+    public function getCitizenship()
+    {
+        switch($this->citizenship) {
+            case CitizenshipStatus::CITIZEN:
+                return 'Canadian citizen';
+            case CitizenshipStatus::PERMANENT_RESIDENT:
+                return 'Permanent resident';
+            default:
+                return 'Other';
+        }
+    }
+
+    public function getLookingForLanguage()
+    {
+        if($this->looking_for_bilingual) {
+            return 'Bilingual positions (English and French)';
+        } else if($this->looking_for_english && $this->looking_for_french) {
+            return 'English or French positions';
+        } else if($this->looking_for_english) {
+            return 'English positions';
+        } else if($this->looking_for_french) {
+            return 'French positions';
+        }
+
+        return '';
+    }
+
+    public function getBilingualEvaluation()
+    {
+        switch($this->bilingual_evaluation) {
+            case BilingualEvaluation::NOT_COMPLETED->name:
+                return 'No';
+            case BilingualEvaluation::COMPLETED_ENGLISH->name:
+                return 'Yes, completed English evaluation';
+            case BilingualEvaluation::COMPLETED_FRENCH->name:
+                return 'Yes, completed French evaluation';
+            default:
+                return '';
+        }
+    }
+
+    public function getSecondLanguageEvaluation()
+    {
+        if($this->comprehension_level || $this->written_level || $this->verbal_level) {
+            return sprintf('%s, %s, %s',
+                $this->comprehension_level ?? "",
+                $this->written_level ?? "",
+                $this->verbal_level ?? ""
+            );
+        }
+
+        return "";
+    }
+
+    public function getGovEmployeeType()
+    {
+        if(!$this->gov_employee_type){
+            return "";
+        }
+
+        return ucwords(strtolower($this->gov_employee_type));
+    }
+
+    public function getClassification()
+    {
+        if(!$this->current_classification) {
+            return "";
+        }
+
+        $classification = $this->currentClassification()->first();
+
+        return $classification->group.'-0'.$classification->level;
+    }
+
+    public function getDepartment()
+    {
+        if(!$this->department) {
+            return "";
+        }
+
+        return $this->department()->get('name');
+    }
+
+    public function getIndigenousCommunities()
+    {
+        if(empty($this->indigenous_communities)) {
+            return null;
+        }
+
+        return array_map(function($community) {
+            return match($community) {
+                IndigenousCommunity::NON_STATUS_FIRST_NATIONS->name => "Non-status First Nations",
+                IndigenousCommunity::STATUS_FIRST_NATIONS->name => "Status First Nations",
+                IndigenousCommunity::INUIT->name => "Inuk (Inuit)",
+                IndigenousCommunity::METIS->name => "Métis",
+                IndigenousCommunity::OTHER->name => "Other"
+            };
+        }, $this->indigenous_communities);
     }
 
     // getIsProfileCompleteAttribute function is correspondent to isProfileComplete attribute in graphql schema

--- a/api/app/Models/WorkExperience.php
+++ b/api/app/Models/WorkExperience.php
@@ -33,4 +33,14 @@ class WorkExperience extends Experience
         'start_date' => 'date',
         'end_date' => 'date',
     ];
+
+    public function getTitle(): string
+    {
+        return sprintf("%s at %s", $this->role, $this->organization);
+    }
+
+    public function getExperienceType(): string
+    {
+        return 'work';
+    }
 }

--- a/api/composer.json
+++ b/api/composer.json
@@ -21,6 +21,7 @@
     "mll-lab/graphql-php-scalars": "^6.2",
     "mll-lab/laravel-graphiql": "^3.0",
     "nuwave/lighthouse": "^6.15",
+    "phpoffice/phpword": "^1.2",
     "santigarcor/laratrust": "^8.0",
     "spatie/laravel-activitylog": "^4.7",
     "staudenmeir/eloquent-has-many-deep": "^1.18",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "072754372b5d391a6ce17866c9e622e7",
+    "content-hash": "732a38756a73887c123c7fb054ed16ad",
     "packages": [
         {
             "name": "brick/math",
@@ -3574,6 +3574,168 @@
                 "source": "https://github.com/paragonie/sodium_compat/tree/v1.20.0"
             },
             "time": "2023-04-30T00:54:53+00:00"
+        },
+        {
+            "name": "phpoffice/math",
+            "version": "0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPOffice/Math.git",
+                "reference": "f0f8cad98624459c540cdd61d2a174d834471773"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPOffice/Math/zipball/f0f8cad98624459c540cdd61d2a174d834471773",
+                "reference": "f0f8cad98624459c540cdd61d2a174d834471773",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xml": "*",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.88 || ^1.0.0",
+                "phpunit/phpunit": "^7.0 || ^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpOffice\\Math\\": "src/Math/",
+                    "Tests\\PhpOffice\\Math\\": "tests/Math/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Progi1984",
+                    "homepage": "https://lefevre.dev"
+                }
+            ],
+            "description": "Math - Manipulate Math Formula",
+            "homepage": "https://phpoffice.github.io/Math/",
+            "keywords": [
+                "MathML",
+                "officemathml",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPOffice/Math/issues",
+                "source": "https://github.com/PHPOffice/Math/tree/0.1.0"
+            },
+            "time": "2023-09-25T12:08:20+00:00"
+        },
+        {
+            "name": "phpoffice/phpword",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPOffice/PHPWord.git",
+                "reference": "e76b701ef538cb749641514fcbc31a68078550fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPOffice/PHPWord/zipball/e76b701ef538cb749641514fcbc31a68078550fa",
+                "reference": "e76b701ef538cb749641514fcbc31a68078550fa",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-xml": "*",
+                "php": "^7.1|^8.0",
+                "phpoffice/math": "^0.1"
+            },
+            "require-dev": {
+                "dompdf/dompdf": "^2.0",
+                "ext-gd": "*",
+                "ext-libxml": "*",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.3",
+                "mpdf/mpdf": "^8.1",
+                "phpmd/phpmd": "^2.13",
+                "phpstan/phpstan-phpunit": "@stable",
+                "phpunit/phpunit": ">=7.0",
+                "symfony/process": "^4.4 || ^5.0",
+                "tecnickcom/tcpdf": "^6.5"
+            },
+            "suggest": {
+                "dompdf/dompdf": "Allows writing PDF",
+                "ext-gd2": "Allows adding images",
+                "ext-xmlwriter": "Allows writing OOXML and ODF",
+                "ext-xsl": "Allows applying XSL style sheet to headers, to main document part, and to footers of an OOXML template",
+                "ext-zip": "Allows writing OOXML and ODF"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpOffice\\PhpWord\\": "src/PhpWord"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker"
+                },
+                {
+                    "name": "Gabriel Bull",
+                    "email": "me@gabrielbull.com",
+                    "homepage": "http://gabrielbull.com/"
+                },
+                {
+                    "name": "Franck Lefevre",
+                    "homepage": "https://rootslabs.net/blog/"
+                },
+                {
+                    "name": "Ivan Lanin",
+                    "homepage": "http://ivan.lanin.org"
+                },
+                {
+                    "name": "Roman Syroeshko",
+                    "homepage": "http://ru.linkedin.com/pub/roman-syroeshko/34/a53/994/"
+                },
+                {
+                    "name": "Antoine de Troostembergh"
+                }
+            ],
+            "description": "PHPWord - A pure PHP library for reading and writing word processing documents (OOXML, ODF, RTF, HTML, PDF)",
+            "homepage": "https://phpoffice.github.io/PHPWord/",
+            "keywords": [
+                "ISO IEC 29500",
+                "OOXML",
+                "Office Open XML",
+                "OpenDocument",
+                "OpenXML",
+                "PhpOffice",
+                "PhpWord",
+                "Rich Text Format",
+                "WordprocessingML",
+                "doc",
+                "docx",
+                "html",
+                "odf",
+                "odt",
+                "office",
+                "pdf",
+                "php",
+                "reader",
+                "rtf",
+                "template",
+                "template processor",
+                "word",
+                "writer"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPOffice/PHPWord/issues",
+                "source": "https://github.com/PHPOffice/PHPWord/tree/1.2.0"
+            },
+            "time": "2023-11-30T11:22:23+00:00"
         },
         {
             "name": "phpoption/phpoption",

--- a/api/config/filesystems.php
+++ b/api/config/filesystems.php
@@ -35,6 +35,11 @@ return [
             'root' => storage_path('app'),
         ],
 
+        'generated' => [
+            'driver' => 'local',
+            'root' => storage_path('app').DIRECTORY_SEPARATOR.'generated'
+        ],
+
         // A somewhat hacky solution to enable deploying the app in a read-only directory
         'tmp' => [
             'driver' => 'local',

--- a/api/programmatic-types.graphql
+++ b/api/programmatic-types.graphql
@@ -54,15 +54,6 @@ type PaginatorInfo {
   total: Int!
 }
 
-"A paginated list of Notification items."
-type NotificationPaginator {
-  "Pagination information about the list of items."
-  paginatorInfo: PaginatorInfo!
-
-  "A list of Notification items."
-  data: [Notification!]!
-}
-
 "A paginated list of User items."
 type UserPaginator {
   "Pagination information about the list of items."
@@ -97,6 +88,15 @@ type PoolCandidateSearchRequestPaginator {
 
   "A list of PoolCandidateSearchRequest items."
   data: [PoolCandidateSearchRequest!]!
+}
+
+"A paginated list of Notification items."
+type NotificationPaginator {
+  "Pagination information about the list of items."
+  paginatorInfo: PaginatorInfo!
+
+  "A list of Notification items."
+  data: [Notification!]!
 }
 
 "Allowed column names for Query.poolCandidatesPaginated.orderBy."
@@ -775,6 +775,16 @@ enum AssessmentDecisionLevel {
   AT_REQUIRED
   ABOVE_REQUIRED
   ABOVE_AND_BEYOND_REQUIRED
+}
+
+enum NotificationFamily {
+  SYSTEM_MESSAGE
+  APPLICATION_UPDATE
+  JOB_ALERT
+}
+
+enum NotificationType {
+  PoolCandidateStatusChanged
 }
 
 "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations."

--- a/api/storage/app/.gitignore
+++ b/api/storage/app/.gitignore
@@ -1,3 +1,4 @@
 *
 !public/
+!generated/
 !.gitignore

--- a/api/storage/app/generated/.gitignore
+++ b/api/storage/app/generated/.gitignore
@@ -1,0 +1,3 @@
+
+*
+!.gitignore


### PR DESCRIPTION
🤖 Resolves #9686 

## 👋 Introduction

Adds the ability to generate word docs of pool candidate profiles.

## 🕵️ Details

I didn't end up doing the ZIP work because this ended up being quite large and didn't want to expand the scope further.

Also, right now it takes 3 steps to create the file and I'm not sure if that makes sense:

```php
$doc = new CandidateProfileDoc(["uuid"]);
$doc-generate(); // We could write here to get rid of the third step. 
$doc->write("filename.docx");
```

I did this so we could write in a different way and pass the doc on fully generated but I'm not sure if that is useful and we could just like less code :woman_shrugging: 

## :globe_with_meridians: Internationalization

We have no way of translating from within laravel. So, while I set it up so we can pass a language into the generator, it only translates the fields where we have the French in the DB. That means all other text only appears in English for now.

## 🧪 Testing

> [!TIP]
> You may need to link storage if you havent `php artisan storage:link`

1. Get either one or multiple pool candidate IDs
2. Drop down into tinker `php artisan tinker`
3. Run `$doc = new \App\Generators\ProfileCandidateDoc([]);` passing in an array of the UUIDs from step 1
4. Run `$doc->generate();` confirming no errors
5. Run `$doc->save('filename.docx');` confirming no errors
    - Filename can be anything, the important part is the extension
6. Navigate to `/api/storage/generated/` in the file system
7. Confirm your generated file is there and looks like [the sample](https://docs.google.com/document/d/13epIYbnfFdYc-T1_d8SqCKhaJcAVJEXDYkhGBmzLLdA/edit)