### PR TITLE
[Bug] Talent search page and more spinners!

### DIFF
--- a/apps/playwright/tests/search-workflows.spec.ts
+++ b/apps/playwright/tests/search-workflows.spec.ts
@@ -181,9 +181,9 @@ test.describe("Talent search", () => {
       .getByRole("checkbox", { name: /overtime \(occasionally\)/i })
       .click();
 
+    await appPage.waitForGraphqlResponse("CandidateCount");
     await expect(poolCard).toBeVisible();
 
-    await appPage.waitForGraphqlResponse("CandidateCount");
     await poolCard.getByRole("button", { name: /request candidates/i }).click();
     await appPage.waitForGraphqlResponse("RequestForm_SearchRequestData");
 

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/EstimatedCandidates.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/EstimatedCandidates.tsx
@@ -111,24 +111,26 @@ const EstimatedCandidates = ({
             ) : (
               <CandidateMessage candidateCount={candidateCount} />
             )}
-            <p>
-              <ScrollToLink to="results" color="black" mode="inline">
-                {candidateCount
-                  ? intl.formatMessage({
-                      defaultMessage: "View results",
-                      id: "3wbcnZ",
-                      description:
-                        "A link to view the pools that contain matching talent.",
-                    })
-                  : intl.formatMessage({
-                      defaultMessage:
-                        "Submit an empty request and we will try to help.",
-                      id: "9qzCX/",
-                      description:
-                        "Link text to scroll to the submit button when no candidates were found",
-                    })}
-              </ScrollToLink>
-            </p>
+            {!updatePending && (
+              <p>
+                <ScrollToLink to="results" color="black" mode="inline">
+                  {candidateCount
+                    ? intl.formatMessage({
+                        defaultMessage: "View results",
+                        id: "3wbcnZ",
+                        description:
+                          "A link to view the pools that contain matching talent.",
+                      })
+                    : intl.formatMessage({
+                        defaultMessage:
+                          "Submit an empty request and we will try to help.",
+                        id: "9qzCX/",
+                        description:
+                          "Link text to scroll to the submit button when no candidates were found",
+                      })}
+                </ScrollToLink>
+              </p>
+            )}
           </div>
         </div>
       </div>

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/EstimatedCandidates.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/EstimatedCandidates.tsx
@@ -109,27 +109,27 @@ const EstimatedCandidates = ({
                 {intl.formatMessage(commonMessages.searching)}
               </Loading>
             ) : (
-              <CandidateMessage candidateCount={candidateCount} />
-            )}
-            {!updatePending && (
-              <p>
-                <ScrollToLink to="results" color="black" mode="inline">
-                  {candidateCount
-                    ? intl.formatMessage({
-                        defaultMessage: "View results",
-                        id: "3wbcnZ",
-                        description:
-                          "A link to view the pools that contain matching talent.",
-                      })
-                    : intl.formatMessage({
-                        defaultMessage:
-                          "Submit an empty request and we will try to help.",
-                        id: "9qzCX/",
-                        description:
-                          "Link text to scroll to the submit button when no candidates were found",
-                      })}
-                </ScrollToLink>
-              </p>
+              <>
+                <CandidateMessage candidateCount={candidateCount} />
+                <p>
+                  <ScrollToLink to="results" color="black" mode="inline">
+                    {candidateCount
+                      ? intl.formatMessage({
+                          defaultMessage: "View results",
+                          id: "3wbcnZ",
+                          description:
+                            "A link to view the pools that contain matching talent.",
+                        })
+                      : intl.formatMessage({
+                          defaultMessage:
+                            "Submit an empty request and we will try to help.",
+                          id: "9qzCX/",
+                          description:
+                            "Link text to scroll to the submit button when no candidates were found",
+                        })}
+                  </ScrollToLink>
+                </p>
+              </>
             )}
           </div>
         </div>

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -4,7 +4,13 @@ import { useNavigate } from "react-router-dom";
 import { useQuery } from "urql";
 import { ReactNode, useState, useEffect } from "react";
 
-import { Button, Heading, Pending, Separator } from "@gc-digital-talent/ui";
+import {
+  Button,
+  Heading,
+  Loading,
+  Pending,
+  Separator,
+} from "@gc-digital-talent/ui";
 import { unpackMaybes, notEmpty } from "@gc-digital-talent/helpers";
 import {
   graphql,
@@ -149,10 +155,14 @@ export const SearchForm = ({ classifications, skills }: SearchFormProps) => {
             </div>
           </div>
           <Separator />
-          <Heading level="h3" size="h4" id="results">
-            {intl.formatMessage(
-              {
-                defaultMessage: `Results:
+          {fetching ? (
+            <Loading inline />
+          ) : (
+            <>
+              <Heading level="h3" size="h4" id="results">
+                {intl.formatMessage(
+                  {
+                    defaultMessage: `Results:
                     { totalCandidateCount, plural,
                       =0 {<testId><b>{totalCandidateCount}</b></testId> matching candidates}
                       =1 {<testId><b>{totalCandidateCount}</b></testId> matching candidate}
@@ -162,65 +172,66 @@ export const SearchForm = ({ classifications, skills }: SearchFormProps) => {
                       =0 {<b>{numPools}</b> pools}
                       =1 {<b>{numPools}</b> pool}
                       other {<b>{numPools}</b> pools} }`,
-                id: "j2qiFb",
-                description:
-                  "Heading for total matching candidates across a certain number of pools in results section of search page.",
-              },
-              {
-                testId,
-                b: styledCount,
-                totalCandidateCount: candidateCount,
-                numPools: results?.length ?? 0,
-              },
-            )}
-          </Heading>
-          <SearchFilterAdvice filters={applicantFilter} />
-
-          {results?.length && candidateCount > 0 ? (
-            <>
-              <p data-h2-margin="base(x1, 0)">
-                <Button
-                  color="primary"
-                  type="submit"
-                  {...poolSubmitProps}
-                  value=""
-                  onClick={handleSubmitAllPools}
-                >
-                  {intl.formatMessage({
-                    defaultMessage: "Request candidates from all pools",
-                    id: "DxNuJ9",
+                    id: "j2qiFb",
                     description:
-                      "Button text to submit search request for candidates across all pools",
-                  })}
-                </Button>
-              </p>
-              <p
-                data-h2-font-size="base(h4)"
-                data-h2-margin="base(x1.5, 0, x.25, 0)"
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Or request candidates by pool",
-                  id: "l1f8zy",
-                  description:
-                    "Lead-in text to list of pools managers can request candidates from",
-                })}
-                {intl.formatMessage(commonMessages.dividingColon)}
-              </p>
-              <div
-                data-h2-display="base(flex)"
-                data-h2-flex-direction="base(column)"
-              >
-                {results.map(({ pool, candidateCount: resultsCount }) => (
-                  <SearchResultCard
-                    key={pool.id}
-                    candidateCount={resultsCount}
-                    pool={pool}
-                  />
-                ))}
-              </div>
+                      "Heading for total matching candidates across a certain number of pools in results section of search page.",
+                  },
+                  {
+                    testId,
+                    b: styledCount,
+                    totalCandidateCount: candidateCount,
+                    numPools: results?.length ?? 0,
+                  },
+                )}
+              </Heading>
+              <SearchFilterAdvice filters={applicantFilter} />
+              {results?.length && candidateCount > 0 ? (
+                <>
+                  <p data-h2-margin="base(x1, 0)">
+                    <Button
+                      color="primary"
+                      type="submit"
+                      {...poolSubmitProps}
+                      value=""
+                      onClick={handleSubmitAllPools}
+                    >
+                      {intl.formatMessage({
+                        defaultMessage: "Request candidates from all pools",
+                        id: "DxNuJ9",
+                        description:
+                          "Button text to submit search request for candidates across all pools",
+                      })}
+                    </Button>
+                  </p>
+                  <p
+                    data-h2-font-size="base(h4)"
+                    data-h2-margin="base(x1.5, 0, x.25, 0)"
+                  >
+                    {intl.formatMessage({
+                      defaultMessage: "Or request candidates by pool",
+                      id: "l1f8zy",
+                      description:
+                        "Lead-in text to list of pools managers can request candidates from",
+                    })}
+                    {intl.formatMessage(commonMessages.dividingColon)}
+                  </p>
+                  <div
+                    data-h2-display="base(flex)"
+                    data-h2-flex-direction="base(column)"
+                  >
+                    {results.map(({ pool, candidateCount: resultsCount }) => (
+                      <SearchResultCard
+                        key={pool.id}
+                        candidateCount={resultsCount}
+                        pool={pool}
+                      />
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <NoResults />
+              )}
             </>
-          ) : (
-            <NoResults />
           )}
         </form>
       </FormProvider>


### PR DESCRIPTION
🤖 Resolves #11393 

## 👋 Introduction

Use the loading/spinner component to obscure more content if fetching is ongoing 
All obscured below the divider per https://github.com/GCTC-NTGC/gc-digital-talent/issues/11393#issuecomment-2371357549

## 🧪 Testing

1. Navigate to search page
2. Observe spinners when search ongoing 

## 📸 Screenshot

Estimated box

![image](https://github.com/user-attachments/assets/7d5beb95-f546-42dc-954e-f79b66ec4894)

Results below the divider

![image](https://github.com/user-attachments/assets/f396663e-26d9-4494-aa5d-6f5117747bbe)




