### PR TITLE
[FIX] Add dev dependencies to Azure build pipeline

### DIFF
--- a/infrastructure/azure-pipelines.yml
+++ b/infrastructure/azure-pipelines.yml
@@ -1,4 +1,12 @@
 name: $(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+parameters:
+  - name: buildMode
+    displayName: Build mode
+    type: string
+    default: default
+    values:
+      - default
+      - dev
 trigger:
   branches:
     include:
@@ -29,8 +37,14 @@ jobs:
       - script: infrastructure/bin/set_php_versions.sh ${{ variables.phpVersion }}
         displayName: "PHP version"
 
-        # -r option to specify the root directory
-      - script: infrastructure/bin/deploy.sh -r $(System.DefaultWorkingDirectory)
+      - script: |
+          if [ ${{ parameters.buildMode }} = 'dev' ]; then
+            # -d option to setup the environment with dev dependencies
+            echo "Building dev..." && infrastructure/bin/deploy.sh -d -r $(System.DefaultWorkingDirectory)
+          else
+            # -r option to specify the root directory
+            echo "Building default..." && infrastructure/bin/deploy.sh -r $(System.DefaultWorkingDirectory)
+          fi
         displayName: Dependencies
         env:
           # Vite requires build-time variable to have the VITE_ prefix


### PR DESCRIPTION
🤖 Resolves #10886 

## 👋 Introduction

This branch adds the ability to include the dev dependencies when deploying to Azure.  Rather than creating a new pipeline, I added a runtime parameter to the existing pipeline.

The one thing I'm not sure about is how the trigger will work.  I hope the default value will be used but we'll find out when it gets merged.  :sweat_smile:  If it doesn't work we can manually trigger the pipeline when needed until the change gets backed out.

## 🧪 Testing

1. Run the Azure Pipeline in dev mode
2. Deploy to an app service
3. SSH in and try a factory in Tinker

## 📸 Screenshot

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/29ffdf38-6ab4-4423-bc2d-323ca0a2621c)

![image](https://github.com/GCTC-NTGC/gc-digital-talent/assets/8978655/5acf817b-da18-4966-9c63-3035c1e967cd)