### PR TITLE
[Tests] Fix SnapshotTest

### DIFF
--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -97,6 +97,14 @@ class SnapshotTest extends TestCase
         $expectedSnapshot['sub'] = $expectedSnapshot['authInfo']['sub'];
         unset($expectedSnapshot['authInfo']);
 
+        // sort experiences the same way as order does not matter for comparison
+        usort($expectedSnapshot['experiences'], function ($a, $b) {
+            return strcmp($a['id'], $b['id']);
+        });
+        usort($decodedActual['experiences'], function ($a, $b) {
+            return strcmp($a['id'], $b['id']);
+        });
+
         assertEquals($expectedSnapshot, $decodedActual);
     }
 


### PR DESCRIPTION
🤖 Resolves #9975

## 👋 Introduction

This is annoying, lets clear it up.
Fixing by sorting the experiences on both the same way, as the order of the experiences does not matter.

## 🧪 Testing

1. Tests repeatedly pass in CI
2. As well as locally

Run
`for i in {1..50}; do docker-compose exec -w /home/site/wwwroot/api webserver sh -c "./vendor/bin/phpunit ./tests/Feature/SnapshotTest.php"; done`

