### PR TITLE
[Feature] Screening and assessment asset skill experience linked skill logic

### DIFF
--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -345,11 +345,7 @@ export const ScreeningDecisionDialog = ({
   const experienceAttachedToSkill = getExperienceSkills(
     unpackMaybes(parsedSnapshot?.experiences),
     skill,
-  )?.some((experience) =>
-    experience?.skills?.find(
-      (experienceSkill) => experienceSkill.id === poolSkill?.skill?.id,
-    ),
-  );
+  ).length > 0;
 
   const classificationGroup = poolCandidate.pool.classification?.group;
 

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -342,10 +342,9 @@ export const ScreeningDecisionDialog = ({
           skill,
         );
 
-  const experienceAttachedToSkill = getExperienceSkills(
-    unpackMaybes(parsedSnapshot?.experiences),
-    skill,
-  ).length > 0;
+  const experienceAttachedToSkill =
+    getExperienceSkills(unpackMaybes(parsedSnapshot?.experiences), skill)
+      .length > 0;
 
   const classificationGroup = poolCandidate.pool.classification?.group;
 

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -31,7 +31,7 @@ import {
   incrementHeadingRank,
 } from "@gc-digital-talent/ui";
 import { BasicForm, Submit } from "@gc-digital-talent/forms";
-import { notEmpty } from "@gc-digital-talent/helpers";
+import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import {
   commonMessages,
   getAssessmentStepType,
@@ -342,6 +342,15 @@ export const ScreeningDecisionDialog = ({
           skill,
         );
 
+  const experienceAttachedToSkill = getExperienceSkills(
+    unpackMaybes(parsedSnapshot?.experiences),
+    skill,
+  )?.some((experience) =>
+    experience?.skills?.find(
+      (experienceSkill) => experienceSkill.id === poolSkill?.skill?.id,
+    ),
+  );
+
   const classificationGroup = poolCandidate.pool.classification?.group;
 
   const educationRequirementOption = getEducationRequirementOptions(
@@ -369,7 +378,8 @@ export const ScreeningDecisionDialog = ({
     )
       return "black";
     if (!hasBeenAssessed)
-      return poolSkill?.type === PoolSkillType.Nonessential
+      return poolSkill?.type === PoolSkillType.Nonessential &&
+        !experienceAttachedToSkill
         ? "black"
         : "warning";
     switch (initialValues?.assessmentDecision) {
@@ -428,7 +438,8 @@ export const ScreeningDecisionDialog = ({
             </span>
           ) : (
             <p>
-              {poolSkill?.type === PoolSkillType.Nonessential
+              {poolSkill?.type === PoolSkillType.Nonessential &&
+              !experienceAttachedToSkill
                 ? intl.formatMessage(poolCandidateMessages.unclaimed)
                 : intl.formatMessage(poolCandidateMessages.toAssess)}
             </p>


### PR DESCRIPTION
🤖 Resolves #10012.

## 👋 Introduction

This PR updates logic so that **Unclaimed** is rendered for an asset skill only when there the applicant (from snapshot) skill does not have a linked experienced on the screening and assessment table.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Create a process with one essential skill and two asset skills
2. Create an application to this process where one of the asset skills has an experience attached and one asset skill that does not have an experience attached
3. Navigate to a candidate's screening and assessment table `/admin/candidates/:candidate-id/application`
4. Verify that **Unclaimed** is rendered for the asset skill with no skill attached
5. Verify that **To assess** is rendered for the asset skill with skill attached

## 📸 Screenshot

![localhost_8000_en_admin_candidates_5a456edc-35b9-4085-a5b3-76bd51f2a277_application](https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/9c83ec62-b3db-46d7-a855-1aedb1a162c5)