### PR TITLE
[Copy] Adds human-readable strings for some API error messages

### DIFF
--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -35,6 +35,10 @@
     "defaultMessage": "Sélectionnez {label}",
     "description": "Text to check checkbox button"
   },
+  "/qdFyj": {
+    "defaultMessage": "Cette compétence ne peut pas être supprimée. Elle est utilisée par un processus qui accepte actuellement les demandes.",
+    "description": "Error message for when skill is used by an active process"
+  },
   "/sSeis": {
     "defaultMessage": "Minorité visible",
     "description": "Group for when someone indicates they are a visible minority"
@@ -295,6 +299,10 @@
     "defaultMessage": "Le profil est incomplet",
     "description": "Message displayed when user attempts to apply to a pool with an incomplete profile"
   },
+  "CDJH4s": {
+    "defaultMessage": "Ce processus ne peut pas être rouvert. Il comporte une compétence requise qui a été supprimée.",
+    "description": "Error message for when a process to be re-opened contains a previously deleted skill"
+  },
   "CF69qZ": {
     "defaultMessage": "Administration des programmes",
     "description": "Full name of abbreviation for PM"
@@ -482,6 +490,10 @@
   "Mco0Km": {
     "defaultMessage": "Vous devez posséder au moins une compétence essentielle.",
     "description": "Error message that at least one Essential Skill is required"
+  },
+  "Me66rb": {
+    "defaultMessage": "L’opération a échoué. Cette compétence a déjà été supprimée.",
+    "description": "Error message for when attempting to delete a previously deleted skill"
   },
   "MidGAP": {
     "defaultMessage": "Supprimer le lien",

--- a/packages/i18n/src/messages/apiMessages.ts
+++ b/packages/i18n/src/messages/apiMessages.ts
@@ -411,6 +411,41 @@ export const apiMessages: { [key: string]: MessageDescriptor } = defineMessages(
       id: "XFFFCu",
       description: "Error message that the verification was not successful.",
     },
+
+    SkillUsedByActivePoster: {
+      defaultMessage:
+        "This skill cannot be deleted. The skill is in use by a process that is currently accepting applications.",
+      id: "/qdFyj",
+      description: "Error message for when skill is used by an active process",
+    },
+    CannotReopenUsingDeletedSkill: {
+      defaultMessage:
+        "This process cannot be re-opened. This process contains a required skill that has been deleted.",
+      id: "CDJH4s",
+      description:
+        "Error message for when a process to be re-opened contains a previously deleted skill",
+    },
+    FailedDueToSkillBeingDeleted: {
+      defaultMessage:
+        "This operation failed. This skill was previously deleted.",
+      id: "Me66rb",
+      description:
+        "Error message for when attempting to delete a previously deleted skill",
+    },
+    EssentialSkillsContainsDeleted: {
+      defaultMessage:
+        "This operation failed. This skill was previously deleted.",
+      id: "Me66rb",
+      description:
+        "Error message for when attempting to delete a previously deleted skill",
+    },
+    NonEssentialSkillsContainsDeleted: {
+      defaultMessage:
+        "This operation failed. This skill was previously deleted.",
+      id: "Me66rb",
+      description:
+        "Error message for when attempting to delete a previously deleted skill",
+    },
   },
 );
 


### PR DESCRIPTION
🤖 Resolves #10359.

## 👋 Introduction

This PR adds human-readable strings for some API error messages.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Verify strings in the code match those in the linked issue.