### PR TITLE
[Feature] Privileged api - backend only

### DIFF
--- a/api/app/Checkers/ProtectedRequestUserChecker.php
+++ b/api/app/Checkers/ProtectedRequestUserChecker.php
@@ -10,10 +10,10 @@ use Illuminate\Support\Facades\Request;
 use Laratrust\Checkers\User\UserDefaultChecker;
 use Laratrust\Helper;
 
-// This class extends the default user checker to add additional checks for protected requests
+// This class extends the default user checker to add additional checks for privileged permissions on unprotected requests
 class ProtectedRequestUserChecker extends UserDefaultChecker
 {
-    // these are the role names with limited permissions that can safely be used on unsecure requests
+    // these are the role names with limited permissions that can safely be used on unprotected requests
     const LIMITED_ROLES = [
         'guest',
         'base_user',

--- a/api/app/Checkers/ProtectedRequestUserChecker.php
+++ b/api/app/Checkers/ProtectedRequestUserChecker.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Request;
 use Laratrust\Checkers\User\UserDefaultChecker;
+use Laratrust\Helper;
 
 // This class extends the default user checker to add additional checks for protected requests
 class ProtectedRequestUserChecker extends UserDefaultChecker
@@ -20,18 +21,20 @@ class ProtectedRequestUserChecker extends UserDefaultChecker
     ];
 
     // decide if it is safe for the current user to use the given role
-    protected function isSafeToUseRole(string $role): bool
+    protected function isSafeToUseRole(string|array|BackedEnum $name): bool
     {
+        $name = Helper::standardize($name);
         $isProtectedRequest = Request::get('isProtectedRequest');
 
         // if it's a protected request then any role is safe to use
         // if it's a limited (unprivileged) role then it's always safe to use
-        return $isProtectedRequest || in_array($role, $this::LIMITED_ROLES);
+        return $isProtectedRequest || in_array($name, $this::LIMITED_ROLES);
     }
 
     // decide if it is safe for the current user to use the given permission
-    protected function isSafeToUsePermission(string $permission): bool
+    protected function isSafeToUsePermission(string|array|BackedEnum $permission): bool
     {
+        $permission = Helper::standardize($permission);
         $isProtectedRequest = Request::get('isProtectedRequest');
 
         $limitedPermissions =

--- a/api/app/Checkers/ProtectedRequestUserChecker.php
+++ b/api/app/Checkers/ProtectedRequestUserChecker.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Checkers;
+
+use App\Models\Permission;
+use BackedEnum;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Request;
+use Laratrust\Checkers\User\UserDefaultChecker;
+
+// This class extends the default user checker to add additional checks for protected requests
+class ProtectedRequestUserChecker extends UserDefaultChecker
+{
+    // these are the role names with limited permissions that can safely be used on unsecure requests
+    const LIMITED_ROLES = [
+        'guest',
+        'base_user',
+        'applicant',
+    ];
+
+    // decide if it is safe for the current user to use the given role
+    protected function isSafeToUseRole(string $role): bool
+    {
+        $isProtectedRequest = Request::get('isProtectedRequest');
+
+        // if it's a protected request then any role is safe to use
+        // if it's a limited (unprivileged) role then it's always safe to use
+        return $isProtectedRequest || in_array($role, $this::LIMITED_ROLES);
+    }
+
+    // decide if it is safe for the current user to use the given permission
+    protected function isSafeToUsePermission(string $permission): bool
+    {
+        $isProtectedRequest = Request::get('isProtectedRequest');
+
+        $limitedPermissions =
+        Cache::remember('limitedPermissions', 3600, function () {
+            return
+          Permission::whereHas('roles', function (Builder $query) {
+              $query->whereIn('name', $this::LIMITED_ROLES);
+          })->pluck('name')->toArray();
+        });
+
+        // if it's a protected request then any permission is safe to use
+        // if it's a limited (unprivileged) permission then it's always safe to use
+        return $isProtectedRequest || in_array($permission, $limitedPermissions);
+    }
+
+    public function currentUserHasRole(
+        string|array|BackedEnum $name,
+        mixed $team = null,
+        bool $requireAll = false
+    ): bool {
+        if (! $this->isSafeToUseRole($name)) {
+            return false; // user effectively doesn't have role if it is unsafe to use it
+        }
+
+        return parent::currentUserHasRole($name, $team, $requireAll);
+    }
+
+    public function currentUserHasPermission(
+        string|array|BackedEnum $permission,
+        mixed $team = null,
+        bool $requireAll = false
+    ): bool {
+        if (! $this->isSafeToUsePermission($permission)) {
+            return false; // user effectively doesn't have permission if it is unsafe to use it
+        }
+
+        return parent::currentUserHasPermission($permission, $team, $requireAll);
+    }
+}

--- a/api/app/GraphQL/Mutations/UpdateSitewideAnnouncement.php
+++ b/api/app/GraphQL/Mutations/UpdateSitewideAnnouncement.php
@@ -7,7 +7,7 @@ namespace App\GraphQL\Mutations;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Validation\UnauthorizedException;
+use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 
 final readonly class UpdateSitewideAnnouncement
 {
@@ -16,7 +16,7 @@ final readonly class UpdateSitewideAnnouncement
     {
         /** @var \App\Models\User */
         $user = Auth::user();
-        throw_unless($user->isAbleTo('update-any-announcement'), UnauthorizedException::class);
+        throw_unless($user->isAbleTo('update-any-announcement'), AuthorizationException::class);
 
         // parse and save the input
         $parsedObj = [

--- a/api/app/Http/Kernel.php
+++ b/api/app/Http/Kernel.php
@@ -22,6 +22,7 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         // \App\Http\Middleware\SimulateFirewallMiddleware::class,
+        \App\Http\Middleware\ProtectedRequest::class,
     ];
 
     /**

--- a/api/app/Http/Middleware/ProtectedRequest.php
+++ b/api/app/Http/Middleware/ProtectedRequest.php
@@ -16,8 +16,7 @@ class ProtectedRequest
      */
     public function handle(Request $request, Closure $next)
     {
-        $path = $request->path();
-        if (str_starts_with($path, 'admin/')) {
+        if ($request->is('admin/*')) {
             $request->merge(['isProtectedRequest' => true]);
         }
 

--- a/api/app/Http/Middleware/ProtectedRequest.php
+++ b/api/app/Http/Middleware/ProtectedRequest.php
@@ -17,7 +17,7 @@ class ProtectedRequest
     public function handle(Request $request, Closure $next)
     {
         $path = $request->path();
-        if (str_starts_with($path, 'admin')) {
+        if (str_starts_with($path, 'admin/')) {
             $request->merge(['isProtectedRequest' => true]);
         }
 

--- a/api/app/Http/Middleware/ProtectedRequest.php
+++ b/api/app/Http/Middleware/ProtectedRequest.php
@@ -18,7 +18,7 @@ class ProtectedRequest
     {
         $path = $request->path();
         if (str_starts_with($path, 'admin')) {
-            $request->merge(['isSecureRequest' => true]);
+            $request->merge(['isProtectedRequest' => true]);
         }
 
         return $next($request);

--- a/api/app/Http/Middleware/ProtectedRequest.php
+++ b/api/app/Http/Middleware/ProtectedRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+/**
+ * Notices if the request is a secure one that would have been
+ * protected by the VPN.
+ */
+class ProtectedRequest
+{
+    /**
+     * @return mixed Any kind of response
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $path = $request->path();
+        if (str_starts_with($path, 'admin')) {
+            $request->merge(['isSecureRequest' => true]);
+        }
+
+        return $next($request);
+    }
+}

--- a/api/app/Providers/RouteServiceProvider.php
+++ b/api/app/Providers/RouteServiceProvider.php
@@ -43,6 +43,9 @@ class RouteServiceProvider extends ServiceProvider
                 ->namespace($this->namespace)
                 ->group(base_path('routes/api.php'));
 
+            Route::namespace($this->namespace)
+                ->group(base_path('routes/graphql.php'));
+
             Route::middleware(['web', 'throttle:web'])
                 ->namespace($this->namespace)
                 ->group(base_path('routes/web.php'));

--- a/api/config/graphiql.php
+++ b/api/config/graphiql.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Routes configuration
+    |--------------------------------------------------------------------------
+    |
+    | Set the key as URI at which the GraphiQL UI can be viewed,
+    | and add any additional configuration for the route.
+    |
+    | You can add multiple routes pointing to different GraphQL endpoints.
+    |
+    */
+
+    'routes' => [
+        '/graphiql' => [
+            'name' => 'graphiql',
+            // 'middleware' => ['web']
+            // 'prefix' => '',
+            // 'domain' => 'graphql.' . env('APP_DOMAIN', 'localhost'),
+
+            /*
+            |--------------------------------------------------------------------------
+            | Default GraphQL endpoint
+            |--------------------------------------------------------------------------
+            |
+            | The default endpoint that the GraphiQL UI is set to.
+            | It assumes you are running GraphQL on the same domain
+            | as GraphiQL, but can be set to any URL.
+            |
+            */
+
+            'endpoint' => '/graphql',
+
+            /*
+            |--------------------------------------------------------------------------
+            | Subscription endpoint
+            |--------------------------------------------------------------------------
+            |
+            | The default subscription endpoint the GraphiQL UI uses to connect to.
+            | Tries to connect to the `endpoint` value if `null` as ws://{{endpoint}}
+            |
+            | Example: `ws://your-endpoint` or `wss://your-endpoint`
+            |
+            */
+
+            'subscription-endpoint' => env('GRAPHIQL_SUBSCRIPTION_ENDPOINT', null),
+        ],
+        // protected endpoint for using privileged permissions
+        '/admin/graphiql' => [
+            'name' => 'graphiql-protected',
+            'endpoint' => '/admin/graphql',
+            'subscription-endpoint' => env('GRAPHIQL_SUBSCRIPTION_ENDPOINT', null),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Control GraphiQL availability
+    |--------------------------------------------------------------------------
+    |
+    | Control if the GraphiQL UI is accessible at all.
+    | This allows you to disable it in certain environments,
+    | for example you might not want it active in production.
+    |
+    */
+
+    'enabled' => env('GRAPHIQL_ENABLED', true),
+];

--- a/api/config/laratrust.php
+++ b/api/config/laratrust.php
@@ -35,7 +35,7 @@ return [
         |           This method doesn't support cache yet.
         | - class that extends Laratrust\Checkers\User\UserChecker
         */
-        'user' => 'default',
+        'user' => App\Checkers\ProtectedRequestUserChecker::class,
 
         /*
         |--------------------------------------------------------------------------

--- a/api/config/laratrust.php
+++ b/api/config/laratrust.php
@@ -35,7 +35,8 @@ return [
         |           This method doesn't support cache yet.
         | - class that extends Laratrust\Checkers\User\UserChecker
         */
-        'user' => App\Checkers\ProtectedRequestUserChecker::class,
+        //'user' => App\Checkers\ProtectedRequestUserChecker::class,
+        'user' => 'default',
 
         /*
         |--------------------------------------------------------------------------

--- a/api/config/lighthouse.php
+++ b/api/config/lighthouse.php
@@ -14,52 +14,8 @@ return [
     |
     */
 
-    'route' => [
-        /*
-         * The URI the endpoint responds to, e.g. mydomain.com/graphql.
-         */
-        'uri' => '/graphql',
-
-        /*
-         * Lighthouse creates a named route for convenient URL generation and redirects.
-         */
-        'name' => 'graphql',
-
-        /*
-         * Beware that middleware defined here runs before the GraphQL execution phase,
-         * make sure to return spec-compliant responses in case an error is thrown.
-         */
-        'middleware' => [
-            // Ensures the request is not vulnerable to cross-site request forgery.
-            // Nuwave\Lighthouse\Http\Middleware\EnsureXHR::class,
-
-            // Always set the `Accept: application/json` header.
-            Nuwave\Lighthouse\Http\Middleware\AcceptJson::class,
-
-            // Logs in a user if they are authenticated. In contrast to Laravel's 'auth'
-            // middleware, this delegates auth and permission checks to the field level.
-            Nuwave\Lighthouse\Http\Middleware\AttemptAuthentication::class,
-
-            // Logs every incoming GraphQL query.
-            // Nuwave\Lighthouse\Http\Middleware\LogGraphQLQueries::class,
-
-            // Logs incoming GraphQL queries made by an admin
-            App\Http\Middleware\AuditQueryMiddleware::class,
-
-            // Logs slow running GraphQL queries
-            App\Http\Middleware\SlowQueryLoggerMiddleware::class,
-
-            // Throttles based on RateLimiter in RouteServiceProvider.
-            'throttle:graphql',
-        ],
-
-        /*
-         * The `prefix`, `domain` and `where` configuration options are optional.
-         */
-        // 'prefix' => '',
-        // 'domain' => '',
-        // 'where' => [],
-    ],
+    // moved to api/routes/graphql.php
+    'route' => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/api/routes/graphql.php
+++ b/api/routes/graphql.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| GraphQL Routes
+|--------------------------------------------------------------------------
+|
+| This is where the routes that execute GraphQL queries are registered.
+|
+*/
+
+/*
+ * Beware that middleware defined here runs before the GraphQL execution phase,
+ * make sure to return spec-compliant responses in case an error is thrown.
+ */
+Route::middleware([
+    // Ensures the request is not vulnerable to cross-site request forgery.
+    // Nuwave\Lighthouse\Http\Middleware\EnsureXHR::class,
+
+    // Always set the `Accept: application/json` header.
+    Nuwave\Lighthouse\Http\Middleware\AcceptJson::class,
+
+    // Logs in a user if they are authenticated. In contrast to Laravel's 'auth'
+    // middleware, this delegates auth and permission checks to the field level.
+    Nuwave\Lighthouse\Http\Middleware\AttemptAuthentication::class,
+
+    // Logs every incoming GraphQL query.
+    // Nuwave\Lighthouse\Http\Middleware\LogGraphQLQueries::class,
+
+    // Logs incoming GraphQL queries made by an admin
+    App\Http\Middleware\AuditQueryMiddleware::class,
+
+    // Logs slow running GraphQL queries
+    App\Http\Middleware\SlowQueryLoggerMiddleware::class,
+
+    // Throttles based on RateLimiter in RouteServiceProvider.
+    'throttle:graphql',
+])->group(function () {
+    // regular access to the graphql controller
+    Route::post('/graphql', Nuwave\Lighthouse\Http\GraphQLController::class)
+        ->name('graphql');
+
+    // "privileged" access to the graphql controller through the VPN
+    Route::post('/admin/graphql', Nuwave\Lighthouse\Http\GraphQLController::class)
+        ->name('graphql-secure');
+});

--- a/api/routes/graphql.php
+++ b/api/routes/graphql.php
@@ -42,7 +42,7 @@ Route::middleware([
     Route::post('/graphql', Nuwave\Lighthouse\Http\GraphQLController::class)
         ->name('graphql');
 
-    // "privileged" access to the graphql controller through the VPN
+    // "privileged" access to the graphql controller through a protected path
     Route::post('/admin/graphql', Nuwave\Lighthouse\Http\GraphQLController::class)
-        ->name('graphql-secure');
+        ->name('graphql-protected');
 });

--- a/api/tests/Feature/ActivityLogTest.php
+++ b/api/tests/Feature/ActivityLogTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\Feature;
+
 use App\Enums\PoolCandidateSearchPositionType;
 use App\Enums\PoolCandidateSearchRequestReason;
 use App\Enums\PoolCandidateStatus;

--- a/api/tests/Feature/ActivityLogTest.php
+++ b/api/tests/Feature/ActivityLogTest.php
@@ -6,11 +6,13 @@ use App\Enums\PoolCandidateStatus;
 use App\Models\Department;
 use App\Models\Pool;
 use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Spatie\Activitylog\Models\Activity;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 use function PHPUnit\Framework\assertEquals;
 
@@ -19,6 +21,7 @@ class ActivityLogTest extends TestCase
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $adminUser;
 

--- a/api/tests/Feature/ApplicantFilterTest.php
+++ b/api/tests/Feature/ApplicantFilterTest.php
@@ -21,12 +21,14 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class ApplicantFilterTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $adminUser;
 

--- a/api/tests/Feature/ApplicantTest.php
+++ b/api/tests/Feature/ApplicantTest.php
@@ -21,12 +21,14 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class ApplicantTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $adminUser;
 

--- a/api/tests/Feature/AssessmentResultTest.php
+++ b/api/tests/Feature/AssessmentResultTest.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\DB;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 use function PHPUnit\Framework\assertNull;
 
@@ -26,6 +27,7 @@ class AssessmentResultTest extends TestCase
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $teamUser;
 

--- a/api/tests/Feature/AssessmentStepTest.php
+++ b/api/tests/Feature/AssessmentStepTest.php
@@ -13,6 +13,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertNotNull;
@@ -23,6 +24,7 @@ class AssessmentStepTest extends TestCase
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $teamUser;
 

--- a/api/tests/Feature/ClassificationTest.php
+++ b/api/tests/Feature/ClassificationTest.php
@@ -10,12 +10,14 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class ClassificationTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
     use WithFaker;
 
     protected $baseUser;

--- a/api/tests/Feature/CountPoolCandidatesByPoolTest.php
+++ b/api/tests/Feature/CountPoolCandidatesByPoolTest.php
@@ -20,12 +20,14 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class CountPoolCandidatesByPoolTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected function setUp(): void
     {

--- a/api/tests/Feature/DepartmentSpecificRecruitmentProcessFormTest.php
+++ b/api/tests/Feature/DepartmentSpecificRecruitmentProcessFormTest.php
@@ -4,11 +4,13 @@ use App\Models\Department;
 use App\Models\DepartmentSpecificRecruitmentProcessForm;
 use App\Models\Skill;
 use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 use function PHPUnit\Framework\assertEquals;
 
@@ -17,6 +19,7 @@ class DepartmentSpecificRecruitmentProcessFormTest extends TestCase
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected User $user;
 

--- a/api/tests/Feature/DepartmentTest.php
+++ b/api/tests/Feature/DepartmentTest.php
@@ -10,12 +10,14 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class DepartmentTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
     use WithFaker;
 
     protected $baseUser;

--- a/api/tests/Feature/DigitalContractingQuestionnaireTest.php
+++ b/api/tests/Feature/DigitalContractingQuestionnaireTest.php
@@ -4,11 +4,13 @@ use App\Models\Department;
 use App\Models\DigitalContractingQuestionnaire;
 use App\Models\Skill;
 use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 use function PHPUnit\Framework\assertEquals;
 
@@ -17,6 +19,7 @@ class DigitalContractingQuestionnaireTest extends TestCase
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected User $user;
 

--- a/api/tests/Feature/DirectivesTest.php
+++ b/api/tests/Feature/DirectivesTest.php
@@ -9,6 +9,7 @@ use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\MocksResolvers;
 use Nuwave\Lighthouse\Testing\UsesTestSchema;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 use function PHPUnit\Framework\assertNotNull;
 use function PHPUnit\Framework\assertSame;
@@ -18,6 +19,7 @@ class DirectivesTest extends TestCase
     use MakesGraphQLRequests;
     use MocksResolvers;
     use RefreshDatabase;
+    use UsesProtectedGraphqlEndpoint;
     use UsesTestSchema;
 
     protected function setUp(): void

--- a/api/tests/Feature/ExperienceTest.php
+++ b/api/tests/Feature/ExperienceTest.php
@@ -15,6 +15,7 @@ use Illuminate\Testing\Fluent\AssertableJson;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 use function PHPUnit\Framework\assertEquals;
 
@@ -24,6 +25,7 @@ class ExperienceTest extends TestCase
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $platformAdmin;
 

--- a/api/tests/Feature/GeneralQuestionResponsesTest.php
+++ b/api/tests/Feature/GeneralQuestionResponsesTest.php
@@ -10,12 +10,14 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class GeneralQuestionResponsesTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $teamUser;
 

--- a/api/tests/Feature/GeneralQuestionTest.php
+++ b/api/tests/Feature/GeneralQuestionTest.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 use function PHPUnit\Framework\assertSame;
 
@@ -16,6 +17,7 @@ class GeneralQuestionTest extends TestCase
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $teamUser;
 

--- a/api/tests/Feature/GenericJobTitleTest.php
+++ b/api/tests/Feature/GenericJobTitleTest.php
@@ -11,12 +11,14 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class GenericJobTitleTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
     use WithFaker;
 
     protected $baseUser;

--- a/api/tests/Feature/KeywordSearchTest.php
+++ b/api/tests/Feature/KeywordSearchTest.php
@@ -11,12 +11,14 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class KeywordSearchTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $platformAdmin;
 

--- a/api/tests/Feature/Mutation/UpdateUserTeamRolesTest.php
+++ b/api/tests/Feature/Mutation/UpdateUserTeamRolesTest.php
@@ -4,17 +4,20 @@ use App\Enums\Role as EnumsRole;
 use App\Models\Role;
 use App\Models\Team;
 use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class UpdateUserTeamRolesTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $adminUser;
 

--- a/api/tests/Feature/NotificationTest.php
+++ b/api/tests/Feature/NotificationTest.php
@@ -17,12 +17,14 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class NotificationTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $notification;
 

--- a/api/tests/Feature/PoolApplicationTest.php
+++ b/api/tests/Feature/PoolApplicationTest.php
@@ -29,6 +29,7 @@ use Illuminate\Testing\Fluent\AssertableJson;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertNotNull;
@@ -38,6 +39,7 @@ class PoolApplicationTest extends TestCase
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
     use WithFaker;
 
     protected $applicantUser;

--- a/api/tests/Feature/PoolCandidateSearchRequestPaginatedTest.php
+++ b/api/tests/Feature/PoolCandidateSearchRequestPaginatedTest.php
@@ -16,12 +16,14 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class PoolCandidateSearchRequestPaginatedTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $adminUser;
 

--- a/api/tests/Feature/PoolCandidateSearchRequestTest.php
+++ b/api/tests/Feature/PoolCandidateSearchRequestTest.php
@@ -14,12 +14,14 @@ use Illuminate\Testing\Fluent\AssertableJson;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class PoolCandidateSearchRequestTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected function setUp(): void
     {

--- a/api/tests/Feature/PoolCandidateSearchTest.php
+++ b/api/tests/Feature/PoolCandidateSearchTest.php
@@ -14,12 +14,14 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class PoolCandidateSearchTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $teamUser;
 

--- a/api/tests/Feature/PoolCandidateTest.php
+++ b/api/tests/Feature/PoolCandidateTest.php
@@ -14,12 +14,14 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class PoolCandidateTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $adminUser;
 

--- a/api/tests/Feature/PoolCandidateUpdateTest.php
+++ b/api/tests/Feature/PoolCandidateUpdateTest.php
@@ -13,6 +13,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 use function PHPUnit\Framework\assertEquals;
 
@@ -20,6 +21,7 @@ class PoolCandidateUpdateTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
+    use UsesProtectedGraphqlEndpoint;
     use WithFaker;
 
     protected $guestUser;

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -15,6 +15,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertSame;
@@ -24,6 +25,7 @@ class PoolTest extends TestCase
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $team;
 

--- a/api/tests/Feature/ProtectedRequestTest.php
+++ b/api/tests/Feature/ProtectedRequestTest.php
@@ -113,6 +113,8 @@ class ProtectedRequestTest extends TestCase
 
     public function testCanNotUsePrivilegedQueryUnprotected()
     {
+        $this->markTestSkipped('Enable to test the route protection logic.');
+
         // simulate a regular request context
         Config::set('lighthouse.route.name', 'graphql');
 

--- a/api/tests/Feature/ProtectedRequestTest.php
+++ b/api/tests/Feature/ProtectedRequestTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
+use Tests\TestCase;
+
+class ProtectedRequestTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+    use RefreshesSchemaCache;
+
+    protected $adminUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(RolePermissionSeeder::class);
+
+        $this->adminUser = User::factory()
+            ->asApplicant()
+            ->asAdmin()
+            ->create([
+                'email' => 'platform-admin-user@test.com',
+                'sub' => 'platform-admin-user@test.com',
+            ]);
+    }
+
+    public function testCanUseLimitedQueryUnprotected()
+    {
+        // simulate a regular request context
+        Config::set('lighthouse.route.name', 'graphql');
+
+        // a limited query can be used in an unprotected request
+        $this->actingAs($this->adminUser, 'api')->graphQL(
+            /** @lang GraphQL */
+            '
+                query skills {
+                    skills { id }
+                }
+            '
+        )->assertJsonStructure([
+            'data' => [
+                'skills',
+
+            ],
+        ]);
+    }
+
+    public function testCanUseLimitedQueryProtected()
+    {
+        // simulate a regular request context
+        Config::set('lighthouse.route.name', 'graphql-protected');
+
+        // a limited query can be used in an unprotected request
+        $this->actingAs($this->adminUser, 'api')->graphQL(
+            /** @lang GraphQL */
+            '
+                query skills {
+                    skills { id }
+                }
+            '
+        )->assertJsonStructure([
+            'data' => [
+                'skills' => [
+                    '*' => ['id'],
+                ],
+            ],
+        ]);
+    }
+
+    public function testCanUsePrivilegedQueryProtected()
+    {
+        // simulate a regular request context
+        Config::set('lighthouse.route.name', 'graphql-protected');
+
+        // a limited query can be used in an unprotected request
+        $this->actingAs($this->adminUser, 'api')->graphQL(
+            /** @lang GraphQL */
+            '
+                mutation createClassification($classification: CreateClassificationInput!) {
+                    createClassification(
+                      classification: $classification
+                    ) { id }
+                  }
+            ',
+            [
+                'classification' => [
+                    'group' => 'AA',
+                    'level' => 1,
+                    'maxSalary' => 100,
+                    'minSalary' => 1,
+                    'name' => [
+                        'en' => 'test en',
+                        'fr' => 'test fr',
+                    ],
+                ],
+            ]
+        )->assertJsonStructure([
+            'data' => [
+                'createClassification' => ['id'],
+            ],
+        ]);
+    }
+
+    public function testCanNotUsePrivilegedQueryUnprotected()
+    {
+        // simulate a regular request context
+        Config::set('lighthouse.route.name', 'graphql');
+
+        // a limited query can be used in an unprotected request
+        $this->actingAs($this->adminUser, 'api')->graphQL(
+            /** @lang GraphQL */
+            '
+                mutation createClassification($classification: CreateClassificationInput!) {
+                    createClassification(
+                      classification: $classification
+                    ) { id }
+                  }
+            ',
+            [
+                'classification' => [
+                    'group' => 'AA',
+                    'level' => 1,
+                    'maxSalary' => 100,
+                    'minSalary' => 1,
+                    'name' => [
+                        'en' => 'test en',
+                        'fr' => 'test fr',
+                    ],
+                ],
+            ]
+        )->assertJsonFragment([
+            'message' => 'This action is unauthorized.',
+        ]);
+
+    }
+}

--- a/api/tests/Feature/ProtectedRequestTest.php
+++ b/api/tests/Feature/ProtectedRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Feature;
 
 use App\Models\User;
 use Database\Seeders\RolePermissionSeeder;
@@ -137,9 +137,7 @@ class ProtectedRequestTest extends TestCase
                     ],
                 ],
             ]
-        )->assertJsonFragment([
-            'message' => 'This action is unauthorized.',
-        ]);
+        )->assertGraphQLErrorMessage('This action is unauthorized.');
 
     }
 }

--- a/api/tests/Feature/ProtectedRequestTest.php
+++ b/api/tests/Feature/ProtectedRequestTest.php
@@ -48,8 +48,9 @@ class ProtectedRequestTest extends TestCase
             '
         )->assertJsonStructure([
             'data' => [
-                'skills',
-
+                'skills' => [
+                    '*' => ['id'],
+                ],
             ],
         ]);
     }

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -8,10 +8,12 @@ use App\Models\User;
 use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Tests\UsesProtectedRequestContext;
 
 class RolePermissionTest extends TestCase
 {
     use RefreshDatabase;
+    use UsesProtectedRequestContext;
 
     private $user;
 

--- a/api/tests/Feature/ScreeningQuestionsTest.php
+++ b/api/tests/Feature/ScreeningQuestionsTest.php
@@ -12,12 +12,14 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class ScreeningQuestionsTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $team;
 

--- a/api/tests/Feature/SkillFamilyTest.php
+++ b/api/tests/Feature/SkillFamilyTest.php
@@ -10,12 +10,14 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class SkillFamilyTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
     use WithFaker;
 
     protected $baseUser;

--- a/api/tests/Feature/SkillTest.php
+++ b/api/tests/Feature/SkillTest.php
@@ -16,12 +16,14 @@ use Illuminate\Testing\Fluent\AssertableJson;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class SkillTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
     use WithFaker;
 
     protected $baseUser;

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -15,6 +15,7 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertNotNull;
@@ -26,6 +27,7 @@ class SnapshotTest extends TestCase
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
     use WithFaker;
 
     protected function setUp(): void

--- a/api/tests/Feature/TeamsTest.php
+++ b/api/tests/Feature/TeamsTest.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 use function PHPUnit\Framework\assertEquals;
 
@@ -17,6 +18,7 @@ class TeamsTest extends TestCase
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
     use WithFaker;
 
     protected $admin;

--- a/api/tests/Feature/UserRoleTest.php
+++ b/api/tests/Feature/UserRoleTest.php
@@ -8,12 +8,14 @@ use Illuminate\Testing\Fluent\AssertableJson;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class UserRoleTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $adminUser;
 

--- a/api/tests/Feature/UserSkillTest.php
+++ b/api/tests/Feature/UserSkillTest.php
@@ -14,6 +14,7 @@ use Illuminate\Testing\Fluent\AssertableJson;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 use function PHPUnit\Framework\assertNotNull;
 use function PHPUnit\Framework\assertNull;
@@ -23,6 +24,7 @@ class UserSkillTest extends TestCase
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     protected $user;
 

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -21,16 +21,19 @@ use App\Models\UserSkill;
 use App\Models\WorkExperience;
 use Database\Seeders\ClassificationSeeder;
 use Database\Seeders\GenericJobTitleSeeder;
+use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
 
 class UserTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;
     use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
 
     // protected $requestResponder;
     protected $platformAdmin;
@@ -46,8 +49,8 @@ class UserTest extends TestCase
         $this->platformAdmin = User::factory()
             ->asAdmin()
             ->create([
-                'email' => 'admin@test.com',
-                'sub' => 'admin@test.com',
+                'email' => 'platform-admin@test.com',
+                'sub' => 'platform-admin@test.com',
 
                 // The following properties make sure this user doesn't match certain test queries, skewing results.
                 'looking_for_english' => null,

--- a/api/tests/Unit/PoolCandidatePolicyTest.php
+++ b/api/tests/Unit/PoolCandidatePolicyTest.php
@@ -10,10 +10,12 @@ use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
+use Tests\UsesProtectedRequestContext;
 
 class PoolCandidatePolicyTest extends TestCase
 {
     use RefreshDatabase;
+    use UsesProtectedRequestContext;
     use WithFaker;
 
     protected $guestUser;

--- a/api/tests/Unit/PoolPolicyTest.php
+++ b/api/tests/Unit/PoolPolicyTest.php
@@ -9,10 +9,12 @@ use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
+use Tests\UsesProtectedRequestContext;
 
 class PoolPolicyTest extends TestCase
 {
     use RefreshDatabase;
+    use UsesProtectedRequestContext;
     use WithFaker;
 
     protected $guestUser;

--- a/api/tests/Unit/ProtectedRequestUserCheckerTest.php
+++ b/api/tests/Unit/ProtectedRequestUserCheckerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Checkers\ProtectedRequestUserChecker;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Request;
+use Tests\TestCase;
+
+use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertTrue;
+
+class ProtectedRequestUserCheckerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $adminUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(RolePermissionSeeder::class);
+
+        $this->adminUser = User::factory()
+            ->asApplicant()
+            ->asAdmin()
+            ->create([
+                'email' => 'platform-admin-user@test.com',
+                'sub' => 'platform-admin-user@test.com',
+            ]);
+    }
+
+    public function testCanUseLimitedPermissionUnprotected()
+    {
+        // simulate a regular request context
+        Request::merge(['isProtectedRequest' => null]);
+        $checker = new ProtectedRequestUserChecker($this->adminUser);
+
+        // a limited permission can be used in an unprotected request
+        $limitedPermission = 'view-any-skill';
+
+        assertTrue($checker->currentUserHasPermission($limitedPermission));
+    }
+
+    public function testCanUseLimitedPermissionProtected()
+    {
+        // simulate a protected request context
+        Request::merge(['isProtectedRequest' => true]);
+        $checker = new ProtectedRequestUserChecker($this->adminUser);
+
+        // a limited permission can be used in an protected request
+        $limitedPermission = 'view-any-skill';
+
+        assertTrue($checker->currentUserHasPermission($limitedPermission));
+    }
+
+    public function testCanUsePrivilegedPermissionProtected()
+    {
+        // simulate a protected request context
+        Request::merge(['isProtectedRequest' => true]);
+        $checker = new ProtectedRequestUserChecker($this->adminUser);
+
+        // a privileged permission can be used only in a protected request
+        $privilegedPermission = 'create-any-classification';
+
+        assertTrue($checker->currentUserHasPermission($privilegedPermission));
+    }
+
+    public function testCanNotUsePrivilegedPermissionUnprotected()
+    {
+        // simulate a protected request context
+        Request::merge(['isProtectedRequest' => null]);
+        $checker = new ProtectedRequestUserChecker($this->adminUser);
+
+        // a privileged permission can be used only in a protected request
+        $privilegedPermission = 'create-any-classification';
+
+        assertFalse($checker->currentUserHasPermission($privilegedPermission));
+    }
+
+    public function testCanNotUseUnknownPermissionUnprotected()
+    {
+        // simulate a protected request context
+        Request::merge(['isProtectedRequest' => null]);
+        $checker = new ProtectedRequestUserChecker($this->adminUser);
+
+        // an unknown permission can not be used in a protected request
+        $unknownPermission = 'not-a-real-permission';
+
+        assertFalse($checker->currentUserHasPermission($unknownPermission));
+    }
+}

--- a/api/tests/Unit/ProtectedRequestUserCheckerTest.php
+++ b/api/tests/Unit/ProtectedRequestUserCheckerTest.php
@@ -71,6 +71,8 @@ class ProtectedRequestUserCheckerTest extends TestCase
 
     public function testCanNotUsePrivilegedPermissionUnprotected()
     {
+        $this->markTestSkipped('Enable to test the route protection logic.');
+
         // simulate a protected request context
         Request::merge(['isProtectedRequest' => null]);
         $checker = new ProtectedRequestUserChecker($this->adminUser);

--- a/api/tests/Unit/ProtectedRequestUserCheckerTest.php
+++ b/api/tests/Unit/ProtectedRequestUserCheckerTest.php
@@ -73,7 +73,7 @@ class ProtectedRequestUserCheckerTest extends TestCase
     {
         $this->markTestSkipped('Enable to test the route protection logic.');
 
-        // simulate a protected request context
+        // simulate an unprotected request context
         Request::merge(['isProtectedRequest' => null]);
         $checker = new ProtectedRequestUserChecker($this->adminUser);
 
@@ -85,7 +85,7 @@ class ProtectedRequestUserCheckerTest extends TestCase
 
     public function testCanNotUseUnknownPermissionUnprotected()
     {
-        // simulate a protected request context
+        // simulate an unprotected request context
         Request::merge(['isProtectedRequest' => null]);
         $checker = new ProtectedRequestUserChecker($this->adminUser);
 

--- a/api/tests/Unit/UserPolicyTest.php
+++ b/api/tests/Unit/UserPolicyTest.php
@@ -10,10 +10,12 @@ use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
+use Tests\UsesProtectedRequestContext;
 
 class UserPolicyTest extends TestCase
 {
     use RefreshDatabase;
+    use UsesProtectedRequestContext;
     use WithFaker;
 
     protected $guest;

--- a/api/tests/UsesProtectedGraphqlEndpoint.php
+++ b/api/tests/UsesProtectedGraphqlEndpoint.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Support\Facades\Config;
+
+trait UsesProtectedGraphqlEndpoint
+{
+    protected function setUpUsesProtectedGraphqlEndpoint(): void
+    {
+        // simulate all tests using protected endpoint
+        Config::set('lighthouse.route.name', 'graphql-protected');
+    }
+}

--- a/api/tests/UsesProtectedRequestContext.php
+++ b/api/tests/UsesProtectedRequestContext.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Support\Facades\Request;
+
+trait UsesProtectedRequestContext
+{
+    protected function setUpUsesProtectedRequestContext(): void
+    {
+        // simulate all tests using protected request context
+        Request::merge(['isProtectedRequest' => true]);
+    }
+}

--- a/api/tests/UsesUnprotectedGraphqlEndpoint.php
+++ b/api/tests/UsesUnprotectedGraphqlEndpoint.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Support\Facades\Config;
+
+trait UsesUnprotectedGraphqlEndpoint
+{
+    protected function setUpUsesUnprotectedGraphqlEndpoint(): void
+    {
+        // simulate all tests using unprotected (regular) endpoint
+        Config::set('lighthouse.route.name', 'graphql');
+    }
+}

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -87,7 +87,14 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
     }
+    # graphql online web interface
     location = /graphiql {
+        fastcgi_pass 127.0.0.1:9000;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
+    }
+    # graphql online web interface - privileged access
+    location = /admin/graphiql {
         fastcgi_pass 127.0.0.1:9000;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -81,6 +81,12 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
     }
+    # privileged access to the API behind the VPN
+    location = /admin/graphql {
+        fastcgi_pass 127.0.0.1:9000;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
+    }
     location = /graphiql {
         fastcgi_pass 127.0.0.1:9000;
         include fastcgi_params;

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -120,7 +120,14 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root/api/public/index.php;
     }
+    # graphql online web interface
     location = /graphiql {
+        fastcgi_pass 127.0.0.1:9000;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root/api/public/index.php;
+    }
+    # graphql online web interface - privileged access
+    location = /admin/graphiql {
         fastcgi_pass 127.0.0.1:9000;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root/api/public/index.php;

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -113,6 +113,13 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root/api/public/index.php;
     }
+    # privileged access to the API behind the VPN
+    location = /admin/graphql {
+        access_log off;
+        fastcgi_pass 127.0.0.1:9000;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root/api/public/index.php;
+    }
     location = /graphiql {
         fastcgi_pass 127.0.0.1:9000;
         include fastcgi_params;


### PR DESCRIPTION
> [!Warning] 
The core functionality of this PR requires a manual change to test breaking features.  Manually back out the changes of [disable breaking changes](https://github.com/GCTC-NTGC/gc-digital-talent/pull/10030/commits/8972a29259957da7c73f199ed888241e7f345f4b) to properly test the API changes.

🤖 Related to (but does not close) #9866

## 👋 Introduction

This branch adds a second route to getting to the graphql API and enforces using it for any operation requiring privileged permissions.  

## 🕵️ Details

It works by using custom routing for lighthouse to accept two different routes.  A middleware adds a request variable when it detects that the protected route is used.  And finally, a custom user checker ensures that Laratrust only allows the permission when the request variable is detected.

The `MakesGraphQLRequests` trait is unable to properly work when custom routing is enabled for lighthouse, like this PR uses.  The vast majority of the file diffs in this PR are just adding a trait to set which route to use in every test.

## 🧪 Testing

### Maintain Existing Functionality

- [ ] Building and running this branch "as-is" maintains current functionality without breaking anything.

### Add New Functionality

1. Back out the changes of [disable breaking changes](https://github.com/GCTC-NTGC/gc-digital-talent/pull/10030/commits/8972a29259957da7c73f199ed888241e7f345f4b) to add new, breaking, functionality.
 
> [!TIP] 
Graphiql will only run on the regular, unprotected route.  To test the protected route you will have to use a different client like Altair, Postman, Edit&Resend, etc.

For the purpose of this PR: 
- a limited permission is one available to the base, guest, or applicant roles
- a privileged permission is one not available to the base, guest, or applicant roles
- the unprotected route is /graphql
- the protected route is /admin/graphql

- [ ] Any operation requiring a limited permissions only will succeed on either route
- [ ] Any operation requiring a privileged permission will fail on the uprotected route
- [ ] Any operation requiring a privileged permission can succeed on the protected route
- [ ] PHPUnit tests pass