### PR TITLE
[Fix] Community route paths

### DIFF
--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -55,12 +55,12 @@ const getRoutes = (lang: Locales) => {
     adminDashboard: () => adminUrl,
 
     // Admin - Communities
-    communityTable: () => path.join(adminUrl, "communities"),
-    communityCreate: () => path.join(adminUrl, "communities", "create"),
+    communityTable: () => [adminUrl, "communities"].join("/"),
+    communityCreate: () => [adminUrl, "communities", "create"].join("/"),
     communityView: (communityId: string) =>
-      path.join(adminUrl, "communities", communityId),
+      [adminUrl, "communities", communityId].join("/"),
     communityManageAccess: (communityId: string) =>
-      path.join(adminUrl, "communities", communityId, "manage-access"),
+      [adminUrl, "communities", communityId, "manage-access"].join("/"),
 
     // Admin - Pools
     poolTable: () => [adminUrl, "pools"].join("/"),


### PR DESCRIPTION
## 👋 Introduction

Fixes and oopsies with resolving merging of communities.

## 🕵️ Details

We removed `path-brwoserify` and it seems it was missed :grimacing: 

## 🧪 Testing

1. Check types `pnpm run tsc`
2. Confirm community links stil work

