### PR TITLE
[Feature] Renders status column by default on Pool Candidate table

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -721,7 +721,7 @@ const PoolCandidatesTable = ({
     ),
   ] as ColumnDef<PoolCandidateWithSkillCount>[];
 
-  const hiddenColumnIds = ["candidacyStatus", "notes", "status"];
+  const hiddenColumnIds = ["candidacyStatus", "notes"];
 
   return (
     <Table<PoolCandidateWithSkillCount>


### PR DESCRIPTION
🤖 Resolves #10064.

## 👋 Introduction

This PR renders status column by default on Pool Candidate table.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/admin/pool-candidates`
2. Verify **Status** column renders by default

## 📸 Screenshot

<img width="659" alt="Screen Shot 2024-04-16 at 09 46 03" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/8c1f0554-f163-4eb5-b119-16acaf8d95e4">