### PR TITLE
[Fix] Adds conditional for skill accordion without `skillLevel`

### DIFF
--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SkillAccordion.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SkillAccordion.tsx
@@ -163,18 +163,21 @@ const SkillAccordion = ({ poolSkillQuery, required }: SkillAccordionProps) => {
             {getLocalizedName(poolSkill.skill.description, intl)}
           </p>
         )}
-        <p>
-          <span data-h2-font-weight="base(700)">
-            {intl.formatMessage({
-              defaultMessage: "Level definition",
-              id: "fqa45V",
-              description: "Label for the definition of a specific skill level",
-            }) + intl.formatMessage(commonMessages.dividingColon)}
-          </span>
-          {definitionAndLevel
-            ? intl.formatMessage(definitionAndLevel.definition)
-            : intl.formatMessage(commonMessages.notFound)}
-        </p>
+        {poolSkill.requiredLevel && (
+          <p>
+            <span data-h2-font-weight="base(700)">
+              {intl.formatMessage({
+                defaultMessage: "Level definition",
+                id: "fqa45V",
+                description:
+                  "Label for the definition of a specific skill level",
+              }) + intl.formatMessage(commonMessages.dividingColon)}
+            </span>
+            {definitionAndLevel
+              ? intl.formatMessage(definitionAndLevel.definition)
+              : intl.formatMessage(commonMessages.notFound)}
+          </p>
+        )}
       </Accordion.Content>
     </Accordion.Item>
   );

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SkillAccordion.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SkillAccordion.tsx
@@ -45,13 +45,13 @@ const Context = ({ required }: ContextProps) => {
 };
 
 interface AccordionSubtitleProps {
-  skillLevel: string | null | undefined;
+  isSkillLevelAvailable: boolean;
   skillLevelItem: string;
   screeningTime: string;
 }
 
 const AccordionSubtitle = ({
-  skillLevel,
+  isSkillLevelAvailable,
   skillLevelItem,
   screeningTime,
 }: AccordionSubtitleProps) => (
@@ -64,7 +64,7 @@ const AccordionSubtitle = ({
     data-h2-flex-direction="base(column) p-tablet(row)"
     data-h2-gap="base(x.5)"
   >
-    {skillLevel && (
+    {isSkillLevelAvailable && (
       <>
         <span>{skillLevelItem}</span>
         <span data-h2-display="base(none) p-tablet(inline)">&bull;</span>
@@ -142,7 +142,7 @@ const SkillAccordion = ({ poolSkillQuery, required }: SkillAccordionProps) => {
         context={<Context required={required} />}
         subtitle={
           <AccordionSubtitle
-            skillLevel={poolSkill.requiredLevel}
+            isSkillLevelAvailable={!!poolSkill.requiredLevel}
             skillLevelItem={skillLevelItem}
             screeningTime={screeningTime}
           />

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SkillAccordion.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SkillAccordion.tsx
@@ -45,11 +45,13 @@ const Context = ({ required }: ContextProps) => {
 };
 
 interface AccordionSubtitleProps {
+  skillLevel: string | null | undefined;
   skillLevelItem: string;
   screeningTime: string;
 }
 
 const AccordionSubtitle = ({
+  skillLevel,
   skillLevelItem,
   screeningTime,
 }: AccordionSubtitleProps) => (
@@ -62,8 +64,12 @@ const AccordionSubtitle = ({
     data-h2-flex-direction="base(column) p-tablet(row)"
     data-h2-gap="base(x.5)"
   >
-    <span>{skillLevelItem}</span>
-    <span data-h2-display="base(none) p-tablet(inline)">&bull;</span>
+    {skillLevel && (
+      <>
+        <span>{skillLevelItem}</span>
+        <span data-h2-display="base(none) p-tablet(inline)">&bull;</span>
+      </>
+    )}
     <span>{screeningTime}</span>
   </span>
 );
@@ -136,6 +142,7 @@ const SkillAccordion = ({ poolSkillQuery, required }: SkillAccordionProps) => {
         context={<Context required={required} />}
         subtitle={
           <AccordionSubtitle
+            skillLevel={poolSkill.requiredLevel}
             skillLevelItem={skillLevelItem}
             screeningTime={screeningTime}
           />


### PR DESCRIPTION
🤖 Resolves #10612.

## 👋 Introduction

This PR adds a conditional statement around the **Level: {skillLevel}** and **Level definition** text for legacy processes that do not have skill levels.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

### SQL query

```sql
SELECT skill_id, required_skill_level FROM pool_skill WHERE pool_id = $pool_id
```

1. `pnpm build`
2. Navigate to a job advertisement `/browse/pools/:pool-id#skill-requirements`
3. Find from the `:pool-id` in the `pool_skill` database table and set `required_skill_level` to `NULL` (see previous SQL query section)
5. Navigate to a job advertisement `/browse/pools/:pool-id#skill-requirements`
6. Verify changed skill accordion with  `NULL` skill level doesn't render **Level: {skillLevel}** text in the accordion trigger or **Level definition** paragraph in the accordion content

## 📸 Screenshot
<img width="849" alt="Screen Shot 2024-06-07 at 16 10 09" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/55fcaa58-bde3-4b41-bddc-f301ee5bdc88">