### PR TITLE
[Fix] Add missing import armed forces

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\ArmedForcesStatus;
 use App\Enums\AssessmentDecision;
 use App\Enums\AssessmentResultType;
 use App\Enums\AssessmentStepType;


### PR DESCRIPTION
🤖 Resolves #11601 

## 👋 Introduction

Adds the missing `ArmedForcesStatus` import in the `PoolCandidate` model.

## 🧪 Testing

1. Login as admin `admin@test.com`
2. Navigate to the pool candidates page `/admin/pool-candidates`
3. Confirm no error, specifically related to `ArmedForcesStatus`

