### PR TITLE
[Tooling] Type check on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "build": "h2-build && turbo run build --filter @gc-digital-talent/web",
+    "build": "h2-build && turbo run build --filter @gc-digital-talent/web && turbo run tsc",
     "build:fresh": "h2-build && turbo run build --filter @gc-digital-talent/web --force",
     "build:css": "h2-build",
     "codegen": "turbo run codegen --filter @gc-digital-talent/graphql",
@@ -29,6 +29,7 @@
     "intl-extract": "turbo run intl-extract",
     "intl-compile": "turbo run intl-compile",
     "lint": "turbo run lint",
+    "lint:fix": "turbo run lint -- --fix",
     "storybook": "pnpm --filter @gc-digital-talent/web run storybook",
     "storybook:design-system": "pnpm --filter @gc-digital-talent/web run storybook:design-system",
     "storybook:web": "pnpm --filter @gc-digital-talent/web run storybook:web",

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,7 @@
   "tasks": {
     "build": {
       "dependsOn": [
+        "tsc",
         "^intl-compile",
         "intl-compile",
         "^codegen"

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,6 @@
   "tasks": {
     "build": {
       "dependsOn": [
-        "tsc",
         "^intl-compile",
         "intl-compile",
         "^codegen"


### PR DESCRIPTION
🤖 Resolves #10907 

## 👋 Introduction

Adds `tsc` as a dependency to the `build` command so we type check on builds and fail if types are not correct.

## 🧪 Testing

1. Run build `pnpm run build:fresh`
2. Confirm tsc is run
3. Force a type error
4. Re-run build `pnpm run build:fresh`
5. Confirm build fails
