### PR TITLE
[Bug] Flaky test in PoolApplicationTest file

### DIFF
--- a/api/tests/Feature/PoolApplicationTest.php
+++ b/api/tests/Feature/PoolApplicationTest.php
@@ -6,6 +6,7 @@ use App\Enums\ClaimVerificationResult;
 use App\Enums\EducationRequirementOption;
 use App\Enums\PoolCandidateStatus;
 use App\Enums\PoolLanguage;
+use App\Enums\SkillCategory;
 use App\Facades\Notify;
 use App\Models\AssessmentStep;
 use App\Models\AwardExperience;
@@ -16,6 +17,7 @@ use App\Models\Pool;
 use App\Models\PoolCandidate;
 use App\Models\ScreeningQuestion;
 use App\Models\ScreeningQuestionResponse;
+use App\Models\Skill;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\WorkExperience;
@@ -407,7 +409,7 @@ class PoolApplicationTest extends TestCase
             );
     }
 
-    public function testApplicationSubmitSkills(): void
+    public function testApplicationSubmitWithoutEssentialTechnicalSkills(): void
     {
         // create a pool, attach one essential skill to it
         $newPool = Pool::factory()->WithPoolSkills(1, 0)->create([
@@ -415,10 +417,13 @@ class PoolApplicationTest extends TestCase
             'advertisement_language' => PoolLanguage::ENGLISH->name, // avoid language requirements
         ]);
 
+        // technical essential skills are required
+        $technicalSkill = Skill::factory()->create(['category' => SkillCategory::TECHNICAL->name]);
+        $newPool->setEssentialPoolSkills([$technicalSkill->id]);
+
         // create an experience with no skills, then attach it to the user
         WorkExperience::factory()->create([
             'user_id' => $this->applicantUser->id,
-
         ]);
 
         $newPoolCandidate = PoolCandidate::factory()->create([
@@ -445,7 +450,6 @@ class PoolApplicationTest extends TestCase
                     'message' => ApiEnums::POOL_CANDIDATE_MISSING_ESSENTIAL_SKILLS,
                 ]],
             ]);
-
     }
 
     public function testApplicationSubmitWithEssentialSkill(): void

--- a/api/tests/Feature/PoolApplicationTest.php
+++ b/api/tests/Feature/PoolApplicationTest.php
@@ -452,14 +452,17 @@ class PoolApplicationTest extends TestCase
             ]);
     }
 
-    public function testApplicationSubmitWithEssentialSkill(): void
+    public function testApplicationSubmitWithEssentialTechnicalSkills(): void
     {
-
         // create a pool, attach one essential skill to it
         $newPool = Pool::factory()->WithPoolSkills(1, 0)->create([
             'closing_date' => Carbon::now()->addDays(1),
             'advertisement_language' => PoolLanguage::ENGLISH->name, // avoid language requirements
         ]);
+
+        // technical essential skills are required
+        $technicalSkill = Skill::factory()->create(['category' => SkillCategory::TECHNICAL->name]);
+        $newPool->setEssentialPoolSkills([$technicalSkill->id]);
 
         $newPoolCandidate = PoolCandidate::factory()->create([
             'user_id' => $this->applicantUser->id,


### PR DESCRIPTION
🤖 Resolves #10475

## 👋 Introduction

Fixes the flaky test.

Appears it was due to the seeding attaching a skill that varied in whether it was technical or behavioural. Only technical skills are required so it would fail to see the expected error if it was a behavioural skill.
Also updated the test after it, that one wasn't flaky but it better asserts its test case this way

## 🧪 Testing

1. CI successful 
2. Local testing 

Run locally

`for i in {1..25}; do docker-compose exec -w /home/site/wwwroot/api webserver sh -c "./vendor/bin/phpunit ./tests/Feature/PoolApplicationTest.php"; done`


