### PR TITLE
[Debture] Remove search comma separation

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -405,15 +405,15 @@ class PoolCandidate extends Model
         return $query;
     }
 
-    public function scopeGeneralSearch(Builder $query, ?array $searchTerms): Builder
+    public function scopeGeneralSearch(Builder $query, ?string $searchTerm): Builder
     {
-        if (empty($searchTerms)) {
+        if (empty($searchTerm)) {
             return $query;
         }
 
-        $query->where(function ($query) use ($searchTerms) {
-            $query->whereHas('user', function ($query) use ($searchTerms) {
-                User::scopeGeneralSearch($query, $searchTerms);
+        $query->where(function ($query) use ($searchTerm) {
+            $query->whereHas('user', function ($query) use ($searchTerm) {
+                User::scopeGeneralSearch($query, $searchTerm);
             });
         });
 

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -933,10 +933,10 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
         return $query;
     }
 
-    public static function scopeGeneralSearch(Builder $query, ?array $searchTerms): Builder
+    public static function scopeGeneralSearch(Builder $query, ?string $searchTerm): Builder
     {
-        if ($searchTerms && is_array($searchTerms)) {
-            $combinedSearchTerm = implode('&', array_map('trim', $searchTerms));
+        if ($searchTerm) {
+            $combinedSearchTerm = trim($searchTerm);
 
             $query
                 // attach the tsquery to every row to use for filtering

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -619,7 +619,7 @@ input UserFilterInput {
   telephone: String @scope
   email: String @scope
   name: String @scope
-  generalSearch: [String] @scope
+  generalSearch: String @scope
   roles: [ID] @scope(name: "roleAssignments")
   trashed: Trashed @trashed
 }
@@ -648,7 +648,7 @@ input ApplicantFilterInput {
 input PoolCandidateSearchInput {
   applicantFilter: ApplicantFilterInput @spread
   email: String @scope
-  generalSearch: [String] @scope
+  generalSearch: String @scope
   name: String @scope
   notes: String @scope
   isGovEmployee: Boolean @scope

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -699,7 +699,7 @@ input UserFilterInput {
   telephone: String
   email: String
   name: String
-  generalSearch: [String]
+  generalSearch: String
   roles: [ID]
   trashed: Trashed
 }
@@ -725,7 +725,7 @@ input ApplicantFilterInput {
 input PoolCandidateSearchInput {
   applicantFilter: ApplicantFilterInput
   email: String
-  generalSearch: [String]
+  generalSearch: String
   name: String
   notes: String
   isGovEmployee: Boolean

--- a/api/tests/Feature/KeywordSearchTest.php
+++ b/api/tests/Feature/KeywordSearchTest.php
@@ -73,7 +73,7 @@ class KeywordSearchTest extends TestCase
             }
         ', [
                 'where' => [
-                    'generalSearch' => ['Toronto'],
+                    'generalSearch' => 'Toronto',
                 ],
             ])->assertJson([
                 'data' => [
@@ -168,7 +168,7 @@ class KeywordSearchTest extends TestCase
             }
         ', [
                 'where' => [
-                    'generalSearch' => ['0987654321'],
+                    'generalSearch' => '0987654321',
                 ],
             ])->assertJson([
                 'data' => [
@@ -223,7 +223,7 @@ class KeywordSearchTest extends TestCase
             }
         ', [
                 'where' => [
-                    'generalSearch' => ['software developer'], // verify it is case insensitive
+                    'generalSearch' => 'software developer', // verify it is case insensitive
                 ],
             ])->assertJson([
                 'data' => [
@@ -278,7 +278,7 @@ class KeywordSearchTest extends TestCase
             }
         ', [
                 'where' => [
-                    'generalSearch' => ['computer'],
+                    'generalSearch' => 'computer',
                 ],
             ])->assertJson([
                 'data' => [
@@ -342,7 +342,7 @@ class KeywordSearchTest extends TestCase
             }
         ', [
                 'where' => [
-                    'generalSearch' => ['award title'],
+                    'generalSearch' => 'award title',
                 ],
             ])->assertJson([
                 'data' => [
@@ -373,7 +373,7 @@ class KeywordSearchTest extends TestCase
             }
         ', [
                 'where' => [
-                    'generalSearch' => ['community title'],
+                    'generalSearch' => 'community title',
                 ],
             ])->assertJson([
                 'data' => [
@@ -469,7 +469,7 @@ class KeywordSearchTest extends TestCase
             }
         ', [
                 'where' => [
-                    'generalSearch' => ['user', 'CDS'],
+                    'generalSearch' => '"user" "CDS"',
                 ],
             ])->assertJson([
                 'data' => [
@@ -521,7 +521,7 @@ class KeywordSearchTest extends TestCase
                  }
              ', [
                 'where' => [
-                    'generalSearch' => ['john'],
+                    'generalSearch' => 'john',
                 ],
             ])->assertJsonCount(
                 3, 'data.usersPaginated.data'
@@ -546,7 +546,7 @@ class KeywordSearchTest extends TestCase
                  }
              ', [
                 'where' => [
-                    'generalSearch' => ['JOHN'],
+                    'generalSearch' => 'JOHN',
                 ],
             ])->assertJsonCount(
                 3, 'data.usersPaginated.data'
@@ -593,7 +593,7 @@ class KeywordSearchTest extends TestCase
                  }
              ', [
                 'where' => [
-                    'generalSearch' => ['abc OR hal'],
+                    'generalSearch' => 'abc OR hal',
                 ],
             ])->assertJsonFragment([
                 'id' => $user1->id,
@@ -614,7 +614,7 @@ class KeywordSearchTest extends TestCase
                  }
              ', [
                 'where' => [
-                    'generalSearch' => ['abc OR johnson@test'],
+                    'generalSearch' => 'abc OR johnson@test',
                 ],
             ])->assertJsonFragment([
                 'id' => $user1->id,
@@ -635,7 +635,7 @@ class KeywordSearchTest extends TestCase
                  }
              ', [
                 'where' => [
-                    'generalSearch' => ['johnso or hal'],
+                    'generalSearch' => 'johnso or hal',
                 ],
             ])->assertJsonFragment([
                 'id' => $user2->id,
@@ -656,7 +656,7 @@ class KeywordSearchTest extends TestCase
                  }
              ', [
                 'where' => [
-                    'generalSearch' => ['BOB@ OR johnson@'],
+                    'generalSearch' => 'BOB@ OR johnson@',
                 ],
             ])->assertJsonFragment([
                 'id' => $user2->id,
@@ -699,7 +699,7 @@ class KeywordSearchTest extends TestCase
                  }
              ', [
                 'where' => [
-                    'generalSearch' => ['"john smith"'],
+                    'generalSearch' => '"john smith"',
                 ],
             ])->assertJsonFragment([
                 'id' => $user1->id,
@@ -718,7 +718,7 @@ class KeywordSearchTest extends TestCase
                  }
              ', [
                 'where' => [
-                    'generalSearch' => ['"johnson" OR john@'],
+                    'generalSearch' => '"johnson" OR john@',
                 ],
             ])->assertJsonFragment([
                 'id' => $user1->id,
@@ -761,7 +761,7 @@ class KeywordSearchTest extends TestCase
                  }
              ', [
                 'where' => [
-                    'generalSearch' => ['john -smith'],
+                    'generalSearch' => 'john -smith',
                 ],
             ])->assertJsonFragment([
                 'id' => $user2->id,
@@ -782,7 +782,7 @@ class KeywordSearchTest extends TestCase
                  }
              ', [
                 'where' => [
-                    'generalSearch' => ['john -bob@test.com'],
+                    'generalSearch' => 'john -bob@test.com',
                 ],
             ])->assertJsonFragment([
                 'id' => $user1->id,
@@ -803,7 +803,7 @@ class KeywordSearchTest extends TestCase
                     }
                 ', [
                 'where' => [
-                    'generalSearch' => ['john -smit -bob@t'],
+                    'generalSearch' => 'john -smit -bob@t',
                 ],
             ])->assertJsonFragment([
                 'id' => $user1->id,
@@ -842,7 +842,7 @@ class KeywordSearchTest extends TestCase
             }
             ', [
                 'where' => [
-                    'generalSearch' => ['bob-jon'],
+                    'generalSearch' => 'bob-jon',
                 ],
             ])->assertJsonFragment([
                 'id' => $user1->id,
@@ -861,7 +861,7 @@ class KeywordSearchTest extends TestCase
             }
             ', [
                 'where' => [
-                    'generalSearch' => ['o_bria'],
+                    'generalSearch' => 'o_bria',
                 ],
             ])->assertJsonFragment([
                 'id' => $user1->id,
@@ -878,7 +878,7 @@ class KeywordSearchTest extends TestCase
             }
             ', [
                 'where' => [
-                    'generalSearch' => ['bob.jone'],
+                    'generalSearch' => 'bob.jone',
                 ],
             ])->assertJsonFragment([
                 'id' => $user2->id,
@@ -897,7 +897,7 @@ class KeywordSearchTest extends TestCase
             }
             ', [
                 'where' => [
-                    'generalSearch' => ['bob jone'],
+                    'generalSearch' => 'bob jone',
                 ],
             ])->assertJsonFragment([
                 'id' => $user1->id,

--- a/api/tests/Feature/PoolCandidateSearchTest.php
+++ b/api/tests/Feature/PoolCandidateSearchTest.php
@@ -521,7 +521,7 @@ class PoolCandidateSearchTest extends TestCase
             $query,
             [
                 'where' => [
-                    'generalSearch' => ['test notes'],
+                    'generalSearch' => 'test notes',
                 ],
             ]
         )->assertJson([

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -2091,7 +2091,7 @@ class UserTest extends TestCase
         ',
             [
                 'where' => [
-                    'generalSearch' => ['sam', '67890'],
+                    'generalSearch' => 'sam 67890',
                 ],
             ]
         )->assertJson([

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -403,8 +403,7 @@ const PoolCandidatesTable = ({
     }
     return {
       // search bar
-      generalSearch:
-        searchBarTerm && !searchType ? searchBarTerm.split(",") : undefined,
+      generalSearch: searchBarTerm && !searchType ? searchBarTerm : undefined,
       email: searchType === "email" ? searchBarTerm : undefined,
       name: searchType === "name" ? searchBarTerm : undefined,
       notes: searchType === "notes" ? searchBarTerm : undefined,

--- a/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
@@ -55,8 +55,7 @@ export function transformUserInput(
 
   return {
     // search bar
-    generalSearch:
-      searchBarTerm && !searchType ? searchBarTerm.split(",") : undefined,
+    generalSearch: searchBarTerm && !searchType ? searchBarTerm : undefined,
     email: searchType === "email" ? searchBarTerm : undefined,
     name: searchType === "name" ? searchBarTerm : undefined,
     telephone: searchType === "phone" ? searchBarTerm : undefined,


### PR DESCRIPTION
🤖 Resolves #9963 

## 👋 Introduction

Remove the comma separation from the text search from front, API, and back. 

## 🧪 Testing

1. Commas will not split, ensure searching not broken for tables
2. Not much to actually test
