### PR TITLE
[Fix] Adds missing arg `user` to `ApplicationInfo` story

### DIFF
--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationInformation/ApplicationInfo.stories.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationInformation/ApplicationInfo.stories.tsx
@@ -46,9 +46,10 @@ mockUser = {
 export default {
   component: ApplicationInformation,
   args: {
-    snapshot: mockUser,
-    application: mockPoolCandidate,
     poolQuery: mockPool,
+    application: mockPoolCandidate,
+    snapshot: mockUser,
+    user: mockUser,
     defaultOpen: true,
   },
 };


### PR DESCRIPTION
🤖 Resolves #10963.

## 👋 Introduction

This PR adds missing arg `user` to `ApplicationInfo` story.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm storybook`
2. Verify `ApplicationInfo` story has no errors