### PR TITLE
[Debt] Constrain types User and Experience

### DIFF
--- a/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
@@ -152,10 +152,6 @@ query getProfile($userId: UUID!) {
     positionDuration
     userSkills {
       id
-      user {
-        id
-        email
-      }
       skill {
         id
         key
@@ -176,10 +172,6 @@ query getProfile($userId: UUID!) {
       # profileExperience fragment
       id
       __typename
-      user {
-        id
-        email
-      }
       details
       skills {
         id
@@ -271,10 +263,6 @@ query getProfile($userId: UUID!) {
     isProfileComplete
     poolCandidates {
       id
-      user {
-        id
-        email
-      }
       status {
         value
         label {
@@ -333,10 +321,6 @@ query getProfile($userId: UUID!) {
         id
         __typename
         details
-        user {
-          id
-          email
-        }
         skills {
           id
           key

--- a/api/app/Http/Resources/AwardExperienceResource.php
+++ b/api/app/Http/Resources/AwardExperienceResource.php
@@ -29,7 +29,6 @@ class AwardExperienceResource extends JsonResource
             'awardedScope' => $this->localizeEnum($this->awarded_scope, AwardedScope::class),
             'details' => $this->details,
             'skills' => SkillResource::collection($this->skills),
-            'user' => new UserStubResource($this->user),
         ];
     }
 }

--- a/api/app/Http/Resources/CommunityExperienceResource.php
+++ b/api/app/Http/Resources/CommunityExperienceResource.php
@@ -24,7 +24,6 @@ class CommunityExperienceResource extends JsonResource
             'endDate' => $this->end_date?->format('Y-m-d'),
             'details' => $this->details,
             'skills' => SkillResource::collection($this->skills),
-            'user' => new UserStubResource($this->user),
         ];
     }
 }

--- a/api/app/Http/Resources/EducationExperienceResource.php
+++ b/api/app/Http/Resources/EducationExperienceResource.php
@@ -31,7 +31,6 @@ class EducationExperienceResource extends JsonResource
             'endDate' => $this->end_date?->format('Y-m-d'),
             'details' => $this->details,
             'skills' => SkillResource::collection($this->skills),
-            'user' => new UserStubResource($this->user),
         ];
     }
 }

--- a/api/app/Http/Resources/PersonalExperienceResource.php
+++ b/api/app/Http/Resources/PersonalExperienceResource.php
@@ -23,7 +23,6 @@ class PersonalExperienceResource extends JsonResource
             'endDate' => $this->end_date?->format('Y-m-d'),
             'details' => $this->details,
             'skills' => SkillResource::collection($this->skills),
-            'user' => new UserStubResource($this->user),
         ];
     }
 }

--- a/api/app/Http/Resources/PoolCandidateResource.php
+++ b/api/app/Http/Resources/PoolCandidateResource.php
@@ -45,7 +45,6 @@ class PoolCandidateResource extends JsonResource
             'archivedAt' => $this->archived_at,
             'submittedAt' => $this->submitted_at,
             'suspendedAt' => $this->suspended_at,
-            'user' => new UserStubResource($this->user),
         ];
     }
 }

--- a/api/app/Http/Resources/WorkExperienceResource.php
+++ b/api/app/Http/Resources/WorkExperienceResource.php
@@ -24,7 +24,6 @@ class WorkExperienceResource extends JsonResource
             'endDate' => $this->end_date?->format('Y-m-d'),
             'details' => $this->details,
             'skills' => SkillResource::collection($this->skills),
-            'user' => new UserStubResource($this->user),
         ];
     }
 }

--- a/apps/web/src/components/CandidateDialog/ChangeDateDialog.tsx
+++ b/apps/web/src/components/CandidateDialog/ChangeDateDialog.tsx
@@ -14,12 +14,12 @@ import {
 import { currentDate } from "@gc-digital-talent/date-helpers";
 import { emptyToNull } from "@gc-digital-talent/helpers";
 import {
-  User,
   PoolCandidate,
   UpdatePoolCandidateStatusInput,
   graphql,
   FragmentType,
   getFragment,
+  User,
 } from "@gc-digital-talent/graphql";
 
 import { getShortPoolTitleHtml } from "~/utils/poolUtils";
@@ -68,7 +68,7 @@ interface ChangeDateDialogProps {
   selectedCandidateQuery: FragmentType<
     typeof ChangeDateDialog_PoolCandidateFragment
   >;
-  user: User;
+  user: Pick<User, "firstName" | "lastName">;
 }
 
 const ChangeDateDialog = ({
@@ -82,6 +82,7 @@ const ChangeDateDialog = ({
     ChangeDateDialog_PoolCandidateFragment,
     selectedCandidateQuery,
   );
+  const { firstName, lastName } = user;
 
   const [{ fetching }, executeMutation] = useMutation(
     UpdatePoolCandidateStatus_Mutation,
@@ -163,7 +164,7 @@ const ChangeDateDialog = ({
             })}
           </p>
           <p data-h2-font-weight="base(800)">
-            - {getFullNameHtml(user.firstName, user.lastName, intl)}
+            - {getFullNameHtml(firstName, lastName, intl)}
           </p>
           <p data-h2-margin="base(x1, 0, 0, 0)">
             {intl.formatMessage({

--- a/apps/web/src/components/ExperienceCard/AwardContent.tsx
+++ b/apps/web/src/components/ExperienceCard/AwardContent.tsx
@@ -11,7 +11,7 @@ import { ContentProps } from "./types";
 const AwardContent = ({
   experience: { awardedTo, issuedBy, awardedScope },
   headingLevel,
-}: ContentProps<AwardExperience>) => {
+}: ContentProps<Omit<AwardExperience, "user">>) => {
   const intl = useIntl();
   const experienceFormLabels = getExperienceFormLabels(intl);
   const notAvailable = intl.formatMessage(commonMessages.notAvailable);

--- a/apps/web/src/components/ExperienceCard/CommunityContent.tsx
+++ b/apps/web/src/components/ExperienceCard/CommunityContent.tsx
@@ -11,7 +11,7 @@ import { ContentProps } from "./types";
 const CommunityContent = ({
   experience: { project },
   headingLevel,
-}: ContentProps<CommunityExperience>) => {
+}: ContentProps<Omit<CommunityExperience, "user">>) => {
   const intl = useIntl();
   const experienceFormLabels = getExperienceFormLabels(intl);
 

--- a/apps/web/src/components/ExperienceCard/EducationContent.tsx
+++ b/apps/web/src/components/ExperienceCard/EducationContent.tsx
@@ -11,7 +11,7 @@ import { ContentProps } from "./types";
 const EducationContent = ({
   experience: { areaOfStudy, status },
   headingLevel,
-}: ContentProps<EducationExperience>) => {
+}: ContentProps<Omit<EducationExperience, "user">>) => {
   const intl = useIntl();
   const experienceFormLabels = getExperienceFormLabels(intl);
 

--- a/apps/web/src/components/ExperienceCard/WorkContent.tsx
+++ b/apps/web/src/components/ExperienceCard/WorkContent.tsx
@@ -11,7 +11,7 @@ import { ContentProps } from "./types";
 const WorkContent = ({
   experience: { division },
   headingLevel,
-}: ContentProps<WorkExperience>) => {
+}: ContentProps<Omit<WorkExperience, "user">>) => {
   const intl = useIntl();
   const experienceFormLabels = getExperienceFormLabels(intl);
 

--- a/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillForm.tsx
+++ b/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillForm.tsx
@@ -17,7 +17,7 @@ const TEXT_AREA_MAX_WORDS = 160;
 
 const getSkillArgs = (
   skillId: Scalars["ID"]["output"],
-  experience?: Experience,
+  experience?: Omit<Experience, "user">,
   details?: string,
   remove?: boolean,
 ) => {
@@ -47,7 +47,7 @@ type FormValues = {
 
 interface ExperienceSkillFormProps {
   defaultValues: FormValues;
-  experiences: Experience[];
+  experiences: Omit<Experience, "user">[];
   onSuccess: () => void;
 }
 

--- a/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillFormDialog.tsx
+++ b/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillFormDialog.tsx
@@ -16,7 +16,7 @@ type FormValues = {
 
 const deriveDefaultValues = (
   skill?: Skill,
-  experience?: Experience,
+  experience?: Omit<Experience, "user">,
 ): FormValues => {
   const details = experience?.skills?.find(
     (experienceSkill) => experienceSkill.id === skill?.id,
@@ -31,8 +31,8 @@ const deriveDefaultValues = (
 interface ExperienceSkillFormDialogProps {
   onSave?: () => void;
   skill?: Skill;
-  experience?: Experience;
-  availableExperiences?: Experience[];
+  experience?: Omit<Experience, "user">;
+  availableExperiences?: Omit<Experience, "user">[];
   trigger?: ReactNode;
 }
 

--- a/apps/web/src/components/ExperienceSortAndFilter/sortAndFilterUtil.ts
+++ b/apps/web/src/components/ExperienceSortAndFilter/sortAndFilterUtil.ts
@@ -19,10 +19,10 @@ import { ExperienceForDate } from "~/types/experience";
 import { FormValues as SortAndFilterValues } from "./ExperienceSortAndFilter";
 
 export function sortAndFilterExperiences(
-  experiences: Experience[] | undefined,
+  experiences: Omit<Experience, "user">[] | undefined,
   sortAndFilterValues: SortAndFilterValues,
   intl: IntlShape,
-): Experience[] {
+): Omit<Experience, "user">[] {
   const experiencesNotNull = experiences?.filter(notEmpty) ?? [];
 
   const experiencesDateNormalized: ExperienceForDate[] = experiencesNotNull.map(

--- a/apps/web/src/components/ExperienceTreeItems/ExperienceTreeItems.tsx
+++ b/apps/web/src/components/ExperienceTreeItems/ExperienceTreeItems.tsx
@@ -4,7 +4,7 @@ import { Experience } from "@gc-digital-talent/graphql";
 import ExperienceCard from "../ExperienceCard/ExperienceCard";
 
 interface ExperienceTreeItemsProps {
-  experiences: Experience[];
+  experiences: Omit<Experience, "user">[];
 }
 
 const ExperienceTreeItems = ({ experiences }: ExperienceTreeItemsProps) => {

--- a/apps/web/src/components/PoolCandidatesTable/SkillMatchDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/SkillMatchDialog.tsx
@@ -14,10 +14,6 @@ const SkillMatchDialog_Query = graphql(/* GraphQL */ `
       experiences {
         id
         __typename
-        user {
-          id
-          email
-        }
         details
         skills {
           id

--- a/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
+++ b/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
@@ -39,6 +39,8 @@ const columnHelper =
 const PoolStatusTable_Fragment = graphql(/* GraphQL */ `
   fragment PoolStatusTable on User {
     id
+    firstName
+    lastName
     poolCandidates {
       id
       status {
@@ -162,7 +164,12 @@ const PoolStatusTable = ({ userQuery }: PoolStatusTableProps) => {
       {
         id: "status",
         enableHiding: false,
-        cell: ({ row: { original: candidate } }) => statusCell(candidate, user),
+        cell: ({ row: { original: candidate } }) =>
+          statusCell(candidate, {
+            firstName: user.firstName,
+            lastName: user.lastName,
+            poolCandidates: user.poolCandidates,
+          }),
         header: intl.formatMessage(commonMessages.status),
         sortingFn: sortStatus,
       },
@@ -222,7 +229,11 @@ const PoolStatusTable = ({ userQuery }: PoolStatusTableProps) => {
       id: "expiryDate",
       enableHiding: false,
       sortingFn: "datetime",
-      cell: ({ row: { original: candidate } }) => expiryCell(candidate, user),
+      cell: ({ row: { original: candidate } }) =>
+        expiryCell(candidate, {
+          firstName: user.firstName,
+          lastName: user.lastName,
+        }),
       header: intl.formatMessage({
         defaultMessage: "Expiry date",
         id: "STDYoR",

--- a/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
+++ b/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
@@ -53,9 +53,6 @@ const PoolStatusTable_Fragment = graphql(/* GraphQL */ `
       expiryDate
       notes
       suspendedAt
-      user {
-        id
-      }
       pool {
         id
         processNumber

--- a/apps/web/src/components/PoolStatusTable/cells.tsx
+++ b/apps/web/src/components/PoolStatusTable/cells.tsx
@@ -5,6 +5,7 @@ import {
   LocalizedString,
   Maybe,
   User,
+  ChangeStatusDialog_UserFragment as ChangeStatusDialogUserFragmentType,
 } from "@gc-digital-talent/graphql";
 import { Link } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
@@ -18,12 +19,15 @@ import ChangeStatusDialog, {
 
 export const statusCell = (
   candidate: FragmentType<typeof ChangeStatusDialog_PoolCandidateFragment>,
-  user: User,
+  user: Pick<
+    ChangeStatusDialogUserFragmentType,
+    "firstName" | "lastName" | "poolCandidates"
+  >,
 ) => <ChangeStatusDialog selectedCandidateQuery={candidate} user={user} />;
 
 export const expiryCell = (
   candidate: FragmentType<typeof ChangeDateDialog_PoolCandidateFragment>,
-  user: User,
+  user: Pick<User, "firstName" | "lastName">,
 ) => <ChangeDateDialog selectedCandidateQuery={candidate} user={user} />;
 
 export function viewTeamLinkCell(

--- a/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
@@ -40,7 +40,7 @@ const getBilingualEvaluation = (
     `Invalid Language Ability '${bilingualEvaluationId}'`,
   );
 
-interface DisplayProps {
+export interface DisplayProps {
   user: PartialUser & { bilingualEvaluation?: BilingualEvaluation };
   context?: "admin" | "default" | "print";
 }

--- a/apps/web/src/components/Profile/components/PersonalInformation/Display.tsx
+++ b/apps/web/src/components/Profile/components/PersonalInformation/Display.tsx
@@ -28,8 +28,24 @@ const SendVerificationEmail_Mutation = graphql(/* GraphQL */ `
   }
 `);
 
+type PartialUser = Pick<
+  User,
+  | "firstName"
+  | "lastName"
+  | "email"
+  | "isEmailVerified"
+  | "telephone"
+  | "preferredLang"
+  | "preferredLanguageForInterview"
+  | "preferredLanguageForExam"
+  | "currentCity"
+  | "currentProvince"
+  | "citizenship"
+  | "armedForcesStatus"
+>;
+
 interface DisplayProps {
-  user: User;
+  user: PartialUser;
   showEmailVerification?: boolean;
 }
 

--- a/apps/web/src/components/Profile/components/PersonalInformation/utils.ts
+++ b/apps/web/src/components/Profile/components/PersonalInformation/utils.ts
@@ -7,6 +7,7 @@ import {
   CitizenshipStatus,
   UpdateUserAsUserInput,
   User,
+  UserProfileFragment as UserProfileFragmentType,
 } from "@gc-digital-talent/graphql";
 
 import profileMessages from "~/messages/profileMessages";
@@ -60,7 +61,9 @@ export const getLabels = (intl: IntlShape) => ({
   armedForcesStatus: intl.formatMessage(profileMessages.veteranStatus),
 });
 
-export const dataToFormValues = (data?: User | null): FormValues => ({
+export const dataToFormValues = (
+  data?: UserProfileFragmentType | null,
+): FormValues => ({
   preferredLang: data?.preferredLang?.value,
   preferredLanguageForInterview: data?.preferredLanguageForInterview?.value,
   preferredLanguageForExam: data?.preferredLanguageForExam?.value,

--- a/apps/web/src/components/Profile/types.ts
+++ b/apps/web/src/components/Profile/types.ts
@@ -5,7 +5,7 @@ import {
   PoolCandidate,
   UpdateUserAsUserInput,
   UpdateUserAsUserMutation,
-  User,
+  UserProfileFragment as UserProfileFragmentType,
 } from "@gc-digital-talent/graphql";
 
 export type SectionKey =
@@ -17,7 +17,7 @@ export type SectionKey =
   | "account";
 
 export interface SectionProps<P = void> {
-  user: Omit<User, "poolCandidates">;
+  user: UserProfileFragmentType;
   isUpdating?: boolean;
   application?: Pick<PoolCandidate, "id"> & { pool: Pick<Pool, "language"> };
   pool?: Maybe<P>;

--- a/apps/web/src/components/Profile/types.ts
+++ b/apps/web/src/components/Profile/types.ts
@@ -17,7 +17,7 @@ export type SectionKey =
   | "account";
 
 export interface SectionProps<P = void> {
-  user: User;
+  user: Omit<User, "poolCandidates">;
   isUpdating?: boolean;
   application?: Pick<PoolCandidate, "id"> & { pool: Pick<Pool, "language"> };
   pool?: Maybe<P>;

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -261,7 +261,7 @@ const SupportingEvidence = ({
   skill,
   headingAs = "h4",
 }: {
-  experiences: Experience[];
+  experiences: Omit<Experience, "user">[];
   skill?: Skill;
   headingAs?: HeadingLevel;
 }) => {

--- a/apps/web/src/components/SkillTree/SkillTree.tsx
+++ b/apps/web/src/components/SkillTree/SkillTree.tsx
@@ -17,7 +17,10 @@ import { getExperienceSkills } from "~/utils/skillUtils";
 import ExperienceCard from "~/components/ExperienceCard/ExperienceCard";
 import ExperienceSkillFormDialog from "~/components/ExperienceSkillFormDialog/ExperienceSkillFormDialog";
 
-const filterExperienceSkills = (experience: Experience, skill: Skill) => {
+const filterExperienceSkills = (
+  experience: Omit<Experience, "user">,
+  skill: Skill,
+) => {
   return {
     ...experience,
     skills: experience.skills?.filter(
@@ -28,7 +31,7 @@ const filterExperienceSkills = (experience: Experience, skill: Skill) => {
 
 interface SkillTreeProps {
   skill: Skill;
-  experiences: Experience[];
+  experiences: Omit<Experience, "user">[];
   headingAs?: HeadingLevel;
   hideConnectButton?: boolean;
   hideEdit?: boolean;

--- a/apps/web/src/components/UserProfile/ExperienceByTypeListing.tsx
+++ b/apps/web/src/components/UserProfile/ExperienceByTypeListing.tsx
@@ -92,7 +92,7 @@ const ExperienceByTypeListing = ({
     experiences
       ?.filter(isAwardExperience)
       .map(
-        (award: AwardExperience) =>
+        (award: Omit<AwardExperience, "user">) =>
           ({
             ...award,
             startDate: award.awardedDate,

--- a/apps/web/src/components/UserProfile/ExperienceByTypeListing.tsx
+++ b/apps/web/src/components/UserProfile/ExperienceByTypeListing.tsx
@@ -35,7 +35,7 @@ const ExperienceByType = ({
   title: string;
   headingLevel?: HeadingRank;
   icon: ReactNode;
-  experiences: Experience[];
+  experiences?: Omit<Experience, "user">[];
   editParam?: string;
   isExperienceOpen: (id: string) => boolean;
   onExperienceOpenChange: (id: string) => void;
@@ -56,7 +56,7 @@ const ExperienceByType = ({
           data-h2-flex-direction="base(column)"
           data-h2-gap="base(x.5 0)"
         >
-          {experiences.map((experience) => (
+          {experiences?.map((experience) => (
             <ExperienceCard
               key={experience.id}
               isOpen={isExperienceOpen(experience.id)}
@@ -73,7 +73,7 @@ const ExperienceByType = ({
   );
 };
 interface ExperienceSectionProps {
-  experiences?: Experience[];
+  experiences?: Omit<Experience, "user">[];
   headingLevel?: HeadingRank;
   editParam?: string;
 }

--- a/apps/web/src/components/UserProfile/ExperienceSection.tsx
+++ b/apps/web/src/components/UserProfile/ExperienceSection.tsx
@@ -28,7 +28,7 @@ import SkillAccordion from "./SkillAccordion/SkillAccordion";
 import ExperienceByTypeListing from "./ExperienceByTypeListing";
 
 interface ExperienceSectionProps {
-  experiences?: Experience[];
+  experiences?: Omit<Experience, "user">[];
   editParam?: string;
   headingLevel?: HeadingRank;
 }

--- a/apps/web/src/components/UserProfile/ExperienceSection.tsx
+++ b/apps/web/src/components/UserProfile/ExperienceSection.tsx
@@ -46,7 +46,7 @@ const ExperienceSection = ({
       experiences
         ?.filter(isAwardExperience)
         .map(
-          (award: AwardExperience) =>
+          (award: Omit<AwardExperience, "user">) =>
             ({
               ...award,
               startDate: award.awardedDate,

--- a/apps/web/src/components/UserProfile/ProfileSections/DiversityEquityInclusionSection.tsx
+++ b/apps/web/src/components/UserProfile/ProfileSections/DiversityEquityInclusionSection.tsx
@@ -15,7 +15,16 @@ import metisIcon from "~/assets/img/metis-true.webp";
 import otherIcon from "~/assets/img/other-true.webp";
 import { anyCriteriaSelected } from "~/validators/profile/diversityEquityInclusion";
 
-const DiversityEquityInclusionSection = ({ user }: { user: User }) => {
+interface DiversityEquityInclusionSectionProps {
+  user: Pick<
+    User,
+    "isWoman" | "hasDisability" | "isVisibleMinority" | "indigenousCommunities"
+  >;
+}
+
+const DiversityEquityInclusionSection = ({
+  user,
+}: DiversityEquityInclusionSectionProps) => {
   const intl = useIntl();
 
   const { isWoman, hasDisability, isVisibleMinority, indigenousCommunities } =

--- a/apps/web/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
+++ b/apps/web/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
@@ -10,13 +10,35 @@ import { User } from "@gc-digital-talent/graphql";
 
 import { wrapAbbr } from "~/utils/nameUtils";
 
-const GovernmentInformationSection = ({ user }: { user: User }) => {
+interface GovernmentInformationSectionProps {
+  user: Pick<
+    User,
+    | "isGovEmployee"
+    | "department"
+    | "govEmployeeType"
+    | "currentClassification"
+    | "hasPriorityEntitlement"
+    | "priorityNumber"
+  >;
+}
+
+const GovernmentInformationSection = ({
+  user,
+}: GovernmentInformationSectionProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
+  const {
+    isGovEmployee,
+    department,
+    govEmployeeType,
+    currentClassification,
+    hasPriorityEntitlement,
+    priorityNumber,
+  } = user;
 
   return (
     <Well>
-      {user.isGovEmployee && (
+      {isGovEmployee && (
         <div data-h2-flex-grid="base(flex-start, x2, x1)">
           <div data-h2-flex-item="base(1of1)">
             <p>
@@ -38,7 +60,7 @@ const GovernmentInformationSection = ({ user }: { user: User }) => {
               </span>
             </p>
           </div>
-          {user.department && (
+          {department && (
             <div data-h2-flex-item="base(1of1)">
               <p>
                 <span data-h2-display="base(block)">
@@ -50,12 +72,12 @@ const GovernmentInformationSection = ({ user }: { user: User }) => {
                   })}
                 </span>
                 <span data-h2-font-weight="base(700)">
-                  {user.department.name[locale]}
+                  {department.name[locale]}
                 </span>
               </p>
             </div>
           )}
-          {user.govEmployeeType && (
+          {govEmployeeType && (
             <div data-h2-flex-item="base(1of1)">
               <p>
                 <span data-h2-display="base(block)">
@@ -66,35 +88,34 @@ const GovernmentInformationSection = ({ user }: { user: User }) => {
                   })}
                 </span>
                 <span data-h2-font-weight="base(700)">
-                  {getLocalizedName(user.govEmployeeType.label, intl)}
+                  {getLocalizedName(govEmployeeType.label, intl)}
                 </span>
               </p>
             </div>
           )}
-          {!!user.currentClassification?.group &&
-            !!user.currentClassification?.level && (
-              <div data-h2-flex-item="base(1of1)">
-                <p>
-                  <span data-h2-display="base(block)">
-                    {intl.formatMessage({
-                      defaultMessage: "Current group and classification:",
-                      id: "MuyuAu",
-                      description:
-                        "Field label before government employment group and level, followed by colon",
-                    })}
-                  </span>
-                  <span data-h2-font-weight="base(700)">
-                    {wrapAbbr(
-                      `${user.currentClassification?.group}-${user.currentClassification?.level}`,
-                      intl,
-                    )}
-                  </span>
-                </p>
-              </div>
-            )}
+          {!!currentClassification?.group && !!currentClassification?.level && (
+            <div data-h2-flex-item="base(1of1)">
+              <p>
+                <span data-h2-display="base(block)">
+                  {intl.formatMessage({
+                    defaultMessage: "Current group and classification:",
+                    id: "MuyuAu",
+                    description:
+                      "Field label before government employment group and level, followed by colon",
+                  })}
+                </span>
+                <span data-h2-font-weight="base(700)">
+                  {wrapAbbr(
+                    `${currentClassification?.group}-${currentClassification?.level}`,
+                    intl,
+                  )}
+                </span>
+              </p>
+            </div>
+          )}
         </div>
       )}
-      {user.isGovEmployee === false && (
+      {isGovEmployee === false && (
         <div data-h2-flex-grid="base(flex-start, x2, x1)">
           <div data-h2-flex-item="base(1of1)">
             <p>
@@ -109,7 +130,7 @@ const GovernmentInformationSection = ({ user }: { user: User }) => {
           </div>
         </div>
       )}
-      {user.isGovEmployee === false && (
+      {isGovEmployee === false && (
         <div data-h2-flex-grid="base(flex-start, x2, x1)">
           <div data-h2-flex-item="base(1of1)">
             <p>
@@ -123,7 +144,7 @@ const GovernmentInformationSection = ({ user }: { user: User }) => {
           </div>
         </div>
       )}
-      {user.hasPriorityEntitlement !== null && (
+      {hasPriorityEntitlement !== null && (
         <div
           data-h2-flex-grid="base(flex-start, x2, x1)"
           data-h2-padding="base(x1, 0, 0, 0)"
@@ -139,7 +160,7 @@ const GovernmentInformationSection = ({ user }: { user: User }) => {
                 })}
               </span>
               <span data-h2-font-weight="base(700)">
-                {user.hasPriorityEntitlement
+                {hasPriorityEntitlement
                   ? intl.formatMessage({
                       defaultMessage: "I do have a priority entitlement",
                       id: "+tKl71",
@@ -153,7 +174,7 @@ const GovernmentInformationSection = ({ user }: { user: User }) => {
               </span>
             </p>
           </div>
-          {user.hasPriorityEntitlement && (
+          {hasPriorityEntitlement && (
             <div data-h2-flex-item="base(1of1)">
               <p>
                 <span data-h2-display="base(block)">
@@ -164,8 +185,8 @@ const GovernmentInformationSection = ({ user }: { user: User }) => {
                   })}
                 </span>
                 <span data-h2-font-weight="base(700)">
-                  {user.priorityNumber
-                    ? user.priorityNumber
+                  {priorityNumber
+                    ? priorityNumber
                     : intl.formatMessage(commonMessages.notProvided)}
                 </span>
               </p>
@@ -174,7 +195,7 @@ const GovernmentInformationSection = ({ user }: { user: User }) => {
         </div>
       )}
 
-      {user.isGovEmployee === null && user.hasPriorityEntitlement === null && (
+      {isGovEmployee === null && hasPriorityEntitlement === null && (
         <div data-h2-flex-grid="base(flex-start, x2, x1)">
           <div data-h2-flex-item="base(1of1)">
             <p>{intl.formatMessage(commonMessages.noInformationProvided)}</p>

--- a/apps/web/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
+++ b/apps/web/src/components/UserProfile/ProfileSections/LanguageInformationSection.tsx
@@ -1,16 +1,21 @@
 import { useIntl } from "react-intl";
 
 import { Well } from "@gc-digital-talent/ui";
-import { User } from "@gc-digital-talent/graphql";
 import { commonMessages } from "@gc-digital-talent/i18n";
 
 import {
   hasAllEmptyFields,
   hasEmptyRequiredFields,
 } from "~/validators/profile/languageInformation";
-import Display from "~/components/Profile/components/LanguageProfile/Display";
+import Display, {
+  DisplayProps,
+} from "~/components/Profile/components/LanguageProfile/Display";
 
-const LanguageInformationSection = ({ user }: { user: User }) => {
+const LanguageInformationSection = ({
+  user,
+}: {
+  user: Pick<DisplayProps, "user">["user"];
+}) => {
   const intl = useIntl();
   return (
     <Well>

--- a/apps/web/src/components/UserProfile/ProfileSections/WorkLocationSection.tsx
+++ b/apps/web/src/components/UserProfile/ProfileSections/WorkLocationSection.tsx
@@ -10,10 +10,15 @@ import {
   hasAllEmptyFields,
 } from "~/validators/profile/workLocation";
 
-const WorkLocationSection = ({ user }: { user: User }) => {
+interface WorkLocationSectionProps {
+  user: Pick<User, "locationPreferences" | "locationExemptions">;
+}
+
+const WorkLocationSection = ({ user }: WorkLocationSectionProps) => {
   const intl = useIntl();
+  const { locationPreferences, locationExemptions } = user;
   // generate array of location preferences localized and formatted with spaces/commas
-  const regionPreferencesSquished = user.locationPreferences?.map((region) =>
+  const regionPreferencesSquished = locationPreferences?.map((region) =>
     getLocalizedName(region?.label, intl, true),
   );
   const regionPreferences = regionPreferencesSquished
@@ -37,7 +42,7 @@ const WorkLocationSection = ({ user }: { user: User }) => {
             </p>
           </div>
         )}
-        {!!user.locationExemptions && (
+        {!!locationExemptions && (
           <div data-h2-flex-item="base(1of1)">
             <p>
               <span data-h2-display="base(block)">
@@ -48,9 +53,7 @@ const WorkLocationSection = ({ user }: { user: User }) => {
                 })}
                 {intl.formatMessage(commonMessages.dividingColon)}
               </span>
-              <span data-h2-font-weight="base(700)">
-                {user.locationExemptions}
-              </span>
+              <span data-h2-font-weight="base(700)">{locationExemptions}</span>
             </p>
           </div>
         )}

--- a/apps/web/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
+++ b/apps/web/src/components/UserProfile/ProfileSections/WorkPreferencesSection.tsx
@@ -14,7 +14,11 @@ import {
 
 import { hasAllEmptyFields } from "~/validators/profile/workPreferences";
 
-const WorkPreferencesSection = ({ user }: { user: User }) => {
+interface WorkPreferencesSectionProps {
+  user: Pick<User, "acceptedOperationalRequirements" | "positionDuration">;
+}
+
+const WorkPreferencesSection = ({ user }: WorkPreferencesSectionProps) => {
   const intl = useIntl();
   const { acceptedOperationalRequirements, positionDuration } = user;
 

--- a/apps/web/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
+++ b/apps/web/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
@@ -67,7 +67,9 @@ const SkillAccordion = ({
 
   const { name, experiences } = skill;
 
-  const getPersonalExperience = (experience: PersonalExperience) => {
+  const getPersonalExperience = (
+    experience: Omit<PersonalExperience, "user">,
+  ) => {
     const { title, description, startDate, endDate, details, skills } =
       experience;
 
@@ -90,7 +92,9 @@ const SkillAccordion = ({
     );
   };
 
-  const getEducationExperience = (experience: EducationExperience) => {
+  const getEducationExperience = (
+    experience: Omit<EducationExperience, "user">,
+  ) => {
     const {
       type,
       thesisTitle,
@@ -152,7 +156,7 @@ const SkillAccordion = ({
     );
   };
 
-  const getAwardExperience = (experience: AwardExperience) => {
+  const getAwardExperience = (experience: Omit<AwardExperience, "user">) => {
     const {
       awardedDate,
       awardedScope,
@@ -214,7 +218,9 @@ const SkillAccordion = ({
     );
   };
 
-  const getCommunityExperience = (experience: CommunityExperience) => {
+  const getCommunityExperience = (
+    experience: Omit<CommunityExperience, "user">,
+  ) => {
     const {
       startDate,
       endDate,
@@ -273,7 +279,7 @@ const SkillAccordion = ({
     );
   };
 
-  const getWorkExperience = (experience: WorkExperience) => {
+  const getWorkExperience = (experience: Omit<WorkExperience, "user">) => {
     const {
       startDate,
       endDate,

--- a/apps/web/src/components/UserProfile/UserProfile.stories.tsx
+++ b/apps/web/src/components/UserProfile/UserProfile.stories.tsx
@@ -5,7 +5,10 @@ import {
   fakeApplicants,
   toLocalizedEnum,
 } from "@gc-digital-talent/fake-data";
-import { User, IndigenousCommunity } from "@gc-digital-talent/graphql";
+import {
+  IndigenousCommunity,
+  AdminUserProfileUserFragment,
+} from "@gc-digital-talent/graphql";
 
 import UserProfile from "./UserProfile";
 
@@ -16,7 +19,7 @@ export default {
   args: {},
 } as Meta;
 
-const TemplateUserProfile: StoryFn<User> = (args) => {
+const TemplateUserProfile: StoryFn<AdminUserProfileUserFragment> = (args) => {
   return <UserProfile user={args} headingLevel="h3" />;
 };
 
@@ -57,7 +60,6 @@ Null.args = {
   hasDisability: null,
   indigenousCommunities: null,
   isVisibleMinority: null,
-  hasDiploma: null,
   locationPreferences: null,
   locationExemptions: null,
   acceptedOperationalRequirements: null,

--- a/apps/web/src/components/UserProfile/UserProfile.tsx
+++ b/apps/web/src/components/UserProfile/UserProfile.tsx
@@ -14,7 +14,7 @@ import {
   incrementHeadingRank,
 } from "@gc-digital-talent/ui";
 import { navigationMessages } from "@gc-digital-talent/i18n";
-import type { User } from "@gc-digital-talent/graphql";
+import type { AdminUserProfileUserFragment } from "@gc-digital-talent/graphql";
 
 import { PAGE_SECTION_ID } from "~/constants/sections/userProfile";
 
@@ -28,7 +28,7 @@ import WorkPreferencesSection from "./ProfileSections/WorkPreferencesSection";
 import SkillShowcaseSection from "./SkillShowcaseSection";
 
 interface UserProfileProps {
-  user: User;
+  user: AdminUserProfileUserFragment;
   headingLevel?: HeadingRank;
 }
 

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
@@ -119,7 +119,9 @@ export const Component = () => {
     true,
   );
 
-  const experiences: Experience[] = unpackMaybes(application.user?.experiences);
+  const experiences: Omit<Experience, "user">[] = unpackMaybes(
+    application.user?.experiences,
+  );
   const experience = experiences?.find((exp) => exp?.id === experienceId);
 
   return application && experience ? (

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
@@ -437,7 +437,9 @@ export const ApplicationCareerTimeline = ({
 export const Component = () => {
   const { application } = useApplication();
 
-  const experiences: Experience[] = unpackMaybes(application.user.experiences);
+  const experiences: Omit<Experience, "user">[] = unpackMaybes(
+    application.user.experiences,
+  );
 
   return application ? (
     <ApplicationCareerTimeline

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
@@ -318,7 +318,9 @@ const ApplicationEducation = ({
 export const Component = () => {
   const { application } = useApplication();
 
-  const experiences: Experience[] = unpackMaybes(application.user.experiences);
+  const experiences: Omit<Experience, "user">[] = unpackMaybes(
+    application.user.experiences,
+  );
 
   return application?.pool ? (
     <ApplicationEducation application={application} experiences={experiences} />

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/LinkCareerTimeline.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/LinkCareerTimeline.tsx
@@ -206,7 +206,7 @@ const CheckListSection = ({
 };
 
 interface LinkCareerTimelineProps {
-  experiences: Experience[];
+  experiences: Omit<Experience, "user">[];
   previousStepPath: string;
   classificationGroup?: string;
 }
@@ -220,7 +220,7 @@ const LinkCareerTimeline = ({
   const experienceItems = experiences.reduce(
     (
       checklistItems: ExperienceItems,
-      experience: Experience,
+      experience: Omit<Experience, "user">,
     ): ExperienceItems => {
       if (isEducationExperience(experience)) {
         const educationExperience = {

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
@@ -63,7 +63,7 @@ export const getPageInfo: GetPageNavInfo = ({
 };
 
 interface ApplicationProfileProps extends ApplicationPageProps {
-  user: User;
+  user: Omit<User, "poolCandidates">;
 }
 
 export const ApplicationProfile = ({

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
@@ -2,7 +2,10 @@ import { useIntl } from "react-intl";
 import { useMutation } from "urql";
 
 import { Heading, Separator, ThrowNotFound } from "@gc-digital-talent/ui";
-import { graphql, User } from "@gc-digital-talent/graphql";
+import {
+  graphql,
+  Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType,
+} from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetPageNavInfo } from "~/types/applicationStep";
@@ -63,7 +66,7 @@ export const getPageInfo: GetPageNavInfo = ({
 };
 
 interface ApplicationProfileProps extends ApplicationPageProps {
-  user: Omit<User, "poolCandidates">;
+  user: ApplicationPoolCandidateFragmentType["user"];
 }
 
 export const ApplicationProfile = ({

--- a/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
@@ -616,7 +616,9 @@ const ApplicationReview = ({
 export const Component = () => {
   const { application } = useApplication();
 
-  const experiences: Experience[] = unpackMaybes(application.user.experiences);
+  const experiences: Omit<Experience, "user">[] = unpackMaybes(
+    application.user.experiences,
+  );
 
   return application?.pool ? (
     <ApplicationReview application={application} experiences={experiences} />

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -13,7 +13,7 @@ import {
 import { toast } from "@gc-digital-talent/toast";
 import { Input } from "@gc-digital-talent/forms";
 import { apiMessages } from "@gc-digital-talent/i18n";
-import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 import {
   ApplicationStep,
   Experience,
@@ -110,7 +110,7 @@ export const ApplicationSkills = ({
     followingPageUrl ?? paths.applicationQuestionsIntro(application.id);
 
   const isSkillsExperiencesIncomplete = isIncomplete(
-    application.user?.experiences?.filter(notEmpty),
+    experiences,
     application.pool,
   );
 

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -375,7 +375,9 @@ export const ApplicationSkills = ({
 export const Component = () => {
   const { application } = useApplication();
 
-  const experiences: Experience[] = unpackMaybes(application.user.experiences);
+  const experiences: Omit<Experience, "user">[] = unpackMaybes(
+    application.user.experiences,
+  );
 
   return application ? (
     <ApplicationSkills application={application} experiences={experiences} />

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -13,7 +13,7 @@ import {
 import { toast } from "@gc-digital-talent/toast";
 import { Input } from "@gc-digital-talent/forms";
 import { apiMessages } from "@gc-digital-talent/i18n";
-import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import {
   ApplicationStep,
   Experience,
@@ -110,7 +110,7 @@ export const ApplicationSkills = ({
     followingPageUrl ?? paths.applicationQuestionsIntro(application.id);
 
   const isSkillsExperiencesIncomplete = isIncomplete(
-    application.user,
+    application.user?.experiences?.filter(notEmpty),
     application.pool,
   );
 

--- a/apps/web/src/pages/Applications/careerTimelineStep/careerTimelineStepValidation.tsx
+++ b/apps/web/src/pages/Applications/careerTimelineStep/careerTimelineStepValidation.tsx
@@ -1,9 +1,12 @@
-import { User } from "@gc-digital-talent/graphql";
+import { Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType } from "@gc-digital-talent/graphql";
+import { notEmpty } from "@gc-digital-talent/helpers";
 
 import { careerTimelineIsIncomplete } from "~/validators/profile";
 
-const stepHasError = (user: User) => {
-  const isIncomplete = careerTimelineIsIncomplete(user);
+const stepHasError = (user: ApplicationPoolCandidateFragmentType["user"]) => {
+  const isIncomplete = careerTimelineIsIncomplete(
+    user?.experiences?.filter(notEmpty),
+  );
   return isIncomplete;
 };
 

--- a/apps/web/src/pages/Applications/educationStep/educationStepValidation.tsx
+++ b/apps/web/src/pages/Applications/educationStep/educationStepValidation.tsx
@@ -1,17 +1,16 @@
 import {
-  User,
   EducationRequirementOption,
   Pool,
-  PoolCandidate,
+  Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType,
 } from "@gc-digital-talent/graphql";
 
 import { ExperienceForDate } from "~/types/experience";
 import { isEducationExperience } from "~/utils/experienceUtils";
 
 const stepHasError = (
-  _user: User,
+  _user: ApplicationPoolCandidateFragmentType["user"],
   _pool: Pool,
-  application: Omit<PoolCandidate, "pool">,
+  application: ApplicationPoolCandidateFragmentType,
 ) => {
   return (
     !application.educationRequirementOption ||

--- a/apps/web/src/pages/Applications/fragment.ts
+++ b/apps/web/src/pages/Applications/fragment.ts
@@ -151,10 +151,6 @@ const Application_PoolCandidateFragment = graphql(/* GraphQL */ `
       experiences {
         id
         __typename
-        user {
-          id
-          email
-        }
         details
         skills {
           id
@@ -348,10 +344,6 @@ const Application_PoolCandidateFragment = graphql(/* GraphQL */ `
       id
       __typename
       details
-      user {
-        id
-        email
-      }
       ... on AwardExperience {
         title
         issuedBy

--- a/apps/web/src/pages/Applications/questionsStep/questionsStepValidation.tsx
+++ b/apps/web/src/pages/Applications/questionsStep/questionsStepValidation.tsx
@@ -1,4 +1,7 @@
-import { User, Pool, PoolCandidate } from "@gc-digital-talent/graphql";
+import {
+  Pool,
+  Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType,
+} from "@gc-digital-talent/graphql";
 
 import {
   generalQuestionsSectionHasMissingResponses,
@@ -6,9 +9,9 @@ import {
 } from "~/validators/profile";
 
 const stepHasError = (
-  _user: User,
+  _user: ApplicationPoolCandidateFragmentType["user"],
   pool: Pool,
-  application: Omit<PoolCandidate, "pool">,
+  application: ApplicationPoolCandidateFragmentType,
 ) => {
   return (
     generalQuestionsSectionHasMissingResponses(application, pool) ||

--- a/apps/web/src/pages/Applications/reviewStep/reviewStepValidation.tsx
+++ b/apps/web/src/pages/Applications/reviewStep/reviewStepValidation.tsx
@@ -1,9 +1,12 @@
-import { User, Pool, PoolCandidate } from "@gc-digital-talent/graphql";
+import {
+  Pool,
+  Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType,
+} from "@gc-digital-talent/graphql";
 
 const stepHasError = (
-  _user: User,
+  _user: ApplicationPoolCandidateFragmentType["user"],
   _pool: Pool,
-  application: Omit<PoolCandidate, "pool">,
+  application: ApplicationPoolCandidateFragmentType,
 ) => {
   return !application.signature;
 };

--- a/apps/web/src/pages/Applications/selfDeclarationStep/selfDeclarationStepValidation.tsx
+++ b/apps/web/src/pages/Applications/selfDeclarationStep/selfDeclarationStepValidation.tsx
@@ -1,8 +1,14 @@
-import { User, Pool } from "@gc-digital-talent/graphql";
+import {
+  Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType,
+  Pool,
+} from "@gc-digital-talent/graphql";
 
 import { diversityEquityInclusionSectionHasEmptyRequiredFields } from "~/validators/profile";
 
-const stepHasError = (user: User, pool: Pool) => {
+const stepHasError = (
+  user: ApplicationPoolCandidateFragmentType["user"],
+  pool: Pool,
+) => {
   const hasEmptyRequiredFields =
     diversityEquityInclusionSectionHasEmptyRequiredFields(user, pool);
   return hasEmptyRequiredFields;

--- a/apps/web/src/pages/Applications/skillsStep/skillsStepValidation.tsx
+++ b/apps/web/src/pages/Applications/skillsStep/skillsStepValidation.tsx
@@ -1,9 +1,19 @@
-import { User, Pool } from "@gc-digital-talent/graphql";
+import {
+  Pool,
+  Experience,
+  Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType,
+} from "@gc-digital-talent/graphql";
+import { notEmpty } from "@gc-digital-talent/helpers";
 
 import { skillRequirementsIsIncomplete } from "~/validators/profile";
 
-const stepHasError = (user: User, pool: Pool) => {
-  return skillRequirementsIsIncomplete(user, pool);
+const stepHasError = (
+  user: ApplicationPoolCandidateFragmentType["user"],
+  pool: Pool,
+) => {
+  const applicantExperiences: Omit<Experience, "user">[] | undefined =
+    user?.experiences?.filter(notEmpty);
+  return skillRequirementsIsIncomplete(applicantExperiences, pool);
 };
 
 export default stepHasError;

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationInformation/ApplicationInformation.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationInformation/ApplicationInformation.tsx
@@ -87,7 +87,7 @@ interface ApplicationInformationProps {
         >;
       })
     | null;
-  snapshot: User;
+  snapshot: User; // recreated from Json
   defaultOpen?: boolean;
 }
 

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationInformation/SkillDisplay.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ApplicationInformation/SkillDisplay.tsx
@@ -10,7 +10,7 @@ import { getExperienceSkills } from "~/utils/skillUtils";
 
 interface SkillExperiencesProps {
   skill: Skill;
-  experiences: Experience[];
+  experiences: Omit<Experience, "user">[];
 }
 
 const SkillExperiences = ({ skill, experiences }: SkillExperiencesProps) => {
@@ -92,7 +92,7 @@ const SkillExperiences = ({ skill, experiences }: SkillExperiencesProps) => {
 
 interface SkillDisplayProps {
   skills: Skill[];
-  experiences: Experience[];
+  experiences: Omit<Experience, "user">[];
 }
 
 const SkillDisplay = ({ skills, experiences }: SkillDisplayProps) => {

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CareerTimelineSection/CareerTimelineSection.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CareerTimelineSection/CareerTimelineSection.tsx
@@ -16,7 +16,7 @@ import useControlledCollapsibleGroup from "~/hooks/useControlledCollapsibleGroup
 import experienceMessages from "~/messages/experienceMessages";
 
 interface CareerTimelineSectionProps {
-  experiences: Experience[];
+  experiences: Omit<Experience, "user">[];
 }
 
 const CareerTimelineSection = ({ experiences }: CareerTimelineSectionProps) => {

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/CareerTimelineAndRecruitmentPage.test.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/CareerTimelineAndRecruitmentPage.test.tsx
@@ -25,7 +25,7 @@ describe("CareerTimelineAndRecruitment tests", () => {
     const e3 = generateExperience("2010-01-03");
     const e4 = generateExperience("2021-01-04");
 
-    const experiences: Experience[] = [e1, e3, e2, e4];
+    const experiences: Omit<Experience, "user">[] = [e1, e3, e2, e4];
     const sortedByDate = experiences.sort(compareByDate); // Should sort to most recent startDate
     expect(sortedByDate).toStrictEqual([e4, e3, e2, e1]);
   });
@@ -35,7 +35,7 @@ describe("CareerTimelineAndRecruitment tests", () => {
     const e3 = generateExperience("", "2010-01-03");
     const e4 = generateExperience("", "2021-01-04");
 
-    const experiences: Experience[] = [e1, e3, e2, e4];
+    const experiences: Omit<Experience, "user">[] = [e1, e3, e2, e4];
     const sortedByDate = experiences.sort(compareByDate); // Should sort to most recent endDate
     expect(sortedByDate).toStrictEqual([e4, e3, e2, e1]);
   });
@@ -46,7 +46,7 @@ describe("CareerTimelineAndRecruitment tests", () => {
     const e4 = generateExperience("", "2021-01-04");
     const e5 = generateExperience("", "2010-01-03");
 
-    const experiences: Experience[] = [e1, e3, e2, e4, e5];
+    const experiences: Omit<Experience, "user">[] = [e1, e3, e2, e4, e5];
     const sortedByDate = experiences.sort(compareByDate); // Should sort to most recent endDate
     expect(sortedByDate).toStrictEqual([e3, e2, e4, e5, e1]);
   });

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineSection.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineSection.tsx
@@ -15,7 +15,7 @@ import useRoutes from "~/hooks/useRoutes";
 import experienceMessages from "~/messages/experienceMessages";
 
 interface CareerTimelineSectionProps {
-  experiences?: Experience[];
+  experiences?: Omit<Experience, "user">[];
   editParam?: string;
   headingLevel?: HeadingRank;
   userId?: string;

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -632,9 +632,6 @@ const ExperienceFormData_Query = graphql(/* GraphQL */ `
       id
       experiences {
         id
-        user {
-          id
-        }
         ...ExperienceFormExperience
       }
     }

--- a/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
@@ -270,10 +270,6 @@ export const UserProfile_FragmentText = /* GraphQL */ `
     positionDuration
     userSkills {
       id
-      user {
-        id
-        email
-      }
       skill {
         id
         key
@@ -294,10 +290,6 @@ export const UserProfile_FragmentText = /* GraphQL */ `
       # profileExperience fragment
       id
       __typename
-      user {
-        id
-        email
-      }
       details
       skills {
         id
@@ -389,10 +381,6 @@ export const UserProfile_FragmentText = /* GraphQL */ `
     isProfileComplete
     poolCandidates {
       id
-      user {
-        id
-        email
-      }
       status {
         value
         label {
@@ -451,10 +439,6 @@ export const UserProfile_FragmentText = /* GraphQL */ `
         id
         __typename
         details
-        user {
-          id
-          email
-        }
         skills {
           id
           key

--- a/apps/web/src/pages/Skills/SkillShowcasePage.tsx
+++ b/apps/web/src/pages/Skills/SkillShowcasePage.tsx
@@ -35,9 +35,6 @@ export const SkillShowcase_UserSkillFragment = graphql(/* GraphQL */ `
     skillLevel
     topSkillsRank
     improveSkillsRank
-    user {
-      id
-    }
     skill {
       id
       key

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -222,9 +222,6 @@ export const UpdateUserSkill_Fragment = graphql(/* GraphQL */ `
       id
       __typename
       details
-      user {
-        id
-      }
       ... on AwardExperience {
         title
         issuedBy

--- a/apps/web/src/pages/Skills/operations.ts
+++ b/apps/web/src/pages/Skills/operations.ts
@@ -111,9 +111,6 @@ const UserSkills_Query = graphql(/* GraphQL */ `
         skillLevel
         topSkillsRank
         improveSkillsRank
-        user {
-          id
-        }
         skill {
           id
           key
@@ -131,9 +128,6 @@ const UserSkills_Query = graphql(/* GraphQL */ `
         }
         experiences {
           id
-          user {
-            id
-          }
         }
       }
     }

--- a/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
+++ b/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
@@ -157,9 +157,6 @@ const AdminUserProfileUser_Fragment = graphql(/* GraphQL */ `
       expiryDate
       notes
       suspendedAt
-      user {
-        id
-      }
       pool {
         id
         name {
@@ -215,10 +212,6 @@ const AdminUserProfileUser_Fragment = graphql(/* GraphQL */ `
     experiences {
       id
       __typename
-      user {
-        id
-        email
-      }
       details
       skills {
         id
@@ -309,9 +302,6 @@ const AdminUserProfileUser_Fragment = graphql(/* GraphQL */ `
     }
     topTechnicalSkillsRanking {
       id
-      user {
-        id
-      }
       skill {
         id
         key
@@ -333,9 +323,6 @@ const AdminUserProfileUser_Fragment = graphql(/* GraphQL */ `
     }
     topBehaviouralSkillsRanking {
       id
-      user {
-        id
-      }
       skill {
         id
         key
@@ -357,9 +344,6 @@ const AdminUserProfileUser_Fragment = graphql(/* GraphQL */ `
     }
     improveTechnicalSkillsRanking {
       id
-      user {
-        id
-      }
       skill {
         id
         key
@@ -381,9 +365,6 @@ const AdminUserProfileUser_Fragment = graphql(/* GraphQL */ `
     }
     improveBehaviouralSkillsRanking {
       id
-      user {
-        id
-      }
       skill {
         id
         key

--- a/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
@@ -22,6 +22,7 @@ import {
   UpdateUserAsAdminMutation,
   User,
   graphql,
+  UpdateUserDataQuery as UpdateUserDataQueryType,
 } from "@gc-digital-talent/graphql";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 
@@ -56,6 +57,21 @@ const UpdateUserOptions_Query = graphql(/* GraphQL */ `
   }
 `);
 
+export type UpdateUserDataAuthInfoType = NonNullable<
+  UpdateUserDataQueryType["user"]
+>["authInfo"];
+
+type PartialUser = Pick<
+  User,
+  | "id"
+  | "email"
+  | "firstName"
+  | "lastName"
+  | "preferredLang"
+  | "preferredLanguageForInterview"
+  | "preferredLanguageForExam"
+  | "telephone"
+>;
 type FormValues = Pick<
   UpdateUserAsAdminInput,
   | "email"
@@ -67,7 +83,7 @@ type FormValues = Pick<
   | "telephone"
 >;
 interface UpdateUserFormProps {
-  initialUser: User;
+  initialUser: PartialUser;
   handleUpdateUser: (
     id: string,
     data: UpdateUserAsAdminInput,
@@ -102,7 +118,7 @@ export const UpdateUserForm = ({
     preferredLang,
     preferredLanguageForExam,
     preferredLanguageForInterview,
-  }: User): FormValues => ({
+  }: PartialUser): FormValues => ({
     email,
     firstName,
     lastName,
@@ -363,7 +379,7 @@ const UpdateUserPage = () => {
               handleUpdateUser={handleUpdateUser}
             />
             <UpdateUserSubForm
-              user={data.user}
+              authInfo={data.user?.authInfo}
               onUpdateSub={handleUpdateUserSub}
             />
             <Heading level="h2" size="h3" data-h2-font-weight="base(700)">
@@ -371,11 +387,13 @@ const UpdateUserPage = () => {
             </Heading>
             <UserRoleTable
               user={data.user}
+              authInfo={data.user?.authInfo}
               availableRoles={availableRoles}
               onUpdateUserRoles={handleUpdateUserRoles}
             />
             <TeamRoleTable
               user={data.user}
+              authInfo={data.user?.authInfo}
               availableRoles={availableRoles}
               onUpdateUserRoles={handleUpdateUserRoles}
             />

--- a/apps/web/src/pages/Users/UpdateUserPage/components/AddIndividualRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/AddIndividualRoleDialog.tsx
@@ -22,12 +22,15 @@ import {
 
 import { getFullNameHtml } from "~/utils/nameUtils";
 
+import { UpdateUserDataAuthInfoType } from "../UpdateUserPage";
+
 type FormValues = {
   roles: Array<string>;
 };
 
 interface AddIndividualRoleDialogProps {
-  user: User;
+  user: Pick<User, "id" | "firstName" | "lastName">;
+  authInfo: UpdateUserDataAuthInfoType;
   availableRoles: Array<Role>;
   onAddRoles: (
     submitData: UpdateUserRolesInput,
@@ -36,12 +39,14 @@ interface AddIndividualRoleDialogProps {
 
 const AddIndividualRoleDialog = ({
   user,
+  authInfo,
   availableRoles,
   onAddRoles,
 }: AddIndividualRoleDialogProps) => {
   const intl = useIntl();
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const userName = getFullNameHtml(user.firstName, user.lastName, intl);
+  const { id, firstName, lastName } = user;
+  const userName = getFullNameHtml(firstName, lastName, intl);
 
   const methods = useForm<FormValues>({
     defaultValues: {
@@ -60,7 +65,7 @@ const AddIndividualRoleDialog = ({
     });
 
     return onAddRoles({
-      userId: user.id,
+      userId: id,
       roleAssignmentsInput: {
         attach: roleInputArray,
       },
@@ -87,7 +92,7 @@ const AddIndividualRoleDialog = ({
     .filter((role) => {
       return (
         !role.isTeamBased &&
-        !user?.authInfo?.roleAssignments?.some(
+        !authInfo?.roleAssignments?.some(
           (assignment) => assignment?.role?.id === role.id,
         )
       );

--- a/apps/web/src/pages/Users/UpdateUserPage/components/AddTeamRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/AddTeamRoleDialog.tsx
@@ -26,6 +26,8 @@ import {
 import { getFullNameHtml } from "~/utils/nameUtils";
 import adminMessages from "~/messages/adminMessages";
 
+import { UpdateUserDataAuthInfoType } from "../UpdateUserPage";
+
 const AddTeamRoleTeams_Query = graphql(/* GraphQL */ `
   query AddTeamRoleTeams {
     teams {
@@ -44,7 +46,8 @@ type FormValues = {
 };
 
 interface AddTeamRoleDialogProps {
-  user: User;
+  user: Pick<User, "id" | "firstName" | "lastName">;
+  authInfo: UpdateUserDataAuthInfoType;
   availableRoles: Array<Role>;
   onAddRoles: (
     submitData: UpdateUserRolesInput,
@@ -53,12 +56,14 @@ interface AddTeamRoleDialogProps {
 
 const AddTeamRoleDialog = ({
   user,
+  authInfo,
   availableRoles,
   onAddRoles,
 }: AddTeamRoleDialogProps) => {
   const intl = useIntl();
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const userName = getFullNameHtml(user.firstName, user.lastName, intl);
+  const { id, firstName, lastName } = user;
+  const userName = getFullNameHtml(firstName, lastName, intl);
 
   const methods = useForm<FormValues>({
     defaultValues: {
@@ -86,7 +91,7 @@ const AddTeamRoleDialog = ({
     });
 
     return onAddRoles({
-      userId: user.id,
+      userId: id,
       roleAssignmentsInput: {
         attach: roleInputArray,
       },
@@ -118,13 +123,13 @@ const AddTeamRoleDialog = ({
 
   const teamId = watch("team");
   useEffect(() => {
-    const roleAssignments = user?.authInfo?.roleAssignments || [];
+    const roleAssignments = authInfo?.roleAssignments || [];
     const activeRoleIds = roleAssignments
       .filter((ra) => ra?.team?.id === teamId)
       .map((r) => r?.role?.id)
       .filter(notEmpty);
     setValue("roles", activeRoleIds);
-  }, [user?.authInfo?.roleAssignments, teamId, setValue]);
+  }, [authInfo?.roleAssignments, teamId, setValue]);
 
   const [{ data: teamsData }] = useQuery({
     query: AddTeamRoleTeams_Query,

--- a/apps/web/src/pages/Users/UpdateUserPage/components/DeleteUserDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/DeleteUserDialog.tsx
@@ -21,19 +21,16 @@ type FormValues = {
 };
 
 interface AddTeamRoleDialogProps {
-  user: User;
+  user: Pick<User, "deletedDate" | "firstName" | "lastName">;
   onDeleteUser: () => Promise<DeleteUserMutation["deleteUser"]>;
 }
 
 const DeleteUserDialog = ({ user, onDeleteUser }: AddTeamRoleDialogProps) => {
   const intl = useIntl();
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const userNameHtml = getFullNameHtml(user.firstName, user.lastName, intl);
-  const userNameExpected = getFullNameLabel(
-    user.firstName,
-    user.lastName,
-    intl,
-  );
+  const { deletedDate, firstName, lastName } = user;
+  const userNameHtml = getFullNameHtml(firstName, lastName, intl);
+  const userNameExpected = getFullNameLabel(firstName, lastName, intl);
 
   const methods = useForm<FormValues>({
     defaultValues: {
@@ -73,7 +70,7 @@ const DeleteUserDialog = ({ user, onDeleteUser }: AddTeamRoleDialogProps) => {
           color="error"
           mode="solid"
           icon={TrashIcon}
-          disabled={!!user.deletedDate}
+          disabled={!!deletedDate}
         >
           {label}
         </Button>

--- a/apps/web/src/pages/Users/UpdateUserPage/components/DeleteUserSection.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/DeleteUserSection.tsx
@@ -8,16 +8,17 @@ import DeleteUserDialog from "./DeleteUserDialog";
 import { DeleteUserFunc } from "../types";
 
 interface DeleteUserSectionProps {
-  user: User;
+  user: Pick<User, "id" | "deletedDate" | "firstName" | "lastName">;
   onDeleteUser: DeleteUserFunc;
 }
 
 const DeleteUserSection = ({ user, onDeleteUser }: DeleteUserSectionProps) => {
   const intl = useIntl();
+  const { id } = user;
 
   const handleDeleteUser = useCallback(async () => {
-    return onDeleteUser(user.id);
-  }, [onDeleteUser, user.id]);
+    return onDeleteUser(id);
+  }, [onDeleteUser, id]);
 
   return (
     <>

--- a/apps/web/src/pages/Users/UpdateUserPage/components/EditTeamRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/EditTeamRoleDialog.tsx
@@ -29,7 +29,7 @@ type FormValues = {
 };
 
 interface EditTeamRoleDialogProps {
-  user: User;
+  user: Pick<User, "id" | "firstName" | "lastName">;
   initialRoles: Array<Role>;
   allRoles: Array<Role>;
   team: Pick<Team, "id" | "displayName">;
@@ -47,7 +47,9 @@ const EditTeamRoleDialog = ({
 }: EditTeamRoleDialogProps) => {
   const intl = useIntl();
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const userDisplayName = getFullNameHtml(user.firstName, user.lastName, intl);
+  const { id, firstName, lastName } = user;
+
+  const userDisplayName = getFullNameHtml(firstName, lastName, intl);
   const teamDisplayName = getLocalizedName(team.displayName, intl);
   const initialRolesIds = initialRoles.map((role) => role.id);
 
@@ -77,7 +79,7 @@ const EditTeamRoleDialog = ({
     });
 
     return onEditRoles({
-      userId: user.id,
+      userId: id,
       roleAssignmentsInput: {
         attach: rolesToAttachArray.length ? rolesToAttachArray : undefined,
         detach: rolesToDetachArray.length ? rolesToDetachArray : undefined,

--- a/apps/web/src/pages/Users/UpdateUserPage/components/IndividualRoleTable.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/IndividualRoleTable.tsx
@@ -13,11 +13,13 @@ import { normalizedText } from "~/components/Table/sortingFns";
 import { UpdateUserRolesFunc } from "../types";
 import AddIndividualRoleDialog from "./AddIndividualRoleDialog";
 import { actionCell, roleCell } from "./helpers";
+import { UpdateUserDataAuthInfoType } from "../UpdateUserPage";
 
 const columnHelper = createColumnHelper<Role>();
 
 interface IndividualRoleTableProps {
-  user: User;
+  user: Pick<User, "id" | "firstName" | "lastName">;
+  authInfo: UpdateUserDataAuthInfoType;
   availableRoles: Array<Role>;
   onUpdateUserRoles: UpdateUserRolesFunc;
 }
@@ -25,6 +27,7 @@ interface IndividualRoleTableProps {
 const IndividualRoleTable = ({
   user,
   availableRoles,
+  authInfo,
   onUpdateUserRoles,
 }: IndividualRoleTableProps) => {
   const intl = useIntl();
@@ -37,7 +40,11 @@ const IndividualRoleTable = ({
         description: "Title displayed for the team table actions column",
       }),
       cell: ({ row: { original: role } }) =>
-        actionCell(role, user, onUpdateUserRoles),
+        actionCell(
+          role,
+          { id: user.id, firstName: user.firstName, lastName: user.lastName },
+          onUpdateUserRoles,
+        ),
     }),
     columnHelper.accessor((role) => getLocalizedName(role.displayName, intl), {
       id: "role",
@@ -52,13 +59,13 @@ const IndividualRoleTable = ({
   ] as ColumnDef<Role>[];
 
   const data = useMemo(() => {
-    const roles = user?.authInfo?.roleAssignments
+    const roles = authInfo?.roleAssignments
       ?.filter(notEmpty)
       .filter((assignment) => !assignment.role?.isTeamBased)
       .map((assignment) => assignment.role)
       .filter(notEmpty);
     return roles || [];
-  }, [user?.authInfo?.roleAssignments]);
+  }, [authInfo?.roleAssignments]);
 
   const handleAddRoles = async (values: UpdateUserRolesInput) => {
     return onUpdateUserRoles(values);
@@ -95,6 +102,7 @@ const IndividualRoleTable = ({
           component: (
             <AddIndividualRoleDialog
               user={user}
+              authInfo={authInfo}
               availableRoles={availableRoles}
               onAddRoles={handleAddRoles}
             />

--- a/apps/web/src/pages/Users/UpdateUserPage/components/RemoveIndividualRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/RemoveIndividualRoleDialog.tsx
@@ -10,20 +10,24 @@ import {
   uiMessages,
 } from "@gc-digital-talent/i18n";
 import { toast } from "@gc-digital-talent/toast";
-import { Role, User } from "@gc-digital-talent/graphql";
+import { Maybe, Role } from "@gc-digital-talent/graphql";
 
 import { getFullNameHtml } from "~/utils/nameUtils";
 
 import { UpdateUserRolesFunc } from "../types";
 
 interface RemoveIndividualRoleDialogProps {
-  user: User;
+  userId: string;
+  firstName?: Maybe<string>;
+  lastName?: Maybe<string>;
   role: Role;
   onUpdateUserRoles: UpdateUserRolesFunc;
 }
 
 const RemoveIndividualRoleDialog = ({
-  user,
+  userId,
+  firstName,
+  lastName,
   role,
   onUpdateUserRoles,
 }: RemoveIndividualRoleDialogProps) => {
@@ -34,7 +38,7 @@ const RemoveIndividualRoleDialog = ({
   const handleRemove = async () => {
     setIsDeleting(true);
     return onUpdateUserRoles({
-      userId: user.id,
+      userId: userId,
       roleAssignmentsInput: {
         detach: [{ roleId: role.id }],
       },
@@ -53,7 +57,7 @@ const RemoveIndividualRoleDialog = ({
       .finally(() => setIsDeleting(false));
   };
 
-  const userName = getFullNameHtml(user.firstName, user.lastName, intl);
+  const userName = getFullNameHtml(firstName, lastName, intl);
   const roleDisplayName = getLocalizedName(role.displayName, intl);
 
   const label = intl.formatMessage(

--- a/apps/web/src/pages/Users/UpdateUserPage/components/RemoveTeamRoleDialog.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/RemoveTeamRoleDialog.tsx
@@ -22,7 +22,7 @@ import {
 import { getFullNameHtml } from "~/utils/nameUtils";
 
 interface RemoveTeamRoleDialogProps {
-  user: User;
+  user: Pick<User, "id" | "firstName" | "lastName">;
   roles: Role[];
   team: Pick<Team, "id" | "displayName">;
   onRemoveRoles: (
@@ -39,6 +39,7 @@ const RemoveTeamRoleDialog = ({
   const intl = useIntl();
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
   const [isOpen, setIsOpen] = useState<boolean>(false);
+  const { id, firstName, lastName } = user;
 
   const handleRemove = async () => {
     const roleInputArray: RoleInput[] = roles.map((r) => {
@@ -46,7 +47,7 @@ const RemoveTeamRoleDialog = ({
     });
     setIsDeleting(true);
     return onRemoveRoles({
-      userId: user.id,
+      userId: id,
       roleAssignmentsInput: {
         detach: roleInputArray,
       },
@@ -75,7 +76,7 @@ const RemoveTeamRoleDialog = ({
       .finally(() => setIsDeleting(false));
   };
 
-  const userName = getFullNameHtml(user.firstName, user.lastName, intl);
+  const userName = getFullNameHtml(firstName, lastName, intl);
   const roleDisplayName = (role: Role) =>
     getLocalizedName(role.displayName, intl);
   const teamDisplayName = getLocalizedName(team.displayName, intl);

--- a/apps/web/src/pages/Users/UpdateUserPage/components/TeamRoleTable.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/TeamRoleTable.tsx
@@ -26,6 +26,7 @@ import {
   teamRolesAccessor,
   teamRolesCell,
 } from "./helpers";
+import { UpdateUserDataAuthInfoType } from "../UpdateUserPage";
 
 type RoleTeamPair = {
   role: Role;
@@ -37,18 +38,21 @@ const columnHelper = createColumnHelper<TeamAssignment>();
 type GetRoleTeamIdFunc = (arg: RoleTeamPair) => Scalars["ID"]["output"];
 
 interface TeamRoleTableProps {
-  user: User;
+  user: Pick<User, "id" | "firstName" | "lastName">;
+  authInfo: UpdateUserDataAuthInfoType;
   availableRoles: Array<Role>;
   onUpdateUserRoles: UpdateUserRolesFunc;
 }
 
 const TeamRoleTable = ({
   user,
+  authInfo,
   availableRoles,
   onUpdateUserRoles,
 }: TeamRoleTableProps) => {
   const intl = useIntl();
   const routes = useRoutes();
+  const { firstName, lastName, id } = user;
 
   const teamRoles = availableRoles.filter(
     (role) =>
@@ -75,7 +79,12 @@ const TeamRoleTable = ({
         description: "Title displayed for the team table actions column",
       }),
       cell: ({ row: { original: teamAssignment } }) =>
-        teamActionCell(teamAssignment, user, handleEditRoles, teamRoles),
+        teamActionCell(
+          teamAssignment,
+          { id: id, firstName: firstName, lastName: lastName },
+          handleEditRoles,
+          teamRoles,
+        ),
     }),
     columnHelper.accessor(
       (teamAssignment) =>
@@ -113,9 +122,7 @@ const TeamRoleTable = ({
   ] as ColumnDef<TeamAssignment>[];
 
   const data = useMemo(() => {
-    const roleTeamPairs: RoleTeamPair[] = (
-      user?.authInfo?.roleAssignments ?? []
-    )
+    const roleTeamPairs: RoleTeamPair[] = (authInfo?.roleAssignments ?? [])
       .map((assignment) => {
         if (assignment?.team && assignment.role && assignment.role.isTeamBased)
           return {
@@ -140,7 +147,7 @@ const TeamRoleTable = ({
         roles: teamGroupOfPairs.map((pair) => pair.role),
       };
     });
-  }, [user?.authInfo?.roleAssignments]);
+  }, [authInfo?.roleAssignments]);
 
   const pageTitle = intl.formatMessage({
     defaultMessage: "Team based roles",
@@ -173,6 +180,7 @@ const TeamRoleTable = ({
           component: (
             <AddTeamRoleDialog
               user={user}
+              authInfo={authInfo}
               availableRoles={teamRoles}
               onAddRoles={handleEditRoles}
             />

--- a/apps/web/src/pages/Users/UpdateUserPage/components/UpdateUserSubForm.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/UpdateUserSubForm.tsx
@@ -8,7 +8,7 @@ import { errorMessages } from "@gc-digital-talent/i18n";
 import {
   UpdateUserSubInput,
   UpdateUserSubMutation,
-  User,
+  UserAuthInfo,
 } from "@gc-digital-talent/graphql";
 
 type FormValues = {
@@ -16,18 +16,21 @@ type FormValues = {
 };
 
 interface UpdateUserSubFormProps {
-  user: User;
+  authInfo: UserAuthInfo | undefined | null;
   onUpdateSub: (
     submitData: UpdateUserSubInput,
   ) => Promise<UpdateUserSubMutation["updateUserSub"]>;
 }
 
-const UpdateUserSubForm = ({ user, onUpdateSub }: UpdateUserSubFormProps) => {
+const UpdateUserSubForm = ({
+  authInfo,
+  onUpdateSub,
+}: UpdateUserSubFormProps) => {
   const intl = useIntl();
 
   const methods = useForm<FormValues>({
     defaultValues: {
-      sub: user?.authInfo?.sub ?? undefined,
+      sub: authInfo?.sub ?? undefined,
     },
   });
 
@@ -35,7 +38,7 @@ const UpdateUserSubForm = ({ user, onUpdateSub }: UpdateUserSubFormProps) => {
 
   const handleUpdateSub = async (formValues: FormValues) => {
     return onUpdateSub({
-      userId: user.id,
+      userId: authInfo?.id,
       sub: formValues.sub,
     }).then(() => {
       toast.success(

--- a/apps/web/src/pages/Users/UpdateUserPage/components/helpers.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/components/helpers.tsx
@@ -30,13 +30,15 @@ export function teamRolesCell(displayNames: string[]) {
 
 export function actionCell(
   role: Role,
-  user: User,
+  user: Pick<User, "id" | "firstName" | "lastName">,
   onUpdateUserRoles: UpdateUserRolesFunc,
 ) {
   return (
     <RemoveIndividualRoleDialog
       role={role}
-      user={user}
+      userId={user.id}
+      firstName={user.firstName}
+      lastName={user.lastName}
       onUpdateUserRoles={onUpdateUserRoles}
     />
   );
@@ -44,7 +46,7 @@ export function actionCell(
 
 export function teamActionCell(
   teamAssignment: TeamAssignment,
-  user: User,
+  user: Pick<User, "id" | "firstName" | "lastName">,
   onUpdateUserRoles: UpdateUserRolesFunc,
   availableRoles: Role[],
 ) {

--- a/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
@@ -158,46 +158,12 @@ export const UserInfo_Fragment = graphql(/* GraphQL */ `
     isWoman
     poolCandidates {
       id
-      status {
-        value
-        label {
-          en
-          fr
-        }
-      }
-      expiryDate
       notes
-      suspendedAt
-      submittedAt
-      isBookmarked
-      placedDepartment {
-        id
-        departmentNumber
-        name {
-          en
-          fr
-        }
-      }
-      user {
-        id
-      }
       pool {
         id
         name {
           en
           fr
-        }
-        classification {
-          id
-          group
-          level
-        }
-        stream {
-          value
-          label {
-            en
-            fr
-          }
         }
         publishingGroup {
           value
@@ -206,13 +172,17 @@ export const UserInfo_Fragment = graphql(/* GraphQL */ `
             fr
           }
         }
-        team {
-          id
-          name
-          displayName {
+        stream {
+          value
+          label {
             en
             fr
           }
+        }
+        classification {
+          id
+          group
+          level
         }
       }
     }
@@ -236,10 +206,6 @@ export const UserInfo_Fragment = graphql(/* GraphQL */ `
     experiences {
       id
       __typename
-      user {
-        id
-        email
-      }
       details
       skills {
         id
@@ -322,9 +288,6 @@ export const UserInfo_Fragment = graphql(/* GraphQL */ `
     }
     topTechnicalSkillsRanking {
       id
-      user {
-        id
-      }
       skill {
         id
         key
@@ -346,9 +309,6 @@ export const UserInfo_Fragment = graphql(/* GraphQL */ `
     }
     topBehaviouralSkillsRanking {
       id
-      user {
-        id
-      }
       skill {
         id
         key
@@ -370,9 +330,6 @@ export const UserInfo_Fragment = graphql(/* GraphQL */ `
     }
     improveTechnicalSkillsRanking {
       id
-      user {
-        id
-      }
       skill {
         id
         key
@@ -394,9 +351,6 @@ export const UserInfo_Fragment = graphql(/* GraphQL */ `
     }
     improveBehaviouralSkillsRanking {
       id
-      user {
-        id
-      }
       skill {
         id
         key

--- a/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
@@ -25,6 +25,7 @@ import {
   CreatePoolCandidateAsAdminInput,
   Pool,
   PoolCandidate,
+  UserInfoFragment as UserInfoFragmentType,
 } from "@gc-digital-talent/graphql";
 
 import { getShortPoolTitleHtml } from "~/utils/poolUtils";
@@ -88,19 +89,24 @@ type FormValues = {
   expiryDate: PoolCandidate["expiryDate"];
 };
 
+type UserInfoFragmentPoolCandidates =
+  NonNullable<UserInfoFragmentType>["poolCandidates"];
+
 interface AddToPoolDialogProps {
-  user: User;
+  user: Pick<User, "id" | "firstName" | "lastName" | "poolCandidates">;
+  poolCandidates: UserInfoFragmentPoolCandidates;
 }
 
-const AddToPoolDialog = ({ user }: AddToPoolDialogProps) => {
+const AddToPoolDialog = ({ user, poolCandidates }: AddToPoolDialogProps) => {
   const intl = useIntl();
   const [open, setOpen] = useState(false);
   const methods = useForm<FormValues>();
+  const { id, firstName, lastName } = user;
 
   const [{ fetching }, executeMutation] = useMutation(AddToPoolDialog_Mutation);
 
   const currentPools: string[] = [];
-  user.poolCandidates?.forEach((candidate) => {
+  poolCandidates?.forEach((candidate) => {
     if (candidate?.pool?.id) {
       currentPools.push(candidate?.pool?.id);
     }
@@ -137,7 +143,7 @@ const AddToPoolDialog = ({ user }: AddToPoolDialogProps) => {
           connect: pool?.id,
         },
         user: {
-          connect: user.id,
+          connect: id,
         },
         expiryDate: formValues.expiryDate || emptyToNull(formValues.expiryDate),
       }).catch((err) => {
@@ -240,7 +246,7 @@ const AddToPoolDialog = ({ user }: AddToPoolDialogProps) => {
             })}
           </p>
           <p data-h2-font-weight="base(800)">
-            - {getFullNameHtml(user.firstName, user.lastName, intl)}
+            - {getFullNameHtml(firstName, lastName, intl)}
           </p>
           <p data-h2-margin="base(x1, 0, 0, 0)">
             {intl.formatMessage({

--- a/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
@@ -93,7 +93,7 @@ type UserInfoFragmentPoolCandidates =
   NonNullable<UserInfoFragmentType>["poolCandidates"];
 
 interface AddToPoolDialogProps {
-  user: Pick<User, "id" | "firstName" | "lastName" | "poolCandidates">;
+  user: Pick<User, "id" | "firstName" | "lastName">;
   poolCandidates: UserInfoFragmentPoolCandidates;
 }
 

--- a/apps/web/src/pages/Users/UserInformationPage/components/CandidateStatusSection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/CandidateStatusSection.tsx
@@ -45,7 +45,7 @@ const CandidateStatusSection = ({
                 "Title of the 'Add user to pools' section of the view-user page",
             })}
           </h4>
-          <AddToPoolDialog user={user} />
+          <AddToPoolDialog user={user} poolCandidates={user.poolCandidates} />
         </>
       )}
     </>

--- a/apps/web/src/types/applicationStep.ts
+++ b/apps/web/src/types/applicationStep.ts
@@ -3,9 +3,8 @@ import { IntlShape } from "react-intl";
 import {
   ApplicationStep,
   Pool,
-  PoolCandidate,
   Scalars,
-  User,
+  Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType,
 } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
@@ -13,7 +12,7 @@ import useRoutes from "~/hooks/useRoutes";
 import { PageNavInfo } from "./pages";
 
 type GetApplicationStepInfoArgs = {
-  application: Omit<PoolCandidate, "pool">;
+  application: ApplicationPoolCandidateFragmentType;
   paths: ReturnType<typeof useRoutes>;
   resourceId?: Scalars["ID"]["output"];
   intl: IntlShape;
@@ -35,9 +34,9 @@ export type ApplicationStepInfo = {
   prerequisites: Array<ApplicationStep>;
   // Is the applicant valid as far as this step is concerned?
   hasError?: (
-    user: User,
+    user: ApplicationPoolCandidateFragmentType["user"],
     pool: Pool,
-    application: Omit<PoolCandidate, "pool">,
+    application: ApplicationPoolCandidateFragmentType,
   ) => boolean;
 };
 

--- a/apps/web/src/types/experience.ts
+++ b/apps/web/src/types/experience.ts
@@ -35,18 +35,18 @@ export type ExperienceType =
   | "work";
 
 export type AnyExperience =
-  | AwardExperience
-  | CommunityExperience
-  | EducationExperience
-  | PersonalExperience
-  | WorkExperience;
+  | Omit<AwardExperience, "user">
+  | Omit<CommunityExperience, "user">
+  | Omit<EducationExperience, "user">
+  | Omit<PersonalExperience, "user">
+  | Omit<WorkExperience, "user">;
 
 export type ExperienceForDate =
-  | (AwardExperience & { startDate: string; endDate: string })
-  | CommunityExperience
-  | EducationExperience
-  | PersonalExperience
-  | WorkExperience;
+  | (Omit<AwardExperience, "user"> & { startDate: string; endDate: string })
+  | Omit<CommunityExperience, "user">
+  | Omit<EducationExperience, "user">
+  | Omit<PersonalExperience, "user">
+  | Omit<WorkExperience, "user">;
 
 type FormValueDateRange = {
   startDate: Scalars["Date"]["input"];

--- a/apps/web/src/utils/experienceUtils.tsx
+++ b/apps/web/src/utils/experienceUtils.tsx
@@ -338,18 +338,22 @@ type SimpleAnyExperience = Omit<AnyExperience, "user">;
 
 export const isAwardExperience = (
   e: SimpleAnyExperience,
-): e is AwardExperience => e.__typename === "AwardExperience";
+): e is Omit<AwardExperience, "user"> => e.__typename === "AwardExperience";
 export const isCommunityExperience = (
   e: SimpleAnyExperience,
-): e is CommunityExperience => e.__typename === "CommunityExperience";
+): e is Omit<CommunityExperience, "user"> =>
+  e.__typename === "CommunityExperience";
 export const isEducationExperience = (
   e: SimpleAnyExperience,
-): e is EducationExperience => e.__typename === "EducationExperience";
+): e is Omit<EducationExperience, "user"> =>
+  e.__typename === "EducationExperience";
 export const isPersonalExperience = (
   e: SimpleAnyExperience,
-): e is PersonalExperience => e.__typename === "PersonalExperience";
-export const isWorkExperience = (e: SimpleAnyExperience): e is WorkExperience =>
-  e.__typename === "WorkExperience";
+): e is Omit<PersonalExperience, "user"> =>
+  e.__typename === "PersonalExperience";
+export const isWorkExperience = (
+  e: SimpleAnyExperience,
+): e is Omit<WorkExperience, "user"> => e.__typename === "WorkExperience";
 
 export const compareByDate = (e1: ExperienceForDate, e2: ExperienceForDate) => {
   // fit AwardExperience to startDate - endDate format
@@ -425,7 +429,9 @@ export const deriveExperienceType = (
  * @param experience
  * @returns
  */
-const getAwardExperienceDefaultValues = (experience: AwardExperience) => {
+const getAwardExperienceDefaultValues = (
+  experience: Omit<AwardExperience, "user">,
+) => {
   const { title, issuedBy, awardedDate, awardedTo, awardedScope } = experience;
   return {
     awardTitle: title,
@@ -443,7 +449,7 @@ const getAwardExperienceDefaultValues = (experience: AwardExperience) => {
  * @returns
  */
 const getCommunityExperienceDefaultValues = (
-  experience: CommunityExperience,
+  experience: Omit<CommunityExperience, "user">,
 ) => {
   const { title, organization, project, startDate, endDate } = experience;
   return {
@@ -463,7 +469,7 @@ const getCommunityExperienceDefaultValues = (
  * @returns
  */
 const getEducationExperienceDefaultValues = (
-  experience: EducationExperience,
+  experience: Omit<EducationExperience, "user">,
 ) => {
   const {
     type,
@@ -492,7 +498,9 @@ const getEducationExperienceDefaultValues = (
  * @param experience
  * @returns
  */
-const getPersonalExperienceDefaultValues = (experience: PersonalExperience) => {
+const getPersonalExperienceDefaultValues = (
+  experience: Omit<PersonalExperience, "user">,
+) => {
   const { title, description, startDate, endDate } = experience;
   return {
     experienceTitle: title,
@@ -510,7 +518,9 @@ const getPersonalExperienceDefaultValues = (experience: PersonalExperience) => {
  * @param experience
  * @returns
  */
-const getWorkExperienceDefaultValues = (experience: WorkExperience) => {
+const getWorkExperienceDefaultValues = (
+  experience: Omit<WorkExperience, "user">,
+) => {
   const { role, organization, division, startDate, endDate } = experience;
   return {
     role,

--- a/apps/web/src/utils/skillUtils.test.ts
+++ b/apps/web/src/utils/skillUtils.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { fakeApplicants, toLocalizedEnum } from "@gc-digital-talent/fake-data";
+import { toLocalizedEnum } from "@gc-digital-talent/fake-data";
 import {
   Experience,
   Skill,
@@ -16,8 +16,6 @@ import {
   invertSkillSkillFamilyTree,
   parseKeywords,
 } from "./skillUtils";
-
-const fakeApplicant = fakeApplicants(1)[0];
 
 const localizedBehavioural = toLocalizedEnum(SkillCategory.Behavioural);
 
@@ -227,10 +225,9 @@ describe("skill util tests", () => {
     expect(actual).toEqual(expected);
   });
   test("inverts an experience tree with a single experience in a single skill", () => {
-    const experiences: Experience[] = [
+    const experiences: Omit<Experience, "user">[] = [
       {
         id: "1",
-        user: fakeApplicant,
         skills: [
           {
             id: "1",
@@ -250,7 +247,6 @@ describe("skill util tests", () => {
         experiences: [
           {
             id: "1",
-            user: fakeApplicant,
             skills: [
               {
                 id: "1",
@@ -267,10 +263,9 @@ describe("skill util tests", () => {
     expect(actual).toEqual(expected);
   });
   test("inverts an experience tree with three experiences in a single skill", () => {
-    const experiences: Experience[] = [
+    const experiences: Omit<Experience, "user">[] = [
       {
         id: "1",
-        user: fakeApplicant,
         skills: [
           {
             id: "1",
@@ -282,7 +277,6 @@ describe("skill util tests", () => {
       },
       {
         id: "2",
-        user: fakeApplicant,
         skills: [
           {
             id: "1",
@@ -294,7 +288,6 @@ describe("skill util tests", () => {
       },
       {
         id: "3",
-        user: fakeApplicant,
         skills: [
           {
             id: "1",
@@ -314,7 +307,6 @@ describe("skill util tests", () => {
         experiences: [
           {
             id: "1",
-            user: fakeApplicant,
             skills: [
               {
                 id: "1",
@@ -326,7 +318,6 @@ describe("skill util tests", () => {
           },
           {
             id: "2",
-            user: fakeApplicant,
             skills: [
               {
                 id: "1",
@@ -338,7 +329,6 @@ describe("skill util tests", () => {
           },
           {
             id: "3",
-            user: fakeApplicant,
             skills: [
               {
                 id: "1",
@@ -355,10 +345,9 @@ describe("skill util tests", () => {
     expect(actual).toEqual(expected);
   });
   test("inverts an experience tree with a single experience in three skills", () => {
-    const experiences: Experience[] = [
+    const experiences: Omit<Experience, "user">[] = [
       {
         id: "1",
-        user: fakeApplicant,
         skills: [
           {
             id: "1",
@@ -390,7 +379,6 @@ describe("skill util tests", () => {
         experiences: [
           {
             id: "1",
-            user: fakeApplicant,
             skills: [
               {
                 id: "1",
@@ -422,7 +410,6 @@ describe("skill util tests", () => {
         experiences: [
           {
             id: "1",
-            user: fakeApplicant,
             skills: [
               {
                 id: "1",
@@ -454,7 +441,6 @@ describe("skill util tests", () => {
         experiences: [
           {
             id: "1",
-            user: fakeApplicant,
             skills: [
               {
                 id: "1",

--- a/apps/web/src/utils/skillUtils.ts
+++ b/apps/web/src/utils/skillUtils.ts
@@ -51,7 +51,7 @@ export function invertSkillSkillFamilyTree(skills: Skill[]): SkillFamily[] {
 }
 
 export type InvertedSkillExperience = Skill & {
-  experiences: Experience[];
+  experiences: Omit<Experience, "user">[];
 };
 /**
  * Transforms an array of experiences with child skills into a tree of skills with child experiences.
@@ -59,7 +59,7 @@ export type InvertedSkillExperience = Skill & {
  * @returns { Skill[] } - The new collection of skills with child experiences
  */
 export function invertSkillExperienceTree(
-  experiences: Experience[],
+  experiences: Omit<Experience, "user">[],
 ): InvertedSkillExperience[] {
   const allChildSkills = flatMap(experiences, (s) => s.skills).filter(notEmpty);
   const uniqueSkills = uniqBy(allChildSkills, "id");
@@ -127,9 +127,9 @@ export const getMissingSkills = (required: Skill[], added?: Skill[]) => {
  * @returns Experience[]  New array of experiences
  */
 export const getExperienceSkills = (
-  experiences: Experience[],
+  experiences: Omit<Experience, "user">[],
   skill?: Pick<Skill, "id">,
-): Experience[] => {
+): Omit<Experience, "user">[] => {
   return experiences.filter((experience) =>
     experience.skills?.some(
       (experienceSkill) => experienceSkill.id === skill?.id,

--- a/apps/web/src/validators/profile/careerTimeline.ts
+++ b/apps/web/src/validators/profile/careerTimeline.ts
@@ -1,8 +1,8 @@
 /* eslint-disable import/prefer-default-export */
-import { User } from "@gc-digital-talent/graphql";
+import { Experience } from "@gc-digital-talent/graphql";
 
-type PartialUser = Pick<User, "experiences">;
+type Experiences = Pick<Experience, "id">[] | undefined | null;
 
-export function isIncomplete({ experiences }: PartialUser): boolean {
+export function isIncomplete(experiences: Experiences): boolean {
   return !experiences?.length;
 }

--- a/apps/web/src/validators/profile/skillRequirements.ts
+++ b/apps/web/src/validators/profile/skillRequirements.ts
@@ -3,10 +3,10 @@ import flatMap from "lodash/flatMap";
 
 import { notEmpty } from "@gc-digital-talent/helpers";
 import {
-  User,
   Pool,
   SkillCategory,
   PoolSkillType,
+  Experience,
 } from "@gc-digital-talent/graphql";
 
 import {
@@ -15,13 +15,16 @@ import {
   getMissingSkills,
 } from "~/utils/skillUtils";
 
-export function isIncomplete(applicant: User, pool: Pool): boolean {
+export function isIncomplete(
+  applicantExperiences: Omit<Experience, "user">[] | undefined | null,
+  pool: Pool,
+): boolean {
   const poolEssentialTechnicalSkills = filterSkillsByCategory(
     filterPoolSkillsByType(pool.poolSkills, PoolSkillType.Essential),
     SkillCategory.Technical,
   );
 
-  const applicantSkills = flatMap(applicant.experiences, (e) => {
+  const applicantSkills = flatMap(applicantExperiences, (e) => {
     return e?.skills;
   }).filter(notEmpty);
 


### PR DESCRIPTION
🤖 Resolves https://github.com/GCTC-NTGC/gc-digital-talent/issues/10799

## 👋 Introduction

Think this finally completes the issue by hitting types 😌 
`User`
`Experience`
The types that may be left aren't used much at all to try and change anything 

## 🕵️ Details

Really takes care of one not so good practice with the nested recursion going on. 
For instance

`user.poolCandidates[X].user`
`user.experiences[X].user`

You definitely query user models where more than necessary with that operation! `Experience` was also a big contributor for that!

## 🧪 Testing

1. All functionality related to types still works (vague instruction as usual)
2. Nothing left to change


