### PR TITLE
[Feature] Improve assessment dialog skill picker

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1103,6 +1103,10 @@
     "defaultMessage": "Veuillez préciser la méthode",
     "description": "Label for _other method of supply_ fieldset in the _digital services contracting questionnaire_"
   },
+  "4RE3DP": {
+    "defaultMessage": "Compétences constituant un atout",
+    "description": "Label for 'asset skills' input on the assessment details dialog"
+  },
   "4RK/oW": {
     "defaultMessage": "Minorité visible",
     "description": "Message for visible minority option in the employment equity section of the request page."
@@ -1602,10 +1606,6 @@
   "7FtbwK": {
     "defaultMessage": "Gestionnaire",
     "description": "Title displayed on the search request table manager column."
-  },
-  "7Jc8aA": {
-    "defaultMessage": "Compétences évaluées",
-    "description": "Label for 'assessed skills' input on the assessment details dialog"
   },
   "7KEfBI": {
     "defaultMessage": "Ces données sont agrégées et utilisées pour cibler les tendances dans les différents ministères. Elles ne sont pas utilisées pour l’analyse d’une décision individuelle d’établissement des contrats.",
@@ -2998,6 +2998,10 @@
   "FGzaie": {
     "defaultMessage": "Statut officiel de l’examen",
     "description": "Bounding box label for official exam status in language information form"
+  },
+  "FKfj8D": {
+    "defaultMessage": "Compétences essentielles",
+    "description": "Label for 'essential skills' input on the assessment details dialog"
   },
   "FMJiDY": {
     "defaultMessage": "Sélectionnez la valeur totale du contrat",

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
@@ -146,6 +146,9 @@ const AssessmentPlanBuilderPage_Query = graphql(/* GraphQL */ `
           category
           key
         }
+        assessmentSteps {
+          id
+        }
       }
       assessmentSteps {
         id

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialog.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialog.tsx
@@ -732,6 +732,7 @@ const AssessmentDetailsDialog = ({
                           description:
                             "Warning message for skills with missing assessment on the 'assessment details' dialog",
                         })}
+                        {intl.formatMessage(commonMessages.dividingColon)}
                       </p>
                       <Chips>
                         {missingSkills.map(({ skill }) => (

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialogLabels.ts
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialogLabels.ts
@@ -31,11 +31,17 @@ const labels = defineMessages({
     description:
       "Label for 'English screening question' input on the assessment details dialog",
   },
-  assessedSkills: {
-    defaultMessage: "Assessed skills",
-    id: "7Jc8aA",
+  essentialSkills: {
+    defaultMessage: "Essential skills",
+    id: "FKfj8D",
     description:
-      "Label for 'assessed skills' input on the assessment details dialog",
+      "Label for 'essential skills' input on the assessment details dialog",
+  },
+  assetSkills: {
+    defaultMessage: "Asset skills",
+    id: "4RE3DP",
+    description:
+      "Label for 'asset skills' input on the assessment details dialog",
   },
 });
 


### PR DESCRIPTION
🤖 Resolves #9849 

## 👋 Introduction

- Adds a `<Well />` containing a list of pool skills that have not been attached to an assessment.
- Splits the skills selection checklist into two separate checklists: Essential skills and Asset skills. The validation should still function the same, requiring at least one skill to be selected among the two lists.

## 🧪 Testing

1. Login as `admin@test.com`
2. Go to admin dashboard and create a new process, adding both essential and asset skills for testing.
3. Go edit the assessment plan (http://localhost:8000/en/admin/pools/{id}/plan)
4. Ensure the list of missing skills is correct.
5. Ensure the essential and asset checklists function correctly and validation still works.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/9fc4f4d5-bafd-4814-9ff8-b1c41398ebf7)
