### PR TITLE
[Fix] Account settings breadcrumb path

### DIFF
--- a/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
+++ b/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
@@ -116,7 +116,7 @@ const AccountSettingsPage = () => {
     crumbs: [
       {
         label: formattedPageTitle,
-        url: paths.accessibility(),
+        url: paths.accountSettings(),
       },
     ],
   });


### PR DESCRIPTION
🤖 Resolves #11394

## 👋 Introduction

Updates the account settings breadcrumb to use the correct path.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as any user
3. Navigate to acccount settings `/applicant/settings`
4. Confirm the breadcrumb links are correct