### PR TITLE
[Feature] Bump PHP CLI memory limit

### DIFF
--- a/infrastructure/bin/post_deployment.sh
+++ b/infrastructure/bin/post_deployment.sh
@@ -27,6 +27,13 @@ fi
 # First block is the header
 BLOCKS="{ \"type\": \"header\", \"text\": { \"type\": \"plain_text\", \"text\": \"Post-deployment script was run\" } }"
 
+# Configure PHP CLI
+if echo 'memory_limit=256M' >> /usr/local/etc/php/conf.d/php.ini ; then
+    add_section_block ":white_check_mark: Configure PHP CLI *successful*."
+else
+    add_section_block ":X: Configure PHP CLI *failed*. $MENTION"
+fi
+
 # Install packages from repository
 if apt-get update && apt-get install --yes --no-install-recommends supervisor cron postgresql-client; then
     add_section_block ":white_check_mark: Install packages from repository *successful*."

--- a/infrastructure/webserver.Dockerfile
+++ b/infrastructure/webserver.Dockerfile
@@ -3,6 +3,8 @@
 # All images: https://mcr.microsoft.com/v2/appsvc/php/tags/list
 FROM mcr.microsoft.com/appsvc/php:8.2-fpm-xdebug_20230908.3.tuxprod
 
+RUN echo 'memory_limit=256M' >> /usr/local/etc/php/conf.d/php.ini
+
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends supervisor cron postgresql-client \
     && apt-get --yes autoremove \


### PR DESCRIPTION
🤖 Resolves #11764 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Bumps the memory limit of the PHP CLI configuration to 256MB.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

### :house: Locally

1. Rebuild your web server image: `docker compose build`
2. "UP" your docker composer network and shell into the webserver container.
3. `php -i | grep 'memory_limit'`

### :cloud: Azure

>[!TIP]
This is deployed to the DEV vertical right now.

1. Deploy to Azure DEV or UAT
2. SSH into the app service
3. `php -i | grep 'memory_limit'`
## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/80875070-b735-4734-8582-3e31c546a1a4)
