### PR TITLE
[Feature] Logging to local file for jobs

### DIFF
--- a/api/app/Jobs/GcNotifyApiRequest.php
+++ b/api/app/Jobs/GcNotifyApiRequest.php
@@ -64,7 +64,7 @@ class GcNotifyApiRequest implements ShouldQueue
 
         if (! is_null($response) && ! $response->successful()) {
             $firstApiErrorMessage = Arr::get($response->json(), 'errors.0.message');
-            $errorMessage = 'Notification failed to send on GcNotifyEmailChannel. '.$firstApiErrorMessage.' ';
+            $errorMessage = 'Notification failed to send on GcNotifyEmailChannel. ['.$firstApiErrorMessage.'] Template ID: '.$this->message->templateId;
             Log::error($errorMessage);
             Log::debug($response->body());
 

--- a/api/app/Jobs/GcNotifyApiRequest.php
+++ b/api/app/Jobs/GcNotifyApiRequest.php
@@ -14,6 +14,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\ThrottlesExceptions;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
 
 class GcNotifyApiRequest implements ShouldQueue
@@ -67,10 +68,12 @@ class GcNotifyApiRequest implements ShouldQueue
             Log::error($errorMessage);
             Log::debug($response->body());
 
-            // workaround until we get better logging in prod
+            // workaround until we get better logging in prod #11289
             $onDemandLog = Log::build([
                 'driver' => 'single',
-                'path' => storage_path('logs/jobs.log'),
+                'path' => App::isProduction() // workaround for storage_path misconfigured in prod #11471
+                    ? '/tmp/api/storage/logs'
+                    : storage_path('logs/jobs.log'),
             ]);
             $onDemandLog->error($errorMessage);
             $onDemandLog->debug($response->body());

--- a/api/app/Jobs/GcNotifyApiRequest.php
+++ b/api/app/Jobs/GcNotifyApiRequest.php
@@ -66,6 +66,15 @@ class GcNotifyApiRequest implements ShouldQueue
             $errorMessage = 'Notification failed to send on GcNotifyEmailChannel. '.$firstApiErrorMessage.' ';
             Log::error($errorMessage);
             Log::debug($response->body());
+
+            // workaround until we get better logging in prod
+            $onDemandLog = Log::build([
+                'driver' => 'single',
+                'path' => storage_path('logs/jobs.log'),
+            ]);
+            $onDemandLog->error($errorMessage);
+            $onDemandLog->debug($response->body());
+
             throw new Exception($errorMessage);
         }
     }

--- a/api/app/Jobs/GcNotifyApiRequest.php
+++ b/api/app/Jobs/GcNotifyApiRequest.php
@@ -72,7 +72,7 @@ class GcNotifyApiRequest implements ShouldQueue
             $onDemandLog = Log::build([
                 'driver' => 'single',
                 'path' => App::isProduction() // workaround for storage_path misconfigured in prod #11471
-                    ? '/tmp/api/storage/logs'
+                    ? '/tmp/api/storage/logs/jobs.log'
                     : storage_path('logs/jobs.log'),
             ]);
             $onDemandLog->error($errorMessage);

--- a/api/app/Jobs/GenerateUserFile.php
+++ b/api/app/Jobs/GenerateUserFile.php
@@ -35,6 +35,12 @@ class GenerateUserFile implements ShouldQueue
             // Notify the user something went wrong
             $this->user->notify(new UserFileGenerationError($this->generator->getFileName()));
             Log::error($e);
+
+            // workaround until we get better logging in prod
+            Log::build([
+                'driver' => 'single',
+                'path' => storage_path('logs/jobs.log'),
+            ])->error($e);
         }
 
     }

--- a/api/app/Jobs/GenerateUserFile.php
+++ b/api/app/Jobs/GenerateUserFile.php
@@ -41,7 +41,7 @@ class GenerateUserFile implements ShouldQueue
             $onDemandLog = Log::build([
                 'driver' => 'single',
                 'path' => App::isProduction() // workaround for storage_path misconfigured in prod #11471
-                    ? '/tmp/api/storage/logs'
+                    ? '/tmp/api/storage/logs/jobs.log'
                     : storage_path('logs/jobs.log'),
             ]);
             $onDemandLog->error($e);


### PR DESCRIPTION
🤖 Resolves #11288 

## 👋 Introduction

This branch adds logging to a local file using on-demand logging for asynchronous Laravel jobs.  It doesn't remove any existing logging - just adds more.

## 🧪 Testing

>[!NOTE]
This is just one way to trigger job logging.  Feel free to test this a different way.

1. Build the branch with dev tools enabled and release it to the dev app service.
2. Change the ID of the GCNOTIFY_TEMPLATE_TEST_EMAIL env variable to any invalid template ID in the app service.
3. SSH into the app service and launch tinker.
4. `User::factory()->create()->notify(new Test('test', GcNotifyEmailChannel::class))`

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/ab925b71-bf55-47f4-b6c6-8a5697722523)