### PR TITLE
[Feature] Add user id to search request table

### DIFF
--- a/api/app/Models/PoolCandidateSearchRequest.php
+++ b/api/app/Models/PoolCandidateSearchRequest.php
@@ -55,6 +55,22 @@ class PoolCandidateSearchRequest extends Model
     ];
 
     /**
+     * Boot function for using with PoolCandidateSearchRequest
+     *
+     * @return void
+     */
+    protected static function boot()
+    {
+        /** @var \App\Models\User */
+        $user = Auth::user();
+
+        parent::boot();
+        static::creating(function ($query) use ($user) {
+            $query->user_id = $user ? $user->id : null;
+        });
+    }
+
+    /**
      * The "booted" method of the model.
      */
     protected static function booted(): void

--- a/api/app/Models/PoolCandidateSearchRequest.php
+++ b/api/app/Models/PoolCandidateSearchRequest.php
@@ -65,8 +65,8 @@ class PoolCandidateSearchRequest extends Model
         $user = Auth::user();
 
         parent::boot();
-        static::creating(function ($query) use ($user) {
-            $query->user_id = $user ? $user->id : null;
+        static::creating(function ($searchRequest) use ($user) {
+            $searchRequest->user_id = $user?->id;
         });
     }
 

--- a/api/database/factories/PoolCandidateSearchRequestFactory.php
+++ b/api/database/factories/PoolCandidateSearchRequestFactory.php
@@ -32,7 +32,7 @@ class PoolCandidateSearchRequestFactory extends Factory
         $communityFetched = Community::inRandomOrder()->first();
         $community = isset($communityFetched) ? $communityFetched : Community::factory()->create();
         $guestUser = null;
-        $users = array(User::inRandomOrder()->first(), $guestUser);
+        $users = [User::inRandomOrder()->first(), $guestUser];
         $user = $users[array_rand($users)];
 
         return [

--- a/api/database/factories/PoolCandidateSearchRequestFactory.php
+++ b/api/database/factories/PoolCandidateSearchRequestFactory.php
@@ -9,6 +9,7 @@ use App\Models\ApplicantFilter;
 use App\Models\Community;
 use App\Models\Department;
 use App\Models\PoolCandidateSearchRequest;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class PoolCandidateSearchRequestFactory extends Factory
@@ -29,8 +30,8 @@ class PoolCandidateSearchRequestFactory extends Factory
     {
 
         $communityFetched = Community::inRandomOrder()->first();
-
         $community = isset($communityFetched) ? $communityFetched : Community::factory()->create();
+        $user = User::inRandomOrder()->first();
 
         return [
             'full_name' => $this->faker->name(),
@@ -49,6 +50,7 @@ class PoolCandidateSearchRequestFactory extends Factory
             'position_type' => $this->faker->randomElement(PoolCandidateSearchPositionType::cases())->name,
             'reason' => $this->faker->randomElement(PoolCandidateSearchRequestReason::cases())->name,
             'community_id' => $community->id,
+            'user_id' => $user->id,
         ];
     }
 

--- a/api/database/factories/PoolCandidateSearchRequestFactory.php
+++ b/api/database/factories/PoolCandidateSearchRequestFactory.php
@@ -31,7 +31,9 @@ class PoolCandidateSearchRequestFactory extends Factory
 
         $communityFetched = Community::inRandomOrder()->first();
         $community = isset($communityFetched) ? $communityFetched : Community::factory()->create();
-        $user = User::inRandomOrder()->first();
+        $guestUser = null;
+        $users = array(User::inRandomOrder()->first(), $guestUser);
+        $user = $users[array_rand($users)];
 
         return [
             'full_name' => $this->faker->name(),
@@ -50,7 +52,7 @@ class PoolCandidateSearchRequestFactory extends Factory
             'position_type' => $this->faker->randomElement(PoolCandidateSearchPositionType::cases())->name,
             'reason' => $this->faker->randomElement(PoolCandidateSearchRequestReason::cases())->name,
             'community_id' => $community->id,
-            'user_id' => $user->id,
+            'user_id' => $user?->id,
         ];
     }
 

--- a/api/database/migrations/2024_08_16_103756_add_user_id_to_pool_candidate_search_requests.php
+++ b/api/database/migrations/2024_08_16_103756_add_user_id_to_pool_candidate_search_requests.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pool_candidate_search_requests', function (Blueprint $table) {
+            $table->uuid('user_id')->nullable();
+            $table->foreign('user_id')->references('id')->on('users')
+                ->onUpdate('cascade')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pool_candidate_search_requests', function (Blueprint $table) {
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/api/tests/Feature/PoolCandidateSearchRequestTest.php
+++ b/api/tests/Feature/PoolCandidateSearchRequestTest.php
@@ -34,13 +34,13 @@ class PoolCandidateSearchRequestTest extends TestCase
         $this->bootRefreshesSchemaCache();
 
         $this->adminUser = User::factory()
-        ->asApplicant()
-        ->asRequestResponder()
-        ->asAdmin()
-        ->create([
-            'email' => 'admin-user@test.com',
-            'sub' => 'admin-user@test.com',
-        ]);
+            ->asApplicant()
+            ->asRequestResponder()
+            ->asAdmin()
+            ->create([
+                'email' => 'admin-user@test.com',
+                'sub' => 'admin-user@test.com',
+            ]);
     }
 
     /**
@@ -269,13 +269,12 @@ class PoolCandidateSearchRequestTest extends TestCase
     }
 
     /**
-     * Test user_id is saved for logged in user, and not saved for guest user
+     * Test that the user_id is null when a guest user creates a PoolCandidateSearchRequest
      *
      * @return void
      */
-    public function testUserIdForLoggedInAndGuestUsers()
+    public function testUserIdForGuestUsers()
     {
-        $this->seed(RolePermissionSeeder::class);
         $this->seed(DepartmentSeeder::class);
         $this->seed(CommunitySeeder::class);
 
@@ -299,7 +298,17 @@ class PoolCandidateSearchRequestTest extends TestCase
 
         $searchRequest = PoolCandidateSearchRequest::first();
         $this->assertNull($searchRequest->user_id);
+    }
 
+    /**
+     * Test that the user_id is set and correct when a logged in user creates a PooLCandidateSearchRequest
+     *
+     * @return void
+     */
+    public function testUserIdForLoggedInUsers()
+    {
+        $this->seed(DepartmentSeeder::class);
+        $this->seed(CommunitySeeder::class);
 
         // Assert user_id is not null after creating with logged in user,
         // and it has the correct id.
@@ -332,8 +341,6 @@ class PoolCandidateSearchRequestTest extends TestCase
             ]
         )->assertSuccessful();
 
-        $this->assertTrue(
-            PoolCandidateSearchRequest::where('user_id', $this->adminUser->id)->exists()
-        );
+        $this->assertTrue(PoolCandidateSearchRequest::where('user_id', $this->adminUser->id)->exists());
     }
 }


### PR DESCRIPTION
🤖 Resolves #10976 

## 👋 Introduction

- Adds a user_id column to the pool_candidate_search_requests table
- If a user is logged in then set the user_id to the logged in users id, if a guest user is logged in then leave it as null

## 🕵️ Details

Add any additional details that could assist with reviewing or testing this PR.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Ensure search requests still works correctly
2. Ensure user id is only set when a user is logged in and not a guest

## 🚚 Deployment

Run migration for new column.
