### PR TITLE
[Debt] Make deployment artifact smaller

### DIFF
--- a/infrastructure/azure-pipelines.yml
+++ b/infrastructure/azure-pipelines.yml
@@ -48,12 +48,12 @@ jobs:
             apps/web/dist/**
             infrastructure/**
             tc-report/**
-          TargetFolder: "$(Build.ArtifactStagingDirectory)/Release"
+          TargetFolder: "$(Build.ArtifactStagingDirectory)/Stage"
 
       - task: ArchiveFiles@2
         displayName: "Archive Files"
         inputs:
-          rootFolderOrFile: "$(Build.ArtifactStagingDirectory)/Release"
+          rootFolderOrFile: "$(Build.ArtifactStagingDirectory)/Stage"
           includeRootFolder: false
           archiveFile: "$(Build.ArtifactStagingDirectory)/Release/Application_$(Build.BuildId).zip"
 

--- a/infrastructure/azure-pipelines.yml
+++ b/infrastructure/azure-pipelines.yml
@@ -39,14 +39,26 @@ jobs:
           # See: https://docs.cypress.io/guides/getting-started/installing-cypress#Skipping-installation
           CYPRESS_INSTALL_BINARY: 0
 
+      - task: CopyFiles@2
+        displayName: "Copy files to staging directory"
+        inputs:
+          SourceFolder: "$(System.DefaultWorkingDirectory)"
+          Contents: |
+            api/**
+            apps/web/dist/**
+            infrastructure/**
+            tc-report/**
+          TargetFolder: "$(Build.ArtifactStagingDirectory)/Release"
+
       - task: ArchiveFiles@2
         displayName: "Archive Files"
         inputs:
-          rootFolderOrFile: $(System.DefaultWorkingDirectory)
+          rootFolderOrFile: "$(Build.ArtifactStagingDirectory)/Release"
           includeRootFolder: false
-          archiveFile: "$(Build.ArtifactStagingDirectory)/Application_$(Build.BuildId).zip"
+          archiveFile: "$(Build.ArtifactStagingDirectory)/Release/Application_$(Build.BuildId).zip"
 
       - task: PublishBuildArtifacts@1
         displayName: "Publish Artifact: gcDigitalTalent"
         inputs:
+          PathtoPublish: "$(Build.ArtifactStagingDirectory)/Release"
           ArtifactName: gcDigitalTalent

--- a/infrastructure/bin/deploy.sh
+++ b/infrastructure/bin/deploy.sh
@@ -72,6 +72,3 @@ pnpm install --frozen-lockfile
 
 ### Build frontend
 pnpm run build
-
-### Remove modules once build completes:
-find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +


### PR DESCRIPTION
🤖 Resolves #9726 

## 👋 Introduction

This branch makes the deployment artifact (and resulting deployment) smaller in Azure.

## 🕵️ Details

The deploy.sh script (really, it's a "build artifact" script) currently builds the application and then zips the entire workspace as the deployment artifact.  This branch copies only the needed files to a staging directory first, then compresses those files for the artifact.

This reduces the deployment artifact size from 611 MB to 395 MB.  The build process does seem to take a little longer (~40s) but still within the normal range we see.

## 🧪 Testing

1. Can build this branch in Azure
2. Can deploy the artifacts from this branch to an app service.

- [ ] Deployed app functions normally.