### PR TITLE
[Copy] Removes d apostrophe from `Combobox`

### DIFF
--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -876,7 +876,7 @@
     "description": "The work region of Canada described as National Capital."
   },
   "eBNZxB": {
-    "defaultMessage": "{count, plural, =0 {0 d'options sélectionnées} =1 {1 option sélectionnée} other {# d’options sélectionnées}}",
+    "defaultMessage": "{count, plural, =0 {0 options sélectionnées} =1 {1 option sélectionnée} other {# options sélectionnées}}",
     "description": "Message displayed telling user how many items they have selected in a multi-select combobox"
   },
   "edeLyW": {


### PR DESCRIPTION
🤖 Resolves #11210.

## 👋 Introduction

This PR removes an incorrect d apostrophe from a string in the `Combobox` component.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

> [!TIP]
> The `Combobox` component itself can be tested using storybook:
> 1. `pnpm intl-compile; pnpm storybook`
> 2. Navigate to http://localhost:6006/?path=/story/forms-src-components-combobox--multi-min-max&globals=locale:fr

1. `pnpm intl-compile; pnpm dev:fresh`
2. Navigate to http://localhost:8000/fr/search
3. Select 0, 1, and 2 _compétences_ in the _Sélection des compétences_ section
4. Verify no d apostrophe

## 📸 Screenshots
<img width="743" alt="Screen Shot 2024-08-13 at 12 14 42" src="https://github.com/user-attachments/assets/2e37fbcd-6dba-4a3e-aa88-27f750d1cd8c">
<img width="753" alt="Screen Shot 2024-08-13 at 12 14 24" src="https://github.com/user-attachments/assets/bd49151e-ca93-49b3-8713-a5a20df604ac">
<img width="742" alt="Screen Shot 2024-08-13 at 12 14 13" src="https://github.com/user-attachments/assets/cce09620-335a-43f1-a01c-cc961511480e">


