### PR TITLE
[Fix] Remove policy from paginated pool candidates query

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -761,7 +761,7 @@ class PoolCandidate extends Model
         ]);
 
         // User does not have any of the required permissions
-        if(!$hasSomePermission) {
+        if (! $hasSomePermission) {
             return $query->where('id', null);
         }
 

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -754,6 +754,17 @@ class PoolCandidate extends Model
             return $query->where('id', null);
         }
 
+        $hasSomePermission = $user->isAbleTo([
+            'view-own-application',
+            'view-team-submittedApplication',
+            'view-any-submittedApplication',
+        ]);
+
+        // User does not have any of the required permissions
+        if(!$hasSomePermission) {
+            return $query->where('id', null);
+        }
+
         $query->where(function (Builder $query) use ($user) {
             if ($user->isAbleTo('view-any-submittedApplication')) {
                 $query->orWhere('submitted_at', '<=', Carbon::now()->toDateTimeString());

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -854,7 +854,7 @@ class PoolCandidate extends Model
         extract($args);
 
         if ($order && $locale) {
-            $query = $query->withMax('pool', 'name->' . $locale)->orderBy('pool_max_name' . $locale, $order);
+            $query = $query->withMax('pool', 'name->'.$locale)->orderBy('pool_max_name'.$locale, $order);
         }
 
         return $query;
@@ -871,7 +871,7 @@ class PoolCandidate extends Model
                     END';
 
         if ($sortOrder && $sortOrder == 'DESC') {
-            $order = $orderWithoutDirection . ' DESC';
+            $order = $orderWithoutDirection.' DESC';
 
             $query
                 ->join('users', 'users.id', '=', 'pool_candidates.user_id')
@@ -879,7 +879,7 @@ class PoolCandidate extends Model
                 ->orderBy('is_bookmarked', 'DESC')
                 ->orderByRaw($order);
         } elseif ($sortOrder && $sortOrder == 'ASC') {
-            $order = $orderWithoutDirection . ' ASC';
+            $order = $orderWithoutDirection.' ASC';
 
             $query
                 ->join('users', 'users.id', '=', 'pool_candidates.user_id')

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -772,17 +772,17 @@ class PoolCandidate extends Model
 
             if ($user->isAbleTo('view-team-submittedApplication')) {
                 $allTeam = $user->rolesTeams()->get();
-                $teamIds = $allTeam->filter(function($team) use($user) {
+                $teamIds = $allTeam->filter(function ($team) use ($user) {
                     return $user->isAbleTo('view-team-submittedApplication', $team);
                 })->pluck('id');
 
                 $query->orWhereHas('pool', function (Builder $query) use ($teamIds) {
                     return $query
                         ->where('submitted_at', '<=', Carbon::now()->toDateTimeString())
-                        ->where(function (Builder $query) use($teamIds) {
+                        ->where(function (Builder $query) use ($teamIds) {
                             $query->orWhereHas('legacyTeam', function (Builder $query) use ($teamIds) {
                                 return $query->whereIn('id', $teamIds);
-                            })->orWhereHas('team', function(Builder $query) use($teamIds) {
+                            })->orWhereHas('team', function (Builder $query) use ($teamIds) {
                                 return $query->whereIn('id', $teamIds);
                             });
                         });

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -854,7 +854,7 @@ class PoolCandidate extends Model
         extract($args);
 
         if ($order && $locale) {
-            $query = $query->withMax('pool', 'name->'.$locale)->orderBy('pool_max_name'.$locale, $order);
+            $query = $query->withMax('pool', 'name->' . $locale)->orderBy('pool_max_name' . $locale, $order);
         }
 
         return $query;
@@ -871,7 +871,7 @@ class PoolCandidate extends Model
                     END';
 
         if ($sortOrder && $sortOrder == 'DESC') {
-            $order = $orderWithoutDirection.' DESC';
+            $order = $orderWithoutDirection . ' DESC';
 
             $query
                 ->join('users', 'users.id', '=', 'pool_candidates.user_id')
@@ -879,7 +879,7 @@ class PoolCandidate extends Model
                 ->orderBy('is_bookmarked', 'DESC')
                 ->orderByRaw($order);
         } elseif ($sortOrder && $sortOrder == 'ASC') {
-            $order = $orderWithoutDirection.' ASC';
+            $order = $orderWithoutDirection . ' ASC';
 
             $query
                 ->join('users', 'users.id', '=', 'pool_candidates.user_id')
@@ -1096,7 +1096,7 @@ class PoolCandidate extends Model
                         continue;
                     }
 
-                    // UNSUFFCESSFUL on essential skills always takes precedence over other statuses, so we can exit the loop right away.
+                    // UNSUCCESSFUL on essential skills always takes precedence over other statuses, so we can exit the loop right away.
                     if ($decision === AssessmentDecision::UNSUCCESSFUL->name) {
                         $hasFailure = true;
                         break;
@@ -1125,7 +1125,6 @@ class PoolCandidate extends Model
                         if (! $isClaimed) {
                             continue;
                         }
-
                     }
 
                     if (! $result || is_null($result->assessment_decision)) {
@@ -1279,12 +1278,12 @@ class PoolCandidate extends Model
                 PoolCandidateStatus::SCREENED_OUT_ASSESSMENT->name,
                 PoolCandidateStatus::SCREENED_OUT_APPLICATION->name => FinalDecision::DISQUALIFIED->name,
 
-                PoolCandidateStatus::QUALIFIED_AVAILABLE->name => FinalDecision::QUALIFIED->name ,
+                PoolCandidateStatus::QUALIFIED_AVAILABLE->name => FinalDecision::QUALIFIED->name,
 
                 PoolCandidateStatus::PLACED_CASUAL->name,
                 PoolCandidateStatus::PLACED_INDETERMINATE->name,
                 PoolCandidateStatus::PLACED_TENTATIVE->name,
-                PoolCandidateStatus::PLACED_TERM->name => FinalDecision::QUALIFIED_PLACED->name ,
+                PoolCandidateStatus::PLACED_TERM->name => FinalDecision::QUALIFIED_PLACED->name,
 
                 PoolCandidateStatus::SCREENED_OUT_NOT_INTERESTED->name,
                 PoolCandidateStatus::SCREENED_OUT_NOT_RESPONSIVE->name => FinalDecision::TO_ASSESS_REMOVED->name,
@@ -1292,11 +1291,10 @@ class PoolCandidate extends Model
                 PoolCandidateStatus::QUALIFIED_UNAVAILABLE->name,
                 PoolCandidateStatus::QUALIFIED_WITHDREW->name => FinalDecision::QUALIFIED_REMOVED->name,
 
-                PoolCandidateStatus::REMOVED->name => FinalDecision::REMOVED->name ,
+                PoolCandidateStatus::REMOVED->name => FinalDecision::REMOVED->name,
                 PoolCandidateStatus::EXPIRED->name => FinalDecision::QUALIFIED_EXPIRED->name,
 
                 default => null
-
             };
         }
 
@@ -1316,7 +1314,6 @@ class PoolCandidate extends Model
                 FinalDecision::QUALIFIED_EXPIRED->name => 250,
                 default => null
             };
-
         } catch (\UnhandledMatchError $e) {
             Log::error($e->getMessage());
 
@@ -1337,6 +1334,5 @@ class PoolCandidate extends Model
             'decision' => $decision,
             'weight' => $weight,
         ];
-
     }
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -938,14 +938,13 @@ type Query {
         ]
       )
   ): [PoolCandidateWithSkillCount]!
+    @guard
     @paginate(
       defaultCount: 10
       maxCount: 1000
       scopes: ["notDraft", "withSkillCount", "authorizedToView"]
       model: "App\\Models\\PoolCandidate"
     )
-    @guard
-    @canResolved(ability: "view", model: "App\\Models\\PoolCandidate")
   # This query lives at api/app/GraphQL/Queries/CountPoolCandidatesByPool.php.
   # Returns the number of candidates by filtering their parent applicant, grouped by pool.
   countPoolCandidatesByPool(

--- a/api/tests/Feature/PoolCandidatesPaginatedTest.php
+++ b/api/tests/Feature/PoolCandidatesPaginatedTest.php
@@ -35,8 +35,8 @@ class PoolCandidatesPaginatedTest extends TestCase
     public PoolCandidate $applicantCandidate;
 
     public string $query =
-    /** GraphQL */
-    '
+        /** GraphQL */
+        '
         query PoolCandidates {
             poolCandidatesPaginated(first: 100) {
                 paginatorInfo {

--- a/api/tests/Feature/PoolCandidatesPaginatedTest.php
+++ b/api/tests/Feature/PoolCandidatesPaginatedTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\PoolCandidateStatus;
+use App\Models\Community;
+use App\Models\Pool;
+use App\Models\PoolCandidate;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
+use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
+
+class PoolCandidatesPaginatedTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+    use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
+
+    public Pool $pool;
+
+    public Team $team;
+
+    public User $applicant;
+
+    public PoolCandidate $noTeamCandidate;
+
+    public PoolCandidate $teamCandidate;
+
+    public PoolCandidate $applicantCandidate;
+
+    public string $query = /** GraphQL */ '
+        query PoolCandidates {
+            poolCandidatesPaginated(first: 100) {
+                paginatorInfo {
+                    total
+                }
+                data {
+                    id
+                }
+            }
+        }
+    ';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(RolePermissionSeeder::class);
+
+        $this->team = Team::factory()->create([
+            'name' => 'candidates-paginated',
+        ]);
+
+        $this->pool = Pool::factory()->create([
+            'team_id' => $this->team->id,
+        ]);
+
+        // A Draft candidate that no one should be able to see
+        PoolCandidate::factory()->create([
+            'pool_candidate_status' => PoolCandidateStatus::DRAFT->name,
+        ]);
+
+        // Random team candidate
+        $this->noTeamCandidate = PoolCandidate::factory()->create([
+            'pool_candidate_status' => PoolCandidateStatus::NEW_APPLICATION->name,
+            'pool_id' => Pool::factory()->create([
+                'team_id' => Team::factory()->create(),
+            ]),
+        ]);
+
+        // Assigned Team
+        $this->teamCandidate = PoolCandidate::factory()->create([
+            'pool_candidate_status' => PoolCandidateStatus::NEW_APPLICATION->name,
+            'pool_id' => $this->pool->id,
+        ]);
+
+        $this->applicant = User::factory()->asApplicant()->create();
+
+        $this->applicantCandidate = PoolCandidate::factory()->create([
+            'pool_candidate_status' => PoolCandidateStatus::DRAFT->name,
+            'user_id' => $this->applicant->id,
+            'pool_id' => $this->pool->id,
+        ]);
+
+    }
+
+    public function testGuestCannotViewAnyApplications(): void
+    {
+        $guest = User::factory()->create();
+        $this->assertPaginatedResponse($guest, 0, []);
+    }
+
+    // Drafts are not visible
+    public function testApplicantCannotViewAny(): void
+    {
+        $this->assertPaginatedResponse($this->applicant, 0, []);
+    }
+
+    public function testPoolOperatorCanViewTeamApplications(): void
+    {
+        $poolOperator = User::factory()
+            ->asPoolOperator($this->team->name)
+            ->create();
+        $this->assertPaginatedResponse($poolOperator, 1, [
+            $this->teamCandidate->id,
+        ]);
+    }
+
+    public function testRequestResponserCanViewAllSubmittedApplications(): void
+    {
+        $requestResponder = User::factory()
+            ->asRequestResponder()
+            ->create();
+        $this->assertPaginatedResponse($requestResponder, 2, [
+            $this->noTeamCandidate->id,
+            $this->teamCandidate->id,
+        ]);
+    }
+
+    public function testCommunityManagerCannotViewAnyApplications(): void
+    {
+        $communityManager = User::factory()
+            ->asCommunityManager()
+            ->create();
+        $this->assertPaginatedResponse($communityManager, 0, []);
+    }
+
+    public function testProcessOperatorCanViewPoolApplications(): void
+    {
+        $processOperator = User::factory()
+            ->asProcessOperator($this->pool->id)
+            ->create();
+        $this->assertPaginatedResponse($processOperator, 0, []);
+    }
+
+    public function testUnassociatedProcessOperationCannotViewAnyApplications(): void
+    {
+        $pool = Pool::factory()->create();
+        $processOperator = User::factory()
+            ->asProcessOperator($pool->id)
+            ->create();
+        $this->assertPaginatedResponse($processOperator, 0, []);
+    }
+
+    public function testCommunityAdminCannotViewAnyApplications(): void
+    {
+        $community = Community::factory()->create();
+        $communityAdmin = User::factory()
+            ->asCommunityAdmin($community->id)
+            ->create();
+        $this->assertPaginatedResponse($communityAdmin, 0, []);
+    }
+
+    public function testPlatformAdminCanViewAllSubmittedApplications(): void
+    {
+        $platformAdmin = User::factory()
+            ->asAdmin()
+            ->create();
+        $this->assertPaginatedResponse($platformAdmin, 2, [
+            $this->noTeamCandidate->id,
+            $this->teamCandidate->id,
+        ]);
+    }
+
+    protected function assertPaginatedResponse(User $user, int $count, array $ids): void
+    {
+        $res = $this->actingAs($user, 'api')
+            ->graphQL($this->query);
+
+        $res->assertJsonFragment([
+            'paginatorInfo' => [
+                'total' => $count,
+            ],
+        ]);
+
+        foreach ($ids as $id) {
+            $res->assertJsonFragment(['id' => $id]);
+        }
+    }
+}

--- a/api/tests/Feature/PoolCandidatesPaginatedTest.php
+++ b/api/tests/Feature/PoolCandidatesPaginatedTest.php
@@ -34,7 +34,9 @@ class PoolCandidatesPaginatedTest extends TestCase
 
     public PoolCandidate $applicantCandidate;
 
-    public string $query = /** GraphQL */ '
+    public string $query =
+    /** GraphQL */
+    '
         query PoolCandidates {
             poolCandidatesPaginated(first: 100) {
                 paginatorInfo {
@@ -87,7 +89,22 @@ class PoolCandidatesPaginatedTest extends TestCase
             'user_id' => $this->applicant->id,
             'pool_id' => $this->pool->id,
         ]);
+    }
 
+    protected function assertPaginatedResponse(User $user, int $count, array $ids): void
+    {
+        $res = $this->actingAs($user, 'api')
+            ->graphQL($this->query);
+
+        $res->assertJsonFragment([
+            'paginatorInfo' => [
+                'total' => $count,
+            ],
+        ]);
+
+        foreach ($ids as $id) {
+            $res->assertJsonFragment(['id' => $id]);
+        }
     }
 
     public function testGuestCannotViewAnyApplications(): void
@@ -179,21 +196,5 @@ class PoolCandidatesPaginatedTest extends TestCase
             $this->noTeamCandidate->id,
             $this->teamCandidate->id,
         ]);
-    }
-
-    protected function assertPaginatedResponse(User $user, int $count, array $ids): void
-    {
-        $res = $this->actingAs($user, 'api')
-            ->graphQL($this->query);
-
-        $res->assertJsonFragment([
-            'paginatorInfo' => [
-                'total' => $count,
-            ],
-        ]);
-
-        foreach ($ids as $id) {
-            $res->assertJsonFragment(['id' => $id]);
-        }
     }
 }

--- a/api/tests/Feature/PoolCandidatesPaginatedTest.php
+++ b/api/tests/Feature/PoolCandidatesPaginatedTest.php
@@ -136,10 +136,12 @@ class PoolCandidatesPaginatedTest extends TestCase
         $processOperator = User::factory()
             ->asProcessOperator($this->pool->id)
             ->create();
-        $this->assertPaginatedResponse($processOperator, 0, []);
+        $this->assertPaginatedResponse($processOperator, 1, [
+            $this->teamCandidate->id,
+        ]);
     }
 
-    public function testUnassociatedProcessOperationCannotViewAnyApplications(): void
+    public function testUnassociatedProcessOperatorCannotViewAnyApplications(): void
     {
         $pool = Pool::factory()->create();
         $processOperator = User::factory()
@@ -148,6 +150,17 @@ class PoolCandidatesPaginatedTest extends TestCase
         $this->assertPaginatedResponse($processOperator, 0, []);
     }
 
+    // TO DO: Update in #10364
+    public function testCommunityRecruiterCannotViewAnyApplications(): void
+    {
+        $community = Community::factory()->create();
+        $processOperator = User::factory()
+            ->asCommunityRecruiter($community->id)
+            ->create();
+        $this->assertPaginatedResponse($processOperator, 0, []);
+    }
+
+    // TO DO: Update in #10364
     public function testCommunityAdminCannotViewAnyApplications(): void
     {
         $community = Community::factory()->create();

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
@@ -40,9 +40,6 @@ export const AssessmentStepTracker_CandidateFragment = graphql(/* GraphQL */ `
         fr
       }
     }
-    pool {
-      id
-    }
     user {
       id
       firstName

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -183,7 +183,7 @@ type StepWithGroupedCandidates = {
 
 export const groupPoolCandidatesByStep = (
   steps: AssessmentStep[],
-  candidates: PoolCandidate[],
+  candidates: Omit<PoolCandidate, "pool">[],
 ): StepWithGroupedCandidates[] => {
   const orderedSteps = sortBy(steps, (step) => step.sortOrder);
 
@@ -280,8 +280,8 @@ export const filterResults = (
 
 // filter out candidates who are disqualified AND have an empty assessment results collection
 export const filterAlreadyDisqualified = (
-  candidates: PoolCandidate[],
-): PoolCandidate[] => {
+  candidates: Omit<PoolCandidate, "pool">[],
+): Omit<PoolCandidate, "pool">[] => {
   const filteredResult = candidates.filter(
     (candidate) =>
       !(


### PR DESCRIPTION
🤖 Resolves #10932 

## 👋 Introduction

Removes the resolved policy on the pool candidates paginated query to improve performance.

## 🕵️ Details

This relies only on the authorized scope for a pool candidate when making a paginated query. Due to this, we had to make the policy more strict by checking to see if a user has any of the required permissions and if they do not, we simply exit early, returning an empty result.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login with different roles
3. Navigate to the pool candidates table
4. Confirm you only see the expected candidates