### PR TITLE
[Fix] Adds French translation for Verify your contact email

### DIFF
--- a/apps/web/src/components/EmailVerification/EmailVerification.tsx
+++ b/apps/web/src/components/EmailVerification/EmailVerification.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useIntl } from "react-intl";
+import { IntlShape, useIntl } from "react-intl";
 import CheckBadgeIcon from "@heroicons/react/24/outline/CheckBadgeIcon";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useMutation } from "urql";
@@ -31,16 +31,17 @@ const VerifyUserEmail_Mutation = graphql(/* GraphQL */ `
 
 const getTitle = (
   emailType: NonNullable<EmailVerificationProps["emailType"]>,
+  intl: IntlShape,
 ) => {
   switch (emailType) {
-    // presumably we'll have more than one type eventually
+    // presumably we'll have more than one type eventually.
     case "contact":
     default:
-      return {
+      return intl.formatMessage({
         defaultMessage: "Verify your contact email",
-        id: "TguSOt",
-        description: "Heading for email verification form",
-      };
+        id: "LpCMiC",
+        description: "Verify your contact email text",
+      });
   }
 };
 
@@ -176,7 +177,7 @@ const EmailVerification = ({
         color="primary"
         data-h2-text-align="base(center) p-tablet(left)"
       >
-        {intl.formatMessage(getTitle(emailType))}
+        {getTitle(emailType, intl)}
       </Heading>
       <p>
         {emailAddress

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -535,10 +535,6 @@
     "defaultMessage": "Utilisez le bouton \"Créer une compétence\" pour commencer.",
     "description": "Instructions for adding a skill item."
   },
-  "0k3vfO": {
-    "defaultMessage": "Vérifiez votre adresse courriel de contact",
-    "description": "Button label for submit and verify email button on getting started form."
-  },
   "0k6j4V": {
     "defaultMessage": "Tâches de travail (anglais)",
     "description": "Label for a process' English work tasks"
@@ -4326,6 +4322,10 @@
   "LocjmN": {
     "defaultMessage": "Retourner aux équipes",
     "description": "Button text to return to the table of teams page"
+  },
+  "LpCMiC": {
+    "defaultMessage": "Vérifiez votre adresse courriel de contact",
+    "description": "Verify your contact email text"
   },
   "LphzpW": {
     "defaultMessage": "Que faire si j’ai besoin de choisir plus que {maxSteps} méthodes d’évaluation?",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -536,7 +536,7 @@
     "description": "Instructions for adding a skill item."
   },
   "0k3vfO": {
-    "defaultMessage": "Vérifier votre adresse courriel de contact",
+    "defaultMessage": "Vérifiez votre adresse courriel de contact",
     "description": "Button label for submit and verify email button on getting started form."
   },
   "0k6j4V": {

--- a/apps/web/src/pages/Auth/RegistrationPages/GettingStartedPage/GettingStartedPage.tsx
+++ b/apps/web/src/pages/Auth/RegistrationPages/GettingStartedPage/GettingStartedPage.tsx
@@ -192,9 +192,8 @@ export const GettingStartedFormFields = ({
         >
           {intl.formatMessage({
             defaultMessage: "Verify your contact email",
-            id: "0k3vfO",
-            description:
-              "Button label for submit and verify email button on getting started form.",
+            id: "LpCMiC",
+            description: "Verify your contact email text",
           })}
         </Button>
         <Button


### PR DESCRIPTION
🤖 Resolves #11298.

## 👋 Introduction

This PR adds a the ability to translate the heading "Verify your contact email" in French. It also consolidates this string with an existing identical one. Finally, it changes the single consolidated "Verify your contact email" string in French to _Vérifiez votre adresse courriel de contact_ using the _impératif_ verb tense.

## 🧪 Testing

1. `pnpm build:fresh`
2. Create a new account
3. Switch to French
4. Observe _Vérifiez votre adresse courriel de contact_ button
5. Attempt to verify email
6. Observe _Vérifiez votre adresse courriel de contact_ heading

## 📸 Screenshots

<img width="1147" alt="Screen Shot 2024-08-21 at 10 39 41" src="https://github.com/user-attachments/assets/2a9c3448-1161-4c28-a280-7e76de905d90">

<img width="1174" alt="Screen Shot 2024-08-21 at 10 39 57" src="https://github.com/user-attachments/assets/bcf9b073-4863-44e7-bc49-a02b082bb53b">