### PR TITLE
Fix] Adds an eager load for team relation

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -242,7 +242,7 @@ type ScreeningQuestion {
 interface HasRoleAssignments {
   id: UUID!
   roleAssignments: [RoleAssignment!]
-  teamIdForRoleAssignment: ID @with(relation: "team") # Used to assign roles associated with this resource using the updateUserRoles mutation.
+  teamIdForRoleAssignment: ID# Used to assign roles associated with this resource using the updateUserRoles mutation.
 }
 
 type Pool implements HasRoleAssignments {
@@ -495,7 +495,7 @@ type Team implements HasRoleAssignments {
   roleAssignments: [RoleAssignment!]
     @hasMany
     @canRoot(ability: "viewTeamMembers")
-  teamIdForRoleAssignment: ID @rename(attribute: "id") @with(relation: "team")
+  teamIdForRoleAssignment: ID @rename(attribute: "id")
 }
 
 type Role {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -242,7 +242,7 @@ type ScreeningQuestion {
 interface HasRoleAssignments {
   id: UUID!
   roleAssignments: [RoleAssignment!]
-  teamIdForRoleAssignment: ID # Used to assign roles associated with this resource using the updateUserRoles mutation.
+  teamIdForRoleAssignment: ID @with(relation: "team") # Used to assign roles associated with this resource using the updateUserRoles mutation.
 }
 
 type Pool implements HasRoleAssignments {
@@ -300,7 +300,7 @@ type Pool implements HasRoleAssignments {
   roleAssignments: [RoleAssignment!]
     @hasManyThrough
     @canRoot(ability: "viewTeamMembers")
-  teamIdForRoleAssignment: ID
+  teamIdForRoleAssignment: ID @with(relation: "team")
   department: Department @belongsTo @canQuery(ability: "view")
 }
 
@@ -477,7 +477,7 @@ type Community implements HasRoleAssignments {
   roleAssignments: [RoleAssignment!]
     @hasManyThrough
     @canRoot(ability: "viewTeamMembers")
-  teamIdForRoleAssignment: ID
+  teamIdForRoleAssignment: ID @with(relation: "team")
   pools: [Pool]
     @hasMany(scopes: ["authorizedToView"])
     @canResolved(ability: "view")
@@ -495,7 +495,7 @@ type Team implements HasRoleAssignments {
   roleAssignments: [RoleAssignment!]
     @hasMany
     @canRoot(ability: "viewTeamMembers")
-  teamIdForRoleAssignment: ID @rename(attribute: "id")
+  teamIdForRoleAssignment: ID @rename(attribute: "id") @with(relation: "team")
 }
 
 type Role {


### PR DESCRIPTION
🤖 Resolves #11398 

## 👋 Introduction

Eager loads the team relation where we use `teamIdForRoleAssignment` 

## 🧪 Testing

1. Open graphiql `/graphiql`
2. Make the listed queries and confirm no lazy load error
 
 ```
query {
  communities {
    teamIdForRoleAssignment
  }
  pools {
    teamIdForRoleAssignment
  }
}
```