### PR TITLE
[Fix] Adds `SEO` to Directive page

### DIFF
--- a/apps/web/src/pages/DirectivePage/DirectivePage.tsx
+++ b/apps/web/src/pages/DirectivePage/DirectivePage.tsx
@@ -25,6 +25,7 @@ import {
 import Hero from "~/components/HeroDeprecated";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import useRoutes from "~/hooks/useRoutes";
+import SEO from "~/components/SEO/SEO";
 
 import Resources from "./Resources";
 
@@ -76,6 +77,13 @@ export const pageTitle = defineMessage({
   description: "Title for the digital talent directive page",
 });
 
+export const pageSubtitle = defineMessage({
+  defaultMessage:
+    "Learn more about how the Government of Canada is strengthening the talent base of the GC digital community.",
+  id: "c/u1K+",
+  description: "Subtitle for the digital talent directive page",
+});
+
 export const Component = () => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -103,14 +111,13 @@ export const Component = () => {
 
   return (
     <>
+      <SEO
+        title={intl.formatMessage(pageTitle)}
+        description={intl.formatMessage(pageSubtitle)}
+      />
       <Hero
         title={intl.formatMessage(pageTitle)}
-        subtitle={intl.formatMessage({
-          defaultMessage:
-            "Learn more about how the Government of Canada is strengthening the talent base of the GC digital community.",
-          id: "c/u1K+",
-          description: "Subtitle for the digital talent directive page",
-        })}
+        subtitle={intl.formatMessage(pageSubtitle)}
         crumbs={crumbs}
         linkSlot={
           <>


### PR DESCRIPTION
🤖 Resolves #11862.

## 👋 Introduction

This PR adds the missing `SEO` component with title and subtitle to the Directive page.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:3000/en/directive-on-digital-talent
3. Verify Directive page title and subtitle of page is used for `<head>` `title` and `description`

## 📸 Screenshots

<img width="1440" alt="Screen Shot 2024-10-28 at 11 32 42" src="https://github.com/user-attachments/assets/377d51ac-cb29-46b4-b43a-7c89901e8a61">
<img width="1440" alt="Screen Shot 2024-10-28 at 11 33 12" src="https://github.com/user-attachments/assets/5209344f-3275-4b55-b350-17f2b688ac9f">

