### PR TITLE
[Fix] Add hidden description skill details label

### DIFF
--- a/apps/web/src/components/SkillsInDetail/SkillsInDetail.tsx
+++ b/apps/web/src/components/SkillsInDetail/SkillsInDetail.tsx
@@ -4,7 +4,11 @@ import XCircleIcon from "@heroicons/react/20/solid/XCircleIcon";
 
 import { Button, CardBasic } from "@gc-digital-talent/ui";
 import { TextArea } from "@gc-digital-talent/forms";
-import { getLocale, errorMessages } from "@gc-digital-talent/i18n";
+import {
+  getLocale,
+  errorMessages,
+  getLocalizedName,
+} from "@gc-digital-talent/i18n";
 
 import type { FormSkills } from "~/types/experience";
 
@@ -78,6 +82,16 @@ const SkillsInDetail = ({ skills, onDelete }: SkillsInDetailProps) => {
                 id={`skill-in-detail-${id}`}
                 name={`skills.${index}.details`}
                 wordLimit={MAX_WORDS}
+                aria-label={intl.formatMessage(
+                  {
+                    id: "Opn8nz",
+                    defaultMessage:
+                      "Describe how {skillName} featured in this role",
+                    description:
+                      "More descriptive label for the textarea in the skills in detail section",
+                  },
+                  { skillName: getLocalizedName(name, intl, true) },
+                )}
                 label={intl.formatMessage({
                   defaultMessage:
                     "Describe how this skill featured in this role",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1,4 +1,12 @@
 {
+  "8kMPLB": {
+    "defaultMessage": "Décrivez la façon dont cette compétence a été mise en valeur dans ce rôle",
+    "description": "Label for the textarea in the skills in detail section."
+  },
+  "Opn8nz": {
+    "defaultMessage": "Décrivez la façon dont la compétence {skillName} a été mise en valeur dans ce rôle",
+    "description": "More descriptive label for the textarea in the skills in detail section"
+  },
   "++a1ZY": {
     "defaultMessage": "Il n’est pas nécessaire d’avoir atteint le niveau de compétences en langue seconde avant de poser sa candidature à un poste bilingue. On vous demandera de passer un test dans le cadre de la procédure d’embauche.",
     "description": "Description for bilingual positions in language requirements dialog"
@@ -2026,10 +2034,6 @@
   "8ioBIZ": {
     "defaultMessage": "Éditeur de compétence",
     "description": "Title for skills editor"
-  },
-  "8kMPLB": {
-    "defaultMessage": "Décrire la façon dont cette compétence a été mise en valeur dans ce rôle",
-    "description": "Label for the textarea in the skills in detail section."
   },
   "8n9opI": {
     "defaultMessage": "Les talents autochtones prêts pour un stage d’apprentissage en TI",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1,12 +1,4 @@
 {
-  "8kMPLB": {
-    "defaultMessage": "Décrivez la façon dont cette compétence a été mise en valeur dans ce rôle",
-    "description": "Label for the textarea in the skills in detail section."
-  },
-  "Opn8nz": {
-    "defaultMessage": "Décrivez la façon dont la compétence {skillName} a été mise en valeur dans ce rôle",
-    "description": "More descriptive label for the textarea in the skills in detail section"
-  },
   "++a1ZY": {
     "defaultMessage": "Il n’est pas nécessaire d’avoir atteint le niveau de compétences en langue seconde avant de poser sa candidature à un poste bilingue. On vous demandera de passer un test dans le cadre de la procédure d’embauche.",
     "description": "Description for bilingual positions in language requirements dialog"
@@ -2034,6 +2026,10 @@
   "8ioBIZ": {
     "defaultMessage": "Éditeur de compétence",
     "description": "Title for skills editor"
+  },
+  "8kMPLB": {
+    "defaultMessage": "Décrivez la façon dont cette compétence a été mise en valeur dans ce rôle",
+    "description": "Label for the textarea in the skills in detail section."
   },
   "8n9opI": {
     "defaultMessage": "Les talents autochtones prêts pour un stage d’apprentissage en TI",
@@ -5042,6 +5038,10 @@
   "OpKC2i": {
     "defaultMessage": "Exceptions relatives au lieu de travail",
     "description": "Work location exceptions label"
+  },
+  "Opn8nz": {
+    "defaultMessage": "Décrivez la façon dont la compétence {skillName} a été mise en valeur dans ce rôle",
+    "description": "More descriptive label for the textarea in the skills in detail section"
   },
   "OqglGZ": {
     "defaultMessage": "Ce volet comprend le travail avec la direction de l’architecture <abbreviation>TI</abbreviation> du ministère, la collaboration avec d’autres volets de <abbreviation>TI</abbreviation> et la recherche sur les technologies émergentes.",


### PR DESCRIPTION
🤖 Resolves #11750 

## 👋 Introduction

Adds a more descriptive, hidden, label for skill details labels to improve the experience for AT users.

> [!NOTE]
> @NienkeBr also provided an updated, visible, French label 

## 🧪 Testing

1. Build the app `pnpm run dev:fresh`
2. Login as any user
3. Navigate to the experience form (add or edit is fine)
4. Add a skill to the form
5. Inspect the details text area
6. Confirm it has the skill name included in the accessible name for the input