### PR TITLE
[Fix] Add missing values to pool candidate csv

### DIFF
--- a/api/app/Generators/PoolCandidateCsvGenerator.php
+++ b/api/app/Generators/PoolCandidateCsvGenerator.php
@@ -169,10 +169,10 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
                 });
                 $values[] = implode(', ', $userSkills->toArray());
 
-                $poolQuestionIds = $candidate->pool->generalQuestions->pluck('id')->toArray();
-                $candidateQuestionIds = $candidate->generalQuestionResponses->pluck('general_question_id')->toArray();
-                foreach ($poolQuestionIds as $questionId) {
-                    if (in_array($questionId, $candidateQuestionIds)) {
+                $poolGeneralQuestionIds = $candidate->pool->generalQuestions->pluck('id')->toArray();
+                $candidateGeneralQuestionIds = $candidate->generalQuestionResponses->pluck('general_question_id')->toArray();
+                foreach ($poolGeneralQuestionIds as $questionId) {
+                    if (in_array($questionId, $candidateGeneralQuestionIds)) {
                         $response = $candidate->generalQuestionResponses->where('general_question_id', $questionId)->first();
                         $this->generalQuestionResponses[$questionId][] = [
                             'candidate' => $currentCandidate,

--- a/api/app/Generators/PoolCandidateCsvGenerator.php
+++ b/api/app/Generators/PoolCandidateCsvGenerator.php
@@ -21,6 +21,7 @@ use App\Traits\Generator\Filterable;
 use App\Traits\Generator\GeneratesFile;
 use Illuminate\Support\Facades\Lang;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInterface
 {
@@ -29,9 +30,15 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
 
     protected array $generalQuestionIds = [];
 
+    protected array $generalQuestionResponses = [];
+
     protected array $screeningQuestionIds = [];
 
+    protected array $screeningQuestionResponses = [];
+
     protected array $skillIds = [];
+
+    protected array $poolSkills = [];
 
     protected array $poolIds = [];
 
@@ -162,38 +169,45 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
                 });
                 $values[] = implode(', ', $userSkills->toArray());
 
+                $poolQuestionIds = $candidate->pool->generalQuestions->pluck('id')->toArray();
                 $candidateQuestionIds = $candidate->generalQuestionResponses->pluck('general_question_id')->toArray();
-                foreach ($this->generalQuestionIds as $questionId) {
+                foreach ($poolQuestionIds as $questionId) {
                     if (in_array($questionId, $candidateQuestionIds)) {
                         $response = $candidate->generalQuestionResponses->where('general_question_id', $questionId)->first();
-                        $values[] = $this->sanitizeString($response->answer);
-                    } else {
-                        $values[] = '';
+                        $this->generalQuestionResponses[$questionId][] = [
+                            'candidate' => $currentCandidate,
+                            'value' => $this->sanitizeString($response->answer),
+                        ];
                     }
                 }
 
+                $poolScreeningQuestionIds = $candidate->pool->screeningQuestions->pluck('id')->toArray();
                 $candidateScreeningQuestionIds = $candidate->screeningQuestionResponses->pluck('screening_question_id')->toArray();
-                foreach ($this->screeningQuestionIds as $questionId) {
+                foreach ($poolScreeningQuestionIds as $questionId) {
                     if (in_array($questionId, $candidateScreeningQuestionIds)) {
                         $response = $candidate->screeningQuestionResponses->where('screening_question_id', $questionId)->first();
-                        $values[] = $this->sanitizeString($response->answer);
-                    } else {
-                        $values[] = '';
+                        $this->screeningQuestionResponses[$questionId][] = [
+                            'candidate' => $currentCandidate,
+                            'value' => $this->sanitizeString($response->answer),
+                        ];
                     }
                 }
 
+                $poolSkillIds = $candidate->pool->poolSkills->pluck('skill_id')->toArray();
                 $candidateSkillIds = $candidate->user->userSkills->pluck('skill_id')->toArray();
-                foreach ($this->skillIds as $skillId) {
+                foreach ($poolSkillIds as $skillId) {
                     if (in_array($skillId, $candidateSkillIds)) {
                         $userSkill = $candidate->user->userSkills->where('skill_id', $skillId)->first();
-                        $values[] = implode("\r\n", $userSkill->experiences
-                            ->map(function ($experience) use ($userSkill) {
-                                $skill = $experience->skills->where('id', $userSkill->skill_id)->first();
 
-                                return $experience->getTitle().': '.$skill->experience_skill->details;
-                            })->toArray());
-                    } else {
-                        $values[] = '';
+                        $this->poolSkills[$skillId][] = [
+                            'candidate' => $currentCandidate,
+                            'value' => implode("\r\n", $userSkill->experiences
+                                ->map(function ($experience) use ($userSkill) {
+                                    $skill = $experience->skills->where('id', $userSkill->skill_id)->first();
+
+                                    return $experience->getTitle().': '.$skill->experience_skill->details;
+                                })->toArray()),
+                        ];
                     }
                 }
 
@@ -208,6 +222,8 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
         }, $this->headerLocaleKeys);
 
         $this->generatePoolHeaders();
+        $this->generatePoolCells($sheet, count($localizedHeaders) + 1);
+
         $sheet->fromArray([
             ...$localizedHeaders,
             $this->localizeHeading('skills'),
@@ -250,7 +266,6 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
 
                     if ($pool->poolSkills->count() > 0) {
                         $skillsByGroup = $pool->poolSkills->groupBy('type');
-
                         foreach ($skillsByGroup as $group => $skills) {
                             foreach ($skills as $skill) {
                                 $this->skillIds[] = $skill->skill_id;
@@ -266,12 +281,50 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
             });
     }
 
+    private function generatePoolCells(Worksheet $sheet, int $columnCount)
+    {
+
+        $currentColumn = $columnCount;
+
+        foreach ($this->generalQuestionIds as $generalQuestionId) {
+            $currentColumn++;
+            if (isset($this->generalQuestionResponses[$generalQuestionId])) {
+                foreach ($this->generalQuestionResponses[$generalQuestionId] as $row) {
+                    $sheet->setCellValue([$currentColumn, $row['candidate'] + 1], $row['value']);
+                }
+            }
+        }
+
+        foreach ($this->screeningQuestionIds as $screeningQuestionId) {
+            $currentColumn++;
+            if (isset($this->screeningQuestionResponses[$screeningQuestionId])) {
+                foreach ($this->screeningQuestionResponses[$screeningQuestionId] as $row) {
+                    $sheet->setCellValue([$currentColumn, $row['candidate'] + 1], $row['value']);
+                }
+            }
+        }
+
+        foreach ($this->skillIds as $skillId) {
+            $currentColumn++;
+            if (isset($this->poolSkills[$skillId])) {
+                foreach ($this->poolSkills[$skillId] as $row) {
+                    $sheet->setCellValue([$currentColumn, $row['candidate'] + 1], $row['value']);
+                }
+            }
+        }
+    }
+
     private function buildQuery()
     {
         $query = PoolCandidate::with([
             'generalQuestionResponses' => ['generalQuestion'],
             'screeningQuestionResponses' => ['screeningQuestion'],
             'educationRequirementExperiences',
+            'pool' => [
+                'generalQuestions',
+                'screeningQuestions',
+                'poolSkills' => ['skill'],
+            ],
             'user' => [
                 'department',
                 'currentClassification',


### PR DESCRIPTION
🤖 Resolves #11519 

## 👋 Introduction

Updates the order we generate values in to add values that depend on the pool after the initial generation.

## 🧪 Testing

1. Start work queue `make queue-work`
2. Login as admin `admin@test.com`
3. Navigate to the candidates table `/admin/pool-candidates`
4. Download CSV of the candidates
5. Compare the download to the snapshots, confirming that the following appears in the expected cells:
    - General question responses
    - Screening question responses
    - Skill details

