### PR TITLE
[Feature] Conditionally render decision dialogs

### DIFF
--- a/apps/web/src/constants/poolCandidate.ts
+++ b/apps/web/src/constants/poolCandidate.ts
@@ -52,8 +52,8 @@ export const RECORD_DECISION_STATUSES = [
 ];
 
 export const REVERT_DECISION_STATUSES = [
+  PoolCandidateStatus.ScreenedOutApplication,
+  PoolCandidateStatus.ScreenedOutAssessment,
   PoolCandidateStatus.QualifiedAvailable,
-  PoolCandidateStatus.QualifiedUnavailable,
-  PoolCandidateStatus.QualifiedWithdrew,
   PoolCandidateStatus.Expired,
 ];

--- a/apps/web/src/constants/poolCandidate.ts
+++ b/apps/web/src/constants/poolCandidate.ts
@@ -43,3 +43,17 @@ export const NOT_PLACED_STATUSES = [
   PoolCandidateStatus.QualifiedAvailable,
   PoolCandidateStatus.PlacedTentative,
 ];
+
+export const RECORD_DECISION_STATUSES = [
+  PoolCandidateStatus.NewApplication,
+  PoolCandidateStatus.ApplicationReview,
+  PoolCandidateStatus.ScreenedIn,
+  PoolCandidateStatus.UnderAssessment,
+];
+
+export const REVERT_DECISION_STATUSES = [
+  PoolCandidateStatus.QualifiedAvailable,
+  PoolCandidateStatus.QualifiedUnavailable,
+  PoolCandidateStatus.QualifiedWithdrew,
+  PoolCandidateStatus.Expired,
+];

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -4,7 +4,6 @@ import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
 import HandRaisedIcon from "@heroicons/react/24/outline/HandRaisedIcon";
 import ExclamationTriangleIcon from "@heroicons/react/24/outline/ExclamationTriangleIcon";
 import { OperationContext, useQuery } from "urql";
-import { ArrowUturnLeftIcon } from "@heroicons/react/20/solid";
 
 import {
   NotFound,
@@ -44,6 +43,10 @@ import AssessmentResultsTable from "~/components/AssessmentResultsTable/Assessme
 import ChangeDateDialog from "~/pages/Users/UserInformationPage/components/ChangeDateDialog";
 import ChangeStatusDialog from "~/pages/Users/UserInformationPage/components/ChangeStatusDialog";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
+import {
+  RECORD_DECISION_STATUSES,
+  REVERT_DECISION_STATUSES,
+} from "~/constants/poolCandidate";
 
 import CareerTimelineSection from "./components/CareerTimelineSection/CareerTimelineSection";
 import ApplicationInformation from "./components/ApplicationInformation/ApplicationInformation";
@@ -51,10 +54,6 @@ import ProfileDetails from "./components/ProfileDetails/ProfileDetails";
 import NotesDialog from "./components/MoreActions/NotesDialog";
 import FinalDecisionDialog from "./components/MoreActions/FinalDecisionDialog";
 import CandidateNavigation from "./components/CandidateNavigation/CandidateNavigation";
-import {
-  RECORD_DECISION_STATUSES,
-  REVERT_DECISION_STATUSES,
-} from "../../../constants/poolCandidate";
 
 const screeningAndAssessmentTitle = defineMessage({
   defaultMessage: "Screening and assessment",

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -4,6 +4,7 @@ import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
 import HandRaisedIcon from "@heroicons/react/24/outline/HandRaisedIcon";
 import ExclamationTriangleIcon from "@heroicons/react/24/outline/ExclamationTriangleIcon";
 import { OperationContext, useQuery } from "urql";
+import { ArrowUturnLeftIcon } from "@heroicons/react/20/solid";
 
 import {
   NotFound,
@@ -50,6 +51,10 @@ import ProfileDetails from "./components/ProfileDetails/ProfileDetails";
 import NotesDialog from "./components/MoreActions/NotesDialog";
 import FinalDecisionDialog from "./components/MoreActions/FinalDecisionDialog";
 import CandidateNavigation from "./components/CandidateNavigation/CandidateNavigation";
+import {
+  RECORD_DECISION_STATUSES,
+  REVERT_DECISION_STATUSES,
+} from "../../../constants/poolCandidate";
 
 const screeningAndAssessmentTitle = defineMessage({
   defaultMessage: "Screening and assessment",
@@ -788,16 +793,27 @@ export const ViewPoolCandidate = ({
               data-h2-gap="base(x.5)"
               data-h2-margin-bottom="base(x1)"
             >
-              <FinalDecisionDialog
-                poolCandidateId={poolCandidate.id}
-                poolCandidateStatus={poolCandidate.status}
-                expiryDate={poolCandidate.expiryDate}
-                essentialSkills={poolCandidate.pool.essentialSkills ?? []}
-                nonessentialSkills={poolCandidate.pool.nonessentialSkills ?? []}
-                assessmentResults={
-                  poolCandidate?.assessmentResults?.filter(notEmpty) ?? []
-                }
-              />
+              {poolCandidate.status &&
+                RECORD_DECISION_STATUSES.includes(poolCandidate.status) && (
+                  <FinalDecisionDialog
+                    poolCandidateId={poolCandidate.id}
+                    poolCandidateStatus={poolCandidate.status}
+                    expiryDate={poolCandidate.expiryDate}
+                    essentialSkills={poolCandidate.pool.essentialSkills ?? []}
+                    nonessentialSkills={
+                      poolCandidate.pool.nonessentialSkills ?? []
+                    }
+                    assessmentResults={
+                      poolCandidate?.assessmentResults?.filter(notEmpty) ?? []
+                    }
+                  />
+                )}
+              {poolCandidate.status &&
+                REVERT_DECISION_STATUSES.includes(poolCandidate.status) && (
+                  // TODO: Add "Revert final decision" dialog in here (#9197)
+                  // eslint-disable-next-line react/jsx-no-useless-fragment
+                  <></>
+                )}
               {/* TODO: Add "Remove" and "Re-instate" dialogs to Pool Candidate
               page (#9198) */}
               {false && (


### PR DESCRIPTION
🤖 Resolves #9315 

## 👋 Introduction

Adds conditional rendering for the Record/Revert final decision dialogs based on the candidates status.

## 🕵️ Details

The revert dialog is being worked on so right now it just has a fragment and nothing shows up. It will be added in #9197 

## 🧪 Testing

> [!TIP]
> If you want to test the revert, just drop a hard coded message in the placeholder fragment spot temporarily before building.

https://github.com/GCTC-NTGC/gc-digital-talent/blob/8ace5559efca71b6e53066e1e98f9d9d656f6e51/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx#L813-L815

1. Build `pnpm run dev`
2. Login as admin `adm,in@test.com`
3. Navigate to a pool candidate
4. Change their status to ones that appear in `RECORD_DECISION_STATUSES` and `REVERT_DECISION_STATUSES`
5. Confirm the button is rendered for the appropriate status

## 📸 Screenshot

![screenshot_18-Apr-2024_08-22-1713442974](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/6020447e-3eac-451f-b6de-434782aaded7)
![screenshot_18-Apr-2024_08-23-1713443012](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/77c10a83-0d2e-462c-920a-e3c176b38a9a)
