### PR TITLE
[Feature] Add "content below" to checklist

### DIFF
--- a/packages/forms/src/components/Checklist/Checklist.stories.tsx
+++ b/packages/forms/src/components/Checklist/Checklist.stories.tsx
@@ -12,6 +12,8 @@ export default {
   component: Checklist,
 };
 
+faker.seed(0);
+
 const Template: StoryFn<typeof Checklist> = (args) => (
   <Form onSubmit={action("Submit Form")}>
     <Checklist {...args} />

--- a/packages/forms/src/components/Checklist/Checklist.stories.tsx
+++ b/packages/forms/src/components/Checklist/Checklist.stories.tsx
@@ -1,5 +1,6 @@
 import { StoryFn } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
+import { faker } from "@faker-js/faker/locale/en";
 
 import { allModes } from "@gc-digital-talent/storybook-helpers";
 
@@ -44,4 +45,13 @@ export const DisabledChecklist = Template.bind({});
 DisabledChecklist.args = {
   ...Default.args,
   disabled: true,
+};
+
+export const ContentBelow = Template.bind({});
+ContentBelow.args = {
+  ...Default.args,
+  items: Default.args.items?.map((item) => ({
+    ...item,
+    contentBelow: faker.lorem.lines(6),
+  })),
 };

--- a/packages/forms/src/components/Checklist/Checklist.tsx
+++ b/packages/forms/src/components/Checklist/Checklist.tsx
@@ -1,6 +1,6 @@
 import get from "lodash/get";
 import { FieldError, useFormContext } from "react-hook-form";
-import { ReactNode } from "react";
+import { Fragment, ReactNode } from "react";
 
 import Checkbox from "../Checkbox";
 import Field from "../Field";
@@ -13,6 +13,7 @@ import useInputDescribedBy from "../../hooks/useInputDescribedBy";
 export interface CheckboxOption {
   value: string | number;
   label: string | ReactNode;
+  contentBelow?: ReactNode;
 }
 
 export type ChecklistProps = Omit<CommonInputProps, "id" | "label"> &
@@ -74,19 +75,31 @@ const Checklist = ({
           data-h2-gap="base(0)"
           data-h2-padding="base(x.25 0)"
         >
-          {items.map(({ value, label }) => {
+          {items.map(({ value, label, contentBelow }) => {
             const id = `${idPrefix}-${value}`;
             return (
-              <Checkbox
-                key={id}
-                id={id}
-                name={name}
-                rules={rules}
-                label={label}
-                disabled={disabled}
-                value={value}
-                inCheckList
-              />
+              <Fragment key={id}>
+                <Checkbox
+                  id={id}
+                  name={name}
+                  rules={rules}
+                  label={label}
+                  disabled={disabled}
+                  value={value}
+                  inCheckList
+                />
+                {contentBelow && (
+                  <div
+                    id={`${id}-content-below`}
+                    data-h2-padding-left="base(x1.7)"
+                    data-h2-padding-right="base(x0.5)"
+                    data-h2-color="base(black.light)"
+                    data-h2-font-size="base(caption)"
+                  >
+                    {contentBelow}
+                  </div>
+                )}
+              </Fragment>
             );
           })}
         </Field.BoundingBox>

--- a/packages/forms/src/components/Checklist/Checklist.tsx
+++ b/packages/forms/src/components/Checklist/Checklist.tsx
@@ -87,6 +87,9 @@ const Checklist = ({
                   disabled={disabled}
                   value={value}
                   inCheckList
+                  {...(contentBelow && {
+                    "aria-describedby": `${id}-content-below`,
+                  })}
                 />
                 {contentBelow && (
                   <div


### PR DESCRIPTION
🤖 Related to (but does not close) #11285 

## 👋 Introduction

This branch adds the ability to add "content below" for checklists.  This is needed for the "area of selection" stuff.

## 🧪 Testing

1.Start Storybook or Chromatic.
2. Check the Checklist \ Content Below story

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/ca88ed46-2f44-48a4-8527-db9a86bd1acc)

