### PR TITLE
[Fix] Fixes `AddAction` table logic

### DIFF
--- a/apps/web/src/components/Table/ResponsiveTable/Table.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/Table.tsx
@@ -217,14 +217,14 @@ interface AddActionProps {
   add: AddDef;
 }
 
-const AddAction = ({ add }: AddActionProps) => (
-  <>
-    {add.linkProps && (
-      <Control
-        data-h2-flex-shrink="base(1)"
-        data-h2-order="base(1)"
-        data-h2-margin-left="base(auto)"
-      >
+const AddAction = ({ add }: AddActionProps) =>
+  add.linkProps || add.component ? (
+    <Control
+      data-h2-flex-shrink="base(1)"
+      data-h2-order="base(1)"
+      data-h2-margin-left="base(auto)"
+    >
+      {add.linkProps && (
         <Link
           icon={PlusCircleIcon}
           color="secondary"
@@ -235,11 +235,10 @@ const AddAction = ({ add }: AddActionProps) => (
         >
           {add.linkProps.label}
         </Link>
-      </Control>
-    )}
-    {add.component && <Control>{add.component}</Control>}
-  </>
-);
+      )}
+      {add.component ?? null}
+    </Control>
+  ) : null;
 
 interface ControlsProps {
   children: ReactNode;


### PR DESCRIPTION
🤖 Resolves #10828.

## 👋 Introduction

This PR fixes `AddAction` logic for the `Table` component.

## 🕵️ Details

The attributes that were styling the `<Control>` were being applied for the `linkProps` case but not for the `component` case.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm build:fresh`
2. Navigate to `/admin/users/:user-id/edit`
3. Verify Individual roles table and Team based roles table add action is right-aligned
4. Navigate to `/applicant/skills#manage`
5. Verify Skills table add action is right-aligned
6. Verify other tables where `add` prop is used render as they did before

## 📸 Screenshots

<img width="1102" alt="Screen Shot 2024-07-15 at 16 13 45" src="https://github.com/user-attachments/assets/5676be28-cdc7-4153-880a-30836b4a0e3f">
<img width="1142" alt="Screen Shot 2024-07-15 at 16 14 04" src="https://github.com/user-attachments/assets/9eece681-1f14-4334-a350-060ea465dc06">