### PR TITLE
[Test] Update experience skill pivot assertions

### DIFF
--- a/api/tests/Feature/ExperienceTest.php
+++ b/api/tests/Feature/ExperienceTest.php
@@ -65,7 +65,7 @@ class ExperienceTest extends TestCase
             $userSkills[2]->id => ['details' => 'third skill'],
         ]);
 
-        $this->actingAs($this->platformAdmin, 'api')->graphQL(<<<'GRAPHQL'
+        $response = $this->actingAs($this->platformAdmin, 'api')->graphQL(<<<'GRAPHQL'
             query getUser($id: UUID!) {
                 user(id: $id) {
                     workExperiences {
@@ -83,22 +83,29 @@ class ExperienceTest extends TestCase
             [
                 'id' => $this->platformAdmin->id,
             ]
-        )->assertJsonFragment([
-            'id' => $userSkills[0]->skill->id,
-            'experienceSkillRecord' => [
-                'details' => 'first skill',
+        );
+
+        $this->assertEqualsCanonicalizing([
+            [
+
+                'id' => $userSkills[0]->skill->id,
+                'experienceSkillRecord' => [
+                    'details' => 'first skill',
+                ],
             ],
-        ])->assertJsonFragment([
-            'id' => $userSkills[1]->skill->id,
-            'experienceSkillRecord' => [
-                'details' => 'second skill',
+            [
+                'id' => $userSkills[1]->skill->id,
+                'experienceSkillRecord' => [
+                    'details' => 'second skill',
+                ],
             ],
-        ])->assertJsonFragment([
-            'id' => $userSkills[2]->skill->id,
-            'experienceSkillRecord' => [
-                'details' => 'third skill',
+            [
+                'id' => $userSkills[2]->skill->id,
+                'experienceSkillRecord' => [
+                    'details' => 'third skill',
+                ],
             ],
-        ]);
+        ], $response['data']['user']['workExperiences'][0]['skills']);
     }
 
     protected function checkCreatesUserSkills($method): void

--- a/api/tests/Feature/ExperienceTest.php
+++ b/api/tests/Feature/ExperienceTest.php
@@ -13,7 +13,6 @@ use Database\Seeders\ClassificationSeeder;
 use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithExceptionHandling;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Testing\Fluent\AssertableJson;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
@@ -66,9 +65,7 @@ class ExperienceTest extends TestCase
             $userSkills[2]->id => ['details' => 'third skill'],
         ]);
 
-        $response = $this->actingAs($this->platformAdmin, 'api')->graphQL(
-            /** @lang GraphQL */
-            '
+        $this->actingAs($this->platformAdmin, 'api')->graphQL(<<<'GRAPHQL'
             query getUser($id: UUID!) {
                 user(id: $id) {
                     workExperiences {
@@ -82,18 +79,26 @@ class ExperienceTest extends TestCase
                     }
                 }
             }
-        ',
+        GRAPHQL,
             [
                 'id' => $this->platformAdmin->id,
             ]
-        );
-        // Assert that the experience  from query with all three skills, and that the pivot details work correctly.
-        $response->assertJson(fn (AssertableJson $json) => $json->has('data.user.workExperiences.0', fn (AssertableJson $json) => $json->where('id', $experience->id)
-            ->has('skills', 3, fn (AssertableJson $json) => $json->where('id', $userSkills[0]->skill_id)
-                ->where('experienceSkillRecord.details', 'first skill')
-            )
-        )
-        );
+        )->assertJsonFragment([
+            'id' => $userSkills[0]->skill->id,
+            'experienceSkillRecord' => [
+                'details' => 'first skill',
+            ],
+        ])->assertJsonFragment([
+            'id' => $userSkills[1]->skill->id,
+            'experienceSkillRecord' => [
+                'details' => 'second skill',
+            ],
+        ])->assertJsonFragment([
+            'id' => $userSkills[2]->skill->id,
+            'experienceSkillRecord' => [
+                'details' => 'third skill',
+            ],
+        ]);
     }
 
     protected function checkCreatesUserSkills($method): void


### PR DESCRIPTION
🤖 Resolves #7483 

## 👋 Introduction

Updates the assertions for the test to check each fragment to avoid order causing errors.

## 🕵️ Details

I don't believe we care about the order or anything so this just checks to see if each skill fragment exists. This should stabilize the test a bit more.

## 🧪 Testing

`for i in {1..10}; do make artisan CMD="test --filter=testSkillRelationshipsWorkWithPivot ./tests/Feature/ExperienceTest.php"; done`

1. Run the test multiple times
2. Confirm no failures