### PR TITLE
[Debt] Make some assessment decisions null

### DIFF
--- a/api/database/factories/AssessmentResultFactory.php
+++ b/api/database/factories/AssessmentResultFactory.php
@@ -38,7 +38,7 @@ class AssessmentResultFactory extends Factory
             'pool_candidate_id' => PoolCandidate::factory(),
             'assessment_result_type' => $assessmentResultType,
             'assessment_decision' => $assessmentDecision,
-            'justifications' => $justifications,
+            'justifications' => $this->nullJustifications($assessmentDecision) ? null : $justifications,
             'assessment_decision_level' => $assessmentResultType === AssessmentResultType::SKILL->name &&
                 $assessmentDecision === AssessmentDecision::SUCCESSFUL->name ?
                 $this->faker->randomElement(array_column(AssessmentDecisionLevel::cases(), 'name')) : null,
@@ -56,10 +56,12 @@ class AssessmentResultFactory extends Factory
         return $this->state(function () use ($type) {
             if ($type === AssessmentResultType::EDUCATION) {
                 $justifications = [$this->faker->randomElement(array_column(AssessmentResultJustification::educationJustifications(), 'name'))];
+                $assessmentDecision = $this->faker->randomElement(array_column(AssessmentDecision::cases(), 'name'));
 
                 return [
                     'assessment_result_type' => $type->name,
-                    'justifications' => $justifications,
+                    'justifications' => $this->nullJustifications($assessmentDecision) ? null : $justifications,
+                    'assessment_decision' => $assessmentDecision,
                     'assessment_decision_level' => null,
                     'skill_decision_notes' => null,
                 ];
@@ -71,7 +73,7 @@ class AssessmentResultFactory extends Factory
 
                 return [
                     'assessment_result_type' => $type->name,
-                    'justifications' => $justifications,
+                    'justifications' => $this->nullJustifications($assessmentDecision) ? null : $justifications,
                     'assessment_decision' => $assessmentDecision,
                     'assessment_decision_level' => $assessmentDecision === AssessmentDecision::SUCCESSFUL->name ?
                         $this->faker->randomElement(array_column(AssessmentDecisionLevel::cases(), 'name')) : null,
@@ -82,5 +84,10 @@ class AssessmentResultFactory extends Factory
 
             return [];
         });
+    }
+
+    private function nullJustifications($decision): bool
+    {
+        return $decision === AssessmentDecision::HOLD->name || is_null($decision);
     }
 }

--- a/api/database/seeders/AssessmentResultTestSeeder.php
+++ b/api/database/seeders/AssessmentResultTestSeeder.php
@@ -185,13 +185,15 @@ class AssessmentResultTestSeeder extends Seeder
         $assessmentDecision,
         $assessmentResultType)
     {
+        $nullJustifications = $assessmentDecision === AssessmentDecision::HOLD->name || is_null($assessmentDecision);
+
         if ($assessmentResultType == null) {
             $assessmentResultType = AssessmentResultType::SKILL;
         } elseif ($assessmentResultType == AssessmentResultType::EDUCATION) {
             AssessmentResult::factory()->withResultType($assessmentResultType)->create([
                 'assessment_step_id' => $assessmentStep->id,
                 'pool_candidate_id' => $poolCandidate->id,
-                'justifications' => $justifications,
+                'justifications' => $nullJustifications ? null : $justifications,
                 'assessment_decision' => $assessmentDecision,
             ]);
         } else {
@@ -201,7 +203,7 @@ class AssessmentResultTestSeeder extends Seeder
                     'pool_candidate_id' => $poolCandidate->id,
                     'pool_skill_id' => $poolSkill,
                     'assessment_decision_level' => $level,
-                    'justifications' => $justifications,
+                    'justifications' => $nullJustifications ? null : $justifications,
                     'assessment_decision' => $assessmentDecision,
                 ]);
             }


### PR DESCRIPTION
🤖 Resolves #10498 

## 👋 Introduction

Makes some justifications on `AssessmentResult` `null` when seeding fresh test data.

## 🕵️ Details

When the result decision is "unsure" or "on hold", the justification should be null in most cases. This updates the seeder to create more accurate data in that scenario instead of always setting a justification regardless of decision

## 🧪 Testing

1. Re-seed fresh data `make seed-fresh`
2. Login to the database at `http://localhost:8080`
3. Confirm that some `justifications` are `null` when the `assessment_decision` is either `null` or `HOLD`

## 📸 Screenshot

![screenshot_10-Jun-2024_14-23-1718043791](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/419f3114-f0d9-4d41-a46b-825866efe8c4)
