### PR TITLE
[Copy] Updates error message copy for firewall rejections

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7407,7 +7407,7 @@
     "description": "Message describing the employment equity filter in the search form."
   },
   "dm3BlY": {
-    "defaultMessage": "Vous avez lu toute la FAQ et n'y avez pas trouvé la réponse que vous cherchiez? <helpLink>Contactez votre équipe pour obtenir de l'aide</helpLink>",
+    "defaultMessage": "Vous avez lu toute la FAQ et n'y avez pas trouvé la réponse que vous cherchiez? <helpLink>Contactez notre équipe pour obtenir de l'aide</helpLink>",
     "description": "GCKey question and answer for more support"
   },
   "dnKWUf": {

--- a/packages/client/src/exchanges/specialErrorExchange.ts
+++ b/packages/client/src/exchanges/specialErrorExchange.ts
@@ -20,7 +20,7 @@ const specialErrorExchange = ({ intl }: { intl: IntlShape }) => {
             result?.error?.response?.status === 403 &&
             result?.error?.networkError?.message?.includes("Request Rejected")
           ) {
-            toast.error(intl.formatMessage(errorMessages.specialCharacters));
+            toast.error(intl.formatMessage(errorMessages.requestRejected));
           }
         }),
       );

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -571,6 +571,10 @@
     "defaultMessage": "Termine demain, à {time}",
     "description": "Text displayed when relative date is tomorrow."
   },
+  "Gv3lBS": {
+    "defaultMessage": "Votre demande n'a pas été complétée. Veuillez réessayer ou contactez notre équipe pour obtenir de l'aide.",
+    "description": "Message for Unauthorized or Request Rejected server response"
+  },
   "Gx8qCK": {
     "defaultMessage": "À propos de moi",
     "description": "Name of About me page"

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -883,10 +883,6 @@
     "defaultMessage": "La date doit être avant ou égale au {date}",
     "description": "Error message when a date was entered that is greater than the maximum required"
   },
-  "Q3Pc71": {
-    "defaultMessage": "Il n’est pas possible de sauvegarder ce texte. Veillez à ce que le texte soit dépourvu de formatage ou de caractères spéciaux, et essayez de nouveau.",
-    "description": "Error message that there might be a special character."
-  },
   "QRXLf/": {
     "defaultMessage": "Chargement des résultats...",
     "description": "Message to display when a search is currently loading results."

--- a/packages/i18n/src/messages/errorMessages.ts
+++ b/packages/i18n/src/messages/errorMessages.ts
@@ -105,11 +105,11 @@ const errorMessages = defineMessages({
     description:
       "Error message when a date was entered that is greater than the maximum required",
   },
-  specialCharacters: {
+  requestRejected: {
     defaultMessage:
-      "The text cannot be saved. Please ensure the text has no formatting or special characters and try again.",
-    id: "Q3Pc71",
-    description: "Error message that there might be a special character.",
+      "Your request wasn't completed. Please try again or contact support for help.",
+    id: "Wg9ONw",
+    description: "Message for Unauthorized or Request Rejected server response",
   },
 });
 

--- a/packages/i18n/src/messages/errorMessages.ts
+++ b/packages/i18n/src/messages/errorMessages.ts
@@ -107,8 +107,8 @@ const errorMessages = defineMessages({
   },
   requestRejected: {
     defaultMessage:
-      "Your request wasn't completed. Please try again or contact support for help.",
-    id: "Wg9ONw",
+      "Your request wasn't completed. Please try again or contact our team for help.",
+    id: "Gv3lBS",
     description: "Message for Unauthorized or Request Rejected server response",
   },
 });


### PR DESCRIPTION
🤖 Resolves #8283.

## 👋 Introduction

This PR updates the message returned in a toast for when requests that are rejected by the firewall.

## 🎁 Bonus

Fixes a typo where **our** was being translated incorrectly as **votre**: https://github.com/GCTC-NTGC/gc-digital-talent/pull/10338/commits/53eda91dfd2f3fc3efc8de552503b67636b883c1.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> [!IMPORTANT]
> Temporarily remove `if` statement wrapping `toast.error(intl.formatMessage(errorMessages.requestRejected));` in https://github.com/GCTC-NTGC/gc-digital-talent/blob/0d3464a8e34e010c6d2e2c922f5685938854a8e0/packages/client/src/exchanges/specialErrorExchange.ts#L24-L30

1. Navigate to a page that makes a request
2. 🐻 witness to the 🍞 💥

## 📸 Screenshots
<img width="580" alt="Screen Shot 2024-05-09 at 15 30 50" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/b60da9c8-5a5d-4876-a9f3-3635a7702f31">
<img width="556" alt="Screen Shot 2024-05-09 at 15 30 41" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/573db5d0-94e6-4da8-a96f-370d8eba8734">

