### PR TITLE
[Feature] Placed tenatative default search request candidate filter

### DIFF
--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.test.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import { screen, within } from "@testing-library/react";
+import React from "react";
+import { Provider as GraphqlProvider } from "urql";
+import { fromValue } from "wonka";
+import { faker } from "@faker-js/faker";
+
+import { renderWithProviders } from "@gc-digital-talent/jest-helpers";
+import {
+  fakeApplicantFilters,
+  fakePoolCandidates,
+  fakeSkills,
+} from "@gc-digital-talent/fake-data";
+import { PoolCandidateStatus } from "@gc-digital-talent/graphql";
+
+import SingleSearchRequestTableApi from "./SearchRequestCandidatesTable";
+
+faker.seed(0);
+
+const mockApplicantFilters = fakeApplicantFilters();
+const mockPoolCandidates = fakePoolCandidates();
+const mockSkills = fakeSkills();
+
+const mockPoolCandidatesWithSkillCount = mockPoolCandidates.map(
+  (poolCandidate) => {
+    const skillCount = faker.number.int({
+      min: 0,
+      max: 10,
+    });
+    return {
+      id: poolCandidate.id,
+      poolCandidate,
+      skillCount: skillCount || null,
+    };
+  },
+);
+
+const mockPaginatorInfo = {
+  count: 20,
+  currentPage: 1,
+  firstItem: 1,
+  hasMorePages: false,
+  lastItem: 20,
+  lastPage: 1,
+  perPage: 20,
+  total: 20,
+};
+
+const mockClient = {
+  executeQuery: () =>
+    fromValue({
+      data: {
+        poolCandidatesPaginated: {
+          data: [mockPoolCandidatesWithSkillCount[0]],
+          paginatorInfo: mockPaginatorInfo,
+        },
+        skills: mockSkills,
+      },
+    }),
+  // See: https://github.com/FormidableLabs/urql/discussions/2057#discussioncomment-1568874
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+const render = () => {
+  return renderWithProviders(
+    <GraphqlProvider value={mockClient}>
+      <SingleSearchRequestTableApi filter={mockApplicantFilters[0]} />,
+    </GraphqlProvider>,
+  );
+};
+
+describe("Search Request Candidates Table", () => {
+  const user = userEvent.setup();
+
+  it("should have default status filters", async () => {
+    render();
+
+    await user.click(screen.getByRole("button", { name: /filters/i }));
+
+    const filters = screen.getByRole("dialog", { name: /filters/i });
+
+    // Checking for 2 of each due to option and chip in combobox
+    expect(await within(filters).findAllByText(/placed casual/i)).toHaveLength(
+      2,
+    );
+    expect(
+      await within(filters).findAllByText(/qualified available/i),
+    ).toHaveLength(2);
+
+    expect(
+      await within(filters).findAllByText(/offer in progress/i),
+    ).toHaveLength(2);
+  });
+});

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.test.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.test.tsx
@@ -15,7 +15,6 @@ import {
   fakePoolCandidates,
   fakeSkills,
 } from "@gc-digital-talent/fake-data";
-import { PoolCandidateStatus } from "@gc-digital-talent/graphql";
 
 import SingleSearchRequestTableApi from "./SearchRequestCandidatesTable";
 

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -96,6 +96,7 @@ const transformApplicantFilterToPoolCandidateSearchInput = (
     poolCandidateStatus: [
       PoolCandidateStatus.QualifiedAvailable,
       PoolCandidateStatus.PlacedCasual,
+      PoolCandidateStatus.PlacedTentative,
     ],
   };
 };


### PR DESCRIPTION
🤖 Resolves #10079 

## 👋 Introduction

Adds placed tentative to the search request tables default fitlers.

## 🧪 Testing

1. Build `pnpm run dev`
2. Login as admin `admin@test.com`
3. Navigate to a search request
4. Scroll down to the candidates table
5. Confirm the status "offer in progress" appears
6. Confirm the query it sent with the filter attached

## 📸 Screenshot

<img width="461" alt="Screenshot 2024-04-24 at 12 28 43 PM" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/2f196860-ebf0-4cb4-9f0c-4c740337fc9b">

