### PR TITLE
[Copy] Fixes typo for pool candidates 

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -467,6 +467,10 @@
     "defaultMessage": "Erreur : nom de compétence non trouvé",
     "description": "Error message when skill name is not found on request page."
   },
+  "0Uvziq": {
+    "defaultMessage": "Candidats du bassin",
+    "description": "Title for pool candidates"
+  },
   "0VlOQq": {
     "defaultMessage": "Modifier - compétence",
     "description": "Page title for the edit skill page."
@@ -11113,10 +11117,6 @@
   "zemp3H": {
     "defaultMessage": "Niveau de sécurité",
     "description": "Label for _security level_ fieldset in the _digital services contracting questionnaire_"
-  },
-  "zfi91j": {
-    "defaultMessage": "Candidats du bassin",
-    "description": "Title for pool candidates"
   },
   "zl6H2p": {
     "defaultMessage": "Questions relatives à l’Initiative en matière numérique",

--- a/apps/web/src/messages/adminMessages.ts
+++ b/apps/web/src/messages/adminMessages.ts
@@ -51,9 +51,9 @@ const messages = defineMessages({
     id: "Myfw+L",
     description: "Title for pools",
   },
-  poolsCandidates: {
-    defaultMessage: "Pools candidates",
-    id: "zfi91j",
+  poolCandidates: {
+    defaultMessage: "Pool candidates",
+    id: "0Uvziq",
     description: "Title for pool candidates",
   },
   publishingGroups: {

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
@@ -167,7 +167,7 @@ export const IndexPoolCandidatePage = () => {
   const intl = useIntl();
   const { poolId } = useRequiredParams<RouteParams>("poolId");
 
-  const pageTitle = intl.formatMessage(adminMessages.poolsCandidates);
+  const pageTitle = intl.formatMessage(adminMessages.poolCandidates);
   const formattedSubTitle = intl.formatMessage(subTitle);
 
   const [{ data, fetching, error }] = useQuery({

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -123,7 +123,7 @@ const SingleSearchRequestTableApi = ({
               expiryStatus: CandidateExpiryFilter.Active,
             }
       }
-      title={intl.formatMessage(adminMessages.poolsCandidates)}
+      title={intl.formatMessage(adminMessages.poolCandidates)}
     />
   );
 };


### PR DESCRIPTION
🤖 Resolves #10192.

## 👋 Introduction

This PR changes to Pools Candidates Pool Candidates and changes key from `adminMessage.poolsCandidates`  to `adminMessage.poolCandidates`.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure codebase has no instances of poolsCandidates or "Pools Candidates"