### PR TITLE
[Fix] Stabilize `srcset` in chromatic

### DIFF
--- a/packages/storybook-helpers/main.ts
+++ b/packages/storybook-helpers/main.ts
@@ -53,6 +53,7 @@ if (sbApp) {
 
 const main: StorybookConfig = {
   stories,
+  staticDirs: ["../src/assets"],
   addons: [
     "@storybook/addon-a11y",
     "@storybook/addon-essentials",

--- a/packages/storybook-helpers/main.ts
+++ b/packages/storybook-helpers/main.ts
@@ -102,6 +102,7 @@ const main: StorybookConfig = {
     config.plugins?.push(
       new PreloadWebpackPlugin({
         rel: "preload",
+        include: "allAssets",
         as(entry: string) {
           if (/\.css$/.test(entry)) return "style";
           if (/\.webp$/.test(entry)) return "image";

--- a/packages/storybook-helpers/main.ts
+++ b/packages/storybook-helpers/main.ts
@@ -8,6 +8,7 @@ const path = require("path");
 const HydrogenPlugin = require("hydrogen-webpack-plugin");
 const TsTransformer = require("@formatjs/ts-transformer");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
+const PreloadWebpackPlugin = require("@vue/preload-webpack-plugin");
 
 const transform = TsTransformer.transform;
 
@@ -95,6 +96,17 @@ const main: StorybookConfig = {
           __dirname,
           "../../apps/web/src/assets/css/hydrogen.css",
         ),
+      }),
+    );
+
+    config.plugins?.push(
+      new PreloadWebpackPlugin({
+        rel: "preload",
+        as(entry: string) {
+          if (/\.css$/.test(entry)) return "style";
+          if (/\.webp$/.test(entry)) return "image";
+          return "script";
+        },
       }),
     );
 

--- a/packages/storybook-helpers/package.json
+++ b/packages/storybook-helpers/package.json
@@ -34,6 +34,7 @@
     "@storybook/addons": "^7.6.17",
     "@storybook/react-webpack5": "^7.6.17",
     "@storybook/types": "^7.6.17",
+    "@vue/preload-webpack-plugin": "^2.0.0",
     "eslint": "^8.57.0",
     "hydrogen-webpack-plugin": "workspace:*",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1080,6 +1080,9 @@ importers:
       '@storybook/types':
         specifier: ^7.6.17
         version: 7.6.17
+      '@vue/preload-webpack-plugin':
+        specifier: ^2.0.0
+        version: 2.0.0(html-webpack-plugin@5.6.0)(webpack@5.90.3)
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -6748,7 +6751,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-darwin-x64@1.4.8:
@@ -6757,7 +6759,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm-gnueabihf@1.4.8:
@@ -6766,7 +6767,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-gnu@1.4.8:
@@ -6775,7 +6775,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-arm64-musl@1.4.8:
@@ -6784,7 +6783,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-gnu@1.4.8:
@@ -6793,7 +6791,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-linux-x64-musl@1.4.8:
@@ -6802,7 +6799,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-arm64-msvc@1.4.8:
@@ -6811,7 +6807,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-ia32-msvc@1.4.8:
@@ -6820,7 +6815,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core-win32-x64-msvc@1.4.8:
@@ -6829,7 +6823,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@swc/core@1.4.8:
@@ -6855,15 +6848,12 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.4.8
       '@swc/core-win32-ia32-msvc': 1.4.8
       '@swc/core-win32-x64-msvc': 1.4.8
-    dev: true
 
   /@swc/counter@0.1.3:
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-    dev: true
 
   /@swc/types@0.1.5:
     resolution: {integrity: sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==}
-    dev: true
 
   /@tanstack/react-table@8.13.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-b6mR3mYkjRtJ443QZh9sc7CvGTce81J35F/XMr0OoWbx0KIM7TTTdyNP2XKObvkLpYnLpCrYDwI3CZnLezWvpg==}
@@ -7844,6 +7834,17 @@ packages:
     transitivePeerDependencies:
       - graphql
     dev: false
+
+  /@vue/preload-webpack-plugin@2.0.0(html-webpack-plugin@5.6.0)(webpack@5.90.3):
+    resolution: {integrity: sha512-RoorRB50WehYbsiWu497q8egZBYlrvOo9KBUG41uth4O023Cbs+7POLm9uw2CAiViBAIhvpw1Y4w4i+MZxOfXw==}
+    engines: {node: '>=6.0.0'}
+    peerDependencies:
+      html-webpack-plugin: ^5.0.0 || ^4.5.1
+      webpack: ^5.20.0 || ^4.1.0
+    dependencies:
+      html-webpack-plugin: 5.6.0(webpack@5.90.3)
+      webpack: 5.90.3(@swc/core@1.4.8)(esbuild@0.18.20)
+    dev: true
 
   /@webassemblyjs/ast@1.11.6:
     resolution: {integrity: sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==}
@@ -11942,7 +11943,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.8)(esbuild@0.18.20)
 
   /htmlparser2@6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
@@ -16462,7 +16463,6 @@ packages:
       serialize-javascript: 6.0.2
       terser: 5.28.1
       webpack: 5.90.3(@swc/core@1.4.8)(esbuild@0.18.20)
-    dev: true
 
   /terser-webpack-plugin@5.3.10(esbuild@0.18.20)(webpack@5.90.3):
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
@@ -16511,6 +16511,7 @@ packages:
       serialize-javascript: 6.0.2
       terser: 5.28.1
       webpack: 5.90.3
+    dev: false
 
   /terser@5.28.1:
     resolution: {integrity: sha512-wM+bZp54v/E9eRRGXb5ZFDvinrJIOaTapx3WUokyVGZu5ucVCK55zEgGd5Dl2fSr3jUo5sDiERErUWLY6QPFyA==}
@@ -17423,6 +17424,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: false
 
   /webpack@5.90.3(@swc/core@1.4.8)(esbuild@0.18.20):
     resolution: {integrity: sha512-h6uDYlWCctQRuXBs1oYpVe6sFcWedl0dpcVaTf/YF67J9bKvwJajFulMVSYKHrksMB3I/pIagRzDxwxkebuzKA==}
@@ -17462,7 +17464,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /webpack@5.90.3(esbuild@0.18.20)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-h6uDYlWCctQRuXBs1oYpVe6sFcWedl0dpcVaTf/YF67J9bKvwJajFulMVSYKHrksMB3I/pIagRzDxwxkebuzKA==}


### PR DESCRIPTION
🤖 Resolves #9636 

## 👋 Introduction

This may fix an issue with stories that include `img[srcset]` being unstable

## 🕵️ Details

I reached out to chromatic suppoer and they suggested preloading assets. I added the `PreloadWebpackPlugin` to see if that will sort things out. At the same time, I noticed we were not passing a static dir option for static assets so I also added that hoping it might make things a bit more stable :woman_shrugging: 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Check to diffs on separate chromatic runs to confirm it seems stable:

 - https://www.chromatic.com/review?appId=61e099a1bb1465003a73d3ce&number=10026&type=linked
 - ... There would be more here but it seems chromatic won't re-run with no changes :/ 
