### PR TITLE
[Debt] Move file generation auth to job

### DIFF
--- a/api/app/Generators/ApplicationDocGenerator.php
+++ b/api/app/Generators/ApplicationDocGenerator.php
@@ -36,6 +36,7 @@ class ApplicationDocGenerator extends DocGenerator implements FileGeneratorInter
             'generalQuestionResponses' => ['generalQuestion'],
         ])
             ->whereIn('id', $this->ids)
+            ->authorizedToView(['userId' => $this->userId])
             ->chunk(200, function ($candidates) use ($section) {
 
                 foreach ($candidates as $candidate) {

--- a/api/app/Generators/PoolCandidateUserDocGenerator.php
+++ b/api/app/Generators/PoolCandidateUserDocGenerator.php
@@ -29,6 +29,7 @@ class PoolCandidateUserDocGenerator extends DocGenerator implements FileGenerato
             'generalQuestionResponses' => ['generalQuestion'],
         ])
             ->whereIn('id', $this->ids)
+            ->authorizedToView(['userId' => $this->userId])
             ->chunk(200, function ($candidates) use ($section) {
                 foreach ($candidates as $candidate) {
                     $this->generateUser($section, $candidate->user);

--- a/api/app/Generators/UserDocGenerator.php
+++ b/api/app/Generators/UserDocGenerator.php
@@ -28,6 +28,7 @@ class UserDocGenerator extends DocGenerator implements FileGeneratorInterface
             'userSkills' => ['skill'],
         ])
             ->whereIn('id', $this->ids)
+            ->authorizedToView(['userId' => $this->userId])
             ->chunk(200, function ($users) use ($section) {
                 foreach ($users as $user) {
                     $this->generateUser($section, $user);

--- a/api/app/GraphQL/Mutations/DownloadApplicationDoc.php
+++ b/api/app/GraphQL/Mutations/DownloadApplicationDoc.php
@@ -29,6 +29,8 @@ final readonly class DownloadApplicationDoc
                 lang: App::getLocale()
             );
 
+            $generator->setUserId($user->id);
+
             $generator->generate()->write();
 
             return $generator->getFileName();

--- a/api/app/GraphQL/Mutations/DownloadPoolCandidateDoc.php
+++ b/api/app/GraphQL/Mutations/DownloadPoolCandidateDoc.php
@@ -30,6 +30,8 @@ final readonly class DownloadPoolCandidateDoc
                 lang: App::getLocale()
             );
 
+            $generator->setUserId($user->id);
+
             $generator->generate()->write();
 
             return $generator->getFileName();

--- a/api/app/GraphQL/Mutations/DownloadUserDoc.php
+++ b/api/app/GraphQL/Mutations/DownloadUserDoc.php
@@ -29,6 +29,8 @@ final readonly class DownloadUserDoc
                 lang: App::getLocale(),
             );
 
+            $generator->setUserId($user->id);
+
             $generator->generate()->write();
 
             return $generator->getFileName();

--- a/api/app/GraphQL/Mutations/DownloadUsersDoc.php
+++ b/api/app/GraphQL/Mutations/DownloadUsersDoc.php
@@ -24,17 +24,10 @@ final class DownloadUsersDoc
         $user = Auth::user();
         throw_unless(is_string($user?->id), UnauthorizedException::class);
 
+        $ids = $args['ids'] ?? [];
         $locale = $args['locale'] ?? 'en';
 
         try {
-            // Make sure this user can see candidates before sending
-            // them to the generation job
-            $ids = User::whereIn('id', $args['ids'])
-                ->authorizedToView()
-                ->get('id')
-                ->pluck('id') // Seems weird but we are just flattening it out
-                ->toArray();
-
             $key = count($ids) > 1 ? 'users' : 'user';
             $fileName = sprintf('%s_%s.docx', Lang::get('filename.'.$key, [], $locale), date('Y-m-d_His'));
 
@@ -45,6 +38,9 @@ final class DownloadUsersDoc
                 dir: $user->id,
                 lang: strtolower($locale),
             );
+
+
+        $generator->setUserId($user->id);
 
             GenerateUserFile::dispatch($generator, $user);
 

--- a/api/app/GraphQL/Mutations/DownloadUsersDoc.php
+++ b/api/app/GraphQL/Mutations/DownloadUsersDoc.php
@@ -4,7 +4,6 @@ namespace App\GraphQL\Mutations;
 
 use App\Generators\UserDocGenerator;
 use App\Jobs\GenerateUserFile;
-use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Log;
@@ -39,8 +38,7 @@ final class DownloadUsersDoc
                 lang: strtolower($locale),
             );
 
-
-        $generator->setUserId($user->id);
+            $generator->setUserId($user->id);
 
             GenerateUserFile::dispatch($generator, $user);
 


### PR DESCRIPTION
🤖 Resolves #11234 

## 👋 Introduction

Moves the authorized to view scope to be run in the job rather than mutations for file generation.

## 🧪 Testing

1. Start the queue `make queue-work`
2. Login as admin `admin@test.com`
3. Download users and candidates from the tables
4. Confirm you still get the expected results
5. Run a mutation with a reduced permission user and IDs for users you do not have access to
6. Confirm those users do not appear in the generated file

