### PR TITLE
[Feature] No queue for single row document downloads

### DIFF
--- a/api/app/GraphQL/Mutations/DownloadPoolCandidateDoc.php
+++ b/api/app/GraphQL/Mutations/DownloadPoolCandidateDoc.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\GraphQL\Mutations;
 
 use App\Generators\PoolCandidateUserDocGenerator;
+use App\Models\PoolCandidate;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
@@ -18,9 +19,23 @@ final readonly class DownloadPoolCandidateDoc
         $user = Auth::user();
         throw_unless(is_string($user?->id), UnauthorizedException::class);
 
+        $targetApplicant = PoolCandidate::find($args['id'])->load(['user']);
+        $firstName = $targetApplicant?->user?->first_name;
+        $lastName = $targetApplicant?->user?->last_name;
+        if (isset($firstName)) {
+            $firstName = iconv('UTF-8', 'ASCII//TRANSLIT', $firstName); // handle accented characters
+            $firstName = preg_replace('/[^a-zA-Z]+/', '', $firstName); // remove anything that isn't an alphabet character
+            $firstName = trim($firstName);
+        }
+        if (isset($lastName)) {
+            $lastName = iconv('UTF-8', 'ASCII//TRANSLIT', $lastName);
+            $lastName = preg_replace('/[^a-zA-Z]+/', '', $lastName);
+            $lastName = trim($lastName);
+        }
+
         try {
 
-            $fileName = sprintf('%s_%s.docx', __('filename.candidate'), date('Y-m-d_His'));
+            $fileName = sprintf('%s - %s - Application - Candidature.docx', $firstName ? $firstName : '', $lastName ? $lastName : '');
 
             $generator = new PoolCandidateUserDocGenerator(
                 ids: [$args['id']],

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -28,6 +28,7 @@ import {
   FragmentType,
   Language,
 } from "@gc-digital-talent/graphql";
+import { useApiRoutes } from "@gc-digital-talent/auth";
 
 import useRoutes from "~/hooks/useRoutes";
 import {
@@ -44,7 +45,7 @@ import { getFullNameLabel } from "~/utils/nameUtils";
 import { getFullPoolTitleLabel } from "~/utils/poolUtils";
 import processMessages from "~/messages/processMessages";
 import { priorityWeightAfterVerification } from "~/utils/poolCandidate";
-import commonTableMessages from "~/components/Table/tableMessages";
+import useAsyncFileDownload from "~/hooks/useAsyncFileDownload";
 
 import skillMatchDialogAccessor from "./SkillMatchDialog";
 import tableMessages from "./tableMessages";
@@ -420,6 +421,12 @@ const DownloadPoolCandidatesDoc_Mutation = graphql(/* GraphQL */ `
   }
 `);
 
+const DownloadSinglePoolCandidateDoc_Mutation = graphql(/* GraphQL */ `
+  mutation DownloadPoolCandidateDoc($id: UUID!, $anonymous: Boolean!) {
+    downloadPoolCandidateDoc(id: $id, anonymous: $anonymous)
+  }
+`);
+
 const context: Partial<OperationContext> = {
   additionalTypenames: ["Skill", "SkillFamily"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
   requestPolicy: "cache-first", // The list of skills will rarely change, so we override default request policy to avoid unnecessary cache updates.
@@ -460,6 +467,7 @@ const PoolCandidatesTable = ({
   const intl = useIntl();
   const locale = getLocale(intl);
   const paths = useRoutes();
+  const apiRoutes = useApiRoutes();
   const initialState = getTableStateFromSearchParams(defaultState);
   const searchParams = new URLSearchParams(window.location.search);
   const filtersEncoded = searchParams.get(SEARCH_PARAM_KEY.FILTERS);
@@ -475,6 +483,13 @@ const PoolCandidatesTable = ({
   const [{ fetching: downloadingDoc }, downloadDoc] = useMutation(
     DownloadPoolCandidatesDoc_Mutation,
   );
+
+  const [{ fetching: downloadingSingleDoc }, downloadSingleDoc] = useMutation(
+    DownloadSinglePoolCandidateDoc_Mutation,
+  );
+
+  const [{ fetching: downloadingAsyncFile }, executeAsyncDownload] =
+    useAsyncFileDownload();
 
   const filterRef = useRef<PoolCandidateSearchInput | undefined>(
     initialFilters,
@@ -618,17 +633,30 @@ const PoolCandidatesTable = ({
   };
 
   const handleDocDownload = (anonymous: boolean) => {
-    downloadDoc({
-      ids: selectedRows,
-      anonymous,
-      locale: locale === "fr" ? Language.Fr : Language.En,
-    })
-      .then((res) => handleDownloadRes(!!res.data))
-      .catch(handleDownloadError);
-  };
-
-  const handleNoRowsSelected = () => {
-    toast.warning(intl.formatMessage(commonTableMessages.noRowsSelected));
+    if (selectedRows.length === 1) {
+      downloadSingleDoc({ id: selectedRows[0], anonymous })
+        .then((res) => {
+          if (res?.data?.downloadPoolCandidateDoc) {
+            executeAsyncDownload({
+              url: apiRoutes.userGeneratedFile(
+                res.data.downloadPoolCandidateDoc,
+              ),
+              fileName: res.data.downloadPoolCandidateDoc,
+            });
+          } else {
+            handleDownloadError();
+          }
+        })
+        .catch(handleDownloadError);
+    } else {
+      downloadDoc({
+        ids: selectedRows,
+        anonymous,
+        locale: locale === "fr" ? Language.Fr : Language.En,
+      })
+        .then((res) => handleDownloadRes(!!res.data))
+        .catch(handleDownloadError);
+    }
   };
 
   const columns = [
@@ -986,11 +1014,16 @@ const PoolCandidatesTable = ({
           component: (
             <DownloadUsersDocButton
               inTable
-              disabled={downloadingDoc}
-              onClick={
-                hasSelectedRows ? handleDocDownload : handleNoRowsSelected
+              disabled={
+                !hasSelectedRows ||
+                downloadingDoc ||
+                downloadingSingleDoc ||
+                downloadingAsyncFile
               }
-              isDownloading={downloadingDoc}
+              onClick={handleDocDownload}
+              isDownloading={
+                downloadingDoc || downloadingSingleDoc || downloadingAsyncFile
+              }
             />
           ),
         },

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -168,14 +168,24 @@ const UserTable = ({ title }: UserTableProps) => {
   );
   const [filterState, setFilterState] =
     useState<UserFilterInput>(initialFilters);
-  const { downloadDoc, downloadingDoc, downloadCsv, downloadingCsv } =
-    useUserDownloads();
+  const {
+    downloadDoc,
+    downloadingDoc,
+    downloadCsv,
+    downloadingCsv,
+    downloadSingleUserDoc,
+    downloadingSingleUserDoc,
+  } = useUserDownloads();
 
   const handleDocDownload = (anonymous: boolean) => {
-    downloadDoc({
-      ids: selectedRows,
-      anonymous,
-    });
+    if (selectedRows.length === 1) {
+      downloadSingleUserDoc({ id: selectedRows[0], anonymous });
+    } else {
+      downloadDoc({
+        ids: selectedRows,
+        anonymous,
+      });
+    }
   };
 
   const handleCsvDownload = () => {
@@ -412,9 +422,11 @@ const UserTable = ({ title }: UserTableProps) => {
           component: (
             <DownloadUsersDocButton
               inTable
-              disabled={!hasSelectedRows || downloadingDoc}
+              disabled={
+                !hasSelectedRows || downloadingDoc || downloadingSingleUserDoc
+              }
               onClick={handleDocDownload}
-              isDownloading={downloadingDoc}
+              isDownloading={downloadingDoc || downloadingSingleUserDoc}
             />
           ),
         },


### PR DESCRIPTION
🤖 Resolves #11534

## 👋 Introduction

Do not use queuing for downloads of a single row in the users or candidates table. 

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->


1. Navigate to users table, have queue work running
2. Select one user and download, then select multiple users then download
3. Observe immediate download for the former, queuing for the latter
4. Go to candidates table and repeat

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/3665ba92-eae5-4b4e-afe1-38709b7a665b)

