### PR TITLE
[Fix] Candidates stuck on assessment step

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -1097,9 +1097,16 @@ class PoolCandidate extends Model
                         $snapshot = $this->profile_snapshot;
 
                         if ($snapshot) {
-                            $claimedSkills = collect($snapshot['userSkills']);
-                            $isClaimed = $claimedSkills->contains(function ($userSkill) use ($poolSkill) {
-                                return $userSkill['skill']['id'] === $poolSkill->skill_id;
+                            $experiences = collect($snapshot['experiences']);
+
+                            $isClaimed = $experiences->contains(function ($experience) use ($poolSkill) {
+                                foreach ($experience['skills'] as $skill) {
+                                    if ($skill['id'] === $poolSkill->skill_id) {
+                                        return true;
+                                    }
+                                }
+
+                                return false;
                             });
                         }
 


### PR DESCRIPTION
🤖 Resolves #11209

## 👋 Introduction

Should prevent candidates getting stuck on a screening and assessment step when everything seems to be assessed.

## 🕵️ Details

Asset skills that candidates had in their skill library but not attached to an experience were appearing as unclaimed but requiring assessment. This updates the check to only require assessment for a skill if the candidate has an attached experience.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. Find or create a published process with 2 or more technical asset skills
2. As a candidate: add one of the technical asset skills to your skill library ensuring it does NOT have an attached experience
3. Apply to the process adding all required information and a technical asset skill other than the one in 2
4. As an admin: view the submitted application `/admin/candidates/'applicationId'/application`
5. Confirm the skill in 2 is marked as 'unclaimed' and the one in 3 as 'to assess'
6. Assess all required skills as demonstrated and confirm the first assessment step is still in progress
7. Assess the skill from 3 as demonstrated and confirm the first assessment step is now marked complete

## 🚚 Deployment

This updates the computeAssessmentStatus function but does not update existing values. The function will need to be called on affected candidates either as a script or telling managers who encounter this to trigger it by updating one of the candidates assessments.