### PR TITLE
[Fix] Adds `FindTalent` link for applicant role, guest in nav menu

### DIFF
--- a/apps/web/src/components/NavMenu/useMainNavLinks.tsx
+++ b/apps/web/src/components/NavMenu/useMainNavLinks.tsx
@@ -362,7 +362,7 @@ const useMainNavLinks = () => {
   const defaultLinks = {
     homeLink: Home,
     roleLinks: roleLinksNoDuplicatesAndSorted,
-    mainLinks: [BrowseJobs],
+    mainLinks: [FindTalent, BrowseJobs],
     accountLinks: loggedIn ? [SignOut] : null,
     authLinks: !loggedIn ? [SignIn, SignUp] : null,
     resourceLinks: [ContactSupport],
@@ -373,7 +373,7 @@ const useMainNavLinks = () => {
     case "applicant":
       return {
         ...defaultLinks,
-        mainLinks: [ApplicantDashboard, BrowseJobs],
+        mainLinks: [ApplicantDashboard, FindTalent, BrowseJobs],
         accountLinks: loggedIn
           ? [
               ApplicantProfile,


### PR DESCRIPTION
🤖 Resolves #11944.

## 👋 Introduction

This PR adds `FindTalent` link for applicant role, guest in nav menu.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/
3. Verify **Find talent** appears in nav menu for guest (not signed in user)
4. Sign in as applicant@test.com
5. Verify **Find talent** appears in nav menu for applicant user
6. Sign out
7. Sign in as manager@test.com
8. Verify **Find talent** appears in nav menu for manager user
9. Sign out
10. Sign in as community@test.com
11. Verify **Find talent** does not appear in nav menu for community user
12. Sign out
13. Sign in as admin@test.com
14. Verify **Find talent** does not appear in nav menu for admin user 

## 📸 Screenshots

### Guest
<img width="1231" alt="Screen Shot 2024-11-13 at 13 41 09" src="https://github.com/user-attachments/assets/ce240007-a537-43d2-9bd9-f692b0931225">

### Applicant
<img width="1232" alt="Screen Shot 2024-11-13 at 13 41 42" src="https://github.com/user-attachments/assets/d6f16459-a88e-4ce5-bc4f-c80ccf40c193">

### Manager
<img width="1228" alt="Screen Shot 2024-11-13 at 13 42 38" src="https://github.com/user-attachments/assets/d5829eca-cdd7-4a77-b61c-3708a3c1ba16">

### Community
<img width="1229" alt="Screen Shot 2024-11-13 at 13 43 44" src="https://github.com/user-attachments/assets/0b28034c-0e3d-452d-a363-694d356e3013">

### Admin
<img width="1232" alt="Screen Shot 2024-11-13 at 13 44 19" src="https://github.com/user-attachments/assets/cb2cb6b5-b53c-4a59-abc2-65fca4198b1f">