### PR TITLE
[Dep] Bump `react-intl` to `6.8`

### DIFF
--- a/apps/playwright/tsconfig.json
+++ b/apps/playwright/tsconfig.json
@@ -7,8 +7,17 @@
     "moduleResolution": "Bundler",
     "esModuleInterop": true,
     "strictNullChecks": true,
+    "skipLibCheck": true,
     "paths": {
-      "~/*": ["./*"]
+      "~/*": [
+        "./*"
+      ]
     }
-  }
+  },
+  "exclude": [
+    "node_modules",
+    "!node_modules/@types",
+    "*/node_modules",
+    "!*/node_modules/@types"
+  ]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -61,7 +61,7 @@
     "react-dom": "^18.2.0",
     "react-helmet-async": "^2.0.5",
     "react-hook-form": "^7.53.2",
-    "react-intl": "^6.7.0",
+    "react-intl": "^6.8.7",
     "react-router-dom": "^6.28.0",
     "react-to-print": "^2.15.1",
     "urql": "^4.2.1"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,7 +29,7 @@
     "graphql": "^16.9.0",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
-    "react-intl": "^6.7.0",
+    "react-intl": "^6.8.7",
     "urql": "^4.2.1"
   },
   "devDependencies": {

--- a/packages/date-helpers/package.json
+++ b/packages/date-helpers/package.json
@@ -22,7 +22,7 @@
     "@gc-digital-talent/graphql": "workspace:*",
     "@gc-digital-talent/i18n": "workspace:*",
     "date-fns": "^4.1.0",
-    "react-intl": "^6.7.0"
+    "react-intl": "^6.8.7"
   },
   "devDependencies": {
     "@gc-digital-talent/eslint-config": "workspace:*",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -57,7 +57,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "react": "^18.3.1",
     "react-hook-form": "^7.53.2",
-    "react-intl": "^6.7.0",
+    "react-intl": "^6.8.7",
     "tsconfig": "workspace:*",
     "typescript": "^5.6.3"
   }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -39,7 +39,7 @@
     "js-yaml": "^4.1.0",
     "json-stable-stringify": "^1.1.1",
     "react": "^18.3.1",
-    "react-intl": "^6.7.0",
+    "react-intl": "^6.8.7",
     "react-router-dom": "^6.28.0",
     "tsconfig": "workspace:*",
     "tsx": "^4.19.2",

--- a/packages/jest-helpers/package.json
+++ b/packages/jest-helpers/package.json
@@ -19,7 +19,7 @@
     "@gc-digital-talent/i18n": "workspace:*",
     "jest": "^29.7.0",
     "react-helmet-async": "^2.0.5",
-    "react-intl": "^6.7.0",
+    "react-intl": "^6.8.7",
     "react-router-dom": "^6.28.0"
   },
   "devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -65,7 +65,7 @@
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "react": "^18.3.1",
-    "react-intl": "^6.7.0",
+    "react-intl": "^6.8.7",
     "react-router-dom": "^6.28.0",
     "tsconfig": "workspace:*",
     "typescript": "^5.6.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: ^7.53.2
         version: 7.53.2(react@18.3.1)
       react-intl:
-        specifier: ^6.7.0
-        version: 6.7.0(react@18.3.1)(typescript@5.6.3)
+        specifier: ^6.8.7
+        version: 6.8.7(react@18.3.1)(typescript@5.6.3)
       react-router-dom:
         specifier: ^6.28.0
         version: 6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -376,8 +376,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       react-intl:
-        specifier: ^6.7.0
-        version: 6.7.0(react@18.3.1)(typescript@5.6.3)
+        specifier: ^6.8.7
+        version: 6.8.7(react@18.3.1)(typescript@5.6.3)
       urql:
         specifier: ^4.2.1
         version: 4.2.1(@urql/core@5.0.8(graphql@16.9.0))(react@18.3.1)
@@ -431,8 +431,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       react-intl:
-        specifier: ^6.7.0
-        version: 6.7.0(react@18.3.1)(typescript@5.6.3)
+        specifier: ^6.8.7
+        version: 6.8.7(react@18.3.1)(typescript@5.6.3)
     devDependencies:
       '@gc-digital-talent/eslint-config':
         specifier: workspace:*
@@ -686,8 +686,8 @@ importers:
         specifier: ^7.53.2
         version: 7.53.2(react@18.3.1)
       react-intl:
-        specifier: ^6.7.0
-        version: 6.7.0(react@18.3.1)(typescript@5.6.3)
+        specifier: ^6.8.7
+        version: 6.8.7(react@18.3.1)(typescript@5.6.3)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -799,8 +799,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
       react-intl:
-        specifier: ^6.7.0
-        version: 6.7.0(react@18.3.1)(typescript@5.6.3)
+        specifier: ^6.8.7
+        version: 6.8.7(react@18.3.1)(typescript@5.6.3)
       react-router-dom:
         specifier: ^6.28.0
         version: 6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -829,8 +829,8 @@ importers:
         specifier: ^2.0.5
         version: 2.0.5(react@18.3.1)
       react-intl:
-        specifier: ^6.7.0
-        version: 6.7.0(react@18.3.1)(typescript@5.6.3)
+        specifier: ^6.8.7
+        version: 6.8.7(react@18.3.1)(typescript@5.6.3)
       react-router-dom:
         specifier: ^6.28.0
         version: 6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1005,7 +1005,7 @@ importers:
         version: 8.4.3(prettier@3.3.3)
       storybook-react-intl:
         specifier: ^3.1.1
-        version: 3.1.1(react-intl@6.7.0(react@18.3.1)(typescript@5.6.3))
+        version: 3.1.1(react-intl@6.8.7(react@18.3.1)(typescript@5.6.3))
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1219,8 +1219,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
       react-intl:
-        specifier: ^6.7.0
-        version: 6.7.0(react@18.3.1)(typescript@5.6.3)
+        specifier: ^6.8.7
+        version: 6.8.7(react@18.3.1)(typescript@5.6.3)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -2020,44 +2020,29 @@ packages:
       vue:
         optional: true
 
-  '@formatjs/ecma402-abstract@2.0.0':
-    resolution: {integrity: sha512-rRqXOqdFmk7RYvj4khklyqzcfQl9vEL/usogncBHRZfZBDOwMGuSRNFl02fu5KGHXdbinju+YXyuR+Nk8xlr/g==}
-
   '@formatjs/ecma402-abstract@2.2.3':
     resolution: {integrity: sha512-aElGmleuReGnk2wtYOzYFmNWYoiWWmf1pPPCYg0oiIQSJj0mjc4eUfzUXaSOJ4S8WzI/cLqnCTWjqz904FT2OQ==}
-
-  '@formatjs/fast-memoize@2.2.0':
-    resolution: {integrity: sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==}
 
   '@formatjs/fast-memoize@2.2.3':
     resolution: {integrity: sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==}
 
-  '@formatjs/icu-messageformat-parser@2.7.8':
-    resolution: {integrity: sha512-nBZJYmhpcSX0WeJ5SDYUkZ42AgR3xiyhNCsQweFx3cz/ULJjym8bHAzWKvG5e2+1XO98dBYC0fWeeAECAVSwLA==}
-
   '@formatjs/icu-messageformat-parser@2.9.3':
     resolution: {integrity: sha512-9L99QsH14XjOCIp4TmbT8wxuffJxGK8uLNO1zNhLtcZaVXvv626N0s4A2qgRCKG3dfYWx9psvGlFmvyVBa6u/w==}
-
-  '@formatjs/icu-skeleton-parser@1.8.2':
-    resolution: {integrity: sha512-k4ERKgw7aKGWJZgTarIcNEmvyTVD9FYh0mTrrBMHZ1b8hUu6iOJ4SzsZlo3UNAvHYa+PnvntIwRPt1/vy4nA9Q==}
 
   '@formatjs/icu-skeleton-parser@1.8.7':
     resolution: {integrity: sha512-fI+6SmS2g7h3srfAKSWa5dwreU5zNEfon2uFo99OToiLF6yxGE+WikvFSbsvMAYkscucvVmTYNlWlaDPp0n5HA==}
 
-  '@formatjs/intl-displaynames@6.6.8':
-    resolution: {integrity: sha512-Lgx6n5KxN16B3Pb05z3NLEBQkGoXnGjkTBNCZI+Cn17YjHJ3fhCeEJJUqRlIZmJdmaXQhjcQVDp6WIiNeRYT5g==}
+  '@formatjs/intl-displaynames@6.8.4':
+    resolution: {integrity: sha512-HDVNBspDAOW0yTWluWTPHX2fk/9iBO4oST4R96f/IUaPGsFtjsHrpakwc+XDRPa3U5RniSEU2z34ZY0W78+E6Q==}
 
-  '@formatjs/intl-listformat@7.5.7':
-    resolution: {integrity: sha512-MG2TSChQJQT9f7Rlv+eXwUFiG24mKSzmF144PLb8m8OixyXqn4+YWU+5wZracZGCgVTVmx8viCf7IH3QXoiB2g==}
-
-  '@formatjs/intl-localematcher@0.5.4':
-    resolution: {integrity: sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==}
+  '@formatjs/intl-listformat@7.7.4':
+    resolution: {integrity: sha512-lipFspH2MZcoeXxR6WSR/Jy9unzJ/iT0w+gbL8vgv25Ap0S9cUtcDVAce4ECEKI1bDtAvEU3b6+9Dha27gAikA==}
 
   '@formatjs/intl-localematcher@0.5.7':
     resolution: {integrity: sha512-GGFtfHGQVFe/niOZp24Kal5b2i36eE2bNL0xi9Sg/yd0TR8aLjcteApZdHmismP5QQax1cMnZM9yWySUUjJteA==}
 
-  '@formatjs/intl@2.10.5':
-    resolution: {integrity: sha512-f9qPNNgLrh2KvoFvHGIfcPTmNGbyy7lyyV4/P6JioDqtTE7Akdmgt+ZzVndr+yMLZnssUShyTMXxM/6aV9eVuQ==}
+  '@formatjs/intl@2.10.14':
+    resolution: {integrity: sha512-4CA1EO75i/mSMHdjwfpgRj3Rsdsm6WjALeu/nlzYhBmAPxGu/Ha5GIRHAet5SO05TnpmqxmEGOsskWqFm0IeoA==}
     peerDependencies:
       typescript: ^4.7 || 5
     peerDependenciesMeta:
@@ -5345,8 +5330,8 @@ packages:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
     engines: {node: '>= 0.4'}
 
-  intl-messageformat@10.5.14:
-    resolution: {integrity: sha512-IjC6sI0X7YRjjyVH9aUgdftcmZK7WXdHeil4KwbjDnRWjnVitKpAx3rr6t6di1joFp5188VqKcobOPA6mCLG/w==}
+  intl-messageformat@10.7.6:
+    resolution: {integrity: sha512-IsMU/hqyy3FJwNJ0hxDfY2heJ7MteSuFvcnCebxRp67di4Fhx1gKKE+qS0bBwUF8yXkX9SsPUhLeX/B6h5SKUA==}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -6690,8 +6675,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
-  react-intl@6.7.0:
-    resolution: {integrity: sha512-f5QhjuKb+WEqiAbL5hDqUs2+sSRkF0vxkTbJ4A8ompt55XTyOHcrDlCXGq4o73ywFFrpgz+78C9IXegSLlya2A==}
+  react-intl@6.8.7:
+    resolution: {integrity: sha512-Ocv8Tg6fXqBdVdkkYohQ79T9rJls3G1lmDSjhqHdK9873BdQFLSeITGgwuGWTRBd6Mg5FL33TBen4FtujCTP0g==}
     peerDependencies:
       react: ^16.6.0 || 17 || 18
       typescript: ^4.7 || 5
@@ -8424,29 +8409,14 @@ snapshots:
 
   '@formatjs/cli@6.3.8': {}
 
-  '@formatjs/ecma402-abstract@2.0.0':
-    dependencies:
-      '@formatjs/intl-localematcher': 0.5.4
-      tslib: 2.8.0
-
   '@formatjs/ecma402-abstract@2.2.3':
     dependencies:
       '@formatjs/fast-memoize': 2.2.3
       '@formatjs/intl-localematcher': 0.5.7
       tslib: 2.8.0
 
-  '@formatjs/fast-memoize@2.2.0':
-    dependencies:
-      tslib: 2.8.0
-
   '@formatjs/fast-memoize@2.2.3':
     dependencies:
-      tslib: 2.8.0
-
-  '@formatjs/icu-messageformat-parser@2.7.8':
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.0.0
-      '@formatjs/icu-skeleton-parser': 1.8.2
       tslib: 2.8.0
 
   '@formatjs/icu-messageformat-parser@2.9.3':
@@ -8455,44 +8425,35 @@ snapshots:
       '@formatjs/icu-skeleton-parser': 1.8.7
       tslib: 2.8.0
 
-  '@formatjs/icu-skeleton-parser@1.8.2':
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.0.0
-      tslib: 2.8.0
-
   '@formatjs/icu-skeleton-parser@1.8.7':
     dependencies:
       '@formatjs/ecma402-abstract': 2.2.3
       tslib: 2.8.0
 
-  '@formatjs/intl-displaynames@6.6.8':
+  '@formatjs/intl-displaynames@6.8.4':
     dependencies:
-      '@formatjs/ecma402-abstract': 2.0.0
-      '@formatjs/intl-localematcher': 0.5.4
+      '@formatjs/ecma402-abstract': 2.2.3
+      '@formatjs/intl-localematcher': 0.5.7
       tslib: 2.8.0
 
-  '@formatjs/intl-listformat@7.5.7':
+  '@formatjs/intl-listformat@7.7.4':
     dependencies:
-      '@formatjs/ecma402-abstract': 2.0.0
-      '@formatjs/intl-localematcher': 0.5.4
-      tslib: 2.8.0
-
-  '@formatjs/intl-localematcher@0.5.4':
-    dependencies:
+      '@formatjs/ecma402-abstract': 2.2.3
+      '@formatjs/intl-localematcher': 0.5.7
       tslib: 2.8.0
 
   '@formatjs/intl-localematcher@0.5.7':
     dependencies:
       tslib: 2.8.0
 
-  '@formatjs/intl@2.10.5(typescript@5.6.3)':
+  '@formatjs/intl@2.10.14(typescript@5.6.3)':
     dependencies:
-      '@formatjs/ecma402-abstract': 2.0.0
-      '@formatjs/fast-memoize': 2.2.0
-      '@formatjs/icu-messageformat-parser': 2.7.8
-      '@formatjs/intl-displaynames': 6.6.8
-      '@formatjs/intl-listformat': 7.5.7
-      intl-messageformat: 10.5.14
+      '@formatjs/ecma402-abstract': 2.2.3
+      '@formatjs/fast-memoize': 2.2.3
+      '@formatjs/icu-messageformat-parser': 2.9.3
+      '@formatjs/intl-displaynames': 6.8.4
+      '@formatjs/intl-listformat': 7.7.4
+      intl-messageformat: 10.7.6
       tslib: 2.8.0
     optionalDependencies:
       typescript: 5.6.3
@@ -12513,11 +12474,11 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.0.6
 
-  intl-messageformat@10.5.14:
+  intl-messageformat@10.7.6:
     dependencies:
-      '@formatjs/ecma402-abstract': 2.0.0
-      '@formatjs/fast-memoize': 2.2.0
-      '@formatjs/icu-messageformat-parser': 2.7.8
+      '@formatjs/ecma402-abstract': 2.2.3
+      '@formatjs/fast-memoize': 2.2.3
+      '@formatjs/icu-messageformat-parser': 2.9.3
       tslib: 2.8.0
 
   invariant@2.2.4:
@@ -14051,19 +14012,19 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  react-intl@6.7.0(react@18.3.1)(typescript@5.6.3):
+  react-intl@6.8.7(react@18.3.1)(typescript@5.6.3):
     dependencies:
-      '@formatjs/ecma402-abstract': 2.0.0
-      '@formatjs/icu-messageformat-parser': 2.7.8
-      '@formatjs/intl': 2.10.5(typescript@5.6.3)
-      '@formatjs/intl-displaynames': 6.6.8
-      '@formatjs/intl-listformat': 7.5.7
+      '@formatjs/ecma402-abstract': 2.2.3
+      '@formatjs/icu-messageformat-parser': 2.9.3
+      '@formatjs/intl': 2.10.14(typescript@5.6.3)
+      '@formatjs/intl-displaynames': 6.8.4
+      '@formatjs/intl-listformat': 7.7.4
       '@types/hoist-non-react-statics': 3.3.5
       '@types/react': 18.3.12
       hoist-non-react-statics: 3.3.2
-      intl-messageformat: 10.5.14
+      intl-messageformat: 10.7.6
       react: 18.3.1
-      tslib: 2.6.3
+      tslib: 2.8.0
     optionalDependencies:
       typescript: 5.6.3
 
@@ -14421,9 +14382,9 @@ snapshots:
 
   storybook-i18n@3.1.1: {}
 
-  storybook-react-intl@3.1.1(react-intl@6.7.0(react@18.3.1)(typescript@5.6.3)):
+  storybook-react-intl@3.1.1(react-intl@6.8.7(react@18.3.1)(typescript@5.6.3)):
     dependencies:
-      react-intl: 6.7.0(react@18.3.1)(typescript@5.6.3)
+      react-intl: 6.8.7(react@18.3.1)(typescript@5.6.3)
       storybook-i18n: 3.1.1
 
   storybook@8.4.3(prettier@3.3.3):


### PR DESCRIPTION
🤖 Resolves #11796 

## 👋 Introduction

Bumps `react-intl` to the latest version.

## 🕵️ Details

Playwright `tsconfig` was checking lib's types and since `Intl` is a browser API it was overlapping and getting confused. Added `skipLibCheck` for playwright only so we avoid this. Also added excludes which should speed up the check...maybe :woman_shrugging: 

## 🧪 Testing

1. Confirm playwright still passes
2. Confirm `react-intl` on latest version
 