### PR TITLE
[Debt] Removes unused dependencies

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -57,7 +57,6 @@
     "framer-motion": "^11.3.24",
     "graphql": "^16.9.0",
     "lodash": "^4.17.21",
-    "path-browserify": "^1.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.2.0",
     "react-helmet-async": "^2.0.5",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -88,7 +88,6 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
-    "core-js": "^3.37.1",
     "dotenv": "^16.4.5",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -1,4 +1,3 @@
-import path from "path-browserify";
 import { useIntl } from "react-intl";
 
 import { Locales, getLocale } from "@gc-digital-talent/i18n";
@@ -23,210 +22,198 @@ const createFragment = (identifier: string | null | undefined): string =>
   identifier ? `#${identifier}` : "";
 
 const getRoutes = (lang: Locales) => {
-  const baseUrl = path.join("/", lang);
-  const adminUrl = path.join(baseUrl, "admin");
-  const applicantUrl = path.join(baseUrl, "applicant");
-  const showcase = path.join(applicantUrl, "skills", "showcase");
+  const baseUrl = `/${lang}`;
+  const adminUrl = [baseUrl, "admin"].join("/");
+  const applicantUrl = [baseUrl, "applicant"].join("/");
+  const showcase = [applicantUrl, "skills", "showcase"].join("/");
 
   return {
     // Main Routes
     home: () => baseUrl,
-    notFound: () => path.join(baseUrl, "404"),
-    support: () => path.join(baseUrl, "support"),
-    search: () => path.join(baseUrl, "search"),
-    request: () => path.join(baseUrl, "search", "request"),
+    notFound: () => [baseUrl, "404"].join("/"),
+    support: () => [baseUrl, "support"].join("/"),
+    search: () => [baseUrl, "search"].join("/"),
+    request: () => [baseUrl, "search", "request"].join("/"),
     requestConfirmation: (requestId: string) =>
-      path.join(baseUrl, "search", "request", requestId),
-    register: () => path.join(baseUrl, "register-info"),
-    login: () => path.join(baseUrl, "login-info"),
-    loggedOut: () => path.join(baseUrl, "logged-out"),
-    userDeleted: () => path.join(baseUrl, "user-deleted"),
-    gettingStarted: () => path.join(baseUrl, "getting-started"),
-    emailVerification: () => path.join(baseUrl, "email-verification"),
-    employeeInformation: () => path.join(baseUrl, "employee-registration"),
-    termsAndConditions: () => path.join(baseUrl, "terms-and-conditions"),
-    privacyPolicy: () => path.join(baseUrl, "privacy-policy"),
-    accessibility: () => path.join(baseUrl, "accessibility-statement"),
-    manager: () => path.join(baseUrl, "manager"),
-    executive: () => path.join(baseUrl, "executive"),
-    skills: () => path.join(baseUrl, "skills"),
-    inclusivityEquity: () => path.join(baseUrl, "inclusivity-equity"),
+      [baseUrl, "search", "request", requestId].join("/"),
+    register: () => [baseUrl, "register-info"].join("/"),
+    login: () => [baseUrl, "login-info"].join("/"),
+    loggedOut: () => [baseUrl, "logged-out"].join("/"),
+    userDeleted: () => [baseUrl, "user-deleted"].join("/"),
+    gettingStarted: () => [baseUrl, "getting-started"].join("/"),
+    emailVerification: () => [baseUrl, "email-verification"].join("/"),
+    employeeInformation: () => [baseUrl, "employee-registration"].join("/"),
+    termsAndConditions: () => [baseUrl, "terms-and-conditions"].join("/"),
+    privacyPolicy: () => [baseUrl, "privacy-policy"].join("/"),
+    accessibility: () => [baseUrl, "accessibility-statement"].join("/"),
+    manager: () => [baseUrl, "manager"].join("/"),
+    executive: () => [baseUrl, "executive"].join("/"),
+    skills: () => [baseUrl, "skills"].join("/"),
+    inclusivityEquity: () => [baseUrl, "inclusivity-equity"].join("/"),
 
     // Admin
     adminDashboard: () => adminUrl,
 
     // Admin - Pools
-    poolTable: () => path.join(adminUrl, "pools"),
-    poolCreate: () => path.join(adminUrl, "pools", "create"),
-    poolView: (poolId: string) => path.join(adminUrl, "pools", poolId),
+    poolTable: () => [adminUrl, "pools"].join("/"),
+    poolCreate: () => [adminUrl, "pools", "create"].join("/"),
+    poolView: (poolId: string) => [adminUrl, "pools", poolId].join("/"),
     poolUpdate: (poolId: string) =>
-      path.join(adminUrl, "pools", poolId, "edit"),
+      [adminUrl, "pools", poolId, "edit"].join("/"),
     assessmentPlanBuilder: (poolId: string) =>
-      path.join(adminUrl, "pools", poolId, "plan"),
+      [adminUrl, "pools", poolId, "plan"].join("/"),
     screeningAndEvaluation: (poolId: string) =>
-      path.join(adminUrl, "pools", poolId, "screening"),
+      [adminUrl, "pools", poolId, "screening"].join("/"),
     poolPreview: (poolId: string) =>
-      path.join(adminUrl, "pools", poolId, "preview"),
+      [adminUrl, "pools", poolId, "preview"].join("/"),
 
     // Admin - Pool Candidates
-    poolCandidates: () => path.join(adminUrl, "pool-candidates"),
+    poolCandidates: () => [adminUrl, "pool-candidates"].join("/"),
     poolCandidateTable: (poolId: string) =>
-      path.join(adminUrl, "pools", poolId, "pool-candidates"),
+      [adminUrl, "pools", poolId, "pool-candidates"].join("/"),
     poolCandidateCreate: (poolId: string) =>
-      path.join(adminUrl, "pools", poolId, "pool-candidates", "create"),
+      [adminUrl, "pools", poolId, "pool-candidates", "create"].join("/"),
     poolCandidateUpdate: (poolId: string, poolCandidateId: string) =>
-      path.join(
+      [
         adminUrl,
         "pools",
         poolId,
         "pool-candidates",
         poolCandidateId,
         "edit",
-      ),
+      ].join("/"),
     poolCandidateApplication: (poolCandidateId: string) =>
-      path.join(adminUrl, "candidates", poolCandidateId, "application"),
+      [adminUrl, "candidates", poolCandidateId, "application"].join("/"),
 
     // Admin - Users
-    userTable: () => path.join(adminUrl, "users"),
-    userCreate: () => path.join(adminUrl, "users", "create"),
-    userView: (userId: string) => path.join(adminUrl, "users", userId),
+    userTable: () => [adminUrl, "users"].join("/"),
+    userCreate: () => [adminUrl, "users", "create"].join("/"),
+    userView: (userId: string) => [adminUrl, "users", userId].join("/"),
     userProfile: (userId: string) =>
-      path.join(adminUrl, "users", userId, "profile"),
+      [adminUrl, "users", userId, "profile"].join("/"),
     userUpdate: (userId: string) =>
-      path.join(adminUrl, "users", userId, "edit"),
+      [adminUrl, "users", userId, "edit"].join("/"),
 
     // Admin - Teams
-    teamTable: () => path.join(adminUrl, "teams"),
-    teamCreate: () => path.join(adminUrl, "teams", "create"),
-    teamView: (teamId: string) => path.join(adminUrl, "teams", teamId),
+    teamTable: () => [adminUrl, "teams"].join("/"),
+    teamCreate: () => [adminUrl, "teams", "create"].join("/"),
+    teamView: (teamId: string) => [adminUrl, "teams", teamId].join("/"),
     teamMembers: (teamId: string) =>
-      path.join(adminUrl, "teams", teamId, "members"),
+      [adminUrl, "teams", teamId, "members"].join("/"),
     teamUpdate: (teamId: string) =>
-      path.join(adminUrl, "teams", teamId, "edit"),
+      [adminUrl, "teams", teamId, "edit"].join("/"),
 
     // Admin - Search Requests
-    searchRequestTable: () => path.join(adminUrl, "talent-requests"),
+    searchRequestTable: () => [adminUrl, "talent-requests"].join("/"),
     searchRequestView: (id: string) =>
-      path.join(adminUrl, "talent-requests", id),
+      [adminUrl, "talent-requests", id].join("/"),
 
     // Admin - Classifications
     classificationTable: () =>
-      path.join(adminUrl, "settings", "classifications"),
+      [adminUrl, "settings", "classifications"].join("/"),
     classificationCreate: () =>
-      path.join(adminUrl, "settings", "classifications", "create"),
+      [adminUrl, "settings", "classifications", "create"].join("/"),
     classificationUpdate: (classificationId: string) =>
-      path.join(
-        adminUrl,
-        "settings",
-        "classifications",
-        classificationId,
-        "edit",
+      [adminUrl, "settings", "classifications", classificationId, "edit"].join(
+        "/",
       ),
 
     // Admin - Skills
-    skillTable: () => path.join(adminUrl, "settings", "skills"),
-    skillCreate: () => path.join(adminUrl, "settings", "skills", "create"),
+    skillTable: () => [adminUrl, "settings", "skills"].join("/"),
+    skillCreate: () => [adminUrl, "settings", "skills", "create"].join("/"),
     skillUpdate: (skillId: string) =>
-      path.join(adminUrl, "settings", "skills", skillId, "edit"),
+      [adminUrl, "settings", "skills", skillId, "edit"].join("/"),
 
     // Admin - Skill Families
-    skillFamilyTable: () => path.join(adminUrl, "settings", "skill-families"),
+    skillFamilyTable: () => [adminUrl, "settings", "skill-families"].join("/"),
     skillFamilyCreate: () =>
-      path.join(adminUrl, "settings", "skill-families", "create"),
+      [adminUrl, "settings", "skill-families", "create"].join("/"),
     skillFamilyUpdate: (skillFamilyId: string) =>
-      path.join(adminUrl, "settings", "skill-families", skillFamilyId, "edit"),
+      [adminUrl, "settings", "skill-families", skillFamilyId, "edit"].join("/"),
 
     // Admin - Departments
-    departmentTable: () => path.join(adminUrl, "settings", "departments"),
+    departmentTable: () => [adminUrl, "settings", "departments"].join("/"),
     departmentCreate: () =>
-      path.join(adminUrl, "settings", "departments", "create"),
+      [adminUrl, "settings", "departments", "create"].join("/"),
     departmentUpdate: (departmentId: string) =>
-      path.join(adminUrl, "settings", "departments", departmentId, "edit"),
+      [adminUrl, "settings", "departments", departmentId, "edit"].join("/"),
 
     // Admin - Announcements
-    announcements: () => path.join(adminUrl, "settings", "announcements"),
+    announcements: () => [adminUrl, "settings", "announcements"].join("/"),
 
     // IAP
-    iap: () => path.join(baseUrl, "indigenous-it-apprentice"),
-    iapManager: () => path.join(baseUrl, "indigenous-it-apprentice", "hire"),
+    iap: () => [baseUrl, "indigenous-it-apprentice"].join("/"),
+    iapManager: () => [baseUrl, "indigenous-it-apprentice", "hire"].join("/"),
 
     // Pools
-    browsePools: () => path.join(baseUrl, "browse", "pools"),
-    pool: (poolId: string) => path.join(baseUrl, "browse", "pools", poolId),
+    browsePools: () => [baseUrl, "browse", "pools"].join("/"),
+    pool: (poolId: string) => [baseUrl, "browse", "pools", poolId].join("/"),
     createApplication: (poolId: string) =>
-      path.join(baseUrl, "browse", "pools", poolId, "create-application"),
+      [baseUrl, "browse", "pools", poolId, "create-application"].join("/"),
 
     // Applications
     application: (applicationId: string) =>
-      path.join(baseUrl, "applications", applicationId),
+      [baseUrl, "applications", applicationId].join("/"),
 
     // Application
     applicationWelcome: (applicationId: string) =>
-      path.join(baseUrl, "applications", applicationId, "welcome"),
+      [baseUrl, "applications", applicationId, "welcome"].join("/"),
     applicationSelfDeclaration: (applicationId: string) =>
-      path.join(baseUrl, "applications", applicationId, "self-declaration"),
+      [baseUrl, "applications", applicationId, "self-declaration"].join("/"),
     applicationProfile: (applicationId: string) =>
-      path.join(baseUrl, "applications", applicationId, "profile"),
+      [baseUrl, "applications", applicationId, "profile"].join("/"),
     applicationCareerTimeline: (applicationId: string) =>
-      path.join(baseUrl, "applications", applicationId, "career-timeline"),
+      [baseUrl, "applications", applicationId, "career-timeline"].join("/"),
     applicationCareerTimelineIntro: (applicationId: string) =>
-      path.join(
+      [
         baseUrl,
         "applications",
         applicationId,
         "career-timeline",
         "introduction",
-      ),
+      ].join("/"),
     applicationCareerTimelineAdd: (applicationId: string) =>
-      path.join(
-        baseUrl,
-        "applications",
-        applicationId,
-        "career-timeline",
-        "add",
+      [baseUrl, "applications", applicationId, "career-timeline", "add"].join(
+        "/",
       ),
     applicationCareerTimelineEdit: (
       applicationId: string,
       experienceId: string,
     ) =>
-      path.join(
+      [
         baseUrl,
         "applications",
         applicationId,
         "career-timeline",
         experienceId,
-      ),
+      ].join("/"),
     applicationEducation: (applicationId: string) =>
-      path.join(baseUrl, "applications", applicationId, "education"),
+      [baseUrl, "applications", applicationId, "education"].join("/"),
     applicationSkills: (applicationId: string) =>
-      path.join(baseUrl, "applications", applicationId, "skills"),
+      [baseUrl, "applications", applicationId, "skills"].join("/"),
     applicationSkillsIntro: (applicationId: string) =>
-      path.join(
-        baseUrl,
-        "applications",
-        applicationId,
-        "skills",
-        "introduction",
+      [baseUrl, "applications", applicationId, "skills", "introduction"].join(
+        "/",
       ),
     applicationQuestions: (applicationId: string) =>
-      path.join(baseUrl, "applications", applicationId, "questions"),
+      [baseUrl, "applications", applicationId, "questions"].join("/"),
     applicationQuestionsIntro: (applicationId: string) =>
-      path.join(
+      [
         baseUrl,
         "applications",
         applicationId,
         "questions",
         "introduction",
-      ),
+      ].join("/"),
     applicationReview: (applicationId: string) =>
-      path.join(baseUrl, "applications", applicationId, "review"),
+      [baseUrl, "applications", applicationId, "review"].join("/"),
     applicationSuccess: (applicationId: string) =>
-      path.join(baseUrl, "applications", applicationId, "success"),
+      [baseUrl, "applications", applicationId, "success"].join("/"),
 
     // Profile Routes
     profile: (section?: UserProfilePageSectionId) => {
       const fragment = section ? `#${section}` : "";
-      return path.join(applicantUrl, "personal-information") + fragment;
+      return [applicantUrl, "personal-information"].join("/") + fragment;
     },
     verifyContactEmail: (opts?: { emailAddress?: string | null }) => {
       const searchParams = new Map<string, string>();
@@ -234,7 +221,7 @@ const getRoutes = (lang: Locales) => {
         searchParams.set("emailAddress", opts.emailAddress);
       }
       return (
-        path.join(applicantUrl, "verify-contact-email") +
+        [applicantUrl, "verify-contact-email"].join("/") +
         createSearchQuery(searchParams)
       );
     },
@@ -244,12 +231,12 @@ const getRoutes = (lang: Locales) => {
       section?: CareerTimelineAndRecruitmentPageSectionId;
     }) => {
       const fragment = opts?.section ? `#${opts.section}` : "";
-      return `${path.join(applicantUrl, "career-timeline")}${fragment}`;
+      return `${[applicantUrl, "career-timeline"].join("/")}${fragment}`;
     },
     editExperience: (experienceId: string) =>
-      path.join(applicantUrl, "career-timeline", experienceId, "edit"),
+      [applicantUrl, "career-timeline", experienceId, "edit"].join("/"),
     createExperience: () =>
-      path.join(applicantUrl, "career-timeline", "create"),
+      [applicantUrl, "career-timeline", "create"].join("/"),
 
     // Profile and Applications
     profileAndApplications: (opts?: {
@@ -269,31 +256,32 @@ const getRoutes = (lang: Locales) => {
       );
     },
 
-    skillLibrary: () => path.join(applicantUrl, "skills"),
-    skillShowcase: () => path.join(showcase),
+    skillLibrary: () => [applicantUrl, "skills"].join("/"),
+    skillShowcase: () => [showcase].join("/"),
     editUserSkill: (skillId: string) =>
-      path.join(applicantUrl, "skills", skillId),
-    topBehaviouralSkills: () => path.join(showcase, "top-5-behavioural-skills"),
-    topTechnicalSkills: () => path.join(showcase, "top-10-technical-skills"),
+      [applicantUrl, "skills", skillId].join("/"),
+    topBehaviouralSkills: () =>
+      [showcase, "top-5-behavioural-skills"].join("/"),
+    topTechnicalSkills: () => [showcase, "top-10-technical-skills"].join("/"),
     improveBehaviouralSkills: () =>
-      path.join(showcase, "3-behavioural-skills-to-improve"),
+      [showcase, "3-behavioural-skills-to-improve"].join("/"),
     improveTechnicalSkills: () =>
-      path.join(showcase, "5-technical-skills-to-train"),
+      [showcase, "5-technical-skills-to-train"].join("/"),
 
     // Notifications
-    notifications: () => path.join(applicantUrl, "notifications"),
+    notifications: () => [applicantUrl, "notifications"].join("/"),
 
     // Directive on digital talent
-    directive: () => path.join(baseUrl, "directive-on-digital-talent"),
+    directive: () => [baseUrl, "directive-on-digital-talent"].join("/"),
     digitalServicesContractingQuestionnaire: () =>
-      path.join(
+      [
         baseUrl,
         "directive-on-digital-talent",
         "digital-services-contracting-questionnaire",
-      ),
+      ].join("/"),
 
     // Account Settings
-    accountSettings: () => path.join(applicantUrl, "settings"),
+    accountSettings: () => [applicantUrl, "settings"].join("/"),
 
     /**
      * Deprecated
@@ -301,7 +289,7 @@ const getRoutes = (lang: Locales) => {
      * The following paths are deprecated and
      * should contain redirects to new ones.
      */
-    myProfileDeprecated: () => path.join("/", lang, "talent", "profile"),
+    myProfileDeprecated: () => ["/", lang, "talent", "profile"].join("/"),
   };
 };
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -26,13 +26,11 @@
     "@gc-digital-talent/ui": "workspace:*",
     "@gc-digital-talent/i18n": "workspace:*",
     "jwt-decode": "^4.0.0",
-    "path-browserify": "^1.0.1",
     "react-router-dom": "^6.26.0",
     "urql": "^4.1.0"
   },
   "devDependencies": {
     "@gc-digital-talent/eslint-config": "workspace:*",
-    "@types/path-browserify": "^1.0.2",
     "@types/react": "^18.3.3",
     "eslint": "^8.57.0",
     "react": "^18.3.1",

--- a/packages/auth/src/hooks/useApiRoutes.ts
+++ b/packages/auth/src/hooks/useApiRoutes.ts
@@ -1,5 +1,3 @@
-import path from "path-browserify";
-
 interface ApiRoutes {
   login: (from?: string, locale?: string) => string;
   refreshAccessToken: () => string;
@@ -24,7 +22,7 @@ const apiRoutes = {
 
     const url = apiHost
       ? new URL(loginPath, apiHost)
-      : path.join("/", "login") + (searchString ? `?${searchString}` : "");
+      : ["login"].join("/") + (searchString ? `?${searchString}` : "");
 
     return url.toString();
   },

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -33,7 +33,6 @@
     "@gc-digital-talent/logger": "workspace:*",
     "@gc-digital-talent/jest-presets": "workspace:*",
     "@types/react": "^18.3.3",
-    "cpy-cli": "^5.0.0",
     "eslint": "^8.57.0",
     "history": "^5.3.0",
     "jest": "^29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,9 +132,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      path-browserify:
-        specifier: ^1.0.1
-        version: 1.0.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -317,9 +314,6 @@ importers:
       jwt-decode:
         specifier: ^4.0.0
         version: 4.0.0
-      path-browserify:
-        specifier: ^1.0.1
-        version: 1.0.1
       react-router-dom:
         specifier: ^6.26.0
         version: 6.26.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -330,9 +324,6 @@ importers:
       '@gc-digital-talent/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config-custom
-      '@types/path-browserify':
-        specifier: ^1.0.2
-        version: 1.0.2
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.3
@@ -3789,9 +3780,6 @@ packages:
   '@types/node@22.1.0':
     resolution: {integrity: sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==}
 
-  '@types/path-browserify@1.0.2':
-    resolution: {integrity: sha512-ZkC5IUqqIFPXx3ASTTybTzmQdwHwe2C0u3eL75ldQ6T9E9IWFJodn6hIfbZGab73DfyiHN4Xw15gNxUq2FbvBA==}
-
   '@types/picomatch@2.3.4':
     resolution: {integrity: sha512-0so8lU8O5zatZS/2Fi4zrwks+vZv7e0dygrgEZXljODXBig97l4cPQD+9LabXfGJOWwoRkTVz6Q4edZvD12UOA==}
 
@@ -6790,9 +6778,6 @@ packages:
 
   pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
-
-  path-browserify@1.0.1:
-    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-case@3.0.4:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
@@ -11659,8 +11644,6 @@ snapshots:
     dependencies:
       undici-types: 6.13.0
 
-  '@types/path-browserify@1.0.2': {}
-
   '@types/picomatch@2.3.4': {}
 
   '@types/prop-types@15.7.12': {}
@@ -15289,8 +15272,6 @@ snapshots:
     dependencies:
       no-case: 3.0.4
       tslib: 2.6.3
-
-  path-browserify@1.0.1: {}
 
   path-case@3.0.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,9 +217,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.1
         version: 4.3.1(vite@5.4.0(@types/node@22.1.0)(lightningcss@1.25.1)(terser@5.31.1))
-      core-js:
-        specifier: ^3.37.1
-        version: 3.37.1
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -4616,9 +4613,6 @@ packages:
 
   core-js-compat@3.37.1:
     resolution: {integrity: sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==}
-
-  core-js@3.37.1:
-    resolution: {integrity: sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==}
 
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
@@ -12736,8 +12730,6 @@ snapshots:
   core-js-compat@3.37.1:
     dependencies:
       browserslist: 4.23.1
-
-  core-js@3.37.1: {}
 
   cosmiconfig@8.3.6(typescript@5.5.4):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -789,9 +789,6 @@ importers:
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.3
-      cpy-cli:
-        specifier: ^5.0.0
-        version: 5.0.0
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -4094,10 +4091,6 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  aggregate-error@4.0.1:
-    resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
-    engines: {node: '>=12'}
-
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -4193,10 +4186,6 @@ packages:
   arraybuffer.prototype.slice@1.0.3:
     resolution: {integrity: sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==}
     engines: {node: '>= 0.4'}
-
-  arrify@3.0.0:
-    resolution: {integrity: sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==}
-    engines: {node: '>=12'}
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
@@ -4464,10 +4453,6 @@ packages:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
 
-  clean-stack@4.2.0:
-    resolution: {integrity: sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==}
-    engines: {node: '>=12'}
-
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
@@ -4631,19 +4616,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  cp-file@10.0.0:
-    resolution: {integrity: sha512-vy2Vi1r2epK5WqxOLnskeKeZkdZvTKfFZQCplE3XWsP+SUJyd5XAUFC9lFgTjjXJF2GMne/UML14iEmkAaDfFg==}
-    engines: {node: '>=14.16'}
-
-  cpy-cli@5.0.0:
-    resolution: {integrity: sha512-fb+DZYbL9KHc0BC4NYqGRrDIJZPXUmjjtqdw4XRRg8iV8dIfghUX/WiL+q4/B/KFTy3sK6jsbUhBaz0/Hxg7IQ==}
-    engines: {node: '>=16'}
-    hasBin: true
-
-  cpy@10.1.0:
-    resolution: {integrity: sha512-VC2Gs20JcTyeQob6UViBLnyP0bYHkBh6EiKzot9vi2DmeGlFT9Wd7VG3NBrkNx/jYvFBeyDOMMHdHQhbtKLgHQ==}
-    engines: {node: '>=16'}
 
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -5084,10 +5056,6 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-
-  escape-string-regexp@5.0.0:
-    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
-    engines: {node: '>=12'}
 
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
@@ -5578,10 +5546,6 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
-  globby@13.2.2:
-    resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   globby@14.0.2:
     resolution: {integrity: sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==}
     engines: {node: '>=18'}
@@ -5764,10 +5728,6 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
-
-  indent-string@5.0.0:
-    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
-    engines: {node: '>=12'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -6263,10 +6223,6 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
-  junk@4.0.1:
-    resolution: {integrity: sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==}
-    engines: {node: '>=12.20'}
-
   just-extend@6.2.0:
     resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
 
@@ -6512,10 +6468,6 @@ packages:
   memoizerific@1.11.3:
     resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
 
-  meow@12.1.1:
-    resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
-    engines: {node: '>=16.10'}
-
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
@@ -6644,9 +6596,6 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-
-  nested-error-stacks@2.1.1:
-    resolution: {integrity: sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==}
 
   nise@6.0.0:
     resolution: {integrity: sha512-K8ePqo9BFvN31HXwEtTNGzgrPpmvgciDsFz8aztFjt4LqKO/JeFD8tBOeuDiCMXrIl/m1YvfH8auSpxfaD09wg==}
@@ -6786,14 +6735,6 @@ packages:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
 
-  p-event@5.0.1:
-    resolution: {integrity: sha512-dd589iCQ7m1L0bmC5NLlVYfy3TbBEsMUfWx9PyAgPeIcFZ/E2yaTZ4Rz4MiBmmJShviiftHVXOqfnfzJ6kyMrQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  p-filter@3.0.0:
-    resolution: {integrity: sha512-QtoWLjXAW++uTX67HZQz1dbTpqBfiidsB6VtQUC9iR85S120+s0T5sO6s+B5MLzFcZkrEd/DGMmCjR+f2Qpxwg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -6817,18 +6758,6 @@ packages:
   p-map@4.0.0:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
-
-  p-map@5.5.0:
-    resolution: {integrity: sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==}
-    engines: {node: '>=12'}
-
-  p-map@6.0.0:
-    resolution: {integrity: sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==}
-    engines: {node: '>=16'}
-
-  p-timeout@5.1.0:
-    resolution: {integrity: sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==}
-    engines: {node: '>=12'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -7717,10 +7646,6 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
-
-  slash@4.0.0:
-    resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
-    engines: {node: '>=12'}
 
   slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
@@ -12118,11 +12043,6 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  aggregate-error@4.0.1:
-    dependencies:
-      clean-stack: 4.2.0
-      indent-string: 5.0.0
-
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -12250,8 +12170,6 @@ snapshots:
       get-intrinsic: 1.2.4
       is-array-buffer: 3.0.4
       is-shared-array-buffer: 1.0.3
-
-  arrify@3.0.0: {}
 
   asap@2.0.6: {}
 
@@ -12608,10 +12526,6 @@ snapshots:
 
   clean-stack@2.2.0: {}
 
-  clean-stack@4.2.0:
-    dependencies:
-      escape-string-regexp: 5.0.0
-
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
@@ -12748,28 +12662,6 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.5.4
-
-  cp-file@10.0.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      nested-error-stacks: 2.1.1
-      p-event: 5.0.1
-
-  cpy-cli@5.0.0:
-    dependencies:
-      cpy: 10.1.0
-      meow: 12.1.1
-
-  cpy@10.1.0:
-    dependencies:
-      arrify: 3.0.0
-      cp-file: 10.0.0
-      globby: 13.2.2
-      junk: 4.0.1
-      micromatch: 4.0.7
-      nested-error-stacks: 2.1.1
-      p-filter: 3.0.0
-      p-map: 6.0.0
 
   create-jest@29.7.0(@types/node@22.1.0)(ts-node@10.9.2(@types/node@22.1.0)(typescript@5.5.4)):
     dependencies:
@@ -13293,8 +13185,6 @@ snapshots:
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
-
-  escape-string-regexp@5.0.0: {}
 
   escodegen@2.1.0:
     dependencies:
@@ -13954,14 +13844,6 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  globby@13.2.2:
-    dependencies:
-      dir-glob: 3.0.1
-      fast-glob: 3.3.2
-      ignore: 5.3.1
-      merge2: 1.4.1
-      slash: 4.0.0
-
   globby@14.0.2:
     dependencies:
       '@sindresorhus/merge-streams': 2.3.0
@@ -14158,8 +14040,6 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
-
-  indent-string@5.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -14893,8 +14773,6 @@ snapshots:
       object.assign: 4.1.5
       object.values: 1.2.0
 
-  junk@4.0.1: {}
-
   just-extend@6.2.0: {}
 
   jwt-decode@4.0.0: {}
@@ -15105,8 +14983,6 @@ snapshots:
     dependencies:
       map-or-similar: 1.5.0
 
-  meow@12.1.1: {}
-
   meow@13.2.0: {}
 
   merge-descriptors@1.0.1: {}
@@ -15199,8 +15075,6 @@ snapshots:
   negotiator@0.6.3: {}
 
   neo-async@2.6.2: {}
-
-  nested-error-stacks@2.1.1: {}
 
   nise@6.0.0:
     dependencies:
@@ -15355,14 +15229,6 @@ snapshots:
 
   os-tmpdir@1.0.2: {}
 
-  p-event@5.0.1:
-    dependencies:
-      p-timeout: 5.1.0
-
-  p-filter@3.0.0:
-    dependencies:
-      p-map: 5.5.0
-
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -15386,14 +15252,6 @@ snapshots:
   p-map@4.0.0:
     dependencies:
       aggregate-error: 3.1.0
-
-  p-map@5.5.0:
-    dependencies:
-      aggregate-error: 4.0.1
-
-  p-map@6.0.0: {}
-
-  p-timeout@5.1.0: {}
 
   p-try@2.2.0: {}
 
@@ -16352,8 +16210,6 @@ snapshots:
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
-
-  slash@4.0.0: {}
 
   slash@5.1.0: {}
 


### PR DESCRIPTION
🤖 Resolves #11131.

## 👋 Introduction

This PR removes the dependencies `core-js`, `cpy-cli`, and `path-browserify`. The `path-browserify` function for joining paths is replaced by [join](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join).

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm i; pnpm build:fresh`
2. Navigate throughout site and ensure all links still work