### PR TITLE
Move template instructions and boilerplate into comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/ 🐛-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/ 🐛-bug-report.md
@@ -8,35 +8,41 @@ assignees: ""
 
 ## 🐛 Bug
 
-Describe the issue you encountered.
+<!-- Describe the issue you encountered. -->
 
 ## 🦋 Expected Behaviour
 
-What should be happening?
+<!-- What should be happening? -->
 
 ## 🕵️ Details
 
-Add any additional details that could assist with troubleshooting/fixing the issue.
+<!-- Add any additional details that could assist with troubleshooting/fixing the issue. -->
 
+<!--
 - **Operating System**: Name and version (if possible).
 - **Browser**: Name and version (if possible).
+-->
 
 ## 📋 Steps to Reproduce
 
+<!--
 1. ...
 2. ...
+-->
 
 ## 📸 Screenshot
 
-Add a screenshot (if possible).
+<!-- Add a screenshot (if possible). -->
 
 ## 🙋‍♀️ Proposed Solution
 
-(optional) Do you have a proposed solution?
+<!-- (optional) Do you have a proposed solution? -->
 
 ## ✅ Acceptance Criteria
 
-A set of assumptions which, when tested, verify that the bug was addressed.
+<!-- A set of assumptions which, when tested, verify that the bug was addressed. -->
 
+<!--
 - [ ] Criteria 1
 - [ ] Criteria 2
+-->

--- a/.github/ISSUE_TEMPLATE/⌨-accessibility-issue.md
+++ b/.github/ISSUE_TEMPLATE/⌨-accessibility-issue.md
@@ -8,40 +8,46 @@ assignees: ""
 
 ## ⌨ Accessibility Issue
 
-Describe the issue you encountered.
+<!-- Describe the issue you encountered. -->
 
 ### WCAG 2.1 Criteria
 
-List any relevant criteria that is failing.
+<!-- List any relevant criteria that is failing. -->
 
 ## 🦋 Expected Behaviour
 
-What should be happening?
+<!-- What should be happening? -->
 
 ## 🕵️ Details
 
-Add any additional details that could assist with troubleshooting/fixing the issue.
+<!-- Add any additional details that could assist with troubleshooting/fixing the issue. -->
 
+<!--
 - **Operating System**: Name and version (if possible).
 - **Browser**: Name and version (if possible).
 - **Assistive Technology**: Name and version (if possible).
+-->
 
 ## 📋 Steps to Reproduce
 
+<!--
 1. ...
 2. ...
+-->
 
 ## 📸 Screenshot
 
-Add a screenshot (if possible).
+<!-- Add a screenshot (if possible). -->
 
 ## 🙋‍♀️ Proposed Solution
 
-(optional) Do you have a proposed solution?
+<!-- (optional) Do you have a proposed solution? -->
 
 ## ✅ Acceptance Criteria
 
-A set of assumptions which, when tested, verify that the issue was addressed.
+<!-- A set of assumptions which, when tested, verify that the issue was addressed. -->
 
+<!--
 - [ ] Criteria 1
 - [ ] Criteria 2
+-->

--- a/.github/ISSUE_TEMPLATE/♻️-debt-refactor.md
+++ b/.github/ISSUE_TEMPLATE/♻️-debt-refactor.md
@@ -8,32 +8,33 @@ assignees: ""
 
 ## ♻️ Debt/Refactor
 
-Describe the problem with the existing implementation.
+<!-- Describe the problem with the existing implementation. -->
 
 ## 🕵️ Details
 
-Add any additional details that could assist with the development of the new feature.
+<!-- Add any additional details that could assist with the development of the new feature. -->
 
 ## 🙋‍♀️ Proposed Solution
 
-(optional) Do you have a proposed solution?
+<!-- (optional) Do you have a proposed solution? -->
 
 ## 🌎 Localization
 
-(optional) Provide any new copy along with translations available.
+<!-- (optional) Provide any new copy along with translations available. -->
 
 ## ✅ Acceptance Criteria
 
-A set of assumptions which, when tested, verify that the debt was addressed and expected functionality has not been affected.
+<!-- A set of assumptions which, when tested, verify that the debt was addressed and expected functionality has not been affected. -->
 
+<!--
 - [ ] Criteria 1
 - [ ] Criteria 2
+ -->
 
 ## 🛑 Blockers
 
-Issues which must be completed before this one.
+<!-- Issues which must be completed before this one. -->
 
 ```[tasklist]
 ### Blocked By
-- [ ] ticket number
 ```

--- a/.github/ISSUE_TEMPLATE/⚙️-new-component.md
+++ b/.github/ISSUE_TEMPLATE/⚙️-new-component.md
@@ -8,15 +8,15 @@ assignees: ""
 
 ## ⚙️ Summary
 
-Purpose and description.
+<!-- Purpose and description. -->
 
 ## 🎨 Design File
 
-Include a link to the design file (if it exists).
-
-### 🧑‍🎨 Designer
-
+<!--
 Include the author of the linked design file's name (or even better, their `@githubUsername`) for future reference.
+ -->
+
+<!-- Include a link to the design file (if it exists). -->
 
 > [!NOTE]  
 > For all layout and spacing guidance, including how this component should respond on smaller devices, please see the Figma file.
@@ -50,38 +50,38 @@ Include the author of the linked design file's name (or even better, their `@git
 
 #### Description
 
-Property description.
+<!-- Property description. -->
 
 #### Screenshot
 
-Property screenshot(s).
+<!-- Property screenshot(s). -->
 
 ## 💡 Interaction states
 
-Summary of interaction states.
+<!-- Summary of interaction states. -->
 
 ### Hover
 
 #### Description
 
-Hover state description.
+<!-- Hover state description. -->
 
 #### Screenshot
 
-Hover state screenshot.
+<!-- Hover state screenshot. -->
 
 ### Focus
 
 #### Description
 
-Focus state description.
+<!-- Focus state description. -->
 
 ### Screenshot
 
-Focus state screenshot.
+<!-- Focus state screenshot. -->
 
 ## 🥰 Accessibility
 
 ### Accessibility feature name
 
-Feature description.
+<!-- Feature description. -->

--- a/.github/ISSUE_TEMPLATE/⚙️-new-component.md
+++ b/.github/ISSUE_TEMPLATE/⚙️-new-component.md
@@ -10,7 +10,7 @@ assignees: ""
 
 <!-- Purpose and description. -->
 
-## 🎨 Design File
+## 🎨 Design
 
 <!--
 Include the author of the linked design file's name (or even better, their `@githubUsername`) for future reference.

--- a/.github/ISSUE_TEMPLATE/✏️-documentation.md
+++ b/.github/ISSUE_TEMPLATE/✏️-documentation.md
@@ -8,19 +8,21 @@ assignees: ""
 
 ## ✏️ Documentation
 
-Describe the update/addition that you are proposing.
+<!-- Describe the update/addition that you are proposing. -->
 
 ## 🕵️ Details
 
-Add any additional details that could assist with the implementation of the new documentation.
+<!-- Add any additional details that could assist with the implementation of the new documentation. -->
 
 ## 🙋‍♀️ Proposed Copy
 
-(optional) Do you have any copy that you would like to propose?
+<!-- (optional) Do you have any copy that you would like to propose? -->
 
 ## ✅ Acceptance Criteria
 
-A set of assumptions which, when tested, verify that the documentation has been added/updated appropriately.
+<!-- A set of assumptions which, when tested, verify that the documentation has been added/updated appropriately. -->
 
+<!--
 - [ ] Criteria
 - [ ] Criteria 2
+ -->

--- a/.github/ISSUE_TEMPLATE/✨-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/✨-feature-request.md
@@ -14,7 +14,7 @@ assignees: ""
 
 <!-- Add any additional details that could assist with the development of the new feature. -->
 
-## 🎨 Design File
+## 🎨 Design
 
 <!-- Include the author of the linked design file's name (or even better, their `@githubUsername`) for future reference. -->
 

--- a/.github/ISSUE_TEMPLATE/✨-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/✨-feature-request.md
@@ -8,44 +8,43 @@ assignees: ""
 
 ## ✨ Feature
 
-Describe the feature that is being requested
+<!-- Describe the feature that is being requested -->
 
 ## 🕵️ Details
 
-Add any additional details that could assist with the development of the new feature.
+<!-- Add any additional details that could assist with the development of the new feature. -->
 
 ## 🎨 Design File
 
-Include a link to the design file (if it exists).
+<!-- Include the author of the linked design file's name (or even better, their `@githubUsername`) for future reference. -->
 
-### 🧑‍🎨 Designer
-
-Include the author of the linked design file's name (or even better, their `@githubUsername`) for future reference.
+<!-- Include a link to the design file (if it exists). -->
 
 ## 📸 Screenshot
 
-Add a screenshot of the new feature (if possible).
+<!-- Add a screenshot of the new feature (if possible). -->
 
 ## 🙋‍♀️ Proposed Implementation
 
-(optional) Do you have a proposed implementation?
+<!-- (optional) Do you have a proposed implementation? -->
 
 ## 🌎 Localization
 
-(optional) Provide any new copy along with translations available.
+<!-- (optional) Provide any new copy along with translations available. -->
 
 ## ✅ Acceptance Criteria
 
-A set of assumptions which, when tested, verify that the feature was properly implemented.
+<!-- A set of assumptions which, when tested, verify that the feature was properly implemented. -->
 
+<!--
 - [ ] Criteria 1
 - [ ] Criteria 2
+ -->
 
 ## 🛑 Blockers
 
-Issues which must be completed before this one.
+<!-- Issues which must be completed before this one. -->
 
 ```[tasklist]
 ### Blocked By
-- [ ] ticket number
 ```

--- a/.github/ISSUE_TEMPLATE/❗-new-notification.md
+++ b/.github/ISSUE_TEMPLATE/❗-new-notification.md
@@ -8,34 +8,42 @@ assignees: ""
 
 ## ✨ Purpose
 
-What is this notification intended to convey, and why?
+<!-- What is this notification intended to convey, and why? -->
 
 ## ❗ Trigger
 
+<!--
 How is this notification generated? Is it in response to some user action (eg submitting a request) or will it require a cron job which runs on a schedule (eg a job poster closes in 24 hours). If it requires a cron job, how often does it need to run?
+ -->
 
 ## 👀 Audience
 
+<!--
 Who will get this notification? (eg all Request Responders, or only applicants with a draft application for related poster)
+ -->
 
 ## 🌎 Copy (localized)
 
 ### Email templates (English and French)
 
-Content of this notification if received as an email.
+<!-- Content of this notification if received as an email. -->
 
 ### In-app string (English and French)
 
-How does this notification appear on the notifications page?
+<!-- How does this notification appear on the notifications page? -->
 
 ### Link
 
+<!--
 What page of the app is most relevant to this notification? (You will be sent there if you click this notification in-app.) Consider if this link should be part of the email template.
+ -->
 
 ## 💾 Content
 
+<!--
 - What Notification Family does this belong to? (see #9555)
 - What is the minimal set of data we need to store in the database in order to generate in-app string and link?
+ -->
 
 ## ✅ Acceptance Criteria
 
@@ -48,9 +56,8 @@ What page of the app is most relevant to this notification? (You will be sent th
 
 ## 🛑 Blockers
 
-Issues which must be completed before this one.
+<!-- Issues which must be completed before this one. -->
 
 ```[tasklist]
 ### Blocked By
-- [ ] ticket number
 ```

--- a/.github/ISSUE_TEMPLATE/🔤-copy.md
+++ b/.github/ISSUE_TEMPLATE/🔤-copy.md
@@ -8,31 +8,33 @@ assignees: ""
 
 ## 🔤 Copy
 
-Describe the update or addition to the copy that you are proposing.
+<!-- Describe the update or addition to the copy that you are proposing. -->
 
 ## 🕵️ Details
 
-Add any additional details that could assist with the implementation of the new or existing copy.
+<!-- Add any additional details that could assist with the implementation of the new or existing copy. -->
 
 ## 🎨 Design File
 
-(optional) Include a link to the design file (if it exists).
-
-### 🧑‍🎨 Designer
-
+<!--
 (optional) Include the author of the linked design file's name (or even better, their `@githubUsername`) for future reference.
+-->
+
+<!-- (optional) Include a link to the design file (if it exists). -->
 
 ## 🙋‍♀️ Proposed Implementation
 
-(optional) Do you have any copy that you would like to propose?
+<!-- (optional) Do you have any copy that you would like to propose? -->
 
 ## 🌎 Localization
 
-(optional) Provide any new copy along with translations available.
+<!-- (optional) Provide any new copy along with translations available. -->
 
 ## ✅ Acceptance Criteria
 
-A set of assumptions which, when tested, verify that the copy has been added or updated appropriately.
+<!-- A set of assumptions which, when tested, verify that the copy has been added or updated appropriately. -->
 
+<!--
 - [ ] Criteria 1
 - [ ] Criteria 2
+-->

--- a/.github/ISSUE_TEMPLATE/🔤-copy.md
+++ b/.github/ISSUE_TEMPLATE/🔤-copy.md
@@ -14,7 +14,7 @@ assignees: ""
 
 <!-- Add any additional details that could assist with the implementation of the new or existing copy. -->
 
-## 🎨 Design File
+## 🎨 Design
 
 <!--
 (optional) Include the author of the linked design file's name (or even better, their `@githubUsername`) for future reference.

--- a/.github/ISSUE_TEMPLATE/🛠️-tooling.md
+++ b/.github/ISSUE_TEMPLATE/🛠️-tooling.md
@@ -8,28 +8,31 @@ assignees: ""
 
 ## 🛠️ Tooling
 
-Describe the additions/changes you would like to see to the tooling.
+<!-- Describe the additions/changes you would like to see to the tooling. -->
 
 ## 🕵️ Details
 
-Add any additional details that could assist with the changes/additions being made.
+<!-- Add any additional details that could assist with the changes/additions being made. -->
 
 ## 🙋‍♀️ Proposed Solution
 
-(optional) Do you have a proposed solution?
+<!-- (optional) Do you have a proposed solution? -->
 
 ## ✅ Acceptance Criteria
 
+<!--
 A set of assumptions which, when tested, verify that the debt tooling was properly updated and remains functional.
+ -->
 
+<!--
 - [ ] Criteria 1
 - [ ] Criteria 2
+ -->
 
 ## 🛑 Blockers
 
-Issues which must be completed before this one.
+<!-- Issues which must be completed before this one. -->
 
 ```[tasklist]
 ### Blocked By
-- [ ] ticket number
 ```

--- a/.github/ISSUE_TEMPLATE/🦔-spike.md
+++ b/.github/ISSUE_TEMPLATE/🦔-spike.md
@@ -8,16 +8,16 @@ assignees: ""
 
 ## 🦔 Spike
 
-Describe the spike.
+<!-- Describe the spike. -->
 
 ## 🕵️ Details
 
-More details, background context, or ideas for how to approach this.
+<!-- More details, background context, or ideas for how to approach this. -->
 
 ## ❓ Questions to answer
 
-What specific questions need to have been answered for this task to be considered complete?
+<!-- What specific questions need to have been answered for this task to be considered complete? -->
 
 ## 🕙 Timebox
 
-How many days are we expected to spend on this?
+<!-- How many days are we expected to spend on this? -->

--- a/.github/ISSUE_TEMPLATE/🧪-tests.md
+++ b/.github/ISSUE_TEMPLATE/🧪-tests.md
@@ -8,28 +8,31 @@ assignees: ""
 
 ## 🧪 Tests
 
-Describe the additions/changes you would like to see to the tests.
+<!-- Describe the additions/changes you would like to see to the tests. -->
 
 ## 🕵️ Details
 
-Add any additional details that could assist with the changes/additions being made.
+<!-- Add any additional details that could assist with the changes/additions being made. -->
 
 ## 🙋‍♀️ Proposed Solution
 
-(optional) Do you have a proposed solution?
+<!-- (optional) Do you have a proposed solution? -->
 
 ## ✅ Acceptance Criteria
 
+<!--
 A set of assumptions which, when tested, verify that the debt tests were properly updated and remains functional/passing.
+ -->
 
+<!--
 - [ ] Criteria 1
 - [ ] Criteria 2
+ -->
 
 ## 🛑 Blockers
 
-Issues which must be completed before this one.
+<!-- Issues which must be completed before this one. -->
 
 ```[tasklist]
 ### Blocked By
-- [ ] ticket number
 ```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,29 @@
-🤖 Resolves {issue #}
+🤖 Resolves <!-- issue # -->
 
 ## 👋 Introduction
 
-Describe what this PR is solving.
+<!-- Describe what this PR is solving. -->
 
 ## 🕵️ Details
 
-Add any additional details that could assist with reviewing or testing this PR.
+<!-- Add any additional details that could assist with reviewing or testing this PR. -->
 
 ## 🧪 Testing
 
-Assist reviewers with steps they can take to test that the PR does what it says it does.
+<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->
 
+<!--
 1. ...
 2. ...
+ -->
 
 ## 📸 Screenshot
 
-Add a screenshot (if possible).
+<!-- Add a screenshot (if possible). -->
 
 ## 🚚 Deployment
 
+<!--
 Add any additional details that are required for deploying the application.
 
 Examples of when this is required include:
@@ -32,3 +35,5 @@ Examples of when this is required include:
 >
 > - Remove deployment section if no steps are needed
 > - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the linked issue if deployment steps are needed
+
+ -->


### PR DESCRIPTION
## 👋 Introduction

I get a bit annoyed when I have to delete a bunch of template instructional text and boilerplate when writing up an issue or PR.  I also get annoyed when said text and boilerplate ends up in posted text.  I had the idea of using comments instead.

Let me know what you think of this idea.  If anyone really doesn't like it we can close this without merging.  :grin: 

## 🕵️ Details

A few small other changes:
- Removed example blocker item from the tasklist.  Those usually aren't added in the markdown editor anyway.
- Merged designer tag into design section.  We probably don't need a whole h3 section for a user name.

