### PR TITLE
[Fix] Playwright report in CI

### DIFF
--- a/apps/playwright/playwright.config.ts
+++ b/apps/playwright/playwright.config.ts
@@ -21,10 +21,10 @@ export default defineConfig({
   workers: process.env.CI ? 1 : "25%",
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI
-    ? "line"
+    ? [["line"], ["html", { open: "never" }]]
     : [["line"], ["html", { open: "on-failure" }]],
-  timeout: Number(process.env.TEST_TIMEOUT ?? 3 * 60 * 1000), // 3 minutes
-  expect: { timeout: Number(process.env.EXPECT_TIMEOUT ?? 30000) }, // 30 seconds
+  timeout: Number(process.env.TEST_TIMEOUT ?? 60 * 1000), // 1 minute
+  expect: { timeout: Number(process.env.EXPECT_TIMEOUT ?? 10000) }, // 10 seconds
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/apps/playwright/tests/footer.spec.ts
+++ b/apps/playwright/tests/footer.spec.ts
@@ -8,7 +8,7 @@ test.describe("Footer", () => {
     test("links to Contact", async ({ page }) => {
       await expect(
         page
-          .getByRole("navigation", { name: /policy and feedback/i }) // aria-label value of nav element in Footer component.
+          .getByRole("navigation", { name: /not a real link/i }) // aria-label value of nav element in Footer component.
           .getByRole("link", { name: /contact us/i }),
       ).toHaveAttribute("href", "/en/support");
     });

--- a/apps/playwright/tests/footer.spec.ts
+++ b/apps/playwright/tests/footer.spec.ts
@@ -8,7 +8,7 @@ test.describe("Footer", () => {
     test("links to Contact", async ({ page }) => {
       await expect(
         page
-          .getByRole("navigation", { name: /not a real link/i }) // aria-label value of nav element in Footer component.
+          .getByRole("navigation", { name: /policy and feedback/i }) // aria-label value of nav element in Footer component.
           .getByRole("link", { name: /contact us/i }),
       ).toHaveAttribute("href", "/en/support");
     });


### PR DESCRIPTION
🤖 Resolves #10654 

## 👋 Introduction

Updates the playwright config so we have html report being generated in CI.

## 🕵️ Details

We only had the line reporter which never generated files to be uploaded. This ads back in `html` reporter. It also reduced the timeouts to hopefully speed up playwright on failures (waiting 3 mins for a fail forces failed tests to run too long)

## 🧪 Testing

> [!NOTE]
> The login-logout tests are flaky in webkit for some reason so you may see some failures for them :cry: 

1. Check [failed run](https://github.com/GCTC-NTGC/gc-digital-talent/actions/runs/10099080085?pr=11069) and confirm report exists
2. Confirm that it still passes
