### PR TITLE
[Feature] Not compliant request status

### DIFF
--- a/api/app/Enums/PoolCandidateSearchStatus.php
+++ b/api/app/Enums/PoolCandidateSearchStatus.php
@@ -9,4 +9,5 @@ enum PoolCandidateSearchStatus
     case WAITING;
     case DONE;
     case DONE_NO_CANDIDATES;
+    case NOT_COMPLIANT;
 }

--- a/api/database/migrations/2024_05_03_182815_update_search_request_status_weight_column_not_complicant.php
+++ b/api/database/migrations/2024_05_03_182815_update_search_request_status_weight_column_not_complicant.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE pool_candidate_search_requests DROP COLUMN request_status_weight;');
+        DB::statement(
+            <<<'SQL'
+                ALTER TABLE pool_candidate_search_requests
+                    ADD COLUMN request_status_weight INT
+                    GENERATED ALWAYS AS
+                        (case
+                            when request_status = 'NEW' then 10
+                            when request_status = 'IN_PROGRESS' then 20
+                            when request_status = 'WAITING' then 30
+                            when request_status = 'DONE' then 40
+                            when request_status = 'DONE_NO_CANDIDATES' then 41
+                            when request_status = 'NOT_COMPLIANT' then 50
+                        end)
+                STORED;
+                SQL,
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement('ALTER TABLE pool_candidate_search_requests DROP COLUMN request_status_weight;');
+        DB::statement(
+            <<<'SQL'
+                ALTER TABLE pool_candidate_search_requests
+                    ADD COLUMN request_status_weight INT
+                    GENERATED ALWAYS AS
+                        (case
+                            when request_status = 'NEW' then 10
+                            when request_status = 'IN_PROGRESS' then 20
+                            when request_status = 'WAITING' then 30
+                            when request_status = 'DONE' then 40
+                        end)
+                STORED;
+                SQL,
+        );
+    }
+};

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -2130,6 +2130,7 @@ enum PoolCandidateSearchStatus {
   WAITING
   DONE
   DONE_NO_CANDIDATES
+  NOT_COMPLIANT
 }
 
 enum PoolCandidateSearchPositionType {

--- a/apps/web/src/components/SearchRequestTable/components/utils.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/utils.tsx
@@ -44,7 +44,7 @@ export function transformSortStateToOrderByClause(
     ["manager", "full_name"],
     ["jobTitle", "job_title"],
     ["email", "email"],
-    ["status", "request_status"],
+    ["status", "request_status_weight"],
     ["requestedDate", "created_at"],
   ]);
 

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -179,6 +179,10 @@
     "defaultMessage": "Atout",
     "description": "The skill is considered nonessential."
   },
+  "2jrMyA": {
+    "defaultMessage": "Non conforme",
+    "description": "The search status is not compliant"
+  },
   "2wKf2U": {
     "defaultMessage": "Modifier",
     "description": "Text to trigger edit action"

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -779,6 +779,11 @@ const poolCandidateSearchStatuses = defineMessages({
     id: "Mau9e6",
     description: "The search status is done with no candidates found",
   },
+  [PoolCandidateSearchStatus.NotCompliant]: {
+    defaultMessage: "Not compliant",
+    id: "2jrMyA",
+    description: "The search status is not compliant",
+  },
 });
 
 export const getPoolCandidateSearchStatus = (


### PR DESCRIPTION
🤖 Resolves #9947 

## 👋 Introduction

Adds a new "Not compliant" status for search requests.

## 🕵️ Details

When I was adding the weight for sorting I noticed two things:

1. We weren't actually using it to sort search requests
2. We did not have a weight for "done - no candidates"

So, I updated the sorting query to use the weight instead of doing it alphanumerically. As well, I added a weight for the no candidates and slotted it in just below the normal "done" status.

## 🧪 Testing

1. Build `pnpm run dev`
2. Login as admin `admin@test.com`
3. Navigate to search request table `/admin/talent-requests`
4. Sort by status
5. Confirm order appears correct
6. Confirm you can edit a search request to set status to "not compliant"

## 📸 Screenshot

![screenshot_03-May-2024_14-54-1714762445](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/dd2e04ec-cc48-48ea-be22-35ee873c4627)
