### PR TITLE
Adjust tries and timeout

### DIFF
--- a/api/app/Listeners/SendNewJobPostedNotification.php
+++ b/api/app/Listeners/SendNewJobPostedNotification.php
@@ -14,6 +14,23 @@ use Throwable;
 class SendNewJobPostedNotification implements ShouldQueue
 {
     /**
+     * The number of seconds the job can run before timing out.
+     * Locally, I can queue about 7400 jobs per minute.
+     *
+     * @var int
+     */
+    public $timeout = 60 * 10;
+
+    /**
+     * The number of times the job may be attempted.
+     * Duplicate runs of this job will result in
+     * duplicate notifications being sent.
+     *
+     * @var int
+     */
+    public $tries = 1;
+
+    /**
      * Create the event listener.
      */
     public function __construct() {}


### PR DESCRIPTION
🤖 Resolves #11152 , #11153 

## 👋 Introduction

I believe the the reason some people got three notifications and some got zero is that the job that queues the notification for each user was timing out and retrying.  This branch sets the timeout to a longer value and disables retries.

## 🕵️ Details

I can see the job that Brinda was referring to in the prod `failed_jobs` table with a TimeoutException.  The default timeout for a job is 60 seconds, the wait to retry is 90 seconds, and our workers are set to 3 retries.  This all lines up with the timeline Brinda logged in the issue.

I seeded 23,000 users locally which is about how many we have who received this notification in prod.  I confirmed that the job fails after 60 seconds, having queued about 7400 jobs.  When I upped the timeout, the full set took a little over 3 minutes.  I picked a timeout of 10 minutes for this job which should be about 3 times as much as we need - assuming that it runs a similar speed in prod.

## 🧪 Testing

1. Start the queue worker
2. Launch Tinker
3. `User::factory()->count(23000)->create(['enabled_email_notifications'=>['JOB_ALERT'], 'enabled_in_app_notifications'=>['JOB_ALERT']])`
4. `$p = Pool::factory()->draft()->create()`
5. `$p->published_at = Carbon/Carbon::now()`
6. `$p->save()`

- [ ] Over 23000 new jobs queued in the `jobs` table
- [ ] The App\Listeners\SendNewJobPostedNotification completes successfully

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/aba10854-e4c5-42b7-91b5-28f97e910ba1)