### PR TITLE
[Feature] Job poster templates page

### DIFF
--- a/api/app/Enums/SupervisoryStatus.php
+++ b/api/app/Enums/SupervisoryStatus.php
@@ -2,8 +2,17 @@
 
 namespace App\Enums;
 
+use App\Traits\HasLocalization;
+
 enum SupervisoryStatus
 {
+    use HasLocalization;
+
     case INDIVIDUAL_CONTRIBUTOR;
     case SUPERVISOR;
+
+    public static function getLangFilename(): string
+    {
+        return 'supervisory_status';
+    }
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -738,7 +738,8 @@ type JobPosterTemplate {
   referenceId: String @rename(attribute: "reference_id")
   name: LocalizedString
   description: LocalizedString
-  supervisoryStatus: SupervisoryStatus @rename(attribute: "supervisory_status")
+  supervisoryStatus: LocalizedSupervisoryStatus
+    @rename(attribute: "supervisory_status")
   stream: LocalizedPoolStream
   workDescription: LocalizedString @rename(attribute: "work_description")
   tasks: LocalizedString

--- a/api/lang/en/supervisory_status.php
+++ b/api/lang/en/supervisory_status.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'individual_contributor' => 'Individual contributor',
+    'supervisor' => 'Supervisor',
+];

--- a/api/lang/fr/supervisory_status.php
+++ b/api/lang/fr/supervisory_status.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'individual_contributor' => 'Contributeur(-trice) individuel(le)',
+    'supervisor' => 'Superviseur(-euse)',
+];

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -203,6 +203,11 @@ type LocalizedSkillLevel {
   label: LocalizedString!
 }
 
+type LocalizedSupervisoryStatus {
+  value: SupervisoryStatus!
+  label: LocalizedString!
+}
+
 type LocalizedWorkRegion {
   value: WorkRegion!
   label: LocalizedString!
@@ -1018,7 +1023,7 @@ type JobPosterTemplate {
   referenceId: String
   name: LocalizedString
   description: LocalizedString
-  supervisoryStatus: SupervisoryStatus
+  supervisoryStatus: LocalizedSupervisoryStatus
   stream: LocalizedPoolStream
   workDescription: LocalizedString
   tasks: LocalizedString

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -460,6 +460,18 @@ const createRoute = (locale: Locales) =>
               ],
             },
             {
+              path: "job-templates",
+              children: [
+                {
+                  index: true,
+                  lazy: () =>
+                    import(
+                      "../pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage"
+                    ),
+                },
+              ],
+            },
+            {
               path: "*",
               loader: () => {
                 throw new Response("Not Found", { status: 404 });

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -295,6 +295,11 @@ const getRoutes = (lang: Locales) => {
     // Account Settings
     accountSettings: () => [applicantUrl, "settings"].join("/"),
 
+    // Job poster templates
+    jobPosterTemplates: () => [baseUrl, "job-templates"].join("/"),
+    jobPosterTemplate: (templateId: string) =>
+      [baseUrl, "job-templates", templateId].join("/"),
+
     /**
      * Deprecated
      *

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -387,6 +387,10 @@
     "defaultMessage": "Collectivité des cadres",
     "description": "Heading for executive jobs in government"
   },
+  "0/jj1v": {
+    "defaultMessage": "Réinitialisez tous les filtres",
+    "description": "Button text to reset a filter form"
+  },
   "00tmhW": {
     "defaultMessage": "Niveau de compétence",
     "description": "Skill level column header for the skill library table"
@@ -1347,6 +1351,10 @@
     "defaultMessage": "Ensemble, nous sommes en mesure de tirer parti de la diversité des expériences et des idées que les personnes autochtones apportent à la fonction publique et de contribuer à la réconciliation au Canada.",
     "description": "Hero subtitle for IAP manager homepage"
   },
+  "58+Hom": {
+    "defaultMessage": "Modèles d'offres d'emploi",
+    "description": "Heading for the page showing list of job poster templates"
+  },
   "5A0a7w": {
     "defaultMessage": "Modifiez la liste des questions de sélection",
     "description": "Edit link text for screening questions section of the application review page."
@@ -1946,6 +1954,10 @@
   "8bJgxK": {
     "defaultMessage": "Français - Votre travail",
     "description": "Label for the French - Your Work textarea in the edit pool page."
+  },
+  "8dUPjb": {
+    "defaultMessage": "Cette bibliothèque contient une série de modèles pour des emplois courants dans les collectivités que nous soutenons. Ces modèles comprennent des informations suggérées et des recommandations pour des éléments tels que le titre du poste, les tâches courantes, les compétences essentielles et les atouts, etc. N'hésitez pas à consulter la liste complète ou, si vous avez une idée du type de poste pour lequel vous recrutez, vous pouvez utiliser la barre de recherche ou les filtres pour trouver des modèles qui correspondent aux spécificités du poste.",
+    "description": "Description of how to use the form to filter job poster templates"
   },
   "8fQWTc": {
     "defaultMessage": "Toute durée (court terme, long terme ou indéterminée) (recommandé)",
@@ -3603,6 +3615,10 @@
     "defaultMessage": "Veuillez sélectionner une compétence pour continuer.",
     "description": "Help text to tell users to select a skill before submitting"
   },
+  "HuA8aL": {
+    "defaultMessage": "Charger d'autres résultats",
+    "description": "Button text to load the next set of results"
+  },
   "HvD7jI": {
     "defaultMessage": "Comment utiliser cet outil",
     "description": "Heading displayed in the How To area of the hero section of the Search page."
@@ -4238,6 +4254,10 @@
   "L1tQMY": {
     "defaultMessage": "La Directive sur les talents numériques apporte des précisions supplémentaires sur les exigences et la prise de décisions en matière d’établissement d’un bassin de talents pour soutenir l’élaboration et la prestation d’initiatives, de produits et de services numériques. Elle vise à fournir des étapes pratiques aux personnes qui participent aux décisions d’établissement d’un bassin de talents et à collecter des données qui seront ensuite utilisées pour améliorer en permanence la qualité, la rapidité et la disponibilité de la recherche de talents numériques.",
     "description": "The directives digital talent and sourcing component"
+  },
+  "L47tv9": {
+    "defaultMessage": "Aucun modèle d'offre d'emploi n'a été trouvé.",
+    "description": "Message displayed when there are no job poster templates meeting a specific criteria"
   },
   "L6MgeM": {
     "defaultMessage": "Afin d’offrir une possibilité équitable afin que tous les Canadiens et toutes les Canadiennes puissant postuler ce poste, la date limite aura lieu à <strong>23:59 heure du Pacifique</strong>, à la date précisée.",
@@ -5027,6 +5047,10 @@
     "defaultMessage": "Date de début/fin",
     "description": "Label for the start/end date for an experience"
   },
+  "PYMFoh": {
+    "defaultMessage": "Recherche par mot-clé",
+    "description": "Label for the keyword search input"
+  },
   "Pasf+O": {
     "defaultMessage": "Les mises à jour de votre profil après l’envoi de votre candidature ne se refléteront pas dans votre dossier de candidature.",
     "description": "List item note 2 for the application review page."
@@ -5050,6 +5074,10 @@
   "PjK/4B": {
     "defaultMessage": "N'a pas été identifié comme membre d'un groupe d'équité en matière d'emploi.",
     "description": "Text on view-user page that the user isn't part of any employment equity groups"
+  },
+  "Pjfjeg": {
+    "defaultMessage": "Présentation de {showing} sur {total} modèles disponibles",
+    "description": "Number of job poster templates being displayed in the list"
   },
   "PmDeul": {
     "defaultMessage": "Utilisez-vous actuellement cette compétence?",
@@ -5606,6 +5634,10 @@
   "SZ2DsZ": {
     "defaultMessage": "Secrétariat du Conseil du Trésor du Canada",
     "description": "Default department for pool"
+  },
+  "SaPE+p": {
+    "defaultMessage": "Filtrer par niveaux",
+    "description": "Label for the classification input"
   },
   "Sb2fEr": {
     "defaultMessage": "Bassin {poolId} introuvable.",
@@ -6234,6 +6266,10 @@
     "defaultMessage": "3. <strong>Saisissez</strong> le code généré <strong>par votre application d’authentification</strong> dans la barre de vérification.",
     "description": "Text for third sign up -> mfa step."
   },
+  "W9SXxj": {
+    "defaultMessage": "Trier par",
+    "description": "Label for the links to change how the list is sorted"
+  },
   "WAO4vD": {
     "defaultMessage": "Date d'expiration",
     "description": "Label displayed on the date field of the change candidate expiry date dialog"
@@ -6465,6 +6501,10 @@
   "XGztC+": {
     "defaultMessage": "Raison du changement",
     "description": "Heading for form to justify updating a published process"
+  },
+  "XIDaGg": {
+    "defaultMessage": "Rechercher un modèle",
+    "description": "Heading for the form to filter job poster templates"
   },
   "XJ/xK1": {
     "defaultMessage": "Consultez notre base de données pour trouver des talents entièrement qualifiés, prêts à être embauchés sans autre processus concurrentiel. Travaillez avec notre équipe pour mettre la dernière main à vos documents de ressources humaines afin que vous puissiez faire une offre et mettre les talents en place rapidement et facilement.",
@@ -7857,6 +7897,10 @@
   "eamuiH": {
     "defaultMessage": "Configuration de votre application d’authentification à deux facteurs",
     "description": "Subtitle for a section explaining setting up mfa"
+  },
+  "eeU13V": {
+    "defaultMessage": "Filtrer par volets de travail",
+    "description": "Legend for pool streams input"
   },
   "eeyR6R": {
     "defaultMessage": "étiqueter et compléter les jeux de données fournis, le cas échéant, pour l’établissement de rapports",
@@ -10422,6 +10466,10 @@
     "defaultMessage": "Services professionnels, administratifs, et de soutien à la gestion",
     "description": "Support services contract commodity"
   },
+  "s7jEFt": {
+    "defaultMessage": "Parcourez une bibliothèque d'offres d'emploi préétablies qui comprennent des suggestions de tâches clés, de compétences requises et de compétences facultatives.",
+    "description": "Description for the page showing list of job poster templates"
+  },
   "s9unRt": {
     "defaultMessage": "Heures supplémentaires à court terme",
     "description": "Overtime on short notice personnel other requirement"
@@ -10977,6 +11025,10 @@
   "vi7jVU": {
     "defaultMessage": "Indiquer comme lue",
     "description": "Button text to mark a notification as read"
+  },
+  "vjbsDe": {
+    "defaultMessage": "Filtrer par type de rôle",
+    "description": "Legend for supervisory status input"
   },
   "vkAhEM": {
     "defaultMessage": "Se connecter à l’aide de CléGC",
@@ -11573,6 +11625,10 @@
   "zDO6tt": {
     "defaultMessage": "Date d'expiration",
     "description": "title for change expiry date dialog on view-user page"
+  },
+  "zDYHRr": {
+    "defaultMessage": "Titre du poste",
+    "description": "Link text to sort by job title"
   },
   "zDzzb/": {
     "defaultMessage": "Pour améliorer vos résultats, essayez de supprimer certains de ces filtres : ",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3887,6 +3887,10 @@
     "defaultMessage": "Le Programme a été conçu pour répondre aux efforts de réconciliation et pour bâtir une relation renouvelée qui est fondée sur les droits, le respect, la collaboration et le partenariat avec les peuples autochtones.",
     "description": "How it works, step 1 content paragraph 1"
   },
+  "J9l5Vd": {
+    "defaultMessage": "P. ex., conception de sites Web",
+    "description": "Placeholder for keyword search input"
+  },
   "JBRqD9": {
     "defaultMessage": "Postes en anglais",
     "description": "Message for the english positions option"
@@ -4938,6 +4942,10 @@
   "OyV6MH": {
     "defaultMessage": "Gérer vos renseignements personnels, votre parcours professionnel, vos compétences, et faire le suivi de vos candidatures.",
     "description": "SEO description for profile and applications hero"
+  },
+  "P/DHOG": {
+    "defaultMessage": "Modèles d'emplois",
+    "description": "Text for the breadcrumb navigation link"
   },
   "P/tHlt": {
     "defaultMessage": "Par type",

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -467,8 +467,8 @@ const JobPosterTemplatesPage = () => {
                     {intl.formatMessage(
                       {
                         defaultMessage:
-                          "Showing {showing} of {total} available template(s)",
-                        id: "vCRIuq",
+                          "Showing {showing} of {total} available templates",
+                        id: "Pjfjeg",
                         description:
                           "Number of job poster templates being displayed in the list",
                       },

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -32,7 +32,11 @@ import {
   localizedEnumToOptions,
 } from "@gc-digital-talent/forms";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
-import { getLocale, getLocalizedName } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  getLocale,
+  getLocalizedName,
+} from "@gc-digital-talent/i18n";
 
 import Hero from "~/components/Hero";
 import SEO from "~/components/SEO/SEO";
@@ -228,20 +232,23 @@ const JobPosterTemplatesPage = () => {
       return show;
     });
 
-    return allTemplates.splice(0, maxShown).sort((a, b) => {
-      if (sortBy === "classification") {
-        return (
-          (a.classification?.group ?? "").localeCompare(
-            b.classification?.group ?? "",
-          ) || (a?.classification?.level ?? 0) - (b?.classification?.level ?? 0)
-        );
-      }
+    return allTemplates
+      .sort((a, b) => {
+        if (sortBy === "classification") {
+          return (
+            (a.classification?.group ?? "").localeCompare(
+              b.classification?.group ?? "",
+            ) ||
+            (a?.classification?.level ?? 0) - (b?.classification?.level ?? 0)
+          );
+        }
 
-      const aName = getLocalizedName(a.name, intl, true);
-      const bName = getLocalizedName(b.name, intl, true);
+        const aName = getLocalizedName(a.name, intl, true);
+        const bName = getLocalizedName(b.name, intl, true);
 
-      return aName.localeCompare(bName);
-    });
+        return aName.localeCompare(bName);
+      })
+      .splice(0, maxShown);
   }, [
     jobPosterTemplates,
     maxShown,
@@ -419,6 +426,7 @@ const JobPosterTemplatesPage = () => {
                         description:
                           "Label for the links to change how the list is sorted",
                       })}
+                      {intl.formatMessage(commonMessages.dividingColon)}
                     </span>
                     <Link
                       aria-describedby="sortBy"

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -415,136 +415,155 @@ const JobPosterTemplatesPage = () => {
             </FormProvider>
           </Sidebar.Sidebar>
           <Sidebar.Content>
-            {filteredJobPosterTemplates.length ? (
+            {fetching ? (
+              <Loading inline />
+            ) : (
               <>
-                <div
-                  data-h2-margin-bottom="base(x.25)"
-                  data-h2-display="base(flex)"
-                  data-h2-flex-direction="base(column) l-tablet(row)"
-                  data-h2-gap="base(x.25)"
-                  data-h2-justify-content="base(space-between)"
-                >
-                  <div
-                    data-h2-display="base(flex)"
-                    data-h2-column-gap="base(x.25)"
-                  >
-                    <span id="sortBy">
-                      {intl.formatMessage({
-                        defaultMessage: "Sort by",
-                        id: "W9SXxj",
-                        description:
-                          "Label for the links to change how the list is sorted",
-                      })}
-                      {intl.formatMessage(commonMessages.dividingColon)}
-                    </span>
-                    <Link
-                      aria-describedby="sortBy"
-                      href={searchParamHref(
-                        "sortBy",
-                        "classification",
-                        searchParams,
-                      )}
-                      {...(sortBy === "classification"
-                        ? { color: "secondary", mode: "inline" }
-                        : { color: "black", mode: "text" })}
+                {filteredJobPosterTemplates.length ? (
+                  <>
+                    <div
+                      data-h2-margin-bottom="base(x.25)"
+                      data-h2-display="base(flex)"
+                      data-h2-flex-direction="base(column) l-tablet(row)"
+                      data-h2-gap="base(x.25)"
+                      data-h2-justify-content="base(space-between)"
                     >
-                      {intl.formatMessage(processMessages.classification)}
-                    </Link>
-                    <Link
-                      aria-describedby="sortBy"
-                      href={searchParamHref("sortBy", "title", searchParams)}
-                      {...(sortBy === "title"
-                        ? { color: "secondary", mode: "inline" }
-                        : { color: "black", mode: "text" })}
-                    >
-                      {intl.formatMessage({
-                        defaultMessage: "Job title",
-                        id: "zDYHRr",
-                        description: "Link text to sort by job title",
-                      })}
-                    </Link>
-                  </div>
-                  <span data-h2-font-weight="base(700)">
-                    {intl.formatMessage(
-                      {
-                        defaultMessage:
-                          "Showing {showing} of {total} available templates",
-                        id: "Pjfjeg",
-                        description:
-                          "Number of job poster templates being displayed in the list",
-                      },
-                      { showing, total },
-                    )}
-                  </span>
-                </div>
-                <CardBasic>
-                  <PreviewList.Root>
-                    {filteredJobPosterTemplates.map((jobPosterTemplate) => (
-                      <PreviewList.Item
-                        key={jobPosterTemplate.id}
-                        title={getLocalizedName(jobPosterTemplate.name, intl)}
-                        headingAs="h3"
-                        action={
-                          <PreviewList.Link
-                            href={paths.jobPosterTemplate(jobPosterTemplate.id)}
-                            label={getLocalizedName(
+                      <div
+                        data-h2-display="base(flex)"
+                        data-h2-column-gap="base(x.25)"
+                      >
+                        <span id="sortBy">
+                          {intl.formatMessage({
+                            defaultMessage: "Sort by",
+                            id: "W9SXxj",
+                            description:
+                              "Label for the links to change how the list is sorted",
+                          })}
+                          {intl.formatMessage(commonMessages.dividingColon)}
+                        </span>
+                        <Link
+                          aria-describedby="sortBy"
+                          href={searchParamHref(
+                            "sortBy",
+                            "classification",
+                            searchParams,
+                          )}
+                          {...(sortBy === "classification"
+                            ? { color: "secondary", mode: "inline" }
+                            : { color: "black", mode: "text" })}
+                        >
+                          {intl.formatMessage(processMessages.classification)}
+                        </Link>
+                        <Link
+                          aria-describedby="sortBy"
+                          href={searchParamHref(
+                            "sortBy",
+                            "title",
+                            searchParams,
+                          )}
+                          {...(sortBy === "title"
+                            ? { color: "secondary", mode: "inline" }
+                            : { color: "black", mode: "text" })}
+                        >
+                          {intl.formatMessage({
+                            defaultMessage: "Job title",
+                            id: "zDYHRr",
+                            description: "Link text to sort by job title",
+                          })}
+                        </Link>
+                      </div>
+                      <span data-h2-font-weight="base(700)">
+                        {intl.formatMessage(
+                          {
+                            defaultMessage:
+                              "Showing {showing} of {total} available templates",
+                            id: "Pjfjeg",
+                            description:
+                              "Number of job poster templates being displayed in the list",
+                          },
+                          { showing, total },
+                        )}
+                      </span>
+                    </div>
+                    <CardBasic>
+                      <PreviewList.Root>
+                        {filteredJobPosterTemplates.map((jobPosterTemplate) => (
+                          <PreviewList.Item
+                            key={jobPosterTemplate.id}
+                            title={getLocalizedName(
                               jobPosterTemplate.name,
                               intl,
                             )}
-                          />
-                        }
-                        metaData={previewMetaData(
-                          intl,
-                          jobPosterTemplate.classification,
-                          jobPosterTemplate.stream,
-                        )}
-                      >
-                        {jobPosterTemplate.description && (
-                          <p>
-                            {getLocalizedName(
-                              jobPosterTemplate.description,
+                            headingAs="h3"
+                            action={
+                              <PreviewList.Link
+                                href={paths.jobPosterTemplate(
+                                  jobPosterTemplate.id,
+                                )}
+                                label={getLocalizedName(
+                                  jobPosterTemplate.name,
+                                  intl,
+                                )}
+                              />
+                            }
+                            metaData={previewMetaData(
                               intl,
-                              true,
+                              jobPosterTemplate.classification,
+                              jobPosterTemplate.stream,
                             )}
-                          </p>
-                        )}
-                      </PreviewList.Item>
-                    ))}
-                  </PreviewList.Root>
-                </CardBasic>
-                {hasMore && (
-                  <>
-                    <Separator orientation="horizontal" decorative space="md" />
-                    <Link
-                      mode="solid"
-                      color="secondary"
-                      href={searchParamHref(
-                        "page",
-                        Math.min(page + 1, total),
-                        searchParams,
-                      )}
-                    >
-                      {intl.formatMessage({
-                        defaultMessage: "Load more results",
-                        id: "HuA8aL",
-                        description:
-                          "Button text to load the next set of results",
-                      })}
-                    </Link>
+                          >
+                            {jobPosterTemplate.description && (
+                              <p>
+                                {getLocalizedName(
+                                  jobPosterTemplate.description,
+                                  intl,
+                                  true,
+                                )}
+                              </p>
+                            )}
+                          </PreviewList.Item>
+                        ))}
+                      </PreviewList.Root>
+                    </CardBasic>
+                    {hasMore && (
+                      <>
+                        <Separator
+                          orientation="horizontal"
+                          decorative
+                          space="md"
+                        />
+                        <Link
+                          mode="solid"
+                          color="secondary"
+                          href={searchParamHref(
+                            "page",
+                            Math.min(page + 1, total),
+                            searchParams,
+                          )}
+                        >
+                          {intl.formatMessage({
+                            defaultMessage: "Load more results",
+                            id: "HuA8aL",
+                            description:
+                              "Button text to load the next set of results",
+                          })}
+                        </Link>
+                      </>
+                    )}
                   </>
+                ) : (
+                  <Well data-h2-text-align="base(center)">
+                    <p>
+                      {intl.formatMessage({
+                        defaultMessage: "No job advertisement templates found.",
+                        id: "L47tv9",
+                        description:
+                          "Message displayed when there are no job poster templates meeting a specific criteria",
+                      })}
+                    </p>
+                  </Well>
                 )}
               </>
-            ) : (
-              <Well data-h2-text-align="base(center)">
-                <p>
-                  {intl.formatMessage({
-                    defaultMessage: "No job advertisement templates found.",
-                    id: "L47tv9",
-                    description:
-                      "Message displayed when there are no job poster templates meeting a specific criteria",
-                  })}
-                </p>
-              </Well>
             )}
           </Sidebar.Content>
         </Sidebar.Wrapper>

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -1,0 +1,74 @@
+import RectangleStackIcon from "@heroicons/react/24/outline/RectangleStackIcon";
+import { defineMessage, useIntl } from "react-intl";
+
+import { Heading } from "@gc-digital-talent/ui";
+
+import Hero from "~/components/Hero";
+import SEO from "~/components/SEO/SEO";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
+import useRoutes from "~/hooks/useRoutes";
+
+const pageTitle = defineMessage({
+  defaultMessage: "Job advertisement templates",
+  id: "58+Hom",
+  description: "Heading for the page showing list of job poster templates",
+});
+
+const pageDescription = defineMessage({
+  defaultMessage:
+    "Browse a library of pre-built job advertisements that include suggestions for key tasks, required, and optional skills.",
+  id: "s7jEFt",
+  description: "Description for the page showing list of job poster templates",
+});
+
+const JobPosterTemplatesPage = () => {
+  const intl = useIntl();
+  const paths = useRoutes();
+
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(pageTitle),
+        url: paths.jobPosterTemplates(),
+      },
+    ],
+  });
+
+  return (
+    <>
+      <SEO
+        title={intl.formatMessage(pageTitle)}
+        description={intl.formatMessage(pageDescription)}
+      />
+      <Hero
+        title={intl.formatMessage(pageTitle)}
+        subtitle={intl.formatMessage(pageDescription)}
+        crumbs={crumbs}
+      />
+      <div data-h2-wrapper="base(center, large, x1) p-tablet(center, large, x2)">
+        <Heading level="h2" size="h3" color="primary" Icon={RectangleStackIcon}>
+          {intl.formatMessage({
+            defaultMessage: "Find a template",
+            id: "XIDaGg",
+            description: "Heading for the form to filter job poster templates",
+          })}
+        </Heading>
+        <p data-h2-margin="base(x1 0)">
+          {intl.formatMessage({
+            defaultMessage:
+              "This library contains a series of templates for common jobs across the communities we support. These templates include suggested information and recommendations for elements such as job title, common tasks in the role, essential and asset skills, and more. Feel free to browse the full list, or, if you have an idea of the type of role you're hiring for, you can use the search bar or filters to find templates that align with the job’s specific details.",
+            id: "8dUPjb",
+            description:
+              "Description of how to use the form to filter job poster templates",
+          })}
+        </p>
+      </div>
+    </>
+  );
+};
+
+export const Component = () => <JobPosterTemplatesPage />;
+
+Component.displayName = "JobPosterTemplatesPage";
+
+export default JobPosterTemplatesPage;

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -481,15 +481,17 @@ const JobPosterTemplatesPage = () => {
                     {filteredJobPosterTemplates.map((jobPosterTemplate) => (
                       <PreviewList.Item
                         key={jobPosterTemplate.id}
-                        title={
-                          <Link
-                            href={paths.jobPosterTemplate(jobPosterTemplate.id)}
-                            color="black"
-                          >
-                            {getLocalizedName(jobPosterTemplate.name, intl)}
-                          </Link>
-                        }
+                        title={getLocalizedName(jobPosterTemplate.name, intl)}
                         headingAs="h3"
+                        action={
+                          <PreviewList.Link
+                            href={paths.jobPosterTemplate(jobPosterTemplate.id)}
+                            label={getLocalizedName(
+                              jobPosterTemplate.name,
+                              intl,
+                            )}
+                          />
+                        }
                         metaData={previewMetaData(
                           intl,
                           jobPosterTemplate.classification,
@@ -497,7 +499,7 @@ const JobPosterTemplatesPage = () => {
                         )}
                       >
                         {jobPosterTemplate.description && (
-                          <p data-h2-margin-bottom="base(x1)">
+                          <p>
                             {getLocalizedName(
                               jobPosterTemplate.description,
                               intl,

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -27,6 +27,7 @@ import {
   SupervisoryStatus,
 } from "@gc-digital-talent/graphql";
 import {
+  alphaSortOptions,
   Checklist,
   Input,
   localizedEnumToOptions,
@@ -341,6 +342,11 @@ const JobPosterTemplatesPage = () => {
                   id="keyword"
                   name="keyword"
                   type="text"
+                  placeholder={intl.formatMessage({
+                    defaultMessage: "e.g. Web design",
+                    id: "PNfAn0",
+                    description: "Placeholder for keyword search input",
+                  })}
                   label={intl.formatMessage({
                     defaultMessage: "Search by keyword",
                     id: "PYMFoh",
@@ -384,9 +390,11 @@ const JobPosterTemplatesPage = () => {
                     <Checklist
                       idPrefix="streams"
                       name="streams"
-                      items={localizedEnumToOptions(
-                        unpackMaybes(data?.poolStreams),
-                        intl,
+                      items={alphaSortOptions(
+                        localizedEnumToOptions(
+                          unpackMaybes(data?.poolStreams),
+                          intl,
+                        ),
                       )}
                       legend={intl.formatMessage({
                         defaultMessage: "Filter by work streams",

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -101,7 +101,9 @@ const JobPosterTemplates_Query = graphql(/* GraphQL */ `
           fr
         }
       }
-      supervisoryStatus
+      supervisoryStatus {
+        value
+      }
       keywords {
         en
         fr
@@ -223,7 +225,7 @@ const JobPosterTemplatesPage = () => {
         show &&
         assertIncludes(
           formData.supervisoryStatuses,
-          jobPosterTemplate.supervisoryStatus,
+          jobPosterTemplate.supervisoryStatus?.value,
         );
       show =
         show &&
@@ -421,8 +423,8 @@ const JobPosterTemplatesPage = () => {
                   >
                     <span id="sortBy">
                       {intl.formatMessage({
-                        defaultMessage: "Sory by",
-                        id: "58Pfbo",
+                        defaultMessage: "Sort by",
+                        id: "W9SXxj",
                         description:
                           "Label for the links to change how the list is sorted",
                       })}

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -327,8 +327,8 @@ const JobPosterTemplatesPage = () => {
                   name="keyword"
                   type="text"
                   placeholder={intl.formatMessage({
-                    defaultMessage: "e.g. Web design",
-                    id: "PNfAn0",
+                    defaultMessage: "E.g., web design",
+                    id: "J9l5Vd",
                     description: "Placeholder for keyword search input",
                   })}
                   label={intl.formatMessage({

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -164,7 +164,7 @@ function searchParamHref(
   return `?${hrefParams.toString()}`;
 }
 
-const PAGE_SIZE = 1;
+const PAGE_SIZE = 8;
 
 type SortKey = "classification" | "title";
 

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -187,10 +187,8 @@ const JobPosterTemplatesPage = () => {
 
   const jobPosterTemplates = unpackMaybes(data?.jobPosterTemplates);
   const total = jobPosterTemplates.length;
-  let maxShown = PAGE_SIZE * page;
-  if (maxShown > total) maxShown = total;
-  const hasMore = maxShown < total;
-  const filteredJobPosterTemplates = useMemo(() => {
+  const maxShown = Math.min(PAGE_SIZE * page, total);
+  const [available, filteredJobPosterTemplates] = useMemo(() => {
     const allTemplates = jobPosterTemplates.filter((jobPosterTemplate) => {
       let show = true;
 
@@ -231,23 +229,26 @@ const JobPosterTemplatesPage = () => {
       return show;
     });
 
-    return allTemplates
-      .sort((a, b) => {
-        if (sortBy === "classification") {
-          return (
-            (a.classification?.group ?? "").localeCompare(
-              b.classification?.group ?? "",
-            ) ||
-            (a?.classification?.level ?? 0) - (b?.classification?.level ?? 0)
-          );
-        }
+    return [
+      allTemplates.length,
+      allTemplates
+        .sort((a, b) => {
+          if (sortBy === "classification") {
+            return (
+              (a.classification?.group ?? "").localeCompare(
+                b.classification?.group ?? "",
+              ) ||
+              (a?.classification?.level ?? 0) - (b?.classification?.level ?? 0)
+            );
+          }
 
-        const aName = getLocalizedName(a.name, intl, true);
-        const bName = getLocalizedName(b.name, intl, true);
+          const aName = getLocalizedName(a.name, intl, true);
+          const bName = getLocalizedName(b.name, intl, true);
 
-        return aName.localeCompare(bName);
-      })
-      .splice(0, maxShown);
+          return aName.localeCompare(bName);
+        })
+        .splice(0, maxShown),
+    ];
   }, [
     jobPosterTemplates,
     maxShown,
@@ -261,6 +262,7 @@ const JobPosterTemplatesPage = () => {
   ]);
 
   const showing = Math.min(filteredJobPosterTemplates.length, maxShown);
+  const hasMore = showing < total && available > showing;
 
   const debouncedResetPage = useMemo(
     () =>

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -1,5 +1,5 @@
 import RectangleStackIcon from "@heroicons/react/24/outline/RectangleStackIcon";
-import { defineMessage, IntlShape, useIntl } from "react-intl";
+import { IntlShape, useIntl } from "react-intl";
 import { FormProvider, useForm } from "react-hook-form";
 import { useQuery } from "urql";
 import { useCallback, useMemo } from "react";
@@ -46,6 +46,8 @@ import useRoutes from "~/hooks/useRoutes";
 import processMessages from "~/messages/processMessages";
 import useDeepCompareEffect from "~/hooks/useDeepCompareEffect";
 
+import pageMessages from "./messages";
+
 interface FormValues {
   keyword: string;
   classifications: string[];
@@ -59,19 +61,6 @@ const defaultValues = {
   supervisoryStatuses: [],
   streams: [],
 } satisfies FormValues;
-
-const pageTitle = defineMessage({
-  defaultMessage: "Job advertisement templates",
-  id: "58+Hom",
-  description: "Heading for the page showing list of job poster templates",
-});
-
-const pageDescription = defineMessage({
-  defaultMessage:
-    "Browse a library of pre-built job advertisements that include suggestions for key tasks, required, and optional skills.",
-  id: "s7jEFt",
-  description: "Description for the page showing list of job poster templates",
-});
 
 const JobPosterTemplates_Query = graphql(/* GraphQL */ `
   query JobPosterTemplates {
@@ -186,7 +175,7 @@ const JobPosterTemplatesPage = () => {
   const crumbs = useBreadcrumbs({
     crumbs: [
       {
-        label: intl.formatMessage(pageTitle),
+        label: intl.formatMessage(pageMessages.breadcrumb),
         url: paths.jobPosterTemplates(),
       },
     ],
@@ -298,12 +287,12 @@ const JobPosterTemplatesPage = () => {
   return (
     <>
       <SEO
-        title={intl.formatMessage(pageTitle)}
-        description={intl.formatMessage(pageDescription)}
+        title={intl.formatMessage(pageMessages.title)}
+        description={intl.formatMessage(pageMessages.description)}
       />
       <Hero
-        title={intl.formatMessage(pageTitle)}
-        subtitle={intl.formatMessage(pageDescription)}
+        title={intl.formatMessage(pageMessages.title)}
+        subtitle={intl.formatMessage(pageMessages.description)}
         crumbs={crumbs}
       />
       <div data-h2-wrapper="base(center, large, x1) p-tablet(center, large, x2)">

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -209,9 +209,15 @@ const JobPosterTemplatesPage = () => {
           show &&
           keywords.some((term) => {
             const sanitizedTerm = term.toLowerCase().trim();
-            return jobPosterTemplate.keywords?.[locale]?.some((keyword) => {
-              return keyword.toLowerCase().trim().includes(sanitizedTerm);
-            });
+            return (
+              jobPosterTemplate.name?.[locale]
+                ?.toLowerCase()
+                .trim()
+                .includes(sanitizedTerm) ||
+              jobPosterTemplate.keywords?.[locale]?.some((keyword) => {
+                return keyword.toLowerCase().trim().includes(sanitizedTerm);
+              })
+            );
           });
       }
 

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -320,7 +320,7 @@ const JobPosterTemplatesPage = () => {
             description: "Heading for the form to filter job poster templates",
           })}
         </Heading>
-        <p data-h2-margin="base(x1 0)">
+        <p data-h2-margin="base(x1 0 x2 0)">
           {intl.formatMessage({
             defaultMessage:
               "This library contains a series of templates for common jobs across the communities we support. These templates include suggested information and recommendations for elements such as job title, common tasks in the role, essential and asset skills, and more. Feel free to browse the full list, or, if you have an idea of the type of role you're hiring for, you can use the search bar or filters to find templates that align with the job’s specific details.",

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/messages.ts
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/messages.ts
@@ -1,0 +1,23 @@
+import { defineMessages } from "react-intl";
+
+const messages = defineMessages({
+  title: {
+    defaultMessage: "Job advertisement templates",
+    id: "58+Hom",
+    description: "Heading for the page showing list of job poster templates",
+  },
+  description: {
+    defaultMessage:
+      "Browse a library of pre-built job advertisements that include suggestions for key tasks, required, and optional skills.",
+    id: "s7jEFt",
+    description:
+      "Description for the page showing list of job poster templates",
+  },
+  breadcrumb: {
+    defaultMessage: "Job templates",
+    id: "P/DHOG",
+    description: "Text for the breadcrumb navigation link",
+  },
+});
+
+export default messages;

--- a/apps/web/src/pages/ManagerDashboardPage/ManagerDashboardPage.tsx
+++ b/apps/web/src/pages/ManagerDashboardPage/ManagerDashboardPage.tsx
@@ -200,7 +200,9 @@ const ManagerDashboard = ({ userQuery }: ManagerDashboardProps) => {
                                   children: "Opened on: April 30th, 2024",
                                 },
                               ]}
-                              buttonName="IT01: Junior application developer"
+                              action={
+                                <PreviewList.Button label="IT01: Junior application developer" />
+                              }
                             />
                             <PreviewList.Item
                               title="IT-02: Application developer"
@@ -222,7 +224,9 @@ const ManagerDashboard = ({ userQuery }: ManagerDashboardProps) => {
                                   children: "Opened on: April 30th, 2024",
                                 },
                               ]}
-                              buttonName="IT-02: Application developer"
+                              action={
+                                <PreviewList.Button label="IT-02: Application developer" />
+                              }
                             />
                             <PreviewList.Item
                               title="IT-02: Database architect"
@@ -244,7 +248,9 @@ const ManagerDashboard = ({ userQuery }: ManagerDashboardProps) => {
                                   children: "Opened on: April 30th, 2024",
                                 },
                               ]}
-                              buttonName="IT-02: Database architect"
+                              action={
+                                <PreviewList.Button label="IT-02: Database architect" />
+                              }
                             />
                           </PreviewList.Root>
                         </div>

--- a/packages/ui/src/components/PreviewList/PreviewList.stories.tsx
+++ b/packages/ui/src/components/PreviewList/PreviewList.stories.tsx
@@ -6,6 +6,8 @@ import { allModes } from "@gc-digital-talent/storybook-helpers";
 
 import PreviewList, { MetaDataProps } from "./PreviewList";
 
+faker.seed(0);
+
 const previewDetails: MetaDataProps[] = [
   {
     key: "it-chip-id",

--- a/packages/ui/src/components/PreviewList/PreviewList.stories.tsx
+++ b/packages/ui/src/components/PreviewList/PreviewList.stories.tsx
@@ -1,4 +1,6 @@
 import { Meta, StoryFn } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import { faker } from "@faker-js/faker";
 
 import { allModes } from "@gc-digital-talent/storybook-helpers";
 
@@ -85,18 +87,51 @@ Default.args = {
       <PreviewList.Item
         title="IT-01: Junior application developer"
         metaData={previewDetails}
-        buttonName="View preview button one"
+        action={
+          <PreviewList.Button
+            label="View preview button one"
+            onClick={() => action("preview button one clicked")()}
+          />
+        }
       />
       <PreviewList.Item
         title="IT-02: Application developer"
         metaData={previewDetailsTwo}
-        buttonName="View preview button two"
+        action={
+          <PreviewList.Button
+            label="View preview button two"
+            onClick={() => action("preview button two clicked")()}
+          />
+        }
       />
       <PreviewList.Item
         title="IT-03: Database architect"
         metaData={previewDetailsThree}
-        buttonName="View preview button three"
+        action={
+          <PreviewList.Button
+            label="View preview button three"
+            onClick={() => action("preview button three clicked")()}
+          />
+        }
       />
     </>
+  ),
+};
+
+export const WithChildren = Template.bind({});
+WithChildren.args = {
+  children: (
+    <PreviewList.Item
+      title="IT-01: Junior application developer"
+      metaData={previewDetails}
+      action={
+        <PreviewList.Button
+          label="View preview button one"
+          onClick={() => action("preview button one clicked")()}
+        />
+      }
+    >
+      <p>{faker.lorem.paragraph()}</p>
+    </PreviewList.Item>
   ),
 };

--- a/packages/ui/src/components/PreviewList/PreviewList.tsx
+++ b/packages/ui/src/components/PreviewList/PreviewList.tsx
@@ -123,7 +123,7 @@ const Root = ({ children, ...rest }: RootProps) => {
       data-h2-display="base(flex)"
       data-h2-flex-direction="base(column)"
       data-h2-row-gap="base(x1)"
-      data-h2-padding-bottom="base:children[:last-child](0) base:children[>](x1)"
+      data-h2-padding-bottom="base:children[>:last-child](0) base:children[>](x1)"
       {...rest}
     >
       {children}

--- a/packages/ui/src/components/PreviewList/PreviewList.tsx
+++ b/packages/ui/src/components/PreviewList/PreviewList.tsx
@@ -31,11 +31,12 @@ const MetaData = ({ children, type, color }: MetaDataProps) => {
 };
 
 interface ItemProps {
-  title: string;
+  title: ReactNode;
   metaData: MetaDataProps[];
-  buttonName: string;
+  buttonName?: string;
   headingAs?: HeadingLevel;
   buttonAriaLabel?: string;
+  children?: ReactNode;
 }
 
 const Item = ({
@@ -44,6 +45,7 @@ const Item = ({
   metaData,
   buttonName,
   buttonAriaLabel,
+  children,
 }: ItemProps) => {
   return (
     <div
@@ -52,7 +54,6 @@ const Item = ({
       data-h2-justify-content="base(space-between)"
       data-h2-align-items="base(flex-start) p-tablet(center)"
       data-h2-gap="base(x.25)"
-      data-h2-padding="base(x1 0)"
       data-h2-border-bottom="base:all:selectors[:not(:last-child)](1px solid)"
       data-h2-border-bottom-color="base:all:selectors[:not(:last-child)](gray.lighter)"
       data-h2-transition="base:children[.PreviewList__Heading](transform 200ms ease)"
@@ -73,6 +74,7 @@ const Item = ({
         >
           {title}
         </Heading>
+        {children && <div>{children}</div>}
         <div
           data-h2-display="base(flex)"
           data-h2-flex-direction="base(column) p-tablet(row)"
@@ -89,19 +91,21 @@ const Item = ({
           ))}
         </div>
       </div>
-      <Button
-        mode="icon_only"
-        color="black"
-        fontSize="caption"
-        icon={MagnifyingGlassPlusIcon}
-        data-h2-position="base:selectors[::after](absolute)"
-        data-h2-content="base:selectors[::after](' ')"
-        data-h2-inset="base:selectors[::after](0)"
-        data-h2-justify-self="base(end)"
-        aria-label={buttonAriaLabel}
-      >
-        {buttonName}
-      </Button>
+      {buttonName && (
+        <Button
+          mode="icon_only"
+          color="black"
+          fontSize="caption"
+          icon={MagnifyingGlassPlusIcon}
+          data-h2-position="base:selectors[::after](absolute)"
+          data-h2-content="base:selectors[::after](' ')"
+          data-h2-inset="base:selectors[::after](0)"
+          data-h2-justify-self="base(end)"
+          aria-label={buttonAriaLabel}
+        >
+          {buttonName}
+        </Button>
+      )}
     </div>
   );
 };
@@ -114,7 +118,14 @@ export interface RootProps {
 
 const Root = ({ children, ...rest }: RootProps) => {
   return (
-    <div role="list" {...rest}>
+    <div
+      role="list"
+      data-h2-display="base(flex)"
+      data-h2-flex-direction="base(column)"
+      data-h2-row-gap="base(x1)"
+      data-h2-padding-bottom="base:children[:last-child](0) base:children[>](x1)"
+      {...rest}
+    >
       {children}
     </div>
   );

--- a/packages/ui/src/components/PreviewList/PreviewList.tsx
+++ b/packages/ui/src/components/PreviewList/PreviewList.tsx
@@ -1,9 +1,10 @@
 import MagnifyingGlassPlusIcon from "@heroicons/react/24/outline/MagnifyingGlassPlusIcon";
 import { ReactElement, ReactNode } from "react";
 
-import Button from "../Button";
+import BaseButton, { ButtonProps as BaseButtonProps } from "../Button";
+import BaseLink, { LinkProps as BaseLinkProps } from "../Link";
 import Chip from "../Chip/Chip";
-import { Color } from "../../types";
+import { ButtonLinkProps, Color } from "../../types";
 import Heading, { HeadingLevel } from "../Heading";
 
 export interface MetaDataProps {
@@ -30,46 +31,75 @@ const MetaData = ({ children, type, color }: MetaDataProps) => {
   }
 };
 
+const actionProps = {
+  mode: "icon_only",
+  color: "black",
+  fontSize: "caption",
+  icon: MagnifyingGlassPlusIcon,
+  "data-h2-position": "base:selectors[::after](absolute)",
+  "data-h2-content": "base:selectors[::after](' ')",
+  "data-h2-inset": "base:selectors[::after](0)",
+  "data-h2-justify-self": "base(end)",
+} satisfies ButtonLinkProps;
+
+interface ButtonProps {
+  onClick?: BaseButtonProps["onClick"];
+  label: string;
+}
+
+const Button = ({ onClick, label }: ButtonProps) => (
+  <BaseButton {...actionProps} onClick={onClick} aria-label={label} />
+);
+
+interface LinkProps {
+  href: BaseLinkProps["href"];
+  label: string;
+}
+
+const Link = ({ href, label }: LinkProps) => (
+  <BaseLink {...actionProps} href={href} aria-label={label} />
+);
+
 interface ItemProps {
-  title: ReactNode;
+  title: string;
   metaData: MetaDataProps[];
-  buttonName?: string;
   headingAs?: HeadingLevel;
-  buttonAriaLabel?: string;
   children?: ReactNode;
+  action?: ReactElement<ButtonProps> | ReactElement<LinkProps> | null;
 }
 
 const Item = ({
   title,
   headingAs = "h3",
   metaData,
-  buttonName,
-  buttonAriaLabel,
+  action,
   children,
 }: ItemProps) => {
   return (
-    <div
+    <li
       data-h2-position="base(relative)"
       data-h2-display="base(flex)"
       data-h2-justify-content="base(space-between)"
       data-h2-align-items="base(flex-start) p-tablet(center)"
-      data-h2-gap="base(x.25)"
+      data-h2-gap="base(x.5)"
       data-h2-border-bottom="base:all:selectors[:not(:last-child)](1px solid)"
       data-h2-border-bottom-color="base:all:selectors[:not(:last-child)](gray.lighter)"
       data-h2-transition="base:children[.PreviewList__Heading](transform 200ms ease)"
-      data-h2-color="base:selectors[:has(button:hover) .PreviewList__Heading](secondary.darker) base:selectors[:has(button:focus-visible) .PreviewList__Heading](black)"
-      data-h2-background-color="base:selectors[:has(button:focus-visible) .PreviewList__Heading](focus)"
-      role="listitem"
+      data-h2-color="base:selectors[:has(:is(button, a):hover) .PreviewList__Heading](secondary.darker) base:all:selectors[:has(:is(button, a):focus-visible) .PreviewList__Heading](black)"
+      data-h2-background-color="base:selectors[:has(:is(button, a):focus-visible) .PreviewList__Heading](focus)"
     >
-      <div>
+      <div
+        data-h2-display="base(flex)"
+        data-h2-flex-direction="base(column)"
+        data-h2-row-gap="base(x.5)"
+      >
         <Heading
           className="PreviewList__Heading"
           level={headingAs}
           data-h2-font-size="base(body)"
           data-h2-font-weight="base(700)"
           data-h2-text-decoration="base(underline)"
-          data-h2-margin-bottom="base(x.5)"
-          data-h2-margin-top="base(0)"
+          data-h2-margin="base(0)"
           data-h2-display="base(inline-block)"
         >
           {title}
@@ -91,22 +121,8 @@ const Item = ({
           ))}
         </div>
       </div>
-      {buttonName && (
-        <Button
-          mode="icon_only"
-          color="black"
-          fontSize="caption"
-          icon={MagnifyingGlassPlusIcon}
-          data-h2-position="base:selectors[::after](absolute)"
-          data-h2-content="base:selectors[::after](' ')"
-          data-h2-inset="base:selectors[::after](0)"
-          data-h2-justify-self="base(end)"
-          aria-label={buttonAriaLabel}
-        >
-          {buttonName}
-        </Button>
-      )}
-    </div>
+      {action}
+    </li>
   );
 };
 
@@ -118,20 +134,22 @@ export interface RootProps {
 
 const Root = ({ children, ...rest }: RootProps) => {
   return (
-    <div
-      role="list"
+    <ul
       data-h2-display="base(flex)"
       data-h2-flex-direction="base(column)"
       data-h2-row-gap="base(x1)"
+      data-h2-padding-left="base(0)"
       data-h2-padding-bottom="base:children[>:last-child](0) base:children[>](x1)"
       {...rest}
     >
       {children}
-    </div>
+    </ul>
   );
 };
 
 export default {
   Root,
   Item,
+  Button,
+  Link,
 };

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -57,6 +57,9 @@ import Pending, {
   type PendingProps,
   LoadingErrorMessage,
 } from "./components/Pending";
+import PreviewList, {
+  type MetaDataProps as PreviewMetaData,
+} from "./components/PreviewList/PreviewList";
 import ResourceBlock from "./components/ResourceBlock";
 import ScrollArea from "./components/ScrollArea";
 import Separator from "./components/Separator";
@@ -92,7 +95,6 @@ import Well, { WellProps } from "./components/Well";
 import { incrementHeadingRank, decrementHeadingRank } from "./utils";
 import useControllableState from "./hooks/useControllableState";
 import TaskCard from "./components/TaskCard";
-import PreviewList from "./components/PreviewList/PreviewList";
 
 export type {
   Color,
@@ -115,6 +117,7 @@ export type {
   MenuLinkProps,
   LoadingProps,
   PendingProps,
+  PreviewMetaData,
   ChipProps,
   SidebarProps,
   SideMenuProps,


### PR DESCRIPTION
🤖 Resolves #11430 

## 👋 Introduction

Adds the index page for job poster templates.

## :clipboard: TODO

- [x] Get supervisory status translations

## 🕵️ Details

## 🧪 Testing

> [!NOTE]
> To test page sizes, you will need to either seed more than 8 templates or temporarily set page size to less than 3.

1. Build app `pnpm run dev:fresh`
2. Navigate to `/job-templates`
3. Confirm the items are shown and filters/sorting/pages function as expected

## 📸 Screenshot
![localhost_8000_en_job-templates_sortBy=title page=1](https://github.com/user-attachments/assets/fa2e84f5-0b73-457d-b28a-4afdbb584cef)



