### PR TITLE
[Debt] Prep for Laravel 11

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -23,7 +23,7 @@
     "nuwave/lighthouse": "^6.15",
     "phpoffice/phpspreadsheet": "^2.0",
     "phpoffice/phpword": "^1.2",
-    "santigarcor/laratrust": "^8.0",
+    "santigarcor/laratrust": "^8.3.0",
     "spatie/laravel-activitylog": "^4.7",
     "staudenmeir/eloquent-has-many-deep": "^1.18",
     "web-token/jwt-library": "^3.3"

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81bedc7b7d40d62434b3726cc1bf05b9",
+    "content-hash": "e45f6dbe0d5fd89e953c78ad0e732dad",
     "packages": [
         {
             "name": "brick/math",
@@ -4505,16 +4505,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.0",
+            "version": "v0.12.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "750bf031a48fd07c673dbe3f11f72362ea306d0d"
+                "reference": "2fd717afa05341b4f8152547f142cd2f130f6818"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/750bf031a48fd07c673dbe3f11f72362ea306d0d",
-                "reference": "750bf031a48fd07c673dbe3f11f72362ea306d0d",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/2fd717afa05341b4f8152547f142cd2f130f6818",
+                "reference": "2fd717afa05341b4f8152547f142cd2f130f6818",
                 "shasum": ""
             },
             "require": {
@@ -4578,9 +4578,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.0"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.4"
             },
-            "time": "2023-12-20T15:28:09+00:00"
+            "time": "2024-06-10T01:18:23+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -4809,27 +4809,27 @@
         },
         {
             "name": "santigarcor/laratrust",
-            "version": "8.2.2",
+            "version": "8.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/santigarcor/laratrust.git",
-                "reference": "c95c52079d522c6707bc0b48dd46506a2faebe76"
+                "reference": "9510e60f891a05bb87164666e26150818cb40b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/santigarcor/laratrust/zipball/c95c52079d522c6707bc0b48dd46506a2faebe76",
-                "reference": "c95c52079d522c6707bc0b48dd46506a2faebe76",
+                "url": "https://api.github.com/repos/santigarcor/laratrust/zipball/9510e60f891a05bb87164666e26150818cb40b3c",
+                "reference": "9510e60f891a05bb87164666e26150818cb40b3c",
                 "shasum": ""
             },
             "require": {
                 "kkszymanowski/traitor": "^1.0",
-                "laravel/framework": "^10.0",
+                "laravel/framework": "^10.0|^11.0",
                 "php": ">=8.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3.2",
-                "orchestra/testbench": "^8.0",
-                "phpunit/phpunit": "^8.4|^9.0"
+                "orchestra/testbench": "^8.0|^9.0",
+                "phpunit/phpunit": "^8.4|^9.0|^10.5"
             },
             "type": "library",
             "extra": {
@@ -4872,7 +4872,7 @@
             ],
             "support": {
                 "issues": "https://github.com/santigarcor/laratrust/issues",
-                "source": "https://github.com/santigarcor/laratrust/tree/8.2.2"
+                "source": "https://github.com/santigarcor/laratrust/tree/8.3.1"
             },
             "funding": [
                 {
@@ -4880,7 +4880,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-01-18T23:02:24+00:00"
+            "time": "2024-04-03T22:48:27+00:00"
         },
         {
             "name": "spatie/laravel-activitylog",
@@ -4975,16 +4975,16 @@
         },
         {
             "name": "spatie/laravel-package-tools",
-            "version": "1.16.3",
+            "version": "1.16.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-package-tools.git",
-                "reference": "59db18c2e20d49a0b6d447bb1c654f6c123beb9e"
+                "reference": "ddf678e78d7f8b17e5cdd99c0c3413a4a6592e53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/59db18c2e20d49a0b6d447bb1c654f6c123beb9e",
-                "reference": "59db18c2e20d49a0b6d447bb1c654f6c123beb9e",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/ddf678e78d7f8b17e5cdd99c0c3413a4a6592e53",
+                "reference": "ddf678e78d7f8b17e5cdd99c0c3413a4a6592e53",
                 "shasum": ""
             },
             "require": {
@@ -5023,7 +5023,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-package-tools/issues",
-                "source": "https://github.com/spatie/laravel-package-tools/tree/1.16.3"
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.16.4"
             },
             "funding": [
                 {
@@ -5031,7 +5031,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-07T07:35:57+00:00"
+            "time": "2024-03-20T07:29:11+00:00"
         },
         {
             "name": "spatie/regex",
@@ -10312,5 +10312,5 @@
     "platform-overrides": {
         "php": "8.2.9"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/api/database/migrations/2024_06_14_163600_add_pool_department.php
+++ b/api/database/migrations/2024_06_14_163600_add_pool_department.php
@@ -38,7 +38,7 @@ return new class extends Migration
 
         // now that it's filled, make non-nullable
         Schema::table('pools', function (Blueprint $table) {
-            $table->uuid('department_id')->nullable(false)->change();
+            $table->uuid('department_id')->nullable(false)->change();  // TODO, double-check when upgrading to Laravel 11
         });
     }
 

--- a/api/programmatic-types.graphql
+++ b/api/programmatic-types.graphql
@@ -72,6 +72,15 @@ type UserPublicProfilePaginator {
   data: [UserPublicProfile!]!
 }
 
+"A paginated list of Pool items."
+type PoolPaginator {
+  "Pagination information about the list of items."
+  paginatorInfo: PaginatorInfo!
+
+  "A list of Pool items."
+  data: [Pool!]!
+}
+
 "A paginated list of PoolCandidateWithSkillCount items."
 type PoolCandidateWithSkillCountPaginator {
   "Pagination information about the list of items."
@@ -99,6 +108,51 @@ type NotificationPaginator {
   data: [Notification!]!
 }
 
+"Allowed column names for Query.poolsPaginated.orderBy."
+enum QueryPoolsPaginatedOrderByUserColumn {
+  FIRST_NAME
+  EMAIL
+}
+
+"Aggregate specification for Query.poolsPaginated.orderBy.user."
+input QueryPoolsPaginatedOrderByUser {
+  "The aggregate function to apply to the column."
+  aggregate: OrderByRelationWithColumnAggregateFunction!
+
+  "Name of the column to use."
+  column: QueryPoolsPaginatedOrderByUserColumn
+}
+
+"Allowed column names for Query.poolsPaginated.orderBy."
+enum QueryPoolsPaginatedOrderByClassificationColumn {
+  GROUP
+  LEVEL
+}
+
+"Aggregate specification for Query.poolsPaginated.orderBy.classification."
+input QueryPoolsPaginatedOrderByClassification {
+  "The aggregate function to apply to the column."
+  aggregate: OrderByRelationWithColumnAggregateFunction!
+
+  "Name of the column to use."
+  column: QueryPoolsPaginatedOrderByClassificationColumn
+}
+
+"Order by clause for Query.poolsPaginated.orderBy."
+input QueryPoolsPaginatedOrderByRelationOrderByClause {
+  "The column that is used for ordering."
+  column: String
+
+  "The direction that is used for ordering."
+  order: SortOrder!
+
+  "Aggregate specification."
+  user: QueryPoolsPaginatedOrderByUser
+
+  "Aggregate specification."
+  classification: QueryPoolsPaginatedOrderByClassification
+}
+
 "Allowed column names for Query.poolCandidatesPaginated.orderBy."
 enum QueryPoolCandidatesPaginatedOrderByUserColumn {
   PRIORITY_WEIGHT
@@ -119,6 +173,20 @@ input QueryPoolCandidatesPaginatedOrderByUser {
   column: QueryPoolCandidatesPaginatedOrderByUserColumn
 }
 
+"Allowed column names for Query.poolCandidatesPaginated.orderBy."
+enum QueryPoolCandidatesPaginatedOrderByPoolColumn {
+  PROCESS_NUMBER
+}
+
+"Aggregate specification for Query.poolCandidatesPaginated.orderBy.pool."
+input QueryPoolCandidatesPaginatedOrderByPool {
+  "The aggregate function to apply to the column."
+  aggregate: OrderByRelationWithColumnAggregateFunction!
+
+  "Name of the column to use."
+  column: QueryPoolCandidatesPaginatedOrderByPoolColumn
+}
+
 "Order by clause for Query.poolCandidatesPaginated.orderBy."
 input QueryPoolCandidatesPaginatedOrderByRelationOrderByClause {
   "The column that is used for ordering."
@@ -129,6 +197,9 @@ input QueryPoolCandidatesPaginatedOrderByRelationOrderByClause {
 
   "Aggregate specification."
   user: QueryPoolCandidatesPaginatedOrderByUser
+
+  "Aggregate specification."
+  pool: QueryPoolCandidatesPaginatedOrderByPool
 }
 
 "Directions for ordering a list of records."
@@ -304,12 +375,6 @@ enum GovEmployeeType {
   INDETERMINATE
 }
 
-enum BilingualEvaluation {
-  COMPLETED_ENGLISH
-  COMPLETED_FRENCH
-  NOT_COMPLETED
-}
-
 enum EvaluatedLanguageAbility {
   X
   A
@@ -330,6 +395,12 @@ enum CitizenshipStatus {
   PERMANENT_RESIDENT
   CITIZEN
   OTHER
+}
+
+enum ClaimVerificationResult {
+  ACCEPTED
+  REJECTED
+  UNVERIFIED
 }
 
 enum ArmedForcesStatus {
@@ -378,6 +449,11 @@ enum PoolStatus {
   ARCHIVED
 }
 
+enum DisqualificationReason {
+  SCREENED_OUT_APPLICATION
+  SCREENED_OUT_ASSESSMENT
+}
+
 enum PoolCandidateStatus {
   DRAFT
   DRAFT_EXPIRED
@@ -398,6 +474,13 @@ enum PoolCandidateStatus {
   PLACED_INDETERMINATE
   EXPIRED
   REMOVED
+}
+
+enum PlacementType {
+  PLACED_TENTATIVE
+  PLACED_CASUAL
+  PLACED_TERM
+  PLACED_INDETERMINATE
 }
 
 enum SecurityStatus {
@@ -470,8 +553,6 @@ enum OperationalRequirement {
   TRAVEL
   TRANSPORT_EQUIPMENT
   DRIVERS_LICENSE
-  OVERTIME_SCHEDULED
-  OVERTIME_SHORT_NOTICE
   OVERTIME_OCCASIONAL
   OVERTIME_REGULAR
 }
@@ -483,6 +564,7 @@ enum GenericJobTitleKey {
   TECHNICAL_ADVISOR_IT03
   SENIOR_ADVISOR_IT04
   MANAGER_IT04
+  EXECUTIVE_EX03
 }
 
 enum PoolCandidateSearchStatus {
@@ -491,6 +573,7 @@ enum PoolCandidateSearchStatus {
   WAITING
   DONE
   DONE_NO_CANDIDATES
+  NOT_COMPLIANT
 }
 
 enum PoolCandidateSearchPositionType {
@@ -783,8 +866,23 @@ enum NotificationFamily {
   JOB_ALERT
 }
 
-enum NotificationType {
-  PoolCandidateStatusChanged
+enum CandidateRemovalReason {
+  REQUESTED_TO_BE_WITHDRAWN
+  NOT_RESPONSIVE
+  OTHER
+}
+
+enum PriorityWeight {
+  PRIORITY_ENTITLEMENT
+  VETERAN
+  CITIZEN_OR_PERMANENT_RESIDENT
+  OTHER
+}
+
+enum OverallAssessmentStatus {
+  TO_ASSESS
+  DISQUALIFIED
+  QUALIFIED
 }
 
 "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations."

--- a/api/schema-directives.graphql
+++ b/api/schema-directives.graphql
@@ -334,6 +334,25 @@ directive @create(
   relation: String
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
+# Directive class: Nuwave\Lighthouse\Schema\Directives\CreateManyDirective
+"""
+Create multiple new Eloquent models with the given arguments.
+"""
+directive @createMany(
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model detection does not work.
+  """
+  model: String
+
+  """
+  Specify the name of the relation on the parent model.
+  This is only needed when using this directive as a nested arg
+  resolver and if the name of the relation is not the arg name.
+  """
+  relation: String
+) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
 # Directive class: Nuwave\Lighthouse\Schema\Directives\DeleteDirective
 """
 Delete one or more models.
@@ -736,12 +755,20 @@ directive @like(
 # Directive class: Nuwave\Lighthouse\Schema\Directives\LimitDirective
 """
 Allow clients to specify the maximum number of results to return when used on an argument,
-or statically limits them when used on a field.
+or statically limit them when used on a field.
 
-This directive does not influence the number of results the resolver queries internally,
-but limits how much of it is returned to clients.
+By default, this directive does not influence the number of results the resolver queries internally,
+but limits how much of it is returned to clients. Use the `builder` argument to change this.
 """
-directive @limit on ARGUMENT_DEFINITION | FIELD_DEFINITION
+directive @limit(
+    """
+    You may set this to `true` if the field uses a query builder,
+    then this directive will apply a LIMIT clause to it.
+    Typically, this option should only be used for root fields,
+    as it may cause wrong results with batched relation queries.
+    """
+    builder: Boolean! = false
+) on ARGUMENT_DEFINITION | FIELD_DEFINITION
 
 # Directive class: Nuwave\Lighthouse\Schema\Directives\MethodDirective
 """
@@ -1102,9 +1129,28 @@ directive @union(
 
 # Directive class: Nuwave\Lighthouse\Schema\Directives\UpdateDirective
 """
-Update an Eloquent model with the input values of the field.
+Update an Eloquent model with the given arguments.
 """
 directive @update(
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model detection does not work.
+  """
+  model: String
+
+  """
+  Specify the name of the relation on the parent model.
+  This is only needed when using this directive as a nested arg
+  resolver and if the name of the relation is not the arg name.
+  """
+  relation: String
+) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
+# Directive class: Nuwave\Lighthouse\Schema\Directives\UpdateManyDirective
+"""
+Update multiple Eloquent models with the given arguments.
+"""
+directive @updateMany(
   """
   Specify the class name of the model to use.
   This is only needed when the default model detection does not work.
@@ -1145,9 +1191,28 @@ directive @upload(
 
 # Directive class: Nuwave\Lighthouse\Schema\Directives\UpsertDirective
 """
-Create or update an Eloquent model with the input values of the field.
+Create or update an Eloquent model with the given arguments.
 """
 directive @upsert(
+  """
+  Specify the class name of the model to use.
+  This is only needed when the default model detection does not work.
+  """
+  model: String
+
+  """
+  Specify the name of the relation on the parent model.
+  This is only needed when using this directive as a nested arg
+  resolver and if the name of the relation is not the arg name.
+  """
+  relation: String
+) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
+# Directive class: Nuwave\Lighthouse\Schema\Directives\UpsertManyDirective
+"""
+Create or update multiple Eloquent models with given arguments.
+"""
+directive @upsertMany(
   """
   Specify the class name of the model to use.
   This is only needed when the default model detection does not work.
@@ -1343,7 +1408,8 @@ and the value `true` is returned - thus the fields return type must be `Boolean!
 
 Once a [queue worker](https://laravel.com/docs/queues#running-the-queue-worker) picks up the job,
 it will actually execute the underlying field resolver.
-The result is not checked for errors, ensure your GraphQL error handling reports relevant exceptions.
+Errors that occur during execution are reported through the Laravel exception handler.
+The handlers in the `config/lighthouse.php` option `error_handlers` are not called.
 """
 directive @async(
     """


### PR DESCRIPTION
🤖 Related to (but does not close) [9754](https://github.com/GCTC-NTGC/gc-digital-talent/issues/9754)

## 👋 Introduction

We can't quite upgrade to Laravel 11 yet but this PR accomplishes a few small things:
- bumps Laratrust to 8.3
- identifies migrations that need to be checked
- unrelated, but running `composer update` rebuilds some graphql files

## 🧪 Testing

1. Rebuild app
2. Verify no functional or visible changes