### PR TITLE
[Debt] Replaces deprecated Storybook `globals`

### DIFF
--- a/apps/web/.storybook/preview.ts
+++ b/apps/web/.storybook/preview.ts
@@ -25,7 +25,7 @@ const messages = {
   },
 };
 
-export const globals = {
+export const initialGlobals = {
   locale: "en",
   locales: {
     en: "English",


### PR DESCRIPTION
🤖 Resolves #11129.

## 👋 Introduction

This PR removes a Storybook a deprecated variable of `globals` and replaces it with `initialGlobals`.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm storybook`
2. Verify storybook deprecation warning no longer appears when running storybook

## 📸 Screenshot

<img width="998" alt="Screen Shot 2024-08-08 at 10 52 10" src="https://github.com/user-attachments/assets/b05beaa6-1897-4baa-84cc-8ee627e8e93c">
