### PR TITLE
[Fix] Mobile layout for step tracker filters

### DIFF
--- a/apps/web/src/components/AssessmentStepTracker/Filters.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/Filters.tsx
@@ -49,8 +49,10 @@ const Filters = ({
       <form onSubmit={methods.handleSubmit(onFiltersChange)}>
         <div
           data-h2-display="base(flex)"
-          data-h2-align-items="base(flex-end)"
+          data-h2-flex-direction="base(column) p-tablet(row)"
+          data-h2-align-items="base(flex-start) p-tablet(flex-end)"
           data-h2-gap="base(x.5)"
+          data-h2-width="base(100%)"
         >
           <Input
             name="query"


### PR DESCRIPTION
🤖 Resolves #11039 

## 👋 Introduction

Fixes the mobile layout for the switches on the assessment step tracker.

## 🧪 Testing

1. Build app `pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Navigate to a pool's assessment step tracker
4. Reduce window width to a phone size
5. Confirm the filters are all visible without need to side scroll

## 📸 Screenshot

![2024-07-29_10-02](https://github.com/user-attachments/assets/5f35463b-4a9d-4813-923c-f8714007dee2)
