### PR TITLE
[Bug] Fix More Information section link text

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1059,6 +1059,10 @@
     "defaultMessage": "En tant qu'employé, quel est votre statut d'emploi?",
     "description": "Employee Status in Government Info Form"
   },
+  "3hLuu4": {
+    "defaultMessage": "Veuillez <a>{name}communiquer avec l’équipe</a> par courriel, si vous avez <strong>des questions</strong> ou <strong>si vous avez besoin de mesures d’adaptation</strong> tout au long de ce processus.",
+    "description": "Opening sentence asking if accommodations are needed"
+  },
   "3hYwWo": {
     "defaultMessage": "Décrivez comment cette compétence s’est appliquée à cette expérience",
     "description": "Heading for the skill experience details section"
@@ -10445,10 +10449,6 @@
   "rJqCuH": {
     "defaultMessage": "Description (anglais)",
     "description": "Label displayed on the create a skill form description (English) field."
-  },
-  "rKUVdL": {
-    "defaultMessage": "Veuillez communiquer avec l’équipe <a>{name}</a> par courriel, si vous avez <strong>des questions</strong> ou <strong>si vous avez besoin de mesures d’adaptation</strong> tout au long de ce processus.",
-    "description": "Opening sentence asking if accommodations are needed"
   },
   "rLd5cC": {
     "defaultMessage": "Aller à la page {pageNumber}",

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -1143,8 +1143,8 @@ export const PoolPoster = ({
                       {intl.formatMessage(
                         {
                           defaultMessage:
-                            "Please contact the <a>{name} team</a> by email if you have <strong>any questions</strong> or <strong>require an accommodation</strong> during this process.",
-                          id: "rKUVdL",
+                            "Please <a>{name}contact the team</a> by email if you have <strong>any questions</strong> or <strong>require an accommodation</strong> during this process.",
+                          id: "3hLuu4",
                           description:
                             "Opening sentence asking if accommodations are needed",
                         },


### PR DESCRIPTION
🤖 Resolves #11704 

## 👋 Introduction

Fix the links in English and French

## 🕵️ Details

The quotes were removed in https://github.com/GCTC-NTGC/gc-digital-talent/pull/11615
The accordion headings no longer have quotes, at least on main

## 🧪 Testing

1. Open a poster in English and expand More Information
2. Observe links

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

![image](https://github.com/user-attachments/assets/c17b0031-1727-412b-b29f-35da2b933f22)

![image](https://github.com/user-attachments/assets/4b064ae7-b433-482a-ae88-f684e2db2997)
