### PR TITLE
[Bugfix] Filter for `displayName` in teams dropdown 

### DIFF
--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -361,6 +361,7 @@ const CreatePoolPage = () => {
   const roleAssignments =
     unpackMaybes(data?.me?.authInfo?.roleAssignments) ?? [];
   const teamsArray = roleAssignmentsToTeams(roleAssignments);
+  const teamsArrayFiltered = teamsArray.filter((team) => !!team.displayName); // filter out lacking a display name as a proxy for new teams TODO #10368
 
   const [, executeMutation] = useMutation(CreatePoolPage_Mutation);
   const handleCreatePool = (
@@ -409,7 +410,7 @@ const CreatePoolPage = () => {
             departmentsQuery={unpackMaybes(data?.departments)}
             communitiesQuery={unpackMaybes(data?.communities)}
             handleCreatePool={handleCreatePool}
-            teamsArray={teamsArray}
+            teamsArray={teamsArrayFiltered}
           />
         </Pending>
       </AdminContentWrapper>


### PR DESCRIPTION
🤖 Resolves #11080

## 👋 Introduction

Filter for teams with a truthy `displayName` and then render them on the create process page. 

## 🧪 Testing

1. Ensure you have teams lacking a name first
2. Then ensure they are not rendered in the dropdown

## 📸 Screenshot

Off main

![image](https://github.com/user-attachments/assets/f9bbae63-afb2-4390-9f3e-819bbf5bea56)

Off branch

![image](https://github.com/user-attachments/assets/ace21027-f3b5-4582-9530-5110acd08d2c)

