### PR TITLE
[Feature] Renames Search Request table `id` column header

### DIFF
--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -200,7 +200,11 @@ const SearchRequestTable = ({ title }: SearchRequestTableProps) => {
   const columns = [
     columnHelper.accessor("id", {
       id: "id",
-      header: intl.formatMessage(adminMessages.id),
+      header: intl.formatMessage({
+        defaultMessage: "Tracking number",
+        id: "SkV4+/",
+        description: "Alternate name for ID column header",
+      }),
     }),
     columnHelper.accessor("jobTitle", {
       id: "jobTitle",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5303,6 +5303,10 @@
     "defaultMessage": "Voyez comment vos données sont consultées et gérez la disponibilité et les communications.",
     "description": "Introductory text displayed in recruitment availability accordion."
   },
+  "SkV4+/": {
+    "defaultMessage": "Numéro de suivi",
+    "description": "Alternate name for ID column header"
+  },
   "Sm9Ml5": {
     "defaultMessage": "Cette compétence   <strong>sera supprimée de toutes les expériences associées</strong>",
     "description": "Notice that deleting a skill removes it from any linked experiences"


### PR DESCRIPTION
🤖 Resolves #9944.

## 👋 Introduction

This PR renames the `id` column header for the Search Request table.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/admin/talent-requests`
2. Click Show or hide columns button
3. Select the Tracking number checkbox
4. Verify values in Tracking number column still render the uuid

## 📸 Screenshots
<img width="1413" alt="Screen Shot 2024-04-02 at 09 30 30" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/318b2c15-7a32-4fc4-b63c-d9a0a910f3a1">
<img width="659" alt="Screen Shot 2024-04-02 at 09 30 07" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/8959e2ee-9338-4474-b7ca-8cddd9947d48">