### PR TITLE
[Fix] Sort classifications on the job templates page

### DIFF
--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -353,6 +353,7 @@ const JobPosterTemplatesPage = () => {
                         .filter(
                           (classification) => classification.group === "IT",
                         )
+                        .sort((a, b) => a.level - b.level)
                         .map((classification) => ({
                           value: classification.id,
                           label: `${classification.group}-0${classification.level}`,


### PR DESCRIPTION
🤖 Resolves #11657

## 👋 Introduction

Sorts the classification filter options on the job templates page in ascending order.

## 🧪 Testing

1. Update some classifications so the IT classifications returned from this query are out of order
```
query classifications {
  classifications {
    group
    level
  }
}
```
2. Visit the job templates page `/en/job-templates` and confirm the classification filter options are sorted

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/3ea22d0b-1e16-42e5-ad01-b02f84a68817)