### PR TITLE
[Fix] Copy skill levels on pool duplication

### DIFF
--- a/api/app/GraphQL/Mutations/DuplicatePool.php
+++ b/api/app/GraphQL/Mutations/DuplicatePool.php
@@ -3,6 +3,7 @@
 namespace App\GraphQL\Mutations;
 
 use App\Models\Pool;
+use App\Models\PoolSkill;
 
 final class DuplicatePool
 {
@@ -17,8 +18,8 @@ final class DuplicatePool
 
         $newPool = $pool->replicate()->fill([
             'name' => [
-                'en' => $pool->name['en'].' (copy)',
-                'fr' => $pool->name['fr'].' (copie)',
+                'en' => $pool->name['en'] . ' (copy)',
+                'fr' => $pool->name['fr'] . ' (copie)',
             ],
             'closing_date' => null,
             'published_at' => null,
@@ -29,14 +30,13 @@ final class DuplicatePool
 
         $newPool->save();
 
-        $skillsToSync = [];
-        foreach ($pool->poolSkills as $poolSkill) {
-            $skillsToSync[] = [
+        $skillsToSync = $pool->poolSkills->map(function (PoolSkill $poolSkill) {
+            return [
                 'skill_id' => $poolSkill->skill->id,
                 'type' => $poolSkill->type,
                 'required_skill_level' => $poolSkill->required_skill_level,
             ];
-        }
+        });
 
         $newPool->poolSkills()->createMany($skillsToSync);
         $newPool->syncApplicationScreeningStepPoolSkills();

--- a/api/app/GraphQL/Mutations/DuplicatePool.php
+++ b/api/app/GraphQL/Mutations/DuplicatePool.php
@@ -17,8 +17,8 @@ final class DuplicatePool
 
         $newPool = $pool->replicate()->fill([
             'name' => [
-                'en' => $pool->name['en'] . ' (copy)',
-                'fr' => $pool->name['fr'] . ' (copie)',
+                'en' => $pool->name['en'].' (copy)',
+                'fr' => $pool->name['fr'].' (copie)',
             ],
             'closing_date' => null,
             'published_at' => null,
@@ -34,7 +34,7 @@ final class DuplicatePool
             $skillsToSync[] = [
                 'skill_id' => $poolSkill->skill->id,
                 'type' => $poolSkill->type,
-                'required_skill_level' => $poolSkill->required_skill_level
+                'required_skill_level' => $poolSkill->required_skill_level,
             ];
         }
 

--- a/api/app/GraphQL/Mutations/DuplicatePool.php
+++ b/api/app/GraphQL/Mutations/DuplicatePool.php
@@ -18,8 +18,8 @@ final class DuplicatePool
 
         $newPool = $pool->replicate()->fill([
             'name' => [
-                'en' => $pool->name['en'] . ' (copy)',
-                'fr' => $pool->name['fr'] . ' (copie)',
+                'en' => $pool->name['en'].' (copy)',
+                'fr' => $pool->name['fr'].' (copie)',
             ],
             'closing_date' => null,
             'published_at' => null,

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -1683,7 +1683,7 @@ class PoolTest extends TestCase
         $originalValues = Arr::only($original->toArray(), $keysToPluck);
         $duplicatedValues = Arr::only($duplicated->toArray(), $keysToPluck);
 
-        $this->assertEquals($originalvalues, $duplicatdValues);
+        $this->assertEquals($originalValues, $duplicatedValues);
 
         $originalSkills = array_map([$this, 'filterSkillKeys'], $original->poolSkills->toArray());
         $duplicatedSkills = array_map([$this, 'filterSkillKeys'], $duplicated->poolSkills->toArray());

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -1680,8 +1680,8 @@ class PoolTest extends TestCase
         // Check exact copied values
         $keysToPluck = ['operational_requirements', 'key_tasks', 'your_impact', 'security_clearance', 'advertisement_language', 'is_remote', 'what_to_expect', 'special_note', 'opportunity_length', 'what_to_expect_admission', 'about_us', 'classification_id'];
 
-        $originalvalues = Arr::only($original->toArray(), $keysToPluck);
-        $duplicatdValues = Arr::only($duplicated->toArray(), $keysToPluck);
+        $originalValues = Arr::only($original->toArray(), $keysToPluck);
+        $duplicatedValues = Arr::only($duplicated->toArray(), $keysToPluck);
 
         $this->assertEquals($originalvalues, $duplicatdValues);
 

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -52,11 +52,7 @@ class PoolTest extends TestCase
         parent::setUp();
         $this->bootRefreshesSchemaCache();
 
-        $this->seed([
-            RolePermissionSeeder::class,
-            SkillFamilySeeder::class,
-            SkillSeeder::class,
-        ]);
+        $this->seed(RolePermissionSeeder::class);
 
         $this->team = Team::factory()->create([
             'name' => 'pool-application-test-team',
@@ -1645,6 +1641,10 @@ class PoolTest extends TestCase
 
     public function testDuplicatePool()
     {
+        $this->seed([
+            SkillFamilySeeder::class,
+            SkillSeeder::class,
+        ]);
 
         $department = Department::factory()->create();
 


### PR DESCRIPTION
🤖 Resolves #10696 

## 👋 Introduction

Updates pool duplication to copy over all pool skill pivot data.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Login as admin `admin@test.com`
2. Create a pool with various skill types and levels
3. Duplicate the pool
4. Confirm skills and all pivot data was copied to the new pool