### PR TITLE
Highlight first visible section of ToC

### DIFF
--- a/packages/ui/src/components/TableOfContents/AnchorLink.tsx
+++ b/packages/ui/src/components/TableOfContents/AnchorLink.tsx
@@ -14,7 +14,15 @@ const AnchorLink = ({ id, children }: AnchorLinkProps) => {
   };
 
   return (
-    <ScrollToLink to={id} color="black" mode="text" onScrollTo={handleScrollTo}>
+    <ScrollToLink
+      data-is-toc-link // Used to find Table of Contents link elements in the Navigation component
+      id={`toc-link-for-${id}`}
+      data-h2-font-weight="base:selectors[.active](bold)"
+      to={id}
+      color="black"
+      mode="text"
+      onScrollTo={handleScrollTo}
+    >
       {children}
     </ScrollToLink>
   );

--- a/packages/ui/src/components/TableOfContents/Section.tsx
+++ b/packages/ui/src/components/TableOfContents/Section.tsx
@@ -9,7 +9,13 @@ const Section = ({
   children,
   ...rest
 }: SectionProps & HTMLAttributes<HTMLDivElement>) => (
-  <div id={id} tabIndex={-1} data-h2-outline="base(none)" {...rest}>
+  <div
+    data-is-toc-section // Used to find section elements in the Navigation component
+    id={id}
+    tabIndex={-1}
+    data-h2-outline="base(none)"
+    {...rest}
+  >
     {children}
   </div>
 );


### PR DESCRIPTION
🤖 Resolves #8029

## 👋 Introduction

The table of contents highlights the link to the first visible section on the page. It highlights using bolded text and the [aria-current](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) property.

## 🕵️ Details

This is accomplished with raw javascript which uses query selectors and attribute/classlist manipulation instead of react refs, to avoid having to modify the Table of Contents architecture. The important function is attached to a scroll event listener by the Navigation wrapper component.

## 🧪 Testing

Try a few pages with table of contents (like job posters and the applicant profile). Check the table of contents storybook.


