### PR TITLE
[Feature] qualify/disqualify/revert a candidate mutations

### DIFF
--- a/api/app/Enums/DisqualificationReason.php
+++ b/api/app/Enums/DisqualificationReason.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum DisqualificationReason
+{
+    case SCREENED_OUT_APPLICATION;
+    case SCREENED_OUT_ASSESSMENT;
+}

--- a/api/app/GraphQL/Mutations/DisqualifyCandidate.php
+++ b/api/app/GraphQL/Mutations/DisqualifyCandidate.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use App\Models\PoolCandidate;
+use Carbon\Carbon;
+
+final class DisqualifyCandidate
+{
+    /**
+     * Disqualify operation for a candidate
+     *
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $candidate = PoolCandidate::find($args['id']);
+        $reason = $args['reason'];
+        $now = Carbon::now();
+
+        $candidate->pool_candidate_status = $reason;
+        $candidate->final_decision_at = $now;
+        $candidate->save();
+
+        return $candidate;
+    }
+}

--- a/api/app/GraphQL/Mutations/DisqualifyCandidate.php
+++ b/api/app/GraphQL/Mutations/DisqualifyCandidate.php
@@ -14,7 +14,7 @@ final class DisqualifyCandidate
      */
     public function __invoke($_, array $args)
     {
-        $candidate = PoolCandidate::find($args['id']);
+        $candidate = PoolCandidate::findOrFail($args['id']);
         $reason = $args['reason'];
         $now = Carbon::now();
 

--- a/api/app/GraphQL/Mutations/PlaceCandidate.php
+++ b/api/app/GraphQL/Mutations/PlaceCandidate.php
@@ -14,7 +14,7 @@ final class PlaceCandidate
      */
     public function __invoke($_, array $args)
     {
-        $candidate = PoolCandidate::find($args['id']);
+        $candidate = PoolCandidate::findOrFail($args['id']);
         $placementType = $args['placementType'];
         $now = Carbon::now();
         $departmentId = $args['departmentId'];

--- a/api/app/GraphQL/Mutations/QualifyCandidate.php
+++ b/api/app/GraphQL/Mutations/QualifyCandidate.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use App\Enums\PoolCandidateStatus;
+use App\Models\PoolCandidate;
+use Carbon\Carbon;
+
+final class QualifyCandidate
+{
+    /**
+     * Qualify operation for a candidate
+     *
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $candidate = PoolCandidate::find($args['id']);
+        $expiryDate = $args['expiryDate'];
+        $now = Carbon::now();
+
+        $candidate->pool_candidate_status = PoolCandidateStatus::QUALIFIED_AVAILABLE->name;
+        $candidate->expiry_date = $expiryDate;
+        $candidate->final_decision_at = $now;
+        $candidate->save();
+
+        return $candidate;
+    }
+}

--- a/api/app/GraphQL/Mutations/QualifyCandidate.php
+++ b/api/app/GraphQL/Mutations/QualifyCandidate.php
@@ -15,7 +15,7 @@ final class QualifyCandidate
      */
     public function __invoke($_, array $args)
     {
-        $candidate = PoolCandidate::find($args['id']);
+        $candidate = PoolCandidate::findOrFail($args['id']);
         $expiryDate = $args['expiryDate'];
         $now = Carbon::now();
 

--- a/api/app/GraphQL/Mutations/RevertFinalDecision.php
+++ b/api/app/GraphQL/Mutations/RevertFinalDecision.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use App\Enums\PoolCandidateStatus;
+use App\Models\PoolCandidate;
+
+final class RevertFinalDecision
+{
+    /**
+     * Reverting the qualify or disqualify candidate operations
+     *
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $candidate = PoolCandidate::find($args['id']);
+
+        $candidate->pool_candidate_status = PoolCandidateStatus::UNDER_ASSESSMENT->name;
+        $candidate->expiry_date = null;
+        $candidate->final_decision_at = null;
+        $candidate->save();
+
+        return $candidate;
+    }
+}

--- a/api/app/GraphQL/Mutations/RevertFinalDecision.php
+++ b/api/app/GraphQL/Mutations/RevertFinalDecision.php
@@ -14,7 +14,7 @@ final class RevertFinalDecision
      */
     public function __invoke($_, array $args)
     {
-        $candidate = PoolCandidate::find($args['id']);
+        $candidate = PoolCandidate::findOrFail($args['id']);
 
         $candidate->pool_candidate_status = PoolCandidateStatus::UNDER_ASSESSMENT->name;
         $candidate->expiry_date = null;

--- a/api/app/GraphQL/Mutations/RevertPlaceCandidate.php
+++ b/api/app/GraphQL/Mutations/RevertPlaceCandidate.php
@@ -14,7 +14,7 @@ final class RevertPlaceCandidate
      */
     public function __invoke($_, array $args)
     {
-        $candidate = PoolCandidate::find($args['id']);
+        $candidate = PoolCandidate::findOrFail($args['id']);
 
         $candidate->pool_candidate_status = PoolCandidateStatus::QUALIFIED_AVAILABLE->name;
         $candidate->placed_at = null;

--- a/api/app/GraphQL/Validators/DisqualifyCandidateValidator.php
+++ b/api/app/GraphQL/Validators/DisqualifyCandidateValidator.php
@@ -20,7 +20,7 @@ final class DisqualifyCandidateValidator extends Validator
     public function rules(): array
     {
         $id = $this->arg('id');
-        $candidate = PoolCandidate::find($id);
+        $candidate = PoolCandidate::findOrFail($id);
         $statusesArray = [
             PoolCandidateStatus::NEW_APPLICATION->name,
             PoolCandidateStatus::APPLICATION_REVIEW->name,

--- a/api/app/GraphQL/Validators/DisqualifyCandidateValidator.php
+++ b/api/app/GraphQL/Validators/DisqualifyCandidateValidator.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Validators;
+
+use App\Enums\PoolCandidateStatus;
+use App\Models\PoolCandidate;
+use Database\Helpers\ApiErrorEnums;
+use Nuwave\Lighthouse\Exceptions\ValidationException;
+use Nuwave\Lighthouse\Validation\Validator;
+
+final class DisqualifyCandidateValidator extends Validator
+{
+    /**
+     * Return the validation rules.
+     *
+     * @return array<string, array<mixed>>
+     */
+    public function rules(): array
+    {
+        $id = $this->arg('id');
+        $candidate = PoolCandidate::find($id);
+        $statusesArray = [
+            PoolCandidateStatus::NEW_APPLICATION->name,
+            PoolCandidateStatus::APPLICATION_REVIEW->name,
+            PoolCandidateStatus::SCREENED_IN->name,
+            PoolCandidateStatus::UNDER_ASSESSMENT->name,
+        ];
+
+        if (! (in_array($candidate->pool_candidate_status, $statusesArray))) {
+            throw ValidationException::withMessages([ApiErrorEnums::INVALID_STATUS_DISQUALIFICATION]);
+        }
+
+        return [];
+    }
+
+    public function messages(): array
+    {
+        return [];
+    }
+}

--- a/api/app/GraphQL/Validators/PlaceCandidateValidator.php
+++ b/api/app/GraphQL/Validators/PlaceCandidateValidator.php
@@ -22,7 +22,7 @@ final class PlaceCandidateValidator extends Validator
     public function rules(): array
     {
         $id = $this->arg('id');
-        $candidate = PoolCandidate::find($id);
+        $candidate = PoolCandidate::findOrFail($id);
         $placedStatuses = array_column(PlacementType::cases(), 'name');
         $statusesArray = [...$placedStatuses, PoolCandidateStatus::QUALIFIED_AVAILABLE->name];
 

--- a/api/app/GraphQL/Validators/QualifyCandidateValidator.php
+++ b/api/app/GraphQL/Validators/QualifyCandidateValidator.php
@@ -21,7 +21,7 @@ final class QualifyCandidateValidator extends Validator
     public function rules(): array
     {
         $id = $this->arg('id');
-        $candidate = PoolCandidate::find($id);
+        $candidate = PoolCandidate::findOrFail($id);
         $endOfDay = Carbon::now()->endOfDay();
 
         $statusesArray = [

--- a/api/app/GraphQL/Validators/QualifyCandidateValidator.php
+++ b/api/app/GraphQL/Validators/QualifyCandidateValidator.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Validators;
+
+use App\Enums\PoolCandidateStatus;
+use App\Models\PoolCandidate;
+use Carbon\Carbon;
+use Database\Helpers\ApiErrorEnums;
+use Nuwave\Lighthouse\Exceptions\ValidationException;
+use Nuwave\Lighthouse\Validation\Validator;
+
+final class QualifyCandidateValidator extends Validator
+{
+    /**
+     * Return the validation rules.
+     *
+     * @return array<string, array<mixed>>
+     */
+    public function rules(): array
+    {
+        $id = $this->arg('id');
+        $candidate = PoolCandidate::find($id);
+        $endOfDay = Carbon::now()->endOfDay();
+
+        $statusesArray = [
+            PoolCandidateStatus::NEW_APPLICATION->name,
+            PoolCandidateStatus::APPLICATION_REVIEW->name,
+            PoolCandidateStatus::SCREENED_IN->name,
+            PoolCandidateStatus::UNDER_ASSESSMENT->name,
+        ];
+
+        if (! (in_array($candidate->pool_candidate_status, $statusesArray))) {
+            throw ValidationException::withMessages([ApiErrorEnums::INVALID_STATUS_QUALIFICATION]);
+        }
+
+        return [
+            'expiryDate' => ['required', 'after:'.$endOfDay],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'expiryDate.required' => ApiErrorEnums::EXPIRY_DATE_REQUIRED,
+            'expiryDate.after' => ApiErrorEnums::EXPIRY_DATE_AFTER_TODAY,
+        ];
+    }
+}

--- a/api/app/GraphQL/Validators/RevertFinalDecisionValidator.php
+++ b/api/app/GraphQL/Validators/RevertFinalDecisionValidator.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Validators;
+
+use App\Enums\PoolCandidateStatus;
+use App\Models\PoolCandidate;
+use Database\Helpers\ApiErrorEnums;
+use Nuwave\Lighthouse\Exceptions\ValidationException;
+use Nuwave\Lighthouse\Validation\Validator;
+
+final class RevertFinalDecisionValidator extends Validator
+{
+    /**
+     * Return the validation rules.
+     *
+     * @return array<string, array<mixed>>
+     */
+    public function rules(): array
+    {
+        $id = $this->arg('id');
+        $candidate = PoolCandidate::find($id);
+
+        $statusesArray = [
+            PoolCandidateStatus::SCREENED_OUT_APPLICATION->name,
+            PoolCandidateStatus::SCREENED_OUT_ASSESSMENT->name,
+            PoolCandidateStatus::QUALIFIED_AVAILABLE->name,
+            PoolCandidateStatus::EXPIRED->name,
+        ];
+
+        if (! (in_array($candidate->pool_candidate_status, $statusesArray))) {
+            throw ValidationException::withMessages([ApiErrorEnums::INVALID_STATUS_REVERT_FINAL_DECISION]);
+        }
+
+        return [];
+    }
+
+    public function messages(): array
+    {
+        return [];
+    }
+}

--- a/api/app/GraphQL/Validators/RevertFinalDecisionValidator.php
+++ b/api/app/GraphQL/Validators/RevertFinalDecisionValidator.php
@@ -20,7 +20,7 @@ final class RevertFinalDecisionValidator extends Validator
     public function rules(): array
     {
         $id = $this->arg('id');
-        $candidate = PoolCandidate::find($id);
+        $candidate = PoolCandidate::findOrFail($id);
 
         $statusesArray = [
             PoolCandidateStatus::SCREENED_OUT_APPLICATION->name,

--- a/api/app/GraphQL/Validators/RevertPlaceCandidateValidator.php
+++ b/api/app/GraphQL/Validators/RevertPlaceCandidateValidator.php
@@ -20,7 +20,7 @@ final class RevertPlaceCandidateValidator extends Validator
     public function rules(): array
     {
         $id = $this->arg('id');
-        $candidate = PoolCandidate::find($id);
+        $candidate = PoolCandidate::findOrFail($id);
         $placedStatuses = array_column(PlacementType::cases(), 'name');
 
         if (! (in_array($candidate->pool_candidate_status, $placedStatuses))) {

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -44,6 +44,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property bool $is_bookmarked
  * @property Illuminate\Support\Carbon $placed_at
  * @property string $placed_department_id
+ * @property Illuminate\Support\Carbon $final_decision_at
  */
 class PoolCandidate extends Model
 {
@@ -67,6 +68,7 @@ class PoolCandidate extends Model
         'submitted_steps' => 'array',
         'is_bookmarked' => 'boolean',
         'placed_at' => 'datetime',
+        'final_decision_at' => 'datetime',
     ];
 
     /**

--- a/api/app/Providers/GraphQLServiceProvider.php
+++ b/api/app/Providers/GraphQLServiceProvider.php
@@ -35,6 +35,7 @@ use App\Enums\DirectiveForms\PersonnelWorkLocation;
 use App\Enums\DirectiveForms\PositionEmploymentType;
 use App\Enums\DirectiveForms\YesNo;
 use App\Enums\DirectiveForms\YesNoUnsure;
+use App\Enums\DisqualificationReason;
 use App\Enums\EducationRequirementOption;
 use App\Enums\EducationStatus;
 use App\Enums\EducationType;
@@ -184,6 +185,15 @@ class GraphQLServiceProvider extends ServiceProvider
                 return new EnumType([
                     'name' => 'PoolStatus',
                     'values' => array_column(PoolStatus::cases(), 'name'),
+                ]);
+            }
+        );
+        $typeRegistry->registerLazy(
+            'DisqualificationReason',
+            static function (): EnumType {
+                return new EnumType([
+                    'name' => 'DisqualificationReason',
+                    'values' => array_column(DisqualificationReason::cases(), 'name'),
                 ]);
             }
         );

--- a/api/database/factories/PoolCandidateFactory.php
+++ b/api/database/factories/PoolCandidateFactory.php
@@ -75,6 +75,23 @@ class PoolCandidateFactory extends Factory
                 ]);
             }
 
+            // set value for final decision at field if applicable
+            $relevantStatusesForFinalDecision = [
+                PoolCandidateStatus::QUALIFIED_AVAILABLE->name,
+                PoolCandidateStatus::QUALIFIED_UNAVAILABLE->name,
+                PoolCandidateStatus::QUALIFIED_WITHDREW->name,
+                PoolCandidateStatus::PLACED_CASUAL->name,
+                PoolCandidateStatus::PLACED_TERM->name,
+                PoolCandidateStatus::PLACED_INDETERMINATE->name,
+                PoolCandidateStatus::EXPIRED->name,
+                PoolCandidateStatus::SCREENED_OUT_APPLICATION->name,
+                PoolCandidateStatus::SCREENED_OUT_ASSESSMENT->name,
+            ];
+            if (in_array($candidateStatus, $relevantStatusesForFinalDecision)) {
+                $poolCandidate->final_decision_at = $this->faker->dateTimeBetween('-4 weeks', '-2 weeks');
+                $poolCandidate->save();
+            }
+
             // placed status sets placed at and placed department fields
             $placedStatuses = PoolCandidateStatus::placedGroup();
             if (in_array($candidateStatus, $placedStatuses)) {

--- a/api/database/helpers/ApiErrorEnums.php
+++ b/api/database/helpers/ApiErrorEnums.php
@@ -35,6 +35,8 @@ class ApiErrorEnums
 
     const INVALID_STATUS_DISQUALIFICATION = 'InvalidStatusForDisqualification';
 
+    const INVALID_STATUS_REVERT_FINAL_DECISION = 'InvalidStatusForRevertFinalDecision';
+
     const INVALID_STATUS_PLACING = 'InvalidStatusForPlacing';
 
     const CANDIDATE_NOT_PLACED = 'CandidateNotPlaced';

--- a/api/database/helpers/ApiErrorEnums.php
+++ b/api/database/helpers/ApiErrorEnums.php
@@ -25,7 +25,14 @@ class ApiErrorEnums
 
     const PROCESS_CLOSING_DATE_EXTEND = 'UpdatePoolClosingDateExtend';
 
+    // pool candidate field validation
+    const EXPIRY_DATE_REQUIRED = 'ExpiryDateRequired';
+
+    const EXPIRY_DATE_AFTER_TODAY = 'ExpiryDateAfterToday';
+
     // ROD status mutation messages
+    const INVALID_STATUS_QUALIFICATION = 'InvalidStatusForQualification';
+
     const INVALID_STATUS_DISQUALIFICATION = 'InvalidStatusForDisqualification';
 
     const INVALID_STATUS_PLACING = 'InvalidStatusForPlacing';

--- a/api/database/helpers/ApiErrorEnums.php
+++ b/api/database/helpers/ApiErrorEnums.php
@@ -26,6 +26,8 @@ class ApiErrorEnums
     const PROCESS_CLOSING_DATE_EXTEND = 'UpdatePoolClosingDateExtend';
 
     // ROD status mutation messages
+    const INVALID_STATUS_DISQUALIFICATION = 'InvalidStatusForDisqualification';
+
     const INVALID_STATUS_PLACING = 'InvalidStatusForPlacing';
 
     const CANDIDATE_NOT_PLACED = 'CandidateNotPlaced';

--- a/api/database/migrations/2024_04_15_194823_add_final_decision_at_field.php
+++ b/api/database/migrations/2024_04_15_194823_add_final_decision_at_field.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Enums\PoolCandidateStatus;
+use Carbon\Carbon;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pool_candidates', function (Blueprint $table) {
+            $table->dateTime('final_decision_at')->nullable();
+        });
+
+        $relevantStatuses = [
+            PoolCandidateStatus::QUALIFIED_AVAILABLE->name,
+            PoolCandidateStatus::QUALIFIED_UNAVAILABLE->name,
+            PoolCandidateStatus::QUALIFIED_WITHDREW->name,
+            PoolCandidateStatus::PLACED_CASUAL->name,
+            PoolCandidateStatus::PLACED_TERM->name,
+            PoolCandidateStatus::PLACED_INDETERMINATE->name,
+            PoolCandidateStatus::EXPIRED->name,
+            PoolCandidateStatus::SCREENED_OUT_APPLICATION->name,
+            PoolCandidateStatus::SCREENED_OUT_ASSESSMENT->name,
+        ];
+        $timeNow = Carbon::now();
+
+        DB::table('pool_candidates')
+            ->whereIn('pool_candidate_status', $relevantStatuses)
+            ->whereNull('final_decision_at')
+            ->update(['final_decision_at' => $timeNow]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pool_candidates', function (Blueprint $table) {
+            $table->dropColumn('final_decision_at');
+        });
+    }
+};

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1679,6 +1679,10 @@ type Mutation {
     @guard
     @canFind(ability: "updateStatus", find: "id", injectArgs: true)
     @validator(class: "App\\GraphQL\\Validators\\DisqualifyCandidateValidator")
+  revertFinalDecision(id: UUID!): PoolCandidate
+    @guard
+    @canFind(ability: "updateStatus", find: "id", injectArgs: true)
+    @validator(class: "App\\GraphQL\\Validators\\RevertFinalDecisionValidator")
   placeCandidate(
     id: UUID!
     placeCandidate: PlaceCandidateInput! @spread

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -319,6 +319,9 @@ type PoolCandidate {
   assessmentResults: [AssessmentResult]
     @hasMany
     @canRoot(ability: "viewAssessmentResults")
+  finalDecisionAt: DateTime
+    @rename(attribute: "final_decision_at")
+    @canRoot(ability: "viewStatus")
   placedAt: DateTime
     @rename(attribute: "placed_at")
     @canRoot(ability: "viewStatus")

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1668,6 +1668,13 @@ type Mutation {
     @delete
     @guard
     @canFind(ability: "delete", find: "id")
+  disqualifyCandidate(
+    id: UUID!
+    reason: DisqualificationReason!
+  ): PoolCandidate
+    @guard
+    @canFind(ability: "updateStatus", find: "id", injectArgs: true)
+    @validator(class: "App\\GraphQL\\Validators\\DisqualifyCandidateValidator")
   placeCandidate(
     id: UUID!
     placeCandidate: PlaceCandidateInput! @spread

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1668,6 +1668,10 @@ type Mutation {
     @delete
     @guard
     @canFind(ability: "delete", find: "id")
+  qualifyCandidate(id: UUID!, expiryDate: Date!): PoolCandidate
+    @guard
+    @canFind(ability: "updateStatus", find: "id", injectArgs: true)
+    @validator(class: "App\\GraphQL\\Validators\\QualifyCandidateValidator")
   disqualifyCandidate(
     id: UUID!
     reason: DisqualificationReason!

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -101,6 +101,7 @@ type Mutation {
   togglePoolCandidateBookmark(id: ID!): Boolean
   updatePoolCandidateNotes(id: UUID!, notes: String): PoolCandidate
   deletePoolCandidate(id: ID!): PoolCandidate
+  qualifyCandidate(id: UUID!, expiryDate: Date!): PoolCandidate
   disqualifyCandidate(id: UUID!, reason: DisqualificationReason!): PoolCandidate
   placeCandidate(id: UUID!, placeCandidate: PlaceCandidateInput!): PoolCandidate
   revertPlaceCandidate(id: UUID!): PoolCandidate

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -421,6 +421,7 @@ type PoolCandidate {
   educationRequirementOption: EducationRequirementOption
   educationRequirementExperiences: [Experience]
   assessmentResults: [AssessmentResult]
+  finalDecisionAt: DateTime
   placedAt: DateTime
   placedDepartment: Department
 }

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -101,6 +101,7 @@ type Mutation {
   togglePoolCandidateBookmark(id: ID!): Boolean
   updatePoolCandidateNotes(id: UUID!, notes: String): PoolCandidate
   deletePoolCandidate(id: ID!): PoolCandidate
+  disqualifyCandidate(id: UUID!, reason: DisqualificationReason!): PoolCandidate
   placeCandidate(id: UUID!, placeCandidate: PlaceCandidateInput!): PoolCandidate
   revertPlaceCandidate(id: UUID!): PoolCandidate
   createClassification(classification: CreateClassificationInput!): Classification
@@ -2002,6 +2003,11 @@ enum PoolStatus {
   PUBLISHED
   CLOSED
   ARCHIVED
+}
+
+enum DisqualificationReason {
+  SCREENED_OUT_APPLICATION
+  SCREENED_OUT_ASSESSMENT
 }
 
 enum PoolCandidateStatus {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -103,6 +103,7 @@ type Mutation {
   deletePoolCandidate(id: ID!): PoolCandidate
   qualifyCandidate(id: UUID!, expiryDate: Date!): PoolCandidate
   disqualifyCandidate(id: UUID!, reason: DisqualificationReason!): PoolCandidate
+  revertFinalDecision(id: UUID!): PoolCandidate
   placeCandidate(id: UUID!, placeCandidate: PlaceCandidateInput!): PoolCandidate
   revertPlaceCandidate(id: UUID!): PoolCandidate
   createClassification(classification: CreateClassificationInput!): Classification

--- a/api/tests/Feature/PoolCandidateUpdateTest.php
+++ b/api/tests/Feature/PoolCandidateUpdateTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\DisqualificationReason;
 use App\Enums\EducationRequirementOption;
 use App\Enums\PlacementType;
 use App\Enums\PoolCandidateStatus;
@@ -49,6 +50,12 @@ class PoolCandidateUpdateTest extends TestCase
     protected $placeCandidateMutation;
 
     protected $revertPlaceCandidateMutation;
+
+    protected $qualifyCandidateMutation;
+
+    protected $disqualifyCandidateMutation;
+
+    protected $revertFinalDecisionMutation;
 
     protected function setUp(): void
     {
@@ -139,6 +146,44 @@ class PoolCandidateUpdateTest extends TestCase
                 }
             }
         }
+    ';
+
+        $this->qualifyCandidateMutation =
+        /** @lang GraphQL */
+        '
+        mutation qualifyCandidate($id: UUID!, $expiryDate: Date!) {
+            qualifyCandidate(id: $id, expiryDate: $expiryDate) {
+              id
+              status
+              expiryDate
+              finalDecisionAt
+            }
+          }
+    ';
+
+        $this->disqualifyCandidateMutation =
+        /** @lang GraphQL */
+        '
+        mutation disqualifyCandidate($id: UUID!, $reason: DisqualificationReason!) {
+            disqualifyCandidate(id: $id, reason: $reason) {
+              id
+              status
+              finalDecisionAt
+            }
+          }
+    ';
+
+        $this->revertFinalDecisionMutation =
+        /** @lang GraphQL */
+        '
+        mutation revertFinalDecision($id: UUID!) {
+            revertFinalDecision(id: $id) {
+              id
+              status
+              expiryDate
+              finalDecisionAt
+            }
+          }
     ';
     }
 
@@ -314,6 +359,40 @@ class PoolCandidateUpdateTest extends TestCase
                 ]
             )
             ->assertGraphQLErrorMessage('This action is unauthorized.');
+
+        $this->poolCandidate->pool_candidate_status = PoolCandidateStatus::NEW_APPLICATION->name;
+        $this->poolCandidate->save();
+
+        $this->actingAs($this->candidateUser, 'api')
+            ->graphQL(
+                $this->qualifyCandidateMutation,
+                [
+                    'id' => $this->poolCandidate->id,
+                    'expiryDate' => config('constants.far_future_date'),
+                ]
+            )
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
+        $this->actingAs($this->candidateUser, 'api')
+            ->graphQL(
+                $this->disqualifyCandidateMutation,
+                [
+                    'id' => $this->poolCandidate->id,
+                    'reason' => DisqualificationReason::SCREENED_OUT_APPLICATION->name,
+                ]
+            )
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
+
+        $this->poolCandidate->pool_candidate_status = PoolCandidateStatus::QUALIFIED_AVAILABLE->name;
+        $this->poolCandidate->save();
+
+        $this->actingAs($this->candidateUser, 'api')
+            ->graphQL(
+                $this->revertFinalDecisionMutation,
+                [
+                    'id' => $this->poolCandidate->id,
+                ]
+            )
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
     public function testPlaceCandidateMutation(): void
@@ -391,5 +470,132 @@ class PoolCandidateUpdateTest extends TestCase
         assertSame($response['status'], PoolCandidateStatus::QUALIFIED_AVAILABLE->name);
         assertNull($response['placedAt']);
         assertNull($response['placedDepartment']);
+    }
+
+    public function testQualifyCandidateMutation(): void
+    {
+        $this->poolCandidate->pool_candidate_status = PoolCandidateStatus::QUALIFIED_AVAILABLE->name;
+        $this->poolCandidate->expiry_date = null;
+        $this->poolCandidate->final_decision_at = null;
+        $this->poolCandidate->save();
+
+        // cannot qualify candidate due to status
+        $this->actingAs($this->poolOperatorUser, 'api')
+            ->graphQL(
+                $this->qualifyCandidateMutation,
+                [
+                    'id' => $this->poolCandidate->id,
+                    'expiryDate' => config('constants.far_future_date'),
+                ]
+            )
+            ->assertGraphQLErrorMessage('InvalidStatusForQualification');
+
+        $this->poolCandidate->pool_candidate_status = PoolCandidateStatus::NEW_APPLICATION->name;
+        $this->poolCandidate->save();
+
+        // cannot qualify candidate due to expiry date validation
+        $this->actingAs($this->poolOperatorUser, 'api')
+            ->graphQL(
+                $this->qualifyCandidateMutation,
+                [
+                    'id' => $this->poolCandidate->id,
+                    'expiryDate' => config('constants.past_date'),
+                ]
+            )
+            ->assertJsonFragment(['message' => 'Validation failed for the field [qualifyCandidate].']);
+
+        // candidate was qualified successfully
+        $response = $this->actingAs($this->poolOperatorUser, 'api')
+            ->graphQL(
+                $this->qualifyCandidateMutation,
+                [
+                    'id' => $this->poolCandidate->id,
+                    'expiryDate' => config('constants.far_future_date'),
+                ]
+            )->json('data.qualifyCandidate');
+
+        assertSame($response['status'], PoolCandidateStatus::QUALIFIED_AVAILABLE->name);
+        assertSame($response['expiryDate'], config('constants.far_future_date'));
+        assertNotNull($response['finalDecisionAt']);
+    }
+
+    public function testDisqualifyCandidateMutation(): void
+    {
+        $this->poolCandidate->pool_candidate_status = PoolCandidateStatus::QUALIFIED_AVAILABLE->name;
+        $this->poolCandidate->expiry_date = null;
+        $this->poolCandidate->final_decision_at = null;
+        $this->poolCandidate->save();
+
+        // cannot disqualify candidate due to status
+        $this->actingAs($this->poolOperatorUser, 'api')
+            ->graphQL(
+                $this->disqualifyCandidateMutation,
+                [
+                    'id' => $this->poolCandidate->id,
+                    'reason' => DisqualificationReason::SCREENED_OUT_APPLICATION->name,
+                ]
+            )
+            ->assertGraphQLErrorMessage('InvalidStatusForDisqualification');
+
+        $this->poolCandidate->pool_candidate_status = PoolCandidateStatus::NEW_APPLICATION->name;
+        $this->poolCandidate->save();
+
+        // candidate was disqualified successfully
+        $response = $this->actingAs($this->poolOperatorUser, 'api')
+            ->graphQL(
+                $this->disqualifyCandidateMutation,
+                [
+                    'id' => $this->poolCandidate->id,
+                    'reason' => DisqualificationReason::SCREENED_OUT_APPLICATION->name,
+                ]
+            )->json('data.disqualifyCandidate');
+
+        assertSame($response['status'], PoolCandidateStatus::SCREENED_OUT_APPLICATION->name);
+        assertNotNull($response['finalDecisionAt']);
+    }
+
+    public function testRevertFinalDecisionMutation(): void
+    {
+        $this->poolCandidate->pool_candidate_status = PoolCandidateStatus::UNDER_ASSESSMENT->name;
+        $this->poolCandidate->expiry_date = null;
+        $this->poolCandidate->final_decision_at = null;
+        $this->poolCandidate->save();
+
+        // candidate was qualified successfully
+        $response = $this->actingAs($this->poolOperatorUser, 'api')
+            ->graphQL(
+                $this->qualifyCandidateMutation,
+                [
+                    'id' => $this->poolCandidate->id,
+                    'expiryDate' => config('constants.far_future_date'),
+                ]
+            )->json('data.qualifyCandidate');
+
+        assertSame($response['status'], PoolCandidateStatus::QUALIFIED_AVAILABLE->name);
+        assertSame($response['expiryDate'], config('constants.far_future_date'));
+        assertNotNull($response['finalDecisionAt']);
+
+        // candidate reverted successfully
+        $response = $this->actingAs($this->poolOperatorUser, 'api')
+            ->graphQL(
+                $this->revertFinalDecisionMutation,
+                [
+                    'id' => $this->poolCandidate->id,
+                ]
+            )->json('data.revertFinalDecision');
+
+        assertSame($response['status'], PoolCandidateStatus::UNDER_ASSESSMENT->name);
+        assertNull($response['expiryDate']);
+        assertNull($response['finalDecisionAt']);
+
+        // cannot revert again due to status changes
+        $this->actingAs($this->poolOperatorUser, 'api')
+            ->graphQL(
+                $this->revertFinalDecisionMutation,
+                [
+                    'id' => $this->poolCandidate->id,
+                ]
+            )
+            ->assertGraphQLErrorMessage('InvalidStatusForRevertFinalDecision');
     }
 }

--- a/api/tests/Feature/PoolCandidateUpdateTest.php
+++ b/api/tests/Feature/PoolCandidateUpdateTest.php
@@ -502,7 +502,7 @@ class PoolCandidateUpdateTest extends TestCase
                     'expiryDate' => config('constants.past_date'),
                 ]
             )
-            ->assertJsonFragment(['message' => 'Validation failed for the field [qualifyCandidate].']);
+            ->assertGraphQLErrorMessage('Validation failed for the field [qualifyCandidate].');
 
         // candidate was qualified successfully
         $response = $this->actingAs($this->poolOperatorUser, 'api')


### PR DESCRIPTION
🤖 Resolves #9190

## 👋 Introduction

Adds the three mutations as well as a `final_decision_at` date time field. Includes factory, schema, and testing. 
Also swaps in the new mutations for the final decision dialog. 

## 🧪 Testing

1. Migrate back and forth
2. Seed fresh
3. Test new mutations, see below
4. Use final decision dialog to qualify or disqualify candidates, remember to reset status first in some cases

```
mutation qualifyCandidate {
  qualifyCandidate(
    id: ":ID"
    expiryDate: ":date"
  ) {
    id
    status
    expiryDate
    finalDecisionAt
  }
}
```
```
mutation disqualifyCandidate {
  disqualifyCandidate(
    id: ":id"
    reason: ":reason"  ) {
    id
    status
    finalDecisionAt
  }
}
```
```
mutation revertFinalDecision {
  revertFinalDecision(id: ":id") {
    id
    status
    expiryDate
    finalDecisionAt
  }
}
```

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/3900938c-0a2d-4628-851c-ff292c7e0d9a)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/cd9529e1-44e3-42a4-beab-ce85a438a342)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/c8167cc4-1a6a-4efd-962b-883c679e718a)



