### PR TITLE
[Fix] `margin-right` on radio group section

### DIFF
--- a/apps/web/src/utils/educationUtils.tsx
+++ b/apps/web/src/utils/educationUtils.tsx
@@ -298,10 +298,7 @@ export const getEducationRequirementOptions = (
               }),
           contentBelow: (
             <>
-              <p
-                data-h2-margin-right="base(x.5)"
-                data-h2-margin-bottom="base(x.5)"
-              >
+              <p data-h2-margin-bottom="base(x.5)">
                 {intl.formatMessage(applicationMessages.appliedWorkExperience)}
               </p>
               <ul>
@@ -332,7 +329,7 @@ export const getEducationRequirementOptions = (
                   "Radio group option for education requirement filter in application education form.",
               }),
           contentBelow: (
-            <p data-h2-margin-right="base(x.5)">
+            <p>
               {isIAP
                 ? intl.formatMessage({
                     defaultMessage:

--- a/apps/web/src/utils/educationUtils.tsx
+++ b/apps/web/src/utils/educationUtils.tsx
@@ -298,7 +298,10 @@ export const getEducationRequirementOptions = (
               }),
           contentBelow: (
             <>
-              <p data-h2-margin="base(0, 0, x.5, 0)">
+              <p
+                data-h2-margin-right="base(x.5)"
+                data-h2-margin-bottom="base(x.5)"
+              >
                 {intl.formatMessage(applicationMessages.appliedWorkExperience)}
               </p>
               <ul>
@@ -329,7 +332,7 @@ export const getEducationRequirementOptions = (
                   "Radio group option for education requirement filter in application education form.",
               }),
           contentBelow: (
-            <p>
+            <p data-h2-margin-right="base(x.5)">
               {isIAP
                 ? intl.formatMessage({
                     defaultMessage:

--- a/packages/forms/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/forms/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -3,6 +3,7 @@ import { action } from "@storybook/addon-actions";
 import { faker } from "@faker-js/faker/locale/en";
 
 import { VIEWPORT, allModes } from "@gc-digital-talent/storybook-helpers";
+import { Link } from "@gc-digital-talent/ui";
 
 import Form from "../BasicForm";
 import Submit from "../Submit";
@@ -110,8 +111,43 @@ LongLegend.args = {
 export const ContentBelow = Template.bind({});
 ContentBelow.args = {
   ...Default.args,
-  items: Default.args.items?.map((item) => ({
-    ...item,
-    contentBelow: faker.lorem.lines(6),
-  })),
+  items: [
+    {
+      value: "one",
+      label: "Box One",
+      contentBelow: faker.lorem.lines(6),
+    },
+    {
+      value: "two",
+      label: "Box Two",
+      contentBelow: (
+        <p>
+          Wrapped in a p.
+          <br />
+          {faker.lorem.lines(6)}
+        </p>
+      ),
+    },
+    {
+      value: "three",
+      label: "Box three",
+      contentBelow: (
+        <p>
+          Wrapped in a p with link and a ul.
+          <br />
+          {faker.lorem.lines(6)}{" "}
+          <Link href="#" color="black" newTab external>
+            An external link with a lot of words
+          </Link>
+          . {faker.lorem.lines(2)}
+          <ul>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+            <li>List item 4</li>
+          </ul>
+        </p>
+      ),
+    },
+  ],
 };

--- a/packages/forms/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/forms/src/components/RadioGroup/RadioGroup.tsx
@@ -161,6 +161,7 @@ const RadioGroup = ({
                   {contentBelow && (
                     <div
                       id={`${id}-content-below`}
+                      data-h2-margin-right="base(x.5)"
                       data-h2-padding-left="base(x1.7)"
                       data-h2-color="base(black.light)"
                       data-h2-font-size="base(caption)"


### PR DESCRIPTION
🤖 Resolves #11227.

## 👋 Introduction

This PR adds `margin-right` on the `contentBelow` part of radio group section.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/en/browse/pools
3. Apply for a process
4. On Step 4, switch to French
5. Observe the text spacing is correct within the radio group section
6. `pnpm storybook`
7. Navigate to http://localhost:6006/?path=/story/forms-src-components-radiogroup--content-below&globals=viewport:phone
8. Observe the text spacing is correct within the radio group section

## 📸 Screenshot

<img width="1202" alt="Screen Shot 2024-10-21 at 13 32 05" src="https://github.com/user-attachments/assets/e538a046-f1e0-4a9d-b64a-2c4168d0280b">
