### PR TITLE
[Feature] Training page backend

### DIFF
--- a/api/app/Enums/CourseFormat.php
+++ b/api/app/Enums/CourseFormat.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+use App\Traits\HasLocalization;
+
+enum CourseFormat
+{
+    use HasLocalization;
+
+    case ON_SITE;
+    case VIRTUAL;
+
+    public static function getLangFilename(): string
+    {
+        return 'course_format';
+    }
+}

--- a/api/app/Enums/CourseLanguage.php
+++ b/api/app/Enums/CourseLanguage.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Enums;
+
+use App\Traits\HasLocalization;
+
+enum CourseLanguage
+{
+    use HasLocalization;
+
+    case ENGLISH;
+    case FRENCH;
+    case BILINGUAL;
+
+    public static function getLangFilename(): string
+    {
+        return 'course_language';
+    }
+}

--- a/api/app/Models/TrainingOpportunity.php
+++ b/api/app/Models/TrainingOpportunity.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class Training Opportunity
+ *
+ * @property string $id
+ * @property \Illuminate\Support\Carbon $created_at
+ * @property ?\Illuminate\Support\Carbon $updated_at
+ * @property array $title
+ * @property string $course_language
+ * @property ?\Illuminate\Support\Carbon $registration_deadline
+ * @property ?\Illuminate\Support\Carbon $training_start
+ * @property ?\Illuminate\Support\Carbon $training_end
+ * @property array $description
+ * @property array $application_url
+ * @property string $course_format
+ */
+class TrainingOpportunity extends Model
+{
+    use HasFactory;
+
+    protected $keyType = 'string';
+
+    /**
+     * The attributes that should be cast.
+     */
+    protected $casts = [
+        'title' => 'array',
+        'registration_deadline' => 'date',
+        'training_start' => 'date',
+        'training_end' => 'date',
+        'description' => 'array',
+        'application_url' => 'array',
+    ];
+
+    /**
+     * The attributes that can be filled using mass-assignment.
+     */
+    protected $fillable = [];
+}

--- a/api/app/Models/TrainingOpportunity.php
+++ b/api/app/Models/TrainingOpportunity.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Enums\CourseLanguage;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -42,4 +44,30 @@ class TrainingOpportunity extends Model
      * The attributes that can be filled using mass-assignment.
      */
     protected $fillable = [];
+
+    /**
+     * Scopes
+     */
+    public static function scopeHidePassedRegistrationDeadline(Builder $query, ?bool $filterBool): Builder
+    {
+        // if true only display where registration deadline is in the future
+        if (isset($filterBool) && $filterBool) {
+            $query->where(function ($query) {
+                $query->whereDate('registration_deadline', '>=', date('Y-m-d'))
+                    ->orWhereNull('registration_deadline');
+            });
+        }
+
+        return $query;
+    }
+
+    public static function scopeOpportunityLanguage(Builder $query, ?string $language): Builder
+    {
+        $courseLanguageArray = array_column(CourseLanguage::cases(), 'name');
+        if (isset($language) && in_array($language, $courseLanguageArray)) {
+            $query->where('course_language', '=', $language);
+        }
+
+        return $query;
+    }
 }

--- a/api/app/Policies/TrainingOpportunityPolicy.php
+++ b/api/app/Policies/TrainingOpportunityPolicy.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class TrainingOpportunityPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Can view the model
+     *
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function view()
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can create training opportunities.
+     */
+    public function create(User $user)
+    {
+        return $user->isAbleTo('create-any-trainingOpportunity');
+    }
+
+    /**
+     * Determine whether the user can update training opportunities, same as creation.
+     */
+    public function update(User $user)
+    {
+        return $user->isAbleTo('create-any-trainingOpportunity');
+    }
+}

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -83,6 +83,7 @@ return [
         'community' => 'community',
         'poolTeamMembers' => 'poolTeamMembers',
         'communityTeamMembers' => 'communityTeamMembers',
+        'trainingOpportunity' => 'trainingOpportunity',
 
         'platformAdminMembership' => 'platformAdminMembership',
         'communityAdminMembership' => 'communityAdminMembership',
@@ -629,6 +630,11 @@ return [
         'view-team-communityTeamMembers' => [
             'en' => 'View the members of this community',
             'fr' => 'Voir les membres de cette communauté',
+        ],
+
+        'create-any-trainingOpportunity' => [
+            'en' => 'Create or update a training opportunity',
+            'fr' => 'Créer ou mettre à jour une opportunité de formation',
         ],
     ],
 
@@ -1221,6 +1227,9 @@ return [
             ],
             'poolTeamMembers' => [
                 'any' => ['view'],
+            ],
+            'trainingOpportunity' => [
+                'any' => ['create'],
             ],
         ],
         'manager' => [

--- a/api/database/factories/TrainingOpportunityFactory.php
+++ b/api/database/factories/TrainingOpportunityFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\CourseFormat;
+use App\Enums\CourseLanguage;
+use App\Models\TrainingOpportunity;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TrainingOpportunityFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = TrainingOpportunity::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        $title = $this->faker->jobTitle();
+        $description = $this->faker->sentences(3, true);
+        $applicationUrl = $this->faker->url();
+        $registrationDeadline = $this->faker->dateTimeBetween('-6 months', '6 months');
+        $trainingStart = $this->faker->dateTimeBetween($registrationDeadline, '9 months');
+        $trainingEnd = $this->faker->boolean() ? $this->faker->dateTimeBetween($trainingStart, '12 months') : null;
+
+        return [
+            'title' => ['en' => $title.' EN', 'fr' => $title.' FR'],
+            'description' => ['en' => $description.' EN', 'fr' => $description.' FR'],
+            'application_url' => ['en' => $applicationUrl.'EN/', 'fr' => $applicationUrl.'FR/'],
+            'registration_deadline' => $registrationDeadline,
+            'training_start' => $trainingStart,
+            'training_end' => $trainingEnd,
+            'course_language' => $this->faker->randomElement(CourseLanguage::cases())->name,
+            'course_format' => $this->faker->randomElement(CourseFormat::cases())->name,
+        ];
+    }
+
+    public function configure()
+    {
+        return $this;
+    }
+}

--- a/api/database/factories/TrainingOpportunityFactory.php
+++ b/api/database/factories/TrainingOpportunityFactory.php
@@ -28,7 +28,7 @@ class TrainingOpportunityFactory extends Factory
         $applicationUrl = $this->faker->url();
         $registrationDeadline = $this->faker->dateTimeBetween('-6 months', '6 months');
         $trainingStart = $this->faker->dateTimeBetween($registrationDeadline, '9 months');
-        $trainingEnd = $this->faker->boolean() ? $this->faker->dateTimeBetween($trainingStart, '12 months') : null;
+        $trainingEnd = $this->faker->optional()->dateTimeBetween($trainingStart, '12 months');
 
         return [
             'title' => ['en' => $title.' EN', 'fr' => $title.' FR'],

--- a/api/database/migrations/2024_11_18_190306_create_training_opportunities_table.php
+++ b/api/database/migrations/2024_11_18_190306_create_training_opportunities_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('training_opportunities', function (Blueprint $table) {
+            $table->uuid('id')->primary()->default(new Expression('public.gen_random_uuid()'));
+            $table->timestamps();
+            $table->jsonb('title')->default(json_encode(['en' => '', 'fr' => '']));
+            $table->string('course_language')->nullable();
+            $table->date('registration_deadline')->nullable();
+            $table->date('training_start')->nullable();
+            $table->date('training_end')->nullable();
+            $table->jsonb('description')->default(json_encode(['en' => '', 'fr' => '']));
+            $table->jsonb('application_url')->default(json_encode(['en' => '', 'fr' => '']));
+            $table->string('course_format')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('training_opportunities');
+    }
+};

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -39,6 +39,7 @@ class DatabaseSeeder extends Seeder
             SearchRequestRandomSeeder::class,
             DigitalContractingQuestionnaireRandomSeeder::class,
             DepartmentSpecificRecruitmentProcessFormRandomSeeder::class,
+            TrainingOpportunityRandomSeeder::class,
         ]);
     }
 }

--- a/api/database/seeders/TrainingOpportunityRandomSeeder.php
+++ b/api/database/seeders/TrainingOpportunityRandomSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\TrainingOpportunity;
+use Illuminate\Database\Seeder;
+
+class TrainingOpportunityRandomSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        TrainingOpportunity::factory()->count(20)->create();
+    }
+}

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1831,6 +1831,28 @@ input UpdateAssessmentResultInput
     @rename(attribute: "assessment_decision_level")
   skillDecisionNotes: String @rename(attribute: "skill_decision_notes")
 }
+input CreateTrainingOpportunityInput {
+  title: LocalizedStringInput!
+  courseLanguage: CourseLanguage! @rename(attribute: "course_language")
+  registrationDeadline: Date! @rename(attribute: "registration_deadline")
+  trainingStart: Date! @rename(attribute: "training_start")
+  trainingEnd: Date @rename(attribute: "training_end")
+  description: LocalizedStringInput!
+  applicationUrl: LocalizedStringInput! @rename(attribute: "application_url")
+  courseFormat: CourseFormat! @rename(attribute: "course_format")
+}
+
+input UpdateTrainingOpportunityInput {
+  id: UUID!
+  title: LocalizedStringInput
+  courseLanguage: CourseLanguage @rename(attribute: "course_language")
+  registrationDeadline: Date @rename(attribute: "registration_deadline")
+  trainingStart: Date @rename(attribute: "training_start")
+  trainingEnd: Date @rename(attribute: "training_end")
+  description: LocalizedStringInput
+  applicationUrl: LocalizedStringInput @rename(attribute: "application_url")
+  courseFormat: CourseFormat @rename(attribute: "course_format")
+}
 
 input PoolSkillBelongsToMany {
   sync: [UUID!]!
@@ -2417,6 +2439,13 @@ type Mutation {
   updateSitewideAnnouncement(
     sitewideAnnouncementInput: SitewideAnnouncementInput! @spread
   ): SitewideAnnouncement @guard
+
+  createTrainingOpportunity(
+    createTrainingOpportunity: CreateTrainingOpportunityInput! @spread
+  ): TrainingOpportunity @create
+  updateTrainingOpportunity(
+    updateTrainingOpportunity: UpdateTrainingOpportunityInput! @spread
+  ): TrainingOpportunity @update
 
   # CSV file downloads
   downloadPoolCandidatesCsv(

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -913,6 +913,23 @@ type SitewideAnnouncement {
   message: LocalizedString!
 }
 
+type TrainingOpportunity {
+  id: UUID
+  title: LocalizedString
+  courseLanguage: LocalizedCourseLanguage @rename(attribute: "course_language")
+  registrationDeadline: Date @rename(attribute: "registration_deadline")
+  trainingStart: Date @rename(attribute: "training_start")
+  trainingEnd: Date @rename(attribute: "training_end")
+  description: LocalizedString
+  applicationUrl: LocalizedString @rename(attribute: "application_url")
+  courseFormat: LocalizedCourseFormat @rename(attribute: "course_format")
+}
+
+input TrainingOpportunitiesFilterInput {
+  hidePassedRegistrationDeadline: Boolean @scope
+  opportunityLanguage: CourseLanguage @scope
+}
+
 input SitewideAnnouncementInput {
   isEnabled: Boolean!
   publishDate: DateTime!
@@ -1066,6 +1083,15 @@ type Query {
     @paginate(defaultCount: 10, scopes: ["authorizedToView"])
 
   sitewideAnnouncement: SitewideAnnouncement
+  trainingOpportunity(id: UUID! @eq): TrainingOpportunity @find
+  trainingOpportunitiesPaginated(
+    where: TrainingOpportunitiesFilterInput
+  ): [TrainingOpportunity]
+    @paginate(
+      defaultCount: 10
+      maxCount: 1000
+      model: "App\\Models\\TrainingOpportunity"
+    )
 
   localizedEnumStrings(
     enumName: String!

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -2442,10 +2442,10 @@ type Mutation {
 
   createTrainingOpportunity(
     createTrainingOpportunity: CreateTrainingOpportunityInput! @spread
-  ): TrainingOpportunity @create
+  ): TrainingOpportunity @create @guard @canModel(ability: "create")
   updateTrainingOpportunity(
     updateTrainingOpportunity: UpdateTrainingOpportunityInput! @spread
-  ): TrainingOpportunity @update
+  ): TrainingOpportunity @update @guard @canModel(ability: "update")
 
   # CSV file downloads
   downloadPoolCandidatesCsv(

--- a/api/lang/en/course_format.php
+++ b/api/lang/en/course_format.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'on_site' => 'On-site',
+    'virtual' => 'Virtual',
+];

--- a/api/lang/en/course_language.php
+++ b/api/lang/en/course_language.php
@@ -1,9 +1,7 @@
 <?php
 
-use Illuminate\Support\Facades\Lang;
-
 return [
-    'english' => Lang::get('common.english_only', [], 'en'),
-    'french' => Lang::get('common.french_only', [], 'en'),
-    'bilingual' => 'Bilingual (English and French)',
+    'english' => 'English',
+    'french' => 'French',
+    'bilingual' => 'Bilingual',
 ];

--- a/api/lang/en/course_language.php
+++ b/api/lang/en/course_language.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Support\Facades\Lang;
+
+return [
+    'english' => Lang::get('common.english_only', [], 'en'),
+    'french' => Lang::get('common.french_only', [], 'en'),
+    'bilingual' => 'Bilingual (English and French)',
+];

--- a/api/lang/fr/course_format.php
+++ b/api/lang/fr/course_format.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'on_site' => 'On-site',
+    'virtual' => 'Virtual',
+];

--- a/api/lang/fr/course_format.php
+++ b/api/lang/fr/course_format.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'on_site' => 'On-site',
-    'virtual' => 'Virtual',
+    'on_site' => 'Sur place',
+    'virtual' => 'Virtuel',
 ];

--- a/api/lang/fr/course_language.php
+++ b/api/lang/fr/course_language.php
@@ -1,9 +1,7 @@
 <?php
 
-use Illuminate\Support\Facades\Lang;
-
 return [
-    'english' => Lang::get('common.english_only', [], 'fr'),
-    'french' => Lang::get('common.french_only', [], 'fr'),
-    'bilingual' => 'Bilingue (français et anglais)',
+    'english' => 'Anglais',
+    'french' => 'Français',
+    'bilingual' => 'Bilingue',
 ];

--- a/api/lang/fr/course_language.php
+++ b/api/lang/fr/course_language.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Support\Facades\Lang;
+
+return [
+    'english' => Lang::get('common.english_only', [], 'fr'),
+    'french' => Lang::get('common.french_only', [], 'fr'),
+    'bilingual' => 'Bilingue (français et anglais)',
+];

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -438,6 +438,8 @@ type Mutation {
   updateAssessmentResult(updateAssessmentResult: UpdateAssessmentResultInput!): AssessmentResult
   deleteAssessmentResult(id: UUID!): AssessmentResult
   updateSitewideAnnouncement(sitewideAnnouncementInput: SitewideAnnouncementInput!): SitewideAnnouncement
+  createTrainingOpportunity(createTrainingOpportunity: CreateTrainingOpportunityInput!): TrainingOpportunity
+  updateTrainingOpportunity(updateTrainingOpportunity: UpdateTrainingOpportunityInput!): TrainingOpportunity
   downloadPoolCandidatesCsv(ids: [UUID!], where: PoolCandidateSearchInput): Boolean!
   downloadUsersCsv(ids: [UUID!], where: UserFilterInput): Boolean!
   downloadApplicationsZip(ids: [UUID!]!): Boolean!
@@ -1810,6 +1812,29 @@ input UpdateAssessmentResultInput {
   justifications: [AssessmentResultJustification]
   assessmentDecisionLevel: AssessmentDecisionLevel
   skillDecisionNotes: String
+}
+
+input CreateTrainingOpportunityInput {
+  title: LocalizedStringInput!
+  courseLanguage: CourseLanguage!
+  registrationDeadline: Date!
+  trainingStart: Date!
+  trainingEnd: Date
+  description: LocalizedStringInput!
+  applicationUrl: LocalizedStringInput!
+  courseFormat: CourseFormat!
+}
+
+input UpdateTrainingOpportunityInput {
+  id: UUID!
+  title: LocalizedStringInput
+  courseLanguage: CourseLanguage
+  registrationDeadline: Date
+  trainingStart: Date
+  trainingEnd: Date
+  description: LocalizedStringInput
+  applicationUrl: LocalizedStringInput
+  courseFormat: CourseFormat
 }
 
 input PoolSkillBelongsToMany {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -53,6 +53,16 @@ type LocalizedCitizenshipStatus {
   label: LocalizedString!
 }
 
+type LocalizedCourseFormat {
+  value: CourseFormat!
+  label: LocalizedString!
+}
+
+type LocalizedCourseLanguage {
+  value: CourseLanguage!
+  label: LocalizedString!
+}
+
 type LocalizedEducationRequirementOption {
   value: EducationRequirementOption!
   label: LocalizedString!
@@ -247,6 +257,7 @@ type Query {
   teams: [Team]!
   roles: [Role]!
   sitewideAnnouncement: SitewideAnnouncement
+  trainingOpportunity(id: UUID!): TrainingOpportunity
   localizedEnumStrings(enumName: String!): [LocalizedEnumString!]
   digitalContractingQuestionnaire(id: UUID!): DigitalContractingQuestionnaire
   digitalContractingQuestionnaires: [DigitalContractingQuestionnaire!]!
@@ -319,6 +330,15 @@ type Query {
     "The offset from which items are returned."
     page: Int
   ): NotificationPaginator!
+  trainingOpportunitiesPaginated(
+    where: TrainingOpportunitiesFilterInput
+
+    "Limits number of fetched items. Maximum allowed value: 1000."
+    first: Int! = 10
+
+    "The offset from which items are returned."
+    page: Int
+  ): TrainingOpportunityPaginator!
 }
 
 type Mutation {
@@ -1182,6 +1202,23 @@ type SitewideAnnouncement {
   expiryDate: DateTime!
   title: LocalizedString!
   message: LocalizedString!
+}
+
+type TrainingOpportunity {
+  id: UUID
+  title: LocalizedString
+  courseLanguage: LocalizedCourseLanguage
+  registrationDeadline: Date
+  trainingStart: Date
+  trainingEnd: Date
+  description: LocalizedString
+  applicationUrl: LocalizedString
+  courseFormat: LocalizedCourseFormat
+}
+
+input TrainingOpportunitiesFilterInput {
+  hidePassedRegistrationDeadline: Boolean
+  opportunityLanguage: CourseLanguage
 }
 
 input SitewideAnnouncementInput {
@@ -2262,6 +2299,15 @@ type NotificationPaginator {
   data: [Notification!]!
 }
 
+"A paginated list of TrainingOpportunity items."
+type TrainingOpportunityPaginator {
+  "Pagination information about the list of items."
+  paginatorInfo: PaginatorInfo!
+
+  "A list of TrainingOpportunity items."
+  data: [TrainingOpportunity!]!
+}
+
 "Allowed column names for Query.poolsPaginated.orderBy."
 enum QueryPoolsPaginatedOrderByUserColumn {
   FIRST_NAME
@@ -2609,6 +2655,17 @@ enum ClaimVerificationResult {
   ACCEPTED
   REJECTED
   UNVERIFIED
+}
+
+enum CourseFormat {
+  ON_SITE
+  VIRTUAL
+}
+
+enum CourseLanguage {
+  ENGLISH
+  FRENCH
+  BILINGUAL
 }
 
 enum AdvertisementType {

--- a/api/tests/Feature/TrainingOpportunityTest.php
+++ b/api/tests/Feature/TrainingOpportunityTest.php
@@ -1,0 +1,360 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\CourseFormat;
+use App\Enums\CourseLanguage;
+use App\Models\TrainingOpportunity;
+use App\Models\User;
+use Database\Seeders\ClassificationSeeder;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithExceptionHandling;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
+use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
+
+class TrainingOpportunityTest extends TestCase
+{
+    use InteractsWithExceptionHandling;
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+    use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
+
+    protected $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->bootRefreshesSchemaCache();
+        $this->withoutExceptionHandling();
+        $this->seed(ClassificationSeeder::class);
+        $this->seed(RolePermissionSeeder::class);
+
+        $this->admin = User::factory()
+            ->asApplicant()
+            ->asAdmin()
+            ->create([
+                'email' => 'admin@test.com',
+                'sub' => 'admin@test.com',
+            ]);
+    }
+
+    public function testQueryingPaginatedDeadlineScope(): void
+    {
+        TrainingOpportunity::truncate();
+        $old = TrainingOpportunity::factory()->create([
+            'registration_deadline' => config('constants.past_date'),
+        ]);
+        $future = TrainingOpportunity::factory()->create([
+            'registration_deadline' => config('constants.far_future_date'),
+        ]);
+
+        // empty filter input returns 2
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+            query trainingOpportunitiesPaginated($where: TrainingOpportunitiesFilterInput) {
+                trainingOpportunitiesPaginated(where: $where) {
+                    data {
+                        id
+                    }
+                    paginatorInfo {
+                        total
+                    }
+                }
+            }
+            ',
+            []
+        )->assertJsonFragment(
+            [
+                'id' => $future->id,
+            ],
+        )
+            ->assertJsonFragment(
+                [
+                    'id' => $old->id,
+                ],
+            )
+            ->assertJsonFragment(
+                [
+                    'total' => 2,
+                ],
+            );
+
+        // false returns 2
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+            query trainingOpportunitiesPaginated($where: TrainingOpportunitiesFilterInput) {
+                trainingOpportunitiesPaginated(where: $where) {
+                    data {
+                        id
+                    }
+                    paginatorInfo {
+                        total
+                    }
+                }
+            }
+            ',
+            [
+                'where' => [
+                    'hidePassedRegistrationDeadline' => false,
+                ],
+            ]
+        )->assertJsonFragment(
+            [
+                'id' => $future->id,
+            ],
+        )
+            ->assertJsonFragment(
+                [
+                    'id' => $old->id,
+                ],
+            )
+            ->assertJsonFragment(
+                [
+                    'total' => 2,
+                ],
+            );
+
+        // true causes filtering, returning 1, the future opportunity
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+            query trainingOpportunitiesPaginated($where: TrainingOpportunitiesFilterInput) {
+                trainingOpportunitiesPaginated(where: $where) {
+                    data {
+                        id
+                    }
+                    paginatorInfo {
+                        total
+                    }
+                }
+            }
+            ',
+            [
+                'where' => [
+                    'hidePassedRegistrationDeadline' => true,
+                ],
+            ]
+        )->assertJsonFragment(
+            [
+                'id' => $future->id,
+            ],
+        )
+            ->assertJsonFragment(
+                [
+                    'total' => 1,
+                ],
+            );
+    }
+
+    public function testQueryingPaginatedCourseLanguage(): void
+    {
+        TrainingOpportunity::truncate();
+        $english = TrainingOpportunity::factory()->create([
+            'course_language' => CourseLanguage::ENGLISH->name,
+        ]);
+        $french = TrainingOpportunity::factory()->create([
+            'course_language' => CourseLanguage::FRENCH->name,
+        ]);
+        $bilingual = TrainingOpportunity::factory()->create([
+            'course_language' => CourseLanguage::BILINGUAL->name,
+        ]);
+
+        // empty filter input returns all 3
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+            query trainingOpportunitiesPaginated($where: TrainingOpportunitiesFilterInput) {
+                trainingOpportunitiesPaginated(where: $where) {
+                    data {
+                        id
+                    }
+                    paginatorInfo {
+                        total
+                    }
+                }
+            }
+            ',
+            []
+        )->assertJsonFragment(
+            [
+                'id' => $english->id,
+            ],
+        )
+            ->assertJsonFragment(
+                [
+                    'id' => $french->id,
+                ],
+            )
+            ->assertJsonFragment(
+                [
+                    'id' => $bilingual->id,
+                ],
+            )
+            ->assertJsonFragment(
+                [
+                    'total' => 3,
+                ],
+            );
+
+        // english returns 1, english
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+            query trainingOpportunitiesPaginated($where: TrainingOpportunitiesFilterInput) {
+                trainingOpportunitiesPaginated(where: $where) {
+                    data {
+                        id
+                    }
+                    paginatorInfo {
+                        total
+                    }
+                }
+            }
+            ',
+            [
+                'where' => [
+                    'opportunityLanguage' => CourseLanguage::ENGLISH->name,
+                ],
+            ]
+        )->assertJsonFragment(
+            [
+                'id' => $english->id,
+            ],
+        )
+            ->assertJsonFragment(
+                [
+                    'total' => 1,
+                ],
+            );
+
+        // french returns 1, french
+        $this->graphQL(
+            /** @lang GraphQL */
+            '
+            query trainingOpportunitiesPaginated($where: TrainingOpportunitiesFilterInput) {
+                trainingOpportunitiesPaginated(where: $where) {
+                    data {
+                        id
+                    }
+                    paginatorInfo {
+                        total
+                    }
+                }
+            }
+            ',
+            [
+                'where' => [
+                    'opportunityLanguage' => CourseLanguage::FRENCH->name,
+                ],
+            ]
+        )->assertJsonFragment(
+            [
+                'id' => $french->id,
+            ],
+        )
+            ->assertJsonFragment(
+                [
+                    'total' => 1,
+                ],
+            );
+    }
+
+    // test that a training opportunity is successfully created
+    public function testCreateTrainingOpportunity(): void
+    {
+        $this->actingAs($this->admin, 'api')->graphQL(
+            /** @lang GraphQL */
+            '
+        mutation createTrainingOpportunity($createTrainingOpportunity: CreateTrainingOpportunityInput!) {
+            createTrainingOpportunity(createTrainingOpportunity: $createTrainingOpportunity) {
+                title {
+                    en
+                    fr
+                }
+                registrationDeadline
+                courseLanguage {
+                    value
+                }
+            }
+        }
+        ',
+            [
+                'createTrainingOpportunity' => [
+                    'title' => ['en' => 'EN', 'fr' => 'FR'],
+                    'description' => ['en' => 'EN', 'fr' => 'FR'],
+                    'applicationUrl' => ['en' => 'EN/', 'fr' => 'FR/'],
+                    'registrationDeadline' => config('constants.far_future_date'),
+                    'trainingStart' => config('constants.far_future_date'),
+                    'courseLanguage' => CourseLanguage::ENGLISH->name,
+                    'courseFormat' => CourseFormat::VIRTUAL->name,
+                ],
+            ]
+        )->assertJsonFragment(
+            [
+                'title' => [
+                    'en' => 'EN',
+                    'fr' => 'FR',
+                ],
+            ],
+        )->assertJsonFragment(
+            [
+                'registrationDeadline' => config('constants.far_future_date'),
+            ],
+        )->assertJsonFragment(
+            [
+                'courseLanguage' => [
+                    'value' => CourseLanguage::ENGLISH->name,
+                ],
+            ],
+        );
+    }
+
+    // test that a training opportunity is successfully updated
+    public function testUpdateTrainingOpportunity(): void
+    {
+        $opportunity = TrainingOpportunity::factory()->create();
+
+        $this->actingAs($this->admin, 'api')->graphQL(
+            /** @lang GraphQL */
+            '
+        mutation updateTrainingOpportunity($updateTrainingOpportunity: UpdateTrainingOpportunityInput!) {
+            updateTrainingOpportunity(updateTrainingOpportunity: $updateTrainingOpportunity) {
+                title {
+                    en
+                    fr
+                }
+                courseLanguage {
+                    value
+                }
+            }
+        }
+        ',
+            [
+                'updateTrainingOpportunity' => [
+                    'id' => $opportunity->id,
+                    'title' => ['en' => 'EN', 'fr' => 'FR'],
+                    'courseLanguage' => CourseLanguage::ENGLISH->name,
+                ],
+            ]
+        )->assertJsonFragment(
+            [
+                'title' => [
+                    'en' => 'EN',
+                    'fr' => 'FR',
+                ],
+            ],
+        )->assertJsonFragment(
+            [
+                'courseLanguage' => [
+                    'value' => CourseLanguage::ENGLISH->name,
+                ],
+            ],
+        );
+    }
+}

--- a/api/tests/Feature/TrainingOpportunityTest.php
+++ b/api/tests/Feature/TrainingOpportunityTest.php
@@ -44,7 +44,6 @@ class TrainingOpportunityTest extends TestCase
 
     public function testQueryingPaginatedDeadlineScope(): void
     {
-        TrainingOpportunity::truncate();
         $old = TrainingOpportunity::factory()->create([
             'registration_deadline' => config('constants.past_date'),
         ]);
@@ -154,7 +153,6 @@ class TrainingOpportunityTest extends TestCase
 
     public function testQueryingPaginatedCourseLanguage(): void
     {
-        TrainingOpportunity::truncate();
         $english = TrainingOpportunity::factory()->create([
             'course_language' => CourseLanguage::ENGLISH->name,
         ]);


### PR DESCRIPTION
🤖 Resolves #11930

## 👋 Introduction

Set up the backend for the feature. New table, seeding, queries, mutations, and testing added. 
New permission added, `create-any-trainingOpportunity` for `platform_admin`

## 🧪 Testing

1. Migrate and seeding
2. Try queries
3. Try mutations

Sample operations

```
query a {
  trainingOpportunity(id: "ID") {
    id
    title {
      en
      fr
    }
    registrationDeadline
    trainingStart
    courseLanguage {
      value
    }
    applicationUrl {
      en
      fr
    }
  }
}
```

```
query b {
  trainingOpportunitiesPaginated(where: {hidePassedRegistrationDeadline: true}) {
    data {
      registrationDeadline
    }
    paginatorInfo {
      count
      total
    }
  }
}
```
```
mutation x {
  createTrainingOpportunity(
    createTrainingOpportunity: {
      title: {en: "en", fr: "fr"}
      description: {en: "en", fr: "fr"}
      courseFormat: ON_SITE
      trainingStart: "2011-05-23"
      courseLanguage: FRENCH
      applicationUrl: {en: "en", fr: "fr"}
      registrationDeadline: "2011-05-23"
   }
  ) {
    id
    title {
      en
      fr
    }
    registrationDeadline
    trainingStart
    courseLanguage {
      value
    }
    applicationUrl {
      en
      fr
    }
  }
}
```

```
mutation y {
  updateTrainingOpportunity(
    updateTrainingOpportunity: {
      id: "10f9adf0-7a84-42fc-9d5d-284d06b4e389"
      title: {en: "en", fr: "fr"}
      description: {en: "en", fr: "fr"}
      courseFormat: VIRTUAL
      trainingStart: "2011-05-23"
      courseLanguage: FRENCH
      applicationUrl: {en: "en", fr: "fr"}
      registrationDeadline: "2011-05-23"
   }
  ) {
    id
    title {
      en
      fr
    }
    registrationDeadline
    trainingStart
    courseLanguage {
      value
    }
    applicationUrl {
      en
      fr
    }
  }
}
```

## 🚚 Deployment

Run role-permission seeder
