### PR TITLE
[Copy] Updates error message when a file no longer exists

### DIFF
--- a/apps/web/src/components/NotificationList/NotificationDownload.tsx
+++ b/apps/web/src/components/NotificationList/NotificationDownload.tsx
@@ -47,8 +47,8 @@ const NotificationDownload = forwardRef<
               intl.formatMessage(
                 {
                   defaultMessage:
-                    "This file is older than 24 hours and is no longer available. Please request a new file. If the problem persists contact support for assistance.",
-                  id: "JFlQjb",
+                    "This file is not available. If it's been more than 24 hours since you requested it, please try requesting the download again. If it's been less than 24 hours or the problem persists, contact support for assistance.",
+                  id: "klyOZZ",
                   description: "Error message when a file no longer exists",
                 },
                 { fileName },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4075,10 +4075,6 @@
     "defaultMessage": "Vous êtes sur le point d'archiver ce processus : {poolName}",
     "description": "Text to confirm the process to be archived"
   },
-  "JFlQjb": {
-    "defaultMessage": "Ce fichier, qui date de plus de 24 heures, n’est plus disponible. Veuillez en demander un nouveau. En cas d’échec de la procédure, communiquez avec les services de soutien.",
-    "description": "Error message when a file no longer exists"
-  },
   "JH2+tK": {
     "defaultMessage": "Instantané de profil non trouvé.",
     "description": "Message displayed for profile snapshot not found."


### PR DESCRIPTION
🤖 Resolves #11098.

## 👋 Introduction

This PR updates the error message when a file no longer exists.

## 🧪 Testing

1. Generate a file (e.g. profile document)
2. Manually delete the generated file in the backend
3. Click the notification
4. Verify message uses updated copy