### PR TITLE
[Fix] Flaky pool bookmark scope test

### DIFF
--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -1534,8 +1534,8 @@ class PoolTest extends TestCase
      */
     public function testPoolBookmarksScope(): void
     {
-        $pool1 = Pool::factory()->create();
-        $pool2 = Pool::factory()->withBookmark($this->adminUser->id)->create();
+        $pool1 = Pool::factory(['created_at' => config('constants.past_date')])->create();
+        $pool2 = Pool::factory(['created_at' => config('constants.past_date')])->withBookmark($this->adminUser->id)->create();
         $pool3 = Pool::factory()->create();
 
         $query = /** @lang GraphQL */


### PR DESCRIPTION
🤖 Resolves #10651.

## 👋 Introduction

Fixes the flaky pool bookmark scope test.

## 🧪 Testing

1. CI successful
2. Local testing succeeds

`for i in {1..25}; do docker-compose run --rm -w /var/www/html/api maintenance sh -c "./vendor/bin/phpunit ./tests/Feature/PoolTest.php"; done`