### PR TITLE
[Fix] Allow community admins to view community access tab

### DIFF
--- a/apps/web/src/pages/Communities/CommunityLayout.tsx
+++ b/apps/web/src/pages/Communities/CommunityLayout.tsx
@@ -6,8 +6,8 @@ import { useQuery } from "urql";
 import { ThrowNotFound, Pending } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
-import { ROLE_NAME, useAuthorization } from "@gc-digital-talent/auth";
-import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { notEmpty } from "@gc-digital-talent/helpers";
 
 import SEO from "~/components/SEO/SEO";
 import AdminHero from "~/components/HeroDeprecated/AdminHero";
@@ -108,6 +108,23 @@ const CommunityLayoutCommunityName_Query = graphql(/* GraphQL */ `
       ...CommunityLayout_Community
       teamIdForRoleAssignment
     }
+    myAuth {
+      roleAssignments {
+        id
+        role {
+          id
+          name
+          isTeamBased
+        }
+        team {
+          id
+          name
+        }
+        teamable {
+          id
+        }
+      }
+    }
   }
 `);
 
@@ -124,11 +141,11 @@ const CommunityLayout = () => {
     },
   });
 
-  const { userAuthInfo } = useAuthorization();
-  const roleAssignments = unpackMaybes(userAuthInfo?.roleAssignments);
+  const roleAssignmentsFiltered =
+    data?.myAuth?.roleAssignments?.filter(notEmpty) ?? [];
   const canAdmin = checkRole(
     [ROLE_NAME.PlatformAdmin, ROLE_NAME.CommunityAdmin],
-    roleAssignments,
+    roleAssignmentsFiltered,
     communityId,
   );
 


### PR DESCRIPTION
🤖 Resolves #11822

## 👋 Introduction

Fix to allow community admins to view the manage access tab for communities.

## 🕵️ Details

This appears to have been a result of #11811 removing teamable from roleAssignments in UserAuthInfo. I resolved this by querying for the users roleAssignments with teamable on the page.

## 🧪 Testing

1. Sign in as a community admin (ex. `community@test.com`)
2. Navigate to the view page for a community `en/admin/communities/{communityId}`
3. Confirm you can view and navigate to the "manage access" tab
4. Confirm you can add community recruiters (but not community admins) to the community

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/f1d4074d-4374-448b-a58e-019545aea192)
