### PR TITLE
[Tooling] Adds Dependabot radix group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,13 @@ updates:
       day: "thursday"
     open-pull-requests-limit: 50
     groups:
+      radix:
+        patterns:
+          - "@radix-ui*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
       storybook:
         patterns:
           - "@storybook*"


### PR DESCRIPTION
🤖 Resolves #10818.

## 👋 Introduction

This PR adds a Dependabot group for radix dependencies so that they are grouped into a single PR.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. 🤞 it works on Dependabot Thursday! 🤷