### PR TITLE
[Tooling] Disables Dependabot from running Chromatic workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   chromatic:
     name: Chromatic
+    # Only run if not dependabot,
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-22.04
     env:
       PNPM_VERSION: "8.15.0"


### PR DESCRIPTION
🤖 Resolves #10108.

## 👋 Introduction

This PR adds a conditional for Chromatic workflow to only run if it is not a dependabot bot-created PR.

### Documentation
REF: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#fetch-metadata-about-a-pull-request