### PR TITLE
[Fix] Update permissions for storage dir

### DIFF
--- a/infrastructure/bin/post_deployment.sh
+++ b/infrastructure/bin/post_deployment.sh
@@ -39,7 +39,8 @@ cd /home/site/wwwroot/api
 # Laravel local cache
 if
     mkdir --parents /tmp/bootstrap/cache /tmp/api/storage/framework/cache/data && \
-    chown www-data:www-data /tmp/bootstrap/cache /tmp/api/storage/framework/cache/data && \
+    chown www-data:www-data /tmp/bootstrap/cache && \
+    chown -R www-data:www-data /tmp/api/storage && \
     php artisan config:cache ;
 then
     add_section_block ":white_check_mark: Laravel cache setup *successful*."


### PR DESCRIPTION
🤖 Resolves #10908 

## 👋 Introduction

Gives ownership of the `api/app/storage` dir to `www-data:www-data`.

## 🕵️ Details

This simply follows the [documentation for laravel deployment](https://laravel.com/docs/11.x/deployment#directory-permissions).

## 🧪 Testing

1. Run `post_deployment.sh`
2. Confirm the `/tmp/api/app/storage` folder is owned by `www-data`