### PR TITLE
[Spike] Example implementation of back-end localized enums

### DIFF
--- a/api/app/Enums/CitizenshipStatus.php
+++ b/api/app/Enums/CitizenshipStatus.php
@@ -12,9 +12,9 @@ enum CitizenshipStatus
     case CITIZEN;
     case OTHER;
 
-    public static function getLangFilename(?string $fileKey = 'profile'): string
+    public static function getLangFilename(): string
     {
 
-        return 'citizenship_status.'.$fileKey;
+        return 'citizenship_status';
     }
 }

--- a/api/app/Enums/CitizenshipStatus.php
+++ b/api/app/Enums/CitizenshipStatus.php
@@ -2,9 +2,19 @@
 
 namespace App\Enums;
 
+use App\Traits\HasLocalization;
+
 enum CitizenshipStatus
 {
+    use HasLocalization;
+
     case PERMANENT_RESIDENT;
     case CITIZEN;
     case OTHER;
+
+    public static function getLangFilename(?string $fileKey = 'profile'): string
+    {
+
+        return 'citizenship_status.'.$fileKey;
+    }
 }

--- a/api/app/GraphQL/Queries/LocalizedEnumStrings.php
+++ b/api/app/GraphQL/Queries/LocalizedEnumStrings.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Queries;
+
+final readonly class LocalizedEnumStrings
+{
+    /** @param  array{}  $args */
+    public function __invoke(null $_, array $args)
+    {
+
+        $enum = 'App\\Enums\\'.$args['enumName'];
+
+        return array_map(function ($case) use ($args, $enum) {
+            return [
+                'value' => $case,
+                'label' => $enum::localizedString($case, $args['intermediaryKey']),
+            ];
+        }, array_column($enum::cases(), 'name'));
+
+    }
+}

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -347,6 +347,16 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
         }
     }
 
+    public function getAdminCitizenshipAttribute()
+    {
+        return CitizenshipStatus::localizedString($this->citizenship, 'admin');
+    }
+
+    public function getProfileCitizenshipAttribute()
+    {
+        return CitizenshipStatus::localizedString($this->citizenship, 'profile');
+    }
+
     public function getLookingForLanguage()
     {
         if ($this->looking_for_bilingual) {

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -349,12 +349,18 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
 
     public function getAdminCitizenshipAttribute()
     {
-        return CitizenshipStatus::localizedString($this->citizenship, 'admin');
+        return [
+            'value' => $this->citizenship,
+            'label' => CitizenshipStatus::localizedString($this->citizenship, 'admin'),
+        ];
     }
 
     public function getProfileCitizenshipAttribute()
     {
-        return CitizenshipStatus::localizedString($this->citizenship, 'profile');
+        return [
+            'value' => $this->citizenship,
+            'label' => CitizenshipStatus::localizedString($this->citizenship, 'profile'),
+        ];
     }
 
     public function getLookingForLanguage()

--- a/api/app/Rules/LocalizedEnumExists.php
+++ b/api/app/Rules/LocalizedEnumExists.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Database\Helpers\ApiErrorEnums;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class LocalizedEnumExists implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+
+        $enum = 'App\\Enums\\'.$value;
+
+        if (! enum_exists($enum)) {
+            $fail(ApiErrorEnums::ENUM_NOT_FOUND);
+        } elseif (! method_exists($enum, 'localizedString')) {
+            $fail(ApiErrorEnums::ENUM_NOT_LOCALIZED);
+        }
+    }
+}

--- a/api/app/Traits/HasLocalization.php
+++ b/api/app/Traits/HasLocalization.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Str;
+
+trait HasLocalization
+{
+    abstract public static function getLangFilename(?string $key): string;
+
+    public static function caseKey(string $case)
+    {
+        return Str::lower(constant("self::$case")->name);
+    }
+
+    public static function localizedString(string $value, ?string $fileKey)
+    {
+        $key = sprintf(
+            '%s.%s',
+            self::getLangFilename($fileKey),
+            self::caseKey($value)
+        );
+
+        return [
+            'en' => Lang::get($key, [], 'en'),
+            'fr' => Lang::get($key, [], 'fr'),
+        ];
+    }
+}

--- a/api/app/Traits/HasLocalization.php
+++ b/api/app/Traits/HasLocalization.php
@@ -7,18 +7,19 @@ use Illuminate\Support\Str;
 
 trait HasLocalization
 {
-    abstract public static function getLangFilename(?string $key): string;
+    abstract public static function getLangFilename(): string;
 
     public static function caseKey(string $case)
     {
         return Str::lower(constant("self::$case")->name);
     }
 
-    public static function localizedString(string $value, ?string $fileKey)
+    public static function localizedString(string $value, ?string $intermediaryKey)
     {
         $key = sprintf(
-            '%s.%s',
-            self::getLangFilename($fileKey),
+            '%s%s.%s',
+            self::getLangFilename(),
+            $intermediaryKey ? '.'.$intermediaryKey : '',
             self::caseKey($value)
         );
 

--- a/api/database/helpers/ApiErrorEnums.php
+++ b/api/database/helpers/ApiErrorEnums.php
@@ -42,4 +42,9 @@ class ApiErrorEnums
     const INVALID_STATUS_PLACING = 'InvalidStatusForPlacing';
 
     const CANDIDATE_NOT_PLACED = 'CandidateNotPlaced';
+
+    // Localized Enums
+    const ENUM_NOT_FOUND = 'EnumNotFound';
+
+    const ENUM_NOT_LOCALIZED = 'EnumNotLocalized';
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -52,6 +52,8 @@ type User {
   currentProvince: ProvinceOrTerritory @rename(attribute: "current_province")
   currentCity: String @rename(attribute: "current_city")
   citizenship: CitizenshipStatus
+  adminCitizenship: LocalizedString @rename(attribute: "admin_citizenship")
+  profileCitizenship: LocalizedString @rename(attribute: "profile_citizenship")
   armedForcesStatus: ArmedForcesStatus @rename(attribute: "armed_forces_status")
 
   # Language

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -636,6 +636,11 @@ type ExperienceSkillRecord {
   details: String
 }
 
+type LocalizedEnumString {
+  value: String!
+  label: LocalizedString!
+}
+
 input ClassificationFilterInput {
   group: String!
   level: Int!
@@ -916,6 +921,12 @@ type Query {
     @paginate(defaultCount: 10, scopes: ["authorizedToView"])
 
   sitewideAnnouncement: SitewideAnnouncement
+
+  localizedEnumStrings(
+    enumName: String!
+      @rules(apply: ["required", "App\\Rules\\LocalizedEnumExists"])
+    intermediaryKey: String
+  ): [LocalizedEnumString!]
 }
 
 input ClassificationBelongsTo {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -52,8 +52,9 @@ type User {
   currentProvince: ProvinceOrTerritory @rename(attribute: "current_province")
   currentCity: String @rename(attribute: "current_city")
   citizenship: CitizenshipStatus
-  adminCitizenship: LocalizedString @rename(attribute: "admin_citizenship")
-  profileCitizenship: LocalizedString @rename(attribute: "profile_citizenship")
+  adminCitizenship: LocalizedEnumString @rename(attribute: "admin_citizenship")
+  profileCitizenship: LocalizedEnumString
+    @rename(attribute: "profile_citizenship")
   armedForcesStatus: ArmedForcesStatus @rename(attribute: "armed_forces_status")
 
   # Language

--- a/api/lang/en/citizenship_status.php
+++ b/api/lang/en/citizenship_status.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Support\Facades\Lang;
+
+return [
+    'profile' => [
+        'citizen' => 'I am a Canadian citizen.',
+        'permanent_resident' => 'I am a permanent resident of Canada.',
+        'other' => Lang::get('common.other', [], 'en'),
+    ],
+
+    'admin' => [
+        'citizen' => 'Canadian Citizen',
+        'permanent_resident' => 'Permanent Resident',
+        'other' => Lang::get('common.other', [], 'en'),
+    ],
+];

--- a/api/lang/en/common.php
+++ b/api/lang/en/common.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'other' => 'Other',
+];

--- a/api/lang/fr/citizenship_status.php
+++ b/api/lang/fr/citizenship_status.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Support\Facades\Lang;
+
+return [
+    'profile' => [
+        'citizen' => 'Je suis un citoyen canadien.',
+        'permanent_resident' => 'Je suis un(e) résident(e) permanent(e) du Canada.',
+        'other' => Lang::get('common.other', [], 'fr'),
+    ],
+
+    'admin' => [
+        'citizen' => 'Citoyen canadien',
+        'permanent_resident' => 'Résident permanent',
+        'other' => Lang::get('common.other', [], 'fr'),
+    ],
+];

--- a/api/lang/fr/common.php
+++ b/api/lang/fr/common.php
@@ -1,0 +1,6 @@
+
+<?php
+
+return [
+    'other' => 'Autre',
+];

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -249,6 +249,8 @@ type User {
   currentProvince: ProvinceOrTerritory
   currentCity: String
   citizenship: CitizenshipStatus
+  adminCitizenship: LocalizedString
+  profileCitizenship: LocalizedString
   armedForcesStatus: ArmedForcesStatus
   lookingForEnglish: Boolean
   lookingForFrench: Boolean

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -31,6 +31,7 @@ type Query {
   teams: [Team]!
   roles: [Role]!
   sitewideAnnouncement: SitewideAnnouncement
+  localizedEnumStrings(enumName: String!, intermediaryKey: String): [LocalizedEnumString!]
   digitalContractingQuestionnaire(id: UUID!): DigitalContractingQuestionnaire
   digitalContractingQuestionnaires: [DigitalContractingQuestionnaire!]!
   departmentSpecificRecruitmentProcessForm(id: UUID!): DepartmentSpecificRecruitmentProcessForm
@@ -716,6 +717,11 @@ type AwardExperience implements Experience {
 
 type ExperienceSkillRecord {
   details: String
+}
+
+type LocalizedEnumString {
+  value: String!
+  label: LocalizedString!
 }
 
 input ClassificationFilterInput {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -250,8 +250,8 @@ type User {
   currentProvince: ProvinceOrTerritory
   currentCity: String
   citizenship: CitizenshipStatus
-  adminCitizenship: LocalizedString
-  profileCitizenship: LocalizedString
+  adminCitizenship: LocalizedEnumString
+  profileCitizenship: LocalizedEnumString
   armedForcesStatus: ArmedForcesStatus
   lookingForEnglish: Boolean
   lookingForFrench: Boolean


### PR DESCRIPTION
🤖 Resolves #10029 

## 👋 Introduction

This is an example implmentation of how we could localized database enum fields on the back-end using laravels built in localization.

## 🕵️ Details

This uses a trait (`HasLocalization`) that can be implemented on enums that need localization. The implmentation has some rough edges around it but should work well, I think :sweat_smile: .

### How it works

The trait requires that the enum implements a `getLangFileName` method that returns a string for the localized file name (found in `app/lang/{locale}`.

The trait also provides a `localizedString` method that accepts a value (name of the enum case) and an optional intermediary key (for multiple translations of each key.

We can then use this in whatever way we want. I have an example of it being passed through graphql incase we would like to avoid duplicating this strings on the frontend. 

For stuff that does not exist in the database (csv column headers, PDF headings) we may need to bite the bullet for now and just duplicate them :cry: 

### Common strings

Some of our enums use a common string. This shows the citizenship status simply accessing the common string of "Other". It is a bit verbose but shouldn't need to be done that often so I am personally fine with this approach.

### Negatives of this approach

#### Fallback/Fault tolerance

I haven't figured out a way to ensure we have translations yet so if you do not provide a translation it will either fallback to the default locale (English) or, just display the "ID" (`citizenship_status.profile.citizen`).

#### Inflation

This may lead to some inflation of the schema, data we are retrieving from the API and model methods. Instead of retrieving just the enum value, we are now grabbing (possibly multiple) localized string representations of the data and need these to be defined on the model. 

However, this might be offset by the reduction of the compiled strings we get anyway when we load the app and make it more "on demand" :thinking: 

## ❓ Question answers

### How hard will it be to maintain a totally separate localization pipeline for the backend?

I don't see this as very difficult to maintain as a pipeline since it is mostly handled by laravel.

### Is it possible to move all the localized constants logic to backend so that all the strings and mapping don't need to be maintained and synchronized between the two?

Yes, I tihnk this clearly demonstrates that we can move all of the localized constant logic to the backend for localization. I picked an exmaple that shows both multiple strings for a single enum value as well as a common string that is shared.

### Is there any way to share messages between the front and the back so we don't have to maintain duplicate message files?

I am currently unable to see how we can share non-database backed strings easily. While we can translate them, sending them to the frontend in an elegant way eludes me at the moment.

### Should we use Laravel's localization library?

Yes, I beleive this demonstrates the ease of use that laravels built in localization provides for our use case.

## 🧪 Testing

```graphql
{
  me {
    profileCitizenship {
      value
      label {
        en
        fr
      }
    }
    adminCitizenship {
      value
      label {
        en
        fr
      }
    }
  }

 profileCitizenshipStatusStrings: localizedEnumStrings(
   enumName: "CitizenshipStatus",
  intermediaryKey: "profile"
  ) {
   value
   label {
     en
     fr
   }
 }
 
  adminCitizenshipStatusStrings: localizedEnumStrings(
    enumName: "CitizenshipStatus", 
    intermediaryKey: "admin"
 ) {
   value
   label {
     en
     fr
   }
 }
}
```

1. Update your `api/.env` file to set the default API user
2. Navigate to `/graphiql`
3. Run the provided query
4. Observe the localized versions of the string

## :camera_flash: Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/d7e18c32-cf0e-47eb-84e0-8f968c552d4d)
