### PR TITLE
[Fix] CSV rendering of characters

### DIFF
--- a/api/app/Generators/CsvGenerator.php
+++ b/api/app/Generators/CsvGenerator.php
@@ -25,6 +25,7 @@ abstract class CsvGenerator extends FileGenerator implements FileGeneratorInterf
         try {
             $path = $this->getPath();
             $writer = new Csv($this->spreadsheet);
+            $writer->setUseBOM(true);
             $writer->setDelimiter(',');
             $writer->setEnclosure('"');
             $writer->setLineEnding("\r\n");


### PR DESCRIPTION
🤖 Resolves #11127 

## 👋 Introduction

Sets BOM for UTF-8 CSV so non-ascii characters are rendered properly.

## 🧪 Testing

1. Start the queue worker `make queue-work`
2. Login as admin `admin@test.com`
3. Navigate to the French candidate search table `/fr/admin/pool-candidates`
4. Download candidates
5. Confirm the file renders properly in Excel by default

## 📸 Screenshot

![2024-08-02_13-11](https://github.com/user-attachments/assets/d833c0cc-1730-430b-a8d0-6d681077dc94)
