### PR TITLE
[Bug] Missing eager load of classification

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -581,6 +581,7 @@ class PoolCandidate extends Model
             'workExperiences.skills',
             'poolCandidates',
             'poolCandidates.pool',
+            'poolCandidates.pool.classification',
             'poolCandidates.educationRequirementAwardExperiences.skills',
             'poolCandidates.educationRequirementCommunityExperiences.skills',
             'poolCandidates.educationRequirementEducationExperiences.skills',


### PR DESCRIPTION
🤖 Resolves #9974 

## 👋 Introduction

Resolve the lazy load instance. Turns out it was missing an eager in the snapshot process

## 🧪 Testing

1. Migrate and seed fresh
2. Run below command

`php artisan db:seed --class=UserRandomSeeder` 

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/ea6d574e-e57d-4290-bdec-7336b2f4fbb6)
