### PR TITLE
[Fix] Adds chromatic mode for `AdminLayout`

### DIFF
--- a/apps/web/src/components/Layout/AdminLayout/AdminLayout.stories.tsx
+++ b/apps/web/src/components/Layout/AdminLayout/AdminLayout.stories.tsx
@@ -10,6 +10,7 @@ import {
   ROLE_NAME,
   RoleName,
 } from "@gc-digital-talent/auth";
+import { allModes } from "@gc-digital-talent/storybook-helpers";
 
 import AdminLayout from "./AdminLayout";
 
@@ -30,6 +31,11 @@ export default {
     roles: {
       control: "check",
       options: availableRoles,
+    },
+  },
+  chromatic: {
+    modes: {
+      light: allModes.light,
     },
   },
 } as Meta<AdminLayoutArgs>;


### PR DESCRIPTION
🤖 Resolves #10343.

## 👋 Introduction

This PR adds chromatic mode for `AdminLayout` to stabilize the theme switcher in the snapshot.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Open chromatic build for this PR
2. Verify canvas and snapshot have the same state (system default) for the theme switcher in `AdminLayout` story