### PR TITLE
[Feature] Sets `type` field on Freshdesk ticket

### DIFF
--- a/api/app/Http/Controllers/SupportController.php
+++ b/api/app/Http/Controllers/SupportController.php
@@ -17,6 +17,13 @@ class SupportController extends Controller
                 'apiResponse' => 'Missing parameters',
             ], 500);
         }
+        // string values available from type field via /api/v2/ticket_fields.
+        $type_map =
+        [
+            'question' => 'Question',
+            'bug' => 'Bug',
+            'feedback' => 'Feedback',
+        ];
         $parameters = [
             'description' => $request->input('description'),
             'subject' => $request->input('subject'),
@@ -25,6 +32,7 @@ class SupportController extends Controller
             'priority' => 1, // Required by Freshdesk API. Priority of the ticket. The default value is 1.
             'status' => 2, // Required by Freshdesk API. Status of the ticket. The default value is 2.
             'tags' => [config('freshdesk.api.ticket_tag')],
+            'type' => array_key_exists($request->input('subject'), $type_map) ? $type_map[$request->input('subject')] : null,
         ];
         if ($request->input('previous_url')) {
             $parameters['custom_fields']['cf_page_url'] = (string) $request->input('previous_url');


### PR DESCRIPTION
🤖 Resolves #10581.

## 👋 Introduction

This PR sets the `type` field on a Freshdesk ticket created via the support page.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> [!IMPORTANT]  
> Freshdesk environment variables will be required to test local submission of the support form.

1. Navigate to `/support` page
2. Fill out and submit the support form
3. Verify that the associated ticket in Freshdesk that was created has the `type` field set to the corresponding subject value