### PR TITLE
[Fix] Stabilize admin workflow test

### DIFF
--- a/apps/playwright/tests/admin/admin-workflows.spec.ts
+++ b/apps/playwright/tests/admin/admin-workflows.spec.ts
@@ -61,8 +61,7 @@ test.describe("Admin workflows", () => {
       /user updated successfully/i,
     );
 
-    await appPage.waitForGraphqlResponse(USERS_PAGINATED_QUERY);
-
+    await searchForUser(appPage, "Applicant");
     await appPage.page
       .getByRole("button", { name: /show or hide columns/i })
       .click();

--- a/apps/playwright/tests/open-graph.spec.ts
+++ b/apps/playwright/tests/open-graph.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 test.describe("Open Graph", () => {
   test("should specify an image", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/en");
     const locator = await page
       .locator('head meta[property="og:image"]')
       .getAttribute("content");


### PR DESCRIPTION
🤖 Resolves #11527 

## 👋 Introduction

Stabilizes the admin workflow test by ensuring the user we are expecting appears on the table before assertions.

## 🧪 Testing

1. Run the test multiple times
2. Confirm test consistently passes