### PR TITLE
[Fix] Remove duplicate meta description

### DIFF
--- a/packages/webpack-config/webpack.base.js
+++ b/packages/webpack-config/webpack.base.js
@@ -78,7 +78,7 @@ module.exports = (basePath, appMeta) => {
         title: meta.title,
         template: "./public/index.html",
         meta: {
-          description: meta.description,
+          description: { content: meta.description, "data-rh": "true", },
           "og:url": { property: "og:url", content: meta.url, "data-rh": "true" },
           "og:type": { property: "og:type", content: meta.type, "data-rh": "true" },
           "og:title": { property: "og:title", content: meta.title, "data-rh": "true" },


### PR DESCRIPTION
🤖 Resolves #9998 

## 👋 Introduction

Removes a duplicate meta description from the `head`

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `pnpm run dev`
2. Inspect the `head`
3. Confirm only one `meta[name=description]`
4. Confirm it updates on page change
