### PR TITLE
[Fix] Prevent attempting to verify null emails

### DIFF
--- a/api/app/GraphQL/Mutations/SendUserEmailVerification.php
+++ b/api/app/GraphQL/Mutations/SendUserEmailVerification.php
@@ -3,7 +3,9 @@
 namespace App\GraphQL\Mutations;
 
 use App\Enums\EmailType;
+use GraphQL\Error\Error;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 
 final class SendUserEmailVerification
 {
@@ -14,10 +16,16 @@ final class SendUserEmailVerification
      */
     public function __invoke($_, array $args)
     {
-        /** @var \App\Models\User */
-        $user = Auth::user();
-        $emailType = isset($args['emailType']) ? EmailType::fromName($args['emailType']) : EmailType::CONTACT;
-        $user->sendEmailVerificationNotification($emailType);
+        try {
+            /** @var \App\Models\User */
+            $user = Auth::user();
+            $emailType = isset($args['emailType']) ? EmailType::fromName($args['emailType']) : EmailType::CONTACT;
+            $user->sendEmailVerificationNotification($emailType);
+        } catch (\Throwable $e) {
+            Log::error('Problem sending email verification code '.$e);
+
+            return new Error($e->getMessage());
+        }
 
         return $user;
     }

--- a/api/app/Notifications/VerifyEmail.php
+++ b/api/app/Notifications/VerifyEmail.php
@@ -7,6 +7,7 @@ use App\Enums\Language;
 use App\Models\User;
 use App\Notifications\Messages\GcNotifyEmailMessage;
 use Error;
+use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Cache;
@@ -49,9 +50,14 @@ class VerifyEmail extends Notification implements CanBeSentViaGcNotifyEmail
                 $templateId = config('notify.templates.verify_email_fr');
             }
 
+            $email = $notifiable->getEmailForVerification($this->emailType);
+            if (! $email) {
+                throw new Exception('Email type '.$this->emailType->name.' not set');
+            }
+
             $message = new GcNotifyEmailMessage(
                 $templateId,
-                $notifiable->getEmailForVerification($this->emailType),
+                $email,
                 [
                     'person name' => $notifiable->first_name,
                     'verification code' => $this->createVerificationCode($notifiable),

--- a/api/tests/Feature/UserVerifyEmailTest.php
+++ b/api/tests/Feature/UserVerifyEmailTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Enums\EmailType;
 use App\Facades\Notify;
 use App\Models\User;
 use App\Notifications\VerifyEmail;
@@ -284,5 +285,19 @@ class UserVerifyEmailTest extends TestCase
 
         // check that verification was cleared
         assertNull($this->regularUser->work_email_verified_at);
+    }
+
+    public function testNullEmailFailsSending()
+    {
+        $this->regularUser->work_email = null;
+        $this->regularUser->work_email_verified_at = null;
+        $this->regularUser->save();
+
+        $this->actingAs($this->regularUser, 'api')
+            ->graphQL($this->sendVerificationEmailMutation, [
+                'emailType' => EmailType::WORK->name,
+            ])
+            ->assertGraphQLErrorMessage('Email type '.EmailType::WORK->name.' not set');
+
     }
 }

--- a/apps/web/src/components/Profile/components/GovernmentInformation/Display.tsx
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/Display.tsx
@@ -155,7 +155,9 @@ const Display = ({
             >
               {workEmail || notProvided}
             </FieldDisplay>
-            {showEmailVerification ? emailVerificationComponents : null}
+            {showEmailVerification && workEmail
+              ? emailVerificationComponents
+              : null}
           </div>
         </>
       )}


### PR DESCRIPTION
🤖 Resolves #11573 

## 👋 Introduction

Prevents users from attempting to verify null emails.

## 🕵️ Details

This is accomplished with two things:

- We hide the link to verify when the email is null on the front end
- If the user somehow gets there with a null email, we verify it exists and return an error when it does not

## 🧪 Testing

1. Login as any user
2. Confirm you have a work email set but not verified
3. Load both the profile and verify email pages
4. Manually set both work email and verified at columns in the DB to null
5. Reload both pages in step 3
6. Confirm no verify link appears on profile
7. Confirm you get error on the verify page

## 📸 Screenshot

![2024-09-24_12-39](https://github.com/user-attachments/assets/3e360663-f770-43a8-999c-f79f0f3eaf39)
