### PR TITLE
[Feature] Add process number to table and advertisement

### DIFF
--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -336,6 +336,15 @@ class Pool extends Model
         return $query;
     }
 
+    public static function scopeProcessNumber(Builder $query, ?string $number): Builder
+    {
+        if ($number) {
+            $query->where('process_number', 'ilike', sprintf('%%%s%%', $number));
+        }
+
+        return $query;
+    }
+
     public static function scopeTeam(Builder $query, ?string $team): Builder
     {
         if ($team) {
@@ -405,6 +414,8 @@ class Pool extends Model
 
                 $query->orWhere(function ($query) use ($term) {
                     self::scopeTeam($query, $term);
+                })->orWhere(function ($query) use ($term) {
+                    self::scopeProcessNumber($query, $term);
                 });
             });
         }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -677,6 +677,7 @@ input PoolFilterInput {
   team: String @scope
   streams: [PoolStream!] @scope
   statuses: [PoolStatus!] @scope
+  processNumber: String @scope
   publishingGroups: [PublishingGroup!] @scope
   classifications: [ClassificationFilterInput!] @scope
 }

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -759,6 +759,7 @@ input PoolFilterInput {
   team: String
   streams: [PoolStream!]
   statuses: [PoolStatus!]
+  processNumber: String
   publishingGroups: [PublishingGroup!]
   classifications: [ClassificationFilterInput!]
 }

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4167,6 +4167,10 @@
     "defaultMessage": "4. Suivez le processus de vérification de l’adresse de courriel. <strong>Un code unique</strong> vous sera envoyé par courriel et vous devrez le saisir dans la CléGC.",
     "description": "Text for fourth sign up -> create step."
   },
+  "LdlxBV": {
+    "defaultMessage": "Numéro du processus de sélection",
+    "description": "Label for a process number"
+  },
   "Ldzk4k": {
     "defaultMessage": "Critères constituent un atout",
     "description": "Asset criteria heading"

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -79,6 +79,7 @@ const PoolTable_Query = graphql(/* GraphQL */ `
         id
         stream
         publishingGroup
+        processNumber
         status
         createdDate
         updatedDate
@@ -264,6 +265,10 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
         header: intl.formatMessage(commonMessages.status),
       },
     ),
+    columnHelper.accessor("processNumber", {
+      id: "processNumber",
+      header: intl.formatMessage(processMessages.processNumber),
+    }),
     columnHelper.accessor(
       (row) => getLocalizedName(row.team?.displayName, intl, true),
       {

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
@@ -184,6 +184,7 @@ export function getOrderByClause(
     ["name", "name"],
     ["publishingGroup", "publishing_group"],
     ["stream", "stream"],
+    ["processNumber", "process_number"],
     ["ownerName", "FIRST_NAME"],
     ["ownerEmail", "EMAIL"],
     ["createdDate", "created_at"],

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -20,6 +20,7 @@ import {
   Well,
   CardBasic,
   Button,
+  Separator,
 } from "@gc-digital-talent/ui";
 import {
   getLocale,
@@ -1212,6 +1213,23 @@ export const PoolPoster = ({
               </Text>
               <ApplicationLink {...applicationLinkProps} />
             </TableOfContents.Section>
+            {pool.processNumber && (
+              <>
+                <Separator orientation="horizontal" space="sm" decorative />
+                <p
+                  data-h2-text-align="base(right)"
+                  data-h2-color="base(black.light)"
+                >
+                  {intl.formatMessage({
+                    defaultMessage: "Selection process number",
+                    id: "LdlxBV",
+                    description: "Label for a process number",
+                  })}
+                  {intl.formatMessage(commonMessages.dividingColon)}
+                  {pool.processNumber}
+                </p>
+              </>
+            )}
           </TableOfContents.Content>
         </TableOfContents.Wrapper>
       </div>


### PR DESCRIPTION
🤖 Resolves #10511 

## 👋 Introduction

Adds the process number to the admin pool table as well as the pool advertisement.

## 🧪 Testing

1. Build `pnpm run dev`
2. Login as admin `admin@test.com`
3. Navigate to the index pools page `/admin/pools`
4. Confirm process number appears and can be sorted as well as found through search
5. View the advertisement of a pool
6. Confirm process number appears at the bottom right

## 📸 Screenshot

![screenshot_04-Jun-2024_08-50-1717505431](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/5ad78403-440b-48cb-9ee1-1205622bbbf8)
![screenshot_04-Jun-2024_08-50-1717505439](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/2b9a1fcc-fae6-4e50-ad30-3c85317af5e9)
