### PR TITLE
[Fix] Remove admin links on public skills table

### DIFF
--- a/apps/web/src/pages/Skills/SkillPage.tsx
+++ b/apps/web/src/pages/Skills/SkillPage.tsx
@@ -13,7 +13,7 @@ import adminMessages from "~/messages/adminMessages";
 import skillBrowserMessages from "~/components/SkillBrowser/messages";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
-import SkillTableApi from "./components/SkillTable";
+import SkillTable from "./components/SkillTable";
 
 export const pageSolidIcon: IconType = BoltSolidIcon;
 export const pageOutlineIcon: IconType = BoltOutlineIcon;
@@ -79,10 +79,11 @@ export const Component = () => {
             })}
           </p>
         </Alert.Root>
-        <SkillTableApi
+        <SkillTable
           title={formattedPageTitle}
           paginationState={{ ...INITIAL_STATE.paginationState, pageSize: 20 }}
           csvDownload
+          isPublic
         />
         <Well id="cant-find-a-skill" data-h2-margin-top="base(x3)">
           <Heading

--- a/apps/web/src/pages/Skills/components/SkillTable.stories.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.stories.tsx
@@ -1,6 +1,7 @@
-import { Meta, StoryFn } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 
 import { fakeSkillFamilies, fakeSkills } from "@gc-digital-talent/fake-data";
+import { MockGraphqlDecorator } from "@gc-digital-talent/storybook-helpers";
 
 import { SkillTable } from "./SkillTable";
 
@@ -9,18 +10,22 @@ const mockSkillFamilies = fakeSkillFamilies();
 
 export default {
   component: SkillTable,
-} as Meta<typeof SkillTable>;
+  args: {
+    title: "Skills",
+  },
+  decorators: [MockGraphqlDecorator],
+  parameters: {
+    apiResponses: {
+      SkillTableSkills: {
+        data: {
+          skills: mockSkills,
+          skillFamilies: mockSkillFamilies,
+        },
+      },
+    },
+  },
+} satisfies Meta<typeof SkillTable>;
 
-const Template: StoryFn<typeof SkillTable> = (args) => {
-  const { skills, skillFamilies, title } = args;
-  return (
-    <SkillTable skills={skills} title={title} skillFamilies={skillFamilies} />
-  );
-};
+type Story = StoryObj<typeof SkillTable>;
 
-export const Default = Template.bind({});
-Default.args = {
-  skills: mockSkills,
-  skillFamilies: mockSkillFamilies,
-  title: "Skills",
-};
+export const Default: Story = {};

--- a/apps/web/src/pages/Skills/components/SkillTable.stories.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import { fakeSkillFamilies, fakeSkills } from "@gc-digital-talent/fake-data";
 import { MockGraphqlDecorator } from "@gc-digital-talent/storybook-helpers";
 
-import { SkillTable } from "./SkillTable";
+import SkillTable from "./SkillTable";
 
 const mockSkills = fakeSkills();
 const mockSkillFamilies = fakeSkillFamilies();

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -122,13 +122,15 @@ interface SkillTableProps {
   paginationState?: PaginationState;
   addButton?: boolean;
   csvDownload?: boolean;
+  isPublic?: boolean;
 }
 
-export const SkillTable = ({
+const SkillTable = ({
   title,
   paginationState,
   addButton,
   csvDownload,
+  isPublic,
 }: SkillTableProps) => {
   const intl = useIntl();
   const cache = createIntlCache();
@@ -189,7 +191,9 @@ export const SkillTable = ({
       },
       cell: ({ row: { original: skill } }) => {
         const skillName = getLocalizedName(skill.name, intl);
-        return cells.edit(skill.id, paths.skillTable(), skillName, skillName);
+        return isPublic
+          ? skillName
+          : cells.edit(skill.id, paths.skillTable(), skillName, skillName);
       },
     }),
     columnHelper.accessor((skill) => familiesAccessor(skill, intl), {

--- a/packages/ui/src/components/Pending/index.ts
+++ b/packages/ui/src/components/Pending/index.ts
@@ -1,4 +1,6 @@
 import Pending, { PendingProps } from "./Pending";
+import ErrorMessage from "./ErrorMessage";
 
 export default Pending;
 export type { PendingProps };
+export { ErrorMessage as LoadingErrorMessage };

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -50,7 +50,10 @@ import Link, {
 import Loading, { type LoadingProps } from "./components/Loading";
 import NavTabs from "./components/Tabs/NavTabs";
 import NotFound, { ThrowNotFound } from "./components/NotFound";
-import Pending, { type PendingProps } from "./components/Pending";
+import Pending, {
+  type PendingProps,
+  LoadingErrorMessage,
+} from "./components/Pending";
 import ScrollArea from "./components/ScrollArea";
 import Separator from "./components/Separator";
 import SideMenu, {
@@ -150,6 +153,7 @@ export {
   MenuLink,
   NavTabs,
   Loading,
+  LoadingErrorMessage,
   Pending,
   NotFound,
   ThrowNotFound,


### PR DESCRIPTION
🤖 Resolves #10387 

## 👋 Introduction

Updates the skill table to allow for displaying with no edit links.

## 🕵️ Details

To avoid all the prop drilling we were doing, this also removes the API wrapper that didn't do much but forward props down to the table.

## 🧪 Testing

1. Build `pnpm run dev`
2. Login as admin `admin@test.com`
3. Navigate to public skills page `/skills`
4. Confirm no edit links
5. Navigate to admin skills page `/admin/skills`
6. Confirm edit links appear

## 📸 Screenshot

![screenshot_17-May-2024_12-00-1715961633](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/28bc6b63-e47f-4a0f-8df1-07dc6d5de4ac)
