### PR TITLE
[Fix] Stabilize priority claim order 

### DIFF
--- a/api/tests/Feature/PoolCandidateTest.php
+++ b/api/tests/Feature/PoolCandidateTest.php
@@ -836,7 +836,10 @@ class PoolCandidateTest extends TestCase
         $unverifiedPriorityAndAcceptedVeteran = PoolCandidate::factory()->create(
             [
                 'pool_id' => $poolOne,
-                'user_id' => User::factory()->create(['citizenship' => CitizenshipStatus::CITIZEN->name]),
+                'user_id' => User::factory()->create([
+                    'has_priority_entitlement' => true,
+                    'citizenship' => CitizenshipStatus::CITIZEN->name,
+                ]),
             ],
         );
         $unverifiedPriorityAndAcceptedVeteran->update([


### PR DESCRIPTION
🤖 Resolves #11586 

## 👋 Introduction

Attempts to stabilize the ordering of candidate priority claims.

## 🕵️ Details

I think this was because the user who had unverified priority was not explicitly set to claim it so it was random and when they never claimed priority entitlement, they would naturally be sorted lower causing the error.

## 🧪 Testing

1. Confirm the `testOrderByClaimVerification` test passes consistently