### PR TITLE
[Bug] Filtering for archived pools fix

### DIFF
--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -470,7 +470,7 @@ class Pool extends Model
         }
 
         // empty defaults to all but archived
-        $query->orWhere(function ($query) {
+        $query->where(function ($query) {
             self::scopeNotArchived($query);
         });
 

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -465,7 +465,14 @@ class Pool extends Model
                     $query->orWhereNull('published_at');
                 }
             });
+
+            return $query;
         }
+
+        // empty defaults to all but archived
+        $query->orWhere(function ($query) {
+            self::scopeNotArchived($query);
+        });
 
         return $query;
     }

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -450,7 +450,10 @@ class Pool extends Model
                 }
 
                 if (in_array(PoolStatus::CLOSED->name, $statuses)) {
-                    $query->orWhere('closing_date', '<=', Carbon::now());
+                    $query->orWhere(function ($query) {
+                        $query->where('closing_date', '<=', Carbon::now());
+                        self::scopeNotArchived($query);
+                    });
                 }
 
                 if (in_array(PoolStatus::PUBLISHED->name, $statuses)) {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -250,8 +250,7 @@ type Pool implements HasRoleAssignments {
   location: LocalizedString @rename(attribute: "advertisement_location")
   securityClearance: LocalizedSecurityStatus
     @rename(attribute: "security_clearance")
-  language: LocalizedPoolLanguage
-    @rename(attribute: "advertisement_language")
+  language: LocalizedPoolLanguage @rename(attribute: "advertisement_language")
   status: LocalizedPoolStatus @rename(attribute: "status")
   stream: LocalizedPoolStream
   processNumber: String @rename(attribute: "process_number")
@@ -898,11 +897,7 @@ type Query {
         ]
       )
   ): [Pool]!
-    @paginate(
-      defaultCount: 10
-      maxCount: 1000
-      scopes: ["authorizedToView", "notArchived"]
-    )
+    @paginate(defaultCount: 10, maxCount: 1000, scopes: ["authorizedToView"])
     @canResolved(ability: "view")
   poolCandidate(id: UUID! @eq): PoolCandidate
     @find

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -740,7 +740,7 @@ input PoolFilterInput {
   name: String @scope
   team: String @scope
   streams: [PoolStream!] @scope
-  statuses: [PoolStatus!] @scope
+  statuses: [PoolStatus!] = [] @scope
   processNumber: String @scope
   publishingGroups: [PublishingGroup!] @scope
   classifications: [ClassificationFilterInput!] @scope

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -994,7 +994,7 @@ input PoolFilterInput {
   name: String
   team: String
   streams: [PoolStream!]
-  statuses: [PoolStatus!]
+  statuses: [PoolStatus!] = []
   processNumber: String
   publishingGroups: [PublishingGroup!]
   classifications: [ClassificationFilterInput!]


### PR DESCRIPTION
🤖 Resolves #10865

## 👋 Introduction

Enable filtering for archived pools to work per intent. Filtered out by default, but returned if wanted

## 🕵️ Details

Just kicking the scope off the query as a blanket application and into the fields scope functions.
Permissions was decided to not be a problem for archived pools

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Navigate to pools table and also ensure you have a pool archived if not seeded
2. Default view returns all but archived pools
3. Play with the filters in the dialog, trying different combinations and check results
4. Ensure you can view archived pools when filtering for them


