### PR TITLE
[Copy] Updates email input label to specify government

### DIFF
--- a/apps/e2e/cypress/e2e/talentsearch/search-workflows.cy.ts
+++ b/apps/e2e/cypress/e2e/talentsearch/search-workflows.cy.ts
@@ -301,7 +301,7 @@ describe("Talent Search Workflow Tests", () => {
 
     cy.findByRole("textbox", { name: /Full name/i }).type("Test Full Name");
 
-    cy.findByRole("textbox", { name: /Government e-mail/i }).type(
+    cy.findByRole("textbox", { name: /Government of Canada email/i }).type(
       "test@tbs-sct.gc.ca",
     );
 

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2595,6 +2595,10 @@
     "defaultMessage": "Le rôle de gestionnaire est nouveau pour vous? Vous souhaitez acquérir de l’expérience de recrutement et en savoir davantage sur les processus de ressources humaines?",
     "description": "Paragraph one, summary on getting hiring experience"
   },
+  "CxZGd2": {
+    "defaultMessage": "Courriel du gouvernement du Canada",
+    "description": "Label for government of canada email input in the request form"
+  },
   "CzK1qY": {
     "defaultMessage": "Supprimé",
     "description": "Label for the trashed field"
@@ -8965,10 +8969,6 @@
   "mR9A3a": {
     "defaultMessage": "Contrat",
     "description": "Contract contract instrument"
-  },
-  "mRNmrR": {
-    "defaultMessage": "Courriel du gouvernement",
-    "description": "Label for government email input in the request form"
   },
   "mS15HC": {
     "defaultMessage": "Ajouter une compétence",

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -328,10 +328,10 @@ export const RequestForm = ({
                 type="email"
                 name="email"
                 label={intl.formatMessage({
-                  defaultMessage: "Government e-mail",
-                  id: "mRNmrR",
+                  defaultMessage: "Government of Canada email",
+                  id: "CxZGd2",
                   description:
-                    "Label for government email input in the request form",
+                    "Label for government of canada email input in the request form",
                 })}
                 rules={{
                   required: intl.formatMessage(errorMessages.required),


### PR DESCRIPTION
🤖 Resolves #9906.

## 👋 Introduction

This PR updates the label of the email input to make the government, in this case the Government of Canada, explicitly named.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm build`
2. Navigate to `/search/request`
3. Verify label for email field contains **Government of Canada**

## 📸 Screenshots

### English
<img width="735" alt="Screen Shot 2024-03-27 at 12 45 21" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/102d8828-9d80-4e6a-9de4-433487c36a18">

### French
<img width="739" alt="Screen Shot 2024-03-27 at 12 45 07" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/9926875f-17c4-424a-b419-a143638f3a84">


