### PR TITLE
[Fix] Improve playwright auth

### DIFF
--- a/apps/playwright/.eslintrc.js
+++ b/apps/playwright/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
   ],
   ignorePatterns: ["tsconfig.json", "test-results/**", "playwright-report/**", ".auth/**"],
   rules: {
+    "@typescript-eslint/no-floating-promises": "error",
     "playwright/expect-expect": [
       "error",
       {

--- a/apps/playwright/fixtures/ApplicationPage.ts
+++ b/apps/playwright/fixtures/ApplicationPage.ts
@@ -115,11 +115,13 @@ class ApplicationPage extends AppPage {
   }
 
   async submit() {
-    this.page
+    await this.page
       .getByRole("textbox", { name: /your full name/i })
       .fill("Signature");
 
-    this.page.getByRole("button", { name: /submit my application/i }).click();
+    await this.page
+      .getByRole("button", { name: /submit my application/i })
+      .click();
   }
 
   /**

--- a/apps/playwright/package.json
+++ b/apps/playwright/package.json
@@ -23,7 +23,8 @@
     "axe-core": "^4.9.1",
     "dotenv": "^16.4.5",
     "eslint": "^8.57.0",
-    "eslint-plugin-playwright": "^1.6.2"
+    "eslint-plugin-playwright": "^1.6.2",
+    "typescript-eslint": "^7.12.0"
   },
   "dependencies": {
     "@axe-core/playwright": "^4.9.1"

--- a/apps/playwright/playwright.config.ts
+++ b/apps/playwright/playwright.config.ts
@@ -18,13 +18,13 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 1 : "25%",
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI
     ? "line"
     : [["line"], ["html", { open: "on-failure" }]],
   timeout: Number(process.env.TEST_TIMEOUT ?? 3 * 60 * 1000), // 3 minutes
-  expect: { timeout: Number(process.env.EXPECT_TIMEOUT ?? 10000) }, // 10 seconds
+  expect: { timeout: Number(process.env.EXPECT_TIMEOUT ?? 30000) }, // 30 seconds
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/apps/playwright/tests/admin/admin-workflows.spec.ts
+++ b/apps/playwright/tests/admin/admin-workflows.spec.ts
@@ -45,13 +45,13 @@ test.describe("Admin workflows", () => {
     await goToUsersPage(appPage);
     await searchForUser(appPage, "Applicant");
 
-    appPage.page.getByRole("link", { name: /edit applicant/i }).click();
-    appPage.waitForGraphqlResponse("UpdateUserData");
+    await appPage.page.getByRole("link", { name: /edit applicant/i }).click();
+    await appPage.waitForGraphqlResponse("UpdateUserData");
 
     await appPage.page
       .getByRole("textbox", { name: /telephone/i })
       .fill("+10123456789");
-    appPage.page
+    await appPage.page
       .getByRole("button", { name: /submit/i })
       .first()
       .click();

--- a/apps/playwright/tests/admin/process-actions.spec.ts
+++ b/apps/playwright/tests/admin/process-actions.spec.ts
@@ -171,6 +171,11 @@ test.describe("Process actions", () => {
     await adminPage.waitForGraphqlResponse("PoolTable");
 
     await adminPage.page
+      .getByRole("textbox", { name: /search processes/i })
+      .fill(PROCESS_TITLE);
+    await adminPage.waitForGraphqlResponse("PoolTable");
+
+    await adminPage.page
       .getByRole("link", { name: new RegExp(PROCESS_TITLE, "i") })
       .click();
 

--- a/apps/playwright/tests/admin/process-permissions.spec.ts
+++ b/apps/playwright/tests/admin/process-permissions.spec.ts
@@ -8,16 +8,19 @@ import { getClassifications } from "~/utils/classification";
 import { loginBySub } from "~/utils/auth";
 
 test.describe("Process permissions", () => {
-  const uniqueTestId = Date.now().valueOf();
-  const unassociatedSub = `playwright.sub.unassociated.${uniqueTestId}`;
-  const unassociatedPoolManagerEmail = `${unassociatedSub}@example.org`;
-  const associatedSub = `playwright.sub.associated.${uniqueTestId}`;
-  const associatedPoolManagerEmail = `${associatedSub}@example.org`;
-  const poolName = `pool auth test ${uniqueTestId}`;
+  let associatedSub;
+  let unassociatedSub;
+  let poolName;
 
   let pool: Pool;
 
   test.beforeAll(async ({ adminPage }) => {
+    const uniqueTestId = Date.now().valueOf();
+    unassociatedSub = `playwright.sub.unassociated.${uniqueTestId}`;
+    const unassociatedPoolManagerEmail = `${unassociatedSub}@example.org`;
+    associatedSub = `playwright.sub.associated.${uniqueTestId}`;
+    const associatedPoolManagerEmail = `${associatedSub}@example.org`;
+    poolName = `pool auth test ${uniqueTestId}`;
     const poolPage = new PoolPage(adminPage.page);
     const teamPage = new TeamPage(adminPage.page);
 

--- a/apps/playwright/utils/auth.ts
+++ b/apps/playwright/utils/auth.ts
@@ -1,4 +1,4 @@
-import { Cookie, Page } from "@playwright/test";
+import { Cookie, Page, expect } from "@playwright/test";
 
 /**
  * Login by sub
@@ -10,33 +10,19 @@ import { Cookie, Page } from "@playwright/test";
  * @param {String} sub
  */
 export async function loginBySub(page: Page, sub: string) {
-  await page.goto("/login-info");
+  await page.goto("/en/login-info");
+  await expect(
+    page.getByRole("heading", { name: /sign in using gckey/i }),
+  ).toBeVisible();
   await page
     .getByRole("link", { name: /continue to gckey and sign in/i })
     .first()
     .click();
   await page.getByPlaceholder("Enter any user/subject").fill(sub);
   await page.getByRole("button", { name: /sign-in/i }).click();
-  /**
-   * Note: Fixes an issue where the URL was redirecting some of the time
-   * We should probably improve this to not reply on a specific operation name.
-   */
-  await page.waitForResponse(
-    async (resp) => {
-      if (await resp.url()?.includes("/graphql")) {
-        const reqJson = await resp.request()?.postDataJSON();
-        return (
-          reqJson.operationName === "ProfileAndApplicationsApplicant" ||
-          reqJson.operationName === "CreateAccount_Query"
-        );
-      }
-
-      return false;
-    },
-    {
-      timeout: 120 * 1000,
-    },
-  );
+  await expect(
+    page.getByRole("heading", { name: /welcome/i, level: 1 }),
+  ).toBeVisible();
 }
 
 export type AuthCookies = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       eslint-plugin-playwright:
         specifier: ^1.6.2
         version: 1.6.2(eslint@8.57.0)
+      typescript-eslint:
+        specifier: ^7.12.0
+        version: 7.12.0(eslint@8.57.0)(typescript@5.4.5)
 
   apps/web:
     dependencies:
@@ -7069,6 +7072,33 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/eslint-plugin@7.12.0(@typescript-eslint/parser@7.12.0)(eslint@8.57.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-7F91fcbuDf/d3S8o21+r3ZncGIke/+eWk0EpO21LXhDfLahriZF9CGj4fbAetEjlaBdjdSm9a6VeXbpbT6Z40Q==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^7.0.0
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 7.12.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 7.12.0
+      '@typescript-eslint/type-utils': 7.12.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 7.12.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/visitor-keys': 7.12.0
+      eslint: 8.57.0
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare: 1.4.0
+      ts-api-utils: 1.3.0(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5):
     resolution: {integrity: sha512-yimw99teuaXVWsBcPO1Ais02kwJ1jmNA1KxE7ng0aT7ndr1pT1wqj0OJnsYVGKKlc4QJai86l/025L6z8CljOg==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -7083,6 +7113,27 @@ packages:
       '@typescript-eslint/types': 7.11.0
       '@typescript-eslint/typescript-estree': 7.11.0(typescript@5.4.5)
       '@typescript-eslint/visitor-keys': 7.11.0
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.57.0
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-dm/J2UDY3oV3TKius2OUZIFHsomQmpHtsV0FTh1WO8EKgHLQ1QCADUqscPgTpU+ih1e21FQSRjXckHn3txn6kQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 7.12.0
+      '@typescript-eslint/types': 7.12.0
+      '@typescript-eslint/typescript-estree': 7.12.0(typescript@5.4.5)
+      '@typescript-eslint/visitor-keys': 7.12.0
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
       typescript: 5.4.5
@@ -7122,6 +7173,14 @@ packages:
       '@typescript-eslint/visitor-keys': 7.11.0
     dev: true
 
+  /@typescript-eslint/scope-manager@7.12.0:
+    resolution: {integrity: sha512-itF1pTnN6F3unPak+kutH9raIkL3lhH1YRPGgt7QQOh43DQKVJXmWkpb+vpc/TiDHs6RSd9CTbDsc/Y+Ygq7kg==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    dependencies:
+      '@typescript-eslint/types': 7.12.0
+      '@typescript-eslint/visitor-keys': 7.12.0
+    dev: true
+
   /@typescript-eslint/type-utils@7.10.0(eslint@8.57.0)(typescript@5.4.5):
     resolution: {integrity: sha512-D7tS4WDkJWrVkuzgm90qYw9RdgBcrWmbbRkrLA4d7Pg3w0ttVGDsvYGV19SH8gPR5L7OtcN5J1hTtyenO9xE9g==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -7134,6 +7193,26 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.10.0(typescript@5.4.5)
       '@typescript-eslint/utils': 7.10.0(eslint@8.57.0)(typescript@5.4.5)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.57.0
+      ts-api-utils: 1.3.0(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/type-utils@7.12.0(eslint@8.57.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-lib96tyRtMhLxwauDWUp/uW3FMhLA6D0rJ8T7HmH7x23Gk1Gwwu8UZ94NMXBvOELn6flSPiBrCKlehkiXyaqwA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 7.12.0(typescript@5.4.5)
+      '@typescript-eslint/utils': 7.12.0(eslint@8.57.0)(typescript@5.4.5)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.4.5)
@@ -7159,6 +7238,11 @@ packages:
 
   /@typescript-eslint/types@7.11.0:
     resolution: {integrity: sha512-MPEsDRZTyCiXkD4vd3zywDCifi7tatc4K37KqTprCvaXptP7Xlpdw0NR2hRJTetG5TxbWDB79Ys4kLmHliEo/w==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    dev: true
+
+  /@typescript-eslint/types@7.12.0:
+    resolution: {integrity: sha512-o+0Te6eWp2ppKY3mLCU+YA9pVJxhUJE15FV7kxuD9jgwIAa+w/ycGJBMrYDTpVGUM/tgpa9SeMOugSabWFq7bg==}
     engines: {node: ^18.18.0 || >=20.0.0}
     dev: true
 
@@ -7249,6 +7333,28 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree@7.12.0(typescript@5.4.5):
+    resolution: {integrity: sha512-5bwqLsWBULv1h6pn7cMW5dXX/Y2amRqLaKqsASVwbBHMZSnHqE/HN4vT4fE0aFsiwxYvr98kqOWh1a8ZKXalCQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 7.12.0
+      '@typescript-eslint/visitor-keys': 7.12.0
+      debug: 4.3.4(supports-color@8.1.1)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.4
+      semver: 7.6.0
+      ts-api-utils: 1.3.0(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@5.4.5):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -7304,6 +7410,22 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/utils@7.12.0(eslint@8.57.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-Y6hhwxwDx41HNpjuYswYp6gDbkiZ8Hin9Bf5aJQn1bpTs3afYY4GX+MPYxma8jtoIV2GRwTM/UJm/2uGCVv+DQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@typescript-eslint/scope-manager': 7.12.0
+      '@typescript-eslint/types': 7.12.0
+      '@typescript-eslint/typescript-estree': 7.12.0(typescript@5.4.5)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/visitor-keys@5.62.0:
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -7333,6 +7455,14 @@ packages:
     engines: {node: ^18.18.0 || >=20.0.0}
     dependencies:
       '@typescript-eslint/types': 7.11.0
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /@typescript-eslint/visitor-keys@7.12.0:
+    resolution: {integrity: sha512-uZk7DevrQLL3vSnfFl5bj4sL75qC9D6EdjemIdbtkuUmIheWpuiiylSY01JxJE7+zGrOWDZrp1WxOuDntvKrHQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    dependencies:
+      '@typescript-eslint/types': 7.12.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -16339,6 +16469,25 @@ packages:
       has-proto: 1.0.3
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
+    dev: true
+
+  /typescript-eslint@7.12.0(eslint@8.57.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-D6HKNbQcnNu3BaN4HkQCR16tgG8Q2AMUWPgvhrJksOXu+d6ys07yC06ONiV2kcsEfWC22voB6C3PvK2MqlBZ7w==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 7.12.0(@typescript-eslint/parser@7.12.0)(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 7.12.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 7.12.0(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /typescript@5.4.5:


### PR DESCRIPTION
🤖 Resolves #10575 

## 👋 Introduction

Improves the authentication of playwright tests to hopefully make them more reliable.

## 🕵️ Details

While the tests consistently pass in CI (with only one worker), when parallelized them, they seem to be flaky which all seems to be coming from the auth. This makes some changes that seem to allow them to pass more consistently when run locally.

> [!NOTE]
> This also adds a [recommended ESLint rule](https://playwright.dev/docs/best-practices#lint-your-tests) to avoid floating promises that could also cause issues with stability.

## 🧪 Testing

> [!NOTE]
> Webkit is still struggling for me but chromium and firefox seem fine :woman_shrugging: 

1. Run tests a few times in firefox `pnpm run e2e:playwright:firefox`
2. Confirm reliabliulity has improved
3. Repeat 1-2 in chromium `pnpm run e2e:playwright:chromium`