### PR TITLE
[Fix] Updates colours for a11y contrast

### DIFF
--- a/packages/forms/src/components/Field/Required.tsx
+++ b/packages/forms/src/components/Field/Required.tsx
@@ -4,7 +4,7 @@ export interface RequiredProps {
 
 const Required = ({ required }: RequiredProps) =>
   required ? (
-    <span data-h2-color="base(error) base:dark(error.lightest)"> *</span>
+    <span data-h2-color="base(error.dark) base:dark(error.lightest)"> *</span>
   ) : null;
 
 export default Required;

--- a/packages/i18n/src/components/richTextElements.tsx
+++ b/packages/i18n/src/components/richTextElements.tsx
@@ -95,7 +95,7 @@ const warning = (text: ReactNode) => (
  * @param text  text to wrap
  */
 const heavyWarning = (text: ReactNode) => (
-  <span data-h2-color="base(warning.dark)" data-h2-font-weight="base(700)">
+  <span data-h2-color="base(warning.darker)" data-h2-font-weight="base(700)">
     {text}
   </span>
 );


### PR DESCRIPTION
🤖 Resolves #10918.

## 👋 Introduction

This PR updates colours to meet contrast for a11y.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm build`
2. Navigate to an admin process page that is set to draft
3. Verify colour contrast of word **draft** is at least WCAG AA
4. Navigate to different instances where a field label required is used
5. Verify colour contrast of asterisk is at least WCAG AA

## 📸 Screenshots
### `heavyWarning`
<img width="478" alt="Screen Shot 2024-07-19 at 10 26 04" src="https://github.com/user-attachments/assets/f5d852f3-2efa-4239-b702-08cc6f251fd4">

<img width="484" alt="Screen Shot 2024-07-19 at 10 25 52" src="https://github.com/user-attachments/assets/de5216fd-b232-440a-a248-c688e3fe0616">

### `Required`

<img alt="Screen Shot 2024-07-19 at 11 35 44" src="https://github.com/user-attachments/assets/fb1eaa01-7de9-40d2-a092-e63b129c6c75">

<img width="800" alt="Screen Shot 2024-07-19 at 11 25 00" src="https://github.com/user-attachments/assets/d81dff3b-2cc4-4631-b97c-18c0bf484979">

<img width="558" alt="Screen Shot 2024-07-19 at 11 26 06" src="https://github.com/user-attachments/assets/03f8dedf-5675-43da-b2df-d5311b014736">
