### PR TITLE
[Fix] Save deleted work email in the right field

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -469,12 +469,11 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
                 }
 
                 // Modify the email(s) to allow use by another user
-                $newContactEmail = $user->email.'-deleted-at-'.Carbon::now()->format('Y-m-d');
-                $user->update(['email' => $newContactEmail]);
+                $user->email = $user->email.'-deleted-at-'.Carbon::now()->format('Y-m-d');
                 if (! is_null($user->work_email)) {
-                    $newWorkEmail = $user->work_email.'-deleted-at-'.Carbon::now()->format('Y-m-d');
-                    $user->update(['email' => $newWorkEmail]);
+                    $user->work_email = $user->work_email.'-deleted-at-'.Carbon::now()->format('Y-m-d');
                 }
+                $user->save();
             }
             $user->searchable();
         });


### PR DESCRIPTION
🤖 Resolves #11962 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Saves the deleted work email in the right field.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->
I refactored the code a little bit to make one database update instead of two.

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Set up a user with a contact email address and a different work email address.
2. Delete the user.
3. Confirm that the email addresses are modified correctly.
4. Repeat for a user with a null work email address.