### PR TITLE
If community doesn't have team, create one in seeder

### DIFF
--- a/api/database/seeders/CommunitySeeder.php
+++ b/api/database/seeders/CommunitySeeder.php
@@ -41,5 +41,14 @@ class CommunitySeeder extends Seeder
                 ]
             );
         }
+
+        Community::all()->each(function (Community $community) {
+            if ($community->team()->exists()) {
+                return;
+            }
+            $community->team()->firstOrCreate([], [
+                'name' => 'community-' . $community->id,
+            ]);
+        });
     }
 }

--- a/api/database/seeders/CommunitySeeder.php
+++ b/api/database/seeders/CommunitySeeder.php
@@ -47,7 +47,7 @@ class CommunitySeeder extends Seeder
                 return;
             }
             $community->team()->firstOrCreate([], [
-                'name' => 'community-' . $community->id,
+                'name' => 'community-'.$community->id,
             ]);
         });
     }


### PR DESCRIPTION
🤖 Resolves #11743 

## 👋 Introduction

We created Communities programmatically on UAT and Prod (maybe Dev, too) without creating their corresponding teams, meaning that users can't be added to them with roles.

New communities created through the UI will have teams created automatically, but this adds some code to CommunitySeeder to add teams for any communities without them.

## 🧪 Testing

1. After running normal local seeding, delete the Community-type teams in the database.
2. Try to add a user to a community. This should fail.
3. Run `php artisan db:seed --class=CommunitySeeder`
4. Repeat step 2, it should work now.


## 🚚 Deployment

Run `php artisan db:seed --class=CommunitySeeder` to ensure all

