### PR TITLE
[Debt] Update file prune command

### DIFF
--- a/api/app/Console/Commands/PruneUserGeneratedFiles.php
+++ b/api/app/Console/Commands/PruneUserGeneratedFiles.php
@@ -36,7 +36,7 @@ class PruneUserGeneratedFiles extends Command
             foreach ($allFiles as $file) {
                 $lastModified = Carbon::createFromTimestamp($disk->lastModified($file));
                 $hoursOld = $now->diffInHours($lastModified);
-                $shouldDelete = $hoursOld > 12;
+                $shouldDelete = $hoursOld > 24;
                 if ($shouldDelete) {
                     $this->info("Deleting $file - $hoursOld hours old");
                     $disk->delete($file);


### PR DESCRIPTION
🤖 Resolves #11016 

## 👋 Introduction

Updates the artisan command that prunes user generated files to be files older than 24 hours instead of 12.

## 🕵️ Details

Looks like this was already being scheduled, so we just needed to update the time.

## 🧪 Testing

> [!NOTE]
> This is kind of hard to test but the following is as good as we can achieve.


1. Place a file in `api/storage/app/user_generated/{iserId}/{filename}/`
2. change its last modified date `touch -d "25 hours ago" filename
3. Update [the schedule time](https://github.com/GCTC-NTGC/gc-digital-talent/blob/6828bd863471c118ed3c9e75e877fad15c0966b8/api/app/Console/Kernel.php#L26-L28) to be just ahead of the current time
4. Wait until just past the time set
5. Run the schedule `make artisan CMD="schedule:run"`
6. Confirm it runs
7. Confirm file removed
