### PR TITLE
[Feature] Job poster templates page

### DIFF
--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -460,6 +460,18 @@ const createRoute = (locale: Locales) =>
               ],
             },
             {
+              path: "job-templates",
+              children: [
+                {
+                  index: true,
+                  lazy: () =>
+                    import(
+                      "../pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage"
+                    ),
+                },
+              ],
+            },
+            {
               path: "*",
               loader: () => {
                 throw new Response("Not Found", { status: 404 });

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -295,6 +295,11 @@ const getRoutes = (lang: Locales) => {
     // Account Settings
     accountSettings: () => [applicantUrl, "settings"].join("/"),
 
+    // Job poster templates
+    jobPosterTemplates: () => [baseUrl, "job-templates"].join("/"),
+    jobPosterTemplate: (templateId: string) =>
+      [baseUrl, "job-templates", templateId].join("/"),
+
     /**
      * Deprecated
      *

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -32,7 +32,11 @@ import {
   localizedEnumToOptions,
 } from "@gc-digital-talent/forms";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
-import { getLocale, getLocalizedName } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  getLocale,
+  getLocalizedName,
+} from "@gc-digital-talent/i18n";
 
 import Hero from "~/components/Hero";
 import SEO from "~/components/SEO/SEO";
@@ -228,20 +232,23 @@ const JobPosterTemplatesPage = () => {
       return show;
     });
 
-    return allTemplates.splice(0, maxShown).sort((a, b) => {
-      if (sortBy === "classification") {
-        return (
-          (a.classification?.group ?? "").localeCompare(
-            b.classification?.group ?? "",
-          ) || (a?.classification?.level ?? 0) - (b?.classification?.level ?? 0)
-        );
-      }
+    return allTemplates
+      .sort((a, b) => {
+        if (sortBy === "classification") {
+          return (
+            (a.classification?.group ?? "").localeCompare(
+              b.classification?.group ?? "",
+            ) ||
+            (a?.classification?.level ?? 0) - (b?.classification?.level ?? 0)
+          );
+        }
 
-      const aName = getLocalizedName(a.name, intl, true);
-      const bName = getLocalizedName(b.name, intl, true);
+        const aName = getLocalizedName(a.name, intl, true);
+        const bName = getLocalizedName(b.name, intl, true);
 
-      return aName.localeCompare(bName);
-    });
+        return aName.localeCompare(bName);
+      })
+      .splice(0, maxShown);
   }, [
     jobPosterTemplates,
     maxShown,
@@ -419,6 +426,7 @@ const JobPosterTemplatesPage = () => {
                         description:
                           "Label for the links to change how the list is sorted",
                       })}
+                      {intl.formatMessage(commonMessages.dividingColon)}
                     </span>
                     <Link
                       aria-describedby="sortBy"

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -1,0 +1,74 @@
+import RectangleStackIcon from "@heroicons/react/24/outline/RectangleStackIcon";
+import { defineMessage, useIntl } from "react-intl";
+
+import { Heading } from "@gc-digital-talent/ui";
+
+import Hero from "~/components/Hero";
+import SEO from "~/components/SEO/SEO";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
+import useRoutes from "~/hooks/useRoutes";
+
+const pageTitle = defineMessage({
+  defaultMessage: "Job advertisement templates",
+  id: "58+Hom",
+  description: "Heading for the page showing list of job poster templates",
+});
+
+const pageDescription = defineMessage({
+  defaultMessage:
+    "Browse a library of pre-built job advertisements that include suggestions for key tasks, required, and optional skills.",
+  id: "s7jEFt",
+  description: "Description for the page showing list of job poster templates",
+});
+
+const JobPosterTemplatesPage = () => {
+  const intl = useIntl();
+  const paths = useRoutes();
+
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(pageTitle),
+        url: paths.jobPosterTemplates(),
+      },
+    ],
+  });
+
+  return (
+    <>
+      <SEO
+        title={intl.formatMessage(pageTitle)}
+        description={intl.formatMessage(pageDescription)}
+      />
+      <Hero
+        title={intl.formatMessage(pageTitle)}
+        subtitle={intl.formatMessage(pageDescription)}
+        crumbs={crumbs}
+      />
+      <div data-h2-wrapper="base(center, large, x1) p-tablet(center, large, x2)">
+        <Heading level="h2" size="h3" color="primary" Icon={RectangleStackIcon}>
+          {intl.formatMessage({
+            defaultMessage: "Find a template",
+            id: "XIDaGg",
+            description: "Heading for the form to filter job poster templates",
+          })}
+        </Heading>
+        <p data-h2-margin="base(x1 0)">
+          {intl.formatMessage({
+            defaultMessage:
+              "This library contains a series of templates for common jobs across the communities we support. These templates include suggested information and recommendations for elements such as job title, common tasks in the role, essential and asset skills, and more. Feel free to browse the full list, or, if you have an idea of the type of role you're hiring for, you can use the search bar or filters to find templates that align with the job’s specific details.",
+            id: "8dUPjb",
+            description:
+              "Description of how to use the form to filter job poster templates",
+          })}
+        </p>
+      </div>
+    </>
+  );
+};
+
+export const Component = () => <JobPosterTemplatesPage />;
+
+Component.displayName = "JobPosterTemplatesPage";
+
+export default JobPosterTemplatesPage;

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -164,7 +164,7 @@ function searchParamHref(
   return `?${hrefParams.toString()}`;
 }
 
-const PAGE_SIZE = 1;
+const PAGE_SIZE = 8;
 
 type SortKey = "classification" | "title";
 

--- a/packages/ui/src/components/PreviewList/PreviewList.tsx
+++ b/packages/ui/src/components/PreviewList/PreviewList.tsx
@@ -31,11 +31,12 @@ const MetaData = ({ children, type, color }: MetaDataProps) => {
 };
 
 interface ItemProps {
-  title: string;
+  title: ReactNode;
   metaData: MetaDataProps[];
-  buttonName: string;
+  buttonName?: string;
   headingAs?: HeadingLevel;
   buttonAriaLabel?: string;
+  children?: ReactNode;
 }
 
 const Item = ({
@@ -44,6 +45,7 @@ const Item = ({
   metaData,
   buttonName,
   buttonAriaLabel,
+  children,
 }: ItemProps) => {
   return (
     <div
@@ -52,7 +54,6 @@ const Item = ({
       data-h2-justify-content="base(space-between)"
       data-h2-align-items="base(flex-start) p-tablet(center)"
       data-h2-gap="base(x.25)"
-      data-h2-padding="base(x1 0)"
       data-h2-border-bottom="base:all:selectors[:not(:last-child)](1px solid)"
       data-h2-border-bottom-color="base:all:selectors[:not(:last-child)](gray.lighter)"
       data-h2-transition="base:children[.PreviewList__Heading](transform 200ms ease)"
@@ -73,6 +74,7 @@ const Item = ({
         >
           {title}
         </Heading>
+        {children && <div>{children}</div>}
         <div
           data-h2-display="base(flex)"
           data-h2-flex-direction="base(column) p-tablet(row)"
@@ -89,19 +91,21 @@ const Item = ({
           ))}
         </div>
       </div>
-      <Button
-        mode="icon_only"
-        color="black"
-        fontSize="caption"
-        icon={MagnifyingGlassPlusIcon}
-        data-h2-position="base:selectors[::after](absolute)"
-        data-h2-content="base:selectors[::after](' ')"
-        data-h2-inset="base:selectors[::after](0)"
-        data-h2-justify-self="base(end)"
-        aria-label={buttonAriaLabel}
-      >
-        {buttonName}
-      </Button>
+      {buttonName && (
+        <Button
+          mode="icon_only"
+          color="black"
+          fontSize="caption"
+          icon={MagnifyingGlassPlusIcon}
+          data-h2-position="base:selectors[::after](absolute)"
+          data-h2-content="base:selectors[::after](' ')"
+          data-h2-inset="base:selectors[::after](0)"
+          data-h2-justify-self="base(end)"
+          aria-label={buttonAriaLabel}
+        >
+          {buttonName}
+        </Button>
+      )}
     </div>
   );
 };
@@ -114,7 +118,14 @@ export interface RootProps {
 
 const Root = ({ children, ...rest }: RootProps) => {
   return (
-    <div role="list" {...rest}>
+    <div
+      role="list"
+      data-h2-display="base(flex)"
+      data-h2-flex-direction="base(column)"
+      data-h2-row-gap="base(x1)"
+      data-h2-padding-bottom="base:children[:last-child](0) base:children[>](x1)"
+      {...rest}
+    >
       {children}
     </div>
   );

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -57,6 +57,9 @@ import Pending, {
   type PendingProps,
   LoadingErrorMessage,
 } from "./components/Pending";
+import PreviewList, {
+  type MetaDataProps as PreviewMetaData,
+} from "./components/PreviewList/PreviewList";
 import ResourceBlock from "./components/ResourceBlock";
 import ScrollArea from "./components/ScrollArea";
 import Separator from "./components/Separator";
@@ -92,7 +95,6 @@ import Well, { WellProps } from "./components/Well";
 import { incrementHeadingRank, decrementHeadingRank } from "./utils";
 import useControllableState from "./hooks/useControllableState";
 import TaskCard from "./components/TaskCard";
-import PreviewList from "./components/PreviewList/PreviewList";
 
 export type {
   Color,
@@ -115,6 +117,7 @@ export type {
   MenuLinkProps,
   LoadingProps,
   PendingProps,
+  PreviewMetaData,
   ChipProps,
   SidebarProps,
   SideMenuProps,


### PR DESCRIPTION
🤖 Resolves #11430 

## 👋 Introduction

Adds the index page for job poster templates.

## :clipboard: TODO

- [ ] Get supervisory status translations

## 🕵️ Details

## 🧪 Testing

> [!NOTE]
> To test page sizes, you will need to either seed more than 8 templates or temporarily set page size to less than 3.

1. Build app `pnpm run dev:fresh`
2. Navigate to `/job-templates`
3. Confirm the items are shown and filters/sorting/pages function as expected

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
