### PR TITLE
[Copy] Removes Third paragraph describing the directive on digital talent

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5607,10 +5607,6 @@
     "defaultMessage": "Solutions logicielles de la <abbreviation>TI</abbreviation>",
     "description": "Title for the 'software solutions' IT work stream"
   },
-  "TmDejD": {
-    "defaultMessage": "Vous souhaitez coordonner une présentation pour votre ministère? <contactLink>Contactez-nous</contactLink>.",
-    "description": "Third paragraph describing the directive on digital talent"
-  },
   "TomxAe": {
     "defaultMessage": "{time} le {date}",
     "description": "A datetime formatted as a certain time on a certain date"

--- a/apps/web/src/pages/DirectivePage/DirectivePage.tsx
+++ b/apps/web/src/pages/DirectivePage/DirectivePage.tsx
@@ -43,12 +43,6 @@ const policyLink = (locale: Locales, chunks: ReactNode) => (
   </Link>
 );
 
-const contactLink = (chunks: ReactNode) => (
-  <Link external href="mailto:GCTalentGC@tbs-sct.gc.ca">
-    {chunks}
-  </Link>
-);
-
 export const pageTitle = defineMessage({
   defaultMessage: "Directive on Digital Talent",
   id: "xXwUGs",
@@ -215,20 +209,6 @@ export const Component = () => {
               description:
                 "Second paragraph describing the directive on digital talent",
             })}
-          </p>
-          <p>
-            {intl.formatMessage(
-              {
-                defaultMessage:
-                  "Want to coordinate a presentation for your department? <contactLink>Contact us</contactLink>.",
-                id: "TmDejD",
-                description:
-                  "Third paragraph describing the directive on digital talent",
-              },
-              {
-                contactLink,
-              },
-            )}
           </p>
           <p>
             <Link color="primary" mode="solid" href={directiveUrl} external>


### PR DESCRIPTION
🤖 Resolves #10648.

## 👋 Introduction

This PR removes the third paragraph describing the directive on digital talent.

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm build`
2. Navigate to `/en/directive-on-digital-talent`
3. Observe only two paragraphs in What is the Directive on Digital Talent? section

## 📸 Screenshot

<img width="1158" alt="Screen Shot 2024-06-12 at 11 19 09" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/ab5d9e0d-91c5-4b15-8f00-6480c04bd483">