### PR TITLE
[Debt] Allow `__typename` underscore dangle

### DIFF
--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.stories.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.stories.tsx
@@ -38,7 +38,6 @@ const profileSnapshot: User = {
     {
       ...poolCandidate,
       educationRequirementOption:
-        // eslint-disable-next-line no-underscore-dangle
         experience.__typename === "EducationExperience"
           ? EducationRequirementOption.Education
           : EducationRequirementOption.AppliedWork,

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -281,7 +281,6 @@ const SearchRequestFilters = ({
 }: SearchRequestFiltersProps) => {
   const intl = useIntl();
   let poolCandidateFilter;
-  // eslint-disable-next-line no-underscore-dangle
   if (filters?.__typename === "ApplicantFilter") {
     return (
       <ApplicantFilters
@@ -291,7 +290,6 @@ const SearchRequestFilters = ({
     );
   }
 
-  // eslint-disable-next-line no-underscore-dangle
   if (filters?.__typename === "PoolCandidateFilter") {
     poolCandidateFilter = filters;
   }

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/components/AnswerInput.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/components/AnswerInput.tsx
@@ -15,7 +15,6 @@ interface AnswerInputProps {
 
 const AnswerInput = ({ index, question }: AnswerInputProps) => {
   const intl = useIntl();
-  // eslint-disable-next-line no-underscore-dangle
   const isScreening = question.__typename === "ScreeningQuestion";
   const answerPrefix = isScreening ? "screeningAnswers" : "generalAnswers";
   const questionId = `${answerPrefix}.${index}.question`;

--- a/apps/web/src/pages/SearchRequests/RequestPage/RequestPage.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/RequestPage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import * as React from "react";
 import { useIntl } from "react-intl";
 import { useLocation } from "react-router-dom";

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -25,7 +25,6 @@ type AbstractFilter = PoolCandidateFilter | ApplicantFilter;
 function isPoolCandidateFilter(
   filter: AbstractFilter,
 ): filter is PoolCandidateFilter {
-  // eslint-disable-next-line no-underscore-dangle
   if (filter.__typename === "PoolCandidateFilter") return true;
 
   return false;

--- a/apps/web/src/types/experience.ts
+++ b/apps/web/src/types/experience.ts
@@ -1,5 +1,3 @@
-// Note: __typename comes from the API so can be ignored here
-/* eslint-disable no-underscore-dangle */
 import { OperationResult } from "urql";
 
 import { FieldLabels } from "@gc-digital-talent/forms";

--- a/apps/web/src/utils/experienceUtils.tsx
+++ b/apps/web/src/utils/experienceUtils.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import { IntlShape, useIntl } from "react-intl";
 import BookOpenIcon from "@heroicons/react/20/solid/BookOpenIcon";
 import BriefcaseIcon from "@heroicons/react/20/solid/BriefcaseIcon";
@@ -411,12 +410,10 @@ export const deriveExperienceType = (
     ["WorkExperience", "work"],
   ]);
 
-  // eslint-disable-next-line no-underscore-dangle
   if (!experience.__typename) {
     return undefined;
   }
 
-  // eslint-disable-next-line no-underscore-dangle
   return map.get(experience.__typename);
 };
 

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -73,6 +73,7 @@ module.exports = {
     "@typescript-eslint/no-use-before-define": "warn",
     "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/no-empty-function": "warn",
+    "no-underscore-dangle": ["error", { "allow": ["__typename"] }]
   },
   settings: {
     "import/extensions": [".ts", ".tsx"],


### PR DESCRIPTION
🤖 Resolves #10206 

## 👋 Introduction

Adds  `__typename` to list of allowed underscore dangle rule in eslint. 

## 🕵️ Details

This comes from the API and we need to use it some places so instead of ignoring the rule in all those places, we are just going to add it to the allow list.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Confirm `pnpm run lint` runs with no errors
