### PR TITLE
[Fix] Stabilize published process notify test 

### DIFF
--- a/api/tests/Feature/Notifications/TriggerNewJobPostedTest.php
+++ b/api/tests/Feature/Notifications/TriggerNewJobPostedTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Notifications;
 
 use App\Enums\NotificationFamily;
+use App\Enums\PublishingGroup;
 use App\Models\Pool;
 use App\Models\Team;
 use App\Models\User;
@@ -74,6 +75,7 @@ class TriggerNewJobPostedTest extends TestCase
             ->for($this->adminUser)
             ->draft()
             ->create([
+                'publishing_group' => PublishingGroup::IT_JOBS->name,
                 'published_at' => null,
             ]);
 


### PR DESCRIPTION
🤖 Resolves #11624 

## 👋 Introduction

Stabilizes the test for notifying users of published processes.

## 🕵️ Details

We recent;y updated it to not send when publishing group was `OTHER`. Since the publishing group for that test was random, it would sometimes create it as other and fail the test.

## 🧪 Testing

1. Run the test multiple times
2. Confirm it consistently passes