### PR TITLE
[Copy] Updates French Label for showing the submitted date of an application

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2612,7 +2612,7 @@
     "description": "Text on a button to save community"
   },
   "BdsZwe": {
-    "defaultMessage": "Candidature formulée le cv",
+    "defaultMessage": "Candidature soumise",
     "description": "Label for showing the submitted date of an application."
   },
   "BfU5BR": {


### PR DESCRIPTION
🤖 Resolves #11987.

## 👋 Introduction

This PR changes the French text for the label for showing the submitted date of an application.

## 🧪 Testing

1. `pnpm build; pnpm storybook`
2. Navigate to http://localhost:6006/?path=/story/components-applicationcard--default&globals=locale:fr
3. Verify text contains _Candidature soumise :_

## 📸 Screenshot

<img width="1440" alt="Screen Shot 2024-11-18 at 09 52 03" src="https://github.com/user-attachments/assets/47c5abae-b3f4-42a4-b5ed-052ccebad2ed">