### PR TITLE
[Fix] Restore nullable property on experience details

### DIFF
--- a/api/database/migrations/2024_03_13_134951_create_experiences_table.php
+++ b/api/database/migrations/2024_03_13_134951_create_experiences_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->softDeletes();
             $table->uuid('user_id');
             $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete(true);
-            $table->text('details');
+            $table->text('details')->nullable();
             $table->string('experience_type')->index();
             $table->jsonb('properties')->nullable();
         });


### PR DESCRIPTION
🤖 Resolves #10146

## 👋 Introduction

This branch makes the `details` column in the new experiences table nullable to match the schema and the five tables that it is replacing.

## 🧪 Testing

1. Check out 57447242a25240c8c53fd53155cd50b3a5a578cb which is the commit right before the merge commit with the flawed migration.
2. Setup the project
3. Manually edit one or more rows in the five experience tables to make the details field null.
4. Check out the project head
5. Run the DB migrations