### PR TITLE
[Tooling] Jest always runs on merging

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -3,10 +3,6 @@ name: Jest
 on:
   push:
     branches: [main]
-    paths:
-      - .github/workflows/*jest*.yml
-      - apps/**
-      - packages/**
   pull_request:
     paths:
       - .github/workflows/*jest*.yml


### PR DESCRIPTION
## 👋 Introduction

Jest does not always run upon merging a branch in, this prevents code coverage uploads. PHP Unit always runs so it always pushes up a new coverage report. 
As seen in devspam, this causes confusion with drastic coverage changes stemming from if either one or two workflows uploaded something

## 🕵️ Details

Just having Jest always run for merges. Shouldn't really run that much more often, but clear up the occasional confusion. 



