### PR TITLE
Update to new blocking-issues version

### DIFF
--- a/.github/workflows/blocking-issues.yml
+++ b/.github/workflows/blocking-issues.yml
@@ -12,7 +12,7 @@ jobs:
     name: Checks for blocking issues
 
     steps:
-      - uses: tristan-orourke/blocking-issues@v1.1
+      - uses: tristan-orourke/blocking-issues@v1.2
         with:
           # Optional: Choose an existing label to use instead of creating a new one.
           # If the label cannot be found, the default one will be created and used.


### PR DESCRIPTION
## 👋 Introduction

This should fix a bug with the blocking-issues action, where the `blocked: dependencies` label is not automatically added or removed from some tickets when it should be.

## 🕵️ Details

I think the root of the issue was that the bot was assuming that issues were always written as `#123`. In fact, they are often written as a full url (eg `https://github.com/org/repo/issues/123`). Thus, it was not parsing many of them correctly.

## 🧪 Testing

I'm not sure if this _can_ be tested? I believe its set up to only run on main. :/
