### PR TITLE
[Tests] Regression tests for application permissions 

### DIFF
--- a/api/tests/Feature/UnprotectedApplicationTest.php
+++ b/api/tests/Feature/UnprotectedApplicationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\PoolCandidate;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
+use Tests\TestCase;
+use Tests\UsesUnprotectedGraphqlEndpoint;
+
+class UnprotectedApplicationTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+    use RefreshesSchemaCache;
+    use UsesUnprotectedGraphqlEndpoint;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolePermissionSeeder::class);
+    }
+
+    public function testApplicantCanViewOwnApplications()
+    {
+        $user = User::factory()
+            ->asApplicant()
+            ->create();
+        $application = PoolCandidate::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $this->actingAs($user, 'api')->graphQL(<<<'GRAPHQL'
+            query {
+                me {
+                    poolCandidates { id }
+                }
+            }
+            GRAPHQL
+        )->assertJson([
+            'data' => [
+                'me' => [
+                    'poolCandidates' => [
+                        ['id' => $application->id],
+                    ],
+                ],
+            ],
+        ]);
+
+    }
+}

--- a/apps/playwright/utils/user.ts
+++ b/apps/playwright/utils/user.ts
@@ -7,6 +7,8 @@ import {
   ArmedForcesStatus,
   CreateUserInput,
   User,
+  UpdateUserAsUserInput,
+  Scalars,
 } from "@gc-digital-talent/graphql";
 
 import { GraphQLRequestFunc, GraphQLResponse } from "./graphql";
@@ -71,6 +73,35 @@ const Test_UpdateUserRolesMutationDocument = /* GraphQL */ `
     }
   }
 `;
+
+export const Test_UpdateUserMutationDocument = /* GraphQL */ `
+  mutation Test_UpdateUser($id: ID!, $user: UpdateUserAsUserInput!) {
+    updateUserAsUser(id: $id, user: $user) {
+      id
+    }
+  }
+`;
+
+interface UpdateUserAsUserArgs {
+  user: Partial<UpdateUserAsUserInput>;
+  id: Scalars["ID"]["input"];
+}
+
+export const updateUser: GraphQLRequestFunc<
+  User,
+  UpdateUserAsUserArgs
+> = async (ctx, { id, user }) => {
+  return ctx
+    .post(Test_UpdateUserMutationDocument, {
+      variables: {
+        id,
+        user,
+      },
+    })
+    .then(
+      (res: GraphQLResponse<"updateUserAsUser", User>) => res.updateUserAsUser,
+    );
+};
 
 type RoleInput = string | [string, string];
 


### PR DESCRIPTION
🤖 Resolves #11147 

## 👋 Introduction

Adds a regression test for permissions of applications on an unprotected endpoint.

## 🕵️ Details

We fixed an error where applications could not view their own applications (https://github.com/GCTC-NTGC/gc-digital-talent/issues/11143) and fixed it in https://github.com/GCTC-NTGC/gc-digital-talent/pull/11145. This adds tests to prevent any regression of that fix.

## 🧪 Testing


1. Confirm added tests meet AC
2. Confirm tests pass reliably
3. Add the code provided to the pool candidate authorization scope
4. Confirm tests fail

```php
// PoolCandidate::scopeAuthorizedToView
 $hasSomePermission = $user->isAbleTo([
   'view-own-application',
   'view-team-submittedApplication',
   'view-any-submittedApplication',
  ]);
  
  if (! $hasSomePermission) {
    $query->where('id', null);
    
    return;
}
```

