### PR TITLE
[Copy] Updates announcement form success message

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9550,6 +9550,10 @@
     "defaultMessage": "Échec de la mise à jour des notes pour le candidat dans le {poolName}",
     "description": "Toast notification for failed update of candidates notes in specified pool"
   },
+  "kY05h1": {
+    "defaultMessage": "L'annonce à l’échelle du site a été mise à jour avec succès!",
+    "description": "Message displayed when a user successfully updates sitewide announcement information"
+  },
   "kbMB6R": {
     "defaultMessage": "Lieu de travail et terminologie",
     "description": "Heading for the pool work location dialog"

--- a/apps/web/src/pages/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/apps/web/src/pages/AnnouncementsPage/AnnouncementsPage.tsx
@@ -4,7 +4,6 @@ import { useQuery, useMutation } from "urql";
 import { SitewideAnnouncementInput, graphql } from "@gc-digital-talent/graphql";
 import { Pending } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
-import { commonMessages } from "@gc-digital-talent/i18n";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 
 import SEO from "~/components/SEO/SEO";

--- a/apps/web/src/pages/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/apps/web/src/pages/AnnouncementsPage/AnnouncementsPage.tsx
@@ -79,7 +79,14 @@ const AnnouncementsPage = () => {
     return executeMutation({ sitewideAnnouncementInput: input }, context).then(
       (result) => {
         if (result.data?.updateSitewideAnnouncement) {
-          toast.success(intl.formatMessage(commonMessages.success));
+          toast.success(
+            intl.formatMessage({
+              defaultMessage: "Sitewide announcement updated successfully!",
+              id: "kY05h1",
+              description:
+                "Message displayed when a user successfully updates sitewide announcement information",
+            }),
+          );
           return;
         }
         throw new Error("Failed to save announcement");

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -251,10 +251,6 @@
     "defaultMessage": "Une erreur s’est produite au moment de placer le candidat. Veuillez communiquer avec le personnel de soutien si le problème persiste.",
     "description": "Error message that placing a candidate failed"
   },
-  "99cWuv": {
-    "defaultMessage": "réussite",
-    "description": "Message for the success status"
-  },
   "9QsHXO": {
     "defaultMessage": "Une erreur s’est produite pendant l'attribution de rôles. Veuillez communiquer avec le personnel de soutien si le problème persiste.",
     "description": "Error message for when an error occurs during role assignment"

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -73,11 +73,6 @@ const commonMessages = defineMessages({
     id: "DdOEWx",
     description: "Message when name value not found",
   },
-  success: {
-    defaultMessage: "success",
-    id: "99cWuv",
-    description: "Message for the success status",
-  },
   dividingColon: {
     defaultMessage: ": ",
     id: "i3Jl6C",


### PR DESCRIPTION
🤖 Resolves #11934.

## 👋 Introduction

This PR updates the announcement form success message to be sentence case and similar to other messages returned on the site.

## 🧪 Testing

1. Navigate to http://localhost:8000/en/admin/settings/announcements
2. Submit form and verify success message in toast matches the [approved copy](https://github.com/GCTC-NTGC/gc-digital-talent/issues/11934#issuecomment-2479179304)

## 📸 Screenshots

<img width="1440" alt="Screen Shot 2024-11-15 at 11 37 08" src="https://github.com/user-attachments/assets/94060f36-dadf-4184-8293-5ab7611be255">
<img width="1440" alt="Screen Shot 2024-11-15 at 11 37 29" src="https://github.com/user-attachments/assets/b86eb470-b074-49d1-9709-860935c55789">
