### PR TITLE
[Copy] Rename email fields to 'Contact email address'

### DIFF
--- a/apps/playwright/tests/applicant/create-account.spec.ts
+++ b/apps/playwright/tests/applicant/create-account.spec.ts
@@ -25,7 +25,7 @@ test.describe("Create account", () => {
 
     await appPage.page
       .getByRole("textbox", {
-        name: /which email do you like to be contacted at/i,
+        name: /contact email address/i,
       })
       .fill(`playwright.${uniqueTestId}@example.org`);
 

--- a/apps/web/src/components/Profile/components/PersonalInformation/utils.ts
+++ b/apps/web/src/components/Profile/components/PersonalInformation/utils.ts
@@ -51,11 +51,7 @@ export const getLabels = (intl: IntlShape) => ({
     id: "dssZUt",
     description: "Label for surname field",
   }),
-  email: intl.formatMessage({
-    defaultMessage: "Personal email",
-    id: "g1++nq",
-    description: "Label for email field",
-  }),
+  email: intl.formatMessage(commonMessages.email),
   citizenship: intl.formatMessage({
     defaultMessage: "Citizenship status",
     id: "7DUfu+",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1027,10 +1027,6 @@
     "defaultMessage": "Souhaitez-vous poursuivre? Ceci vous éloignera de cette page-ci.",
     "description": "Text explaining what will happen after duplicating a pool and confirming the action"
   },
-  "3UkIDo": {
-    "defaultMessage": "Courriel :",
-    "description": "Display text for the email field on users"
-  },
   "3W/NbE": {
     "defaultMessage": "Sélectionné(e)",
     "description": "Message displayed when candidate has been screened in at a specific assessment step"
@@ -1830,6 +1826,10 @@
   "82Oe0C": {
     "defaultMessage": "J'envisagerais d'accepter un emploi qui...",
     "description": "Legend for optional work preferences check list in work preferences form"
+  },
+  "83ujdI": {
+    "defaultMessage": "Address courriel de correspondance :",
+    "description": "Display text for the contact email field on users"
   },
   "84XrK+": {
     "defaultMessage": "On ne trouve aucun élément ici.",
@@ -4375,10 +4375,6 @@
     "defaultMessage": "Cette liste permet au candidat de préciser <strong>jusqu’à 5 compétences techniques </strong> pour lesquelles ils souhaitent recevoir une formation.",
     "description": "Description of a users technical skills to be improved for admins"
   },
-  "MTwQ3S": {
-    "defaultMessage": "À quel courriel souhaitez-vous être contacté(e)?",
-    "description": "Label displayed for the email field in create account form."
-  },
   "MUwxzr": {
     "defaultMessage": "Faisons maintenant le lien entre vos expériences et les compétences essentielles pour ce poste. Il s’agit de l’étape la plus importante du processus de candidature. Comme pour l’étape d’expérience et d’études minimales, si vous avez besoin d’ajouter ou de modifier une expérience dans votre parcours professionnel, vous pouvez le faire en revenant à l’<careerTimelineLink>étape du parcours professionnel</careerTimelineLink> dans le formulaire de candidature.",
     "description": "Lead in paragraph for adding experiences to a users skills"
@@ -4914,10 +4910,6 @@
   "PerY/b": {
     "defaultMessage": "Reproduction non commerciale",
     "description": "Non commercial reproduction list in ownership and usage section"
-  },
-  "PhrOLp": {
-    "defaultMessage": "Courriel de la personne-ressource",
-    "description": "Label for the French team display name input"
   },
   "Pi5icf": {
     "defaultMessage": "Gérer un critère de compétences",
@@ -8054,10 +8046,6 @@
     "defaultMessage": "Groupes de publication",
     "description": "Title for publishing groups"
   },
-  "g1++nq": {
-    "defaultMessage": "Adresse de courriel personnelle",
-    "description": "Label for email field"
-  },
   "g2We9g": {
     "defaultMessage": "Une partie du contenu de ce site pourrait faire l’objet du droit d’auteur d’une tierce partie. Lorsque des informations sont produites et que le gouvernement du Canada n’est pas le détenteur des droits d’auteur, le contenu est protégé par la <copyrightLink>Loi sur le droit d’auteur</copyrightLink> et des ententes internationales. Les détails relatifs au droit d’auteur figurent sur les pages pertinentes.",
     "description": "Commercial reproduction list description in ownership and usage section"
@@ -9474,10 +9462,6 @@
     "defaultMessage": "Enregistrer la disponibilité",
     "description": "Button text to save availability in a recruitment"
   },
-  "nGNj5Q": {
-    "defaultMessage": "Courriel de la personne-ressource",
-    "description": "Contact email"
-  },
   "nIJlba": {
     "defaultMessage": "Obtention réussie d’un diplôme d’études secondaires ou un équivalent du GED.",
     "description": "Message under radio button in IAP application education page."
@@ -10449,10 +10433,6 @@
   "sycoGU": {
     "defaultMessage": "Pas nécessairement. La plupart des possibilités d’apprentissage peuvent être réalisées en travaillant de la maison, pourvu qu’il y ait une connexion à Internet. Certains postes ont des exigences propres à l’emplacement. Nous accordons une importance à la famille et à la communauté, et nous encourageons les gens à se joindre à notre famille sans avoir à quitter la leur, et à faire partie de notre communauté tout en restant dans la leur. Parlez à votre gestionnaire d’embauche de votre situation ou de vos préférences, et nous ferons de notre mieux pour travailler avec vous afin de trouver une solution appropriée.",
     "description": "Learn more dialog question six paragraph one"
-  },
-  "szLvj0": {
-    "defaultMessage": "Votre courriel",
-    "description": "Support form email field label"
   },
   "szVmh/": {
     "defaultMessage": "Description de l’apprentissage",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1827,10 +1827,6 @@
     "defaultMessage": "J'envisagerais d'accepter un emploi qui...",
     "description": "Legend for optional work preferences check list in work preferences form"
   },
-  "83ujdI": {
-    "defaultMessage": "Address courriel de correspondance :",
-    "description": "Display text for the contact email field on users"
-  },
   "84XrK+": {
     "defaultMessage": "On ne trouve aucun élément ici.",
     "description": "Default message for an empty table"

--- a/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
@@ -13,7 +13,11 @@ import {
 } from "@gc-digital-talent/forms";
 import { toast } from "@gc-digital-talent/toast";
 import { ROLE_NAME, useAuthorization } from "@gc-digital-talent/auth";
-import { errorMessages, getLanguage } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  errorMessages,
+  getLanguage,
+} from "@gc-digital-talent/i18n";
 import { emptyToNull, unpackMaybes } from "@gc-digital-talent/helpers";
 import {
   graphql,
@@ -110,12 +114,7 @@ export const CreateAccountForm = ({
       description:
         "Label displayed for the last name field in create account form.",
     }),
-    email: intl.formatMessage({
-      defaultMessage: "Which email do you like to be contacted at?",
-      id: "MTwQ3S",
-      description:
-        "Label displayed for the email field in create account form.",
-    }),
+    email: intl.formatMessage(commonMessages.email),
     preferredLang: intl.formatMessage({
       defaultMessage: "What is your preferred contact language?",
       id: "0ScnOT",

--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
@@ -8,7 +8,11 @@ import { ReactNode, useState } from "react";
 
 import { toast } from "@gc-digital-talent/toast";
 import { Input, Submit, TextArea, Select } from "@gc-digital-talent/forms";
-import { errorMessages, uiMessages } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  errorMessages,
+  uiMessages,
+} from "@gc-digital-talent/i18n";
 import { Heading, Pending, Button } from "@gc-digital-talent/ui";
 import { useLogger } from "@gc-digital-talent/logger";
 import { User, graphql } from "@gc-digital-talent/graphql";
@@ -174,11 +178,7 @@ const SupportForm = ({
               id="email"
               name="email"
               type="email"
-              label={intl.formatMessage({
-                defaultMessage: "Your email",
-                id: "szLvj0",
-                description: "Support form email field label",
-              })}
+              label={intl.formatMessage(commonMessages.email)}
               rules={{
                 required: intl.formatMessage(errorMessages.required),
               }}

--- a/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamFormFields.tsx
+++ b/apps/web/src/pages/Teams/CreateTeamPage/components/CreateTeamFormFields.tsx
@@ -4,7 +4,11 @@ import { useFormContext } from "react-hook-form";
 import kebabCase from "lodash/kebabCase";
 
 import { Input, Combobox, TextArea } from "@gc-digital-talent/forms";
-import { errorMessages, getLocalizedName } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  errorMessages,
+  getLocalizedName,
+} from "@gc-digital-talent/i18n";
 import { notEmpty } from "@gc-digital-talent/helpers";
 import { Maybe, Department } from "@gc-digital-talent/graphql";
 
@@ -94,11 +98,7 @@ const CreateTeamFormFields = ({ departments }: CreateTeamFormFieldsProps) => {
           type="email"
           id="contactEmail"
           name="contactEmail"
-          label={intl.formatMessage({
-            defaultMessage: "Contact email",
-            id: "PhrOLp",
-            description: "Label for the French team display name input",
-          })}
+          label={intl.formatMessage(commonMessages.email)}
           rules={{
             required: intl.formatMessage(errorMessages.required),
           }}

--- a/apps/web/src/pages/Teams/ViewTeamPage/components/ViewTeam.tsx
+++ b/apps/web/src/pages/Teams/ViewTeamPage/components/ViewTeam.tsx
@@ -1,7 +1,7 @@
 import { useIntl } from "react-intl";
 
 import { Chip, Chips } from "@gc-digital-talent/ui";
-import { getLocalizedName } from "@gc-digital-talent/i18n";
+import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 
@@ -128,11 +128,7 @@ const ViewTeam = ({ teamQuery }: ViewTeamProps) => {
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
           <p data-h2-margin-top="base(x1)">
-            {intl.formatMessage({
-              defaultMessage: "Contact email",
-              id: "nGNj5Q",
-              description: "Contact email",
-            })}
+            {intl.formatMessage(commonMessages.email)}
           </p>
           <p
             data-h2-color="base:all(black)"

--- a/apps/web/src/pages/Users/UserInformationPage/components/AboutSection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/AboutSection.tsx
@@ -32,9 +32,9 @@ const AboutSection = ({ user }: BasicUserInformationProps) => {
         <div data-h2-flex-item="base(1of1) p-tablet(1of2) desktop(1of3)">
           <p data-h2-font-weight="base(700)">
             {intl.formatMessage({
-              defaultMessage: "Email:",
-              id: "3UkIDo",
-              description: "Display text for the email field on users",
+              defaultMessage: "Contact email address:",
+              id: "83ujdI",
+              description: "Display text for the contact email field on users",
             })}
           </p>
           <p>{user.email}</p>

--- a/apps/web/src/pages/Users/UserInformationPage/components/AboutSection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/AboutSection.tsx
@@ -31,11 +31,8 @@ const AboutSection = ({ user }: BasicUserInformationProps) => {
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2) desktop(1of3)">
           <p data-h2-font-weight="base(700)">
-            {intl.formatMessage({
-              defaultMessage: "Contact email address:",
-              id: "83ujdI",
-              description: "Display text for the contact email field on users",
-            })}
+            {intl.formatMessage(commonMessages.email)}
+            {intl.formatMessage(commonMessages.dividingColon)}
           </p>
           <p>{user.email}</p>
         </div>

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -99,6 +99,10 @@
     "defaultMessage": "Le candidat/la candidate sera informé(e) de toute modification apportée au présent formulaire.",
     "description": "Caption notifying the user about who can know about the results of form changes"
   },
+  "1UX8RD": {
+    "defaultMessage": "Address courriel de correspondance",
+    "description": "Title for contact email address"
+  },
   "1Wbu+6": {
     "defaultMessage": "Premières Nations détenant le statut ",
     "description": "The indigenous community for status First Nations"
@@ -1322,10 +1326,6 @@
   "dIZ4oj": {
     "defaultMessage": "m'exige de <strong>transporter, soulever et installer des équipements pesant jusqu'à 20 kg</strong>.",
     "description": "The operational requirement described as transport equipment up to 20kg."
-  },
-  "dJd5/f": {
-    "defaultMessage": "Courriel",
-    "description": "Title for email"
   },
   "dRvWzH": {
     "defaultMessage": "Baccalauréat",

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -150,9 +150,9 @@ const commonMessages = defineMessages({
     description: "Title for name",
   },
   email: {
-    defaultMessage: "Email",
-    id: "dJd5/f",
-    description: "Title for email",
+    defaultMessage: "Contact email address",
+    id: "1UX8RD",
+    description: "Title for contact email address",
   },
   inApp: {
     defaultMessage: "In-app",


### PR DESCRIPTION
🤖 Resolves #10822.

## 👋 Introduction

Renames several email fields to 'Contact email address'.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Confirm the various locations listed in the issue now use 'Contact email address'
    - Profile
    - Registration form
    - Pool Candidate table
    - User table
    - Profile , CSV downloads
2. Look for anywhere else I may have missed