### PR TITLE
[Copy] Update copy in special notes section

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -639,6 +639,10 @@
     "defaultMessage": "Aucun courriel fourni",
     "description": "Fallback for email value"
   },
+  "1MJGsD": {
+    "defaultMessage": "Cette possibilité d'emploi s'adresse aux employés internes de classification {classification} ou équivalente avec la préférence accordée à ceux aux ministères énumérés*",
+    "description": "Title of a note describing that a pool is only open to employees, at-level, with departmental preference. Has an asterisk for fine print."
+  },
   "1MtuHa": {
     "defaultMessage": "Veuillez préciser le facteur",
     "description": "Label for _other operations considerations_ fieldset in the _digital services contracting questionnaire_"
@@ -995,6 +999,10 @@
     "defaultMessage": "Création de la classification réussie!",
     "description": "Message displayed to user after classification is created successfully."
   },
+  "3FAEil": {
+    "defaultMessage": "Cette possibilité d'emploi s'adresse aux employés internes, la préférence étant donnée aux personnes travaillant dans les ministères énumérés*",
+    "description": "Title of a note describing that a pool is only open to employees with departmental preference. Has an asterisk for fine print."
+  },
   "3GLqD1": {
     "defaultMessage": "Fermer le processus immédiatement",
     "description": "Submit button text to close a process"
@@ -1279,10 +1287,6 @@
     "defaultMessage": "Pour toute question ou préoccupation concernant le questionnaire, veuillez contacter <link>Talents numériques du GC</link> pour obtenir de plus amples renseignements.",
     "description": "Paragraph four of the _instructions_ section of the _digital services contracting questionnaire_"
   },
-  "4l0wGu": {
-    "defaultMessage": "Cette possibilité s'adresse aux employés internes de classification {classification} ou équivalente",
-    "description": "Title of a note describing that a pool is only open to employees at-level"
-  },
   "4lRUZt": {
     "defaultMessage": "Vous êtes sur le point de modifier l’information publiée dans l’annonce suivante",
     "description": "Warning message when attempting to update a published process advertisement"
@@ -1546,10 +1550,6 @@
   "66qMwD": {
     "defaultMessage": "« ... réfère à une personne dont les activités quotidiennes sont limitées en raison d'un trouble ou d'une difficulté à accomplir certaines tâches. La seule exception à cet égard concerne les troubles du développement, le répondant qui a reçu un tel diagnostic étant considéré comme ayant une incapacité. »",
     "description": "Definition of Person with a disability from the StatsCan 'Classification of Status of Disability' page."
-  },
-  "66xc/o": {
-    "defaultMessage": "Cette possibilité s'adresse aux employés internes de classification {classification} ou équivalente avec la préférence accordée à ceux aux ministères énumérés*",
-    "description": "Title of a note describing that a pool is only open to employees, at-level, with departmental preference. Has an asterisk for fine print."
   },
   "69BfF3": {
     "defaultMessage": "Découvrez un talent en vous servant d’un jeu de filtres détaillés, y compris la classification, les langues et les compétences.",
@@ -3343,6 +3343,10 @@
     "defaultMessage": "Lien avec l’expérience supprimé!",
     "description": "Success message displayed after unlinking an experience to a skill"
   },
+  "FrQmN+": {
+    "defaultMessage": "Cette possibilité d'emploi est réservée aux employés actuels du gouvernement du Canada ou aux personnes employées par une agence du gouvernement du Canada. En postulant, vous confirmez que vous êtes un employé en service et que les informations sur l'employé que vous fournissez dans votre profil sont à jour.",
+    "description": "Body of a note describing that a pool is only open to employees"
+  },
   "Fs444j": {
     "defaultMessage": "Définir les évaluations utilisées pour évaluer chaque compétence dans l'annonce.",
     "description": "Information about what an assessment plan represents"
@@ -3971,10 +3975,6 @@
     "defaultMessage": "Instantané de profil non trouvé.",
     "description": "Message displayed for profile snapshot not found."
   },
-  "JKEDRo": {
-    "defaultMessage": "Cette possibilité s'adresse aux employés internes, la préférence étant donnée aux personnes travaillant dans les ministères énumérés*",
-    "description": "Title of a note describing that a pool is only open to employees with departmental preference. Has an asterisk for fine print."
-  },
   "JRlnNk": {
     "defaultMessage": "Gestion de la collectivité numérique",
     "description": "Title for the Digital Community Management"
@@ -4362,6 +4362,10 @@
   "LCVNJq": {
     "defaultMessage": "Mise à jour réussie des renseignements sur la diversité, l’équité et l’inclusion!",
     "description": "Message displayed when a user successfully updates their diversity, equity, and inclusion information."
+  },
+  "LDVGvh": {
+    "defaultMessage": "Cette possibilité d'emploi s'adresse aux employés internes de classification {classification} ou équivalente",
+    "description": "Title of a note describing that a pool is only open to employees at-level"
   },
   "LDrXbc": {
     "defaultMessage": "contiennent des renseignements protégés ou classifiés du gouvernement du Canada",
@@ -5327,6 +5331,10 @@
     "defaultMessage": "Suivre le placement de ce candidat à l'aide des options suivantes.",
     "description": "Subtitle for job placement dialog"
   },
+  "QXB3EX": {
+    "defaultMessage": "Cette possibilité d'emploi est réservée aux employés actuels du gouvernement du Canada ou aux personnes employées par une agence du gouvernement du Canada qui sont présentement classés comme {classification} ou un équivalent organisationnel. En postulant, vous confirmez que vous êtes un employé en service et que les informations sur l'employé que vous fournissez dans votre profil sont à jour.",
+    "description": "Body of a note describing that a pool is only open to employees at-level"
+  },
   "QXiUo/": {
     "defaultMessage": "Pour commencer",
     "description": "Main heading in getting started page."
@@ -5506,6 +5514,10 @@
   "RDHbAx": {
     "defaultMessage": "Qu'est-ce que je fais si j'ai effacé l'appli ou changé de téléphone et que je n'ai pas les codes de récupération?",
     "description": "GCKey question for when user does not have recovery codes"
+  },
+  "RGl+Dr": {
+    "defaultMessage": "Cette possibilité d'emploi s'adresse aux employés internes",
+    "description": "Title of a note describing that a pool is only open to employees"
   },
   "RHTrvR": {
     "defaultMessage": "IT-03 : Conseiller technique ou Chef d'équipe",
@@ -6449,10 +6461,6 @@
   "WYJnLs": {
     "defaultMessage": "Demande",
     "description": "Heading displayed above the single search request component."
-  },
-  "WcU42I": {
-    "defaultMessage": "Cette possibilité s'adresse aux employés internes",
-    "description": "Title of a note describing that a pool is only open to employees"
   },
   "Wd9+xg": {
     "defaultMessage": "Utilisez le bouton \"Ajouter une nouvelle compétence\" pour commencer.",
@@ -9210,10 +9218,6 @@
     "defaultMessage": "Niveaux de compétence technique",
     "description": "Heading for the skills level definitions of technical skills"
   },
-  "k9moOJ": {
-    "defaultMessage": "Cette possibilité est réservée aux employés actuels du gouvernement du Canada ou aux personnes employées par une agence du gouvernement du Canada. En postulant, vous confirmez que vous êtes un employé en service et que les informations sur l'employé que vous fournissez dans votre profil sont à jour.",
-    "description": "Body of a note describing that a pool is only open to employees"
-  },
   "kHypfJ": {
     "defaultMessage": "Du concept au code",
     "description": "Title for how the platform was created"
@@ -10165,10 +10169,6 @@
   "pVCsBB": {
     "defaultMessage": "Catégorie de travail",
     "description": "Label for pool advertisement stream"
-  },
-  "pVx/jP": {
-    "defaultMessage": "Cette possibilité est réservée aux employés actuels du gouvernement du Canada ou aux personnes employées par une agence du gouvernement du Canada qui sont présentement classés comme {classification} ou un équivalent organisationnel. En postulant, vous confirmez que vous êtes un employé en service et que les informations sur l'employé que vous fournissez dans votre profil sont à jour.",
-    "description": "Body of a note describing that a pool is only open to employees at-level"
   },
   "pWoAv0": {
     "defaultMessage": "Le Programme d’apprentissage en TI pour les personnes autochtones est une initiative du gouvernement du Canada visant particulièrement les Premières Nations, les Inuits et les Métis. C’est un chemin vers un emploi dans la fonction publique fédérale pour les personnes autochtones qui ont une passion pour la technologie de l’information (TI).",

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
@@ -57,8 +57,8 @@ const deriveAreaOfSelectionMessages = (
         title: intl.formatMessage(
           {
             defaultMessage:
-              "This opportunity is for internal employees with a classification of {classification} or equivalent with preference given to those at the departments listed*",
-            id: "66xc/o",
+              "This job opportunity is for internal employees with a classification of {classification} or equivalent with preference given to those at the departments listed*",
+            id: "1MJGsD",
             description:
               "Title of a note describing that a pool is only open to employees, at-level, with departmental preference. Has an asterisk for fine print.",
           },
@@ -70,8 +70,8 @@ const deriveAreaOfSelectionMessages = (
         body: intl.formatMessage(
           {
             defaultMessage:
-              "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency who are currently classified as {classification} or an organizational equivalent. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
-            id: "pVx/jP",
+              "This job opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency who are currently classified as {classification} or an organizational equivalent. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
+            id: "QXB3EX",
             description:
               "Body of a note describing that a pool is only open to employees at-level",
           },
@@ -98,8 +98,8 @@ const deriveAreaOfSelectionMessages = (
         title: intl.formatMessage(
           {
             defaultMessage:
-              "This opportunity is for internal employees with a classification of {classification} or equivalent",
-            id: "4l0wGu",
+              "This job opportunity is for internal employees with a classification of {classification} or equivalent",
+            id: "LDVGvh",
             description:
               "Title of a note describing that a pool is only open to employees at-level",
           },
@@ -110,8 +110,8 @@ const deriveAreaOfSelectionMessages = (
         body: intl.formatMessage(
           {
             defaultMessage:
-              "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency who are currently classified as {classification} or an organizational equivalent. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
-            id: "pVx/jP",
+              "This job opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency who are currently classified as {classification} or an organizational equivalent. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
+            id: "QXB3EX",
             description:
               "Body of a note describing that a pool is only open to employees at-level",
           },
@@ -129,16 +129,16 @@ const deriveAreaOfSelectionMessages = (
       return {
         title: intl.formatMessage({
           defaultMessage:
-            "This opportunity is for internal employees with preference given to those at the departments listed*",
-          id: "JKEDRo",
+            "This job opportunity is for internal employees with preference given to those at the departments listed*",
+          id: "3FAEil",
           description:
             "Title of a note describing that a pool is only open to employees with departmental preference. Has an asterisk for fine print.",
         }),
         // The same message is used for employees only. There is no mention of the departmental preference.
         body: intl.formatMessage({
           defaultMessage:
-            "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
-          id: "k9moOJ",
+            "This job opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
+          id: "FrQmN+",
           description:
             "Body of a note describing that a pool is only open to employees",
         }),
@@ -160,15 +160,15 @@ const deriveAreaOfSelectionMessages = (
     // fall-through for employees only
     return {
       title: intl.formatMessage({
-        defaultMessage: "This opportunity is for internal employees",
-        id: "WcU42I",
+        defaultMessage: "This job opportunity is for internal employees",
+        id: "RGl+Dr",
         description:
           "Title of a note describing that a pool is only open to employees",
       }),
       body: intl.formatMessage({
         defaultMessage:
-          "This opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
-        id: "k9moOJ",
+          "This job opportunity is reserved for existing employees of the Government of Canada or persons employed by a Government of Canada agency. By applying you are confirming that you are an active employee and that the employee information you provide as a part of your profile is up-to-date.",
+        id: "FrQmN+",
         description:
           "Body of a note describing that a pool is only open to employees",
       }),


### PR DESCRIPTION
🤖 Resolves #11708

## 👋 Introduction

Makes minor updates to the text in the special area of selection note on job posters to change "opportunity" to "job opportunity" and "possibilité" to "possibilité d'emploi".

## 🧪 Testing

Update a draft pool and view the it's job poster to confirm the copy is updated in each of the following cases:
1. Area of selection is employees and neither At-level or Departmental preference
2. Area of selection is employees and At-level only
3. Area of selection is employees and Departmental preference only
4. Area of selection is employees and both At-level and Departmental preference

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/33846b58-c049-45be-a9e5-2857a3dc66d1)