### PR TITLE
[Feature] Admin side skills page link

### DIFF
--- a/apps/web/src/components/Layout/AdminLayout/AdminLayout.tsx
+++ b/apps/web/src/components/Layout/AdminLayout/AdminLayout.tsx
@@ -67,6 +67,10 @@ import {
   pageTitle as announcementsPageTitle,
   pageOutlineIcon as announcementsPageIcon,
 } from "~/pages/AnnouncementsPage/AnnouncementsPage";
+import {
+  adminPageTitle as skillPageTitle,
+  pageOutlineIcon as skillPageIcon,
+} from "~/pages/Skills/SkillPage";
 
 import SitewideBanner from "../SitewideBanner";
 import SkipLink from "../SkipLink";
@@ -217,6 +221,19 @@ const AdminLayout = () => {
             ) && (
               <SideMenuItem href={paths.teamTable()} icon={indexTeamPageIcon}>
                 {intl.formatMessage(indexTeamPageTitle)}
+              </SideMenuItem>
+            )}
+            {checkRole(
+              [
+                ROLE_NAME.PoolOperator,
+                ROLE_NAME.RequestResponder,
+                ROLE_NAME.CommunityManager,
+                ROLE_NAME.PlatformAdmin,
+              ],
+              roleAssignments,
+            ) && (
+              <SideMenuItem href={paths.skills()} icon={skillPageIcon}>
+                {intl.formatMessage(skillPageTitle)}
               </SideMenuItem>
             )}
           </SideMenuCategory>

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1855,6 +1855,10 @@
     "defaultMessage": "Voir l’annonce",
     "description": "Link text to view a specific pool advertisement"
   },
+  "8ioBIZ": {
+    "defaultMessage": "Éditeur de compétence",
+    "description": "Title for skills editor"
+  },
   "8kMPLB": {
     "defaultMessage": "Décrire la façon dont cette compétence a été mise en valeur dans ce rôle",
     "description": "Label for the textarea in the skills in detail section."
@@ -3634,6 +3638,10 @@
   "J3Ud6R": {
     "defaultMessage": "Exigence de sélection : <strong>{educationRequirementOption}</strong>.",
     "description": "Application snapshot minimum experience section description"
+  },
+  "J6atIv": {
+    "defaultMessage": "Liste de compétences",
+    "description": "Link text for explore skills page"
   },
   "J8Nltm": {
     "defaultMessage": "Comment vous avez pu mettre en œuvre la compétence \"{skillName}\" dans le cadre de cette expérience",

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -48,6 +48,10 @@ import {
   pageTitle as announcementsPageTitle,
   pageSolidIcon as announcementsPageIcon,
 } from "~/pages/AnnouncementsPage/AnnouncementsPage";
+import {
+  adminPageTitle as skillPageTitle,
+  pageSolidIcon as skillPageIcon,
+} from "~/pages/Skills/SkillPage";
 
 import LinkWell from "./components/LinkWell";
 
@@ -150,6 +154,11 @@ const DashboardPage = ({ currentUser }: DashboardPageProps) => {
                   }),
                   href: adminRoutes.teamTable(),
                   icon: indexTeamPageIcon,
+                },
+                {
+                  label: intl.formatMessage(skillPageTitle),
+                  href: adminRoutes.skills(),
+                  icon: skillPageIcon,
                 },
               ]}
             />

--- a/apps/web/src/pages/Skills/IndexSkillPage.tsx
+++ b/apps/web/src/pages/Skills/IndexSkillPage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { MessageDescriptor, defineMessage, useIntl } from "react-intl";
-import BoltOutlineIcon from "@heroicons/react/24/outline/BoltIcon";
-import BoltSolidIcon from "@heroicons/react/24/solid/BoltIcon";
+import LightBulbOutlineIcon from "@heroicons/react/24/outline/LightBulbIcon";
+import LightBulbSolidIcon from "@heroicons/react/24/solid/LightBulbIcon";
 
 import { IconType } from "@gc-digital-talent/ui";
 
@@ -14,12 +14,12 @@ import SkillTableApi from "./components/SkillTable";
 import AdminHero from "../../components/Hero/AdminHero";
 
 export const pageTitle: MessageDescriptor = defineMessage({
-  defaultMessage: "Skills",
-  id: "/UKT+/",
-  description: "Title for skills",
+  defaultMessage: "Skills editor",
+  id: "8ioBIZ",
+  description: "Title for skills editor",
 });
-export const pageSolidIcon: IconType = BoltSolidIcon;
-export const pageOutlineIcon: IconType = BoltOutlineIcon;
+export const pageSolidIcon: IconType = LightBulbSolidIcon;
+export const pageOutlineIcon: IconType = LightBulbOutlineIcon;
 
 export const IndexSkillPage = () => {
   const intl = useIntl();

--- a/apps/web/src/pages/Skills/SkillPage.tsx
+++ b/apps/web/src/pages/Skills/SkillPage.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { defineMessage, useIntl } from "react-intl";
+import BoltOutlineIcon from "@heroicons/react/24/outline/BoltIcon";
+import BoltSolidIcon from "@heroicons/react/24/solid/BoltIcon";
 
-import { Alert, Heading, Link, Well } from "@gc-digital-talent/ui";
+import { Alert, Heading, IconType, Link, Well } from "@gc-digital-talent/ui";
 
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
@@ -13,12 +15,20 @@ import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import SkillTableApi from "./components/SkillTable";
 
+export const pageSolidIcon: IconType = BoltSolidIcon;
+export const pageOutlineIcon: IconType = BoltOutlineIcon;
+
 const suggestionLink = (chunks: React.ReactNode, href: string) => (
   <Link href={href} state={{ referrer: window.location.href }}>
     {chunks}
   </Link>
 );
 
+export const adminPageTitle = defineMessage({
+  defaultMessage: "Skills list",
+  id: "J6atIv",
+  description: "Link text for explore skills page",
+});
 const pageTitle = defineMessage(adminMessages.skills);
 const pageSubtitle = defineMessage({
   defaultMessage: "Explore all the skills on our site.",


### PR DESCRIPTION
🤖 Resolves #9880 

## 👋 Introduction

- Adds a link to Skills page on the admin dashboard and admin sidebar.
- Changes icons and name of previous skills page

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

1. Run `pnpm run dev`
2. Login as `admin@test.com`
3. Go to admin dashboard
4. Ensure new links show up on side menu and dashboard, as well as naming and icons are correct.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/418edc86-5db1-46e2-bfc5-c253a404899e)
