### PR TITLE
[Fix] Personal information Indigenous identity

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -34,6 +34,7 @@ gctalent
 heroicons
 ilike
 Inclusivity
+inuk
 Inuk
 jwks
 Laratrust
@@ -65,8 +66,8 @@ subquery
 TALENTSEARCH
 tanstack
 teamable
-TELEWORK
 Telework
+TELEWORK
 testid
 textbox
 Timeframe

--- a/apps/web/src/components/SelfDeclaration/CommunitySelection.tsx
+++ b/apps/web/src/components/SelfDeclaration/CommunitySelection.tsx
@@ -1,5 +1,5 @@
-import { useFormContext } from "react-hook-form";
-import { useIntl } from "react-intl";
+import { FieldValues, FormState, useFormContext } from "react-hook-form";
+import { IntlShape, useIntl } from "react-intl";
 import { ReactNode, useEffect, useId } from "react";
 
 import {
@@ -21,6 +21,24 @@ interface RowProps {
   children: ReactNode;
 }
 
+interface FirstNationSectionProps {
+  labels: FieldLabels;
+  intl: IntlShape;
+  customAlertId: string;
+  formState: FormState<FieldValues>;
+  communitiesValue: string[];
+}
+
+interface InukSectionProps {
+  labels: FieldLabels;
+  intl: IntlShape;
+}
+
+interface MetisSectionProps {
+  labels: FieldLabels;
+  intl: IntlShape;
+}
+
 const Row = ({ children }: RowProps) => (
   <div
     data-h2-display="base(grid)"
@@ -30,6 +48,135 @@ const Row = ({ children }: RowProps) => (
   >
     {children}
   </div>
+);
+
+const FirstNationSection = ({
+  labels,
+  intl,
+  customAlertId,
+  formState,
+  communitiesValue,
+}: FirstNationSectionProps) => (
+  <>
+    <Row>
+      <div data-h2-grid-column="base(span 3)">
+        <Checkbox
+          id="firstNations"
+          name="communities"
+          boundingBox
+          boundingBoxLabel={labels.firstNations}
+          trackUnsaved={false}
+          value="firstNations"
+          label={intl.formatMessage({
+            defaultMessage: '"I am First Nations"',
+            id: "Wpj2OY",
+            description: "Text for the option to self-declare as first nations",
+          })}
+          aria-describedby={customAlertId}
+        />
+        {formState.errors.firstNationsCustom && (
+          <Field.Error id={customAlertId} data-h2-margin-top="base(x.25)">
+            {formState.errors.firstNationsCustom.message?.toString()}
+          </Field.Error>
+        )}
+      </div>
+      <div>
+        <CommunityIcon values={["firstNations"]} community="first-nations" />
+      </div>
+    </Row>
+    {communitiesValue.includes("firstNations") && (
+      <Row>
+        <div data-h2-grid-column="base(span 3)">
+          <RadioGroup
+            idPrefix="firstNationsStatus"
+            name="isStatus"
+            legend={intl.formatMessage({
+              defaultMessage: "First Nations status",
+              id: "0KY1My",
+              description:
+                "Legend for selecting First Nations status or non-status",
+            })}
+            rules={{ required: intl.formatMessage(errorMessages.required) }}
+            items={[
+              {
+                value: "status",
+                label: intl.formatMessage({
+                  defaultMessage: '"I am Status First Nations"',
+                  id: "ssJxrj",
+                  description:
+                    "Text for the option to self-declare as a status first nations",
+                }),
+              },
+              {
+                value: "nonStatus",
+                label: intl.formatMessage({
+                  defaultMessage: '"I am Non-Status First Nations"',
+                  id: "sSE4kt",
+                  description:
+                    "Text for the option to self-declare as a non-status first nations",
+                }),
+              },
+            ]}
+          />
+        </div>
+        <div />
+      </Row>
+    )}
+  </>
+);
+
+const InukSection = ({ labels, intl }: InukSectionProps) => (
+  <Row>
+    <div data-h2-grid-column="base(span 3)">
+      <Checklist
+        idPrefix="inuk"
+        id="inuk"
+        name="communities"
+        legend={labels.inuk}
+        trackUnsaved={false}
+        items={[
+          {
+            value: "inuk",
+            label: intl.formatMessage({
+              defaultMessage: `"I am Inuk"`,
+              id: "vDb+O+",
+              description: "Label text for Inuk community declaration",
+            }),
+          },
+        ]}
+      />
+    </div>
+    <div>
+      <CommunityIcon values={["inuk"]} community="inuit" />
+    </div>
+  </Row>
+);
+
+const MetisSection = ({ labels, intl }: MetisSectionProps) => (
+  <Row>
+    <div data-h2-grid-column="base(span 3)">
+      <Checklist
+        idPrefix="metis"
+        id="metis"
+        name="communities"
+        legend={labels.metis}
+        trackUnsaved={false}
+        items={[
+          {
+            value: "metis",
+            label: intl.formatMessage({
+              defaultMessage: `"I am Métis"`,
+              id: "/81xCT",
+              description: "Label text for Métis community declaration",
+            }),
+          },
+        ]}
+      />
+    </div>
+    <div>
+      <CommunityIcon values={["metis"]} community="metis" />
+    </div>
+  </Row>
 );
 
 interface CommunityListProps {
@@ -80,130 +227,6 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
     }
   };
 
-  const firstNations = (
-    <>
-      <Row>
-        <div data-h2-grid-column="base(span 3)">
-          <Checkbox
-            id="firstNations"
-            name="communities"
-            boundingBox
-            boundingBoxLabel={labels.firstNations}
-            trackUnsaved={false}
-            value="firstNations"
-            label={intl.formatMessage({
-              defaultMessage: '"I am First Nations"',
-              id: "Wpj2OY",
-              description:
-                "Text for the option to self-declare as first nations",
-            })}
-            aria-describedby={customAlertId}
-          />
-          {formState.errors.firstNationsCustom && (
-            <Field.Error id={customAlertId} data-h2-margin-top="base(x.25)">
-              {formState.errors.firstNationsCustom.message?.toString()}
-            </Field.Error>
-          )}
-        </div>
-        <div>
-          <CommunityIcon values={["firstNations"]} community="first-nations" />
-        </div>
-      </Row>
-      {communitiesValue.includes("firstNations") && (
-        <Row>
-          <div data-h2-grid-column="base(span 3)">
-            <RadioGroup
-              idPrefix="firstNationsStatus"
-              name="isStatus"
-              legend={intl.formatMessage({
-                defaultMessage: "First Nations status",
-                id: "0KY1My",
-                description:
-                  "Legend for selecting First Nations status or non-status",
-              })}
-              rules={{ required: intl.formatMessage(errorMessages.required) }}
-              items={[
-                {
-                  value: "status",
-                  label: intl.formatMessage({
-                    defaultMessage: '"I am Status First Nations"',
-                    id: "ssJxrj",
-                    description:
-                      "Text for the option to self-declare as a status first nations",
-                  }),
-                },
-                {
-                  value: "nonStatus",
-                  label: intl.formatMessage({
-                    defaultMessage: '"I am Non-Status First Nations"',
-                    id: "sSE4kt",
-                    description:
-                      "Text for the option to self-declare as a non-status first nations",
-                  }),
-                },
-              ]}
-            />
-          </div>
-          <div />
-        </Row>
-      )}
-    </>
-  );
-
-  const inuk = (
-    <Row>
-      <div data-h2-grid-column="base(span 3)">
-        <Checklist
-          idPrefix="inuk"
-          id="inuk"
-          name="communities"
-          legend={labels.inuk}
-          trackUnsaved={false}
-          items={[
-            {
-              value: "inuk",
-              label: intl.formatMessage({
-                defaultMessage: `"I am Inuk"`,
-                id: "vDb+O+",
-                description: "Label text for Inuk community declaration",
-              }),
-            },
-          ]}
-        />
-      </div>
-      <div>
-        <CommunityIcon values={["inuk"]} community="inuit" />
-      </div>
-    </Row>
-  );
-
-  const metis = (
-    <Row>
-      <div data-h2-grid-column="base(span 3)">
-        <Checklist
-          idPrefix="metis"
-          id="metis"
-          name="communities"
-          legend={labels.metis}
-          trackUnsaved={false}
-          items={[
-            {
-              value: "metis",
-              label: intl.formatMessage({
-                defaultMessage: `"I am Métis"`,
-                id: "/81xCT",
-                description: "Label text for Métis community declaration",
-              }),
-            },
-          ]}
-        />
-      </div>
-      <div>
-        <CommunityIcon values={["metis"]} community="metis" />
-      </div>
-    </Row>
-  );
-
   return (
     <>
       <div
@@ -213,15 +236,27 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
       >
         {locale === "fr" ? (
           <>
-            {inuk}
-            {metis}
-            {firstNations}
+            <InukSection labels={labels} intl={intl} />
+            <MetisSection labels={labels} intl={intl} />
+            <FirstNationSection
+              labels={labels}
+              intl={intl}
+              customAlertId={customAlertId}
+              formState={formState}
+              communitiesValue={communitiesValue}
+            />
           </>
         ) : (
           <>
-            {firstNations}
-            {inuk}
-            {metis}
+            <FirstNationSection
+              labels={labels}
+              intl={intl}
+              customAlertId={customAlertId}
+              formState={formState}
+              communitiesValue={communitiesValue}
+            />
+            <InukSection labels={labels} intl={intl} />
+            <MetisSection labels={labels} intl={intl} />
           </>
         )}
         <Row>

--- a/apps/web/src/components/SelfDeclaration/CommunitySelection.tsx
+++ b/apps/web/src/components/SelfDeclaration/CommunitySelection.tsx
@@ -1,6 +1,6 @@
 import { useFormContext } from "react-hook-form";
 import { useIntl } from "react-intl";
-import { ReactNode, useState, useEffect, useId } from "react";
+import { ReactNode, useEffect, useId } from "react";
 
 import {
   FieldLabels,
@@ -9,12 +9,10 @@ import {
   Checkbox,
   RadioGroup,
 } from "@gc-digital-talent/forms";
-import { Alert } from "@gc-digital-talent/ui";
 import { errorMessages } from "@gc-digital-talent/i18n";
 
 import { FirstNationsStatus } from "~/utils/indigenousDeclaration";
 
-import HelpLink from "./HelpLink";
 import { hasCommunityAndOther } from "./utils";
 import CommunityIcon from "./CommunityIcon";
 import CommunityChips from "./CommunityChips";
@@ -40,8 +38,6 @@ interface CommunityListProps {
 
 export const CommunityList = ({ labels }: CommunityListProps) => {
   const intl = useIntl();
-  const [isAlertOpen, setIsAlertOpen] = useState<boolean>(false);
-  const [hasDismissedAlert, setHasDismissedAlert] = useState<boolean>(false);
   const { watch, setValue, resetField, setError, clearErrors, formState } =
     useFormContext();
 
@@ -51,11 +47,6 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
   ] = watch(["communities", "isStatus"]);
 
   const isOtherAndHasCommunity = hasCommunityAndOther(communitiesValue);
-
-  useEffect(() => {
-    // Is not represented and has at least on other community selected
-    setIsAlertOpen(!!(isOtherAndHasCommunity && !hasDismissedAlert));
-  }, [isOtherAndHasCommunity, setIsAlertOpen, hasDismissedAlert]);
 
   useEffect(() => {
     if (
@@ -77,11 +68,6 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
     }
   }, [clearErrors, communitiesValue, intl, setError]);
   const customAlertId = useId();
-
-  const handleAlertDismiss = () => {
-    setIsAlertOpen(false);
-    setHasDismissedAlert(true);
-  };
 
   const handleDismissCommunity = (community: string) => {
     const newCommunities = communitiesValue.filter(
@@ -245,34 +231,9 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
       <CommunityChips
         communities={communitiesValue}
         status={isStatus}
-        otherAlert={!!(isOtherAndHasCommunity && isAlertOpen)}
+        otherAlert={!!isOtherAndHasCommunity}
         onDismiss={handleDismissCommunity}
       />
-      {isAlertOpen && (
-        <Alert.Root type="warning" dismissible onDismiss={handleAlertDismiss}>
-          <Alert.Title>
-            {intl.formatMessage({
-              defaultMessage:
-                'Are you sure you meant to select "I am Indigenous and I don\'t see my community here?"',
-              id: "at11n5",
-              description:
-                "Title for the alert warning users about selection not represented and a represented community",
-            })}
-          </Alert.Title>
-          <p>
-            {intl.formatMessage({
-              defaultMessage:
-                "The program is for First Nations, Inuit, and Métis peoples within the geographic boundaries of Canada. At a later step of the application process, you may be asked to provide proof that you are Indigenous. You can read more about how this will be verified below.",
-              id: "Ap86I/",
-              description:
-                "Text explaining the program and the possibility of needing to provide proof.",
-            })}
-          </p>
-          <Alert.Footer>
-            <HelpLink />
-          </Alert.Footer>
-        </Alert.Root>
-      )}
     </>
   );
 };

--- a/apps/web/src/components/SelfDeclaration/CommunitySelection.tsx
+++ b/apps/web/src/components/SelfDeclaration/CommunitySelection.tsx
@@ -9,7 +9,7 @@ import {
   Checkbox,
   RadioGroup,
 } from "@gc-digital-talent/forms";
-import { errorMessages } from "@gc-digital-talent/i18n";
+import { errorMessages, getLocale } from "@gc-digital-talent/i18n";
 
 import { FirstNationsStatus } from "~/utils/indigenousDeclaration";
 
@@ -38,6 +38,7 @@ interface CommunityListProps {
 
 export const CommunityList = ({ labels }: CommunityListProps) => {
   const intl = useIntl();
+  const locale = getLocale(intl);
   const { watch, setValue, resetField, setError, clearErrors, formState } =
     useFormContext();
 
@@ -79,6 +80,130 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
     }
   };
 
+  const firstNations = (
+    <>
+      <Row>
+        <div data-h2-grid-column="base(span 3)">
+          <Checkbox
+            id="firstNations"
+            name="communities"
+            boundingBox
+            boundingBoxLabel={labels.firstNations}
+            trackUnsaved={false}
+            value="firstNations"
+            label={intl.formatMessage({
+              defaultMessage: '"I am First Nations"',
+              id: "Wpj2OY",
+              description:
+                "Text for the option to self-declare as first nations",
+            })}
+            aria-describedby={customAlertId}
+          />
+          {formState.errors.firstNationsCustom && (
+            <Field.Error id={customAlertId} data-h2-margin-top="base(x.25)">
+              {formState.errors.firstNationsCustom.message?.toString()}
+            </Field.Error>
+          )}
+        </div>
+        <div>
+          <CommunityIcon values={["firstNations"]} community="first-nations" />
+        </div>
+      </Row>
+      {communitiesValue.includes("firstNations") && (
+        <Row>
+          <div data-h2-grid-column="base(span 3)">
+            <RadioGroup
+              idPrefix="firstNationsStatus"
+              name="isStatus"
+              legend={intl.formatMessage({
+                defaultMessage: "First Nations status",
+                id: "0KY1My",
+                description:
+                  "Legend for selecting First Nations status or non-status",
+              })}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
+              items={[
+                {
+                  value: "status",
+                  label: intl.formatMessage({
+                    defaultMessage: '"I am Status First Nations"',
+                    id: "ssJxrj",
+                    description:
+                      "Text for the option to self-declare as a status first nations",
+                  }),
+                },
+                {
+                  value: "nonStatus",
+                  label: intl.formatMessage({
+                    defaultMessage: '"I am Non-Status First Nations"',
+                    id: "sSE4kt",
+                    description:
+                      "Text for the option to self-declare as a non-status first nations",
+                  }),
+                },
+              ]}
+            />
+          </div>
+          <div />
+        </Row>
+      )}
+    </>
+  );
+
+  const inuk = (
+    <Row>
+      <div data-h2-grid-column="base(span 3)">
+        <Checklist
+          idPrefix="inuk"
+          id="inuk"
+          name="communities"
+          legend={labels.inuk}
+          trackUnsaved={false}
+          items={[
+            {
+              value: "inuk",
+              label: intl.formatMessage({
+                defaultMessage: `"I am Inuk"`,
+                id: "vDb+O+",
+                description: "Label text for Inuk community declaration",
+              }),
+            },
+          ]}
+        />
+      </div>
+      <div>
+        <CommunityIcon values={["inuk"]} community="inuit" />
+      </div>
+    </Row>
+  );
+
+  const metis = (
+    <Row>
+      <div data-h2-grid-column="base(span 3)">
+        <Checklist
+          idPrefix="metis"
+          id="metis"
+          name="communities"
+          legend={labels.metis}
+          trackUnsaved={false}
+          items={[
+            {
+              value: "metis",
+              label: intl.formatMessage({
+                defaultMessage: `"I am Métis"`,
+                id: "/81xCT",
+                description: "Label text for Métis community declaration",
+              }),
+            },
+          ]}
+        />
+      </div>
+      <div>
+        <CommunityIcon values={["metis"]} community="metis" />
+      </div>
+    </Row>
+  );
+
   return (
     <>
       <div
@@ -86,122 +211,19 @@ export const CommunityList = ({ labels }: CommunityListProps) => {
         data-h2-gap="base(x1 0)"
         data-h2-flex-direction="base(column)"
       >
-        <Row>
-          <div data-h2-grid-column="base(span 3)">
-            <Checkbox
-              id="firstNations"
-              name="communities"
-              boundingBox
-              boundingBoxLabel={labels.firstNations}
-              trackUnsaved={false}
-              value="firstNations"
-              label={intl.formatMessage({
-                defaultMessage: '"I am First Nations"',
-                id: "Wpj2OY",
-                description:
-                  "Text for the option to self-declare as first nations",
-              })}
-              aria-describedby={customAlertId}
-            />
-            {formState.errors.firstNationsCustom && (
-              <Field.Error id={customAlertId} data-h2-margin-top="base(x.25)">
-                {formState.errors.firstNationsCustom.message?.toString()}
-              </Field.Error>
-            )}
-          </div>
-          <div>
-            <CommunityIcon
-              values={["firstNations"]}
-              community="first-nations"
-            />
-          </div>
-        </Row>
-        {communitiesValue.includes("firstNations") && (
-          <Row>
-            <div data-h2-grid-column="base(span 3)">
-              <RadioGroup
-                idPrefix="firstNationsStatus"
-                name="isStatus"
-                legend={intl.formatMessage({
-                  defaultMessage: "First Nations status",
-                  id: "0KY1My",
-                  description:
-                    "Legend for selecting First Nations status or non-status",
-                })}
-                rules={{ required: intl.formatMessage(errorMessages.required) }}
-                items={[
-                  {
-                    value: "status",
-                    label: intl.formatMessage({
-                      defaultMessage: '"I am Status First Nations"',
-                      id: "ssJxrj",
-                      description:
-                        "Text for the option to self-declare as a status first nations",
-                    }),
-                  },
-                  {
-                    value: "nonStatus",
-                    label: intl.formatMessage({
-                      defaultMessage: '"I am Non-Status First Nations"',
-                      id: "sSE4kt",
-                      description:
-                        "Text for the option to self-declare as a non-status first nations",
-                    }),
-                  },
-                ]}
-              />
-            </div>
-            <div />
-          </Row>
+        {locale === "fr" ? (
+          <>
+            {inuk}
+            {metis}
+            {firstNations}
+          </>
+        ) : (
+          <>
+            {firstNations}
+            {inuk}
+            {metis}
+          </>
         )}
-        <Row>
-          <div data-h2-grid-column="base(span 3)">
-            <Checklist
-              idPrefix="inuk"
-              id="inuk"
-              name="communities"
-              legend={labels.inuk}
-              trackUnsaved={false}
-              items={[
-                {
-                  value: "inuk",
-                  label: intl.formatMessage({
-                    defaultMessage: `"I am Inuk"`,
-                    id: "vDb+O+",
-                    description: "Label text for Inuk community declaration",
-                  }),
-                },
-              ]}
-            />
-          </div>
-          <div>
-            <CommunityIcon values={["inuk"]} community="inuit" />
-          </div>
-        </Row>
-        <Row>
-          <div data-h2-grid-column="base(span 3)">
-            <Checklist
-              idPrefix="metis"
-              id="metis"
-              name="communities"
-              legend={labels.metis}
-              trackUnsaved={false}
-              items={[
-                {
-                  value: "metis",
-                  label: intl.formatMessage({
-                    defaultMessage: `"I am Métis"`,
-                    id: "/81xCT",
-                    description: "Label text for Métis community declaration",
-                  }),
-                },
-              ]}
-            />
-          </div>
-          <div>
-            <CommunityIcon values={["metis"]} community="metis" />
-          </div>
-        </Row>
         <Row>
           <div data-h2-grid-column="base(span 3)">
             <Checklist

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2311,10 +2311,6 @@
     "defaultMessage": "Ce numéro de processus est obtenu auprès de votre atelier RH",
     "description": "Additional context describing the pools process number."
   },
-  "Ap86I/": {
-    "defaultMessage": "Ce programme s’adresse aux membres des Premières Nations, aux Inuits et aux Métis qui se trouvent au Canada. Lors d’une étape ultérieure de la procédure de demande, vous aurez peut-être à fournir une preuve que vous êtes une personne autochtone. Vous pouvez en savoir plus sur la vérification de votre statut ci-dessous.",
-    "description": "Text explaining the program and the possibility of needing to provide proof."
-  },
   "Aqz3Ma": {
     "defaultMessage": "La spécialisation est pertinente à l’exigence du diplôme",
     "description": "Text for education accepted information context in screening decision dialog"
@@ -7041,10 +7037,6 @@
   "aqkSW2": {
     "defaultMessage": "Inscrivez-vous plutôt",
     "description": "Link text to register instead of signing in"
-  },
-  "at11n5": {
-    "defaultMessage": "Êtes-vous sûr de vouloir sélectionner : « Je suis autochtone, mais je ne trouve pas ma communauté ici? »",
-    "description": "Title for the alert warning users about selection not represented and a represented community"
   },
   "axQDlj": {
     "defaultMessage": "Contactez-nous pour nous faire part de votre rétroaction ou d'un problème.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -220,7 +220,7 @@
     "description": "How it works, step 2 heading"
   },
   "/81xCT": {
-    "defaultMessage": "« Je suis métis(se) »",
+    "defaultMessage": "« Je suis métisse ou métis »",
     "description": "Label text for Métis community declaration"
   },
   "/8qCuC": {

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclarationForm.test.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclarationForm.test.tsx
@@ -92,30 +92,6 @@ describe("SelfDeclarationForm", () => {
     ).toBeInTheDocument();
   });
 
-  it("should display alert if community selected with other", async () => {
-    renderSelfDeclarationForm();
-
-    fireEvent.click(screen.getByRole("radio", { name: /i affirm that/i }));
-
-    fireEvent.click(
-      await screen.findByRole("checkbox", {
-        name: /i am inuk/i,
-      }),
-    );
-
-    fireEvent.click(
-      await screen.findByRole("checkbox", {
-        name: /i don't see my community/i,
-      }),
-    );
-
-    expect(
-      await within(await screen.findByRole("alert")).findByRole("heading", {
-        name: /are you sure/i,
-      }),
-    ).toBeInTheDocument();
-  });
-
   it("should submit with all required fields", async () => {
     mockCallback.mockReset();
     renderSelfDeclarationForm();

--- a/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclarationForm.test.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSelfDeclarationPage/SelfDeclarationForm.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import "@testing-library/jest-dom";
-import { screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { Provider as GraphqlProvider } from "urql";
 import { pipe, fromValue, delay } from "wonka";
 


### PR DESCRIPTION
🤖 Resolves #11232.

## 👋 Introduction

This PR removes an alert that was not relevant to the profile in the Indigenous identity section of the user profile. It also updates some copy to use full doublets instead of abbreviated doublets. Finally, it orders listed communities in the `CommunitySelection` to be ordered alphabetically depending on the locale selected (en or fr).

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:3000/en/applicant/personal-information#diversity-equity-inclusion-section
3. Engage the Edit this information button
4. Uncheck all the checkboxes except My community isn't listed
5. Verify the alert warning does not appear, no matter which combination of checkboxes you select
6. Switch to French
7. Engage the Edit this information button
8. Verify the text for Métis reads _Je suis métisse ou métis_
9. Verify the communities are listed alphabetically: _Inuk_, _Métis_, _Premières Nations_

## 📸 Screenshots

<img width="945" alt="Screen Shot 2024-08-23 at 09 48 16" src="https://github.com/user-attachments/assets/5ca1b81f-6f96-4c52-ac16-a093f77f415e">

<img width="940" alt="Screen Shot 2024-08-23 at 09 49 09" src="https://github.com/user-attachments/assets/df115e5d-87bc-4c61-a396-a600c7ec24e8">

