### PR TITLE
[Fix] Removes notifications margin on empty `ul`

### DIFF
--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -143,7 +143,7 @@ const DialogPortalWithPresence = ({
             </DialogPrimitive.Description>
           </div>
           <NotificationList live inDialog limit={30} onRead={executeQuery} />
-          <p data-h2-margin="base(x.5 x1)">
+          <p data-h2-margin="base(x1)">
             <DialogPrimitive.Close asChild>
               <Link href={paths.notifications()} mode="solid" color="secondary">
                 {intl.formatMessage({

--- a/apps/web/src/components/NotificationList/NotificationList.tsx
+++ b/apps/web/src/components/NotificationList/NotificationList.tsx
@@ -77,7 +77,6 @@ const NotificationList = ({
         data-h2-padding="base(0)"
         data-h2-display="base(flex)"
         data-h2-flex-direction="base(column)"
-        data-h2-margin="base(x1 0)"
         {...(!inDialog && {
           "data-h2-gap": "base(x.25 0)",
         })}


### PR DESCRIPTION
🤖 Resolves #10916.

## 👋 Introduction

This PR removes margin from the `<ul>` element in the `NotificationDialog` component and adds equal margin to the `<p>` element in `NotificationDialog` component.

> [!NOTE]  
> Removing the empty `<ul>` was not possible but at least this solution doesn't render visible margin where it shouldn't be.

## 👏 Acknowledgement
thanks @esizer.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm build`
2. Navigate to `/applicant/notifications`
3. Verify notifications work on the notifications page and dialog as they did before but without the margin on an empty `<ul>` 

## 📸 Screenshot

<img width="454" alt="Screen Shot 2024-07-19 at 13 50 45" src="https://github.com/user-attachments/assets/c5a60230-4edb-42ec-a33a-5dfec042a2b6">