### PR TITLE
Avoid loading teamable in myAuth query

### DIFF
--- a/packages/auth/src/components/AuthorizationContainer.tsx
+++ b/packages/auth/src/components/AuthorizationContainer.tsx
@@ -6,8 +6,10 @@ import {
   UserAuthInfo,
 } from "@gc-digital-talent/graphql";
 
+type SimpleRoleAssignment = Exclude<RoleAssignment, "teamable">;
+
 export interface AuthorizationState {
-  roleAssignments: Maybe<RoleAssignment[]>;
+  roleAssignments: Maybe<SimpleRoleAssignment[]>;
   userAuthInfo?: Maybe<UserAuthInfo>;
   isLoaded: boolean;
 }
@@ -19,7 +21,7 @@ export const AuthorizationContext = createContext<AuthorizationState>({
 });
 
 interface AuthorizationContainerProps {
-  roleAssignments: Maybe<RoleAssignment[]>;
+  roleAssignments: Maybe<SimpleRoleAssignment[]>;
   userAuthInfo?: Maybe<UserAuthInfo>;
   isLoaded: boolean;
   children?: ReactNode;

--- a/packages/auth/src/components/AuthorizationProvider.tsx
+++ b/packages/auth/src/components/AuthorizationProvider.tsx
@@ -23,9 +23,6 @@ const authorizationQuery = graphql(/** GraphQL */ `
           id
           name
         }
-        teamable {
-          id
-        }
       }
     }
   }


### PR DESCRIPTION
🤖 Resolves #11811

## 👋 Introduction

Removes `teamable` from myAuth query.

## 🕵️ Details

The main thing to review and test here is that this teamable object isn't used anywhere else.

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

<!--
1. ...
2. ...
 -->

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the linked issue if deployment steps are needed

 -->
