### PR TITLE
[Fix] Workaround memory error for storybook

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
     "lint:fix": "eslint ./src --fix --ext .js,.ts,.jsx,.tsx",
     "prettier": "prettier --write ./src/js",
     "production": "pnpm run build",
-    "build-storybook": "storybook build",
+    "build-storybook": "NODE_OPTIONS='--max-old-space-size=8192' storybook build",
     "storybook": "storybook dev -p 6006",
     "storybook:design-system": "SB_APP=design storybook dev -p 6006",
     "storybook:web": "SB_APP=web storybook dev -p 6006",


### PR DESCRIPTION
🤖 Resolves #10471 

## 👋 Introduction

Adds a workaround to get storybook building again while we work on a permanent fix.

## 🧪 Testing

1. Build storybook `pnpm run build-storybook`
2. Confirm it builds
3. Confirm chromatic builds