### PR TITLE
[Feature] Add striping to card accordions

### DIFF
--- a/packages/ui/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.stories.tsx
@@ -172,8 +172,14 @@ Nested.args = {
     <>
       <Text />
       <Accordion.Root type="single" collapsible>
-        <Accordion.Item value="two">
-          <Accordion.Trigger>Accordion Two</Accordion.Trigger>
+        <Accordion.Item value="sub-one">
+          <Accordion.Trigger>Accordion Sub One</Accordion.Trigger>
+          <Accordion.Content>
+            <Text />
+          </Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="sub-two">
+          <Accordion.Trigger>Accordion Sub Two</Accordion.Trigger>
           <Accordion.Content>
             <Text />
           </Accordion.Content>

--- a/packages/ui/src/components/Accordion/Accordion.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.tsx
@@ -29,6 +29,12 @@ const Root = forwardRef<ElementRef<typeof AccordionPrimitive.Root>, RootProps>(
         "base:selectors[>.Accordion__Item > .Accordion__Header .Accordion__Icon path](1.5)",
       "data-h2-font-size":
         "base:selectors[>.Accordion__Item > .Accordion__Header .Accordion__Heading](h6, 1)",
+      "data-h2-background-color": `
+        base:selectors[>.Accordion__Item:nth-child(odd)](foreground)
+
+        base:selectors[>.Accordion__Item:nth-child(even)](background.dark.3)
+        base:dark:selectors[>.Accordion__Item:nth-child(even)](rgba(53, 57, 75, .5))
+      `,
     };
 
     let paddingStyles: Record<string, string> =

--- a/packages/ui/src/components/Accordion/Accordion.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.tsx
@@ -121,14 +121,17 @@ const Root = forwardRef<ElementRef<typeof AccordionPrimitive.Root>, RootProps>(
     }
 
     return (
-      <AccordionPrimitive.Root
-        ref={forwardedRef}
-        data-h2-display="base(flex)"
-        data-h2-flex-direction="base(column)"
-        {...baseStyles}
-        {...paddingStyles}
-        {...rest}
-      />
+      <>
+        {mode === "card" ? "I'm a card!" : null}
+        <AccordionPrimitive.Root
+          ref={forwardedRef}
+          data-h2-display="base(flex)"
+          data-h2-flex-direction="base(column)"
+          {...baseStyles}
+          {...paddingStyles}
+          {...rest}
+        />
+      </>
     );
   },
 );

--- a/packages/ui/src/components/Accordion/Accordion.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.tsx
@@ -121,17 +121,14 @@ const Root = forwardRef<ElementRef<typeof AccordionPrimitive.Root>, RootProps>(
     }
 
     return (
-      <>
-        {mode === "card" ? "I'm a card!" : null}
-        <AccordionPrimitive.Root
-          ref={forwardedRef}
-          data-h2-display="base(flex)"
-          data-h2-flex-direction="base(column)"
-          {...baseStyles}
-          {...paddingStyles}
-          {...rest}
-        />
-      </>
+      <AccordionPrimitive.Root
+        ref={forwardedRef}
+        data-h2-display="base(flex)"
+        data-h2-flex-direction="base(column)"
+        {...baseStyles}
+        {...paddingStyles}
+        {...rest}
+      />
     );
   },
 );

--- a/packages/ui/src/components/Accordion/Accordion.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.tsx
@@ -29,12 +29,6 @@ const Root = forwardRef<ElementRef<typeof AccordionPrimitive.Root>, RootProps>(
         "base:selectors[>.Accordion__Item > .Accordion__Header .Accordion__Icon path](1.5)",
       "data-h2-font-size":
         "base:selectors[>.Accordion__Item > .Accordion__Header .Accordion__Heading](h6, 1)",
-      "data-h2-background-color": `
-        base:selectors[>.Accordion__Item:nth-child(odd)](foreground)
-
-        base:selectors[>.Accordion__Item:nth-child(even)](background.dark.3)
-        base:dark:selectors[>.Accordion__Item:nth-child(even)](rgba(53, 57, 75, .5))
-      `,
     };
 
     let paddingStyles: Record<string, string> =

--- a/packages/ui/src/components/Accordion/Accordion.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.tsx
@@ -112,8 +112,10 @@ const Root = forwardRef<ElementRef<typeof AccordionPrimitive.Root>, RootProps>(
           base:selectors[>.Accordion__Item:nth-child(even)](background.dark.3)
           base:dark:selectors[>.Accordion__Item:nth-child(even)](rgba(53, 57, 75, .5))
         `,
-        "data-h2-border-top":
-          "base:selectors[>.Accordion__Item + .Accordion__Item](thin solid gray)",
+        "data-h2-border-top": `
+          base:selectors[>.Accordion__Item + .Accordion__Item](thin solid black.darkest.2)
+          base:dark:selectors[>.Accordion__Item + .Accordion__Item](thin solid white.lightest.5)
+        `,
         "data-h2-overflow": "base(hidden)",
         "data-h2-radius": "base(s)",
         "data-h2-shadow": "base(l)",

--- a/packages/ui/src/components/Accordion/Accordion.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.tsx
@@ -114,7 +114,7 @@ const Root = forwardRef<ElementRef<typeof AccordionPrimitive.Root>, RootProps>(
         `,
         "data-h2-border-top": `
           base:selectors[>.Accordion__Item + .Accordion__Item](thin solid black.darkest.2)
-          base:dark:selectors[>.Accordion__Item + .Accordion__Item](thin solid white.lightest.5)
+          base:dark:selectors[>.Accordion__Item + .Accordion__Item](thin solid black.darkest.5)
         `,
         "data-h2-overflow": "base(hidden)",
         "data-h2-radius": "base(s)",

--- a/packages/ui/src/components/Accordion/Accordion.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.tsx
@@ -105,8 +105,13 @@ const Root = forwardRef<ElementRef<typeof AccordionPrimitive.Root>, RootProps>(
     if (mode === "card") {
       baseStyles = {
         ...baseStyles,
-        "data-h2-background-color":
-          "base:selectors[>.Accordion__Item](foreground)",
+        // custom out-of-system colour used for even dark items: Colors/Background/Manual/Dark-30:Foreground-Light-50
+        "data-h2-background-color": `
+          base:selectors[>.Accordion__Item:nth-child(odd)](foreground)
+
+          base:selectors[>.Accordion__Item:nth-child(even)](background.dark.3)
+          base:dark:selectors[>.Accordion__Item:nth-child(even)](rgba(53, 57, 75, .5))
+        `,
         "data-h2-border-top":
           "base:selectors[>.Accordion__Item + .Accordion__Item](thin solid gray)",
         "data-h2-overflow": "base(hidden)",


### PR DESCRIPTION
🤖 Resolves #11497 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
This branch adds candy striping to the base card accordion component.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->


1. Rebuild and check some pages with card accordions.
2. Check in dark mode as well.
3. Review the Chromatic diffs.


## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/8e58c5f2-0066-48e4-b5a6-196c0d7db4ee)

