### PR TITLE
[Tooling] Add `no-only-tests` ESLint rule

### DIFF
--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -29,6 +29,7 @@ module.exports = {
   ],
   plugins: [
     "import",
+    "no-only-tests",
     "@typescript-eslint",
     "turbo"
   ],
@@ -65,6 +66,7 @@ module.exports = {
         pathGroupsExcludedImportTypes: ["@gc-digital-talent/**"],
       },
     ],
+    "no-only-tests/no-only-tests": "error",
     "no-param-reassign": "warn",
     "no-use-before-define": "off",
     "no-shadow": "off",

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -16,6 +16,7 @@
     "eslint-plugin-formatjs": "^4.12.2",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsx-a11y": "^6.8.0",
+    "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-promise": "^6.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,6 +582,9 @@ importers:
       eslint-plugin-jsx-a11y:
         specifier: ^6.8.0
         version: 6.8.0(eslint@8.57.0)
+      eslint-plugin-no-only-tests:
+        specifier: ^3.1.0
+        version: 3.1.0
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -10733,6 +10736,11 @@ packages:
       minimatch: 3.1.2
       object.entries: 1.1.7
       object.fromentries: 2.0.7
+    dev: true
+
+  /eslint-plugin-no-only-tests@3.1.0:
+    resolution: {integrity: sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==}
+    engines: {node: '>=5.0.0'}
     dev: true
 
   /eslint-plugin-node@11.1.0(eslint@8.57.0):


### PR DESCRIPTION
🤖 Resolves #9226 

## 👋 Introduction

Adds the `no-only-tests` ESLint rule and configures it to error to prevent accidentally committing focused tests.

## 🧪 Testing

1. Open up a (Typescript) test file
2. Add a `.only` to any of the tests
3. Confirm you get a lint error
4. Repeat for the following folders:
    - `./packages/**`
    - `./apps/e2e/**`
    - `./apps/playwright`
    - `./apps/web/**`
