### PR TITLE
[Fix] GraphQL response content type

### DIFF
--- a/api/lang/fr/armed_forces_status.php
+++ b/api/lang/fr/armed_forces_status.php
@@ -1,4 +1,3 @@
-
 <?php
 
 return [

--- a/api/lang/fr/assessment_decision.php
+++ b/api/lang/fr/assessment_decision.php
@@ -1,4 +1,3 @@
-
 <?php
 
 return [


### PR DESCRIPTION
🤖 Resolves #10980, resolves #10917 


## 👋 Introduction

Fixes an error where graphql could sometimes return a content type of `text/html`

## 🕵️ Details

I initially thought that this had to do with `@self` since the only queries causing an issue were ones that used that directive. However, I started building those queries out adding fields one at a time until I hit the unexpected content type.

Turns out they had a sneaky thing in common, they both use `ArmedForcesStatus` enum (via the user type). After looking into it, I noticed an empty line at the start of the lang file. Removing this fixed the problem. 

i'm not sure how we can catch this in the future since it technically isn't incorrect :face_with_spiral_eyes: 

## 🧪 Testing

1. Login as admin `admin@test.com`
2. Navigate to any page that queries for armed forces of assessment decision
3. Confirm the query returns with `Content-Type application/json`
4. Confirm no white space at beginning of `api/lang/**` files