### PR TITLE
[Feature] Removes edit, candidates columns from Processes table

### DIFF
--- a/apps/e2e/cypress/e2e/admin/pools.cy.ts
+++ b/apps/e2e/cypress/e2e/admin/pools.cy.ts
@@ -269,6 +269,8 @@ describe("Pools", () => {
       .first()
       .click();
 
+    cy.findByRole("link", { name: /edit advertisement/i }).click();
+
     cy.wait("@gqlEditPoolPageQuery");
 
     cy.findByRole("button", { name: /edit advertisement details/i }).click();

--- a/apps/e2e/cypress/e2e/admin/pools.cy.ts
+++ b/apps/e2e/cypress/e2e/admin/pools.cy.ts
@@ -265,7 +265,7 @@ describe("Pools", () => {
     cy.findByRole("button", { name: /show 10/i }).click();
     cy.get("[role=menuitemradio]").contains(/50/i).click();
 
-    cy.findAllByRole("link", { name: /edit test pool en/i })
+    cy.findAllByRole("link", { name: /test pool en/i })
       .first()
       .click();
 

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1471,10 +1471,6 @@
     "defaultMessage": "Masquer les candidatures en cours ({applicationCount})",
     "description": "Heading for applications in progress accordion on profile and applications."
   },
-  "6R9N+h": {
-    "defaultMessage": "Voir les candidats<hidden> pour {label}</hidden>",
-    "description": "Text for a link to the Pool Candidates table"
-  },
   "6Ru0Ha": {
     "defaultMessage": "Si vous avez des questions au sujet de CléGC, veuillez contacter l'équipe de CléGC à l'adresse",
     "description": "GCKey answer for who to contact about GCKey, introduction sentence"
@@ -2886,10 +2882,6 @@
   "Ed+xy1": {
     "defaultMessage": "Décision disqualifiée",
     "description": "Disqualified decision input"
-  },
-  "EdUZaX": {
-    "defaultMessage": "Candidats",
-    "description": "Header for the View Candidates column of the Pools table"
   },
   "EdybCb": {
     "defaultMessage": "<strong>informatique</strong>",

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -31,7 +31,6 @@ import {
   fullNameCell,
   ownerEmailAccessor,
   ownerNameAccessor,
-  poolCandidatesViewCell,
   poolNameAccessor,
   viewCell,
   viewTeamLinkCell,
@@ -104,16 +103,6 @@ export const PoolTable = ({ pools, title }: PoolTableProps) => {
         header: intl.formatMessage(processMessages.publishingGroup),
       },
     ),
-    columnHelper.display({
-      id: "candidates",
-      header: intl.formatMessage({
-        defaultMessage: "Candidates",
-        id: "EdUZaX",
-        description: "Header for the View Candidates column of the Pools table",
-      }),
-      cell: ({ row: { original: pool } }) =>
-        poolCandidatesViewCell(paths.poolCandidateTable(pool.id), intl, pool),
-    }),
     columnHelper.accessor(
       (row) =>
         intl.formatMessage(

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -157,16 +157,6 @@ export const PoolTable = ({ pools, title }: PoolTableProps) => {
       }),
       cell: ({ row: { original: pool } }) => emailLinkAccessor(pool, intl),
     }),
-    columnHelper.display({
-      id: "edit",
-      header: intl.formatMessage(commonMessages.edit),
-      cell: ({ row: { original: pool } }) =>
-        cells.edit(
-          pool.id,
-          paths.poolTable(),
-          getLocalizedName(pool.name, intl),
-        ),
-    }),
     columnHelper.accessor(({ createdDate }) => accessors.date(createdDate), {
       id: "createdDate",
       enableColumnFilter: false,

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
@@ -10,7 +10,6 @@ import {
   Pool,
 } from "@gc-digital-talent/graphql";
 
-import { getShortPoolTitleHtml } from "~/utils/poolUtils";
 import { getFullNameHtml } from "~/utils/nameUtils";
 
 export function poolNameAccessor(pool: Pool, intl: IntlShape) {
@@ -18,25 +17,6 @@ export function poolNameAccessor(pool: Pool, intl: IntlShape) {
   return `${name.toLowerCase()} ${
     pool.stream ? intl.formatMessage(getPoolStream(pool.stream)) : ""
   }`;
-}
-
-export function poolCandidatesViewCell(
-  poolCandidatesTableUrl: string,
-  intl: IntlShape,
-  pool: Maybe<Pool>,
-) {
-  return (
-    <Link href={poolCandidatesTableUrl} color="black" data-h2-padding="base(0)">
-      {intl.formatMessage(
-        {
-          defaultMessage: "View Candidates<hidden> for {label}</hidden>",
-          id: "6R9N+h",
-          description: "Text for a link to the Pool Candidates table",
-        },
-        { label: getShortPoolTitleHtml(intl, pool) },
-      )}
-    </Link>
-  );
 }
 
 export function viewCell(url: string, pool: Pool, intl: IntlShape) {


### PR DESCRIPTION
🤖 Resolves #8850.

## 👋 Introduction

This PR removes the **Edit** and **Candidates** columns from Processes table.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm build`
2. Navigate to `/admin/pools`
3. Click **Show or hide columns** button
4. Verify there are no checkboxes for **Edit** or **Candidates**

## 📸 Screenshot

<img width="994" alt="Screen Shot 2024-03-28 at 11 47 45" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/dc216b98-5a86-4098-a297-95d839d899f6">
