### PR TITLE
Roll back maintenance to 22.04

### DIFF
--- a/infrastructure/maintenance-container/Dockerfile
+++ b/infrastructure/maintenance-container/Dockerfile
@@ -1,5 +1,5 @@
 # aliased image used in build
-FROM node:20.11.0 as node
+FROM node:20.11.0 AS node
 
 # base
 FROM ubuntu:22.04

--- a/infrastructure/maintenance-container/Dockerfile
+++ b/infrastructure/maintenance-container/Dockerfile
@@ -2,15 +2,22 @@
 FROM node:20.11.0 as node
 
 # base
-FROM ubuntu:23.10
+FROM ubuntu:22.04
 
 # install apt packages
+# first install software-properties-common to get add-apt-repository
+# then add ondrej PPA
+# then update again and install everything else
 # installing tzdata has an interactive prompt by default
 RUN apt-get update \
+  && apt-get install -y software-properties-common \
+  && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
+  && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
   && apt-get install -y perl unzip wget curl \
-  && apt-get install -y php8.2 php-mbstring php-xml php-pgsql php-zip php-curl php-bcmath php-gd \
-  && apt-get install --yes --no-install-recommends git postgresql-client
+  && apt-get install -y php8.2 php8.2-mbstring php8.2-xml php8.2-pgsql php8.2-zip php8.2-curl php8.2-bcmath php8.2-gd \
+  && apt-get install --yes --no-install-recommends git postgresql-client \
+  && apt-get clean
 
 # install node from official image
 # https://gist.github.com/BretFisher/da34530726ff8076b83b583e527e91ed


### PR DESCRIPTION
🤖 Resolves #12029 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Rolls the base Ubuntu version of the maintenance container back to 22.04.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->
I don't love that we have to call `apt-get update` twice but I don't think there's any way around it.

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Rebuild the container `docker compose build maintenance --no-cache`
2. Test out various make commands
3. Test out maintnenace shell `docker compose run --rm maintenance bash`
4. Confirm Playwright CI runs in GH
