### PR TITLE
[Copy] Changes votre to notre on FAQ

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -316,7 +316,7 @@
     "description": "Message displayed when candidate has been disqualified"
   },
   "/eSALf": {
-    "defaultMessage": "Veuillez contacter votre <helpLink>Bureau d'aide</helpLink> qui vous aidera à récupérer votre compte.",
+    "defaultMessage": "Veuillez contacter notre <helpLink>Bureau d'aide</helpLink> qui vous aidera à récupérer votre compte.",
     "description": "GCKey answer for when user authenticator codes not accepted"
   },
   "/esEW+": {
@@ -8223,7 +8223,7 @@
     "description": "Description of the Office of the Chief Information Officer"
   },
   "h8AdRp": {
-    "defaultMessage": "Vous ne pouvez pas récupérer vos informations de connexion, mais vous pouvez contacter votre <helpLink>Bureau d'aide</helpLink> qui vous aidera à récupérer votre compte.",
+    "defaultMessage": "Vous ne pouvez pas récupérer vos informations de connexion, mais vous pouvez contacter notre <helpLink>Bureau d'aide</helpLink> qui vous aidera à récupérer votre compte.",
     "description": "GCKey answer for when user does not have recovery codes"
   },
   "h8BHov": {
@@ -8435,7 +8435,7 @@
     "description": "Title for the all pool candidates page"
   },
   "i20Mlb": {
-    "defaultMessage": "Nous ne pouvons pas supprimer l'authentification à deux facteurs, mais vous pouvez contacter votre <helpLink>Bureau d'aide</helpLink> qui vous aidera à récupérer votre compte.",
+    "defaultMessage": "Nous ne pouvons pas supprimer l'authentification à deux facteurs, mais vous pouvez contacter notre <helpLink>Bureau d'aide</helpLink> qui vous aidera à récupérer votre compte.",
     "description": "GCKey answer for ability to remove two-factor authentication"
   },
   "i2LB7R": {


### PR DESCRIPTION
🤖 Resolves #11213.

## 👋 Introduction

This PR changes the word _votre_ to _notre_ on FAQ so that the help desk is **our** help desk rather than **your** which doesn't make sense.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm intl-compile; pnpm dev:fresh`
2. Navigate to http://localhost:8000/fr/login-info
3. Select 0, 1, and 2 _compétences_ in the _Sélection des compétences_ section
4. Verify the first 3 questions in the FAQ reads ".... notre Bureau d'aide..." and no longer "votre Bureau d'aide"

## 📸 Screenshots

<img width="986" alt="Screen Shot 2024-08-13 at 12 38 00" src="https://github.com/user-attachments/assets/ef79bef0-9367-4f83-afe3-bf0a34c5de64">

<img width="978" alt="Screen Shot 2024-08-13 at 12 38 11" src="https://github.com/user-attachments/assets/7a0d00ec-1dbb-45f6-a9b0-a3d4664bd183">

<img width="979" alt="Screen Shot 2024-08-13 at 12 38 28" src="https://github.com/user-attachments/assets/b2c11d54-9d46-41b5-b32b-cbe0798df919">

