### PR TITLE
[Fix] Message after unlinking an experience with a skill

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3244,7 +3244,7 @@
     "description": "Context for _digital initiative plan submitted_ fieldset in the _digital services contracting questionnaire_"
   },
   "FpDMGu": {
-    "defaultMessage": "Lien établi avec l’expérience!",
+    "defaultMessage": "Lien avec l’expérience supprimé!",
     "description": "Success message displayed after unlinking an experience to a skill"
   },
   "Fs444j": {


### PR DESCRIPTION
🤖 Resolves #11299.

## 👋 Introduction

This PR fixes the message after unlinking an experience with a skill in French.

## 🧪 Testing

1. Navigate to http://localhost:8000/en/applicant/skills
2. Add a new skill
3. Navigate to that skill
4. Switch to French
5. Link an experience
6. Observe toast message _Lien établi avec l’expérience!_
7. Remove this experience
8. Verify toast message is _Lien avec l’expérience supprimé!_

## 📸 Screenshot

<img width="982" alt="Screen Shot 2024-08-21 at 14 26 35" src="https://github.com/user-attachments/assets/3db121cd-1f8e-4bda-9b7c-33548e848816">
