### PR TITLE
[Fix] Dialog descriptions

### DIFF
--- a/apps/web/src/components/FilterDialog/FilterDialog.tsx
+++ b/apps/web/src/components/FilterDialog/FilterDialog.tsx
@@ -114,7 +114,7 @@ const FilterDialog = <TFieldValues extends FieldValues>({
           })}
         </Button>
       </Dialog.Trigger>
-      <Dialog.Content wide>
+      <Dialog.Content wide hasSubtitle>
         <Dialog.Header
           subtitle={intl.formatMessage({
             defaultMessage:

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -442,7 +442,7 @@ export const ScreeningDecisionDialog = ({
           )}
         </Button>
       </Dialog.Trigger>
-      <Dialog.Content>
+      <Dialog.Content hasSubtitle>
         <Dialog.Header subtitle={headers.subtitle}>
           {headers.title}
         </Dialog.Header>

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ClaimVerification/ClaimVerificationDialog.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ClaimVerification/ClaimVerificationDialog.tsx
@@ -137,7 +137,7 @@ const ClaimVerificationDialog = ({
           )}
         </Button>
       </Dialog.Trigger>
-      <Dialog.Content>
+      <Dialog.Content hasSubtitle>
         <Dialog.Header
           subtitle={
             isPriority

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialog.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialog.tsx
@@ -470,7 +470,7 @@ const AssessmentDetailsDialog = ({
   return (
     <Dialog.Root open={isOpen} onOpenChange={(open) => setIsOpen(open)}>
       <Dialog.Trigger>{trigger}</Dialog.Trigger>
-      <Dialog.Content>
+      <Dialog.Content hasSubtitle>
         <Dialog.Header
           subtitle={intl.formatMessage({
             defaultMessage: "Provide additional details about this assessment",

--- a/apps/web/src/pages/Pools/EditPoolPage/components/ClosingDateSection/ClosingDateDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/ClosingDateSection/ClosingDateDialog.tsx
@@ -26,7 +26,7 @@ const ClosingDateDialog = ({ title }: { title: ReactNode }): JSX.Element => {
           {title}
         </Button>
       </Dialog.Trigger>
-      <Dialog.Content>
+      <Dialog.Content hasSubtitle>
         <Dialog.Header
           subtitle={intl.formatMessage({
             defaultMessage:

--- a/apps/web/src/pages/Pools/EditPoolPage/components/GeneralQuestionsSection/GeneralQuestionDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/GeneralQuestionsSection/GeneralQuestionDialog.tsx
@@ -93,7 +93,7 @@ const GeneralQuestionDialog = ({
           </CardRepeater.Add>
         )}
       </Dialog.Trigger>
-      <Dialog.Content>
+      <Dialog.Content hasSubtitle>
         <Dialog.Header
           subtitle={intl.formatMessage({
             defaultMessage:

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SkillLevelDialog.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SkillLevelDialog.tsx
@@ -25,7 +25,7 @@ const SkillLevelDialog = () => {
           })}
         </Button>
       </Dialog.Trigger>
-      <Dialog.Content>
+      <Dialog.Content hasSubtitle>
         <Dialog.Header
           subtitle={intl.formatMessage({
             defaultMessage:

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/WorkLocationDialog.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/WorkLocationDialog.tsx
@@ -26,7 +26,7 @@ const WorkLocationDialog = ({ workLocation }: WorkLocationDialogProps) => {
           })}
         />
       </Dialog.Trigger>
-      <Dialog.Content>
+      <Dialog.Content hasSubtitle>
         <Dialog.Header
           subtitle={intl.formatMessage({
             defaultMessage:

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -532,7 +532,7 @@ export const UpdateUserSkillForm = ({
                             })}
                           </Button>
                         </Dialog.Trigger>
-                        <Dialog.Content>
+                        <Dialog.Content hasSubtitle>
                           <Dialog.Header
                             subtitle={intl.formatMessage({
                               defaultMessage:

--- a/packages/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.stories.tsx
@@ -29,7 +29,7 @@ const Template: StoryFn<typeof Dialog.Root> = () => (
     <Dialog.Trigger>
       <Button>Open Dialog</Button>
     </Dialog.Trigger>
-    <Dialog.Content>
+    <Dialog.Content hasSubtitle>
       <Dialog.Header subtitle="A dialog is a window overlaid on either the primary window or another dialog window.">
         Basic Dialog
       </Dialog.Header>

--- a/packages/ui/src/components/Dialog/Dialog.test.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.test.tsx
@@ -22,7 +22,7 @@ const DefaultChildren = () => (
     <Dialog.Trigger>
       <Button>Open Dialog</Button>
     </Dialog.Trigger>
-    <Dialog.Content>
+    <Dialog.Content hasSubtitle>
       <Dialog.Header subtitle="Dialog Subtitle">Dialog Title</Dialog.Header>
       <Dialog.Body>
         <p>{faker.lorem.sentences(3)}</p>
@@ -103,7 +103,7 @@ describe("Dialog", () => {
           <Dialog.Trigger>
             <Button icon={PlusIcon}>Open Dialog</Button>
           </Dialog.Trigger>
-          <Dialog.Content>
+          <Dialog.Content hasSubtitle>
             <Dialog.Header subtitle="Dialog Subtitle">
               Dialog Title
             </Dialog.Header>

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -90,6 +90,7 @@ interface DialogProps extends DialogPrimitiveContentProps {
   container?: HTMLElement;
   wide?: boolean;
   closeLabel?: string;
+  hasSubtitle?: boolean;
 }
 
 type DialogPrimitiveContentProps = ComponentPropsWithoutRef<
@@ -101,7 +102,14 @@ const Content = forwardRef<
   DialogProps
 >(
   (
-    { container, closeLabel, wide = false, children, ...props },
+    {
+      container,
+      closeLabel,
+      children,
+      wide = false,
+      hasSubtitle = false,
+      ...props
+    },
     forwardedRef,
   ) => {
     const intl = useIntl();
@@ -118,6 +126,9 @@ const Content = forwardRef<
               : {
                   "data-h2-max-width": "base(x32)",
                 })}
+            {...(!hasSubtitle && {
+              "aria-describedby": undefined,
+            })}
             {...props}
           >
             <StyledClose>


### PR DESCRIPTION
🤖 Resolves #10864 

## 👋 Introduction

Fixes an issue with dialogs missing descriptions.

## 🕵️ Details

I was wrong about it being as simple as I assumed. The place where we need to apply the prop override was on a different component. Sadly, without making larger changes to how we compose the `Dialog`, for now we just need to pass `hasSubtitle` to `Dialog.Content` when there is a subtitle present.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Confirm dialogs with no subtitle have no warnings in console
3. Confirm dialogs with subtitles still have the `aria-describedby` attribute and is properly associated to the subtitle
