### PR TITLE
[Fix] Updates table `nullMessage` descriptions

### DIFF
--- a/apps/web/src/components/Table/ResponsiveTable/NullMessage.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/NullMessage.tsx
@@ -3,6 +3,8 @@ import { ReactNode } from "react";
 
 import { Heading, Well } from "@gc-digital-talent/ui";
 
+import tableMessages from "../tableMessages";
+
 export interface NullMessageProps {
   /** Heading for the message */
   title?: ReactNode;
@@ -24,21 +26,10 @@ const NullMessage = ({ title, description }: NullMessageProps) => {
   return (
     <Well data-h2-margin="base(x1 0)" data-h2-text-align="base(center)">
       <Heading data-h2-margin-top="base(0)" data-h2-font-size="base(copy)">
-        {title ||
-          intl.formatMessage({
-            defaultMessage: "There aren't any items here.",
-            id: "84XrK+",
-            description: "Default message for an empty table",
-          })}
+        {title || intl.formatMessage(tableMessages.noItemsTitle)}
       </Heading>
       <p>
-        {description ||
-          intl.formatMessage({
-            defaultMessage:
-              'Get started by adding an item using the "Add a new item" button provided.',
-            id: "/GIL9l",
-            description: "Default description for an empty table",
-          })}
+        {description || intl.formatMessage(tableMessages.noItemsDescription)}
       </p>
     </Well>
   );

--- a/apps/web/src/components/Table/ResponsiveTable/NullMessage.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/NullMessage.tsx
@@ -26,8 +26,8 @@ const NullMessage = ({ title, description }: NullMessageProps) => {
       <Heading data-h2-margin-top="base(0)" data-h2-font-size="base(copy)">
         {title ||
           intl.formatMessage({
-            defaultMessage: "There aren't any items here yet.",
-            id: "H5kSPB",
+            defaultMessage: "There aren't any items here.",
+            id: "84XrK+",
             description: "Default message for an empty table",
           })}
       </Heading>

--- a/apps/web/src/components/Table/ResponsiveTable/NullMessage.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/NullMessage.tsx
@@ -25,12 +25,10 @@ const NullMessage = ({ title, description }: NullMessageProps) => {
 
   return (
     <Well data-h2-margin="base(x1 0)" data-h2-text-align="base(center)">
-      <Heading data-h2-margin-top="base(0)" data-h2-font-size="base(copy)">
+      <Heading data-h2-margin="base(0)" data-h2-font-size="base(copy)">
         {title || intl.formatMessage(tableMessages.noItemsTitle)}
       </Heading>
-      <p>
-        {description || intl.formatMessage(tableMessages.noItemsDescription)}
-      </p>
+      {description && <p data-h2-margin-top="base(x1)">{description}</p>}
     </Well>
   );
 };

--- a/apps/web/src/components/Table/tableMessages.ts
+++ b/apps/web/src/components/Table/tableMessages.ts
@@ -6,6 +6,17 @@ const messages = defineMessages({
     id: "cIqhQK",
     description: "Message when there is no data to display in a table",
   },
+  noItemsTitle: {
+    defaultMessage: "There aren't any items here.",
+    id: "84XrK+",
+    description: "Default message for an empty table",
+  },
+  noItemsDescription: {
+    defaultMessage:
+      'Get started by adding an item using the "Add a new item" button provided.',
+    id: "/GIL9l",
+    description: "Default description for an empty table",
+  },
 });
 
 export default messages;

--- a/apps/web/src/components/Table/tableMessages.ts
+++ b/apps/web/src/components/Table/tableMessages.ts
@@ -1,11 +1,6 @@
 import { defineMessages } from "react-intl";
 
 const messages = defineMessages({
-  noItems: {
-    defaultMessage: "There are no items to display.",
-    id: "cIqhQK",
-    description: "Message when there is no data to display in a table",
-  },
   noItemsTitle: {
     defaultMessage: "There aren't any items here.",
     id: "84XrK+",

--- a/apps/web/src/components/Table/tableMessages.ts
+++ b/apps/web/src/components/Table/tableMessages.ts
@@ -11,12 +11,6 @@ const messages = defineMessages({
     id: "84XrK+",
     description: "Default message for an empty table",
   },
-  noItemsDescription: {
-    defaultMessage:
-      'Get started by adding an item using the "Add a new item" button provided.',
-    id: "/GIL9l",
-    description: "Default description for an empty table",
-  },
 });
 
 export default messages;

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1819,6 +1819,10 @@
     "defaultMessage": "J'envisagerais d'accepter un emploi qui...",
     "description": "Legend for optional work preferences check list in work preferences form"
   },
+  "84XrK+": {
+    "defaultMessage": "On ne trouve aucun élément ici.",
+    "description": "Default message for an empty table"
+  },
   "84rSVg": {
     "defaultMessage": "Permettre une croissance dans le cadre de sa portée de recrutement, en ciblant d’autres domaines professionnels à l’avenir.",
     "description": "Talent portal strategy item 2 content"
@@ -3462,10 +3466,6 @@
   "H5EXEi": {
     "defaultMessage": "En savoir plus sur cette possibilité et commencer à rédiger une demande d'emploi.",
     "description": "Subtitle for a pool advertisement page"
-  },
-  "H5kSPB": {
-    "defaultMessage": "On ne trouve aucun élément jusqu’à présent.",
-    "description": "Default message for an empty table"
   },
   "H8cs1r": {
     "defaultMessage": "Services consultatifs auprès des secteurs d’activité de la <abbreviation>TI</abbreviation>",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -191,6 +191,10 @@
     "defaultMessage": "Voir {name} <hidden>{hiddenLabel}</hidden>",
     "description": "Title displayed for the View Item column."
   },
+  "+zSc5y": {
+    "defaultMessage": "Utilisez le bouton \"Créer une équipe\" pour commencer.",
+    "description": "Instructions for adding a team item."
+  },
   "/+naWC": {
     "defaultMessage": "À évaluer",
     "description": "Message displayed when candidate has yet to be assessed at a specific assessment step"
@@ -230,10 +234,6 @@
   "/DCykA": {
     "defaultMessage": "J'envisagerais d'accepter un emploi d'une durée de...",
     "description": "Legend Text for required work preferences options in work preferences form"
-  },
-  "/GIL9l": {
-    "defaultMessage": "Ajoutez un élément pour commencer en cliquant sur le bouton afficher « Ajouter un nouvel élément ».",
-    "description": "Default description for an empty table"
   },
   "/I7wrY": {
     "defaultMessage": "Lier des compétences en vedette",
@@ -351,6 +351,10 @@
     "defaultMessage": "Statut du bassin de candidats",
     "description": "Label for the current applications pool status"
   },
+  "/pbxol": {
+    "defaultMessage": "Utilisez le bouton \"Ajouter une nouvelle adhésion\" pour commencer.",
+    "description": "Instructions for adding team membership to a user."
+  },
   "/qN7tM": {
     "defaultMessage": "Expérience supprimée",
     "description": "Message displayed to user after experience deleted."
@@ -402,6 +406,10 @@
   "07p+1J": {
     "defaultMessage": "Avez-vous d'autres questions? N'hésitez pas à <link> communiquer avec notre équipe</link> pour obtenir de plus amples renseignements. ",
     "description": "Third paragraph for pool closing date dialog"
+  },
+  "07sCDh": {
+    "defaultMessage": "Utilisez le bouton \"Créer un processus\" pour commencer.",
+    "description": "Instructions for adding a process item."
   },
   "08rkLr": {
     "defaultMessage": "Durée de la possibilité",
@@ -530,6 +538,10 @@
   "0jV7Rn": {
     "defaultMessage": "Complet",
     "description": "Simplified status label for a complete process advertisement or assessment"
+  },
+  "0jwdac": {
+    "defaultMessage": "Utilisez le bouton \"Créer une compétence\" pour commencer.",
+    "description": "Instructions for adding a skill item."
   },
   "0k6j4V": {
     "defaultMessage": "Tâches de travail (anglais)",
@@ -5479,6 +5491,10 @@
     "defaultMessage": "Vous recevrez des candidats qui ont :",
     "description": "Title for the candidate list in the 'Indigenous talent ready for IT apprenticeships' section"
   },
+  "SfbDLA": {
+    "defaultMessage": "Utilisez le bouton \"Ajouter un nouveau membre\" pour commencer.",
+    "description": "Instructions for adding a member to a team."
+  },
   "SfhT1q": {
     "defaultMessage": "Acquérir de l'expérience en matière d'embauche",
     "description": "Title to get hiring experience"
@@ -5646,6 +5662,10 @@
   "Tjd942": {
     "defaultMessage": "Solutions logicielles de la <abbreviation>TI</abbreviation>",
     "description": "Title for the 'software solutions' IT work stream"
+  },
+  "Tl2FNA": {
+    "defaultMessage": "Utilisez le bouton \"Créer une classification\" pour commencer.",
+    "description": "Instructions for adding a classification item."
   },
   "TomxAe": {
     "defaultMessage": "{time} le {date}",
@@ -6085,6 +6105,10 @@
   "WAcWqh": {
     "defaultMessage": "{title} évaluation - {skillName}",
     "description": "Header for application screening decision dialog."
+  },
+  "WCOVvw": {
+    "defaultMessage": "Utilisez le bouton \"Ajouter un nouveau rôle\" pour commencer.",
+    "description": "Instructions for adding a role to a user."
   },
   "WDKT2K": {
     "defaultMessage": "Qu'est-ce qu'une CléGC?",
@@ -11302,6 +11326,10 @@
     "defaultMessage": "Un code d’identification de dossier personnel (CIDP)",
     "description": "Item 4 in the candidate list in the 'Indigenous talent ready for IT apprenticeships' section"
   },
+  "yat9wx": {
+    "defaultMessage": "Utilisez le bouton \"Créer un ministère\" pour commencer.",
+    "description": "Instructions for adding a department item."
+  },
   "ybzxmU": {
     "defaultMessage": "Membre des FAC",
     "description": "Veteran/member label"
@@ -11477,6 +11505,10 @@
   "znuDvD": {
     "defaultMessage": "Sélectionner des compétences dans votre bibliothèque ou en ajouter de toutes nouvelles.",
     "description": "Subtitle for the find a skill dialog within the skill showcase"
+  },
+  "zp1ShM": {
+    "defaultMessage": "Utilisez le bouton \"Créer une famille de compétences\" pour commencer.",
+    "description": "Instructions for adding a skill family item."
   },
   "zp8FqH": {
     "defaultMessage": "Vos réponses aux  <strong>questions de présélection seront évaluées</strong> dans le cadre de votre demande d'emploi. Veillez donc à consacrer à chaque question le temps et la réflexion nécessaires pour donner une réponse qui vous reflète réellement votre identité et votre expérience.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7298,10 +7298,6 @@
     "defaultMessage": "Candidature",
     "description": "Label for the application link column"
   },
-  "cIqhQK": {
-    "defaultMessage": "Il n'y a aucun élément à afficher.",
-    "description": "Message when there is no data to display in a table"
-  },
   "cL3OoZ": {
     "defaultMessage": "Notification non lue",
     "description": "Link text to show unread notifications"

--- a/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
+++ b/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
@@ -18,6 +18,7 @@ import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import cells from "~/components/Table/cells";
 import adminMessages from "~/messages/adminMessages";
 import { normalizedText } from "~/components/Table/sortingFns";
+import tableMessages from "~/components/Table/tableMessages";
 
 export const ClassificationTableRow_Fragment = graphql(/* GraphQL */ `
   fragment ClassificationTableRow on Classification {
@@ -156,6 +157,9 @@ export const ClassificationTable = ({
           }),
           from: currentUrl,
         },
+      }}
+      nullMessage={{
+        description: intl.formatMessage(tableMessages.noItemsDescription),
       }}
     />
   );

--- a/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
+++ b/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
@@ -18,7 +18,6 @@ import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import cells from "~/components/Table/cells";
 import adminMessages from "~/messages/adminMessages";
 import { normalizedText } from "~/components/Table/sortingFns";
-import tableMessages from "~/components/Table/tableMessages";
 
 export const ClassificationTableRow_Fragment = graphql(/* GraphQL */ `
   fragment ClassificationTableRow on Classification {
@@ -159,7 +158,12 @@ export const ClassificationTable = ({
         },
       }}
       nullMessage={{
-        description: intl.formatMessage(tableMessages.noItemsDescription),
+        description: intl.formatMessage({
+          defaultMessage:
+            'Use the "Create Classification" button to get started.',
+          id: "Tl2FNA",
+          description: "Instructions for adding a classification item.",
+        }),
       }}
     />
   );

--- a/apps/web/src/pages/Departments/components/DepartmentTable.tsx
+++ b/apps/web/src/pages/Departments/components/DepartmentTable.tsx
@@ -17,7 +17,6 @@ import useRoutes from "~/hooks/useRoutes";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import cells from "~/components/Table/cells";
 import { normalizedText } from "~/components/Table/sortingFns";
-import tableMessages from "~/components/Table/tableMessages";
 
 const columnHelper = createColumnHelper<Department>();
 
@@ -113,7 +112,11 @@ export const DepartmentTable = ({
         },
       }}
       nullMessage={{
-        description: intl.formatMessage(tableMessages.noItemsDescription),
+        description: intl.formatMessage({
+          defaultMessage: 'Use the "Create Department" button to get started.',
+          id: "yat9wx",
+          description: "Instructions for adding a department item.",
+        }),
       }}
     />
   );

--- a/apps/web/src/pages/Departments/components/DepartmentTable.tsx
+++ b/apps/web/src/pages/Departments/components/DepartmentTable.tsx
@@ -17,6 +17,7 @@ import useRoutes from "~/hooks/useRoutes";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import cells from "~/components/Table/cells";
 import { normalizedText } from "~/components/Table/sortingFns";
+import tableMessages from "~/components/Table/tableMessages";
 
 const columnHelper = createColumnHelper<Department>();
 
@@ -110,6 +111,9 @@ export const DepartmentTable = ({
           }),
           from: currentUrl,
         },
+      }}
+      nullMessage={{
+        description: intl.formatMessage(tableMessages.noItemsDescription),
       }}
     />
   );

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -40,6 +40,7 @@ import accessors from "~/components/Table/accessors";
 import cells from "~/components/Table/cells";
 import adminMessages from "~/messages/adminMessages";
 import processMessages from "~/messages/processMessages";
+import tableMessages from "~/components/Table/tableMessages";
 
 import {
   classificationAccessor,
@@ -439,6 +440,9 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
             description: "Heading displayed above the Create process form.",
           }),
         },
+      }}
+      nullMessage={{
+        description: intl.formatMessage(tableMessages.noItemsDescription),
       }}
     />
   );

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -40,7 +40,6 @@ import accessors from "~/components/Table/accessors";
 import cells from "~/components/Table/cells";
 import adminMessages from "~/messages/adminMessages";
 import processMessages from "~/messages/processMessages";
-import tableMessages from "~/components/Table/tableMessages";
 
 import {
   classificationAccessor,
@@ -442,7 +441,11 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
         },
       }}
       nullMessage={{
-        description: intl.formatMessage(tableMessages.noItemsDescription),
+        description: intl.formatMessage({
+          defaultMessage: 'Use the "Create process" button to get started.',
+          id: "07sCDh",
+          description: "Instructions for adding a process item.",
+        }),
       }}
     />
   );

--- a/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
+++ b/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
@@ -13,7 +13,6 @@ import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import cells from "~/components/Table/cells";
 import adminMessages from "~/messages/adminMessages";
 import { normalizedText } from "~/components/Table/sortingFns";
-import tableMessages from "~/components/Table/tableMessages";
 
 const columnHelper = createColumnHelper<SkillFamily>();
 
@@ -110,7 +109,12 @@ export const SkillFamilyTable = ({
         },
       }}
       nullMessage={{
-        description: intl.formatMessage(tableMessages.noItemsDescription),
+        description: intl.formatMessage({
+          defaultMessage:
+            'Use the "Create Skill Family" button to get started.',
+          id: "zp1ShM",
+          description: "Instructions for adding a skill family item.",
+        }),
       }}
     />
   );

--- a/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
+++ b/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
@@ -13,6 +13,7 @@ import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import cells from "~/components/Table/cells";
 import adminMessages from "~/messages/adminMessages";
 import { normalizedText } from "~/components/Table/sortingFns";
+import tableMessages from "~/components/Table/tableMessages";
 
 const columnHelper = createColumnHelper<SkillFamily>();
 
@@ -107,6 +108,9 @@ export const SkillFamilyTable = ({
           }),
           from: currentUrl,
         },
+      }}
+      nullMessage={{
+        description: intl.formatMessage(tableMessages.noItemsDescription),
       }}
     />
   );

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -28,7 +28,6 @@ import {
   SEARCH_PARAM_KEY,
 } from "~/components/Table/ResponsiveTable/constants";
 import messages from "~/lang/frCompiled.json";
-import tableMessages from "~/components/Table/tableMessages";
 
 import {
   categoryAccessor,
@@ -302,7 +301,11 @@ const SkillTable = ({
           : undefined
       }
       nullMessage={{
-        description: intl.formatMessage(tableMessages.noItemsDescription),
+        description: intl.formatMessage({
+          defaultMessage: 'Use the "Create skill" button to get started.',
+          id: "0jwdac",
+          description: "Instructions for adding a skill item.",
+        }),
       }}
       filter={{
         state: filterState,

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -28,6 +28,7 @@ import {
   SEARCH_PARAM_KEY,
 } from "~/components/Table/ResponsiveTable/constants";
 import messages from "~/lang/frCompiled.json";
+import tableMessages from "~/components/Table/tableMessages";
 
 import {
   categoryAccessor,
@@ -300,6 +301,9 @@ const SkillTable = ({
             }
           : undefined
       }
+      nullMessage={{
+        description: intl.formatMessage(tableMessages.noItemsDescription),
+      }}
       filter={{
         state: filterState,
         component: (

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
@@ -18,6 +18,7 @@ import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import cells from "~/components/Table/cells";
 import { normalizedText } from "~/components/Table/sortingFns";
 import adminMessages from "~/messages/adminMessages";
+import tableMessages from "~/components/Table/tableMessages";
 
 import { MyRoleTeam } from "./types";
 import {
@@ -157,6 +158,9 @@ export const TeamTable = ({
           }),
           from: currentUrl,
         },
+      }}
+      nullMessage={{
+        description: intl.formatMessage(tableMessages.noItemsDescription),
       }}
     />
   );

--- a/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
+++ b/apps/web/src/pages/Teams/IndexTeamPage/components/TeamTable/TeamTable.tsx
@@ -18,7 +18,6 @@ import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import cells from "~/components/Table/cells";
 import { normalizedText } from "~/components/Table/sortingFns";
 import adminMessages from "~/messages/adminMessages";
-import tableMessages from "~/components/Table/tableMessages";
 
 import { MyRoleTeam } from "./types";
 import {
@@ -160,7 +159,11 @@ export const TeamTable = ({
         },
       }}
       nullMessage={{
-        description: intl.formatMessage(tableMessages.noItemsDescription),
+        description: intl.formatMessage({
+          defaultMessage: 'Use the "Create Team" button to get started.',
+          id: "+zSc5y",
+          description: "Instructions for adding a team item.",
+        }),
       }}
     />
   );

--- a/apps/web/src/pages/Teams/TeamMembersPage/TeamMembersPage.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/TeamMembersPage.tsx
@@ -20,7 +20,6 @@ import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
-import tableMessages from "~/components/Table/tableMessages";
 
 import AddTeamMemberDialog from "./components/AddTeamMemberDialog";
 import { actionCell, emailLinkCell, roleAccessor, roleCell } from "./helpers";
@@ -126,10 +125,14 @@ const TeamMembers = ({ teamQuery }: TeamMembersProps) => {
           add: {
             component: <AddTeamMemberDialog team={team} members={members} />,
           },
+          nullMessage: {
+            description: intl.formatMessage({
+              defaultMessage: 'Use the "Add new member" button to get started.',
+              id: "SfbDLA",
+              description: "Instructions for adding a member to a team.",
+            }),
+          },
         })}
-        nullMessage={{
-          description: intl.formatMessage(tableMessages.noItemsDescription),
-        }}
       />
     </>
   );

--- a/apps/web/src/pages/Teams/TeamMembersPage/TeamMembersPage.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/TeamMembersPage.tsx
@@ -20,6 +20,7 @@ import useRequiredParams from "~/hooks/useRequiredParams";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import tableMessages from "~/components/Table/tableMessages";
 
 import AddTeamMemberDialog from "./components/AddTeamMemberDialog";
 import { actionCell, emailLinkCell, roleAccessor, roleCell } from "./helpers";
@@ -126,6 +127,9 @@ const TeamMembers = ({ teamQuery }: TeamMembersProps) => {
             component: <AddTeamMemberDialog team={team} members={members} />,
           },
         })}
+        nullMessage={{
+          description: intl.formatMessage(tableMessages.noItemsDescription),
+        }}
       />
     </>
   );

--- a/apps/web/src/pages/Users/UpdateUserPage/components/IndividualRoleTable.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/IndividualRoleTable.tsx
@@ -9,6 +9,7 @@ import { UpdateUserRolesInput, Role, User } from "@gc-digital-talent/graphql";
 
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import { normalizedText } from "~/components/Table/sortingFns";
+import tableMessages from "~/components/Table/tableMessages";
 
 import { UpdateUserRolesFunc } from "../types";
 import AddIndividualRoleDialog from "./AddIndividualRoleDialog";
@@ -99,6 +100,9 @@ const IndividualRoleTable = ({
               onAddRoles={handleAddRoles}
             />
           ),
+        }}
+        nullMessage={{
+          description: intl.formatMessage(tableMessages.noItemsDescription),
         }}
       />
     </>

--- a/apps/web/src/pages/Users/UpdateUserPage/components/IndividualRoleTable.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/IndividualRoleTable.tsx
@@ -9,7 +9,6 @@ import { UpdateUserRolesInput, Role, User } from "@gc-digital-talent/graphql";
 
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import { normalizedText } from "~/components/Table/sortingFns";
-import tableMessages from "~/components/Table/tableMessages";
 
 import { UpdateUserRolesFunc } from "../types";
 import AddIndividualRoleDialog from "./AddIndividualRoleDialog";
@@ -102,7 +101,11 @@ const IndividualRoleTable = ({
           ),
         }}
         nullMessage={{
-          description: intl.formatMessage(tableMessages.noItemsDescription),
+          description: intl.formatMessage({
+            defaultMessage: 'Use the "Add new role" button to get started.',
+            id: "WCOVvw",
+            description: "Instructions for adding a role to a user.",
+          }),
         }}
       />
     </>

--- a/apps/web/src/pages/Users/UpdateUserPage/components/TeamRoleTable.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/TeamRoleTable.tsx
@@ -17,7 +17,6 @@ import useRoutes from "~/hooks/useRoutes";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import { normalizedText } from "~/components/Table/sortingFns";
 import adminMessages from "~/messages/adminMessages";
-import tableMessages from "~/components/Table/tableMessages";
 
 import { TeamAssignment, UpdateUserRolesFunc } from "../types";
 import AddTeamRoleDialog from "./AddTeamRoleDialog";
@@ -180,7 +179,12 @@ const TeamRoleTable = ({
           ),
         }}
         nullMessage={{
-          description: intl.formatMessage(tableMessages.noItemsDescription),
+          description: intl.formatMessage({
+            defaultMessage:
+              'Use the "Add new membership" button to get started.',
+            id: "/pbxol",
+            description: "Instructions for adding team membership to a user.",
+          }),
         }}
       />
     </>

--- a/apps/web/src/pages/Users/UpdateUserPage/components/TeamRoleTable.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/TeamRoleTable.tsx
@@ -17,6 +17,7 @@ import useRoutes from "~/hooks/useRoutes";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import { normalizedText } from "~/components/Table/sortingFns";
 import adminMessages from "~/messages/adminMessages";
+import tableMessages from "~/components/Table/tableMessages";
 
 import { TeamAssignment, UpdateUserRolesFunc } from "../types";
 import AddTeamRoleDialog from "./AddTeamRoleDialog";
@@ -177,6 +178,9 @@ const TeamRoleTable = ({
               onAddRoles={handleEditRoles}
             />
           ),
+        }}
+        nullMessage={{
+          description: intl.formatMessage(tableMessages.noItemsDescription),
         }}
       />
     </>


### PR DESCRIPTION
🤖 Resolves #9463.

## 👋 Introduction

This PR removes the fallback for the `nullMessage.description` prop for the `Table` component and adds custom messages for where there is an `add` prop.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to tables
2. Verify any table that has an add or create button has an instructional description when the table yields no results.

## 📸 Screenshots

### `add` prop exists
<img width="1254" alt="Screen Shot 2024-06-25 at 15 38 47" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/d9aaf59e-c72f-4a48-a5ac-36b9f5ade779">

### `add` prop does not exist
<img width="1257" alt="Screen Shot 2024-06-25 at 15 43 33" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/5638c261-77da-4b9b-a742-646b2646503a">
