### PR TITLE
[Debt] Removes `ErrorBoundary` export

### DIFF
--- a/apps/web/src/components/Layout/Layout.tsx
+++ b/apps/web/src/components/Layout/Layout.tsx
@@ -16,8 +16,6 @@ import SkipLink from "./SkipLink";
 import MainNavMenu from "../NavMenu/MainNavMenu";
 import { Project } from "../SEO/Favicon";
 
-export { ErrorBoundary } from "./ErrorBoundary/ErrorBoundary";
-
 interface LayoutProps {
   project: Project;
   title: string;


### PR DESCRIPTION
🤖 Resolves #11972.

## 👋 Introduction

This PR removes the unnecessary export declaration of `ErrorBoundary`.

## 🧪 Testing

1. Navigate to http://localhost:8000/en/non-existing-slug
2. Verify [ErrorBoundary](https://www.chromatic.com/component?appId=61e099a1bb1465003a73d3ce&csfId=components-layout-errorboundary&buildNumber=9267&k=67379f763fb45e6e176dfe57-1600px-interactive-true&h=7&b=-1) is still rendered

