### PR TITLE
[Fix] Add postgresql client to app service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,4 @@ lint-php:
 	$(DOCKER_API) "vendor/bin/pint --test"
 
 queue-work:
-	docker-compose exec sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan queue:work"
+	docker-compose exec webserver sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan queue:work"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,9 @@ services:
       - 8080:8080
 
   webserver:
-    # All images: https://mcr.microsoft.com/v2/appsvc/php/tags/list
-    image: mcr.microsoft.com/appsvc/php:8.2-fpm-xdebug_20230908.3.tuxprod
+    build:
+      context: ./
+      dockerfile: infrastructure/webserver.Dockerfile
     restart: always
     volumes:
       - ./:/home/site/wwwroot

--- a/infrastructure/bin/post_deployment.sh
+++ b/infrastructure/bin/post_deployment.sh
@@ -28,7 +28,7 @@ fi
 BLOCKS="{ \"type\": \"header\", \"text\": { \"type\": \"plain_text\", \"text\": \"Post-deployment script was run\" } }"
 
 # Install packages from repository
-if apt-get update && apt-get install -y supervisor cron; then
+if apt-get update && apt-get install --yes --no-install-recommends supervisor cron postgresql-client; then
     add_section_block ":white_check_mark: Install packages from repository *successful*."
 else
     add_section_block ":X: Install packages from repository *failed*. $MENTION"

--- a/infrastructure/maintenance-container/Dockerfile
+++ b/infrastructure/maintenance-container/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
   && apt-get install -y perl unzip wget curl \
   && apt-get install -y php8.2 php-mbstring php-xml php-pgsql php-zip php-curl php-bcmath php-gd \
-  && apt-get install ---yes --no-install-recommends git postgresql-client
+  && apt-get install --yes --no-install-recommends git postgresql-client
 
 # install node from official image
 # https://gist.github.com/BretFisher/da34530726ff8076b83b583e527e91ed

--- a/infrastructure/webserver.Dockerfile
+++ b/infrastructure/webserver.Dockerfile
@@ -1,0 +1,9 @@
+# This setup should only install things that are set up in infrastructure/bin/post_deployment.sh as well
+
+# All images: https://mcr.microsoft.com/v2/appsvc/php/tags/list
+FROM mcr.microsoft.com/appsvc/php:8.2-fpm-xdebug_20230908.3.tuxprod
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends supervisor cron postgresql-client \
+    && apt-get --yes autoremove \
+    && apt-get clean


### PR DESCRIPTION
🤖 Resolves #10777 

## 👋 Introduction

This branch adds the postgresql to the app service setup to ensure that a fresh setup is possible.  It also adds it to the local webserver docker container to mirror the setup.

## 🕵️ Details

I created a custom Dockerfile for the webserver image.  Before, we were pretty strict about using a pristine image but this is a convenient way to mimic some of the customization we perform on the image during post-deploy.

## 🧪 Testing

### :house: Locally

1. Rebuild the webserver image `docker-compose build webserver`
2. Composer install by whatever method you normally use

- [ ] Can perform a database reset in the webserver container  `docker-compose exec webserver sh -c "php /home/site/wwwroot/api/artisan migrate:fresh"`

### :cloud: Azure

1. Deploy this branch to the dev vertical
2. SSH in

- [ ] Can perform a database reset `php /home/site/wwwroot/api/artisan migrate:fresh`

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/42ed0049-4857-46f3-a724-c0001a0d362f)
