### PR TITLE
[Fix] Make `/browse` return 404

### DIFF
--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -304,6 +304,12 @@ const createRoute = (locale: Locales) =>
               path: "browse",
               children: [
                 {
+                  index: true,
+                  loader: () => {
+                    throw new NotFoundError();
+                  },
+                },
+                {
                   path: "pools",
                   children: [
                     {

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -346,6 +346,12 @@ const createRoute = (locale: Locales) =>
               path: "applications",
               children: [
                 {
+                  index: true,
+                  loader: () => {
+                    throw new NotFoundError();
+                  },
+                },
+                {
                   path: ":applicationId",
                   lazy: () => import("../pages/Applications/ApplicationLayout"),
                   children: [
@@ -737,6 +743,12 @@ const createRoute = (locale: Locales) =>
             {
               path: "settings",
               children: [
+                {
+                  index: true,
+                  loader: () => {
+                    throw new NotFoundError();
+                  },
+                },
                 {
                   path: "classifications",
                   children: [


### PR DESCRIPTION
🤖 Resolves #11717 

## 👋 Introduction

Updates the index route at `/browse` show the 404 page.

## 🧪 Testing

1. Build the app `pnpm run dev:fresh`
2. Navigate to `/browse`
3. Confirm not found (404) page
4. Navigate to `/browse/pools`
5. Confirm expected page is rendered

## 📸 Screenshot

![2024-10-15_09-41](https://github.com/user-attachments/assets/adda01c7-1b8e-466e-9238-6401d798df22)
