### PR TITLE
[Copy] Updates occupational group abbreviations in French

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -240,7 +240,7 @@
     "description": "Title for the 'planning and reporting' IT work stream"
   },
   "/SLyVF": {
-    "defaultMessage": "Les analystes (<abbreviation>TI-02</abbreviation>) fournissent des services techniques, des conseils, des analyses et de la recherche dans leur domaine d'expertise pour appuyer la prestation de services aux clients et aux intervenants. Les analystes de la <abbreviation>TI</abbreviation> se retrouvent dans tous les volets de travail.",
+    "defaultMessage": "Les analystes (<abbreviation>IT-02</abbreviation>) fournissent des services techniques, des conseils, des analyses et de la recherche dans leur domaine d'expertise pour appuyer la prestation de services aux clients et aux intervenants. Les analystes de la <abbreviation>TI</abbreviation> se retrouvent dans tous les volets de travail.",
     "description": "blurb describing IT-02"
   },
   "/Sobod": {
@@ -784,7 +784,7 @@
     "description": "Subtitle for the assessment plan builder"
   },
   "2aBKgf": {
-    "defaultMessage": "Il y a deux types d'employés du <abbreviation>TI-04</abbreviation> : ceux qui suivent un cheminement en gestion et les contributeurs individuels.",
+    "defaultMessage": "Il y a deux types d'employés du <abbreviation>IT-04</abbreviation> : ceux qui suivent un cheminement en gestion et les contributeurs individuels.",
     "description": "IT-04 description precursor"
   },
   "2aE/gp": {
@@ -1708,11 +1708,11 @@
     "description": "Success message after submission for the application review page."
   },
   "7wcfnG": {
-    "defaultMessage": "Il y a deux types d'employés du <abbreviation>TI-03</abbreviation> : ceux qui suivent un cheminement en gestion et les contributeurs individuels.",
+    "defaultMessage": "Il y a deux types d'employés du <abbreviation>IT-03</abbreviation> : ceux qui suivent un cheminement en gestion et les contributeurs individuels.",
     "description": "IT-03 description precursor"
   },
   "7xDPj5": {
-    "defaultMessage": "<strong>Contributeur individuel</strong> : Les conseillers techniques en <abbreviation>TI</abbreviation> (<abbreviation>TI-03</abbreviation>) fournissent des conseils techniques spécialisés, des recommandations et du soutien sur les solutions et les services dans leur domaine d'expertise pour appuyer la prestation de services aux clients et aux intervenants. Les conseillers techniques en <abbreviation>TI</abbreviation> se trouvent dans tous les volets de travail.",
+    "defaultMessage": "<strong>Contributeur individuel</strong> : Les conseillers techniques en <abbreviation>TI</abbreviation> (<abbreviation>IT-03</abbreviation>) fournissent des conseils techniques spécialisés, des recommandations et du soutien sur les solutions et les services dans leur domaine d'expertise pour appuyer la prestation de services aux clients et aux intervenants. Les conseillers techniques en <abbreviation>TI</abbreviation> se trouvent dans tous les volets de travail.",
     "description": "IT-03 advisor description"
   },
   "80DOGy": {
@@ -3328,7 +3328,7 @@
     "description": "Label for _solicitation procedure_ fieldset in the _digital services contracting questionnaire_"
   },
   "GtZyhK": {
-    "defaultMessage": "Technicien (<abbreviation>TI-01</abbreviation>)",
+    "defaultMessage": "Technicien (<abbreviation>IT-01</abbreviation>)",
     "description": "Title for the 'IT-01 Technician' classification"
   },
   "GtrrJ3": {
@@ -3456,7 +3456,7 @@
     "description": "Context for _work requirement description_ textbox in the _digital services contracting questionnaire_"
   },
   "I/fGUN": {
-    "defaultMessage": "Analyste (<abbreviation>TI-02</abbreviation>)",
+    "defaultMessage": "Analyste (<abbreviation>IT-02</abbreviation>)",
     "description": "Title for the 'IT-02 Analyst' classification"
   },
   "I2CtZJ": {
@@ -3988,7 +3988,7 @@
     "description": "Essential criteria heading"
   },
   "KpNUo0": {
-    "defaultMessage": "Gestionnaires et conseillers principaux (<abbreviation>TI-04</abbreviation>)",
+    "defaultMessage": "Gestionnaires et conseillers principaux (<abbreviation>IT-04</abbreviation>)",
     "description": "Title for the 'IT-04 Manager' classification"
   },
   "KqAp09": {
@@ -4444,7 +4444,7 @@
     "description": "Title displayed on the User table Candidate Name column."
   },
   "NeR+6V": {
-    "defaultMessage": "<strong>Contributeur individuel</strong> : Les conseillers principaux en <abbreviation>TI</abbreviation> (<abbreviation>TI-04</abbreviation>) fournissent des conseils techniques et une orientation stratégique d'experts dans leur domaine d'expertise en matière de fourniture de solutions et de services à des clients internes ou externes et à des intervenants.",
+    "defaultMessage": "<strong>Contributeur individuel</strong> : Les conseillers principaux en <abbreviation>TI</abbreviation> (<abbreviation>IT-04</abbreviation>) fournissent des conseils techniques et une orientation stratégique d'experts dans leur domaine d'expertise en matière de fourniture de solutions et de services à des clients internes ou externes et à des intervenants.",
     "description": "IT-04 senior advisor description precursor to work stream list"
   },
   "NeY5Ac": {
@@ -5228,7 +5228,7 @@
     "description": "introduction to the skill summary section in the assessment plan builder"
   },
   "S02Y/P": {
-    "defaultMessage": "Chefs d’équipe et conseillers techniques (<abbreviation>TI-03</abbreviation>)",
+    "defaultMessage": "Chefs d’équipe et conseillers techniques (<abbreviation>IT-03</abbreviation>)",
     "description": "Title for the 'IT-03 Advisor' classification"
   },
   "S2if5C": {
@@ -6419,7 +6419,7 @@
     "description": "Message displayed to user after experience fails to be deleted."
   },
   "YVuyjO": {
-    "defaultMessage": "<strong>Cheminement en gestion</strong> : les gestionnaires de la <abbreviation>TI</abbreviation> (<abbreviation>TI-04</abbreviation>) sont responsables de la gestion du développement et de la prestation des services et des activités de <abbreviation>TI</abbreviation> par l'entremise de chefs d'équipe subalternes, de conseillers techniques et d'équipes de projet, pour la prestation des services aux clients et aux intervenants. Les gestionnaires de la <abbreviation>TI</abbreviation> se trouvent dans tous les volets de travail.",
+    "defaultMessage": "<strong>Cheminement en gestion</strong> : les gestionnaires de la <abbreviation>TI</abbreviation> (<abbreviation>IT-04</abbreviation>) sont responsables de la gestion du développement et de la prestation des services et des activités de <abbreviation>TI</abbreviation> par l'entremise de chefs d'équipe subalternes, de conseillers techniques et d'équipes de projet, pour la prestation des services aux clients et aux intervenants. Les gestionnaires de la <abbreviation>TI</abbreviation> se trouvent dans tous les volets de travail.",
     "description": "IT-04 manager path description"
   },
   "YW3A7H": {
@@ -8467,7 +8467,7 @@
     "description": "Heading for total matching candidates across a certain number of pools in results section of search page."
   },
   "j3OROA": {
-    "defaultMessage": "Les techniciens (<abbreviation>TI-01</abbreviation>) fournissent un soutien technique pour l'élaboration, la mise en œuvre, l'intégration et la maintenance de la prestation de services aux clients et aux intervenants",
+    "defaultMessage": "Les techniciens (<abbreviation>IT-01</abbreviation>) fournissent un soutien technique pour l'élaboration, la mise en œuvre, l'intégration et la maintenance de la prestation de services aux clients et aux intervenants",
     "description": "blurb describing IT-01"
   },
   "j3WBqJ": {
@@ -10187,7 +10187,7 @@
     "description": "Label displayed on Personal Experience form for learning description section"
   },
   "t+WUYM": {
-    "defaultMessage": "<strong>Cheminement en gestion</strong> : Chefs d'équipe de la <abbreviation>TI</abbreviation> (<abbreviation>TI-03</abbreviation>) sont chargés de superviser le travail et les équipes de projet pour les services et les opérations de la <abbreviation>TI</abbreviation> dans leur domaine d'expertise afin de soutenir la prestation de services aux clients et aux intervenants. Les chefs d'équipe de la <abbreviation>TI</abbreviation> se trouvent dans tous les volets de travail.",
+    "defaultMessage": "<strong>Cheminement en gestion</strong> : Chefs d'équipe de la <abbreviation>TI</abbreviation> (<abbreviation>IT-03</abbreviation>) sont chargés de superviser le travail et les équipes de projet pour les services et les opérations de la <abbreviation>TI</abbreviation> dans leur domaine d'expertise afin de soutenir la prestation de services aux clients et aux intervenants. Les chefs d'équipe de la <abbreviation>TI</abbreviation> se trouvent dans tous les volets de travail.",
     "description": "IT-03 team lead path description"
   },
   "t28EG0": {

--- a/apps/web/src/utils/nameUtils.tsx
+++ b/apps/web/src/utils/nameUtils.tsx
@@ -145,8 +145,8 @@ export const wrapAbbr = (text: ReactNode, intl: IntlShape, title?: string) => {
     );
   }
   switch (stringifyText) {
-    // Regex that matches all IT(en)/TI(fr) classifications with levels
-    case stringifyText.match(/[IT][TI]-0\d/)?.input:
+    // Regex that matches all IT classifications with levels
+    case stringifyText.match(/[IT]-0\d/)?.input:
       return (
         <abbr title={intl.formatMessage(getAbbreviations("IT"))}>
           <span aria-label={splitAndJoin(stringifyText.replace("-0", ""))}>
@@ -154,15 +154,15 @@ export const wrapAbbr = (text: ReactNode, intl: IntlShape, title?: string) => {
           </span>
         </abbr>
       );
-    // Regex that matches all IT(en)/TI(fr) classifications
+    // Regex that matches all IT(en)/TI(fr)
     case stringifyText.match(/[IT][TI]/)?.input:
       return (
         <abbr title={intl.formatMessage(getAbbreviations("IT"))}>
           <span aria-label={splitAndJoin(stringifyText)}>{text}</span>
         </abbr>
       );
-    // Regex that matches all AS(en)/SA(fr) classifications with levels
-    case stringifyText.match(/[AS][SA]-0\d/)?.input:
+    // Regex that matches all AS classifications with levels
+    case stringifyText.match(/[AS]-0\d/)?.input:
       return (
         <abbr title={intl.formatMessage(getAbbreviations("AS"))}>
           <span aria-label={splitAndJoin(stringifyText.replace("-0", ""))}>
@@ -170,8 +170,7 @@ export const wrapAbbr = (text: ReactNode, intl: IntlShape, title?: string) => {
           </span>
         </abbr>
       );
-    // Regex that matches all AS(en)/SA(fr) classifications
-    case stringifyText.match(/[AS][SA]/)?.input:
+    case stringifyText.match("AS")?.input:
       return (
         <abbr title={intl.formatMessage(getAbbreviations("AS"))}>
           <span aria-label={splitAndJoin(stringifyText)}>{text}</span>


### PR DESCRIPTION
🤖 Resolves #10425.

## 👋 Introduction

This PR changes the occupational group abbreviation for IT in French from TI to IT since the [Government of Canada does not translate the acronym](https://www.canada.ca/fr/secretariat-conseil-tresor/services/conventions-collectives/groupes-professionnels/technologies-information.html). 

It also changes the occupational group abbreviation for AS in French from SA to AS since the [Government of Canada does not translate the acronym](https://www.canada.ca/fr/secretariat-conseil-tresor/services/conventions-collectives/groupes-professionnels/services-programmes-administration.html#occ-as).

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm build`
2. Navigate to More information (Informations complémentaires) section of a process
3. Switch to French
4. Expand the accordions and make sure there is no TI-0X or TI references

## 📸 Screenshot

<img width="1150" alt="Screen Shot 2024-05-22 at 11 01 43" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/a7d7bc25-5a39-4dfe-a7f9-ba9b68050afa">