### PR TITLE
[Fix] `AssessmentResult` justification seeding

### DIFF
--- a/api/database/seeders/AssessmentResultTestSeeder.php
+++ b/api/database/seeders/AssessmentResultTestSeeder.php
@@ -157,7 +157,7 @@ class AssessmentResultTestSeeder extends Seeder
             $publishedPool->poolSkills()->pluck('id')->toArray(),
             $assessmentStep,
             null,
-            [AssessmentResultJustification::SKILL_FAILED_INSUFFICIENTLY_DEMONSTRATED],
+            [AssessmentResultJustification::SKILL_FAILED_INSUFFICIENTLY_DEMONSTRATED->name],
             AssessmentDecision::HOLD->name,
             assessmentResultType::SKILL);
 
@@ -191,7 +191,7 @@ class AssessmentResultTestSeeder extends Seeder
             AssessmentResult::factory()->withResultType($assessmentResultType)->create([
                 'assessment_step_id' => $assessmentStep->id,
                 'pool_candidate_id' => $poolCandidate->id,
-                'justifications' => json_encode($justifications),
+                'justifications' => $justifications,
                 'assessment_decision' => $assessmentDecision,
             ]);
         } else {
@@ -201,7 +201,7 @@ class AssessmentResultTestSeeder extends Seeder
                     'pool_candidate_id' => $poolCandidate->id,
                     'pool_skill_id' => $poolSkill,
                     'assessment_decision_level' => $level,
-                    'justifications' => json_encode($justifications),
+                    'justifications' => $justifications,
                     'assessment_decision' => $assessmentDecision,
                 ]);
             }


### PR DESCRIPTION
🤖 Resolves #10477 

## 👋 Introduction

Fixes an issue where `AssessmentResult.justification` data was being serialized twice during seeding.

## 🕵️ Details

We were missing `->name` accessor on an enum in the justification array which required us to use `json_encode` since PHP cannot serialize non-backed enums (which ours are).

## 🧪 Testing

1. Seed fresh data `make seed-fresh`
2. Confirm the `justification` column only contains `json` or `null` and no `string`s.
