### PR TITLE
[Fix] Comment why applicant tests were skipped

### DIFF
--- a/api/tests/Unit/UserPolicyTest.php
+++ b/api/tests/Unit/UserPolicyTest.php
@@ -162,7 +162,7 @@ class UserPolicyTest extends TestCase
      *
      * @return void
      */
-    public function viewAnyApplicants()
+    public function testViewAnyApplicants()
     {
         $this->assertFalse($this->guest->can('viewAnyApplicants', User::class));
         $this->assertFalse($this->applicant->can('viewAnyApplicants', User::class));
@@ -177,7 +177,7 @@ class UserPolicyTest extends TestCase
      *
      * @return void
      */
-    public function viewApplicant()
+    public function testViewApplicant()
     {
         $pool = Pool::factory()->create([
             'team_id' => $this->team->id,

--- a/api/tests/Unit/UserPolicyTest.php
+++ b/api/tests/Unit/UserPolicyTest.php
@@ -164,6 +164,8 @@ class UserPolicyTest extends TestCase
      */
     public function testViewAnyApplicants()
     {
+        $this->markTestSkipped('Remove skip in #8291');
+
         $this->assertFalse($this->guest->can('viewAnyApplicants', User::class));
         $this->assertFalse($this->applicant->can('viewAnyApplicants', User::class));
         $this->assertFalse($this->poolOperator->can('viewAnyApplicants', User::class));
@@ -179,6 +181,8 @@ class UserPolicyTest extends TestCase
      */
     public function testViewApplicant()
     {
+        $this->markTestSkipped('Remove skip in #8291');
+
         $pool = Pool::factory()->create([
             'team_id' => $this->team->id,
         ]);


### PR DESCRIPTION
🤖 Resolves #11203 

## 👋 Introduction

This adds a description that the skips are temporary and what PR they will eventually be used in.

## 🕵️ Details

Turns out, it was intentional that these tests were not running as they were preemptively written for future functionality :sweat_smile: This just adds a proper skip with a message.

@tristan-orourke I hope I used the correct PR number. Let me know if I am mistaken.

## 🧪 Testing

1. Run tests `make artisan CMD="test ./tests/Unit/UserPolicyTest.php"`
2. Confirm the tests are skipped but display a message

