### PR TITLE
[Fix] Education requirement in assessment dialog

### DIFF
--- a/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
+++ b/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
@@ -11,6 +11,7 @@ import {
   graphql,
   PoolSkillType,
   AssessmentResultsTableFragment as AssessmentResultsTableFragmentType,
+  Experience,
 } from "@gc-digital-talent/graphql";
 import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import { Well } from "@gc-digital-talent/ui";
@@ -33,6 +34,16 @@ export const AssessmentResultsTable_Fragment = graphql(/* GraphQL */ `
   fragment AssessmentResultsTable on PoolCandidate {
     id
     profileSnapshot
+    educationRequirementOption {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    educationRequirementExperiences {
+      id
+    }
     assessmentStatus {
       currentStep
       overallAssessmentStatus
@@ -168,10 +179,12 @@ export const AssessmentResultsTable_Fragment = graphql(/* GraphQL */ `
 
 interface AssessmentResultsTableProps {
   poolCandidateQuery: FragmentType<typeof AssessmentResultsTable_Fragment>;
+  experiences: Omit<Experience, "user">[];
 }
 
 const AssessmentResultsTable = ({
   poolCandidateQuery,
+  experiences,
 }: AssessmentResultsTableProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -272,6 +285,7 @@ const AssessmentResultsTable = ({
           id,
           header,
           poolCandidate,
+          experiences,
           assessmentStep: {
             id: assessmentStep.id,
             type: assessmentStep.type,

--- a/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
+++ b/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
@@ -44,6 +44,17 @@ export const AssessmentResultsTable_Fragment = graphql(/* GraphQL */ `
     educationRequirementExperiences {
       id
     }
+    screeningQuestionResponses {
+      id
+      answer
+      screeningQuestion {
+        id
+        question {
+          en
+          fr
+        }
+      }
+    }
     assessmentStatus {
       currentStep
       overallAssessmentStatus

--- a/apps/web/src/components/AssessmentResultsTable/types.ts
+++ b/apps/web/src/components/AssessmentResultsTable/types.ts
@@ -7,6 +7,7 @@ import {
   PoolSkill,
   Skill,
   AssessmentResultsTableFragment as AssessmentResultsTableFragmentType,
+  Experience,
 } from "@gc-digital-talent/graphql";
 import { IconType } from "@gc-digital-talent/ui";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
@@ -34,6 +35,7 @@ export type AssessmentResultsTableFragmentStepType =
 export interface AssessmentTableRowColumnProps {
   id: string;
   poolCandidate: AssessmentResultsTableFragmentType;
+  experiences: Omit<Experience, "user">[];
   assessmentStep: AssessmentResultsTableFragmentStepType;
   intl: IntlShape;
   header: JSX.Element;

--- a/apps/web/src/components/AssessmentResultsTable/utils.tsx
+++ b/apps/web/src/components/AssessmentResultsTable/utils.tsx
@@ -148,6 +148,7 @@ const columnHelper = createColumnHelper<AssessmentTableRow>();
 export const buildColumn = ({
   id,
   poolCandidate,
+  experiences,
   assessmentStep,
   intl,
   header,
@@ -202,9 +203,14 @@ export const buildColumn = ({
                     }
                   : null
               }
+              experiences={experiences}
               poolCandidate={{
                 id: poolCandidate.id,
                 profileSnapshot: poolCandidate.profileSnapshot,
+                educationRequirementOption:
+                  poolCandidate.educationRequirementOption,
+                educationRequirementExperiences:
+                  poolCandidate.educationRequirementExperiences,
                 pool: {
                   classification: poolCandidate.pool.classification,
                   publishingGroup: poolCandidate.pool.publishingGroup,

--- a/apps/web/src/components/AssessmentResultsTable/utils.tsx
+++ b/apps/web/src/components/AssessmentResultsTable/utils.tsx
@@ -207,6 +207,8 @@ export const buildColumn = ({
               poolCandidate={{
                 id: poolCandidate.id,
                 profileSnapshot: poolCandidate.profileSnapshot,
+                screeningQuestionResponses:
+                  poolCandidate.screeningQuestionResponses,
                 educationRequirementOption:
                   poolCandidate.educationRequirementOption,
                 educationRequirementExperiences:
@@ -238,6 +240,8 @@ export const buildColumn = ({
               poolCandidate={{
                 id: poolCandidate.id,
                 profileSnapshot: poolCandidate.profileSnapshot,
+                screeningQuestionResponses:
+                  poolCandidate.screeningQuestionResponses,
                 pool: {
                   classification: poolCandidate.pool.classification,
                   publishingGroup: poolCandidate.pool.publishingGroup,

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.stories.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.stories.tsx
@@ -13,15 +13,12 @@ import {
   fakePoolSkills,
   fakeSkills,
   fakeUserSkills,
-  toLocalizedEnum,
 } from "@gc-digital-talent/fake-data";
 import {
   AssessmentDecision,
   AssessmentDecisionLevel,
   AssessmentResultJustification,
   AssessmentStepType,
-  EducationRequirementOption,
-  User,
 } from "@gc-digital-talent/graphql";
 
 import { ScreeningDecisionDialog } from "./ScreeningDecisionDialog";
@@ -35,64 +32,7 @@ experience.skills?.push(skill);
 poolCandidate.user.experiences?.push(experience);
 poolCandidate.user.userSkills?.push(fakeUserSkills(1, skill)[0]);
 
-const profileSnapshot: User = {
-  id: poolCandidate.user.id,
-  firstName: poolCandidate.user.firstName,
-  experiences: [experience],
-  poolCandidates: [
-    {
-      ...poolCandidate,
-      educationRequirementOption: toLocalizedEnum(
-        experience.__typename === "EducationExperience"
-          ? EducationRequirementOption.Education
-          : EducationRequirementOption.AppliedWork,
-      ),
-      screeningQuestionResponses: [
-        {
-          id: "494effde-1168-44e1-8130-9775af800975",
-          answer:
-            "Impedit consectetur sit quia aut laboriosam corporis. Nam esse voluptatem tempora explicabo aut ipsum. Hic pariatur quod omnis qui reiciendis doloribus. Modi praesentium beatae adipisci sequi est corrupti aliquam.",
-          screeningQuestion: {
-            id: "673782a9-e754-4538-96af-7c4462c6b7e9",
-            question: {
-              en: "Labore eum alias ea ratione cum nam. EN?",
-              fr: "Labore eum alias ea ratione cum nam. FR?",
-            },
-            sortOrder: 1,
-          },
-        },
-        {
-          id: "ab2a2b47-527c-46d5-b366-f7e9563e10e8",
-          answer:
-            "Eos facilis et esse asperiores iste nihil maxime. Qui quis omnis aut maiores consequatur hic. Nobis eligendi consectetur ipsum magni saepe quia. Eum sed hic aliquam voluptas incidunt illo architecto.",
-          screeningQuestion: {
-            id: "8ecf9391-8773-4c2b-b120-813dbb721e09",
-            question: {
-              en: "Architecto eum veritatis atque et. EN?",
-              fr: "Architecto eum veritatis atque et. FR?",
-            },
-            sortOrder: 2,
-          },
-        },
-        {
-          id: "b2129ca9-6c57-4e9d-a7f3-e0a0cc1e466e",
-          answer:
-            "Nam delectus id sed molestias cum dolorem nostrum enim. Praesentium non reprehenderit suscipit placeat est sed ducimus. Officiis alias amet beatae aspernatur id. Delectus possimus officia explicabo enim amet.",
-          screeningQuestion: {
-            id: "7cd8970d-cc4b-4128-b94d-bac0952c6c0b",
-            question: {
-              en: "Rerum vel nesciunt qui ea fuga libero. EN?",
-              fr: "Rerum vel nesciunt qui ea fuga libero. FR?",
-            },
-            sortOrder: 3,
-          },
-        },
-      ],
-      educationRequirementExperiences: [experience],
-    },
-  ],
-};
-poolCandidate.profileSnapshot = JSON.stringify(profileSnapshot);
+poolCandidate.profileSnapshot = JSON.stringify(poolCandidate.user);
 
 export default {
   component: ScreeningDecisionDialog,
@@ -101,6 +41,7 @@ export default {
     assessmentStep,
     poolCandidate,
     poolSkill,
+    experiences: [experience],
     onSubmit: action("Submit Form"),
     isOpen: true,
   },

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -219,7 +219,7 @@ const AssessmentStepTypeSection = ({
 const ScreeningQuestions = ({
   poolCandidate,
 }: {
-  poolCandidate: PoolCandidate | undefined;
+  poolCandidate: Pick<PoolCandidate, "screeningQuestionResponses"> | undefined;
 }) => {
   const intl = useIntl();
   const screeningQuestionResponses =
@@ -311,7 +311,10 @@ interface ScreeningDecisionDialogProps {
   >;
   poolCandidate: Pick<
     PoolCandidate,
-    "id" | "educationRequirementOption" | "profileSnapshot"
+    | "id"
+    | "educationRequirementOption"
+    | "profileSnapshot"
+    | "screeningQuestionResponses"
   > & {
     pool: Pick<Pool, "classification" | "publishingGroup">;
   } & {
@@ -352,9 +355,6 @@ export const ScreeningDecisionDialog = ({
   });
 
   const parsedSnapshot: Maybe<User> = JSON.parse(poolCandidate.profileSnapshot);
-  const snapshotCandidate = parsedSnapshot?.poolCandidates
-    ?.filter(notEmpty)
-    .find(({ id }) => id === poolCandidate.id);
 
   const headers = useHeaders({
     type: dialogType,
@@ -486,7 +486,7 @@ export const ScreeningDecisionDialog = ({
             type={dialogType}
           />
           {dialogType === "SCREENING_QUESTIONS" ? (
-            <ScreeningQuestions poolCandidate={snapshotCandidate} />
+            <ScreeningQuestions poolCandidate={poolCandidate} />
           ) : (
             <SupportingEvidence experiences={experiences} skill={skill} />
           )}
@@ -554,7 +554,10 @@ const ScreeningDecisionDialogApi = ({
   experiences?: Omit<Experience, "user">[];
   poolCandidate: Pick<
     PoolCandidate,
-    "id" | "educationRequirementOption" | "profileSnapshot"
+    | "id"
+    | "educationRequirementOption"
+    | "screeningQuestionResponses"
+    | "profileSnapshot"
   > & {
     pool: Pick<Pool, "classification" | "publishingGroup">;
   } & {

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -298,6 +298,12 @@ const SupportingEvidence = ({
   );
 };
 
+export type EducationRequirementExperiences = Maybe<
+  Maybe<{
+    id: Scalars["UUID"]["output"];
+  }>[]
+>;
+
 interface ScreeningDecisionDialogProps {
   assessmentStep?: Maybe<Pick<AssessmentStep, "type" | "title">>;
   assessmentResult?: Maybe<
@@ -309,7 +315,7 @@ interface ScreeningDecisionDialogProps {
   > & {
     pool: Pick<Pool, "classification" | "publishingGroup">;
   } & {
-    educationRequirementExperiences: { id: Scalars["UUID"]["output"] }[];
+    educationRequirementExperiences?: EducationRequirementExperiences;
   };
   experiences: Omit<Experience, "user">[];
   hasBeenAssessed: boolean;
@@ -545,14 +551,14 @@ const ScreeningDecisionDialogApi = ({
   educationRequirement,
 }: {
   assessmentStep: Pick<AssessmentStep, "id" | "type" | "title">;
-  experiences: Omit<Experience, "user">[];
+  experiences?: Omit<Experience, "user">[];
   poolCandidate: Pick<
     PoolCandidate,
     "id" | "educationRequirementOption" | "profileSnapshot"
   > & {
     pool: Pick<Pool, "classification" | "publishingGroup">;
   } & {
-    educationRequirementExperiences: { id: Scalars["UUID"]["output"] }[];
+    educationRequirementExperiences?: EducationRequirementExperiences;
   };
   assessmentResult?: Maybe<
     Pick<
@@ -680,7 +686,7 @@ const ScreeningDecisionDialogApi = ({
       initialValues={initialValues}
       hasBeenAssessed={hasBeenAssessed}
       educationRequirement={educationRequirement}
-      experiences={experiences}
+      experiences={unpackMaybes(experiences)}
       onSubmit={(formValues) =>
         hasBeenAssessed
           ? handleUpdateAssessment(

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -298,7 +298,7 @@ const SupportingEvidence = ({
   );
 };
 
-export type EducationRequirementExperiences = Maybe<
+type EducationRequirementExperiences = Maybe<
   Maybe<{
     id: Scalars["UUID"]["output"];
   }>[]

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -294,7 +294,10 @@ export const ViewPoolCandidate = ({
               >
                 {intl.formatMessage(screeningAndAssessmentTitle)}
               </Heading>
-              <AssessmentResultsTable poolCandidateQuery={poolCandidate} />
+              <AssessmentResultsTable
+                poolCandidateQuery={poolCandidate}
+                experiences={nonEmptyExperiences}
+              />
             </div>
             <ClaimVerification verificationQuery={poolCandidate} />
             {parsedSnapshot ? (


### PR DESCRIPTION
🤖 Resolves #11531 

## 👋 Introduction

Fixes the assessment status table dialog to show education requirement along with evidence.

## 🕵️ Details

> [!NOTE]
> This is not the best solution but for urgency, it works.

We were relying on the snapshot to render this but that information recently removed from the snapshot so no longer exists. This instead queries the info from the pool candidate directly and drills the required info down.

## 🧪 Testing

1. Build the app `pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Apply to a process, taking note of the education requirement option/experience to select
4. Navigate to the admin view of the application
5. Open the education requirement assessment dialog
6. Confirm the option and experience you selected appears in the dialog

## 📸 Screenshot

![2024-09-16_15-48](https://github.com/user-attachments/assets/e89181b6-2b27-4acd-b67e-135560f10c35)
