### PR TITLE
[Debt] Compress assets at built time

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -92,13 +92,14 @@
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "jest-axe": "^9.0.0",
-    "jest-fail-on-console": "^3.3.0",
     "jest-diff": "^29.7.0",
+    "jest-fail-on-console": "^3.3.0",
     "prettier": "^3.3.2",
     "ts-jest": "^29.1.5",
     "tsconfig": "workspace:*",
     "typescript": "^5.5.3",
     "vite": "^5.3.3",
+    "vite-plugin-compression2": "^1.1.2",
     "vite-plugin-html": "^3.2.2"
   }
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,6 +4,7 @@ import childProcess from "child_process";
 import dotenv from "dotenv";
 import react from "@vitejs/plugin-react";
 import { createHtmlPlugin } from "vite-plugin-html";
+import { compression } from "vite-plugin-compression2";
 import { Plugin, defineConfig } from "vite";
 
 import { hydrogen_watch } from "@hydrogen-css/hydrogen";
@@ -225,5 +226,6 @@ export default defineConfig(({ command }) => ({
         ],
       },
     }),
+    compression(),
   ],
 }));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
       vite:
         specifier: ^5.3.3
         version: 5.3.3
+      vite-plugin-compression2:
+        specifier: ^1.1.2
+        version: 1.1.2
       vite-plugin-html:
         specifier: ^3.2.2
         version: 3.2.2(vite@5.3.3)
@@ -15742,6 +15745,14 @@ packages:
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+    dev: true
+
+  /vite-plugin-compression2@1.1.2:
+    resolution: {integrity: sha512-kZ2ZG85uPc5o1ehz2uCNXg1uh05AtSyZ0rMQfHl90WHLP+wkxFTMm8wAhEKERtcbl7lMJXiOnHpwSWG+GloaoA==}
+    dependencies:
+      '@rollup/pluginutils': 5.1.0
+    transitivePeerDependencies:
+      - rollup
     dev: true
 
   /vite-plugin-html@3.2.2(vite@5.3.3):


### PR DESCRIPTION
🤖 Resolves #10935 

## 👋 Introduction

Compresses our assets at build time.

## 🧪 Testing

1. Build the project `pnpm run build:fresh`
2. Navigate to the homepage
3. Confirm the assets are not the full size
4. Confirm the header exists `Content-Encoding: gzip`

## 📸 Screenshot

![screenshot_10-Jul-2024_13-09-1720631383](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/917a6567-abae-4c42-b5d5-0c9f922113c9)
