### PR TITLE
[Fix] Adds null state for when no skills have been linked to any experiences

### DIFF
--- a/apps/web/src/components/UserProfile/ExperienceSection.tsx
+++ b/apps/web/src/components/UserProfile/ExperienceSection.tsx
@@ -7,6 +7,7 @@ import {
   HeadingRank,
   Link,
   Button,
+  Well,
 } from "@gc-digital-talent/ui";
 import { commonMessages, getLocale } from "@gc-digital-talent/i18n";
 import { AwardExperience, Experience } from "@gc-digital-talent/graphql";
@@ -195,12 +196,7 @@ const ExperienceSection = ({
             ))}
           </Accordion.Root>
         ) : (
-          <div
-            data-h2-background-color="base(background.dark)"
-            data-h2-border="base(1px solid background.darker)"
-            data-h2-padding="base(x1)"
-            data-h2-radius="base(s)"
-          >
+          <Well>
             <p>
               {intl.formatMessage({
                 defaultMessage:
@@ -210,17 +206,12 @@ const ExperienceSection = ({
                   "Null state for when no skills have been linked to any experiences",
               })}
             </p>
-          </div>
+          </Well>
         )}
       </Tabs.Content>
     </Tabs.Root>
   ) : (
-    <div
-      data-h2-background-color="base(background.dark)"
-      data-h2-border="base(1px solid background.darker)"
-      data-h2-padding="base(x1)"
-      data-h2-radius="base(s)"
-    >
+    <Well>
       {!editPath ? (
         <p>{intl.formatMessage(commonMessages.noInformationProvided)}</p>
       ) : (
@@ -244,7 +235,7 @@ const ExperienceSection = ({
           </p>
         </>
       )}
-    </div>
+    </Well>
   );
 };
 

--- a/apps/web/src/components/UserProfile/ExperienceSection.tsx
+++ b/apps/web/src/components/UserProfile/ExperienceSection.tsx
@@ -8,7 +8,7 @@ import {
   Link,
   Button,
 } from "@gc-digital-talent/ui";
-import { getLocale } from "@gc-digital-talent/i18n";
+import { commonMessages, getLocale } from "@gc-digital-talent/i18n";
 import { AwardExperience, Experience } from "@gc-digital-talent/graphql";
 
 import {
@@ -222,14 +222,7 @@ const ExperienceSection = ({
       data-h2-radius="base(s)"
     >
       {!editPath ? (
-        <p>
-          {intl.formatMessage({
-            defaultMessage: "No information has been provided",
-            id: "4Xa7Pd",
-            description:
-              "Message on Admin side when user not filled Experience section.",
-          })}
-        </p>
+        <p>{intl.formatMessage(commonMessages.noInformationProvided)}</p>
       ) : (
         <>
           <p data-h2-padding="base(0, 0, x1, 0)">

--- a/apps/web/src/components/UserProfile/ExperienceSection.tsx
+++ b/apps/web/src/components/UserProfile/ExperienceSection.tsx
@@ -194,7 +194,24 @@ const ExperienceSection = ({
               />
             ))}
           </Accordion.Root>
-        ) : null}
+        ) : (
+          <div
+            data-h2-background-color="base(background.dark)"
+            data-h2-border="base(1px solid background.darker)"
+            data-h2-padding="base(x1)"
+            data-h2-radius="base(s)"
+          >
+            <p>
+              {intl.formatMessage({
+                defaultMessage:
+                  "No skills have been linked to any experiences.",
+                id: "23/pqm",
+                description:
+                  "Null state for when no skills have been linked to any experiences",
+              })}
+            </p>
+          </div>
+        )}
       </Tabs.Content>
     </Tabs.Root>
   ) : (

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -715,6 +715,10 @@
     "defaultMessage": "Cette section porte sur les renseignements qui fournissent au demandeur le contexte du type de travail qu'il fera, avec qui il travaillera et l'incidence du rôle sur les Canadiens et les Canadiennes.",
     "description": "Sub title for basic information"
   },
+  "23/pqm": {
+    "defaultMessage": "Aucune compétence n'a été liée à des expériences.",
+    "description": "Null state for when no skills have been linked to any experiences"
+  },
   "248YQT": {
     "defaultMessage": "Pas encore prêt à partir? Retournez à la page d'accueil, découvrez de nouvelles possibilités, ou apprenez-en plus sur certaines recherches derrière cette plateforme.",
     "description": "Description of the links presented on the logged out page."

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1135,10 +1135,6 @@
     "defaultMessage": "Rôles des membres",
     "description": "Title displayed for the team members table roles column."
   },
-  "4Xa7Pd": {
-    "defaultMessage": "Aucune information n'a été fournie",
-    "description": "Message on Admin side when user not filled Experience section."
-  },
   "4Z3/xp": {
     "defaultMessage": "Supprimer le candidat",
     "description": "Title for action to remove a candidate"


### PR DESCRIPTION
🤖 Resolves #10198.

## 👋 Introduction

This PR adds null state for when no skills have been linked to any experiences.

## 🎁 Bonus

- [Consolidated `No information has been provided` strings](https://github.com/GCTC-NTGC/gc-digital-talent/commit/2e9091f266e53cc2ade9ac7b69ab5c3aeb9270bb) where the only difference was a period (kept the one with correct punctuation and 🪓 the one without.
- [Replaced `div` with `Well` component for no skills have been linked to any experiences null state and no experiences null state](https://github.com/GCTC-NTGC/gc-digital-talent/pull/10336/commits/e55b417efb77f5395309d755d66164dc7e4d002e).

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. As a user with an admin role, navigate to `/admin/users/:user-id/profile#career-timeline-section`
2. Ensure the user's page who is being visited has at least one experience but none of the experiences can have linked skills
3. Click the "By Skills" tab
4. Verify null state message exists

## 📸 Screenshot

<img width="742" alt="Screen Shot 2024-05-10 at 12 01 04" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/bfc72379-88a7-44dc-a6d4-747fbb9b468b">

