### PR TITLE
[Debt] Updates Azure Pipelines ubuntu image 

### DIFF
--- a/infrastructure/azure-pipelines-dev.yml
+++ b/infrastructure/azure-pipelines-dev.yml
@@ -13,7 +13,7 @@ jobs:
   - job: build_artifact
     displayName: Build artifact
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     steps:
       - checkout: self
         clean: true

--- a/infrastructure/azure-pipelines.yml
+++ b/infrastructure/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
   - job: build_artifact
     displayName: Build artifact
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     steps:
       - checkout: self
         clean: true

--- a/infrastructure/bin/set_php_versions.sh
+++ b/infrastructure/bin/set_php_versions.sh
@@ -10,6 +10,11 @@ set -o nounset
 # Assign PHP version from arg if supplied. Runs default PHP bin without.
 PHP_VERSION=$1
 
+# GitHub runner only includes one version of PHP that is not necesarrily the value of the assigned therefore the Personal Package Archive (PPA) is necessary.
+sudo add-apt-repository ppa:ondrej/php
+sudo apt update
+sudo apt-get install php${PHP_VERSION}
+
 sudo update-alternatives --set php /usr/bin/php${PHP_VERSION}
 sudo update-alternatives --set phar /usr/bin/phar${PHP_VERSION}
 sudo update-alternatives --set phpdbg /usr/bin/phpdbg${PHP_VERSION}

--- a/infrastructure/bin/set_php_versions.sh
+++ b/infrastructure/bin/set_php_versions.sh
@@ -11,14 +11,8 @@ set -o nounset
 PHP_VERSION=$1
 
 # GitHub runner only includes one version of PHP that is not necesarrily the value of the assigned therefore the Personal Package Archive (PPA) is necessary.
-sudo add-apt-repository ppa:ondrej/php
+LC_ALL=C.UTF-8 sudo add-apt-repository ppa:ondrej/php
 sudo apt update
-sudo apt-get install php${PHP_VERSION}
-
-sudo update-alternatives --set php /usr/bin/php${PHP_VERSION}
-sudo update-alternatives --set phar /usr/bin/phar${PHP_VERSION}
-sudo update-alternatives --set phpdbg /usr/bin/phpdbg${PHP_VERSION}
-sudo update-alternatives --set php-cgi /usr/bin/php-cgi${PHP_VERSION}
-sudo update-alternatives --set phar.phar /usr/bin/phar.phar${PHP_VERSION}
+sudo apt-get install -y php${PHP_VERSION} php-mbstring php-xml php-pgsql php-zip php-curl php-bcmath php-gd
 
 php -version

--- a/infrastructure/bin/set_php_versions.sh
+++ b/infrastructure/bin/set_php_versions.sh
@@ -13,6 +13,6 @@ PHP_VERSION=$1
 # GitHub runner only includes one version of PHP that is not necesarrily the value of the assigned therefore the Personal Package Archive (PPA) is necessary.
 LC_ALL=C.UTF-8 sudo add-apt-repository ppa:ondrej/php
 sudo apt update
-sudo apt-get install -y php${PHP_VERSION} php${PHP_VERSION}-mbstring php${PHP_VERSION}-xml php${PHP_VERSION}-pgsql php${PHP_VERSION}-zip php${PHP_VERSION}-curl php${PHP_VERSION}-bcmath php${PHP_VERSION}-gd
+sudo apt-get install -y php${PHP_VERSION} php${PHP_VERSION}-mbstring php${PHP_VERSION}-xml php${PHP_VERSION}-pgsql php${PHP_VERSION}-zip php${PHP_VERSION}-curl php${PHP_VERSION}-bcmath php${PHP_VERSION}-gd php${PHP_VERSION}-dom
 
 php -version

--- a/infrastructure/bin/set_php_versions.sh
+++ b/infrastructure/bin/set_php_versions.sh
@@ -12,7 +12,7 @@ PHP_VERSION=$1
 
 # GitHub runner only includes one version of PHP that is not necesarrily the value of the assigned therefore the Personal Package Archive (PPA) is necessary.
 LC_ALL=C.UTF-8 sudo add-apt-repository ppa:ondrej/php
-sudo apt update
+sudo apt-get update
 sudo apt-get install -y php${PHP_VERSION} php${PHP_VERSION}-mbstring php${PHP_VERSION}-xml php${PHP_VERSION}-pgsql php${PHP_VERSION}-zip php${PHP_VERSION}-curl php${PHP_VERSION}-bcmath php${PHP_VERSION}-gd php${PHP_VERSION}-dom
 
 php -version

--- a/infrastructure/bin/set_php_versions.sh
+++ b/infrastructure/bin/set_php_versions.sh
@@ -13,6 +13,6 @@ PHP_VERSION=$1
 # GitHub runner only includes one version of PHP that is not necesarrily the value of the assigned therefore the Personal Package Archive (PPA) is necessary.
 LC_ALL=C.UTF-8 sudo add-apt-repository ppa:ondrej/php
 sudo apt update
-sudo apt-get install -y php${PHP_VERSION} php-mbstring php-xml php-pgsql php-zip php-curl php-bcmath php-gd
+sudo apt-get install -y php${PHP_VERSION} php${PHP_VERSION}-mbstring php${PHP_VERSION}-xml php${PHP_VERSION}-pgsql php${PHP_VERSION}-zip php${PHP_VERSION}-curl php${PHP_VERSION}-bcmath php${PHP_VERSION}-gd
 
 php -version


### PR DESCRIPTION
🤖 Resolves #10202.

## 👋 Introduction

This PR updates the Azure Pipeline `vmImage` to use the same version of Ubuntu as the GitHub action worklfows.

## 🕵️ Details

Because the GitHub runner `ubuntu-22.04` only includes a single version of PHP, version 8.1, which is different from what is currently used by us, version 8.2, a PPA is required in order to install a different version of PHP along with its extensions.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Deploy in Azure to dev vertical
2. Verify PHP version 8.2 is installed and app works as it did before the PPA