### PR TITLE
[Debt] Fix styling to more actions side menu notes section

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -10602,6 +10602,10 @@
     "defaultMessage": "Classification",
     "description": "Label displayed on the pool form classification field."
   },
+  "w0IA+c": {
+    "defaultMessage": "Ajouter une note",
+    "description": "Button text to start adding pool candidate notes"
+  },
   "w1/0Cd": {
     "defaultMessage": "Diplôme exigé",
     "description": "Diploma required"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -10603,7 +10603,7 @@
     "description": "Label displayed on the pool form classification field."
   },
   "w0IA+c": {
-    "defaultMessage": "Ajouter une note",
+    "defaultMessage": "Ajouter des notes",
     "description": "Button text to start adding pool candidate notes"
   },
   "w1/0Cd": {

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/CandidateNavigation.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/CandidateNavigation.tsx
@@ -64,6 +64,7 @@ const CandidateNavigation = ({
           icon={ArrowLeftCircleIcon}
           aria-label={intl.formatMessage(messages.previousCandidate)}
           {...commonLinkProps}
+          data-h2-display="base(flex)"
         />
       )}
       <div data-h2-text-align="base(center)" data-h2-grid-column="base(2)">
@@ -87,6 +88,7 @@ const CandidateNavigation = ({
           icon={ArrowRightCircleIcon}
           aria-label={intl.formatMessage(messages.nextCandidate)}
           {...commonLinkProps}
+          data-h2-display="base(flex)"
         />
       )}
     </div>

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/NotesForm.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/NotesForm.tsx
@@ -46,28 +46,40 @@ const PoolCandidate_UpdateNotesMutation = graphql(/* GraphQL */ `
 
 const Display = ({ notes }: { notes?: Maybe<string> }) => {
   const intl = useIntl();
-
+  const hasNotes = !!notes;
   return (
     <>
       <ToggleForm.FieldDisplay
         hasError={false}
         label={intl.formatMessage(adminMessages.notes)}
       >
-        <div
-          data-h2-margin-top="base(x.5)"
-          data-h2-max-height="base(10rem)"
-          data-h2-overflow-y="base(scroll)"
-        >
-          {notes || intl.formatMessage(commonMessages.notProvided)}
-        </div>
+        {hasNotes && (
+          <div
+            data-h2-margin-top="base(x.5)"
+            data-h2-max-height="base(10rem)"
+            data-h2-overflow-y="base(auto)"
+          >
+            {notes}
+          </div>
+        )}
       </ToggleForm.FieldDisplay>
-      <ToggleForm.Trigger data-h2-margin-top="base(x.5)">
-        {intl.formatMessage({
-          defaultMessage: "Edit notes",
-          id: "CTl5IT",
-          description: "Button text to start editing pool candidate notes",
-        })}
-      </ToggleForm.Trigger>
+      {hasNotes ? (
+        <ToggleForm.Trigger data-h2-margin-top="base(x.5)">
+          {intl.formatMessage({
+            defaultMessage: "Edit notes",
+            id: "CTl5IT",
+            description: "Button text to start editing pool candidate notes",
+          })}
+        </ToggleForm.Trigger>
+      ) : (
+        <ToggleForm.Trigger data-h2-margin-top="base(x.5)">
+          {intl.formatMessage({
+            defaultMessage: "Add notes",
+            id: "w0IA+c",
+            description: "Button text to start adding pool candidate notes",
+          })}
+        </ToggleForm.Trigger>
+      )}
     </>
   );
 };


### PR DESCRIPTION
🤖 Resolves #10530 

## 👋 Introduction

- Fixes notes section scroll styling by setting overflow-y to auto.
-  Switches trigger button text from "Edit notes to "Add notes" depending on state.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build app `pnpm run dev`
2. Login as `admin@test.com`
3. View a pool candidate on admin side (e.g. `http://localhost:8000/en/admin/candidates/{poolCandidateId}/application`)
4. Ensure notes looks correct after adding and removing notes.
