### PR TITLE
[Copy] Adds sentence to skill requirements description job advertisement

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5119,6 +5119,10 @@
     "defaultMessage": "Commencer à rédiger une demande d'emploi",
     "description": "Title for the apply now section of a pool advertisement"
   },
+  "Qxl9Ec": {
+    "defaultMessage": "Afin d’écourter le processus de demande, l’information n’est recueillie que sur certaines compétences particulières à l’étape de la demande. Celles-ci sont identifiées individuellement sous le nom de la compétence en se servant de la mention « Évaluées à l’étape initiale de la demande ». D’autres évaluations suivront plus tard au cours de votre processus de demande si elle s’avère réussie. Ces évaluations supplémentaires peuvent être menées sur toutes les compétences obligatoires ou facultatives.",
+    "description": "Descriptive text about how skills are used during the application process"
+  },
   "QzU2SL": {
     "defaultMessage": "Veuillez remplir toute l’information relative à l'annonce avant de la publier.",
     "description": "Error message displayed when user attempts to publish an incomplete advertisement"
@@ -6173,10 +6177,6 @@
   "Wpj2OY": {
     "defaultMessage": "« Je suis membre d’une Première Nation »",
     "description": "Text for the option to self-declare as first nations"
-  },
-  "WppiY9": {
-    "defaultMessage": "Afin d’écourter le processus de demande, l’information n’est recueillie que sur certaines compétences particulières à l’étape de la demande. Celles-ci sont identifiées individuellement sous le nom de la compétence en se servant de la mention « Évaluées à l’étape initiale de la demande ». D’autres évaluations suivront plus tard au cours de votre processus de demande si elle s’avère réussie.",
-    "description": "Descriptive text about how skills are used during the application process"
   },
   "WqOnFF": {
     "defaultMessage": "Autres commentaires",

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -865,8 +865,8 @@ export const PoolPoster = ({
               <Text>
                 {intl.formatMessage({
                   defaultMessage:
-                    'To make the application process shorter, information is only collected on specific skills during the application stage. These are each identified under the skill name using "Assessed during initial application". Additional assessments will follow later if your application is successful.',
-                  id: "WppiY9",
+                    'To make the application process shorter, information is only collected on specific skills during the application stage. These are each identified under the skill name using "Assessed during initial application". Additional assessments will follow later if your application is successful. These additional assessments may be conducted on any of the required or optional skills.',
+                  id: "Qxl9Ec",
                   description:
                     "Descriptive text about how skills are used during the application process",
                 })}


### PR DESCRIPTION
🤖 Resolves #10616.

## 👋 Introduction

This PR adds a sentence to the skill requirements description on the job advertisement page.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm build`
2. Navigate to `/en/browse/pools/:pool-id#skill-requirements`
3. Verify new sentence renders at the end of the second paragraph of the description in English
4. Switch to French
5. Verify new sentence renders at the end of the second paragraph of the description in French

## 📸 Screenshots
<img width="1193" alt="Screen Shot 2024-06-07 at 11 57 53" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/dbcd4327-303f-40d1-a54e-8c6cfaa23dd9">
<img width="1197" alt="Screen Shot 2024-06-07 at 11 57 28" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/5f4b76d9-8aa2-4085-a0e0-a48578eecb36">
