### PR TITLE
[Copy] Fixes CAF typos in French

### DIFF
--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -920,7 +920,7 @@
     "description": "Label for a year input field"
   },
   "iYNLo1": {
-    "defaultMessage": "e suis un <strong>membre actif </strong> des Forces armées canadiennes.",
+    "defaultMessage": "Je suis un <strong>membre actif </strong> des Forces armées canadiennes.",
     "description": "declare self to be a CAF member"
   },
   "ijGl5r": {
@@ -1236,7 +1236,7 @@
     "description": "Descriptor for an info alert"
   },
   "vPDtGU": {
-    "defaultMessage": "e ne suis pas membre des Forces armées canadiennes.",
+    "defaultMessage": "Je ne suis pas membre des Forces armées canadiennes.",
     "description": "declare self to not be in the CAF without bolding"
   },
   "vvtqRv": {


### PR DESCRIPTION
🤖 Resolves #10928.

## 👋 Introduction

This PR fixes two typos related to CAF strings in French.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to `/fr/applicant/personal-information#about-section`
2. Change the value of the _Statut d'ancien combattant_ field
3. Verify all states on the edit and read views do not contain a typo

## 📸 Screenshots

<img width="840" alt="Screen Shot 2024-07-10 at 10 40 23" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/b72e4820-68e0-477d-aa37-d5c810bb1abe">
<img width="882" alt="Screen Shot 2024-07-10 at 10 40 08" src="https://github.com/GCTC-NTGC/gc-digital-talent/assets/3046459/c48d910e-07f4-4981-bdc5-f1c334aec12f">
