### PR TITLE
[Fix] Assessment status logic

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -1093,11 +1093,15 @@ class PoolCandidate extends Model
                     }
                 } else {
                     if ($poolSkill->skill->category === SkillCategory::TECHNICAL->name) {
+                        $isClaimed = false;
                         $snapshot = $this->profile_snapshot;
-                        $claimedSkills = collect($snapshot['userSkills']);
-                        $isClaimed = $claimedSkills->contains(function ($userSkill) use ($poolSkill) {
-                            return $userSkill['skill']['id'] === $poolSkill->skill_id;
-                        });
+
+                        if ($snapshot) {
+                            $claimedSkills = collect($snapshot['userSkills']);
+                            $isClaimed = $claimedSkills->contains(function ($userSkill) use ($poolSkill) {
+                                return $userSkill['skill']['id'] === $poolSkill->skill_id;
+                            });
+                        }
 
                         if (! $isClaimed) {
                             continue;
@@ -1188,7 +1192,7 @@ class PoolCandidate extends Model
 
         if ($currentStep >= $totalSteps) {
             $lastStepDecision = end($decisions);
-            if ($lastStepDecision['decision'] !== AssessmentDecision::HOLD->name) {
+            if ($lastStepDecision['decision'] !== AssessmentDecision::HOLD->name && ! is_null($lastStepDecision['decision'])) {
                 $overallAssessmentStatus = OverallAssessmentStatus::QUALIFIED->name;
                 $currentStep = null;
             }

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -1084,7 +1084,7 @@ class PoolCandidate extends Model
 
                         continue;
                     }
-                } else {
+                } else { // $poolSkill is an ASSET skill
 
                     // We do not need to evaluate non-essential technical skills that are not on
                     // the users snapshot, so skip the result check

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -1043,32 +1043,6 @@ class PoolCandidate extends Model
 
             $isApplicationScreening = $step->type === AssessmentStepType::APPLICATION_SCREENING->name;
             $stepResults = $this->assessmentResults->where('assessment_step_id', $stepId);
-            $hasEssentialSkillsToAssess = $step->poolSkills->contains(function ($poolSkill) {
-                return $poolSkill->type === PoolSkillType::ESSENTIAL->name;
-            });
-
-            // If no essential skills are to be assessed
-            // and not on application screening (requires education assessment)
-            // then it is an automatic pass
-            if (! $hasEssentialSkillsToAssess && ! $isApplicationScreening) {
-                $decisions[] = [
-                    'step' => $stepId,
-                    'decision' => AssessmentDecision::SUCCESSFUL->name,
-                ];
-
-                continue;
-            }
-
-            // Nothing has been assessed or, not all claimed skills have been assessed
-            // so we can't assign a decision yet
-            if ($stepResults->isEmpty()) {
-                $decisions[] = [
-                    'step' => $stepId,
-                    'decision' => null,
-                ];
-
-                continue;
-            }
 
             foreach ($step->poolSkills as $poolSkill) {
                 $result = $stepResults->firstWhere('pool_skill_id', $poolSkill->id);
@@ -1107,12 +1081,12 @@ class PoolCandidate extends Model
                             continue;
                         }
 
-                        if (! $result || is_null($result->assessment_decision)) {
-                            $hasToAssess = true;
+                    }
 
-                            continue;
-                        }
+                    if (! $result || is_null($result->assessment_decision)) {
+                        $hasToAssess = true;
 
+                        continue;
                     }
                 }
             }
@@ -1126,6 +1100,8 @@ class PoolCandidate extends Model
 
                         continue;
                     }
+
+                    $decision = $result->assessment_decision;
 
                     if ($decision === AssessmentDecision::UNSUCCESSFUL->name) {
                         $hasFailure = true;

--- a/api/database/factories/PoolCandidateFactory.php
+++ b/api/database/factories/PoolCandidateFactory.php
@@ -251,4 +251,14 @@ class PoolCandidateFactory extends Factory
                 ]);
         });
     }
+
+    /**
+     * Create a snapshot for the pool candidate
+     */
+    public function withSnapshot()
+    {
+        return $this->afterCreating(function (PoolCandidate $poolCandidate) {
+            $poolCandidate->setApplicationSnapshot();
+        });
+    }
 }

--- a/api/tests/Feature/CandidateAssessmentStatusTest.php
+++ b/api/tests/Feature/CandidateAssessmentStatusTest.php
@@ -506,7 +506,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function testMultipleEssentialMustPassToIncrementStep()
+    public function testAllSkillsMustPassToIncrementStep()
     {
 
         $pool = Pool::factory()
@@ -529,6 +529,15 @@ class CandidateAssessmentStatusTest extends TestCase
             'type' => PoolSkillType::NONESSENTIAL->name,
         ]);
 
+        $stepOne = $pool->assessmentSteps->first();
+
+        $stepTwo = AssessmentStep::factory()
+            ->afterCreating(function (AssessmentStep $step) use ($poolSkillOne, $poolSkillTwo) {
+                $step->poolSkills()->sync([$poolSkillOne->id, $poolSkillTwo->id]);
+            })->create([
+                'pool_id' => $pool->id,
+            ]);
+
         $user = User::factory()->create();
         UserSkill::factory()->create([
             'user_id' => $user->id,
@@ -541,15 +550,6 @@ class CandidateAssessmentStatusTest extends TestCase
             'submitted_at' => config('constants.past_date'),
             'expiry_date' => config('constants.far_future_date'),
         ]);
-
-        $stepOne = $pool->assessmentSteps->first();
-
-        $stepTwo = AssessmentStep::factory()
-            ->afterCreating(function (AssessmentStep $step) use ($poolSkillOne, $poolSkillTwo) {
-                $step->poolSkills()->sync([$poolSkillOne->id, $poolSkillTwo->id]);
-            })->create([
-                'pool_id' => $pool->id,
-            ]);
 
         AssessmentResult::factory()
             ->withResultType(AssessmentResultType::EDUCATION)


### PR DESCRIPTION
🤖 Resolves #10919 

## 👋 Introduction

Fixes a few gaps in the logic when computing the assessment status.

## 🕵️ Details

The main issue was, we were computing it based on available results. So, as soon as a single success occurred, the user passed the step. We have rewrote the logic to do it based off of skills needing to be assessed. There is some frontend stuff that is a little odd but this is how it should work now:

1. On every step, all skills (except for unclaimed optional technical skills) must be assessed before the step is considered complete and the user can move on to the next step
2. On the first step (application screening), all technical skills and education requirement must pass
3. Every other step,
    1. If a skill is essential and failed, step automatically fails
    2. If the skill is unsure or has not been assessed, the step is marked as "to assess"
    3. If all essential skills succeed, step is marked with success
    4. All other skills only count towards the step completion but not the actual status of the step

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Login as admin
2. Create a pool that has a few assessment steps making sure to mix up the types and categories of each skill type
3. Setup your user to have the following skills from the pool:
    - All essential technical skills
    - Missing at least one nonessential technical skill
    - Missing some essential and nonessential behavioural skills
4. Apply to the pool
5. Navigate tot he admin view of the application from step 4
6. Begin assessing the candidates skill, changing up the assessments to check the logic outlined
    - First step only passes once all skills + education have been assessed and are success or on hold
    - Other steps must have all essential skills and claimed (in the snapshot) non-essenital technical skills assessed before the step is incremented
    - Any essential skill failure is immediate disqualification
    - Step success is only determined after all skills (excluding unclaimed technical skills) have been asssessed
