### PR TITLE
[Fix] Set a max page for notifications paginatation

### DIFF
--- a/apps/web/src/components/NotificationList/NotificationList.tsx
+++ b/apps/web/src/components/NotificationList/NotificationList.tsx
@@ -1,4 +1,5 @@
 import { useSearchParams } from "react-router-dom";
+import { useQuery } from "urql";
 
 import { graphql } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
@@ -10,6 +11,16 @@ import NotificationActions from "./NotificationActions";
 import NotificationListPage from "./NotificationListPage";
 import NotificationItem from "./NotificationItem";
 import NotificationPortal from "./NotificationPortal";
+
+const MaxNotifcationPages_Query = graphql(/* GraphQL */ `
+  query MaxNotificationPages($where: NotificationFilterInput) {
+    notifications(where: $where, page: 1) {
+      paginatorInfo {
+        lastPage
+      }
+    }
+  }
+`);
 
 const NotificationPolling_Query = graphql(/* GraphQL */ `
   query NotificationPolling($where: NotificationFilterInput) {
@@ -41,6 +52,14 @@ const NotificationList = ({
 }: NotificationListProps) => {
   const now = nowUTCDateTime();
   const [searchParams] = useSearchParams();
+  const onlyUnread =
+    searchParams.has("unread") && searchParams.get("unread") !== null;
+  const [{ data: maxPagesData }] = useQuery({
+    query: MaxNotifcationPages_Query,
+    variables: {
+      where: { onlyUnread },
+    },
+  });
   const [{ data }] = usePollingQuery(
     {
       query: NotificationPolling_Query,
@@ -56,10 +75,12 @@ const NotificationList = ({
     },
     60,
   );
-  const pagesToLoad =
+  const lastPage = maxPagesData?.notifications.paginatorInfo.lastPage ?? 1;
+  let pagesToLoad =
     paginate && searchParams.has("page") ? Number(searchParams.get("page")) : 1;
-  const onlyUnread =
-    searchParams.has("unread") && searchParams.get("unread") !== null;
+  if (pagesToLoad > lastPage) {
+    pagesToLoad = lastPage;
+  }
 
   const pagesArray = Array.from(Array(pagesToLoad).keys());
   const liveNotifications = unpackMaybes(data?.notifications?.data);

--- a/apps/web/src/components/NotificationList/NotificationList.tsx
+++ b/apps/web/src/components/NotificationList/NotificationList.tsx
@@ -12,7 +12,7 @@ import NotificationListPage from "./NotificationListPage";
 import NotificationItem from "./NotificationItem";
 import NotificationPortal from "./NotificationPortal";
 
-const MaxNotifcationPages_Query = graphql(/* GraphQL */ `
+const MaxNotificationPages_Query = graphql(/* GraphQL */ `
   query MaxNotificationPages($where: NotificationFilterInput) {
     notifications(where: $where, page: 1, first: 10) {
       paginatorInfo {
@@ -55,7 +55,7 @@ const NotificationList = ({
   const onlyUnread =
     searchParams.has("unread") && searchParams.get("unread") !== null;
   const [{ data: maxPagesData }] = useQuery({
-    query: MaxNotifcationPages_Query,
+    query: MaxNotificationPages_Query,
     variables: {
       where: { onlyUnread },
     },

--- a/apps/web/src/components/NotificationList/NotificationList.tsx
+++ b/apps/web/src/components/NotificationList/NotificationList.tsx
@@ -14,7 +14,7 @@ import NotificationPortal from "./NotificationPortal";
 
 const MaxNotifcationPages_Query = graphql(/* GraphQL */ `
   query MaxNotificationPages($where: NotificationFilterInput) {
-    notifications(where: $where, page: 1) {
+    notifications(where: $where, page: 1, first: 10) {
       paginatorInfo {
         lastPage
       }


### PR DESCRIPTION
🤖 Resolves #11024 

## 👋 Introduction

Prevents users from requesting more than the max number of pages available.

## 🕵️ Details

While our throttle would prevent this from causing too much issue on the server, the user could request a max array size and crash their client. This helps avoid that mistake.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build app `pnpm run dev:fresh`
2. Login as any user
3. Navigate to `http://localhost:8000/en/applicant/notifications?pages=5000`
4. Confirm that the number of queries created is not 5000 but the max pages (should be 1 since no notifications exist)