### PR TITLE
[Feat] Add published date to pools table

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3103,6 +3103,10 @@
     "defaultMessage": "Droit d’auteur",
     "description": "Heading for comments and interaction section"
   },
+  "FBSOkb": {
+    "defaultMessage": "Publié",
+    "description": "Title displayed on the Pool table published at column"
+  },
   "FC5tje": {
     "defaultMessage": "Autres commentaires",
     "description": "Label for additional comments textarea in the request form."

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -92,6 +92,7 @@ const PoolTable_PoolFragment = graphql(/* GraphQL */ `
         fr
       }
     }
+    publishedAt
     createdDate
     updatedDate
     name {
@@ -391,6 +392,20 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
           },
           intl,
         ),
+    }),
+    columnHelper.accessor(({ publishedAt }) => accessors.date(publishedAt), {
+      id: "publishedAt",
+      enableColumnFilter: false,
+      header: intl.formatMessage({
+        defaultMessage: "Published",
+        id: "FBSOkb",
+        description: "Title displayed on the Pool table published at column",
+      }),
+      cell: ({
+        row: {
+          original: { publishedAt },
+        },
+      }) => cells.date(publishedAt, intl),
     }),
     columnHelper.accessor(({ createdDate }) => accessors.date(createdDate), {
       id: "createdDate",

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -443,7 +443,13 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
       data={filteredData}
       columns={columns}
       isLoading={fetching}
-      hiddenColumnIds={["id", "createdDate", "ownerEmail", "ownerName"]}
+      hiddenColumnIds={[
+        "id",
+        "publishedAt",
+        "createdDate",
+        "ownerEmail",
+        "ownerName",
+      ]}
       search={{
         internal: false,
         label: intl.formatMessage({

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
@@ -175,6 +175,7 @@ export function getOrderByClause(
     ["processNumber", "process_number"],
     ["ownerName", "FIRST_NAME"],
     ["ownerEmail", "EMAIL"],
+    ["publishedAt", "published_at"],
     ["createdDate", "created_at"],
     ["updatedDate", "updated_at"],
     ["classification", "classification"],


### PR DESCRIPTION
🤖 Resolves #11044 

## 👋 Introduction

Adds published at date to the pools table.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Logion as admin `admin@test.com`
3. Navigate to pools table `/admin/pools`
4. Confirm the published column shows up
5. Confirm it sorts as expected
6. Confirm you can show/hide it

## 📸 Screenshot

![2024-07-25_12-49](https://github.com/user-attachments/assets/a2a08f1e-ad60-44cf-bb0d-cfd53be5f643)
