### PR TITLE
[Bug] Fix error display of core requirements location

### DIFF
--- a/apps/web/src/pages/Pools/EditPoolPage/components/CoreRequirementsSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/CoreRequirementsSection/Display.tsx
@@ -21,7 +21,7 @@ const Display = ({
   const notProvided = intl.formatMessage(commonMessages.notProvided);
   const { language, securityClearance, location, isRemote } = pool;
 
-  const hasLocation = !!(isRemote ?? location?.[locale]);
+  const hasLocation = isRemote || (!!location?.en && !!location?.fr);
 
   return (
     <>


### PR DESCRIPTION
🤖 Resolves #11751

## 👋 Introduction

Fix the input error issue. It appears the logic to determine whether it was truly not complete was not quite right

## 🧪 Testing

1. Edit a draft pool
2. Ensure location does not incorrectly present in an errored state

## 📸 Screenshot

Error state

![image](https://github.com/user-attachments/assets/29d6d5b4-f828-469e-a5de-9d19de4c6f7c)

All good

![image](https://github.com/user-attachments/assets/72f15ff3-92bd-4f0a-903a-4d4b99e76ecf)

![image](https://github.com/user-attachments/assets/a937e055-125d-416e-801f-ecd260930f57)
