### PR TITLE
[Fix] Notifications settings inverted

### DIFF
--- a/apps/web/src/pages/Notifications/NotificationsPage/NotificationsPage.tsx
+++ b/apps/web/src/pages/Notifications/NotificationsPage/NotificationsPage.tsx
@@ -67,9 +67,8 @@ const NotificationsPage = () => {
                   })}
                 </p>
                 <p>
-                  {/** Update URL when page is created in (ticket not created yet?) */}
                   <Link
-                    href={paths.home()}
+                    href={`${paths.accountSettings()}#notification-settings`}
                     icon={Cog8ToothIcon}
                     mode="inline"
                     color="primary"

--- a/apps/web/src/pages/Profile/AccountSettings/types.ts
+++ b/apps/web/src/pages/Profile/AccountSettings/types.ts
@@ -5,7 +5,7 @@ export type UpdateNotificationInput = {
   ignoredInAppNotifications: NotificationFamily[];
 };
 
-type NotificationType = "email" | "inApp";
+export type NotificationType = "email" | "inApp";
 
 export type FormValues = {
   systemMessages: NotificationType[];

--- a/apps/web/src/pages/Profile/AccountSettings/utils.ts
+++ b/apps/web/src/pages/Profile/AccountSettings/utils.ts
@@ -1,108 +1,79 @@
 import { NotificationFamily } from "@gc-digital-talent/graphql";
 
-import { FormValues, UpdateNotificationInput } from "./types";
+import { FormValues, UpdateNotificationInput, NotificationType } from "./types";
+
+const inputNameToFamilyMap: Record<keyof FormValues, NotificationFamily> = {
+  systemMessages: NotificationFamily.SystemMessage,
+  applicationUpdates: NotificationFamily.ApplicationUpdate,
+  jobAlerts: NotificationFamily.JobAlert,
+};
 
 export const formValuesToData = (values: FormValues) => {
-  let data: UpdateNotificationInput = {
+  const data: UpdateNotificationInput = {
     ignoredEmailNotifications: [],
     ignoredInAppNotifications: [],
   };
 
-  data = values.applicationUpdates.reduce((acc, curr) => {
-    switch (curr) {
-      case "email":
-        return {
-          ...acc,
-          ignoredEmailNotifications: [NotificationFamily.ApplicationUpdate],
-        };
-      case "inApp":
-        return {
-          ...acc,
-          ignoredInAppNotifications: [NotificationFamily.ApplicationUpdate],
-        };
-      default: {
-        return acc;
-      }
-    }
-  }, data);
+  const keys = Object.keys(values) as Array<keyof FormValues>;
+  keys.forEach((key) => {
+    const family = inputNameToFamilyMap[key];
+    const enabledTypes = values[key];
 
-  data = values.jobAlerts.reduce((acc, curr) => {
-    switch (curr) {
-      case "email":
-        return {
-          ...acc,
-          ignoredEmailNotifications: [
-            ...acc.ignoredEmailNotifications,
-            NotificationFamily.JobAlert,
-          ],
-        };
-      case "inApp":
-        return {
-          ...acc,
-          ignoredInAppNotifications: [
-            ...acc.ignoredInAppNotifications,
-            NotificationFamily.JobAlert,
-          ],
-        };
-      default: {
-        return acc;
+    // System messages cannot be ignored
+    if (family && family !== NotificationFamily.SystemMessage) {
+      if (!enabledTypes.includes("email")) {
+        data.ignoredEmailNotifications = [
+          ...data.ignoredEmailNotifications,
+          family,
+        ];
+      }
+
+      if (!enabledTypes.includes("inApp")) {
+        data.ignoredInAppNotifications = [
+          ...data.ignoredInAppNotifications,
+          family,
+        ];
       }
     }
-  }, data);
+  });
 
   return data;
 };
 
-export const dataValuesToFormValues = ({
-  ignoredEmailNotifications,
-  ignoredInAppNotifications,
-}: {
+type IgnoredNotifications = {
   ignoredEmailNotifications: NotificationFamily[];
   ignoredInAppNotifications: NotificationFamily[];
-}) => {
-  let defaultValues: FormValues = {
+};
+
+const getIgnoredNotificationFamilyValue = (
+  {
+    ignoredEmailNotifications,
+    ignoredInAppNotifications,
+  }: IgnoredNotifications,
+  family: NotificationFamily,
+): NotificationType[] => {
+  let values: NotificationType[] = [];
+  if (!ignoredEmailNotifications.includes(family)) {
+    values = [...values, "email"];
+  }
+  if (!ignoredInAppNotifications.includes(family)) {
+    values = [...values, "inApp"];
+  }
+  return values;
+};
+
+export const dataValuesToFormValues = (
+  ignoredNotifications: IgnoredNotifications,
+) => {
+  return {
     systemMessages: ["email", "inApp"],
-    applicationUpdates: [],
-    jobAlerts: [],
-  };
-
-  defaultValues = ignoredEmailNotifications.reduce((acc, curr) => {
-    switch (curr) {
-      case NotificationFamily.ApplicationUpdate:
-        return {
-          ...acc,
-          applicationUpdates: ["email"],
-        };
-      case NotificationFamily.JobAlert:
-        return {
-          ...acc,
-          jobAlerts: ["email"],
-        };
-      default: {
-        return acc;
-      }
-    }
-  }, defaultValues);
-
-  defaultValues = ignoredInAppNotifications.reduce((acc, curr) => {
-    switch (curr) {
-      case NotificationFamily.ApplicationUpdate:
-        return {
-          ...acc,
-          applicationUpdates: acc.applicationUpdates
-            ? [...acc.applicationUpdates, "inApp"]
-            : ["inApp"],
-        };
-      case NotificationFamily.JobAlert:
-        return {
-          ...acc,
-          jobAlerts: acc.jobAlerts ? [...acc.jobAlerts, "inApp"] : ["inApp"],
-        };
-      default: {
-        return defaultValues;
-      }
-    }
-  }, defaultValues);
-
-  return defaultValues;
+    applicationUpdates: getIgnoredNotificationFamilyValue(
+      ignoredNotifications,
+      NotificationFamily.ApplicationUpdate,
+    ),
+    jobAlerts: getIgnoredNotificationFamilyValue(
+      ignoredNotifications,
+      NotificationFamily.JobAlert,
+    ),
+  } satisfies FormValues;
 };


### PR DESCRIPTION
🤖 Resolves #10329 

## 👋 Introduction

Updates the notification settings to display the proper value in the check boxes.

## 🕵️ Details

This also fixes the link from the notifications page to notification settings.

## 🧪 Testing

1. Build `pnpm run dev`
2. Go to your notifications page
3. Click on the "Update settings" link in the sidebar
4. Confirm it takes you to the Notification settings section on the Account settings page
5. Update settings
6. Confirm the check boxes are checked for items not in the ignored array
