### PR TITLE
[Fix] Profile about section completeness

### DIFF
--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
@@ -75,6 +75,16 @@ export const DashboardHeadingUser_Fragment = graphql(/* GraphQL */ `
   fragment DashboardHeadingUser on User {
     id
     firstName
+    lastName
+    email
+    telephone
+    preferredLang
+    preferredLanguageForInterview
+    preferredLanguageForExam
+    currentCity
+    currentProvince
+    citizenship
+    armedForcesStatus
     locationPreferences
     positionDuration
     isGovEmployee

--- a/apps/web/src/validators/profile/about.ts
+++ b/apps/web/src/validators/profile/about.ts
@@ -47,6 +47,7 @@ export function hasEmptyRequiredFields({
   email,
   preferredLang,
   preferredLanguageForInterview,
+  preferredLanguageForExam,
   currentCity,
   currentProvince,
   citizenship,
@@ -59,7 +60,7 @@ export function hasEmptyRequiredFields({
     !telephone ||
     !preferredLang ||
     !preferredLanguageForInterview ||
-    !preferredLanguageForInterview ||
+    !preferredLanguageForExam ||
     !currentCity ||
     !currentProvince ||
     !citizenship ||


### PR DESCRIPTION
🤖 Resolves #10435.

## 👋 Introduction

This PR adds back fields that are needed in the `DashboardHeadingUser` fragment.

## 🦴 Bonus

704cb763ea6d99c6a4a9dbb027f54c6bedff3f04: Removes a duplicate key (`preferredLanguageForInterview`) and adds in a missing key, `preferredLanguageForExam`, for the `aboutSectionHasEmptyRequiredFields` validator function.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm build`
2. Create a user account
3. Navigate to `/applicant`
4. Observe incomplete status (red) on Personal and contact info item
5. Navigate to `/applicant/personal-information#about-section`
6. Fill in required fields and submit form
7. Navigate to `/applicant`
8. Observe complete status (green) on Personal and contact info item

## 📸 Screenshot

<img width="407" alt="Screen Shot 2024-05-22 at 14 42 06" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/fd5857e7-f0bf-4a83-b20b-c960d2d76d81">
