### PR TITLE
[Debt] Update to use `@date-fns/tz`

### DIFF
--- a/packages/date-helpers/package.json
+++ b/packages/date-helpers/package.json
@@ -18,10 +18,10 @@
     "preset": "@gc-digital-talent/jest-presets/jest/node"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.1.1",
     "@gc-digital-talent/graphql": "workspace:*",
     "@gc-digital-talent/i18n": "workspace:*",
-    "date-fns": "^3.6.0",
-    "date-fns-tz": "3.0.0",
+    "date-fns": "^4.1.0",
     "react-intl": "^6.7.0"
   },
   "devDependencies": {

--- a/packages/date-helpers/src/date.test.ts
+++ b/packages/date-helpers/src/date.test.ts
@@ -2,8 +2,9 @@
  * @jest-environment jsdom
  */
 
-import { toDate } from "date-fns-tz";
 import { createIntl, createIntlCache } from "react-intl";
+import { parseISO } from "date-fns";
+import { tz } from "@date-fns/tz";
 
 import {
   convertDateTimeToDate,
@@ -62,10 +63,10 @@ describe("relativeClosingDate tests", () => {
   // https://dateful.com/convert/pacific-time-pt?t=1159pm&d=2021-12-31&tz2=Eastern-Time-ET
   test("today in a different time zone", () => {
     const s = f({
-      closingDate: toDate("2021-12-31 23:59:59", {
-        timeZone: "Canada/Pacific",
+      closingDate: parseISO("2021-12-31 23:59:59", {
+        in: tz("Canada/Pacific"),
       }),
-      now: toDate("2022-01-01 1:00:00", { timeZone: "Canada/Eastern" }),
+      now: parseISO("2022-01-01 01:00:00", { in: tz("Canada/Eastern") }),
       intl,
       timeZone: "Canada/Pacific",
     });
@@ -75,10 +76,10 @@ describe("relativeClosingDate tests", () => {
   // https://dateful.com/convert/pacific-time-pt?t=1159pm&d=2021-12-31&tz2=Eastern-Time-ET
   test("tomorrow in a different time zone", () => {
     const s = f({
-      closingDate: toDate("2021-12-31 23:59:59", {
-        timeZone: "Canada/Pacific",
+      closingDate: parseISO("2021-12-31 23:59:59", {
+        in: tz("Canada/Pacific"),
       }),
-      now: toDate("2021-12-31 00:00:00", { timeZone: "Canada/Eastern" }),
+      now: parseISO("2021-12-31 00:00:00", { in: tz("Canada/Eastern") }),
       intl,
       timeZone: "Canada/Pacific",
     });
@@ -88,10 +89,10 @@ describe("relativeClosingDate tests", () => {
   // https://dateful.com/convert/pacific-time-pt?t=1159pm&d=2021-12-31&tz2=Eastern-Time-ET
   test("future days in a different time zone", () => {
     const s = f({
-      closingDate: toDate("2021-12-31 23:59:59", {
-        timeZone: "Canada/Pacific",
+      closingDate: parseISO("2021-12-31 23:59:59", {
+        in: tz("Canada/Pacific"),
       }),
-      now: toDate("2021-12-01", { timeZone: "Canada/Eastern" }),
+      now: parseISO("2021-12-01", { in: tz("Canada/Eastern") }),
       intl,
       timeZone: "Canada/Pacific",
     });

--- a/packages/date-helpers/src/index.ts
+++ b/packages/date-helpers/src/index.ts
@@ -76,24 +76,18 @@ export const relativeClosingDate = ({
   timeZone,
   customFormat,
 }: relativeClosingDateOptions): string => {
-  const inTz = timeZone ? tz(timeZone) : undefined;
-  // A date formatting function that can use time zones optionally
-  const myFormatFunc = (
-    date: Date,
-    formatPattern: string,
-    options?: FormatOptions,
-  ) =>
-    format(date, formatPattern, {
-      ...options,
-      in: inTz,
-    });
+  const formatOpts: FormatOptions = {
+    in: timeZone ? tz(timeZone) : undefined,
+  };
 
   const strLocale = getLocale(intl);
   const locale = strLocale === "fr" ? fr : undefined;
-  const time = myFormatFunc(closingDate, `p`, {
+  const time = format(closingDate, `p`, {
+    ...formatOpts,
     locale,
   });
-  const dateTime = myFormatFunc(closingDate, customFormat ?? `PPP p`, {
+  const dateTime = format(closingDate, customFormat ?? `PPP p`, {
+    ...formatOpts,
     locale,
   });
 
@@ -102,8 +96,8 @@ export const relativeClosingDate = ({
   }
 
   if (
-    myFormatFunc(now, DATE_FORMAT_STRING) ===
-    myFormatFunc(closingDate, DATE_FORMAT_STRING)
+    format(now, DATE_FORMAT_STRING, formatOpts) ===
+    format(closingDate, DATE_FORMAT_STRING, formatOpts)
   ) {
     return intl.formatMessage(dateMessages.deadlineToday, {
       time,
@@ -111,8 +105,8 @@ export const relativeClosingDate = ({
   }
 
   if (
-    myFormatFunc(add(now, { days: 1 }), DATE_FORMAT_STRING) ===
-    myFormatFunc(closingDate, DATE_FORMAT_STRING)
+    format(add(now, { days: 1 }), DATE_FORMAT_STRING, formatOpts) ===
+    format(closingDate, DATE_FORMAT_STRING, formatOpts)
   ) {
     return intl.formatMessage(dateMessages.deadlineTomorrow, { time });
   }

--- a/packages/eslint-config-custom/react.js
+++ b/packages/eslint-config-custom/react.js
@@ -120,7 +120,7 @@ module.exports = {
               "Please import the individual function, not the entire library.",
           },
           {
-            group: ["date-fns", "date-fns-tz", "!date-fns/", "!date-fns-tz/"],
+            group: ["date-fns", "!date-fns/"],
             message:
               "Please import the individual function, not the entire library.",
           },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,6 +418,9 @@ importers:
 
   packages/date-helpers:
     dependencies:
+      '@date-fns/tz':
+        specifier: ^1.1.1
+        version: 1.1.2
       '@gc-digital-talent/graphql':
         specifier: workspace:*
         version: link:../graphql
@@ -425,11 +428,8 @@ importers:
         specifier: workspace:*
         version: link:../i18n
       date-fns:
-        specifier: ^3.6.0
-        version: 3.6.0
-      date-fns-tz:
-        specifier: 3.0.0
-        version: 3.0.0(date-fns@3.6.0)
+        specifier: ^4.1.0
+        version: 4.1.0
       react-intl:
         specifier: ^6.7.0
         version: 6.7.0(react@18.3.1)(typescript@5.6.3)
@@ -1695,6 +1695,9 @@ packages:
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss-selector-parser: ^6.0.13
+
+  '@date-fns/tz@1.1.2':
+    resolution: {integrity: sha512-Xmg2cPmOPQieCLAdf62KtFPU9y7wbQDq1OAzrs/bEQFvhtCPXDiks1CHDE/sTXReRfh/MICVkw/vY6OANHUGiA==}
 
   '@dual-bundle/import-meta-resolve@4.1.0':
     resolution: {integrity: sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==}
@@ -4569,13 +4572,11 @@ packages:
   dataloader@2.2.2:
     resolution: {integrity: sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==}
 
-  date-fns-tz@3.0.0:
-    resolution: {integrity: sha512-YgRowJwvCAAjN1A5F2l1ZjnYKThX7YDq399qo+ThXFpeOqinN1u8SUqfM5IdRQSpai18Iy3EBMb6/CXTSnDstg==}
-    peerDependencies:
-      date-fns: ^3.0.0
-
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
@@ -8659,6 +8660,8 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.1.0
 
+  '@date-fns/tz@1.1.2': {}
+
   '@dual-bundle/import-meta-resolve@4.1.0': {}
 
   '@esbuild/aix-ppc64@0.21.5':
@@ -12048,12 +12051,9 @@ snapshots:
 
   dataloader@2.2.2: {}
 
-  date-fns-tz@3.0.0(date-fns@3.6.0):
-    dependencies:
-      date-fns: 3.6.0
-      lodash.clonedeep: 4.5.0
-
   date-fns@3.6.0: {}
+
+  date-fns@4.1.0: {}
 
   debounce@1.2.1: {}
 


### PR DESCRIPTION
🤖 Resolves #11570 

## 👋 Introduction

Replaces the `date-fns-tz` library with `@date-fns/tz`

## 🕵️ Details

Hopefully our tests are good for this :sweat_smile: 

## 🧪 Testing

1. Confirm no references to `data-fns-tz`
2. Confirm helpers that use timezones still function as expected