### PR TITLE
[Feature] Add intl command to api

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -137,7 +137,7 @@ jobs:
             echo ":x: API has matching strings" | tee -a $GITHUB_STEP_SUMMARY;
             exit 1;
           else
-            echo ":heavy_check_mark: No matching strings in API | tee -a $GITHUB_STEP_SUMMARY;
+            echo ":heavy_check_mark: No matching strings in API" | tee -a $GITHUB_STEP_SUMMARY;
             exit 0;
           fi
 

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -49,19 +49,21 @@ jobs:
         run: |
           pnpm run check-intl --force
 
-      - name: "Build docker image: api"
-        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up api --detach
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+          extensions: bcmath
+
+      - name: Install composer dependencies
+        working-directory: api
+        run: |
+          cp .env.example .env
+          composer install --no-interaction --prefer-dist --optimize-autoloader
 
       - name: "Generate lang files: api"
-        run: |
-          docker compose exec --no-TTY api php artisan app:check-intl
-
-      - name: "Copy files: api"
-        if: always()
-        run: |
-          if docker exec -it api sh -c "test -f /var/www/html/api/storage/missingStrings.json"; then
-            docker compose cp api:/var/www/html/api/storage/app/missingStrings.json ./api/storage/app/
-          fi
+        working-directory: api
+        run: php artisan app:check-intl
 
       - name: "Verify no untranslated file: i18n"
         if: always()

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -59,7 +59,9 @@ jobs:
       - name: "Copy files: api"
         if: always()
         run: |
-          docker compose cp api:/var/www/html/api/storage/app/*.json ./api/storage/app/
+          if docker exec -it api sh -c "test -f /var/www/html/api/storage/missingStrings.json"; then
+            docker compose cp api:/var/www/html/api/storage/app/missingStrings.json ./api/storage/app/
+          fi
 
       - name: "Verify no untranslated file: i18n"
         if: always()

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -53,6 +53,7 @@ jobs:
         run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up api --detach
 
       - name: "Generate lang files: api"
+        continue-on-error: true # continue so we can copy files for upload
         run: |
           docker compose exec --no-TTY api php artisan app:check-intl
           docker compose cp api:/var/www/html/api/storage/app/missingFiles.json ./api/storage/app/

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -58,11 +58,8 @@ jobs:
 
       - name: "Copy files: api"
         if: always()
-        continue-on-error: true
         run: |
-          docker compose cp api:/var/www/html/api/storage/app/missingFiles.json ./api/storage/app/
-          docker compose cp api:/var/www/html/api/storage/app/missingStrings.json ./api/storage/app/
-          docker compose cp api:/var/www/html/api/storage/app/exactMatches.json ./api/storage/app/
+          docker compose cp api:/var/www/html/api/storage/app/*.json ./api/storage/app/
 
       - name: "Verify no untranslated file: i18n"
         if: always()

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -113,40 +113,15 @@ jobs:
             exit 0;
           fi
 
-      - name: "Verify all files: api"
+      - name: "Verify: api"
         if: always()
         working-directory: api/storage/app
         run: >
-          if test -f "missingFiles.json"; then
+          if test -f "intlErrors.json"; then
             echo ":x: API has missing files" | tee -a $GITHUB_STEP_SUMMARY;
             exit 1;
           else
             echo ":heavy_check_mark: All API files exist" | tee -a $GITHUB_STEP_SUMMARY;
-            exit 0;
-          fi
-
-
-      - name: "Verify all strings: api"
-        if: always()
-        working-directory: api/storage/app
-        run: >
-          if test -f "missingStrings.json"; then
-            echo ":x: API has missing strings" | tee -a $GITHUB_STEP_SUMMARY;
-            exit 1;
-          else
-            echo ":heavy_check_mark: All API enums have strings" | tee -a $GITHUB_STEP_SUMMARY;
-            exit 0;
-          fi
-
-      - name: "Verify no matching strings: api"
-        if: always()
-        working-directory: api/storage/app
-        run: >
-          if test -f "exactMatches.json"; then
-            echo ":x: API has matching strings" | tee -a $GITHUB_STEP_SUMMARY;
-            exit 1;
-          else
-            echo ":heavy_check_mark: No matching strings in API" | tee -a $GITHUB_STEP_SUMMARY;
             exit 0;
           fi
 
@@ -159,7 +134,5 @@ jobs:
             apps/**/lang/untranslated.json
             packages/**/lang/untranslated.json
             !packages/node_modules/**
-            api/**/missingFiles.json
-            api/**/missingStrings.json
-            api/**/exactMatches.json
+            api/**/intlErrors.json
           if-no-files-found: ignore

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -53,9 +53,12 @@ jobs:
         run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up api --detach
 
       - name: "Generate lang files: api"
-        continue-on-error: true # continue so we can copy files for upload
         run: |
           docker compose exec --no-TTY api php artisan app:check-intl
+
+      - name: "Copy files: api"
+        continue-on-error: true
+        run: |
           docker compose cp api:/var/www/html/api/storage/app/missingFiles.json ./api/storage/app/
           docker compose cp api:/var/www/html/api/storage/app/missingStrings.json ./api/storage/app/
           docker compose cp api:/var/www/html/api/storage/app/exactMatches.json ./api/storage/app/

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -49,6 +49,13 @@ jobs:
         run: |
           pnpm run check-intl --force
 
+      - name: "Build docker image: api"
+        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up api --detach
+
+      - name: "Generate lang files: api"
+        run: |
+          docker compose exec --no-TTY api php artisan app:check-intl
+
       - name: "Verify no untranslated file: i18n"
         if: always()
         working-directory: packages/i18n/src/lang
@@ -97,13 +104,42 @@ jobs:
             exit 0;
           fi
 
+      - name: "Verify all files: api"
+        if: always()
+        working-directory: api/storage/app
+        run: >
+          if test -f "missingFiles.json"; then
+            echo ":x: API has missing files" | tee -a $GITHUB_STEP_SUMMARY;
+            exit 1;
+          else
+            echo ":heavy_check_mark: All API files exist" | tee -a $GITHUB_STEP_SUMMARY;
+            exit 0;
+          fi
 
-      - name: "Build docker image: api"
-        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up api --detach
 
-      - name: "Verify: api"
-        run: |
-          docker compose exec --no-TTY api php artisan app:check-intl
+      - name: "Verify all strings: api"
+        if: always()
+        working-directory: api/storage/app
+        run: >
+          if test -f "missingStrings.json"; then
+            echo ":x: API has missing strings" | tee -a $GITHUB_STEP_SUMMARY;
+            exit 1;
+          else
+            echo ":heavy_check_mark: All API enums have strings" | tee -a $GITHUB_STEP_SUMMARY;
+            exit 0;
+          fi
+
+      - name: "Verify all strings: api"
+        if: always()
+        working-directory: api/storage/app
+        run: >
+          if test -f "exactMatches.json"; then
+            echo ":x: API has matching strings" | tee -a $GITHUB_STEP_SUMMARY;
+            exit 1;
+          else
+            echo ":heavy_check_mark: No matching strings in API | tee -a $GITHUB_STEP_SUMMARY;
+            exit 0;
+          fi
 
       - name: "Upload untranslated files: all workspaces"
         if: always()

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -129,7 +129,7 @@ jobs:
             exit 0;
           fi
 
-      - name: "Verify all strings: api"
+      - name: "Verify no matching strings: api"
         if: always()
         working-directory: api/storage/app
         run: >
@@ -150,7 +150,7 @@ jobs:
             apps/**/lang/untranslated.json
             packages/**/lang/untranslated.json
             !packages/node_modules/**
-            api/storage/app/missingFiles.json
-            api/storage/app/missingStrings.json
-            api/storage/app/exactMatches.json
+            api/**/missingFiles.json
+            api/**/missingStrings.json
+            api/**/exactMatches.json
           if-no-files-found: ignore

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -57,6 +57,7 @@ jobs:
           docker compose exec --no-TTY api php artisan app:check-intl
 
       - name: "Copy files: api"
+        if: always()
         continue-on-error: true
         run: |
           docker compose cp api:/var/www/html/api/storage/app/missingFiles.json ./api/storage/app/

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -55,7 +55,9 @@ jobs:
       - name: "Generate lang files: api"
         run: |
           docker compose exec --no-TTY api php artisan app:check-intl
-          docker compose cp api:/var/www/html/api/storage/app/**/*.json ./api/storage/app/
+          docker compose cp api:/var/www/html/api/storage/app/missingFiles.json ./api/storage/app/
+          docker compose cp api:/var/www/html/api/storage/app/missingStrings.json ./api/storage/app/
+          docker compose cp api:/var/www/html/api/storage/app/exactMatches.json ./api/storage/app/
 
       - name: "Verify no untranslated file: i18n"
         if: always()

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -55,6 +55,7 @@ jobs:
       - name: "Generate lang files: api"
         run: |
           docker compose exec --no-TTY api php artisan app:check-intl
+          docker compose cp api:/var/www/html/api/storage/app/**/*.json ./api/storage/app/
 
       - name: "Verify no untranslated file: i18n"
         if: always()

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -5,13 +5,17 @@ on:
     branches: [main]
     paths:
       - .github/workflows/translations.yml
-      - packages/**
       - apps/**
+      - packages/**
+      - api/app/Enums/**
+      - api/lang/**
   pull_request:
     paths:
       - .github/workflows/translations.yml
       - apps/**
       - packages/**
+      - api/app/Enums/**
+      - api/lang/**
   merge_group:
     branches: [main]
 jobs:
@@ -93,6 +97,14 @@ jobs:
             exit 0;
           fi
 
+
+      - name: "Build docker image: api"
+        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up api --detach
+
+      - name: "Verify: api"
+        run: |
+          docker compose exec --no-TTY api php artisan app:check-intl
+
       - name: "Upload untranslated files: all workspaces"
         if: always()
         uses: actions/upload-artifact@v4
@@ -102,4 +114,7 @@ jobs:
             apps/**/lang/untranslated.json
             packages/**/lang/untranslated.json
             !packages/node_modules/**
+            api/storage/app/missingFiles.json
+            api/storage/app/missingStrings.json
+            api/storage/app/exactMatches.json
           if-no-files-found: ignore

--- a/api/app/Console/Commands/CheckIntl.php
+++ b/api/app/Console/Commands/CheckIntl.php
@@ -57,8 +57,8 @@ class CheckIntl extends Command
      * to have an associated string
      */
     private $knownMissing = [
-        // 'assessment_result_justification.skill_accepted',
-        // 'indigenous_community.legacy_is_indigenous',
+        'assessment_result_justification.skill_accepted',
+        'indigenous_community.legacy_is_indigenous',
     ];
 
     /**
@@ -70,20 +70,20 @@ class CheckIntl extends Command
      * both locales, so we can safely ignore them
      */
     private $allowedMatch = [
-        // 'awarded_scope.international',
-        // 'awarded_scope.national',
-        // 'awarded_scope.provincial',
-        // 'awarded_scope.local',
-        // 'education_type.certification',
-        // 'indigenous_community.inuit',
-        // 'indigenous_community.metis',
-        // 'province_or_territory.alberta',
-        // 'province_or_territory.manitoba',
-        // 'province_or_territory.nunavut',
-        // 'province_or_territory.ontario',
-        // 'province_or_territory.saskatchewan',
-        // 'province_or_territory.yukon',
-        // 'skill_level.lead',
+        'awarded_scope.international',
+        'awarded_scope.national',
+        'awarded_scope.provincial',
+        'awarded_scope.local',
+        'education_type.certification',
+        'indigenous_community.inuit',
+        'indigenous_community.metis',
+        'province_or_territory.alberta',
+        'province_or_territory.manitoba',
+        'province_or_territory.nunavut',
+        'province_or_territory.ontario',
+        'province_or_territory.saskatchewan',
+        'province_or_territory.yukon',
+        'skill_level.lead',
     ];
 
     /**
@@ -112,17 +112,17 @@ class CheckIntl extends Command
 
         if ($missingFiles || $missingStrings || $exactMatches) {
             if ($missingFiles) {
-                Storage::disk('local')->put('missingFiles.json', json_encode($this->missingFiles));
+                Storage::disk('local')->put('missingFiles.json', json_encode($this->missingFiles, JSON_FORCE_OBJECT));
                 $this->error("Missing files:\r\n\r\n".$this->localeArrayToString($this->missingFiles));
             }
 
             if ($missingStrings) {
-                Storage::disk('local')->put('missingStrings.json', json_encode($this->missingStrings));
+                Storage::disk('local')->put('missingStrings.json', json_encode($this->missingStrings, JSON_FORCE_OBJECT));
                 $this->error("Missing strings:\r\n\r\n".$this->localeArrayToString($this->missingStrings));
             }
 
             if ($exactMatches) {
-                Storage::disk('local')->put('exactMatches.json', json_encode($this->exactMatches));
+                Storage::disk('local')->put('exactMatches.json', json_encode($this->exactMatches, JSON_FORCE_OBJECT));
                 $this->error("Some strings are idential in both EN and FR:\r\n".$this->arrayToString($this->exactMatches));
             }
 

--- a/api/app/Console/Commands/CheckIntl.php
+++ b/api/app/Console/Commands/CheckIntl.php
@@ -44,7 +44,6 @@ class CheckIntl extends Command
      * Matching strings
      *
      * Any string that is the same in both locales
-     * usually indicates
      */
     private $exactMatches = [];
 

--- a/api/app/Console/Commands/CheckIntl.php
+++ b/api/app/Console/Commands/CheckIntl.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Discoverers\EnumDiscoverer;
+use App\Traits\HasLocalization;
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Facades\Storage;
+
+class CheckIntl extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:check-intl';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Verify enums are translated an nothing is missing';
+
+    /**
+     * The enums that are localized
+     */
+    private $localizedEnums;
+
+    /**
+     * Missing translation files
+     */
+    private $missingFiles = ['en' => [], 'fr' => []];
+
+    /**
+     * Missing strings
+     */
+    private $missingStrings = ['en' => [], 'fr' => []];
+
+    /**
+     * Matching strings
+     *
+     * Any string that is the same in both locales
+     * usually indicates
+     */
+    private $exactMatches = [];
+
+    /**
+     * Allowed missing strings
+     *
+     * EnumName.case_key
+     *
+     * NOTE: Some cases we know are missing and do not intend
+     * to have an associated string
+     */
+    private $knownMissing = [
+        // 'assessment_result_justification.skill_accepted',
+        // 'indigenous_community.legacy_is_indigenous',
+    ];
+
+    /**
+     * Allowed exact matches
+     *
+     * EnumName.case_key
+     *
+     * NOTE: Some strings are known to be identical in
+     * both locales, so we can safely ignore them
+     */
+    private $allowedMatch = [
+        // 'awarded_scope.international',
+        // 'awarded_scope.national',
+        // 'awarded_scope.provincial',
+        // 'awarded_scope.local',
+        // 'education_type.certification',
+        // 'indigenous_community.inuit',
+        // 'indigenous_community.metis',
+        // 'province_or_territory.alberta',
+        // 'province_or_territory.manitoba',
+        // 'province_or_territory.nunavut',
+        // 'province_or_territory.ontario',
+        // 'province_or_territory.saskatchewan',
+        // 'province_or_territory.yukon',
+        // 'skill_level.lead',
+    ];
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->localizedEnums = EnumDiscoverer::discoverLocalizedEnums();
+
+        /** @var HasLocalization $enum */
+        foreach ($this->localizedEnums as $enum) {
+            $fileName = $enum::getLangFilename().'.php';
+            $enFileExists = $this->checkFileExists($fileName, 'en');
+            $frFileExists = $this->checkFileExists($fileName, 'fr');
+
+            // No sense in chekcing strings if both files are missing
+            if ($enFileExists || $frFileExists) {
+                $this->checkStrings($enum);
+            }
+
+        }
+
+        $missingFiles = ! empty(Arr::flatten($this->missingFiles));
+        $missingStrings = ! empty(Arr::flatten($this->missingStrings));
+        $exactMatches = ! empty($this->exactMatches);
+
+        if ($missingFiles || $missingStrings || $exactMatches) {
+            if ($missingFiles) {
+                Storage::disk('local')->put('missingFiles.json', json_encode($this->missingFiles));
+                $this->error("Missing files:\r\n\r\n".$this->localeArrayToString($this->missingFiles));
+            }
+
+            if ($missingStrings) {
+                Storage::disk('local')->put('missingStrings.json', json_encode($this->missingStrings));
+                $this->error("Missing strings:\r\n\r\n".$this->localeArrayToString($this->missingStrings));
+            }
+
+            if ($exactMatches) {
+                Storage::disk('local')->put('exactMatches.json', json_encode($this->exactMatches));
+                $this->error("Some strings are idential in both EN and FR:\r\n".$this->arrayToString($this->exactMatches));
+            }
+
+            return Command::FAILURE;
+        }
+
+        $this->info('Your translation files are ready to go!');
+
+        return Command::SUCCESS;
+    }
+
+    /*
+    * Check that a lang file exists
+    */
+    private function checkFileExists(string $fileName, string $locale)
+    {
+        if (! file_exists(lang_path($locale.'/'.$fileName))) {
+            $this->missingFiles[$locale][] = $fileName;
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check that strgins exist and no
+     * exact macthes exist across locales
+     *
+     * @var HasLocalization
+     */
+    private function checkStrings($enum)
+    {
+        $keys = Arr::map(array_column($enum::cases(), 'name'), function ($case) {
+            return strtolower($case);
+        });
+
+        foreach ($keys as $key) {
+            $langKey = $enum::getLangKey($key);
+
+            if (! in_array($langKey, $this->knownMissing)) {
+                $hasEn = Lang::hasForLocale($langKey, 'en');
+                $hasFr = Lang::hasForLocale($langKey, 'fr');
+
+                if ($hasEn && $hasFr && ! in_array($langKey, $this->allowedMatch)) {
+                    if (Lang::get($langKey, [], 'en') === Lang::get($langKey, [], 'fr')) {
+                        $this->exactMatches[] = $langKey;
+                    }
+                } else {
+                    if (! $hasEn) {
+                        $this->missingStrings['en'][] = $langKey;
+                    }
+
+                    if (! $hasFr) {
+                        $this->missingStrings['fr'][] = $langKey;
+                    }
+                }
+            }
+
+        }
+    }
+
+    private function localeArrayToString(array $arr)
+    {
+        $string = '';
+        if (isset($arr['en']) && ! empty($arr['en'])) {
+            $string .= "English:\r\n".$this->arrayToString($arr['en'])."\r\n";
+        }
+
+        if (isset($arr['fr']) && ! empty($arr['fr'])) {
+            $string .= "French:\r\n".$this->arrayToString($arr['fr'])."\r\n";
+        }
+
+        return $string;
+    }
+
+    /**
+     * Create a string list from array
+     */
+    private function arrayToString(array $arr)
+    {
+        return implode("\r\n", Arr::map($arr, function ($value) {
+            return "\t- $value";
+        }));
+    }
+}

--- a/api/app/Console/Commands/CheckIntl.php
+++ b/api/app/Console/Commands/CheckIntl.php
@@ -23,7 +23,7 @@ class CheckIntl extends Command
      *
      * @var string
      */
-    protected $description = 'Verify enums are translated an nothing is missing';
+    protected $description = 'Verify enums are translated and nothing is missing';
 
     /**
      * The enums that are localized
@@ -99,7 +99,7 @@ class CheckIntl extends Command
             $enFileExists = $this->checkFileExists($fileName, 'en');
             $frFileExists = $this->checkFileExists($fileName, 'fr');
 
-            // No sense in chekcing strings if both files are missing
+            // No sense in checking strings if both files are missing.
             if ($enFileExists || $frFileExists) {
                 $this->checkStrings($enum);
             }
@@ -123,7 +123,7 @@ class CheckIntl extends Command
 
             if ($exactMatches) {
                 Storage::disk('local')->put('exactMatches.json', json_encode($this->exactMatches));
-                $this->error("Some strings are idential in both EN and FR:\r\n".$this->arrayToString($this->exactMatches));
+                $this->error("Some strings are identical in both EN and FR:\r\n".$this->arrayToString($this->exactMatches));
             }
 
             return Command::FAILURE;
@@ -149,8 +149,8 @@ class CheckIntl extends Command
     }
 
     /**
-     * Check that strgins exist and no
-     * exact macthes exist across locales
+     * Check that strings exist and no
+     * exact matches exist across locales
      *
      * @var HasLocalization
      */

--- a/api/app/Console/Commands/CheckIntl.php
+++ b/api/app/Console/Commands/CheckIntl.php
@@ -57,8 +57,8 @@ class CheckIntl extends Command
      * to have an associated string
      */
     private $knownMissing = [
-        'assessment_result_justification.skill_accepted',
-        'indigenous_community.legacy_is_indigenous',
+        // 'assessment_result_justification.skill_accepted',
+        // 'indigenous_community.legacy_is_indigenous',
     ];
 
     /**
@@ -70,20 +70,20 @@ class CheckIntl extends Command
      * both locales, so we can safely ignore them
      */
     private $allowedMatch = [
-        'awarded_scope.international',
-        'awarded_scope.national',
-        'awarded_scope.provincial',
-        'awarded_scope.local',
-        'education_type.certification',
-        'indigenous_community.inuit',
-        'indigenous_community.metis',
-        'province_or_territory.alberta',
-        'province_or_territory.manitoba',
-        'province_or_territory.nunavut',
-        'province_or_territory.ontario',
-        'province_or_territory.saskatchewan',
-        'province_or_territory.yukon',
-        'skill_level.lead',
+        // 'awarded_scope.international',
+        // 'awarded_scope.national',
+        // 'awarded_scope.provincial',
+        // 'awarded_scope.local',
+        // 'education_type.certification',
+        // 'indigenous_community.inuit',
+        // 'indigenous_community.metis',
+        // 'province_or_territory.alberta',
+        // 'province_or_territory.manitoba',
+        // 'province_or_territory.nunavut',
+        // 'province_or_territory.ontario',
+        // 'province_or_territory.saskatchewan',
+        // 'province_or_territory.yukon',
+        // 'skill_level.lead',
     ];
 
     /**
@@ -112,17 +112,17 @@ class CheckIntl extends Command
 
         if ($missingFiles || $missingStrings || $exactMatches) {
             if ($missingFiles) {
-                Storage::disk('local')->put('missingFiles.json', json_encode($this->missingFiles, JSON_FORCE_OBJECT));
+                Storage::disk('local')->put('missingFiles.json', json_encode($this->missingFiles));
                 $this->error("Missing files:\r\n\r\n".$this->localeArrayToString($this->missingFiles));
             }
 
             if ($missingStrings) {
-                Storage::disk('local')->put('missingStrings.json', json_encode($this->missingStrings, JSON_FORCE_OBJECT));
+                Storage::disk('local')->put('missingStrings.json', json_encode($this->missingStrings));
                 $this->error("Missing strings:\r\n\r\n".$this->localeArrayToString($this->missingStrings));
             }
 
             if ($exactMatches) {
-                Storage::disk('local')->put('exactMatches.json', json_encode($this->exactMatches, JSON_FORCE_OBJECT));
+                Storage::disk('local')->put('exactMatches.json', json_encode($this->exactMatches));
                 $this->error("Some strings are idential in both EN and FR:\r\n".$this->arrayToString($this->exactMatches));
             }
 

--- a/api/app/Console/Commands/CheckIntl.php
+++ b/api/app/Console/Commands/CheckIntl.php
@@ -57,8 +57,8 @@ class CheckIntl extends Command
      * to have an associated string
      */
     private $knownMissing = [
-        // 'assessment_result_justification.skill_accepted',
-        // 'indigenous_community.legacy_is_indigenous',
+        'assessment_result_justification.skill_accepted',
+        'indigenous_community.legacy_is_indigenous',
     ];
 
     /**
@@ -70,20 +70,20 @@ class CheckIntl extends Command
      * both locales, so we can safely ignore them
      */
     private $allowedMatch = [
-        // 'awarded_scope.international',
-        // 'awarded_scope.national',
-        // 'awarded_scope.provincial',
-        // 'awarded_scope.local',
-        // 'education_type.certification',
-        // 'indigenous_community.inuit',
-        // 'indigenous_community.metis',
-        // 'province_or_territory.alberta',
-        // 'province_or_territory.manitoba',
-        // 'province_or_territory.nunavut',
-        // 'province_or_territory.ontario',
-        // 'province_or_territory.saskatchewan',
-        // 'province_or_territory.yukon',
-        // 'skill_level.lead',
+        'awarded_scope.international',
+        'awarded_scope.national',
+        'awarded_scope.provincial',
+        'awarded_scope.local',
+        'education_type.certification',
+        'indigenous_community.inuit',
+        'indigenous_community.metis',
+        'province_or_territory.alberta',
+        'province_or_territory.manitoba',
+        'province_or_territory.nunavut',
+        'province_or_territory.ontario',
+        'province_or_territory.saskatchewan',
+        'province_or_territory.yukon',
+        'skill_level.lead',
     ];
 
     /**

--- a/api/app/Console/Commands/CheckIntl.php
+++ b/api/app/Console/Commands/CheckIntl.php
@@ -121,7 +121,7 @@ class CheckIntl extends Command
             'fr' => $hasFrFile ? Lang::get(key: $fileName, locale: 'fr') : [],
         ];
 
-        $exisingKeys = [
+        $existingKeys = [
             'en' => array_keys($existing['en']),
             'fr' => array_keys($existing['fr']),
         ];
@@ -142,7 +142,7 @@ class CheckIntl extends Command
                 }
 
                 // Key exists in one locale but not the other
-                if (! in_array($key, $exisingKeys[$oppositeLocale])) {
+                if (! in_array($key, $existingKeys[$oppositeLocale])) {
                     $this->errors['orphan_strings'][$locale][$fileName][] = $key;
                 }
 

--- a/api/app/Discoverers/EnumDiscoverer.php
+++ b/api/app/Discoverers/EnumDiscoverer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Discoverers;
+
+use App\Traits\HasLocalization;
+use Spatie\StructureDiscoverer\Data\DiscoveredStructure;
+use Spatie\StructureDiscoverer\Discover;
+use Spatie\StructureDiscoverer\Enums\Sort;
+
+class EnumDiscoverer
+{
+    private static $sort = Sort::Name;
+
+    private static function path()
+    {
+        return app_path('Enums');
+    }
+
+    public static function discoverEnums()
+    {
+        return Discover::in(self::path())
+            ->enums()
+                // TODO: Language has a custom implementation remove in #10964
+            ->custom(fn (DiscoveredStructure $structure) => $structure->name !== 'Language')
+            ->sortBy(self::$sort)
+            ->get();
+    }
+
+    public static function discoverLocalizedEnums()
+    {
+
+        return Discover::in(self::path())
+            ->enums()
+            ->custom(function (DiscoveredStructure $structure) {
+                return in_array(HasLocalization::class, class_uses($structure->getFcqn()));
+            })
+            ->sortBy(self::$sort)
+            ->get();
+    }
+}

--- a/api/app/Providers/GraphQLServiceProvider.php
+++ b/api/app/Providers/GraphQLServiceProvider.php
@@ -32,7 +32,7 @@ class GraphQLServiceProvider extends ServiceProvider
             }
         );
 
-        // Discover all enums in the App\Enum namepsace to register them with GraphQL
+        // Discover all enums in the App\Enum namespace to register them with GraphQL
         $enums = EnumDiscoverer::discoverEnums();
 
         /** @var \UnitEnum $enum */

--- a/api/app/Traits/HasLocalization.php
+++ b/api/app/Traits/HasLocalization.php
@@ -19,15 +19,20 @@ trait HasLocalization
 
     public static function localizedString(string $value)
     {
-        $key = sprintf(
-            '%s.%s',
-            self::getLangFilename(),
-            self::caseKey($value)
-        );
+        $key = self::getLangKey($value);
 
         return [
             'en' => Lang::get($key, [], 'en'),
             'fr' => Lang::get($key, [], 'fr'),
         ];
+    }
+
+    public static function getLangKey(string $value): string
+    {
+        return sprintf(
+            '%s.%s',
+            self::getLangFilename(),
+            self::caseKey($value)
+        );
     }
 }

--- a/api/storage/app/.gitignore
+++ b/api/storage/app/.gitignore
@@ -2,4 +2,6 @@
 !public/
 !user_generated/
 !.gitignore
-*.json
+missingStrings.json
+missingFiles.json
+exactMatches.json

--- a/api/storage/app/.gitignore
+++ b/api/storage/app/.gitignore
@@ -2,3 +2,4 @@
 !public/
 !user_generated/
 !.gitignore
+*.json

--- a/api/storage/app/.gitignore
+++ b/api/storage/app/.gitignore
@@ -2,6 +2,4 @@
 !public/
 !user_generated/
 !.gitignore
-missingStrings.json
-missingFiles.json
-exactMatches.json
+intlErrors.json


### PR DESCRIPTION
🤖 Resolves #10900 

## 👋 Introduction

Adds a command to verify strings on the api.

## 🕵️ Details

Similar to the `pnpm run check-intl:*` scripts, this checks our new api strings. It looks for:

 - Missing files for an enum
 - Missing strings for each localized enum string
 - Strings that match exactly

## :wrench: Usage

Run the command with: `make artisan CMD="app:check-intl"` which outputs a list of errors if there are any and stores the output json in `api/storage/app`.

If there are known missing strings (we have some) or known exact matches where the word is known to be the same in English and French, you can add them to the allow lists defined on the command.

If the allow lists get too large then maybe we can consider moving them to a config file? :thinking: 

## 🧪 Testing

1. Run `make artisan CMD="app:check-intl"`
2. Confirm success
3. Force errors by deleting some files in `api/lang` and commenting out items in the allow list
4. Confirm errors appear
5. Confirm [action runs as expected](https://github.com/GCTC-NTGC/gc-digital-talent/actions/runs/9913720763?pr=10978)