### PR TITLE
[Fix] Application document title

### DIFF
--- a/api/app/Generators/ApplicationDocGenerator.php
+++ b/api/app/Generators/ApplicationDocGenerator.php
@@ -27,7 +27,7 @@ class ApplicationDocGenerator extends DocGenerator implements FileGeneratorInter
         $this->setup();
 
         $section = $this->doc->addSection();
-        $section->addTitle($this->localizeHeading(count($this->ids) > 1 ? 'candidate_profiles' : 'candidate_profile'), 1);
+        $section->addTitle($this->localizeHeading('application_snapshot'), 1);
 
         PoolCandidate::with([
             'educationRequirementExperiences',

--- a/api/lang/en/headings.php
+++ b/api/lang/en/headings.php
@@ -52,6 +52,7 @@ return [
     'education_requirement_experiences' => 'Education requirement experiences',
     'skills' => 'Skills',
     // Section headings
+    'application_snapshot' => 'Application snapshot',
     'candidate_profiles' => 'Candidate profiles',
     'candidate_profile' => 'Candidate profile',
     'user_profile' => 'User profile',

--- a/api/lang/fr/headings.php
+++ b/api/lang/fr/headings.php
@@ -51,6 +51,7 @@ return [
     'education_requirement_experiences' => 'Expériences relatives aux exigences pédagogiques',
     'skills' => 'Compétences',
     // Section headings
+    'application_snapshot' => 'Capture d\'écran de la demande',
     'candidate_profiles' => 'Profils des candidats',
     'candidate_profile' => 'Profil des candidat',
     'user_profile' => 'Profil de l\'utilisateur',

--- a/api/lang/fr/headings.php
+++ b/api/lang/fr/headings.php
@@ -51,7 +51,7 @@ return [
     'education_requirement_experiences' => 'Expériences relatives aux exigences pédagogiques',
     'skills' => 'Compétences',
     // Section headings
-    'application_snapshot' => 'Capture d\'écran de la demande',
+    'application_snapshot' => 'Capture d\'écran de la candidature',
     'candidate_profiles' => 'Profils des candidats',
     'candidate_profile' => 'Profil des candidat',
     'user_profile' => 'Profil de l\'utilisateur',


### PR DESCRIPTION
🤖 Resolves #11493 

## 👋 Introduction

Fixes the application document to have the title "Application snapshot", distinguishing it from profile documents.

## 🧪 Testing

1. Login as admin `admin@test.com`
2. Navigate to an pool candidate page in the admin view
3. Downoad their application
4. Confirm the title is "Application snapshot"
5. Confirm the title in French is "Capture d'écran de la candidature"

## 📸 Screenshot

![2024-09-13_11-33](https://github.com/user-attachments/assets/fd2631af-5414-43f2-b61c-d00c17307b91)

![2024-09-13_10-19](https://github.com/user-attachments/assets/2e9301ea-8f25-405b-b902-f31653bc8dde)
