### PR TITLE
[Fix] Associate notification dialog title and description with dialog

### DIFF
--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -111,16 +111,18 @@ const DialogPortalWithPresence = ({
               data-h2-gap="base(x.25 0)"
               data-h2-margin-bottom="base(x.5)"
             >
-              <Heading
-                level="h2"
-                size="h5"
-                color="primary"
-                Icon={BellAlertIcon}
-                data-h2-margin="base(0)"
-                data-h2-line-height="base(1)"
-              >
-                {intl.formatMessage(notificationMessages.title)}
-              </Heading>
+              <DialogPrimitive.Title asChild>
+                <Heading
+                  level="h2"
+                  size="h5"
+                  color="primary"
+                  Icon={BellAlertIcon}
+                  data-h2-margin="base(0)"
+                  data-h2-line-height="base(1)"
+                >
+                  {intl.formatMessage(notificationMessages.title)}
+                </Heading>
+              </DialogPrimitive.Title>
               <div data-h2-display="base(flex)" data-h2-gap="base(x.25 0)">
                 <Dialog.Close asChild>
                   <Button
@@ -137,19 +139,21 @@ const DialogPortalWithPresence = ({
                 </Dialog.Close>
               </div>
             </div>
-            <p>
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "Welcome to your notification panel. Click or tap a notification to be taken to the relevant page. Use the <icon></icon> icon to mark a specific notification as read, pin it, or delete it.",
-                  id: "koUnRG",
-                  description: "Instructions on how to manage notifications",
-                },
-                {
-                  icon: () => ellipsis(),
-                },
-              )}
-            </p>
+            <DialogPrimitive.Description>
+              <p>
+                {intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "Welcome to your notification panel. Click or tap a notification to be taken to the relevant page. Use the <icon></icon> icon to mark a specific notification as read, pin it, or delete it.",
+                    id: "koUnRG",
+                    description: "Instructions on how to manage notifications",
+                  },
+                  {
+                    icon: () => ellipsis(),
+                  },
+                )}
+              </p>
+            </DialogPrimitive.Description>
           </div>
           <NotificationList live inDialog limit={30} onRead={executeQuery} />
           <p data-h2-margin="base(x.5 x1)">

--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -113,16 +113,18 @@ const NotificationDialog = () => {
                     data-h2-gap="base(x.25 0)"
                     data-h2-margin-bottom="base(x.5)"
                   >
-                    <Heading
-                      level="h2"
-                      size="h5"
-                      color="primary"
-                      Icon={BellAlertIcon}
-                      data-h2-margin="base(0)"
-                      data-h2-line-height="base(1)"
-                    >
-                      {intl.formatMessage(notificationMessages.title)}
-                    </Heading>
+                    <DialogPrimitive.Title asChild>
+                      <Heading
+                        level="h2"
+                        size="h5"
+                        color="primary"
+                        Icon={BellAlertIcon}
+                        data-h2-margin="base(0)"
+                        data-h2-line-height="base(1)"
+                      >
+                        {intl.formatMessage(notificationMessages.title)}
+                      </Heading>
+                    </DialogPrimitive.Title>
                     <div
                       data-h2-display="base(flex)"
                       data-h2-gap="base(x.25 0)"
@@ -142,20 +144,22 @@ const NotificationDialog = () => {
                       </Dialog.Close>
                     </div>
                   </div>
-                  <p>
-                    {intl.formatMessage(
-                      {
-                        defaultMessage:
-                          "Welcome to your notification panel. Click or tap a notification to be taken to the relevant page. Use the <icon></icon> icon to mark a specific notification as read, pin it, or delete it.",
-                        id: "koUnRG",
-                        description:
-                          "Instructions on how to manage notifications",
-                      },
-                      {
-                        icon: () => ellipsis(),
-                      },
-                    )}
-                  </p>
+                  <DialogPrimitive.Description asChild>
+                    <p>
+                      {intl.formatMessage(
+                        {
+                          defaultMessage:
+                            "Welcome to your notification panel. Click or tap a notification to be taken to the relevant page. Use the <icon></icon> icon to mark a specific notification as read, pin it, or delete it.",
+                          id: "koUnRG",
+                          description:
+                            "Instructions on how to manage notifications",
+                        },
+                        {
+                          icon: () => ellipsis(),
+                        },
+                      )}
+                    </p>
+                  </DialogPrimitive.Description>
                 </div>
                 <NotificationList
                   live


### PR DESCRIPTION
🤖 Resolves #10850 

## 👋 Introduction

Associates the title and description for notifications with the parent dialog.

## 🕵️ Details

I just forgot to use the primitves since this is a custom solution :sweat_smile: 

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `pnpm run dev`
2. Login as any user
3. Open notification dialog
4. Confirm no errors in console
5. Inspect the dialog a11y tree
6. Confirm it has the proper title and description

## 📸 Screenshot

![screenshot_02-Jul-2024_16-00-1719950410](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/74767fa6-5071-46a4-91a3-de795a879793)
