### PR TITLE
[Debt] Deprecates `PoolCandidateFilter` model, `poolCandidateFilter` field

### DIFF
--- a/api/app/Models/PoolCandidateFilter.php
+++ b/api/app/Models/PoolCandidateFilter.php
@@ -11,6 +11,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 /**
  * Class PoolCandidateFilter
  *
+ * @deprecated
+ *
  * @property int $id
  * @property bool $has_diploma
  * @property bool $has_disability

--- a/api/app/Models/PoolCandidateFilter.php
+++ b/api/app/Models/PoolCandidateFilter.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 /**
  * Class PoolCandidateFilter
  *
- * @deprecated
+ * @deprecated Replaced by ApplicantFilter.
  *
  * @property int $id
  * @property bool $has_diploma

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -454,7 +454,9 @@ type PoolCandidateSearchRequest {
   status: PoolCandidateSearchStatus @rename(attribute: "request_status")
   statusChangedAt: DateTime @rename(attribute: "request_status_changed_at")
   adminNotes: String @rename(attribute: "admin_notes")
-  poolCandidateFilter: PoolCandidateFilter @belongsTo
+  poolCandidateFilter: PoolCandidateFilter
+    @belongsTo
+    @deprecated(reason: "Replaced by applicantFilter")
   applicantFilter: ApplicantFilter @belongsTo
   wasEmpty: Boolean @rename(attribute: "was_empty")
   managerJobTitle: String @rename(attribute: "manager_job_title")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -540,7 +540,7 @@ type PoolCandidateSearchRequest {
   status: PoolCandidateSearchStatus
   statusChangedAt: DateTime
   adminNotes: String
-  poolCandidateFilter: PoolCandidateFilter
+  poolCandidateFilter: PoolCandidateFilter @deprecated(reason: "Replaced by applicantFilter")
   applicantFilter: ApplicantFilter
   wasEmpty: Boolean
   managerJobTitle: String


### PR DESCRIPTION
🤖 Resolves #10211.

## 👋 Introduction

This PR adds deprecated tags to the `PoolCandidateFilter` model and the `poolCandidateFilter` field.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Open `api/app/Models/PoolCandidateSearchRequest.php` Line 83 in IDE 
2. Observe `PoolCandidateFilter` code has strikethrough and deprecated
3. Navigate to http://localhost:8000/graphiql
4. Write query `PoolCandidateSearchRequest. poolCandidateFilter`
5. Observe deprecation message for `poolCandidateFilter`

## 📸 Screenshots
<img width="801" alt="Screen Shot 2024-05-06 at 12 32 00" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/faaec8a3-d4c7-4d08-8cc5-61e960b5063e">

<img width="1381" alt="Screen Shot 2024-05-06 at 13 07 31" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/b9aa8634-3beb-47dc-a558-7fe64786a45b">