### PR TITLE
[Feature] Promotional email set to opt in

### DIFF
--- a/api/database/migrations/2024_04_18_210339_job_alert_default_ignored.php
+++ b/api/database/migrations/2024_04_18_210339_job_alert_default_ignored.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement(
+            <<<'SQL'
+            ALTER TABLE users
+            ALTER COLUMN ignored_email_notifications
+            SET DEFAULT '["JOB_ALERT"]'::jsonb
+            SQL, []
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement(
+            <<<'SQL'
+            ALTER TABLE users
+            ALTER COLUMN ignored_email_notifications
+            SET DEFAULT null
+            SQL, []
+        );
+    }
+};

--- a/api/database/migrations/2024_04_18_210339_job_alert_default_ignored.php
+++ b/api/database/migrations/2024_04_18_210339_job_alert_default_ignored.php
@@ -17,6 +17,10 @@ return new class extends Migration
             SET DEFAULT '["JOB_ALERT"]'::jsonb
             SQL, []
         );
+
+        DB::table('users')->update([
+            'ignored_email_notifications' => ['JOB_ALERT'],
+        ]);
     }
 
     /**


### PR DESCRIPTION
🤖 Resolves #10086

## 👋 Introduction

Sets JOB_ALERT as default ignored for emails and updates existing models to reflect that. 
Elected to do a migration as it covers both tasks in one go. 

## 🧪 Testing

1. Migrate back and forth, nothing broke
2. Create a new user, run `User::create()` in tinker for example
3. Query notification fields in `/graphiql`

## 🚚 Deployment

Nothing currently needs to be done
