### PR TITLE
[Fix] Adds unformatted version of string for CSV column header

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/poolCandidateCsv.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/poolCandidateCsv.tsx
@@ -361,7 +361,13 @@ export const getPoolCandidateCsvHeaders = (
     },
     {
       id: "secondLanguageExamCompleted",
-      displayName: getLabels(intl).secondLanguageExamCompletedLabel,
+      displayName: intl.formatMessage({
+        defaultMessage:
+          "I have completed a Public Service Commission evaluation of my second official language.",
+        id: "pXLPjN",
+        description:
+          "Statement for completion of a Public Service Commission evaluation of a second official language",
+      }),
     },
     {
       id: "secondLanguageExamValidity",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9634,6 +9634,10 @@
     "defaultMessage": "Le Programme d’apprentissage en TI pour les personnes autochtones est une initiative du gouvernement du Canada visant particulièrement les Premières Nations, les Inuits et les Métis. C’est un chemin vers un emploi dans la fonction publique fédérale pour les personnes autochtones qui ont une passion pour la technologie de l’information (TI).",
     "description": "First paragraph about the program"
   },
+  "pXLPjN": {
+    "defaultMessage": "J’ai fait l’objet d’une évaluation par la Commission de la fonction publique dans ma deuxième langue officielle.",
+    "description": "Statement for completion of a Public Service Commission evaluation of a second official language"
+  },
   "pXiwEH": {
     "defaultMessage": "Fermer immédiatement",
     "description": "Option to close the pool"

--- a/apps/web/src/pages/Users/IndexUserPage/components/userCsv.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/userCsv.tsx
@@ -176,7 +176,13 @@ export const getUserCsvHeaders = (intl: IntlShape) => [
   },
   {
     id: "secondLanguageExamCompleted",
-    displayName: getLabels(intl).secondLanguageExamCompletedLabel,
+    displayName: intl.formatMessage({
+      defaultMessage:
+        "I have completed a Public Service Commission evaluation of my second official language.",
+      id: "pXLPjN",
+      description:
+        "Statement for completion of a Public Service Commission evaluation of a second official language",
+    }),
   },
   {
     id: "secondLanguageExamValidity",


### PR DESCRIPTION
🤖 Resolves #10335.

## 👋 Introduction

This PR adds unformatted version of string for the column header **I have completed a Public Service Commission evaluation of my second official language.** in the pool candidates and users generated CSV documents.

## 🕵️ Details

It would have been nice to remove the `<strong>` tags wrapping parts of the original string altogether but 🤷.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Download CSV on pool candidates table
2. Observe column title for **I have completed a Public Service Commission evaluation of my second official language.** is without `object` 
3. Download CSV on users table
4. Observe column title for **I have completed a Public Service Commission evaluation of my second official language.** is without `object`