### PR TITLE
[Feature] Adds a content security policy in report mode

### DIFF
--- a/api/app/Http/Controllers/CspReportController.php
+++ b/api/app/Http/Controllers/CspReportController.php
@@ -11,9 +11,10 @@ class CspReportController extends Controller
     {
         $report = $request->json()->all();
         $message = sprintf(
-            'CSP violation, %s, %s, %s',
+            'CSP violation, %s, %s, %s, %s',
             $report['csp-report']['blocked-uri'] ?? '',
             $report['csp-report']['violated-directive'] ?? '',
+            $report['csp-report']['source-file'] ?? '',
             json_encode($report['csp-report'])
         );
 

--- a/api/app/Http/Controllers/CspReportController.php
+++ b/api/app/Http/Controllers/CspReportController.php
@@ -13,7 +13,7 @@ class CspReportController extends Controller
         $message = sprintf(
             'CSP violation, %s, %s, %s',
             $report['csp-report']['blocked-uri'] ?? '',
-            $report['csp-report']['column-number'] ?? '',
+            $report['csp-report']['violated-directive'] ?? '',
             json_encode($report['csp-report'])
         );
 

--- a/api/app/Http/Controllers/CspReportController.php
+++ b/api/app/Http/Controllers/CspReportController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class CspReportController extends Controller
+{
+    public function report(Request $request)
+    {
+        $report = $request->json()->all();
+        $message = sprintf(
+            'CSP violation, %s, %s, %s',
+            $report['csp-report']['blocked-uri'] ?? '',
+            $report['csp-report']['column-number'] ?? '',
+            json_encode($report['csp-report'])
+        );
+
+        Log::warning($message);
+    }
+}

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\CspReportController;
 use App\Http\Controllers\SupportController;
 use App\Http\Controllers\UserGeneratedFilesController;
 use Illuminate\Support\Facades\Route;
@@ -24,3 +25,5 @@ Route::prefix('user-generated-files')
         // api/config/auth.php
             ->middleware('auth:api');
     });
+
+Route::post('csp-report', [CspReportController::class, 'report']);

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,7 +6,6 @@ import react from "@vitejs/plugin-react";
 import { createHtmlPlugin } from "vite-plugin-html";
 import { compression } from "vite-plugin-compression2";
 import { Plugin, defineConfig } from "vite";
-
 import { hydrogen_watch } from "@hydrogen-css/hydrogen";
 
 dotenv.config({ path: "./.env" });
@@ -101,6 +100,9 @@ export default defineConfig(({ command }) => ({
   },
   server: {
     port: 3000,
+  },
+  html: {
+    cspNonce: "**CSP_NONCE**",
   },
   resolve: {
     extensions: [".ts", ".tsx", ".json", ".js"],
@@ -224,6 +226,6 @@ export default defineConfig(({ command }) => ({
         ],
       },
     }),
-    compression(),
+    compression({ exclude: /index\.html/i }),
   ],
 }));

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -226,6 +226,13 @@ export default defineConfig(({ command }) => ({
         ],
       },
     }),
+    /**
+     * NOTE: We are not compressing the index.html
+     * so we can use the ngx_http_sub_module to
+     * replace values at runtime
+     *
+     * REF: https://nginx.org/en/docs/http/ngx_http_sub_module.html
+     */
     compression({ exclude: /index\.html/i }),
   ],
 }));

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -16,6 +16,23 @@ server {
     # redirect server error pages
     error_page   404  /404;
 
+    # CSP Headers
+    set $cspNonce $request_id;
+    sub_filter_types *;
+    sub_filter '**CSP_NONCE**' $cspNonce;
+    sub_filter_once off;
+
+    add_header Reporting-Endpoints csp="/api/csp-report";
+    add_header Content-Security-Policy-Report-Only
+      "default-src 'self';
+      font-src fonts.gstatic.com 'self';
+      style-src-elem fonts.googleapis.com 'self';
+      script-src-elem 'self' 'nonce-$cspNonce';
+      img-src 'self' data:;
+      report-uri /api/csp-report/;
+      report-to csp;
+      " always;
+
     # Permanent redirects to avoid dead links
     location = /en/communities/digital-talent {
         absolute_redirect on;

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -26,7 +26,7 @@ server {
     add_header Content-Security-Policy-Report-Only
       "default-src 'self';
       font-src fonts.gstatic.com 'self';
-      style-src-elem fonts.googleapis.com 'self';
+      style-src-elem fonts.googleapis.com 'self' 'unsafe-inline';
       script-src-elem 'self' 'nonce-$cspNonce';
       img-src 'self' data:;
       report-uri /api/csp-report/;

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -23,15 +23,7 @@ server {
     sub_filter_once off;
 
     add_header Reporting-Endpoints csp="/api/csp-report";
-    add_header Content-Security-Policy-Report-Only
-      "default-src 'self';
-      font-src fonts.gstatic.com 'self';
-      style-src-elem fonts.googleapis.com 'self' 'unsafe-inline';
-      script-src-elem 'self' 'nonce-$cspNonce';
-      img-src 'self' data:;
-      report-uri /api/csp-report/;
-      report-to csp;
-      " always;
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'unsafe-inline'; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' data:; report-uri /api/csp-report/; report-to csp;" always;
 
     # Permanent redirects to avoid dead links
     location = /en/communities/digital-talent {

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -29,6 +29,23 @@ server {
     # The following are only added if they do not already exist.  Avoid overwriting headers from PHP.
     add_header Cache-Control $hdr_cache_control;
 
+    # CSP Headers
+    set $cspNonce $request_id;
+    sub_filter_types *;
+    sub_filter '**CSP_NONCE**' $cspNonce;
+    sub_filter_once off;
+
+    add_header Reporting-Endpoints csp="/api/csp-report";
+    add_header Content-Security-Policy-Report-Only
+      "default-src 'self';
+      font-src fonts.gstatic.com 'self';
+      style-src-elem fonts.googleapis.com 'self';
+      script-src-elem 'self' 'nonce-$cspNonce';
+      img-src 'self' data:;
+      report-uri /api/csp-report/;
+      report-to csp;
+      " always;
+
     # Permanent redirects to avoid dead links
     location = /en/communities/digital-talent {
         absolute_redirect on;

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -39,7 +39,7 @@ server {
     add_header Content-Security-Policy-Report-Only
       "default-src 'self';
       font-src fonts.gstatic.com 'self';
-      style-src-elem fonts.googleapis.com 'self';
+      style-src-elem fonts.googleapis.com 'self' 'unsafe-inline';
       script-src-elem 'self' 'nonce-$cspNonce';
       img-src 'self' data:;
       report-uri /api/csp-report/;

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -36,15 +36,7 @@ server {
     sub_filter_once off;
 
     add_header Reporting-Endpoints csp="/api/csp-report";
-    add_header Content-Security-Policy-Report-Only
-      "default-src 'self';
-      font-src fonts.gstatic.com 'self';
-      style-src-elem fonts.googleapis.com 'self' 'unsafe-inline';
-      script-src-elem 'self' 'nonce-$cspNonce';
-      img-src 'self' data:;
-      report-uri /api/csp-report/;
-      report-to csp;
-      " always;
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'unsafe-inline'; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' data:; report-uri /api/csp-report/; report-to csp;" always;
 
     # Permanent redirects to avoid dead links
     location = /en/communities/digital-talent {


### PR DESCRIPTION
🤖 Resolves #10614 

## 👋 Introduction

This adds a starting point for our content security policy in report mode along with an endpoint to log the report.

## 🕵️ Details

For those wondering how to read the policy [MDN has good documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) on it. I'll try my best to describe our specific policy:

- `default-src 'self'` This is the default, where self means anything coming from our domain
- `font-src fonts.gstatic.com 'self'` Is allowing google fonts
- `style-src-elem fonts.googleapis.com 'self' 'unsafe-inline' Allows styles from google fonts and inline.
    - NOTE: This is unsafe and I describe why later on
- `img-src 'self' data;` This is allowing images where the url starts with `data:` 
    - We may be able to get rid of this if we no longer process images through vite
    - We need this since vite can serve images as base64 if it means it is most optimal way of serving an image
- `report-uri` and `report-to` is telling the policy to report violations to our endpoint

### Unsafe inline styles

Sadly, we must allow unsafe inline styles since `@radix-ui` uses the `react-remove-scroll` library which injects a style tag we have no control over. There is an issue regarding this and hopefully we have a solution shortly but I tihnk having a policy with on unsafe is probably better than no policy at all :sweat_smile: 

 - https://github.com/radix-ui/primitives/issues/3063

## 🧪 Testing

> [!NOTE]
> Right now, I tihnk only firefox will report over localhost so it is best to test in that browser. This is because CSP will only report over a secure context and AFAIK only firefox considers localhost to be a secure context. 

1. Force violations by removing the nonce from the rule `'nonce-$cspNonce'` part
2. Reload nginx `docker exec $(docker ps | grep webserver | awk  '{ print $1 }') service nginx reload`
3. Maybe need to cache the new route `make artisan CMD="route:cache"`
4. Rebuild app `pnpm run dev:fresh`
5. Bounce around the site observing the console to confirm violations being reporting but stil allowed to run scripts
6. Open laravel logs and confirm the CSP Violation warnings
7. Undo change from step 1
8. Repeat steps 2-5 but check that the violations are gone