### PR TITLE
[Fix] Notification dialog null state

### DIFF
--- a/apps/web/src/components/NotificationList/NotificationList.tsx
+++ b/apps/web/src/components/NotificationList/NotificationList.tsx
@@ -113,7 +113,7 @@ const NotificationList = ({
           );
         })}
       </ul>
-      <NotificationPortal.Containers />
+      <NotificationPortal.Containers inDialog={inDialog} />
     </>
   );
 };

--- a/apps/web/src/components/NotificationList/NotificationListPage.tsx
+++ b/apps/web/src/components/NotificationList/NotificationListPage.tsx
@@ -97,7 +97,10 @@ const NotificationListPage = ({
       ) : null}
       {fetching && exclude.length === 0 && <Loading inline />}
       {showNullMessage && (
-        <NotificationPortal.Portal containerId={NULL_MESSAGE_ROOT_ID}>
+        <NotificationPortal.Portal
+          containerId={NULL_MESSAGE_ROOT_ID}
+          inDialog={inDialog}
+        >
           <Well
             {...(inDialog && {
               "data-h2-margin": "base(0 x1)",

--- a/apps/web/src/components/NotificationList/NotificationPortal.tsx
+++ b/apps/web/src/components/NotificationList/NotificationPortal.tsx
@@ -4,23 +4,34 @@ import { createPortal } from "react-dom";
 export const LOAD_MORE_ROOT_ID = "notification-load-more";
 export const NULL_MESSAGE_ROOT_ID = "notification-null-message";
 
-export const NotificationPortalContainers = () => (
-  <>
-    <div id={LOAD_MORE_ROOT_ID} />
-    <div id={NULL_MESSAGE_ROOT_ID} />
-  </>
-);
+export const NotificationPortalContainers = ({
+  inDialog,
+}: {
+  inDialog?: boolean;
+}) => {
+  const prefix = inDialog ? "dialog-" : "";
+  return (
+    <>
+      <div id={`${prefix}${LOAD_MORE_ROOT_ID}`} />
+      <div id={`${prefix}${NULL_MESSAGE_ROOT_ID}`} />
+    </>
+  );
+};
 
 interface NotificationPortalProps {
   containerId: string;
+  inDialog?: boolean;
   children: React.ReactNode;
 }
 
 const NotificationPortal = ({
   children,
+  inDialog,
   containerId,
 }: NotificationPortalProps) => {
-  const containerRoot = document.getElementById(containerId);
+  const containerRoot = document.getElementById(
+    `${inDialog ? "dialog-" : ""}${containerId}`,
+  );
 
   return containerRoot ? createPortal(children, containerRoot) : null;
 };


### PR DESCRIPTION
🤖 Resolves #9960 

## 👋 Introduction

Fixes an issue where the notification dialog was not properly rendering its null state.

## 🕵️ Details

These were using portals to render the null state but, the portal had the wrong ID. This fixes it to make the IDs unique and available for the root of the portal.

## 🧪 Testing

1. `pnpm run dev`
2. Login as any role
3. Make sure you have no notifications for the user you logged in as
4. Open the notification dialog
5. Confirm the null message appears

## 📸 Screenshot

![screenshot_02-May-2024_13-11-1714669862](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/c1516e67-2505-4f4b-9f0d-cc7b4737eff2)
