### PR TITLE
[Debt] Replace `useLocale` hook

### DIFF
--- a/apps/web/src/components/Header/Header.tsx
+++ b/apps/web/src/components/Header/Header.tsx
@@ -18,6 +18,7 @@ interface HeaderProps {
 
 const Header = ({ width }: HeaderProps) => {
   const intl = useIntl();
+  // eslint-disable-next-line no-restricted-syntax
   const { locale } = useLocale();
 
   const location = useLocation();

--- a/apps/web/src/components/Layout/AdminLayout/AdminLayout.tsx
+++ b/apps/web/src/components/Layout/AdminLayout/AdminLayout.tsx
@@ -14,7 +14,7 @@ import {
   SideMenuContentWrapper,
   SideMenuItem,
 } from "@gc-digital-talent/ui";
-import { uiMessages, useLocale } from "@gc-digital-talent/i18n";
+import { uiMessages, getLocale } from "@gc-digital-talent/i18n";
 import { ROLE_NAME, useAuthorization } from "@gc-digital-talent/auth";
 
 import Footer from "~/components/Footer/Footer";
@@ -107,7 +107,7 @@ const OpenMenuButton = React.forwardRef<
 
 const AdminLayout = () => {
   const intl = useIntl();
-  const { locale } = useLocale();
+  const locale = getLocale(intl);
   const paths = useRoutes();
   useLayoutTheme("default");
   const isSmallScreen = useIsSmallScreen();

--- a/apps/web/src/components/Layout/IAPLayout.tsx
+++ b/apps/web/src/components/Layout/IAPLayout.tsx
@@ -7,8 +7,8 @@ import { AnimatePresence } from "framer-motion";
 import {
   NestedLanguageProvider,
   Messages,
-  useLocale,
   commonMessages,
+  getLocale,
 } from "@gc-digital-talent/i18n";
 import { getRuntimeVariable } from "@gc-digital-talent/env";
 import { useAuthentication, useAuthorization } from "@gc-digital-talent/auth";
@@ -50,7 +50,8 @@ const IAPSeo = () => {
 };
 
 const Layout = () => {
-  const { locale } = useLocale();
+  const intl = useIntl();
+  const locale = getLocale(intl);
   const location = useLocation();
   const { userAuthInfo } = useAuthorization();
   const { loggedIn } = useAuthentication();

--- a/apps/web/src/components/Layout/Layout.tsx
+++ b/apps/web/src/components/Layout/Layout.tsx
@@ -12,7 +12,7 @@ import {
 import {
   commonMessages,
   navigationMessages,
-  useLocale,
+  getLocale,
 } from "@gc-digital-talent/i18n";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 
@@ -32,7 +32,7 @@ import SkipLink from "./SkipLink";
 
 const Layout = () => {
   const intl = useIntl();
-  const { locale } = useLocale();
+  const locale = getLocale(intl);
   const paths = useRoutes();
   useLayoutTheme("default");
 

--- a/apps/web/src/components/Layout/SitewideBanner.tsx
+++ b/apps/web/src/components/Layout/SitewideBanner.tsx
@@ -3,11 +3,12 @@ import React from "react";
 import { isAfter } from "date-fns/isAfter";
 import { isBefore } from "date-fns/isBefore";
 import { useQuery } from "urql";
+import { useIntl } from "react-intl";
 
 import { graphql } from "@gc-digital-talent/graphql";
 import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 import { Alert } from "@gc-digital-talent/ui";
-import { useLocale } from "@gc-digital-talent/i18n";
+import { getLocale } from "@gc-digital-talent/i18n";
 import { RichTextRenderer, htmlToRichTextJSON } from "@gc-digital-talent/forms";
 
 const SitewideBanner_Query = graphql(/* GraphQL */ `
@@ -29,7 +30,8 @@ const SitewideBanner_Query = graphql(/* GraphQL */ `
 `);
 
 const SitewideBanner = () => {
-  const { locale } = useLocale();
+  const intl = useIntl();
+  const locale = getLocale(intl);
 
   const [{ data }] = useQuery({
     query: SitewideBanner_Query,

--- a/apps/web/src/components/Profile/components/GovernmentInformation/FormFields.tsx
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/FormFields.tsx
@@ -15,7 +15,7 @@ import {
   errorMessages,
   getGovEmployeeType,
   uiMessages,
-  useLocale,
+  getLocale,
 } from "@gc-digital-talent/i18n";
 import { notEmpty } from "@gc-digital-talent/helpers";
 import {
@@ -77,7 +77,7 @@ const FormFields = ({
   labels,
 }: FormFieldsProps) => {
   const intl = useIntl();
-  const { locale } = useLocale();
+  const locale = getLocale(intl);
   const departments = getFragment(
     GovernmentInfoDepartment_Fragment,
     departmentsQuery,

--- a/apps/web/src/components/Profile/components/LanguageProfile/ConsideredLanguages.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/ConsideredLanguages.tsx
@@ -12,7 +12,7 @@ import {
   errorMessages,
   getEvaluatedLanguageAbility,
   getLanguage,
-  useLocale,
+  getLocale,
 } from "@gc-digital-talent/i18n";
 import { Link } from "@gc-digital-talent/ui";
 import { EvaluatedLanguageAbility, Language } from "@gc-digital-talent/graphql";
@@ -35,7 +35,7 @@ interface ConsideredLanguagesProps {
 
 const ConsideredLanguages = ({ labels }: ConsideredLanguagesProps) => {
   const intl = useIntl();
-  const { locale } = useLocale();
+  const locale = getLocale(intl);
   const { watch, resetField } = useFormContext();
 
   const languageEvaluationPageLink = (msg: React.ReactNode) => {

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -1850,6 +1850,7 @@ const createRoute = (
   ]);
 
 const Router = () => {
+  // eslint-disable-next-line no-restricted-syntax
   const { locale } = useLocale();
   const routes = useRoutes();
   const featureFlags = useFeatureFlags();

--- a/apps/web/src/components/SEO/SEO.tsx
+++ b/apps/web/src/components/SEO/SEO.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Helmet } from "react-helmet-async";
 import { useIntl } from "react-intl";
 
-import { commonMessages, useLocale } from "@gc-digital-talent/i18n";
+import { commonMessages, getLocale } from "@gc-digital-talent/i18n";
 
 import Favicon from "./Favicon";
 
@@ -16,7 +16,7 @@ interface SEOProps {
 
 const SEO = ({ title, description, type = "website" }: SEOProps) => {
   const intl = useIntl();
-  const { locale } = useLocale();
+  const locale = getLocale(intl);
   const defaultTitle = intl.formatMessage(commonMessages.projectTitle);
 
   const defaultDescription = intl.formatMessage({

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -1,6 +1,7 @@
 import path from "path-browserify";
+import { useIntl } from "react-intl";
 
-import { useLocale, Locales } from "@gc-digital-talent/i18n";
+import { Locales, getLocale } from "@gc-digital-talent/i18n";
 
 import { ExperienceType } from "~/types/experience";
 import { PageSectionId as UserProfilePageSectionId } from "~/components/UserProfile/constants";
@@ -315,7 +316,8 @@ const getRoutes = (lang: Locales) => {
 };
 
 const useRoutes = () => {
-  const { locale } = useLocale();
+  const intl = useIntl();
+  const locale = getLocale(intl);
 
   return getRoutes(locale);
 };

--- a/apps/web/src/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useIntl } from "react-intl";
 
 import { Alert, Link } from "@gc-digital-talent/ui";
-import { useLocale } from "@gc-digital-talent/i18n";
+import { getLocale } from "@gc-digital-talent/i18n";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetPageNavInfo } from "~/types/applicationStep";
@@ -42,7 +42,7 @@ export const getPageInfo: GetPageNavInfo = ({ application, paths, intl }) => {
 
 const ApplicationSuccess = ({ application }: ApplicationPageProps) => {
   const intl = useIntl();
-  const { locale } = useLocale();
+  const locale = getLocale(intl);
   const paths = useRoutes();
   const { currentStepOrdinal, isIAP } = useApplicationContext();
   const pageInfo = getPageInfo({

--- a/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/DigitalServicesContractingQuestionnairePage.tsx
+++ b/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/DigitalServicesContractingQuestionnairePage.tsx
@@ -7,7 +7,7 @@ import { useMutation, useQuery } from "urql";
 import { Link, Pending, TableOfContents } from "@gc-digital-talent/ui";
 import { notEmpty } from "@gc-digital-talent/helpers";
 import { BasicForm } from "@gc-digital-talent/forms";
-import { useLocale } from "@gc-digital-talent/i18n";
+import { getLocale } from "@gc-digital-talent/i18n";
 import { toast } from "@gc-digital-talent/toast";
 import {
   Department,
@@ -56,7 +56,7 @@ export const DigitalServicesContractingQuestionnaire = ({
   defaultValues,
 }: DigitalServicesContractingQuestionnaireProps) => {
   const intl = useIntl();
-  const localeState = useLocale();
+  const locale = getLocale(intl);
   const paths = useRoutes();
 
   const crumbs = useBreadcrumbs({
@@ -118,7 +118,7 @@ export const DigitalServicesContractingQuestionnaire = ({
               color="secondary"
               block
               external
-              href={localeState.locale === "fr" ? contractingFr : contractingEn}
+              href={locale === "fr" ? contractingFr : contractingEn}
             >
               {intl.formatMessage({
                 defaultMessage: "Download a copy of this form",

--- a/apps/web/src/pages/DirectivePage/DirectivePage.tsx
+++ b/apps/web/src/pages/DirectivePage/DirectivePage.tsx
@@ -10,7 +10,7 @@ import { Heading, Link, Accordion, CardFlat } from "@gc-digital-talent/ui";
 import {
   Locales,
   navigationMessages,
-  useLocale,
+  getLocale,
 } from "@gc-digital-talent/i18n";
 import { useFeatureFlags } from "@gc-digital-talent/env";
 
@@ -57,7 +57,7 @@ export const pageTitle = defineMessage({
 
 const DirectivePage = () => {
   const intl = useIntl();
-  const { locale } = useLocale();
+  const locale = getLocale(intl);
   const paths = useRoutes();
   const { directiveForms: directiveFormsFlag } = useFeatureFlags();
 

--- a/apps/web/src/pages/DirectivePage/Resources.tsx
+++ b/apps/web/src/pages/DirectivePage/Resources.tsx
@@ -5,7 +5,7 @@ import FolderOpenIcon from "@heroicons/react/24/outline/FolderOpenIcon";
 import ArrowDownOnSquareIcon from "@heroicons/react/24/outline/ArrowDownOnSquareIcon";
 
 import { Card, CardBasic, Heading, Link } from "@gc-digital-talent/ui";
-import { uiMessages, useLocale } from "@gc-digital-talent/i18n";
+import { uiMessages, getLocale } from "@gc-digital-talent/i18n";
 
 import trainingSession from "~/assets/img/Directive_landing_page_graphics_R1-01.webp";
 import decisionTree from "~/assets/img/Directive_landing_page_graphics_R1-02.webp";
@@ -31,7 +31,7 @@ import procurementDocxFr from "~/assets/documents/Orientation_approvisionnement_
 
 const Resources = () => {
   const intl = useIntl();
-  const localeState = useLocale();
+  const locale = getLocale(intl);
   return (
     <>
       <section>
@@ -107,11 +107,7 @@ const Resources = () => {
               block
               external
               download
-              href={
-                localeState.locale === "en"
-                  ? decisionTreePdfEn
-                  : decisionTreePdfFr
-              }
+              href={locale === "en" ? decisionTreePdfEn : decisionTreePdfFr}
               data-h2-margin="base(0, 0, x1, 0)"
             >
               {intl.formatMessage({
@@ -128,11 +124,7 @@ const Resources = () => {
               block
               external
               download
-              href={
-                localeState.locale === "en"
-                  ? decisionTreeDocxEn
-                  : decisionTreeDocxFr
-              }
+              href={locale === "en" ? decisionTreeDocxEn : decisionTreeDocxFr}
             >
               {intl.formatMessage({
                 defaultMessage:
@@ -213,7 +205,7 @@ const Resources = () => {
                   external
                   download
                   href={
-                    localeState.locale === "en"
+                    locale === "en"
                       ? guidanceManagerPdfEn
                       : guidanceManagerPdfFr
                   }
@@ -244,7 +236,7 @@ const Resources = () => {
                       "Aria label for download guidance for managers plain text link.",
                   })}
                   href={
-                    localeState.locale === "en"
+                    locale === "en"
                       ? guidanceManagerDocxEn
                       : guidanceManagerDocxFr
                   }
@@ -309,7 +301,7 @@ const Resources = () => {
                     description:
                       "Aria label for download guidance for human resources pdf link.",
                   })}
-                  href={localeState.locale === "en" ? hrPdfEn : hrPdfFr}
+                  href={locale === "en" ? hrPdfEn : hrPdfFr}
                   icon={ArrowDownOnSquareIcon}
                   data-h2-margin="base(x1, 0, x1, 0)"
                   data-h2-justify-content="base(flex-start)"
@@ -329,7 +321,7 @@ const Resources = () => {
                     description:
                       "Aria label for download guidance for human resources plain text link.",
                   })}
-                  href={localeState.locale === "en" ? hrDocxEn : hrDocxFr}
+                  href={locale === "en" ? hrDocxEn : hrDocxFr}
                   icon={ArrowDownOnSquareIcon}
                   data-h2-justify-content="base(flex-start)"
                 >
@@ -385,11 +377,7 @@ const Resources = () => {
                   block
                   external
                   download
-                  href={
-                    localeState.locale === "en"
-                      ? procurementPdfEn
-                      : procurementPdfFr
-                  }
+                  href={locale === "en" ? procurementPdfEn : procurementPdfFr}
                   aria-label={intl.formatMessage({
                     defaultMessage:
                       "Download the implementation guidance for procurement officers (PDF)",
@@ -416,11 +404,7 @@ const Resources = () => {
                     description:
                       "Aria label for download guidance for procurement officers plain text link.",
                   })}
-                  href={
-                    localeState.locale === "en"
-                      ? procurementDocxEn
-                      : procurementDocxFr
-                  }
+                  href={locale === "en" ? procurementDocxEn : procurementDocxFr}
                   icon={ArrowDownOnSquareIcon}
                   data-h2-justify-content="base(flex-start)"
                 >

--- a/apps/web/src/pages/Home/HomePage/components/About/About.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/About/About.tsx
@@ -3,13 +3,13 @@ import { useIntl } from "react-intl";
 import NewspaperIcon from "@heroicons/react/24/outline/NewspaperIcon";
 
 import { CardFlat, Heading } from "@gc-digital-talent/ui";
-import { useLocale } from "@gc-digital-talent/i18n";
+import { getLocale } from "@gc-digital-talent/i18n";
 
 import { wrapAbbr } from "~/utils/nameUtils";
 
 const About = () => {
   const intl = useIntl();
-  const { locale } = useLocale();
+  const locale = getLocale(intl);
   return (
     <div
       data-h2-background="base(home-footer-linear)"

--- a/apps/web/src/pages/Pools/EditPoolPage/components/CoreRequirementsSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/CoreRequirementsSection/Display.tsx
@@ -6,7 +6,7 @@ import {
   getLanguageRequirement,
   getLocalizedName,
   getSecurityClearance,
-  useLocale,
+  getLocale,
 } from "@gc-digital-talent/i18n";
 
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
@@ -16,7 +16,7 @@ import { DisplayProps } from "../../types";
 
 const Display = ({ pool, subtitle }: DisplayProps) => {
   const intl = useIntl();
-  const { locale } = useLocale();
+  const locale = getLocale(intl);
   const notProvided = intl.formatMessage(commonMessages.notProvided);
   const { language, securityClearance, location, isRemote } = pool;
 

--- a/packages/auth/src/components/AuthenticationProvider.tsx
+++ b/packages/auth/src/components/AuthenticationProvider.tsx
@@ -12,6 +12,7 @@ interface AuthenticationContainerProps {
 
 const AuthenticationProvider = ({ children }: AuthenticationContainerProps) => {
   const apiPaths = useApiRoutes();
+  // eslint-disable-next-line no-restricted-syntax
   const { locale } = useLocale();
   const refreshTokenSetPath = apiPaths.refreshAccessToken();
 

--- a/packages/eslint-config-custom/react.js
+++ b/packages/eslint-config-custom/react.js
@@ -150,6 +150,10 @@ module.exports = {
         message:
           "The name of the program is IT Apprenticeship Program for Indigenous Peoples.",
       },
+      {
+        selector: "CallExpression[callee.name='useLocale']",
+        message: "Please use getLocale instead."
+      }
     ],
   },
 };

--- a/packages/forms/src/components/ErrorSummary.tsx
+++ b/packages/forms/src/components/ErrorSummary.tsx
@@ -12,7 +12,7 @@ import {
 import {
   commonMessages,
   errorMessages,
-  useLocale,
+  getLocale,
 } from "@gc-digital-talent/i18n";
 
 import type { FieldLabels } from "./BasicForm";
@@ -29,7 +29,7 @@ const numberRegex = /(\d+)/g;
 /**
  * Get Field Label
  *
- * User the field name to extract the associated label
+ * , getLocaleUser the field name to extract the associated label
  *
  * @param {string} name - The name property of the field
  * @param {FieldLabels} labels - Available labels
@@ -113,7 +113,7 @@ const ErrorSummary = React.forwardRef<
   ErrorSummaryProps
 >(({ labels, show }, forwardedRef) => {
   const intl = useIntl();
-  const { locale } = useLocale();
+  const locale = getLocale(intl);
   const { errors } = useFormState();
 
   // Don't show if the form is valid

--- a/packages/forms/src/components/ErrorSummary.tsx
+++ b/packages/forms/src/components/ErrorSummary.tsx
@@ -29,7 +29,7 @@ const numberRegex = /(\d+)/g;
 /**
  * Get Field Label
  *
- * , getLocaleUser the field name to extract the associated label
+ * Use the field name to extract the associated label
  *
  * @param {string} name - The name property of the field
  * @param {FieldLabels} labels - Available labels

--- a/packages/i18n/src/components/LanguageProvider.tsx
+++ b/packages/i18n/src/components/LanguageProvider.tsx
@@ -12,6 +12,7 @@ interface LanguageProviderProps {
 }
 
 const LanguageProvider = ({ messages, children }: LanguageProviderProps) => {
+  // eslint-disable-next-line no-restricted-syntax
   const { locale } = useLocale();
   const compiledMessages = useIntlLanguages(locale, messages);
 


### PR DESCRIPTION
🤖 Resolves #10133 

## 👋 Introduction

Replaces the `useLocale` hook with the `getLocale` helper in pages and components.

## 🕵️ Details

The `useLocale` is for use above the `LanguageProvider` or, setting the locale. This replaces it in any place it was being used outside of those use cases.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `pnpm run dev`
2. Confirm language switching still works for the places where locale was updated
3. Confirm `useLocale` only appears in `Header`, `Router` and context providers

