### PR TITLE
[Fix] Remove `php-gd` from post deploy install

### DIFF
--- a/infrastructure/bin/post_deployment.sh
+++ b/infrastructure/bin/post_deployment.sh
@@ -23,7 +23,7 @@ fi
 BLOCKS="{ \"type\": \"header\", \"text\": { \"type\": \"plain_text\", \"text\": \"Post-deployment script was run\" } }"
 
 # Install packages from repository
-if apt-get update && apt-get install -y supervisor cron php-gd; then
+if apt-get update && apt-get install -y supervisor cron; then
     BLOCKS="$BLOCKS, { \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \":white_check_mark: Install packages from repository *successful*.\" } }"
 else
     BLOCKS="$BLOCKS, { \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \":X: Install packages from repository *failed*. $MENTION\" } }"


### PR DESCRIPTION
🤖 Resolves #10072 

## 👋 Introduction

Remove `php-gd` install from the post deployment script.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Confirm the `post_deployment.sh` script runs successfully with no errors
2. Confirm you can still generate CSV files locally for testing
