### PR TITLE
[a11y] Announce mark all as read success to ATs

### DIFF
--- a/apps/web/src/components/NotificationList/NotificationActions.tsx
+++ b/apps/web/src/components/NotificationList/NotificationActions.tsx
@@ -2,6 +2,7 @@ import { useIntl } from "react-intl";
 import { useMutation } from "urql";
 
 import { Button, Link, useAnnouncer } from "@gc-digital-talent/ui";
+import { commonMessages, errorMessages } from "@gc-digital-talent/i18n";
 
 import useRoutes from "~/hooks/useRoutes";
 
@@ -40,12 +41,14 @@ const NotificationActions = ({
       })
       .catch(() => {
         announce(
-          intl.formatMessage({
-            defaultMessage: "Error: could not mark notifications as read.",
-            id: "lpx9/e",
-            description:
-              "Message announced to assistive technology when error occurred making notifications as read",
-          }),
+          intl.formatMessage(errorMessages.error) +
+            intl.formatMessage(commonMessages.dividingColon) +
+            intl.formatMessage({
+              defaultMessage: "could not mark notifications as read.",
+              id: "rmsF/w",
+              description:
+                "Message announced to assistive technology when error occurred making notifications as read",
+            }),
         );
       });
   };

--- a/apps/web/src/components/NotificationList/NotificationActions.tsx
+++ b/apps/web/src/components/NotificationList/NotificationActions.tsx
@@ -26,17 +26,28 @@ const NotificationActions = ({
     useMutation(MarkAllNotificationsAsRead_Mutation);
 
   const handleMarkAllNotificationsAsRead = () => {
-    executeMarkAllAsReadMutation({}).then(() => {
-      announce(
-        intl.formatMessage({
-          defaultMessage: "Notifications marked as read successfully.",
-          id: "7tAIPo",
-          description:
-            "Message announced to assistive technology when notifications marked as read",
-        }),
-      );
-      onRead?.();
-    });
+    executeMarkAllAsReadMutation({})
+      .then(() => {
+        announce(
+          intl.formatMessage({
+            defaultMessage: "Notifications marked as read successfully.",
+            id: "7tAIPo",
+            description:
+              "Message announced to assistive technology when notifications marked as read",
+          }),
+        );
+        onRead?.();
+      })
+      .catch(() => {
+        announce(
+          intl.formatMessage({
+            defaultMessage: "Error: could not mark notifications as read.",
+            id: "lpx9/e",
+            description:
+              "Message announced to assistive technology when error occurred making notifications as read",
+          }),
+        );
+      });
   };
 
   return (

--- a/apps/web/src/components/NotificationList/NotificationActions.tsx
+++ b/apps/web/src/components/NotificationList/NotificationActions.tsx
@@ -1,7 +1,7 @@
 import { useIntl } from "react-intl";
 import { useMutation } from "urql";
 
-import { Button, Link } from "@gc-digital-talent/ui";
+import { Button, Link, useAnnouncer } from "@gc-digital-talent/ui";
 
 import useRoutes from "~/hooks/useRoutes";
 
@@ -20,12 +20,21 @@ const NotificationActions = ({
 }: NotificationActionsProps) => {
   const intl = useIntl();
   const paths = useRoutes();
+  const { announce } = useAnnouncer();
 
   const [{ fetching: markingAllAsRead }, executeMarkAllAsReadMutation] =
     useMutation(MarkAllNotificationsAsRead_Mutation);
 
   const handleMarkAllNotificationsAsRead = () => {
     executeMarkAllAsReadMutation({}).then(() => {
+      announce(
+        intl.formatMessage({
+          defaultMessage: "Notifications marked as read successfully.",
+          id: "7tAIPo",
+          description:
+            "Message announced to assistive technology when notifications marked as read",
+        }),
+      );
       onRead?.();
     });
   };

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5200,7 +5200,7 @@
     "description": "IT-03 classification label including titles"
   },
   "RHwGy2": {
-    "defaultMessage": "Erreur: la publication du processus a échoué",
+    "defaultMessage": "Erreur : la publication du processus a échoué",
     "description": "Message displayed to user after pool fails to get publish."
   },
   "RIi/3q": {
@@ -9078,10 +9078,6 @@
     "defaultMessage": "À propos du Portail des talents autochtones",
     "description": "Talent Portal information heading"
   },
-  "lpx9/e": {
-    "defaultMessage": "Erreur: impossible de marquer les notifications comme lues.",
-    "description": "Message announced to assistive technology when error occurred making notifications as read"
-  },
   "lr6PWk": {
     "defaultMessage": "Si vous n’avez pas encore d’application d’authentification, vous devrez en télécharger une. Des fournisseurs numériques comme Google Authenticator et Microsoft Authenticator offrent des applications d’authentification. Quelle que soit l’application que vous choisissez, veillez à ce qu’elle provienne d’un fournisseur réputé.",
     "description": "Copy explaining mfa apps"
@@ -10129,6 +10125,10 @@
   "rmmLVI": {
     "defaultMessage": "Sélectionner un membre d’un groupe visé par l’équité en matière d’emploi par nomination, si plusieurs candidats qualifiés sont disponibles.",
     "description": "List item 3, how self-declaration data is used"
+  },
+  "rmsF/w": {
+    "defaultMessage": "impossible de marquer les notifications comme lues.",
+    "description": "Message announced to assistive technology when error occurred making notifications as read"
   },
   "rtzp80": {
     "defaultMessage": "Dressez la liste des compétences, de la formation ou de l’expérience précises requises pour effectuer le travail demandé.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1739,6 +1739,10 @@
     "defaultMessage": "Signer et continuer",
     "description": "Button text to submit the Indigenous self-declaration form."
   },
+  "7tAIPo": {
+    "defaultMessage": "Notifications marquées comme lues avec succès.",
+    "description": "Message announced to assistive technology when notifications marked as read"
+  },
   "7tdU/G": {
     "defaultMessage": "Erreur : échec de votre suppression des résultats de recherche.",
     "description": "Alert displayed to the user when application card dialog fails."
@@ -9073,6 +9077,10 @@
   "loDwKe": {
     "defaultMessage": "À propos du Portail des talents autochtones",
     "description": "Talent Portal information heading"
+  },
+  "lpx9/e": {
+    "defaultMessage": "Erreur: impossible de marquer les notifications comme lues.",
+    "description": "Message announced to assistive technology when error occurred making notifications as read"
   },
   "lr6PWk": {
     "defaultMessage": "Si vous n’avez pas encore d’application d’authentification, vous devrez en télécharger une. Des fournisseurs numériques comme Google Authenticator et Microsoft Authenticator offrent des applications d’authentification. Quelle que soit l’application que vous choisissez, veillez à ce qu’elle provienne d’un fournisseur réputé.",

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1771,6 +1771,10 @@
     "defaultMessage": "Durée indéterminée (permanente)",
     "description": "Duration that is permanent"
   },
+  "ra+8d1": {
+    "defaultMessage": "Erreur",
+    "description": "Generic error message"
+  },
   "rbhjTC": {
     "defaultMessage": "Bibliothèque des compétences",
     "description": "Name of the skill library page"

--- a/packages/i18n/src/messages/errorMessages.ts
+++ b/packages/i18n/src/messages/errorMessages.ts
@@ -1,6 +1,11 @@
 import { defineMessages } from "react-intl";
 
 const errorMessages = defineMessages({
+  error: {
+    defaultMessage: "Error",
+    id: "ra+8d1",
+    description: "Generic error message",
+  },
   required: {
     // These errors must be passed to react-hook-form as error messages, and it only expects strings.
     // However, when we use rich text elements like `<hidden>`, formatMessage will return ReactNode.


### PR DESCRIPTION
🤖 Resolves #10636 

## 👋 Introduction

Adds an announcement to ATs that the "mark all as read" was a success and an error alert on failure.

## 🧪 Testing

1. Build `pnpm run dev`
2. Login as any user (easier with `admin@test.com`)
3. Generate some notifications for the user
4. Open a screen reader
5. Use the "mark all as read" button either in the notifications dialog or on the `/applicant/notifications` page
6. Confirm success feedback is provided (announced)