### PR TITLE
[Fix] Sets accordion trigger for Your talent requests to `h3`

### DIFF
--- a/apps/web/src/pages/Manager/ManagerDashboardPage/ManagerDashboardPage.tsx
+++ b/apps/web/src/pages/Manager/ManagerDashboardPage/ManagerDashboardPage.tsx
@@ -239,6 +239,7 @@ const ManagerDashboard = ({ userQuery }: ManagerDashboardProps) => {
                                   <PoolCandidateSearchRequestPreviewListItem
                                     key={request.id}
                                     poolCandidateSearchRequestQuery={request}
+                                    headingAs="h4"
                                   />
                                 ),
                               )}

--- a/apps/web/src/pages/Manager/ManagerDashboardPage/ManagerDashboardPage.tsx
+++ b/apps/web/src/pages/Manager/ManagerDashboardPage/ManagerDashboardPage.tsx
@@ -190,7 +190,7 @@ const ManagerDashboard = ({ userQuery }: ManagerDashboardProps) => {
                     data-h2-padding-bottom="base:selectors[>.Accordion__Item > .Accordion__Content](x.5)"
                   >
                     <Accordion.Item value="your_talent_searches">
-                      <Accordion.Trigger>
+                      <Accordion.Trigger as="h3">
                         {intl.formatMessage(
                           {
                             defaultMessage: "Your talent requests ({count})",

--- a/apps/web/src/pages/Manager/components/PoolCandidateSearchRequestPreviewListItem.tsx
+++ b/apps/web/src/pages/Manager/components/PoolCandidateSearchRequestPreviewListItem.tsx
@@ -8,7 +8,7 @@ import {
   PreviewListItemFragment,
 } from "@gc-digital-talent/graphql";
 import { commonMessages } from "@gc-digital-talent/i18n";
-import { PreviewList } from "@gc-digital-talent/ui";
+import { HeadingLevel, PreviewList } from "@gc-digital-talent/ui";
 import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 
@@ -58,12 +58,14 @@ function buildTitle(request: PreviewListItemFragment, intl: IntlShape): string {
 }
 
 interface PoolCandidateSearchRequestPreviewListItemProps {
+  headingAs?: HeadingLevel;
   poolCandidateSearchRequestQuery: FragmentType<
     typeof PreviewListItemPoolCandidateSearchRequest_Fragment
   >;
 }
 
 const PoolCandidateSearchRequestPreviewListItem = ({
+  headingAs,
   poolCandidateSearchRequestQuery,
 }: PoolCandidateSearchRequestPreviewListItemProps) => {
   const intl = useIntl();
@@ -141,6 +143,7 @@ const PoolCandidateSearchRequestPreviewListItem = ({
             onClick={() => setDialogOpen(true)}
           />
         }
+        headingAs={headingAs}
       />
       <ReviewTalentRequestDialog
         open={dialogOpen}


### PR DESCRIPTION
🤖 Resolves #11974.

## 👋 Introduction

This PR updates the "Your talent requests" heading to be an `h3`. It also adds a prop of `headingAs` to the `PoolCandidateSearchRequestPreviewListItem` component in order to control its heading level.

## 🧪 Testing

1. Navigate to http://localhost:3000/en/manager/dashboard
2. Verify the "Your talent requests" heading level of `h3`

## 📸 Screenshot

<img width="1425" alt="Screen Shot 2024-11-19 at 11 39 04" src="https://github.com/user-attachments/assets/3a1b1862-e89e-4659-a967-508363e8c836">
