### PR TITLE
[Fix] Hydrating snapshots for document download

### DIFF
--- a/api/app/Traits/HydratesSnapshot.php
+++ b/api/app/Traits/HydratesSnapshot.php
@@ -22,6 +22,10 @@ trait HydratesSnapshot
 
     public static function isFieldLocalizedEnum(mixed $snapshot, mixed $snapshotField): bool
     {
+        if (! isset($snapshot[$snapshotField]) || is_string($snapshot[$snapshotField])) {
+            return false;
+        }
+
         // validator for a single localized enum
         $singleEnumValidator = Validator::make($snapshot, [
             $snapshotField.'.value' => 'required|string',

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -212,6 +212,13 @@ class SnapshotTest extends TestCase
                         ),
                     ],
                 ],
+                // Empty string details
+                // NOTE: Regression test for empty strings treated as localized enums
+                'experiences' => [
+                    [
+                        'details' => '',
+                    ],
+                ],
             ],
         ]);
 
@@ -233,6 +240,12 @@ class SnapshotTest extends TestCase
                 [
                     'value' => OperationalRequirement::ON_CALL->name,
                     'label' => OperationalRequirement::localizedString(OperationalRequirement::ON_CALL->name),
+                ],
+            ],
+            // Empty string details
+            'experiences' => [
+                [
+                    'details' => '',
                 ],
             ],
         ], $snapshot);


### PR DESCRIPTION
🤖 Resolves #11537 

## 👋 Introduction

Fixes an issue where checking if a snapshot field was a localized enum was slightly too permissive.

## 🕵️ Details

It appears empty strings were passing the validation setup to assert whether a field was a localized enum or not. I'm not not sure how it was passing the validation since it require that the `value` key was required and if it did not exist, it fell through to an array validation. To me, both of those should have failed on an empty string but they were not.

So, this just adds an additional top level check and if it is either null or a string, it will fail early which seems to fix the issue.

## 🧪 Testing


1. Login as admin `admin@test.com`
2. Add an experience (community was what was failing but I think it could be any so try them all maybe?)
3. Apply to a process
4. Navigate tot he snapshot of the application in the database
5. Update the experience(s) in the snapshot to have an empty string as the details (maybe even other fields too)
6. Attempt to download the application for that application
7. Confirm it downloads as expected