### PR TITLE
[Bug/copy] Have "Other reason" require decision notes

### DIFF
--- a/api/lang/en/assessment_result_justification.php
+++ b/api/lang/en/assessment_result_justification.php
@@ -8,5 +8,5 @@ return [
     'education_failed_requirement_not_met' => 'Not enough education or experience to meet the requirement',
     'skill_failed_insufficiently_demonstrated' => 'Not sufficiently demonstrated to meet the requirement',
     'failed_not_enough_information' => 'Not enough information provided',
-    'failed_other' => 'Other reason for screening out.',
+    'failed_other' => 'Other reason for screening out',
 ];

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialogForm.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialogForm.tsx
@@ -84,6 +84,9 @@ const ScreeningDecisionDialogForm = ({
       AssessmentResultJustification.EducationAcceptedCombinationEducationWorkExperience ||
     watchJustifications ===
       AssessmentResultJustification.EducationAcceptedWorkExperienceEquivalency;
+  const decisionNotesRequired = watchJustifications?.includes(
+    AssessmentResultJustification.FailedOther,
+  );
 
   /**
    * Reset un-rendered fields
@@ -234,7 +237,7 @@ const ScreeningDecisionDialogForm = ({
             wordLimit={TEXT_AREA_MAX_WORDS}
             label={labels.decisionNotes}
             rules={
-              isAssessmentOnHold
+              isAssessmentOnHold || decisionNotesRequired
                 ? { required: intl.formatMessage(errorMessages.required) }
                 : { required: undefined }
             }

--- a/apps/web/src/components/ScreeningDecisions/useLabels.ts
+++ b/apps/web/src/components/ScreeningDecisions/useLabels.ts
@@ -28,11 +28,6 @@ const getLabels = (intl: IntlShape) => {
       description:
         "Label for demonstrated notes text area in the screening decision dialog.",
     }),
-    failedOther: intl.formatMessage({
-      defaultMessage: "Other reason for screening out.",
-      id: "C5uhBP",
-      description: "Label for radio option in the screening decision dialog.",
-    }),
   } as const;
 };
 

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2527,10 +2527,6 @@
     "defaultMessage": "La plupart des offres d’emploi ne nécessiteront pas de note spéciale. Cette section est réservée à des circonstances particulières. Cette note spéciale peut notamment servir à indiquer si un processus peut être utilisé pour embaucher dans plusieurs classifications ou non et si le processus est limité aux candidatures d’un groupe visé par l’équité en matière d’emploi spécifique.",
     "description": "Describes the 'special note' section of a process' advertisement."
   },
-  "C5uhBP": {
-    "defaultMessage": "Autre motif de l’exclusion au processus de présélection.",
-    "description": "Label for radio option in the screening decision dialog."
-  },
   "C6kQXh": {
     "defaultMessage": "{experienceCount, plural, =0 {0 expérience} =1 {1 expérience} other {# expériences}}",
     "description": "list a number of unknown experiences"


### PR DESCRIPTION
🤖 Resolves #11391

## 👋 Introduction

Require decision notes if the justifications contains the "Other" option, as well as remove a bit of stray punctuation. 
One label was no longer used with the backend enums addition so it was 🪓 
<!-- Describe what this PR is solving. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Navigate to `/en/admin/candidates/:id/application`
2. Observe required conditional dependent on justifications checklist

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/bbd559df-52f4-4647-ad0d-448a764aebe7)

![image](https://github.com/user-attachments/assets/3905e87b-f7d4-4172-8ce8-3b24ab435a6a)


<!-- Add a screenshot (if possible). -->


<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the linked issue if deployment steps are needed

 -->
