### PR TITLE
[Fix] Icon button layout

### DIFF
--- a/packages/ui/src/components/ButtonLinkContent/ButtonLinkContent.tsx
+++ b/packages/ui/src/components/ButtonLinkContent/ButtonLinkContent.tsx
@@ -108,8 +108,10 @@ const ButtonLinkContent = ({
       "data-h2-margin-top": "base(-x.2)",
     };
   }
-  let contentDisplay = {
-    "data-h2-display": "base(block) base:children[>*](inline-block)",
+  let contentDisplay: Record<string, string> = {
+    "data-h2-display": "base(flex) base:children[>*](inline-block)",
+    "data-h2-flex-wrap": "base(nowrap)",
+    "data-h2-align-items": "base(flex-start)",
     "data-h2-vertical-align": "base:children[>*](middle)",
   };
   if (mode === "text") {
@@ -178,6 +180,7 @@ const ButtonLinkContent = ({
       </span>
     );
   }
+
   return (
     <span {...contentDisplay} {...rest}>
       {Icon && (

--- a/packages/ui/src/components/ButtonLinkContent/ButtonLinkContent.tsx
+++ b/packages/ui/src/components/ButtonLinkContent/ButtonLinkContent.tsx
@@ -109,10 +109,10 @@ const ButtonLinkContent = ({
     };
   }
   let contentDisplay: Record<string, string> = {
-    "data-h2-display": "base(flex) base:children[>*](inline-block)",
-    "data-h2-flex-wrap": "base(nowrap)",
-    "data-h2-align-items": "base(flex-start)",
-    "data-h2-vertical-align": "base:children[>*](middle)",
+    "data-h2-display": "base(flex)",
+    "data-h2-flex-flow": "base(row nowrap)",
+    "data-h2-justify-content": "base(flex-start)",
+    "data-h2-align-items": "base(stretch)",
   };
   if (mode === "text") {
     contentDisplay = {
@@ -182,11 +182,25 @@ const ButtonLinkContent = ({
   }
 
   return (
-    <span {...contentDisplay} {...rest}>
+    <span {...contentDisplay} {...textSize} {...rest}>
       {Icon && (
-        <Icon data-h2-margin-right="base(x.25)" {...iconSize} {...iconMargin} />
+        <div
+          data-h2-display="base(flex)"
+          data-h2-justify-content="base(center)"
+          data-h2-align-items="base(flex-start)"
+        >
+          <Icon
+            data-h2-height="base(1em)"
+            data-h2-margin-right="base(x.25)"
+            {...iconMargin}
+          />
+        </div>
       )}
-      <span {...textSize} data-h2-text-decoration="base(underline)">
+      <span
+        data-h2-text-decoration="base(underline)"
+        data-h2-align-self="base(flex-start)"
+        data-h2-line-height="base(1em)"
+      >
         {children}
       </span>
       {UtilityIcon && (


### PR DESCRIPTION
🤖 Resolves #11941 

## 👋 Introduction

Updates buttons to use flex layout to get the desired wrapping.

## :exclamation: Issue

I'm not sure this is currently possible. We have additional line-height that is automatically added by hydrogen. What is happening is, the icon cannot align with the text because we use the automatic relative line height added via the `data-h2-font-size` attribute. When attempting to create an icon that aligns with the first line of text, it becomes very difficult because our line-height is predetermined.

I overwrote the line height but it is causing a bunch of other issues with alignment and I am having a hard time untangling this because of how complicated our "simple" button component is :confounded: 

We have a bunch of extra cruft to support CTA links that look much different as well as the counter badge.

I'm not sure where to go from here since this technically fixes the issue but it introduces more :confused: 

## 🧪 Testing

1. Login as admin `admin@test.com`
2. Navigate to a table with sorting enables `/admin/users` is a good example
3. Confirm the icons do not appear on their own line

## 📸 Screenshot

![2024-11-15_13-18](https://github.com/user-attachments/assets/34f0a9c5-493a-4d2c-b3a8-2b41f155a495)
