### PR TITLE
[Fix] Removes trailing space in status link

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2655,6 +2655,10 @@
     "defaultMessage": "Agrandir toutes les sections<hidden> de l’information sur la demande</hidden>",
     "description": "Button text to open all application information accordions"
   },
+  "DG4c6M": {
+    "defaultMessage": "{status}<hidden> changer le statut pour {poolName}</hidden>",
+    "description": "Button to change a users status in a pool - located in the table on view-user page"
+  },
   "DHQasU": {
     "defaultMessage": "Voir les notes",
     "description": "Button label for view notes on view pool candidate page"
@@ -4914,10 +4918,6 @@
   "QJ5uDV": {
     "defaultMessage": "Sélectionnez un volet",
     "description": "Placeholder for stream filter in search form."
-  },
-  "QJPsGW": {
-    "defaultMessage": "{status} <hidden>changer le statut pour {poolName}</hidden>",
-    "description": "Button to change a users status in a pool - located in the table on view-user page"
   },
   "QJi1ZQ": {
     "defaultMessage": "Annuler la décision et mettre le statut à jour",

--- a/apps/web/src/pages/Users/UserInformationPage/components/ChangeStatusDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/ChangeStatusDialog.tsx
@@ -176,8 +176,8 @@ const ChangeStatusDialog = ({
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "{status} <hidden>Change status for {poolName}</hidden>",
-                id: "QJPsGW",
+                  "{status}<hidden> Change status for {poolName}</hidden>",
+                id: "DG4c6M",
                 description:
                   "Button to change a users status in a pool - located in the table on view-user page",
               },


### PR DESCRIPTION
🤖 Resolves #10283.

## 👋 Introduction

This PR removes a trailing space on status link in red Candidate status box that shouldn't exist.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm build`
2. Navigate to `/admin/candidates/:candidate-id/application`
3. Observe no trailing space on status link in red Candidate status box

## 📸 Screenshots

### English
<img width="767" alt="Screen Shot 2024-05-08 at 09 47 45" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/4b96b447-c26d-45e1-9bfc-f8871678a525">

### French
<img width="813" alt="Screen Shot 2024-05-08 at 09 47 28" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/e9437d05-b8a9-4abc-942c-5d89bc101957">