### PR TITLE
[Bugfix] Application screening passing without education

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -1119,6 +1119,11 @@ class PoolCandidate extends Model
             if ($isApplicationScreening) {
                 $educationResults = $stepResults->where('assessment_result_type', AssessmentResultType::EDUCATION->name);
 
+                // automatically to assess if education results null or empty
+                if (! isset($educationResults) || count($educationResults) == 0) {
+                    $hasToAssess = true;
+                }
+
                 foreach ($educationResults as $result) {
                     if (! $result || is_null($result->assessment_decision)) {
                         $hasToAssess = true;


### PR DESCRIPTION
🤖 Resolves #11158 

## 👋 Introduction

Handles the step being passed before it actually should be.
This was due to education results being an empty array and thus skipped by the for loop block, resolved with a falsy case. 

## 🧪 Testing

1. Have a user apply to the pool
2. Navigate to that candidates assessment
3. Assess skills on application screening making sure to not assess the education requirement
4. Observe the step no longer passes while education requirement is still "to assess"

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/78d390a4-2b5f-46c1-aab0-572109fc71aa)

