### PR TITLE
Small local env tweaks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,6 +57,21 @@
       "reloadOnChange": {
         "watch": ["${workspaceFolder}/apps/web/dist"]
       }
+    },
+    {
+      "name": "Firefox Storybook",
+      "type": "firefox",
+      "request": "launch",
+      "reAttach": true,
+      "url": "http://localhost:6006/",
+      "profile": "debug-profile",
+      "keepProfileChanges": true,
+      "pathMappings": [
+        {
+          "url": "http://localhost:6006/src",
+          "path": "${workspaceFolder}/apps/web/src"
+        }
+      ]
     }
   ]
 }

--- a/Makefile.nix
+++ b/Makefile.nix
@@ -17,38 +17,36 @@ setup_all: setup_api setup_web
 refresh_all: refresh_api refresh_web
 
 setup_api:
-	rm api/bootstrap/cache/*.php --force
 	cp api/.env.example api/.env --preserve=all
 	cd api && composer install --prefer-dist
 	php api/artisan key:generate
 	php api/artisan migrate:fresh --seed
 	php api/artisan lighthouse:print-schema --write
-	php api/artisan config:clear
 	touch api/storage/logs/laravel.log
-	sudo chown -R www-data:www-data api/storage
-	sudo chmod -R a+r,a+w api/storage
+	docker-compose exec webserver sh -c "chown -R www-data:www-data /home/site/wwwroot/api/storage"
+	docker-compose exec webserver sh -c "chmod -R a+r,a+w /home/site/wwwroot/api/storage /home/site/wwwroot/api/bootstrap/cache"
+	php api/artisan optimize:clear
 
 refresh_api:
-	rm api/bootstrap/cache/*.php --force
 	cd api && composer install --prefer-dist
 	php api/artisan migrate
 	php api/artisan lighthouse:print-schema --write
-	php api/artisan config:clear
+	php api/artisan optimize:clear
 
 setup_web:
 	cp apps/web/.env.example apps/web/.env --preserve=all
-	pnpm install --force
+	pnpm install
 	pnpm run dev:fresh
 
 refresh_web:
-	pnpm install --force
+	pnpm install
 	pnpm run dev
 
 git_clean:
 	sudo git clean -xdf
 
 compose_up:
-	docker-compose up --detach --build
+	docker-compose up --detach
 
 compose_down:
 	docker-compose down

--- a/api/.env.example
+++ b/api/.env.example
@@ -77,7 +77,7 @@ OAUTH_API_CLIENT_SECRET="ignored-secret"
 # OAUTH_API_CLIENT_ID=
 # OAUTH_API_CLIENT_SECRET=
 # gckeymfa for MFA on (production); gckey for MFA off (for testing purposes on local, dev, or uat: cannot be overridden in production)
-# OAUTH_ACR_VALUES=gckeymfa
+# OAUTH_ACR_VALUES=gckey
 
 # Freshdesk API (for docs: api/config/freshdesk.php)
 FRESHDESK_API_TICKETS_ENDPOINT=

--- a/infrastructure/conf/mock-oauth2-server.json
+++ b/infrastructure/conf/mock-oauth2-server.json
@@ -3,7 +3,7 @@
   "tokenCallbacks": [
     {
       "issuerId": "oxauth",
-      "tokenExpiry": 120,
+      "tokenExpiry": 600,
       "requestMappings": [
         {
           "requestParam": "client_id",


### PR DESCRIPTION
## 👋 Introduction

This PR is just a collection of small local tweaks to help my DX a bit.  I don't know if these affect anyone else - I'm scratching my own itches here.

## 🕵️ Details

### Debug

- Add a debugging profile for Firefox + Storybook

### Linux Makefile

- Remove most uses of `sudo`.  Uses the webserver container instead
- Switch `config:clear` to `optimize:clear`.  See [#10625](https://github.com/GCTC-NTGC/gc-digital-talent/issues/10625)
- Remove `--force` from pnpm.  It doesn't seem to be necessary anymore.
- Remove `--build` from compose up.  It became a lot slower with the custom webserver image.

### Env

- Default GCKey MFA to OFF.  I can't remember the last time I wanted to turn MFA on locally.

### Mock Auth

- Bumped token lifetime from 2 minutes to 10 minutes.  That aligns with prod and gives you a bit more time in Graphiql.


## 🧪 Testing

You can try debugging Storybook, the Linux makefile (`make -f Makefile.nix [command]`), GCKey, and mock auth if you want.  :grin:   I know I'm the (probably) the only one who uses most of this stuff.  I guess just make sure that I didn't break something that you use.  :laughing: 