### PR TITLE
[Bug] Resolve `view-any-submittedApplication` and authorized scope issue

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -749,28 +749,26 @@ class PoolCandidate extends Model
             return $query->where('id', null);
         }
 
-        if (! $user->isAbleTo('view-any-submittedApplication')) {
-            $query->where(function (Builder $query) use ($user) {
-                if ($user->isAbleTo('view-any-submittedApplication')) {
-                    $query->orWhere('submitted_at', '<=', Carbon::now()->toDateTimeString());
-                }
+        $query->where(function (Builder $query) use ($user) {
+            if ($user->isAbleTo('view-any-submittedApplication')) {
+                $query->orWhere('submitted_at', '<=', Carbon::now()->toDateTimeString());
+            }
 
-                if ($user->isAbleTo('view-team-submittedApplication')) {
-                    $teamIds = $user->rolesTeams()->get()->pluck('id');
-                    $query->orWhereHas('pool', function (Builder $query) use ($teamIds) {
-                        return $query
-                            ->where('submitted_at', '<=', Carbon::now()->toDateTimeString())
-                            ->whereHas('legacyTeam', function (Builder $query) use ($teamIds) {
-                                return $query->whereIn('id', $teamIds);
-                            });
-                    });
-                }
+            if ($user->isAbleTo('view-team-submittedApplication')) {
+                $teamIds = $user->rolesTeams()->get()->pluck('id');
+                $query->orWhereHas('pool', function (Builder $query) use ($teamIds) {
+                    return $query
+                        ->where('submitted_at', '<=', Carbon::now()->toDateTimeString())
+                        ->whereHas('legacyTeam', function (Builder $query) use ($teamIds) {
+                            return $query->whereIn('id', $teamIds);
+                        });
+                });
+            }
 
-                if ($user->isAbleTo('view-own-application')) {
-                    $query->orWhere('user_id', $user->id);
-                }
-            });
-        }
+            if ($user->isAbleTo('view-own-application')) {
+                $query->orWhere('user_id', $user->id);
+            }
+        });
 
         return $query;
     }

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -31,6 +31,8 @@ use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
 use Tests\UsesProtectedGraphqlEndpoint;
 
+use function PHPUnit\Framework\assertSame;
+
 class UserTest extends TestCase
 {
     use MakesGraphQLRequests;
@@ -2489,5 +2491,53 @@ class UserTest extends TestCase
         )->assertJsonFragment([
             'sub' => 'admin123',
         ]);
+    }
+
+    public function testUsersNestedPoolCandidates(): void
+    {
+        // applicant has one submitted and one draft application
+        $applicant = User::factory()->asApplicant()->create();
+        $draftApplication = PoolCandidate::factory()->create([
+            'user_id' => $applicant->id,
+            'pool_candidate_status' => PoolCandidateStatus::DRAFT->name,
+            'submitted_at' => null,
+        ]);
+        $submittedApplication = PoolCandidate::factory()->create([
+            'user_id' => $applicant->id,
+            'pool_candidate_status' => PoolCandidateStatus::NEW_APPLICATION->name,
+            'submitted_at' => config('constants.past_date'),
+        ]);
+
+        $candidateCount = count(PoolCandidate::all());
+        assertSame(2, $candidateCount);
+
+        $query =
+            /** @lang GraphQL */
+            '
+            query user($id: UUID!) {
+                user(id: $id) {
+                    poolCandidates {
+                        id
+                    }
+                }
+            }
+        ';
+
+        // assert admin can fetch applicant user and their applications without error
+        // assert the JSON superset only contains one application
+        $this->actingAs($this->platformAdmin, 'api')
+            ->graphQL($query,
+                [
+                    'id' => $applicant->id,
+                ]
+            )->assertJson([
+                'data' => [
+                    'user' => [
+                        'poolCandidates' => [
+                            ['id' => $submittedApplication->id],
+                        ],
+                    ],
+                ],
+            ]);
     }
 }


### PR DESCRIPTION
🤖 Resolves #10902

## 👋 Introduction

Resolve the scope and policy conflict by removing the two lines requested in the issue. 

## 🧪 Testing

1. Attempt to replicate the issue per reproduction steps

>     Create an applicant who has submitted one application and has at least one other application still in draft
>     Log in as a platform_admin and/or as a Request Responder
>     You should see the applicant in the table for the relevant process
>     You should be able to click the user and see their profile (this currently fails)
>     You should be able to view the user's profile (this currently fails)

2. Ideally no longer see issues







