### PR TITLE
[Feature] Update experience skill dialog

### DIFF
--- a/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillForm.tsx
+++ b/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillForm.tsx
@@ -1,13 +1,7 @@
 import { useIntl } from "react-intl";
 import { useForm, FormProvider } from "react-hook-form";
 
-import {
-  Dialog,
-  Button,
-  Heading,
-  Accordion,
-  Well,
-} from "@gc-digital-talent/ui";
+import { Dialog, Button, Heading, Well } from "@gc-digital-talent/ui";
 import { Select, TextArea } from "@gc-digital-talent/forms";
 import { errorMessages, formMessages } from "@gc-digital-talent/i18n";
 import { toast } from "@gc-digital-talent/toast";
@@ -178,56 +172,52 @@ const ExperienceSkillForm = ({
             description: "Instructions on how to describe a skill",
           })}
         </p>
-        <div data-h2-margin="base(x.5, 0)">
-          <Accordion.Root type="single" size="sm" collapsible>
-            <Accordion.Item value="skillQuestions">
-              <Accordion.Trigger as="h3">
-                {intl.formatMessage({
-                  defaultMessage: "How to best describe a skill experience",
-                  id: "1/Q9jX",
-                  description:
-                    "Title for instructions on how to describe a skill",
-                })}
-              </Accordion.Trigger>
-              <Accordion.Content>
-                <ul data-h2-padding="base(0, 0, 0, x1)">
-                  <li>
-                    {intl.formatMessage({
-                      defaultMessage:
-                        "What did you accomplish, create or deliver using this skill?",
-                      id: "WEVxYV",
-                      description: "Question for clarifying skill details",
-                    })}
-                  </li>
-                  <li>
-                    {intl.formatMessage({
-                      defaultMessage:
-                        "What tasks or activities did you do that relate to this skill?",
-                      id: "ac1z9L",
-                      description: "Question about related tasks to a skill",
-                    })}
-                  </li>
-                  <li>
-                    {intl.formatMessage({
-                      defaultMessage:
-                        "Were there any special techniques or approaches that you used?",
-                      id: "Ivvi/F",
-                      description: "Question about techniques used for a skill",
-                    })}
-                  </li>
-                  <li>
-                    {intl.formatMessage({
-                      defaultMessage:
-                        "How much responsibility did you have in this role?",
-                      id: "Qjpmm8",
-                      description: "Question for clarifying skill details",
-                    })}
-                  </li>
-                </ul>
-              </Accordion.Content>
-            </Accordion.Item>
-          </Accordion.Root>
-        </div>
+        <Heading
+          level="h3"
+          size="h6"
+          data-h2-font-size="base(copy)"
+          data-h2-margin-top="base(x.5)"
+        >
+          {intl.formatMessage({
+            defaultMessage: "How to best describe a skill experience",
+            id: "1/Q9jX",
+            description: "Title for instructions on how to describe a skill",
+          })}
+        </Heading>
+        <ul data-h2-margin="base(x.5 0 x1 0)">
+          <li>
+            {intl.formatMessage({
+              defaultMessage:
+                "How did you demonstrate this skill in this role?",
+              id: "3eeKdd",
+              description: "Question for clarifying skill details",
+            })}
+          </li>
+          <li>
+            {intl.formatMessage({
+              defaultMessage:
+                "What tasks or activities did you do that relate to this skill?",
+              id: "ac1z9L",
+              description: "Question about related tasks to a skill",
+            })}
+          </li>
+          <li>
+            {intl.formatMessage({
+              defaultMessage:
+                "Were there any special techniques or approaches that you used?",
+              id: "Ivvi/F",
+              description: "Question about techniques used for a skill",
+            })}
+          </li>
+          <li>
+            {intl.formatMessage({
+              defaultMessage:
+                "How much responsibility did you have in this role?",
+              id: "Qjpmm8",
+              description: "Question for clarifying skill details",
+            })}
+          </li>
+        </ul>
         {!selectedExperienceId ? (
           <Well>
             <p data-h2-text-align="base(center)">

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1011,6 +1011,10 @@
     "defaultMessage": "Date de réception",
     "description": "Title displayed on the Pool Candidates table Date Received column."
   },
+  "3eeKdd": {
+    "defaultMessage": "De quelle façon avez-vous démontré cette compétence dans ce rôle?",
+    "description": "Question for clarifying skill details"
+  },
   "3f9P13": {
     "defaultMessage": "En tant qu'employé, quel est votre statut d'emploi?",
     "description": "Employee Status in Government Info Form"


### PR DESCRIPTION
🤖 Resolves #10569 

## 👋 Introduction

Updates the link experience to skill dialog to move question prompts out of accordion. As well as changes the first prompt.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `pnpm run dev`
2. Login as applicant `applicant@test.com`
3. Start application
4. Continue to skills section
5. Open the link experience dialog
6. Confirm it matches the ticket descrioption

## 📸 Screenshot

![screenshot_05-Jun-2024_16-52-1717620762](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/97188273-f593-40df-aabc-f7d6440c4fa0)
