### PR TITLE
[Fix] Adjust document question headings

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/poolCandidateCsv.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/poolCandidateCsv.tsx
@@ -220,17 +220,16 @@ export const getPoolCandidateCsvHeaders = (
   const generalQuestionHeaders = pool?.generalQuestions
     ? pool.generalQuestions.filter(notEmpty).map((generalQuestion, index) => ({
         id: generalQuestion.id,
-        displayName: intl.formatMessage(
+        displayName: `${intl.formatMessage(
           {
-            defaultMessage: "General question {index}: {question}",
-            id: "0UUjDn",
+            defaultMessage: "General question {index}",
+            id: "EWvBgF",
             description: "CSV Header, general question column. ",
           },
           {
             index: generalQuestion.sortOrder || index + 1,
-            question: getLocalizedName(generalQuestion.question, intl),
           },
-        ),
+        )}${intl.formatMessage(commonMessages.dividingColon)}${getLocalizedName(generalQuestion.question, intl)}`,
       }))
     : [];
 

--- a/apps/web/src/components/PoolCandidatesTable/poolCandidateCsv.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/poolCandidateCsv.tsx
@@ -222,9 +222,9 @@ export const getPoolCandidateCsvHeaders = (
         id: generalQuestion.id,
         displayName: intl.formatMessage(
           {
-            defaultMessage: "Screening question {index}: {question}",
-            id: "5nlauT",
-            description: "CSV Header, Screening question column. ",
+            defaultMessage: "General question {index}: {question}",
+            id: "0UUjDn",
+            description: "CSV Header, general question column. ",
           },
           {
             index: generalQuestion.sortOrder || index + 1,

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1383,10 +1383,6 @@
     "defaultMessage": "Quelle application d'authentification devrais-je installer?",
     "description": "GCKey question for which authenticator app to use"
   },
-  "5nlauT": {
-    "defaultMessage": "Question filtre {index} : {question}",
-    "description": "CSV Header, Screening question column. "
-  },
   "5pQfyv": {
     "defaultMessage": "Postes en français",
     "description": "Message for the french positions option"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2867,6 +2867,10 @@
     "defaultMessage": "Modifier les principales compétences comportementales",
     "description": "Link text for editing a users top behavioural skills"
   },
+  "EWvBgF": {
+    "defaultMessage": "Questions générales {index}",
+    "description": "CSV Header, general question column. "
+  },
   "EYPaLh": {
     "defaultMessage": "Vous avez obtenu un diplôme à l’extérieur du Canada? <foreignDegreeLink>Apprenez-en davantage sur les équivalences pour les diplômes étrangers.</foreignDegreeLink>",
     "description": "External link message for the EX graduation with degree requirement."

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationPrintButton/ApplicationPrintDocument.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationPrintButton/ApplicationPrintDocument.tsx
@@ -301,7 +301,7 @@ const ApplicationPrintDocument = React.forwardRef<
                 </BreakingPageSection>
                 <PageSection>
                   <Heading level="h3" data-h2-font-weight="base(700)">
-                    {intl.formatMessage(processMessages.screeningQuestions)}
+                    {intl.formatMessage(processMessages.generalQuestions)}
                   </Heading>
                   <ul>
                     {relevantPoolCandidate.generalQuestionResponses?.map(


### PR DESCRIPTION
🤖 Resolves #9997 

## 👋 Introduction

Updates the headings for questions on pool candidate documents to be appropriately labelled based on the date displayed.

## 🕵️ Details

I think I did this correctly based on the discussion in stand up :sweat_smile: . Anyway, feel free to nitpick here so we get this right.

## 🧪 Testing

1. Build `pnpm run dev`
2. Login as admin `admin@test.com`
3. Navigate to a pool candidate
4. Select the "Print application" option
5. Confirm the section for questions has the appropriate heading (General questions)
6. Navigate to a pool "Talent placement" tab
7. Download CSV for candidates
8. Confirm the question columns are labelled as "General question: X"

## 📸 Screenshot

![screenshot_12-Apr-2024_12-27-1712939241](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/51327001-a269-4553-bde3-0c1b65a4a094)

