### PR TITLE
[Fix] Delete notification focus management

### DIFF
--- a/apps/web/src/components/NotificationList/NotificationButton.tsx
+++ b/apps/web/src/components/NotificationList/NotificationButton.tsx
@@ -29,6 +29,7 @@ const NotificationButton = forwardRef<HTMLButtonElement, NotificationLinkProps>(
         type="button"
         ref={forwardedRef}
         onClick={handleClick}
+        data-notification-link
         data-h2-text-align="base(left)"
         data-h2-background="base(none)"
         {...styles.link(isUnread, fetching)}

--- a/apps/web/src/components/NotificationList/NotificationDownload.tsx
+++ b/apps/web/src/components/NotificationList/NotificationDownload.tsx
@@ -67,6 +67,7 @@ const NotificationDownload = forwardRef<
       ref={forwardedRef}
       href={href}
       onClick={handleClick}
+      data-notification-link
       {...styles.link(isUnread, fetching || downloadingFile)}
     >
       {children}

--- a/apps/web/src/components/NotificationList/NotificationItem.tsx
+++ b/apps/web/src/components/NotificationList/NotificationItem.tsx
@@ -1,7 +1,7 @@
 import { useIntl } from "react-intl";
 import EllipsisVerticalIcon from "@heroicons/react/20/solid/EllipsisVerticalIcon";
 import { useMutation } from "urql";
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useEffect, useRef } from "react";
 
 import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
 import {
@@ -105,6 +105,7 @@ const NotificationItem = ({
     NotificationItem_Fragment,
     notificationQuery,
   );
+  const itemRef = useRef<HTMLLIElement>(null);
   const info = useNotificationInfo(notification);
   const isUnread = notification.readAt === null;
 
@@ -117,6 +118,19 @@ const NotificationItem = ({
   useEffect(() => {
     if (focusRef) focusRef.current?.focus();
   }, [focusRef]);
+
+  // Store the next list item on mount
+  // Then, attempt to focus it on unmount
+  useEffect(() => {
+    const nextListItem = itemRef.current?.nextElementSibling;
+    return () => {
+      nextListItem
+        ?.querySelector<
+          HTMLAnchorElement | HTMLButtonElement
+        >("[data-notification-link]")
+        ?.focus();
+    };
+  }, []);
 
   if (!info) return null;
 
@@ -145,7 +159,7 @@ const NotificationItem = ({
   };
 
   return (
-    <li>
+    <li ref={itemRef}>
       <CardBasic
         data-h2-display="base(flex)"
         {...(inDialog

--- a/apps/web/src/components/NotificationList/NotificationLink.tsx
+++ b/apps/web/src/components/NotificationList/NotificationLink.tsx
@@ -35,6 +35,7 @@ const NotificationLink = forwardRef<
       ref={forwardedRef}
       to={href}
       onClick={handleClick}
+      data-notification-link
       {...styles.link(isUnread, fetching)}
     >
       {children}


### PR DESCRIPTION
🤖 Resolves #10637 

## 👋 Introduction

Attempts to focus the next notification in the list on delete.

## 🕵️ Details

This stores a reference to the next item in the list on mount. If it exists when the component is unmounting (deleted) it will attempt to move focus to that next item.

## 🧪 Testing

> [!TIP]
> I found that the easiest way to seed some notifications is downloading a few files while the worker is running

1. Build the app `pnpm run dev:fresh`
2. Login as any user
3. Seed some notifications for the user
4. Using only your keyboard, delete a notification
5. Confirm that the focus is moved to the next item in the list
