### PR TITLE
Publish pool dialog only closes on mutation success

### DIFF
--- a/apps/web/src/hooks/usePoolMutations.ts
+++ b/apps/web/src/hooks/usePoolMutations.ts
@@ -225,8 +225,8 @@ const usePoolMutations = (returnPath?: string) => {
     );
   };
 
-  const publish = (id: string) => {
-    executePublishMutation({ id })
+  const publish = async (id: string) => {
+    await executePublishMutation({ id })
       .then((result) => {
         if (result.data?.publishPool) {
           navigateBack();

--- a/apps/web/src/pages/Pools/ViewPoolPage/components/PublishProcessDialog.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/components/PublishProcessDialog.tsx
@@ -48,12 +48,6 @@ const PublishProcessDialog = ({
     });
   }
 
-  const handlePublish = async () => {
-    await onPublish().then(() => {
-      setIsOpen(false);
-    });
-  };
-
   return (
     <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
       <Dialog.Trigger>
@@ -122,11 +116,7 @@ const PublishProcessDialog = ({
               )}
           </ul>
           <Dialog.Footer>
-            <Button
-              color="secondary"
-              onClick={handlePublish}
-              disabled={isFetching}
-            >
+            <Button color="secondary" onClick={onPublish} disabled={isFetching}>
               {title}
             </Button>
             <Dialog.Close>


### PR DESCRIPTION
🤖 Resolves #10339.

## 👋 Introduction

Makes the publish pool dialog only close after the mutation succeeds.

## 🕵️ Details

I actually changed it to stop closing the dialog automatically at all since we navigate away from the page when the mutation succeeds anyway.

## 🧪 Testing

1. Slow down the publish pool mutation (add a manual delay, throttle in browser, etc)
2. Find or create a draft pool and ensure it is ready to be published
3. Navigate to the process information page for the draft pool `/admin/pools/{id}`
4. Select to publish the pool
5. Confirm the dialog does not close until the mutation succeeds and that it navigates to the 'processes' page `/admin/pools`
6. Force the publish pool mutation to fail
7. Repeat steps 2-4
8. Confirm the dialog does not close (or navigate away) when the mutation fails.