### PR TITLE
[Fix] Increase uniqueness community key factory

### DIFF
--- a/api/database/factories/CommunityFactory.php
+++ b/api/database/factories/CommunityFactory.php
@@ -25,7 +25,7 @@ class CommunityFactory extends Factory
         $description = $this->faker->sentence();
 
         return [
-            'key' => $this->faker->slug(2),
+            'key' => $this->faker->unique()->slug(5),
             'name' => ['en' => $name.' EN', 'fr' => $name.' FR'],
             'description' => ['en' => $description.' EN', 'fr' => $description.' FR'],
         ];


### PR DESCRIPTION
🤖 Resolves #11644 

## 👋 Introduction

Increases the uniqueness of the community key factory by increasing the words in the result and using the `unique` method.

## 🕵️ Details

I'm not sure the `unique` key works when called separately so I also increased the words. We were using 2 which was sometimes causing collisions. 

## 🧪 Testing

1. Create a seeder to generates a lot of communities (1000?)
2. Run the seeder
3. Confirm unique constraint is not violated

