### PR TITLE
[Feature] Last active at tracking

### DIFF
--- a/api/app/Providers/AuthServiceProvider.php
+++ b/api/app/Providers/AuthServiceProvider.php
@@ -21,7 +21,6 @@ use App\Policies\PoolCandidatePolicy;
 use App\Policies\PoolPolicy;
 use App\Policies\UserPolicy;
 use App\Services\OpenIdBearerTokenService;
-use Carbon\Carbon;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
@@ -96,16 +95,11 @@ class AuthServiceProvider extends ServiceProvider
 
             // By this point we have verified that the token is legitimate
             $userMatch = User::where('sub', $sub)->withTrashed()->first();
-            $now = Carbon::now();
 
             if ($userMatch) {
                 if ($userMatch->deleted_at != null) {
                     throw new AuthenticationException('Login as deleted user: '.$userMatch->sub, 'user_deleted');
                 }
-
-                // update last active field now that sign in confirmed
-                $userMatch->last_sign_in_at = $now;
-                $userMatch->save();
 
                 return $userMatch;
             } else {
@@ -117,10 +111,6 @@ class AuthServiceProvider extends ServiceProvider
                     Role::where('name', 'base_user')->sole(),
                     Role::where('name', 'applicant')->sole(),
                 ], null);
-
-                // fill in last active with first login
-                $newUser->last_sign_in_at = $now;
-                $newUser->save();
 
                 return $newUser;
             }

--- a/api/database/migrations/2024_09_03_171609_add_last_active_timestamp.php
+++ b/api/database/migrations/2024_09_03_171609_add_last_active_timestamp.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('last_sign_in_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('last_sign_in_at');
+        });
+    }
+};

--- a/api/tests/Feature/AuthServiceProviderTest.php
+++ b/api/tests/Feature/AuthServiceProviderTest.php
@@ -7,7 +7,6 @@ use App\Models\Role;
 use App\Models\User;
 use App\Providers\AuthServiceProvider;
 use App\Services\OpenIdBearerTokenService;
-use Carbon\Carbon;
 use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lcobucci\JWT\Token\DataSet;
@@ -15,9 +14,6 @@ use Lcobucci\JWT\Validation\ConstraintViolation;
 use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
 use Mockery\MockInterface;
 use Tests\TestCase;
-
-use function PHPUnit\Framework\assertGreaterThanOrEqual;
-use function PHPUnit\Framework\assertLessThanOrEqual;
 
 class AuthServiceProviderTest extends TestCase
 {
@@ -170,38 +166,5 @@ class AuthServiceProviderTest extends TestCase
         $resolvedUser = $this->provider->resolveUserOrAbort($fakeToken, $mockTokenService);
         // make sure our test user did not get wiped
         $this->assertDatabaseHas('users', ['sub' => $testSub, 'first_name' => 'test']);
-    }
-
-    public function testUserLoginWithLastActive()
-    {
-        $testSub = 'test-sub';
-        $beforeLoginTime = Carbon::now()->toDateTimeString();
-        $mockClaims = \Mockery::mock(new DataSet(['sub' => $testSub], ''));
-
-        $fakeToken = 'fake-token';
-        $mockTokenService = \Mockery::mock(OpenIdBearerTokenService::class);
-        $mockTokenService->shouldReceive('validateAndGetClaims')
-            ->with($fakeToken)
-            ->andReturn($mockClaims);
-
-        // create user manually
-        $existingUser = new User;
-        $existingUser->sub = 'test-sub';
-        $existingUser->first_name = 'test';
-        $existingUser->save();
-
-        // they should exist now
-        $this->assertDatabaseHas('users', ['sub' => $testSub, 'first_name' => 'test']);
-
-        // simulate logging in
-        $resolvedUser = $this->provider->resolveUserOrAbort($fakeToken, $mockTokenService);
-
-        $lastActiveString = $resolvedUser->last_sign_in_at->toDateTimeString();
-        $afterLoginTime = Carbon::now()->toDateTimeString();
-
-        // assert login filled in a value for last active
-        // exact matching flaky, so assert it is between, inclusively, the before and after strings
-        assertGreaterThanOrEqual($beforeLoginTime, $lastActiveString);
-        assertLessThanOrEqual($afterLoginTime, $lastActiveString);
     }
 }


### PR DESCRIPTION
🤖 Resolves #11426 

## 👋 Introduction

Adds a field to track last active and handles updating it through an authorization callback
<!-- Describe what this PR is solving. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Migration works
2. Open up database tool and check logging in updates the new field

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/797ce138-c5e1-4b2b-9383-8567b88582c3)

<!-- Add a screenshot (if possible). -->


<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the linked issue if deployment steps are needed

 -->
