### PR TITLE
Spike permission check framework

### DIFF
--- a/api/app/Interfaces/PermissionResourceInterface.php
+++ b/api/app/Interfaces/PermissionResourceInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Interfaces;
+
+use App\Models\Team;
+
+interface PermissionResourceInterface
+{
+    /**
+     * Return the owner of the resource, if it exists.
+     *
+     * @return string
+     */
+    public function ownerId();
+
+    /**
+     * Return all the teams this resource may be accessed by.
+     *
+     * @return Team[]
+     */
+    public function teams();
+
+    public function resourceName(): string;
+}

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -7,6 +7,7 @@ use App\Enums\PoolSkillType;
 use App\Enums\PoolStatus;
 use App\Enums\SkillCategory;
 use App\GraphQL\Validators\PoolIsCompleteValidator;
+use App\Interfaces\PermissionResourceInterface;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -48,7 +49,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property Illuminate\Support\Carbon $published_at
  * @property Illuminate\Support\Carbon $archived_at
  */
-class Pool extends Model
+class Pool extends Model implements PermissionResourceInterface
 {
     use HasFactory;
     use LogsActivity;
@@ -128,6 +129,22 @@ class Pool extends Model
             ->logOnlyDirty()
             ->dontSubmitEmptyLogs();
     }
+
+    public function ownerId()
+    {
+        return $this->user_id;
+    }
+    // Posters can be considered to be teams themselves, as well as belonging to a community.
+    public function teams()
+    {
+        return [$this->id, $this->team_id];
+    }
+    public function resourceName(): string
+    {
+        return 'pool';
+    }
+
+
 
     public function user(): BelongsTo
     {

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -137,7 +137,8 @@ class Pool extends Model implements PermissionResourceInterface
     // Posters can be considered to be teams themselves, as well as belonging to a community.
     public function teams()
     {
-        return [$this->id, $this->team_id];
+        $this->load('team';)
+        return [$this, $this->team];
     }
     public function resourceName(): string
     {

--- a/api/app/Policies/PoolPolicy.php
+++ b/api/app/Policies/PoolPolicy.php
@@ -192,10 +192,6 @@ class PoolPolicy
      */
     public function viewAssessmentPlan(User $user, Pool $pool)
     {
-        if ($user->isAbleTo('view-any-assessmentPlan')) {
-            return true;
-        }
-
         return (new PermissionCheckService($user))->userCan('view', $pool, 'assessmentPlan');
     }
 }

--- a/api/app/Services/PermissionCheckService.php
+++ b/api/app/Services/PermissionCheckService.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Services;
+
+use App\Interfaces\PermissionResourceInterface;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+
+class PermissionCheckService
+{
+    private $user;
+
+    public function __construct(User $user = null)
+    {
+    $this->user = $user;
+    }
+
+    public function userCan(string $action, PermissionResourceInterface $resource, string $overrideResourceName = null): bool
+    {
+        // If the user is not authenticated, they cannot perform any actions.
+        if ($this->user === null) {
+            // TODO: this is not strictly true! Instead, we should check the Guest user role.
+            return false;
+        }
+
+        $resourceName = $overrideResourceName ?? $resource->resourceName();
+
+        // If the user has the ability to perform the action on any resource, return true.
+        if ($this->user->isAbleTo($action . '-any-' . $resourceName)) {
+            return true;
+        }
+        // If the user has the ability to perform the action on their own resources, and owns this resource, return true.
+        if ($resource->ownerId() !== null && $this->user->isAbleTo($action . '-own-' . $resourceName) && $this->user->id === $resource->ownerId()) {
+            return true;
+        }
+        // If the user has the ability to perform the action on a team's resources, and this resource is owned by a team they are a member of, return true.
+        foreach ($resource->teams() as $team) {
+            if ($this->user->isAbleTo($action . '-team-' . $resourceName, $team)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
🤖 Related to #10144.

## 👋 Introduction

Testing a framework which generalizes the multiple ways a user might have access to a resource.

## 🕵️ Details

When users have a permission related to a resource, it may apply to all instances of the resource, or specific resources owned by the user, or resources associated with a team. This framework is meant to avoid devs having to check each instance appropriately. This may especially helpful as we the notion of 'team' becomes more abstract.

This is very early, just looking for feedback for now. 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. ...
2. ...

## 📸 Screenshot

Add a screenshot (if possible).

## 🚚 Deployment

Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the linked issue if deployment steps are needed
