### PR TITLE
[Debt] Priority weight enum

### DIFF
--- a/api/app/Enums/PriorityWeight.php
+++ b/api/app/Enums/PriorityWeight.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+enum PriorityWeight
+{
+    case PRIORITY_ENTITLEMENT;
+    case VETERAN;
+    case CITIZEN_OR_PERMANENT_RESIDENT;
+    case OTHER;
+
+    public static function weight(string $weight): int
+    {
+        return match ($weight) {
+            self::PRIORITY_ENTITLEMENT->name => 10,
+            self::VETERAN->name => 20,
+            self::CITIZEN_OR_PERMANENT_RESIDENT->name => 30,
+            self::OTHER->name => 40
+        };
+    }
+}

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Enums\CandidateExpiryFilter;
 use App\Enums\CandidateSuspendedFilter;
 use App\Enums\PoolCandidateStatus;
+use App\Enums\PriorityWeight;
 use App\Enums\PublishingGroup;
 use App\Http\Resources\UserResource;
 use App\Observers\PoolCandidateObserver;
@@ -652,9 +653,9 @@ class PoolCandidate extends Model
                     foreach ($priorityWeights as $index => $priorityWeight) {
                         if ($index === 0) {
                             // First iteration must use where instead of orWhere, as seen in filterWorkRegions
-                            $query->where('priority_weight', $priorityWeight);
+                            $query->where('priority_weight', PriorityWeight::weight($priorityWeight));
                         } else {
-                            $query->orWhere('priority_weight', $priorityWeight);
+                            $query->orWhere('priority_weight', PriorityWeight::weight($priorityWeight));
                         }
                     }
                 });

--- a/api/app/Providers/GraphQLServiceProvider.php
+++ b/api/app/Providers/GraphQLServiceProvider.php
@@ -61,6 +61,7 @@ use App\Enums\PoolSkillType;
 use App\Enums\PoolStatus;
 use App\Enums\PoolStream;
 use App\Enums\PositionDuration;
+use App\Enums\PriorityWeight;
 use App\Enums\ProvinceOrTerritory;
 use App\Enums\PublishingGroup;
 use App\Enums\SecurityStatus;
@@ -677,6 +678,16 @@ class GraphQLServiceProvider extends ServiceProvider
                 return new EnumType([
                     'name' => 'CandidateRemovalReason',
                     'values' => array_column(CandidateRemovalReason::cases(), 'name'),
+                ]);
+            }
+        );
+
+        $typeRegistry->registerLazy(
+            'PriorityWeight',
+            static function (): EnumType {
+                return new EnumType([
+                    'name' => 'PriorityWeight',
+                    'values' => array_column(PriorityWeight::cases(), 'name'),
                 ]);
             }
         );

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -711,7 +711,7 @@ input PoolCandidateSearchInput {
   name: String @scope
   notes: String @scope
   isGovEmployee: Boolean @scope
-  priorityWeight: [Int] @scope(name: "priorityWeight")
+  priorityWeight: [PriorityWeight] @scope(name: "priorityWeight")
   poolCandidateStatus: [PoolCandidateStatus]
     @scope(name: "poolCandidateStatuses")
   expiryStatus: CandidateExpiryFilter @scope(name: "expiryStatus")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -790,7 +790,7 @@ input PoolCandidateSearchInput {
   name: String
   notes: String
   isGovEmployee: Boolean
-  priorityWeight: [Int]
+  priorityWeight: [PriorityWeight]
   poolCandidateStatus: [PoolCandidateStatus]
   expiryStatus: CandidateExpiryFilter
   suspendedStatus: CandidateSuspendedFilter
@@ -2575,5 +2575,12 @@ enum NotificationFamily {
 enum CandidateRemovalReason {
   REQUESTED_TO_BE_WITHDRAWN
   NOT_RESPONSIVE
+  OTHER
+}
+
+enum PriorityWeight {
+  PRIORITY_ENTITLEMENT
+  VETERAN
+  CITIZEN_OR_PERMANENT_RESIDENT
   OTHER
 }

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
@@ -155,7 +155,12 @@ const PoolCandidateFilterDialog = ({
           idPrefix="priorityWeight"
           name="priorityWeight"
           legend={intl.formatMessage(adminMessages.category)}
-          items={enumToOptions(PriorityWeight).map(({ value }) => ({
+          items={enumToOptions(PriorityWeight, [
+            PriorityWeight.PriorityEntitlement,
+            PriorityWeight.Veteran,
+            PriorityWeight.CitizenOrPermanentResident,
+            PriorityWeight.Other,
+          ]).map(({ value }) => ({
             value,
             label: intl.formatMessage(getPoolCandidatePriorities(value)),
           }))}

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
@@ -20,6 +20,7 @@ import {
   PoolStream,
   PublishingGroup,
   WorkRegion,
+  PriorityWeight,
 } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 import {
@@ -31,12 +32,12 @@ import {
   getLanguageAbility,
   getLocalizedName,
   getOperationalRequirement,
+  getPoolCandidatePriorities,
   getPoolCandidateStatus,
   getPoolStream,
   getPublishingGroup,
   getWorkRegion,
   navigationMessages,
-  poolCandidatePriorities,
 } from "@gc-digital-talent/i18n";
 
 import adminMessages from "~/messages/adminMessages";
@@ -154,13 +155,9 @@ const PoolCandidateFilterDialog = ({
           idPrefix="priorityWeight"
           name="priorityWeight"
           legend={intl.formatMessage(adminMessages.category)}
-          items={Object.keys(poolCandidatePriorities).map((key) => ({
-            value: Number(key),
-            label: intl.formatMessage(
-              poolCandidatePriorities[
-                Number(key) as keyof typeof poolCandidatePriorities
-              ],
-            ),
+          items={enumToOptions(PriorityWeight).map(({ value }) => ({
+            value,
+            label: intl.formatMessage(getPoolCandidatePriorities(value)),
           }))}
         />
         <Combobox

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -49,6 +49,7 @@ import Table, {
 import { getFullNameLabel } from "~/utils/nameUtils";
 import { getFullPoolTitleLabel } from "~/utils/poolUtils";
 import processMessages from "~/messages/processMessages";
+import { getPriorityWeight } from "~/utils/poolCandidate";
 
 import skillMatchDialogAccessor from "./SkillMatchDialog";
 import tableMessages from "./tableMessages";
@@ -591,7 +592,7 @@ const PoolCandidatesTable = ({
       ({ poolCandidate: { user } }) =>
         intl.formatMessage(
           user.priorityWeight
-            ? getPoolCandidatePriorities(user.priorityWeight)
+            ? getPoolCandidatePriorities(getPriorityWeight(user.priorityWeight))
             : commonMessages.notFound,
         ),
       {

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -39,6 +39,7 @@ import useRoutes from "~/hooks/useRoutes";
 import { getFullNameLabel } from "~/utils/nameUtils";
 import {
   getCandidateStatusChip,
+  getPriorityWeight,
   statusToJobPlacement,
 } from "~/utils/poolCandidate";
 import {
@@ -48,6 +49,7 @@ import {
   stringToEnumLocation,
   stringToEnumOperational,
   stringToEnumPoolCandidateStatus,
+  stringToEnumPriorityWeight,
 } from "~/utils/userUtils";
 import { getFullPoolTitleLabel } from "~/utils/poolUtils";
 import processMessages from "~/messages/processMessages";
@@ -70,12 +72,18 @@ export const priorityCell = (
         data-h2-color="base(primary.darker)"
         data-h2-font-weight="base(700)"
       >
-        {intl.formatMessage(getPoolCandidatePriorities(priority))}
+        {intl.formatMessage(
+          getPoolCandidatePriorities(getPriorityWeight(priority)),
+        )}
       </span>
     );
   }
   return (
-    <span>{intl.formatMessage(getPoolCandidatePriorities(priority))}</span>
+    <span>
+      {intl.formatMessage(
+        getPoolCandidatePriorities(getPriorityWeight(priority)),
+      )}
+    </span>
   );
 };
 
@@ -776,9 +784,11 @@ export function transformFormValuesToFilterState(
         return stringToEnumPoolCandidateStatus(status);
       })
       .filter(notEmpty),
-    priorityWeight: data.priorityWeight.map((priority) => {
-      return Number(priority);
-    }),
+    priorityWeight: data.priorityWeight
+      .map((priorityWeight) => {
+        return stringToEnumPriorityWeight(priorityWeight);
+      })
+      .filter(notEmpty),
     expiryStatus: data.expiryStatus
       ? stringToEnumCandidateExpiry(data.expiryStatus)
       : undefined,

--- a/apps/web/src/utils/poolCandidate.ts
+++ b/apps/web/src/utils/poolCandidate.ts
@@ -30,6 +30,7 @@ import {
   Maybe,
   PoolCandidateStatus,
   PublishingGroup,
+  PriorityWeight,
 } from "@gc-digital-talent/graphql";
 import {
   getOrThrowError,
@@ -715,3 +716,19 @@ export const getCombinedStatusLabel = (
     statusLabelKey,
     `Invalid statusLabelKey '${statusLabelKey}'`,
   );
+
+export const getPriorityWeight = (priorityWeight: number): PriorityWeight => {
+  if (priorityWeight === 10) {
+    return PriorityWeight.PriorityEntitlement;
+  }
+
+  if (priorityWeight === 20) {
+    return PriorityWeight.Veteran;
+  }
+
+  if (priorityWeight === 30) {
+    return PriorityWeight.CitizenOrPermanentResident;
+  }
+
+  return PriorityWeight.Other;
+};

--- a/apps/web/src/utils/userUtils.ts
+++ b/apps/web/src/utils/userUtils.ts
@@ -11,6 +11,7 @@ import {
   OperationalRequirement,
   PoolCandidateStatus,
   PositionDuration,
+  PriorityWeight,
   WorkRegion,
 } from "@gc-digital-talent/graphql";
 
@@ -55,6 +56,15 @@ export function stringToEnumPoolCandidateStatus(
     )
   ) {
     return selection as PoolCandidateStatus;
+  }
+  return undefined;
+}
+
+export function stringToEnumPriorityWeight(
+  selection: string,
+): PriorityWeight | undefined {
+  if (Object.values(PriorityWeight).includes(selection as PriorityWeight)) {
+    return selection as PriorityWeight;
   }
   return undefined;
 }

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -39,6 +39,7 @@ import {
   PoolOpportunityLength,
   PlacementType,
   CandidateRemovalReason,
+  PriorityWeight,
 } from "@gc-digital-talent/graphql";
 import { hasKey } from "@gc-digital-talent/helpers";
 import { defaultLogger } from "@gc-digital-talent/logger";
@@ -1577,22 +1578,22 @@ export const getSecurityClearance = (
   );
 
 export const poolCandidatePriorities = defineMessages({
-  10: {
+  [PriorityWeight.PriorityEntitlement]: {
     defaultMessage: "Priority Entitlement",
     id: "j1p7LR",
     description: "Priority text for users with priority entitlement",
   },
-  20: {
+  [PriorityWeight.Veteran]: {
     defaultMessage: "Veteran",
     id: "oU8C65",
     description: "Priority text for veterans",
   },
-  30: {
+  [PriorityWeight.CitizenOrPermanentResident]: {
     defaultMessage: "Citizen or Resident",
     id: "oMyc4e",
     description: "Priority text for citizens of canada",
   },
-  40: commonMessages.other,
+  [PriorityWeight.Other]: commonMessages.other,
 });
 
 export const getPoolCandidatePriorities = (


### PR DESCRIPTION
🤖 Resolves #8668 

## 👋 Introduction

- Adds PriorityWeight enum
- Updates PoolCandidateSearchInput to accept enum instead of the associated integer weights to help make it more readable on the frontend.
- Question: I've added a static function which contains a map of the enum value to it's associated weight, and returns the weight (int). Should we also update the `user.priorityWeight` field to be the PriorityWeight enum as well, and call that method when needed?


## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build app `make setup` 
2. Login as `admin@test.com`
3. Go to pool candidates table and ensure the "Category" filter (priorityWeight) works correctly.
