### PR TITLE
Remove auth requirement from Manager home page

### DIFF
--- a/apps/web/src/pages/Home/ManagerHomePage/ManagerHomePage.tsx
+++ b/apps/web/src/pages/Home/ManagerHomePage/ManagerHomePage.tsx
@@ -7,7 +7,6 @@ import UserPlusIcon from "@heroicons/react/24/outline/UserPlusIcon";
 
 import { CardFlat, Flourish, Heading, Link } from "@gc-digital-talent/ui";
 import { navigationMessages } from "@gc-digital-talent/i18n";
-import { ROLE_NAME } from "@gc-digital-talent/auth";
 
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
@@ -25,7 +24,6 @@ import peopleSittingOnCouch from "~/assets/img/people-sitting-on-couch-discussin
 import peopleSittingInLine from "~/assets/img/people-sitting-in-a-line-smiling-at-another-person.webp";
 import { TALENTSEARCH_SUPPORT_EMAIL } from "~/constants/talentSearchConstants";
 import DirectiveBlock from "~/components/DirectiveBlock/DirectiveBlock";
-import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
 const pageTitle = defineMessage({
   defaultMessage: "Managers community",
@@ -391,11 +389,7 @@ const ManagerHomePage = () => {
   );
 };
 
-export const Component = () => (
-  <RequireAuth roles={[ROLE_NAME.PlatformAdmin, ROLE_NAME.Manager]}>
-    <ManagerHomePage />
-  </RequireAuth>
-);
+export const Component = () => <ManagerHomePage />;
 
 Component.displayName = "ManagerHomePage";
 


### PR DESCRIPTION
🤖 Resolves #12022

## 👋 Introduction

Manager info page should be public.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

Try to view /manager as a guest user, and as an applicant user.
