### PR TITLE
[Bugfix] Allow applicants to see their applications listed on dashboard

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -723,11 +723,9 @@ class PoolCandidate extends Model
             return $query->where('id', null);
         }
 
-        $hasSomePermission = $user->isAbleTo([
-            'view-own-application',
-            'view-team-submittedApplication',
-            'view-any-submittedApplication',
-        ]);
+        $hasSomePermission = $user->isAbleTo('view-own-application')
+            || $user->isAbleTo('view-team-submittedApplication')
+            || $user->isAbleTo('view-any-submittedApplication');
 
         // User does not have any of the required permissions
         if (! $hasSomePermission) {


### PR DESCRIPTION
🤖 Resolves #11143

## 👋 Introduction

Fixes a recently introduced bug which stopped applicants from seeing their own applications on their dashboard.

Future tickets will be created do add regression testing and fix the root cause. This is a quick fix for now.

## 🕵️ Details

The root cause of this has to do with our custom `ProtectedRequestUserChecker`. 

[Laratrust](https://laratrust.santigarcor.me/docs/8.x/usage/roles-and-permissions.html#checking-for-roles-permissions) allows you to pass an array of permissions into `isAbleTo`. If the user has any one of the permissions, it should return true.

However, our custom UserChecker first checks that none of those permissions are 'privileged'. If any of them are, it returns false unless the request came in through the protected endpoint.

So, because we passed an array of permissions to `isAbleTo` which included both privileged and non-privileged permissions, it was always failing unless on the protected endpoint.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Log in as `applicant@test.com`. If necessary, apply to a job.
2. Go to the applicant dashboard. You should see your applications listed.

## 📸 Screenshot

It should look something like this: 
![image](https://github.com/user-attachments/assets/d75d1fd2-f7ed-4040-9765-5198c29d36a6)