### PR TITLE
[Fix] Theme decorator setting theme too often

### DIFF
--- a/packages/storybook-helpers/decorators/ThemeDecorator.tsx
+++ b/packages/storybook-helpers/decorators/ThemeDecorator.tsx
@@ -1,6 +1,6 @@
 import { DecoratorHelpers } from "@storybook/addon-themes";
 import type { DecoratorFunction, Renderer } from "@storybook/types";
-import React from "react";
+import React, { useEffect, useMemo } from "react";
 
 import {
   Theme,
@@ -34,12 +34,15 @@ type ThemeSetterProps = {
 };
 const ThemeSetter = ({ theme }: ThemeSetterProps) => {
   const { setTheme, key, mode } = useTheme();
-  if (theme.key !== key || theme.mode !== mode) {
-    setTheme({
-      key: theme.key,
-      mode: theme.mode,
-    });
-  }
+
+  useEffect(() => {
+    if (theme.key !== key || theme.mode !== mode) {
+      setTheme({
+        key: theme.key,
+        mode: theme.mode,
+      });
+    }
+  }, [key, mode, setTheme, theme.key, theme.mode]);
   return null;
 };
 
@@ -55,10 +58,14 @@ const withThemeFromHydrogen = <TRenderer extends Renderer = any>({
     const { themeOverride } = useThemeParameters();
     const selected = themeOverride || selectedTheme || defaultTheme;
 
-    const themeArr = themes[selected].split(" ") as [
-      ThemeKey | undefined,
-      ThemeMode | undefined,
-    ];
+    const themeArr = useMemo(
+      () =>
+        themes[selected].split(" ") as [
+          ThemeKey | undefined,
+          ThemeMode | undefined,
+        ],
+      [selected],
+    );
 
     return (
       <ThemeProvider>


### PR DESCRIPTION
## 👋 Introduction

Fixes an issue where the theme was trying to update too often in storybook causing an error.

## 🕵️ Details

Recently we removed the `useEffect` to prevent infinite re-renders but apparently it was needed. This merges the two concepts along with a memo to help avoid infinite re-renders and stabilize things a bit.

## 🧪 Testing

1. Run storybook `pnpm run storybook`
2. Bounce around stories
3. Open the javasript console
4. Confirm no errors related to the `ThemeDecorator` or `ThemeSetter` components

