### PR TITLE
[Debt] Replace `motion` with `motion.create`

### DIFF
--- a/packages/forms/src/components/Combobox/Input.tsx
+++ b/packages/forms/src/components/Combobox/Input.tsx
@@ -119,7 +119,7 @@ const iconVariants = {
   },
 };
 
-const AnimatedToggleIcon = motion(ChevronDownIcon);
+const AnimatedToggleIcon = motion.create(ChevronDownIcon);
 
 const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
   ({ isOpen, ...rest }, forwardedRef) => (

--- a/packages/forms/src/components/Combobox/Menu.tsx
+++ b/packages/forms/src/components/Combobox/Menu.tsx
@@ -77,7 +77,7 @@ const Available = ({ count, total, ...rest }: AvailableProps) => {
   );
 };
 
-const AnimatedFetchingIcon = motion(ArrowPathIcon);
+const AnimatedFetchingIcon = motion.create(ArrowPathIcon);
 
 const Fetching = forwardRef<HTMLSpanElement, HTMLSpanProps>(
   (props, forwardedRef) => {

--- a/packages/forms/src/components/Repeater/Repeater.tsx
+++ b/packages/forms/src/components/Repeater/Repeater.tsx
@@ -36,7 +36,7 @@ export interface RepeaterFieldsetProps {
   isLast?: boolean;
 }
 
-const MotionFieldset = motion(Field.Fieldset);
+const MotionFieldset = motion.create(Field.Fieldset);
 
 const Fieldset = ({
   index,


### PR DESCRIPTION
🤖 Resolves #11675 

## 👋 Introduction

Replaces the deprecated `motion` with `motion.create`.

## 🧪 Testing

1. Confirm no instances of just `motion`
2. Confirm animations on affected components still function
 