### PR TITLE
[Copy] Adds missing s to description of search form work location field

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -747,6 +747,10 @@
     "defaultMessage": "Minorité visible",
     "description": "CSV Header, Visible Minority column"
   },
+  "20vfz6": {
+    "defaultMessage": "Si vous avez des exigences plus détaillées concernant le lieu de travail, veuillez nous en faire part dans la section des commentaires du formulaire de soumission. Vous pouvez sélectionner plus d’une région.",
+    "description": "Message describing the work location filter in the search form."
+  },
   "21QCEK": {
     "defaultMessage": "« J’atteste que les renseignements que j’ai fournis sont vrais »",
     "description": "Signature list item on sign and submit page."
@@ -10225,10 +10229,6 @@
   "sLqKuH": {
     "defaultMessage": "Créer votre parcours professionnel",
     "description": "Title for career timeline page when there are no experiences yet"
-  },
-  "sM+4cP": {
-    "defaultMessage": "Si vous avez des exigences plus détaillées concernant le lieu de travail, veuillez nous en faire part dans la section des commentaires du formulaire de soumission. Vous pouvez sélectionner plus d’une région.",
-    "description": "Message describing the work location filter in the search form."
   },
   "sQkwFY": {
     "defaultMessage": "Une fois que vous avez sélectionné les critères auxquels vous répondez, cette section vous demande de nous indiquer quels sont les éléments spécifiques de votre parcours professionnel qui répondent à cette option. Si vous devez ajouter quelque chose à votre parcours professionnel, vous pouvez le faire en retournant à l’étape du parcours professionnel dans le formulaire de candidature.",

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
@@ -256,8 +256,8 @@ const FormFields = ({ classifications, skills }: FormFieldsProps) => {
         })}
         text={intl.formatMessage({
           defaultMessage:
-            "If you have more detailed work location requirement, let us know in the comment section of the submission form. You can select more than one region.",
-          id: "sM+4cP",
+            "If you have more detailed work location requirements, let us know in the comment section of the submission form. You can select more than one region.",
+          id: "20vfz6",
           description:
             "Message describing the work location filter in the search form.",
         })}


### PR DESCRIPTION
🤖 Resolves #11211.

## 👋 Introduction

This PR adds a missing **s** to the message describing the work location filter in the search form in English.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm intl-compile; pnpm dev:fresh`
2. Navigate to http://localhost:8000/en/search
3. Verify plural s exists for work location requirements in **Work location** section

## 📸 Screenshot

<img width="766" alt="Screen Shot 2024-08-13 at 12 26 18" src="https://github.com/user-attachments/assets/c5e08546-d8f5-4aac-8016-6dc25620e067">