### PR TITLE
[Feature] Removes `SupportAction` from `ApplicationCard`

### DIFF
--- a/apps/web/src/components/ApplicationCard/ApplicationActions.tsx
+++ b/apps/web/src/components/ApplicationCard/ApplicationActions.tsx
@@ -137,40 +137,6 @@ const SeeAdvertisementAction = ({
   );
 };
 
-const SupportAction = ({ show, title }: ActionProps) => {
-  const intl = useIntl();
-  const paths = useRoutes();
-  if (!show) {
-    return null;
-  }
-
-  return (
-    <Link
-      href={paths.support()}
-      state={{ referrer: window.location.href }}
-      mode="inline"
-      color="black"
-      fontSize="caption"
-      aria-label={intl.formatMessage(
-        {
-          defaultMessage: "Get support for the {title} job",
-          id: "yE/QNS",
-          description: "Link text to direct a user to the support page",
-        },
-        {
-          title,
-        },
-      )}
-    >
-      {intl.formatMessage({
-        defaultMessage: "Get support",
-        id: "rXdaZW",
-        description: "Link text to direct a user to the support page",
-      })}
-    </Link>
-  );
-};
-
 interface CopyApplicationIdActionProps extends ActionProps {
   id: Scalars["UUID"]["output"];
 }
@@ -364,7 +330,6 @@ export default {
   ContinueAction,
   SeeAdvertisementAction,
   DeleteAction,
-  SupportAction,
   ViewAction,
   CopyApplicationIdAction,
   VisitCareerTimelineAction,

--- a/apps/web/src/components/ApplicationCard/ApplicationCard.test.tsx
+++ b/apps/web/src/components/ApplicationCard/ApplicationCard.test.tsx
@@ -70,7 +70,7 @@ describe("ApplicationCard", () => {
       ),
     });
     const links = screen.queryAllByRole("link");
-    expect(links).toHaveLength(3);
+    expect(links).toHaveLength(2);
     expect(links[0]).toHaveAttribute(
       "href",
       expect.stringContaining(mockApplication.id),
@@ -92,7 +92,7 @@ describe("ApplicationCard", () => {
     });
 
     const links = screen.queryAllByRole("link");
-    expect(links).toHaveLength(4);
+    expect(links).toHaveLength(3);
     expect(links[0]).toHaveAttribute(
       "href",
       expect.stringContaining(mockApplication.id),
@@ -128,7 +128,7 @@ describe("ApplicationCard", () => {
       ),
     });
     const links = screen.queryAllByRole("link");
-    expect(links).toHaveLength(3);
+    expect(links).toHaveLength(2);
     const qualifiedLabel = screen.queryByText("Submission date passed");
 
     expect(qualifiedLabel).toBeInTheDocument();

--- a/apps/web/src/components/ApplicationCard/ApplicationCard.test.tsx
+++ b/apps/web/src/components/ApplicationCard/ApplicationCard.test.tsx
@@ -111,11 +111,6 @@ describe("ApplicationCard", () => {
       expect.stringContaining(PAGE_SECTION_ID.QUALIFIED_RECRUITMENT_PROCESSES),
     );
 
-    expect(links[3]).toHaveTextContent("Get support");
-    expect(links[3]).toHaveAttribute(
-      "href",
-      expect.stringContaining("support"),
-    );
     const hiredCasualLabel = screen.queryByText("Hired (Casual)");
     expect(hiredCasualLabel).toBeInTheDocument();
   });

--- a/apps/web/src/components/ApplicationCard/ApplicationCard.tsx
+++ b/apps/web/src/components/ApplicationCard/ApplicationCard.tsx
@@ -232,7 +232,6 @@ const ApplicationCard = ({
           show={isApplicantQualified}
           title={applicationTitleString}
         />
-        <ApplicationActions.SupportAction show title={applicationTitleString} />
         <ApplicationActions.DeleteAction
           show={applicationIsDraft}
           title={applicationTitleString}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -10842,10 +10842,6 @@
     "defaultMessage": "La soumission de votre demande est réussie.",
     "description": "Subtitle for the request confirmation page."
   },
-  "rXdaZW": {
-    "defaultMessage": "Obtenir du soutien",
-    "description": "Link text to direct a user to the support page"
-  },
   "rZ0GyE": {
     "defaultMessage": "Modifications apportées aux procédures obligatoires en 2024",
     "description": "Heading for section describing the 2024 changes to the directive"
@@ -11957,10 +11953,6 @@
   "yCHFQo": {
     "defaultMessage": "Bilingue (intermédiaire – BBB/BBB)",
     "description": "Bilingual intermediate personnel language"
-  },
-  "yE/QNS": {
-    "defaultMessage": "Obtenez du soutien pour le poste {title}",
-    "description": "Link text to direct a user to the support page"
   },
   "yExs/j": {
     "defaultMessage": "Nous sommes désolés, mais nous ne pouvons pas trouver la page que vous cherchez.",


### PR DESCRIPTION
🤖 Resolves #11969.

## 👋 Introduction

This PR removes the support link from the `ApplicationCard` component.

## 🧪 Testing

1. `pnpm storybook`
2. Verify no Get support text on `ApplicationCard` component http://localhost:6006/?path=/story/components-applicationcard--default