### PR TITLE
[Fix] Step tracker filter reset

### DIFF
--- a/apps/web/src/components/AssessmentStepTracker/AssessmentResultsFilterDialog.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentResultsFilterDialog.tsx
@@ -90,7 +90,7 @@ const AssessmentResultsFilterDialog = ({
     <FilterDialog<FormValues>
       {...{ onSubmit, resetValues }}
       options={{ defaultValues: initialValues }}
-      modifyFilterCount={-1}
+      modifyFilterCount={-3}
     >
       <div
         data-h2-display="base(grid)"

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentResultsFilterDialog.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentResultsFilterDialog.tsx
@@ -85,10 +85,12 @@ const AssessmentResultsFilterDialog = ({
     value,
     label: intl.formatMessage(message),
   });
+
   return (
     <FilterDialog<FormValues>
       {...{ onSubmit, resetValues }}
       options={{ defaultValues: initialValues }}
+      modifyFilterCount={-1}
     >
       <div
         data-h2-display="base(grid)"
@@ -125,11 +127,10 @@ const AssessmentResultsFilterDialog = ({
           }))}
         />
         <div data-h2-grid-column="l-tablet(span 2)">
-          <Select
-            id="operationalRequirement"
-            name="operationalRequirement"
-            enableNull
-            nullSelection={intl.formatMessage(formMessages.defaultPlaceholder)}
+          <Combobox
+            id="operationalRequirements"
+            name="operationalRequirements"
+            isMulti
             label={intl.formatMessage(navigationMessages.workPreferences)}
             options={localizedEnumToOptions(
               data?.operationalRequirements,

--- a/apps/web/src/components/AssessmentStepTracker/types.ts
+++ b/apps/web/src/components/AssessmentStepTracker/types.ts
@@ -7,6 +7,4 @@ export type FormValues = {
   priorityWeight: string[];
   skills: string[];
   workRegion: string[];
-  suspendedStatus: string;
-  expiryStatus: string;
 };

--- a/apps/web/src/components/AssessmentStepTracker/types.ts
+++ b/apps/web/src/components/AssessmentStepTracker/types.ts
@@ -1,12 +1,10 @@
 export type FormValues = {
   equity: string[];
-  expiryStatus: string;
   govEmployee: string;
   languageAbility: string;
-  operationalRequirement: string[];
+  operationalRequirements: string[];
   pools: string[];
   priorityWeight: string[];
   skills: string[];
-  suspendedStatus: string;
   workRegion: string[];
 };

--- a/apps/web/src/components/AssessmentStepTracker/types.ts
+++ b/apps/web/src/components/AssessmentStepTracker/types.ts
@@ -7,4 +7,6 @@ export type FormValues = {
   priorityWeight: string[];
   skills: string[];
   workRegion: string[];
+  suspendedStatus: string;
+  expiryStatus: string;
 };

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -15,6 +15,8 @@ import {
   ClaimVerificationResult,
   AssessmentStepTracker_CandidateFragment,
   PoolCandidateSearchInput,
+  CandidateExpiryFilter,
+  CandidateSuspendedFilter,
 } from "@gc-digital-talent/graphql";
 import { notEmpty } from "@gc-digital-talent/helpers";
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
@@ -348,6 +350,8 @@ export function transformPoolCandidateSearchInputToFormValues(
       input?.applicantFilter?.skills?.filter(notEmpty).map((s) => s.id) ?? [],
     workRegion:
       input?.applicantFilter?.locationPreferences?.filter(notEmpty) ?? [],
+    expiryStatus: CandidateExpiryFilter.Active, // add default filters
+    suspendedStatus: CandidateSuspendedFilter.Active,
   };
 }
 

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -15,8 +15,6 @@ import {
   ClaimVerificationResult,
   AssessmentStepTracker_CandidateFragment,
   PoolCandidateSearchInput,
-  CandidateExpiryFilter,
-  CandidateSuspendedFilter,
 } from "@gc-digital-talent/graphql";
 import { notEmpty } from "@gc-digital-talent/helpers";
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -342,7 +342,7 @@ export function transformPoolCandidateSearchInputToFormValues(
       : [],
     govEmployee: input?.isGovEmployee ? "true" : "",
     languageAbility: input?.applicantFilter?.languageAbility ?? "",
-    operationalRequirement:
+    operationalRequirements:
       input?.applicantFilter?.operationalRequirements?.filter(notEmpty) ?? [],
     pools: [poolId],
     priorityWeight: input?.priorityWeight?.map((pw) => String(pw)) ?? [],
@@ -350,8 +350,6 @@ export function transformPoolCandidateSearchInputToFormValues(
       input?.applicantFilter?.skills?.filter(notEmpty).map((s) => s.id) ?? [],
     workRegion:
       input?.applicantFilter?.locationPreferences?.filter(notEmpty) ?? [],
-    expiryStatus: CandidateExpiryFilter.Active, // add default filters
-    suspendedStatus: CandidateSuspendedFilter.Active,
   };
 }
 
@@ -383,8 +381,8 @@ export function transformFormValuesToFilterState(
             })
             .filter(notEmpty)
         : undefined,
-      operationalRequirements: !isEmpty(data.operationalRequirement)
-        ? data.operationalRequirement
+      operationalRequirements: !isEmpty(data.operationalRequirements)
+        ? data.operationalRequirements
             .map((requirement) => {
               return stringToEnumOperational(requirement);
             })

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -350,8 +350,6 @@ export function transformPoolCandidateSearchInputToFormValues(
       input?.applicantFilter?.skills?.filter(notEmpty).map((s) => s.id) ?? [],
     workRegion:
       input?.applicantFilter?.locationPreferences?.filter(notEmpty) ?? [],
-    expiryStatus: CandidateExpiryFilter.Active, // add default filters
-    suspendedStatus: CandidateSuspendedFilter.Active,
   };
 }
 
@@ -405,5 +403,7 @@ export function transformFormValuesToFilterState(
           })
           .filter(notEmpty)
       : undefined,
+    expiryStatus: CandidateExpiryFilter.Active, // add default filters
+    suspendedStatus: CandidateSuspendedFilter.Active,
   };
 }

--- a/apps/web/src/components/FilterDialog/FilterDialog.tsx
+++ b/apps/web/src/components/FilterDialog/FilterDialog.tsx
@@ -94,6 +94,7 @@ const FilterDialog = <TFieldValues extends FieldValues>({
     setIsOpen(newOpen);
   };
 
+  const modifiedFitlerCount = filterCount + (modifyFilterCount ?? 0);
   return (
     <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
       <Dialog.Trigger>
@@ -102,8 +103,8 @@ const FilterDialog = <TFieldValues extends FieldValues>({
           type="button"
           block
           icon={AdjustmentsVerticalIcon}
-          {...(filterCount > 0 && {
-            counter: filterCount + (modifyFilterCount ?? 0),
+          {...(modifiedFitlerCount > 0 && {
+            counter: modifiedFitlerCount,
           })}
         >
           {intl.formatMessage({

--- a/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
+++ b/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
@@ -8,6 +8,8 @@ import {
   FragmentType,
   Scalars,
   PoolCandidateSearchInput,
+  CandidateSuspendedFilter,
+  CandidateExpiryFilter,
 } from "@gc-digital-talent/graphql";
 import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
@@ -127,11 +129,13 @@ const ScreeningAndEvaluationPage = () => {
 
   useEffect(() => {
     if (lastPage) {
-      batchLoader({ applicantFilter: { pools: [{ id: poolId }] } }).then(
-        (res) => {
-          setCandidates(res);
-        },
-      );
+      batchLoader({
+        applicantFilter: { pools: [{ id: poolId }] },
+        suspendedStatus: CandidateSuspendedFilter.Active,
+        expiryStatus: CandidateExpiryFilter.Active,
+      }).then((res) => {
+        setCandidates(res);
+      });
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
🤖 Resolves #11043 

## 👋 Introduction

Fixes the reset of the step tracker filter count as well as updating operational requirements to be multiselect.

## 🕵️ Details

Also, while working on this, I realized we had an issue in the filter dialog. When you modified the count, we were still checking the original count to show the badge so I fixed that as well.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Navigate to a step tracker
4. Apply some filters
5. Confirm they function and the count badge in the button is accurate
6. Reset the filters
7. Confirm filters reset as expected and the badge count also resets
