### PR TITLE
[Debt] Reduce queries on view pool candidate page

### DIFF
--- a/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
+++ b/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
@@ -380,11 +380,11 @@ const ChangeStatusDialog = ({
                   {fetching
                     ? intl.formatMessage(commonMessages.saving)
                     : intl.formatMessage({
-                      defaultMessage: "Change status",
-                      id: "iuve97",
-                      description:
-                        "Confirmation button for change status dialog",
-                    })}
+                        defaultMessage: "Change status",
+                        id: "iuve97",
+                        description:
+                          "Confirmation button for change status dialog",
+                      })}
                 </Button>
                 <Dialog.Close>
                   <Button type="button" color="warning" mode="inline">

--- a/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
+++ b/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
@@ -158,9 +158,7 @@ const ChangeStatusDialog = ({
 
   // an array of the user's pool candidates and filter out all the nulls and maybes
   const userPoolCandidatesSafe = user.poolCandidates
-    ? user.poolCandidates.filter(notEmpty).map((poolCandidate) => {
-      return poolCandidate;
-    })
+    ? user.poolCandidates.filter(notEmpty).map((poolCandidate) => poolCandidate)
     : [];
 
   // all the user's pools by pool ID

--- a/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
+++ b/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
@@ -47,6 +47,34 @@ const PoolCandidateStatuses_Query = graphql(/* GraphQL */ `
   }
 `);
 
+const StatusInput = () => {
+  const intl = useIntl();
+  const [{ data }] = useQuery({ query: PoolCandidateStatuses_Query });
+
+  return (
+    <Select
+      id="changeStatusDialog-status"
+      name="status"
+      label={intl.formatMessage({
+        defaultMessage: "Pool status",
+        id: "n9YPWe",
+        description:
+          "Label displayed on the status field of the change candidate status dialog",
+      })}
+      nullSelection={intl.formatMessage({
+        defaultMessage: "Select a pool status",
+        id: "Bkxf6p",
+        description:
+          "Placeholder displayed on the status field of the change candidate status dialog.",
+      })}
+      rules={{
+        required: intl.formatMessage(errorMessages.required),
+      }}
+      options={localizedEnumToOptions(data?.poolCandidateStatuses, intl)}
+    />
+  );
+};
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ChangeStatusDialog_UserFragment = graphql(/* GraphQL */ `
   fragment ChangeStatusDialog_User on User {
@@ -123,7 +151,6 @@ const ChangeStatusDialog = ({
   const intl = useIntl();
   const [open, setOpen] = useState(false);
   const methods = useForm<FormValues>();
-  const [{ data }] = useQuery({ query: PoolCandidateStatuses_Query });
 
   const [{ fetching }, executeMutation] = useMutation(
     UpdatePoolCandidateStatus_Mutation,
@@ -132,8 +159,8 @@ const ChangeStatusDialog = ({
   // an array of the user's pool candidates and filter out all the nulls and maybes
   const userPoolCandidatesSafe = user.poolCandidates
     ? user.poolCandidates.filter(notEmpty).map((poolCandidate) => {
-        return poolCandidate;
-      })
+      return poolCandidate;
+    })
     : [];
 
   // all the user's pools by pool ID
@@ -325,29 +352,7 @@ const ChangeStatusDialog = ({
                 })}
               </p>
               <div data-h2-margin="base(x.5, 0, x.125, 0)">
-                <Select
-                  id="changeStatusDialog-status"
-                  name="status"
-                  label={intl.formatMessage({
-                    defaultMessage: "Pool status",
-                    id: "n9YPWe",
-                    description:
-                      "Label displayed on the status field of the change candidate status dialog",
-                  })}
-                  nullSelection={intl.formatMessage({
-                    defaultMessage: "Select a pool status",
-                    id: "Bkxf6p",
-                    description:
-                      "Placeholder displayed on the status field of the change candidate status dialog.",
-                  })}
-                  rules={{
-                    required: intl.formatMessage(errorMessages.required),
-                  }}
-                  options={localizedEnumToOptions(
-                    data?.poolCandidateStatuses,
-                    intl,
-                  )}
-                />
+                <StatusInput />
               </div>
               <p data-h2-margin="base(x1, 0, 0, 0)">
                 {intl.formatMessage({
@@ -377,11 +382,11 @@ const ChangeStatusDialog = ({
                   {fetching
                     ? intl.formatMessage(commonMessages.saving)
                     : intl.formatMessage({
-                        defaultMessage: "Change status",
-                        id: "iuve97",
-                        description:
-                          "Confirmation button for change status dialog",
-                      })}
+                      defaultMessage: "Change status",
+                      id: "iuve97",
+                      description:
+                        "Confirmation button for change status dialog",
+                    })}
                 </Button>
                 <Dialog.Close>
                   <Button type="button" color="warning" mode="inline">

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/NotesForm.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/NotesForm.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useIntl } from "react-intl";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import ChatBubbleBottomCenterIcon from "@heroicons/react/24/outline/ChatBubbleBottomCenterIcon";


### PR DESCRIPTION
🤖 Resolves #10987 

## 👋 Introduction

Moves enum queries in dialogs do they are only run once the dialog is open.

## 🕵️ Details

Seems like a lot of these queries were resolved already so I just cleaned up the remaining two.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as an admin `admin@test.com`
3. Navigate to a pool candidate
4. Confirm only one query is being made to get page content
5. Confirm the affected dialogs still function
