### PR TITLE
[Fix] Stabilize snapshots

### DIFF
--- a/apps/web/src/components/Footer/Footer.tsx
+++ b/apps/web/src/components/Footer/Footer.tsx
@@ -60,9 +60,11 @@ const Footer = ({ width }: FooterProps) => {
       }),
     },
   ];
+
   let footerWidth = {
     "data-h2-container": "base(center, large, x1) p-tablet(center, large, x2)",
   };
+
   if (width === "full") {
     footerWidth = {
       "data-h2-container": "base(center, full, x1) p-tablet(center, full, x2)",

--- a/packages/storybook-helpers/main.ts
+++ b/packages/storybook-helpers/main.ts
@@ -36,8 +36,20 @@ const main: StorybookConfig = {
   // REF: https://stackoverflow.com/questions/77540892/chromatic-github-action-is-failing
   viteFinal(config) {
     config.plugins = (config.plugins ?? []).filter(
-      (plugin) => plugin && "name" in plugin && plugin.name !== "vite:dts",
+      (plugin) =>
+        plugin &&
+        "name" in plugin &&
+        plugin.name !== "vite:dts" &&
+        // Filter out git version plugin to hardcode for
+        // Stable snapshots
+        plugin.name !== "git-version",
     );
+    config.define = {
+      ...config.define,
+      // Hardcode vars for stable snapshots
+      BUILD_DATE: JSON.stringify("1970-01-01"),
+      VERSION: JSON.stringify("v1.0.0"),
+    };
     return config;
   },
 };


### PR DESCRIPTION
🤖 Resolves #10769 

## 👋 Introduction

Stabilizes the footer snapshots.

## 🕵️ Details

We had some dynamic variables leading for false positives on chromatic diffs. This hardcodes those to make the snapshots more stable.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Run storybook `pnpm run storybook`
2. Confirm footer store contains the hard coded data

## 📸 Screenshot

![screenshot_24-Jun-2024_15-55-1719258929](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/a945a749-ff90-4ea2-9d94-1d590ee6ce97)
