### PR TITLE
[Copy] Updates nav menu actions to use sentence case

### DIFF
--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -11,10 +11,6 @@
     "defaultMessage": "Je m'identifie en tant que femme.",
     "description": "Statement for when someone indicates they are a woman"
   },
-  "+ZPD1J": {
-    "defaultMessage": "Fermer le menu",
-    "description": "Text label for button that closes side menu."
-  },
   "/62GQm": {
     "defaultMessage": "Capacité démontrée à accomplir de façon constante des tâches de complexité faible à modérée sous une supervision minimale et des tâches de complexité plus élevée sous une supervision et un mentorat modérés. Généralement associée à des postes intermédiaires.",
     "description": "The technical skill level definition for intermediate"
@@ -283,6 +279,10 @@
     "defaultMessage": "Niveau d’entrée",
     "description": "The technical skill level for beginner"
   },
+  "AiFpbo": {
+    "defaultMessage": "Fermer le menu",
+    "description": "Text label for button that closes side menu."
+  },
   "AlECuf": {
     "defaultMessage": "Le statut du candidat est irrégulier.",
     "description": "Message displayed to user after attempting to update a candidate with an unexpected status."
@@ -478,10 +478,6 @@
   "KGX4bI": {
     "defaultMessage": "{count, plural, =0 { <strong>0</strong> résultats équivalents} =1 {<strong>1</strong> résultats équivalents} other {<strong>#</strong> résultats équivalents}} de {total, plural, =0 {<strong>0</strong> options disponibles} =1 {<strong>1</strong> option disponible} other {<strong>#</strong> options disponibles}}",
     "description": "Message showing number of matching items from all available options in combobox menu"
-  },
-  "KMSWLW": {
-    "defaultMessage": "Ouvrir le menu",
-    "description": "Text label for button that opens side menu."
   },
   "Ko0JX/": {
     "defaultMessage": "Constamment démontrée comme étant bien développée dans des conditions quotidiennes auprès de tous les publics, fréquemment démontrée dans des situations de stress et dans des situations modérément difficiles auprès de la plupart des publics, et démontrée par intermittence dans des conditions de stress important et dans des situations difficiles.",
@@ -906,6 +902,10 @@
   "dxjUnU": {
     "defaultMessage": "Région de la capitale nationale (Ottawa, en Ontario et Gatineau, au Québec.)",
     "description": "The work region of Canada described as National Capital."
+  },
+  "e6YQ8t": {
+    "defaultMessage": "Ouvrir le menu",
+    "description": "Text label for button that opens side menu."
   },
   "eBNZxB": {
     "defaultMessage": "{count, plural, =0 {0 options sélectionnées} =1 {1 option sélectionnée} other {# options sélectionnées}}",

--- a/packages/i18n/src/messages/uiMessages.ts
+++ b/packages/i18n/src/messages/uiMessages.ts
@@ -61,13 +61,13 @@ const uiMessages = defineMessages({
     description: "Text that appears in links that open in a new tab.",
   },
   closeMenu: {
-    defaultMessage: "Close Menu",
-    id: "+ZPD1J",
+    defaultMessage: "Close menu",
+    id: "AiFpbo",
     description: "Text label for button that closes side menu.",
   },
   openMenu: {
-    defaultMessage: "Open Menu",
-    id: "KMSWLW",
+    defaultMessage: "Open menu",
+    id: "e6YQ8t",
     description: "Text label for button that opens side menu.",
   },
   onThisPage: {


### PR DESCRIPTION
🤖 Resolves #12016.

## 👋 Introduction

This PR updates the open and close nav menu actions to use sentence case instead of title case.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/en/
3. Verify nav menu button action reads Open menu
4. Open nav menu
5. Verify nav menu button action reads Close menu

## 📸 Screenshots

<img width="488" alt="Screen Shot 2024-11-20 at 09 35 17" src="https://github.com/user-attachments/assets/bd6e7b21-dc09-4d95-81a4-bc339b877bce">
<img width="495" alt="Screen Shot 2024-11-20 at 09 35 23" src="https://github.com/user-attachments/assets/0769e2b3-d333-45f1-93b0-ccc35967fd0c">
