### PR TITLE
[Feat] Change word counts for FR in application

### DIFF
--- a/apps/web/src/components/ExperienceFormFields/AdditionalDetails.tsx
+++ b/apps/web/src/components/ExperienceFormFields/AdditionalDetails.tsx
@@ -26,7 +26,7 @@ const AdditionalDetails = ({ experienceType }: AdditionalDetailsProps) => {
   const type = useWatch({ name: "experienceType" });
   const derivedType = type ?? experienceType;
 
-  const wordCouldLimits: Record<Locales, number> = {
+  const wordCountLimits: Record<Locales, number> = {
     en: TEXT_AREA_MAX_WORDS_EN,
     fr: Math.round(TEXT_AREA_MAX_WORDS_EN * FRENCH_WORDS_PER_ENGLISH_WORD),
   } as const;
@@ -61,7 +61,7 @@ const AdditionalDetails = ({ experienceType }: AdditionalDetailsProps) => {
               id={FIELD_NAME}
               name={FIELD_NAME}
               rows={TEXT_AREA_ROWS}
-              wordLimit={wordCouldLimits[locale]}
+              wordLimit={wordCountLimits[locale]}
               label={experienceLabels.details}
               rules={{ required: intl.formatMessage(errorMessages.required) }}
             />

--- a/apps/web/src/components/ExperienceFormFields/AdditionalDetails.tsx
+++ b/apps/web/src/components/ExperienceFormFields/AdditionalDetails.tsx
@@ -1,17 +1,18 @@
 import { useWatch } from "react-hook-form";
 import { useIntl } from "react-intl";
 
-import { errorMessages } from "@gc-digital-talent/i18n";
+import { errorMessages, getLocale, Locales } from "@gc-digital-talent/i18n";
 import { TextArea } from "@gc-digital-talent/forms";
 import { Heading } from "@gc-digital-talent/ui";
 
 import { ExperienceType } from "~/types/experience";
 import { getExperienceFormLabels } from "~/utils/experienceUtils";
+import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants";
 
 import NullExperienceType from "./NullExperienceType";
 
 const TEXT_AREA_ROWS = 3;
-const TEXT_AREA_MAX_WORDS = 200;
+const TEXT_AREA_MAX_WORDS_EN = 200;
 const FIELD_NAME = "details";
 
 interface AdditionalDetailsProps {
@@ -20,9 +21,15 @@ interface AdditionalDetailsProps {
 
 const AdditionalDetails = ({ experienceType }: AdditionalDetailsProps) => {
   const intl = useIntl();
+  const locale = getLocale(intl);
   const experienceLabels = getExperienceFormLabels(intl);
   const type = useWatch({ name: "experienceType" });
   const derivedType = type ?? experienceType;
+
+  const wordCouldLimits: Record<Locales, number> = {
+    en: TEXT_AREA_MAX_WORDS_EN,
+    fr: Math.round(TEXT_AREA_MAX_WORDS_EN * FRENCH_WORDS_PER_ENGLISH_WORD),
+  } as const;
 
   return (
     <>
@@ -54,7 +61,7 @@ const AdditionalDetails = ({ experienceType }: AdditionalDetailsProps) => {
               id={FIELD_NAME}
               name={FIELD_NAME}
               rows={TEXT_AREA_ROWS}
-              wordLimit={TEXT_AREA_MAX_WORDS}
+              wordLimit={wordCouldLimits[locale]}
               label={experienceLabels.details}
               rules={{ required: intl.formatMessage(errorMessages.required) }}
             />

--- a/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillForm.tsx
+++ b/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillForm.tsx
@@ -132,7 +132,7 @@ const ExperienceSkillForm = ({
     }
   };
 
-  const wordCouldLimits: Record<Locales, number> = {
+  const wordCountLimits: Record<Locales, number> = {
     en: TEXT_AREA_MAX_WORDS_EN,
     fr: Math.round(TEXT_AREA_MAX_WORDS_EN * FRENCH_WORDS_PER_ENGLISH_WORD),
   } as const;
@@ -245,7 +245,7 @@ const ExperienceSkillForm = ({
           <TextArea
             id="details"
             name="details"
-            wordLimit={wordCouldLimits[locale]}
+            wordLimit={wordCountLimits[locale]}
             label={intl.formatMessage({
               defaultMessage: "Describe how you used this skill",
               id: "L7PqXn",

--- a/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillForm.tsx
+++ b/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillForm.tsx
@@ -3,7 +3,12 @@ import { useForm, FormProvider } from "react-hook-form";
 
 import { Dialog, Button, Heading, Well } from "@gc-digital-talent/ui";
 import { Select, TextArea } from "@gc-digital-talent/forms";
-import { errorMessages, formMessages } from "@gc-digital-talent/i18n";
+import {
+  errorMessages,
+  formMessages,
+  getLocale,
+  Locales,
+} from "@gc-digital-talent/i18n";
 import { toast } from "@gc-digital-talent/toast";
 import { Experience, Scalars } from "@gc-digital-talent/graphql";
 
@@ -12,8 +17,9 @@ import {
   getExperienceName,
 } from "~/utils/experienceUtils";
 import { useExperienceMutations } from "~/hooks/useExperienceMutations";
+import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants";
 
-const TEXT_AREA_MAX_WORDS = 160;
+const TEXT_AREA_MAX_WORDS_EN = 160;
 
 const getSkillArgs = (
   skillId: Scalars["ID"]["output"],
@@ -57,6 +63,7 @@ const ExperienceSkillForm = ({
   experiences,
 }: ExperienceSkillFormProps) => {
   const intl = useIntl();
+  const locale = getLocale(intl);
   const methods = useForm<FormValues>({
     defaultValues,
   });
@@ -124,6 +131,11 @@ const ExperienceSkillForm = ({
         });
     }
   };
+
+  const wordCouldLimits: Record<Locales, number> = {
+    en: TEXT_AREA_MAX_WORDS_EN,
+    fr: Math.round(TEXT_AREA_MAX_WORDS_EN * FRENCH_WORDS_PER_ENGLISH_WORD),
+  } as const;
 
   return (
     <FormProvider {...methods}>
@@ -233,7 +245,7 @@ const ExperienceSkillForm = ({
           <TextArea
             id="details"
             name="details"
-            wordLimit={TEXT_AREA_MAX_WORDS}
+            wordLimit={wordCouldLimits[locale]}
             label={intl.formatMessage({
               defaultMessage: "Describe how you used this skill",
               id: "L7PqXn",

--- a/apps/web/src/constants/talentSearchConstants.ts
+++ b/apps/web/src/constants/talentSearchConstants.ts
@@ -2,3 +2,5 @@ export const TALENTSEARCH_SUPPORT_EMAIL =
   process.env.TALENTSEARCH_SUPPORT_EMAIL! ?? "support-soutien@talent.canada.ca";
 export const API_SUPPORT_ENDPOINT =
   process.env.API_SUPPORT_ENDPOINT! ?? "/api/support/tickets";
+// We allow word counts to be higher in French
+export const FRENCH_WORDS_PER_ENGLISH_WORD = 7 / 5;

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/components/AnswerInput.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/components/AnswerInput.tsx
@@ -26,7 +26,7 @@ const AnswerInput = ({ index, question }: AnswerInputProps) => {
   const answerPrefix = isScreening ? "screeningAnswers" : "generalAnswers";
   const questionId = `${answerPrefix}.${index}.question`;
 
-  const wordCouldLimits: Record<Locales, number> = {
+  const wordCountLimits: Record<Locales, number> = {
     en: TEXT_AREA_MAX_WORDS_EN,
     fr: Math.round(TEXT_AREA_MAX_WORDS_EN * FRENCH_WORDS_PER_ENGLISH_WORD),
   } as const;
@@ -45,7 +45,7 @@ const AnswerInput = ({ index, question }: AnswerInputProps) => {
         name={`${answerPrefix}.${index}.answer`}
         aria-labelledby={questionId}
         rows={TEXT_AREA_ROWS}
-        wordLimit={wordCouldLimits[locale]}
+        wordLimit={wordCountLimits[locale]}
         label={intl.formatMessage(
           {
             defaultMessage: "Answer to question {number}",

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/components/AnswerInput.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/components/AnswerInput.tsx
@@ -1,11 +1,18 @@
 import { useIntl } from "react-intl";
 
 import { TextArea } from "@gc-digital-talent/forms";
-import { errorMessages, getLocalizedName } from "@gc-digital-talent/i18n";
+import {
+  errorMessages,
+  getLocale,
+  getLocalizedName,
+  Locales,
+} from "@gc-digital-talent/i18n";
 import { GeneralQuestion, ScreeningQuestion } from "@gc-digital-talent/graphql";
 
+import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants";
+
 const TEXT_AREA_ROWS = 3;
-const TEXT_AREA_MAX_WORDS = 200;
+const TEXT_AREA_MAX_WORDS_EN = 200;
 
 interface AnswerInputProps {
   index: number;
@@ -14,9 +21,15 @@ interface AnswerInputProps {
 
 const AnswerInput = ({ index, question }: AnswerInputProps) => {
   const intl = useIntl();
+  const locale = getLocale(intl);
   const isScreening = question.__typename === "ScreeningQuestion";
   const answerPrefix = isScreening ? "screeningAnswers" : "generalAnswers";
   const questionId = `${answerPrefix}.${index}.question`;
+
+  const wordCouldLimits: Record<Locales, number> = {
+    en: TEXT_AREA_MAX_WORDS_EN,
+    fr: Math.round(TEXT_AREA_MAX_WORDS_EN * FRENCH_WORDS_PER_ENGLISH_WORD),
+  } as const;
 
   return (
     <>
@@ -32,7 +45,7 @@ const AnswerInput = ({ index, question }: AnswerInputProps) => {
         name={`${answerPrefix}.${index}.answer`}
         aria-labelledby={questionId}
         rows={TEXT_AREA_ROWS}
-        wordLimit={TEXT_AREA_MAX_WORDS}
+        wordLimit={wordCouldLimits[locale]}
         label={intl.formatMessage(
           {
             defaultMessage: "Answer to question {number}",


### PR DESCRIPTION
🤖 Resolves #11496 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
This branch updates the text areas listed in the issue for the application process to increase the limits when the locale is FR.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->
The ratio was added as an app-wide constant that individual pages use to calculate the right limit.

## 🧪 Testing

> [!Warning] 
These pages break in Vite Watch mode for an as-of-yet unknown reason.  It seems to be related to the use of `process` in the constants file and other pages experience it too.  Use a regular dev or prod build for testing.

1. Rebuild the app
2. Start a new application and proceed through the steps.
3. Note the three places with text areas and switch back and forth between EN and FR.

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/8d3e87c5-db81-4d65-964b-3289ff44bf1a)
