### PR TITLE
[Copy] Updates French version of Office of the Chief Information Officer

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -724,7 +724,7 @@
     "description": "How it works, step 1 heading"
   },
   "1pbvy+": {
-    "defaultMessage": "La Directive sur les talents numériques introduit de nouvelles exigences pour les ministères, qui doivent informer le Bureau de la dirigeante principale de l’information du Canada des besoins actuels et prévus en matière de talents numériques. Cette collecte de données est agrégée et croisée avec d’autres sources de données. Ces données sont ensuite utilisées pour fournir des renseignements opérationnels à l’échelle du gouvernement et des ministères, et pour améliorer le recrutement et la formation ciblés.",
+    "defaultMessage": "La Directive sur les talents numériques introduit de nouvelles exigences pour les ministères, qui doivent informer le Bureau du dirigeant principal de l’information du Canada des besoins actuels et prévus en matière de talents numériques. Cette collecte de données est agrégée et croisée avec d’autres sources de données. Ces données sont ensuite utilisées pour fournir des renseignements opérationnels à l’échelle du gouvernement et des ministères, et pour améliorer le recrutement et la formation ciblés.",
     "description": "The directives planning and reporting component"
   },
   "1q/MmU": {
@@ -6171,7 +6171,7 @@
     "description": "Intro to list of items developers consider for accessibility"
   },
   "WieVH/": {
-    "defaultMessage": "En vertu de la nouvelle Directive, les ministères sont tenus de fournir des renseignements supplémentaires au Bureau de la dirigeante principale de l’information du Canada. Ces données sont ensuite utilisées pour créer des renseignements opérationnels et des processus de recrutement accélérés au service des ministères et des organismes du gouvernement fédéral. L’objectif est de veiller à ce que la collectivité du numérique du GC ait accès aux talents dont elle a besoin pour fournir des services numériques modernes et efficaces aux Canadiens.",
+    "defaultMessage": "En vertu de la nouvelle Directive, les ministères sont tenus de fournir des renseignements supplémentaires au Bureau du dirigeant principal de l’information du Canada. Ces données sont ensuite utilisées pour créer des renseignements opérationnels et des processus de recrutement accélérés au service des ministères et des organismes du gouvernement fédéral. L’objectif est de veiller à ce que la collectivité du numérique du GC ait accès aux talents dont elle a besoin pour fournir des services numériques modernes et efficaces aux Canadiens.",
     "description": "Second paragraph describing the directive on digital talent"
   },
   "WlMSeh": {
@@ -9191,7 +9191,7 @@
     "description": "Title for the notification settings."
   },
   "maMA3/": {
-    "defaultMessage": "Le Bureau de la dirigeante principale de l’information du Canada (BDPI) du Secrétariat du Conseil du Trésor du Canada (SCT) est responsable de la durabilité et du perfectionnement de la collectivité du numérique du gouvernement du Canada (GC), y compris :",
+    "defaultMessage": "Le Bureau du dirigeant principal de l’information du Canada (BDPI) du Secrétariat du Conseil du Trésor du Canada (SCT) est responsable de la durabilité et du perfectionnement de la collectivité du numérique du gouvernement du Canada (GC), y compris :",
     "description": "Introduction to the _supporting the community_ section of the _digital services contracting questionnaire_"
   },
   "maibxu": {


### PR DESCRIPTION
🤖 Resolves #11160.

## 👋 Introduction

This PR updates French version of Office of the Chief Information Officer since the name of the office itself changed in early 2024 when a new Chief Information Officer of Canada was appointed.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/fr/directive-on-digital-talent
3. Observe _de la dirigeante principale_ has been replaced with _du dirigeant principal_
4. `pnpm storybook`
5. Navigate to http://localhost:6006/?path=/story/pages-directive-on-digital-talent-digital-services-contracting-questionnaire--empty&globals=locale:fr
6. Observe _de la dirigeante principale_ has been replaced with _du dirigeant principal_

## 📸 Screenshots

<img width="1154" alt="Screen Shot 2024-08-14 at 10 52 48" src="https://github.com/user-attachments/assets/38fa8424-aff1-4727-8a31-a1b6dbcf2af2">

<img width="1358" alt="Screen Shot 2024-08-14 at 10 54 54" src="https://github.com/user-attachments/assets/0b7c0867-c537-45df-8284-2327e1b2ed0c">