### PR TITLE
[Docs] Adds `request_responder`, `community_manager` roles

### DIFF
--- a/documentation/sign-in-canada.md
+++ b/documentation/sign-in-canada.md
@@ -25,10 +25,10 @@
 4. Start your account at the [Welcome to GC Digital Talent](http://localhost:8000/en/create-account) page
 5. Copy the email address entered on the Welcome to GC Digital Talent page form for later
 6. Run `php artisan tinker` in `/api` directory
-7. Run the following code block in tinker to add `base_user`, `applicant`, and `platform_admin` roles to the user previously created (replace *username@domain.tld* with email previously copied in step 5)
+7. Run the following code block in tinker to add `base_user`, `applicant`, `request_responder`, `community_manager`, and `platform_admin` roles to the user previously created (replace *username@domain.tld* with email previously copied in step 5)
 
 ```
 $user = User::where('email', 'username@domain.tld')->sole();
-$user->addRoles(['base_user', 'applicant', 'platform_admin']);
+$user->addRoles(['base_user', 'applicant', 'request_responder', 'community_manager', 'platform_admin']);
 $user->roles()->get()->pluck('name');
 ```


### PR DESCRIPTION
🤖 Resolves #10766.

## 👋 Introduction

This PR adds `request_responder`, `community_manager` roles to the Sign in Canada documentation example.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Observe `documentation/sign-in-canada.md` account creation adds `request_responder`, `community_manager` roles to the user
2. Verify updated tinker command still works