### PR TITLE
[Fix] Reduce previous url to max length for freshdesk

### DIFF
--- a/api/app/Http/Controllers/SupportController.php
+++ b/api/app/Http/Controllers/SupportController.php
@@ -6,8 +6,12 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
+use function Safe\parse_url;
+
 class SupportController extends Controller
 {
+    private static $MAX_URL_LENGTH = 255;
+
     public function createTicket(Request $request)
     {
         if (! config('freshdesk.api.tickets_endpoint') || ! config('freshdesk.api.key')) {
@@ -35,7 +39,15 @@ class SupportController extends Controller
             'type' => array_key_exists($request->input('subject'), $type_map) ? $type_map[$request->input('subject')] : null,
         ];
         if ($request->input('previous_url')) {
-            $parameters['custom_fields']['cf_page_url'] = (string) $request->input('previous_url');
+            $url = parse_url((string) $request->input('previous_url'));
+            $path = $url['path'] ?? '/';
+            if (isset($url['query'])) {
+                $path .= '?'.$url['query'];
+            }
+            if (strlen($path) > self::$MAX_URL_LENGTH) {
+                $path = substr($path, 0, self::$MAX_URL_LENGTH);
+            }
+            $parameters['custom_fields']['cf_page_url'] = $path;
         }
         if ($request->input('user_id')) {
             $parameters['unique_external_id'] = (string) $request->input('user_id');


### PR DESCRIPTION
🤖 Resolves #11484 

## 👋 Introduction

Fixes an issue where the previous url field was too long for freshdesk.

## 🕵️ Details

This does two things:

1. Only passes the path and query
    - We do not need any other parts like domain since we only set this on our pages so we can assume the domain is ours
2. Trims path + query to max length

## 🧪 Testing

1. Set anything for the freshdesk variable sin `api/.env` (they can be anything, we don't need to send a request but you can if you have that)
2. Confirm the previous URL is a max length of 255 characters
