### PR TITLE
[Fix] Adds `eslint` rules `no-console`, `no-alert`

### DIFF
--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -85,6 +85,7 @@ module.exports = {
     "no-use-before-define": "off",
     "no-shadow": "off",
     "no-console": "error",
+    "no-alert": "error",
     "@typescript-eslint/no-use-before-define": "warn",
     "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/no-empty-function": "warn",

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -84,6 +84,7 @@ module.exports = {
     "no-param-reassign": "warn",
     "no-use-before-define": "off",
     "no-shadow": "off",
+    "no-console": "error",
     "@typescript-eslint/no-use-before-define": "warn",
     "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/no-empty-function": "warn",


### PR DESCRIPTION
🤖 Resolves #11277.

## 👋 Introduction

This PR adds the `eslint` rules `no-console` and `no-alert` that had been removed as part of the airbnb rules in https://github.com/GCTC-NTGC/gc-digital-talent/pull/11095.

## ❓ Question

> [!NOTE]  
> Is this still strictly true?

https://github.com/GCTC-NTGC/gc-digital-talent/blob/c17c53b33104412ec1651fd1e76708169a7128a8/documentation/style-guide.md?plain=1#L42-L45

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Add `console.log(1)` and `alert(1)` somewhere in a .tsx file 
2. `pnpm lint`
3. Observe errors during lint process

## 📸 Screenshot

<img width="862" alt="Screen Shot 2024-08-16 at 16 01 32" src="https://github.com/user-attachments/assets/cb0f4afa-73b2-48bd-8591-6cb33b4690f2">
