### PR TITLE
[Copy] Add API messages

### DIFF
--- a/packages/i18n/src/messages/apiMessages.ts
+++ b/packages/i18n/src/messages/apiMessages.ts
@@ -160,6 +160,49 @@ export const apiMessages: { [key: string]: MessageDescriptor } = defineMessages(
       description: "Error message that a given pool skill is not valid.",
     },
 
+    // RoD assorted
+    ExpiryDateRequired: {
+      defaultMessage: "Expiry date is missing. Enter a date.",
+      id: "mcL1kc",
+      description: "Error message that an expiry date must be added",
+    },
+    ExpiryDateAfterToday: {
+      defaultMessage: "Expiry date must be after today. Enter a valid date.",
+      id: "k8IB9g",
+      description: "Error message that an expiry date must be in the future",
+    },
+    InvalidStatusForQualification: {
+      defaultMessage:
+        "An error occurred during qualification. Contact support if this problem persists.",
+      id: "or2gwQ",
+      description: "Error message that qualifying a candidate failed",
+    },
+    InvalidStatusForDisqualification: {
+      defaultMessage:
+        "An error occurred during disqualification. Contact support if this problem persists.",
+      id: "IxWjU1",
+      description: "Error message that disqualifying a candidate failed",
+    },
+    InvalidStatusForRevertFinalDecision: {
+      defaultMessage:
+        "An error occurred while reverting final decision. Contact support if this problem persists.",
+      id: "556RGm",
+      description:
+        "Error message that reverting the final decision for a candidate failed",
+    },
+    InvalidStatusForPlacing: {
+      defaultMessage:
+        "An error occurred while placing the candidate. Contact support if this problem persists.",
+      id: "8kUa5H",
+      description: "Error message that placing a candidate failed",
+    },
+    CandidateNotPlaced: {
+      defaultMessage:
+        "An error occurred while placing the candidate. Contact support if this problem persists.",
+      id: "8kUa5H",
+      description: "Error message that placing a candidate failed",
+    },
+
     // pool updating
     UpdatePoolClosingDateFuture: {
       defaultMessage: "The pool must have a closing date after today.",


### PR DESCRIPTION
🤖 Resolves #10075

## 👋 Introduction

Adds some new front end messages to connect to API errors. 

## 🧪 Testing

A little tricky given most of these should never be seen due to front side validation

1. Test for example status mutations, navigate to an application
2. Open up a database tool and change the status
3. Attempt to fire a status mutation from the application page, do not refresh the page after changing status in the database tool

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/92921f8b-04ab-4042-8939-101cfa6d9c29)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/40485260/753163ce-4d90-486e-bddb-5fd972ced08f)

