### PR TITLE
[Fix] Updates French Office of the Chief Information Officer of Canada

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4636,7 +4636,7 @@
     "description": "Text explaining what will happen when duplicating a process"
   },
   "NjHXGh": {
-    "defaultMessage": "En savoir plus<hidden> sur le Bureau de la dirigeante principale de l’information</hidden>",
+    "defaultMessage": "En savoir plus<hidden> sur le Bureau du dirigeant principal de l'information</hidden>",
     "description": "Link text for the Office of the Chief Information Officer"
   },
   "NlYIHM": {
@@ -8287,7 +8287,7 @@
     "description": "Label for the profile complete field"
   },
   "h7URQB": {
-    "defaultMessage": "Talents numériques du <abbreviation>GC</abbreviation> n’est qu’une des nombreuses initiatives menées par le bureau de la dirigeante principale de l’information du Canada (BDPI). Apprenez-en davantage sur le rôle du BDPI au sein du gouvernement du Canada. Consultez l’Ambition numérique du Canada 2022 pour connaître la direction future du BDPI.",
+    "defaultMessage": "Talents numériques du <abbreviation>GC</abbreviation> n’est qu’une des nombreuses initiatives menées par le bureau du dirigeant principal de l'information du Canada (BDPI). Apprenez-en davantage sur le rôle du BDPI au sein du gouvernement du Canada. Consultez l’Ambition numérique du Canada 2022 pour connaître la direction future du BDPI.",
     "description": "Description of the Office of the Chief Information Officer"
   },
   "h8AdRp": {
@@ -8539,7 +8539,7 @@
     "description": "Title displayed for the Edit column."
   },
   "i9cA5V": {
-    "defaultMessage": "Bureau de la dirigeante principale de l’information",
+    "defaultMessage": "Bureau du dirigeant principal de l'information",
     "description": "Title for the Office of the Chief Information Officer"
   },
   "i9ovz7": {

--- a/apps/web/src/pages/Home/HomePage/components/About/About.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/About/About.tsx
@@ -56,7 +56,7 @@ const About = () => {
                     href:
                       locale === "en"
                         ? "https://www.canada.ca/en/treasury-board-secretariat/corporate/mandate/chief-information-officer.html"
-                        : "https://www.canada.ca/fr/secretariat-conseil-tresor/organisation/mandat/dirigeante-principale-information.html",
+                        : "https://www.canada.ca/fr/secretariat-conseil-tresor/organisation/mandat/dirigeant-principal-information.html",
                     label: intl.formatMessage({
                       defaultMessage:
                         "Learn more<hidden> about the Office of the Chief Information Officer</hidden>",


### PR DESCRIPTION
🤖 Resolves #11156.

## 👋 Introduction

This PR updates the spelling of the Office of the Chief Information Officer of Canada in French as well as a related broken URL.

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm build`
2. Navigate to `/fr/`
3. Verify copy is _le bureau du dirigeant principal de l'information_ instead of _le bureau de la dirigeante principale de l'information_ in heading, paragraph, and hidden text link of _En savoir plus_
4. Verify URL for link _En savoir plus_ navigates to https://www.canada.ca/fr/secretariat-conseil-tresor/organisation/mandat/dirigeant-principal-information.html

## 📸 Screenshot

<img width="1020" alt="Screen Shot 2024-08-07 at 11 58 23" src="https://github.com/user-attachments/assets/ec3e9dab-863e-42ff-ac73-a74bca377e9f">