### PR TITLE
[Bug] Fix experience migration JSON escaping

### DIFF
--- a/api/database/migrations/2024_03_13_134951_create_experiences_table.php
+++ b/api/database/migrations/2024_03_13_134951_create_experiences_table.php
@@ -55,7 +55,7 @@ return new class extends Migration
                                 'end_date', end_date,
                                 'title', title,
                                 'organization', organization,
-                                'project'
+                                'project', project
                             )
                         SQL))
                 );
@@ -88,7 +88,7 @@ return new class extends Migration
                                 'start_date', start_date,
                                 'end_date', end_date,
                                 'title', title,
-                                'description'
+                                'description', description
                             )
                         SQL))
                 );

--- a/api/database/migrations/2024_03_13_134951_create_experiences_table.php
+++ b/api/database/migrations/2024_03_13_134951_create_experiences_table.php
@@ -34,13 +34,13 @@ return new class extends Migration
                     DB::table('award_experiences')
                         ->select(DB::raw(<<<'SQL'
                             id, created_at, updated_at, deleted_at, user_id, details, 'App\Models\AwardExperience',
-                            (concat('{',
-                            '"awarded_date": ', coalesce('"' || (awarded_date) || '"' , 'null'), ',',
-                            '"title": "', title, '",',
-                            '"issued_by": "', issued_by, '",',
-                            '"awarded_to": "', awarded_to, '",',
-                            '"awarded_scope": "', awarded_scope, '"',
-                            '}'))::jsonb
+                            json_build_object(
+                                'awarded_date', awarded_date,
+                                'title', title,
+                                'issued_by', issued_by,
+                                'awarded_to', awarded_to,
+                                'awarded_scope', awarded_scope
+                            )
                         SQL))
                 );
 
@@ -50,13 +50,13 @@ return new class extends Migration
                     DB::table('community_experiences')
                         ->select(DB::raw(<<<'SQL'
                             id, created_at, updated_at, deleted_at, user_id, details, 'App\Models\CommunityExperience',
-                            (concat('{',
-                            '"start_date": ', coalesce('"' || (start_date) || '"' , 'null'), ',',
-                            '"end_date": ', coalesce('"' || (end_date) || '"' , 'null'), ',',
-                            '"title": "', title, '",',
-                            '"organization": "', organization, '",',
-                            '"project": "', project, '"',
-                            '}'))::jsonb
+                            json_build_object(
+                                'start_date', start_date,
+                                'end_date', end_date,
+                                'title', title,
+                                'organization', organization,
+                                'project'
+                            )
                         SQL))
                 );
 
@@ -66,15 +66,15 @@ return new class extends Migration
                     DB::table('education_experiences')
                         ->select(DB::raw(<<<'SQL'
                             id, created_at, updated_at, deleted_at, user_id, details, 'App\Models\EducationExperience',
-                            (concat('{',
-                            '"start_date": ', coalesce('"' || (start_date) || '"' , 'null'), ',',
-                            '"end_date": ', coalesce('"' || (end_date) || '"' , 'null'), ',',
-                            '"institution": "', institution, '",',
-                            '"area_of_study": "', area_of_study, '",',
-                            '"thesis_title": "', thesis_title, '",',
-                            '"type": "', type, '",',
-                            '"status": "', status, '"',
-                            '}'))::jsonb
+                            json_build_object(
+                                'start_date', start_date,
+                                'end_date', end_date,
+                                'institution', institution,
+                                'area_of_study', area_of_study,
+                                'thesis_title', thesis_title,
+                                'type', type,
+                                'status', status
+                            )
                         SQL))
                 );
 
@@ -84,12 +84,12 @@ return new class extends Migration
                     DB::table('personal_experiences')
                         ->select(DB::raw(<<<'SQL'
                             id, created_at, updated_at, deleted_at, user_id, details,'App\Models\PersonalExperience',
-                            (concat('{',
-                            '"start_date": ', coalesce('"' || (start_date) || '"' , 'null'), ',',
-                            '"end_date": ', coalesce('"' || (end_date) || '"' , 'null'), ',',
-                            '"title": "', title, '",',
-                            '"description": "', description, '"',
-                            '}'))::jsonb
+                            json_build_object(
+                                'start_date', start_date,
+                                'end_date', end_date,
+                                'title', title,
+                                'description'
+                            )
                         SQL))
                 );
 
@@ -99,13 +99,13 @@ return new class extends Migration
                     DB::table('work_experiences')
                         ->select(DB::raw(<<<'SQL'
                             id, created_at, updated_at, deleted_at, user_id, details,'App\Models\WorkExperience',
-                            (concat('{',
-                            '"start_date": ', coalesce('"' || (start_date) || '"' , 'null'), ',',
-                            '"end_date": ', coalesce('"' || (end_date) || '"' , 'null'), ',',
-                            '"role": "', role, '",',
-                            '"organization": "', organization, '",',
-                            '"division": "', division, '"',
-                            '}'))::jsonb
+                            json_build_object(
+                                'start_date', start_date,
+                                'end_date', end_date,
+                                'role', role,
+                                'organization', organization,
+                                'division', division
+                            )
                         SQL))
                 );
 


### PR DESCRIPTION
🤖 Resolves #10146 

## 👋 Introduction

This branch fixes the JSON escaping of fields in the database migration for the experience refactor.

## 🕵️ Details

Manual string concatenation is not a great way to construct JSON literals since it doesn't handle escaping any of the JSON reserved characters. :facepalm: This branch instead uses the PostgreSQL builtin function `json_build_object` to contstruct the objects safely.

## 🧪 Testing

1. Check out https://github.com/GCTC-NTGC/gc-digital-talent/commit/57447242a25240c8c53fd53155cd50b3a5a578cb which is the commit right before the merge commit with the flawed migration.
2. Setup the project
3. Manually edit one or more rows in the five experience tables to add some reserved JSON characters or full JSON literals.
4. Check out the branch head
5. Run the DB migrations

- [ ] fields with JSON literals accurately survived migration
- [ ] Can CRUD experience rows with reserved characters in the app 
- [ ] Can rollback the migration properly