### PR TITLE
[Fix] Validate closing date is not in past on process

### DIFF
--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -30,7 +30,7 @@ import {
   hasEmptyRequiredFields as poolNameError,
   isInNullState as educationRequirementIsNull,
 } from "~/validators/process/classification";
-import { hasEmptyRequiredFields as closingDateError } from "~/validators/process/closingDate";
+import { hasInvalidRequiredFields as closingDateError } from "~/validators/process/closingDate";
 import { hasEmptyRequiredFields as yourImpactError } from "~/validators/process/yourImpact";
 import { hasEmptyRequiredFields as keyTasksError } from "~/validators/process/keyTasks";
 import { hasEmptyRequiredFields as coreRequirementsError } from "~/validators/process/coreRequirements";

--- a/apps/web/src/pages/Pools/EditPoolPage/components/ClosingDateSection/ClosingDateSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/ClosingDateSection/ClosingDateSection.tsx
@@ -16,7 +16,10 @@ import { PoolStatus, Pool, UpdatePoolInput } from "@gc-digital-talent/graphql";
 
 import useDeepCompareEffect from "~/hooks/useDeepCompareEffect";
 import { getExperienceFormLabels } from "~/utils/experienceUtils";
-import { hasEmptyRequiredFields } from "~/validators/process/closingDate";
+import {
+  hasEmptyRequiredFields,
+  hasInvalidRequiredFields,
+} from "~/validators/process/closingDate";
 import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
 
@@ -45,10 +48,11 @@ const ClosingDateSection = ({
   const intl = useIntl();
   const experienceFormLabels = getExperienceFormLabels(intl);
   const emptyRequired = hasEmptyRequiredFields(pool);
+  const invalidRequired = hasInvalidRequiredFields(pool);
   const { isSubmitting } = useEditPoolContext();
   const { isEditing, setIsEditing, icon } = useToggleSectionInfo({
     isNull: emptyRequired, // Only one field
-    emptyRequired,
+    emptyRequired: invalidRequired,
     fallbackIcon: CalendarIcon,
   });
 

--- a/apps/web/src/validators/process/closingDate.ts
+++ b/apps/web/src/validators/process/closingDate.ts
@@ -1,7 +1,19 @@
-import { Pool } from "@gc-digital-talent/graphql";
+import isPast from "date-fns/isPast";
 
-// Only one field to check here
-// eslint-disable-next-line import/prefer-default-export
+import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
+import { Pool, PoolStatus } from "@gc-digital-talent/graphql";
+
 export function hasEmptyRequiredFields({ closingDate }: Pool): boolean {
+  return !closingDate;
+}
+
+export function hasInvalidRequiredFields({
+  closingDate,
+  status,
+}: Pool): boolean {
+  if (status === PoolStatus.Draft && closingDate) {
+    return isPast(parseDateTimeUtc(closingDate));
+  }
+
   return !closingDate;
 }


### PR DESCRIPTION
🤖 Resolves #9987 

## 👋 Introduction

Updates the front end validation for a process closing date when it is in draft to check if it is a past date and return an error.

## 🧪 Testing

1. Build `pnpm run dev`
2. Create a process and complete it but do not publish
3. Edit the process directly in the database to set closing date to a past date
4. Review the process to confirm you cannot publish and error icons appear for closing date/basic information

## 📸 Screenshot

![screenshot_04-Apr-2024_13-03-1712250203](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/005aab27-1f4f-4119-9267-24ea98b4815b)
