### PR TITLE
[Fix] Allow sorting candidates table by skill count

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -663,7 +663,7 @@ const PoolCandidatesTable = ({
         ),
       },
     ),
-    columnHelper.display({
+    columnHelper.accessor("skillCount", {
       id: "skillCount",
       header: intl.formatMessage(tableMessages.skillCount),
       cell: ({

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -314,8 +314,6 @@ export function transformSortStateToOrderByClause(
     return !!columnName;
   });
 
-  console.log(sortingRule);
-
   if (
     sortingRule &&
     ["dateReceived", "candidacyStatus", "status", "notes"].includes(
@@ -357,7 +355,6 @@ export function transformSortStateToOrderByClause(
     filterState?.applicantFilter?.skills &&
     filterState.applicantFilter.skills.length > 0
   ) {
-    console.log("is skill count");
     return {
       column: "skill_count",
       order: sortingRule.desc ? SortOrder.Desc : SortOrder.Asc,

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -306,12 +306,15 @@ export function transformSortStateToOrderByClause(
     ["priority", "PRIORITY_WEIGHT"],
     ["status", "status_weight"],
     ["notes", "notes"],
+    ["skillCount", "skillCount"],
   ]);
 
   const sortingRule = sortingRules?.find((rule) => {
     const columnName = columnMap.get(rule.id);
     return !!columnName;
   });
+
+  console.log(sortingRule);
 
   if (
     sortingRule &&
@@ -354,6 +357,7 @@ export function transformSortStateToOrderByClause(
     filterState?.applicantFilter?.skills &&
     filterState.applicantFilter.skills.length > 0
   ) {
+    console.log("is skill count");
     return {
       column: "skill_count",
       order: sortingRule.desc ? SortOrder.Desc : SortOrder.Asc,
@@ -377,26 +381,12 @@ export function getSortOrder(
   sortingRules?: SortingState,
   filterState?: PoolCandidateSearchInput,
   doNotUseBookmark?: boolean,
-  recordDecisionActive?: boolean,
 ): QueryPoolCandidatesPaginatedOrderByRelationOrderByClause[] {
   const hasProcess = sortingRules?.find((rule) => rule.id === "process");
   return [
     ...(doNotUseBookmark
       ? []
       : [{ column: "is_bookmarked", order: SortOrder.Desc }]),
-    ...(recordDecisionActive
-      ? []
-      : [
-          { column: "status_weight", order: SortOrder.Asc },
-          {
-            user: {
-              aggregate: OrderByRelationWithColumnAggregateFunction.Max,
-              column:
-                "PRIORITY_WEIGHT" as QueryPoolCandidatesPaginatedOrderByUserColumn,
-            },
-            order: SortOrder.Asc,
-          },
-        ]),
     // Do not apply other filters if we are sorting by process
     ...(!hasProcess
       ? [transformSortStateToOrderByClause(sortingRules, filterState)]


### PR DESCRIPTION
🤖 Resolves #10235 

## 👋 Introduction

Adds the ability for sorting the pool candidates table by the skill count column

## 🕵️ Details

While working on this, I noticed we still had some old code for "locking" columns when record of decision flag is not present. Since we recently removed this flag, the locking was happening at the query level when it was not meant to be. So, this also removes that old code to no longer lock column sorting on this table.

## 🧪 Testing

1. Build `pnpm run dev`
2. Login as admin `admin@test.com`
3. Navigate to the pool candidates table (`/admin/pool-candidates`)
4. Add alot of skills tot he filters
    - Also, remove the government employee filter and set both status filters to "all" to maximize the candidates displayed
5. Sort by the "skill count" column
6. Confirm the results are sorted as expected

## 📸 Screenshot

![screenshot_06-May-2024_15-28-1715023693](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/66470cef-99a6-456c-b55f-8267563449ef)
