### PR TITLE
[Fix] `ExperienceSortAndFilter` spacing

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
@@ -322,7 +322,7 @@ export const ApplicationCareerTimeline = ({
 
       <div
         data-h2-flex-grid="base(center, x1, x1)"
-        data-h2-margin-bottom="base(x.5)"
+        data-h2-padding-bottom="base(x.5)"
       >
         <ExperienceSortAndFilter
           initialFormValues={sortAndFilterValues}

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineSection.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineSection.tsx
@@ -47,7 +47,7 @@ const CareerTimelineSection = ({
     <>
       <div
         data-h2-flex-grid="base(center, x1, x1)"
-        data-h2-margin-bottom="base(x.5)"
+        data-h2-padding-bottom="base(x.5)"
       >
         <ExperienceSortAndFilter
           initialFormValues={sortAndFilterValues}


### PR DESCRIPTION
🤖 Resolves #10784.

## 👋 Introduction

This PR fixes the spacing between actions and well or cards for the career timeline in the profile and application contexts.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/applicant/career-timeline#manage-your-career-timeline`
2. Verify spacing between actions and well or cards matches design
3. Navigate to `/applications/:application-id/career-timeline`
4. Verify spacing between actions and well or cards matches design

## 📸 Screenshots

<img width="1186" alt="Screen Shot 2024-06-26 at 14 17 24" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/f47e423d-3ccc-4658-922a-cbf3ec7c385b">
<img width="1185" alt="Screen Shot 2024-06-26 at 14 17 07" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/9b2e1b00-500b-43dd-8ee2-56c9bfbcf92d">
