### PR TITLE
[Fix] Removes `SkillAccordion` extra spaces

### DIFF
--- a/apps/web/src/components/UserProfile/SkillAccordion/SkillAccordion.test.tsx
+++ b/apps/web/src/components/UserProfile/SkillAccordion/SkillAccordion.test.tsx
@@ -81,7 +81,7 @@ describe("SkillAccordion", () => {
 
     await openAccordion(testSkill.name.en);
 
-    expect(screen.getByText("1 Experience")).toBeInTheDocument();
+    expect(screen.getByText("1 experience")).toBeInTheDocument();
     expect(
       screen.getByRole("region", {
         name: new RegExp(testSkill.name.en || "", "i"),
@@ -100,7 +100,7 @@ describe("SkillAccordion", () => {
     renderSkillAccordion(testSkill);
     await openAccordion(testSkill.name.en);
 
-    expect(screen.getByText("1 Experience")).toBeInTheDocument();
+    expect(screen.getByText("1 experience")).toBeInTheDocument();
 
     const detail = screen.getByRole("region", {
       name: new RegExp(testSkill.name.en || "", "i"),
@@ -127,7 +127,7 @@ describe("SkillAccordion", () => {
 
     await openAccordion(testSkill.name.en);
 
-    expect(screen.getByText("1 Experience")).toBeInTheDocument();
+    expect(screen.getByText("1 experience")).toBeInTheDocument();
 
     const detail = screen.getByRole("region", {
       name: new RegExp(testSkill.name.en || "", "i"),
@@ -153,7 +153,7 @@ describe("SkillAccordion", () => {
 
     await openAccordion(testSkill.name.en);
 
-    expect(screen.getByText("1 Experience")).toBeInTheDocument();
+    expect(screen.getByText("1 experience")).toBeInTheDocument();
 
     const detail = screen.getByRole("region", {
       name: new RegExp(testSkill.name.en || "", "i"),
@@ -179,7 +179,7 @@ describe("SkillAccordion", () => {
 
     await openAccordion(testSkill.name.en);
 
-    expect(screen.getByText("1 Experience")).toBeInTheDocument();
+    expect(screen.getByText("1 experience")).toBeInTheDocument();
 
     const detail = screen.getByRole("region", {
       name: new RegExp(testSkill.name.en || "", "i"),
@@ -201,7 +201,7 @@ describe("SkillAccordion", () => {
 
     await openAccordion(testSkill.name.en);
 
-    expect(screen.getByText("2 Experiences")).toBeInTheDocument();
+    expect(screen.getByText("2 experiences")).toBeInTheDocument();
 
     const detail = screen.getByRole("region", {
       name: new RegExp(testSkill.name.en || "", "i"),

--- a/apps/web/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
+++ b/apps/web/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
@@ -9,6 +9,7 @@ import {
   getAwardedTo,
   getEducationStatus,
   getEducationType,
+  commonMessages,
 } from "@gc-digital-talent/i18n";
 import {
   Skill,
@@ -20,6 +21,7 @@ import {
 } from "@gc-digital-talent/graphql";
 
 import {
+  getExperienceFormLabels,
   isAwardExperience,
   isCommunityExperience,
   isEducationExperience,
@@ -65,6 +67,8 @@ const SkillAccordion = ({
   const intl = useIntl();
   const locale = getLocale(intl);
 
+  const experienceFormLabels = getExperienceFormLabels(intl);
+
   const { name, experiences } = skill;
 
   const getPersonalExperience = (experience: PersonalExperience) => {
@@ -75,13 +79,17 @@ const SkillAccordion = ({
 
     return (
       <>
-        <p data-h2-color="base(primary.darker)">{title}</p>
-        <p data-h2-margin="base(0, 0, x.5, 0)">
-          {getDateRange({ endDate, startDate, intl })}
-        </p>
-        <p>{description}</p>
-        <p>{justification}</p>
-        <p>{details}</p>
+        {title && <p data-h2-color="base(primary.darker)">{title}</p>}
+        {endDate || startDate ? (
+          <p data-h2-margin="base(0, 0, x.5, 0)">
+            {getDateRange({ endDate, startDate, intl })}
+          </p>
+        ) : (
+          ""
+        )}
+        {description && <p>{description}</p>}
+        {justification && <p>{justification}</p>}
+        {details && <p>{details}</p>}
       </>
     );
   };
@@ -102,42 +110,49 @@ const SkillAccordion = ({
     const justification = skills ? grabSkillJustification(skills, skill) : "";
 
     return (
-      <div>
-        <p>
-          {intl.formatMessage(experienceMessages.educationAt, {
-            areaOfStudy: (
-              <span data-h2-color="base(primary.darker)">{areaOfStudy}</span>
-            ),
-            institution,
-          })}
-        </p>
-        <p data-h2-margin="base(0, 0, x.5, 0)">
-          {getDateRange({ endDate, startDate, intl })}
-        </p>
-        <p>
-          {type ? intl.formatMessage(getEducationType(type)) : ""}{" "}
-          <span
-            data-h2-color="base(primary.darker)"
-            data-h2-font-style="base(italic)"
-          >
-            {status ? intl.formatMessage(getEducationStatus(status)) : ""}{" "}
-          </span>
-        </p>
-        <p>
-          {thesisTitle
-            ? intl.formatMessage(
-                {
-                  defaultMessage: "Thesis: {thesisTitle}",
-                  id: "omDlZN",
-                  description: "Thesis, if applicable",
-                },
-                { thesisTitle },
-              )
-            : ""}
-        </p>
+      <>
+        {areaOfStudy || institution ? (
+          <p>
+            {intl.formatMessage(experienceMessages.educationAt, {
+              areaOfStudy: (
+                <span data-h2-color="base(primary.darker)">{areaOfStudy}</span>
+              ),
+              institution,
+            })}
+          </p>
+        ) : (
+          ""
+        )}
+        {endDate || startDate ? (
+          <p data-h2-margin="base(0, 0, x.5, 0)">
+            {getDateRange({ endDate, startDate, intl })}
+          </p>
+        ) : (
+          ""
+        )}
+        {type && status ? (
+          <p>
+            {intl.formatMessage(getEducationType(type))}{" "}
+            <span
+              data-h2-color="base(primary.darker)"
+              data-h2-font-style="base(italic)"
+            >
+              {intl.formatMessage(getEducationStatus(status))}
+            </span>
+          </p>
+        ) : (
+          ""
+        )}
+        {thesisTitle && (
+          <p>
+            {experienceFormLabels.thesisTitle}
+            {intl.formatMessage(commonMessages.dividingColon)}
+            {thesisTitle}
+          </p>
+        )}
         <p>{details}</p>
         <p>{justification}</p>
-      </div>
+      </>
     );
   };
 
@@ -156,51 +171,49 @@ const SkillAccordion = ({
 
     return (
       <>
-        <p>
-          {intl.formatMessage(
-            {
-              defaultMessage: "<primary>{title}</primary> issued by {issuedBy}",
-              id: "cK/hoN",
-              description: "The award title is issued by some group",
-            },
-            { issuedBy, title },
-          )}
-        </p>
-        <p data-h2-margin="base(0, 0, x.5, 0)">
-          {awardedDate && formattedDate(awardedDate, intl)}
-        </p>
-        <p>
-          {intl.formatMessage({
-            defaultMessage: "Awarded to: ",
-            id: "3JL02L",
-            description: "The award was given to",
-          })}{" "}
-          {awardedTo ? intl.formatMessage(getAwardedTo(awardedTo)) : ""}
-        </p>
-        <p>
-          {intl.formatMessage({
-            defaultMessage: "Scope: ",
-            id: "FAOzjP",
-            description: "The scope of the award given",
-          })}{" "}
-          {awardedScope
-            ? intl.formatMessage(getAwardedScope(awardedScope))
-            : ""}
-        </p>
-        <p>{justification}</p>
-        <p
-          data-h2-color="base(primary.darker)"
-          data-h2-font-weight="base(700)"
-          data-h2-margin="base(x1, 0, x.25, 0)"
-        >
-          {intl.formatMessage({
-            defaultMessage: "Additional details:",
-            id: "QfOWr0",
-            description: "Additional details if provided (without details)",
-          })}
-        </p>
-
-        <p>{details}</p>
+        {title || issuedBy ? (
+          <p>
+            {intl.formatMessage(experienceMessages.awardIssuedBy, {
+              title: <span data-h2-color="base(primary.darker)">{title}</span>,
+              issuedBy,
+            })}
+          </p>
+        ) : (
+          ""
+        )}
+        {awardedDate && (
+          <p data-h2-margin="base(0, 0, x.5, 0)">
+            {formattedDate(awardedDate, intl)}
+          </p>
+        )}
+        {awardedTo && (
+          <p>
+            {experienceFormLabels.awardedTo}
+            {intl.formatMessage(commonMessages.dividingColon)}
+            {intl.formatMessage(getAwardedTo(awardedTo))}
+          </p>
+        )}
+        {awardedScope && (
+          <p>
+            {experienceFormLabels.awardedScope}
+            {intl.formatMessage(commonMessages.dividingColon)}
+            {intl.formatMessage(getAwardedScope(awardedScope))}
+          </p>
+        )}
+        {justification && <p>{justification}</p>}
+        {details && (
+          <>
+            <p
+              data-h2-color="base(primary.darker)"
+              data-h2-font-weight="base(700)"
+              data-h2-margin="base(x1, 0, x.25, 0)"
+            >
+              {experienceFormLabels.details}
+              {intl.formatMessage(commonMessages.dividingColon)}
+            </p>
+            <p>{details}</p>
+          </>
+        )}
       </>
     );
   };
@@ -220,42 +233,46 @@ const SkillAccordion = ({
 
     return (
       <>
-        <p>
-          {intl.formatMessage(
-            {
-              defaultMessage: "<primary>{title}</primary> at {organization}",
-              id: "UPx6kk",
-              description: "Title at organization",
-            },
-            { organization, title },
-          )}
-        </p>
-        <p data-h2-margin="base(0, 0, x.5, 0)">
-          {getDateRange({ endDate, startDate, intl })}
-        </p>
-        <p>
-          {intl.formatMessage(
-            {
-              defaultMessage: "Project: {project}",
-              id: "gtLuDM",
-              description: "Project Name",
-            },
-            { project },
-          )}
-        </p>
+        {title || organization ? (
+          <p>
+            {intl.formatMessage(experienceMessages.communityAt, {
+              title: <span data-h2-color="base(primary.darker)">{title}</span>,
+              organization,
+            })}
+          </p>
+        ) : (
+          ""
+        )}
+        {endDate || startDate ? (
+          <p data-h2-margin="base(0, 0, x.5, 0)">
+            {getDateRange({ endDate, startDate, intl })}
+          </p>
+        ) : (
+          ""
+        )}
+        {project && (
+          <>
+            <p>
+              {experienceFormLabels.project}
+              {intl.formatMessage(commonMessages.dividingColon)}
+            </p>
+            <p>{project}</p>
+          </>
+        )}
         <p>{justification}</p>
-        <p
-          data-h2-color="base(primary.darker)"
-          data-h2-font-weight="base(700)"
-          data-h2-margin="base(x1, 0, x.25, 0)"
-        >
-          {intl.formatMessage({
-            defaultMessage: "Additional details:",
-            id: "QfOWr0",
-            description: "Additional details if provided (without details)",
-          })}
-        </p>
-        <p>{details}</p>
+        {details && (
+          <>
+            <p
+              data-h2-color="base(primary.darker)"
+              data-h2-font-weight="base(700)"
+              data-h2-margin="base(x1, 0, x.25, 0)"
+            >
+              {experienceFormLabels.details}
+              {intl.formatMessage(commonMessages.dividingColon)}
+            </p>
+            <p>{details}</p>
+          </>
+        )}
       </>
     );
   };
@@ -275,60 +292,61 @@ const SkillAccordion = ({
 
     return (
       <>
-        <p>
-          {intl.formatMessage(
-            {
-              defaultMessage: "<primary>{role}</primary> at {organization}",
-              id: "VOheZB",
-              description:
-                "Role at organization in work experience block of skill accordion.",
-            },
-            { organization, role },
-          )}
-        </p>
-        <p data-h2-margin="base(0, 0, x.5, 0)">
-          {getDateRange({ endDate, startDate, intl })}
-        </p>
-        <p>{division}</p>
-        <p>{justification}</p>
-        <p
-          data-h2-color="base(primary.darker)"
-          data-h2-font-weight="base(700)"
-          data-h2-margin="base(x1, 0, x.25, 0)"
-        >
-          {intl.formatMessage({
-            defaultMessage: "Additional details:",
-            id: "QfOWr0",
-            description: "Additional details if provided (without details)",
-          })}
-        </p>
-        <p>{details}</p>
+        {role || organization ? (
+          <p>
+            {intl.formatMessage(experienceMessages.workAt, {
+              role: <span data-h2-color="base(primary.darker)">{role}</span>,
+              organization,
+            })}
+          </p>
+        ) : (
+          ""
+        )}
+        {endDate || startDate ? (
+          <p data-h2-margin="base(0, 0, x.5, 0)">
+            {getDateRange({ endDate, startDate, intl })}
+          </p>
+        ) : (
+          ""
+        )}
+        {division && <p>{division}</p>}
+        {justification && <p>{justification}</p>}
+        {details && (
+          <>
+            <p
+              data-h2-color="base(primary.darker)"
+              data-h2-font-weight="base(700)"
+              data-h2-margin="base(x1, 0, x.25, 0)"
+            >
+              {experienceFormLabels.details}
+              {intl.formatMessage(commonMessages.dividingColon)}
+            </p>
+            <p>{details}</p>
+          </>
+        )}
       </>
     );
   };
+
   const renderWithExperience = () => {
     return experiences?.map((experience) => {
       return (
         <ul data-h2-padding="base(0, 0, 0, x1)" key={experience?.id}>
           <li data-h2-margin="base(x1, 0, 0, 0)">
-            {isPersonalExperience(experience!)
-              ? getPersonalExperience(experience)
-              : ""}
-            {isEducationExperience(experience!)
-              ? getEducationExperience(experience)
-              : ""}
-            {isAwardExperience(experience!)
-              ? getAwardExperience(experience)
-              : ""}
-            {isCommunityExperience(experience!)
-              ? getCommunityExperience(experience)
-              : ""}
-            {isWorkExperience(experience!) ? getWorkExperience(experience) : ""}
+            {isPersonalExperience(experience!) &&
+              getPersonalExperience(experience)}
+            {isEducationExperience(experience!) &&
+              getEducationExperience(experience)}
+            {isAwardExperience(experience!) && getAwardExperience(experience)}
+            {isCommunityExperience(experience!) &&
+              getCommunityExperience(experience)}
+            {isWorkExperience(experience!) && getWorkExperience(experience)}
           </li>
         </ul>
       );
     });
   };
+
   const renderNoExperience = () => {
     return (
       <p>
@@ -365,22 +383,17 @@ const SkillAccordion = ({
     <Accordion.Item value={skill.id}>
       <Accordion.Trigger
         as={headingLevel}
-        context={
-          experiences?.length === 1
-            ? intl.formatMessage({
-                defaultMessage: "1 Experience",
-                id: "dQseX7",
-                description: "Pluralization for one experience",
-              })
-            : intl.formatMessage(
-                {
-                  defaultMessage: "{experienceLength} Experiences",
-                  id: "xNVsei",
-                  description: "Pluralization for zero or multiple experiences",
-                },
-                { experienceLength: experiences ? experiences.length : 0 },
-              )
-        }
+        context={intl.formatMessage(
+          {
+            defaultMessage:
+              "{experienceCount, plural, =0 {0 experiences} =1 {1 experience} other {# experiences}}",
+            id: "C6kQXh",
+            description: "list a number of unknown experiences",
+          },
+          {
+            experienceCount: experiences ? experiences.length : 0,
+          },
+        )}
       >
         {name[locale]}
       </Accordion.Trigger>

--- a/apps/web/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
+++ b/apps/web/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
@@ -28,6 +28,7 @@ import {
 } from "~/utils/experienceUtils";
 import { InvertedSkillExperience } from "~/utils/skillUtils";
 import { getDateRange, formattedDate } from "~/utils/dateUtils";
+import experienceMessages from "~/messages/experienceMessages";
 
 export interface SkillAccordionProps {
   skill: InvertedSkillExperience;
@@ -103,15 +104,12 @@ const SkillAccordion = ({
     return (
       <div>
         <p>
-          <span data-h2-color="base(primary.darker)">{areaOfStudy}</span>{" "}
-          {intl.formatMessage(
-            {
-              defaultMessage: " at {institution}",
-              id: "CX/qKY",
-              description: "Study at institution",
-            },
-            { institution },
-          )}
+          {intl.formatMessage(experienceMessages.educationAt, {
+            areaOfStudy: (
+              <span data-h2-color="base(primary.darker)">{areaOfStudy}</span>
+            ),
+            institution,
+          })}
         </p>
         <p data-h2-margin="base(0, 0, x.5, 0)">
           {getDateRange({ endDate, startDate, intl })}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2491,10 +2491,6 @@
     "defaultMessage": "Vous pouvez autodéclarer votre appartenance à une ou plusieurs des communautés énumérées alphabétiquement ci-dessous.",
     "description": "Text that appears before employment equity form options."
   },
-  "CX/qKY": {
-    "defaultMessage": "à {institution}",
-    "description": "Study at institution"
-  },
   "CY+493": {
     "defaultMessage": "Pour en apprendre davantage",
     "description": "Button text to learn more about the program"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -959,10 +959,6 @@
     "defaultMessage": "Lancement de la troisième cohorte du programme de mentorat de la collectivité du numérique destiné aux membres des groupes d’équité en matière d’emploi.",
     "description": "Description of the mentorship program"
   },
-  "3JL02L": {
-    "defaultMessage": "Décerné à :",
-    "description": "The award was given to"
-  },
   "3MboNR": {
     "defaultMessage": "Veuillez sélectionner une date d’expiration",
     "description": "Label for date selection input for expiry date"
@@ -2979,10 +2975,6 @@
     "defaultMessage": "Droit d’auteur",
     "description": "Heading for comments and interaction section"
   },
-  "FAOzjP": {
-    "defaultMessage": "Portée :",
-    "description": "The scope of the award given"
-  },
   "FC5tje": {
     "defaultMessage": "Autres commentaires",
     "description": "Label for additional comments textarea in the request form."
@@ -4927,10 +4919,6 @@
     "defaultMessage": "Il manque des renseignements personnels",
     "description": "Error message displayed when a users personal information is incomplete"
   },
-  "QfOWr0": {
-    "defaultMessage": "Détails additionnels :",
-    "description": "Additional details if provided (without details)"
-  },
   "QgX0vb": {
     "defaultMessage": "Retirer<hidden> {skillName}</hidden>",
     "description": "Button text to delete a personnel skill requirement"
@@ -5611,10 +5599,6 @@
     "defaultMessage": "Autochtone selon la définition de ce programme",
     "description": "Heading for the definition of Indigenous dialog"
   },
-  "UPx6kk": {
-    "defaultMessage": "<primary>{title}</primary> à {organization}",
-    "description": "Title at organization"
-  },
   "UQlyXu": {
     "defaultMessage": "Les apprentis feront l’expérience d’un apprentissage au travail et pendant la formation en ligne dans un ou plusieurs domaines de la technologie de l’information. On s’attend à ce que les apprentis démontrent leur intérêt et leur passion pour la technologie en étant prêts à observer, à apprendre et à pratiquer de nouvelles compétences qui sont développées au cours du programme. En moyenne, un apprenti passera quatre jours par semaine en apprentissage pratique, tandis que le cinquième jour de la semaine sera consacré au perfectionnement personnel et professionnel par la formation en ligne et par d’autres possibilités de formation et de perfectionnement.",
     "description": "Learn more dialog question eight paragraph one"
@@ -5789,10 +5773,6 @@
   "VN6uCI": {
     "defaultMessage": "Ces compétences essentielles ont été évaluées dans le cadre du processus :",
     "description": "Text showing the essentials skills assessed during the process"
-  },
-  "VOheZB": {
-    "defaultMessage": "<primary>{role}</primary> à {organization}",
-    "description": "Role at organization in work experience block of skill accordion."
   },
   "VUPlmN": {
     "defaultMessage": "Premières Nations (inscrites ou non)",
@@ -7094,10 +7074,6 @@
     "defaultMessage": "Il n'y a aucun élément à afficher.",
     "description": "Message when there is no data to display in a table"
   },
-  "cK/hoN": {
-    "defaultMessage": "<primary>{title}</primary> délivré par {issuedBy}",
-    "description": "The award title is issued by some group"
-  },
   "cL3OoZ": {
     "defaultMessage": "Notification non lue",
     "description": "Link text to show unread notifications"
@@ -7293,10 +7269,6 @@
   "dJXjhw": {
     "defaultMessage": "Sélectionnez un volet",
     "description": "Placeholder for stream filter in browse opportunities form."
-  },
-  "dQseX7": {
-    "defaultMessage": "1 expérience",
-    "description": "Pluralization for one experience"
   },
   "dSfDu1": {
     "defaultMessage": "Aidez les gestionnaires à comprendre les domaines dans lesquels vous souhaitez améliorer des compétences comportementales. Vous pouvez modifier cette vitrine à tout moment et vous êtes libre de mettre les compétences dans l’ordre qui vous convient. Les compétences que vous ajoutez à la vitrine qui ne sont pas déjà dans votre bibliothèque seront ajoutées automatiquement.",
@@ -7969,10 +7941,6 @@
   "gsaza3": {
     "defaultMessage": "Prévoyez-vous un effet de report ou d’entraînement immédiat sur d’autres services en termes de niveaux de personnel ou de compétences requises?",
     "description": "Label for _has immediate impact on other departments_ fieldset in the _digital services contracting questionnaire_"
-  },
-  "gtLuDM": {
-    "defaultMessage": "Projet : {project}",
-    "description": "Project Name"
   },
   "gtU+9w": {
     "defaultMessage": "Bienvenue aux cadres",
@@ -9434,10 +9402,6 @@
     "defaultMessage": "Le présent énoncé a été préparé le 8 novembre 2022.",
     "description": "Disclaimer for the when the accessibility statement was last updated"
   },
-  "omDlZN": {
-    "defaultMessage": "Thèse : {thesisTitle}",
-    "description": "Thesis, if applicable"
-  },
   "opkSia": {
     "defaultMessage": "Gérer « {skillName} »",
     "description": "Page title for the skill self evaluation page"
@@ -10741,10 +10705,6 @@
   "xM6U6U": {
     "defaultMessage": "Sans objet (s. o.)",
     "description": "Not applicable contract supply method"
-  },
-  "xNVsei": {
-    "defaultMessage": "{experienceLength} Expériences",
-    "description": "Pluralization for zero or multiple experiences"
   },
   "xPaVvi": {
     "defaultMessage": "Comme l’indiquent les <link>Procédures obligatoires sur les talents numériques</link>, il incombe au chef opérationnel de remplir et de soumettre le questionnaire sur les contrats de services numériques s’il fournit des services numériques.",


### PR DESCRIPTION
🤖 Resolves #10196.

## 👋 Introduction

This PR removes some extra spaces rendered in `SkillAccordion`. Also, it consolidates some i18n messages and brings some of the messages in line with those used for the experience labels which needed only a bit of refactoring in the `SkillAccordion` component in order to eliminate some duplicates. Finally, it adds some conditional rendering in order to avoid empty HTML tags.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run storybook
2. Navigate to Accordion Education Example story
3. Observe extra spaces
4. Check Chromatic for any other different to **Accordion {Type} Example stories**