### PR TITLE
[Fix] Adds missing `parameters` key

### DIFF
--- a/apps/web/src/components/Hero/Hero.stories.tsx
+++ b/apps/web/src/components/Hero/Hero.stories.tsx
@@ -28,13 +28,15 @@ export default {
       },
     ],
   },
-  chromatic: {
-    modes: {
-      light: allModes.light,
-      "light mobile": allModes["light mobile"],
-      dark: allModes.dark,
-      "light iap": allModes["light iap desktop"],
-      "dark iap": allModes["dark iap desktop"],
+  parameters: {
+    chromatic: {
+      modes: {
+        light: allModes.light,
+        "light mobile": allModes["light mobile"],
+        dark: allModes.dark,
+        "light iap": allModes["light iap desktop"],
+        "dark iap": allModes["dark iap desktop"],
+      },
     },
   },
 } as Meta<typeof Hero>;

--- a/apps/web/src/components/Layout/AdminLayout/AdminLayout.stories.tsx
+++ b/apps/web/src/components/Layout/AdminLayout/AdminLayout.stories.tsx
@@ -33,9 +33,11 @@ export default {
       options: availableRoles,
     },
   },
-  chromatic: {
-    modes: {
-      light: allModes.light,
+  parameters: {
+    chromatic: {
+      modes: {
+        light: allModes.light,
+      },
     },
   },
 } as Meta<AdminLayoutArgs>;

--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -13,10 +13,12 @@ import DropdownMenu from "./DropdownMenu";
 export default {
   component: DropdownMenu.Root,
   decorators: [OverlayOrDialogDecorator],
-  chromatic: {
-    modes: {
-      light: allModes.light,
-      dark: allModes.dark,
+  parameters: {
+    chromatic: {
+      modes: {
+        light: allModes.light,
+        dark: allModes.dark,
+      },
     },
   },
 } as Meta;


### PR DESCRIPTION
🤖 Resolves #10851.

## 👋 Introduction

This PR fixes unstable storybook snapshots in Chromatic and adds modes to several stories that were not taking the listed snapshots because of the missing `parameters` key.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Open Chromatic build for this PR
2. Verify canvas and snapshot have the same state (system default) for the theme switcher in `AdminLayout` story
3. Verify `DropdownMenu` and `Hero` stories have snapshots for all the modes listed