### PR TITLE
[Copy] Adds conditional for `screeningTime` based on required or optional skill

### DIFF
--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SkillAccordion.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SkillAccordion.tsx
@@ -47,7 +47,7 @@ const Context = ({ required }: ContextProps) => {
 interface AccordionSubtitleProps {
   isSkillLevelAvailable: boolean;
   skillLevelItem: string;
-  screeningTime: string;
+  screeningTime?: string | null;
 }
 
 const AccordionSubtitle = ({
@@ -67,10 +67,14 @@ const AccordionSubtitle = ({
     {isSkillLevelAvailable && (
       <>
         <span>{skillLevelItem}</span>
-        <span data-h2-display="base(none) p-tablet(inline)">&bull;</span>
       </>
     )}
-    <span>{screeningTime}</span>
+    {screeningTime && (
+      <>
+        <span data-h2-display="base(none) p-tablet(inline)">&bull;</span>
+        <span>{screeningTime}</span>
+      </>
+    )}
   </span>
 );
 
@@ -149,7 +153,7 @@ const SkillAccordion = ({ poolSkillQuery, required }: SkillAccordionProps) => {
           <AccordionSubtitle
             isSkillLevelAvailable={!!poolSkill.requiredLevel}
             skillLevelItem={skillLevelItem}
-            screeningTime={screeningTime}
+            screeningTime={required ? screeningTime : null}
           />
         }
       >


### PR DESCRIPTION
🤖 Resolves #11363.

## 👋 Introduction

This PR adds a conditional for `screeningTime` based on required or optional skill.

## 🧪 Testing

1. `pnpm build:fresh`
2. `pnpm storybook`
3. Navigate to http://localhost:6006/?path=/story/pages-pools-pooladvertisementpage--open
4. Verify no screening time copy in skill accordion for skills that are optional

## 📸 Screenshot

<img width="1192" alt="Screen Shot 2024-08-23 at 15 29 00" src="https://github.com/user-attachments/assets/b018cb92-1fd6-4b77-ae52-9941c3954707">

