### PR TITLE
[Debt] Add pool eloquent builder class

### DIFF
--- a/api/app/Builders/PoolBuilder.php
+++ b/api/app/Builders/PoolBuilder.php
@@ -109,6 +109,58 @@ class PoolBuilder extends Builder
 
         // empty defaults to all but archived
         return $this->whereNotArchived();
+    }
+
+    public function generalSearch(?string $term): self
+    {
+        if (! $term) {
+            return $this;
+        }
+
+        return $this->where(function ($query) use ($term) {
+            $query->name($term)
+                ->orWhere(function ($query) use ($term) {
+                    $query->team($term);
+                })->orWhere(function ($query) use ($term) {
+                    $query->processNumber($term);
+                });
+        });
+    }
+
+    public function publishingGroups(?array $publishingGroups): self
+    {
+        if (empty($publishingGroups)) {
+            return $this;
+        }
+
+        return $this->whereIn('publishing_group', $publishingGroups);
+    }
+
+    public function streams(?array $streams): self
+    {
+
+        if (empty($streams)) {
+            return $this;
+        }
+
+        return $this->whereIn('stream', $streams);
+    }
+
+    public function whereClassifications(?array $classifications): self
+    {
+        if (empty($classifications)) {
+            return $this;
+        }
+
+        return $this->whereHas('classification', function ($query) use ($classifications) {
+            $query->where(function ($query) use ($classifications) {
+                foreach ($classifications as $classification) {
+                    $query->orWhere(function ($query) use ($classification) {
+                        $query->where('group', $classification['group'])->where('level', $classification['level']);
+                    });
+                }
+            });
+        });
 
     }
 }

--- a/api/app/Builders/PoolBuilder.php
+++ b/api/app/Builders/PoolBuilder.php
@@ -2,6 +2,8 @@
 
 namespace App\Builders;
 
+use App\Enums\PoolStatus;
+use App\Models\Team;
 use Illuminate\Database\Eloquent\Builder;
 
 class PoolBuilder extends Builder
@@ -13,11 +15,100 @@ class PoolBuilder extends Builder
 
     public function whereNotClosed(): self
     {
-        return $this->where('closing_date', '>', now());
+        return $this->where(function ($query) {
+            $query->whereNull('closing_date')
+                ->orWhere('closing_date', '>', now());
+        });
+    }
+
+    public function whereClosed(): self
+    {
+        return $this->where('closing_date', '<=', now());
     }
 
     public function whereCurrentlyActive(): self
     {
         return $this->wherePublished()->whereNotClosed();
+    }
+
+    public function whereNotArchived(): self
+    {
+        return $this->where(function ($query) {
+            $query->whereNull('archived_at')
+                ->orWhere('archived_at', '>', now());
+        });
+    }
+
+    public function name(?string $name): self
+    {
+
+        if (! $name) {
+            return $this;
+        }
+
+        return $this->where(function ($query) use ($name) {
+            $term = sprintf('%%%s%%', $name);
+
+            return $query->where('name->en', 'ilike', $term)
+                ->orWhere('name->fr', 'ilike', $term);
+        });
+    }
+
+    public function processNumber(?string $number): self
+    {
+        if (! $number) {
+            return $this;
+        }
+
+        return $this->where('process_number', 'ilike', sprintf('%%%s%%', $number));
+    }
+
+    public function team(?string $team): self
+    {
+        if (! $team) {
+            return $this;
+        }
+
+        return $this->whereHas('legacyTeam', function ($query) use ($team) {
+            Team::scopeDisplayName($query, $team);
+        });
+    }
+
+    public function statuses(?array $statuses): self
+    {
+        if (! empty($statuses)) {
+
+            $this->where(function ($query) use ($statuses) {
+
+                if (in_array(PoolStatus::ARCHIVED->name, $statuses)) {
+                    $query->orWhere('archived_at', '<=', now());
+                }
+
+                if (in_array(PoolStatus::CLOSED->name, $statuses)) {
+                    $query->orWhere(function ($query) {
+                        $query->whereClosed()
+                            ->whereNotArchived($query);
+                    });
+                }
+
+                if (in_array(PoolStatus::PUBLISHED->name, $statuses)) {
+                    $query->orWhere(function ($query) {
+                        $query->wherePublished()
+                            ->whereNotClosed()
+                            ->whereNotArchived();
+                    });
+                }
+
+                if (in_array(PoolStatus::DRAFT->name, $statuses)) {
+                    $query->orWhereNull('published_at');
+                }
+            });
+
+            return $this;
+        }
+
+        // empty defaults to all but archived
+        return $this->whereNotArchived();
+
     }
 }

--- a/api/app/Builders/PoolBuilder.php
+++ b/api/app/Builders/PoolBuilder.php
@@ -10,4 +10,14 @@ class PoolBuilder extends Builder
     {
         return $this->where('published_at', '<=', now());
     }
+
+    public function whereNotClosed(): self
+    {
+        return $this->where('closing_date', '>', now());
+    }
+
+    public function whereCurrentlyActive(): self
+    {
+        return $this->wherePublished()->whereNotClosed();
+    }
 }

--- a/api/app/Builders/PoolBuilder.php
+++ b/api/app/Builders/PoolBuilder.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Builders;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class PoolBuilder extends Builder
+{
+    public function wherePublished(): self
+    {
+        return $this->where('published_at', '<=', now());
+    }
+}

--- a/api/app/Console/Commands/SendNotificationsApplicationDeadlineApproaching.php
+++ b/api/app/Console/Commands/SendNotificationsApplicationDeadlineApproaching.php
@@ -41,10 +41,10 @@ class SendNotificationsApplicationDeadlineApproaching extends Command
         $this->info('Running for closing date '.$closingDayInPacific->toDateString().' (Pacific)');
         $startOfClosingDayInUtc = $closingDayInPacific->copy()->startOfDay()->setTimezone('Etc/UTC')->toDateTimeString();
         $endOfClosingDayInUtc = $closingDayInPacific->copy()->endOfDay()->setTimezone('Etc/UTC')->toDateTimeString();
-
         $this->info("Finding pools closing between $startOfClosingDayInUtc and $endOfClosingDayInUtc (UTC)");
 
-        $poolsClosingOnClosingDay = Pool::wasPublished()
+        $poolsClosingOnClosingDay = Pool::query()
+            ->wherePublished()
             ->where('closing_date', '>=', $startOfClosingDayInUtc)
             ->where('closing_date', '<=', $endOfClosingDayInUtc)
             ->with('classification')

--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -25,11 +25,11 @@ final class CountPoolCandidatesByPool
             $query->wherePublished();
 
             if (array_key_exists('qualifiedClassifications', $filters)) {
-                Pool::scopeClassifications($query, $filters['qualifiedClassifications']);
+                $query->whereClassifications($filters['qualifiedClassifications']);
             }
 
             if (array_key_exists('qualifiedStreams', $filters)) {
-                Pool::scopeStreams($query, $filters['qualifiedStreams']);
+                $query->streams($filters['qualifiedStreams']);
             }
         });
 

--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -22,7 +22,7 @@ final class CountPoolCandidatesByPool
         $queryBuilder = PoolCandidate::query();
 
         $queryBuilder->whereHas('pool', function ($query) use ($filters) {
-            $query->wasPublished();
+            $query->wherePublished();
 
             if (array_key_exists('qualifiedClassifications', $filters)) {
                 Pool::scopeClassifications($query, $filters['qualifiedClassifications']);

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -404,14 +404,6 @@ class Pool extends Model
         return $this->team?->id;
     }
 
-    public static function scopeCurrentlyActive(Builder $query)
-    {
-        $query->where('published_at', '<=', Carbon::now()->toDateTimeString())
-            ->where('closing_date', '>', Carbon::now()->toDateTimeString());
-
-        return $query;
-    }
-
     public static function scopeName(Builder $query, ?string $name): Builder
     {
         if ($name) {

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -161,6 +161,12 @@ class Pool extends Model
         });
     }
 
+    /**
+     * Binds the eloquent builder to the model to allow for
+     * applying scopes directly to Pool query builders
+     *
+     * i.e Pool::query()->wherePublished();
+     */
     public function newEloquentBuilder($query): PoolBuilder
     {
         return new PoolBuilder($query);

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -404,60 +404,6 @@ class Pool extends Model
         return $this->team?->id;
     }
 
-    public static function scopeGeneralSearch(Builder $query, ?string $term): Builder
-    {
-        if ($term) {
-            $query->where(function ($query) use ($term) {
-                $query->name($term);
-
-                $query->orWhere(function ($query) use ($term) {
-                    $query->team($term);
-                })->orWhere(function ($query) use ($term) {
-                    $query->processNumber($term);
-                });
-            });
-        }
-
-        return $query;
-    }
-
-    public static function scopePublishingGroups(Builder $query, ?array $publishingGroups): Builder
-    {
-        if (! empty($publishingGroups)) {
-            $query->whereIn('publishing_group', $publishingGroups);
-        }
-
-        return $query;
-    }
-
-    public static function scopeStreams(Builder $query, ?array $streams): Builder
-    {
-        if (! empty($streams)) {
-            $query->whereIn('stream', $streams);
-        }
-
-        return $query;
-    }
-
-    public static function scopeClassifications(Builder $query, ?array $classifications): Builder
-    {
-        if (empty($classifications)) {
-            return $query;
-        }
-
-        $query->whereHas('classification', function ($query) use ($classifications) {
-            $query->where(function ($query) use ($classifications) {
-                foreach ($classifications as $classification) {
-                    $query->orWhere(function ($query) use ($classification) {
-                        $query->where('group', $classification['group'])->where('level', $classification['level']);
-                    });
-                }
-            });
-        });
-
-        return $query;
-    }
-
     /**
      * Filter for pools the user is allowed to admin, based on scopeAuthorizedToAdmin
      */

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Builders\PoolBuilder;
 use App\Enums\AssessmentStepType;
 use App\Enums\PoolSkillType;
 use App\Enums\PoolStatus;
@@ -160,6 +161,11 @@ class Pool extends Model
                 'name' => 'pool-'.$pool->id,
             ]);
         });
+    }
+
+    public function newEloquentBuilder($query): PoolBuilder
+    {
+        return new PoolBuilder($query);
     }
 
     public function getActivitylogOptions(): LogOptions
@@ -396,13 +402,6 @@ class Pool extends Model
     public function getTeamIdForRoleAssignmentAttribute()
     {
         return $this->team?->id;
-    }
-
-    public function scopeWasPublished(Builder $query)
-    {
-        $query->where('published_at', '<=', Carbon::now()->toDateTimeString());
-
-        return $query;
     }
 
     public static function scopeCurrentlyActive(Builder $query)

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -313,7 +313,7 @@ class PoolCandidate extends Model
         }
 
         $query->whereHas('pool', function ($query) use ($classifications) {
-            Pool::scopeClassifications($query, $classifications);
+            $query->whereClassifications($classifications);
         });
 
         return $query;
@@ -357,7 +357,7 @@ class PoolCandidate extends Model
         }
 
         $query = $query->whereHas('pool', function ($query) use ($publishingGroups) {
-            $query->whereIn('publishing_group', $publishingGroups);
+            $query->publishingGroups($publishingGroups);
         });
 
         return $query;

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -1086,7 +1086,7 @@ class PoolCandidate extends Model
         }
 
         $query = $query->whereHas('pool', function ($query) use ($processNumber) {
-            $query->where('process_number', 'ilike', "%$processNumber%");
+            $query->processNumber($processNumber);
         });
 
         return $query;

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -744,7 +744,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
             $filters = Arr::get($args ?? [], 'where', []);
 
             $innerQueryBuilder->whereHas('pool', function ($query) use ($filters) {
-                $query->wasPublished();
+                $query->wherePublished();
 
                 if (array_key_exists('qualifiedClassifications', $filters)) {
                     Pool::scopeClassifications($query, $filters['qualifiedClassifications']);

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -747,11 +747,11 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
                 $query->wherePublished();
 
                 if (array_key_exists('qualifiedClassifications', $filters)) {
-                    Pool::scopeClassifications($query, $filters['qualifiedClassifications']);
+                    $query->whereClassifications($filters['qualifiedClassifications']);
                 }
 
                 if (array_key_exists('qualifiedStreams', $filters)) {
-                    Pool::scopeStreams($query, $filters['qualifiedStreams']);
+                    $query->streams($filters['qualifiedStreams']);
                 }
             });
 

--- a/api/app/Rules/SkillNotUsedByActivePool.php
+++ b/api/app/Rules/SkillNotUsedByActivePool.php
@@ -16,9 +16,8 @@ class SkillNotUsedByActivePool implements ValidationRule
     {
         // validation fails if skill is in use by an active pool
         $skillId = $value;
-        $activePoolsUsingSkill = Pool::where((function ($query) {
-            Pool::scopeCurrentlyActive($query);
-        }))
+        $activePoolsUsingSkill = Pool::query()
+            ->whereCurrentlyActive()
             ->where(function ($query) use ($skillId) {
                 $query->whereHas('poolSkills', function ($query) use ($skillId) {
                     return $query->where('skill_id', $skillId);

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -776,7 +776,8 @@ input PoolFilterInput {
   statuses: [PoolStatus!] = [] @scope
   processNumber: String @scope
   publishingGroups: [PublishingGroup!] @scope
-  classifications: [ClassificationFilterInput!] @scope
+  classifications: [ClassificationFilterInput!]
+    @scope(name: "whereClassifications")
   canAdmin: Boolean @scope
 }
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -242,7 +242,7 @@ type ScreeningQuestion {
 interface HasRoleAssignments {
   id: ID!
   roleAssignments: [RoleAssignment!]
-  teamIdForRoleAssignment: ID# Used to assign roles associated with this resource using the updateUserRoles mutation.
+  teamIdForRoleAssignment: ID # Used to assign roles associated with this resource using the updateUserRoles mutation.
 }
 
 type Pool implements HasRoleAssignments {
@@ -903,7 +903,7 @@ type Query {
     publishingGroup: PublishingGroup
       @where(key: "publishing_group", operator: "=")
   ): [Pool!]!
-    @all(scopes: ["wasPublished", "notArchived"])
+    @all(scopes: ["wherePublished", "notArchived"])
     @canModel(ability: "viewAnyPublished", model: "Pool")
   pools: [Pool]!
     @all(scopes: ["authorizedToView", "notArchived"])
@@ -965,7 +965,9 @@ type Query {
     where: ApplicantFilterInput
   ): [CandidateSearchPoolResult!]!
   classification(id: UUID! @eq): Classification @find @canModel(ability: "view")
-  classifications(availableInSearch: Boolean @scope): [Classification]! @all @canModel(ability: "viewAny")
+  classifications(availableInSearch: Boolean @scope): [Classification]!
+    @all
+    @canModel(ability: "viewAny")
   department(id: UUID! @eq): Department @find @canModel(ability: "view")
   departments: [Department]! @all @canModel(ability: "viewAny")
   poolCandidateSearchRequest(id: ID! @eq): PoolCandidateSearchRequest
@@ -2260,9 +2262,15 @@ type Mutation {
   ): Boolean! @guard
 
   # Downloads for single entity, returning file name if successful or null on error
-  downloadUserDoc(id: UUID! anonymous: Boolean!): String @guard @canFind(ability: "view", find: "id", model: "User")
-  downloadPoolCandidateDoc(id: UUID! anonymous: Boolean!): String @guard @canFind(ability: "view", find: "id", model: "PoolCandidate")
-  downloadApplicationDoc(id: UUID!): String @guard @canFind(ability: "view", find: "id", model: "PoolCandidate")
+  downloadUserDoc(id: UUID!, anonymous: Boolean!): String
+    @guard
+    @canFind(ability: "view", find: "id", model: "User")
+  downloadPoolCandidateDoc(id: UUID!, anonymous: Boolean!): String
+    @guard
+    @canFind(ability: "view", find: "id", model: "PoolCandidate")
+  downloadApplicationDoc(id: UUID!): String
+    @guard
+    @canFind(ability: "view", find: "id", model: "PoolCandidate")
 }
 
 #import directiveForms.graphql

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -903,10 +903,10 @@ type Query {
     publishingGroup: PublishingGroup
       @where(key: "publishing_group", operator: "=")
   ): [Pool!]!
-    @all(scopes: ["wherePublished", "notArchived"])
+    @all(scopes: ["wherePublished", "whereNotArchived"])
     @canModel(ability: "viewAnyPublished", model: "Pool")
   pools: [Pool]!
-    @all(scopes: ["authorizedToView", "notArchived"])
+    @all(scopes: ["authorizedToView", "whereNotArchived"])
     @canResolved(ability: "view")
     @deprecated(reason: "pools is deprecated. Use poolsPaginated instead.")
   poolsPaginated(

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -683,9 +683,7 @@ class PoolTest extends TestCase
         $allPools = Pool::all();
         assertSame(count($allPools), 7);
 
-        $activePools = Pool::where((function ($query) {
-            Pool::scopeCurrentlyActive($query);
-        }))->get();
+        $activePools = Pool::query()->whereCurrentlyActive()->get();
         assertSame(count($activePools), 4); // assert 7 pools present but only 4 are considered "active"
     }
 


### PR DESCRIPTION
🤖 Resolves #11231 

## 👋 Introduction

Adds a specific eloquent builder for the pool model and moves scopes there.

## 🕵️ Details

I attempted to keep the naming as close as possible to what it is now but had to make some minor changes. Some scopes are prefixed with SQL like keywords, matching built in builder methods. I did this in an attempted to avoid name collisions with relationships (i.e `classifications`).

I made this changes only where needed to keep the scope smaller but maybe we want to use the keyword prefix for other methods in the future (`whereInPublishingGroup` vs `publishingGroups`). I think this makes the intention of the methods more clear.

## 🧪 Testing

1. Confirm existing scope tests are passing
2. Interact with places the scopes are used (mainly browse jobs and pools table)
3. Confirm they still function as expected