### PR TITLE
[Copy] Change contract to employment and remove quotes

### DIFF
--- a/api/lang/en/headings.php
+++ b/api/lang/en/headings.php
@@ -40,7 +40,7 @@ return [
     'work_location' => 'Work location',
     'location_preferences' => 'Work location preferences',
     'location_exemptions' => 'Location exemptions',
-    'contract_duration' => 'Contract duration preference',
+    'contract_duration' => 'Employment duration preference',
     'accept_temporary' => 'Accept temporary',
     'accepted_operational_requirements' => 'Acceptable job requirements',
     'rejected_operational_requirements' => 'Would not consider a job that requires: ',

--- a/api/lang/fr/headings.php
+++ b/api/lang/fr/headings.php
@@ -39,7 +39,7 @@ return [
     'work_location' => 'Lieu de travail',
     'location_preferences' => 'Préférences pour le lieu de travail',
     'location_exemptions' => 'Exemptions de lieux',
-    'contract_duration' => 'Préférence pour la durée du contrat',
+    'contract_duration' => 'Préférence pour la durée de l\'emploi',
     'accept_temporary' => 'Accepter les temporaires',
     'accepted_operational_requirements' => 'Envisagerait d\'accepter un emploi qui : ',
     'rejected_operational_requirements' => 'N\'envisagerait pas d\'accepter un emploi qui : ',

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2859,8 +2859,8 @@
     "defaultMessage": "Lieu actuel :",
     "description": "Display text for the current location field on users"
   },
-  "DNpCdL": {
-    "defaultMessage": "Type de contrat",
+  "Mqek+i": {
+    "defaultMessage": "Type d'emploi",
     "description": "Employee Status in Employee Info Form"
   },
   "DOmsNQ": {
@@ -10266,8 +10266,8 @@
     "defaultMessage": "Fait l’objet d’une évaluation complète en fonction de l’énoncé des critères de mérite du programme d’apprentissage en TI pour les personnes autochtones et avoir été jugé qualifié pour le rôle d’apprenti IT-01 (ou équivalent)",
     "description": "Item 2 in the candidate list in the 'Indigenous talent ready for IT apprenticeships' section"
   },
-  "q2YMXX": {
-    "defaultMessage": "\"Oui, je suis un(e) employé(e) du gouvernement du Canada.\"",
+  "Td2+oC": {
+    "defaultMessage": "Oui, je suis un(e) employé(e) du gouvernement du Canada.",
     "description": "Label displayed for is a government employee option"
   },
   "q5FQbu": {
@@ -11006,8 +11006,8 @@
     "defaultMessage": "« Je comprends que je fais partie d'une collectivité qui se fait confiance »",
     "description": "Signature list item on sign and submit page."
   },
-  "uoqhRN": {
-    "defaultMessage": "\"Non, je ne suis pas un(e) employé(e) du gouvernement du Canada.\"",
+  "yUSG9Z": {
+    "defaultMessage": "Non, je ne suis pas un(e) employé(e) du gouvernement du Canada.",
     "description": "Label displayed for is not a government employee option"
   },
   "uqiPvH": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2859,10 +2859,6 @@
     "defaultMessage": "Lieu actuel :",
     "description": "Display text for the current location field on users"
   },
-  "Mqek+i": {
-    "defaultMessage": "Type d'emploi",
-    "description": "Employee Status in Employee Info Form"
-  },
   "DOmsNQ": {
     "defaultMessage": "Non démontré suffisamment dans le cadre de la présente méthode d’évaluation – faire passer à de plus amples mises à l’essai. (Ne s’applique qu’aux occasions où les points sont cumulatifs à l’échelle des méthodes d’évaluation. Ne s’applique pas dans les cas où les candidats doivent répondre à certains critères essentiels à chaque étape).",
     "description": "Note for when an assessment was unsuccessful but put on hold"
@@ -4623,6 +4619,10 @@
     "defaultMessage": "Tâches de travail (français)",
     "description": "Label for a process' French work tasks"
   },
+  "Mqek+i": {
+    "defaultMessage": "Type d'emploi",
+    "description": "Employee Status in Employee Info Form"
+  },
   "MsLKAj": {
     "defaultMessage": "Voir l’expérience pour {experienceName}",
     "description": "Assistive technology link text to view a specific experience"
@@ -4826,6 +4826,10 @@
   "NuT+Rx": {
     "defaultMessage": "Procéder à la mise à jour du sujet",
     "description": "Heading label for update a user's subject form"
+  },
+  "NwlRd5": {
+    "defaultMessage": "J'accepte de recevoir des notifications par courriel de Talents numériques du GC.",
+    "description": "Text for the option consent to email notifications."
   },
   "NxrKpM": {
     "defaultMessage": "Statut de la candidature",
@@ -5915,6 +5919,14 @@
     "defaultMessage": "Exigences",
     "description": "Heading for the contract requirements section on the digital services contracting questionnaire"
   },
+  "Td2+oC": {
+    "defaultMessage": "Oui, je suis un(e) employé(e) du gouvernement du Canada.",
+    "description": "Label displayed for is a government employee option"
+  },
+  "TfEUPu": {
+    "defaultMessage": "Préférence pour la durée de l'emploi",
+    "description": "Legend Text for required work preferences options in work preferences form"
+  },
   "TfbBB7": {
     "defaultMessage": "Collectivité {communityId} introuvable.",
     "description": "Message displayed for community not found."
@@ -6193,10 +6205,6 @@
   "VD/o5X": {
     "defaultMessage": "Aucune compétence trouvée.",
     "description": "Messaged displayed when no skill exists."
-  },
-  "TfEUPu": {
-    "defaultMessage": "Préférence pour la durée de l'emploi",
-    "description": "Legend Text for required work preferences options in work preferences form"
   },
   "VHG9Gm": {
     "defaultMessage": "Désélectionner <hidden> rangées sélectionnées</hidden>",
@@ -10266,10 +10274,6 @@
     "defaultMessage": "Fait l’objet d’une évaluation complète en fonction de l’énoncé des critères de mérite du programme d’apprentissage en TI pour les personnes autochtones et avoir été jugé qualifié pour le rôle d’apprenti IT-01 (ou équivalent)",
     "description": "Item 2 in the candidate list in the 'Indigenous talent ready for IT apprenticeships' section"
   },
-  "Td2+oC": {
-    "defaultMessage": "Oui, je suis un(e) employé(e) du gouvernement du Canada.",
-    "description": "Label displayed for is a government employee option"
-  },
   "q5FQbu": {
     "defaultMessage": "À venir!",
     "description": "Heading for a coming soon section"
@@ -11006,10 +11010,6 @@
     "defaultMessage": "« Je comprends que je fais partie d'une collectivité qui se fait confiance »",
     "description": "Signature list item on sign and submit page."
   },
-  "yUSG9Z": {
-    "defaultMessage": "Non, je ne suis pas un(e) employé(e) du gouvernement du Canada.",
-    "description": "Label displayed for is not a government employee option"
-  },
   "uqiPvH": {
     "defaultMessage": "Suivi de vos candidatures",
     "description": "Heading for track applications section on the profile and applications."
@@ -11598,6 +11598,10 @@
     "defaultMessage": "Téléchargez le guide de mise en œuvre pour les gestionnaires",
     "description": "Aria label for download guidance for managers plain text link."
   },
+  "yUSG9Z": {
+    "defaultMessage": "Non, je ne suis pas un(e) employé(e) du gouvernement du Canada.",
+    "description": "Label displayed for is not a government employee option"
+  },
   "yV/mQS": {
     "defaultMessage": "Les employées et employés du gouvernement du Canada ou les personnes employées par une agence du gouvernement du Canada qui sont présentement classés comme {classificationString} ou un équivalent organisationnel dans leur poste d'attache.",
     "description": "At-level application criteria"
@@ -11633,10 +11637,6 @@
   "yat9wx": {
     "defaultMessage": "Utilisez le bouton \"Créer un ministère\" pour commencer.",
     "description": "Instructions for adding a department item."
-  },
-  "NwlRd5": {
-    "defaultMessage": "J'accepte de recevoir des notifications par courriel de Talents numériques du GC.",
-    "description": "Text for the option consent to email notifications."
   },
   "yfzR+U": {
     "defaultMessage": "Il semble que vous n’ayez pas encore ajouté d’expériences à votre parcours professionnel.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6194,8 +6194,8 @@
     "defaultMessage": "Aucune compétence trouvée.",
     "description": "Messaged displayed when no skill exists."
   },
-  "VFK3wC": {
-    "defaultMessage": "Préférence pour la durée du contrat",
+  "TfEUPu": {
+    "defaultMessage": "Préférence pour la durée de l'emploi",
     "description": "Legend Text for required work preferences options in work preferences form"
   },
   "VHG9Gm": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4619,10 +4619,6 @@
     "defaultMessage": "Tâches de travail (français)",
     "description": "Label for a process' French work tasks"
   },
-  "Mqek+i": {
-    "defaultMessage": "Type d'emploi",
-    "description": "Employee Status in Employee Info Form"
-  },
   "MsLKAj": {
     "defaultMessage": "Voir l’expérience pour {experienceName}",
     "description": "Assistive technology link text to view a specific experience"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -11634,8 +11634,8 @@
     "defaultMessage": "Utilisez le bouton \"Créer un ministère\" pour commencer.",
     "description": "Instructions for adding a department item."
   },
-  "ydjlRN": {
-    "defaultMessage": "\"J'accepte de recevoir des notifications par courriel de Talents numériques du GC.\"",
+  "NwlRd5": {
+    "defaultMessage": "J'accepte de recevoir des notifications par courriel de Talents numériques du GC.",
     "description": "Text for the option consent to email notifications."
   },
   "yfzR+U": {

--- a/apps/web/src/messages/profileMessages.ts
+++ b/apps/web/src/messages/profileMessages.ts
@@ -34,8 +34,8 @@ const messages = defineMessages({
     description: "Title for priority status",
   },
   contractDuration: {
-    defaultMessage: "Contract duration preference",
-    id: "VFK3wC",
+    defaultMessage: "Employment duration preference",
+    id: "TfEUPu",
     description:
       "Legend Text for required work preferences options in work preferences form",
   },

--- a/apps/web/src/pages/Auth/RegistrationPages/EmployeeInformationPage/EmployeeInformationPage.test.tsx
+++ b/apps/web/src/pages/Auth/RegistrationPages/EmployeeInformationPage/EmployeeInformationPage.test.tsx
@@ -89,7 +89,7 @@ describe("Create Account Form tests", () => {
     // Ensure conditional form elements don't exist yet.
     expect(
       screen.queryByRole("group", {
-        name: /contract type/i,
+        name: /employment type/i,
       }),
     ).not.toBeInTheDocument();
     expect(
@@ -122,7 +122,7 @@ describe("Create Account Form tests", () => {
 
     expect(
       screen.getByRole("group", {
-        name: /contract type/i,
+        name: /employment type/i,
       }),
     ).toBeInTheDocument();
     expect(

--- a/apps/web/src/pages/Auth/RegistrationPages/EmployeeInformationPage/EmployeeInformationPage.tsx
+++ b/apps/web/src/pages/Auth/RegistrationPages/EmployeeInformationPage/EmployeeInformationPage.tsx
@@ -441,8 +441,8 @@ export const EmployeeInformationForm = ({
     }),
     govEmployeeType: intl.formatMessage({
       defaultMessage: "Employment type",
-      id: "Mqek+i",
-      description: "Employee Status in Employee Info Form",
+      id: "xzSXz9",
+      description: "Employment type label",
     }),
     workEmail: intl.formatMessage({
       defaultMessage: "Work email address",

--- a/apps/web/src/pages/Auth/RegistrationPages/EmployeeInformationPage/EmployeeInformationPage.tsx
+++ b/apps/web/src/pages/Auth/RegistrationPages/EmployeeInformationPage/EmployeeInformationPage.tsx
@@ -223,9 +223,8 @@ export const EmployeeInformationFormFields = ({
             {
               value: "no",
               label: intl.formatMessage({
-                defaultMessage:
-                  '"No, I am not a Government of Canada employee."',
-                id: "uoqhRN",
+                defaultMessage: "No, I am not a Government of Canada employee.",
+                id: "yUSG9Z",
                 description:
                   "Label displayed for is not a government employee option",
               }),
@@ -233,8 +232,8 @@ export const EmployeeInformationFormFields = ({
             {
               value: "yes",
               label: intl.formatMessage({
-                defaultMessage: '"Yes, I am a Government of Canada employee."',
-                id: "q2YMXX",
+                defaultMessage: "Yes, I am a Government of Canada employee.",
+                id: "Td2+oC",
                 description:
                   "Label displayed for is a government employee option",
               }),
@@ -441,8 +440,8 @@ export const EmployeeInformationForm = ({
       description: "Label for department select input in Employee Info Form",
     }),
     govEmployeeType: intl.formatMessage({
-      defaultMessage: "Contract type",
-      id: "DNpCdL",
+      defaultMessage: "Employment type",
+      id: "Mqek+i",
       description: "Employee Status in Employee Info Form",
     }),
     workEmail: intl.formatMessage({

--- a/apps/web/src/pages/Auth/RegistrationPages/GettingStartedPage/GettingStartedPage.tsx
+++ b/apps/web/src/pages/Auth/RegistrationPages/GettingStartedPage/GettingStartedPage.tsx
@@ -160,8 +160,8 @@ export const GettingStartedFormFields = ({
           boundingBoxLabel={labels.emailConsent}
           label={intl.formatMessage({
             defaultMessage:
-              '"I agree to receive email notifications from GC Digital Talent."',
-            id: "ydjlRN",
+              "I agree to receive email notifications from GC Digital Talent.",
+            id: "NwlRd5",
             description: "Text for the option consent to email notifications.",
           })}
         />

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -787,8 +787,8 @@
     "defaultMessage": "Ajouter le lien",
     "description": "Button text for adding a link in the rich text editor"
   },
-  "ZX5gv1": {
-    "defaultMessage": "\"Je suis un(e) employé(e) nommé(e) pour une période indéterminée.\"",
+  "2fFKCI": {
+    "defaultMessage": "Je suis un(e) employé(e) nommé(e) pour une période indéterminée.",
     "description": "Indeterminate selection for government employee type."
   },
   "ZhQEUx": {
@@ -831,8 +831,8 @@
     "defaultMessage": "Je <strong>ne suis pas</strong> des Forces armées canadiennes.",
     "description": "declare self to not be in the CAF"
   },
-  "bE1GJ9": {
-    "defaultMessage": "\"J'ai un contrat d'employé(e) temporaire.\"",
+  "UZMVuy": {
+    "defaultMessage": "J'ai un contrat d'employé(e) temporaire.",
     "description": "Casual selection for government employee type."
   },
   "bXECaV": {
@@ -919,8 +919,8 @@
     "defaultMessage": "Sélectionnez une option",
     "description": "Null selection for select input"
   },
-  "faMBJc": {
-    "defaultMessage": "\"Je suis étudiant(e).\"",
+  "2kqbbB": {
+    "defaultMessage": "Je suis étudiant(e).",
     "description": "Student selection for government employee type."
   },
   "fb/Smc": {
@@ -1015,8 +1015,8 @@
     "defaultMessage": "La date d’expiration doit être postérieure à aujourd’hui. Veuillez saisir une date valide.",
     "description": "Error message that an expiry date must be in the future"
   },
-  "k8NLSx": {
-    "defaultMessage": "\"J'ai un poste doté pour une période déterminée.\"",
+  "Nf2jAz": {
+    "defaultMessage": "J'ai un poste doté pour une période déterminée.",
     "description": "Term selection for government employee type."
   },
   "kDw+xr": {

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -115,6 +115,14 @@
     "defaultMessage": "La question donnée à l'écran n'existe pas.",
     "description": "Error message that the screening question could not be found."
   },
+  "2fFKCI": {
+    "defaultMessage": "Je suis un(e) employé(e) nommé(e) pour une période indéterminée.",
+    "description": "Indeterminate selection for government employee type."
+  },
+  "2kqbbB": {
+    "defaultMessage": "Je suis étudiant(e).",
+    "description": "Student selection for government employee type."
+  },
   "2wKf2U": {
     "defaultMessage": "Modifiez",
     "description": "Text to trigger edit action"
@@ -531,6 +539,10 @@
     "defaultMessage": "Modifier la séquence de {from} à {to}",
     "description": "Button text for moving an item from one position to another"
   },
+  "Nf2jAz": {
+    "defaultMessage": "J'ai un poste doté pour une période déterminée.",
+    "description": "Term selection for government employee type."
+  },
   "OBQ8b9": {
     "defaultMessage": "(s'ouvre dans un nouvel onglet)",
     "description": "Text that appears in links that open in a new tab."
@@ -695,6 +707,10 @@
     "defaultMessage": "J'accepte d'avoir un emploi qui nécessite des déplacements.",
     "description": "The operational requirement described as travel as required."
   },
+  "UZMVuy": {
+    "defaultMessage": "J'ai un contrat d'employé(e) temporaire.",
+    "description": "Casual selection for government employee type."
+  },
   "V3+fXY": {
     "defaultMessage": "L’exigence relative à l’éducation est incomplete",
     "description": "Message displayed when user attempts to apply to a pool with incomplete education requirement"
@@ -787,10 +803,6 @@
     "defaultMessage": "Ajouter le lien",
     "description": "Button text for adding a link in the rich text editor"
   },
-  "2fFKCI": {
-    "defaultMessage": "Je suis un(e) employé(e) nommé(e) pour une période indéterminée.",
-    "description": "Indeterminate selection for government employee type."
-  },
   "ZhQEUx": {
     "defaultMessage": "Ce champ requiert des dates ultérieures seulement.",
     "description": "Error message that the provided date must be in the future."
@@ -830,10 +842,6 @@
   "bAaDat": {
     "defaultMessage": "Je <strong>ne suis pas</strong> des Forces armées canadiennes.",
     "description": "declare self to not be in the CAF"
-  },
-  "UZMVuy": {
-    "defaultMessage": "J'ai un contrat d'employé(e) temporaire.",
-    "description": "Casual selection for government employee type."
   },
   "bXECaV": {
     "defaultMessage": "Il est impossible d'ignorer le groupe de notifications en question.",
@@ -918,10 +926,6 @@
   "fUF8rg": {
     "defaultMessage": "Sélectionnez une option",
     "description": "Null selection for select input"
-  },
-  "2kqbbB": {
-    "defaultMessage": "Je suis étudiant(e).",
-    "description": "Student selection for government employee type."
   },
   "fb/Smc": {
     "defaultMessage": "Portfolio de compétences",
@@ -1014,10 +1018,6 @@
   "k8IB9g": {
     "defaultMessage": "La date d’expiration doit être postérieure à aujourd’hui. Veuillez saisir une date valide.",
     "description": "Error message that an expiry date must be in the future"
-  },
-  "Nf2jAz": {
-    "defaultMessage": "J'ai un poste doté pour une période déterminée.",
-    "description": "Term selection for government employee type."
   },
   "kDw+xr": {
     "defaultMessage": "Chaque compétence doit être incluse dans une évaluation",

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -551,23 +551,23 @@ export const getOperationalRequirement = (
 
 const govEmployeeType = defineMessages({
   [GovEmployeeType.Student]: {
-    defaultMessage: '"I am a student."',
-    id: "faMBJc",
+    defaultMessage: "I am a student.",
+    id: "2kqbbB",
     description: "Student selection for government employee type.",
   },
   [GovEmployeeType.Casual]: {
-    defaultMessage: '"I have a casual contract."',
-    id: "bE1GJ9",
+    defaultMessage: "I have a casual contract.",
+    id: "UZMVuy",
     description: "Casual selection for government employee type.",
   },
   [GovEmployeeType.Term]: {
-    defaultMessage: '"I have a term position."',
-    id: "k8NLSx",
+    defaultMessage: "I have a term position.",
+    id: "Nf2jAz",
     description: "Term selection for government employee type.",
   },
   [GovEmployeeType.Indeterminate]: {
-    defaultMessage: '"I am an indeterminate employee."',
-    id: "ZX5gv1",
+    defaultMessage: "I am an indeterminate employee.",
+    id: "2fFKCI",
     description: "Indeterminate selection for government employee type.",
   },
 });


### PR DESCRIPTION
🤖 Resolves #11613.

## 👋 Introduction

Updates the copy for "Contract type" to "Employment type" and "Contract duration" to "Employment duration" on a few pages. Also removes quotes from form fields in registration pages. All updates are mirrored in french.

## 🧪 Testing

1. Confirm the removed quotes in registration forms
2. Confirm "Contract type" updated to "Employment type" on the Employee Information page
3. Confirm "Contract duration" updated to "Employment duration" in a few places:
    - Applicant profile
    - Admin view applicant profile
    - Snapshot
    - Profile download

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/b10cc9e8-1c00-4f38-b584-a331ca71c98d)
![image](https://github.com/user-attachments/assets/573776da-20b2-40a9-909b-894c0c41170e)
