### PR TITLE
[Fix] Move unread notification indicator

### DIFF
--- a/apps/web/src/components/NotificationList/NotificationItem.tsx
+++ b/apps/web/src/components/NotificationList/NotificationItem.tsx
@@ -143,94 +143,101 @@ const NotificationItem = ({
             })}
       >
         <div
-          data-h2-padding="base(0 x.5)"
-          data-h2-align-self="base(flex-end)"
-          data-h2-font-size="base(copy)"
+          data-h2-display="base(grid)"
+          data-h2-grid-template-columns="base(x.5 1fr)"
+          data-h2-grid-template-rows="base(auto auto)"
+          data-h2-gap="base(x.25)"
         >
-          {isUnread && (
-            <svg
-              data-h2-color="base(tertiary)"
-              data-h2-height="base(x.25)"
-              data-h2-width="base(x.25)"
-              viewBox="0 0 8 8"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <circle cx="3.5" cy="3.5" r="3.375" fill="currentColor" />
-            </svg>
-          )}
-        </div>
-        <div
-          data-h2-display="base(flex)"
-          data-h2-flex-direction="base(column-reverse)"
-          data-h2-gap="base(x.5 0)"
-          data-h2-flex-grow="base(1)"
-        >
-          <LinkWrapper inDialog={inDialog}>
-            <BaseLink
-              to={info.href}
-              onClick={handleLinkClicked}
-              data-h2-text-decoration="base(none)"
-              data-h2-color="base:hover(secondary.darker)"
-              data-h2-outline="base(none)"
-              {...(isUnread && {
-                "data-h2-font-weight": "base(700)",
-              })}
-            >
-              {info.message}
-            </BaseLink>
-          </LinkWrapper>
+          <div
+            data-h2-font-size="base(copy)"
+            data-h2-grid-row="base(2)"
+            data-h2-margin="base(0 auto)"
+          >
+            {isUnread && (
+              <svg
+                data-h2-color="base(tertiary)"
+                data-h2-height="base(x.25)"
+                data-h2-width="base(x.25)"
+                viewBox="0 0 8 8"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle cx="3.5" cy="3.5" r="3.375" fill="currentColor" />
+              </svg>
+            )}
+          </div>
+          <div
+            data-h2-grid-row="base(2)"
+            data-h2-display="base(flex)"
+            data-h2-align-items="base(flex-start)"
+            data-h2-gap="base(x.25)"
+          >
+            <LinkWrapper inDialog={inDialog}>
+              <BaseLink
+                to={info.href}
+                onClick={handleLinkClicked}
+                data-h2-text-decoration="base(none)"
+                data-h2-color="base:hover(secondary.darker)"
+                data-h2-outline="base(none)"
+                {...(isUnread && {
+                  "data-h2-font-weight": "base(700)",
+                })}
+              >
+                {info.message}
+              </BaseLink>
+            </LinkWrapper>
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger>
+                <Button
+                  mode="icon_only"
+                  color="secondary"
+                  data-h2-color="base(black) base:all:hover(secondary.darkest) base:all:focus-visible(black)"
+                  icon={EllipsisVerticalIcon}
+                  aria-label={intl.formatMessage(
+                    {
+                      defaultMessage: "Manage {notificationName}",
+                      id: "lSSz6L",
+                      description: "Button text for managing a notification",
+                    },
+                    { notificationName: info.label },
+                  )}
+                />
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content align="end">
+                <DropdownMenu.Item asChild onSelect={toggleReadStatus}>
+                  <Button mode="inline" block disabled={isTogglingReadStatus}>
+                    {isUnread
+                      ? intl.formatMessage({
+                          defaultMessage: "Mark as read",
+                          id: "vi7jVU",
+                          description:
+                            "Button text to mark a notification as read",
+                        })
+                      : intl.formatMessage({
+                          defaultMessage: "Mark as unread",
+                          id: "2SnhXV",
+                          description:
+                            "Button text to mark a notification as unread",
+                        })}
+                  </Button>
+                </DropdownMenu.Item>
+                <RemoveDialog
+                  id={notification.id}
+                  message={info.message}
+                  date={createdAt}
+                />
+              </DropdownMenu.Content>
+            </DropdownMenu.Root>
+          </div>
           <p
             className="Notification__Date"
             data-h2-font-size="base(caption)"
             data-h2-color="base(black.light)"
+            data-h2-grid-column="base(2)"
+            data-h2-grid-row="base(1)"
           >
             {createdAt}
           </p>
-        </div>
-        <div data-h2-align-self="base(center)">
-          <DropdownMenu.Root>
-            <DropdownMenu.Trigger>
-              <Button
-                mode="icon_only"
-                color="secondary"
-                data-h2-color="base(black) base:all:hover(secondary.darkest) base:all:focus-visible(black)"
-                icon={EllipsisVerticalIcon}
-                aria-label={intl.formatMessage(
-                  {
-                    defaultMessage: "Manage {notificationName}",
-                    id: "lSSz6L",
-                    description: "Button text for managing a notification",
-                  },
-                  { notificationName: info.label },
-                )}
-              />
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content align="end">
-              <DropdownMenu.Item asChild onSelect={toggleReadStatus}>
-                <Button mode="inline" block disabled={isTogglingReadStatus}>
-                  {isUnread
-                    ? intl.formatMessage({
-                        defaultMessage: "Mark as read",
-                        id: "vi7jVU",
-                        description:
-                          "Button text to mark a notification as read",
-                      })
-                    : intl.formatMessage({
-                        defaultMessage: "Mark as unread",
-                        id: "2SnhXV",
-                        description:
-                          "Button text to mark a notification as unread",
-                      })}
-                </Button>
-              </DropdownMenu.Item>
-              <RemoveDialog
-                id={notification.id}
-                message={info.message}
-                date={createdAt}
-              />
-            </DropdownMenu.Content>
-          </DropdownMenu.Root>
         </div>
       </CardBasic>
       {inDialog && (


### PR DESCRIPTION
🤖 Resolves #10209 

## 👋 Introduction

Moves the unread indicator on notifications to the top of the notification text.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `pnpm dev`
2. Seed a notification
    - Easy way is logging in as admin `admin@test.com`, applying to process, then changing your status on that process
3. Check both the notification dialog and notification page `/applicant/notifications`
4. Confirm the unread indicator aligns with the top text

## 📸 Screenshot

![screenshot_13-May-2024_12-29-1715617794](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/1f7a9f85-f7a5-4524-b772-379f0570a5a6)
