### PR TITLE
[Fix] Anonymous view of communities

### DIFF
--- a/api/app/Policies/CommunityPolicy.php
+++ b/api/app/Policies/CommunityPolicy.php
@@ -15,7 +15,7 @@ class CommunityPolicy
      *
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function viewAny()
+    public function viewAny(?User $user)
     {
         return true;
     }

--- a/apps/e2e/cypress/e2e/talentsearch/search-workflows.cy.ts
+++ b/apps/e2e/cypress/e2e/talentsearch/search-workflows.cy.ts
@@ -151,6 +151,8 @@ describe("Talent Search Workflow Tests", () => {
       });
     });
 
+    // Ensure anonymous users can complete the workflow
+    cy.logout();
     cy.visit("/en/search");
 
     // first request is without any filters


### PR DESCRIPTION
🤖 Resolves #10476 

## 👋 Introduction

This fixes the communities policy to allow anonymous users to view any.

## 🕵️ Details

The policy omitted the option user argument that lead to requiring the policy to be authenticated. It seems odd, but we need to include `?User $user` in the arguments to allow anonymous users (even if we never use it).

REF: https://laravel.com/docs/11.x/authorization#guest-users

## 🧪 Testing

1. Ensure you are not logged in
2. Confirm you can submit a search request