### PR TITLE
[Feature] Admin table classification filter doesn't also filter status

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -781,6 +781,24 @@ class User extends Model implements Authenticatable, LaratrustUser
     }
 
     /**
+     * Scopes the query to only return users in a pool with one of the specified classifications.
+     * If $classifications is empty, this scope will be ignored.
+     *
+     * @param  array|null  $classifications  Each classification is an object with a group and a level field.
+     */
+    public static function scopeAppliedClassifications(Builder $query, ?array $classifications): Builder
+    {
+        if (empty($classifications)) {
+            return $query;
+        }
+        $query->whereHas('poolCandidates', function ($query) use ($classifications) {
+            PoolCandidate::scopeAppliedClassifications($query, $classifications);
+        });
+
+        return $query;
+    }
+
+    /**
      * Scopes the query to only return users who are available in a pool with one of the specified classifications.
      * If $classifications is empty, this scope will be ignored.
      *

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -653,6 +653,10 @@ input PoolCandidateSearchInput {
   expiryStatus: CandidateExpiryFilter @scope(name: "expiryStatus")
   suspendedStatus: CandidateSuspendedFilter @scope(name: "suspendedStatus")
   publishingGroups: [PublishingGroup] @scope(name: "publishingGroups") # Filters applicants based on the publishing group of the pool
+  # Filters applicants based on the classification of all pools they are currently in.
+  # There is also a classification field as part of ApplicantFilterInput however it includes scoping for availability.
+  appliedClassifications: [ClassificationFilterInput]
+    @scope(name: "appliedClassifications")
 }
 
 input PoolCandidateSearchRequestInput {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -728,6 +728,7 @@ input PoolCandidateSearchInput {
   expiryStatus: CandidateExpiryFilter
   suspendedStatus: CandidateSuspendedFilter
   publishingGroups: [PublishingGroup]
+  appliedClassifications: [ClassificationFilterInput]
 }
 
 input PoolCandidateSearchRequestInput {

--- a/api/tests/Feature/PoolCandidateSearchTest.php
+++ b/api/tests/Feature/PoolCandidateSearchTest.php
@@ -5,6 +5,7 @@ use App\Enums\CandidateExpiryFilter;
 use App\Enums\CandidateSuspendedFilter;
 use App\Enums\CitizenshipStatus;
 use App\Enums\PoolCandidateStatus;
+use App\Models\Classification;
 use App\Models\Pool;
 use App\Models\PoolCandidate;
 use App\Models\Team;
@@ -479,6 +480,127 @@ class PoolCandidateSearchTest extends TestCase
             [
                 'where' => [
                     'isGovEmployee' => true,
+                ],
+            ]
+        )->assertJson([
+            'data' => [
+                'poolCandidatesPaginated' => [
+                    'paginatorInfo' => [
+                        'count' => 5,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testPoolCandidatesSearchClassification(): void
+    {
+        // Create qualified right classification candidates
+        $classificationIT1 = Classification::factory()->create([
+            'group' => 'IT',
+            'level' => 1,
+        ]);
+        $poolIT1 = Pool::factory()->create([
+            'team_id' => $this->team->id,
+            'classification_id' => $classificationIT1->id,
+        ]);
+        PoolCandidate::factory()->count(5)->create([
+            'pool_id' => $poolIT1->id,
+            'expiry_date' => config('constants.far_future_date'),
+            'pool_candidate_status' => PoolCandidateStatus::PLACED_CASUAL->name,
+            'suspended_at' => null,
+        ]);
+
+        // Wrong classification candidates
+        $classificationIT2 = Classification::factory()->create([
+            'group' => 'IT',
+            'level' => 2,
+        ]);
+        $poolIT2 = Pool::factory()->create([
+            'team_id' => $this->team->id,
+            'classification_id' => $classificationIT2->id,
+        ]);
+        PoolCandidate::factory()->count(3)->create([
+            'pool_id' => $poolIT2->id,
+            'expiry_date' => config('constants.far_future_date'),
+            'pool_candidate_status' => PoolCandidateStatus::PLACED_CASUAL->name,
+            'suspended_at' => null,
+        ]);
+
+        PoolCandidate::factory()->create([
+            'pool_id' => $poolIT1->id,
+            'expiry_date' => config('constants.far_future_date'),
+            'pool_candidate_status' => PoolCandidateStatus::UNDER_ASSESSMENT->name,
+            'suspended_at' => null,
+        ]);
+
+        $query =
+            /** @lang GraphQL */
+            '
+            query poolCandidatesPaginated ($where: PoolCandidateSearchInput) {
+                poolCandidatesPaginated (
+                  where: $where) {
+                    paginatorInfo {
+                        count
+                    }
+                }
+            }
+        ';
+
+        // assert all 9 returned
+        $this->actingAs($this->teamUser, 'api')->graphQL(
+            $query,
+            [
+                'where' => [
+                    'appliedClassifications' => null,
+                ],
+            ]
+        )->assertJson([
+            'data' => [
+                'poolCandidatesPaginated' => [
+                    'paginatorInfo' => [
+                        'count' => 9,
+                    ],
+                ],
+            ],
+        ]);
+
+        // assert the 6 right classifications returned - regardless of qualified status
+        $this->actingAs($this->teamUser, 'api')->graphQL(
+            $query,
+            [
+                'where' => [
+                    'appliedClassifications' => [
+                        [
+                            'group' => 'IT',
+                            'level' => 1,
+                        ],
+                    ],
+                ],
+            ]
+        )->assertJson([
+            'data' => [
+                'poolCandidatesPaginated' => [
+                    'paginatorInfo' => [
+                        'count' => 6,
+                    ],
+                ],
+            ],
+        ]);
+
+        // assert the 5 qualified right classification candidates returned
+        $this->actingAs($this->teamUser, 'api')->graphQL(
+            $query,
+            [
+                'where' => [
+                    'applicantFilter' => [
+                        'qualifiedClassifications' => [
+                            [
+                                'group' => 'IT',
+                                'level' => 1,
+                            ],
+                        ],
+                    ],
                 ],
             ]
         )->assertJson([

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -404,6 +404,7 @@ const PoolCandidatesTable = ({
       suspendedStatus: fancyFilterState?.suspendedStatus,
       isGovEmployee: fancyFilterState?.isGovEmployee,
       publishingGroups: fancyFilterState?.publishingGroups,
+      appliedClassifications: fancyFilterState?.appliedClassifications,
     };
   };
 

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -725,7 +725,7 @@ export function transformPoolCandidateSearchInputToFormValues(
   return {
     publishingGroups: input?.publishingGroups?.filter(notEmpty) ?? [],
     classifications:
-      input?.applicantFilter?.qualifiedClassifications
+      input?.appliedClassifications
         ?.filter(notEmpty)
         .map((c) => `${c.group}-${c.level}`) ?? [],
     stream: input?.applicantFilter?.qualifiedStreams?.filter(notEmpty) ?? [],
@@ -774,10 +774,6 @@ export function transformFormValuesToFilterState(
       languageAbility: data.languageAbility
         ? stringToEnumLanguage(data.languageAbility)
         : undefined,
-      qualifiedClassifications: data.classifications.map((classification) => {
-        const splitString = classification.split("-");
-        return { group: splitString[0], level: Number(splitString[1]) };
-      }),
       qualifiedStreams: data.stream as PoolStream[],
       operationalRequirements: data.operationalRequirement
         .map((requirement) => {
@@ -820,5 +816,9 @@ export function transformFormValuesToFilterState(
       : undefined,
     isGovEmployee: data.govEmployee ? true : undefined, // massage from FormValue type to PoolCandidateSearchInput
     publishingGroups: data.publishingGroups as PublishingGroup[],
+    appliedClassifications: data.classifications.map((classification) => {
+      const splitString = classification.split("-");
+      return { group: splitString[0], level: Number(splitString[1]) };
+    }),
   };
 }

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -59,8 +59,6 @@ const transformApplicantFilterToPoolCandidateSearchInput = (
   // Therefore, transforming ApplicantFilter to ApplicantFilterInput requires omitting any fields not included in the Input type.
   const mapping: MappingType = {
     equity: omitIdAndTypename,
-    qualifiedClassifications: (classifications) =>
-      classifications?.filter(notEmpty).map(classificationToInput),
     hasDiploma: identity,
     languageAbility: identity,
     locationPreferences: identity,
@@ -92,6 +90,9 @@ const transformApplicantFilterToPoolCandidateSearchInput = (
       },
       emptyFilter,
     ),
+    appliedClassifications: applicantFilter.qualifiedClassifications
+      ?.filter(notEmpty)
+      .map(classificationToInput),
     poolCandidateStatus: [
       PoolCandidateStatus.QualifiedAvailable,
       PoolCandidateStatus.PlacedCasual,


### PR DESCRIPTION
🤖 Resolves #10081

## 👋 Introduction

Updates the pool candidate tables classification filters to not also filter out unqualified candidates.

## 🕵️ Details

Adds a new appliedClassifications field to PoolCandidateSearchInput which won't also filter based on status.

## 🧪 Testing

1. Ensure you have a pool with at least on each of qualified, expired, and non-qualified status (ex. screened in) as well as at least one qualified candidate of a different classification.
2. Navigate to the search page `/search`.
3. Filter to the classification of the pool in step one and make note of the candidate count.
4. Fill out the necessary fields to submit and talent request for the classification.
5. Navigate to the talent requests page `/admin/talent-requests`.
6. Select to view your new request.
7. Scroll down to the candidate results section and clear any filters you added to submit the request.
8. Confirm the number of candidates matches the count in step 3. Note: "Removed" candidates won't be filtered out - ignore them in this count.
9. Change the "Expiry status" and "Candidacy status" filters to all and confirm they both increase the candidate count.