### PR TITLE
[Fix] Reset scroll on close button focus

### DIFF
--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useIntl } from "react-intl";
 import { AnimatePresence, m, usePresence } from "framer-motion";
 import BellAlertIcon from "@heroicons/react/24/outline/BellAlertIcon";
@@ -48,6 +48,7 @@ const DialogPortalWithPresence = ({
   const paths = useRoutes();
   const [isPresent] = usePresence();
   const [render, setRender] = useState<boolean>(isPresent);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     let timerId: ReturnType<typeof setTimeout>;
@@ -62,6 +63,12 @@ const DialogPortalWithPresence = ({
     }
     return () => clearTimeout(timerId);
   }, [isPresent]);
+
+  const handleCloseFocus = () => {
+    if (containerRef?.current) {
+      containerRef.current.scrollTop = 0;
+    }
+  };
 
   return render ? (
     <Dialog.Portal forceMount>
@@ -78,6 +85,7 @@ const DialogPortalWithPresence = ({
       />
       <DialogPrimitive.Content forceMount asChild>
         <m.div
+          ref={containerRef}
           initial={{ x: "100%", scale: 0.95 }}
           animate={{ x: 0, scale: 1 }}
           exit={{ x: "100%", scale: 0.95 }}
@@ -123,6 +131,7 @@ const DialogPortalWithPresence = ({
                     mode="icon_only"
                     color="black"
                     icon={XMarkIcon}
+                    onFocus={handleCloseFocus}
                     aria-label={intl.formatMessage({
                       defaultMessage: "Close notifications",
                       id: "J1n6QO",


### PR DESCRIPTION
🤖 Resolves #10638 

## 👋 Introduction

This resets the notification dialog scrollY to 0 when you focus the close button.

## 🕵️ Details

I'm not really sure why this was not working before and I don't love this solution but it works.

## 🧪 Testing

> [!TIP]
> I found that the easiest way to seed some notifications is downloading a few files while the worker is running

1. Build the app `pnpm run dev:fresh`
2. Login as any user
3. Seed some notifications for the user (do a lot, enough to get the notification dialog to scroll)
4. Using only your keyboard, tab through the list
5. Confirm that the scroll position is reset when the focus cycles back up to the top (close button)
