### PR TITLE
[Debt] Constrain types classification, team, and department

### DIFF
--- a/apps/web/src/components/PoolCard/PoolCard.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.tsx
@@ -86,7 +86,7 @@ export const PoolCard_Fragment = graphql(/* GraphQL */ `
 
 const getSalaryRange = (
   locale: string,
-  classification?: Maybe<Classification>,
+  classification?: Maybe<Pick<Classification, "minSalary" | "maxSalary">>,
 ) => {
   if (!classification) return null;
 

--- a/apps/web/src/components/Profile/components/GovernmentInformation/utils.ts
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/utils.ts
@@ -25,7 +25,7 @@ import { FormValues, PartialUser } from "./types";
 const classificationFormToId = (
   group: string | undefined,
   level: string | undefined,
-  classifications: Classification[],
+  classifications: Pick<Classification, "group" | "level" | "id">[],
 ): string | undefined => {
   return classifications.find(
     (classification) =>
@@ -35,7 +35,7 @@ const classificationFormToId = (
 
 export const formValuesToSubmitData = (
   values: FormValues,
-  classifications: Classification[],
+  classifications: Pick<Classification, "group" | "level" | "id">[],
 ): UpdateUserAsUserInput => {
   const classificationId = classificationFormToId(
     values.currentClassificationGroup,
@@ -220,7 +220,7 @@ export const getGroupOptions = (
  * @returns
  */
 export const getLevelOptions = (
-  classifications: Classification[],
+  classifications: Pick<Classification, "group" | "level">[],
   groupSelection: Classification["group"],
 ) =>
   classifications

--- a/apps/web/src/components/Profile/components/GovernmentInformation/utils.ts
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/utils.ts
@@ -181,7 +181,7 @@ export const getLabels = (intl: IntlShape) => ({
  * Get classification group options
  */
 export const getGroupOptions = (
-  classifications: Classification[],
+  classifications: Pick<Classification, "group" | "name">[],
   intl: IntlShape,
 ) => {
   const classGroupsWithDupes: {

--- a/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.tsx
+++ b/apps/web/src/components/QualifiedRecruitmentCard/QualifiedRecruitmentCard.tsx
@@ -64,11 +64,6 @@ export const QualifiedRecruitmentCard_Fragment = graphql(/* GraphQL */ `
         en
         fr
       }
-      classification {
-        id
-        group
-        level
-      }
       department {
         id
         departmentNumber

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -33,7 +33,7 @@ const ApplicantFilters = ({
   selectedClassifications,
 }: {
   applicantFilter?: Maybe<ApplicantFilter>;
-  selectedClassifications?: Maybe<Classification>[];
+  selectedClassifications?: Maybe<Pick<Classification, "group" | "level">>[];
 }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -277,7 +277,7 @@ const ApplicantFilters = ({
 
 interface SearchRequestFiltersProps {
   filters?: Maybe<ApplicantFilter | PoolCandidateFilter>;
-  selectedClassifications?: Maybe<Classification>[];
+  selectedClassifications?: Maybe<Pick<Classification, "group" | "level">>[];
 }
 
 const SearchRequestFilters = ({

--- a/apps/web/src/components/SearchRequestTable/components/helpers.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/helpers.tsx
@@ -12,7 +12,9 @@ import {
 import useRoutes from "~/hooks/useRoutes";
 
 export function classificationAccessor(
-  classifications: Maybe<Maybe<Classification>[]> | undefined,
+  classifications:
+    | Maybe<Maybe<Pick<Classification, "group" | "level">>[]>
+    | undefined,
 ) {
   return classifications
     ?.filter(notEmpty)
@@ -21,7 +23,9 @@ export function classificationAccessor(
 }
 
 export function classificationsCell(
-  classifications: Maybe<Maybe<Classification>[] | undefined> | undefined,
+  classifications:
+    | Maybe<Maybe<Pick<Classification, "group" | "level">>[] | undefined>
+    | undefined,
   intl: IntlShape,
 ) {
   const filteredClassifications = classifications

--- a/apps/web/src/pages/Applications/fragment.ts
+++ b/apps/web/src/pages/Applications/fragment.ts
@@ -288,18 +288,6 @@ const Application_PoolCandidateFragment = graphql(/* GraphQL */ `
         id
         group
         level
-        name {
-          en
-          fr
-        }
-        genericJobTitles {
-          id
-          key
-          name {
-            en
-            fr
-          }
-        }
       }
       poolSkills {
         id

--- a/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
@@ -59,7 +59,6 @@ export const CreateAccount_QueryFragment = graphql(/** GraphQL */ `
   fragment CreateAccount_QueryFragment on Query {
     departments {
       id
-      departmentNumber
       name {
         en
         fr
@@ -73,8 +72,6 @@ export const CreateAccount_QueryFragment = graphql(/** GraphQL */ `
       }
       group
       level
-      minSalary
-      maxSalary
     }
     languages: localizedEnumStrings(enumName: "Language") {
       value

--- a/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/CreateAccountPage.tsx
@@ -100,7 +100,6 @@ export const CreateAccountForm = ({
   const intl = useIntl();
   const govInfoLabels = getGovernmentInfoLabels(intl);
   const result = getFragment(CreateAccount_QueryFragment, query);
-  const departments = unpackMaybes(result?.departments);
   const classifications = unpackMaybes(result?.classifications);
 
   const labels = {
@@ -277,8 +276,8 @@ export const CreateAccountForm = ({
                 </p>
                 <GovernmentInfoFormFields
                   labels={labels}
-                  departments={departments}
-                  classifications={classifications}
+                  departmentsQuery={result?.departments}
+                  classificationsQuery={result?.classifications}
                 />
                 <div
                   data-h2-margin="base(x2, 0, 0, 0)"

--- a/apps/web/src/pages/Auth/CreateAccountPage/components/GovernmentInfoForm.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/components/GovernmentInfoForm.tsx
@@ -18,13 +18,13 @@ import {
   FieldLabels,
   enumToOptions,
 } from "@gc-digital-talent/forms";
-import { empty, notEmpty } from "@gc-digital-talent/helpers";
+import { empty, notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import { Link } from "@gc-digital-talent/ui";
 import {
   Classification,
   UpdateUserAsUserInput,
   GovEmployeeType,
-  Department,
+  CreateAccount_QueryFragmentFragment,
 } from "@gc-digital-talent/graphql";
 
 import { splitAndJoin } from "~/utils/nameUtils";
@@ -184,15 +184,15 @@ export const getGovernmentInfoLabels = (intl: IntlShape) => ({
   }),
 });
 interface GovernmentInfoFormFieldsProps {
-  departments: Department[];
-  classifications: Classification[];
+  departmentsQuery?: CreateAccount_QueryFragmentFragment["departments"];
+  classificationsQuery?: CreateAccount_QueryFragmentFragment["classifications"];
   labels: FieldLabels;
 }
 
 // inner component
 export const GovernmentInfoFormFields = ({
-  departments,
-  classifications,
+  departmentsQuery,
+  classificationsQuery,
   labels,
 }: GovernmentInfoFormFieldsProps) => {
   const intl = useIntl();
@@ -206,6 +206,8 @@ export const GovernmentInfoFormFields = ({
       "currentClassificationGroup",
       "priorityEntitlementYesNo",
     ]);
+  const departments = unpackMaybes(departmentsQuery);
+  const classifications = unpackMaybes(classificationsQuery);
 
   const classGroupsWithDupes: {
     label: string;

--- a/apps/web/src/pages/Auth/CreateAccountPage/components/GovernmentInfoForm.tsx
+++ b/apps/web/src/pages/Auth/CreateAccountPage/components/GovernmentInfoForm.tsx
@@ -57,7 +57,7 @@ const priorityEntitlementLink = (locale: string, chunks: ReactNode) => {
 const classificationFormToId = (
   group: string | undefined,
   level: string | undefined,
-  classifications: Classification[],
+  classifications: Pick<Classification, "group" | "level" | "id">[],
 ): string | undefined => {
   return classifications.find(
     (classification) =>
@@ -67,7 +67,7 @@ const classificationFormToId = (
 
 export const formValuesToSubmitData = (
   values: FormValues,
-  classifications: Classification[],
+  classifications: Pick<Classification, "group" | "level" | "id">[],
 ): UpdateUserAsUserInput => {
   const classificationId = classificationFormToId(
     values.currentClassificationGroup,

--- a/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
+++ b/apps/web/src/pages/Classifications/components/ClassificationTable.tsx
@@ -8,9 +8,9 @@ import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import { Pending } from "@gc-digital-talent/ui";
 import {
   graphql,
-  Classification,
   FragmentType,
   getFragment,
+  ClassificationTableRowFragment,
 } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
@@ -33,7 +33,7 @@ export const ClassificationTableRow_Fragment = graphql(/* GraphQL */ `
   }
 `);
 
-const columnHelper = createColumnHelper<Classification>();
+const columnHelper = createColumnHelper<ClassificationTableRowFragment>();
 
 interface ClassificationTableProps {
   classificationsQuery: FragmentType<typeof ClassificationTableRow_Fragment>[];
@@ -116,7 +116,7 @@ export const ClassificationTable = ({
           }-0${classification.level}`,
         ),
     }),
-  ] as ColumnDef<Classification>[];
+  ] as ColumnDef<ClassificationTableRowFragment>[];
 
   const data = classifications.filter(notEmpty);
 
@@ -124,7 +124,7 @@ export const ClassificationTable = ({
   const currentUrl = `${pathname}${search}${hash}`;
 
   return (
-    <Table<Classification>
+    <Table<ClassificationTableRowFragment>
       caption={title}
       data={data}
       columns={columns}

--- a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
+++ b/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
@@ -42,25 +42,6 @@ const CreateApplicationApplications_Query = graphql(/* GraphQL */ `
           stream {
             value
           }
-          classification {
-            id
-            group
-            level
-            name {
-              en
-              fr
-            }
-            genericJobTitles {
-              id
-              key
-              name {
-                en
-                fr
-              }
-            }
-            minSalary
-            maxSalary
-          }
         }
       }
     }

--- a/apps/web/src/pages/Departments/components/DepartmentTable.tsx
+++ b/apps/web/src/pages/Departments/components/DepartmentTable.tsx
@@ -8,7 +8,7 @@ import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import { Pending } from "@gc-digital-talent/ui";
 import {
   graphql,
-  Department,
+  DepartmentTableRowFragment,
   FragmentType,
   getFragment,
 } from "@gc-digital-talent/graphql";
@@ -18,7 +18,7 @@ import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import cells from "~/components/Table/cells";
 import { normalizedText } from "~/components/Table/sortingFns";
 
-const columnHelper = createColumnHelper<Department>();
+const columnHelper = createColumnHelper<DepartmentTableRowFragment>();
 
 export const DepartmentTableRow_Fragment = graphql(/* GraphQL */ `
   fragment DepartmentTableRow on Department {
@@ -72,7 +72,7 @@ export const DepartmentTable = ({
           getLocalizedName(department.name, intl, true),
         ),
     }),
-  ] as ColumnDef<Department>[];
+  ] as ColumnDef<DepartmentTableRowFragment>[];
 
   const data = departments.filter(notEmpty);
 
@@ -80,7 +80,7 @@ export const DepartmentTable = ({
   const currentUrl = `${pathname}${search}${hash}`;
 
   return (
-    <Table<Department>
+    <Table<DepartmentTableRowFragment>
       data={data}
       caption={title}
       columns={columns}

--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -71,7 +71,7 @@ interface CreatePoolFormProps {
     teamId: string,
     data: CreatePoolInput,
   ) => Promise<CreatePoolMutation["createPool"]>;
-  teamsArray: Team[];
+  teamsArray: Pick<Team, "id" | "displayName">[];
 }
 
 export const CreatePoolForm = ({
@@ -242,9 +242,13 @@ export const CreatePoolForm = ({
   );
 };
 
+type ConstrainedTeamOnRoleAssignment = {
+  team?: Maybe<Pick<Team, "id" | "displayName">>;
+};
+
 const roleAssignmentsToTeams = (
-  roleAssignmentArray: Maybe<RoleAssignment[]>,
-): Team[] => {
+  roleAssignmentArray: Maybe<ConstrainedTeamOnRoleAssignment[]>,
+): Pick<Team, "id" | "displayName">[] => {
   const flattenedTeams = roleAssignmentArray?.flatMap(
     (roleAssign) => roleAssign.team,
   );
@@ -268,7 +272,6 @@ const CreatePoolPage_Query = graphql(/* GraphQL */ `
           id
           team {
             id
-            name
             displayName {
               en
               fr

--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -14,7 +14,6 @@ import {
 import { Pending, Link } from "@gc-digital-talent/ui";
 import {
   graphql,
-  RoleAssignment,
   CreatePoolInput,
   CreatePoolMutation,
   Maybe,

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
@@ -112,7 +112,6 @@ export const PoolClassification_Fragment = graphql(/* GraphQL */ `
 export const PoolDepartment_Fragment = graphql(/* GraphQL */ `
   fragment PoolDepartment on Department {
     id
-    departmentNumber
     name {
       en
       fr

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
@@ -86,7 +86,7 @@ export const getClassificationOptions = (
 };
 
 export const getDepartmentOptions = (
-  departments: readonly Department[],
+  departments: readonly Pick<Department, "id" | "name">[],
   intl: IntlShape,
 ): Option[] => {
   return departments.filter(notEmpty).map(({ id, name }) => ({

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
@@ -71,7 +71,7 @@ export function fullNameCell(pool: Pool, intl: IntlShape) {
 }
 
 export function classificationAccessor(
-  classification: Maybe<Classification> | undefined,
+  classification: Maybe<Pick<Classification, "group" | "level">> | undefined,
 ) {
   return classification
     ? `${classification.group}-0${classification.level}`
@@ -79,7 +79,7 @@ export function classificationAccessor(
 }
 
 export function classificationCell(
-  classification: Maybe<Classification> | undefined,
+  classification: Maybe<Pick<Classification, "group" | "level">> | undefined,
 ) {
   if (!classification) return null;
 

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
@@ -151,33 +151,6 @@ const CareerTimelineApplication_Fragment = graphql(/* GraphQL */ `
       stream {
         value
       }
-      classification {
-        id
-        group
-        level
-        name {
-          en
-          fr
-        }
-        genericJobTitles {
-          id
-          key
-          name {
-            en
-            fr
-          }
-        }
-        minSalary
-        maxSalary
-      }
-      department {
-        id
-        departmentNumber
-        name {
-          en
-          fr
-        }
-      }
     }
   }
 `);

--- a/apps/web/src/pages/SearchRequests/RequestPage/RequestPage.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/RequestPage.tsx
@@ -15,7 +15,7 @@ type LocationState = {
   applicantFilter: ApplicantFilterInput;
   initialValues: SearchFormValues;
   candidateCount: number;
-  selectedClassifications: Classification[];
+  selectedClassifications?: Pick<Classification, "group" | "level">[];
 };
 
 export const Component = () => {

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -196,7 +196,7 @@ export interface RequestFormProps {
   applicantFilter: Maybe<ApplicantFilterInput>;
   candidateCount: Maybe<number>;
   searchFormInitialValues?: SearchFormValues;
-  selectedClassifications?: Maybe<Classification>[];
+  selectedClassifications?: Maybe<Pick<Classification, "group" | "level">>[];
   handleCreatePoolCandidateSearchRequest: (
     data: CreatePoolCandidateSearchRequestInput,
   ) => Promise<CreateRequestMutation["createPoolCandidateSearchRequest"]>;
@@ -776,7 +776,7 @@ const RequestFormApi = ({
   applicantFilter: Maybe<ApplicantFilterInput>;
   candidateCount: Maybe<number>;
   searchFormInitialValues?: SearchFormValues;
-  selectedClassifications?: Maybe<Classification>[];
+  selectedClassifications?: Maybe<Pick<Classification, "group" | "level">>[];
 }) => {
   const intl = useIntl();
   const [{ data: lookupData, fetching, error }] = useQuery({

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
@@ -54,7 +54,7 @@ const SearchRequestOptions_Query = graphql(/* GraphQL */ `
 `);
 
 interface FormFieldsProps {
-  classifications: Classification[];
+  classifications: Pick<Classification, "group" | "level">[];
   skills: Skill[];
 }
 

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -38,7 +38,7 @@ const styledCount = (chunks: ReactNode) => (
 
 interface SearchFormProps {
   pools: Pool[];
-  classifications: Classification[];
+  classifications: Pick<Classification, "group" | "level" | "id">[];
   skills: Skill[];
 }
 

--- a/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
@@ -74,7 +74,7 @@ export const getClassificationLabel = (
  * @returns {string}
  */
 const getCurrentClassification = (
-  selectedClassifications?: Maybe<Classification[]>,
+  selectedClassifications?: Maybe<Pick<Classification, "group" | "level">[]>,
 ): string => {
   return selectedClassifications && selectedClassifications?.length > 0
     ? formatClassificationString(selectedClassifications[0])
@@ -138,7 +138,7 @@ export const applicantFilterToQueryArgs = (
  */
 export const dataToFormValues = (
   data: ApplicantFilterInput,
-  selectedClassifications?: Maybe<Classification[]>,
+  selectedClassifications?: Maybe<Pick<Classification, "group" | "level">[]>,
   pools?: Pool[],
 ): FormValues => {
   const safePools = data.pools?.filter(notEmpty) ?? [];

--- a/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
@@ -55,7 +55,7 @@ export const getAvailableClassifications = (
 };
 
 export const getClassificationLabel = (
-  { group, level }: Classification,
+  { group, level }: Pick<Classification, "group" | "level">,
   labels: Record<string, MessageDescriptor>,
   intl: IntlShape,
 ) => {
@@ -185,7 +185,7 @@ export const dataToFormValues = (
 export const formValuesToData = (
   values: FormValues,
   pools: Pool[],
-  classifications: Classification[],
+  classifications: Pick<Classification, "group" | "level" | "id">[],
 ): ApplicantFilterInput => {
   const selectedClassification = classifications.find((classification) => {
     return formatClassificationString(classification) === values.classification;

--- a/apps/web/src/pages/Teams/TeamMembersPage/helpers.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/helpers.tsx
@@ -4,7 +4,8 @@ import { IntlShape } from "react-intl";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 import { Link, Chip, Chips } from "@gc-digital-talent/ui";
 import { notEmpty } from "@gc-digital-talent/helpers";
-import { Maybe, Role, Team } from "@gc-digital-talent/graphql";
+import { Maybe, Role } from "@gc-digital-talent/graphql";
+import { TeamMembersPage_TeamFragment as TeamMembersPageTeamFragmentType } from "@gc-digital-talent/graphql";
 
 import { TeamMember } from "~/utils/teamUtils";
 
@@ -24,7 +25,10 @@ function orderRoles(roles: Array<Role>, intl: IntlShape) {
   });
 }
 
-export const actionCell = (user: TeamMember, team: Team) => (
+export const actionCell = (
+  user: TeamMember,
+  team: TeamMembersPageTeamFragmentType,
+) => (
   <div
     data-h2-display="base(flex)"
     data-h2-flex-wrap="base(wrap)"

--- a/apps/web/src/pages/Teams/TeamMembersPage/helpers.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/helpers.tsx
@@ -4,8 +4,11 @@ import { IntlShape } from "react-intl";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 import { Link, Chip, Chips } from "@gc-digital-talent/ui";
 import { notEmpty } from "@gc-digital-talent/helpers";
-import { Maybe, Role } from "@gc-digital-talent/graphql";
-import { TeamMembersPage_TeamFragment as TeamMembersPageTeamFragmentType } from "@gc-digital-talent/graphql";
+import {
+  Maybe,
+  Role,
+  TeamMembersPage_TeamFragment as TeamMembersPageTeamFragmentType,
+} from "@gc-digital-talent/graphql";
 
 import { TeamMember } from "~/utils/teamUtils";
 

--- a/apps/web/src/pages/Users/UpdateUserPage/components/EditTeamRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/EditTeamRoleDialog.tsx
@@ -31,7 +31,7 @@ interface EditTeamRoleDialogProps {
   user: User;
   initialRoles: Array<Role>;
   allRoles: Array<Role>;
-  team: Team;
+  team: Pick<Team, "id" | "displayName">;
   onEditRoles: (
     submitData: UpdateUserRolesInput,
   ) => Promise<UpdateUserRolesMutation["updateUserRoles"]>;

--- a/apps/web/src/pages/Users/UpdateUserPage/components/RemoveTeamRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/RemoveTeamRoleDialog.tsx
@@ -23,7 +23,7 @@ import { getFullNameHtml } from "~/utils/nameUtils";
 interface RemoveTeamRoleDialogProps {
   user: User;
   roles: Role[];
-  team: Team;
+  team: Pick<Team, "id" | "displayName">;
   onRemoveRoles: (
     submitData: UpdateUserRolesInput,
   ) => Promise<UpdateUserRolesMutation["updateUserRoles"]>;

--- a/apps/web/src/pages/Users/UpdateUserPage/components/TeamRoleTable.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/TeamRoleTable.tsx
@@ -29,7 +29,7 @@ import {
 
 type RoleTeamPair = {
   role: Role;
-  team: Team;
+  team: Pick<Team, "id" | "name">;
 };
 
 const columnHelper = createColumnHelper<TeamAssignment>();

--- a/apps/web/src/pages/Users/UpdateUserPage/types.ts
+++ b/apps/web/src/pages/Users/UpdateUserPage/types.ts
@@ -15,6 +15,6 @@ export type DeleteUserFunc = (
 ) => Promise<DeleteUserMutation["deleteUser"]>;
 
 export type TeamAssignment = {
-  team: Team;
+  team: Pick<Team, "id" | "name" | "displayName">;
   roles: Role[];
 };

--- a/apps/web/src/types/searchRequest.ts
+++ b/apps/web/src/types/searchRequest.ts
@@ -22,7 +22,7 @@ export type FormValues = Pick<
   educationRequirement: "has_diploma" | "no_diploma";
   poolCandidates?: UserPoolFilterInput;
   pool?: Scalars["ID"]["output"];
-  selectedClassifications?: Classification[];
+  selectedClassifications?: Pick<Classification, "group" | "level">[];
   count?: number;
   allPools?: boolean; // Prevent `was_empty` when requesting all pools
 };
@@ -33,6 +33,6 @@ export type BrowserHistoryState = {
   applicantFilter?: ApplicantFilterInput;
   candidateCount: number;
   initialValues?: FormValues;
-  selectedClassifications?: Classification[];
+  selectedClassifications?: Pick<Classification, "group" | "level">[];
   allPools?: boolean;
 };

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -104,7 +104,7 @@ export const formatClassificationString = ({
 };
 interface formattedPoolPosterTitleProps {
   title: Maybe<string> | undefined;
-  classification: Maybe<Classification> | undefined;
+  classification: Maybe<Pick<Classification, "group" | "level">> | undefined;
   stream?: Maybe<LocalizedPoolStream>;
   short?: boolean;
   intl: IntlShape;
@@ -462,7 +462,7 @@ export function getClassificationName(
 
 export const getClassificationSalaryRangeUrl = (
   locale: Locales,
-  classification?: Maybe<Classification>,
+  classification?: Maybe<Pick<Classification, "group">>,
 ): string | null => {
   let localizedUrl: Record<Locales, string> | null = null;
   switch (classification?.group) {

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -46,7 +46,7 @@ import { wrapAbbr } from "./nameUtils";
  */
 export const poolMatchesClassification = (
   pool: Pool,
-  classification: Classification,
+  classification: Pick<Classification, "group" | "level">,
 ): boolean => {
   return (
     pool.classification?.group === classification?.group &&


### PR DESCRIPTION
🤖 Progresses #10799

## 👋 Introduction

Chips away at the issue by targeting types
`Team`
`Classification`
`Department`

## 🕵️ Details

Make the issue less daunting by electing to chip away at it over time.
There are many types to look at, but it is complicated by nesting of types too. For instance, may need to shake out `Classification` more once type `Pool` has been constrained as the former can be nested in the latter

Thoughts? @esizer 

## 🧪 Testing

1. All functionality related to the three types still works
2. Nothing left to change



