### PR TITLE
[Bug] Remove other_justification_notes from AssessmentResultFactory

### DIFF
--- a/api/database/factories/AssessmentResultFactory.php
+++ b/api/database/factories/AssessmentResultFactory.php
@@ -60,8 +60,6 @@ class AssessmentResultFactory extends Factory
                 return [
                     'assessment_result_type' => $type->name,
                     'justifications' => $justifications,
-                    'other_justification_notes' => in_array(AssessmentResultJustification::FAILED_OTHER->name, $justifications) ?
-                        $this->faker->paragraph() : null,
                     'assessment_decision_level' => null,
                     'skill_decision_notes' => null,
                 ];
@@ -74,8 +72,6 @@ class AssessmentResultFactory extends Factory
                 return [
                     'assessment_result_type' => $type->name,
                     'justifications' => $justifications,
-                    'other_justification_notes' => in_array(AssessmentResultJustification::FAILED_OTHER->name, $justifications) ?
-                        $this->faker->paragraph() : null,
                     'assessment_decision' => $assessmentDecision,
                     'assessment_decision_level' => $assessmentDecision === AssessmentDecision::SUCCESSFUL->name ?
                         $this->faker->randomElement(array_column(AssessmentDecisionLevel::cases(), 'name')) : null,


### PR DESCRIPTION
🤖 Resolves #10162 

## 👋 Introduction

- Removes `other-justification-notes` from AssessmentResultFactory.

## 🧪 Testing

1. Try running fresh migration and seeder `php artisan migrate:fresh --seed`
2. Ensure no errors pop up

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/22059495/9569bc2d-0ed0-416b-92da-7480b2e7f462)
