### PR TITLE
[Fix] Adds "other" back to priority cell

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -72,8 +72,10 @@ export const priorityCell = (
     case 30:
       priority = PriorityWeight.CitizenOrPermanentResident;
       break;
+    case 40:
+      priority = PriorityWeight.Other;
+      break;
     default:
-    // null
   }
 
   if (!priority) return null;

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -76,6 +76,7 @@ export const priorityCell = (
       priority = PriorityWeight.Other;
       break;
     default:
+    // null
   }
 
   if (!priority) return null;


### PR DESCRIPTION
🤖 Resolves #11154 

## 👋 Introduction

Updates the priority cell on pool candidates table to render "other" when the weight for it is present.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Build `pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Navigate to any pool candidates table
4. Observe "Other" appearing in the category column when weight is `40`

## 📸 Screenshot

![2024-08-09_08-19](https://github.com/user-attachments/assets/34d1f9fb-d3cf-416b-9aa8-f5d7667f2e24)
