### PR TITLE
[Fix] Pin chromatic to previous patch release

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -56,7 +56,7 @@ jobs:
           pnpm build
 
       - name: "Publish Storybook: all"
-        uses: chromaui/action@v11
+        uses: chromaui/action@v11.3.0
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           # Auto-accept UI Tests on Chromatic platform.


### PR DESCRIPTION
:robot: Resolves #10296

## 👋 Introduction

Pins chromatic action to a stable patch release to fix the workflow and allow dependabot to bump it in the future.

## 🧪 Testing

Check chromatic? :thinking: 