### PR TITLE
[Fix] Mark experience data as stale after adding

### DIFF
--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -476,7 +476,7 @@ const context: Partial<OperationContext> = {
     "PersonalExperience",
     "WorkExperience",
   ], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
-  requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
+  requestPolicy: "cache-first", // The list of skills and experiences will rarely change, so we override default request policy to avoid unnecessary cache updates.
 };
 
 const ExperienceFormData_Query = graphql(/* GraphQL */ `

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -467,7 +467,15 @@ export const ExperienceForm = ({
 };
 
 const context: Partial<OperationContext> = {
-  additionalTypenames: ["Skill", "SkillFamily"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
+  additionalTypenames: [
+    "Skill",
+    "SkillFamily",
+    "AwardExperience",
+    "CommunityExperience",
+    "EducationExperience",
+    "PersonalExperience",
+    "WorkExperience",
+  ], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
   requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
 };
 


### PR DESCRIPTION
🤖 Resolves #9902 

## 👋 Introduction

Fixes an issue where attempting to edit an experience right after adding it (without hard refresh) caused the form to be empty.

## 🕵️ Details

I could only reproduce this if I had no experiences of a specific type. Once at least one experience was added this was no longer an issue. So, I'd test both scenarios to be certain this is fixed.

## 🧪 Testing

> [!IMPORTANT]
> It would be best to test this first with no experiences, then with one experience but adding another of a different type. Then again with one of the same type.

1. Build `pnpm run dev`
2. Login as applicant `applicant@test.com`
3. Navigate to your career timeline
4. Add an experience, returning to career timeline
5. Attempt to edit the newly added experience
6. Confirm the form appears with the appropriate data