### PR TITLE
[Fix] Prevent notifications for process with other publishing group

### DIFF
--- a/api/app/Listeners/SendNewJobPostedNotification.php
+++ b/api/app/Listeners/SendNewJobPostedNotification.php
@@ -3,6 +3,7 @@
 namespace App\Listeners;
 
 use App\Enums\NotificationFamily;
+use App\Enums\PublishingGroup;
 use App\Events\PoolPublished;
 use App\Models\User;
 use App\Notifications\NewJobPosted;
@@ -41,6 +42,10 @@ class SendNewJobPostedNotification implements ShouldQueue
     public function handle(PoolPublished $event): void
     {
         $pool = $event->result;
+
+        if ($pool->publishing_group === PublishingGroup::OTHER->name) {
+            return;
+        }
 
         $notification = new NewJobPosted(
             $pool->name['en'],


### PR DESCRIPTION
🤖 Resolves #11538 

## 👋 Introduction

Updates the event listener to send notifications for published process to exclude those that have the 'other' publishing group.

## 🧪 Testing

1. Start your job queue `make queue-work`
2. Login as admin `admin@test/com`
3. Set your notification preferences to accept new job postings
4. Create a process under the "other" publishing group
5. Publish that process
6. Confirm notification **is not** sent
7. Repeat steps 4+5 but with any publishing group except "other"
8. Confirm notification **is** sent
