### PR TITLE
[Debt] Migrate pool classification to one to many

### DIFF
--- a/api/app/GraphQL/Mutations/DuplicatePool.php
+++ b/api/app/GraphQL/Mutations/DuplicatePool.php
@@ -25,7 +25,6 @@ final class DuplicatePool
         ]);
         $newPool->save();
 
-        $newPool->classifications()->sync($pool->classifications->pluck('id'));
         $newPool->setEssentialPoolSkills($pool->essentialSkills->pluck('id'));
         $newPool->setNonessentialPoolSkills($pool->nonessentialSkills->pluck('id'));
 

--- a/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
@@ -89,21 +89,13 @@ query getProfile($userId: UUID!) {
           fr
         }
         stream
-        classifications {
+        classification {
           id
           group
           level
           name {
             en
             fr
-          }
-          genericJobTitles {
-            id
-            key
-            name {
-              en
-              fr
-            }
           }
           minSalary
           maxSalary

--- a/api/app/GraphQL/Mutations/PublishPool.php
+++ b/api/app/GraphQL/Mutations/PublishPool.php
@@ -19,7 +19,7 @@ final class PublishPool
     {
         $pool = Pool::find($args['id'])
             ->load([
-                'classifications',
+                'classification',
                 'essentialSkills' => function ($query) {
                     $query->withTrashed(); // eager load soft deleted skills too
                 },

--- a/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
+++ b/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
@@ -26,8 +26,7 @@ final class PoolIsCompleteValidator extends Validator
             // Pool name and classification
             'name.en' => ['string'],
             'name.fr' => ['string'],
-            'classifications' => ['required', 'array', 'size:1'],
-            'classifications.*.id' => ['required', 'uuid', 'exists:classifications,id'],
+            'classification_id' => ['required', 'uuid', 'exists:classifications,id'],
             'stream' => ['required', 'string'],
             'opportunity_length' => ['required', 'string'],
 

--- a/api/app/Http/Resources/ClassificationResource.php
+++ b/api/app/Http/Resources/ClassificationResource.php
@@ -19,10 +19,8 @@ class ClassificationResource extends JsonResource
             'group' => $this->group,
             'level' => $this->level,
             'name' => $this->name,
-            'salary' => [
-                'min' => $this->min_salary,
-                'max' => $this->max_salary,
-            ],
+            'minSalary' => $this->min_salary,
+            'maxSalary' => $this->max_salary,
         ];
     }
 }

--- a/api/app/Http/Resources/PoolResource.php
+++ b/api/app/Http/Resources/PoolResource.php
@@ -18,7 +18,7 @@ class PoolResource extends JsonResource
             'id' => $this->id,
             'name' => $this->name,
             'stream' => $this->stream,
-            'classifications' => ClassificationResource::collection($this->classifications),
+            'classification' => (new ClassificationResource($this->classification)),
             'closingDate' => $this->closing_date,
         ];
     }

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -16,7 +16,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
@@ -272,8 +271,6 @@ class Pool extends Model
             $poolCompleteValidation->rules(),
             $poolCompleteValidation->messages()
         );
-
-        Log::debug($validator->errors()->toArray());
 
         if ($validator->fails()) {
             return false;

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
@@ -115,6 +116,7 @@ class Pool extends Model
         'key_tasks',
         'special_note',
         'advertisement_language',
+        'classification_id',
     ];
 
     public function getActivitylogOptions(): LogOptions
@@ -137,9 +139,9 @@ class Pool extends Model
         return $this->belongsTo(Team::class);
     }
 
-    public function classifications(): BelongsToMany
+    public function classification(): BelongsTo
     {
-        return $this->belongsToMany(Classification::class);
+        return $this->belongsTo(Classification::class);
     }
 
     public function poolCandidates(): HasMany
@@ -263,13 +265,15 @@ class Pool extends Model
     // is the pool considered "complete", filled out entirely by the pool operator
     public function getIsCompleteAttribute()
     {
-        $pool = $this->load(['classifications', 'essentialSkills', 'nonessentialSkills', 'poolSkills']);
+        $pool = $this->load(['classification', 'essentialSkills', 'nonessentialSkills', 'poolSkills']);
 
         $poolCompleteValidation = new PoolIsCompleteValidator;
         $validator = Validator::make($pool->toArray(),
             $poolCompleteValidation->rules(),
             $poolCompleteValidation->messages()
         );
+
+        Log::debug($validator->errors()->toArray());
 
         if ($validator->fails()) {
             return false;

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -265,7 +265,7 @@ class PoolCandidate extends Model
             })
             // Now ensure the PoolCandidate is in a pool with the right classification
             ->whereHas('pool', function ($query) use ($classifications) {
-                $query->whereHas('classifications', function ($query) use ($classifications) {
+                $query->whereHas('classification', function ($query) use ($classifications) {
                     $query->where(function ($query) use ($classifications) {
                         foreach ($classifications as $classification) {
                             $query->orWhere(function ($query) use ($classification) {
@@ -577,7 +577,6 @@ class PoolCandidate extends Model
             'workExperiences.skills',
             'poolCandidates',
             'poolCandidates.pool',
-            'poolCandidates.pool.classifications',
             'poolCandidates.educationRequirementAwardExperiences.skills',
             'poolCandidates.educationRequirementCommunityExperiences.skills',
             'poolCandidates.educationRequirementEducationExperiences.skills',
@@ -594,6 +593,7 @@ class PoolCandidate extends Model
         $pool = Pool::with([
             'essentialSkills',
             'nonessentialSkills',
+            'classification',
         ])->findOrFail($this->pool_id);
         $essentialSkillIds = $pool->essentialSkills()->pluck('skills.id')->toArray();
         $nonessentialSkillIds = $pool->nonessentialSkills()->pluck('skills.id')->toArray();
@@ -809,7 +809,7 @@ class PoolCandidate extends Model
             'workExperiences.skills',
             'poolCandidates',
             'poolCandidates.pool',
-            'poolCandidates.pool.classifications',
+            'poolCandidates.pool.classification',
             'poolCandidates.educationRequirementAwardExperiences.skills',
             'poolCandidates.educationRequirementCommunityExperiences.skills',
             'poolCandidates.educationRequirementEducationExperiences.skills',

--- a/api/database/factories/ApplicantFilterFactory.php
+++ b/api/database/factories/ApplicantFilterFactory.php
@@ -90,7 +90,7 @@ class ApplicantFilterFactory extends Factory
                 $this->faker->numberBetween($minCount, 1)
             )->get();
             $filter->pools()->saveMany($pools);
-            $filter->qualifiedClassifications()->saveMany($pools->flatMap(fn ($pool) => $pool->classifications));
+            $filter->qualifiedClassifications()->saveMany($pools->flatMap(fn ($pool) => $pool->classification));
             $stream = (empty($pools) || count($pools) === 0) ? $this->faker->randomElements(
                 array_column(PoolStream::cases(), 'name'),
             ) : [$pools[0]->stream];

--- a/api/database/factories/PoolCandidateFactory.php
+++ b/api/database/factories/PoolCandidateFactory.php
@@ -99,9 +99,9 @@ class PoolCandidateFactory extends Factory
             }
 
             // set education requirement option, influenced by classification of pool
-            $classificationOne = $poolCandidate->pool->classifications()->first();
-            if ($classificationOne) {
-                if ($classificationOne->group === 'EX') {
+            $classification = $poolCandidate->pool->classification;
+            if ($classification) {
+                if ($classification->group === 'EX') {
                     $poolCandidate->update([
                         'education_requirement_option' => EducationRequirementOption::PROFESSIONAL_DESIGNATION->name,
                     ]);

--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -56,6 +56,11 @@ class PoolFactory extends Factory
             $teamId = Team::factory()->create()->id;
         }
 
+        $classification = Classification::inRandomOrder()->first();
+        if (! $classification) {
+            $classification = Classification::factory()->create();
+        }
+
         $name = $this->faker->unique()->company();
 
         // this is essentially the draft state
@@ -63,15 +68,14 @@ class PoolFactory extends Factory
             'name' => ['en' => $name, 'fr' => $name],
             'user_id' => $adminUserId,
             'team_id' => $teamId,
+            'classification_id' => $classification->id,
         ];
     }
 
     public function configure()
     {
         return $this->afterCreating(function (Pool $pool) {
-            $classifications = Classification::inRandomOrder()->limit(1)->get();
             $skills = Skill::inRandomOrder()->limit(10)->get();
-            $pool->classifications()->saveMany($classifications);
 
             foreach ($skills->slice(0, 5) as $skill) {
                 $poolSkill = new PoolSkill();

--- a/api/database/migrations/2024_03_26_181120_remove_pool_classification_table.php
+++ b/api/database/migrations/2024_03_26_181120_remove_pool_classification_table.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pools', function (Blueprint $table) {
+            $table->uuid('classification_id');
+            $table->foreign('classification_id')->references('id')->on('classifications');
+        });
+
+        DB::table('classification_pool')->lazyById()->each(
+            function ($row) {
+                DB::table('pools')
+                    ->where('id', $row->pool_id)
+                    ->update(['classification_id' => $row->classification_id]);
+            }
+        );
+
+        Schema::dropIfExists('classification_pool');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::create('classification_pool', function (Blueprint $table) {
+            $table->uuid('classification_id');
+            $table->foreign('classification_id')->references('id')->on('classifications');
+            $table->uuid('pool_id');
+            $table->foreign('pool_id')->references('id')->on('pools');
+        });
+
+        DB::table('pools')
+            ->whereNotNull('classification_id')
+            ->lazyById()
+            ->each(function ($row) {
+                DB::table('classification_pool')->insert([
+                    'classification_id' => $row->classification_id,
+                    'pool_id' => $row->id,
+                ]);
+            });
+
+        Schema::table('pool', function (Blueprint $table) {
+            $table->dropForeign(['classification_id']);
+            $table->dropColumn('classification_id');
+        });
+    }
+};

--- a/api/database/seeders/PoolTestSeeder.php
+++ b/api/database/seeders/PoolTestSeeder.php
@@ -57,7 +57,7 @@ class PoolTestSeeder extends Seeder
                 // constrain CMO Digital Careers pool to predictable values
                 if ($identifier['name->en'] == 'CMO Digital Careers') {
                     $classificationIT01Id = Classification::select('id')->where('group', 'ilike', 'IT')->where('level', 1)->sole()->id;
-                    $createdPool->classifications()->sync([$classificationIT01Id]);
+                    $createdPool->classification_id = $classificationIT01Id;
                     $createdPool->stream = PoolStream::BUSINESS_ADVISORY_SERVICES->name;
                     $createdPool->advertisement_language = PoolLanguage::VARIOUS->name;
                     $createdPool->save();

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -176,7 +176,7 @@ type Pool {
   owner: UserPublicProfile @belongsTo(relation: "user")
   team: Team @belongsTo @canModel(ability: "viewAny")
   name: LocalizedString
-  classifications: [Classification] @belongsToMany
+  classification: Classification @belongsTo
   operationalRequirements: [OperationalRequirement]
     @rename(attribute: "operational_requirements")
   poolCandidates: [PoolCandidate]

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1363,7 +1363,7 @@ input GenericJobTitleBelongsToMany {
 }
 
 input CreatePoolInput {
-  classifications: ClassificationBelongsToMany
+  classification: ClassificationBelongsTo
 }
 
 input CreateGeneralQuestionInput {
@@ -1392,7 +1392,7 @@ input SyncScreeningQuestionsInput {
 input UpdatePoolInput {
   # Pool name and classification
   name: LocalizedStringInput
-  classifications: ClassificationBelongsToMany
+  classification: ClassificationBelongsTo
   stream: PoolStream
   processNumber: String @rename(attribute: "process_number")
   # Closing date

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -316,7 +316,7 @@ type Pool {
   owner: UserPublicProfile
   team: Team
   name: LocalizedString
-  classifications: [Classification]
+  classification: Classification
   operationalRequirements: [OperationalRequirement]
   poolCandidates: [PoolCandidate]
   keyTasks: LocalizedString

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1191,7 +1191,7 @@ input GenericJobTitleBelongsToMany {
 }
 
 input CreatePoolInput {
-  classifications: ClassificationBelongsToMany
+  classification: ClassificationBelongsTo
 }
 
 input CreateGeneralQuestionInput {
@@ -1219,7 +1219,7 @@ input SyncScreeningQuestionsInput {
 
 input UpdatePoolInput {
   name: LocalizedStringInput
-  classifications: ClassificationBelongsToMany
+  classification: ClassificationBelongsTo
   stream: PoolStream
   processNumber: String
   closingDate: DateTime

--- a/api/tests/Feature/ApplicantFilterTest.php
+++ b/api/tests/Feature/ApplicantFilterTest.php
@@ -385,9 +385,7 @@ class ApplicantFilterTest extends TestCase
                 'operational_requirements' => $candidate->user->accepted_operational_requirements,
             ]
         );
-        $filter->qualifiedClassifications()->saveMany(
-            $pool->classifications->unique()
-        );
+        $filter->qualifiedClassifications()->saveMany([$pool->classification]);
         $candidateUser = User::with([
             'awardExperiences',
             'awardExperiences.skills',

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -560,14 +560,12 @@ class PoolTest extends TestCase
     public function testCannotPublishWithDeletedSkill(): void
     {
         // create complete but unpublished pool with a deleted skill
-        $classification = Classification::factory()->create();
         $pool = Pool::factory()
             ->published()
             ->create([
                 'published_at' => null,
                 'closing_date' => config('constants.far_future_datetime'),
             ]);
-        $pool->classifications()->sync([$classification->id]);
         $skill1 = Skill::factory()->create();
         $skill2 = Skill::factory()->create(['deleted_at' => config('constants.past_datetime')]);
         $pool->setEssentialPoolSkills([$skill1->id, $skill2->id]);
@@ -699,7 +697,6 @@ class PoolTest extends TestCase
         ]);
         $clearedRelationsPool = Pool::factory()->create();
         $clearedRelationsPool->essentialSkills()->sync([]);
-        $clearedRelationsPool->classifications()->sync([]);
 
         // test complete pool is marked as true, the others marked as false
         $this->actingAs($this->adminUser, 'api')
@@ -739,7 +736,6 @@ class PoolTest extends TestCase
                 }
             }
         ';
-        Classification::factory()->create();
         Skill::factory()->create();
 
         $completePool = Pool::factory()

--- a/apps/e2e/cypress.d.ts
+++ b/apps/e2e/cypress.d.ts
@@ -75,13 +75,13 @@ declare global {
        * Custom command to create an pool.
        * @param {string} userId - ID of the user owning the application
        * @param {string} teamId - ID of the team to assign to the pool
-       * @param {array<string>} classificationIds - Array of the classification Ids to assign to the pool
+       * @param {string} classificationIds - Classification to assign to the pool
        * @example cy.createPool('userUUID', 'teamUUID', ['classificationId])
        */
       createPool(
         userId: string,
         teamId: string,
-        classificationIds: string[],
+        classificationId: string,
       ): Chainable<Pool>;
       /**
        * Custom command to update an existing pool.

--- a/apps/e2e/cypress/e2e/api/artisan-commands.cy.ts
+++ b/apps/e2e/cypress/e2e/api/artisan-commands.cy.ts
@@ -23,7 +23,7 @@ const poolQueryDoc = /* GraphQL */ `
       status
       language
       securityClearance
-      classifications {
+      classification {
         id
         group
         level

--- a/apps/e2e/cypress/e2e/talentsearch/submit-application-iap.cy.ts
+++ b/apps/e2e/cypress/e2e/talentsearch/submit-application-iap.cy.ts
@@ -73,7 +73,7 @@ describe("Submit Application for IAP Workflow Tests", () => {
         .then((adminUserId) => {
           cy.get<string>("@testClassificationId").then(
             (testClassificationId) => {
-              cy.createPool(adminUserId, dcmId, [testClassificationId])
+              cy.createPool(adminUserId, dcmId, testClassificationId)
                 .its("id")
                 .as("testPoolId")
                 .then((testPoolId) => {

--- a/apps/e2e/cypress/support/poolCommands.ts
+++ b/apps/e2e/cypress/support/poolCommands.ts
@@ -21,7 +21,7 @@ const commandCreatePoolDoc = /* GraphQL */ `
   }
 `;
 
-Cypress.Commands.add("createPool", (userId, teamId, classificationIds) => {
+Cypress.Commands.add("createPool", (userId, teamId, classificationId) => {
   // there are no optional fields on the variables for this mutation
   cy.graphqlRequest<CreatePoolMutation>({
     operationName: "Command_CreatePool",
@@ -30,8 +30,8 @@ Cypress.Commands.add("createPool", (userId, teamId, classificationIds) => {
       userId,
       teamId,
       pool: {
-        classifications: {
-          sync: classificationIds,
+        classification: {
+          connect: classificationId,
         },
       },
     },

--- a/apps/e2e/cypress/support/poolHelpers.ts
+++ b/apps/e2e/cypress/support/poolHelpers.ts
@@ -27,37 +27,35 @@ export function createAndPublishPool({
   classification,
   poolAlias,
 }: CreateAndPublishPoolArgs) {
-  cy.createPool(adminUserId, teamId, [classification.id]).then(
-    (createdPool) => {
-      cy.get<Skill>("@testSkill").then((skill) => {
-        cy.updatePool(createdPool.id, {
-          name: {
-            en: englishName || `Cypress Test Pool EN ${Date.now().valueOf()}`,
-            fr: `Cypress Test Pool FR ${Date.now().valueOf()}`,
-          },
-          stream: PoolStream.BusinessAdvisoryServices,
-          closingDate: `${FAR_FUTURE_DATE} 00:00:00`,
-          yourImpact: {
-            en: "test impact EN",
-            fr: "test impact FR",
-          },
-          keyTasks: { en: "key task EN", fr: "key task FR" },
-          language: PoolLanguage.Various,
-          securityClearance: SecurityStatus.Secret,
-          location: {
-            en: "test location EN",
-            fr: "test location FR",
-          },
-          isRemote: true,
-          publishingGroup: PublishingGroup.ItJobs,
-          opportunityLength: PoolOpportunityLength.Various,
-        });
-        cy.createPoolSkill(createdPool.id, skill.id, {
-          type: PoolSkillType.Essential,
-          requiredLevel: SkillLevel.Beginner,
-        });
-        cy.publishPool(createdPool.id).as(poolAlias);
+  cy.createPool(adminUserId, teamId, classification.id).then((createdPool) => {
+    cy.get<Skill>("@testSkill").then((skill) => {
+      cy.updatePool(createdPool.id, {
+        name: {
+          en: englishName || `Cypress Test Pool EN ${Date.now().valueOf()}`,
+          fr: `Cypress Test Pool FR ${Date.now().valueOf()}`,
+        },
+        stream: PoolStream.BusinessAdvisoryServices,
+        closingDate: `${FAR_FUTURE_DATE} 00:00:00`,
+        yourImpact: {
+          en: "test impact EN",
+          fr: "test impact FR",
+        },
+        keyTasks: { en: "key task EN", fr: "key task FR" },
+        language: PoolLanguage.Various,
+        securityClearance: SecurityStatus.Secret,
+        location: {
+          en: "test location EN",
+          fr: "test location FR",
+        },
+        isRemote: true,
+        publishingGroup: PublishingGroup.ItJobs,
+        opportunityLength: PoolOpportunityLength.Various,
       });
-    },
-  );
+      cy.createPoolSkill(createdPool.id, skill.id, {
+        type: PoolSkillType.Essential,
+        requiredLevel: SkillLevel.Beginner,
+      });
+      cy.publishPool(createdPool.id).as(poolAlias);
+    });
+  });
 }

--- a/apps/web/src/components/EducationRequirements/EducationRequirements.tsx
+++ b/apps/web/src/components/EducationRequirements/EducationRequirements.tsx
@@ -12,7 +12,6 @@ import {
   foreignDegreeLink,
   postSecondaryLink,
 } from "~/pages/Applications/ApplicationEducationPage/utils";
-import { ClassificationGroup } from "~/utils/poolUtils";
 
 type TextProps = React.HTMLProps<HTMLParagraphElement>;
 
@@ -77,7 +76,7 @@ const Or = (props: React.HTMLProps<HTMLDivElement>) => {
 
 interface EducationRequirementsProps {
   isIAP: boolean;
-  classificationGroup?: ClassificationGroup;
+  classificationGroup?: string;
   headingAs?: HeadingLevel;
 }
 

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
@@ -65,7 +65,7 @@ const PoolCandidateFilterDialog_Query = graphql(/* GraphQL */ `
         fr
       }
       publishingGroup
-      classifications {
+      classification {
         id
         group
         level

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -140,7 +140,7 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
               en
               fr
             }
-            classifications {
+            classification {
               id
               group
               level

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -430,7 +430,7 @@ export const PoolCandidatesTable_SelectPoolCandidatesQuery = graphql(
             fr
           }
           stream
-          classifications {
+          classification {
             id
             name {
               en

--- a/apps/web/src/components/PoolCard/PoolCard.stories.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.stories.tsx
@@ -13,20 +13,12 @@ const fakedPool3 = fakedPools[2];
 const fakedPool4 = fakedPools[3];
 const fakedPoolNull = fakedPools[0];
 
-if (
-  fakedPool3.classifications &&
-  fakedPool3.classifications[0] &&
-  fakedPool3.classifications[0].minSalary
-) {
-  fakedPool3.classifications[0].minSalary = null;
+if (fakedPool3.classification?.minSalary) {
+  fakedPool3.classification.minSalary = null;
 }
 
-if (
-  fakedPool4.classifications &&
-  fakedPool4.classifications[0] &&
-  fakedPool4.classifications[0].maxSalary
-) {
-  fakedPool4.classifications[0].maxSalary = null;
+if (fakedPool4.classification?.maxSalary) {
+  fakedPool4.classification.maxSalary = null;
 }
 
 // idea stolen from ProfilePage.stories.tsx

--- a/apps/web/src/components/PoolCard/PoolCard.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.tsx
@@ -22,19 +22,13 @@ import useRoutes from "~/hooks/useRoutes";
 import IconLabel from "./IconLabel";
 
 const getSalaryRanges = (pool: Pool, locale: string) => {
-  if (!pool.classifications) return null;
+  if (!pool.classification) return null;
 
-  return pool.classifications
-    .map((classification) => {
-      if (!classification) return undefined;
-
-      return localizeSalaryRange(
-        classification.minSalary,
-        classification.maxSalary,
-        locale,
-      );
-    })
-    .filter(notEmpty);
+  return localizeSalaryRange(
+    pool.classification.minSalary,
+    pool.classification.maxSalary,
+    locale,
+  );
 };
 
 export interface PoolCardProps {
@@ -47,14 +41,12 @@ const PoolCard = ({ pool, headingLevel = "h3" }: PoolCardProps) => {
   const locale = getLocale(intl);
   const paths = useRoutes();
 
-  const { classifications } = pool;
-  const classification = classifications ? classifications[0] : null;
-
-  let classificationAbbr; // type wrangling the complex type into a string
-  if (classification) {
-    const { group, level } = classification;
-    classificationAbbr = wrapAbbr(`${group}-0${level}`, intl);
-  }
+  const classificationAbbr = pool.classification
+    ? wrapAbbr(
+        `${pool.classification.group}-0${pool.classification.level}`,
+        intl,
+      )
+    : "";
   const salaryRanges = getSalaryRanges(pool, locale);
 
   const notAvailableAbbr = intl.formatMessage({

--- a/apps/web/src/components/PoolCard/PoolCard.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.tsx
@@ -12,7 +12,6 @@ import {
   localizeSalaryRange,
   commonMessages,
 } from "@gc-digital-talent/i18n";
-import { notEmpty } from "@gc-digital-talent/helpers";
 import { Pool } from "@gc-digital-talent/graphql";
 
 import { getShortPoolTitleHtml } from "~/utils/poolUtils";
@@ -21,7 +20,7 @@ import useRoutes from "~/hooks/useRoutes";
 
 import IconLabel from "./IconLabel";
 
-const getSalaryRanges = (pool: Pool, locale: string) => {
+const getSalaryRange = (pool: Pool, locale: string) => {
   if (!pool.classification) return null;
 
   return localizeSalaryRange(
@@ -47,7 +46,7 @@ const PoolCard = ({ pool, headingLevel = "h3" }: PoolCardProps) => {
         intl,
       )
     : "";
-  const salaryRanges = getSalaryRanges(pool, locale);
+  const salaryRange = getSalaryRange(pool, locale);
 
   const notAvailableAbbr = intl.formatMessage({
     defaultMessage: "N/A",
@@ -174,9 +173,7 @@ const PoolCard = ({ pool, headingLevel = "h3" }: PoolCardProps) => {
               }) + intl.formatMessage(commonMessages.dividingColon)
             }
           >
-            {salaryRanges
-              ? salaryRanges[0]
-              : intl.formatMessage(commonMessages.notAvailable)}
+            {salaryRange ?? intl.formatMessage(commonMessages.notAvailable)}
           </IconLabel>
         </div>
         <div data-h2-margin-top="base(x1)">

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -46,7 +46,7 @@ import { toast } from "@gc-digital-talent/toast";
 
 import { getExperienceSkills } from "~/utils/skillUtils";
 import { getEducationRequirementOptions } from "~/pages/Applications/ApplicationEducationPage/utils";
-import { ClassificationGroup, isIAPPool } from "~/utils/poolUtils";
+import { isIAPPool } from "~/utils/poolUtils";
 import poolCandidateMessages from "~/messages/poolCandidateMessages";
 
 import useLabels from "./useLabels";
@@ -342,9 +342,7 @@ export const ScreeningDecisionDialog = ({
           skill,
         );
 
-  const classificationGroup = poolCandidate.pool.classifications
-    ? (poolCandidate.pool.classifications[0]?.group as ClassificationGroup)
-    : undefined;
+  const classificationGroup = poolCandidate.pool.classification?.group;
 
   const educationRequirementOption = getEducationRequirementOptions(
     intl,

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -27,14 +27,12 @@ import processMessages from "~/messages/processMessages";
 
 import FilterBlock from "./FilterBlock";
 
-type SimpleClassification = Pick<Classification, "group" | "level">;
-
 const ApplicantFilters = ({
   applicantFilter,
   selectedClassifications,
 }: {
   applicantFilter?: Maybe<ApplicantFilter>;
-  selectedClassifications?: Maybe<SimpleClassification>[];
+  selectedClassifications?: Maybe<Classification>[];
 }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -286,7 +284,7 @@ const ApplicantFilters = ({
 
 interface SearchRequestFiltersProps {
   filters?: Maybe<ApplicantFilter | PoolCandidateFilter>;
-  selectedClassifications?: Maybe<SimpleClassification>[];
+  selectedClassifications?: Maybe<Classification>[];
 }
 
 const SearchRequestFilters = ({

--- a/apps/web/src/pages/Applications/ApplicationContext.tsx
+++ b/apps/web/src/pages/Applications/ApplicationContext.tsx
@@ -3,17 +3,13 @@ import React from "react";
 import { useTheme } from "@gc-digital-talent/theme";
 import { Application_PoolCandidateFragment } from "@gc-digital-talent/graphql";
 
-import {
-  isIAPPool,
-  getClassificationGroup,
-  ClassificationGroup,
-} from "~/utils/poolUtils";
+import { isIAPPool } from "~/utils/poolUtils";
 
 interface ApplicationContextState {
   isIAP: boolean;
   followingPageUrl?: string;
   currentStepOrdinal?: number;
-  classificationGroup?: ClassificationGroup;
+  classificationGroup?: string;
 }
 
 const defaultContext: ApplicationContextState = {
@@ -51,7 +47,7 @@ const ApplicationContextProvider = ({
       isIAP: isIAPPool(application.pool),
       followingPageUrl,
       currentStepOrdinal,
-      classificationGroup: getClassificationGroup(application.pool),
+      classificationGroup: application.pool.classification?.group,
     }),
     [application.pool, followingPageUrl, currentStepOrdinal],
   );

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/LinkCareerTimeline.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/LinkCareerTimeline.tsx
@@ -6,6 +6,7 @@ import { Checklist, CheckboxOption } from "@gc-digital-talent/forms";
 import { errorMessages } from "@gc-digital-talent/i18n";
 import { Heading, Link, Well } from "@gc-digital-talent/ui";
 import {
+  Classification,
   EducationRequirementOption,
   Experience,
 } from "@gc-digital-talent/graphql";
@@ -17,7 +18,6 @@ import {
   isPersonalExperience,
   isWorkExperience,
 } from "~/utils/experienceUtils";
-import { ClassificationGroup } from "~/utils/poolUtils";
 
 const essentialExperienceMessages = defineMessages({
   computerScience: {
@@ -71,7 +71,7 @@ interface LinkCareerTimelineProps {
   experiences: Experience[];
   watchEducationRequirement: EducationRequirementOption;
   previousStepPath: string;
-  classificationGroup?: ClassificationGroup;
+  classificationGroup?: string;
 }
 
 const LinkCareerTimeline = ({

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/LinkCareerTimeline.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/LinkCareerTimeline.tsx
@@ -6,7 +6,6 @@ import { Checklist, CheckboxOption } from "@gc-digital-talent/forms";
 import { errorMessages } from "@gc-digital-talent/i18n";
 import { Heading, Link, Well } from "@gc-digital-talent/ui";
 import {
-  Classification,
   EducationRequirementOption,
   Experience,
 } from "@gc-digital-talent/graphql";

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/utils.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/utils.tsx
@@ -8,7 +8,6 @@ import { Radio } from "@gc-digital-talent/forms";
 import { EducationRequirementOption } from "@gc-digital-talent/graphql";
 
 import applicationMessages from "~/messages/applicationMessages";
-import { ClassificationGroup } from "~/utils/poolUtils";
 
 export const qualityStandardsLink = (
   chunks: React.ReactNode,
@@ -97,7 +96,7 @@ const appliedWorkListMessages = (isIAP = false) => [
 export const getEducationRequirementOptions = (
   intl: IntlShape,
   locale: Locales,
-  classificationGroup?: ClassificationGroup,
+  classificationGroup?: string,
   isIAP = false,
 ): Radio[] => {
   switch (classificationGroup) {

--- a/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
@@ -168,9 +168,7 @@ const ApplicationReview = ({
   const generalQuestionResponses =
     application.generalQuestionResponses?.filter(notEmpty) || [];
 
-  const classificationGroup = application.pool.classifications
-    ? application.pool.classifications[0]?.group
-    : undefined;
+  const classificationGroup = application.pool.classification?.group;
   return (
     <section>
       <Heading

--- a/apps/web/src/pages/Applications/fragment.ts
+++ b/apps/web/src/pages/Applications/fragment.ts
@@ -144,7 +144,7 @@ const Application_PoolCandidateFragment = graphql(/* GraphQL */ `
       closingDate
       publishingGroup
       language
-      classifications {
+      classification {
         id
         group
         level

--- a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
+++ b/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
@@ -37,7 +37,7 @@ const CreateApplicationApplications_Query = graphql(/* GraphQL */ `
             fr
           }
           stream
-          classifications {
+          classification {
             id
             group
             level

--- a/apps/web/src/pages/Home/ExecutiveHomePage/ExecutiveHomePage.tsx
+++ b/apps/web/src/pages/Home/ExecutiveHomePage/ExecutiveHomePage.tsx
@@ -502,7 +502,7 @@ const ExecutiveHomePage_Query = graphql(/* GraphQL */ `
       status
       language
       securityClearance
-      classifications {
+      classification {
         id
         group
         level

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
@@ -43,7 +43,7 @@ const IndexPoolCandidatePage_Query = graphql(/* GraphQL */ `
       status
       language
       securityClearance
-      classifications {
+      classification {
         id
         group
         level

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -92,7 +92,7 @@ const PoolCandidate_SnapshotQuery = graphql(/* GraphQL */ `
               en
               fr
             }
-            classifications {
+            classification {
               id
               group
               level
@@ -259,7 +259,7 @@ const PoolCandidate_SnapshotQuery = graphql(/* GraphQL */ `
           fr
         }
         stream
-        classifications {
+        classification {
           id
           group
           level
@@ -431,7 +431,7 @@ const PoolCandidate_SnapshotQuery = graphql(/* GraphQL */ `
         fr
       }
       stream
-      classifications {
+      classification {
         id
         group
         level

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationInformation/EducationRequirementsDisplay.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationInformation/EducationRequirementsDisplay.tsx
@@ -20,9 +20,7 @@ const EducationRequirementsDisplay = ({
 }: EducationRequirementsDisplayProps) => {
   const intl = useIntl();
 
-  const classificationGroup = application?.pool.classifications
-    ? application.pool.classifications[0]?.group
-    : "";
+  const classificationGroup = application?.pool.classification?.group ?? "";
 
   return (
     <>

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationPrintButton/ApplicationPrintDocument.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationPrintButton/ApplicationPrintDocument.tsx
@@ -181,9 +181,7 @@ const ApplicationPrintDocument = React.forwardRef<
       (c) => c !== IndigenousCommunity.LegacyIsIndigenous,
     ) || [];
 
-  const classificationGroup = relevantPoolCandidate?.pool.classifications
-    ? relevantPoolCandidate.pool.classifications[0]?.group
-    : "";
+  const classificationGroup = relevantPoolCandidate?.pool.classification?.group;
 
   return (
     <div style={{ display: "none" }}>

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationStatusForm/ApplicationStatusForm.tsx
@@ -259,7 +259,7 @@ const ApplicationStatusForm_PoolCandidateFragment = graphql(/* GraphQL */ `
       }
       stream
       publishingGroup
-      classifications {
+      classification {
         id
         group
         level

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/BrowsePoolsPage.tsx
@@ -49,7 +49,7 @@ const BrowsePoolsPage_Query = graphql(/* GraphQL */ `
       status
       language
       securityClearance
-      classifications {
+      classification {
         id
         group
         level

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.test.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.test.tsx
@@ -24,7 +24,7 @@ const publishedPool: Pool = {
   publishingGroup: PublishingGroup.ItJobsOngoing,
   status: PoolStatus.Published,
   stream: PoolStream.BusinessAdvisoryServices,
-  classifications: [{ id: "it-01", group: "IT", level: 1 }],
+  classification: { id: "it-01", group: "IT", level: 1 },
 };
 
 const renderBrowsePoolsPage = ({ pools }: OngoingRecruitmentSectionProps) => {

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
@@ -66,8 +66,9 @@ const selectPoolForSection = (
           // must match section stream
           p.stream === stream &&
           // must include section classification group and level
-          !!p.classifications?.find(
-            (c) => c?.group === group && c.level === level,
+          !!(
+            p.classification?.group === group &&
+            p.classification.level === level
           ),
       )
   );

--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -31,7 +31,7 @@ import AdminHero from "~/components/Hero/AdminHero";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 type FormValues = {
-  classification: string[];
+  classification: string;
   team: string;
 };
 
@@ -60,8 +60,8 @@ export const CreatePoolForm = ({
 
   // submission section, and navigate to edit the created pool
   const formValuesToSubmitData = (values: FormValues): CreatePoolInput => ({
-    classifications: {
-      sync: values.classification,
+    classification: {
+      connect: values.classification,
     },
   });
   const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -566,7 +566,7 @@ const EditPoolPage_Query = graphql(/* GraphQL */ `
       language
       securityClearance
       isComplete
-      classifications {
+      classification {
         id
         group
         level

--- a/apps/web/src/pages/Pools/EditPoolPage/components/EducationRequirementsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/EducationRequirementsSection.tsx
@@ -7,7 +7,6 @@ import { getLocale } from "@gc-digital-talent/i18n";
 import { PublishingGroup } from "@gc-digital-talent/graphql";
 
 import EducationRequirements from "~/components/EducationRequirements/EducationRequirements";
-import { getClassificationGroup } from "~/utils/poolUtils";
 import { isInNullState } from "~/validators/process/classification";
 import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
 import { wrapAbbr } from "~/utils/nameUtils";
@@ -31,15 +30,10 @@ const EducationRequirementsSection = ({
     emptyRequired: isNull, // Not a required field
     fallbackIcon: TagIcon,
   });
-  const classificationGroup = getClassificationGroup(pool);
-  const { classifications } = pool;
-  const classification = classifications ? classifications[0] : null;
-
-  let classificationAbbr; // type wrangling the complex type into a string
-  if (classification) {
-    const { group, level } = classification;
-    classificationAbbr = wrapAbbr(`${group}-0${level}`, intl);
-  }
+  const classificationGroup = pool.classification?.group;
+  const classificationAbbr = pool.classification
+    ? wrapAbbr(`${classificationGroup}-0${pool.classification.level}`, intl)
+    : "";
 
   const qualityStandardsLink = (chunks: React.ReactNode) => {
     const href =

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -18,7 +18,7 @@ const Display = ({ pool }: DisplayProps) => {
   const intl = useIntl();
   const notProvided = intl.formatMessage(commonMessages.notProvided);
   const {
-    classifications,
+    classification,
     stream,
     name,
     processNumber,
@@ -33,11 +33,11 @@ const Display = ({ pool }: DisplayProps) => {
       data-h2-grid-template-columns="p-tablet(repeat(2, 1fr))"
     >
       <ToggleForm.FieldDisplay
-        hasError={!classifications?.length}
+        hasError={!classification}
         label={intl.formatMessage(processMessages.classification)}
       >
-        {classifications && classifications[0]
-          ? getClassificationName(classifications[0], intl)
+        {classification
+          ? getClassificationName(classification, intl)
           : notProvided}
       </ToggleForm.FieldDisplay>
       <ToggleForm.FieldDisplay

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
@@ -15,21 +15,10 @@ import {
   Pool,
   PoolStream,
   PublishingGroup,
-  Scalars,
   UpdatePoolInput,
 } from "@gc-digital-talent/graphql";
 
 import { sortedOpportunityLengths } from "~/utils/poolUtils";
-
-const firstId = (
-  collection: Maybe<Maybe<Classification>[]> | undefined,
-): Scalars["ID"]["output"] | undefined => {
-  if (!collection) return undefined;
-
-  if (collection.length < 1) return undefined;
-
-  return collection[0]?.id;
-};
 
 export type FormValues = {
   classification?: Classification["id"];

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
@@ -42,7 +42,7 @@ export type FormValues = {
 };
 
 export const dataToFormValues = (initialData: Pool): FormValues => ({
-  classification: firstId(initialData.classifications), // behavior is undefined when there is more than one
+  classification: initialData.classification?.id ?? "",
   stream: initialData.stream ?? undefined,
   specificTitleEn: initialData.name?.en ?? "",
   specificTitleFr: initialData.name?.fr ?? "",
@@ -53,7 +53,7 @@ export const dataToFormValues = (initialData: Pool): FormValues => ({
 
 export type PoolNameSubmitData = Pick<
   UpdatePoolInput,
-  | "classifications"
+  | "classification"
   | "name"
   | "stream"
   | "processNumber"
@@ -64,9 +64,11 @@ export type PoolNameSubmitData = Pick<
 export const formValuesToSubmitData = (
   formValues: FormValues,
 ): PoolNameSubmitData => ({
-  classifications: {
-    sync: formValues.classification ? [formValues.classification] : [],
-  },
+  classification: formValues.classification
+    ? {
+        connect: formValues.classification,
+      }
+    : undefined,
   stream: formValues.stream ? formValues.stream : undefined,
   name: {
     en: formValues.specificTitleEn,

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -26,7 +26,7 @@ import processMessages from "~/messages/processMessages";
 import {
   classificationAccessor,
   classificationSortFn,
-  classificationsCell,
+  classificationCell,
   emailLinkAccessor,
   fullNameCell,
   ownerEmailAccessor,
@@ -63,22 +63,19 @@ export const PoolTable = ({ pools, title }: PoolTableProps) => {
       cell: ({ row: { original: pool } }) =>
         viewCell(paths.poolView(pool.id), pool, intl),
     }),
-    columnHelper.accessor(
-      (row) => classificationAccessor(row.classifications),
-      {
-        id: "classifications",
-        header: intl.formatMessage({
-          defaultMessage: "Group and Level",
-          id: "FGUGtr",
-          description:
-            "Title displayed for the Pool table Group and Level column.",
-        }),
-        sortingFn: (rowA: Row<Pool>, rowB: Row<Pool>) =>
-          classificationSortFn(rowA.original, rowB.original),
-        cell: ({ row: { original: pool } }) =>
-          classificationsCell(pool.classifications),
-      },
-    ),
+    columnHelper.accessor((row) => classificationAccessor(row.classification), {
+      id: "classification",
+      header: intl.formatMessage({
+        defaultMessage: "Group and Level",
+        id: "FGUGtr",
+        description:
+          "Title displayed for the Pool table Group and Level column.",
+      }),
+      sortingFn: (rowA: Row<Pool>, rowB: Row<Pool>) =>
+        classificationSortFn(rowA.original, rowB.original),
+      cell: ({ row: { original: pool } }) =>
+        classificationCell(pool.classification),
+    }),
     columnHelper.accessor(
       (row) =>
         intl.formatMessage(
@@ -263,7 +260,7 @@ const PoolTable_Query = graphql(/* GraphQL */ `
         en
         fr
       }
-      classifications {
+      classification {
         id
         group
         level

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
@@ -2,8 +2,7 @@ import React from "react";
 import { IntlShape } from "react-intl";
 
 import { getLocalizedName, getPoolStream } from "@gc-digital-talent/i18n";
-import { Link, Chip, Chips } from "@gc-digital-talent/ui";
-import { notEmpty } from "@gc-digital-talent/helpers";
+import { Link, Chip } from "@gc-digital-talent/ui";
 import {
   Classification,
   LocalizedString,
@@ -78,32 +77,23 @@ export function fullNameCell(pool: Pool, intl: IntlShape) {
 }
 
 export function classificationAccessor(
-  classifications: Maybe<Maybe<Classification>[]> | undefined,
+  classification: Maybe<Classification> | undefined,
 ) {
-  return classifications
-    ?.filter(notEmpty)
-    ?.map((c) => `${c.group}-0${c.level}`)
-    ?.join(", ");
+  return classification
+    ? `${classification.group}-0${classification.level}`
+    : "";
 }
 
 export function classificationSortFn(rowA: Pool, rowB: Pool) {
   // passing in sortType to override default sort
   const rowAGroup =
-    rowA.classifications && rowA.classifications[0]
-      ? rowA.classifications[0].group
-      : "";
+    rowA.classification && rowA.classification ? rowA.classification.group : "";
   const rowBGroup =
-    rowB.classifications && rowB.classifications[0]
-      ? rowB.classifications[0].group
-      : "";
+    rowB.classification && rowB.classification ? rowB.classification.group : "";
   const rowALevel =
-    rowA.classifications && rowA.classifications[0]
-      ? rowA.classifications[0].level
-      : 0;
+    rowA.classification && rowA.classification ? rowA.classification.level : 0;
   const rowBLevel =
-    rowB.classifications && rowB.classifications[0]
-      ? rowB.classifications[0].level
-      : 0;
+    rowB.classification && rowB.classification ? rowB.classification.level : 0;
 
   if (rowAGroup.toLowerCase() > rowBGroup.toLowerCase()) {
     return 1;
@@ -121,23 +111,16 @@ export function classificationSortFn(rowA: Pool, rowB: Pool) {
   return 0;
 }
 
-export function classificationsCell(
-  classifications: Maybe<Maybe<Classification>[] | undefined> | undefined,
+export function classificationCell(
+  classification: Maybe<Classification> | undefined,
 ) {
-  const filteredClassifications = classifications
-    ? classifications.filter(notEmpty)
-    : [];
-  const chipsArray = filteredClassifications.map((classification) => {
-    return (
-      <Chip
-        key={`${classification.group}-0${classification.level}`}
-        color="primary"
-      >
-        {`${classification.group}-0${classification.level}`}
-      </Chip>
-    );
-  });
-  return chipsArray.length > 0 ? <Chips>{chipsArray}</Chips> : null;
+  if (!classification) return null;
+
+  return (
+    <Chip color="primary">
+      {`${classification.group}-0${classification.level}`}
+    </Chip>
+  );
 }
 
 export function emailLinkAccessor(pool: Pool, intl: IntlShape) {

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -50,7 +50,6 @@ import {
 
 import {
   formatClassificationString,
-  getClassificationGroup,
   getClassificationSalaryRangeUrl,
   getFullPoolTitleHtml,
   getShortPoolTitleLabel,
@@ -141,7 +140,7 @@ export const PoolPoster = ({
   const [skillsValue, setSkillsValue] = React.useState<string[]>([]);
   const [linkCopied, setLinkCopied] = React.useState<boolean>(false);
 
-  const classification = pool.classifications ? pool.classifications[0] : null;
+  const { classification } = pool;
   const genericJobTitles =
     classification?.genericJobTitles?.filter(notEmpty) || [];
   let classificationString = ""; // type wrangling the complex type into a string
@@ -308,7 +307,7 @@ export const PoolPoster = ({
     },
   };
 
-  const classificationGroup = getClassificationGroup(pool);
+  const classificationGroup = pool.classification?.group;
 
   return (
     <>
@@ -1158,7 +1157,7 @@ const PoolAdvertisementPage_Query = graphql(/* GraphQL */ `
       language
       securityClearance
       opportunityLength
-      classifications {
+      classification {
         id
         group
         level

--- a/apps/web/src/pages/Pools/PoolLayout.tsx
+++ b/apps/web/src/pages/Pools/PoolLayout.tsx
@@ -25,7 +25,7 @@ import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminHero from "~/components/Hero/AdminHero";
 
 interface PoolHeaderProps {
-  pool: Pick<Pool, "id" | "classifications" | "stream" | "name" | "team">;
+  pool: Pick<Pool, "id" | "classification" | "stream" | "name" | "team">;
 }
 
 const PoolHeader = ({ pool }: PoolHeaderProps) => {
@@ -91,7 +91,7 @@ const PoolLayout_Query = graphql(/* GraphQL */ `
         fr
       }
       stream
-      classifications {
+      classification {
         id
         group
         level

--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -393,7 +393,7 @@ const ViewPoolPage_Query = graphql(/* GraphQL */ `
       status
       stream
       closingDate
-      classifications {
+      classification {
         id
         name {
           en

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/CareerTimelineAndRecruitmentPage.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/CareerTimelineAndRecruitmentPage.tsx
@@ -86,7 +86,7 @@ const CareerTimelineExperiences_Query = graphql(/* GraphQL */ `
           }
           publishingGroup
           stream
-          classifications {
+          classification {
             id
             group
             level

--- a/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
@@ -385,7 +385,7 @@ const ProfileUser_Query = graphql(/* GraphQL */ `
             fr
           }
           stream
-          classifications {
+          classification {
             id
             group
             level

--- a/apps/web/src/pages/ProfileAndApplicationsPage/ProfileAndApplicationsPage.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/ProfileAndApplicationsPage.tsx
@@ -184,7 +184,7 @@ const ProfileAndApplicationsApplicant_Query = graphql(/* GraphQL */ `
           }
           publishingGroup
           stream
-          classifications {
+          classification {
             id
             group
             level

--- a/apps/web/src/pages/SearchRequests/RequestPage/RequestPage.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/RequestPage.tsx
@@ -3,10 +3,12 @@ import * as React from "react";
 import { useIntl } from "react-intl";
 import { useLocation } from "react-router-dom";
 
-import { ApplicantFilterInput } from "@gc-digital-talent/graphql";
+import {
+  ApplicantFilterInput,
+  Classification,
+} from "@gc-digital-talent/graphql";
 
 import Hero from "~/components/Hero/Hero";
-import { SimpleClassification } from "~/types/pool";
 import { FormValues as SearchFormValues } from "~/types/searchRequest";
 
 import CreateRequest from "./components/RequestForm";
@@ -15,7 +17,7 @@ type LocationState = {
   applicantFilter: ApplicantFilterInput;
   initialValues: SearchFormValues;
   candidateCount: number;
-  selectedClassifications: SimpleClassification[];
+  selectedClassifications: Classification[];
 };
 
 const RequestPage = () => {

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -44,7 +44,6 @@ import {
 import SEO from "~/components/SEO/SEO";
 import SearchRequestFilters from "~/components/SearchRequestFilters/SearchRequestFilters";
 import useRoutes from "~/hooks/useRoutes";
-import { SimpleClassification } from "~/types/pool";
 import {
   BrowserHistoryState,
   FormValues as SearchFormValues,
@@ -94,7 +93,7 @@ export interface RequestFormProps {
   applicantFilter: Maybe<ApplicantFilterInput>;
   candidateCount: Maybe<number>;
   searchFormInitialValues?: SearchFormValues;
-  selectedClassifications?: Maybe<SimpleClassification>[];
+  selectedClassifications?: Maybe<Classification>[];
   handleCreatePoolCandidateSearchRequest: (
     data: CreatePoolCandidateSearchRequestInput,
   ) => Promise<CreateRequestMutation["createPoolCandidateSearchRequest"]>;
@@ -622,7 +621,7 @@ const RequestForm_SearchRequestDataQuery = graphql(/* GraphQL */ `
         en
         fr
       }
-      classifications {
+      classification {
         id
         group
         level
@@ -641,7 +640,7 @@ const RequestFormApi = ({
   applicantFilter: Maybe<ApplicantFilterInput>;
   candidateCount: Maybe<number>;
   searchFormInitialValues?: SearchFormValues;
-  selectedClassifications?: Maybe<SimpleClassification>[];
+  selectedClassifications?: Maybe<Classification>[];
 }) => {
   const intl = useIntl();
   const [{ data: lookupData, fetching, error }] = useQuery({

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -91,11 +91,17 @@ export const SearchForm = ({
         },
         allPools: values.allPools,
         candidateCount: values.count,
-        selectedClassifications: selectedPool
-          ? selectedPool.classifications?.filter(notEmpty)
+        selectedClassifications: selectedPool?.classification
+          ? [selectedPool.classification]
           : applicantFilter?.qualifiedClassifications?.filter(notEmpty),
       },
     });
+  };
+
+  const handleSubmitAllPools = () => {
+    setValue("allPools", true);
+    setValue("pool", "");
+    setValue("count", candidateCount);
   };
 
   return (
@@ -187,11 +193,7 @@ export const SearchForm = ({
                   type="submit"
                   {...poolSubmitProps}
                   value=""
-                  onClick={() => {
-                    setValue("allPools", true);
-                    setValue("pool", "");
-                    setValue("count", candidateCount);
-                  }}
+                  onClick={handleSubmitAllPools}
                 >
                   {intl.formatMessage({
                     defaultMessage: "Request candidates from all pools",
@@ -249,7 +251,7 @@ const SearchForm_Query = graphql(/* GraphQL */ `
         en
         fr
       }
-      classifications {
+      classification {
         id
         group
         level

--- a/apps/web/src/pages/SearchRequests/SearchPage/hooks.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/hooks.ts
@@ -57,7 +57,7 @@ const CandidateCount_Query = graphql(/* GraphQL */ `
           fr
         }
         stream
-        classifications {
+        classification {
           id
           group
           level

--- a/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
@@ -17,7 +17,6 @@ import {
   PositionDuration,
 } from "@gc-digital-talent/graphql";
 
-import { SimpleClassification } from "~/types/pool";
 import { FormValues, NullSelection } from "~/types/searchRequest";
 import {
   formatClassificationString,
@@ -30,7 +29,7 @@ export const getAvailableClassifications = (
   pools: Pool[],
 ): Classification[] => {
   const classifications = pools
-    ?.flatMap((pool) => pool?.classifications)
+    ?.flatMap((pool) => pool?.classification)
     .filter(notEmpty)
     .reduce((currentClassifications, classification) => {
       let newClassifications = [...currentClassifications];
@@ -71,11 +70,11 @@ export const getClassificationLabel = (
  * As well as transforming it to a useable string.
  *
  * @param {ApplicantFilterInput} data
- * @param {Maybe<SimpleClassification[]>} selectedClassifications
+ * @param {Maybe<Classification[]>} selectedClassifications
  * @returns {string}
  */
 const getCurrentClassification = (
-  selectedClassifications?: Maybe<SimpleClassification[]>,
+  selectedClassifications?: Maybe<Classification[]>,
 ): string => {
   return selectedClassifications && selectedClassifications?.length > 0
     ? formatClassificationString(selectedClassifications[0])
@@ -139,7 +138,7 @@ export const applicantFilterToQueryArgs = (
  */
 export const dataToFormValues = (
   data: ApplicantFilterInput,
-  selectedClassifications?: Maybe<SimpleClassification[]>,
+  selectedClassifications?: Maybe<Classification[]>,
   pools?: Pool[],
 ): FormValues => {
   const safePools = data.pools?.filter(notEmpty) ?? [];

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
@@ -264,7 +264,7 @@ const ViewSearchRequest_SearchRequestFragment = graphql(/* GraphQL */ `
           en
           fr
         }
-        classifications {
+        classification {
           id
           group
           level
@@ -305,7 +305,7 @@ const ViewSearchRequest_SearchRequestFragment = graphql(/* GraphQL */ `
           fr
         }
         stream
-        classifications {
+        classification {
           id
           group
           level

--- a/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
+++ b/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
@@ -102,7 +102,7 @@ const AdminUserProfile_Query = graphql(/* GraphQL */ `
             en
             fr
           }
-          classifications {
+          classification {
             id
             group
             level
@@ -281,7 +281,7 @@ const AdminUserProfile_Query = graphql(/* GraphQL */ `
         fr
       }
       stream
-      classifications {
+      classification {
         id
         group
         level

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserFilterDialog.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserFilterDialog.tsx
@@ -71,7 +71,7 @@ const UserFilterData_Query = graphql(/* GraphQL */ `
         en
         fr
       }
-      classifications {
+      classification {
         id
         name {
           en

--- a/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
@@ -295,7 +295,7 @@ export const UsersTable_SelectUsersQuery = graphql(/* GraphQL */ `
             fr
           }
           stream
-          classifications {
+          classification {
             id
             group
             level

--- a/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
@@ -149,7 +149,7 @@ const UserInformation_Query = graphql(/* GraphQL */ `
             en
             fr
           }
-          classifications {
+          classification {
             id
             group
             level
@@ -328,7 +328,7 @@ const UserInformation_Query = graphql(/* GraphQL */ `
         fr
       }
       stream
-      classifications {
+      classification {
         id
         group
         level

--- a/apps/web/src/types/pool.ts
+++ b/apps/web/src/types/pool.ts
@@ -1,23 +1,6 @@
 import { IconType } from "@gc-digital-talent/ui";
-import {
-  Pool,
-  Classification,
-  Maybe,
-  UserPublicProfile,
-} from "@gc-digital-talent/graphql";
 
 import { Status, StatusColor } from "~/components/StatusItem/StatusItem";
-
-export type SimpleClassification = Pick<Classification, "group" | "level">;
-type SimpleOwner = Pick<UserPublicProfile, "email" | "firstName" | "lastName">;
-
-export type SimplePool = Pick<
-  Pool,
-  "id" | "name" | "classifications" | "stream"
-> & {
-  classifications?: Maybe<Array<Maybe<SimpleClassification>>>;
-  owner?: Maybe<SimpleOwner>;
-};
 
 export interface EditPoolSectionMetadata {
   id: string;

--- a/apps/web/src/types/searchRequest.ts
+++ b/apps/web/src/types/searchRequest.ts
@@ -5,9 +5,8 @@ import {
   PoolStream,
   UserPoolFilterInput,
   Classification,
+  Pool,
 } from "@gc-digital-talent/graphql";
-
-import { SimpleClassification, SimplePool } from "~/types/pool";
 
 export const NullSelection = "NULL_SELECTION";
 
@@ -24,7 +23,7 @@ export type FormValues = Pick<
   employmentEquity: string[] | undefined;
   educationRequirement: "has_diploma" | "no_diploma";
   poolCandidates?: UserPoolFilterInput;
-  pools?: SimplePool[];
+  pools?: Pool[];
   pool?: Scalars["ID"]["output"];
   selectedClassifications?: Classification[];
   count?: number;
@@ -37,6 +36,6 @@ export type BrowserHistoryState = {
   applicantFilter?: ApplicantFilterInput;
   candidateCount: number;
   initialValues?: FormValues;
-  selectedClassifications?: SimpleClassification[];
+  selectedClassifications?: Classification[];
   allPools?: boolean;
 };

--- a/apps/web/src/types/searchRequest.ts
+++ b/apps/web/src/types/searchRequest.ts
@@ -5,7 +5,6 @@ import {
   PoolStream,
   UserPoolFilterInput,
   Classification,
-  Pool,
 } from "@gc-digital-talent/graphql";
 
 export const NullSelection = "NULL_SELECTION";
@@ -23,7 +22,6 @@ export type FormValues = Pick<
   employmentEquity: string[] | undefined;
   educationRequirement: "has_diploma" | "no_diploma";
   poolCandidates?: UserPoolFilterInput;
-  pools?: Pool[];
   pool?: Scalars["ID"]["output"];
   selectedClassifications?: Classification[];
   count?: number;

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -37,12 +37,7 @@ import { PageNavInfo } from "~/types/pages";
 import useRoutes from "~/hooks/useRoutes";
 import poolMessages from "~/messages/poolMessages";
 import { ONGOING_PUBLISHING_GROUPS } from "~/constants/pool";
-import {
-  PageNavKeys,
-  PoolCompleteness,
-  SimpleClassification,
-  SimplePool,
-} from "~/types/pool";
+import { PageNavKeys, PoolCompleteness } from "~/types/pool";
 import messages from "~/messages/adminMessages";
 
 import { wrapAbbr } from "./nameUtils";
@@ -56,15 +51,12 @@ import { wrapAbbr } from "./nameUtils";
  * @returns boolean
  */
 export const poolMatchesClassification = (
-  pool: SimplePool,
-  classification: SimpleClassification,
+  pool: Pool,
+  classification: Classification,
 ): boolean => {
   return (
-    pool.classifications?.some(
-      (poolClassification) =>
-        poolClassification?.group === classification?.group &&
-        poolClassification?.level === classification?.level,
-    ) ?? false
+    pool.classification?.group === classification?.group &&
+    pool.classification?.level === classification?.level
   );
 };
 
@@ -207,7 +199,7 @@ export const poolTitle = (
 
   const formattedTitle = formattedPoolPosterTitle({
     title: specificTitle,
-    classification: pool?.classifications?.[0],
+    classification: pool?.classification,
     stream: pool?.stream,
     short: options?.short,
     intl,
@@ -381,17 +373,6 @@ export const isOngoingPublishingGroup = (
 ): boolean =>
   publishingGroup ? ONGOING_PUBLISHING_GROUPS.includes(publishingGroup) : false;
 
-export type ClassificationGroup = "AS" | "EX" | "PM" | "IT" | "EC";
-
-export function getClassificationGroup(
-  pool: Maybe<Pool>,
-): ClassificationGroup | undefined {
-  const classification = pool?.classifications ? pool.classifications[0] : null;
-  return classification?.group
-    ? (classification.group as ClassificationGroup)
-    : undefined;
-}
-
 export const getAdvertisementStatus = (pool?: Pool): PoolCompleteness => {
   if (!pool) return "incomplete";
 
@@ -506,7 +487,7 @@ export const formatClosingDate = (
 
 export const getClassificationSalaryRangeUrl = (
   locale: Locales,
-  classification: Maybe<Classification>,
+  classification?: Maybe<Classification>,
 ): string | null => {
   let localizedUrl: Record<Locales, string> | null = null;
   switch (classification?.group) {

--- a/apps/web/src/validators/process/classification.ts
+++ b/apps/web/src/validators/process/classification.ts
@@ -1,4 +1,3 @@
-import { empty } from "@gc-digital-talent/helpers";
 import { Pool } from "@gc-digital-talent/graphql";
 
 /*
@@ -22,7 +21,7 @@ export function isInNullState({
 }
 
 export function hasEmptyRequiredFields({
-  classifications,
+  classification,
   stream,
   name,
   processNumber,
@@ -30,7 +29,7 @@ export function hasEmptyRequiredFields({
   opportunityLength,
 }: Pool): boolean {
   return !!(
-    empty(classifications) ||
+    !classification ||
     !stream ||
     !name?.en ||
     !name?.fr ||

--- a/packages/fake-data/src/fakePools.ts
+++ b/packages/fake-data/src/fakePools.ts
@@ -91,8 +91,7 @@ const generatePool = (
       en: englishName || `${faker.company.catchPhrase()} EN`,
       fr: frenchName || `${faker.company.catchPhrase()} FR`,
     },
-    classifications:
-      faker.helpers.arrayElements<Classification>(classifications),
+    classification: faker.helpers.arrayElement<Classification>(classifications),
     keyTasks: toLocalizedString(faker.lorem.paragraphs()),
     stream: faker.helpers.arrayElement<PoolStream>(Object.values(PoolStream)),
     processNumber: faker.helpers.maybe(() => faker.lorem.word()),


### PR DESCRIPTION
🤖 Resolves #9846 

## 👋 Introduction

Removes the `classification_pool` pivot table and converts the relationship of Pool -> Classification to a one to many.

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

1. Refresh API `make refresh-api`
2. Build app `pnpm run dev`
3. Confirm places were pool classifications are used still functions as expected
