### PR TITLE
[Tooling] Removes Firefox tests from Playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -63,7 +63,7 @@ jobs:
           cache: pnpm
 
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium webkit --with-deps
 
       - name: Run Chromium Tests
         run: pnpm run e2e:playwright:chromium

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -74,15 +74,6 @@ jobs:
           path: apps/playwright/playwright-report/
           retention-days: 30
 
-      - name: Run Firefox Tests
-        run: pnpm run e2e:playwright:firefox
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: firefox-report
-          path: apps/playwright/playwright-report/
-          retention-days: 30
-
       - name: Run Webkit Tests
         run: pnpm run e2e:playwright:webkit
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
🤖 Resolves #10552.

## 👋 Introduction

This PR removes Firefox tests from Playwright workflow.

## 🕵️ Details

It also limits the browsers installed to `chromium` and `webkit` as `firefox` is no longer needed to be installed.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Verify playwright GitHub workflow does not install Firefox
2. Verify playwright GitHub workflow passes