### PR TITLE
[Debt] Enables passing environment variables to Playwright config

### DIFF
--- a/apps/playwright/playwright.config.ts
+++ b/apps/playwright/playwright.config.ts
@@ -1,10 +1,9 @@
-import { defineConfig, devices } from "@playwright/test";
+import path from "path";
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// require('dotenv').config();
+import { defineConfig, devices } from "@playwright/test";
+import dotenv from "dotenv";
+
+dotenv.config({ path: path.resolve(__dirname, ".env") });
 
 /**
  * See https://playwright.dev/docs/test-configuration.


### PR DESCRIPTION
🤖 Resolves #11265.

## 👋 Introduction

This PR enables passing environment variables to Playwright config.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Create .env file in `apps/playwright`
2. Add `TEST_TIMEOUT=1` to `apps/playwright/.env`
3. `pnpm e2e:playwright`
4. Observe playwright fail immediately
5. Comment out TEST_TIMEOUT=1` in `apps/playwright/.env`
6. Observe playwright not fail immediately 

## 📸 Screenshot

<img width="860" alt="Screen Shot 2024-08-15 at 13 59 46" src="https://github.com/user-attachments/assets/9e3e783f-ce5b-49ce-b0ac-e3ea4c8af52b">