### PR TITLE
[Debt] Fix Nginx Warnings

### DIFF
--- a/infrastructure/bin/post_deployment.sh
+++ b/infrastructure/bin/post_deployment.sh
@@ -85,10 +85,15 @@ else
 fi
 
 # Copy nginx config and reload
-if /home/site/wwwroot/infrastructure/bin/substitute_file.sh /home/site/wwwroot/infrastructure/conf/nginx-conf-deploy/default /etc/nginx/sites-available/default '$NGINX_PORT $ROBOTS_FILENAME' && nginx -s reload ; then
-    add_section_block ":white_check_mark: Config copy for Nginx *successful*."
+if
+    touch /etc/nginx/conf.d/default.conf && \
+    /home/site/wwwroot/infrastructure/bin/substitute_file.sh \
+        /home/site/wwwroot/infrastructure/conf/nginx-conf-deploy/default \
+        /etc/nginx/sites-available/default '$NGINX_PORT $ROBOTS_FILENAME' && \
+    nginx -s reload ; then
+    add_section_block ":white_check_mark: Set up Nginx *successful*."
 else
-    add_section_block ":X: Config copy for Nginx *failed*. $MENTION"
+    add_section_block ":X: Set up Nginx *failed*. $MENTION"
 fi
 
 # Copy custom PHP-FPM config

--- a/infrastructure/bin/post_deployment.sh
+++ b/infrastructure/bin/post_deployment.sh
@@ -89,7 +89,7 @@ if
     touch /etc/nginx/conf.d/default.conf && \
     /home/site/wwwroot/infrastructure/bin/substitute_file.sh \
         /home/site/wwwroot/infrastructure/conf/nginx-conf-deploy/default \
-        /etc/nginx/sites-available/default '$NGINX_PORT $ROBOTS_FILENAME' && \
+        /etc/nginx/sites-available/default '$NGINX_PORT $ROBOTS_FILENAME $HTTP_DISGUISED_HOST' && \
     nginx -s reload ; then
     add_section_block ":white_check_mark: Set up Nginx *successful*."
 else

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -9,7 +9,7 @@ server {
 
     root /home/site/wwwroot;
     index  index.php index.html index.htm;
-    #server_name talent.canada.ca www.talent.canada.ca;
+    server_name $HTTP_DISGUISED_HOST;
     absolute_redirect off;
     gzip_static on;
 

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -37,13 +37,6 @@ server {
     # Permanent redirect for IAP french vanity url
     location = /apprentis-autochtone-ti { return 301 /fr/indigenous-it-apprentice$is_args$args; }
 
-    # Disable .git directory
-    location ~ /\.git {
-        deny all;
-        access_log off;
-        log_not_found off;
-    }
-
     # handle special cases
     location = /robots.txt {
         alias /home/site/wwwroot/infrastructure/conf/$ROBOTS_FILENAME;

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -62,13 +62,6 @@ server {
         break;
     }
 
-    # Disable .git directory
-    location ~ /\.git {
-        deny all;
-        access_log off;
-        log_not_found off;
-    }
-
     # handle special cases
     location = /robots.txt {
         alias /home/site/wwwroot/infrastructure/conf/dev.robots.txt;

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -19,7 +19,7 @@ server {
     listen [::]:8080;
     root /home/site/wwwroot;
     index  index.php index.html index.htm;
-    #server_name localhost;
+    server_name localhost;
     gzip_static on;
     absolute_redirect off;
 


### PR DESCRIPTION
🤖 Resolves #7155 

## 👋 Introduction

This fixes the config issues from the Nginx Amplify static analysis tool.

## 🕵️ Details

1. To fix the "missing a default.conf file" warning I added a `touch` command to the post-deploy script to create an empty file.
2. To fix the "missing a server_name directive" warning I added a substitution from an Azure variable that holds the domain name of the site.
3. To fix the two warnings about the git rule, I deleted it. :axe:  We no longer send the entire workspace to the app service so there's no way a real .git directory will be present.  If someone wants to see our git repo they can go to GH to get it.  :grin: 

## 🧪 Testing

1. Site can be built and visited locally.
2. Site can be built and visited in Azure.

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/66983652-e159-4c8f-9322-c4bcbc86ddfc)