### PR TITLE
[Feature] Add assessment status sync command

### DIFF
--- a/api/app/Console/Commands/SyncAssessmentStatus.php
+++ b/api/app/Console/Commands/SyncAssessmentStatus.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\PoolCandidate;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+
+class SyncAssessmentStatus extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:sync-assessment-status';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Syncs pool candidate assessment statuses with new logic';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        PoolCandidate::chunk(100, function (Collection $candidates) {
+            foreach ($candidates as $candidate) {
+                $assessmentStatus = $candidate->computeAssessmentStatus();
+
+                $candidate->computed_assessment_status = $assessmentStatus;
+
+                $candidate->save();
+            }
+        });
+    }
+}


### PR DESCRIPTION
🤖 Resolves #10960 

## 👋 Introduction

Adds a command that allows us to sync candidates assessment statuses.

## 🧪 Testing

1. Seed some candidates
2. Remove their status or change it to be incorrect
3. Run the command `make artisan CMD="app:sync-assessment-status"`
4. Check to ensure their status updated as expected

## :truck: Deployment

After deployment run the artisan command to sync new asessessment statuses:

```sh
php artisan app:sync-assessment-status
```