### PR TITLE
[Perf] Lazy load site banner

### DIFF
--- a/apps/web/src/components/Layout/BannerContent.tsx
+++ b/apps/web/src/components/Layout/BannerContent.tsx
@@ -1,0 +1,28 @@
+import { Alert } from "@gc-digital-talent/ui";
+import { RichTextRenderer, htmlToRichTextJSON } from "@gc-digital-talent/forms";
+
+interface BannerContentProps {
+  title: string;
+  message: string;
+}
+
+const BannerContent = ({ title, message }: BannerContentProps) => (
+  <div
+    data-h2-background-color="base(foreground) base:dark(white)"
+    data-h2-padding="base(x1, 0)"
+  >
+    <div data-h2-container="base(center, large, x1)">
+      <Alert.Root
+        type="warning"
+        live
+        data-h2-shadow="base(none)"
+        data-h2-margin="base(0, -x1, 0, -x1)"
+      >
+        <Alert.Title>{title}</Alert.Title>
+        <RichTextRenderer node={htmlToRichTextJSON(message)} />
+      </Alert.Root>
+    </div>
+  </div>
+);
+
+export default BannerContent;

--- a/apps/web/src/components/Layout/SitewideBanner.tsx
+++ b/apps/web/src/components/Layout/SitewideBanner.tsx
@@ -3,12 +3,14 @@ import { isAfter } from "date-fns/isAfter";
 import { isBefore } from "date-fns/isBefore";
 import { useQuery } from "urql";
 import { useIntl } from "react-intl";
+import { lazy, Suspense } from "react";
 
 import { graphql } from "@gc-digital-talent/graphql";
 import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
-import { Alert } from "@gc-digital-talent/ui";
+import { Loading } from "@gc-digital-talent/ui";
 import { getLocale } from "@gc-digital-talent/i18n";
-import { RichTextRenderer, htmlToRichTextJSON } from "@gc-digital-talent/forms";
+
+const BannerContent = lazy(() => import("./BannerContent"));
 
 const SitewideBanner_Query = graphql(/* GraphQL */ `
   query SitewideBanner {
@@ -66,22 +68,9 @@ const SitewideBanner = () => {
 
   return (
     showMaintenanceBanner && (
-      <div
-        data-h2-background-color="base(foreground) base:dark(white)"
-        data-h2-padding="base(x1, 0)"
-      >
-        <div data-h2-container="base(center, large, x1)">
-          <Alert.Root
-            type="warning"
-            live
-            data-h2-shadow="base(none)"
-            data-h2-margin="base(0, -x1, 0, -x1)"
-          >
-            <Alert.Title>{title}</Alert.Title>
-            <RichTextRenderer node={htmlToRichTextJSON(message)} />
-          </Alert.Root>
-        </div>
-      </div>
+      <Suspense fallback={<Loading inline />}>
+        <BannerContent title={title} message={message} />
+      </Suspense>
     )
   );
 };


### PR DESCRIPTION
🤖 Resolves #10897 

## 👋 Introduction

Updates the site banner to be dynamically imported so it does not need to load when there is no message to be displayed.

## 🕵️ Details

Since the banner contains rich text, we need to load tiptap to render the data. Tiptap is one of our larger libraries (307kb) so we should only load it when we need it.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Navigate to the homepage
3. Confirm tip tap is not loaded
4. Enable the banner
5. Navigate home
6. Confirm tiptap is loaded and banner renders

## 📸 Screenshot

### Not loaded

![screenshot_05-Jul-2024_12-08-1720195696](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/a5de4a65-d04c-4bd9-a62e-f984db473aa4)

### Loaded

![screenshot_05-Jul-2024_12-11-1720195864](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/dec1202f-8843-4dfa-ad88-9a2d90ad17d4)

