### PR TITLE
[Feature] Adds process number to process information page

### DIFF
--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -29,6 +29,7 @@ import { checkRole } from "~/utils/teamUtils";
 import usePoolMutations from "~/hooks/usePoolMutations";
 import { getAssessmentPlanStatus } from "~/validators/pool/assessmentPlan";
 import messages from "~/messages/adminMessages";
+import processMessages from "~/messages/processMessages";
 
 import SubmitForPublishingDialog from "./components/SubmitForPublishingDialog";
 import DuplicateProcessDialog from "./components/DuplicateProcessDialog";
@@ -151,6 +152,15 @@ export const ViewPool = ({
                 description:
                   "Information about what an advertisement represents",
               })}
+            </p>
+            <p data-h2-margin="base(x1 0)">
+              {intl.formatMessage(processMessages.processNumber)}
+              {intl.formatMessage(commonMessages.dividingColon)}
+              {pool.processNumber || (
+                <span data-h2-color="base(error.darkest)">
+                  {intl.formatMessage(commonMessages.notProvided)}
+                </span>
+              )}
             </p>
             <ProcessCard.Footer>
               {advertisementStatus !== "submitted" && (
@@ -392,6 +402,7 @@ const ViewPoolPage_Query = graphql(/* GraphQL */ `
       isComplete
       status
       stream
+      processNumber
       closingDate
       classification {
         id


### PR DESCRIPTION
🤖 Resolves #9949.

## 👋 Introduction

This PR adds the process number to the process information page.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm build`
2. Create a process with the Process number field left empty
3. Navigate to Process information page's Advertisement information section
4. Observe **Process number: Not provided**
5. Enter a value in the field for Process number
6. Navigate to Process information page's Advertisement information section
7. Observe **Process number: `valueEntered`**

## 📸 Screenshots

### With a process number
<img width="1175" alt="Screen Shot 2024-03-28 at 15 57 50" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/69c07929-5e62-4279-88d8-ed11f3743467">

### Without a process number
<img width="1178" alt="Screen Shot 2024-03-28 at 15 58 20" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/6431412e-e2a7-45ae-a2e7-89574e806cb8">
