### PR TITLE
[Fix] `PoolCandidate` category accessor return

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -284,7 +284,11 @@ class PoolCandidate extends Model
             $category = PriorityWeight::OTHER;
         }
 
-        return $category;
+        return [
+            'weight' => $category->weight($category->name),
+            'value' => $category->name,
+            'label' => PriorityWeight::localizedString($category->name),
+        ];
     }
 
     public static function scopeQualifiedStreams(Builder $query, ?array $streams): Builder

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -266,7 +266,7 @@ class PoolCandidate extends Model
 
     public function getCategoryAttribute()
     {
-        $category = null;
+        $category = PriorityWeight::OTHER;
 
         $this->loadMissing(['user' => [
             'citizenship',
@@ -280,8 +280,6 @@ class PoolCandidate extends Model
             $category = PriorityWeight::VETERAN;
         } elseif ($this->user->citizenship === CitizenshipStatus::CITIZEN->name || $this->user->citizenship === CitizenshipStatus::PERMANENT_RESIDENT->name) {
             $category = PriorityWeight::CITIZEN_OR_PERMANENT_RESIDENT;
-        } else {
-            $category = PriorityWeight::OTHER;
         }
 
         return [


### PR DESCRIPTION
🤖 Resolves #11678 

## 👋 Introduction

Fixes the return type of the pool candidate category accessor.

## 🧪 Testing

1. Login as admin `admin@test.com`
2. Navigate to the pool candidates page `/admin/pool-candidates`
3. Confirm no errors and category displays as expected
