### PR TITLE
[Fix] Supporting evidence for essential skills

### DIFF
--- a/apps/web/src/components/AssessmentResultsTable/utils.tsx
+++ b/apps/web/src/components/AssessmentResultsTable/utils.tsx
@@ -237,6 +237,7 @@ export const buildColumn = ({
                 title: assessmentStep.title,
               }}
               assessmentResult={assessmentResult} // always undefined
+              experiences={experiences}
               poolCandidate={{
                 id: poolCandidate.id,
                 profileSnapshot: poolCandidate.profileSnapshot,


### PR DESCRIPTION
🤖 Resolves #11544 

## 👋 Introduction

Fixes supporting evidence not appearing for essential skill assessments in the screening dialog.

## 🕵️ Details

Missed drilling experiences on the different dialog render for essential skills (was only doing it for the non-skill based dialogs.

## 🧪 Testing

1. Build app `pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Navigate to a pool candidate in the admin interface
4. Open the screening dialog for a claimed skill
5. Confirm the supporting evidence (experience card w/ details) appears

## 📸 Screenshot

![2024-09-18_12-38](https://github.com/user-attachments/assets/e9323237-6a78-465e-b1e8-0db87de8a360)
