### PR TITLE
[Bug] Resolve flaky `ApplicantFilterTest` test

### DIFF
--- a/api/tests/Feature/ApplicantFilterTest.php
+++ b/api/tests/Feature/ApplicantFilterTest.php
@@ -359,7 +359,7 @@ class ApplicantFilterTest extends TestCase
                 'stream' => PoolStream::BUSINESS_ADVISORY_SERVICES->name,
             ]);
         // Create candidates who may show up in searches
-        $candidates = PoolCandidate::factory()->count(100)->availableInSearch()->create([
+        $candidates = PoolCandidate::factory()->count(10)->availableInSearch()->create([
             'pool_id' => $pool->id,
             'user_id' => User::factory()->withSkillsAndExperiences(10),
         ]);
@@ -392,7 +392,7 @@ class ApplicantFilterTest extends TestCase
             'experiences',
             'experiences.skills',
         ])->find($candidate->user_id);
-        $candidateSkills = $candidateUser->experiences->pluck('skills')->flatten()->unique();
+        $candidateSkills = $candidateUser->experiences[0]->skills;
         $filter->skills()->saveMany($candidateSkills->shuffle()->take(3));
         $filter->pools()->save($pool);
         $filter->qualified_streams = $pool->stream;


### PR DESCRIPTION
🤖 Resolves #10201 

## 👋 Introduction

Resolve the intermittent failures. 

Appears to be due to the `->unique()` not exactly working as expected, simplified this step instead.
As well, don't think this test needs seeding of 100 candidates, so cut that down a bit. Performance improved!

## 🧪 Testing

1. CI succeeds
2. Run below locally successfully

```
for i in {1..50}; do docker-compose exec -w /home/site/wwwroot/api webserver sh -c "./vendor/bin/phpunit ./tests/Feature/ApplicantFilterTest.php"; done
```

Faster!

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/aea69fce-0715-4bdc-ba2e-4aef963de813)

