### PR TITLE
[Debt] Remove remaining ROD feature flag checks

### DIFF
--- a/api/app/Rules/AssessmentStepComplete.php
+++ b/api/app/Rules/AssessmentStepComplete.php
@@ -14,15 +14,12 @@ class AssessmentStepComplete implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        $flagBoolean = config('feature.record_of_decision');
 
-        if ($flagBoolean) {
-            $assessmentStep = AssessmentStep::find($value)->load('poolSkills');
+        $assessmentStep = AssessmentStep::find($value)->load('poolSkills');
 
-            // check step has at least one pool skill
-            if (count($assessmentStep->poolSkills) === 0 && $assessmentStep->type !== AssessmentStepType::APPLICATION_SCREENING->name) {
-                $fail('AssessmentStepMissingSkills');
-            }
+        // check step has at least one pool skill
+        if (count($assessmentStep->poolSkills) === 0 && $assessmentStep->type !== AssessmentStepType::APPLICATION_SCREENING->name) {
+            $fail('AssessmentStepMissingSkills');
         }
     }
 }

--- a/api/app/Rules/PoolSkillIsAssessed.php
+++ b/api/app/Rules/PoolSkillIsAssessed.php
@@ -13,15 +13,12 @@ class PoolSkillIsAssessed implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        $flagBoolean = config('feature.record_of_decision');
 
-        if ($flagBoolean) {
-            $poolSkill = PoolSkill::find($value)->load('assessmentSteps');
+        $poolSkill = PoolSkill::find($value)->load('assessmentSteps');
 
-            // check pool skill has at least one assessment connected
-            if (count($poolSkill->assessmentSteps) === 0) {
-                $fail('PoolSkillsWithoutAssessments');
-            }
+        // check pool skill has at least one assessment connected
+        if (count($poolSkill->assessmentSteps) === 0) {
+            $fail('PoolSkillsWithoutAssessments');
         }
     }
 }

--- a/api/app/Rules/QuestionsAnswered.php
+++ b/api/app/Rules/QuestionsAnswered.php
@@ -42,19 +42,17 @@ class QuestionsAnswered implements ValidationRule
             }
         }
 
-        if (config('feature.record_of_decision')) {
-            $screeningQuestions = ScreeningQuestion::where('pool_id', $value)
-                ->get()
-                ->pluck('id');
+        $screeningQuestions = ScreeningQuestion::where('pool_id', $value)
+            ->get()
+            ->pluck('id');
 
-            if (count($screeningQuestions)) {
-                $responseCount = $this->application->screeningQuestionResponses()
-                    ->whereIn('screening_question_id', $screeningQuestions)
-                    ->count();
+        if (count($screeningQuestions)) {
+            $responseCount = $this->application->screeningQuestionResponses()
+                ->whereIn('screening_question_id', $screeningQuestions)
+                ->count();
 
-                if ($responseCount < count($screeningQuestions)) {
-                    $fail(ApiEnums::POOL_CANDIDATE_MISSING_QUESTION_RESPONSE);
-                }
+            if ($responseCount < count($screeningQuestions)) {
+                $fail(ApiEnums::POOL_CANDIDATE_MISSING_QUESTION_RESPONSE);
             }
         }
     }

--- a/api/tests/Feature/PoolApplicationTest.php
+++ b/api/tests/Feature/PoolApplicationTest.php
@@ -548,10 +548,6 @@ class PoolApplicationTest extends TestCase
 
     public function testApplicationSubmitScreeningQuestions(): void
     {
-        if (! config('feature.record_of_decision')) {
-            $this->markTestSkipped('record_of_decision is off');
-        }
-
         $newPool = Pool::factory()->published()->create([
             'closing_date' => Carbon::now()->addDays(1),
             'advertisement_language' => PoolLanguage::ENGLISH->name, // avoid language requirements

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -777,9 +777,6 @@ class PoolTest extends TestCase
 
     public function testAssessmentStepValidation(): void
     {
-        if (! config('feature.record_of_decision')) {
-            $this->markTestSkipped('record_of_decision is off');
-        }
 
         Classification::factory()->create();
         Skill::factory()->count(5)->create([
@@ -832,9 +829,6 @@ class PoolTest extends TestCase
 
     public function testPoolSkillValidation(): void
     {
-        if (! config('feature.record_of_decision')) {
-            $this->markTestSkipped('record_of_decision is off');
-        }
 
         Classification::factory()->create();
         Skill::factory()->create([


### PR DESCRIPTION
🤖 Resolves #9973 

## 👋 Introduction

Removes the remaining ROD feature flag checks on the back end.

## 🕵️ Details

Even though we removed the feature flag, there were some remaining checks to skip tests and validation. This removes those from the code so the tests and validation now  run.

## 🧪 Testing

1. Run tests `make artisan CMD="test"`
2. Confirm they all run and pass
3. Attempt to publish a pool with a missing skill assessment
4. Confirm validation returns failure
5. Attempt to submit an application with missing screening question response
6. Confirm validation returns error

