### PR TITLE
[Feature] Local-only makefile for Linux

### DIFF
--- a/Makefile.nix
+++ b/Makefile.nix
@@ -1,6 +1,6 @@
 # Usage:
 # setup_all          # setup all the components
-# refresh_all        # setup all the components
+# refresh_all        # refresh all the components
 # make setup_api     # build the Laravel backend
 # make refresh_api   # refresh the Laravel backend
 # make setup_web     # build the React frontend

--- a/Makefile.nix
+++ b/Makefile.nix
@@ -1,0 +1,62 @@
+# Usage:
+# setup_all          # setup all the components
+# refresh_all        # setup all the components
+# make setup_api     # build the Laravel backend
+# make refresh_api   # refresh the Laravel backend
+# make setup_web     # build the React frontend
+# make refresh_web   # refresh the React frontend
+# make git_clean     # use git to remove all untracked files - DANGER!
+# make compose_up   # bring up the docker compose network
+# make compose_down # bring down the docker compose network
+
+.PHONY: setup_all refresh_all setup_api refresh_api setup_web refresh_web git_clean
+
+setup_all: setup_api setup_web
+	@echo "setup_all"
+
+refresh_all: refresh_api refresh_web
+	@echo "refresh_all"
+
+setup_api:
+	@echo "setup_api"
+	rm api/bootstrap/cache/*.php --force
+	cp api/.env.example api/.env --preserve=all
+	cd api && composer install --prefer-dist
+	php api/artisan key:generate
+	php api/artisan migrate:fresh --seed
+	php api/artisan lighthouse:print-schema --write
+	php api/artisan config:clear
+	touch api/storage/logs/laravel.log
+	sudo chown -R www-data:www-data api/storage
+	sudo chmod -R a+r,a+w api/storage
+
+refresh_api:
+	@echo "refresh_api"
+	rm api/bootstrap/cache/*.php --force
+	cd api && composer install --prefer-dist
+	php api/artisan migrate
+	php api/artisan lighthouse:print-schema --write
+	php api/artisan config:clear
+
+setup_web:
+	@echo "setup_web"
+	cp apps/web/.env.example apps/web/.env --preserve=all
+	pnpm install --force
+	pnpm run dev:fresh
+
+refresh_web:
+	@echo "refresh_web"
+	pnpm install --force
+	pnpm run dev
+
+git_clean:
+	@echo "git_clean"
+	sudo git clean -xdf
+
+compose_up:
+	@echo "compose_up"
+	docker-compose up --detach --build
+
+compose_down:
+	@echo "compose_down"
+	docker-compose down


### PR DESCRIPTION
🤖 Resolves #9838 

## 👋 Introduction

This branch adds a makefile especially for Linux environments where the right versions of php, composer, node, and pnpm are already installed.  It does not use the maintenance container and, as a result, does not have any files owned by root.  It also does not use any of the maintenance scripts.

Unfortunately, our environment requires setting the ownership to www-data on certain files so there is a sudo prompt in the "setup" script.

The scripts will fail if any files are already owned by root.  I recommend cleaning your workspace first with the `git_clean` script.  WARNING - it will delete all uncommitted files!  It also has a sudo prompt.

I found a VS Code extension (https://marketplace.visualstudio.com/items?itemName=carlos-algms.make-task-provider) that works nicely with it.  It allows you to pick the name of the makefile that you want to use with it.

If all this is too niche and no one else finds this useful I can close this and I'll submit a PR with just a gitignore entry and I'll keep using it out of my own stash.

## 🧪 Testing

`make --file Makefile.nix setup_all`
`ext install carlos-algms.make-task-provider`

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/fb820262-05b2-4bd8-b795-23be3f1f295f)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/87ffa9dd-c19b-4d66-9ff0-c15adecdeada)