### PR TITLE
[Fix] Adds namespace to `UserVerifyEmailTest` PHPUnit test

### DIFF
--- a/api/tests/Feature/UserVerifyEmailTest.php
+++ b/api/tests/Feature/UserVerifyEmailTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\Feature;
+
 use App\Facades\Notify;
 use App\Models\User;
 use App\Notifications\VerifyEmail;


### PR DESCRIPTION
🤖 Resolves #10681.

## 👋 Introduction

This PR adds a namespace to the `UserVerifyEmailTest` PHPUnit test.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Verify `UserVerifyEmailTest` file is not skipped during autoloading in CI: https://github.com/GCTC-NTGC/gc-digital-talent/actions/runs/9508374286/job/26209558009?pr=10682#step:7:542
2. Verify `UserVerifyEmailTest` does not comply with psr-4 autoloading standard message does not show CI: https://github.com/GCTC-NTGC/gc-digital-talent/actions/runs/9508374289/job/26209558172?pr=10682#step:5:316