### PR TITLE
[Fix] Add community seeder to prod seeder

### DIFF
--- a/api/database/seeders/ProdSeeder.php
+++ b/api/database/seeders/ProdSeeder.php
@@ -19,6 +19,7 @@ class ProdSeeder extends Seeder
             GenericJobTitleSeeder::class,
             SkillFamilySeeder::class,
             SkillSeeder::class,
+            CommunitySeeder::class,
             TeamSeeder::class,
         ]);
     }


### PR DESCRIPTION
🤖 Resolves #10767 

## 👋 Introduction

Adds the community seeder to the list of seeders run in production.

## 🧪 Testing

1. Refresh database `make artisan CMD="migrate:fresh"`
2. Run prod seeder `make artisan CMD="db:seed --class=ProdSeeder"`
3. Check database and confirm bot initial communities exist

## 📸 Screenshot

![screenshot_03-Jul-2024_08-17-1720009076](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/30f8dcdb-76e6-4d67-88c9-7da05b705b5a)
