### PR TITLE
[Fix] Disable add button as soon as limit reached

### DIFF
--- a/apps/web/src/pages/Pools/EditPoolPage/components/GeneralQuestionsSection/GeneralQuestionDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/GeneralQuestionsSection/GeneralQuestionDialog.tsx
@@ -21,11 +21,13 @@ const TEXT_AREA_MAX_WORDS = 200;
 interface GeneralQuestionDialogProps {
   question?: GeneralQuestion;
   index?: number;
+  disabled?: boolean;
 }
 
 const GeneralQuestionDialog = ({
   question,
   index,
+  disabled,
 }: GeneralQuestionDialogProps) => {
   const intl = useIntl();
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
@@ -65,12 +67,13 @@ const GeneralQuestionDialog = ({
       <Dialog.Trigger>
         {isUpdate ? (
           <CardRepeater.Edit
+            disabled={disabled}
             aria-label={intl.formatMessage(formMessages.repeaterEdit, {
               index,
             })}
           />
         ) : (
-          <CardRepeater.Add>
+          <CardRepeater.Add disabled={disabled}>
             {intl.formatMessage({
               defaultMessage: "Add a new question",
               id: "uEqA50",

--- a/apps/web/src/pages/Pools/EditPoolPage/components/GeneralQuestionsSection/GeneralQuestionsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/GeneralQuestionsSection/GeneralQuestionsSection.tsx
@@ -34,6 +34,7 @@ const GeneralQuestionsSection = ({
   onSave,
 }: GeneralQuestionsProps) => {
   const intl = useIntl();
+  const [isUpdating, setIsUpdating] = React.useState<boolean>(false);
   const initialQuestions = React.useMemo(
     () =>
       sortBy(
@@ -55,15 +56,20 @@ const GeneralQuestionsSection = ({
   };
 
   // disabled unless status is draft
-  const formDisabled = pool.status !== PoolStatus.Draft;
+  const formDisabled = pool.status !== PoolStatus.Draft || isUpdating;
 
   const handleUpdate = (newQuestions: GeneralQuestion[]) => {
+    setIsUpdating(true);
     const generalQuestions = repeaterQuestionsToSubmitData(
       newQuestions,
       questions,
     );
     setQuestions(newQuestions);
-    onSave({ generalQuestions }).catch(resetQuestions);
+    onSave({ generalQuestions })
+      .then(() => {
+        setIsUpdating(false);
+      })
+      .catch(resetQuestions);
   };
 
   return (
@@ -86,7 +92,7 @@ const GeneralQuestionsSection = ({
           disabled={isSubmitting || formDisabled}
           max={MAX_GENERAL_QUESTIONS}
           onUpdate={handleUpdate}
-          add={<GeneralQuestionDialog />}
+          add={<GeneralQuestionDialog disabled={formDisabled} />}
         >
           {questions.map((generalQuestion, index) => (
             <GeneralQuestionCard

--- a/packages/ui/src/components/CardRepeater/Button.tsx
+++ b/packages/ui/src/components/CardRepeater/Button.tsx
@@ -50,7 +50,7 @@ export const Action = React.forwardRef<HTMLButtonElement, ActionButtonProps>(
 export const Add = React.forwardRef<
   HTMLButtonElement,
   React.ComponentPropsWithoutRef<typeof Button>
->(({ children, ...rest }, forwardedRef) => {
+>(({ children, disabled, ...rest }, forwardedRef) => {
   const intl = useIntl();
   const { max, total } = useCardRepeaterContext();
   const reachedMax = Boolean(max && total >= max);
@@ -59,7 +59,7 @@ export const Add = React.forwardRef<
     <Button
       ref={forwardedRef}
       icon={PlusCircleIcon}
-      disabled={reachedMax}
+      disabled={reachedMax || disabled}
       type="button"
       mode="placeholder"
       block


### PR DESCRIPTION
🤖 Resolves #9908 

## 👋 Introduction

Fixes an issue where users could add more than the maximum general questions to a job poster.

## 🕵️ Details

This came down to two things:

1. We were spreading all props to the add button meaning the `disabled={maxReached}` could be overwritten by accident
2. We don't have server validation so we need to rely more on the frontend (disabling the form until we know if you can add more)

## 🧪 Testing

1. Build `pnpm dev`
2. Login as admin `admin@test.com
3. Create a process
4. Scroll down to the general questions section
5. Add questions as fast as you can
6. Confirm that you can;t add more than the max (10) no matter how quickly you add them
