### PR TITLE
[Test] Skips directive forms PHPUnit tests and Chromatic snapshotting

### DIFF
--- a/api/tests/Feature/DigitalContractingQuestionnaireTest.php
+++ b/api/tests/Feature/DigitalContractingQuestionnaireTest.php
@@ -29,6 +29,8 @@ class DigitalContractingQuestionnaireTest extends TestCase
     {
         parent::setUp();
 
+        $this->markTestSkipped('Feature does not have an imminent launch.');
+
         $this->seed(RolePermissionSeeder::class);
 
         $this->bootRefreshesSchemaCache();

--- a/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/DigitalServicesContractingQuestionnairePage.stories.tsx
+++ b/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/DigitalServicesContractingQuestionnairePage.stories.tsx
@@ -43,6 +43,9 @@ const meta: Meta<typeof DigitalServicesContractingQuestionnaire> = {
       });
     },
   },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 export default meta;
 type Story = StoryObj<typeof DigitalServicesContractingQuestionnaire>;

--- a/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/fieldsSets/PersonnelRequirementFieldset.stories.tsx
+++ b/apps/web/src/pages/DirectiveForms/DigitalServicesContractingQuestionnaire/fieldsSets/PersonnelRequirementFieldset.stories.tsx
@@ -25,6 +25,9 @@ const meta: Meta<typeof PersonnelRequirementFieldset> = {
     skills: mockSkills,
     fieldsetName: "fakeField",
   },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 export default meta;
 


### PR DESCRIPTION
🤖 Resolves #10644.

## 👋 Introduction

This PR skips directive forms tests and Chromatic snapshotting since the feature has no imminent launch.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> [!NOTE]
> Since storybook is not working, there is no way to test the disabling of Chromatic snapshots at the moment.

1. `make artisan CMD="test"`
2. Observe skipped tests for `DigitalContractingQuestionnaireTest`

## 📸 Screenshot

<img width="476" alt="Screen Shot 2024-06-12 at 12 31 11" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/e894be5c-7a8a-4e41-be05-cf0732025379">