### PR TITLE
[Fix] Move screening and assessment a11y test to playwright

### DIFF
--- a/apps/playwright/tests/admin/accessibility.spec.ts
+++ b/apps/playwright/tests/admin/accessibility.spec.ts
@@ -10,4 +10,19 @@ test.describe("Admin accessibility", () => {
     const accessibilityScanResults = await makeAxeBuilder().analyze();
     expect(accessibilityScanResults.violations).toEqual([]);
   });
+
+  test("Assessment step tracker", async ({ appPage, makeAxeBuilder }) => {
+    await loginBySub(appPage.page, "admin@test.com", false);
+    await appPage.page.goto("/en/admin/pools");
+    await appPage.page
+      .getByRole("link", { name: /cmo digital careers/i })
+      .click();
+    await appPage.page
+      .getByRole("link", { name: /screening and assessment/i })
+      .click();
+    await appPage.waitForGraphqlResponse("ScreeningAndEvaluation_Candidates");
+
+    const accessibilityScanResults = await makeAxeBuilder().analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
 });

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.test.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.test.tsx
@@ -5,10 +5,10 @@
 import "@testing-library/jest-dom";
 import { Provider as GraphqlProvider } from "urql";
 import { pipe, fromValue, delay } from "wonka";
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 
-import { axeTest, renderWithProviders } from "@gc-digital-talent/jest-helpers";
+import { renderWithProviders } from "@gc-digital-talent/jest-helpers";
 import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import {
   AssessmentDecision,
@@ -95,13 +95,6 @@ describe("AssessmentStepTracker", () => {
     await user.click(screen.getByRole("switch", { name: /on hold/i }));
     await user.click(screen.getByRole("switch", { name: /unsuccessful/i }));
   };
-
-  it("should have no accessibility errors", async () => {
-    const { container } = renderAssessmentStepTracker();
-    await waitFor(async () => {
-      await axeTest(container);
-    });
-  });
 
   it("should display candidates with the correct ordinals", async () => {
     renderAssessmentStepTracker();


### PR DESCRIPTION
🤖 Resolves #11940  

## 👋 Introduction

Moves the assessment step tracker accessibility test to playwright.

## 🧪 Testing

1. Confirm test has similar or more coverage
2. Confirm test passes consistently