### PR TITLE
[Fix] Profile print documents

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -82,6 +82,11 @@ import {
   jobPlacementDialogAccessor,
 } from "./JobPlacementDialog";
 import { PoolCandidate_BookmarkFragment } from "../CandidateBookmark/CandidateBookmark";
+import { ProfileDocument_Fragment } from "../ProfileDocument/ProfileDocument";
+
+type SelectedCandidate = PoolCandidate & {
+  user?: PoolCandidate["user"] & FragmentType<typeof ProfileDocument_Fragment>;
+};
 
 const columnHelper = createColumnHelper<PoolCandidateWithSkillCount>();
 
@@ -451,9 +456,9 @@ const PoolCandidatesTable = ({
   });
   const [isSelecting, setIsSelecting] = useState<boolean>(false);
   const [selectingFor, setSelectingFor] = useState<SelectingFor>(null);
-  const [selectedCandidates, setSelectedCandidates] = useState<PoolCandidate[]>(
-    [],
-  );
+  const [selectedCandidates, setSelectedCandidates] = useState<
+    SelectedCandidate[]
+  >([]);
   const searchParams = new URLSearchParams(window.location.search);
   const filtersEncoded = searchParams.get(SEARCH_PARAM_KEY.FILTERS);
   const initialFilters: PoolCandidateSearchInput = useMemo(
@@ -985,7 +990,7 @@ const PoolCandidatesTable = ({
       print={{
         component: (
           <UserProfilePrintButton
-            users={selectedCandidates}
+            users={selectedCandidates.map((candidate) => candidate.user)}
             beforePrint={async () => {
               await querySelected("print");
             }}

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -426,6 +426,7 @@ export const PoolCandidatesTable_SelectPoolCandidatesQuery = graphql(
           }
         }
         user {
+          ...ProfileDocument
           id
           email
           firstName

--- a/apps/web/src/components/PrintButton/SingleUserProfilePrintButton.tsx
+++ b/apps/web/src/components/PrintButton/SingleUserProfilePrintButton.tsx
@@ -10,10 +10,12 @@ import {
   Color,
   DropdownMenu,
 } from "@gc-digital-talent/ui";
-import { User } from "@gc-digital-talent/graphql";
+import { FragmentType } from "@gc-digital-talent/graphql";
 
 import printStyles from "~/styles/printStyles";
-import ProfileDocument from "~/components/ProfileDocument/ProfileDocument";
+import ProfileDocument, {
+  ProfileDocument_Fragment,
+} from "~/components/ProfileDocument/ProfileDocument";
 
 const documentTitle = defineMessage({
   defaultMessage: "Candidate profile",
@@ -22,7 +24,7 @@ const documentTitle = defineMessage({
 });
 
 interface SingleUserProfilePrintButtonProps {
-  users: User[];
+  users: FragmentType<typeof ProfileDocument_Fragment>[];
   color: Color;
   mode: ButtonLinkMode;
 }
@@ -85,8 +87,12 @@ const SingleUserProfilePrintButton = ({
           </DropdownMenu.Item>
         </DropdownMenu.Content>
       </DropdownMenu.Root>
-      <ProfileDocument anonymous results={users} ref={anonymousComponentRef} />
-      <ProfileDocument results={users} ref={fullComponentRef} />
+      <ProfileDocument
+        anonymous
+        userQuery={users}
+        ref={anonymousComponentRef}
+      />
+      <ProfileDocument userQuery={users} ref={fullComponentRef} />
     </>
   );
 };

--- a/apps/web/src/components/PrintButton/UserProfilePrintButton.tsx
+++ b/apps/web/src/components/PrintButton/UserProfilePrintButton.tsx
@@ -9,16 +9,18 @@ import {
   Color,
   DropdownMenu,
 } from "@gc-digital-talent/ui";
-import { PoolCandidate, User } from "@gc-digital-talent/graphql";
+import { FragmentType } from "@gc-digital-talent/graphql";
 
 import printStyles from "~/styles/printStyles";
-import ProfileDocument from "~/components/ProfileDocument/ProfileDocument";
+import ProfileDocument, {
+  ProfileDocument_Fragment,
+} from "~/components/ProfileDocument/ProfileDocument";
 import SpinnerIcon from "~/components/SpinnerIcon/SpinnerIcon";
 
 type UserProfileDocumentTypes = "all-info" | "anonymous";
 
 interface UserProfilePrintButtonProps {
-  users: User[] | PoolCandidate[];
+  users: FragmentType<typeof ProfileDocument_Fragment>[];
   color: Color;
   mode: ButtonLinkMode;
   fontSize?: "caption" | "body";
@@ -140,8 +142,8 @@ const UserProfilePrintButton = ({
       </DropdownMenu.Root>
       <ProfileDocument
         anonymous={isAnonymous === "anonymous"}
-        results={users}
         ref={componentRef}
+        userQuery={users}
       />
     </>
   );

--- a/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
+++ b/apps/web/src/components/ProfileDocument/ProfileDocument.tsx
@@ -18,11 +18,12 @@ import {
   navigationMessages,
 } from "@gc-digital-talent/i18n";
 import {
+  graphql,
   OperationalRequirement,
   PositionDuration,
-  User,
   IndigenousCommunity,
-  PoolCandidate,
+  FragmentType,
+  getFragment,
 } from "@gc-digital-talent/graphql";
 
 import { getFullNameLabel } from "~/utils/nameUtils";
@@ -32,8 +33,396 @@ import { anyCriteriaSelected as anyCriteriaSelectedDiversityEquityInclusion } fr
 import UserSkillList from "./UserSkillList";
 import Display from "../Profile/components/LanguageProfile/Display";
 
+export const ProfileDocument_Fragment = graphql(/* GraphQL */ `
+  fragment ProfileDocument on User {
+    id
+    email
+    firstName
+    lastName
+    telephone
+    citizenship {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    armedForcesStatus {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    preferredLang {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    preferredLanguageForInterview {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    preferredLanguageForExam {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    currentProvince {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    currentCity
+    lookingForEnglish
+    lookingForFrench
+    lookingForBilingual
+    firstOfficialLanguage {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    secondLanguageExamCompleted
+    secondLanguageExamValidity
+    comprehensionLevel {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    writtenLevel {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    verbalLevel {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    estimatedLanguageAbility {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    isGovEmployee
+    govEmployeeType {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    hasPriorityEntitlement
+    priorityNumber
+    locationPreferences {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    locationExemptions
+    positionDuration
+    acceptedOperationalRequirements {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    indigenousCommunities {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    indigenousDeclarationSignature
+    hasDisability
+    isVisibleMinority
+    isWoman
+    poolCandidates {
+      id
+      status {
+        value
+        label {
+          en
+          fr
+        }
+      }
+      expiryDate
+      notes
+      suspendedAt
+      user {
+        id
+      }
+      pool {
+        id
+        name {
+          en
+          fr
+        }
+        classification {
+          id
+          group
+          level
+        }
+        stream {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        publishingGroup {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        team {
+          id
+          name
+          displayName {
+            en
+            fr
+          }
+        }
+      }
+    }
+    department {
+      id
+      departmentNumber
+      name {
+        en
+        fr
+      }
+    }
+    currentClassification {
+      id
+      group
+      level
+      name {
+        en
+        fr
+      }
+    }
+    experiences {
+      id
+      __typename
+      user {
+        id
+        email
+      }
+      details
+      skills {
+        id
+        key
+        name {
+          en
+          fr
+        }
+        description {
+          en
+          fr
+        }
+        keywords {
+          en
+          fr
+        }
+        category {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        experienceSkillRecord {
+          details
+        }
+      }
+      ... on AwardExperience {
+        title
+        issuedBy
+        awardedDate
+        awardedTo {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        awardedScope {
+          value
+          label {
+            en
+            fr
+          }
+        }
+      }
+      ... on CommunityExperience {
+        title
+        organization
+        project
+        startDate
+        endDate
+      }
+      ... on EducationExperience {
+        institution
+        areaOfStudy
+        thesisTitle
+        startDate
+        endDate
+        type {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        status {
+          value
+          label {
+            en
+            fr
+          }
+        }
+      }
+      ... on PersonalExperience {
+        title
+        description
+        startDate
+        endDate
+      }
+      ... on WorkExperience {
+        role
+        organization
+        division
+        startDate
+        endDate
+      }
+    }
+    topTechnicalSkillsRanking {
+      id
+      user {
+        id
+      }
+      skill {
+        id
+        key
+        category {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        name {
+          en
+          fr
+        }
+      }
+      skillLevel
+      topSkillsRank
+      improveSkillsRank
+    }
+    topBehaviouralSkillsRanking {
+      id
+      user {
+        id
+      }
+      skill {
+        id
+        key
+        category {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        name {
+          en
+          fr
+        }
+      }
+      skillLevel
+      topSkillsRank
+      improveSkillsRank
+    }
+    improveTechnicalSkillsRanking {
+      id
+      user {
+        id
+      }
+      skill {
+        id
+        key
+        category {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        name {
+          en
+          fr
+        }
+      }
+      skillLevel
+      topSkillsRank
+      improveSkillsRank
+    }
+    improveBehaviouralSkillsRanking {
+      id
+      user {
+        id
+      }
+      skill {
+        id
+        key
+        category {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        name {
+          en
+          fr
+        }
+      }
+      skillLevel
+      topSkillsRank
+      improveSkillsRank
+    }
+  }
+`);
+
 interface ProfileDocumentProps {
-  results: User[] | PoolCandidate[];
+  userQuery: FragmentType<typeof ProfileDocument_Fragment>[];
   anonymous?: boolean;
 }
 
@@ -56,9 +445,10 @@ const BreakingPageSection = ({ children }: { children: ReactNode }) => (
 );
 
 const ProfileDocument = forwardRef<HTMLDivElement, ProfileDocumentProps>(
-  ({ results, anonymous }, ref) => {
+  ({ userQuery, anonymous }, ref) => {
     const intl = useIntl();
     const locale = getLocale(intl);
+    const results = getFragment(ProfileDocument_Fragment, userQuery);
 
     return (
       <div style={{ display: "none" }}>
@@ -89,8 +479,7 @@ const ProfileDocument = forwardRef<HTMLDivElement, ProfileDocumentProps>(
             )}
             {results &&
               results.map((initialResult, index) => {
-                const result: User =
-                  "user" in initialResult ? initialResult.user : initialResult;
+                const result = initialResult;
 
                 const regionPreferencesSquished =
                   result.locationPreferences?.map((region) =>

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -66,6 +66,7 @@ const PoolCandidate_SnapshotQuery = graphql(/* GraphQL */ `
       }
       user {
         ...ApplicationProfileDetails
+        ...ProfileDocument
         id
         firstName
         lastName
@@ -793,6 +794,7 @@ export const ViewPoolCandidate = ({
                 <ErrorBoundary>
                   <ApplicationInformation
                     poolQuery={poolCandidate.pool}
+                    user={poolCandidate.user}
                     snapshot={parsedSnapshot}
                     application={snapshotCandidate}
                   />

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationInformation/ApplicationInformation.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationInformation/ApplicationInformation.tsx
@@ -32,6 +32,7 @@ import WorkPreferencesDisplay from "~/components/Profile/components/WorkPreferen
 import { categorizeSkill, groupPoolSkillByType } from "~/utils/skillUtils";
 import applicationMessages from "~/messages/applicationMessages";
 import processMessages from "~/messages/processMessages";
+import { ProfileDocument_Fragment } from "~/components/ProfileDocument/ProfileDocument";
 
 import ApplicationPrintButton from "../ApplicationPrintButton/ApplicationPrintButton";
 import EducationRequirementsDisplay from "./EducationRequirementsDisplay";
@@ -91,12 +92,14 @@ interface ApplicationInformationProps {
       })
     | null;
   snapshot: User;
+  user: FragmentType<typeof ProfileDocument_Fragment>;
   defaultOpen?: boolean;
 }
 
 const ApplicationInformation = ({
   poolQuery,
   snapshot,
+  user,
   application,
   defaultOpen = false,
 }: ApplicationInformationProps) => {
@@ -164,7 +167,8 @@ const ApplicationInformation = ({
               mode="inline"
               color="secondary"
               pool={pool}
-              user={snapshot}
+              user={[user]}
+              snapshot={snapshot}
             />
           )}
           <Button mode="inline" color="secondary" onClick={toggleSections}>

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationPrintButton/ApplicationPrintButton.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationPrintButton/ApplicationPrintButton.tsx
@@ -12,12 +12,14 @@ import {
 } from "@gc-digital-talent/ui";
 import { FragmentType, User } from "@gc-digital-talent/graphql";
 
+import ProfileDocument, {
+  ProfileDocument_Fragment,
+} from "~/components/ProfileDocument/ProfileDocument";
 import printStyles from "~/styles/printStyles";
 
 import ApplicationPrintDocument, {
   ApplicationPrintDocument_PoolFragment,
 } from "./ApplicationPrintDocument";
-import ProfileDocument from "../../../../../components/ProfileDocument/ProfileDocument";
 
 const printApplication = defineMessage({
   defaultMessage: "Print application",
@@ -26,7 +28,8 @@ const printApplication = defineMessage({
 });
 
 interface ApplicationPrintButtonProps {
-  user: User;
+  snapshot: User;
+  user: FragmentType<typeof ProfileDocument_Fragment>[];
   pool: FragmentType<typeof ApplicationPrintDocument_PoolFragment>;
   color: Color;
   mode: ButtonLinkMode;
@@ -34,6 +37,7 @@ interface ApplicationPrintButtonProps {
 }
 
 const ApplicationPrintButton = ({
+  snapshot,
   user,
   pool,
   color,
@@ -113,12 +117,12 @@ const ApplicationPrintButton = ({
         </DropdownMenu.Content>
       </DropdownMenu.Root>
       <ApplicationPrintDocument
-        user={user}
+        user={snapshot}
         poolQuery={pool}
         ref={applicationRef}
       />
-      <ProfileDocument results={[user]} ref={fullProfileRef} />
-      <ProfileDocument anonymous results={[user]} ref={anonymousProfileRef} />
+      <ProfileDocument userQuery={user} ref={fullProfileRef} />
+      <ProfileDocument anonymous userQuery={user} ref={anonymousProfileRef} />
     </>
   );
 };

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
@@ -50,6 +50,7 @@ export const MoreActions_Fragment = graphql(/* GraphQL */ `
       id
       firstName
       lastName
+      ...ProfileDocument
     }
     status {
       value
@@ -179,7 +180,8 @@ const MoreActions = ({
               mode="inline"
               color="secondary"
               pool={poolCandidate.pool}
-              user={parsedSnapshot}
+              snapshot={parsedSnapshot}
+              user={[poolCandidate.user]}
               buttonLabel={intl.formatMessage(commonMessages.print)}
             />
           </CardBasic>

--- a/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
+++ b/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
@@ -19,6 +19,7 @@ import SingleUserProfilePrintButton from "~/components/PrintButton/SingleUserPro
 
 const AdminUserProfileUser_Fragment = graphql(/* GraphQL */ `
   fragment AdminUserProfileUser on User {
+    ...ProfileDocument
     id
     email
     firstName

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -17,7 +17,12 @@ import {
   getLocalizedName,
 } from "@gc-digital-talent/i18n";
 import { toast } from "@gc-digital-talent/toast";
-import { User, UserFilterInput, graphql } from "@gc-digital-talent/graphql";
+import {
+  FragmentType,
+  User,
+  UserFilterInput,
+  graphql,
+} from "@gc-digital-talent/graphql";
 
 import Table, {
   getTableStateFromSearchParams,
@@ -38,6 +43,7 @@ import {
 import accessors from "~/components/Table/accessors";
 import useSelectedRows from "~/hooks/useSelectedRows";
 import UserProfilePrintButton from "~/components/PrintButton/UserProfilePrintButton";
+import { ProfileDocument_Fragment } from "~/components/ProfileDocument/ProfileDocument";
 
 import {
   UsersTable_SelectUsersQuery,
@@ -49,6 +55,8 @@ import {
 } from "./utils";
 import UserFilterDialog, { FormValues } from "./UserFilterDialog";
 import { getUserCsvData, getUserCsvHeaders } from "./userCsv";
+
+type SelectedApplicants = FragmentType<typeof ProfileDocument_Fragment>[];
 
 const columnHelper = createColumnHelper<User>();
 
@@ -153,7 +161,8 @@ const UserTable = ({ title }: UserTableProps) => {
   const client = useClient();
   const [selectingFor, setSelectingFor] = useState<SelectingFor>(null);
   const [isSelecting, setIsSelecting] = useState<boolean>(false);
-  const [selectedApplicants, setSelectedApplicants] = useState<User[]>([]);
+  const [selectedApplicants, setSelectedApplicants] =
+    useState<SelectedApplicants>([]);
   const searchParams = new URLSearchParams(window.location.search);
   const filtersEncoded = searchParams.get(SEARCH_PARAM_KEY.FILTERS);
   const initialFilters: UserFilterInput = useMemo(
@@ -343,7 +352,7 @@ const UserTable = ({ title }: UserTableProps) => {
       })
       .toPromise()
       .then((result) => {
-        const users: User[] = unpackMaybes(result.data?.applicants);
+        const users = unpackMaybes(result.data?.applicants);
 
         if (result.error) {
           toast.error(intl.formatMessage(errorMessages.unknown));

--- a/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
@@ -168,6 +168,7 @@ export function transformUserFilterInputToFormValues(
 export const UsersTable_SelectUsersQuery = graphql(/* GraphQL */ `
   query UsersTable_SelectUsers($ids: [ID]!) {
     applicants(includeIds: $ids) {
+      ...ProfileDocument
       id
       email
       firstName


### PR DESCRIPTION
🤖 Resolves #10866 

## 👋 Introduction

Fixes the user profile print documents to print the correct information.

## 🕵️ Details

Looks as though the profile print document accepted either a `PoolCandidate` or `User` which is not expected. The document should always be the `User`. So when printing the user profile from the application page, we were passing in the snapshot which was missing data and since the document accepted the entire `PoolCandidate` type, it was fine with this.

I noticed a lot of tech debt in these print documents and how we actually go about doing it which could be why we are finding issues with them Is it worth taking a closer look in another ticket or just push the server generated version higher up in the priority list? :thinking: 

## 🧪 Testing

1. Build the app `pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Generate all possible print documents
    - Pool candidate table, user profile (this one is confusing because while we are on the pool candidates table, we are actually printing the user profiles and not the application itself)
    - Pool candidate page (Application + user profile)
    - User table (User profiles)
    - User profile page (User profile)
