### PR TITLE
[Feature] Distinguishes asset skills on candidate screening and assessment table

### DIFF
--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -368,7 +368,10 @@ export const ScreeningDecisionDialog = ({
       poolSkill?.type === PoolSkillType.Nonessential
     )
       return "black";
-    if (!hasBeenAssessed) return "warning";
+    if (!hasBeenAssessed)
+      return poolSkill?.type === PoolSkillType.Nonessential
+        ? "black"
+        : "warning";
     switch (initialValues?.assessmentDecision) {
       case AssessmentDecision.Successful:
         return "success";
@@ -424,7 +427,11 @@ export const ScreeningDecisionDialog = ({
               )}
             </span>
           ) : (
-            <p>{intl.formatMessage(poolCandidateMessages.toAssess)}</p>
+            <p>
+              {poolSkill?.type === PoolSkillType.Nonessential
+                ? intl.formatMessage(poolCandidateMessages.unclaimed)
+                : intl.formatMessage(poolCandidateMessages.toAssess)}
+            </p>
           )}
         </Button>
       </Dialog.Trigger>

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4295,6 +4295,10 @@
     "defaultMessage": "Ce à quoi vous pouvez vous attendre",
     "description": "Heading for the section about user expectations for their request"
   },
+  "N2/Y9w": {
+    "defaultMessage": "Non réclamé",
+    "description": "Message displayed when candidate has yet to be assessed at a specific assessment step for a skill that is non-essential"
+  },
   "N3uD4m": {
     "defaultMessage": "Mes équipes",
     "description": "Link text for current users teams page"

--- a/apps/web/src/messages/poolCandidateMessages.ts
+++ b/apps/web/src/messages/poolCandidateMessages.ts
@@ -86,6 +86,12 @@ const messages = defineMessages({
     description:
       "Message displayed when candidate was unsuccessful but put on hold",
   },
+  unclaimed: {
+    defaultMessage: "Unclaimed",
+    id: "N2/Y9w",
+    description:
+      "Message displayed when candidate has yet to be assessed at a specific assessment step for a skill that is non-essential",
+  },
 });
 
 export default messages;

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -694,12 +694,16 @@ export const ViewPoolCandidate = ({
 
   const chips = (
     <Chips>
-      <Chip color={statusChip.color} data-h2-font-weight="base(700)">
+      <Chip
+        key="status"
+        color={statusChip.color}
+        data-h2-font-weight="base(700)"
+      >
         {statusChip.label}
       </Chip>
       {poolCandidate.user.hasPriorityEntitlement ||
       poolCandidate.user.priorityWeight === 10 ? (
-        <Chip color="black">
+        <Chip key="priority" color="black">
           {intl.formatMessage({
             defaultMessage: "Priority",
             id: "xGMcBO",
@@ -709,7 +713,7 @@ export const ViewPoolCandidate = ({
       ) : null}
       {poolCandidate.user.armedForcesStatus === ArmedForcesStatus.Veteran ||
       poolCandidate.user.priorityWeight === 20 ? (
-        <Chip color="black">
+        <Chip key="veteran" color="black">
           {intl.formatMessage({
             defaultMessage: "Veteran",
             id: "16iCWc",


### PR DESCRIPTION
🤖 Resolves #9848.

## 👋 Introduction

This PR distinguishes between asset and essential skills on a candidate's screening and assessment table.

## 🍬 Bonus

c9563ceb81f21a7620970294efd010e8f61a3bcb fixes a non-unique key error.

## 🎩 Acknowledgement

@esizer for helping find the component 😉 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Create a process with one essential skill and one asset skill
2. Add a candidate to the process
3. Navigate to a candidate's screening and assessment table `/admin/candidates/:candidate-id/application`
4. Verify that **Unclaimed** is rendered for the asset skill

## 📸 Screenshot

<img width="918" alt="Screen Shot 2024-04-04 at 15 50 23" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/9dd4204a-a02d-4b40-8b1c-d5f4d81609ad">
