### PR TITLE
[Feat] Makes laravel aware of client locale

### DIFF
--- a/api/app/Http/Middleware/AcceptLanguageMiddleware.php
+++ b/api/app/Http/Middleware/AcceptLanguageMiddleware.php
@@ -25,9 +25,7 @@ class AcceptLanguageMiddleware
     public function handle(Request $request, Closure $next)
     {
         $locale = $request->getPreferredLanguage($this->availableLocales);
-        if ($locale == 'en' || $locale == 'fr') {
-            App::setLocale($locale);
-        }
+        App::setLocale($locale);
 
         return $next($request);
     }

--- a/api/app/Http/Middleware/AcceptLanguageMiddleware.php
+++ b/api/app/Http/Middleware/AcceptLanguageMiddleware.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+
+/**
+ * Sets the application locale based on
+ * the `Accept-Language` header
+ *
+ * REF: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
+ */
+class AcceptLanguageMiddleware
+{
+    /**
+     * @return mixed Any kind of response
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $locale = $request->header('Accept-Language', 'en') ?? '';
+        App::setLocale($locale);
+
+        return $next($request);
+    }
+}

--- a/api/app/Http/Middleware/AcceptLanguageMiddleware.php
+++ b/api/app/Http/Middleware/AcceptLanguageMiddleware.php
@@ -24,53 +24,11 @@ class AcceptLanguageMiddleware
      */
     public function handle(Request $request, Closure $next)
     {
-        $headerLocale = $request->header('Accept-Language', 'en');
-        $locale = $this->getLocale($headerLocale);
+        $locale = $request->getPreferredLanguage($this->availableLocales);
         if ($locale == 'en' || $locale == 'fr') {
             App::setLocale($locale);
         }
 
         return $next($request);
-    }
-
-    private function getLocale(?string $header)
-    {
-        if (! $header) {
-            return $this->availableLocales[0];
-        }
-
-        /**
-         *  Parse header string into a $locale => $quality array
-         *
-         *  If a quality is not present, it defaults to highest priority
-         *  We denote this by a decreasing value of 100, giving higher
-         *  priority to locales that appear earlier in the string
-         */
-        $defaultQuality = 100;
-        $localePairs = explode(',', $header);
-        $weightedLocales = [];
-        foreach ($localePairs as $pair) {
-            $pairArr = explode(';', $pair);
-            $quality = isset($pairArr[1]) ? str_replace('q=', '', $pairArr[1]) : null;
-            $quality = $quality ? floatval($quality) : $defaultQuality--;
-
-            $weightedLocales[$pairArr[0]] = $quality;
-        }
-
-        // Sort by quality in descending order
-        arsort($weightedLocales);
-
-        // Attempt to find a letter code that matches our
-        // supported locales in order of priority
-        $preferredLocale = $this->availableLocales[0];
-        foreach (array_keys($weightedLocales) as $locale) {
-            $twoLetter = substr($locale, 0, 2);
-            if (in_array($twoLetter, $this->availableLocales)) {
-                $preferredLocale = $twoLetter;
-                break;
-            }
-        }
-
-        return $preferredLocale;
     }
 }

--- a/api/app/Http/Middleware/AcceptLanguageMiddleware.php
+++ b/api/app/Http/Middleware/AcceptLanguageMiddleware.php
@@ -15,13 +15,62 @@ use Illuminate\Support\Facades\App;
 class AcceptLanguageMiddleware
 {
     /**
+     * Languages we support
+     */
+    private array $availableLocales = ['en', 'fr'];
+
+    /**
      * @return mixed Any kind of response
      */
     public function handle(Request $request, Closure $next)
     {
-        $locale = $request->header('Accept-Language', 'en') ?? '';
-        App::setLocale($locale);
+        $headerLocale = $request->header('Accept-Language', 'en');
+        $locale = $this->getLocale($headerLocale);
+        if ($locale == 'en' || $locale == 'fr') {
+            App::setLocale($locale);
+        }
 
         return $next($request);
+    }
+
+    private function getLocale(?string $header)
+    {
+        if (! $header) {
+            return $this->availableLocales[0];
+        }
+
+        /**
+         *  Parse header string into a $locale => $quality array
+         *
+         *  If a quality is not present, it defaults to highest priority
+         *  We denote this by a decreasing value of 100, giving higher
+         *  priority to locales that appear earlier in the string
+         */
+        $defaultQuality = 100;
+        $localePairs = explode(',', $header);
+        $weightedLocales = [];
+        foreach ($localePairs as $pair) {
+            $pairArr = explode(';', $pair);
+            $quality = isset($pairArr[1]) ? str_replace('q=', '', $pairArr[1]) : null;
+            $quality = $quality ? floatval($quality) : $defaultQuality--;
+
+            $weightedLocales[$pairArr[0]] = $quality;
+        }
+
+        // Sort by quality in descending order
+        arsort($weightedLocales);
+
+        // Attempt to find a letter code that matches our
+        // supported locales in order of priority
+        $preferredLocale = $this->availableLocales[0];
+        foreach (array_keys($weightedLocales) as $locale) {
+            $twoLetter = substr($locale, 0, 2);
+            if (in_array($twoLetter, $this->availableLocales)) {
+                $preferredLocale = $twoLetter;
+                break;
+            }
+        }
+
+        return $preferredLocale;
     }
 }

--- a/api/routes/graphql.php
+++ b/api/routes/graphql.php
@@ -35,6 +35,9 @@ Route::middleware([
     // Logs slow running GraphQL queries
     App\Http\Middleware\SlowQueryLoggerMiddleware::class,
 
+    // Set the app locale
+    App\Http\Middleware\AcceptLanguageMiddleware::class,
+
     // Throttles based on RateLimiter in RouteServiceProvider.
     'throttle:graphql',
 ])->group(function () {

--- a/api/tests/Unit/AcceptLanguageMiddlewareTest.php
+++ b/api/tests/Unit/AcceptLanguageMiddlewareTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Middleware\AcceptLanguageMiddleware;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+use Tests\TestCase;
+
+class AcceptLanguageMiddlewareTest extends TestCase
+{
+    /**
+     * @dataProvider provider
+     */
+    public function testLocaleSet($header, $expected): void
+    {
+        $request = Request::create(route('graphql'));
+        if ($header) {
+            $request->headers->set('Accept-Language', $header);
+        } else {
+            $request->headers->remove('Accept-Language');
+        }
+
+        $next = function () {
+            return response(App::getLocale());
+        };
+
+        $middleware = new AcceptLanguageMiddleware();
+        $response = $middleware->handle($request, $next);
+
+        $this->assertEquals($expected, $response->getContent());
+    }
+
+    public static function provider(): array
+    {
+        return [
+            'fallback to English when not set' => [false, 'en'],
+            'sets English' => ['en', 'en'],
+            'sets French' => ['fr', 'fr'],
+        ];
+    }
+}

--- a/api/tests/Unit/AcceptLanguageMiddlewareTest.php
+++ b/api/tests/Unit/AcceptLanguageMiddlewareTest.php
@@ -17,7 +17,7 @@ class AcceptLanguageMiddlewareTest extends TestCase
         $request = Request::create(route('graphql'));
         if ($header) {
             $request->headers->set('Accept-Language', $header);
-        } else {
+        } elseif ($header == 'unset') {
             $request->headers->remove('Accept-Language');
         }
 
@@ -34,7 +34,17 @@ class AcceptLanguageMiddlewareTest extends TestCase
     public static function provider(): array
     {
         return [
-            'fallback to English when not set' => [false, 'en'],
+            // NOTE: Browsers send by default so we should only change when we get a value we can handle
+            'does not modify default value' => [false, 'en'],
+            'does not modify unexpected value' => ['mt-MT;q=0.9,ta-IN;q=0.8,eu-ES;q=0.7', 'en'],
+            'does not modify invalid value' => ['invalid-language-value', 'en'],
+            // If the header does not exist, we should fallback to English
+            'fallback to English when not set' => ['unset', 'en'],
+            // Can get an expected locale out of a list of unexpected values
+            'sets English from list' => ['mt-MT;q=0.9,en-US;q=0.8,eu-ES;q=0.7', 'en'],
+            'sets French from list' => ['mt-MT;q=0.9,fr-LU;q=0.8,eu-ES;q=0.7', 'fr'],
+            'weights by quality' => ['en;q=0.8,eu-ES;q=0.7,fr-LU;q=0.9;', 'fr'],
+            // If a valid value is sent, make sure locale is updated
             'sets English' => ['en', 'en'],
             'sets French' => ['fr', 'fr'],
         ];

--- a/packages/client/src/components/ClientProvider/ClientProvider.tsx
+++ b/packages/client/src/components/ClientProvider/ClientProvider.tsx
@@ -165,7 +165,7 @@ const ClientProvider = ({
         ],
       })
     );
-  }, [client, intl, logger]);
+  }, [client, intl, locale, logger]);
 
   return <Provider value={internalClient}>{children}</Provider>;
 };

--- a/packages/client/src/components/ClientProvider/ClientProvider.tsx
+++ b/packages/client/src/components/ClientProvider/ClientProvider.tsx
@@ -21,6 +21,7 @@ import { useLogger } from "@gc-digital-talent/logger";
 import { toast } from "@gc-digital-talent/toast";
 import { uniqueItems } from "@gc-digital-talent/helpers";
 import type { LogoutReason } from "@gc-digital-talent/auth";
+import { getLocale } from "@gc-digital-talent/i18n";
 
 import {
   buildValidationErrorMessageNode,
@@ -53,6 +54,7 @@ const ClientProvider = ({
   children?: ReactNode;
 }) => {
   const intl = useIntl();
+  const locale = getLocale(intl);
   const authContext = useAuthentication();
   const logger = useLogger();
   // Create a mutable object to hold the auth state
@@ -68,6 +70,7 @@ const ClientProvider = ({
       createClient({
         url: `${apiHost}${apiUri}`,
         requestPolicy: "cache-and-network",
+        fetchOptions: { headers: { "Accept-Language": locale } },
         exchanges: [
           cacheExchange,
           protectedEndpointExchange,


### PR DESCRIPTION
🤖 Resolves #11336 

## 👋 Introduction

Uses the `Accept-Language` header to set the app locale for graphql requests.

## 🕵️ Details

REF: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language

For the server, we add a middleware that parses the `Accept-Language` header to get the preferred locale and set the app locale to one we support falling back to English.

On the client, we attach the header to all graphql requests basing it on the locale set in `react-intl`.

## 🧪 Testing

1. Hard to test but maybe just review the tests and ensure they pass and are comprehensive?