### PR TITLE
[Fix] Can Delete A Draft Pool

### DIFF
--- a/api/database/migrations/2024_04_15_192939_cascase_pool_delete.php
+++ b/api/database/migrations/2024_04_15_192939_cascase_pool_delete.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('screening_questions', function (Blueprint $table) {
+            // drop and recreate the index with cascade on delete
+            $table->dropForeign('screening_questions_pool_id_foreign');
+            $table->foreign('pool_id')->references('id')->on('pools')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('screening_questions', function (Blueprint $table) {
+            // drop and recreate the index without cascade on delete
+            $table->dropForeign('screening_questions_pool_id_foreign');
+            $table->foreign('pool_id')->references('id')->on('pools');
+        });
+    }
+};

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -891,4 +891,29 @@ class PoolTest extends TestCase
         )
             ->assertJsonFragment(['id' => $completePool->id]);
     }
+
+    // a pool operator can successfully delete a pool that they created but is still in draft
+    public function testCanDeleteDraftPool(): void
+    {
+        $pool = Pool::factory()
+            ->for($this->poolOperator)
+            ->withAssessments()
+            ->draft()
+            ->create([
+                'team_id' => $this->team,
+            ]);
+
+        $this->actingAs($this->poolOperator, 'api')->graphQL(
+            /** @lang GraphQL */
+            '   mutation DeletePool($id: ID!) {
+                    deletePool(id: $id) { id }
+                } ',
+            ['id' => $pool->id]
+        )
+            ->assertExactJson([
+                'data' => [
+                    'deletePool' => ['id' => $pool->id],
+                ],
+            ]);
+    }
 }


### PR DESCRIPTION
🤖 Resolves #10053 

## 👋 Introduction

This branch add "cascade on delete" to the `screening_questions` to `pools` foreign key.  It also adds a test to confirm the fix and prevent regression.

## 🧪 Testing

1. Migration can go up and down.
2. Tests pass.
3. Can delete a draft pool with screening questions in the admin site.