### PR TITLE
[Feature] Updates Digital Community Management `contact_email` value in seeder

### DIFF
--- a/api/database/seeders/TeamSeeder.php
+++ b/api/database/seeders/TeamSeeder.php
@@ -22,7 +22,7 @@ class TeamSeeder extends Seeder
                     'en' => 'Digital Community Management',
                     'fr' => 'Gestion de la collectivité numérique',
                 ],
-                'contact_email' => 'gctalent-talentgc@support-soutien.gc.ca',
+                'contact_email' => 'support-soutien@talent.canada.ca',
                 'department_ids' => [Department::select('id')->where('name->en', 'Treasury Board Secretariat')->sole()->id],
             ],
             [


### PR DESCRIPTION
🤖 Resolves #10910.

## 👋 Introduction

This PR updates Digital Community Management `contact_email` value in seeder.

## 🕵️ Details

See: https://github.com/GCTC-NTGC/gc-digital-talent/issues/10910#issuecomment-2231670273

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Verify no instances of [gctalent-talentgc@support-soutien.gc.ca](mailto:gctalent-talentgc@support-soutien.gc.ca) in codebase
2. Verify `contact_email` value in seeder for Digital Community Management is [support-soutien@talent.canada.ca](mailto:support-soutien@talent.canada.ca)
