### PR TITLE
[Docs] Changes markdown formatting to use alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,5 @@ We strongly recommend running the project entirely with Docker. In this case the
 
 Then, follow the instructions in [`/maintenance/README.md`](/maintenance/README.md) to build the project docker containers and run the build scripts. That should handle everything!
 
-### Complications?
-
-- Make sure virtualization is enabled in your machine's BIOS (this is for Docker Desktop)
-- Docker is finicky—try exiting it entirely and restarting it
+> [!TIP]
+> If using Docker Desktop, make sure virtualization is enabled in your machine's BIOS.

--- a/apps/e2e/cypress/README.md
+++ b/apps/e2e/cypress/README.md
@@ -64,10 +64,8 @@ cy.findByRole("button", { name: /Non-existing Button Text/i }).should(
 cy.findByLabelText(/Label text/i, { timeout: 7000 }).should("exist");
 ```
 
-Note: `get*()` queries are not available, as they're not compatible with how
-Cypress works by default.
-
-See official documentation linked above for examples.
+> [!NOTE]  
+> `get*()` queries are not available, as they are not compatible with how Cypress works by default.
 
 ## Commands
 

--- a/documentation/accessibility.md
+++ b/documentation/accessibility.md
@@ -32,7 +32,8 @@ In the following example, we have a `<nav>` element where we capture an `onKeyDo
 
 ## E2E Testing
 
-_Note:_ This may change but should remain similar.
+> [!NOTE]  
+> This may change but should remain similar.
 
 ### `cypress-axe`
 

--- a/documentation/notifications.md
+++ b/documentation/notifications.md
@@ -2,9 +2,8 @@
 
 Sometimes, it is necessary to communicate with our users outside of the application. In order to do that, we can send emails and SMS messages using [GC Notify](https://notification.canada.ca/). This is done on the server in the `api` Laravel project.
 
-> **Note**
-> It may be useful to read over the [GC Notify documentation](https://documentation.notification.canada.ca/)
-> to get a better understanding of how the client operates.
+> [!NOTE]
+> It may be useful to read the [GC Notify documentation](https://documentation.notification.canada.ca/) to get a better understanding of how the client operates.
 
 We do this using the `App\Notify\Client` via a facade (`App\Facades\Notify`). This is bound as a singleton to the the service container.
 

--- a/documentation/translation.md
+++ b/documentation/translation.md
@@ -20,7 +20,8 @@ The i18n subproject contains a script (`dist/cli.js`) to help manage the react-i
 
 The checkIntl script can be run with different flags and options. For more details on how individual options work, see the checkIntl file itself. In practice, it is easiest to save the commands, with options included, as **package.json** scripts.
 
-Note: each subproject using react-intl (e.g. packages/i18n, apps/web, etc.) requires its own set of commands, and must be managed separately.
+> [!NOTE]  
+> Each sub-project using react-intl (e.g. packages/i18n, apps/web, etc.) requires its own set of commands, and must be managed separately.
 
 For example, to ensure translations in the apps/web project are up to date:
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -18,7 +18,7 @@ To log into the app database with Adminer, use the following credentials:
 
 ## Connecting api service to database
 
-The environment variables in `../api/.env.example` are already configured to connect to the database from inside a docker-compose network. Note that, if you want to run migrations or data seeders, you will need to run them inside the container, like so:
+The environment variables in [`/api/.env.example`](/api/.env.example) are already configured to connect to the database from inside a docker-compose network. If you want to run migrations or data seeders, you will need to run them inside the container.
 
 - `docker-compose exec -w /home/site/wwwroot/api webserver sh -c "php artisan migrate"`
 - `docker-compose exec -w /home/site/wwwroot/api webserver sh -c "php artisan db:seed"`

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -18,7 +18,7 @@ To log into the app database with Adminer, use the following credentials:
 
 ## Connecting api service to database
 
-The environment variables in `../api/.env.example` are already configured to connect to connect to the database from inside a docker-compose network. Note that, if you want to run migrations or data seeders, you will need to run them inside the container, like so:
+The environment variables in `../api/.env.example` are already configured to connect to the database from inside a docker-compose network. Note that, if you want to run migrations or data seeders, you will need to run them inside the container, like so:
 
 - `docker-compose exec -w /home/site/wwwroot/api webserver sh -c "php artisan migrate"`
 - `docker-compose exec -w /home/site/wwwroot/api webserver sh -c "php artisan db:seed"`

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -51,4 +51,5 @@ In order to compile and render UI for development, you have two options:
 - Allow the first compile to happen
 - Make some changes, watch it recompile, and your Storybook page should automatically refresh
 
-**Note:** Having trouble with Storybook `.cache` permissions? Try running `sudo chmod 777 -R node_modules/.cache` from the relevant workspace.
+> [!TIP]  
+> Having trouble with Storybook `.cache` permissions? Try running `sudo chmod 777 -R node_modules/.cache` from the relevant workspace.


### PR DESCRIPTION
## 👋 Introduction

This PR changes formatting in some of the markdown files to use [GitHub's alert markdown extension](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts). It also fixes a typo and changes some other copy syntax.

> [!TIP]
> An apple a day keeps the doctor away.