### PR TITLE
[Feature] Temporary area of selection on pool card

### DIFF
--- a/apps/web/src/components/PoolCard/PoolCard.stories.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.stories.tsx
@@ -34,9 +34,6 @@ Null.args = {
 export const WithWhoCanApply = Template.bind({});
 WithWhoCanApply.args = {
   ...Default.args,
-  whoCanApply: [
-    "Employees only",
-    "At-level only",
-    "Departmental preference",
-  ].join(" • "),
+  areaOfSelection: "EMPLOYEES",
+  selectionLimitations: ["AT_LEVEL_ONLY", "DEPARTMENTAL_PREFERENCE"],
 };

--- a/apps/web/src/components/PoolCard/PoolCard.stories.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.stories.tsx
@@ -30,3 +30,9 @@ export const Null = Template.bind({});
 Null.args = {
   poolQuery: makeFragmentData(nullPool, PoolCard_Fragment),
 };
+
+export const WithWhoCanApply = Template.bind({});
+WithWhoCanApply.args = {
+  poolQuery: makeFragmentData(nullPool, PoolCard_Fragment),
+  whoCanApply: "Employees only. At-level only, Department preference.",
+};

--- a/apps/web/src/components/PoolCard/PoolCard.stories.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.stories.tsx
@@ -33,6 +33,10 @@ Null.args = {
 
 export const WithWhoCanApply = Template.bind({});
 WithWhoCanApply.args = {
-  poolQuery: makeFragmentData(nullPool, PoolCard_Fragment),
-  whoCanApply: "Employees only. At-level only, Department preference.",
+  ...Default.args,
+  whoCanApply: [
+    "Employees only",
+    "At-level only",
+    "Departmental preference",
+  ].join(" • "),
 };

--- a/apps/web/src/components/PoolCard/PoolCard.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.tsx
@@ -2,6 +2,7 @@ import { useIntl } from "react-intl";
 import CurrencyDollarIcon from "@heroicons/react/24/outline/CurrencyDollarIcon";
 import BoltIcon from "@heroicons/react/24/outline/BoltIcon";
 import CalendarIcon from "@heroicons/react/24/outline/CalendarIcon";
+import UsersIcon from "@heroicons/react/24/outline/UsersIcon";
 
 import {
   Heading,
@@ -215,7 +216,7 @@ const PoolCard = ({
         <div
           data-h2-display="base(block) l-tablet(flex)"
           data-h2-gap="base(x2)"
-          data-h2-margin-top="base(x1) base:children[>p:last-child](x1) l-tablet:children[>p:last-child](0px)"
+          data-h2-margin-top="base(x1) base:children[>p](x1) l-tablet:children[>p](0px)"
         >
           <IconLabel
             icon={CalendarIcon}
@@ -250,6 +251,20 @@ const PoolCard = ({
                   id: "Hd0nHP",
                 })}
           </IconLabel>
+          {whoCanApply ? (
+            <IconLabel
+              icon={UsersIcon}
+              label={
+                intl.formatMessage({
+                  defaultMessage: "Who can apply",
+                  id: "/lByjT",
+                  description: "Label for pool advertisement area of selection",
+                }) + intl.formatMessage(commonMessages.dividingColon)
+              }
+            >
+              {whoCanApply}
+            </IconLabel>
+          ) : undefined}
           <IconLabel
             icon={CurrencyDollarIcon}
             label={

--- a/apps/web/src/components/PoolCard/PoolCard.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.tsx
@@ -107,9 +107,15 @@ const getSalaryRange = (
 export interface PoolCardProps {
   poolQuery: FragmentType<typeof PoolCard_Fragment>;
   headingLevel?: HeadingRank;
+  // this will soon be part of the Pool model
+  whoCanApply?: string;
 }
 
-const PoolCard = ({ poolQuery, headingLevel = "h3" }: PoolCardProps) => {
+const PoolCard = ({
+  poolQuery,
+  headingLevel = "h3",
+  whoCanApply,
+}: PoolCardProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
   const paths = useRoutes();

--- a/apps/web/src/components/PoolCard/PoolCard.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.tsx
@@ -1,4 +1,4 @@
-import { useIntl } from "react-intl";
+import { IntlShape, useIntl } from "react-intl";
 import CurrencyDollarIcon from "@heroicons/react/24/outline/CurrencyDollarIcon";
 import BoltIcon from "@heroicons/react/24/outline/BoltIcon";
 import CalendarIcon from "@heroicons/react/24/outline/CalendarIcon";
@@ -105,17 +105,70 @@ const getSalaryRange = (
   );
 };
 
+const deriveWhoCanApplyString = (
+  areaOfSelection: PoolCardProps["areaOfSelection"],
+  selectionLimitations: PoolCardProps["selectionLimitations"],
+  intl: IntlShape,
+): string | null => {
+  if (areaOfSelection == "PUBLIC") {
+    return intl.formatMessage({
+      defaultMessage: "Open to the public",
+      id: "L0eho2",
+      description: "Combined eligibility string for 'open to the public'",
+    });
+  }
+  if (areaOfSelection == "EMPLOYEES") {
+    if (
+      selectionLimitations?.includes("AT_LEVEL_ONLY") &&
+      selectionLimitations?.includes("DEPARTMENTAL_PREFERENCE")
+    ) {
+      return intl.formatMessage({
+        defaultMessage: "Employees (at-level, departmental preference)",
+        id: "4VQGU4",
+        description:
+          "Combined eligibility string for 'employees only', 'at-level only', and 'departmental preference'",
+      });
+    }
+    if (selectionLimitations?.includes("AT_LEVEL_ONLY")) {
+      return intl.formatMessage({
+        defaultMessage: "Employees (at-level)",
+        id: "JCX6jN",
+        description:
+          "Combined eligibility string for 'employees only' and 'at-level only'",
+      });
+    }
+    if (selectionLimitations?.includes("DEPARTMENTAL_PREFERENCE")) {
+      return intl.formatMessage({
+        defaultMessage: "Employees (departmental preference)",
+        id: "g6coYl",
+        description:
+          "Combined eligibility string for 'employees only' and 'departmental preference'",
+      });
+    }
+    // fall-through for employees only
+    return intl.formatMessage({
+      defaultMessage: "Employees",
+      id: "TOnXeM",
+      description:
+        "Combined eligibility string for 'employees only' with no other limitations",
+    });
+  }
+  return null;
+};
+
 export interface PoolCardProps {
   poolQuery: FragmentType<typeof PoolCard_Fragment>;
   headingLevel?: HeadingRank;
-  // this will soon be part of the Pool model
-  whoCanApply?: string;
+  // these will soon be part of the Pool model
+  areaOfSelection?: "PUBLIC" | "EMPLOYEES";
+  selectionLimitations?: ("AT_LEVEL_ONLY" | "DEPARTMENTAL_PREFERENCE")[];
 }
 
 const PoolCard = ({
   poolQuery,
   headingLevel = "h3",
-  whoCanApply,
+  areaOfSelection,
+  selectionLimitations,
 }: PoolCardProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -251,7 +304,7 @@ const PoolCard = ({
                   id: "Hd0nHP",
                 })}
           </IconLabel>
-          {whoCanApply ? (
+          {areaOfSelection ? (
             <IconLabel
               icon={UsersIcon}
               label={
@@ -262,7 +315,11 @@ const PoolCard = ({
                 }) + intl.formatMessage(commonMessages.dividingColon)
               }
             >
-              {whoCanApply}
+              {deriveWhoCanApplyString(
+                areaOfSelection,
+                selectionLimitations,
+                intl,
+              ) ?? intl.formatMessage(commonMessages.notAvailable)}
             </IconLabel>
           ) : undefined}
           <IconLabel

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -339,6 +339,10 @@
     "defaultMessage": "Avez-vous un droit de priorité?",
     "description": "Priority Entitlement Status in Government Info Form"
   },
+  "/lByjT": {
+    "defaultMessage": "Qui peut postuler",
+    "description": "Label for pool advertisement area of selection"
+  },
   "/lVSP/": {
     "defaultMessage": "Voir toutes les notifications",
     "description": "Link text for the notifications page"
@@ -1198,6 +1202,10 @@
   "4V/DsD": {
     "defaultMessage": "En savoir plus<hidden> à propos de la collectivité des gestionnaires</hidden>",
     "description": "Link text to the managers community"
+  },
+  "4VQGU4": {
+    "defaultMessage": "Employé(e)s (de même niveau, préférences ministérielles)",
+    "description": "Combined eligibility string for 'employees only', 'at-level only', and 'departmental preference'"
   },
   "4W8uc/": {
     "defaultMessage": "La présente section vous permet, <strong>de façon facultative,</strong> d’ajouter jusqu’à 10 questions d’ordre général qui seront posées aux candidats dans le cadre du processus de demande. Veuillez prendre note que celles-ci ne <strong>sont pas des questions de filtrage</strong>. Des questions de filtrage seront ajoutées une fois que vous aurez façonné votre plan d’évaluation.",
@@ -3851,6 +3859,10 @@
     "defaultMessage": "Confirmation du besoin d’une note spéciale ",
     "description": "Label for input confirmation of need for special note on edit pool."
   },
+  "JCX6jN": {
+    "defaultMessage": "Employé(e)s (de même niveau)",
+    "description": "Combined eligibility string for 'employees only' and 'at-level only'"
+  },
   "JDQvla": {
     "defaultMessage": "Ces notes sont disponibles pour tous les gestionnaires de ce bassin, mais pas pour les candidats.",
     "description": "Description of pool candidate notes field"
@@ -4186,6 +4198,10 @@
   "Kyf9At": {
     "defaultMessage": "Définir les renseignements et les exigences de ce processus de recrutement.",
     "description": "Description of a process' advertisement"
+  },
+  "L0eho2": {
+    "defaultMessage": "Ouvert au public",
+    "description": "Combined eligibility string for 'open to the public'"
   },
   "L1tQMY": {
     "defaultMessage": "La Directive sur les talents numériques apporte des précisions supplémentaires sur les exigences et la prise de décisions en matière d’établissement d’un bassin de talents pour soutenir l’élaboration et la prestation d’initiatives, de produits et de services numériques. Elle vise à fournir des étapes pratiques aux personnes qui participent aux décisions d’établissement d’un bassin de talents et à collecter des données qui seront ensuite utilisées pour améliorer en permanence la qualité, la rapidité et la disponibilité de la recherche de talents numériques.",
@@ -5674,6 +5690,10 @@
   "TN9ndX": {
     "defaultMessage": "Tentez d’utiliser un autre terme ou une autre recherche pour la compétence, en vous servant du bouton \"Ajouter une nouvelle compétence\" fourni à cet effet.",
     "description": "Message displayed when no skills match a users filters"
+  },
+  "TOnXeM": {
+    "defaultMessage": "Employé(e)s",
+    "description": "Combined eligibility string for 'employees only' with no other limitations"
   },
   "TPw/0u": {
     "defaultMessage": "sont menaçants, violents, intimidants ou harcelants",
@@ -8077,6 +8097,10 @@
   "g5JeNf": {
     "defaultMessage": "Poursuivre ma demande",
     "description": "Link text to continue an existing, draft application"
+  },
+  "g6coYl": {
+    "defaultMessage": "Employé(e)s (préférences ministérielles)",
+    "description": "Combined eligibility string for 'employees only' and 'departmental preference'"
   },
   "g7RC9u": {
     "defaultMessage": "Note spéciale (français)",


### PR DESCRIPTION
🤖 Related to (but does not close) #11285

## 👋 Introduction

This branch adds a temporary area of selection field to the pool card if the new `areaOfSelection` prop is provided.  This allows the new feature to be added before we're finished rebuilding the pool card.  It builds a combined string from the combination of the two new props.  The combined strings were provided by Nienke.

## 🧪 Testing

1. Launch Storybook or Chromatic
2. View Pool Card / With Who Can Apply

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/8688fa63-1b21-4d48-bbe1-d26026739d9d)

