### PR TITLE
[Feature] Adds department to job advertisement

### DIFF
--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -166,6 +166,12 @@ export const PoolAdvertisement_Fragment = graphql(/* GraphQL */ `
         fr
       }
     }
+    department {
+      name {
+        en
+        fr
+      }
+    }
     opportunityLength {
       value
       label {
@@ -308,6 +314,8 @@ export const PoolPoster = ({
   const [skillsValue, setSkillsValue] = useState<string[]>([]);
   const [linkCopied, setLinkCopied] = useState<boolean>(false);
   const pool = getFragment(PoolAdvertisement_Fragment, poolQuery);
+
+  const departmentName = getLocalizedName(pool.department?.name, intl, true);
 
   const { classification } = pool;
   const genericJobTitles =
@@ -679,6 +687,13 @@ export const PoolPoster = ({
                       />
                     ) : undefined
                   }
+                />
+                <DataRow
+                  label={
+                    intl.formatMessage(commonMessages.department) +
+                    intl.formatMessage(commonMessages.dividingColon)
+                  }
+                  value={departmentName}
                 />
                 <DataRow
                   label={


### PR DESCRIPTION
🤖 Resolves #11801.

## 👋 Introduction

This PR adds the Department label and value from a pool to the job advertisement.

## 🧪 Testing

1. Navigate to a job advertisement at http://localhost:8000/en/browse/pools
2. Navigate to Employment details section
3. Verify Department label and value exists 

## 📸 Screenshots

<img width="1179" alt="Screen Shot 2024-10-21 at 12 03 24" src="https://github.com/user-attachments/assets/d9313de7-6e86-4eba-beac-dca40221d006">
<img width="1169" alt="Screen Shot 2024-10-21 at 12 03 42" src="https://github.com/user-attachments/assets/49435199-0bf1-4b5a-a0cc-123877b6ab66">

