### PR TITLE
[Tooling] Adds Chromatic modes including French for Digital Talent, IAP home pages

### DIFF
--- a/apps/web/src/pages/Home/HomePage/HomePage.stories.tsx
+++ b/apps/web/src/pages/Home/HomePage/HomePage.stories.tsx
@@ -23,3 +23,9 @@ Default.parameters = {
     },
   },
 };
+
+export const French = Template.bind({});
+French.parameters = {
+  layout: "fullscreen",
+  locale: "fr",
+};

--- a/apps/web/src/pages/Home/HomePage/HomePage.stories.tsx
+++ b/apps/web/src/pages/Home/HomePage/HomePage.stories.tsx
@@ -20,12 +20,7 @@ Default.parameters = {
       light: allModes.light,
       "light mobile": allModes["light mobile"],
       dark: allModes.dark,
+      french: allModes.french,
     },
   },
-};
-
-export const French = Template.bind({});
-French.parameters = {
-  layout: "fullscreen",
-  locale: "fr",
 };

--- a/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
@@ -72,6 +72,9 @@ Default.parameters = {
 
 export const French = Template.bind({});
 French.parameters = {
+  themes: {
+    themeOverride: THEMES.iap.light,
+  },
   locale: "fr",
 };
 

--- a/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
@@ -51,7 +51,9 @@ export default {
     layout: "fullscreen",
     chromatic: {
       modes: {
-        mobile: allModes.mobile,
+        light: allModes["light iap desktop"],
+        "light mobile": allModes["light mobile"],
+        dark: allModes["dark iap mobile"],
       },
     },
   },
@@ -76,11 +78,4 @@ French.parameters = {
     themeOverride: THEMES.iap.light,
   },
   locale: "fr",
-};
-
-export const Dark = Template.bind({});
-Dark.parameters = {
-  themes: {
-    themeOverride: THEMES.iap.dark,
-  },
 };

--- a/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
@@ -76,6 +76,7 @@ French.parameters = {
     themeOverride: THEMES.iap.light,
   },
   locale: "fr",
+  chromatic: { delay: 2000 },
 };
 
 export const Dark = Template.bind({});

--- a/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
@@ -76,7 +76,7 @@ French.parameters = {
     themeOverride: THEMES.iap.light,
   },
   locale: "fr",
-  chromatic: { delay: 2000 },
+  chromatic: { delay: 10000 },
 };
 
 export const Dark = Template.bind({});

--- a/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
@@ -54,6 +54,7 @@ export default {
         light: allModes["light iap desktop"],
         "light mobile": allModes["light mobile"],
         dark: allModes["dark iap mobile"],
+        french: allModes["iap french"],
       },
     },
   },
@@ -70,12 +71,4 @@ Default.parameters = {
   themes: {
     themeOverride: THEMES.iap.light,
   },
-};
-
-export const French = Template.bind({});
-French.parameters = {
-  themes: {
-    themeOverride: THEMES.iap.light,
-  },
-  locale: "fr",
 };

--- a/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
@@ -53,7 +53,7 @@ export default {
       modes: {
         light: allModes["light iap desktop"],
         "light mobile": allModes["light mobile"],
-        dark: allModes["dark iap mobile"],
+        dark: allModes["dark iap desktop"],
         french: allModes["iap french"],
       },
     },

--- a/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
@@ -72,11 +72,7 @@ Default.parameters = {
 
 export const French = Template.bind({});
 French.parameters = {
-  themes: {
-    themeOverride: THEMES.iap.light,
-  },
   locale: "fr",
-  chromatic: { delay: 10000 },
 };
 
 export const Dark = Template.bind({});

--- a/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
@@ -50,7 +50,7 @@ export default {
     },
     layout: "fullscreen",
     chromatic: {
-      mode: {
+      modes: {
         mobile: allModes.mobile,
       },
     },

--- a/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
+++ b/apps/web/src/pages/Home/IAPHomePage/Home.stories.tsx
@@ -70,6 +70,14 @@ Default.parameters = {
   },
 };
 
+export const French = Template.bind({});
+French.parameters = {
+  themes: {
+    themeOverride: THEMES.iap.light,
+  },
+  locale: "fr",
+};
+
 export const Dark = Template.bind({});
 Dark.parameters = {
   themes: {

--- a/packages/storybook-helpers/modes.ts
+++ b/packages/storybook-helpers/modes.ts
@@ -54,6 +54,13 @@ const allModes = {
     theme: THEMES.iap.light,
     viewport: DIMENSIONS.phone.width,
   },
+  french: {
+    locale: "fr",
+  },
+  "iap french": {
+    locale: "fr",
+    theme: THEMES.iap.light,
+  },
 };
 
 export default allModes;

--- a/packages/storybook-helpers/modes.ts
+++ b/packages/storybook-helpers/modes.ts
@@ -51,7 +51,7 @@ const allModes = {
     viewport: DIMENSIONS.phone.width,
   },
   "dark iap mobile": {
-    theme: THEMES.iap.light,
+    theme: THEMES.iap.dark,
     viewport: DIMENSIONS.phone.width,
   },
   french: {


### PR DESCRIPTION
🤖 Resolves #4371.

## 👋 Introduction

This PR adds French Chromatic modes for Digital Talent, IAP home pages.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm storybook:web`
2. Open Chromatic for this branch
3. Observe snapshots variants for **Pages/Home Page/IAP** and **Pages/Home Page/Digital Talent**