### PR TITLE
[Bug] Missing styling for chevron in Screening and assessment page

### DIFF
--- a/packages/ui/src/components/Board/Board.tsx
+++ b/packages/ui/src/components/Board/Board.tsx
@@ -13,6 +13,7 @@ import { BoardProvider, useBoardContext } from "./BoardProvider";
 import { findColumns } from "./utils";
 import { BoardColumn } from "./types";
 import { ARROW_KEY, isArrowKey } from "../../utils/keyboard";
+import getFontColor from "../../utils/button/getButtonFontColor";
 
 type RootProps = React.HTMLProps<HTMLDivElement> & {
   defaultItem?: number;
@@ -363,6 +364,7 @@ const Info = ({
             data-h2-height="base(x.75)"
             data-h2-width="base(x.75)"
             data-h2-transition="base(transform 150ms ease)"
+            {...getFontColor({ mode: "inline", color: "black" })}
           />
           <span className="Info__Trigger__Title">{title}</span>
         </span>


### PR DESCRIPTION
🤖 Resolves #10194

## 👋 Introduction

Improve the styling for the chevron, using the font function.
Replicates the styling used for accordion components and the collapsible elsewhere, though, could not just nest things in buttons without chaining buttons. 

## 🧪 Testing

1. Navigate to Board component
2. Switch to Dark
3. Styling of chevron changes

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/770f2bc5-6759-418f-b84d-9e7423c1ebbf)

