### PR TITLE
[Feature] Async candidate CSV

### DIFF
--- a/api/app/Events/UserFileGenerated.php
+++ b/api/app/Events/UserFileGenerated.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class UserFileGenerated
+{
+    use Dispatchable,  SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public string $fileName, public string $userId) {}
+}

--- a/api/app/Generators/CandidateProfileCsv.php
+++ b/api/app/Generators/CandidateProfileCsv.php
@@ -70,6 +70,7 @@ class CandidateProfileCsv extends CsvGenerator
     {
         $candidates = PoolCandidate::with([
             'generalQuestionResponses' => ['generalQuestion'],
+            'educationRequirementExperiences',
             'user' => [
                 'department',
                 'currentClassification',
@@ -208,6 +209,8 @@ class CandidateProfileCsv extends CsvGenerator
             // 2 is added to the key to account for the header row and 0 index
             $sheet->fromArray($values, null, 'A'.$key + 2);
         });
+
+        return $this;
 
     }
 }

--- a/api/app/Generators/CsvGenerator.php
+++ b/api/app/Generators/CsvGenerator.php
@@ -2,7 +2,7 @@
 
 namespace App\Generators;
 
-use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Log;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Csv;
 
@@ -15,20 +15,22 @@ abstract class CsvGenerator extends FileGenerator
         $this->spreadsheet = new Spreadsheet();
     }
 
-    public function write(string $fileName)
+    public function write(string $fileName, ?string $dir)
     {
-        /** @var \Illuminate\Filesystem\FilesystemManager */
-        $disk = Storage::disk('user_generated');
+        $path = $this->getPath($fileName, $dir);
 
-        $path = $disk->path($fileName);
+        try {
 
-        $writer = new Csv($this->spreadsheet);
-        $writer->setDelimiter(',');
-        $writer->setEnclosure('"');
-        $writer->setLineEnding("\r\n");
-        $writer->setSheetIndex(0);
+            $writer = new Csv($this->spreadsheet);
+            $writer->setDelimiter(',');
+            $writer->setEnclosure('"');
+            $writer->setLineEnding("\r\n");
+            $writer->setSheetIndex(0);
+            $writer->save($path);
 
-        return $writer->save($path);
+        } catch (\Exception $e) {
+            Log::error('Error saving csv: '.$fileName.' '.$e->getMessage());
+        }
     }
 
     public function sanitizeString(string $string): string

--- a/api/app/Generators/DocGenerator.php
+++ b/api/app/Generators/DocGenerator.php
@@ -2,7 +2,6 @@
 
 namespace App\Generators;
 
-use Illuminate\Support\Facades\Storage;
 use PhpOffice\PhpWord\Element;
 use PhpOffice\PhpWord\IOFactory;
 use PhpOffice\PhpWord\PhpWord;
@@ -26,12 +25,10 @@ abstract class DocGenerator extends FileGenerator
         $this->strong = ['bold' => true];
     }
 
-    public function write(string $fileName)
+    public function write(string $fileName, ?string $dir)
     {
-        /** @var \Illuminate\Filesystem\FilesystemManager */
-        $disk = Storage::disk('user_generated');
 
-        $path = $disk->path($fileName);
+        $path = $this->getPath($fileName, $dir);
 
         $writer = IOFactory::createWriter($this->doc);
 

--- a/api/app/Generators/FileGenerator.php
+++ b/api/app/Generators/FileGenerator.php
@@ -2,11 +2,14 @@
 
 namespace App\Generators;
 
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+
 abstract class FileGenerator
 {
     abstract public function generate();
 
-    abstract public function write(string $fileName);
+    abstract public function write(string $fileName, ?string $dir);
 
     protected function sanitizeEnum(string $enum): string
     {
@@ -16,5 +19,16 @@ abstract class FileGenerator
     public function yesOrNo(bool $value): string
     {
         return $value ? 'Yes' : 'No';
+    }
+
+    public function getPath(string $fileName, ?string $dir, ?string $disk = 'userGenerated')
+    {
+        /** @var \Illuminate\Filesystem\FilesystemManager */
+        $disk = Storage::disk($disk);
+        if ($dir && ! $disk->exists($dir)) {
+            File::makeDirectory($disk->path($dir));
+        }
+
+        return $disk->path(sprintf('%s/%s', $dir ? DIRECTORY_SEPARATOR.$dir : '', $fileName));
     }
 }

--- a/api/app/GraphQL/Mutations/DownloadPoolCandidatesCsv.php
+++ b/api/app/GraphQL/Mutations/DownloadPoolCandidatesCsv.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use App\Jobs\GenerateCandidateCSV;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\UnauthorizedException;
+
+final class DownloadPoolCandidatesCsv
+{
+    /**
+     * Dispatches the generation of a
+     * csv containing pool candidates
+     */
+    public function __invoke($_, array $args)
+    {
+
+        $userId = Auth::id();
+        throw_unless(is_string($userId), UnauthorizedException::class);
+
+        $locale = $args['locale'] ?? 'en';
+
+        try {
+            GenerateCandidateCSV::dispatch($args['ids'], $userId, strtolower($locale));
+
+            return true;
+        } catch (\Exception $e) {
+            Log::error('Error starting candidate csv generation '.$e->getMessage());
+
+            return false;
+        }
+
+        return false;
+    }
+}

--- a/api/app/Jobs/GenerateCandidateCSV.php
+++ b/api/app/Jobs/GenerateCandidateCSV.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Events\UserFileGenerated;
+use App\Generators\CandidateProfileCsv;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class GenerateCandidateCSV implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(public array $candidateIds, public string $userId, public string $lang = 'en') {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+
+        try {
+            $generator = new CandidateProfileCsv($this->candidateIds, $this?->lang);
+            $fileName = 'candidates_'.date('Y-m-d_His').'.csv';
+            $generator->generate()->write($fileName, $this->userId);
+
+            UserFileGenerated::dispatch($fileName, $this->userId);
+        } catch (\Exception $e) {
+            Log::debug('Error generating file: '.$e->getMessage());
+        }
+
+    }
+}

--- a/api/app/Listeners/SendFileGeneratedNotification.php
+++ b/api/app/Listeners/SendFileGeneratedNotification.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\UserFileGenerated;
+use App\Models\User;
+use App\Notifications\UserFileGenerated as NotificationsUserFileGenerated;
+
+class SendFileGeneratedNotification
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct() {}
+
+    /**
+     * Handle the event.
+     */
+    public function handle(UserFileGenerated $event): void
+    {
+        $user = User::findOrFail($event->userId);
+        $notification = new NotificationsUserFileGenerated($event->fileName);
+        $user->notify($notification);
+    }
+}

--- a/api/app/Notifications/UserFileGenerated.php
+++ b/api/app/Notifications/UserFileGenerated.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+class UserFileGenerated extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(public string $fileName) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(User $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(User $notifiable): array
+    {
+        return [
+            'fileName' => $this->fileName,
+        ];
+    }
+}

--- a/api/app/Providers/EventServiceProvider.php
+++ b/api/app/Providers/EventServiceProvider.php
@@ -4,7 +4,9 @@ namespace App\Providers;
 
 use App\Events\AssessmentResultSaved;
 use App\Events\PoolPublished;
+use App\Events\UserFileGenerated;
 use App\Listeners\ComputeFinalDecisionAndCurrentStep;
+use App\Listeners\SendFileGeneratedNotification;
 use App\Listeners\SendNewJobPostedNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
@@ -21,6 +23,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         PoolPublished::class => [
             SendNewJobPostedNotification::class,
+        ],
+        UserFileGenerated::class => [
+            SendFileGeneratedNotification::class,
         ],
     ];
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -199,6 +199,15 @@ type SystemNotification implements Notification {
   href: LocalizedString
 }
 
+type UserFileGeneratedNotification implements Notification {
+  id: ID!
+  readAt: DateTime @rename(attribute: "read_at")
+  createdAt: DateTime! @rename(attribute: "created_at")
+  updatedAt: DateTime! @rename(attribute: "updated_at")
+
+  fileName: String
+}
+
 type UserPublicProfile @model(class: "\\App\\Models\\User") {
   id: ID!
   email: Email
@@ -2203,6 +2212,9 @@ type Mutation {
   updateSitewideAnnouncement(
     sitewideAnnouncementInput: SitewideAnnouncementInput! @spread
   ): SitewideAnnouncement @guard
+
+  # File downloads
+  downloadPoolCandidatesCsv(ids: [UUID!]!, locale: Language): Boolean! @guard
 }
 
 #import directiveForms.graphql

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -388,6 +388,7 @@ type Mutation {
   updateAssessmentResult(updateAssessmentResult: UpdateAssessmentResultInput!): AssessmentResult
   deleteAssessmentResult(id: UUID!): AssessmentResult
   updateSitewideAnnouncement(sitewideAnnouncementInput: SitewideAnnouncementInput!): SitewideAnnouncement
+  downloadPoolCandidatesCsv(ids: [UUID!]!, locale: Language): Boolean!
   createDigitalContractingQuestionnaire(digitalContractingQuestionnaire: DigitalContractingQuestionnaireInput!): DigitalContractingQuestionnaire
   updateDigitalContractingQuestionnaire(id: UUID!, digitalContractingQuestionnaire: DigitalContractingQuestionnaireInput!): DigitalContractingQuestionnaire
   deleteDigitalContractingQuestionnaire(id: UUID!): DigitalContractingQuestionnaire
@@ -548,6 +549,14 @@ type SystemNotification implements Notification {
   updatedAt: DateTime!
   message: LocalizedString
   href: LocalizedString
+}
+
+type UserFileGeneratedNotification implements Notification {
+  id: ID!
+  readAt: DateTime
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  fileName: String
 }
 
 type UserPublicProfile {

--- a/apps/web/src/components/NotificationList/NotificationItem.tsx
+++ b/apps/web/src/components/NotificationList/NotificationItem.tsx
@@ -18,14 +18,16 @@ import {
   parseDateTimeUtc,
 } from "@gc-digital-talent/date-helpers";
 import { commonMessages } from "@gc-digital-talent/i18n";
+import { toast } from "@gc-digital-talent/toast";
 
 import useNotificationInfo from "~/hooks/useNotificationInfo";
+import asyncDownload from "~/utils/download";
 
-import RemoveDialog from "./RemoveDialog";
 import {
   MarkNotificationAsRead_Mutation,
   MarkNotificationAsUnread_Mutation,
 } from "./mutations";
+import RemoveDialog from "./RemoveDialog";
 
 type LinkWrapperProps = {
   inDialog?: boolean;
@@ -73,8 +75,38 @@ const NotificationItem_Fragment = graphql(/* GraphQL */ `
         fr
       }
     }
+    ... on UserFileGeneratedNotification {
+      fileName
+    }
   }
 `);
+
+type LinkComponentProps = React.ComponentProps<"a"> & {
+  external?: boolean;
+};
+
+const LinkComponent = ({
+  external,
+  href,
+  children,
+  ...rest
+}: LinkComponentProps) => {
+  if (external) {
+    return (
+      // Note: we need an <a> to download
+      // eslint-disable-next-line react/forbid-elements
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <BaseLink to={href ?? ""} {...rest}>
+      {children}
+    </BaseLink>
+  );
+};
 
 interface NotificationItemProps {
   /** The actual notification type */
@@ -120,13 +152,32 @@ const NotificationItem = ({
     mutation({ id: notification.id });
   };
 
-  const handleLinkClicked = (event: MouseEvent<HTMLAnchorElement>) => {
+  const handleLinkClicked = async (event: MouseEvent<HTMLAnchorElement>) => {
     event.stopPropagation();
+    if (info.download) {
+      event.preventDefault();
+    }
 
     executeMarkAsReadMutation({ id: notification.id }).then((res) => {
       if (res.data?.markNotificationAsRead) {
         onRead?.();
-        navigate(info.href);
+        if (!info.download || !info.external) {
+          navigate(info.href);
+        } else if (info.download) {
+          asyncDownload(info.href, info.download, () => {
+            toast.error(
+              intl.formatMessage(
+                {
+                  defaultMessage:
+                    "There was a problem on our end. {fileName} failed to download. If you continue to receive this error, please get in touch with our support team",
+                  id: "KiMQQd",
+                  description: "Error message when a file download fails",
+                },
+                { fileName: info.download },
+              ),
+            );
+          });
+        }
       }
       return false;
     });
@@ -192,9 +243,11 @@ const NotificationItem = ({
             data-h2-width="base(100%)"
           >
             <LinkWrapper inDialog={inDialog}>
-              <BaseLink
-                to={info.href}
+              <LinkComponent
+                href={info.href}
                 ref={focusRef}
+                external={info.external}
+                download={info.download}
                 onClick={handleLinkClicked}
                 data-h2-text-decoration="base(none)"
                 data-h2-color="base:hover(secondary.darker)"
@@ -204,7 +257,7 @@ const NotificationItem = ({
                 })}
               >
                 {info.message}
-              </BaseLink>
+              </LinkComponent>
             </LinkWrapper>
             <DropdownMenu.Root>
               <DropdownMenu.Trigger>

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -7,7 +7,7 @@ import {
   SortingState,
   createColumnHelper,
 } from "@tanstack/react-table";
-import { OperationContext, useClient, useQuery } from "urql";
+import { OperationContext, useClient, useMutation, useQuery } from "urql";
 import isEqual from "lodash/isEqual";
 import DataLoader from "dataloader";
 
@@ -29,7 +29,9 @@ import {
   PoolCandidateWithSkillCount,
   PublishingGroup,
   FragmentType,
+  Language,
 } from "@gc-digital-talent/graphql";
+import { Button } from "@gc-digital-talent/ui";
 
 import useRoutes from "~/hooks/useRoutes";
 import {
@@ -68,15 +70,14 @@ import {
   getPoolNameSort,
   getClaimVerificationSort,
 } from "./helpers";
-import { rowSelectCell } from "../Table/ResponsiveTable/RowSelection";
+import {
+  actionButtonStyles,
+  rowSelectCell,
+} from "../Table/ResponsiveTable/RowSelection";
 import { normalizedText } from "../Table/sortingFns";
 import accessors from "../Table/accessors";
 import PoolCandidateFilterDialog from "./PoolCandidateFilterDialog";
 import { FormValues } from "./types";
-import {
-  getPoolCandidateCsvData,
-  getPoolCandidateCsvHeaders,
-} from "./poolCandidateCsv";
 import {
   JobPlacementDialog_Fragment,
   jobPlacementDialogAccessor,
@@ -403,6 +404,12 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
   }
 `);
 
+const DownloadPoolCandidatesCsv_Mutation = graphql(/* GraphQL */ `
+  mutation DownloadPoolCandidatesCsv($ids: [UUID!]!, $locale: Language) {
+    downloadPoolCandidatesCsv(ids: $ids, locale: $locale)
+  }
+`);
+
 const context: Partial<OperationContext> = {
   additionalTypenames: ["Skill", "SkillFamily"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
   requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
@@ -455,6 +462,10 @@ const PoolCandidatesTable = ({
   const initialFilters: PoolCandidateSearchInput = useMemo(
     () => (filtersEncoded ? JSON.parse(filtersEncoded) : initialFilterInput),
     [filtersEncoded, initialFilterInput],
+  );
+
+  const [{ fetching: downloadingCsv }, downloadCsv] = useMutation(
+    DownloadPoolCandidatesCsv_Mutation,
   );
 
   const filterRef = useRef<PoolCandidateSearchInput | undefined>(
@@ -599,6 +610,25 @@ const PoolCandidatesTable = ({
   const filteredSkillIds = filterState?.applicantFilter?.skills
     ?.filter(notEmpty)
     .map((skill) => skill.id);
+
+  const handleDownloadError = () => {
+    toast.error(intl.formatMessage(errorMessages.downloadRequestFailed));
+  };
+
+  const handleCsvDownload = () => {
+    downloadCsv({
+      ids: selectedRows,
+      locale: locale === "fr" ? Language.Fr : Language.En,
+    })
+      .then((res) => {
+        if (res.data) {
+          toast.success(intl.formatMessage(commonMessages.preparingDownload));
+        } else {
+          handleDownloadError();
+        }
+      })
+      .catch(handleDownloadError);
+  };
 
   const isPoolCandidate = (
     candidate: Error | PoolCandidate | null,
@@ -956,29 +986,20 @@ const PoolCandidatesTable = ({
             ),
           }),
       }}
-      download={{
-        disableBtn: isSelecting,
-        fetching: isSelecting && selectingFor === "download",
-        selection: {
-          csv: {
-            headers: getPoolCandidateCsvHeaders(intl, currentPool),
-            data: async () => {
-              const selected = await querySelected("download");
-              return getPoolCandidateCsvData(selected ?? [], intl);
-            },
-            fileName: intl.formatMessage(
-              {
-                defaultMessage: "pool_candidates_{date}.csv",
-                id: "aWsXoR",
-                description: "Filename for pool candidate CSV file download",
-              },
-              {
-                date: new Date().toISOString(),
-              },
-            ),
-          },
-        },
-      }}
+      asyncDownload={
+        <Button
+          {...actionButtonStyles}
+          onClick={handleCsvDownload}
+          disabled={downloadingCsv}
+        >
+          {intl.formatMessage({
+            defaultMessage: "Download CSV",
+            id: "mxOuYK",
+            description:
+              "Text label for button to download a csv file of items in a table.",
+          })}
+        </Button>
+      }
       print={{
         component: (
           <UserProfilePrintButton

--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -68,6 +68,8 @@ interface TableProps<TData, TFilters> {
   print?: DatasetPrint;
   /** Enable downloading selected rows and/or all data (requires rowSelect) */
   download?: DatasetDownload;
+  /** Async download button */
+  asyncDownload?: ReactNode;
   /** Enable the "add item" button */
   add?: AddDef;
   filter?: FilterDef<TFilters>;
@@ -87,6 +89,7 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
   search,
   sort,
   download,
+  asyncDownload,
   print,
   add,
   pagination,
@@ -372,6 +375,7 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
                 {...{
                   rowSelect: !!rowSelect,
                   download,
+                  asyncDownload,
                   print,
                   isLoading,
                   count: Object.values(rowSelection).length,

--- a/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
@@ -15,6 +15,7 @@ import {
   Dispatch,
   HTMLAttributes,
   MouseEventHandler,
+  ReactNode,
   SetStateAction,
   useCallback,
   useEffect,
@@ -135,7 +136,10 @@ const Bullet = (props: Omit<BulletProps, "children">) => (
 );
 
 // Simple common props for action buttons
-const actionButtonStyles: Pick<ButtonProps, "mode" | "color" | "fontSize"> = {
+export const actionButtonStyles: Pick<
+  ButtonProps,
+  "mode" | "color" | "fontSize"
+> = {
   mode: "inline",
   color: "whiteFixed",
   fontSize: "caption",
@@ -154,6 +158,8 @@ interface ActionsProps {
   print?: DatasetPrint;
   /** Enable the one or both (selection, all) download buttons */
   download?: DatasetDownload;
+  /** Button to trigger an async download */
+  asyncDownload?: ReactNode;
 }
 
 /**
@@ -169,6 +175,7 @@ const Actions = ({
   onClear,
   print,
   download,
+  asyncDownload,
 }: ActionsProps) => {
   const intl = useIntl();
 
@@ -275,6 +282,19 @@ const Actions = ({
                   </DownloadCsv>
                 </span>
               )}
+
+              {asyncDownload ? (
+                <span
+                  data-h2-align-items="base(center)"
+                  data-h2-display="base(flex)"
+                  data-h2-gap="base(0 x.5)"
+                >
+                  <span data-h2-display="base(none) l-tablet(block)">
+                    <Bullet data-h2-display="base(none) l-tablet(block)" />
+                  </span>
+                  {asyncDownload}
+                </span>
+              ) : null}
 
               {(print?.onPrint || print?.component) && (
                 <span

--- a/apps/web/src/hooks/useNotificationInfo.ts
+++ b/apps/web/src/hooks/useNotificationInfo.ts
@@ -1,4 +1,4 @@
-import { IntlShape, useIntl } from "react-intl";
+import { defineMessage, IntlShape, useIntl } from "react-intl";
 import { ReactNode } from "react";
 
 import {
@@ -7,14 +7,16 @@ import {
   NewJobPostedNotification,
   Notification,
   SystemNotification,
+  UserFileGeneratedNotification,
 } from "@gc-digital-talent/graphql";
-import { getLocalizedName } from "@gc-digital-talent/i18n";
+import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import {
   formDateStringToDate,
   formatDate,
 } from "@gc-digital-talent/date-helpers";
 import { useLogger } from "@gc-digital-talent/logger";
 import { GraphqlType } from "@gc-digital-talent/helpers";
+import { useApiRoutes } from "@gc-digital-talent/auth";
 
 import useRoutes from "./useRoutes";
 
@@ -22,6 +24,8 @@ type NotificationInfo = {
   message: ReactNode;
   label: string;
   href: string;
+  download?: string;
+  external?: boolean;
 };
 
 function isApplicationDeadlineApproachingNotification(
@@ -167,11 +171,38 @@ const systemNotificationToInfo = (
   };
 };
 
+function isUserFileGeneratedNotification(
+  notification: GraphqlType,
+): notification is UserFileGeneratedNotification {
+  return notification.__typename === "UserFileGeneratedNotification";
+}
+
+const fileDownloadMessage = defineMessage({
+  defaultMessage: "Your file is ready for download",
+  id: "+6syC7",
+  description: "Notification for when q requested download is ready",
+});
+
+const userFileGeneratedNotificationToInfo = (
+  notification: UserFileGeneratedNotification,
+  paths: ReturnType<typeof useApiRoutes>,
+  intl: IntlShape,
+): NotificationInfo => {
+  return {
+    message: `${intl.formatMessage(fileDownloadMessage)}${intl.formatMessage(commonMessages.dividingColon)}${notification.fileName}`,
+    href: paths.userGeneratedFile(notification.fileName ?? ""),
+    label: `${intl.formatMessage(fileDownloadMessage)}${intl.formatMessage(commonMessages.dividingColon)}${notification.fileName}`,
+    download: notification.fileName ?? "",
+    external: true,
+  };
+};
+
 const useNotificationInfo = (
   notification: Notification & GraphqlType,
 ): NotificationInfo | null => {
   const intl = useIntl();
   const paths = useRoutes();
+  const apiPaths = useApiRoutes();
   const logger = useLogger();
 
   if (isApplicationDeadlineApproachingNotification(notification)) {
@@ -192,6 +223,10 @@ const useNotificationInfo = (
 
   if (isNewJobPostedNotification(notification)) {
     return newJobPostedNotificationToInfo(notification, paths, intl);
+  }
+
+  if (isUserFileGeneratedNotification(notification)) {
+    return userFileGeneratedNotificationToInfo(notification, apiPaths, intl);
   }
 
   if (isSystemNotification(notification)) {

--- a/apps/web/src/utils/download.ts
+++ b/apps/web/src/utils/download.ts
@@ -1,0 +1,36 @@
+import { ACCESS_TOKEN } from "@gc-digital-talent/auth";
+
+function asyncDownload(url: string, fileName: string, onError?: () => void) {
+  const accessToken = localStorage.getItem(ACCESS_TOKEN);
+  fetch(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  })
+    .then((res) => {
+      if (res.status !== 200) {
+        throw new Error(`Response status: ${res.status}`);
+      }
+
+      return res.blob();
+    })
+    .then((blob) => {
+      const newBlob = new Blob([blob]);
+
+      const blobUrl = window.URL.createObjectURL(newBlob);
+
+      const link = document.createElement("a");
+      link.href = blobUrl;
+      link.setAttribute("download", fileName);
+      document.body.appendChild(link);
+      link.click();
+      link.parentNode?.removeChild(link);
+
+      // clean up Url
+      window.URL.revokeObjectURL(blobUrl);
+    })
+    .catch(onError);
+}
+
+export default asyncDownload;

--- a/packages/auth/src/hooks/useApiRoutes.ts
+++ b/packages/auth/src/hooks/useApiRoutes.ts
@@ -3,6 +3,7 @@ import path from "path-browserify";
 interface ApiRoutes {
   login: (from?: string, locale?: string) => string;
   refreshAccessToken: () => string;
+  userGeneratedFile: (fileName: string) => string;
 }
 
 const isDevServer =
@@ -29,6 +30,10 @@ const apiRoutes = {
   },
   refreshAccessToken: (): string =>
     apiHost ? new URL("refresh", apiHost).toString() : "/refresh",
+  userGeneratedFile: (fileName: string): string => {
+    const filePath = `api/user-generated-files/${fileName}`;
+    return apiHost ? new URL(filePath, apiHost).toString() : filePath;
+  },
 };
 export default apiRoutes;
 

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -259,6 +259,12 @@ const commonMessages = defineMessages({
     id: "nMX0n8",
     description: "Message to user when no experiences of that type exist.",
   },
+  preparingDownload: {
+    defaultMessage:
+      "Preparing your file for download. You will receive a notification when it is ready.",
+    id: "5RTQe6",
+    description: "Message to user when they request a file for download",
+  },
 });
 
 export default commonMessages;

--- a/packages/i18n/src/messages/errorMessages.ts
+++ b/packages/i18n/src/messages/errorMessages.ts
@@ -116,6 +116,12 @@ const errorMessages = defineMessages({
     id: "Gv3lBS",
     description: "Message for Unauthorized or Request Rejected server response",
   },
+  downloadRequestFailed: {
+    defaultMessage:
+      "There was a problem downloading your file.  If you continue to receive this error, please get in touch with our support team.",
+    id: "qNERoQ",
+    description: "Message for when the download request failed",
+  },
 });
 
 export default errorMessages;


### PR DESCRIPTION
🤖 Resolves #9693 

## 👋 Introduction

Updates candidate CSV download to be asynchronous.

## 🕵️ Details

This might be  a little hard to reason about (I know putting the pieces together was not exactly straight forward :sweat_smile: ) What happens is:

1. User requests a download
2. A job is dispatched to the queue
    - If it fails to dispatch the user gets a generic error message (we don't know file name yet so it is not included)
3. The queue picks the job up when it is ready and starts generating the file
4. Once the file has been written to disk,  we dispatch an event
5. The event listener picks up the event and dispatches a notification to the queue
6. The queue then picks up the notification and sends it to the appropriate user
7. At this time, the notification is created and once the notification poll runs, it should be in the notification pane
8. When the user clicks on the notification it sends off an async request to the file controller
9. The file controller checks to make sure the user has access to that file and if they do, it is streamed back down
10. When the stream is complete we create a fake link and click it down download the streamed file
   - If anything goes wrong during the stream, the user should get a slightly more specific error message
11. Congrats, you should finally have the CSV :tada: 

## :clipboard: TO DO

- [ ] Fix the table footer link bolding
- [ ] Localize the CSV
- [ ] Refactor generator for better performance?
- [ ] Look into the file scrub
- [ ] Test, test, test

## :question: Questions

### Authorisation

Right now, since this job is done in the queue, we can't really tell if the user who triggered the job has access to those files. Not sure how worrisome this is but, we have the user id so maybe we can just `Auth::loginById($userId)` then use the `scopeAuthorizedToView`? :thinking: 

### Expiration

I know these files expire but the notification will persist. Should we delete the notifications at the same time as the file deletion or just let the user try and see the error?

## 🧪 Testing

1. Buld the app `pnpm run dev:fresh`
2. Best to clear cache as well `make artisan CMD="optimize:clear"`
3. Start the worker queue `make queue-work`
4. Login as admin `admin@test.com`
5. Go to the a pool candidates table
6. Select any number of candidates... Go for 500!
7. Click "Download CSV"
8. Confirm the success toast appears
9. Confirm the job was picked up by the queue
10. Navgiate home `/en`
11. Wait for notification (shouldn't take too long)
12. Click the new notification
13. Confirm it downloads the expected file
14. Go and delete the file from the server
15. Try and download again and confirm you get an error toast

## 📸 Screenshot

![2024-07-16_19-04](https://github.com/user-attachments/assets/225c2dc6-6b48-4f0f-9f09-9bb7c9a840dd)
