### PR TITLE
[Accessibility] Focus on first loaded item

### DIFF
--- a/apps/web/src/components/NotificationList/NotificationItem.tsx
+++ b/apps/web/src/components/NotificationList/NotificationItem.tsx
@@ -2,7 +2,7 @@ import { useIntl } from "react-intl";
 import { Link as BaseLink, useNavigate } from "react-router-dom";
 import EllipsisVerticalIcon from "@heroicons/react/20/solid/EllipsisVerticalIcon";
 import { useMutation } from "urql";
-import { ReactNode, MouseEvent } from "react";
+import { ReactNode, MouseEvent, useEffect } from "react";
 
 import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
 import {
@@ -80,12 +80,14 @@ interface NotificationItemProps {
   /** The actual notification type */
   notification: FragmentType<typeof NotificationItem_Fragment>;
   inDialog?: boolean;
+  focusRef?: React.MutableRefObject<HTMLAnchorElement | null>;
   onRead?: () => void;
 }
 
 const NotificationItem = ({
   notification: notificationQuery,
   inDialog,
+  focusRef,
   onRead,
 }: NotificationItemProps) => {
   const intl = useIntl();
@@ -102,6 +104,10 @@ const NotificationItem = ({
   );
   const [{ fetching: markingAsUnread }, executeMarkAsUnreadMutation] =
     useMutation(MarkNotificationAsUnread_Mutation);
+
+  useEffect(() => {
+    if (focusRef) focusRef.current?.focus();
+  }, [focusRef]);
 
   if (!info) return null;
 
@@ -185,6 +191,7 @@ const NotificationItem = ({
             <LinkWrapper inDialog={inDialog}>
               <BaseLink
                 to={info.href}
+                ref={focusRef}
                 onClick={handleLinkClicked}
                 data-h2-text-decoration="base(none)"
                 data-h2-color="base:hover(secondary.darker)"

--- a/apps/web/src/components/NotificationList/NotificationListPage.tsx
+++ b/apps/web/src/components/NotificationList/NotificationListPage.tsx
@@ -1,6 +1,7 @@
 import { useIntl } from "react-intl";
 import { useQuery } from "urql";
 import { useSearchParams } from "react-router-dom";
+import { useRef } from "react";
 
 import { Scalars, graphql } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
@@ -80,13 +81,18 @@ const NotificationListPage = ({
     !fetching &&
     exclude.length === 0;
 
+  const firstNewNotification = useRef<HTMLAnchorElement>(null);
+
   return (
     <>
       {notifications.length > 0 ? (
         <>
-          {notifications.map((notification) => (
+          {notifications.map((notification, index) => (
             <NotificationItem
               key={notification.id}
+              focusRef={
+                index === 0 && page !== 1 ? firstNewNotification : undefined
+              }
               notification={notification}
               inDialog={inDialog}
               onRead={onRead}


### PR DESCRIPTION
🤖 Resolves #10640 

## 👋 Introduction

- Moves focus onto the first item of newly loaded notifications

## 🧪 Testing

I found the easiest way to seed data was adding `admin@test.com` to a pool, then changing the pool candidate status as many times as needed...

1. Login as `admin@test.com`
2. Seed data
3. Go to notifications page
4. Try loading more notifications and ensure that focus lands on first loaded notification.
