### PR TITLE
[Debt] Merge pool candidates queries

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/JobPlacement.stories.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/JobPlacement.stories.tsx
@@ -45,7 +45,7 @@ export default {
   decorators: [OverlayOrDialogDecorator, MockGraphqlDecorator],
   args: {
     defaultOpen: true,
-    jobPlacementOptions: makeFragmentData(
+    optionsQuery: makeFragmentData(
       {
         departments,
         placementTypes: fakeLocalizedEnum(PlacementType),

--- a/apps/web/src/components/PoolCandidatesTable/JobPlacement.stories.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/JobPlacement.stories.tsx
@@ -18,6 +18,7 @@ import {
 
 import JobPlacementDialog, {
   JobPlacementDialog_Fragment,
+  JobPlacementOptions_Query,
 } from "./JobPlacementDialog";
 
 const fakedCandidate = fakePoolCandidates(1)[0];
@@ -43,17 +44,14 @@ export default {
   component: JobPlacementDialog,
   decorators: [OverlayOrDialogDecorator, MockGraphqlDecorator],
   args: {
-    departments,
     defaultOpen: true,
-  },
-  parameters: {
-    apiResponses: {
-      JobPlacementOptions: {
-        data: {
-          placementTypes: fakeLocalizedEnum(PlacementType),
-        },
+    jobPlacementOptions: makeFragmentData(
+      {
+        departments,
+        placementTypes: fakeLocalizedEnum(PlacementType),
       },
-    },
+      JobPlacementOptions_Query,
+    ),
   },
 } as Meta;
 

--- a/apps/web/src/components/PoolCandidatesTable/JobPlacementDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/JobPlacementDialog.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useIntl } from "react-intl";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
-import { useMutation, useQuery } from "urql";
+import { useMutation } from "urql";
 
 import {
   RadioGroup,
@@ -11,7 +11,6 @@ import {
   objectsToSortedOptions,
 } from "@gc-digital-talent/forms";
 import {
-  Department,
   FragmentType,
   PlacementType,
   PoolCandidateStatus,

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
@@ -28,7 +28,7 @@ import FilterDialog, {
 import { FormValues } from "./types";
 import PoolFilterInput from "../PoolFilterInput/PoolFilterInput";
 
-export const PoolCandidateFilterDialog_Query = graphql(/* GraphQL */ `
+const PoolCandidateFilterDialog_Query = graphql(/* GraphQL */ `
   fragment PoolCandidateFilterDialog on Query {
     classifications {
       group

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
@@ -1,5 +1,4 @@
 import { MessageDescriptor, useIntl } from "react-intl";
-import { OperationContext, useQuery } from "urql";
 
 import {
   Checkbox,
@@ -28,11 +27,6 @@ import FilterDialog, {
 } from "../FilterDialog/FilterDialog";
 import { FormValues } from "./types";
 import PoolFilterInput from "../PoolFilterInput/PoolFilterInput";
-
-const context: Partial<OperationContext> = {
-  additionalTypenames: ["Skill", "SkillFamily"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
-  requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
-};
 
 export const PoolCandidateFilterDialog_Query = graphql(/* GraphQL */ `
   fragment PoolCandidateFilterDialog on Query {

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
@@ -10,7 +10,7 @@ import {
   Select,
   localizedEnumToOptions,
 } from "@gc-digital-talent/forms";
-import { graphql } from "@gc-digital-talent/graphql";
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 import {
   commonMessages,
@@ -34,8 +34,8 @@ const context: Partial<OperationContext> = {
   requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
 };
 
-const PoolCandidateFilterDialog_Query = graphql(/* GraphQL */ `
-  query PoolCandidateFilterDialog_Query {
+export const PoolCandidateFilterDialog_Query = graphql(/* GraphQL */ `
+  fragment PoolCandidateFilterDialog on Query {
     classifications {
       group
       level
@@ -119,20 +119,18 @@ const PoolCandidateFilterDialog_Query = graphql(/* GraphQL */ `
 
 type PoolCandidateFilterDialogProps = CommonFilterDialogProps<FormValues> & {
   hidePoolFilter?: boolean;
+  query?: FragmentType<typeof PoolCandidateFilterDialog_Query>;
 };
 
 const PoolCandidateFilterDialog = ({
+  query,
   onSubmit,
   resetValues,
   initialValues,
   hidePoolFilter,
 }: PoolCandidateFilterDialogProps) => {
   const intl = useIntl();
-
-  const [{ data, fetching }] = useQuery({
-    query: PoolCandidateFilterDialog_Query,
-    context,
-  });
+  const data = getFragment(PoolCandidateFilterDialog_Query, query);
 
   const classifications = unpackMaybes(data?.classifications);
   const skills = unpackMaybes(data?.skills);
@@ -202,7 +200,6 @@ const PoolCandidateFilterDialog = ({
         <Combobox
           id="classifications"
           name="classifications"
-          {...{ fetching }}
           isMulti
           label={intl.formatMessage(adminMessages.classifications)}
           options={classifications.map(({ group, level }) => ({
@@ -293,7 +290,6 @@ const PoolCandidateFilterDialog = ({
           <Combobox
             id="skills"
             name="skills"
-            {...{ fetching }}
             isMulti
             label={intl.formatMessage(adminMessages.skills)}
             options={skills.map(({ id, name }) => ({

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -403,6 +403,11 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
   }
 `);
 
+const context: Partial<OperationContext> = {
+  additionalTypenames: ["Skill", "SkillFamily"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
+  requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
+};
+
 const defaultState = {
   ...INITIAL_STATE,
   // hiddenColumnIds: ["candidacyStatus", "notes"],
@@ -588,6 +593,7 @@ const PoolCandidatesTable = ({
 
   const [{ data: tableData, fetching: fetchingTableData }] = useQuery({
     query: CandidatesTable_Query,
+    context,
   });
   const allSkills = unpackMaybes(tableData?.skills);
   const filteredSkillIds = filterState?.applicantFilter?.skills

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -7,7 +7,7 @@ import {
   SortingState,
   createColumnHelper,
 } from "@tanstack/react-table";
-import { useClient, useQuery } from "urql";
+import { OperationContext, useClient, useQuery } from "urql";
 import isEqual from "lodash/isEqual";
 import DataLoader from "dataloader";
 

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -20,7 +20,6 @@ import {
   graphql,
   ArmedForcesStatus,
   PoolCandidateSnapshotQuery,
-  Department,
 } from "@gc-digital-talent/graphql";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -38,6 +38,7 @@ import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import ErrorBoundary from "~/components/ErrorBoundary/ErrorBoundary";
 import pageTitles from "~/messages/pageTitles";
+import { JobPlacementOptionsFragmentType } from "~/components/PoolCandidatesTable/JobPlacementDialog";
 
 import CareerTimelineSection from "./components/CareerTimelineSection/CareerTimelineSection";
 import ApplicationInformation from "./components/ApplicationInformation/ApplicationInformation";
@@ -53,6 +54,7 @@ const screeningAndAssessmentTitle = defineMessage({
 
 const PoolCandidate_SnapshotQuery = graphql(/* GraphQL */ `
   query PoolCandidateSnapshot($poolCandidateId: UUID!) {
+    ...JobPlacementOptions
     poolCandidate(id: $poolCandidateId) {
       ...MoreActions
       ...ClaimVerification
@@ -632,12 +634,12 @@ const PoolCandidate_SnapshotQuery = graphql(/* GraphQL */ `
 
 export interface ViewPoolCandidateProps {
   poolCandidate: NonNullable<PoolCandidateSnapshotQuery["poolCandidate"]>;
-  departments: Department[];
+  jobPlacementOptions: JobPlacementOptionsFragmentType;
 }
 
 export const ViewPoolCandidate = ({
   poolCandidate,
-  departments,
+  jobPlacementOptions,
 }: ViewPoolCandidateProps) => {
   const intl = useIntl();
   const paths = useRoutes();
@@ -743,7 +745,7 @@ export const ViewPoolCandidate = ({
             </p>
             <MoreActions
               poolCandidate={poolCandidate}
-              departments={departments}
+              jobPlacementOptions={jobPlacementOptions}
             />
             <div
               data-h2-display="base(flex)"
@@ -870,7 +872,7 @@ export const ViewPoolCandidatePage = () => {
       {data?.poolCandidate ? (
         <ViewPoolCandidate
           poolCandidate={data.poolCandidate}
-          departments={data.departments.filter(notEmpty)}
+          jobPlacementOptions={data}
         />
       ) : (
         <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
@@ -2,7 +2,6 @@ import { useIntl } from "react-intl";
 import UserCircleIcon from "@heroicons/react/20/solid/UserCircleIcon";
 
 import {
-  Department,
   FragmentType,
   Maybe,
   User,

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
@@ -19,6 +19,7 @@ import {
 } from "~/constants/poolCandidate";
 import useRoutes from "~/hooks/useRoutes";
 import JobPlacementDialog, {
+  JobPlacementOptionsFragmentType,
   PLACEMENT_TYPE_STATUSES,
 } from "~/components/PoolCandidatesTable/JobPlacementDialog";
 import { isQualifiedStatus, isRemovedStatus } from "~/utils/poolCandidate";
@@ -66,12 +67,12 @@ export const MoreActions_Fragment = graphql(/* GraphQL */ `
 
 interface MoreActionsProps {
   poolCandidate: FragmentType<typeof MoreActions_Fragment>;
-  departments: Department[];
+  jobPlacementOptions: JobPlacementOptionsFragmentType;
 }
 
 const MoreActions = ({
   poolCandidate: poolCandidateQuery,
-  departments,
+  jobPlacementOptions,
 }: MoreActionsProps) => {
   const intl = useIntl();
   const paths = useRoutes();
@@ -142,7 +143,7 @@ const MoreActions = ({
                   {intl.formatMessage(commonMessages.dividingColon)}
                   <JobPlacementDialog
                     jobPlacementDialogQuery={poolCandidate}
-                    departments={departments}
+                    optionsQuery={jobPlacementOptions}
                     context="view"
                   />
                 </span>

--- a/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.stories.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.stories.tsx
@@ -3,11 +3,13 @@ import { StoryFn } from "@storybook/react";
 
 import {
   fakeDepartments,
+  fakeLocalizedEnum,
   fakePools,
   fakeUser,
   toLocalizedEnum,
 } from "@gc-digital-talent/fake-data";
 import {
+  PlacementType,
   PoolCandidate,
   PoolCandidateStatus,
   makeFragmentData,
@@ -17,6 +19,8 @@ import {
   FAR_PAST_DATE,
 } from "@gc-digital-talent/date-helpers";
 import { MockGraphqlDecorator } from "@gc-digital-talent/storybook-helpers";
+
+import { JobPlacementOptions_Query } from "~/components/PoolCandidatesTable/JobPlacementDialog";
 
 import UserInformationPage, {
   UserInfo_Fragment,
@@ -129,7 +133,13 @@ const Template: StoryFn<typeof UserInformationPage> = () => {
   return (
     <UserInformation
       userQuery={makeFragmentData(typeAdjustedUser, UserInfo_Fragment)}
-      departments={mockDepartments}
+      jobPlacementOptions={makeFragmentData(
+        {
+          departments: mockDepartments,
+          placementTypes: fakeLocalizedEnum(PlacementType),
+        },
+        JobPlacementOptions_Query,
+      )}
     />
   );
 };

--- a/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
@@ -22,6 +22,7 @@ import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWr
 import useRequiredParams from "~/hooks/useRequiredParams";
 import adminMessages from "~/messages/adminMessages";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import { JobPlacementOptionsFragmentType } from "~/components/PoolCandidatesTable/JobPlacementDialog";
 
 import AboutSection from "./components/AboutSection";
 import CandidateStatusSection from "./components/CandidateStatusSection";
@@ -422,12 +423,12 @@ export const UserInfo_Fragment = graphql(/* GraphQL */ `
 
 interface UserInformationProps {
   userQuery: FragmentType<typeof UserInfo_Fragment>;
-  departments: Department[];
+  jobPlacementOptions: JobPlacementOptionsFragmentType;
 }
 
 export const UserInformation = ({
   userQuery,
-  departments,
+  jobPlacementOptions,
 }: UserInformationProps) => {
   const intl = useIntl();
   const user = getFragment(UserInfo_Fragment, userQuery);
@@ -452,7 +453,12 @@ export const UserInformation = ({
           "Title of the 'Candidate status' section of the view-user page",
       }),
       titleIcon: CalculatorIcon,
-      content: <CandidateStatusSection user={user} departments={departments} />,
+      content: (
+        <CandidateStatusSection
+          user={user}
+          jobPlacementOptions={jobPlacementOptions}
+        />
+      ),
     },
     {
       id: "notes",
@@ -511,14 +517,7 @@ const UserInformation_Query = graphql(/* GraphQL */ `
       ...UserInfo
     }
 
-    departments {
-      id
-      departmentNumber
-      name {
-        en
-        fr
-      }
-    }
+    ...JobPlacementOptions
   }
 `);
 
@@ -535,7 +534,6 @@ const UserInformationPage = () => {
   });
 
   const user = data?.user;
-  const departments = unpackMaybes(data?.departments);
 
   return (
     <AdminContentWrapper>
@@ -548,7 +546,7 @@ const UserInformationPage = () => {
       />
       <Pending fetching={fetching} error={error}>
         {user ? (
-          <UserInformation userQuery={user} departments={departments} />
+          <UserInformation userQuery={user} jobPlacementOptions={data} />
         ) : (
           <ThrowNotFound />
         )}

--- a/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
@@ -6,10 +6,8 @@ import UserIcon from "@heroicons/react/24/outline/UserIcon";
 import { useQuery } from "urql";
 
 import { Pending, TableOfContents, ThrowNotFound } from "@gc-digital-talent/ui";
-import { unpackMaybes } from "@gc-digital-talent/helpers";
 import { commonMessages } from "@gc-digital-talent/i18n";
 import {
-  Department,
   FragmentType,
   Scalars,
   getFragment,

--- a/apps/web/src/pages/Users/UserInformationPage/components/CandidateStatusSection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/CandidateStatusSection.tsx
@@ -9,7 +9,7 @@ import UserCandidatesTable from "./UserCandidatesTable/UserCandidatesTable";
 
 const CandidateStatusSection = ({
   user,
-  departments,
+  jobPlacementOptions,
 }: UserInformationProps) => {
   const intl = useIntl();
   const { roleAssignments, isLoaded } = useAuthorization();
@@ -33,7 +33,7 @@ const CandidateStatusSection = ({
       <UserCandidatesTable
         userQuery={user}
         title={titleString}
-        departments={departments ?? []}
+        jobPlacementOptions={jobPlacementOptions}
       />
       {isAdmin && (
         <>

--- a/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/UserCandidatesTable.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/UserCandidatesTable.tsx
@@ -2,12 +2,7 @@ import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { useIntl } from "react-intl";
 import { useQuery } from "urql";
 
-import {
-  Department,
-  FragmentType,
-  getFragment,
-  graphql,
-} from "@gc-digital-talent/graphql";
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 
@@ -23,6 +18,7 @@ import adminMessages from "~/messages/adminMessages";
 import {
   JobPlacementDialog_Fragment,
   jobPlacementDialogAccessor,
+  JobPlacementOptionsFragmentType,
 } from "~/components/PoolCandidatesTable/JobPlacementDialog";
 import cells from "~/components/Table/cells";
 import accessors from "~/components/Table/accessors";
@@ -150,13 +146,13 @@ const UserCandidatesTableStrings_Query = graphql(/* GraphQL */ `
 
 interface UserCandidatesTableProps {
   userQuery: FragmentType<typeof UserCandidatesTableRow_Fragment>;
-  departments: Department[];
+  jobPlacementOptions: JobPlacementOptionsFragmentType;
   title: string;
 }
 
 const UserCandidatesTable = ({
   userQuery,
-  departments,
+  jobPlacementOptions,
   title,
 }: UserCandidatesTableProps) => {
   const intl = useIntl();
@@ -248,7 +244,7 @@ const UserCandidatesTable = ({
         cell: ({ row: { original: poolCandidate } }) =>
           jobPlacementDialogAccessor(
             poolCandidate as FragmentType<typeof JobPlacementDialog_Fragment>,
-            departments,
+            jobPlacementOptions,
           ),
         enableSorting: false,
       },

--- a/apps/web/src/pages/Users/UserInformationPage/types.ts
+++ b/apps/web/src/pages/Users/UserInformationPage/types.ts
@@ -1,9 +1,11 @@
-import { Department, UserInfoFragment } from "@gc-digital-talent/graphql";
+import { UserInfoFragment } from "@gc-digital-talent/graphql";
+
+import { JobPlacementOptionsFragmentType } from "~/components/PoolCandidatesTable/JobPlacementDialog";
 
 export interface BasicUserInformationProps {
   user: UserInfoFragment;
 }
 
 export interface UserInformationProps extends BasicUserInformationProps {
-  departments?: Department[];
+  jobPlacementOptions: JobPlacementOptionsFragmentType;
 }


### PR DESCRIPTION
🤖 Resolves #10926 

## 👋 Introduction

This merges a lot of the queries being run on the "Candidate search" page using fragments to run them all at the page level.

## 🕵️ Details

While working on this I noticed two things:

1. We are needed to drill a lot of props (see job placement) and I was wondering if we could work on this a bit :sweat_smile: 
2. We have a few other places that could probably be merged using fragments
3. We are grabbing some data before we actually need it (i.e all skills/pools for the comboboxes in the filter dialog) 

## 🧪 Testing

1. Build `pnpm run dev`
2. Login as admin `admin@test.com`
3. Navigate to `/admin/pool-candidates`
4. Inspect the network tab to see reduced query count. Should be 4 (minimum amount I could do)
    1. Auth query
    2. Site banner
    3. Candidates
    4. Additional data for filters/dialogs

## 📸 Screenshot

![screenshot_11-Jul-2024_14-27-1720722449](https://github.com/GCTC-NTGC/gc-digital-talent/assets/4127998/2889ff9e-d938-443f-bb0d-e6f5f8397990)
