### PR TITLE
[Copy] Update skills page titles

### DIFF
--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -241,7 +241,7 @@ const createRoute = (locale: Locales) =>
                   children: [
                     {
                       index: true,
-                      lazy: () => import("../pages/Skills/SkillLibraryPage"),
+                      lazy: () => import("../pages/Skills/SkillPortfolioPage"),
                     },
                     {
                       path: ":skillId",

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -268,7 +268,7 @@ const getRoutes = (lang: Locales) => {
       );
     },
 
-    skillLibrary: () => [applicantUrl, "skills"].join("/"),
+    skillPortfolio: () => [applicantUrl, "skills"].join("/"),
     skillShowcase: () => [showcase].join("/"),
     editUserSkill: (skillId: string) =>
       [applicantUrl, "skills", skillId].join("/"),

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
@@ -552,12 +552,12 @@ const DashboardHeading = ({ userQuery }: DashboardHeadingProps) => {
         </HeroCard>
         <HeroCard
           color="quaternary"
-          title={intl.formatMessage(navigationMessages.skillLibrary)}
+          title={intl.formatMessage(navigationMessages.skillPortfolio)}
           href={`${skillLibraryUrl}#manage`}
         >
           <StatusItem
             layout="hero"
-            title={intl.formatMessage(navigationMessages.skillLibrary)}
+            title={intl.formatMessage(navigationMessages.skillPortfolio)}
             itemCount={skillLibraryCount}
             status={skillLibraryStatus}
             href={`${skillLibraryUrl}#manage`}

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
@@ -225,7 +225,7 @@ const DashboardHeading = ({ userQuery }: DashboardHeadingProps) => {
   const workExperiences = notEmptyExperiences?.filter(isWorkExperience) || [];
 
   const skillShowcaseUrl = paths.skillShowcase();
-  const skillLibraryUrl = paths.skillLibrary();
+  const skillLibraryUrl = paths.skillPortfolio();
 
   const hasTopSkills =
     user.topBehaviouralSkillsRanking?.length &&
@@ -274,7 +274,7 @@ const DashboardHeading = ({ userQuery }: DashboardHeadingProps) => {
               "whiteFixed",
             ),
           a3: (chunks: ReactNode) =>
-            buildLink(paths.skillLibrary(), chunks, "whiteFixed"),
+            buildLink(paths.skillPortfolio(), chunks, "whiteFixed"),
           a4: (chunks: ReactNode) =>
             buildScrollToLink(
               "track-applications-section",

--- a/apps/web/src/pages/Skills/SkillPage.tsx
+++ b/apps/web/src/pages/Skills/SkillPage.tsx
@@ -2,12 +2,12 @@ import { defineMessage, useIntl } from "react-intl";
 import { ReactNode } from "react";
 
 import { Alert, Heading, Link, Well } from "@gc-digital-talent/ui";
+import { navigationMessages } from "@gc-digital-talent/i18n";
 
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import Hero from "~/components/Hero";
 import { INITIAL_STATE } from "~/components/Table/ResponsiveTable/constants";
-import adminMessages from "~/messages/adminMessages";
 import skillBrowserMessages from "~/components/SkillBrowser/messages";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
@@ -19,7 +19,7 @@ const suggestionLink = (chunks: ReactNode, href: string) => (
   </Link>
 );
 
-const pageTitle = defineMessage(adminMessages.skills);
+const pageTitle = defineMessage(navigationMessages.skillsLibrary);
 const pageSubtitle = defineMessage({
   defaultMessage: "Explore all the skills on our site.",
   id: "eTOg2E",

--- a/apps/web/src/pages/Skills/SkillPortfolioPage.tsx
+++ b/apps/web/src/pages/Skills/SkillPortfolioPage.tsx
@@ -72,7 +72,7 @@ const SkillPortfolio = ({ userSkills, skills }: SkillPortfolioProps) => {
       },
       {
         label: intl.formatMessage(navigationMessages.skillPortfolio),
-        url: paths.skillLibrary(),
+        url: paths.skillPortfolio(),
       },
     ],
   });

--- a/apps/web/src/pages/Skills/SkillPortfolioPage.tsx
+++ b/apps/web/src/pages/Skills/SkillPortfolioPage.tsx
@@ -15,21 +15,21 @@ import useRoutes from "~/hooks/useRoutes";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
-import SkillLibraryTable, {
-  SkillLibraryTable_SkillFragment,
-  SkillLibraryTable_UserSkillFragment,
-} from "./components/SkillLibraryTable";
+import SkillPortfolioTable, {
+  SkillPortfolioTable_SkillFragment,
+  SkillPortfolioTable_UserSkillFragment,
+} from "./components/SkillPortfolioTable";
 
 const SkillPortfolioPage_Query = graphql(/* GraphQL */ `
   query SkillPortfolioPageQuery {
     me {
       id
       userSkills {
-        ...SkillLibraryTable_UserSkill
+        ...SkillPortfolioTable_UserSkill
       }
     }
     skills {
-      ...SkillLibraryTable_Skill
+      ...SkillPortfolioTable_Skill
     }
   }
 `);
@@ -41,8 +41,8 @@ interface PageSection {
 type PageSections = Record<string, PageSection>;
 
 interface SkillPortfolioProps {
-  userSkills: FragmentType<typeof SkillLibraryTable_UserSkillFragment>[];
-  skills: FragmentType<typeof SkillLibraryTable_SkillFragment>[];
+  userSkills: FragmentType<typeof SkillPortfolioTable_UserSkillFragment>[];
+  skills: FragmentType<typeof SkillPortfolioTable_SkillFragment>[];
 }
 
 const SkillPortfolio = ({ userSkills, skills }: SkillPortfolioProps) => {
@@ -122,7 +122,7 @@ const SkillPortfolio = ({ userSkills, skills }: SkillPortfolioProps) => {
                   description: "Description on how to use behavioural skills",
                 })}
               </p>
-              <SkillLibraryTable
+              <SkillPortfolioTable
                 caption={sections.manage.title}
                 userSkillsQuery={userSkills}
                 allSkillsQuery={skills}

--- a/apps/web/src/pages/Skills/SkillPortfolioPage.tsx
+++ b/apps/web/src/pages/Skills/SkillPortfolioPage.tsx
@@ -20,8 +20,8 @@ import SkillLibraryTable, {
   SkillLibraryTable_UserSkillFragment,
 } from "./components/SkillLibraryTable";
 
-const SkillLibraryPage_Query = graphql(/* GraphQL */ `
-  query SkillLibraryPageQuery {
+const SkillPortfolioPage_Query = graphql(/* GraphQL */ `
+  query SkillPortfolioPageQuery {
     me {
       id
       userSkills {
@@ -40,12 +40,12 @@ interface PageSection {
 }
 type PageSections = Record<string, PageSection>;
 
-interface SkillLibraryProps {
+interface SkillPortfolioProps {
   userSkills: FragmentType<typeof SkillLibraryTable_UserSkillFragment>[];
   skills: FragmentType<typeof SkillLibraryTable_SkillFragment>[];
 }
 
-const SkillLibrary = ({ userSkills, skills }: SkillLibraryProps) => {
+const SkillPortfolio = ({ userSkills, skills }: SkillPortfolioProps) => {
   const intl = useIntl();
   const paths = useRoutes();
 
@@ -71,13 +71,13 @@ const SkillLibrary = ({ userSkills, skills }: SkillLibraryProps) => {
         url: paths.profileAndApplications(),
       },
       {
-        label: intl.formatMessage(navigationMessages.skillLibrary),
+        label: intl.formatMessage(navigationMessages.skillPortfolio),
         url: paths.skillLibrary(),
       },
     ],
   });
 
-  const pageTitle = intl.formatMessage(navigationMessages.skillLibrary);
+  const pageTitle = intl.formatMessage(navigationMessages.skillPortfolio);
 
   const pageDescription = intl.formatMessage({
     defaultMessage: "Add, edit, and manage the skills on your profile.",
@@ -163,9 +163,9 @@ const context: Partial<OperationContext> = {
   additionalTypenames: ["UserSkill"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
 };
 
-const SkillLibraryPage = () => {
+const SkillPortfolioPage = () => {
   const [{ data, fetching, error }] = useQuery({
-    query: SkillLibraryPage_Query,
+    query: SkillPortfolioPage_Query,
     context,
   });
 
@@ -174,17 +174,17 @@ const SkillLibraryPage = () => {
 
   return (
     <Pending fetching={fetching} error={error}>
-      <SkillLibrary userSkills={userSkills} skills={skills} />
+      <SkillPortfolio userSkills={userSkills} skills={skills} />
     </Pending>
   );
 };
 
 export const Component = () => (
   <RequireAuth roles={[ROLE_NAME.Applicant]}>
-    <SkillLibraryPage />
+    <SkillPortfolioPage />
   </RequireAuth>
 );
 
-Component.displayName = "SkillLibraryPage";
+Component.displayName = "SkillPortfolioPage";
 
-export default SkillLibraryPage;
+export default SkillPortfolioPage;

--- a/apps/web/src/pages/Skills/SkillShowcasePage.tsx
+++ b/apps/web/src/pages/Skills/SkillShowcasePage.tsx
@@ -110,7 +110,7 @@ export const SkillShowcase = ({
         url: paths.profileAndApplications(),
       },
       {
-        label: intl.formatMessage(navigationMessages.skillLibrary),
+        label: intl.formatMessage(navigationMessages.skillPortfolio),
         url: paths.skillLibrary(),
       },
       {

--- a/apps/web/src/pages/Skills/SkillShowcasePage.tsx
+++ b/apps/web/src/pages/Skills/SkillShowcasePage.tsx
@@ -111,7 +111,7 @@ export const SkillShowcase = ({
       },
       {
         label: intl.formatMessage(navigationMessages.skillPortfolio),
-        url: paths.skillLibrary(),
+        url: paths.skillPortfolio(),
       },
       {
         label: pageTitle,
@@ -161,7 +161,7 @@ export const SkillShowcase = ({
               </TableOfContents.ListItem>
             </TableOfContents.List>
             <Link
-              href={paths.skillLibrary()}
+              href={paths.skillPortfolio()}
               color="secondary"
               mode="solid"
               block={false}

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -335,7 +335,7 @@ export const UpdateUserSkillForm = ({
   const fromShowcase = from && from === "showcase";
   const returnPath = fromShowcase
     ? paths.skillShowcase()
-    : paths.skillLibrary();
+    : paths.skillPortfolio();
 
   const availableExperiences = experiences.filter(
     (exp) =>
@@ -433,7 +433,7 @@ export const UpdateUserSkillForm = ({
 
       {
         label: intl.formatMessage(navigationMessages.skillPortfolio),
-        url: paths.skillLibrary(),
+        url: paths.skillPortfolio(),
       },
       ...(fromShowcase
         ? [

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -432,7 +432,7 @@ export const UpdateUserSkillForm = ({
       },
 
       {
-        label: intl.formatMessage(navigationMessages.skillLibrary),
+        label: intl.formatMessage(navigationMessages.skillPortfolio),
         url: paths.skillLibrary(),
       },
       ...(fromShowcase

--- a/apps/web/src/pages/Skills/components/SkillPortfolioTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillPortfolioTable.tsx
@@ -16,7 +16,7 @@ import {
   graphql,
   SkillCategory,
   SkillLevel,
-  SkillLibraryTable_UserSkillFragment as SkillLibraryTableUserSkillFragmentType,
+  SkillPortfolioTable_UserSkillFragment as SkillPortfolioTableUserSkillFragmentType,
 } from "@gc-digital-talent/graphql";
 
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
@@ -26,8 +26,8 @@ import SkillBrowserDialog from "~/components/SkillBrowser/SkillBrowserDialog";
 
 import { CreateUserSkill_Mutation } from "../operations";
 
-export const SkillLibraryTable_UserSkillFragment = graphql(/* GraphQL */ `
-  fragment SkillLibraryTable_UserSkill on UserSkill {
+export const SkillPortfolioTable_UserSkillFragment = graphql(/* GraphQL */ `
+  fragment SkillPortfolioTable_UserSkill on UserSkill {
     id
     whenSkillUsed
     skillLevel
@@ -53,8 +53,8 @@ export const SkillLibraryTable_UserSkillFragment = graphql(/* GraphQL */ `
   }
 `);
 
-export const SkillLibraryTable_SkillFragment = graphql(/* GraphQL */ `
-  fragment SkillLibraryTable_Skill on Skill {
+export const SkillPortfolioTable_SkillFragment = graphql(/* GraphQL */ `
+  fragment SkillPortfolioTable_Skill on Skill {
     id
     key
     category {
@@ -92,16 +92,16 @@ export const SkillLibraryTable_SkillFragment = graphql(/* GraphQL */ `
 `);
 
 type UserSkillCell = CellContext<
-  SkillLibraryTableUserSkillFragmentType,
+  SkillPortfolioTableUserSkillFragmentType,
   unknown
 >;
 
 const columnHelper =
-  createColumnHelper<SkillLibraryTableUserSkillFragmentType>();
+  createColumnHelper<SkillPortfolioTableUserSkillFragmentType>();
 
 const skillLevelSort = (
-  a: Row<SkillLibraryTableUserSkillFragmentType>,
-  b: Row<SkillLibraryTableUserSkillFragmentType>,
+  a: Row<SkillPortfolioTableUserSkillFragmentType>,
+  b: Row<SkillPortfolioTableUserSkillFragmentType>,
 ) => {
   const order = [
     SkillLevel.Beginner,
@@ -133,28 +133,28 @@ const skillNameCell = (
   </Link>
 );
 
-interface SkillLibraryTableProps {
+interface SkillPortfolioTableProps {
   caption: string;
-  userSkillsQuery: FragmentType<typeof SkillLibraryTable_UserSkillFragment>[];
-  allSkillsQuery: FragmentType<typeof SkillLibraryTable_SkillFragment>[];
+  userSkillsQuery: FragmentType<typeof SkillPortfolioTable_UserSkillFragment>[];
+  allSkillsQuery: FragmentType<typeof SkillPortfolioTable_SkillFragment>[];
 }
 
-const SkillLibraryTable = ({
+const SkillPortfolioTable = ({
   caption,
   userSkillsQuery,
   allSkillsQuery,
-}: SkillLibraryTableProps) => {
+}: SkillPortfolioTableProps) => {
   const intl = useIntl();
   const paths = useRoutes();
   const { userAuthInfo } = useAuthorization();
   const [, executeCreateMutation] = useMutation(CreateUserSkill_Mutation);
 
   const userSkills = getFragment(
-    SkillLibraryTable_UserSkillFragment,
+    SkillPortfolioTable_UserSkillFragment,
     userSkillsQuery,
   );
   const allSkills = getFragment(
-    SkillLibraryTable_SkillFragment,
+    SkillPortfolioTable_SkillFragment,
     allSkillsQuery,
   );
 
@@ -229,10 +229,10 @@ const SkillLibraryTable = ({
       enableColumnFilter: false,
       sortingFn: skillLevelSort,
     }),
-  ] as ColumnDef<SkillLibraryTableUserSkillFragmentType>[];
+  ] as ColumnDef<SkillPortfolioTableUserSkillFragmentType>[];
 
   return (
-    <Table<SkillLibraryTableUserSkillFragmentType>
+    <Table<SkillPortfolioTableUserSkillFragmentType>
       caption={caption}
       data={userSkills}
       columns={columns}
@@ -302,4 +302,4 @@ const SkillLibraryTable = ({
   );
 };
 
-export default SkillLibraryTable;
+export default SkillPortfolioTable;

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -859,6 +859,10 @@
     "defaultMessage": "Ce nom d’équipe est déjà utilisé",
     "description": "Error message that the given team name is already in use."
   },
+  "dBc/+T": {
+    "defaultMessage": "Bibliothèque de compétences",
+    "description": "Name of the skills library page"
+  },
   "dXiRk8": {
     "defaultMessage": "Capacité démontrée à accomplir de façon constante des tâches de faible complexité sous une supervision minimale et des tâches de complexité modérée sous une forte supervision ou un mentorat direct. Généralement associée à des postes juniors ou de niveau d’entrée.",
     "description": "The technical skill level definition for beginner"
@@ -918,6 +922,10 @@
   "faMBJc": {
     "defaultMessage": "\"Je suis étudiant(e).\"",
     "description": "Student selection for government employee type."
+  },
+  "fb/Smc": {
+    "defaultMessage": "Portfolio de compétences",
+    "description": "Name of the skills portfolio page"
   },
   "fdv2bM": {
     "defaultMessage": "Capacité démontrée à déterminer, définir, entreprendre et exécuter des tâches d’une grande complexité avec de vastes domaines de répercussions, même dans des circonstances difficiles. Capacité démontrée à diriger le développement de tâches, et potentiellement d’équipes, pour l’organisation dans ce domaine. Généralement associée à des postes de gestionnaire ou de responsable technique.",
@@ -1174,10 +1182,6 @@
   "ra+8d1": {
     "defaultMessage": "Erreur",
     "description": "Generic error message"
-  },
-  "rbhjTC": {
-    "defaultMessage": "Bibliothèque des compétences",
-    "description": "Name of the skill library page"
   },
   "rjHrNp": {
     "defaultMessage": "Parcourir les possibilités d'emploi",

--- a/packages/i18n/src/messages/navigationMessages.ts
+++ b/packages/i18n/src/messages/navigationMessages.ts
@@ -51,10 +51,15 @@ const navigationMessages = defineMessages({
     id: "TUfJUD",
     description: "Name of Career timeline page",
   },
-  skillLibrary: {
-    defaultMessage: "Skill library",
-    id: "rbhjTC",
-    description: "Name of the skill library page",
+  skillPortfolio: {
+    defaultMessage: "Skills portfolio",
+    id: "fb/Smc",
+    description: "Name of the skills portfolio page",
+  },
+  skillsLibrary: {
+    defaultMessage: "Skills library",
+    id: "dBc/+T",
+    description: "Name of the skills library page",
   },
   skillShowcase: {
     defaultMessage: "Skill showcase",


### PR DESCRIPTION
🤖 Resolves #11588 

## 👋 Introduction

Updates the page titles for skill pages.

## 🕵️ Details

I also changed the `SkillLibraryPage` component to be `SkillPortfolioPage` to avoid confusion.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as an application user
3. Navigate to `/applicant/skills`
4. Confirm page title is "Skills portfolio" along with all breadcrumbs
5. Navigate to `/skill`
6. Confirm page title is "Skills library" along with breadcrumbs

## 📸 Screenshot

![2024-09-25_12-47_1](https://github.com/user-attachments/assets/93dd49a7-67d5-40cc-b1d2-94fef418c3dc)
![2024-09-25_12-47](https://github.com/user-attachments/assets/1824f897-0f68-488e-9a9e-dfeba2b81d8c)
