### PR TITLE
[Fix] Add fallback to preferred locale

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -198,7 +198,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
      */
     public function preferredLocale(): string
     {
-        return $this->preferred_lang;
+        return $this?->preferred_lang ?? 'en';
     }
 
     public function pools(): HasMany


### PR DESCRIPTION
🤖 Resolves #10862 

## 👋 Introduction

Adds a fallback (English) to the users preferred locale

## 🧪 Testing

1. Null out a users `preferred_lang`
2. Attempt to send a notification to them
3. Confirm to null locale error
