### PR TITLE
[Debt] Updates title tag to match page tab title

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6134,10 +6134,6 @@
     "defaultMessage": "Octroi de contrat pour des services numériques",
     "description": "Short name for Digital Services Contracting Form"
   },
-  "X4TOhW": {
-    "defaultMessage": "Candidats",
-    "description": "Page title for the admin pool candidates index page"
-  },
   "X5tRR4": {
     "defaultMessage": "Il n’existe aucune compétence jusqu’à présent.",
     "description": "Title for no skills in a users library"

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
@@ -179,7 +179,14 @@ export const IndexPoolCandidatePage = () => {
 
   return (
     <AdminContentWrapper>
-      <SEO title={pageTitle} description={formattedSubTitle} />
+      <SEO
+        title={intl.formatMessage({
+          defaultMessage: "Talent placement",
+          id: "0YpfAG",
+          description: "Title for candidates tab for a process",
+        })}
+        description={formattedSubTitle}
+      />
       <Pending fetching={fetching} error={error}>
         <p data-h2-margin="base(x1, 0)">{formattedSubTitle}</p>
         <PoolCandidatesTable

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -351,17 +351,12 @@ export const useAdminPoolPages = (intl: IntlShape, pool: Pick<Pool, "id">) => {
       {
         icon: UserGroupIcon,
         title: intl.formatMessage({
-          defaultMessage: "Candidates",
-          id: "X4TOhW",
-          description: "Page title for the admin pool candidates index page",
+          defaultMessage: "Talent placement",
+          id: "0YpfAG",
+          description: "Title for candidates tab for a process",
         }),
         link: {
           url: paths.poolCandidateTable(pool.id),
-          label: intl.formatMessage({
-            defaultMessage: "Talent placement",
-            id: "0YpfAG",
-            description: "Title for candidates tab for a process",
-          }),
         },
       },
     ],


### PR DESCRIPTION
🤖 Resolves #9788.

## 👋 Introduction

This PR updates the `<title>` tag to match page tab title.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/admin/pools/:pool-id`
2. Click on Talent placement link
3. Observe the `<title>` tag is the same as the page tab title.

## 🎥 Screen recording

https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/94cb1977-3ab7-4971-ba19-eca91c8a207b