### PR TITLE
[Feature] Editing published pools

### DIFF
--- a/api/app/GraphQL/Validators/UpdatePublishedPoolInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdatePublishedPoolInputValidator.php
@@ -28,6 +28,21 @@ final class UpdatePublishedPoolInputValidator extends Validator
                     'required',
                 ]),
             ],
+            // Optional Fields
+            'specialNote.en' => ['required_with:specialNote.fr', 'string'],
+            'specialNote.fr' => ['required_with:specialNote.en', 'string'],
+            'aboutUs.en' => ['required_with:aboutUs.fr', 'string', 'nullable'],
+            'aboutUs.fr' => ['required_with:aboutUs.en', 'string', 'nullable'],
+            'whatToExpectAdmission.en' => ['required_with:whatToExpectAdmission.fr', 'string', 'nullable'],
+            'whatToExpectAdmission.fr' => ['required_with:whatToExpectAdmission.en', 'string', 'nullable'],
+            'whatToExpect.en' => ['required_with:whatToExpect.fr', 'string', 'nullable'],
+            'whatToExpect.fr' => ['required_with:whatToExpect.en', 'string', 'nullable'],
+
+            // Always required fields
+            'yourImpact.en' => ['required_with:yourImpact.fr', 'string'],
+            'yourImpact.fr' => ['required_with:yourImpact.en', 'string'],
+            'keyTasks.en' => ['required_with:keyTasks.fr', 'string'],
+            'keyTasks.fr' => ['required_with:keyTasks.en', 'string'],
         ];
     }
 

--- a/api/app/GraphQL/Validators/UpdatePublishedPoolInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdatePublishedPoolInputValidator.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Validators;
+
+use App\Enums\PoolStatus;
+use App\Models\Pool;
+use Database\Helpers\ApiErrorEnums;
+use Illuminate\Validation\Rule;
+use Nuwave\Lighthouse\Validation\Validator;
+
+final class UpdatePublishedPoolInputValidator extends Validator
+{
+    /**
+     * Return the validation rules.
+     *
+     * @return array<string, array<mixed>>
+     */
+    public function rules(): array
+    {
+
+        $pool = Pool::find($this->arg('id'));
+
+        return [
+            'changeJustification' => [
+                Rule::when($pool->status === PoolStatus::PUBLISHED->name, [
+                    'required',
+                ]),
+            ],
+        ];
+    }
+
+    /**
+     * Return the messages
+     */
+    public function messages(): array
+    {
+        return [
+            'changeJustification.required' => ApiErrorEnums::CHANGE_JUSTIFICATION_REQUIRED,
+        ];
+    }
+}

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -41,6 +41,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property string $publishing_group
  * @property string $opportunity_length
  * @property string $closing_reason
+ * @property string $change_justification
  * @property string $team_id
  * @property Illuminate\Support\Carbon $created_at
  * @property Illuminate\Support\Carbon $updated_at

--- a/api/app/Policies/PoolPolicy.php
+++ b/api/app/Policies/PoolPolicy.php
@@ -124,6 +124,17 @@ class PoolPolicy
     }
 
     /**
+     * Determine whether the user can published draft pools.
+     *
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function updatePublished(User $user, Pool $pool)
+    {
+        return $pool->getStatusAttribute() === PoolStatus::PUBLISHED->name
+            && $user->isAbleTo('update-any-publishedPool');
+    }
+
+    /**
      * Determine whether the user can publish the pool.
      *
      * @return \Illuminate\Auth\Access\Response|bool

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -236,6 +236,10 @@ return [
             'en' => 'Update unpublished Pools in this Team',
             'fr' => 'Mise à jour des bassins non publiés dans cette équipe',
         ],
+        'update-any-publishedPool' => [
+            'en' => 'Update published Pools in this Team',
+            'fr' => 'Mise à jour des bassins publiée dans cette équipe',
+        ],
         'publish-team-pool' => [
             'en' => 'Publish Pools in this Team',
             'fr' => 'Publier des bassins dans cette équipe',
@@ -749,6 +753,9 @@ return [
             'pool' => [
                 'any' => ['view', 'publish'],
             ],
+            'publishedPool' => [
+                'any' => ['update'],
+            ],
             'teamMembers' => [
                 'any' => ['view'],
             ],
@@ -790,6 +797,9 @@ return [
             ],
             'pool' => [
                 'any' => ['view', 'publish'],
+            ],
+            'publishedPool' => [
+                'any' => ['update'],
             ],
             'application' => [
                 'any' => ['create'],

--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -162,6 +162,7 @@ class PoolFactory extends Factory
                 'process_number' => $this->faker->word(),
                 'publishing_group' => $this->faker->randomElement(array_column(PublishingGroup::cases(), 'name')),
                 'opportunity_length' => $this->faker->randomElement(array_column(PoolOpportunityLength::cases(), 'name')),
+                'change_justification' => $this->faker()->boolean(50) ? $this->faker()->paragraph() : null,
             ];
         });
     }

--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -162,7 +162,7 @@ class PoolFactory extends Factory
                 'process_number' => $this->faker->word(),
                 'publishing_group' => $this->faker->randomElement(array_column(PublishingGroup::cases(), 'name')),
                 'opportunity_length' => $this->faker->randomElement(array_column(PoolOpportunityLength::cases(), 'name')),
-                'change_justification' => $this->faker()->boolean(50) ? $this->faker()->paragraph() : null,
+                'change_justification' => $this->faker->boolean(50) ? $this->faker->paragraph() : null,
             ];
         });
     }

--- a/api/database/helpers/ApiErrorEnums.php
+++ b/api/database/helpers/ApiErrorEnums.php
@@ -25,6 +25,8 @@ class ApiErrorEnums
 
     const PROCESS_CLOSING_DATE_EXTEND = 'UpdatePoolClosingDateExtend';
 
+    const CHANGE_JUSTIFICATION_REQUIRED = 'ChangeJustificationRequired';
+
     // pool candidate field validation
     const EXPIRY_DATE_REQUIRED = 'ExpiryDateRequired';
 

--- a/api/database/migrations/2024_05_10_120743_add_edit_justification_column_pools_table.php
+++ b/api/database/migrations/2024_05_10_120743_add_edit_justification_column_pools_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pools', function (Blueprint $table) {
+            $table->text('change_justification')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+
+        Schema::table('pools', function (Blueprint $table) {
+            $table->dropIfExists('change_justification');
+        });
+    }
+};

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1443,6 +1443,18 @@ input UpdatePoolInput {
   generalQuestions: UpdateGeneralQuestionsHasMany
 }
 
+input UpdatePublishedPoolInput @validator {
+  id: ID
+  changeJustification: String @rename(attribute: "change_justification")
+  yourImpact: LocalizedStringInput @rename(attribute: "your_impact")
+  keyTasks: LocalizedStringInput @rename(attribute: "key_tasks")
+  whatToExpect: LocalizedStringInput @rename(attribute: "what_to_expect")
+  specialNote: LocalizedStringInput @rename(attribute: "special_note")
+  whatToExpectAdmission: LocalizedStringInput
+    @rename(attribute: "what_to_expect_admission")
+  aboutUs: LocalizedStringInput @rename(attribute: "about_us")
+}
+
 input CreatePoolSkillInput {
   type: PoolSkillType!
   requiredLevel: SkillLevel @rename(attribute: "required_skill_level")
@@ -1844,6 +1856,10 @@ type Mutation {
     @update
     @guard
     @canFind(ability: "updateDraft", find: "id")
+  updatePublishedPool(id: ID!, pool: UpdatePublishedPoolInput! @spread): Pool
+    @update
+    @guard
+    @canFind(ability: "updatePublished", find: "id")
   createPoolSkill(
     poolId: ID! @rename(attribute: "pool_id")
     skillId: ID! @rename(attribute: "skill_id")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -140,6 +140,7 @@ type Mutation {
   createPool(userId: ID!, teamId: ID!, pool: CreatePoolInput!): Pool
   duplicatePool(id: ID!, teamId: ID!): Pool
   updatePool(id: ID!, pool: UpdatePoolInput!): Pool
+  updatePublishedPool(id: ID!, pool: UpdatePublishedPoolInput!): Pool
   createPoolSkill(poolId: ID!, skillId: ID!, poolSkill: CreatePoolSkillInput!): PoolSkill
   updatePoolSkill(id: ID!, poolSkill: UpdatePoolSkillInput!): PoolSkill
   deletePoolSkill(id: ID!): PoolSkill
@@ -1269,6 +1270,17 @@ input UpdatePoolInput {
   publishingGroup: PublishingGroup
   opportunityLength: PoolOpportunityLength
   generalQuestions: UpdateGeneralQuestionsHasMany
+}
+
+input UpdatePublishedPoolInput {
+  id: ID
+  changeJustification: String
+  yourImpact: LocalizedStringInput
+  keyTasks: LocalizedStringInput
+  whatToExpect: LocalizedStringInput
+  specialNote: LocalizedStringInput
+  whatToExpectAdmission: LocalizedStringInput
+  aboutUs: LocalizedStringInput
 }
 
 input CreatePoolSkillInput {

--- a/apps/web/src/hooks/useCanUserEditPool.ts
+++ b/apps/web/src/hooks/useCanUserEditPool.ts
@@ -1,0 +1,22 @@
+import { useAuthorization, ROLE_NAME } from "@gc-digital-talent/auth";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { Maybe, PoolStatus } from "@gc-digital-talent/graphql";
+
+import { checkRole } from "../utils/teamUtils";
+
+const useCanUserEditPool = (status?: Maybe<PoolStatus>) => {
+  const { userAuthInfo } = useAuthorization();
+
+  if (status === PoolStatus.Draft) return true;
+
+  if (status === PoolStatus.Published) {
+    return checkRole(
+      [ROLE_NAME.CommunityManager, ROLE_NAME.PlatformAdmin],
+      unpackMaybes(userAuthInfo?.roleAssignments),
+    );
+  }
+
+  return false;
+};
+
+export default useCanUserEditPool;

--- a/apps/web/src/hooks/usePoolMutations.ts
+++ b/apps/web/src/hooks/usePoolMutations.ts
@@ -9,6 +9,7 @@ import {
   Scalars,
   CreatePoolSkillInput,
   UpdatePoolSkillInput,
+  UpdatePublishedPoolInput,
 } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
@@ -20,6 +21,14 @@ const UpdatePool_Mutation = graphql(/* GraphQL */ `
       generalQuestions {
         id
       }
+    }
+  }
+`);
+
+const UpdatePublishedPool_Mutation = graphql(/* GraphQL */ `
+  mutation UpdatePublishedPool($id: ID!, $pool: UpdatePublishedPoolInput!) {
+    updatePublishedPool(id: $id, pool: $pool) {
+      id
     }
   }
 `);
@@ -119,6 +128,10 @@ const usePoolMutations = (returnPath?: string) => {
 
   const [{ fetching: updateFetching }, executeUpdateMutation] =
     useMutation(UpdatePool_Mutation);
+  const [
+    { fetching: updatePublishedFetching },
+    executeUpdatePublishedMutation,
+  ] = useMutation(UpdatePublishedPool_Mutation);
 
   const handleUpdateError = () => {
     toast.error(
@@ -137,6 +150,31 @@ const usePoolMutations = (returnPath?: string) => {
     return executeUpdateMutation({ id, pool })
       .then((result) => {
         if (result.data?.updatePool) {
+          toast.success(
+            intl.formatMessage({
+              defaultMessage: "Process updated successfully!",
+              id: "/ZlzNi",
+              description: "Message displayed to user after pool is updated",
+            }),
+          );
+
+          return Promise.resolve();
+        }
+        return handleUpdateError();
+      })
+      .catch(handleUpdateError);
+  };
+
+  const updatePublished = async (
+    id: string,
+    pool: UpdatePublishedPoolInput,
+  ) => {
+    return executeUpdatePublishedMutation({
+      id,
+      pool: { id, ...pool },
+    })
+      .then((result) => {
+        if (result.data?.updatePublishedPool) {
           toast.success(
             intl.formatMessage({
               defaultMessage: "Process updated successfully!",
@@ -457,6 +495,7 @@ const usePoolMutations = (returnPath?: string) => {
   return {
     isFetching:
       updateFetching ||
+      updatePublishedFetching ||
       extendFetching ||
       publishFetching ||
       closeFetching ||
@@ -469,6 +508,7 @@ const usePoolMutations = (returnPath?: string) => {
       deletePoolSkillFetching,
     mutations: {
       update,
+      updatePublished,
       extend,
       publish,
       close,

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -19,6 +19,7 @@ import {
   Skill,
   FragmentType,
   getFragment,
+  UpdatePublishedPoolInput,
 } from "@gc-digital-talent/graphql";
 
 import { EditPoolSectionMetadata } from "~/types/pool";
@@ -170,6 +171,7 @@ export interface EditPoolFormProps {
   classifications: FragmentType<typeof PoolClassification_Fragment>[];
   skills: Array<Skill>;
   onSave: (submitData: PoolSubmitData) => Promise<void>;
+  onUpdatePublished: (submitData: UpdatePublishedPoolInput) => Promise<void>;
   poolSkillMutations: PoolSkillMutationsType;
 }
 
@@ -178,6 +180,7 @@ export const EditPoolForm = ({
   classifications,
   skills,
   onSave,
+  onUpdatePublished,
   poolSkillMutations,
 }: EditPoolFormProps): JSX.Element => {
   const intl = useIntl();
@@ -481,6 +484,7 @@ export const EditPoolForm = ({
                     poolQuery={pool}
                     sectionMetadata={sectionMetadata.specialNote}
                     onSave={onSave}
+                    onUpdatePublished={onUpdatePublished}
                   />
                 </TableOfContents.Section>
                 <TableOfContents.Section
@@ -633,6 +637,7 @@ const EditPoolPage_Query = graphql(/* GraphQL */ `
   query EditPoolPage($poolId: UUID!) {
     # the existing data of the pool to edit
     pool(id: $poolId) {
+      status
       ...EditPool
     }
 
@@ -730,6 +735,9 @@ export const EditPoolPage = () => {
             classifications={unpackMaybes(data.classifications)}
             skills={data.skills.filter(notEmpty)}
             onSave={(saveData) => mutations.update(poolId, saveData)}
+            onUpdatePublished={(updateData) =>
+              mutations.updatePublished(poolId, updateData)
+            }
             poolSkillMutations={poolSkillMutations}
           />
         </EditPoolContext.Provider>

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -561,16 +561,19 @@ export const EditPoolForm = ({
                         poolQuery={pool}
                         sectionMetadata={sectionMetadata.yourImpact}
                         onSave={onSave}
+                        onUpdatePublished={onUpdatePublished}
                       />
                       <WorkTasksSection
                         poolQuery={pool}
                         sectionMetadata={sectionMetadata.workTasks}
                         onSave={onSave}
+                        onUpdatePublished={onUpdatePublished}
                       />
                       <AboutUsSection
                         poolQuery={pool}
                         sectionMetadata={sectionMetadata.aboutUs}
                         onSave={onSave}
+                        onUpdatePublished={onUpdatePublished}
                       />
                     </div>
                   </TableOfContents.Section>
@@ -606,11 +609,13 @@ export const EditPoolForm = ({
                         poolQuery={pool}
                         sectionMetadata={sectionMetadata.whatToExpect}
                         onSave={onSave}
+                        onUpdatePublished={onUpdatePublished}
                       />
                       <WhatToExpectAdmissionSection
                         poolQuery={pool}
                         sectionMetadata={sectionMetadata.whatToExpectAdmission}
                         onSave={onSave}
+                        onUpdatePublished={onUpdatePublished}
                       />
                     </div>
                   </TableOfContents.Section>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/AboutUsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/AboutUsSection.tsx
@@ -23,14 +23,19 @@ import {
 import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
 import processMessages from "~/messages/processMessages";
+import useCanUserEditPool from "~/hooks/useCanUserEditPool";
 
 import { useEditPoolContext } from "../EditPoolContext";
-import { SectionProps } from "../../types";
+import { PublishedEditableSectionProps, SectionProps } from "../../types";
 import Display from "./Display";
 import ActionWrapper from "../ActionWrapper";
+import UpdatePublishedProcessDialog, {
+  type FormValues as UpdateFormValues,
+} from "../UpdatePublishedProcessDialog/UpdatePublishedProcessDialog";
 
 export const EditPoolAboutUs_Fragment = graphql(/* GraphQL */ `
   fragment EditPoolAboutUs on Pool {
+    ...UpdatePublishedProcessDialog
     id
     status
     aboutUs {
@@ -50,7 +55,8 @@ export type AboutUsSubmitData = Pick<UpdatePoolInput, "aboutUs">;
 type AboutUsSectionProps = SectionProps<
   AboutUsSubmitData,
   FragmentType<typeof EditPoolAboutUs_Fragment>
->;
+> &
+  PublishedEditableSectionProps;
 
 const TEXT_AREA_MAX_WORDS_EN = 100;
 const TEXT_AREA_MAX_WORDS_FR = TEXT_AREA_MAX_WORDS_EN + 30;
@@ -59,10 +65,12 @@ const AboutUsSection = ({
   poolQuery,
   sectionMetadata,
   onSave,
+  onUpdatePublished,
 }: AboutUsSectionProps): JSX.Element => {
   const intl = useIntl();
   const pool = getFragment(EditPoolAboutUs_Fragment, poolQuery);
   const isNull = hasAllEmptyFields(pool);
+  const canEdit = useCanUserEditPool(pool.status);
   const { isSubmitting } = useEditPoolContext();
   const { isEditing, setIsEditing, icon } = useToggleSectionInfo({
     isNull,
@@ -79,7 +87,13 @@ const AboutUsSection = ({
   const methods = useForm<FormValues>({
     defaultValues: dataToFormValues(pool),
   });
-  const { handleSubmit } = methods;
+  const { handleSubmit, watch } = methods;
+  const values = watch();
+
+  const onSuccess = (formValues: FormValues) => {
+    methods.reset(formValues, { keepDirty: true });
+    setIsEditing(false);
+  };
 
   const handleSave = async (formValues: FormValues) => {
     return onSave({
@@ -88,17 +102,19 @@ const AboutUsSection = ({
         fr: formValues.aboutUsFr ?? "",
       },
     })
-      .then(() => {
-        methods.reset(formValues, {
-          keepDirty: false,
-        });
-        setIsEditing(false);
-      })
+      .then(() => onSuccess(formValues))
       .catch(() => methods.reset(formValues));
   };
 
-  // disabled unless status is draft
-  const formDisabled = pool.status !== PoolStatus.Draft;
+  const handleUpdatePublished = async (formValues: UpdateFormValues) => {
+    await onUpdatePublished({
+      ...formValues,
+      aboutUs: {
+        en: values.aboutUsEn,
+        fr: values.aboutUsFr,
+      },
+    }).then(() => onSuccess({ ...values }));
+  };
 
   const subtitle = intl.formatMessage({
     defaultMessage:
@@ -122,7 +138,7 @@ const AboutUsSection = ({
         data-h2-font-weight="base(700)"
         toggle={
           <ToggleForm.LabelledTrigger
-            disabled={formDisabled}
+            disabled={!canEdit}
             sectionTitle={sectionMetadata.title}
           />
         }
@@ -151,24 +167,20 @@ const AboutUsSection = ({
                   id="aboutUsEn"
                   label={intl.formatMessage(processMessages.aboutUsEn)}
                   name="aboutUsEn"
-                  {...(!formDisabled && {
-                    wordLimit: TEXT_AREA_MAX_WORDS_EN,
-                  })}
-                  readOnly={formDisabled}
+                  wordLimit={TEXT_AREA_MAX_WORDS_EN}
+                  readOnly={!canEdit}
                 />
                 <RichTextInput
                   id="aboutUsFr"
                   label={intl.formatMessage(processMessages.aboutUsFr)}
                   name="aboutUsFr"
-                  {...(!formDisabled && {
-                    wordLimit: TEXT_AREA_MAX_WORDS_FR,
-                  })}
-                  readOnly={formDisabled}
+                  wordLimit={TEXT_AREA_MAX_WORDS_FR}
+                  readOnly={!canEdit}
                 />
               </div>
 
               <ActionWrapper>
-                {!formDisabled && (
+                {canEdit && pool.status === PoolStatus.Draft && (
                   <Submit
                     text={intl.formatMessage(formMessages.saveChanges)}
                     aria-label={intl.formatMessage({
@@ -179,6 +191,12 @@ const AboutUsSection = ({
                     color="secondary"
                     mode="solid"
                     isSubmitting={isSubmitting}
+                  />
+                )}{" "}
+                {canEdit && pool.status === PoolStatus.Published && (
+                  <UpdatePublishedProcessDialog
+                    poolQuery={pool}
+                    onUpdatePublished={handleUpdatePublished}
                   />
                 )}
                 <ToggleSection.Close>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/SpecialNoteSection/SpecialNoteSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/SpecialNoteSection/SpecialNoteSection.tsx
@@ -7,26 +7,32 @@ import { Button, ToggleSection } from "@gc-digital-talent/ui";
 import { Checkbox, RichTextInput, Submit } from "@gc-digital-talent/forms";
 import { commonMessages, formMessages } from "@gc-digital-talent/i18n";
 import {
-  PoolStatus,
   LocalizedString,
   Pool,
   UpdatePoolInput,
   graphql,
   FragmentType,
   getFragment,
+  PoolStatus,
 } from "@gc-digital-talent/graphql";
+import { useAuthorization } from "@gc-digital-talent/auth";
 
 import { hasAllEmptyFields } from "~/validators/process/specialNote";
 import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
+import { userCanEditPool } from "~/utils/poolUtils";
 
 import { useEditPoolContext } from "../EditPoolContext";
-import { SectionProps } from "../../types";
+import { PublishedEditableSectionProps, SectionProps } from "../../types";
 import Display from "./Display";
 import ActionWrapper from "../ActionWrapper";
+import UpdatePublishedProcessDialog, {
+  type FormValues as UpdateFormValues,
+} from "../UpdatePublishedProcessDialog/UpdatePublishedProcessDialog";
 
 const EditPoolSpecialNote_Fragment = graphql(/* GraphQL */ `
   fragment EditPoolSpecialNote on Pool {
+    ...UpdatePublishedProcessDialog
     id
     status
     specialNote {
@@ -47,7 +53,8 @@ export type SpecialNoteSubmitData = Pick<UpdatePoolInput, "specialNote">;
 type SpecialNoteSectionProps = SectionProps<
   SpecialNoteSubmitData,
   FragmentType<typeof EditPoolSpecialNote_Fragment>
->;
+> &
+  PublishedEditableSectionProps;
 
 const TEXT_AREA_MAX_WORDS_EN = 100;
 const TEXT_AREA_MAX_WORDS_FR = TEXT_AREA_MAX_WORDS_EN + 30;
@@ -56,8 +63,10 @@ const SpecialNoteSection = ({
   poolQuery,
   sectionMetadata,
   onSave,
+  onUpdatePublished,
 }: SpecialNoteSectionProps): JSX.Element => {
   const intl = useIntl();
+  const { userAuthInfo } = useAuthorization();
   const pool = getFragment(EditPoolSpecialNote_Fragment, poolQuery);
   const isNull = hasAllEmptyFields(pool);
   const { isSubmitting } = useEditPoolContext();
@@ -80,7 +89,16 @@ const SpecialNoteSection = ({
     defaultValues: dataToFormValues(pool),
   });
   const { handleSubmit, watch } = methods;
-  const watchHasSpecialNote = watch("hasSpecialNote");
+  const [watchHasSpecialNote, specialNoteEn, specialNoteFr] = watch([
+    "hasSpecialNote",
+    "specialNoteEn",
+    "specialNoteFr",
+  ]);
+
+  const onSuccess = (formValues: FormValues) => {
+    methods.reset(formValues, { keepDirty: false });
+    setIsEditing(false);
+  };
 
   const handleSave = async (formValues: FormValues) => {
     return onSave({
@@ -92,16 +110,30 @@ const SpecialNoteSection = ({
         : null, // Save data if confirmation box (hasSpecialNote) is selected
     })
       .then(() => {
-        methods.reset(formValues, {
-          keepDirty: false,
-        });
-        setIsEditing(false);
+        onSuccess(formValues);
       })
       .catch(() => methods.reset(formValues));
   };
 
-  // disabled unless status is draft
-  const formDisabled = pool.status !== PoolStatus.Draft;
+  const handleUpdatePublished = async (formValues: UpdateFormValues) => {
+    await onUpdatePublished({
+      ...formValues,
+      specialNote: watchHasSpecialNote
+        ? {
+            en: specialNoteEn,
+            fr: specialNoteFr,
+          }
+        : null,
+    }).then(() => {
+      onSuccess({
+        hasSpecialNote: watchHasSpecialNote,
+        specialNoteEn,
+        specialNoteFr,
+      });
+    });
+  };
+
+  const canEdit = userCanEditPool(pool.status, userAuthInfo?.roleAssignments);
 
   const subtitle = intl.formatMessage({
     defaultMessage:
@@ -124,7 +156,7 @@ const SpecialNoteSection = ({
         size="h3"
         toggle={
           <ToggleForm.LabelledTrigger
-            disabled={formDisabled}
+            disabled={!canEdit}
             sectionTitle={sectionMetadata.title}
           />
         }
@@ -161,7 +193,7 @@ const SpecialNoteSection = ({
                     description:
                       "Checkbox selection that confirms need for a special note on edit page.",
                   })}
-                  disabled={formDisabled}
+                  disabled={!canEdit}
                 />
               </div>
               {watchHasSpecialNote && (
@@ -180,10 +212,8 @@ const SpecialNoteSection = ({
                         "Label for the English - Special note for this process textarea on edit pool page.",
                     })}
                     name="specialNoteEn"
-                    {...(!formDisabled && {
-                      wordLimit: TEXT_AREA_MAX_WORDS_EN,
-                    })}
-                    readOnly={formDisabled}
+                    wordLimit={TEXT_AREA_MAX_WORDS_EN}
+                    readOnly={!canEdit}
                   />
                   <RichTextInput
                     id="whatToExpectFr"
@@ -194,16 +224,14 @@ const SpecialNoteSection = ({
                         "Label for the French - Special note for this process textarea in the edit pool page.",
                     })}
                     name="specialNoteFr"
-                    {...(!formDisabled && {
-                      wordLimit: TEXT_AREA_MAX_WORDS_FR,
-                    })}
-                    readOnly={formDisabled}
+                    wordLimit={TEXT_AREA_MAX_WORDS_FR}
+                    readOnly={!canEdit}
                   />
                 </div>
               )}
 
               <ActionWrapper>
-                {!formDisabled && (
+                {canEdit && pool.status === PoolStatus.Draft && (
                   <Submit
                     text={intl.formatMessage(formMessages.saveChanges)}
                     aria-label={intl.formatMessage({
@@ -215,6 +243,12 @@ const SpecialNoteSection = ({
                     color="secondary"
                     mode="solid"
                     isSubmitting={isSubmitting}
+                  />
+                )}
+                {canEdit && pool.status === PoolStatus.Published && (
+                  <UpdatePublishedProcessDialog
+                    poolQuery={pool}
+                    onUpdatePublished={handleUpdatePublished}
                   />
                 )}
                 <ToggleSection.Close>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/SpecialNoteSection/SpecialNoteSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/SpecialNoteSection/SpecialNoteSection.tsx
@@ -15,12 +15,11 @@ import {
   getFragment,
   PoolStatus,
 } from "@gc-digital-talent/graphql";
-import { useAuthorization } from "@gc-digital-talent/auth";
 
 import { hasAllEmptyFields } from "~/validators/process/specialNote";
 import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
-import { userCanEditPool } from "~/utils/poolUtils";
+import useCanUserEditPool from "~/hooks/useCanUserEditPool";
 
 import { useEditPoolContext } from "../EditPoolContext";
 import { PublishedEditableSectionProps, SectionProps } from "../../types";
@@ -66,9 +65,9 @@ const SpecialNoteSection = ({
   onUpdatePublished,
 }: SpecialNoteSectionProps): JSX.Element => {
   const intl = useIntl();
-  const { userAuthInfo } = useAuthorization();
   const pool = getFragment(EditPoolSpecialNote_Fragment, poolQuery);
   const isNull = hasAllEmptyFields(pool);
+  const canEdit = useCanUserEditPool(pool.status);
   const { isSubmitting } = useEditPoolContext();
   const { isEditing, setIsEditing, icon } = useToggleSectionInfo({
     isNull,
@@ -109,9 +108,7 @@ const SpecialNoteSection = ({
           }
         : null, // Save data if confirmation box (hasSpecialNote) is selected
     })
-      .then(() => {
-        onSuccess(formValues);
-      })
+      .then(() => onSuccess(formValues))
       .catch(() => methods.reset(formValues));
   };
 
@@ -132,8 +129,6 @@ const SpecialNoteSection = ({
       });
     });
   };
-
-  const canEdit = userCanEditPool(pool.status, userAuthInfo?.roleAssignments);
 
   const subtitle = intl.formatMessage({
     defaultMessage:

--- a/apps/web/src/pages/Pools/EditPoolPage/components/UpdatePublishedProcessDialog/UpdatePublishedProcessDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/UpdatePublishedProcessDialog/UpdatePublishedProcessDialog.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import { FormProvider, useForm } from "react-hook-form";
+
+import { Button, Dialog, Heading, Well } from "@gc-digital-talent/ui";
+import {
+  FragmentType,
+  UpdatePublishedPoolInput,
+  getFragment,
+  graphql,
+} from "@gc-digital-talent/graphql";
+import {
+  commonMessages,
+  errorMessages,
+  formMessages,
+} from "@gc-digital-talent/i18n";
+import { TextArea } from "@gc-digital-talent/forms";
+
+import { getShortPoolTitleHtml } from "~/utils/poolUtils";
+
+import { PublishedEditableSectionProps } from "../../types";
+
+const UpdatePublishedProcessDialog_Fragment = graphql(/* GraphQL */ `
+  fragment UpdatePublishedProcessDialog on Pool {
+    id
+    stream
+    name {
+      en
+      fr
+    }
+    classification {
+      id
+      group
+      level
+    }
+  }
+`);
+
+export type FormValues = Partial<UpdatePublishedPoolInput>;
+
+interface UpdatePublishedProcessDialogProps
+  extends PublishedEditableSectionProps {
+  poolQuery: FragmentType<typeof UpdatePublishedProcessDialog_Fragment>;
+}
+
+const UpdatePublishedProcessDialog = ({
+  onUpdatePublished,
+  poolQuery,
+}: UpdatePublishedProcessDialogProps) => {
+  const intl = useIntl();
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const pool = getFragment(UpdatePublishedProcessDialog_Fragment, poolQuery);
+  const title = getShortPoolTitleHtml(intl, pool);
+
+  const methods = useForm<FormValues>({
+    defaultValues: {
+      changeJustification: null,
+    },
+  });
+
+  const handleUpdate = async (values: FormValues) => {
+    await onUpdatePublished(values).then(() => {
+      setIsOpen(false);
+    });
+  };
+
+  const handleSave = () => {
+    methods.handleSubmit(handleUpdate)();
+  };
+
+  const label = intl.formatMessage({
+    defaultMessage: "Change justification",
+    id: "XGztC+",
+    description: "Heading for form to justify updating a published process",
+  });
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
+      <Dialog.Trigger>
+        <Button>{intl.formatMessage(formMessages.saveChanges)}</Button>
+      </Dialog.Trigger>
+      <Dialog.Content>
+        <Dialog.Header>{label}</Dialog.Header>
+        <Dialog.Body>
+          <Well color="warning" data-h2-margin-bottom="base(x1)">
+            <Heading level="h3" size="h6" data-h2-margin-top="base(0)">
+              {intl.formatMessage({
+                defaultMessage: "Warning!",
+                id: "iUK2PO",
+                description: "Heading for a potentially dangerous action alert",
+              })}
+            </Heading>
+            <p>
+              {intl.formatMessage({
+                defaultMessage:
+                  "You are about to change information currently published on the following advertisement",
+                id: "4lRUZt",
+                description:
+                  "Warning message when attempting to update a published process advertisement",
+              })}
+              {intl.formatMessage(commonMessages.dividingColon)}
+              <span data-h2-font-weight="base(700)">{title}</span>
+            </p>
+          </Well>
+          <FormProvider {...methods}>
+            <form onSubmit={methods.handleSubmit(handleUpdate)}>
+              <TextArea
+                name="changeJustification"
+                id="changeJustification"
+                label={label}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
+              />
+              <Dialog.Footer>
+                <Button color="error" type="button" onClick={handleSave}>
+                  {intl.formatMessage(formMessages.saveChanges)}
+                </Button>
+                <Dialog.Close>
+                  <Button color="warning" mode="inline">
+                    {intl.formatMessage(formMessages.cancelGoBack)}
+                  </Button>
+                </Dialog.Close>
+              </Dialog.Footer>
+            </form>
+          </FormProvider>
+        </Dialog.Body>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};
+
+export default UpdatePublishedProcessDialog;

--- a/apps/web/src/pages/Pools/EditPoolPage/components/WorkTasksSection/WorkTasksSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/WorkTasksSection/WorkTasksSection.tsx
@@ -22,14 +22,19 @@ import {
 } from "~/validators/process/keyTasks";
 import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
+import useUserCanEditPool from "~/hooks/useCanUserEditPool";
 
 import { useEditPoolContext } from "../EditPoolContext";
-import { SectionProps } from "../../types";
+import { PublishedEditableSectionProps, SectionProps } from "../../types";
 import Display from "./Display";
 import ActionWrapper from "../ActionWrapper";
+import UpdatePublishedProcessDialog, {
+  type FormValues as UpdateFormValues,
+} from "../UpdatePublishedProcessDialog/UpdatePublishedProcessDialog";
 
 const EditPoolKeyTasks_Fragment = graphql(/* GraphQL */ `
   fragment EditPoolKeyTasks on Pool {
+    ...UpdatePublishedProcessDialog
     id
     status
     keyTasks {
@@ -49,7 +54,8 @@ export type WorkTasksSubmitData = Pick<UpdatePoolInput, "keyTasks">;
 type WorkTasksSectionProps = SectionProps<
   WorkTasksSubmitData,
   FragmentType<typeof EditPoolKeyTasks_Fragment>
->;
+> &
+  PublishedEditableSectionProps;
 
 const TEXT_AREA_MAX_WORDS_EN = 400;
 const TEXT_AREA_MAX_WORDS_FR = TEXT_AREA_MAX_WORDS_EN + 100;
@@ -58,11 +64,13 @@ const WorkTasksSection = ({
   poolQuery,
   sectionMetadata,
   onSave,
+  onUpdatePublished,
 }: WorkTasksSectionProps): JSX.Element => {
   const intl = useIntl();
   const pool = getFragment(EditPoolKeyTasks_Fragment, poolQuery);
   const isNull = hasAllEmptyFields(pool);
   const emptyRequired = hasEmptyRequiredFields(pool);
+  const canEdit = useUserCanEditPool(pool.status);
   const { isSubmitting } = useEditPoolContext();
   const { isEditing, setIsEditing, icon } = useToggleSectionInfo({
     isNull,
@@ -78,7 +86,14 @@ const WorkTasksSection = ({
   const methods = useForm<FormValues>({
     defaultValues: dataToFormValues(pool),
   });
-  const { handleSubmit } = methods;
+  const { handleSubmit, watch } = methods;
+  const values = watch();
+
+  const onSuccess = (formValues: FormValues) => {
+    methods.reset(formValues, { keepDirty: true });
+    setIsEditing(false);
+  };
+
   const handleSave = async (formValues: FormValues) => {
     return onSave({
       keyTasks: {
@@ -86,17 +101,19 @@ const WorkTasksSection = ({
         fr: formValues.YourWorkFr,
       },
     })
-      .then(() => {
-        methods.reset(formValues, {
-          keepDirty: false,
-        });
-        setIsEditing(false);
-      })
+      .then(() => onSuccess(formValues))
       .catch(() => methods.reset(formValues));
   };
 
-  // disabled unless status is draft
-  const formDisabled = pool.status !== PoolStatus.Draft;
+  const handleUpdatePublished = async (formValues: UpdateFormValues) => {
+    await onUpdatePublished({
+      ...formValues,
+      keyTasks: {
+        en: values.YourWorkEn,
+        fr: values.YourWorkFr,
+      },
+    }).then(() => onSuccess({ ...values }));
+  };
 
   const subtitle = intl.formatMessage({
     defaultMessage:
@@ -119,7 +136,7 @@ const WorkTasksSection = ({
         size="h4"
         toggle={
           <ToggleForm.LabelledTrigger
-            disabled={formDisabled}
+            disabled={!canEdit}
             sectionTitle={sectionMetadata.title}
           />
         }
@@ -150,8 +167,8 @@ const WorkTasksSection = ({
                       "Label for the English - Your Work textarea in the edit pool page.",
                   })}
                   name="YourWorkEn"
-                  {...(!formDisabled && { wordLimit: TEXT_AREA_MAX_WORDS_EN })}
-                  readOnly={formDisabled}
+                  wordLimit={TEXT_AREA_MAX_WORDS_EN}
+                  readOnly={!canEdit}
                 />
                 <RichTextInput
                   id="YourWorkFr"
@@ -162,13 +179,13 @@ const WorkTasksSection = ({
                       "Label for the French - Your Work textarea in the edit pool page.",
                   })}
                   name="YourWorkFr"
-                  {...(!formDisabled && { wordLimit: TEXT_AREA_MAX_WORDS_FR })}
-                  readOnly={formDisabled}
+                  wordLimit={TEXT_AREA_MAX_WORDS_FR}
+                  readOnly={!canEdit}
                 />
               </div>
 
               <ActionWrapper>
-                {!formDisabled && (
+                {canEdit && pool.status === PoolStatus.Draft && (
                   <Submit
                     text={intl.formatMessage(formMessages.saveChanges)}
                     aria-label={intl.formatMessage({
@@ -180,6 +197,12 @@ const WorkTasksSection = ({
                     color="secondary"
                     mode="solid"
                     isSubmitting={isSubmitting}
+                  />
+                )}
+                {canEdit && pool.status === PoolStatus.Published && (
+                  <UpdatePublishedProcessDialog
+                    poolQuery={pool}
+                    onUpdatePublished={handleUpdatePublished}
                   />
                 )}
                 <ToggleSection.Close>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/YourImpactSection/YourImpactSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/YourImpactSection/YourImpactSection.tsx
@@ -22,14 +22,19 @@ import {
 } from "~/validators/process/yourImpact";
 import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
+import useCanUserEditPool from "~/hooks/useCanUserEditPool";
 
 import { useEditPoolContext } from "../EditPoolContext";
-import { SectionProps } from "../../types";
+import { PublishedEditableSectionProps, SectionProps } from "../../types";
 import Display from "./Display";
 import ActionWrapper from "../ActionWrapper";
+import UpdatePublishedProcessDialog, {
+  type FormValues as UpdateFormValues,
+} from "../UpdatePublishedProcessDialog/UpdatePublishedProcessDialog";
 
 const EditPoolYourImpact_Fragment = graphql(/* GraphQL */ `
   fragment EditPoolYourImpact on Pool {
+    ...UpdatePublishedProcessDialog
     id
     status
     yourImpact {
@@ -49,7 +54,8 @@ export type YourImpactSubmitData = Pick<UpdatePoolInput, "yourImpact">;
 type YourImpactSectionProps = SectionProps<
   YourImpactSubmitData,
   FragmentType<typeof EditPoolYourImpact_Fragment>
->;
+> &
+  PublishedEditableSectionProps;
 
 const TEXT_AREA_MAX_WORDS_EN = 200;
 const TEXT_AREA_MAX_WORDS_FR = TEXT_AREA_MAX_WORDS_EN + 100;
@@ -58,10 +64,12 @@ const YourImpactSection = ({
   poolQuery,
   sectionMetadata,
   onSave,
+  onUpdatePublished,
 }: YourImpactSectionProps): JSX.Element => {
   const intl = useIntl();
   const pool = getFragment(EditPoolYourImpact_Fragment, poolQuery);
   const isNull = hasAllEmptyFields(pool);
+  const canEdit = useCanUserEditPool(pool.status);
   const emptyRequired = hasEmptyRequiredFields(pool);
   const { isSubmitting } = useEditPoolContext();
   const { isEditing, setIsEditing, icon } = useToggleSectionInfo({
@@ -78,7 +86,13 @@ const YourImpactSection = ({
   const methods = useForm<FormValues>({
     defaultValues: dataToFormValues(pool),
   });
-  const { handleSubmit } = methods;
+  const { handleSubmit, watch } = methods;
+  const values = watch();
+
+  const onSuccess = (formValues: FormValues) => {
+    methods.reset(formValues, { keepDirty: true });
+    setIsEditing(false);
+  };
 
   const handleSave = async (formValues: FormValues) => {
     return onSave({
@@ -87,17 +101,19 @@ const YourImpactSection = ({
         fr: formValues.yourImpactFr,
       },
     })
-      .then(() => {
-        methods.reset(formValues, {
-          keepDirty: false,
-        });
-        setIsEditing(false);
-      })
+      .then(() => onSuccess(formValues))
       .catch(() => methods.reset(formValues));
   };
 
-  // disabled unless status is draft
-  const formDisabled = pool.status !== PoolStatus.Draft;
+  const handleUpdatePublished = async (formValues: UpdateFormValues) => {
+    await onUpdatePublished({
+      ...formValues,
+      yourImpact: {
+        en: values.yourImpactEn,
+        fr: values.yourImpactFr,
+      },
+    }).then(() => onSuccess({ ...values }));
+  };
 
   const subtitle = intl.formatMessage({
     defaultMessage:
@@ -120,7 +136,7 @@ const YourImpactSection = ({
         size="h4"
         toggle={
           <ToggleForm.LabelledTrigger
-            disabled={formDisabled}
+            disabled={!canEdit}
             sectionTitle={sectionMetadata.title}
           />
         }
@@ -151,8 +167,8 @@ const YourImpactSection = ({
                       "Label for the English - Your Impact textarea in the edit pool page.",
                   })}
                   name="yourImpactEn"
-                  {...(!formDisabled && { wordLimit: TEXT_AREA_MAX_WORDS_EN })}
-                  readOnly={formDisabled}
+                  wordLimit={TEXT_AREA_MAX_WORDS_EN}
+                  readOnly={!canEdit}
                 />
                 <RichTextInput
                   id="yourImpactFr"
@@ -163,12 +179,12 @@ const YourImpactSection = ({
                       "Label for the French - Your Impact textarea in the edit pool page.",
                   })}
                   name="yourImpactFr"
-                  {...(!formDisabled && { wordLimit: TEXT_AREA_MAX_WORDS_FR })}
-                  readOnly={formDisabled}
+                  wordLimit={TEXT_AREA_MAX_WORDS_FR}
+                  readOnly={!canEdit}
                 />
               </div>
               <ActionWrapper>
-                {!formDisabled && (
+                {canEdit && pool.status === PoolStatus.Draft && (
                   <Submit
                     text={intl.formatMessage(formMessages.saveChanges)}
                     aria-label={intl.formatMessage({
@@ -180,6 +196,12 @@ const YourImpactSection = ({
                     color="secondary"
                     mode="solid"
                     isSubmitting={isSubmitting}
+                  />
+                )}
+                {canEdit && pool.status === PoolStatus.Published && (
+                  <UpdatePublishedProcessDialog
+                    poolQuery={pool}
+                    onUpdatePublished={handleUpdatePublished}
                   />
                 )}
                 <ToggleSection.Close>

--- a/apps/web/src/pages/Pools/EditPoolPage/types.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/types.ts
@@ -4,6 +4,7 @@ import {
   CreatePoolSkillInput,
   UpdatePoolSkillInput,
   Pool,
+  UpdatePublishedPoolInput,
 } from "@gc-digital-talent/graphql";
 
 import { EditPoolSectionMetadata } from "~/types/pool";
@@ -17,6 +18,10 @@ export type SectionProps<T, F> = {
   poolQuery: F;
   sectionMetadata: EditPoolSectionMetadata;
   onSave: (submitData: T) => Promise<void>;
+};
+
+export type PublishedEditableSectionProps = {
+  onUpdatePublished: (submitData: UpdatePublishedPoolInput) => Promise<void>;
 };
 
 export type SectionKey =

--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -109,6 +109,8 @@ export const ViewPool = ({
     [ROLE_NAME.CommunityManager, ROLE_NAME.PlatformAdmin],
     roleAssignments,
   );
+  // Same roles can edit submitted advertisements
+  const canEdit = advertisementStatus !== "submitted" || canPublish;
 
   let closingDate = "";
   if (pool.closingDate) {
@@ -198,10 +200,12 @@ export const ViewPool = ({
               )}
             </p>
             <ProcessCard.Footer>
-              {advertisementStatus !== "submitted" && (
+              {canEdit && (
                 <Link
                   mode="inline"
-                  color="secondary"
+                  color={
+                    pool.status === PoolStatus.Published ? "error" : "secondary"
+                  }
                   href={paths.poolUpdate(pool.id)}
                 >
                   {intl.formatMessage({

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -537,26 +537,3 @@ export const sortedOpportunityLengths = [
   PoolOpportunityLength.Indeterminate,
   PoolOpportunityLength.Various,
 ];
-
-/**
- * Determine if a pool can be edited
- *
- * @param poolStatus
- * @param roleAssignments
- * @returns
- */
-export function userCanEditPool(
-  poolStatus?: Maybe<PoolStatus>,
-  roleAssignments?: Maybe<Maybe<RoleAssignment>[]> | undefined,
-) {
-  if (poolStatus === PoolStatus.Draft) return true;
-
-  if (poolStatus === PoolStatus.Published) {
-    return checkRole(
-      [ROLE_NAME.CommunityManager, ROLE_NAME.PlatformAdmin],
-      unpackMaybes(roleAssignments),
-    );
-  }
-
-  return false;
-}

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -16,7 +16,7 @@ import {
   navigationMessages,
 } from "@gc-digital-talent/i18n";
 import { ROLE_NAME, RoleName } from "@gc-digital-talent/auth";
-import { notEmpty } from "@gc-digital-talent/helpers";
+import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import {
   parseDateTimeUtc,
   relativeClosingDate,
@@ -41,6 +41,7 @@ import { PageNavKeys, PoolCompleteness } from "~/types/pool";
 import messages from "~/messages/adminMessages";
 
 import { wrapAbbr } from "./nameUtils";
+import { checkRole } from "./teamUtils";
 
 /**
  * Check if a pool matches a
@@ -536,3 +537,26 @@ export const sortedOpportunityLengths = [
   PoolOpportunityLength.Indeterminate,
   PoolOpportunityLength.Various,
 ];
+
+/**
+ * Determine if a pool can be edited
+ *
+ * @param poolStatus
+ * @param roleAssignments
+ * @returns
+ */
+export function userCanEditPool(
+  poolStatus?: Maybe<PoolStatus>,
+  roleAssignments?: Maybe<Maybe<RoleAssignment>[]> | undefined,
+) {
+  if (poolStatus === PoolStatus.Draft) return true;
+
+  if (poolStatus === PoolStatus.Published) {
+    return checkRole(
+      [ROLE_NAME.CommunityManager, ROLE_NAME.PlatformAdmin],
+      unpackMaybes(roleAssignments),
+    );
+  }
+
+  return false;
+}


### PR DESCRIPTION
🤖 Resolves #9907 

## 👋 Introduction

This allows both platform admins and community managers make changes to some fields of a published pool.

## 🕵️ Details

Adds the following:

- New change justification field to Pool model
- New permission and mutation for updating a published pool
- New dialog for the rich text fields to edit them when a pool is published

## 🧪 Testing

1. Refresh api `make refresh-api`
2. Build app `pnpm run dev`
3. Login as a pool operator `pool@test.com`
4. Create a pool and publish it
5. Confirm you cannot edit any of the field after publishing
6. Login as a community manager `community@test.com`
7. Confirm you can edit the rich text fields
8. Login as admin `admin@test.com`
9. Confirm you can edit the rich text fields

## 📸 Screenshot

![screenshot_10-May-2024_14-05-1715364346](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/f83ba7ee-6939-483d-b612-b39384665e16)
