### PR TITLE
[Fix] Tune notification throttle

### DIFF
--- a/api/app/Jobs/GcNotifyApiRequest.php
+++ b/api/app/Jobs/GcNotifyApiRequest.php
@@ -30,6 +30,7 @@ class GcNotifyApiRequest implements ShouldQueue
         return [
             (new GcNotifyRateLimited),
             (new ThrottlesExceptions(10, 5))
+                ->byJob()
                 ->backoff(5),
         ];
     }

--- a/api/app/Jobs/GcNotifyApiRequest.php
+++ b/api/app/Jobs/GcNotifyApiRequest.php
@@ -15,7 +15,6 @@ use Illuminate\Queue\Middleware\ThrottlesExceptions;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Str;
 
 class GcNotifyApiRequest implements ShouldQueue
 {
@@ -67,14 +66,6 @@ class GcNotifyApiRequest implements ShouldQueue
             $errorMessage = 'Notification failed to send on GcNotifyEmailChannel. '.$firstApiErrorMessage.' ';
             Log::error($errorMessage);
             Log::debug($response->body());
-
-            // Sometimes, it's not worth retrying
-            if (Str::startsWith($firstApiErrorMessage, 'Can’t send to this recipient using a team-only API key')) {
-                $this->fail();
-
-                return;
-            }
-
             throw new Exception($errorMessage);
         }
     }


### PR DESCRIPTION
🤖 Resolves : #10820 

## 👋 Introduction

This branch sets the notification throttle to bucket by job.  It also tunes the retry timing.  

## 🕵️ Details

This will behave differently now:
1. If a single job hits the exception throttle, all other jobs will continue in their own timing without changes.
2. The tuned exception throttle works like this: "Wait four minutes between tries.  Try again up to three times then blocked for 10 minutes.  Job fails if not complete in 30 minutes total."

Note: as far as I can tell, if a message is accepted by the API but is not deliverable it does not trigger an API error.  So this may not even be an issue in production.

## 🧪 Testing

1. Set up the "steps to reproduce" from the issue.
2. Observer that your legitimate email is properly sent.