### PR TITLE
[Fix] Add auth paths to allowed cors

### DIFF
--- a/api/config/cors.php
+++ b/api/config/cors.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'paths' => ['api/*', 'sanctum/csrf-cookie', 'graphql', 'admin/graphql'],
+    'paths' => ['api/*', 'sanctum/csrf-cookie', 'graphql', 'admin/graphql', 'refresh', 'login'],
 
     'allowed_methods' => ['*'],
 


### PR DESCRIPTION
🤖 Resolves #10779 

## 👋 Introduction

Adds our missing auth paths to the allowed cors paths for the dev server.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Set token expiry to a low amount in ./infrastructure/conf/mock-oauth2-server.json
2. Bust config cache `make artisan CMD="config:cache"`
3. Run he dev server pnpm run watch
4. Login
5. Wait for the token to expire
6. Navigate to attempt a refresh
7. Confirm token can be refreshed