### PR TITLE
[Fix] Fix consistent types for `useRequiredParams`

### DIFF
--- a/apps/web/src/hooks/useRequiredParams.ts
+++ b/apps/web/src/hooks/useRequiredParams.ts
@@ -58,7 +58,9 @@ function assertParam(
  * @param enforceUUID
  */
 const useRequiredParams = <
-  T extends Record<string, string>,
+  // Note: Constrained by the useParams generic also not knowing
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends Record<PropertyKey, any>,
   K extends keyof T = keyof T,
 >(
   keys: K | K[],

--- a/apps/web/src/hooks/useRequiredParams.ts
+++ b/apps/web/src/hooks/useRequiredParams.ts
@@ -58,9 +58,7 @@ function assertParam(
  * @param enforceUUID
  */
 const useRequiredParams = <
-  // Note: Constrained by the useParams generic also not knowing
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  T extends Record<PropertyKey, any>,
+  T extends Record<string, string>,
   K extends keyof T = keyof T,
 >(
   keys: K | K[],

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
@@ -62,7 +62,7 @@ export const getPageInfo: GetPageNavInfo = ({
   };
 };
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   experienceId: string;
   applicationId: string;
 }

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
@@ -62,11 +62,10 @@ export const getPageInfo: GetPageNavInfo = ({
   };
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   experienceId: string;
   applicationId: string;
-};
+}
 
 interface ApplicationCareerTimelineEditProps extends ApplicationPageProps {
   experience: AnyExperience;

--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -31,7 +31,7 @@ import { ContextType } from "./useApplication";
 import Application_PoolCandidateFragment from "./fragment";
 import { getApplicationSteps } from "./utils";
 
-interface RouteParams extends Record<PropertyKey, string> {
+interface RouteParams extends Record<string, string> {
   experienceId: string;
 }
 

--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -31,10 +31,9 @@ import { ContextType } from "./useApplication";
 import Application_PoolCandidateFragment from "./fragment";
 import { getApplicationSteps } from "./utils";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams extends Record<PropertyKey, string> {
   experienceId: string;
-};
+}
 
 interface ApplicationPageWrapperProps {
   query: FragmentType<typeof Application_PoolCandidateFragment>;

--- a/apps/web/src/pages/Applications/useApplicationId.ts
+++ b/apps/web/src/pages/Applications/useApplicationId.ts
@@ -1,9 +1,8 @@
 import useRequiredParams from "~/hooks/useRequiredParams";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   applicationId: string;
-};
+}
 
 const useApplicationId = () => {
   const { applicationId } = useRequiredParams<RouteParams>("applicationId");

--- a/apps/web/src/pages/Applications/useApplicationId.ts
+++ b/apps/web/src/pages/Applications/useApplicationId.ts
@@ -1,6 +1,6 @@
 import useRequiredParams from "~/hooks/useRequiredParams";
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   applicationId: string;
 }
 

--- a/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
@@ -220,7 +220,7 @@ export const UpdateClassificationForm = ({
   );
 };
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   classificationId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
@@ -220,10 +220,9 @@ export const UpdateClassificationForm = ({
   );
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   classificationId: Scalars["ID"]["output"];
-};
+}
 
 const Classification_Query = graphql(/* GraphQL */ `
   query Classification($id: UUID!) {

--- a/apps/web/src/pages/Communities/CommunityLayout.tsx
+++ b/apps/web/src/pages/Communities/CommunityLayout.tsx
@@ -111,7 +111,7 @@ const CommunityLayoutCommunityName_Query = graphql(/* GraphQL */ `
   }
 `);
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   communityId: string;
 }
 

--- a/apps/web/src/pages/Communities/CommunityLayout.tsx
+++ b/apps/web/src/pages/Communities/CommunityLayout.tsx
@@ -111,10 +111,9 @@ const CommunityLayoutCommunityName_Query = graphql(/* GraphQL */ `
   }
 `);
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   communityId: string;
-};
+}
 
 const CommunityLayout = () => {
   const { communityId } = useRequiredParams<RouteParams>("communityId");

--- a/apps/web/src/pages/Communities/CommunityMembersPage/CommunityMembersPage.tsx
+++ b/apps/web/src/pages/Communities/CommunityMembersPage/CommunityMembersPage.tsx
@@ -160,10 +160,9 @@ const CommunityMembersTeam_Query = graphql(/* GraphQL */ `
   }
 `);
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   communityId: Scalars["ID"]["output"];
-};
+}
 
 const CommunityMembersPage = () => {
   const { communityId } = useRequiredParams<RouteParams>("communityId");

--- a/apps/web/src/pages/Communities/CommunityMembersPage/CommunityMembersPage.tsx
+++ b/apps/web/src/pages/Communities/CommunityMembersPage/CommunityMembersPage.tsx
@@ -160,7 +160,7 @@ const CommunityMembersTeam_Query = graphql(/* GraphQL */ `
   }
 `);
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   communityId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Communities/ViewCommunityPage/ViewCommunityPage.tsx
+++ b/apps/web/src/pages/Communities/ViewCommunityPage/ViewCommunityPage.tsx
@@ -20,10 +20,9 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
 import CommunitySection from "./components/CommunitySection";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   communityId: Scalars["ID"]["output"];
-};
+}
 
 const ViewCommunity_Query = graphql(/* GraphQL */ `
   query ViewCommunity($id: UUID!) {

--- a/apps/web/src/pages/Communities/ViewCommunityPage/ViewCommunityPage.tsx
+++ b/apps/web/src/pages/Communities/ViewCommunityPage/ViewCommunityPage.tsx
@@ -20,7 +20,7 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
 import CommunitySection from "./components/CommunitySection";
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   communityId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
+++ b/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
@@ -17,10 +17,9 @@ import useRoutes from "~/hooks/useRoutes";
 import useRequiredParams from "~/hooks/useRequiredParams";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   poolId: Scalars["ID"]["output"];
-};
+}
 
 const CreateApplicationApplications_Query = graphql(/* GraphQL */ `
   query CreateApplicationApplications {

--- a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
+++ b/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
@@ -17,7 +17,7 @@ import useRoutes from "~/hooks/useRoutes";
 import useRequiredParams from "~/hooks/useRequiredParams";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   poolId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
@@ -146,10 +146,9 @@ export const UpdateDepartmentForm = ({
   );
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   departmentId: Scalars["ID"]["output"];
-};
+}
 
 const Department_Query = graphql(/* GraphQL */ `
   query Department($id: UUID!) {

--- a/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
@@ -146,7 +146,7 @@ export const UpdateDepartmentForm = ({
   );
 };
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   departmentId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/JobPosterTemplatePage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/JobPosterTemplatePage.tsx
@@ -218,7 +218,7 @@ const JobPosterTemplatePage_Query = graphql(/* GraphQL */ `
   }
 `);
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   templateId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/JobPosterTemplatePage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/JobPosterTemplatePage.tsx
@@ -218,10 +218,9 @@ const JobPosterTemplatePage_Query = graphql(/* GraphQL */ `
   }
 `);
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   templateId: Scalars["ID"]["output"];
-};
+}
 
 const context: Partial<OperationContext> = {
   requestPolicy: "cache-first",

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
@@ -17,7 +17,7 @@ import adminMessages from "~/messages/adminMessages";
 import useRequiredParams from "~/hooks/useRequiredParams";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   poolId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
@@ -17,10 +17,9 @@ import adminMessages from "~/messages/adminMessages";
 import useRequiredParams from "~/hooks/useRequiredParams";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   poolId: Scalars["ID"]["output"];
-};
+}
 
 const IndexPoolCandidatePage_Query = graphql(/* GraphQL */ `
   query IndexPoolCandidatePage($id: UUID!) {

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -357,11 +357,10 @@ const context: Partial<OperationContext> = {
   additionalTypenames: ["AssessmentResult"],
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   poolId: Scalars["ID"]["output"];
   poolCandidateId: Scalars["ID"]["output"];
-};
+}
 
 export const ViewPoolCandidatePage = () => {
   const intl = useIntl();

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -357,7 +357,7 @@ const context: Partial<OperationContext> = {
   additionalTypenames: ["AssessmentResult"],
 };
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   poolId: Scalars["ID"]["output"];
   poolCandidateId: Scalars["ID"]["output"];
 }

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
@@ -136,10 +136,9 @@ export const AssessmentPlanBuilder = ({
   );
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   poolId: Scalars["ID"]["output"];
-};
+}
 
 const AssessmentPlanBuilderPage_Query = graphql(/* GraphQL */ `
   query AssessmentPlanBuilderPage($poolId: UUID!) {

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/AssessmentPlanBuilderPage.tsx
@@ -136,7 +136,7 @@ export const AssessmentPlanBuilder = ({
   );
 };
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   poolId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -811,10 +811,9 @@ const EditPoolPage_Query = graphql(/* GraphQL */ `
   }
 `);
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   poolId: Scalars["ID"]["output"];
-};
+}
 
 const context: Partial<OperationContext> = {
   additionalTypenames: ["PoolSkill"],

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -811,7 +811,7 @@ const EditPoolPage_Query = graphql(/* GraphQL */ `
   }
 `);
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   poolId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Pools/ManageAccessPage/ManageAccessPage.tsx
+++ b/apps/web/src/pages/Pools/ManageAccessPage/ManageAccessPage.tsx
@@ -154,7 +154,7 @@ const ManageAccessPage_PoolQuery = graphql(/* GraphQL */ `
   }
 `);
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   poolId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Pools/ManageAccessPage/ManageAccessPage.tsx
+++ b/apps/web/src/pages/Pools/ManageAccessPage/ManageAccessPage.tsx
@@ -154,10 +154,9 @@ const ManageAccessPage_PoolQuery = graphql(/* GraphQL */ `
   }
 `);
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   poolId: Scalars["ID"]["output"];
-};
+}
 
 const ManageAccessPoolPage = () => {
   const { poolId } = useRequiredParams<RouteParams>("poolId");

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -1282,10 +1282,9 @@ const PoolNotFound = () => {
   );
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   poolId: Scalars["ID"]["output"];
-};
+}
 
 const PoolAdvertisementPage_Query = graphql(/* GraphQL */ `
   query PoolAdvertisementPage($id: UUID!) {

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -1282,7 +1282,7 @@ const PoolNotFound = () => {
   );
 };
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   poolId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Pools/PoolLayout.tsx
+++ b/apps/web/src/pages/Pools/PoolLayout.tsx
@@ -201,7 +201,7 @@ const PoolLayout_Query = graphql(/* GraphQL */ `
   }
 `);
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   poolId: string;
 }
 

--- a/apps/web/src/pages/Pools/PoolLayout.tsx
+++ b/apps/web/src/pages/Pools/PoolLayout.tsx
@@ -201,10 +201,9 @@ const PoolLayout_Query = graphql(/* GraphQL */ `
   }
 `);
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   poolId: string;
-};
+}
 
 const PoolLayout = () => {
   const { poolId } = useRequiredParams<RouteParams>("poolId");

--- a/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
+++ b/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
@@ -24,7 +24,7 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import { transformFormValuesToFilterState } from "~/components/AssessmentStepTracker/utils";
 import { FormValues } from "~/components/AssessmentStepTracker/types";
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   poolId: Scalars["ID"]["input"];
 }
 

--- a/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
+++ b/apps/web/src/pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage.tsx
@@ -24,10 +24,9 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import { transformFormValuesToFilterState } from "~/components/AssessmentStepTracker/utils";
 import { FormValues } from "~/components/AssessmentStepTracker/types";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   poolId: Scalars["ID"]["input"];
-};
+}
 
 const ScreeningAndEvaluation_PoolQuery = graphql(/* GraphQL */ `
   query ScreeningAndEvaluation_Pools(

--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -505,7 +505,7 @@ export const ViewPool = ({
   );
 };
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   poolId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -505,10 +505,9 @@ export const ViewPool = ({
   );
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   poolId: Scalars["ID"]["output"];
-};
+}
 
 const ViewPoolPage_Query = graphql(/* GraphQL */ `
   query ViewPoolPage($id: UUID!) {

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -638,12 +638,11 @@ const ExperienceFormData_Query = graphql(/* GraphQL */ `
   }
 `);
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams extends Record<PropertyKey, string> {
   userId: Scalars["ID"]["output"];
   experienceType: ExperienceType;
   experienceId: Scalars["ID"]["output"];
-};
+}
 
 interface ExperienceFormContainerProps {
   edit?: boolean;

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -638,7 +638,7 @@ const ExperienceFormData_Query = graphql(/* GraphQL */ `
   }
 `);
 
-interface RouteParams extends Record<PropertyKey, string> {
+interface RouteParams extends Record<string, string> {
   userId: Scalars["ID"]["output"];
   experienceType: ExperienceType;
   experienceId: Scalars["ID"]["output"];

--- a/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
@@ -32,10 +32,9 @@ const subTitle = defineMessage({
   description: "Subtitle for the request confirmation page.",
 });
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RequestConfirmationParams = {
+interface RouteParams {
   requestId: Scalars["ID"]["output"];
-};
+}
 
 const mailLink = (chunks: ReactNode) => (
   <Link external href="mailto:recruitmentimit-recrutementgiti@tbs-sct.gc.ca">
@@ -46,8 +45,7 @@ const mailLink = (chunks: ReactNode) => (
 export const Component = () => {
   const intl = useIntl();
   const paths = useRoutes();
-  const { requestId } =
-    useRequiredParams<RequestConfirmationParams>("requestId");
+  const { requestId } = useRequiredParams<RouteParams>("requestId");
 
   const formattedPageTitle = intl.formatMessage(pageTitle);
   const formattedSubTitle = intl.formatMessage(subTitle);

--- a/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
@@ -32,7 +32,7 @@ const subTitle = defineMessage({
   description: "Subtitle for the request confirmation page.",
 });
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   requestId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/ViewSearchRequestPage.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/ViewSearchRequestPage.tsx
@@ -6,10 +6,9 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
 import ViewSearchRequestApi from "./components/ViewSearchRequest";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   searchRequestId: Scalars["ID"]["output"];
-};
+}
 
 export const SingleSearchRequestPage = () => {
   const { searchRequestId } = useRequiredParams<RouteParams>("searchRequestId");

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/ViewSearchRequestPage.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/ViewSearchRequestPage.tsx
@@ -6,7 +6,7 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
 import ViewSearchRequestApi from "./components/ViewSearchRequest";
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   searchRequestId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
@@ -273,10 +273,9 @@ export const UpdateSkillFamilyForm = ({
   );
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   skillFamilyId: Scalars["ID"]["output"];
-};
+}
 
 const UpdateSkillFamilyData_Query = graphql(/* GraphQL */ `
   query SkillFamilySkillsData($id: UUID!) {

--- a/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
@@ -273,7 +273,7 @@ export const UpdateSkillFamilyForm = ({
   );
 };
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   skillFamilyId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Skills/UpdateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateSkillPage.tsx
@@ -337,7 +337,7 @@ export const UpdateSkillForm = ({
   );
 };
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   skillId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Skills/UpdateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateSkillPage.tsx
@@ -337,10 +337,9 @@ export const UpdateSkillForm = ({
   );
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   skillId: Scalars["ID"]["output"];
-};
+}
 
 const UpdateSkillData_Query = graphql(/* GraphQL */ `
   query UpdateSkillData($id: UUID!) {

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -769,7 +769,7 @@ export const UpdateUserSkillForm = ({
   );
 };
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   skillId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -769,10 +769,9 @@ export const UpdateUserSkillForm = ({
   );
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   skillId: Scalars["ID"]["output"];
-};
+}
 
 const UpdateUserSkill_Query = graphql(/* GraphQL */ `
   query UserSkill($skillId: UUID!) {

--- a/apps/web/src/pages/Teams/TeamLayout.tsx
+++ b/apps/web/src/pages/Teams/TeamLayout.tsx
@@ -121,7 +121,7 @@ const TeamLayoutTeamName_Query = graphql(/* GraphQL */ `
   }
 `);
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   teamId: string;
 }
 

--- a/apps/web/src/pages/Teams/TeamLayout.tsx
+++ b/apps/web/src/pages/Teams/TeamLayout.tsx
@@ -121,10 +121,9 @@ const TeamLayoutTeamName_Query = graphql(/* GraphQL */ `
   }
 `);
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   teamId: string;
-};
+}
 
 const TeamLayout = () => {
   const { teamId } = useRequiredParams<RouteParams>("teamId");

--- a/apps/web/src/pages/Teams/TeamMembersPage/TeamMembersPage.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/TeamMembersPage.tsx
@@ -143,7 +143,7 @@ const TeamMembersTeam_Query = graphql(/* GraphQL */ `
   }
 `);
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   teamId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Teams/TeamMembersPage/TeamMembersPage.tsx
+++ b/apps/web/src/pages/Teams/TeamMembersPage/TeamMembersPage.tsx
@@ -143,10 +143,9 @@ const TeamMembersTeam_Query = graphql(/* GraphQL */ `
   }
 `);
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   teamId: Scalars["ID"]["output"];
-};
+}
 
 const TeamMembersPage = () => {
   const { teamId } = useRequiredParams<RouteParams>("teamId");

--- a/apps/web/src/pages/Teams/UpdateTeamPage/UpdateTeamPage.tsx
+++ b/apps/web/src/pages/Teams/UpdateTeamPage/UpdateTeamPage.tsx
@@ -34,10 +34,9 @@ const UpdateTeamData_Query = graphql(/* GraphQL */ `
   }
 `);
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   teamId: string;
-};
+}
 
 const EditTeamPage = () => {
   const intl = useIntl();

--- a/apps/web/src/pages/Teams/UpdateTeamPage/UpdateTeamPage.tsx
+++ b/apps/web/src/pages/Teams/UpdateTeamPage/UpdateTeamPage.tsx
@@ -34,7 +34,7 @@ const UpdateTeamData_Query = graphql(/* GraphQL */ `
   }
 `);
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   teamId: string;
 }
 

--- a/apps/web/src/pages/Teams/ViewTeamPage/ViewTeamPage.tsx
+++ b/apps/web/src/pages/Teams/ViewTeamPage/ViewTeamPage.tsx
@@ -15,10 +15,9 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
 import ViewTeam, { ViewTeamPageFragment } from "./components/ViewTeam";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   teamId: Scalars["ID"]["output"];
-};
+}
 
 interface ViewTeamContentProps {
   teamQuery: ViewTeamPageFragment;

--- a/apps/web/src/pages/Teams/ViewTeamPage/ViewTeamPage.tsx
+++ b/apps/web/src/pages/Teams/ViewTeamPage/ViewTeamPage.tsx
@@ -15,7 +15,7 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
 import ViewTeam, { ViewTeamPageFragment } from "./components/ViewTeam";
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   teamId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
+++ b/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
@@ -424,10 +424,9 @@ const AdminUserProfile_Query = graphql(/* GraphQL */ `
   }
 `);
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   userId: Scalars["ID"]["output"];
-};
+}
 
 const AdminUserProfilePage = () => {
   const { userId } = useRequiredParams<RouteParams>("userId");

--- a/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
+++ b/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
@@ -424,7 +424,7 @@ const AdminUserProfile_Query = graphql(/* GraphQL */ `
   }
 `);
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   userId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
@@ -279,7 +279,7 @@ const context: Partial<OperationContext> = {
   requestPolicy: "cache-first", // The list of roles will rarely change, so we override default request policy to avoid unnecessary cache updates.
 };
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   userId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
@@ -279,10 +279,9 @@ const context: Partial<OperationContext> = {
   requestPolicy: "cache-first", // The list of roles will rarely change, so we override default request policy to avoid unnecessary cache updates.
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   userId: Scalars["ID"]["output"];
-};
+}
 
 const UpdateUserPage = () => {
   const intl = useIntl();

--- a/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
@@ -473,10 +473,9 @@ const UserInformation_Query = graphql(/* GraphQL */ `
   }
 `);
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   userId: Scalars["ID"]["output"];
-};
+}
 
 const UserInformationPage = () => {
   const { userId } = useRequiredParams<RouteParams>("userId");

--- a/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
@@ -473,7 +473,7 @@ const UserInformation_Query = graphql(/* GraphQL */ `
   }
 `);
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   userId: Scalars["ID"]["output"];
 }
 

--- a/apps/web/src/pages/Users/UserLayout.tsx
+++ b/apps/web/src/pages/Users/UserLayout.tsx
@@ -115,7 +115,7 @@ const UserHeader = ({ user }: UserHeaderProps) => {
   );
 };
 
-interface RouteParams {
+interface RouteParams extends Record<string, string> {
   userId: string;
 }
 

--- a/apps/web/src/pages/Users/UserLayout.tsx
+++ b/apps/web/src/pages/Users/UserLayout.tsx
@@ -115,10 +115,9 @@ const UserHeader = ({ user }: UserHeaderProps) => {
   );
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RouteParams = {
+interface RouteParams {
   userId: string;
-};
+}
 
 const UserName_Query = graphql(/* GraphQL */ `
   query UserName($userId: UUID!) {


### PR DESCRIPTION
🤖 Resolves #11383 

## 👋 Introduction

Fixes the type signature for `useRequiredParams` so we can use consistent types (`interface`).

## 🕵️ Details

The issue was the extension of the generic requiring a string. Interfaces do not implement that interface. So, we need to extend it in our definitions.

## 🧪 Testing

1. Confirm no lint errors
2. Confirm `useRequiredParams` still functions