### PR TITLE
[Feature] Adds job templates links to admin menu and dashboard

### DIFF
--- a/apps/web/src/components/Layout/AdminLayout/AdminLayout.tsx
+++ b/apps/web/src/components/Layout/AdminLayout/AdminLayout.tsx
@@ -231,6 +231,26 @@ export const Component = () => {
                 {intl.formatMessage(pageTitles.skillsList)}
               </SideMenuItem>
             )}
+            {checkRole(
+              [
+                ROLE_NAME.PoolOperator,
+                ROLE_NAME.RequestResponder,
+                ROLE_NAME.CommunityManager,
+                ROLE_NAME.PlatformAdmin,
+              ],
+              roleAssignments,
+            ) && (
+              <SideMenuItem
+                href={paths.jobPosterTemplates()}
+                icon={pageIcons.jobTemplates.outline}
+              >
+                {intl.formatMessage({
+                  defaultMessage: "Job templates",
+                  id: "Ilg37j",
+                  description: "Title for job templates",
+                })}
+              </SideMenuItem>
+            )}
           </SideMenuCategory>
           <SideMenuCategory
             title={intl.formatMessage({

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3883,6 +3883,10 @@
     "defaultMessage": "Si vous êtes à la recherche du talent, vous avez frappé à la bonne porte. Notre base de données de talents est ouverte à la plupart des ministères et des agences. Veuillez remplir une demande pour trouver des candidats qualifiés. Tous les candidats qualifiés dans des bassins ont été évalués et ont réussi l’évaluation.",
     "description": "Content displayed in the find talent page explaining the page and what it offers to users."
   },
+  "Ilg37j": {
+    "defaultMessage": "Modèles d'emplois",
+    "description": "Title for job templates"
+  },
   "Ilot3b": {
     "defaultMessage": "Que se passe-t-il après lorsqu’une personne achève le programme de 24 mois?",
     "description": "Learn more dialog question three heading"

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -115,6 +115,16 @@ const DashboardPage = ({ currentUser }: DashboardPageProps) => {
                   href: adminRoutes.skills(),
                   icon: pageIcons.skillsList.solid,
                 },
+                {
+                  // deviates from page title
+                  label: intl.formatMessage({
+                    defaultMessage: "Job templates",
+                    id: "Ilg37j",
+                    description: "Title for job templates",
+                  }),
+                  href: adminRoutes.jobPosterTemplates(),
+                  icon: pageIcons.jobTemplates.solid,
+                },
               ]}
             />
           )}

--- a/apps/web/src/utils/pageIcons.ts
+++ b/apps/web/src/utils/pageIcons.ts
@@ -14,6 +14,8 @@ import MegaphoneOutlineIcon from "@heroicons/react/24/outline/MegaphoneIcon";
 import MegaphoneSolidIcon from "@heroicons/react/24/solid/MegaphoneIcon";
 import PaperAirplaneOutlineIcon from "@heroicons/react/24/outline/PaperAirplaneIcon";
 import PaperAirplaneSolidIcon from "@heroicons/react/24/solid/PaperAirplaneIcon";
+import RectangleStackIcon from "@heroicons/react/24/solid/RectangleStackIcon";
+import RectangleStackOutlineIcon from "@heroicons/react/24/outline/RectangleStackIcon";
 import SquaresPlusOutlineIcon from "@heroicons/react/24/outline/SquaresPlusIcon";
 import SquaresPlusSolidIcon from "@heroicons/react/24/solid/SquaresPlusIcon";
 import TagOutlineIcon from "@heroicons/react/24/outline/TagIcon";
@@ -50,6 +52,10 @@ const pageIcons: Record<string, PageIcon> = {
   departments: {
     solid: BuildingOffice2SolidIcon,
     outline: BuildingOffice2OutlineIcon,
+  },
+  jobTemplates: {
+    solid: RectangleStackIcon,
+    outline: RectangleStackOutlineIcon,
   },
   poolCandidates: {
     solid: IdentificationSolidIcon,


### PR DESCRIPTION
🤖 Resolves #11798.

## 👋 Introduction

This PR adds job templates links to the admin menu and dashboard.

## 🧪 Testing

1. Navigate to http://localhost:8000/en/admin
2. Verify a link exists in the menu to Job templates in the Recruitment section
3. Verify a link exists in the dashboard to Job templates in the Managing a recruitment process section 

## 📸 Screenshots

### English
<img width="1440" alt="Screen Shot 2024-10-22 at 12 26 32" src="https://github.com/user-attachments/assets/3a255eab-3daf-4ed4-a0d3-2f747294a72c">

### French
<img width="1440" alt="Screen Shot 2024-10-22 at 12 26 43" src="https://github.com/user-attachments/assets/1b27642c-a1b6-48e9-86c3-e717bebc9550">