### PR TITLE
[Feat] Area of selection

### DIFF
--- a/api/app/Enums/PoolAreaOfSelection.php
+++ b/api/app/Enums/PoolAreaOfSelection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+use App\Traits\HasLocalization;
+
+enum PoolAreaOfSelection
+{
+    use HasLocalization;
+
+    case PUBLIC;
+    case EMPLOYEES;
+
+    public static function getLangFilename(): string
+    {
+        return 'pool_area_of_selection';
+    }
+}

--- a/api/app/Enums/PoolSelectionLimitation.php
+++ b/api/app/Enums/PoolSelectionLimitation.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+use App\Traits\HasLocalization;
+
+enum PoolSelectionLimitation
+{
+    use HasLocalization;
+
+    case AT_LEVEL_ONLY;
+    case DEPARTMENTAL_PREFERENCE;
+
+    public static function getLangFilename(): string
+    {
+        return 'pool_selection_limitation';
+    }
+}

--- a/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
+++ b/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
@@ -2,7 +2,9 @@
 
 namespace App\GraphQL\Validators;
 
+use App\Enums\PoolAreaOfSelection;
 use App\Enums\PoolLanguage;
+use App\Enums\PoolSelectionLimitation;
 use App\Enums\PublishingGroup;
 use App\Enums\SecurityStatus;
 use App\Rules\SkillNotDeleted;
@@ -70,6 +72,9 @@ final class PoolIsCompleteValidator extends Validator
             'what_to_expect_admission.en' => ['required_with:what_to_expect_admission.fr', 'string', 'nullable'],
             'what_to_expect_admission.fr' => ['required_with:what_to_expect_admission.en', 'string', 'nullable'],
             'publishing_group' => ['required', Rule::in(array_column(PublishingGroup::cases(), 'name'))],
+            'area_of_selection' => ['required', Rule::in(array_column(PoolAreaOfSelection::cases(), 'name'))],
+            'selection_limitations' => ['prohibited_unless:area_of_selection,'.PoolAreaOfSelection::PUBLIC->name],
+            'selection_limitations.*' => [Rule::in(array_column(PoolSelectionLimitation::cases(), 'name'))],
         ];
     }
 
@@ -92,6 +97,7 @@ final class PoolIsCompleteValidator extends Validator
             'your_impact.fr.required' => 'FrenchYourImpactRequired',
             'special_note.en.required' => 'EnglishSpecialNoteRequired',
             'special_note.fr.required' => 'EnglishSpecialNoteRequired',
+            'area_of_selection.required' => 'PoolAreaOfSelectionRequired',
         ];
     }
 }

--- a/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
+++ b/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
@@ -73,7 +73,7 @@ final class PoolIsCompleteValidator extends Validator
             'what_to_expect_admission.fr' => ['required_with:what_to_expect_admission.en', 'string', 'nullable'],
             'publishing_group' => ['required', Rule::in(array_column(PublishingGroup::cases(), 'name'))],
             'area_of_selection' => ['required', Rule::in(array_column(PoolAreaOfSelection::cases(), 'name'))],
-            'selection_limitations' => ['prohibited_unless:area_of_selection,'.PoolAreaOfSelection::PUBLIC->name],
+            'selection_limitations' => ['prohibited_unless:area_of_selection,'.PoolAreaOfSelection::EMPLOYEES->name],
             'selection_limitations.*' => [Rule::in(array_column(PoolSelectionLimitation::cases(), 'name'))],
         ];
     }

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -49,6 +49,8 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property string $team_id
  * @property string $department_id
  * @property string $community_id
+ * @property string $area_of_selection
+ * @property array $selection_limitations
  * @property Illuminate\Support\Carbon $created_at
  * @property Illuminate\Support\Carbon $updated_at
  * @property Illuminate\Support\Carbon $closing_date
@@ -82,6 +84,7 @@ class Pool extends Model
         'published_at' => 'datetime',
         'is_remote' => 'boolean',
         'archived_at' => 'datetime',
+        'selection_limitations' => 'array',
     ];
 
     /**

--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -248,7 +248,7 @@ class PoolFactory extends Factory
                 'change_justification' => $this->faker->boolean(50) ? $this->faker->paragraph() : null,
                 'area_of_selection' => $this->faker->randomElement(array_column(PoolAreaOfSelection::cases(), 'name')),
                 'selection_limitations' => function (array $attributes) {
-                    return $attributes['area_of_selection'] == PoolAreaOfSelection::PUBLIC->name
+                    return $attributes['area_of_selection'] == PoolAreaOfSelection::EMPLOYEES->name
                         ? $this->faker->randomElements(
                             array_column(PoolSelectionLimitation::cases(), 'name'),
                             $this->faker->numberBetween(0, count(PoolSelectionLimitation::cases()))

--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -207,7 +207,7 @@ class PoolFactory extends Factory
                 'opportunity_length' => $this->faker->randomElement(array_column(PoolOpportunityLength::cases(), 'name')),
                 'area_of_selection' => $this->faker->optional()->randomElement(array_column(PoolAreaOfSelection::cases(), 'name')),
                 'selection_limitations' => function (array $attributes) {
-                    return $attributes['area_of_selection'] == PoolAreaOfSelection::PUBLIC->name
+                    return $attributes['area_of_selection'] == PoolAreaOfSelection::EMPLOYEES->name
                         ? $this->faker->randomElements(
                             array_column(PoolSelectionLimitation::cases(), 'name'),
                             $this->faker->numberBetween(0, count(PoolSelectionLimitation::cases()))

--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -4,8 +4,10 @@ namespace Database\Factories;
 
 use App\Enums\AssessmentStepType;
 use App\Enums\OperationalRequirement;
+use App\Enums\PoolAreaOfSelection;
 use App\Enums\PoolLanguage;
 use App\Enums\PoolOpportunityLength;
+use App\Enums\PoolSelectionLimitation;
 use App\Enums\PoolSkillType;
 use App\Enums\PoolStream;
 use App\Enums\PublishingGroup;
@@ -203,6 +205,15 @@ class PoolFactory extends Factory
                 'process_number' => $this->faker->word(),
                 'publishing_group' => $this->faker->randomElement(array_column(PublishingGroup::cases(), 'name')),
                 'opportunity_length' => $this->faker->randomElement(array_column(PoolOpportunityLength::cases(), 'name')),
+                'area_of_selection' => $this->faker->optional()->randomElement(array_column(PoolAreaOfSelection::cases(), 'name')),
+                'selection_limitations' => function (array $attributes) {
+                    return $attributes['area_of_selection'] == PoolAreaOfSelection::PUBLIC->name
+                        ? $this->faker->randomElements(
+                            array_column(PoolSelectionLimitation::cases(), 'name'),
+                            $this->faker->numberBetween(0, count(PoolSelectionLimitation::cases()))
+                        )
+                        : [];
+                },
             ];
         });
     }
@@ -235,6 +246,15 @@ class PoolFactory extends Factory
                 'publishing_group' => $this->faker->randomElement(array_column(PublishingGroup::cases(), 'name')),
                 'opportunity_length' => $this->faker->randomElement(array_column(PoolOpportunityLength::cases(), 'name')),
                 'change_justification' => $this->faker->boolean(50) ? $this->faker->paragraph() : null,
+                'area_of_selection' => $this->faker->randomElement(array_column(PoolAreaOfSelection::cases(), 'name')),
+                'selection_limitations' => function (array $attributes) {
+                    return $attributes['area_of_selection'] == PoolAreaOfSelection::PUBLIC->name
+                        ? $this->faker->randomElements(
+                            array_column(PoolSelectionLimitation::cases(), 'name'),
+                            $this->faker->numberBetween(0, count(PoolSelectionLimitation::cases()))
+                        )
+                        : [];
+                },
             ];
         });
     }

--- a/api/database/migrations/2024_08_28_145445_create_area_of_selection.php
+++ b/api/database/migrations/2024_08_28_145445_create_area_of_selection.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pools', function (Blueprint $table) {
+            $table->string('area_of_selection')->nullable(true);
+            $table->jsonb('selection_limitations')->nullable(false)->default(json_encode([]));
+        });
+
+        DB::table('pools')
+            ->whereNotNull('published_at')
+            ->update(['area_of_selection' => 'PUBLIC']);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pools', function (Blueprint $table) {
+            $table->dropColumn('area_of_selection');
+            $table->dropColumn('selection_limitations');
+        });
+    }
+};

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -302,6 +302,10 @@ type Pool implements HasRoleAssignments {
     @canRoot(ability: "viewTeamMembers")
   teamIdForRoleAssignment: ID @with(relation: "team")
   department: Department @belongsTo @canQuery(ability: "view")
+  areaOfSelection: LocalizedPoolAreaOfSelection
+    @rename(attribute: "area_of_selection")
+  selectionLimitations: [LocalizedPoolSelectionLimitation!]
+    @rename(attribute: "selection_limitations")
 }
 
 type GeneralQuestionResponse {
@@ -1647,6 +1651,9 @@ input UpdatePoolInput {
   opportunityLength: PoolOpportunityLength
     @rename(attribute: "opportunity_length")
   generalQuestions: UpdateGeneralQuestionsHasMany
+  areaOfSelection: PoolAreaOfSelection @rename(attribute: "area_of_selection")
+  selectionLimitations: [LocalizedPoolSelectionLimitation!]
+    @rename(attribute: "selection_limitations")
 }
 
 input UpdatePublishedPoolInput @validator {
@@ -2231,8 +2238,8 @@ type Mutation {
 
   # File downloads
   downloadPoolCandidatesCsv(
-    ids: [UUID!],
-    where: PoolCandidateSearchInput,
+    ids: [UUID!]
+    where: PoolCandidateSearchInput
     locale: Language
   ): Boolean! @guard
   downloadPoolCandidatesDoc(
@@ -2241,7 +2248,7 @@ type Mutation {
     locale: Language
   ): Boolean! @guard
   downloadUsersCsv(
-    ids: [UUID!],
+    ids: [UUID!]
     where: UserFilterInput
     locale: Language
   ): Boolean! @guard

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1652,7 +1652,7 @@ input UpdatePoolInput {
     @rename(attribute: "opportunity_length")
   generalQuestions: UpdateGeneralQuestionsHasMany
   areaOfSelection: PoolAreaOfSelection @rename(attribute: "area_of_selection")
-  selectionLimitations: [LocalizedPoolSelectionLimitation!]
+  selectionLimitations: [PoolSelectionLimitation!]
     @rename(attribute: "selection_limitations")
 }
 

--- a/api/lang/en/pool_area_of_selection.php
+++ b/api/lang/en/pool_area_of_selection.php
@@ -2,5 +2,5 @@
 
 return [
     'public' => 'The public',
-    'employees' => 'Employees and persons employed',
+    'employees' => 'Existing employees of the Government of Canada or persons employed by an agency',
 ];

--- a/api/lang/en/pool_area_of_selection.php
+++ b/api/lang/en/pool_area_of_selection.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'public' => 'The public',
+    'employees' => 'Persons employed',
+];

--- a/api/lang/en/pool_area_of_selection.php
+++ b/api/lang/en/pool_area_of_selection.php
@@ -2,5 +2,5 @@
 
 return [
     'public' => 'The public',
-    'employees' => 'Existing employees of the Government of Canada or persons employed by an agency',
+    'employees' => 'Employees or persons employed by the Government of Canada',
 ];

--- a/api/lang/en/pool_area_of_selection.php
+++ b/api/lang/en/pool_area_of_selection.php
@@ -2,5 +2,5 @@
 
 return [
     'public' => 'The public',
-    'employees' => 'Persons employed',
+    'employees' => 'Employees and persons employed',
 ];

--- a/api/lang/en/pool_selection_limitation.php
+++ b/api/lang/en/pool_selection_limitation.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'at_level_only' => 'At-level only',
+    'departmental_preference' => 'Departmental preference',
+];

--- a/api/lang/fr/pool_area_of_selection.php
+++ b/api/lang/fr/pool_area_of_selection.php
@@ -2,5 +2,5 @@
 
 return [
     'public' => 'Le public',
-    'employees' => 'Employés actuels du gouvernement du Canada ou personnes employées par une agence',
+    'employees' => 'Employés ou personnes employées par le gouvernement du Canada',
 ];

--- a/api/lang/fr/pool_area_of_selection.php
+++ b/api/lang/fr/pool_area_of_selection.php
@@ -2,5 +2,5 @@
 
 return [
     'public' => 'Le public',
-    'employees' => 'Personnes employées',
+    'employees' => 'Employés actuels du gouvernement du Canada ou personnes employées par une agence',
 ];

--- a/api/lang/fr/pool_area_of_selection.php
+++ b/api/lang/fr/pool_area_of_selection.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'public' => 'Le public',
+    'employees' => 'Personnes employées',
+];

--- a/api/lang/fr/pool_selection_limitation.php
+++ b/api/lang/fr/pool_selection_limitation.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'at_level_only' => 'À niveau seulement',
+    'departmental_preference' => 'Préférence ministérielle',
+];

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1657,6 +1657,8 @@ input UpdatePoolInput {
   publishingGroup: PublishingGroup
   opportunityLength: PoolOpportunityLength
   generalQuestions: UpdateGeneralQuestionsHasMany
+  areaOfSelection: PoolAreaOfSelection
+  selectionLimitations: [LocalizedPoolSelectionLimitation!]
 }
 
 input UpdatePublishedPoolInput {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1658,7 +1658,7 @@ input UpdatePoolInput {
   opportunityLength: PoolOpportunityLength
   generalQuestions: UpdateGeneralQuestionsHasMany
   areaOfSelection: PoolAreaOfSelection
-  selectionLimitations: [LocalizedPoolSelectionLimitation!]
+  selectionLimitations: [PoolSelectionLimitation!]
 }
 
 input UpdatePublishedPoolInput {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -661,6 +661,8 @@ type Pool implements HasRoleAssignments {
   roleAssignments: [RoleAssignment!]
   teamIdForRoleAssignment: ID
   department: Department
+  areaOfSelection: LocalizedPoolAreaOfSelection
+  selectionLimitations: [LocalizedPoolSelectionLimitation!]
 }
 
 type GeneralQuestionResponse {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -113,6 +113,11 @@ type LocalizedPlacementType {
   label: LocalizedString!
 }
 
+type LocalizedPoolAreaOfSelection {
+  value: PoolAreaOfSelection!
+  label: LocalizedString!
+}
+
 type LocalizedPoolCandidateSearchPositionType {
   value: PoolCandidateSearchPositionType!
   label: LocalizedString!
@@ -140,6 +145,11 @@ type LocalizedPoolLanguage {
 
 type LocalizedPoolOpportunityLength {
   value: PoolOpportunityLength!
+  label: LocalizedString!
+}
+
+type LocalizedPoolSelectionLimitation {
+  value: PoolSelectionLimitation!
   label: LocalizedString!
 }
 
@@ -2763,6 +2773,11 @@ enum PlacementType {
   PLACED_INDETERMINATE
 }
 
+enum PoolAreaOfSelection {
+  PUBLIC
+  EMPLOYEES
+}
+
 enum PoolCandidateSearchPositionType {
   INDIVIDUAL_CONTRIBUTOR
   TEAM_LEAD
@@ -2820,6 +2835,11 @@ enum PoolOpportunityLength {
   TERM_TWO_YEARS
   INDETERMINATE
   VARIOUS
+}
+
+enum PoolSelectionLimitation {
+  AT_LEVEL_ONLY
+  DEPARTMENTAL_PREFERENCE
 }
 
 enum PoolSkillType {

--- a/apps/playwright/utils/pools.ts
+++ b/apps/playwright/utils/pools.ts
@@ -2,6 +2,7 @@ import {
   CreatePoolSkillInput,
   LocalizedString,
   Pool,
+  PoolAreaOfSelection,
   PoolLanguage,
   PoolOpportunityLength,
   PoolSkill,
@@ -39,6 +40,8 @@ const defaultPool: Partial<UpdatePoolInput> = {
   },
   isRemote: true,
   publishingGroup: PublishingGroup.ItJobs,
+  areaOfSelection: PoolAreaOfSelection.Public,
+  selectionLimitations: [],
 };
 
 const Test_CreatePoolMutationDocument = /* GraphQL */ `

--- a/apps/web/src/components/PoolCard/PoolCard.stories.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.stories.tsx
@@ -34,6 +34,4 @@ Null.args = {
 export const WithWhoCanApply = Template.bind({});
 WithWhoCanApply.args = {
   ...Default.args,
-  areaOfSelection: "EMPLOYEES",
-  selectionLimitations: ["AT_LEVEL_ONLY", "DEPARTMENTAL_PREFERENCE"],
 };

--- a/apps/web/src/components/PoolCard/PoolCard.stories.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.stories.tsx
@@ -1,7 +1,7 @@
 import { StoryFn, Meta } from "@storybook/react";
 
 import { fakePools } from "@gc-digital-talent/fake-data";
-import { makeFragmentData } from "@gc-digital-talent/graphql";
+import { makeFragmentData, Pool } from "@gc-digital-talent/graphql";
 
 import PoolCard, { PoolCard_Fragment } from "./PoolCard";
 
@@ -14,6 +14,12 @@ const nullPool: any = {};
 Object.keys(fakedPoolNull).forEach((key) => {
   nullPool[key] = null;
 });
+
+const poolWithoutWhoCanApply: Pool = {
+  ...fakedPool,
+  areaOfSelection: null,
+  selectionLimitations: [],
+};
 
 export default {
   component: PoolCard,
@@ -31,7 +37,7 @@ Null.args = {
   poolQuery: makeFragmentData(nullPool, PoolCard_Fragment),
 };
 
-export const WithWhoCanApply = Template.bind({});
-WithWhoCanApply.args = {
-  ...Default.args,
+export const WithoutWhoCanApply = Template.bind({});
+WithoutWhoCanApply.args = {
+  poolQuery: makeFragmentData(poolWithoutWhoCanApply, PoolCard_Fragment),
 };

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4911,6 +4911,10 @@
     "defaultMessage": "Sélectionnez les filtres",
     "description": "Candidate search filter dialog: title"
   },
+  "PAOXlo": {
+    "defaultMessage": "* La préférence sera accordée aux anciens combattants, aux citoyens canadiens et aux résidents permanents.",
+    "description": "Fine print for hiring policy for pool advertisement"
+  },
   "PAySDr": {
     "defaultMessage": "Familles de compétences (français)",
     "description": "Title for skill families in French"
@@ -6969,10 +6973,6 @@
   "aCKQVB": {
     "defaultMessage": "Question (EN)",
     "description": "Label for an English general question"
-  },
-  "aCg/OZ": {
-    "defaultMessage": "La préférence sera accordée aux anciens combattants, aux citoyens canadiens et aux résidents permanents.",
-    "description": "First hiring policy for pool advertisement"
   },
   "aDRIDD": {
     "defaultMessage": "Éducation actuelle",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1263,6 +1263,10 @@
     "defaultMessage": "Pour toute question ou préoccupation concernant le questionnaire, veuillez contacter <link>Talents numériques du GC</link> pour obtenir de plus amples renseignements.",
     "description": "Paragraph four of the _instructions_ section of the _digital services contracting questionnaire_"
   },
+  "4l0wGu": {
+    "defaultMessage": "Cette possibilité s'adresse aux employés internes de classification {classification} ou équivalente",
+    "description": "Title of a note describing that a pool is only open to employees at-level"
+  },
   "4lRUZt": {
     "defaultMessage": "Vous êtes sur le point de modifier l’information publiée dans l’annonce suivante",
     "description": "Warning message when attempting to update a published process advertisement"
@@ -1407,6 +1411,10 @@
     "defaultMessage": "Mentionner des prix et des marques de reconnaissance en particulier que vous avez reçus pour votre dévouement exceptionnel.",
     "description": "Description for award experience section"
   },
+  "5S5zo0": {
+    "defaultMessage": "Limites de la sélection des employés",
+    "description": "Label for a process' selection limitations"
+  },
   "5SKmte": {
     "defaultMessage": "Modifier<hidden> le regroupement des compétences</hidden>",
     "description": "Breadcrumb title for the edit skill family page link."
@@ -1514,6 +1522,10 @@
   "66qMwD": {
     "defaultMessage": "« ... réfère à une personne dont les activités quotidiennes sont limitées en raison d'un trouble ou d'une difficulté à accomplir certaines tâches. La seule exception à cet égard concerne les troubles du développement, le répondant qui a reçu un tel diagnostic étant considéré comme ayant une incapacité. »",
     "description": "Definition of Person with a disability from the StatsCan 'Classification of Status of Disability' page."
+  },
+  "66xc/o": {
+    "defaultMessage": "Cette possibilité s'adresse aux employés internes de classification {classification} ou équivalente avec la préférence accordée à ceux aux ministères énumérés*",
+    "description": "Title of a note describing that a pool is only open to employees, at-level, with departmental preference. Has an asterisk for fine print."
   },
   "69BfF3": {
     "defaultMessage": "Découvrez un talent en vous servant d’un jeu de filtres détaillés, y compris la classification, les langues et les compétences.",
@@ -1978,6 +1990,10 @@
   "8ownC2": {
     "defaultMessage": "Veuillez préciser la raison",
     "description": "Label for _an other contracting rationale_ field in the _digital services contracting questionnaire_"
+  },
+  "8t1KYs": {
+    "defaultMessage": "* La préférence sera accordée aux personnes employées par les ministères ou agences (ministère) suivants : {department}.",
+    "description": "Fine print of a note describing that a pool is only open to employees with departmental preference"
   },
   "8v/v3u": {
     "defaultMessage": "Compétences requises",
@@ -3111,6 +3127,10 @@
     "defaultMessage": "Il manque des renseignements obligatoires sur la langue",
     "description": "Error message displayed when a users language information is incomplete"
   },
+  "F6AwoP": {
+    "defaultMessage": "Qui résident au Canada, sont citoyens canadiens ou résidents permanents à l'étranger",
+    "description": "Regular criteria item needed in order to apply"
+  },
   "F6L/Rv": {
     "defaultMessage": "Modifier {skillName}",
     "description": "Edit a skill"
@@ -3879,6 +3899,10 @@
     "defaultMessage": "Instantané de profil non trouvé.",
     "description": "Message displayed for profile snapshot not found."
   },
+  "JKEDRo": {
+    "defaultMessage": "Cette possibilité s'adresse aux employés internes, la préférence étant donnée aux personnes travaillant dans les ministères énumérés*",
+    "description": "Title of a note describing that a pool is only open to employees with departmental preference. Has an asterisk for fine print."
+  },
   "JRlnNk": {
     "defaultMessage": "Gestion de la collectivité numérique",
     "description": "Title for the Digital Community Management"
@@ -4094,6 +4118,10 @@
   "KXy+Ei": {
     "defaultMessage": "AC",
     "description": "Short form code representing 'veteran'"
+  },
+  "KY4zuB": {
+    "defaultMessage": "Les employés du gouvernement du Canada qui : ",
+    "description": "Title for a list of criteria needed for employees to apply"
   },
   "KZtBcM": {
     "defaultMessage": "Examiner la demande<hidden> {name}</hidden>",
@@ -6265,6 +6293,10 @@
   "WYJnLs": {
     "defaultMessage": "Demande",
     "description": "Heading displayed above the single search request component."
+  },
+  "WcU42I": {
+    "defaultMessage": "Cette possibilité s'adresse aux employés internes",
+    "description": "Title of a note describing that a pool is only open to employees"
   },
   "Wd9+xg": {
     "defaultMessage": "Utilisez le bouton \"Ajouter une nouvelle compétence\" pour commencer.",
@@ -8886,6 +8918,10 @@
     "defaultMessage": "Travail à distance facultatif (recommandé)",
     "description": "Label displayed for 'remote optional' option"
   },
+  "js5ZcB": {
+    "defaultMessage": "Cela indiquera aux candidats que les personnes employées par les ministères liés à cette possibilité seront accordées la préférence lors de la sélection.",
+    "description": "Caption for the departmental-preference selection limitation"
+  },
   "jtEouE": {
     "defaultMessage": "Ajouter l'utilisateur au bassin",
     "description": "Title of the 'Add user to pools' section of the view-user page"
@@ -8945,6 +8981,10 @@
   "k8lEf0": {
     "defaultMessage": "Niveaux de compétence technique",
     "description": "Heading for the skills level definitions of technical skills"
+  },
+  "k9moOJ": {
+    "defaultMessage": "Cette possibilité est réservée aux employés actuels du gouvernement du Canada ou aux personnes employées par une agence du gouvernement du Canada. En postulant, vous confirmez que vous êtes un employé en service et que les informations sur l'employé que vous fournissez dans votre profil sont à jour.",
+    "description": "Body of a note describing that a pool is only open to employees"
   },
   "kHypfJ": {
     "defaultMessage": "Du concept au code",
@@ -9750,6 +9790,10 @@
     "defaultMessage": "Vous êtes sur le point de modifier le statut de cet utilisateur :",
     "description": "Première section du texte de la boîte de dialogue Modifier le statut du candidat"
   },
+  "p+rROQ": {
+    "defaultMessage": "Cela indiquera aux candidats que seuls les employés à niveau ou de niveau équivalent seront pris en considération pour cette possibilité.",
+    "description": "Caption for the at-level-only selection limitation"
+  },
   "p/Qp/u": {
     "defaultMessage": "Nom du candidat",
     "description": "Title displayed on the Pool Candidates table name column."
@@ -9873,6 +9917,14 @@
   "pVCsBB": {
     "defaultMessage": "Catégorie de travail",
     "description": "Label for pool advertisement stream"
+  },
+  "pVnp82": {
+    "defaultMessage": "Présentement, vous êtes titulaire d'un {classificationString} la classification du poste d’attache",
+    "description": "At-level application criteria"
+  },
+  "pVx/jP": {
+    "defaultMessage": "Cette possibilité est réservée aux employés actuels du gouvernement du Canada ou aux personnes employées par une agence du gouvernement du Canada qui sont présentement classés comme {classification} ou un équivalent organisationnel. En postulant, vous confirmez que vous êtes un employé en service et que les informations sur l'employé que vous fournissez dans votre profil sont à jour.",
+    "description": "Body of a note describing that a pool is only open to employees at-level"
   },
   "pWoAv0": {
     "defaultMessage": "Le Programme d’apprentissage en TI pour les personnes autochtones est une initiative du gouvernement du Canada visant particulièrement les Premières Nations, les Inuits et les Métis. C’est un chemin vers un emploi dans la fonction publique fédérale pour les personnes autochtones qui ont une passion pour la technologie de l’information (TI).",
@@ -11469,6 +11521,10 @@
   "zMa59V": {
     "defaultMessage": "Veuillez ne pas fournir des renseignements personnels supplémentaires qui ne sont pas requis à cette fin.",
     "description": "Paragraph for privacy policy page"
+  },
+  "zNgDex": {
+    "defaultMessage": "Zone de sélection",
+    "description": "Label for a process' area of selection"
   },
   "zRw5Fs": {
     "defaultMessage": "Retirez {userName} de {poolName}.",

--- a/apps/web/src/messages/processMessages.ts
+++ b/apps/web/src/messages/processMessages.ts
@@ -162,6 +162,16 @@ const messages = defineMessages({
     id: "LyUTqa",
     description: "Education requirement title",
   },
+  areaOfSelection: {
+    defaultMessage: "Area of selection",
+    id: "zNgDex",
+    description: "Label for a process' area of selection",
+  },
+  selectionLimitations: {
+    defaultMessage: "Employee selection limitations",
+    id: "5S5zo0",
+    description: "Label for a process' selection limitations",
+  },
 });
 
 export default messages;

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -266,7 +266,7 @@ export const EditPoolForm = ({
 
   const basicInfoHasError =
     poolNameError({
-      areaOfSelection: pool.areaOfSelection,
+      areaOfSelection: pool.areaOfSelection?.value,
       classification: pool.classification,
       department: pool.department,
       stream: pool.stream,

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -211,6 +211,7 @@ export const EditPool_Fragment = graphql(/* GraphQL */ `
       }
     }
     isRemote
+    areaOfSelection
   }
 `);
 
@@ -263,6 +264,7 @@ export const EditPoolForm = ({
 
   const basicInfoHasError =
     poolNameError({
+      areaOfSelection: pool.areaOfSelection,
       classification: pool.classification,
       department: pool.department,
       stream: pool.stream,

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -211,7 +211,9 @@ export const EditPool_Fragment = graphql(/* GraphQL */ `
       }
     }
     isRemote
-    areaOfSelection
+    areaOfSelection {
+      value
+    }
   }
 `);
 

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -213,6 +213,10 @@ export const EditPool_Fragment = graphql(/* GraphQL */ `
     isRemote
     areaOfSelection {
       value
+      label {
+        en
+        fr
+      }
     }
   }
 `);
@@ -266,7 +270,7 @@ export const EditPoolForm = ({
 
   const basicInfoHasError =
     poolNameError({
-      areaOfSelection: pool.areaOfSelection?.value,
+      areaOfSelection: pool.areaOfSelection,
       classification: pool.classification,
       department: pool.department,
       stream: pool.stream,
@@ -304,6 +308,7 @@ export const EditPoolForm = ({
     poolName: {
       id: "pool-name",
       hasError: poolNameError({
+        areaOfSelection: pool.areaOfSelection,
         classification: pool.classification,
         department: pool.department,
         stream: pool.stream,

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -82,7 +82,7 @@ const Display = ({
                     ) ? (
                     <CheckCircleIcon
                       data-h2-height="base(x0.75)"
-                      data-h2-color="base(success.lighter )"
+                      data-h2-color="base(success) base:dark(success.lighter)"
                     />
                   ) : (
                     <XCircleIcon

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -6,6 +6,7 @@ import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import {
   EditPoolNameFragment,
   LocalizedEnumString,
+  PoolAreaOfSelection,
   PoolSelectionLimitation,
 } from "@gc-digital-talent/graphql";
 
@@ -50,46 +51,47 @@ const Display = ({
         >
           {getLocalizedName(areaOfSelection?.label, intl) || notProvided}
         </ToggleForm.FieldDisplay>
-        <ToggleForm.FieldDisplay
-          data-h2-grid-column="p-tablet(1 / span 2)"
-          hasError={!areaOfSelection}
-          label={intl.formatMessage(processMessages.selectionLimitations)}
-        >
-          <div
-            data-h2-display="base(flex)"
-            data-h2-flex-direction="base(column)"
-            data-h2-gap="base(x0.25)"
-            data-h2-margin-top="base(x0.25)"
+        {areaOfSelection?.value === PoolAreaOfSelection.Employees ? (
+          <ToggleForm.FieldDisplay
+            data-h2-grid-column="p-tablet(1 / span 2)"
+            label={intl.formatMessage(processMessages.selectionLimitations)}
           >
-            {allPoolSelectionLimitations?.map((singleSelectionLimitation) => {
-              return (
-                <div
-                  key={singleSelectionLimitation.value}
-                  data-h2-display="base(flex)"
-                  data-h2-gap="base(x0.25)"
-                  data-h2-align-items="base(center)"
-                >
-                  {poolSelectionLimitations
-                    ?.map((l) => l.value)
-                    .includes(
-                      singleSelectionLimitation.value as PoolSelectionLimitation,
-                    ) ? (
-                    <CheckCircleIcon
-                      data-h2-height="base(x0.75)"
-                      data-h2-color="base(success) base:dark(success.lighter)"
-                    />
-                  ) : (
-                    <XCircleIcon
-                      data-h2-height="base(x0.75)"
-                      data-h2-color="base(background.darker)"
-                    />
-                  )}
-                  {getLocalizedName(singleSelectionLimitation.label, intl)}
-                </div>
-              );
-            })}
-          </div>
-        </ToggleForm.FieldDisplay>
+            <div
+              data-h2-display="base(flex)"
+              data-h2-flex-direction="base(column)"
+              data-h2-gap="base(x0.25)"
+              data-h2-margin-top="base(x0.25)"
+            >
+              {allPoolSelectionLimitations?.map((singleSelectionLimitation) => {
+                return (
+                  <div
+                    key={singleSelectionLimitation.value}
+                    data-h2-display="base(flex)"
+                    data-h2-gap="base(x0.25)"
+                    data-h2-align-items="base(center)"
+                  >
+                    {poolSelectionLimitations
+                      ?.map((l) => l.value)
+                      .includes(
+                        singleSelectionLimitation.value as PoolSelectionLimitation,
+                      ) ? (
+                      <CheckCircleIcon
+                        data-h2-height="base(x0.75)"
+                        data-h2-color="base(success) base:dark(success.lighter)"
+                      />
+                    ) : (
+                      <XCircleIcon
+                        data-h2-height="base(x0.75)"
+                        data-h2-color="base(background.darker)"
+                      />
+                    )}
+                    {getLocalizedName(singleSelectionLimitation.label, intl)}
+                  </div>
+                );
+              })}
+            </div>
+          </ToggleForm.FieldDisplay>
+        ) : null}
         <ToggleForm.FieldDisplay
           hasError={!classification}
           label={intl.formatMessage(processMessages.classification)}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -1,7 +1,13 @@
 import { useIntl } from "react-intl";
+import CheckCircleIcon from "@heroicons/react/20/solid/CheckCircleIcon";
+import XCircleIcon from "@heroicons/react/20/solid/XCircleIcon";
 
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
-import { EditPoolNameFragment } from "@gc-digital-talent/graphql";
+import {
+  EditPoolNameFragment,
+  LocalizedEnumString,
+  PoolSelectionLimitation,
+} from "@gc-digital-talent/graphql";
 
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
 import { getClassificationName } from "~/utils/poolUtils";
@@ -9,10 +15,17 @@ import processMessages from "~/messages/processMessages";
 
 import { DisplayProps } from "../../types";
 
-const Display = ({ pool }: DisplayProps<EditPoolNameFragment>) => {
+const Display = ({
+  pool,
+  poolSelectionLimitations: allSelectionLimitations,
+}: DisplayProps<EditPoolNameFragment> & {
+  poolSelectionLimitations: LocalizedEnumString[] | null | undefined;
+}) => {
   const intl = useIntl();
   const notProvided = intl.formatMessage(commonMessages.notProvided);
   const {
+    areaOfSelection,
+    selectionLimitations: poolSelectionLimitations,
     classification,
     department,
     stream,
@@ -30,6 +43,53 @@ const Display = ({ pool }: DisplayProps<EditPoolNameFragment>) => {
         data-h2-grid-template-columns="p-tablet(repeat(2, 1fr))"
         data-h2-margin-bottom="base(x1)"
       >
+        <ToggleForm.FieldDisplay
+          data-h2-grid-column="p-tablet(1 / span 2)"
+          hasError={!areaOfSelection}
+          label={intl.formatMessage(processMessages.areaOfSelection)}
+        >
+          {getLocalizedName(areaOfSelection?.label, intl) || notProvided}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          data-h2-grid-column="p-tablet(1 / span 2)"
+          hasError={!areaOfSelection}
+          label={intl.formatMessage(processMessages.selectionLimitations)}
+        >
+          <div
+            data-h2-display="base(flex)"
+            data-h2-flex-direction="base(column)"
+            data-h2-gap="base(x0.25)"
+            data-h2-margin-top="base(x0.25)"
+          >
+            {allSelectionLimitations?.map((singleSelectionLimitation) => {
+              return (
+                <div
+                  key={singleSelectionLimitation.value}
+                  data-h2-display="base(flex)"
+                  data-h2-gap="base(x0.25)"
+                  data-h2-align-items="base(center)"
+                >
+                  {poolSelectionLimitations
+                    ?.map((l) => l.value)
+                    .includes(
+                      singleSelectionLimitation.value as PoolSelectionLimitation,
+                    ) ? (
+                    <CheckCircleIcon
+                      data-h2-height="base(x0.75)"
+                      data-h2-color="base(success.lighter )"
+                    />
+                  ) : (
+                    <XCircleIcon
+                      data-h2-height="base(x0.75)"
+                      data-h2-color="base(background.darker)"
+                    />
+                  )}
+                  {getLocalizedName(singleSelectionLimitation.label, intl)}
+                </div>
+              );
+            })}
+          </div>
+        </ToggleForm.FieldDisplay>
         <ToggleForm.FieldDisplay
           hasError={!classification}
           label={intl.formatMessage(processMessages.classification)}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -35,6 +35,12 @@ const Display = ({
     opportunityLength,
   } = pool;
 
+  allSelectionLimitations?.sort((a, b) =>
+    getLocalizedName(a.label, intl).localeCompare(
+      getLocalizedName(b.label, intl),
+    ),
+  );
+
   return (
     <>
       <div

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -78,11 +78,15 @@ const Display = ({
                       <CheckCircleIcon
                         data-h2-height="base(x0.75)"
                         data-h2-color="base(success) base:dark(success.lighter)"
+                        aria-hidden="false"
+                        aria-label={intl.formatMessage(commonMessages.yes)}
                       />
                     ) : (
                       <XCircleIcon
                         data-h2-height="base(x0.75)"
                         data-h2-color="base(background.darker)"
+                        aria-hidden="false"
+                        aria-label={intl.formatMessage(commonMessages.no)}
                       />
                     )}
                     {getLocalizedName(singleSelectionLimitation.label, intl)}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -17,9 +17,9 @@ import { DisplayProps } from "../../types";
 
 const Display = ({
   pool,
-  poolSelectionLimitations: allSelectionLimitations,
+  allPoolSelectionLimitations,
 }: DisplayProps<EditPoolNameFragment> & {
-  poolSelectionLimitations: LocalizedEnumString[] | null | undefined;
+  allPoolSelectionLimitations: LocalizedEnumString[];
 }) => {
   const intl = useIntl();
   const notProvided = intl.formatMessage(commonMessages.notProvided);
@@ -34,12 +34,6 @@ const Display = ({
     publishingGroup,
     opportunityLength,
   } = pool;
-
-  allSelectionLimitations?.sort((a, b) =>
-    getLocalizedName(a.label, intl).localeCompare(
-      getLocalizedName(b.label, intl),
-    ),
-  );
 
   return (
     <>
@@ -67,7 +61,7 @@ const Display = ({
             data-h2-gap="base(x0.25)"
             data-h2-margin-top="base(x0.25)"
           >
-            {allSelectionLimitations?.map((singleSelectionLimitation) => {
+            {allPoolSelectionLimitations?.map((singleSelectionLimitation) => {
               return (
                 <div
                   key={singleSelectionLimitation.value}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
@@ -1,4 +1,4 @@
-import { JSX } from "react";
+import { JSX, useEffect } from "react";
 import { useIntl } from "react-intl";
 import { FormProvider, useForm } from "react-hook-form";
 import TagIcon from "@heroicons/react/24/outline/TagIcon";
@@ -221,7 +221,26 @@ const PoolNameSection = ({
   const methods = useForm<FormValues>({
     defaultValues: dataToFormValues(pool),
   });
-  const { handleSubmit } = methods;
+  const { handleSubmit, watch, resetField } = methods;
+
+  // hooks to watch, needed for conditional rendering
+  const [selectedAreaOfSelection] = watch(["areaOfSelection"]);
+  const isAreaOfSelectionEmployeesOnly =
+    selectedAreaOfSelection === PoolAreaOfSelection.Employees;
+
+  /**
+   * Reset un-rendered fields
+   */
+  useEffect(() => {
+    const resetDirtyField = (name: keyof FormValues) => {
+      resetField(name, { keepDirty: false, defaultValue: null });
+    };
+
+    // Reset all optional fields
+    if (!isAreaOfSelectionEmployeesOnly) {
+      resetDirtyField("selectionLimitations");
+    }
+  }, [resetField, isAreaOfSelectionEmployeesOnly]);
 
   const handleSave = async (formValues: FormValues) => {
     return onSave(formValuesToSubmitData(formValues))
@@ -334,17 +353,19 @@ const PoolNameSection = ({
                     )}
                   />
                 </div>
-                <div data-h2-grid-column="l-tablet(1 / span 2)">
-                  <Checklist
-                    id="selectionLimitations"
-                    idPrefix="selectionLimitations"
-                    name="selectionLimitations"
-                    legend={intl.formatMessage(
-                      processMessages.selectionLimitations,
-                    )}
-                    items={allPoolSelectionLimitationItems}
-                  />
-                </div>
+                {isAreaOfSelectionEmployeesOnly && (
+                  <div data-h2-grid-column="l-tablet(1 / span 2)">
+                    <Checklist
+                      id="selectionLimitations"
+                      idPrefix="selectionLimitations"
+                      name="selectionLimitations"
+                      legend={intl.formatMessage(
+                        processMessages.selectionLimitations,
+                      )}
+                      items={allPoolSelectionLimitationItems}
+                    />
+                  </div>
+                )}
                 <Select
                   id="classification"
                   label={intl.formatMessage({

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
@@ -94,6 +94,19 @@ const EditPoolName_Fragment = graphql(/* GraphQL */ `
       en
       fr
     }
+    areaOfSelection {
+      label {
+        en
+        fr
+      }
+    }
+    selectionLimitations {
+      value
+      label {
+        en
+        fr
+      }
+    }
   }
 `);
 
@@ -137,6 +150,15 @@ const PoolNameOptions_Query = graphql(/* GraphQL */ `
     }
     opportunityLengths: localizedEnumStrings(
       enumName: "PoolOpportunityLength"
+    ) {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    poolSelectionLimitations: localizedEnumStrings(
+      enumName: "PoolSelectionLimitation"
     ) {
       value
       label {
@@ -229,7 +251,14 @@ const PoolNameSection = ({
       <p>{subtitle}</p>
       <ToggleSection.Content>
         <ToggleSection.InitialContent>
-          {isNull ? <ToggleForm.NullDisplay /> : <Display pool={pool} />}
+          {isNull ? (
+            <ToggleForm.NullDisplay />
+          ) : (
+            <Display
+              pool={pool}
+              poolSelectionLimitations={data?.poolSelectionLimitations}
+            />
+          )}
         </ToggleSection.InitialContent>
         <ToggleSection.OpenContent>
           <FormProvider {...methods}>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
@@ -10,9 +10,12 @@ import {
   formMessages,
   uiMessages,
   sortOpportunityLength,
+  getLocalizedName,
 } from "@gc-digital-talent/i18n";
 import {
+  Checklist,
   Input,
+  RadioGroup,
   Select,
   Submit,
   localizedEnumToOptions,
@@ -22,6 +25,7 @@ import {
   FragmentType,
   getFragment,
   graphql,
+  LocalizedEnumString,
 } from "@gc-digital-talent/graphql";
 
 import {
@@ -157,7 +161,16 @@ const PoolNameOptions_Query = graphql(/* GraphQL */ `
         fr
       }
     }
-    poolSelectionLimitations: localizedEnumStrings(
+    allPoolAreaOfSelections: localizedEnumStrings(
+      enumName: "PoolAreaOfSelection"
+    ) {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    allPoolSelectionLimitations: localizedEnumStrings(
       enumName: "PoolSelectionLimitation"
     ) {
       value
@@ -217,6 +230,20 @@ const PoolNameSection = ({
       .catch(() => methods.reset(formValues));
   };
 
+  const enumCompare = (
+    a: Pick<LocalizedEnumString, "label">,
+    b: Pick<LocalizedEnumString, "label">,
+  ) =>
+    getLocalizedName(a.label, intl).localeCompare(
+      getLocalizedName(b.label, intl),
+    );
+
+  const allPoolSelectionLimitations = data?.allPoolSelectionLimitations ?? [];
+  allPoolSelectionLimitations.sort(enumCompare);
+
+  const allPoolAreaOfSelections = data?.allPoolAreaOfSelections ?? [];
+  allPoolSelectionLimitations.sort(enumCompare);
+
   // disabled unless status is draft
   const formDisabled = pool.status?.value !== PoolStatus.Draft;
 
@@ -256,7 +283,7 @@ const PoolNameSection = ({
           ) : (
             <Display
               pool={pool}
-              poolSelectionLimitations={data?.poolSelectionLimitations}
+              allPoolSelectionLimitations={allPoolSelectionLimitations}
             />
           )}
         </ToggleSection.InitialContent>
@@ -269,6 +296,33 @@ const PoolNameSection = ({
                 data-h2-grid-template-columns="l-tablet(repeat(2, 1fr))"
                 data-h2-margin-bottom="base(x1)"
               >
+                <div data-h2-grid-column="l-tablet(1 / span 2)">
+                  <RadioGroup
+                    id="areaOfSelection"
+                    idPrefix="areaOfSelection"
+                    legend={intl.formatMessage(processMessages.areaOfSelection)}
+                    name="areaOfSelection"
+                    disabled={formDisabled}
+                    items={localizedEnumToOptions(
+                      allPoolAreaOfSelections,
+                      intl,
+                    )}
+                  />
+                </div>
+                <div data-h2-grid-column="l-tablet(1 / span 2)">
+                  <Checklist
+                    id="selectionLimitations"
+                    idPrefix="selectionLimitations"
+                    name="selectionLimitations"
+                    legend={intl.formatMessage(
+                      processMessages.selectionLimitations,
+                    )}
+                    items={localizedEnumToOptions(
+                      allPoolSelectionLimitations,
+                      intl,
+                    )}
+                  />
+                </div>
                 <Select
                   id="classification"
                   label={intl.formatMessage({

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
@@ -59,8 +59,8 @@ export type PoolNameSubmitData = Pick<
 export const formValuesToSubmitData = (
   formValues: FormValues,
 ): PoolNameSubmitData => ({
-  areaOfSelection: formValues.areaOfSelection ?? undefined,
-  selectionLimitations: formValues.selectionLimitations ?? undefined,
+  areaOfSelection: formValues.areaOfSelection,
+  selectionLimitations: formValues.selectionLimitations ?? [],
   classification: formValues.classification
     ? {
         connect: formValues.classification,

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
@@ -13,9 +13,13 @@ import {
   PublishingGroup,
   UpdatePoolInput,
   Department,
+  PoolAreaOfSelection,
+  PoolSelectionLimitation,
 } from "@gc-digital-talent/graphql";
 
 export interface FormValues {
+  areaOfSelection?: Maybe<PoolAreaOfSelection>;
+  selectionLimitations?: Maybe<PoolSelectionLimitation[]>;
   classification?: Classification["id"];
   department?: Department["id"];
   stream?: PoolStream;
@@ -27,6 +31,8 @@ export interface FormValues {
 }
 
 export const dataToFormValues = (initialData: Pool): FormValues => ({
+  areaOfSelection: initialData.areaOfSelection?.value ?? undefined,
+  selectionLimitations: initialData.selectionLimitations?.map((l) => l.value),
   classification: initialData.classification?.id ?? "",
   department: initialData.department?.id ?? "",
   stream: initialData.stream?.value ?? undefined,
@@ -39,6 +45,8 @@ export const dataToFormValues = (initialData: Pool): FormValues => ({
 
 export type PoolNameSubmitData = Pick<
   UpdatePoolInput,
+  | "areaOfSelection"
+  | "selectionLimitations"
   | "classification"
   | "department"
   | "name"
@@ -51,6 +59,8 @@ export type PoolNameSubmitData = Pick<
 export const formValuesToSubmitData = (
   formValues: FormValues,
 ): PoolNameSubmitData => ({
+  areaOfSelection: formValues.areaOfSelection ?? undefined,
+  selectionLimitations: formValues.selectionLimitations ?? undefined,
   classification: formValues.classification
     ? {
         connect: formValues.classification,

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -1,4 +1,4 @@
-import { defineMessage, MessageDescriptor, useIntl } from "react-intl";
+import { defineMessage, IntlShape, useIntl } from "react-intl";
 import { useQuery } from "urql";
 import MapIcon from "@heroicons/react/24/outline/MapIcon";
 import InformationCircleIcon from "@heroicons/react/20/solid/InformationCircleIcon";
@@ -270,6 +270,12 @@ export const PoolAdvertisement_Fragment = graphql(/* GraphQL */ `
         fr
       }
     }
+    department {
+      name {
+        en
+        fr
+      }
+    }
     areaOfSelection {
       value
     }
@@ -296,15 +302,14 @@ const subTitle = defineMessage({
 const deriveAreaOfSelectionMessages = (
   areaOfSelection: PoolAreaOfSelection | null | undefined,
   selectionLimitations: PoolSelectionLimitation[],
+  classificationString: string,
+  departmentString: string,
+  intl: IntlShape,
 ): {
-  title: MessageDescriptor;
-  body: MessageDescriptor;
-  finePrint?: MessageDescriptor;
+  title: ReactNode;
+  body: ReactNode;
+  finePrint?: ReactNode;
 } | null => {
-  if (areaOfSelection == PoolAreaOfSelection.Public) {
-    // no note for public pools
-    return null;
-  }
   if (areaOfSelection == PoolAreaOfSelection.Employees) {
     if (
       selectionLimitations?.includes(PoolSelectionLimitation.AtLevelOnly) &&
@@ -313,46 +318,69 @@ const deriveAreaOfSelectionMessages = (
       )
     ) {
       return {
-        title: defineMessage({
-          defaultMessage:
-            "This opportunity is for internal employees with a classification of IT-02 or equivalent with preference given to those at the departments listed*",
-          id: "MB5xq+",
-          description:
-            "Title of a note describing that a pool is only open to employees, at-level, with departmental preference",
-        }),
-        body: defineMessage({
-          defaultMessage:
-            "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency who are currently classified as IT-02 or an organizational equivalent. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
-          id: "0XIVna",
-          description:
-            "Body of a note describing that a pool is only open to employees, at-level, with departmental preference",
-        }),
-        finePrint: defineMessage({
-          defaultMessage:
-            "* Preference will be given to persons employed with the following departments or agencies: Canadian Space Agency.",
-          id: "ZNsAyq",
-          description:
-            "Fine print of a note describing that a pool is only open to employees, at-level, with departmental preference",
-        }),
+        title: intl.formatMessage(
+          {
+            defaultMessage:
+              "This opportunity is for internal employees with a classification of {classification} or equivalent with preference given to those at the departments listed*",
+            id: "66xc/o",
+            description:
+              "Title of a note describing that a pool is only open to employees, at-level, with departmental preference. Has an asterisk for fine print.",
+          },
+          {
+            classification: classificationString,
+          },
+        ),
+        body: intl.formatMessage(
+          {
+            defaultMessage:
+              "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency who are currently classified as {classification} or an organizational equivalent. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
+            id: "t+92o9",
+            description:
+              "Body of a note describing that a pool is only open to employees, at-level, with departmental preference",
+          },
+          { classification: classificationString },
+        ),
+        finePrint: intl.formatMessage(
+          {
+            defaultMessage:
+              "* Preference will be given to persons employed with the following departments or agencies: {department}.",
+            id: "SoW0qk",
+            description:
+              "Fine print of a note describing that a pool is only open to employees, at-level, with departmental preference",
+          },
+          {
+            department: departmentString,
+          },
+        ),
       };
     }
 
     if (selectionLimitations?.includes(PoolSelectionLimitation.AtLevelOnly)) {
       return {
-        title: defineMessage({
-          defaultMessage:
-            "This opportunity is for internal employees with a classification of IT-02 or equivalent",
-          id: "WPGtVj",
-          description:
-            "Title of a note describing that a pool is only open to employees at-level",
-        }),
-        body: defineMessage({
-          defaultMessage:
-            "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency who are currently classified as IT-02 or an organizational equivalent. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
-          id: "Lwn4Il",
-          description:
-            "Body of a note describing that a pool is only open to employees at-level",
-        }),
+        title: intl.formatMessage(
+          {
+            defaultMessage:
+              "This opportunity is for internal employees with a classification of {classification} or equivalent",
+            id: "4l0wGu",
+            description:
+              "Title of a note describing that a pool is only open to employees at-level",
+          },
+          {
+            classification: classificationString,
+          },
+        ),
+        body: intl.formatMessage(
+          {
+            defaultMessage:
+              "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency who are currently classified as {classification} or an organizational equivalent. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
+            id: "pVx/jP",
+            description:
+              "Body of a note describing that a pool is only open to employees at-level",
+          },
+          {
+            classification: classificationString,
+          },
+        ),
       };
     }
     if (
@@ -361,39 +389,44 @@ const deriveAreaOfSelectionMessages = (
       )
     ) {
       return {
-        title: defineMessage({
+        title: intl.formatMessage({
           defaultMessage:
             "This opportunity is for internal employees with preference given to those at the departments listed*",
-          id: "8onVC9",
+          id: "JKEDRo",
           description:
-            "Title of a note describing that a pool is only open to employees with departmental preference",
+            "Title of a note describing that a pool is only open to employees with departmental preference. Has an asterisk for fine print.",
         }),
-        body: defineMessage({
+        body: intl.formatMessage({
           defaultMessage:
             "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
           id: "LdpAcC",
           description:
             "Body of a note describing that a pool is only open to employees with departmental preference",
         }),
-        finePrint: defineMessage({
-          defaultMessage:
-            "* Preference will be given to persons employed with the following departments or agencies: Canadian Space Agency.",
-          id: "wzzK7Z",
-          description:
-            "Fine print of a note describing that a pool is only open to employees with departmental preference",
-        }),
+        finePrint: intl.formatMessage(
+          {
+            defaultMessage:
+              "* Preference will be given to persons employed with the following departments or agencies: {department}.",
+            id: "8t1KYs",
+            description:
+              "Fine print of a note describing that a pool is only open to employees with departmental preference",
+          },
+          {
+            department: departmentString,
+          },
+        ),
       };
     }
 
     // fall-through for employees only
     return {
-      title: defineMessage({
+      title: intl.formatMessage({
         defaultMessage: "This opportunity is for internal employees",
         id: "WcU42I",
         description:
           "Title of a note describing that a pool is only open to employees",
       }),
-      body: defineMessage({
+      body: intl.formatMessage({
         defaultMessage:
           "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
         id: "k9moOJ",
@@ -610,6 +643,9 @@ export const PoolPoster = ({
   const areaOfSelectionMessages = deriveAreaOfSelectionMessages(
     pool.areaOfSelection?.value,
     unpackMaybes(pool.selectionLimitations).map((l) => l.value),
+    classificationString,
+    getLocalizedName(pool.department?.name, intl),
+    intl,
   );
 
   return (
@@ -774,15 +810,15 @@ export const PoolPoster = ({
                     data-h2-margin-top="base(0)"
                     data-h2-font-size="base(body)"
                   >
-                    {intl.formatMessage(areaOfSelectionMessages.title)}
+                    {areaOfSelectionMessages.title}
                   </Heading>
-                  {intl.formatMessage(areaOfSelectionMessages.body)}
+                  {areaOfSelectionMessages.body}
                   {areaOfSelectionMessages.finePrint ? (
                     <div
                       data-h2-font-size="base(caption)"
                       data-h2-margin-top="base(x0.5)"
                     >
-                      {intl.formatMessage(areaOfSelectionMessages.finePrint)}
+                      {areaOfSelectionMessages.finePrint}
                     </div>
                   ) : null}
                 </Well>

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -1,4 +1,4 @@
-import { defineMessage, IntlShape, useIntl } from "react-intl";
+import { defineMessage, useIntl } from "react-intl";
 import { useQuery } from "urql";
 import MapIcon from "@heroicons/react/24/outline/MapIcon";
 import InformationCircleIcon from "@heroicons/react/20/solid/InformationCircleIcon";
@@ -44,9 +44,6 @@ import {
   PoolSkillType,
   FragmentType,
   getFragment,
-  PoolAreaOfSelection,
-  PoolSelectionLimitation,
-  Classification,
 } from "@gc-digital-talent/graphql";
 
 import {
@@ -78,6 +75,7 @@ import LanguageRequirementDialog from "./components/LanguageRequirementDialog";
 import ClosedEarlyDeadlineDialog from "./components/ClosedEarlyDeadlineDialog";
 import DeadlineValue from "./components/DeadlineValue";
 import AreaOfSelectionWell from "./components/AreaOfSelectionWell";
+import WhoCanApplyText from "./components/WhoCanApplyText";
 
 interface SectionContent {
   id: string;
@@ -129,93 +127,6 @@ const DeadlineDialogReturn = ({
   }
 
   return null;
-};
-
-const buildWhoCanApplyText = (
-  areaOfSelection: PoolAreaOfSelection | null | undefined,
-  selectionLimitations: PoolSelectionLimitation[] | undefined,
-  classification: Pick<Classification, "group" | "level"> | null | undefined,
-  intl: IntlShape,
-) => {
-  let body: ReactNode;
-  const classificationString =
-    !!classification?.group && !!classification?.level
-      ? formatClassificationString({
-          group: classification.group,
-          level: classification.level,
-        })
-      : intl.formatMessage(commonMessages.notProvided);
-
-  if (areaOfSelection == PoolAreaOfSelection.Employees) {
-    body = (
-      <>
-        {intl.formatMessage({
-          defaultMessage: "Employees of the Government of Canada who:",
-          id: "KY4zuB",
-          description:
-            "Title for a list of criteria needed for employees to apply",
-        })}
-        <ul>
-          {selectionLimitations?.includes(
-            PoolSelectionLimitation.AtLevelOnly,
-          ) ? (
-            <li data-h2-margin-top="base(x0.5)">
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "Currently hold an {classificationString} classification in their substantive role",
-                  id: "pVnp82",
-                  description: "At-level application criteria",
-                },
-                {
-                  classificationString,
-                },
-              )}
-            </li>
-          ) : null}
-          <li data-h2-margin-top="base(x0.5)">
-            {intl.formatMessage({
-              defaultMessage:
-                "Are residing in Canada, are Canadian citizens, or are permanent residents abroad",
-              id: "F6AwoP",
-              description: "Regular criteria item needed in order to apply",
-            })}
-          </li>
-        </ul>
-      </>
-    );
-  } else {
-    body = (
-      <>
-        {intl.formatMessage({
-          defaultMessage:
-            "Persons residing in Canada, and Canadian citizens and permanent residents abroad.",
-          id: "faWz84",
-          description: "List of criteria needed in order to apply",
-        })}
-      </>
-    );
-  }
-
-  const finePrint = intl.formatMessage({
-    defaultMessage:
-      "* Preference will be given to veterans, Canadian citizens, and to permanent residents.",
-    id: "PAOXlo",
-    description: "Fine print for hiring policy for pool advertisement",
-  });
-
-  return (
-    <>
-      <Text data-h2-margin-top="base(0)">{body}</Text>
-      <Text
-        data-h2-margin-bottom="base(0)"
-        data-h2-font-size="base(caption)"
-        data-h2-color="base(black.70)"
-      >
-        {finePrint}
-      </Text>
-    </>
-  );
 };
 
 export const PoolAdvertisement_Fragment = graphql(/* GraphQL */ `
@@ -360,12 +271,7 @@ export const PoolAdvertisement_Fragment = graphql(/* GraphQL */ `
       }
     }
     ...AreaOfSelectionNote
-    areaOfSelection {
-      value
-    }
-    selectionLimitations {
-      value
-    }
+    ...WhoCanApplyText
   }
 `);
 
@@ -1177,12 +1083,7 @@ export const PoolPoster = ({
                     })}
                   </Accordion.Trigger>
                   <Accordion.Content>
-                    {buildWhoCanApplyText(
-                      pool.areaOfSelection?.value,
-                      pool.selectionLimitations?.map((l) => l.value),
-                      pool.classification,
-                      intl,
-                    )}
+                    <WhoCanApplyText poolQuery={pool} />
                   </Accordion.Content>
                 </Accordion.Item>
                 {genericJobTitles.length ? (

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
@@ -14,7 +14,7 @@ import { getLocalizedName } from "@gc-digital-talent/i18n";
 
 import { formatClassificationString } from "~/utils/poolUtils";
 
-export const PoolAreaOfSelectionNote_Fragment = graphql(/* GraphQL */ `
+const PoolAreaOfSelectionNote_Fragment = graphql(/* GraphQL */ `
   fragment AreaOfSelectionNote on Pool {
     classification {
       group
@@ -35,7 +35,7 @@ export const PoolAreaOfSelectionNote_Fragment = graphql(/* GraphQL */ `
   }
 `);
 
-export const deriveAreaOfSelectionMessages = (
+const deriveAreaOfSelectionMessages = (
   areaOfSelection: PoolAreaOfSelection,
   selectionLimitations: PoolSelectionLimitation[],
   classificationString: string,

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
@@ -77,13 +77,14 @@ export const deriveAreaOfSelectionMessages = (
           },
           { classification: classificationString },
         ),
+        // The same message is used for just departmental preference. There is no mention of being at-level.
         finePrint: intl.formatMessage(
           {
             defaultMessage:
               "* Preference will be given to persons employed with the following departments or agencies: {department}.",
-            id: "SoW0qk",
+            id: "8t1KYs",
             description:
-              "Fine print of a note describing that a pool is only open to employees, at-level, with departmental preference",
+              "Fine print of a note describing that a pool is only open to employees with departmental preference",
           },
           {
             department: departmentString,

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
@@ -1,0 +1,239 @@
+import { IntlShape, useIntl } from "react-intl";
+import { ReactNode } from "react";
+
+import {
+  FragmentType,
+  getFragment,
+  graphql,
+  PoolAreaOfSelection,
+  PoolSelectionLimitation,
+} from "@gc-digital-talent/graphql";
+import { Heading, Well } from "@gc-digital-talent/ui";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { getLocalizedName } from "@gc-digital-talent/i18n";
+
+import { formatClassificationString } from "~/utils/poolUtils";
+
+export const PoolAreaOfSelectionNote_Fragment = graphql(/* GraphQL */ `
+  fragment AreaOfSelectionNote on Pool {
+    classification {
+      group
+      level
+    }
+    department {
+      name {
+        en
+        fr
+      }
+    }
+    areaOfSelection {
+      value
+    }
+    selectionLimitations {
+      value
+    }
+  }
+`);
+
+export const deriveAreaOfSelectionMessages = (
+  areaOfSelection: PoolAreaOfSelection,
+  selectionLimitations: PoolSelectionLimitation[],
+  classificationString: string,
+  departmentString: string,
+  intl: IntlShape,
+): {
+  title: ReactNode;
+  body: ReactNode;
+  finePrint?: ReactNode;
+} | null => {
+  if (areaOfSelection == PoolAreaOfSelection.Employees) {
+    if (
+      selectionLimitations?.includes(PoolSelectionLimitation.AtLevelOnly) &&
+      selectionLimitations?.includes(
+        PoolSelectionLimitation.DepartmentalPreference,
+      )
+    ) {
+      return {
+        title: intl.formatMessage(
+          {
+            defaultMessage:
+              "This opportunity is for internal employees with a classification of {classification} or equivalent with preference given to those at the departments listed*",
+            id: "66xc/o",
+            description:
+              "Title of a note describing that a pool is only open to employees, at-level, with departmental preference. Has an asterisk for fine print.",
+          },
+          {
+            classification: classificationString,
+          },
+        ),
+        body: intl.formatMessage(
+          {
+            defaultMessage:
+              "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency who are currently classified as {classification} or an organizational equivalent. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
+            id: "t+92o9",
+            description:
+              "Body of a note describing that a pool is only open to employees, at-level, with departmental preference",
+          },
+          { classification: classificationString },
+        ),
+        finePrint: intl.formatMessage(
+          {
+            defaultMessage:
+              "* Preference will be given to persons employed with the following departments or agencies: {department}.",
+            id: "SoW0qk",
+            description:
+              "Fine print of a note describing that a pool is only open to employees, at-level, with departmental preference",
+          },
+          {
+            department: departmentString,
+          },
+        ),
+      };
+    }
+
+    if (selectionLimitations?.includes(PoolSelectionLimitation.AtLevelOnly)) {
+      return {
+        title: intl.formatMessage(
+          {
+            defaultMessage:
+              "This opportunity is for internal employees with a classification of {classification} or equivalent",
+            id: "4l0wGu",
+            description:
+              "Title of a note describing that a pool is only open to employees at-level",
+          },
+          {
+            classification: classificationString,
+          },
+        ),
+        body: intl.formatMessage(
+          {
+            defaultMessage:
+              "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency who are currently classified as {classification} or an organizational equivalent. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
+            id: "pVx/jP",
+            description:
+              "Body of a note describing that a pool is only open to employees at-level",
+          },
+          {
+            classification: classificationString,
+          },
+        ),
+      };
+    }
+    if (
+      selectionLimitations?.includes(
+        PoolSelectionLimitation.DepartmentalPreference,
+      )
+    ) {
+      return {
+        title: intl.formatMessage({
+          defaultMessage:
+            "This opportunity is for internal employees with preference given to those at the departments listed*",
+          id: "JKEDRo",
+          description:
+            "Title of a note describing that a pool is only open to employees with departmental preference. Has an asterisk for fine print.",
+        }),
+        body: intl.formatMessage({
+          defaultMessage:
+            "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
+          id: "LdpAcC",
+          description:
+            "Body of a note describing that a pool is only open to employees with departmental preference",
+        }),
+        finePrint: intl.formatMessage(
+          {
+            defaultMessage:
+              "* Preference will be given to persons employed with the following departments or agencies: {department}.",
+            id: "8t1KYs",
+            description:
+              "Fine print of a note describing that a pool is only open to employees with departmental preference",
+          },
+          {
+            department: departmentString,
+          },
+        ),
+      };
+    }
+
+    // fall-through for employees only
+    return {
+      title: intl.formatMessage({
+        defaultMessage: "This opportunity is for internal employees",
+        id: "WcU42I",
+        description:
+          "Title of a note describing that a pool is only open to employees",
+      }),
+      body: intl.formatMessage({
+        defaultMessage:
+          "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
+        id: "k9moOJ",
+        description:
+          "Body of a note describing that a pool is only open to employees",
+      }),
+    };
+  }
+
+  return null;
+};
+
+interface AreaOfSelectionWellProps {
+  poolQuery: FragmentType<typeof PoolAreaOfSelectionNote_Fragment>;
+}
+
+const AreaOfSelectionWell = ({ poolQuery }: AreaOfSelectionWellProps) => {
+  const intl = useIntl();
+  const pool = getFragment(PoolAreaOfSelectionNote_Fragment, poolQuery);
+
+  const areaOfSelection = pool.areaOfSelection?.value;
+  if (!areaOfSelection) {
+    return null;
+  }
+
+  const selectionLimitations = unpackMaybes(pool.selectionLimitations).map(
+    (l) => l.value,
+  );
+
+  if (!pool.classification?.group || !pool.classification?.level) {
+    return null;
+  }
+  const classificationString = formatClassificationString({
+    group: pool.classification.group,
+    level: pool.classification.level,
+  });
+
+  const departmentString = getLocalizedName(pool.department?.name, intl, true);
+  if (!departmentString) {
+    return null;
+  }
+
+  const areaOfSelectionMessages = deriveAreaOfSelectionMessages(
+    areaOfSelection,
+    selectionLimitations,
+    classificationString,
+    departmentString,
+    intl,
+  );
+  if (!areaOfSelectionMessages) {
+    return null;
+  }
+
+  return (
+    <Well data-h2-margin="base(x1 0)" color="warning">
+      <Heading
+        level="h3"
+        size="h6"
+        data-h2-margin-top="base(0)"
+        data-h2-font-size="base(body)"
+      >
+        {areaOfSelectionMessages.title}
+      </Heading>
+      {areaOfSelectionMessages.body}
+      {areaOfSelectionMessages.finePrint ? (
+        <div data-h2-font-size="base(caption)" data-h2-margin-top="base(x0.5)">
+          {areaOfSelectionMessages.finePrint}
+        </div>
+      ) : null}
+    </Well>
+  );
+};
+
+export default AreaOfSelectionWell;

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
@@ -66,13 +66,14 @@ export const deriveAreaOfSelectionMessages = (
             classification: classificationString,
           },
         ),
+        // The body is the same as the message for just at-level. No mention of departmental preference.
         body: intl.formatMessage(
           {
             defaultMessage:
               "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency who are currently classified as {classification} or an organizational equivalent. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
-            id: "t+92o9",
+            id: "pVx/jP",
             description:
-              "Body of a note describing that a pool is only open to employees, at-level, with departmental preference",
+              "Body of a note describing that a pool is only open to employees at-level",
           },
           { classification: classificationString },
         ),
@@ -132,12 +133,13 @@ export const deriveAreaOfSelectionMessages = (
           description:
             "Title of a note describing that a pool is only open to employees with departmental preference. Has an asterisk for fine print.",
         }),
+        // The same message is used for employees only. There is no mention of the departmental preference.
         body: intl.formatMessage({
           defaultMessage:
             "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
-          id: "LdpAcC",
+          id: "k9moOJ",
           description:
-            "Body of a note describing that a pool is only open to employees with departmental preference",
+            "Body of a note describing that a pool is only open to employees",
         }),
         finePrint: intl.formatMessage(
           {

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/WhoCanApplyText.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/WhoCanApplyText.tsx
@@ -1,0 +1,147 @@
+import { ReactNode } from "react";
+import { IntlShape, useIntl } from "react-intl";
+
+import {
+  FragmentType,
+  getFragment,
+  graphql,
+  PoolAreaOfSelection,
+  PoolSelectionLimitation,
+} from "@gc-digital-talent/graphql";
+import { commonMessages } from "@gc-digital-talent/i18n";
+
+import { formatClassificationString } from "~/utils/poolUtils";
+
+import Text from "./Text";
+
+const PoolWhoCanApplyText_Fragment = graphql(/* GraphQL */ `
+  fragment WhoCanApplyText on Pool {
+    classification {
+      group
+      level
+    }
+    areaOfSelection {
+      value
+    }
+    selectionLimitations {
+      value
+    }
+  }
+`);
+
+const deriveWhoCanApplyMessages = (
+  areaOfSelection: PoolAreaOfSelection,
+  selectionLimitations: PoolSelectionLimitation[],
+  classificationString: string,
+  intl: IntlShape,
+): {
+  body: ReactNode;
+  finePrint?: ReactNode;
+} => {
+  let body;
+
+  if (areaOfSelection == PoolAreaOfSelection.Employees) {
+    body = (
+      <>
+        {intl.formatMessage({
+          defaultMessage: "Employees of the Government of Canada who:",
+          id: "KY4zuB",
+          description:
+            "Title for a list of criteria needed for employees to apply",
+        })}
+        <ul>
+          {selectionLimitations?.includes(
+            PoolSelectionLimitation.AtLevelOnly,
+          ) ? (
+            <li data-h2-margin-top="base(x0.5)">
+              {intl.formatMessage(
+                {
+                  defaultMessage:
+                    "Currently hold an {classificationString} classification in their substantive role",
+                  id: "pVnp82",
+                  description: "At-level application criteria",
+                },
+                {
+                  classificationString,
+                },
+              )}
+            </li>
+          ) : null}
+          <li data-h2-margin-top="base(x0.5)">
+            {intl.formatMessage({
+              defaultMessage:
+                "Are residing in Canada, are Canadian citizens, or are permanent residents abroad",
+              id: "F6AwoP",
+              description: "Regular criteria item needed in order to apply",
+            })}
+          </li>
+        </ul>
+      </>
+    );
+  } else {
+    body = (
+      <>
+        {intl.formatMessage({
+          defaultMessage:
+            "Persons residing in Canada, and Canadian citizens and permanent residents abroad.",
+          id: "faWz84",
+          description: "List of criteria needed in order to apply",
+        })}
+      </>
+    );
+  }
+
+  const finePrint = intl.formatMessage({
+    defaultMessage:
+      "* Preference will be given to veterans, Canadian citizens, and to permanent residents.",
+    id: "PAOXlo",
+    description: "Fine print for hiring policy for pool advertisement",
+  });
+
+  return { body, finePrint };
+};
+
+interface WhoCanApplyTextProps {
+  poolQuery: FragmentType<typeof PoolWhoCanApplyText_Fragment>;
+}
+
+const WhoCanApplyText = ({ poolQuery }: WhoCanApplyTextProps) => {
+  const intl = useIntl();
+  const pool = getFragment(PoolWhoCanApplyText_Fragment, poolQuery);
+
+  const areaOfSelection =
+    pool.areaOfSelection?.value ?? PoolAreaOfSelection.Public;
+
+  const selectionLimitations =
+    pool.selectionLimitations?.map((l) => l.value) ?? [];
+
+  const classificationString =
+    !!pool.classification?.group && !!pool.classification?.level
+      ? formatClassificationString({
+          group: pool.classification.group,
+          level: pool.classification.level,
+        })
+      : intl.formatMessage(commonMessages.notProvided);
+
+  const { body, finePrint } = deriveWhoCanApplyMessages(
+    areaOfSelection,
+    selectionLimitations,
+    classificationString,
+    intl,
+  );
+
+  return (
+    <>
+      <Text data-h2-margin-top="base(0)">{body}</Text>
+      <Text
+        data-h2-margin-bottom="base(0)"
+        data-h2-font-size="base(caption)"
+        data-h2-color="base(black.70)"
+      >
+        {finePrint}
+      </Text>
+    </>
+  );
+};
+
+export default WhoCanApplyText;

--- a/apps/web/src/validators/process/classification.ts
+++ b/apps/web/src/validators/process/classification.ts
@@ -24,6 +24,7 @@ export function isInNullState({
 }
 
 export function hasEmptyRequiredFields({
+  areaOfSelection,
   classification,
   department,
   stream,
@@ -33,6 +34,7 @@ export function hasEmptyRequiredFields({
   opportunityLength,
 }: Pick<
   Pool,
+  | "areaOfSelection"
   | "classification"
   | "department"
   | "stream"
@@ -42,6 +44,7 @@ export function hasEmptyRequiredFields({
   | "opportunityLength"
 >): boolean {
   return !!(
+    !areaOfSelection ||
     !classification ||
     !department ||
     !stream ||

--- a/apps/web/src/validators/process/classification.ts
+++ b/apps/web/src/validators/process/classification.ts
@@ -1,4 +1,4 @@
-import { Pool } from "@gc-digital-talent/graphql";
+import { LocalizedPoolAreaOfSelection, Pool } from "@gc-digital-talent/graphql";
 
 /*
   Checks null state for advertisement details section of edit pool page.
@@ -34,7 +34,6 @@ export function hasEmptyRequiredFields({
   opportunityLength,
 }: Pick<
   Pool,
-  | "areaOfSelection"
   | "classification"
   | "department"
   | "stream"
@@ -42,9 +41,11 @@ export function hasEmptyRequiredFields({
   | "processNumber"
   | "publishingGroup"
   | "opportunityLength"
->): boolean {
+> & {
+  areaOfSelection: LocalizedPoolAreaOfSelection["value"] | undefined;
+}): boolean {
   return !!(
-    !areaOfSelection?.value ||
+    !areaOfSelection ||
     !classification ||
     !department ||
     !stream ||

--- a/apps/web/src/validators/process/classification.ts
+++ b/apps/web/src/validators/process/classification.ts
@@ -34,6 +34,7 @@ export function hasEmptyRequiredFields({
   opportunityLength,
 }: Pick<
   Pool,
+  | "areaOfSelection"
   | "classification"
   | "department"
   | "stream"
@@ -41,11 +42,9 @@ export function hasEmptyRequiredFields({
   | "processNumber"
   | "publishingGroup"
   | "opportunityLength"
-> & {
-  areaOfSelection: LocalizedPoolAreaOfSelection["value"] | undefined;
-}): boolean {
+>): boolean {
   return !!(
-    !areaOfSelection ||
+    !areaOfSelection?.value ||
     !classification ||
     !department ||
     !stream ||

--- a/apps/web/src/validators/process/classification.ts
+++ b/apps/web/src/validators/process/classification.ts
@@ -44,7 +44,7 @@ export function hasEmptyRequiredFields({
   | "opportunityLength"
 >): boolean {
   return !!(
-    !areaOfSelection ||
+    !areaOfSelection?.value ||
     !classification ||
     !department ||
     !stream ||

--- a/apps/web/src/validators/process/classification.ts
+++ b/apps/web/src/validators/process/classification.ts
@@ -1,4 +1,4 @@
-import { LocalizedPoolAreaOfSelection, Pool } from "@gc-digital-talent/graphql";
+import { Pool } from "@gc-digital-talent/graphql";
 
 /*
   Checks null state for advertisement details section of edit pool page.

--- a/packages/fake-data/src/fakePools.ts
+++ b/packages/fake-data/src/fakePools.ts
@@ -25,6 +25,8 @@ import {
   SkillLevel,
   Department,
   PoolOpportunityLength,
+  PoolAreaOfSelection,
+  PoolSelectionLimitation,
 } from "@gc-digital-talent/graphql";
 
 import fakeScreeningQuestions from "./fakeScreeningQuestions";
@@ -87,6 +89,9 @@ const generatePool = (
       };
     }),
   ];
+  const areaOfSelection = toLocalizedEnum(
+    faker.helpers.arrayElement(Object.values(PoolAreaOfSelection)),
+  );
   return {
     id: faker.string.uuid(),
     owner: pick(ownerUser, [
@@ -146,6 +151,15 @@ const generatePool = (
       )[0],
       fakeAssessmentSteps(1, AssessmentStepType.InterviewFollowup)[0],
     ],
+    areaOfSelection: areaOfSelection,
+    selectionLimitations:
+      areaOfSelection.value == PoolAreaOfSelection.Employees
+        ? faker.helpers.arrayElements(
+            Object.values(PoolSelectionLimitation).map((l) =>
+              toLocalizedEnum(l),
+            ),
+          )
+        : [],
   };
 };
 

--- a/packages/forms/src/utils.ts
+++ b/packages/forms/src/utils.ts
@@ -85,8 +85,27 @@ export function enumToOptions(
 export function localizedEnumToOptions(
   list: Maybe<LocalizedEnumString>[] | undefined | null,
   intl: IntlShape,
+  sortOrder?: LocalizedEnumString["value"][],
 ): Option[] {
-  return unpackMaybes(list).map(({ value, label }) => ({
+  const localizedEnums = unpackMaybes(list);
+  if (sortOrder) {
+    localizedEnums.sort((a, b) => {
+      const aPosition = sortOrder.indexOf(a.value);
+      const bPosition = sortOrder.indexOf(b.value);
+      if (aPosition >= 0 && bPosition >= 0)
+        // both are in sort list => sort by by that order
+        return sortOrder.indexOf(a.value) - sortOrder.indexOf(b.value);
+      if (aPosition >= 0 && bPosition < 0)
+        // only a is in sort list => sort a before b
+        return -1;
+      if (aPosition < 0 && bPosition >= 0)
+        // only b is in sort list => sort b before a
+        return 1;
+      // neither is in sort list => keep original order
+      return 0;
+    });
+  }
+  return localizedEnums.map(({ value, label }) => ({
     value,
     label: getLocalizedName(label, intl),
   }));


### PR DESCRIPTION
🤖 Resolves #11285 

## 👋 Introduction

<!-- Describe what this PR is solving. -->

This branch adds the "area of selection" feature where pools can be designated as open to the public or just employees, and what category of employees.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->


1. Build the project, including running the migration.
2. Log in as admin and test the pool editor.
3. As any user test the pool advertisement page.

- [ ] All exist pools marked as PUBLIC
- [ ] Can set a draft pool to EMPLOYEES
- [ ] Can not publish without a selection or if area limitations are set when selection set to PUBLIC
- [ ] Can only set DEPARTMENTAL_PREFERENCE and AT_LEVEL_ONLY when set to EMPLOYEES
- [ ] Pool cards show area of selection (temporary styling - finish in [#11286](https://github.com/GCTC-NTGC/gc-digital-talent/issues/11286))
- [ ] Pool advertisement shows changing note at the top for EMPLOYEES
- [ ] Pool advertisement "who can apply" accordion changes for EMPLOYEES


## 📸 Screenshot

![image](https://github.com/user-attachments/assets/232e7601-cfc6-44e2-95b8-a8037832c196)



