### PR TITLE
[Bug] Previewing a draft pool

### DIFF
--- a/apps/e2e/cypress/e2e/admin/pools.cy.ts
+++ b/apps/e2e/cypress/e2e/admin/pools.cy.ts
@@ -299,6 +299,15 @@ describe("Pools", () => {
     cy.findAllByRole("link", { name: /test pool en/i })
       .first()
       .click();
+
+    cy.findAllByRole("link", { name: /preview advertisement/i })
+      .first()
+      .invoke("attr", "target", "_self") // https://medium.com/@anshita.bhasin/how-to-handle-opening-of-a-new-tab-in-cypress-f995d7152b80
+      .click();
+
+    cy.findByRole("heading", { name: /employment details/i })
+      .should("exist")
+      .and("be.visible");
   });
 
   /**

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -572,6 +572,13 @@ const createRoute = (locale: Locales) =>
               ],
             },
             {
+              path: "pools/:poolId/preview",
+              lazy: () =>
+                import(
+                  "../pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage"
+                ),
+            },
+            {
               path: "pool-candidates",
               lazy: () =>
                 import(

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -59,6 +59,8 @@ const getRoutes = (lang: Locales) => {
       path.join(adminUrl, "pools", poolId, "plan"),
     screeningAndEvaluation: (poolId: string) =>
       path.join(adminUrl, "pools", poolId, "screening"),
+    poolPreview: (poolId: string) =>
+      path.join(adminUrl, "pools", poolId, "preview"),
 
     // Admin - Pool Candidates
     poolCandidates: () => path.join(adminUrl, "pool-candidates"),

--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -215,7 +215,11 @@ export const ViewPool = ({
               <Link
                 mode="inline"
                 color="secondary"
-                href={paths.pool(pool.id)}
+                href={
+                  advertisementStatus === "submitted"
+                    ? paths.pool(pool.id)
+                    : paths.poolPreview(pool.id)
+                }
                 newTab
               >
                 {advertisementStatus === "submitted"


### PR DESCRIPTION
🤖 Resolves #10373

## 👋 Introduction

Enable previewing a draft pool with the protected endpoint functional as well as have it asserted in E2E testing. 

## 🧪 Testing

1. Have protected endpoints active
2. Navigate to process main page (`en/admin/pools/:id`) for a published pool
3. Observe the view link directing you to the advertisement talent side
4. Navigate to the process page for a draft pool
5. Observe the preview link directing you to a poster view nested within admin

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/ccfd6c38-ae12-43ef-9bfa-90da46b92266)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/64bf0d25-36cb-496a-bec4-fcd12376c838)



