### PR TITLE
[Feature] Update time stamps on manual pool candidate status changes

### DIFF
--- a/api/app/GraphQL/Mutations/UpdatePoolCandidateStatus.php
+++ b/api/app/GraphQL/Mutations/UpdatePoolCandidateStatus.php
@@ -23,6 +23,7 @@ final readonly class UpdatePoolCandidateStatus
                 PoolCandidateStatus::QUALIFIED_AVAILABLE->name => 'final_decision_at',
 
                 PoolCandidateStatus::SCREENED_OUT_NOT_RESPONSIVE->name,
+                PoolCandidateStatus::SCREENED_OUT_NOT_INTERESTED->name,
                 PoolCandidateStatus::QUALIFIED_UNAVAILABLE->name,
                 PoolCandidateStatus::QUALIFIED_WITHDREW->name,
                 PoolCandidateStatus::REMOVED->name => 'removed_at',

--- a/api/app/GraphQL/Mutations/UpdatePoolCandidateStatus.php
+++ b/api/app/GraphQL/Mutations/UpdatePoolCandidateStatus.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations;
+
+use App\Enums\PoolCandidateStatus;
+use App\Models\PoolCandidate;
+use Illuminate\Support\Facades\Log;
+
+final readonly class UpdatePoolCandidateStatus
+{
+    /** @param  array{}  $args */
+    public function __invoke(null $_, array $args)
+    {
+        $candidate = PoolCandidate::findOrFail($args['id']);
+
+        Log::debug($args);
+
+        if (isset($args['pool_candidate_status']) && $args['pool_candidate_status'] !== $candidate->pool_candidate_status) {
+            $status = $args['pool_candidate_status'];
+
+            $timestamp = match ($status) {
+                PoolCandidateStatus::SCREENED_OUT_ASSESSMENT->name,
+                PoolCandidateStatus::SCREENED_OUT_APPLICATION->name,
+                PoolCandidateStatus::QUALIFIED_AVAILABLE->name => 'final_decision_at',
+
+                PoolCandidateStatus::SCREENED_OUT_NOT_RESPONSIVE->name,
+                PoolCandidateStatus::QUALIFIED_UNAVAILABLE->name,
+                PoolCandidateStatus::QUALIFIED_WITHDREW->name,
+                PoolCandidateStatus::REMOVED->name => 'removed_at',
+
+                PoolCandidateStatus::PLACED_TENTATIVE->name,
+                PoolCandidateStatus::PLACED_CASUAL->name,
+                PoolCandidateStatus::PLACED_TERM->name,
+                PoolCandidateStatus::PLACED_INDETERMINATE->name => 'placed_at',
+
+                default => null// no-op
+            };
+
+            if ($timestamp) {
+                $candidate->$timestamp = now();
+            }
+
+            $candidate->pool_candidate_status = $status;
+        }
+
+        if (isset($args['expiry_date'])) {
+            $candidate->expiry_date = $args['expiry_date'];
+        }
+
+        $candidate->save();
+
+        return $candidate;
+    }
+}

--- a/api/app/GraphQL/Mutations/UpdatePoolCandidateStatus.php
+++ b/api/app/GraphQL/Mutations/UpdatePoolCandidateStatus.php
@@ -6,7 +6,6 @@ namespace App\GraphQL\Mutations;
 
 use App\Enums\PoolCandidateStatus;
 use App\Models\PoolCandidate;
-use Illuminate\Support\Facades\Log;
 
 final readonly class UpdatePoolCandidateStatus
 {
@@ -14,8 +13,6 @@ final readonly class UpdatePoolCandidateStatus
     public function __invoke(null $_, array $args)
     {
         $candidate = PoolCandidate::findOrFail($args['id']);
-
-        Log::debug($args);
 
         if (isset($args['pool_candidate_status']) && $args['pool_candidate_status'] !== $candidate->pool_candidate_status) {
             $status = $args['pool_candidate_status'];

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1972,7 +1972,6 @@ type Mutation {
     id: UUID!
     poolCandidate: UpdatePoolCandidateStatusInput! @spread
   ): PoolCandidate
-    @update
     @guard
     @canFind(ability: "updateStatus", find: "id", injectArgs: true)
   # Return a boolean to prevent automatically updating the client's cache

--- a/api/tests/Feature/PoolCandidateUpdateTest.php
+++ b/api/tests/Feature/PoolCandidateUpdateTest.php
@@ -18,9 +18,11 @@ use App\Models\PoolCandidate;
 use App\Models\Skill;
 use App\Models\Team;
 use App\Models\User;
+use Carbon\Carbon;
 use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Str;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
 use Tests\UsesProtectedGraphqlEndpoint;
@@ -56,6 +58,8 @@ class PoolCandidateUpdateTest extends TestCase
     protected $poolCandidate;
 
     protected $unauthorizedMessage;
+
+    protected $manualStatusUpdateMutation;
 
     protected $placeCandidateMutation;
 
@@ -133,6 +137,17 @@ class PoolCandidateUpdateTest extends TestCase
         ]);
 
         $this->unauthorizedMessage = 'This action is unauthorized.';
+
+        $this->manualStatusUpdateMutation = <<<'GRAPHQL'
+            mutation updatePoolCandidateStatus($id: UUID!, $candidate: UpdatePoolCandidateStatusInput!) {
+                updatePoolCandidateStatus(id: $id, poolCandidate: $candidate) {
+                    status { value }
+                    finalDecisionAt
+                    placedAt
+                    removedAt
+                }
+            }
+        GRAPHQL;
 
         $this->placeCandidateMutation =
         /** @lang GraphQL */
@@ -964,5 +979,111 @@ class PoolCandidateUpdateTest extends TestCase
             ->assertJsonFragment([
                 'id' => $candidate->id,
             ]);
+    }
+
+    /**
+     * @dataProvider manualStatusProvider
+     */
+    public function testManualStatusUpdatesTimestamps($status, $timestamp)
+    {
+        // Ensure time stamps are set to compare against
+        // and we are starting from no status
+        $past = config('constants.past_datetime');
+        $this->poolCandidate->pool_candidate_status = PoolCandidateStatus::NEW_APPLICATION->name;
+        $this->poolCandidate->final_decision_at = $past;
+        $this->poolCandidate->placed_at = $past;
+        $this->poolCandidate->removed_at = $past;
+        $this->poolCandidate->save();
+
+        $camelTimestamp = Str::camel($timestamp);
+        $original = $this->poolCandidate->$timestamp;
+
+        $response = $this->actingAs($this->poolOperatorUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => $status],
+            ]);
+
+        // Assert the expected time stamp was changed
+        $data = $response['data']['updatePoolCandidateStatus'];
+        $new = new Carbon($data[$camelTimestamp]);
+        $this->assertGreaterThan($original->timestamp, $new->timestamp, sprintf(
+            '%s is not greater than %s',
+            $new->toDayDateTimeString(),
+            $original->toDayDateTimeString()
+        ));
+
+        // Ensure other time stamps remain the same
+        $unchanged = array_diff(['final_decision_at', 'removed_at', 'placed_at'], [$timestamp]);
+        foreach ($unchanged as $unchagedTimestamp) {
+            $this->assertEquals($this->poolCandidate->$unchagedTimestamp, $data[Str::camel($unchagedTimestamp)]);
+        }
+
+        // Attempt to make change again and assert it does not affect timestamp
+        $noChangeResponse = $this->actingAs($this->poolOperatorUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => $status],
+            ]);
+
+        $unChangeData = $noChangeResponse['data']['updatePoolCandidateStatus'];
+        $unchanged = new Carbon($unChangeData[$camelTimestamp]);
+
+        $this->assertEquals($new->timestamp, $unchanged->timestamp);
+    }
+
+    public static function manualStatusProvider()
+    {
+        return [
+            // Final decision
+            'screened out assessment sets final decision' => [
+                PoolCandidateStatus::SCREENED_OUT_ASSESSMENT->name,
+                'final_decision_at',
+            ],
+            'screened out application sets final decision' => [
+                PoolCandidateStatus::SCREENED_OUT_APPLICATION->name,
+                'final_decision_at',
+            ],
+            'qualified available sets final decision' => [
+                PoolCandidateStatus::QUALIFIED_AVAILABLE->name,
+                'final_decision_at',
+            ],
+
+            // Removed
+            'screened out not responsive sets removed at' => [
+                PoolCandidateStatus::SCREENED_OUT_NOT_RESPONSIVE->name,
+                'removed_at',
+            ],
+            'qualified unavailable sets removed at' => [
+                PoolCandidateStatus::QUALIFIED_UNAVAILABLE->name,
+                'removed_at',
+            ],
+            'qualified withdrew sets removed at' => [
+                PoolCandidateStatus::QUALIFIED_WITHDREW->name,
+                'removed_at',
+            ],
+            'removed sets removed at' => [
+                PoolCandidateStatus::REMOVED->name,
+                'removed_at',
+            ],
+
+            // Placed
+            'placed tenative sets removed at' => [
+                PoolCandidateStatus::PLACED_TENTATIVE->name,
+                'placed_at',
+            ],
+            'placed casual sets placed at' => [
+                PoolCandidateStatus::PLACED_CASUAL->name,
+                'placed_at',
+            ],
+            'placed term sets placed at' => [
+                PoolCandidateStatus::PLACED_CASUAL->name,
+                'placed_at',
+            ],
+            'placed indetermined sets placed at' => [
+                PoolCandidateStatus::PLACED_INDETERMINATE->name,
+                'placed_at',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
🤖 Resolves #11490 

## 👋 Introduction

Updates the manual pool candidate status mutation to also update the appropriate timestamps.

## 🕵️ Details

While not explictly stated in the ticket, I added a check to make sure the status was actually changing from its existing value before setting the timestamp which makes sense to me. If this is wrong, let me know and I can change that.

## 🧪 Testing

1. Login as admin `admin@test.com`
2. Take not of the following time stamps: `placed_at`, `final_decision_at` and `removed_at` from the database for a candidate
3. Use the manual status change dialog to change the status
4. Confirm the appropriate time stamps are updated while the others remain untouched 