### PR TITLE
[Feature] Batch candidate query for screening and evaluation

### DIFF
--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.stories.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.stories.tsx
@@ -2,13 +2,25 @@ import React from "react";
 import type { StoryFn } from "@storybook/react";
 
 import { MockGraphqlDecorator } from "@gc-digital-talent/storybook-helpers";
+import { makeFragmentData } from "@gc-digital-talent/graphql";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 
-import AssessmentStepTracker from "./AssessmentStepTracker";
+import AssessmentStepTracker, {
+  AssessmentStepTracker_CandidateFragment,
+  AssessmentStepTracker_PoolFragment,
+} from "./AssessmentStepTracker";
 import { poolWithAssessmentSteps } from "./testData";
 
 export default {
   component: AssessmentStepTracker,
   decorators: [MockGraphqlDecorator],
+  args: {
+    fetching: false,
+    poolQuery: makeFragmentData(
+      poolWithAssessmentSteps,
+      AssessmentStepTracker_PoolFragment,
+    ),
+  },
   parameters: {
     apiResponsesConfig: {
       latency: {
@@ -32,13 +44,13 @@ const Template: StoryFn<typeof AssessmentStepTracker> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  pool: poolWithAssessmentSteps,
+  candidateQuery: unpackMaybes(poolWithAssessmentSteps.poolCandidates).map(
+    (candidate) =>
+      makeFragmentData(candidate, AssessmentStepTracker_CandidateFragment),
+  ),
 };
 
 export const Null = Template.bind({});
 Null.args = {
-  pool: {
-    ...poolWithAssessmentSteps,
-    poolCandidates: [],
-  },
+  candidateQuery: [],
 };

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.test.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.test.tsx
@@ -13,12 +13,15 @@ import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import {
   AssessmentDecision,
   PoolCandidateStatus,
+  makeFragmentData,
 } from "@gc-digital-talent/graphql";
 
 import { NO_DECISION } from "~/utils/assessmentResults";
 
 import AssessmentStepTracker, {
   AssessmentStepTrackerProps,
+  AssessmentStepTracker_CandidateFragment,
+  AssessmentStepTracker_PoolFragment,
 } from "./AssessmentStepTracker";
 import {
   groupPoolCandidatesByStep,
@@ -51,7 +54,15 @@ const defaultFilters: ResultFilters = {
 
 // This should always make the component visible
 const defaultProps: AssessmentStepTrackerProps = {
-  pool: poolWithAssessmentSteps,
+  fetching: false,
+  candidateQuery: unpackMaybes(poolWithAssessmentSteps.poolCandidates).map(
+    (candidate) =>
+      makeFragmentData(candidate, AssessmentStepTracker_CandidateFragment),
+  ),
+  poolQuery: makeFragmentData(
+    poolWithAssessmentSteps,
+    AssessmentStepTracker_PoolFragment,
+  ),
 };
 const mockClient = {
   executeQuery: jest.fn(() => pipe(fromValue({}), delay(0))),

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
@@ -126,7 +126,7 @@ const AssessmentStepTracker = ({
                 </Board.ColumnHeader>
                 <ResultsDetails {...{ resultCounts, step, filters }} />
                 {fetching ? (
-                  <Well fontSize="caption" data-h2-margin="base(0 x.5)">
+                  <Well fontSize="caption" data-h2-margin="base(x.5)">
                     <div
                       data-h2-display="base(flex)"
                       data-h2-align-items="base(center)"

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -14,7 +14,11 @@ import {
   AssessmentStep,
 } from "@gc-digital-talent/graphql";
 import { notEmpty } from "@gc-digital-talent/helpers";
-import { commonMessages } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  getAssessmentStepType,
+  getLocalizedName,
+} from "@gc-digital-talent/i18n";
 
 import { NO_DECISION, NullableDecision } from "~/utils/assessmentResults";
 import poolCandidateMessages from "~/messages/poolCandidateMessages";
@@ -286,4 +290,19 @@ export const filterAlreadyDisqualified = (
       ),
   );
   return filteredResult;
+};
+
+export const generateStepName = (
+  step: AssessmentStep,
+  intl: IntlShape,
+): string => {
+  // check if title exists in LocalizedString object, then return empty string if not for a truthy check
+  const titleLocalized = getLocalizedName(step.title, intl, true);
+  if (titleLocalized) {
+    return titleLocalized;
+  }
+  if (step.type) {
+    return intl.formatMessage(getAssessmentStepType(step.type));
+  }
+  return intl.formatMessage(commonMessages.notAvailable);
 };

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6634,6 +6634,10 @@
     "defaultMessage": "Numéro de priorité :",
     "description": "Label for applicant's priority number value"
   },
+  "ZVfbLF": {
+    "defaultMessage": "Erreur lors du chargement des candidats",
+    "description": "Error message when pool candidates could not be loaded"
+  },
   "ZWnKEJ": {
     "defaultMessage": "Famille de compétences {skillFamilyId} non trouvée.",
     "description": "Message displayed for skillFamily not found."

--- a/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
+++ b/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
@@ -85,7 +85,7 @@ const ScreeningAndEvaluationPage = () => {
   const batchLoader = React.useCallback(async () => {
     const batches = [];
 
-    for (let i = 0; i < lastPage; i += 1) {
+    for (let i = 1; i <= lastPage; i += 1) {
       batches.push(
         client
           .query(ScreeningAndEvaluation_CandidatesQuery, {

--- a/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
+++ b/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
@@ -103,8 +103,8 @@ const ScreeningAndEvaluationPage = () => {
     } catch {
       toast.error(
         intl.formatMessage({
-          defaultMessage: "Error loading candidates.",
-          id: "CuCiy/",
+          defaultMessage: "Error loading candidates",
+          id: "ZVfbLF",
           description: "Error message when pool candidates could not be loaded",
         }),
       );

--- a/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
+++ b/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
@@ -1,105 +1,138 @@
 import React from "react";
-import { useQuery } from "urql";
+import { useClient, useQuery } from "urql";
+import { useIntl } from "react-intl";
 
+import { graphql, FragmentType, Scalars } from "@gc-digital-talent/graphql";
 import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
-import {
-  graphql,
-  getFragment,
-  FragmentType,
-  Scalars,
-} from "@gc-digital-talent/graphql";
+import { toast } from "@gc-digital-talent/toast";
 
 import useRequiredParams from "~/hooks/useRequiredParams";
-import AssessmentStepTracker from "~/components/AssessmentStepTracker/AssessmentStepTracker";
+import AssessmentStepTracker, {
+  AssessmentStepTracker_CandidateFragment,
+} from "~/components/AssessmentStepTracker/AssessmentStepTracker";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 
-const ScreeningAndEvaluation_AssessmentResultFragment = graphql(/* GraphQL */ `
-  fragment ScreeningAndEvaluation_Pool on Pool {
-    id
-    poolCandidates {
-      id
-      isBookmarked
-      status
-      pool {
-        id
-      }
-      user {
-        id
-        firstName
-        lastName
-        armedForcesStatus
-        hasPriorityEntitlement
-      }
-      assessmentResults {
-        id
-        assessmentStep {
-          id
-        }
-        assessmentDecision
-        assessmentDecisionLevel
-        assessmentResultType
-        poolSkill {
-          id
-          type
-        }
-      }
-    }
-    assessmentSteps {
-      id
-      title {
-        en
-        fr
-      }
-      type
-      sortOrder
-      poolSkills {
-        id
-        type
-      }
-    }
-  }
-`);
-
-type ScreeningAndEvaluationProps = {
-  query: FragmentType<typeof ScreeningAndEvaluation_AssessmentResultFragment>;
-};
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const ScreeningAndEvaluation = ({ query }: ScreeningAndEvaluationProps) => {
-  const pool = getFragment(
-    ScreeningAndEvaluation_AssessmentResultFragment,
-    query,
-  );
-
-  return <AssessmentStepTracker pool={pool} />;
-};
-
 type RouteParams = {
-  poolId: Scalars["ID"]["output"];
+  poolId: Scalars["ID"]["input"];
 };
 
-const ScreeningAndEvaluation_PoolsQuery = graphql(/* GraphQL */ `
-  query ScreeningAndEvaluation_Pools($poolId: UUID!) {
+const ScreeningAndEvaluation_PoolQuery = graphql(/* GraphQL */ `
+  query ScreeningAndEvaluation_Pools(
+    $poolId: UUID!
+    $pools: [IdInput]
+    $first: Int!
+  ) {
     pool(id: $poolId) {
-      ...ScreeningAndEvaluation_Pool
+      ...AssessmentStepTracker_Pool
+    }
+    poolCandidatesPaginated(
+      where: { applicantFilter: { pools: $pools } }
+      first: $first
+    ) {
+      paginatorInfo {
+        lastPage
+      }
     }
   }
 `);
+
+const ScreeningAndEvaluation_CandidatesQuery = graphql(/* GraphQL */ `
+  query ScreeningAndEvaluation_Candidates(
+    $pools: [IdInput]
+    $first: Int!
+    $page: Int
+  ) {
+    poolCandidatesPaginated(
+      where: { applicantFilter: { pools: $pools } }
+      first: $first
+      page: $page
+    ) {
+      paginatorInfo {
+        hasMorePages
+        currentPage
+      }
+      data {
+        poolCandidate {
+          id
+          ...AssessmentStepTracker_Candidate
+        }
+      }
+    }
+  }
+`);
+
+const CANDIDATES_BATCH_SIZE = 100;
 
 const ScreeningAndEvaluationPage = () => {
   const { poolId } = useRequiredParams<RouteParams>("poolId");
+  const client = useClient();
+  const intl = useIntl();
+  const [fetchingCandidates, setFetchingCandidates] =
+    React.useState<boolean>(true);
+  const [candidates, setCandidates] = React.useState<
+    FragmentType<typeof AssessmentStepTracker_CandidateFragment>[]
+  >([]);
   const [{ data, fetching, error }] = useQuery({
-    query: ScreeningAndEvaluation_PoolsQuery,
+    query: ScreeningAndEvaluation_PoolQuery,
     variables: {
       poolId,
+      first: CANDIDATES_BATCH_SIZE,
+      pools: [{ id: poolId }],
     },
   });
+  const lastPage = data?.poolCandidatesPaginated.paginatorInfo.lastPage ?? 0;
+
+  const batchLoader = React.useCallback(async () => {
+    const batches = [];
+
+    for (let i = 0; i < lastPage; i += 1) {
+      batches.push(
+        client
+          .query(ScreeningAndEvaluation_CandidatesQuery, {
+            pools: [{ id: poolId }],
+            first: CANDIDATES_BATCH_SIZE,
+            page: i,
+          })
+          .then((result) => result.data?.poolCandidatesPaginated.data ?? []),
+      );
+    }
+
+    try {
+      const batchedData = await Promise.all(batches);
+      return batchedData.flat().map((c) => c.poolCandidate);
+    } catch {
+      toast.error(
+        intl.formatMessage({
+          defaultMessage: "Error loading candidates.",
+          id: "CuCiy/",
+          description: "Error message when pool candidates could not be loaded",
+        }),
+      );
+      return [];
+    } finally {
+      setFetchingCandidates(false);
+    }
+  }, [client, intl, lastPage, poolId]);
+
+  React.useEffect(() => {
+    if (lastPage) {
+      batchLoader().then((res) => {
+        setCandidates(res);
+      });
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lastPage]);
 
   return (
     <AdminContentWrapper>
       <Pending fetching={fetching} error={error}>
         {data?.pool ? (
-          <ScreeningAndEvaluation query={data.pool} />
+          <AssessmentStepTracker
+            poolQuery={data?.pool}
+            fetching={fetching || fetchingCandidates}
+            candidateQuery={candidates}
+          />
         ) : (
           <ThrowNotFound />
         )}


### PR DESCRIPTION
🤖 Resolves #10223 

## 👋 Introduction

Updates the screening and evaluation page to use a batched, paginated query to prevent memory errors on large data sets.

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

> [!TIP]
> To test this effectively, it is best to seed a lot of candidates for a specific pool.
> `PoolCandidate::factory()->create(['pool_id' => '{poolId}']);`

1. Build `pnpm run dev`
2. Navigate to screening and decision page for a pool
3. Confirm the columns show loading message at first
4. Confirm data is batched in sizes of 100
