### PR TITLE
[Feature] Render decision notes for successful education assessments

### DIFF
--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialogForm.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialogForm.tsx
@@ -157,25 +157,36 @@ const ScreeningDecisionDialogForm = ({
       {watchAssessmentDecision === AssessmentDecision.Successful && (
         <div>
           {dialogType === "EDUCATION" ? (
-            <div data-h2-margin-bottom="base(x1)">
-              <CardOptionGroup
-                idPrefix="justifications"
-                name="justifications"
-                legend={labels.justification}
-                items={successfulOptions}
-                rules={{
-                  required: intl.formatMessage(errorMessages.required),
-                }}
-                context={
-                  educationContext ? (
-                    <ContextBlock
-                      messages={educationContext.messages}
-                      key={educationContext.key}
-                    />
-                  ) : null
-                }
-              />
-            </div>
+            <>
+              <div data-h2-margin-bottom="base(x1)">
+                <CardOptionGroup
+                  idPrefix="justifications"
+                  name="justifications"
+                  legend={labels.justification}
+                  items={successfulOptions}
+                  rules={{
+                    required: intl.formatMessage(errorMessages.required),
+                  }}
+                  context={
+                    educationContext ? (
+                      <ContextBlock
+                        messages={educationContext.messages}
+                        key={educationContext.key}
+                      />
+                    ) : null
+                  }
+                />
+              </div>
+              <div data-h2-margin-bottom="base(x1)">
+                <TextArea
+                  id="skillDecisionNotes"
+                  name="skillDecisionNotes"
+                  rows={TEXT_AREA_ROWS}
+                  wordLimit={TEXT_AREA_MAX_WORDS}
+                  label={labels.decisionNotes}
+                />
+              </div>
+            </>
           ) : (
             <>
               <div data-h2-margin-bottom="base(x1)">


### PR DESCRIPTION
🤖 Resolves #11927 

## 👋 Introduction

Always render decision notes for education assessments. So in this case, render the input for successful decisions as well. 

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Navigate to assessments for a candidate
2. Observe notes input rendered for education assessments

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/f3375d80-3c5c-47c8-8c06-8464044f9d6d)
