### PR TITLE
[Bug] French formatting on poster page

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -947,10 +947,6 @@
     "defaultMessage": "3. Remplissez vos <strong>questions de récupération</strong>. Vous devez utiliser une <strong>personne</strong> et <strong>une date mémorables</strong>.",
     "description": "Text for third sign up -> create step."
   },
-  "3HIQl/": {
-    "defaultMessage": "Pour postuler à cet emploi, vous devrez être en mesure de démontrer que vous possédez <strong>toutes les compétences</strong> marquées <heavyPrimary>Requises</heavyPrimary>. Si vous possédez l'une des compétences <heavySecondary>Facultatives</heavySecondary> nous vous recommandons de l'inclure, car elle augmentera vos chances de trouver un emploi.",
-    "description": "Descriptive text about how skills are defined and used for pool advertisements and applications"
-  },
   "3HJ51b": {
     "defaultMessage": "Femme",
     "description": "Text on view-user page that the user is a woman"
@@ -7561,6 +7557,10 @@
   "eickbr": {
     "defaultMessage": "Minorité visible",
     "description": "Text on view-user page that the user is part of a visible minority"
+  },
+  "eihm6A": {
+    "defaultMessage": "Pour postuler à cet emploi, vous devrez être en mesure de démontrer que vous possédez <strong>toutes les compétences</strong> marquées <heavyPrimary>« Requises »</heavyPrimary>. Si vous possédez l'une des compétences <heavySecondary>« Facultatives »</heavySecondary> nous vous recommandons de l'inclure, car elle augmentera vos chances de trouver un emploi.",
+    "description": "Descriptive text about how skills are defined and used for pool advertisements and applications"
   },
   "ekDavD": {
     "defaultMessage": "Renseignements sur les accords commerciaux",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -947,6 +947,10 @@
     "defaultMessage": "3. Remplissez vos <strong>questions de récupération</strong>. Vous devez utiliser une <strong>personne</strong> et <strong>une date mémorables</strong>.",
     "description": "Text for third sign up -> create step."
   },
+  "3HIQl/": {
+    "defaultMessage": "Pour postuler à cet emploi, vous devrez être en mesure de démontrer que vous possédez <strong>toutes les compétences</strong> marquées <heavyPrimary>Requises</heavyPrimary>. Si vous possédez l'une des compétences <heavySecondary>Facultatives</heavySecondary> nous vous recommandons de l'inclure, car elle augmentera vos chances de trouver un emploi.",
+    "description": "Descriptive text about how skills are defined and used for pool advertisements and applications"
+  },
   "3HJ51b": {
     "defaultMessage": "Femme",
     "description": "Text on view-user page that the user is a woman"
@@ -7557,10 +7561,6 @@
   "eickbr": {
     "defaultMessage": "Minorité visible",
     "description": "Text on view-user page that the user is part of a visible minority"
-  },
-  "eihm6A": {
-    "defaultMessage": "Pour postuler à cet emploi, vous devrez être en mesure de démontrer que vous possédez <strong>toutes les compétences</strong> marquées <heavyPrimary>\"Requises\"</heavyPrimary>. Si vous possédez l'une des compétences<heavySecondary>\"Facultatives,\"</heavySecondary> nous vous recommandons de l'inclure, car elle augmentera vos chances de trouver un emploi.",
-    "description": "Descriptive text about how skills are defined and used for pool advertisements and applications"
   },
   "ekDavD": {
     "defaultMessage": "Renseignements sur les accords commerciaux",

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -758,8 +758,8 @@ export const PoolPoster = ({
               <Text>
                 {intl.formatMessage({
                   defaultMessage:
-                    'In order to apply for this job you will need to be able to demonstrate that you have <strong>all the skills</strong> marked <heavyPrimary>"Required"</heavyPrimary>. If you have any of the <heavySecondary>"Optional"</heavySecondary> skills you are encouraged to include them because it will increase your chances of a job placement.',
-                  id: "eihm6A",
+                    "In order to apply for this job you will need to be able to demonstrate that you have <strong>all the skills</strong> marked <heavyPrimary>Required</heavyPrimary>. If you have any of the <heavySecondary>Optional</heavySecondary> skills you are encouraged to include them because it will increase your chances of a job placement.",
+                  id: "3HIQl/",
                   description:
                     "Descriptive text about how skills are defined and used for pool advertisements and applications",
                 })}

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -758,8 +758,8 @@ export const PoolPoster = ({
               <Text>
                 {intl.formatMessage({
                   defaultMessage:
-                    "In order to apply for this job you will need to be able to demonstrate that you have <strong>all the skills</strong> marked <heavyPrimary>Required</heavyPrimary>. If you have any of the <heavySecondary>Optional</heavySecondary> skills you are encouraged to include them because it will increase your chances of a job placement.",
-                  id: "3HIQl/",
+                    'In order to apply for this job you will need to be able to demonstrate that you have <strong>all the skills</strong> marked <heavyPrimary>"Required"</heavyPrimary>. If you have any of the <heavySecondary>"Optional"</heavySecondary> skills you are encouraged to include them because it will increase your chances of a job placement.',
+                  id: "eihm6A",
                   description:
                     "Descriptive text about how skills are defined and used for pool advertisements and applications",
                 })}


### PR DESCRIPTION
🤖 Resolves #10071 

## 👋 Introduction

Resolve the typos present, as well as implement the suggestion. I think it looks nicer that way as it cleanly matches the accordion. 

## 🧪 Testing

1. Navigate to `/en/browse/pools/:id`
2. Then in French

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/2ca1060e-f213-4194-a435-4899fb45207c)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/ba739dce-cf74-4361-9f06-f4f65adfb914)

