### PR TITLE
[Feature] Admin view and edit work email

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -974,6 +974,15 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
         return $query;
     }
 
+    public static function scopeWorkEmail(Builder $query, ?string $email): Builder
+    {
+        if ($email) {
+            $query->where('work_email', 'ilike', "%{$email}%");
+        }
+
+        return $query;
+    }
+
     public static function scopeIsGovEmployee(Builder $query, ?bool $isGovEmployee): Builder
     {
         if ($isGovEmployee) {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -808,6 +808,7 @@ input UserFilterInput {
   isGovEmployee: Boolean @scope
   telephone: String @scope
   email: String @scope
+  workEmail: String @scope
   name: String @scope
   generalSearch: String @scope
   roles: [ID] @scope(name: "roleAssignments")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1087,6 +1087,7 @@ input UserFilterInput {
   isGovEmployee: Boolean
   telephone: String
   email: String
+  workEmail: String
   name: String
   generalSearch: String
   roles: [ID]

--- a/apps/web/src/components/Profile/components/GovernmentInformation/utils.ts
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/utils.ts
@@ -2,7 +2,7 @@ import { IntlShape } from "react-intl";
 import uniqBy from "lodash/uniqBy";
 
 import { empty } from "@gc-digital-talent/helpers";
-import { getLocalizedName } from "@gc-digital-talent/i18n";
+import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import {
   Classification,
   GovEmployeeType,
@@ -175,11 +175,7 @@ export const getLabels = (intl: IntlShape) => ({
     id: "gnGAe8",
     description: "Label displayed on classification level input",
   }),
-  workEmail: intl.formatMessage({
-    defaultMessage: "Work email address",
-    id: "jWx0oF",
-    description: "Label displayed on work email input",
-  }),
+  workEmail: intl.formatMessage(commonMessages.workEmail),
   priorityEntitlementYesNo: intl.formatMessage({
     defaultMessage: "Do you have a priority entitlement?",
     id: "/h9mNu",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9234,10 +9234,6 @@
     "defaultMessage": "Pourquoi faut-il recueillir ces données?",
     "description": "Heading for the Why collect section on the digital services contracting questionnaire"
   },
-  "jWx0oF": {
-    "defaultMessage": "Adresse courriel professionnelle",
-    "description": "Label displayed on work email input"
-  },
   "jXUnrt": {
     "defaultMessage": "Vous n’avez toujours pas ajouté de questions.",
     "description": "Message that appears when there are no general messages for a pool"

--- a/apps/web/src/pages/Auth/RegistrationPages/EmployeeInformationPage/EmployeeInformationPage.tsx
+++ b/apps/web/src/pages/Auth/RegistrationPages/EmployeeInformationPage/EmployeeInformationPage.tsx
@@ -32,6 +32,7 @@ import {
   UpdateUserAsUserInput,
 } from "@gc-digital-talent/graphql";
 import {
+  commonMessages,
   errorMessages,
   getGovEmployeeType,
   getLocalizedName,
@@ -445,11 +446,7 @@ export const EmployeeInformationForm = ({
       id: "xzSXz9",
       description: "Employment type label",
     }),
-    workEmail: intl.formatMessage({
-      defaultMessage: "Work email address",
-      id: "jWx0oF",
-      description: "Label displayed on work email input",
-    }),
+    workEmail: intl.formatMessage(commonMessages.workEmail),
     currentClassificationGroup: intl.formatMessage({
       defaultMessage: "Group",
       id: "wJnIJx",

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -78,6 +78,7 @@ const UsersPaginated_Query = graphql(/* GraphQL */ `
       data {
         id
         email
+        isGovEmployee
         workEmail
         firstName
         lastName
@@ -268,6 +269,22 @@ const UserTable = ({ title }: UserTableProps) => {
       header: intl.formatMessage(commonMessages.email),
       cell: ({ getValue }) => cells.email(getValue()),
     }),
+    columnHelper.accessor(
+      (user) =>
+        user.isGovEmployee
+          ? intl.formatMessage(commonMessages.yes)
+          : intl.formatMessage(commonMessages.no),
+      {
+        id: "isGovEmployee",
+        header: intl.formatMessage({
+          defaultMessage: "Government employee",
+          id: "bOA3EH",
+          description: "Label for the government employee field",
+        }),
+        enableColumnFilter: false,
+        enableSorting: false,
+      },
+    ),
     columnHelper.accessor("workEmail", {
       id: "workEmail",
       header: intl.formatMessage(commonMessages.workEmail),
@@ -397,6 +414,7 @@ const UserTable = ({ title }: UserTableProps) => {
       columns={columns}
       isLoading={fetching}
       hiddenColumnIds={[
+        "isGovEmployee",
         "workEmail",
         "telephone",
         "preferredLang",

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -78,6 +78,7 @@ const UsersPaginated_Query = graphql(/* GraphQL */ `
       data {
         id
         email
+        workEmail
         firstName
         lastName
         telephone
@@ -267,6 +268,11 @@ const UserTable = ({ title }: UserTableProps) => {
       header: intl.formatMessage(commonMessages.email),
       cell: ({ getValue }) => cells.email(getValue()),
     }),
+    columnHelper.accessor("workEmail", {
+      id: "workEmail",
+      header: intl.formatMessage(commonMessages.workEmail),
+      cell: ({ getValue }) => cells.email(getValue()),
+    }),
     columnHelper.accessor(
       (user) =>
         rolesAccessor(unpackMaybes(user?.authInfo?.roleAssignments), intl),
@@ -391,6 +397,7 @@ const UserTable = ({ title }: UserTableProps) => {
       columns={columns}
       isLoading={fetching}
       hiddenColumnIds={[
+        "workEmail",
         "telephone",
         "preferredLang",
         "createdDate",

--- a/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
@@ -76,6 +76,7 @@ export function transformSortStateToOrderByClause(
     ["id", "id"],
     ["candidateName", "first_name"],
     ["email", "email"],
+    ["workEmail", "work_email"],
     ["telephone", "telephone"],
     ["preferredLang", "preferred_lang"],
     ["createdDate", "created_at"],

--- a/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
@@ -56,6 +56,7 @@ export function transformUserInput(
     // search bar
     generalSearch: searchBarTerm && !searchType ? searchBarTerm : undefined,
     email: searchType === "email" ? searchBarTerm : undefined,
+    workEmail: searchType === "workEmail" ? searchBarTerm : undefined,
     name: searchType === "name" ? searchBarTerm : undefined,
     telephone: searchType === "phone" ? searchBarTerm : undefined,
 

--- a/apps/web/src/pages/Users/UpdateUserPage/operations.ts
+++ b/apps/web/src/pages/Users/UpdateUserPage/operations.ts
@@ -60,6 +60,8 @@ export const UpdateUserData_Query = graphql(/* GraphQL */ `
       firstName
       lastName
       telephone
+      isGovEmployee
+      workEmail
       preferredLang {
         value
         label {

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1398,5 +1398,9 @@
   "zhqK/P": {
     "defaultMessage": "Non précisé",
     "description": "Unspecified, has not been set or defined"
+  },
+  "pOL68A": {
+    "defaultMessage": "Adresse courriel professionnelle",
+    "description": "Title for work email address"
   }
 }

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -320,6 +320,11 @@ const commonMessages = defineMessages({
     id: "09LIbL",
     description: "Label to identify a date element",
   },
+  workEmail: {
+    defaultMessage: "Work email address",
+    id: "pOL68A",
+    description: "Title for work email address",
+  },
 });
 
 export default commonMessages;


### PR DESCRIPTION
🤖 Resolves #11740.

## 👋 Introduction

Adds the work email and government employee (after some discussion with @Jerryescandon) fields to the users table and admin edit user pages.

## 🧪 Testing

1. Navigate to the users table `/admin/users`
2. Confirm the work email and government employee fields are hidden by default
3. Toggle the fields on and confirm they appear as expected
4. Select to edit a user
5. Confirm the fields appear as expected (the work email field should only appear if the user is a government employee)
6. Confirm updating the fields works as expected

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/1d488e03-088b-4426-a95b-806a858b9c94)
![image](https://github.com/user-attachments/assets/53184141-ddb1-442b-a4ff-9d6e3aa6da41)
