### PR TITLE
[Bugfix] Fix archived_at property access

### DIFF
--- a/api/app/Generators/PoolCandidateCsvGenerator.php
+++ b/api/app/Generators/PoolCandidateCsvGenerator.php
@@ -120,7 +120,7 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
                     $this->localizeEnum($candidate->user->current_province, ProvinceOrTerritory::class), // Current province
                     $candidate->submitted_at ? $candidate->submitted_at->format('Y-m-d') : '', // Date received
                     $candidate->expiry_date ? $candidate->expiry_date->format('Y-m-d') : '', // Expiry date
-                    $candidate->archived_at ? $candidate->archival_at->format('Y-m-d') : '', // Archival date
+                    $candidate->archived_at ? $candidate->archived_at->format('Y-m-d') : '', // Archival date
                     $candidate->user->first_name, // First name
                     $candidate->user->last_name, // Last name
                     $candidate->user->email, // Email


### PR DESCRIPTION
🤖 Resolves #11442 

## 👋 Introduction

This branch fixes a bug where pool candidates that have an `archived_at` value set cannot be rendered in a CSV.

## 🧪 Testing

1. Set the `archived_at` field in a pool_candidate
2. Confirm you can still download that candidate as a CSV file