### PR TITLE
[Feature] Adds alert to skills page

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6294,6 +6294,10 @@
     "defaultMessage": "Sélectionnez un groupe des publications",
     "description": "Placeholder for publishing group field"
   },
+  "Y1zzqe": {
+    "defaultMessage": "Cette liste de compétences est en cours d’élaboration. De nouvelles compétences sont ajoutées de façon continue.",
+    "description": "Message for skills page"
+  },
   "Y2PPGY": {
     "defaultMessage": "Imprimer le profil sans les coordonnées",
     "description": "Button label for print user anonymous profile"

--- a/apps/web/src/pages/Skills/SkillPage.tsx
+++ b/apps/web/src/pages/Skills/SkillPage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { defineMessage, useIntl } from "react-intl";
 
-import { Heading, Link, Well } from "@gc-digital-talent/ui";
+import { Alert, Heading, Link, Well } from "@gc-digital-talent/ui";
 
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
@@ -54,6 +54,21 @@ export const SkillPage = () => {
         data-h2-container="base(center, large, x1) p-tablet(center, large, x2)"
         data-h2-margin="base(x3)"
       >
+        <Alert.Root
+          type="info"
+          dismissible
+          live={false}
+          data-h2-margin="base(0, 0, x2, 0)"
+        >
+          <p>
+            {intl.formatMessage({
+              defaultMessage:
+                "This list of skills is under development. New skills are being added on an ongoing basis.",
+              id: "Y1zzqe",
+              description: "Message for skills page",
+            })}
+          </p>
+        </Alert.Root>
         <SkillTableApi
           title={formattedPageTitle}
           paginationState={{ ...INITIAL_STATE.paginationState, pageSize: 20 }}


### PR DESCRIPTION
🤖 Resolves #9955.

## 👋 Introduction

This PR adds an alert to the skills page.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/skills`
2. Observe dismissible alert

## 📸 Screenshot

<img width="1305" alt="Screen Shot 2024-04-02 at 16 33 25" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/d9e59a00-6c78-4394-9365-b57f1a25ea0b">

