### PR TITLE
[Fix] Hides edit button in `ExperienceCard` on admin user profile

### DIFF
--- a/apps/web/src/components/UserProfile/ExperienceByTypeListing.tsx
+++ b/apps/web/src/components/UserProfile/ExperienceByTypeListing.tsx
@@ -64,6 +64,7 @@ const ExperienceByType = ({
               experience={experience}
               headingLevel={headingLevel}
               editParam={editParam}
+              showEdit={false}
             />
           ))}
         </div>

--- a/apps/web/src/components/UserProfile/ExperienceSection.tsx
+++ b/apps/web/src/components/UserProfile/ExperienceSection.tsx
@@ -170,6 +170,7 @@ const ExperienceSection = ({
               onOpenChange={() => toggleExpandedItem(experience.id)}
               isOpen={isExpanded(experience.id)}
               experience={experience}
+              showEdit={false}
               editParam={editParam}
             />
           ))}


### PR DESCRIPTION
🤖 Resolves #10197.

## 👋 Introduction

This PR hides edit button for all users in the admin user profile since this is not the intended user flow to edit experiences.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. As a user with an admin role, navigate to `/admin/users/:user-id/profile#career-timeline-section`
2. Ensure the user's page who is being visited has existing experiences and is not the current user
3. Observe  lack of an edit button on `ExperienceCard` in By Type and By Date tabs

## 📸 Screenshots

<img width="884" alt="Screen Shot 2024-04-29 at 13 25 07" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/9840a354-b4f2-434d-a836-747b1e19952b">
<img width="881" alt="Screen Shot 2024-04-29 at 13 24 38" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/67f8a1b0-aaf6-40e3-94c7-e9f65b04a62a">
