### PR TITLE
[Feature] Add "Other" Publishing group to the searchable list of groups

### DIFF
--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -32,8 +32,8 @@ final class CountPoolCandidatesByPool
         // available candidates scope (scope CANDIDATE_STATUS_QUALIFIED_AVAILABLE or CANDIDATE_STATUS_PLACED_CASUAL, or PLACED_TENTATIVE)
         PoolCandidate::scopeAvailable($queryBuilder);
 
-        // Only display IT candidates
-        PoolCandidate::scopeInITPublishingGroup($queryBuilder);
+        // Only display IT & OTHER publishing group candidates
+        PoolCandidate::scopeInTalentSearchablePublishingGroup($queryBuilder);
 
         $queryBuilder->whereHas('user', function (Builder $userQuery) use ($filters) {
             // user filters go here

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -315,15 +315,15 @@ class PoolCandidate extends Model
     }
 
     /**
-     * Scope is IT
+     * Scope is IT & OTHER Publishing Groups
      *
      * Restrict a query by pool candidates that are for pools
-     * containing IT specific publishing groups
+     * containing IT and OTHER publishing groups
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query  The existing query being built
      * @return \Illuminate\Database\Eloquent\Builder The resulting query
      */
-    public static function scopeInITPublishingGroup(Builder $query)
+    public static function scopeInTalentSearchablePublishingGroup(Builder $query)
     {
         $query = self::scopePublishingGroups($query, [
             PublishingGroup::IT_JOBS_ONGOING->name,

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -328,6 +328,7 @@ class PoolCandidate extends Model
         $query = self::scopePublishingGroups($query, [
             PublishingGroup::IT_JOBS_ONGOING->name,
             PublishingGroup::IT_JOBS->name,
+            PublishingGroup::OTHER->name,
         ]);
 
         return $query;

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -841,11 +841,11 @@ class User extends Model implements Authenticatable, LaratrustUser
     /**
      * Return users who have an available PoolCandidate in at least one IT pool.
      */
-    public static function scopeAvailableInITPublishingGroup(Builder $query): Builder
+    public static function scopeTalentSearchablePublishingGroup(Builder $query): Builder
     {
         return $query->whereHas('poolCandidates', function ($innerQueryBuilder) {
             PoolCandidate::scopeAvailable($innerQueryBuilder);
-            PoolCandidate::scopeInITPublishingGroup($innerQueryBuilder);
+            PoolCandidate::scopeInTalentSearchablePublishingGroup($innerQueryBuilder);
 
             return $innerQueryBuilder;
         });

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -731,7 +731,7 @@ type Query {
     @canModel(ability: "viewBasicInfo", model: "User")
   # countApplicants returns the number of candidates matching its filters, and requires no special permissions.
   countApplicants(where: ApplicantFilterInput): Int!
-    @count(model: "User", scopes: ["availableInITPublishingGroup"])
+    @count(model: "User", scopes: ["talentSearchablePublishingGroup"])
   pool(id: UUID! @eq): Pool @find @canQuery(ability: "view")
   publishedPools(
     closingAfter: DateTime @where(key: "closing_date", operator: ">")


### PR DESCRIPTION
🤖 Resolves #10062 

## 👋 Introduction

This PR allows IT-05 group that is published under "OTHER" publishing group to be searchable via the Find Talent form along with existing IT_JOBS_ONGOING, IT-JOBS. 

Technically it will allow any group that is published under "Other" will be part of the count candidates query.
I'm unsure whether this will bite back us though. 

## 🕵️ Details
The scopeInITPublishingGroup has been modified to include "Other" publishing group.
However it is not ITPublishingGroup any more.
Should we rename this scope? 
Would like dev suggestion

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Create a process with IT-05 and publish under "Other" group
3. Apply for the same process via `View Advertisement` and apply from there. ( This will NOT be shown on browse pools page) 
4. Go to the process and qualify yourself
5. Checkout the search form initial total estimated count should be increased by 1 and IT-05 should be visible at the bottom. 
6. Now checkout IT-05 is available for search in the classification drop down
7. Filter the candidate for IT-05 and submit the request
8. Go to Requests page and view the request. 

## 📸 Screenshot

![Screenshot 2024-04-16 at 3 19 25 PM](https://github.com/GCTC-NTGC/gc-digital-talent/assets/89482910/da8669ff-6832-4163-9b63-952b0d4e325b)


![Screenshot 2024-04-16 at 3 32 46 PM](https://github.com/GCTC-NTGC/gc-digital-talent/assets/89482910/0b24da5c-8d41-41e1-984c-2a25e6a9858f)

