### PR TITLE
[Debt] Improve pool candidate count query

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -183,7 +183,6 @@ type Pool {
     @guard
   poolCandidatesCount: Int
     @count(relation: "poolCandidates", scopes: ["notDraft"])
-    @guard
   keyTasks: LocalizedString @rename(attribute: "key_tasks")
   yourImpact: LocalizedString @rename(attribute: "your_impact")
   whatToExpect: LocalizedString @rename(attribute: "what_to_expect")

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -181,6 +181,9 @@ type Pool {
     @hasMany(relation: "publishedPoolCandidates", scopes: ["authorizedToView"])
     @canResolved(ability: "view")
     @guard
+  poolCandidatesCount: Int
+    @count(relation: "poolCandidates", scopes: ["notDraft"])
+    @guard
   keyTasks: LocalizedString @rename(attribute: "key_tasks")
   yourImpact: LocalizedString @rename(attribute: "your_impact")
   whatToExpect: LocalizedString @rename(attribute: "what_to_expect")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -328,6 +328,7 @@ type Pool {
   classification: Classification
   operationalRequirements: [OperationalRequirement]
   poolCandidates: [PoolCandidate]
+  poolCandidatesCount: Int
   keyTasks: LocalizedString
   yourImpact: LocalizedString
   whatToExpect: LocalizedString

--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -55,6 +55,7 @@ export const ViewPool_Fragment = graphql(/* GraphQL */ `
     closingDate
     processNumber
     stream
+    poolCandidatesCount
     classification {
       id
       group
@@ -69,16 +70,6 @@ export const ViewPool_Fragment = graphql(/* GraphQL */ `
     }
     assessmentSteps {
       id
-    }
-    poolCandidates {
-      id
-      pool {
-        id
-      }
-      user {
-        id
-        email
-      }
     }
   }
 `);
@@ -372,7 +363,7 @@ export const ViewPool = ({
                       "The number of applicants to a specific process",
                   },
                   {
-                    count: pool?.poolCandidates?.length ?? 0,
+                    count: pool.poolCandidatesCount ?? 0,
                   },
                 )}
               </p>


### PR DESCRIPTION
🤖 Resolves #10231 

## 👋 Introduction

Updates the candidate count query to use a new field that counts the rows of non-draft pool candidates on a pool.

## 🧪 Testing

1. Build `pnpm run dev`
2. Login as admin `admin@test.com`
3. Navigate to the main "Process information" page for a published pool with candidates
4. Confirm the total candidates count matches the non-draft pool candidates in the pool

## 📸 Screenshot

![screenshot_03-May-2024_14-16-1714760187](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/d35b754d-9720-4775-a6b3-40d4757af6d9)
