### PR TITLE
[Debt] Removes `cmoIdentifier` field and `cmo_identifier` column

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -27,7 +27,6 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * Class PoolCandidate
  *
  * @property string $id
- * @property string $cmo_identifier
  * @property Illuminate\Support\Carbon $expiry_date
  * @property Illuminate\Support\Carbon $archived_at
  * @property Illuminate\Support\Carbon $submitted_at

--- a/api/database/factories/PoolCandidateFactory.php
+++ b/api/database/factories/PoolCandidateFactory.php
@@ -45,7 +45,6 @@ class PoolCandidateFactory extends Factory
         $removedStatuses = PoolCandidateStatus::removedGroup();
 
         return [
-            'cmo_identifier' => $this->faker->word(),
             'expiry_date' => $this->faker->dateTimeBetween('-1 years', '3 years'),
             'pool_candidate_status' => $this->faker->boolean() ?
                 $this->faker->randomElement([PoolCandidateStatus::QUALIFIED_AVAILABLE, PoolCandidateStatus::PLACED_CASUAL])->name :

--- a/api/database/migrations/2024_04_25_143252_remove_cmo_identifier_column_pool_candidates_table.php
+++ b/api/database/migrations/2024_04_25_143252_remove_cmo_identifier_column_pool_candidates_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pool_candidates', function (Blueprint $table) {
+            $table->dropColumn('cmo_identifier');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('pool_candidates', function (Blueprint $table) {
+            $table->string('cmo_identifier')->nullable(true);
+        });
+    }
+};

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -282,10 +282,6 @@ type PoolCandidate {
   id: ID!
   pool: Pool! @belongsTo @canResolved(ability: "view")
   user: User! @belongsTo(relation: "user") @canResolved(ability: "view")
-  # cmoIdentifier can be an arbitrary string used to relate this candidate to an external database.
-  cmoIdentifier: ID
-    @rename(attribute: "cmo_identifier")
-    @deprecated(reason: "Field no longer used")
   # Expiry date for this candidate being in the pool.
   expiryDate: Date @rename(attribute: "expiry_date")
 

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -406,7 +406,6 @@ type PoolCandidate {
   id: ID!
   pool: Pool!
   user: User!
-  cmoIdentifier: ID @deprecated(reason: "Field no longer used")
   expiryDate: Date
   status: PoolCandidateStatus
   statusWeight: Int

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -235,7 +235,6 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
             priorityWeight
           }
           isBookmarked
-          cmoIdentifier
           expiryDate
           status
           submittedAt

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -730,7 +730,6 @@ export const PoolCandidatesTable_SelectPoolCandidatesQuery = graphql(
             }
           }
         }
-        cmoIdentifier
         expiryDate
         status
         submittedAt

--- a/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
@@ -41,7 +41,6 @@ const AddToPoolDialog_Mutation = graphql(/* GraphQL */ `
       user {
         id
       }
-      cmoIdentifier
       expiryDate
       status
     }

--- a/apps/web/src/pages/Users/UserInformationPage/components/mutation.ts
+++ b/apps/web/src/pages/Users/UserInformationPage/components/mutation.ts
@@ -6,7 +6,6 @@ const UpdatePoolCandidateStatus_Mutation = graphql(/* GraphQL */ `
     $poolCandidate: UpdatePoolCandidateStatusInput!
   ) {
     updatePoolCandidateStatus(id: $id, poolCandidate: $poolCandidate) {
-      cmoIdentifier
       expiryDate
       status
     }

--- a/packages/fake-data/src/fakePoolCandidates.ts
+++ b/packages/fake-data/src/fakePoolCandidates.ts
@@ -36,9 +36,6 @@ const generatePoolCandidate = (pools: Pool[], users: User[]): PoolCandidate => {
     id: faker.string.uuid(),
     pool,
     user,
-    cmoIdentifier: faker.helpers.slugify(
-      faker.lorem.words(faker.number.int({ min: 1, max: 3 })),
-    ),
     educationRequirementExperiences: fakeExperiences(1),
     educationRequirementOption:
       faker.helpers.arrayElement<EducationRequirementOption>(


### PR DESCRIPTION
🤖 Resolves #10155.

## 👋 Introduction

This PR removes the `cmoIdentifier` field from the `PoolCandidate` GraphQL type and the `cmo_identifier` column from the `pool_candidates` database table.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure no instances of `cmoIdentifier` or `cmo_identifier` in the codebase (exceptions being in migration files)
2. Build app
3. Navigate to PoolCandidatesTable
4. Ensure page loads with no errors
5. `php artisan migrate`
6. Observe `cmo_identifier` column does not exist in the `pool_candidates` database table
7. `php artisan migrate:rollback --step=1`
8. Observe `cmo_identifier` column does exist with NULL values in its rows in the `pool_candidates` database table