### PR TITLE
[Fix] Reduce unnecessary queries on screening and assessment page

### DIFF
--- a/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
+++ b/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
@@ -29,11 +29,11 @@ type RouteParams = {
 };
 
 const ScreeningAndEvaluation_PoolQuery = graphql(/* GraphQL */ `
-  query ScreeningAndEvaluation_Pools($poolId: UUID!, $first: Int!) {
+query ScreeningAndEvaluation_Pools($poolId: UUID!, $first: Int!, $where: PoolCandidateSearchInput) {
     pool(id: $poolId) {
       ...AssessmentStepTracker_Pool
     }
-    poolCandidatesPaginated(first: $first) {
+    poolCandidatesPaginated(first: $first, where: $where) {
       paginatorInfo {
         lastPage
       }
@@ -78,6 +78,11 @@ const ScreeningAndEvaluationPage = () => {
     variables: {
       poolId,
       first: CANDIDATES_BATCH_SIZE,
+      where: {
+        applicantFilter: { pools: [{ id: poolId }] },
+        suspendedStatus: CandidateSuspendedFilter.Active,
+        expiryStatus: CandidateExpiryFilter.Active,
+      }
     },
   });
   const lastPage = data?.poolCandidatesPaginated.paginatorInfo.lastPage ?? 0;
@@ -140,6 +145,7 @@ const ScreeningAndEvaluationPage = () => {
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastPage]);
+
 
   return (
     <AdminContentWrapper>

--- a/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
+++ b/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
@@ -29,7 +29,11 @@ type RouteParams = {
 };
 
 const ScreeningAndEvaluation_PoolQuery = graphql(/* GraphQL */ `
-query ScreeningAndEvaluation_Pools($poolId: UUID!, $first: Int!, $where: PoolCandidateSearchInput) {
+  query ScreeningAndEvaluation_Pools(
+    $poolId: UUID!
+    $first: Int!
+    $where: PoolCandidateSearchInput
+  ) {
     pool(id: $poolId) {
       ...AssessmentStepTracker_Pool
     }
@@ -82,7 +86,7 @@ const ScreeningAndEvaluationPage = () => {
         applicantFilter: { pools: [{ id: poolId }] },
         suspendedStatus: CandidateSuspendedFilter.Active,
         expiryStatus: CandidateExpiryFilter.Active,
-      }
+      },
     },
   });
   const lastPage = data?.poolCandidatesPaginated.paginatorInfo.lastPage ?? 0;
@@ -145,7 +149,6 @@ const ScreeningAndEvaluationPage = () => {
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastPage]);
-
 
   return (
     <AdminContentWrapper>


### PR DESCRIPTION
🤖 Resolves #11135

## 👋 Introduction

Fixes and issue where we were running an unnecessary amount of queries on the screening and assessment page severely impacting performance.

## 🕵️ Details

We had a query at the top for pool candidates to determine the page size so we could run the correct number of queries in batches. However, this query had no filters applied to it at all, meaning it was running a count of all pool candidates, not just active ones on the current pool.

Because of this, the pager count was based on all candidates and not the ones we were looking for. 

This is applying the same filters to the top level query so it gets the proper page count.

## 🧪 Testing

> [!NOTE]
> You can also tweak the batch size for better testing.

https://github.com/GCTC-NTGC/gc-digital-talent/blob/60a37565053b5ca25e5f8a34e76591c000270216/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx#L65

1. Seed many, many candidates
2. Build `pnpm run dev`
3. login as admin `admin@test.com
4. Confirm number of candidates in a specific pool
5. Navigate to that pools screening and assessment page
6. Confirm the nummber of queries for candidates sent matches the expeted number based on `candidates.length / BATCH_SIZE`
