### PR TITLE
[FIX] Roll back framer-motion

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -53,7 +53,7 @@
     "@tanstack/react-table": "^8.17.3",
     "dataloader": "^2.2.2",
     "date-fns": "^3.6.0",
-    "framer-motion": "^11.2.12",
+    "framer-motion": "11.2.10",
     "graphql": "^16.9.0",
     "lodash": "^4.17.21",
     "path-browserify": "^1.0.1",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -30,7 +30,7 @@
     "@tiptap/starter-kit": "^2.4.0",
     "date-fns": "^3.6.0",
     "downshift": "^9.0.6",
-    "framer-motion": "^11.2.12",
+    "framer-motion": "11.2.10",
     "lodash": "^4.17.21",
     "react-dom": "^18.2.0"
   },

--- a/packages/storybook-helpers/package.json
+++ b/packages/storybook-helpers/package.json
@@ -15,7 +15,7 @@
     "@storybook/react": "^8.1.10",
     "@urql/core": "^5.0.4",
     "chromatic": "^11.5.4",
-    "framer-motion": "^11.2.12",
+    "framer-motion": "11.2.10",
     "graphql": "^16.9.0",
     "lodash": "^4.17.21",
     "react-helmet-async": "^2.0.5",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,7 +35,7 @@
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-toggle-group": "^1.1.0",
     "chromatic": "^11.5.4",
-    "framer-motion": "^11.2.12",
+    "framer-motion": "11.2.10",
     "lodash": "^4.17.21",
     "react-csv-downloader": "^3.1.0",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
     dependencies:
       '@axe-core/playwright':
         specifier: ^4.9.1
-        version: 4.9.1(playwright-core@1.44.1)
+        version: 4.9.1(playwright-core@1.45.0)
     devDependencies:
       '@gc-digital-talent/date-helpers':
         specifier: workspace:*
@@ -121,8 +121,8 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
       framer-motion:
-        specifier: ^11.2.12
-        version: 11.2.12(react-dom@18.3.1)(react@18.3.1)
+        specifier: 11.2.10
+        version: 11.2.10(react-dom@18.3.1)(react@18.3.1)
       graphql:
         specifier: ^16.9.0
         version: 16.9.0
@@ -622,8 +622,8 @@ importers:
         specifier: ^9.0.6
         version: 9.0.6(react@18.3.1)
       framer-motion:
-        specifier: ^11.2.12
-        version: 11.2.12(react-dom@18.3.1)(react@18.3.1)
+        specifier: 11.2.10
+        version: 11.2.10(react-dom@18.3.1)(react@18.3.1)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -952,8 +952,8 @@ importers:
         specifier: ^11.5.4
         version: 11.5.4
       framer-motion:
-        specifier: ^11.2.12
-        version: 11.2.12(react-dom@18.3.1)(react@18.3.1)
+        specifier: 11.2.10
+        version: 11.2.10(react-dom@18.3.1)(react@18.3.1)
       graphql:
         specifier: ^16.9.0
         version: 16.9.0
@@ -1146,8 +1146,8 @@ importers:
         specifier: ^11.5.4
         version: 11.5.4
       framer-motion:
-        specifier: ^11.2.12
-        version: 11.2.12(react-dom@18.3.1)(react@18.3.1)
+        specifier: 11.2.10
+        version: 11.2.10(react-dom@18.3.1)(react@18.3.1)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1299,13 +1299,13 @@ packages:
       default-browser-id: 3.0.0
     dev: true
 
-  /@axe-core/playwright@4.9.1(playwright-core@1.44.1):
+  /@axe-core/playwright@4.9.1(playwright-core@1.45.0):
     resolution: {integrity: sha512-8m4WZbZq7/aq7ZY5IG8GqV+ZdvtGn/iJdom+wBg+iv/3BAOBIfNQtIu697a41438DzEEyptXWmC3Xl5Kx/o9/g==}
     peerDependencies:
       playwright-core: '>= 1.0.0'
     dependencies:
       axe-core: 4.9.1
-      playwright-core: 1.44.1
+      playwright-core: 1.45.0
     dev: false
 
   /@babel/code-frame@7.24.7:
@@ -10081,8 +10081,8 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /framer-motion@11.2.12(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-lCjkV4nA9rWOy2bhR4RZzkp2xpB++kFmUZ6D44V9VQaxk+JDmbDd5lq+u58DjJIIllE8AZEXp9OG/TyDN4FB/w==}
+  /framer-motion@11.2.10(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-/gr3PLZUVFCc86a9MqCUboVrALscrdluzTb3yew+2/qKBU8CX6nzs918/SRBRCqaPbx0TZP10CB6yFgK2C5cYQ==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0
@@ -12824,17 +12824,10 @@ packages:
     dependencies:
       find-up: 5.0.0
 
-  /playwright-core@1.44.1:
-    resolution: {integrity: sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==}
-    engines: {node: '>=16'}
-    hasBin: true
-    dev: false
-
   /playwright-core@1.45.0:
     resolution: {integrity: sha512-lZmHlFQ0VYSpAs43dRq1/nJ9G/6SiTI7VPqidld9TDefL9tX87bTKExWZZUF5PeRyqtXqd8fQi2qmfIedkwsNQ==}
     engines: {node: '>=18'}
     hasBin: true
-    dev: true
 
   /playwright@1.45.0:
     resolution: {integrity: sha512-4z3ac3plDfYzGB6r0Q3LF8POPR20Z8D0aXcxbJvmfMgSSq1hkcgvFRXJk9rUq5H/MJ0Ktal869hhOdI/zUTeLA==}


### PR DESCRIPTION
🤖 Resolves #10796 

## 👋 Introduction

This branch rolls back the version of framer-motion in use.  It seems like the latest update "fixes" something that breaks our notification pane.

## 🧪 Testing

1. Rebuild
2. Make sure notification pane goes in and out without locking the app

> [!Note]
This is a quick-and-dirty fix.  I'll post an issue to try to solve the root cause and write that regression test.