### PR TITLE
[Copy] IAP Manager Home French typos

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4764,7 +4764,7 @@
     "description": "Heading for the quotes sections"
   },
   "PvYso4": {
-    "defaultMessage": "<link>L'Ambition numérique</link>, publiée en 2022, donne des directives sur la façon d'accroître la représentation des groupes sous-resprésentés en ayant recours à des programmes tels le Programme d'apprrentissage en TI pour les peuples autochtones.",
+    "defaultMessage": "<link>L'Ambition numérique</link>, publiée en 2022, donne des directives sur la façon d'accroître la représentation des groupes sous-représentés en ayant recours à des programmes tels le Programme d'apprrentissage en TI pour les peuples autochtones.",
     "description": "Paragraph 1 of the 'A commitment to diverse digital talent' section"
   },
   "PymrxL": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4764,7 +4764,7 @@
     "description": "Heading for the quotes sections"
   },
   "PvYso4": {
-    "defaultMessage": "<link>L'Ambition numérique</link>, publiée en 2022, donne des directives sur la façon d'accroître la représentation des groupes sous-représentés en ayant recours à des programmes tels le Programme d'apprrentissage en TI pour les peuples autochtones.",
+    "defaultMessage": "<link>L'Ambition numérique</link>, publiée en 2022, donne des directives sur la façon d'accroître la représentation des groupes sous-représentés en ayant recours à des programmes tels le Programme d'apprentissage en TI pour les peuples autochtones.",
     "description": "Paragraph 1 of the 'A commitment to diverse digital talent' section"
   },
   "PymrxL": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4763,10 +4763,6 @@
     "defaultMessage": "Ce que nous entendons",
     "description": "Heading for the quotes sections"
   },
-  "PvYso4": {
-    "defaultMessage": "<link>L'Ambition numérique</link>, publiée en 2022, donne des directives sur la façon d'accroître la représentation des groupes sous-représentés en ayant recours à des programmes tels le Programme d'apprentissage en TI pour les peuples autochtones.",
-    "description": "Paragraph 1 of the 'A commitment to diverse digital talent' section"
-  },
   "PymrxL": {
     "defaultMessage": "Sélectionner une classification pour afficher les exigences en matière de formation.",
     "description": "Null message for education requirement section"
@@ -7045,6 +7041,10 @@
   "c39xT8": {
     "defaultMessage": "Modifier les options de votre expérience.",
     "description": "Link text to edit experience information on profile."
+  },
+  "c4R8FH": {
+    "defaultMessage": "<link>L'Ambition numérique</link>, publiée en 2022, donne des directives sur la façon d'accroître la représentation des groupes sous-représentés en ayant recours à des programmes tels le Programme d'apprentissage en TI pour les personnes autochtones.",
+    "description": "Paragraph 1 of the 'A commitment to diverse digital talent' section"
   },
   "c70xDW": {
     "defaultMessage": "Requises",

--- a/apps/web/src/pages/Home/IAPManagerHomePage/IAPManagerHomePage.tsx
+++ b/apps/web/src/pages/Home/IAPManagerHomePage/IAPManagerHomePage.tsx
@@ -792,8 +792,8 @@ export const IAPManagerHomePage = () => {
                 {intl.formatMessage(
                   {
                     defaultMessage:
-                      "The <link>Digital Ambition</link>, released in 2022, provides direction on how to increase representation of under-represented groups by leveraging programs like the IT Apprenticeship Program for Indigenous peoples.",
-                    id: "PvYso4",
+                      "The <link>Digital Ambition</link>, released in 2022, provides direction on how to increase representation of under-represented groups by leveraging programs like the IT Apprenticeship Program for Indigenous Peoples.",
+                    id: "c4R8FH",
                     description:
                       "Paragraph 1 of the 'A commitment to diverse digital talent' section",
                   },


### PR DESCRIPTION
🤖 Resolves #9868.

## 👋 Introduction

This PR fixes typos in French at `/indigenous-it-apprentice/hire` and makes the program title is consistent (in both English and French) with what is used on the rest of the application: IT Apprenticeship Program for Indigenous Peoples (English) and Programme d’apprentissage en TI pour les personnes autochtones (French).

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/indigenous-it-apprentice/hire`
2. Verify no spelling errors in French in Paragraph 1 of the 'A commitment to diverse digital talent' section
3. Verify the program title for IT Apprenticeship Program for Indigenous Peoples is consistent with what is on other parts of the site (for example, `/indigenous-it-apprentice/`) in English and French

## 📸 Screenshots

<img width="1072" alt="Screen Shot 2024-03-25 at 13 16 51" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/0d65226d-e104-41d2-879b-71b2315be27d">
<img width="1070" alt="Screen Shot 2024-03-25 at 13 16 34" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/e7776f9d-4c70-40c6-b0fc-b1bf30ce13ec">

