### PR TITLE
[Tooling] Upgrade to docker compose 2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -83,16 +83,30 @@
   "laravel-pint.executablePath": "api/vendor/bin/pint",
   "terminal.integrated.profiles.linux": {
     "Maintenance": {
-      "path": "docker-compose",
-      "args": ["run", "--rm", "--workdir=/var/www/html", "maintenance", "bash"],
+      "path": "docker",
+      "args": [
+        "compose",
+        "run",
+        "--rm",
+        "--workdir=/var/www/html",
+        "maintenance",
+        "bash"
+      ],
       "overrideName": true,
       "icon": "terminal-ubuntu"
     }
   },
   "terminal.integrated.profiles.osx": {
     "Maintenance": {
-      "path": "docker-compose",
-      "args": ["run", "--rm", "--workdir=/var/www/html", "maintenance", "bash"],
+      "path": "docker",
+      "args": [
+        "compose",
+        "run",
+        "--rm",
+        "--workdir=/var/www/html",
+        "maintenance",
+        "bash"
+      ],
       "overrideName": true,
       "icon": "terminal-ubuntu"
     }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,8 +7,8 @@
       "label": "Setup Project",
       "type": "shell",
 
-      "command": "docker-compose",
-      "args": ["run", "--rm", "maintenance", "bash", "setup.sh"],
+      "command": "docker",
+      "args": ["compose", "run", "--rm", "maintenance", "bash", "setup.sh"],
 
       "presentation": {
         "echo": true,
@@ -24,8 +24,15 @@
       "label": "Refresh Frontend",
       "type": "shell",
 
-      "command": "docker-compose",
-      "args": ["run", "--rm", "maintenance", "bash", "refresh_frontend.sh"],
+      "command": "docker",
+      "args": [
+        "compose",
+        "run",
+        "--rm",
+        "maintenance",
+        "bash",
+        "refresh_frontend.sh"
+      ],
 
       "presentation": {
         "echo": true,
@@ -41,8 +48,15 @@
       "label": "Refresh API",
       "type": "shell",
 
-      "command": "docker-compose",
-      "args": ["run", "--rm", "maintenance", "bash", "refresh_api.sh"],
+      "command": "docker",
+      "args": [
+        "compose",
+        "run",
+        "--rm",
+        "maintenance",
+        "bash",
+        "refresh_api.sh"
+      ],
 
       "presentation": {
         "echo": true,
@@ -58,8 +72,15 @@
       "label": "Refresh Web",
       "type": "shell",
 
-      "command": "docker-compose",
-      "args": ["run", "--rm", "maintenance", "bash", "refresh_frontend.sh"],
+      "command": "docker",
+      "args": [
+        "compose",
+        "run",
+        "--rm",
+        "maintenance",
+        "bash",
+        "refresh_frontend.sh"
+      ],
 
       "presentation": {
         "echo": true,
@@ -75,8 +96,15 @@
       "label": "Refresh All",
       "type": "shell",
 
-      "command": "docker-compose",
-      "args": ["run", "--rm", "maintenance", "bash", "refresh_all.sh"],
+      "command": "docker",
+      "args": [
+        "compose",
+        "run",
+        "--rm",
+        "maintenance",
+        "bash",
+        "refresh_all.sh"
+      ],
 
       "presentation": {
         "echo": true,
@@ -92,8 +120,8 @@
       "label": "Docker Compose Down",
       "type": "shell",
 
-      "command": "docker-compose",
-      "args": ["down"],
+      "command": "docker",
+      "args": ["compose", "down"],
 
       "presentation": {
         "echo": true,
@@ -109,8 +137,8 @@
       "label": "Docker Compose Up",
       "type": "shell",
 
-      "command": "docker-compose",
-      "args": ["up", "--detach", "--build"],
+      "command": "docker",
+      "args": ["compose", "up", "--detach", "--build"],
 
       "presentation": {
         "echo": true,

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 .PHONY: up down setup clean-modules refresh refresh-frontend refresh-api seed-fresh migrate artisan phpstan queue-work composer
 
-DOCKER_RUN=docker-compose run --rm maintenance bash
-DOCKER_API=docker-compose run --rm -w /var/www/html/api maintenance sh -c
-DOCKER_PNPM=docker-compose run -w /var/www/html --rm maintenance pnpm
+DOCKER_RUN=docker compose run --rm maintenance bash
+DOCKER_API=docker compose run --rm -w /var/www/html/api maintenance sh -c
+DOCKER_PNPM=docker compose run -w /var/www/html --rm maintenance pnpm
 
 up:
-	docker-compose up --build --detach
+	docker compose up --build --detach
 
 down:
-	docker-compose down
+	docker compose down
 
 setup:
 	$(DOCKER_RUN) setup.sh
@@ -51,7 +51,7 @@ phpstan:
 	$(DOCKER_API) "vendor/bin/phpstan analyse -c phpstan.neon"
 
 queue-work:
-	docker-compose exec webserver sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan queue:work"
+	docker compose exec webserver sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan queue:work"
 
 test:
 	$(DOCKER_API) "php artisan test $(CMD)"

--- a/Makefile.nix
+++ b/Makefile.nix
@@ -23,8 +23,8 @@ setup_api:
 	php api/artisan migrate:fresh --seed
 	php api/artisan lighthouse:print-schema --write
 	touch api/storage/logs/laravel.log
-	docker-compose exec webserver sh -c "chown -R www-data:www-data /home/site/wwwroot/api/storage"
-	docker-compose exec webserver sh -c "chmod -R a+r,a+w /home/site/wwwroot/api/storage /home/site/wwwroot/api/bootstrap/cache"
+	docker compose exec webserver sh -c "chown -R www-data:www-data /home/site/wwwroot/api/storage"
+	docker compose exec webserver sh -c "chmod -R a+r,a+w /home/site/wwwroot/api/storage /home/site/wwwroot/api/bootstrap/cache"
 	php api/artisan optimize:clear
 
 refresh_api:
@@ -46,10 +46,10 @@ git_clean:
 	sudo git clean -xdf
 
 compose_up:
-	docker-compose up --detach
+	docker compose up --detach
 
 compose_down:
-	docker-compose down
+	docker compose down
 
 queue_work:
-	docker-compose exec webserver sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan queue:work"
+	docker compose exec webserver sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan queue:work"

--- a/api/README.md
+++ b/api/README.md
@@ -13,11 +13,11 @@
 
 ### Running with Docker containers
 
-See `../infrastructure/README.md` for instructions for running this service, along with client services and a database, with a single docker-compose command.
+See `../infrastructure/README.md` for instructions for running this service, along with client services and a database, with a single docker compose command.
 
 Note that you will still need to copy .env.example to .env and add an APP_KEY.
 
-To initialize the database from inside the container, run `docker-compose exec -w /home/site/wwwroot/api webserver sh -c "php artisan migrate:fresh --seed"`.
+To initialize the database from inside the container, run `docker compose exec -w /home/site/wwwroot/api webserver sh -c "php artisan migrate:fresh --seed"`.
 
 ## Local Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
   #
   #   3. Rebuild docker container:
   #
-  #       $ docker-compose up --detach --build mock-auth
+  #       $ docker compose up --detach --build mock-auth
   #
   #   4. Confirm working by visiting:
   #

--- a/documentation/linux-setup.md
+++ b/documentation/linux-setup.md
@@ -31,7 +31,17 @@ You should see the same list of files visible in [the github repository online](
 
 ## Docker compose
 
-[Docker](https://www.docker.com/) compose is used to run the services for this app. It should have been installed with your operating system automatically.
+[Docker Compose](https://docs.docker.com/compose/) is used to run the services for this app. You may have to install Compose version 2 manually.
+
+```
+sudo apt-get install docker-compose-v2
+```
+
+Double-check:
+
+```
+docker compose version
+```
 
 If you haven't before, add your user to the `docker` group and activate the group:
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,6 +1,6 @@
 # Local Dev Environment
 
-Run `docker-compose up -d` here to create several containers containing a postgres database, and the other components of the app. The app will be hosted at http://localhost:8000.
+Run `docker compose up -d` here to create several containers containing a postgres database, and the other components of the app. The app will be hosted at http://localhost:8000.
 
 This configuration is meant to model the infrastructure of the production server, with separate projects running in a single PHP container, and a separate database. Requests are routed between the different projects as per the `./infrastructure/conf/nginx-conf-local/default` file.
 
@@ -18,7 +18,7 @@ To log into the app database with Adminer, use the following credentials:
 
 ## Connecting api service to database
 
-The environment variables in [`/api/.env.example`](/api/.env.example) are already configured to connect to the database from inside a docker-compose network. If you want to run migrations or data seeders, you will need to run them inside the container.
+The environment variables in [`/api/.env.example`](/api/.env.example) are already configured to connect to the database from inside a docker compose network. If you want to run migrations or data seeders, you will need to run them inside the container.
 
-- `docker-compose exec -w /home/site/wwwroot/api webserver sh -c "php artisan migrate"`
-- `docker-compose exec -w /home/site/wwwroot/api webserver sh -c "php artisan db:seed"`
+- `docker compose exec -w /home/site/wwwroot/api webserver sh -c "php artisan migrate"`
+- `docker compose exec -w /home/site/wwwroot/api webserver sh -c "php artisan db:seed"`

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -6,8 +6,8 @@ This project contains a collection of scripts to use a maintenance container to 
 
 To set up a local development environment, run these commands from anywhere in repo:
 
-1. Build and run the containers: `docker-compose up --detach --build`
-2. To setup the apps: `docker-compose run --rm maintenance bash setup.sh`
+1. Build and run the containers: `docker compose up --detach --build`
+2. To setup the apps: `docker compose run --rm maintenance bash setup.sh`
 3. Next you can log in:
    - For testing admin accounts:
      1. Navigate to http://localhost:8000/login
@@ -23,12 +23,12 @@ To set up a local development environment, run these commands from anywhere in r
 
 To refresh each sub-project after they have been setup run one of the refresh scripts:
 
-- `docker-compose run --rm maintenance bash refresh_api.sh`
-- `docker-compose run --rm maintenance bash refresh_frontend.sh`
+- `docker compose run --rm maintenance bash refresh_api.sh`
+- `docker compose run --rm maintenance bash refresh_frontend.sh`
 
 Or refresh all of them in order:
 
-- `docker-compose run --rm maintenance bash refresh_all.sh`
+- `docker compose run --rm maintenance bash refresh_all.sh`
 
 ## Working on UI
 


### PR DESCRIPTION
🤖 Resolves #10685 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
This branch upgrades documentation and tooling to expect that Docker Compose 2 is installed locally.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->
The migration guide at https://docs.docker.com/compose/releases/migrate/ lists only a few edge cases where v2 isn't fully compatible with v1.  It seems like no changes are needed for our project.

## 🧪 Testing

> [!important]
If you are using a variant of Ubuntu 22.04 locally or in WSL you might need to install Docker Compose v2 with:
`sudo apt-get install docker-compose-v2`

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

- [ ] All our tooling works as usual
  - [ ] terminals
  - [ ] build tasks
  - [ ] make files
- [ ] Documentation is up to date


## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/c1ea8e97-e33f-40c4-98bc-fa2da1f7f4d7)
