### PR TITLE
[Feature] Removes beta label from theme switcher

### DIFF
--- a/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.tsx
@@ -7,24 +7,6 @@ import MoonIcon from "@heroicons/react/24/solid/MoonIcon";
 import { ToggleGroup } from "@gc-digital-talent/ui";
 import { useTheme } from "@gc-digital-talent/theme";
 
-const Beta = () => {
-  const intl = useIntl();
-
-  return (
-    <span
-      data-h2-font-size="base(caption)"
-      data-h2-font-weight="base(700)"
-      data-h2-text-transform="base(uppercase)"
-    >
-      {intl.formatMessage({
-        defaultMessage: "Beta",
-        id: "RTR3mh",
-        description: "Label to indicate a feature is in beta",
-      })}
-    </span>
-  );
-};
-
 const ThemeSwitcher = () => {
   const intl = useIntl();
   const { setMode, fullMode } = useTheme();
@@ -43,7 +25,6 @@ const ThemeSwitcher = () => {
       value={fullMode}
       onValueChange={setMode}
       aria-label={groupLabel}
-      label={<Beta />}
     >
       <ToggleGroup.Item
         value="pref"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5139,10 +5139,6 @@
     "defaultMessage": "Brève description de l'équipe (en français)",
     "description": "Label for team description in French language"
   },
-  "RTR3mh": {
-    "defaultMessage": "Bêta",
-    "description": "Label to indicate a feature is in beta"
-  },
   "RTf/0v": {
     "defaultMessage": "L’utilisateur perdra tous les rôles suivants au sein de l’équipe : ",
     "description": "Text notifying user which role will be removed from the user"


### PR DESCRIPTION
🤖 Resolves #10299.

## 👋 Introduction

This PR removes beta label from theme switcher.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm build`
2. Navigate to home page
3. Verify beta label is no longer part of the theme switcher

## 📸 Screenshot

<img width="1181" alt="Screen Shot 2024-05-09 at 11 29 00" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/1e5a3029-6424-402d-a7fd-8cd6328a073e">
