### PR TITLE
whitelist refresh error

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -150,7 +150,15 @@ class AuthController extends Controller
                 'refresh_token' => $refreshToken,
             ]);
         if ($response->failed()) {
-            Log::error('Failed when POSTing to the token URI in refresh');
+            $errorCode = $response->json('error');
+            $isNormalErrorCode = $errorCode == 'invalid_grant';
+
+            $errorMessageToLog = 'Failed when POSTing to the token URI in refresh '.$errorCode;
+            if (! $isNormalErrorCode) {
+                Log::error($errorMessageToLog);
+            } else {
+                Log::debug($errorMessageToLog);
+            }
             Log::debug((string) $response->getBody());
 
             return response('Failed to get token', 400);

--- a/api/app/Services/OpenIdBearerTokenService.php
+++ b/api/app/Services/OpenIdBearerTokenService.php
@@ -158,7 +158,15 @@ class OpenIdBearerTokenService
                 ]);
 
             if ($response->failed()) {
-                Log::error('Failed when GETting the introspection verification in verifyJwtWithIntrospection');
+                $errorCode = $response->json('error');
+                $isNormalErrorCode = $errorCode == 'access_denied';
+
+                $errorMessageToLog = 'Failed when GETting the introspection verification in verifyJwtWithIntrospection '.$errorCode;
+                if (! $isNormalErrorCode) {
+                    Log::error($errorMessageToLog);
+                } else {
+                    Log::debug($errorMessageToLog);
+                }
                 Log::debug((string) $response->getBody());
                 throw new Exception('Failed to get introspection');
             }


### PR DESCRIPTION
🤖 Resolves #10746

## 👋 Introduction

This branch updates the backend to recognize common error codes from SIC and then logs it at a DEBUG level.

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

### Refresh Error

1. Set up with SIC
2. Log in
3. In an external tool, like Postman, use up the current refresh token
4. Wait until the app tries refresh on its own, or try to manually use the old refresh token again in Postman

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/7a64c66d-5a71-408f-8b14-8bc2a4752490)

- [ ] Error is logged at DEBUG level

### Introspection Error

1. Set up with SIC
2. Log in
3. Set up a query with Graphiql, like a "me" query
4. Log out
5. Issue query in Graphiql

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/8effac79-8512-4151-bb3f-d7e1b424f3ca)

- [ ] Error is logged at the DEBUG level

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/ab39f34f-f8f4-4f03-8077-d6dd07b67b95)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/a9069cf9-4e0a-45af-a946-354022dfbaa1)
