### PR TITLE
[Debt] Removes unnecessary `NavMenuProps` export

### DIFF
--- a/packages/ui/src/components/NavMenu/NavMenuWrapper.tsx
+++ b/packages/ui/src/components/NavMenu/NavMenuWrapper.tsx
@@ -15,7 +15,7 @@ import useControllableState from "../../hooks/useControllableState";
 import { NavMenuProvider } from "./NavMenuProvider";
 import NavMenu from "./NavMenu";
 
-export interface NavMenuProps {
+interface NavMenuProps {
   /** Sets the section to be 'open' by default */
   defaultOpen?: boolean;
   /** Controllable open state */


### PR DESCRIPTION
🤖 Resolves #11970.

## 👋 Introduction

This PR removes an unnecessary export declaration of `NavMenuProps` which is not used within other modules.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/
3. Verify nav menu still works as before