### PR TITLE
[Fix] Table control layout

### DIFF
--- a/apps/web/src/components/FilterDialog/FilterDialog.tsx
+++ b/apps/web/src/components/FilterDialog/FilterDialog.tsx
@@ -100,6 +100,7 @@ const FilterDialog = <TFieldValues extends FieldValues>({
         <Button
           color="quaternary"
           type="button"
+          block
           icon={AdjustmentsVerticalIcon}
           {...(filterCount > 0 && {
             counter: filterCount + (modifyFilterCount ?? 0),

--- a/apps/web/src/components/Table/ResponsiveTable/SearchForm.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/SearchForm.tsx
@@ -111,7 +111,7 @@ const SearchForm = <T,>({
   const allTableMsg = overrideAllTableMsg ?? defaultAllTableMsg;
 
   return (
-    <div data-h2-width="base(100%) l-tablet(auto)">
+    <div data-h2-width="base(100%) laptop(auto)">
       <Field.Label
         htmlFor={id}
         data-h2-display="base(inline-block)"
@@ -119,10 +119,7 @@ const SearchForm = <T,>({
       >
         {label}
       </Field.Label>
-      <div
-        data-h2-display="base(flex)"
-        data-h2-width="base(100%) l-tablet(auto)"
-      >
+      <div data-h2-display="base(flex)" data-h2-width="base(100%) laptop(auto)">
         {showDropdown ? (
           <DropdownMenu.Root>
             <DropdownMenu.Trigger>
@@ -189,11 +186,11 @@ const SearchForm = <T,>({
             data-h2-border-color="base(gray) base:focus-visible(focus)"
             data-h2-margin-left="base(0)"
             data-h2-padding="base(x.5 x1.5 x.5 x.5)"
-            data-h2-width="base(100%) l-tablet(auto)"
+            data-h2-width="base(100%) laptop(auto)"
             {...(showDropdown
               ? {
                   "data-h2-radius": "base(0, s, s, 0)",
-                  "data-h2-border-left-color": "l-tablet(transparent)",
+                  "data-h2-border-left-color": "laptop(transparent)",
                 }
               : {
                   "data-h2-radius": "base(s)",

--- a/apps/web/src/components/Table/ResponsiveTable/Table.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/Table.tsx
@@ -206,7 +206,11 @@ type ControlProps = DetailedHTMLProps<
 >;
 
 const Control = (props: ControlProps) => (
-  <div data-h2-width="base(100%) l-tablet(auto)" {...props} />
+  <div
+    data-h2-width="base(100%) p-tablet(auto)"
+    data-h2-order="base(0)"
+    {...props}
+  />
 );
 
 interface AddActionProps {
@@ -216,7 +220,11 @@ interface AddActionProps {
 const AddAction = ({ add }: AddActionProps) => (
   <>
     {add.linkProps && (
-      <Control data-h2-flex-shrink="base(1)">
+      <Control
+        data-h2-flex-shrink="base(1)"
+        data-h2-order="base(1)"
+        data-h2-margin-left="base(auto)"
+      >
         <Link
           icon={PlusCircleIcon}
           color="secondary"
@@ -242,24 +250,14 @@ const Controls = ({ children, add }: ControlsProps) => (
   <div
     data-h2-display="base(flex)"
     data-h2-align-items="base(flex-end)"
-    data-h2-flex-direction="base(column) l-tablet(row)"
-    data-h2-gap="base(x.25 0) l-tablet(0 x.25)"
+    data-h2-gap="base(x.25)"
     data-h2-margin-bottom="base(x1) l-tablet(x.25)"
-    data-h2-justify-content="base(space-between)"
+    data-h2-justify-content="base(flex-start)"
     data-h2-font-size="base(caption)"
+    data-h2-flex-wrap="base(wrap)"
   >
     {add && <AddAction add={add} />}
-    <div
-      data-h2-display="base(flex)"
-      data-h2-align-items="base(flex-end)"
-      data-h2-flex-direction="base(column) l-tablet(row)"
-      data-h2-gap="base(x.25 0) l-tablet(0 x.25)"
-      data-h2-flex-grow="base(1)"
-      data-h2-order="base(-1)"
-      data-h2-width="base(100%) l-tablet(auto)"
-    >
-      {children}
-    </div>
+    {children}
   </div>
 );
 

--- a/apps/web/src/components/Table/ResponsiveTable/Table.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/Table.tsx
@@ -207,7 +207,7 @@ type ControlProps = DetailedHTMLProps<
 
 const Control = (props: ControlProps) => (
   <div
-    data-h2-width="base(100%) p-tablet(auto)"
+    data-h2-width="base(100%) l-tablet(auto)"
     data-h2-order="base(0)"
     {...props}
   />


### PR DESCRIPTION
🤖 Resolves #10038 

## 👋 Introduction

Fixes the layout of the table controls on smaller screens.

## 🕵️ Details

The provided layout did not work well on small screens so that was left unchanged and only the medium sized screens were affected in this.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `pnpm run dev`
2. Login as admin `admin@test.com`
3. Navigate to a table with all controls (search, hide columns, filter, add)
    - The process table is a good example of this
4. Resize your window slowly
5. Confirm the buttons have an acceptable layout on all screen sizes until ~312px

## 📸 Screenshot

![screenshot_22-May-2024_08-57-1716382653](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/b27b86c0-da3b-4b49-b69b-f55a0c0f6116)
![screenshot_22-May-2024_08-57-1716382658](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/0415b56c-57ea-4459-aff8-505c5f8402dc)
![screenshot_22-May-2024_08-57-1716382664](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/5d0e22b9-de53-4499-850e-7d0f582d0811)
