### PR TITLE
[Tooling] Eslint warnings changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,8 +64,7 @@ jobs:
 
       - name: "Run ESlint: all workspaces"
         working-directory: ./
-        # Pass arg to eslint so that any warnings will raise error code and fail workflow.
-        run: pnpm run lint -- --max-warnings=0
+        run: pnpm run lint
 
       - name: "Run typescript linting: all workspaces"
         # Allow tsc linting to happen even if js linting step raises errors.

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -46,14 +46,14 @@ module.exports = {
   ],
   rules: {
     camelcase: [
-      "warn",
+      "error",
       {
         allow: ["w*Query$", "w*Fragment$", "w*Mutation$", "w*Document$"],
       },
     ],
-    "consistent-return": "warn",
+    "consistent-return": "error",
     "import/no-extraneous-dependencies": "off",
-    "import/extensions": ["warn", "never", { json: "always" }],
+    "import/extensions": ["error", "never", { json: "always" }],
     "import/order": [
       "error",
       {
@@ -81,18 +81,18 @@ module.exports = {
       },
     ],
     "no-only-tests/no-only-tests": "error",
-    "no-param-reassign": "warn",
+    "no-param-reassign": "error",
     "no-use-before-define": "off",
     "no-shadow": "off",
     "no-console": "error",
     "no-alert": "error",
-    "@typescript-eslint/no-use-before-define": "warn",
+    "@typescript-eslint/no-use-before-define": "error",
     "@typescript-eslint/no-shadow": "error",
-    "@typescript-eslint/no-empty-function": "warn",
+    "@typescript-eslint/no-empty-function": "error",
     "no-underscore-dangle": ["error", { allow: ["__typename"] }],
 
-    // CI Only rules to keep local snappy
-    "import/no-named-as-default": process.env.CI ? "warn" : "off",
+    // CI Only rules to keep local snappy, deprecation kept as a warn
+    "import/no-named-as-default": process.env.CI ? "error" : "off",
     "import/namespace": process.env.CI ? "error" : "off",
     "deprecation/deprecation": process.env.CI ? "warn" : "off",
 

--- a/packages/eslint-config-custom/react.js
+++ b/packages/eslint-config-custom/react.js
@@ -46,7 +46,7 @@ module.exports = {
     "react/require-default-props": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": [
-      "warn",
+      "error",
       {
         additionalHooks: "(useDeepCompareEffect)",
       },
@@ -88,7 +88,7 @@ module.exports = {
       },
     ],
     "@typescript-eslint/no-restricted-types": [
-      "warn",
+      "error",
       {
         types: {
           "React.FunctionComponent":


### PR DESCRIPTION
🤖 Resolves #11465

## 👋 Introduction

Workflow no longer fails on warnings, additionally, most warnings changed to be error with the sole exception being deprecation warnings. 
<!-- Describe what this PR is solving. -->


## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->


1. Workflows pass
2. Eric's stamp of approval




<!-- Add a screenshot (if possible). -->



<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the linked issue if deployment steps are needed

 -->
