### PR TITLE
[Bugfix] Stabilize `PreviewList` story

### DIFF
--- a/packages/ui/src/components/PreviewList/PreviewList.stories.tsx
+++ b/packages/ui/src/components/PreviewList/PreviewList.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryFn } from "@storybook/react";
-import { faker } from "@faker-js/faker";
 
 import { allModes } from "@gc-digital-talent/storybook-helpers";
 
@@ -16,7 +15,7 @@ const previewDetails: MetaDataProps[] = [
   {
     key: "it-text-2-id",
     type: "text",
-    children: `Manager: ${faker.person.firstName()} ${faker.person.lastName()}`,
+    children: "Manager: Dale Monroe",
   },
   {
     key: "it-text-3-id",


### PR DESCRIPTION
🤖 Resolves #11308  <!-- issue # -->

## 👋 Introduction

Stabilize the story.
First I was going to set the seed value but noticed faker was being called to set just a single name while everything else was hardcoded. So I elected to just set the name as well to our dear superadmin's
<!-- Describe what this PR is solving. -->

## 🧪 Testing

1. Static name

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/8e3407cc-f1c9-428b-a270-634b8f287b59)

<!-- Add a screenshot (if possible). -->


