### PR TITLE
[Fix] `HasRoleAssignments` interface id field

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -240,7 +240,7 @@ type ScreeningQuestion {
 }
 
 interface HasRoleAssignments {
-  id: UUID!
+  id: ID!
   roleAssignments: [RoleAssignment!]
   teamIdForRoleAssignment: ID # Used to assign roles associated with this resource using the updateUserRoles mutation.
 }

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -603,7 +603,7 @@ type ScreeningQuestion {
 }
 
 interface HasRoleAssignments {
-  id: UUID!
+  id: ID!
   roleAssignments: [RoleAssignment!]
   teamIdForRoleAssignment: ID
 }


### PR DESCRIPTION
🤖 Resolves #11397 

## 👋 Introduction

Updates the `id` field on the `HasRoleAssignments` interface to `ID` so that the types that implement it meet the spec.

## 🕵️ Details

We should probably look into using `UUID` for the types instead of this but  that is going to require updating frontend code.

## 🧪 Testing

1. ope graphiql `/graphiql`
2. Confirm the schema appears
3. Confirm no errors related to the interface when fetching the schema
