### PR TITLE
[Copy] Removes word optionally from additional details field description

### DIFF
--- a/apps/web/src/components/ExperienceFormFields/AdditionalDetails.tsx
+++ b/apps/web/src/components/ExperienceFormFields/AdditionalDetails.tsx
@@ -45,8 +45,8 @@ const AdditionalDetails = ({ experienceType }: AdditionalDetailsProps) => {
             <p data-h2-margin="base(0, 0, x1, 0)">
               {intl.formatMessage({
                 defaultMessage:
-                  "Optionally describe <strong>key tasks</strong>, <strong>responsibilities</strong>, or <strong>other information</strong> you feel were crucial in making this experience important.",
-                id: "KteuZ5",
+                  "Describe <strong>key tasks</strong>, <strong>responsibilities</strong>, or <strong>other information</strong> you feel were crucial in making this experience important.",
+                id: "KKLx+Z",
                 description:
                   "Help text for the experience additional details field",
               })}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3863,6 +3863,10 @@
     "defaultMessage": "État du processus",
     "description": "Title for card for actions related to changing the status of a process"
   },
+  "KKLx+Z": {
+    "defaultMessage": "<strong>Tâches</strong>, <strong>responsabilités</strong> ou autre <strong>information clés</strong> qui, selon vous, sont essentielles à l’importance de cette expérience.",
+    "description": "Help text for the experience additional details field"
+  },
   "KKXJFE": {
     "defaultMessage": "Fiabilité",
     "description": "Reliability screening level"
@@ -3982,10 +3986,6 @@
   "Kss450": {
     "defaultMessage": "Une option de prolongation du contrat est-elle actuellement prévue?",
     "description": "Label for _contract extendable_ fieldset in the _digital services contracting questionnaire_"
-  },
-  "KteuZ5": {
-    "defaultMessage": "<strong>Tâches</strong>, <strong>responsabilités</strong> ou autre <strong>information clés facultatives</strong> qui, selon vous, sont essentielles à l’importance de cette expérience.",
-    "description": "Help text for the experience additional details field"
   },
   "Kyf9At": {
     "defaultMessage": "Définir les renseignements et les exigences de ce processus de recrutement.",


### PR DESCRIPTION
🤖 Resolves #10222.

## 👋 Introduction

This PR removes the word **optionally** from the additional details field description since the additional details field is required and not optional.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/users/:user-id/personal-information/career-timeline/:experience-id/edit#additional-details`
2. Verify the word **optionally** does not appear anywhere in the description of the additional details field
3. Navigate to `/applications/:application-id/career-timeline/add`
4. Verify the word **optionally** does not appear anywhere in the description of the additional details field

## 📸 Screenshots

### French

#### Profile
<img width="1438" alt="Screen Shot 2024-05-01 at 09 46 46" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/4c0591b8-afee-4d3b-a8f5-3c115efeafc4">

#### Application
<img width="1440" alt="Screen Shot 2024-05-01 at 09 47 01" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/3d27b2a8-8d5c-4a56-9120-a82eaee39430">

### English

#### Profile
<img width="1438" alt="Screen Shot 2024-05-01 at 09 46 08" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/497c9604-95fc-47bd-afea-c8ca67d6c8bc">

#### Application
<img width="1440" alt="Screen Shot 2024-05-01 at 09 46 17" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/eedcc739-a8de-4112-bce8-9eb700274b2f">