### PR TITLE
[Debt] User creation shifted to `authCallback()`

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -59,12 +59,8 @@ jobs:
           DB_HOST: localhost
         run: |
           if [ github.actor != 'dependabot[bot]' ]; then
-            php artisan key:generate
-            php artisan config:cache
             php artisan test --parallel --processes=2 --coverage-clover=coverage.xml
           else
-            php artisan key:generate
-            php artisan config:cache
             php artisan test
           fi
       - name: Upload coverage report to Codecov

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -52,6 +52,8 @@ jobs:
           sudo apt-get install --yes --no-install-recommends postgresql-client
           cp .env.example .env
           composer install --prefer-dist --no-scripts
+          php artisan key:generate
+          php artisan config:cache
 
       - name: PHPUnit tests
         working-directory: api

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -52,8 +52,6 @@ jobs:
           sudo apt-get install --yes --no-install-recommends postgresql-client
           cp .env.example .env
           composer install --prefer-dist --no-scripts
-          php artisan key:generate
-          php artisan config:cache
 
       - name: PHPUnit tests
         working-directory: api
@@ -61,8 +59,12 @@ jobs:
           DB_HOST: localhost
         run: |
           if [ github.actor != 'dependabot[bot]' ]; then
+            php artisan key:generate
+            php artisan config:cache
             php artisan test --parallel --processes=2 --coverage-clover=coverage.xml
           else
+            php artisan key:generate
+            php artisan config:cache
             php artisan test
           fi
       - name: Upload coverage report to Codecov

--- a/api/app/Providers/AuthServiceProvider.php
+++ b/api/app/Providers/AuthServiceProvider.php
@@ -11,7 +11,6 @@ use App\Models\EducationExperience;
 use App\Models\PersonalExperience;
 use App\Models\Pool;
 use App\Models\PoolCandidate;
-use App\Models\Role;
 use App\Models\User;
 use App\Models\WorkExperience;
 use App\Policies\ClassificationPolicy;
@@ -103,16 +102,8 @@ class AuthServiceProvider extends ServiceProvider
 
                 return $userMatch;
             } else {
-                // No user found for given subscriber - lets auto-register them
-                $newUser = new User;
-                $newUser->sub = $sub;
-                $newUser->save();
-                $newUser->syncRoles([  // every new user is automatically an base_user and an applicant
-                    Role::where('name', 'base_user')->sole(),
-                    Role::where('name', 'applicant')->sole(),
-                ], null);
-
-                return $newUser;
+                // No user found for given subscriber
+                throw new AuthenticationException('Login as un-retrievable user: '.$userMatch->sub, 'user_not_found');
             }
         }
 

--- a/api/app/Providers/AuthServiceProvider.php
+++ b/api/app/Providers/AuthServiceProvider.php
@@ -103,7 +103,7 @@ class AuthServiceProvider extends ServiceProvider
                 return $userMatch;
             } else {
                 // No user found for given subscriber
-                throw new AuthenticationException('Login as un-retrievable user: '.$userMatch->sub, 'user_not_found');
+                throw new AuthenticationException('Login as un-retrievable user: '.$sub, 'user_not_found');
             }
         }
 

--- a/api/phpunit.xml
+++ b/api/phpunit.xml
@@ -17,6 +17,7 @@
   <coverage  />
   <php>
     <server name="APP_ENV" value="testing"/>
+    <server name="APP_KEY" value="12345678901234567890123456789012"/>
     <server name="BCRYPT_ROUNDS" value="4"/>
     <server name="CACHE_DRIVER" value="array"/>
     <!-- <server name="DB_CONNECTION" value="sqlite"/> -->

--- a/api/tests/Feature/AuthServiceProviderTest.php
+++ b/api/tests/Feature/AuthServiceProviderTest.php
@@ -7,7 +7,6 @@ use App\Models\Role;
 use App\Models\User;
 use App\Providers\AuthServiceProvider;
 use App\Services\OpenIdBearerTokenService;
-use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lcobucci\JWT\Token\DataSet;
 use Lcobucci\JWT\Validation\ConstraintViolation;
@@ -90,48 +89,6 @@ class AuthServiceProviderTest extends TestCase
         } catch (AuthenticationException $e) {
             $this->assertEquals('token_validation', $e->getExtensions()['reason'], 'Unexpected reason on AuthenticationException');
         }
-    }
-
-    /**
-     * @test
-     * The test checks that a user is automatically created if it doesn't yet exist (by sub)
-     * Also check that the new user has no roles
-     */
-    public function testUserIsAutoCreatedWhenMissing()
-    {
-        $this->seed(RolePermissionSeeder::class);
-
-        $testSub = 'test-sub';
-
-        // DataSet is a final class, and so we need to use it as a proxied partial mock.
-        // See: https://docs.mockery.io/en/latest/reference/final_methods_classes.html#dealing-with-final-classes-methods
-        $mockClaims = \Mockery::mock(new DataSet(['sub' => $testSub], ''));
-
-        $fakeToken = 'fake-token';
-        $mockTokenService = \Mockery::mock(OpenIdBearerTokenService::class);
-        $mockTokenService->shouldReceive('validateAndGetClaims')
-            ->with($fakeToken)
-            ->andReturn($mockClaims);
-
-        // starting off, they shouldn't exist
-        $this->assertDatabaseMissing('users', ['sub' => $testSub]);
-
-        // this resolve should auto-create them
-        $resolvedUser = $this->provider->resolveUserOrAbort($fakeToken, $mockTokenService);
-
-        // they should exist now, but should not be admin
-        $newUser = User::where('sub', $testSub)->sole();
-        $this->assertModelExists($newUser);
-
-        $expectedRoleNames = [
-            Role::where('name', 'base_user')->sole()->name,
-            Role::where('name', 'applicant')->sole()->name,
-        ];
-        $actualRoleNames = $newUser->roles->map(function ($role) {
-            return $role->name;
-        })->toArray();
-
-        $this->assertEqualsCanonicalizing($actualRoleNames, $expectedRoleNames);
     }
 
     /**

--- a/api/tests/Unit/AuthControllerTest.php
+++ b/api/tests/Unit/AuthControllerTest.php
@@ -6,7 +6,6 @@ use App\Models\Role;
 use App\Models\User;
 use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
@@ -20,9 +19,6 @@ class AuthControllerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-
-        Artisan::call('key:generate');
-        Artisan::call('config:cache');
     }
 
     public function testNewUserCreationOnLogin()

--- a/api/tests/Unit/AuthControllerTest.php
+++ b/api/tests/Unit/AuthControllerTest.php
@@ -6,6 +6,7 @@ use App\Models\Role;
 use App\Models\User;
 use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
@@ -19,6 +20,9 @@ class AuthControllerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        Artisan::call('key:generate');
+        Artisan::call('config:cache');
     }
 
     public function testNewUserCreationOnLogin()

--- a/api/tests/Unit/AuthControllerTest.php
+++ b/api/tests/Unit/AuthControllerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Role;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+use function PHPUnit\Framework\assertNotNull;
+use function PHPUnit\Framework\assertSame;
+
+class AuthControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testNewUserCreationOnLogin()
+    {
+        $this->seed(RolePermissionSeeder::class);
+
+        // starting with zero users
+        assertSame(0, count(User::all()));
+
+        // JWT payload
+        // {
+        //     "sub": "1234567890",
+        //     "nonce": "abc",
+        //     "state": "abc",
+        //     "iat": 1516239022
+        //   }
+        Http::fakeSequence()
+            ->push([
+                'id_token' => 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibm9uY2UiOiJhYmMiLCJzdGF0ZSI6ImFiYyIsImlhdCI6MTUxNjIzOTAyMn0.p4GMaQjmIcUAxjAZ7Y51C1q1mu5sVXJLdX1zybt4jFc',
+            ], 200)
+            ->whenEmpty(Http::response());
+
+        $response = $this->withSession([
+            'state' => 'abc',
+            'nonce' => 'abc',
+        ])->call('GET', '/auth-callback', [
+            'state' => 'abc',
+            'nonce' => 'abc',
+            'code' => 'code',
+        ]);
+
+        // ensure a user was created bringing the count up to one, with the expected sub per payload above and last sign in set
+        assertSame(1, count(User::all()));
+        $newUser = User::where('sub', '1234567890')->sole();
+        $this->assertModelExists($newUser);
+        assertNotNull($newUser->last_sign_in_at);
+
+        $response = $this->withSession([
+            'state' => 'abc',
+            'nonce' => 'abc',
+        ])->call('GET', '/auth-callback', [
+            'state' => 'abc',
+            'nonce' => 'abc',
+            'code' => 'code',
+        ]);
+
+        // ensure no users were created from the second request and the users stayed constant
+        assertSame(1, count(User::all()));
+        $newUser = User::where('sub', '1234567890')->sole();
+        $this->assertModelExists($newUser);
+        assertNotNull($newUser->last_sign_in_at);
+
+        // assert new user has expected roles
+        $expectedRoleNames = [
+            Role::where('name', 'base_user')->sole()->name,
+            Role::where('name', 'applicant')->sole()->name,
+        ];
+        $actualRoleNames = $newUser->roles->map(function ($role) {
+            return $role->name;
+        })->toArray();
+        $this->assertEqualsCanonicalizing($actualRoleNames, $expectedRoleNames);
+    }
+}


### PR DESCRIPTION
🤖 Resolves #11466

## 👋 Introduction

Shift user creation to the callback in AuthController.php
Nothing fancy needed to be done


## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Can log in normally with existing user
2. User creation works
3. Sign in values updated or set appropriately
4. Test above with SiC
