### PR TITLE
[Fix] Dropdown colour contrast

### DIFF
--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
@@ -120,35 +120,47 @@ const Item = React.forwardRef<
   />
 ));
 
+type CheckboxItemProps = React.ComponentPropsWithoutRef<
+  typeof DropdownMenuPrimitive.CheckboxItem
+> & {
+  color?: ButtonProps["color"];
+};
+
 const CheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->((props, forwardedRef) => (
+  CheckboxItemProps
+>(({ color = "primary", ...rest }, forwardedRef) => (
   <DropdownMenuPrimitive.CheckboxItem
     ref={forwardedRef}
     {...{
       ...getBaseStyle({ mode: "inline" }),
-      ...getFontColor({ mode: "inline", color: "secondary" }),
-      ...getBackgroundColor({ mode: "inline", color: "secondary" }),
+      ...getFontColor({ mode: "inline", color }),
+      ...getBackgroundColor({ mode: "inline", color }),
     }}
     {...itemStyleProps}
-    {...props}
+    {...rest}
   />
 ));
 
+type RadioItemProps = React.ComponentPropsWithoutRef<
+  typeof DropdownMenuPrimitive.RadioItem
+> & {
+  color?: ButtonProps["color"];
+};
+
 const RadioItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
->((props, forwardedRef) => (
+  RadioItemProps
+>(({ color = "primary", ...rest }, forwardedRef) => (
   <DropdownMenuPrimitive.RadioItem
     ref={forwardedRef}
     {...{
       ...getBaseStyle({ mode: "inline" }),
-      ...getFontColor({ mode: "inline", color: "secondary" }),
-      ...getBackgroundColor({ mode: "inline", color: "secondary" }),
+      ...getFontColor({ mode: "inline", color }),
+      ...getBackgroundColor({ mode: "inline", color }),
     }}
     {...itemStyleProps}
-    {...props}
+    {...rest}
   />
 ));
 

--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
@@ -125,8 +125,13 @@ const CheckboxItem = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
 >((props, forwardedRef) => (
   <DropdownMenuPrimitive.CheckboxItem
-    {...itemStyleProps}
     ref={forwardedRef}
+    {...{
+      ...getBaseStyle({ mode: "inline" }),
+      ...getFontColor({ mode: "inline", color: "secondary" }),
+      ...getBackgroundColor({ mode: "inline", color: "secondary" }),
+    }}
+    {...itemStyleProps}
     {...props}
   />
 ));
@@ -136,8 +141,13 @@ const RadioItem = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
 >((props, forwardedRef) => (
   <DropdownMenuPrimitive.RadioItem
-    {...itemStyleProps}
     ref={forwardedRef}
+    {...{
+      ...getBaseStyle({ mode: "inline" }),
+      ...getFontColor({ mode: "inline", color: "secondary" }),
+      ...getBackgroundColor({ mode: "inline", color: "secondary" }),
+    }}
+    {...itemStyleProps}
     {...props}
   />
 ));

--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
@@ -107,7 +107,7 @@ type ItemProps = React.ComponentPropsWithoutRef<
 const Item = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
   ItemProps
->(({ color = "primary", ...rest }, forwardedRef) => (
+>(({ color = "secondary", ...rest }, forwardedRef) => (
   <DropdownMenuPrimitive.Item
     ref={forwardedRef}
     {...{
@@ -129,7 +129,7 @@ type CheckboxItemProps = React.ComponentPropsWithoutRef<
 const CheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
   CheckboxItemProps
->(({ color = "primary", ...rest }, forwardedRef) => (
+>(({ color = "secondary", ...rest }, forwardedRef) => (
   <DropdownMenuPrimitive.CheckboxItem
     ref={forwardedRef}
     {...{
@@ -151,7 +151,7 @@ type RadioItemProps = React.ComponentPropsWithoutRef<
 const RadioItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
   RadioItemProps
->(({ color = "primary", ...rest }, forwardedRef) => (
+>(({ color = "secondary", ...rest }, forwardedRef) => (
   <DropdownMenuPrimitive.RadioItem
     ref={forwardedRef}
     {...{


### PR DESCRIPTION
🤖 Resolves #9996 

## 👋 Introduction

Fixes colour constrast in the dropdown menu.

## 🕵️ Details

We updated the styles for links and buttons in dropdown but forgot to apply those changes for checkboxes and radio buttons :cry: 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `pnpm run dev`
2. Navigate to a dropdown (admin tables is a good spot)
3. Confirm they have the secondary colour and proper contrast ratio

## 📸 Screenshot

![screenshot_05-Apr-2024_13-25-1712337936](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/166b7987-ca6e-47d8-b3e9-dee5f41d251b)
![screenshot_05-Apr-2024_13-25-1712337943](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/dfaddf87-fbf0-47b8-9f92-f9fdf76ea3cc)

