### PR TITLE
[Copy] Updates subtitle on Privacy policy page in French

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6427,7 +6427,7 @@
     "description": "Title for the list of team members page"
   },
   "Vz719J": {
-    "defaultMessage": "Apprenez-en advantage sur la façon don’t le site Talents numériques du GC traite de la vie privée des utilisateurs.",
+    "defaultMessage": "Apprenez-en davantage sur la façon dont Talents numériques du GC traite de la vie privée des utilisateurs et utilisatrices.",
     "description": "Sub title for the websites privacy policy"
   },
   "W+Lub4": {


### PR DESCRIPTION
🤖 Resolves #11815.

## 👋 Introduction

This PR updates the subtitle on the Privacy policy page in French.

## 🧪 Testing

1. Navigate to http://localhost:8000/fr/privacy-policy
2. Verify subtitle is _Apprenez-en davantage sur la façon dont Talents numériques du GC traite de la vie privée des utilisateurs et utilisatrices._

## 📸 Screenshot
<img width="1440" alt="Screen Shot 2024-10-22 at 12 39 52" src="https://github.com/user-attachments/assets/8028e17f-165a-4055-9695-450e9935aba8">
