### PR TITLE
[Dep] Bump `ts-jest` to `29.2.5`

### DIFF
--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -1,6 +1,10 @@
 import type { Config } from "jest";
+import { createDefaultPreset } from "ts-jest";
+
+const defaultPreset = createDefaultPreset();
 
 const config: Config = {
+  ...defaultPreset,
   roots: ["src"],
   preset: "@gc-digital-talent/jest-presets/jest/browser",
   // https://alexjover.com/blog/enhance-jest-configuration-with-module-aliases/

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -94,7 +94,7 @@
     "jest-diff": "^29.7.0",
     "jest-fail-on-console": "^3.3.0",
     "prettier": "^3.3.3",
-    "ts-jest": "^29.2.3",
+    "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "tsconfig": "workspace:*",
     "typescript": "^5.6.3",

--- a/apps/web/src/lang/lang.test.ts
+++ b/apps/web/src/lang/lang.test.ts
@@ -5,8 +5,8 @@ import * as rawI18nEnMessages from "@gc-digital-talent/i18n/en.json";
 import * as rawI18nFrMessages from "@gc-digital-talent/i18n/fr.json";
 import { notEmpty } from "@gc-digital-talent/helpers";
 
-import * as rawWebEnMessages from "./en.json";
-import * as rawWebFrMessages from "./fr.json";
+import rawWebEnMessages from "./en.json";
+import rawWebFrMessages from "./fr.json";
 
 describe("message files", () => {
   /*

--- a/packages/jest-presets/package.json
+++ b/packages/jest-presets/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "jest-axe": "^9.0.0",
-    "ts-jest": "^29.2.3"
+    "ts-jest": "^29.2.5"
   },
   "devDependencies": {
     "jest-environment-jsdom": "^29.7.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,8 +236,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       ts-jest:
-        specifier: ^29.2.3
-        version: 29.2.3(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3)
+        specifier: ^29.2.5
+        version: 29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.9.0)(typescript@5.6.3)
@@ -499,7 +499,7 @@ importers:
         version: 3.0.0(typescript@5.6.3)
       eslint-plugin-formatjs:
         specifier: ^5.2.2
-        version: 5.2.2(ts-jest@29.2.3(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3))(typescript@5.6.3)
+        version: 5.2.2(ts-jest@29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3))(typescript@5.6.3)
       eslint-plugin-import:
         specifier: ^2.31.0
         version: 2.31.0(@typescript-eslint/parser@8.13.0(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)
@@ -875,8 +875,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       ts-jest:
-        specifier: ^29.2.3
-        version: 29.2.3(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.23.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
+        specifier: ^29.2.5
+        version: 29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.23.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
     devDependencies:
       jest-environment-jsdom:
         specifier: ^29.7.0
@@ -966,7 +966,7 @@ importers:
     devDependencies:
       '@formatjs/ts-transformer':
         specifier: ^3.13.22
-        version: 3.13.22(ts-jest@29.2.3(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.23.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3))
+        version: 3.13.22(ts-jest@29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.23.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3))
       '@gc-digital-talent/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config-custom
@@ -6908,11 +6908,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.6.2:
-    resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.6.3:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
@@ -7235,8 +7230,8 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
 
-  ts-jest@29.2.3:
-    resolution: {integrity: sha512-yCcfVdiBFngVz9/keHin9EnsrQtQtEu3nRykNy9RVp+FiPFFbPJ3Sg6Qg4+TkmH0vMP5qsTKgXSsk80HRwvdgQ==}
+  ts-jest@29.2.5:
+    resolution: {integrity: sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -8473,7 +8468,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.6.3
 
-  '@formatjs/ts-transformer@3.13.22(ts-jest@29.2.3(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.23.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3))':
+  '@formatjs/ts-transformer@3.13.22(ts-jest@29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.23.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3))':
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.9.3
       '@types/json-stable-stringify': 1.0.36
@@ -8483,7 +8478,7 @@ snapshots:
       tslib: 2.8.0
       typescript: 5.6.3
     optionalDependencies:
-      ts-jest: 29.2.3(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.23.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
+      ts-jest: 29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.23.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
 
   '@graphql-codegen/add@5.0.3(graphql@16.9.0)':
     dependencies:
@@ -11790,10 +11785,10 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-formatjs@5.2.2(ts-jest@29.2.3(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3))(typescript@5.6.3):
+  eslint-plugin-formatjs@5.2.2(ts-jest@29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.9.3
-      '@formatjs/ts-transformer': 3.13.22(ts-jest@29.2.3(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.23.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3))
+      '@formatjs/ts-transformer': 3.13.22(ts-jest@29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.23.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3))
       '@types/eslint': 9.6.1
       '@types/picomatch': 3.0.1
       '@typescript-eslint/utils': 8.13.0(eslint@8.57.0)(typescript@5.6.3)
@@ -14247,8 +14242,6 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.6.2: {}
-
   semver@7.6.3: {}
 
   sentence-case@3.0.4:
@@ -14638,7 +14631,7 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-jest@29.2.3(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.23.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3):
+  ts-jest@29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.23.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -14648,7 +14641,7 @@ snapshots:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.6.2
+      semver: 7.6.3
       typescript: 5.6.3
       yargs-parser: 21.1.1
     optionalDependencies:
@@ -14658,7 +14651,7 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.25.7)
       esbuild: 0.23.0
 
-  ts-jest@29.2.3(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3):
+  ts-jest@29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -14668,7 +14661,7 @@ snapshots:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.6.2
+      semver: 7.6.3
       typescript: 5.6.3
       yargs-parser: 21.1.1
     optionalDependencies:


### PR DESCRIPTION
🤖 Resolves #11364 

## 👋 Introduction

Bumps `ts-jest` to the latest version.

## 🧪 Testing

1. Confirm `ts-jest` is on version `29.2.5`
2. Confirm no lint errors
3. Confirm tests run and pass as expected
