### PR TITLE
[Fix] Allow filling in screening question

### DIFF
--- a/apps/web/src/pages/Applications/utils.ts
+++ b/apps/web/src/pages/Applications/utils.ts
@@ -32,8 +32,8 @@ export const getApplicationSteps = ({
   experienceId,
 }: GetApplicationPagesArgs): ApplicationStepInfo[] => {
   const showQuestionStep =
-    application.pool.generalQuestions?.length ??
-    application.pool.screeningQuestions?.length;
+    !!application.pool.generalQuestions?.length ||
+    !!application.pool.screeningQuestions?.length;
 
   // build the order of step functions to call
   const stepInfoFunctions = [


### PR DESCRIPTION
🤖 Resolves #11748 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Fixes a bad null coalescing fix.  In this case, it was actually supposed to be an OR, not a null coalesce.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->
The way the logic for the "should I show the questions step" was being calculated was "only show if there are general questions".  This specific pool has no general questions but does have screening questions.  The screening questions were skipped, then.

## 🧪 Testing

1. Set up a pool with zero general questions but at least one screening question.
2. Submit an application to the pool, verifying that you filled in the screening questions.
3. Try with other pools using different permutations of questions.