### PR TITLE
[Fix] Add missing fragment for `UserInformationPage` component

### DIFF
--- a/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/UserCandidatesTable.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/UserCandidatesTable.tsx
@@ -11,7 +11,6 @@ import { normalizedText } from "~/components/Table/sortingFns";
 import { getFullNameLabel } from "~/utils/nameUtils";
 import tableMessages from "~/components/PoolCandidatesTable/tableMessages";
 import useRoutes from "~/hooks/useRoutes";
-import { PoolCandidate_BookmarkFragment } from "~/components/CandidateBookmark/CandidateBookmark";
 import { getFullPoolTitleLabel } from "~/utils/poolUtils";
 import processMessages from "~/messages/processMessages";
 import adminMessages from "~/messages/adminMessages";
@@ -47,6 +46,7 @@ const UserCandidatesTableRow_Fragment = graphql(/* GraphQL */ `
       }
     }
     poolCandidates {
+      ...PoolCandidate_Bookmark
       id
       isBookmarked
       status {
@@ -159,10 +159,7 @@ const UserCandidatesTable = ({
       header: () => bookmarkHeader(intl),
       enableHiding: false,
       cell: ({ row: { original: poolCandidate } }) =>
-        bookmarkCell(
-          poolCandidate as FragmentType<typeof PoolCandidate_BookmarkFragment>,
-          poolCandidate.isBookmarked,
-        ),
+        bookmarkCell(poolCandidate, poolCandidate.isBookmarked),
       meta: {
         shrink: true,
         hideMobileHeader: true,


### PR DESCRIPTION
Resolves #11237 

## 👋 Introduction

`UserInformationPage` or `/admin/users/:userId` was broken due to type erroring, specifically the `UserCandidatesTable` component for users with applications.
A fragment was needed and some unneeded and probably to blame type coercing was removed. Whoops

## 🧪 Testing

1. User information page works/loads for users with a non-empty candidates table

## 📸 Screenshot

Before

![image](https://github.com/user-attachments/assets/1b7b81e9-0109-4290-8a09-50d18ebbe8b4)

After

![image](https://github.com/user-attachments/assets/bc551a12-1205-4ba2-93ce-1e320b57c8f7)



