### PR TITLE
[Fix] Increment CSV row count by 1

### DIFF
--- a/api/app/Generators/PoolCandidateCsvGenerator.php
+++ b/api/app/Generators/PoolCandidateCsvGenerator.php
@@ -212,7 +212,7 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
                 }
 
                 // 1 is added to the key to account for the header row
-                $sheet->fromArray($values, null, 'A'.$currentCandidate);
+                $sheet->fromArray($values, null, 'A'.$currentCandidate + 1);
                 $currentCandidate++;
             }
         });

--- a/api/app/Generators/PoolCandidateCsvGenerator.php
+++ b/api/app/Generators/PoolCandidateCsvGenerator.php
@@ -212,7 +212,7 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
                 }
 
                 // 1 is added to the key to account for the header row
-                $sheet->fromArray($values, null, 'A'.$currentCandidate + 1);
+                $sheet->fromArray($values, null, sprintf('A%d', $currentCandidate + 1));
                 $currentCandidate++;
             }
         });

--- a/api/app/Generators/UserCsvGenerator.php
+++ b/api/app/Generators/UserCsvGenerator.php
@@ -121,7 +121,7 @@ class UserCsvGenerator extends CsvGenerator implements FileGeneratorInterface
                 ];
 
                 // 1 is added to the key to account for the header row
-                $sheet->fromArray($values, null, 'A'.$currentUser);
+                $sheet->fromArray($values, null, 'A'.$currentUser + 1);
                 $currentUser++;
             }
         });

--- a/api/app/Generators/UserCsvGenerator.php
+++ b/api/app/Generators/UserCsvGenerator.php
@@ -121,7 +121,7 @@ class UserCsvGenerator extends CsvGenerator implements FileGeneratorInterface
                 ];
 
                 // 1 is added to the key to account for the header row
-                $sheet->fromArray($values, null, 'A'.$currentUser + 1);
+                $sheet->fromArray($values, null, sprintf('A%d', $currentUser + 1));
                 $currentUser++;
             }
         });


### PR DESCRIPTION
🤖 Resolves #11963 

## 👋 Introduction

Adds `1` to the CSV row count to account for the header row and not overwrite it.

## 🧪 Testing

1. Start the queue `make queue-work`
2. Login as admin `admin@test.com`
3. Navigate to the candidates table `/en/admin/pool-candidates`
4. Select one row
5. Download CSV and confirm 2 rows are present (1 for headers, other for candidate)
6. Repeat for users table `/en/admin/users`
