### PR TITLE
[Fix] Add check for empty decisions on assessment step sync

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -1185,7 +1185,7 @@ class PoolCandidate extends Model
 
         if ($currentStep >= $totalSteps) {
             $lastStepDecision = end($decisions);
-            if ($lastStepDecision['decision'] !== AssessmentDecision::HOLD->name && ! is_null($lastStepDecision['decision'])) {
+            if ($lastStepDecision && $lastStepDecision['decision'] !== AssessmentDecision::HOLD->name && ! is_null($lastStepDecision['decision'])) {
                 $overallAssessmentStatus = OverallAssessmentStatus::QUALIFIED->name;
                 $currentStep = null;
             }


### PR DESCRIPTION
🤖 Resolves #11085 

## 👋 Introduction

Adds a truth check on the `end` call on our decisions array before attempting to access an index in case the array is empty.

## 🧪 Testing

1. Empty out some deicisions for assessment result
2. Run the sync `make artisan CMD="app:sync-assessment-status"`
3. Confirm no errors