### PR TITLE
[Fix] Prefix login path

### DIFF
--- a/packages/auth/src/hooks/useApiRoutes.ts
+++ b/packages/auth/src/hooks/useApiRoutes.ts
@@ -22,7 +22,7 @@ const apiRoutes = {
 
     const url = apiHost
       ? new URL(loginPath, apiHost)
-      : ["login"].join("/") + (searchString ? `?${searchString}` : "");
+      : ["/login"].join("/") + (searchString ? `?${searchString}` : "");
 
     return url.toString();
   },


### PR DESCRIPTION
🤖 Resolves #11387 

## 👋 Introduction

Adds a prefix to the login path for non-local dev builds to build it off the root domain.

## 🧪 Testing

1. Set `apiHost` to false in `useApiRoutes`
2. Build `pnpm run dev:fresh`
3. Navigate to `/login-info`
4. Confirm the GCKey button links to the proper path
