### PR TITLE
[Debt] Candidate status attribute

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -584,36 +584,6 @@ class PoolCandidate extends Model
         return $query;
     }
 
-    /* accessor to obtain pool candidate status, additional logic exists to override database field sometimes*/
-    // pool_candidate_status database value passed into accessor as an argument
-    public function getPoolCandidateStatusAttribute($candidateStatus)
-    {
-        // pull info
-        // $submittedAt = $this->submitted_at;
-        // $expiryDate = $this->expiry_date;
-        // $currentTime = date('Y-m-d H:i:s');
-        // $isExpired = $currentTime > $expiryDate ? true : false;
-
-        // // ensure null submitted_at returns either draft or expired draft
-        // if ($submittedAt == null){
-        //     if($isExpired) {
-        //         return ApiEnums::CANDIDATE_STATUS_DRAFT_EXPIRED;
-        //     }
-        //     return ApiEnums::CANDIDATE_STATUS_DRAFT;
-        // }
-
-        // // ensure expired returned if past expiry date with exception for PLACED
-        // if ($candidateStatus != ApiEnums::CANDIDATE_STATUS_PLACED_CASUAL && $candidateStatus != ApiEnums::CANDIDATE_STATUS_PLACED_TERM && $candidateStatus != ApiEnums::CANDIDATE_STATUS_PLACED_INDETERMINATE) {
-        //     if ($isExpired) {
-        //         return ApiEnums::CANDIDATE_STATUS_EXPIRED;
-        //     }
-        //     return $candidateStatus;
-        // }
-
-        // no overriding
-        return $candidateStatus;
-    }
-
     public function scopePriorityWeight(Builder $query, ?array $priorityWeights): Builder
     {
         if (empty($priorityWeights)) {


### PR DESCRIPTION
🤖 Resolves #11032 

## 👋 Introduction

Removes the candidate status attribute that only contained commented out code and returned the unaltered attribute.

## 🧪 Testing

1. Confirm pool candidate status still returns the expected result
