### PR TITLE
[Fix] (Non) Veteran seeding

### DIFF
--- a/api/database/seeders/PoolCandidateTestSeeder.php
+++ b/api/database/seeders/PoolCandidateTestSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Enums\ApplicationStep;
+use App\Enums\ArmedForcesStatus;
 use App\Enums\CitizenshipStatus;
 use App\Enums\PoolCandidateStatus;
 use App\Models\Pool;
@@ -64,6 +65,7 @@ class PoolCandidateTestSeeder extends Seeder
                 'email' => 'veteran@test.com',
                 'sub' => 'veteran@test.com',
                 'citizenship' => CitizenshipStatus::CITIZEN->name,
+                'armed_forces_status' => ArmedForcesStatus::VETERAN->name,
             ]);
 
         // 3- Try-hard Not a veteran
@@ -79,6 +81,7 @@ class PoolCandidateTestSeeder extends Seeder
                 'email' => 'try-hard@test.com',
                 'sub' => 'try-hard@test.com',
                 'citizenship' => CitizenshipStatus::PERMANENT_RESIDENT->name,
+                'armed_forces_status' => null,
             ]);
 
         //4- Absent Canadian

--- a/api/database/seeders/PoolCandidateTestSeeder.php
+++ b/api/database/seeders/PoolCandidateTestSeeder.php
@@ -81,7 +81,7 @@ class PoolCandidateTestSeeder extends Seeder
                 'email' => 'try-hard@test.com',
                 'sub' => 'try-hard@test.com',
                 'citizenship' => CitizenshipStatus::PERMANENT_RESIDENT->name,
-                'armed_forces_status' => null,
+                'armed_forces_status' => ArmedForcesStatus::NON_CAF->name,
             ]);
 
         //4- Absent Canadian


### PR DESCRIPTION
🤖 Resolves #10507 

## 👋 Introduction

Updates seeders for (non) veteran candidates to be accurate.

## 🧪 Testing

1. Run seeders `make seed-fresh`
2. Confirm the candidates labelled "Veteran" and "Not a veteran" have the proper armed forces status
