### PR TITLE
[Fix] Show skill details in document downloads

### DIFF
--- a/api/app/Models/UserSkill.php
+++ b/api/app/Models/UserSkill.php
@@ -124,7 +124,7 @@ class UserSkill extends Model
             ->withTimestamps()
             ->withPivot(['details', 'deleted_at'])
             ->wherePivotNull('deleted_at')
-            ->as('experience_skill_pivot');
+            ->as('experience_skill');
     }
 
     public function experiences()
@@ -138,6 +138,6 @@ class UserSkill extends Model
             ->withTimestamps()
             ->withPivot(['details', 'deleted_at'])
             ->wherePivotNull('deleted_at')
-            ->as('experience_skill_pivot');
+            ->as('experience_skill');
     }
 }

--- a/api/app/Traits/Generator/GeneratesUserDoc.php
+++ b/api/app/Traits/Generator/GeneratesUserDoc.php
@@ -317,8 +317,8 @@ trait GeneratesUserDoc
             $experience->userSkills->each(function ($userSkill) use ($section) {
                 $skillRun = $section->addListItemRun();
                 $skillRun->addText($userSkill->skill->name[$this->lang], $this->strong);
-                if (isset($skill->experience_skill->details)) {
-                    $skillRun->addText(': '.$skill->experience_skill->details);
+                if (isset($userSkill->experience_skill->details)) {
+                    $skillRun->addText($this->colon().$userSkill->experience_skill->details);
                 }
             });
         }


### PR DESCRIPTION
🤖 Resolves #11488 

## 👋 Introduction

Fixes an issue where skill details were not being displayed in profile and application downloads.

## 🕵️ Details

Looks like there were two issues,

1. We were trying to get details from the skill but they exist on the user skill
2. Not all skill pivots had the same alias so they would not appear

## 🧪 Testing

1. Login as admin `admin@test.com`
2. Apply to a process making sure you have one of each experience type with skill details
3. Navigate to the candidate admin page for the application in step 2
4. Download both a profile and application document
5. Confirm the details for skills on all experience types appear

## 📸 Screenshot

![2024-09-11_13-08](https://github.com/user-attachments/assets/67ff23cc-4735-4819-b352-25d0061bfc3a)
![2024-09-11_13-07](https://github.com/user-attachments/assets/dfe71977-752e-4d5c-b9f8-d57d767a0448)
