### PR TITLE
[Fix] Notification dialog null spacing

### DIFF
--- a/apps/web/src/components/NotificationList/NotificationListPage.tsx
+++ b/apps/web/src/components/NotificationList/NotificationListPage.tsx
@@ -98,7 +98,11 @@ const NotificationListPage = ({
       {fetching && exclude.length === 0 && <Loading inline />}
       {showNullMessage && (
         <NotificationPortal.Portal containerId={NULL_MESSAGE_ROOT_ID}>
-          <Well>
+          <Well
+            {...(inDialog && {
+              "data-h2-margin": "base(0 x1)",
+            })}
+          >
             <p data-h2-font-weight="base(700)" data-h2-margin-bottom="base(x1)">
               {intl.formatMessage({
                 defaultMessage: "There aren't any notifications here.",


### PR DESCRIPTION
🤖 Resolves #9961 

## 👋 Introduction

Adds the appropriate spacing to the notification dialog null message when in the dialog.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `pnpm run dev`
2. Open the notification dialog
3. Confirm the null message lines up with the other content

## 📸 Screenshot

![screenshot_11-Apr-2024_13-09-1712855377](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/2faca0b1-97f9-4a57-90b7-472eeb7cfdca)
