### PR TITLE
[Copy] Replaces Oupse with Oups in French

### DIFF
--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1324,7 +1324,7 @@
     "description": "The work region of Canada described as Telework."
   },
   "xAxxmc": {
-    "defaultMessage": "Oupse! Vous avez des erreurs!",
+    "defaultMessage": "Oups! Vous avez des erreurs!",
     "description": "Title for error summary on profile forms"
   },
   "xEkbvy": {


### PR DESCRIPTION
🤖 Resolves #11297.

## 👋 Introduction

This PR replaces the typo _Oupse_ with _Oups_ in French.

## 🧪 Testing

Assist reviewers with steps they can take to test that the PR does what it says it does.

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/fr/applicant/personal-information#about-section
3. Edit the _Renseignements personnels et coordonnées_ section
4. Leave _Prénom_ form field blank and submit form
5. Observe Oups message
6. Verify _Oups_ does not have a trailing e

## 📸 Screenshot

<img width="1169" alt="Screen Shot 2024-08-21 at 10 21 31" src="https://github.com/user-attachments/assets/f6b37b48-5556-4269-985e-361e542a4fee">