### PR TITLE
[Fix] Notification dialog z-index

### DIFF
--- a/apps/web/src/components/NavMenu/MainNavMenu.tsx
+++ b/apps/web/src/components/NavMenu/MainNavMenu.tsx
@@ -286,7 +286,7 @@ const MainNavMenu = () => {
           data-h2-position="base(fixed)"
           data-h2-bottom="base(x.75)"
           data-h2-right="base(x.75)"
-          data-h2-z-index="base(9999)"
+          data-h2-z-index="base(10)"
           data-h2-display="base(flex)"
           data-h2-gap="base(x.5)"
         >

--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -80,7 +80,7 @@ const DialogPortalWithPresence = ({
         data-h2-background-color="base:all(black.light)"
         data-h2-position="base(fixed)"
         data-h2-location="base(0)"
-        data-h2-z-index="base(9997)"
+        data-h2-z-index="base(97)"
       />
       <DialogPrimitive.Content forceMount asChild>
         <m.div
@@ -102,7 +102,7 @@ const DialogPortalWithPresence = ({
           data-h2-margin="base(x.5 x.5 x.5 auto)"
           data-h2-radius="base(s)"
           data-h2-shadow="base(0 0.55rem 1rem -0.2rem rgba(0, 0, 0, .5))"
-          data-h2-z-index="base(9998)"
+          data-h2-z-index="base(98)"
         >
           <div data-h2-padding="base(x1)">
             <div

--- a/packages/ui/src/components/NavMenu/NavMenuWrapper.tsx
+++ b/packages/ui/src/components/NavMenu/NavMenuWrapper.tsx
@@ -98,7 +98,7 @@ const NavMenuWrapper = ({
             data-h2-right="base(x.75) l-tablet(auto)"
             data-h2-left="base(x.75) l-tablet(auto)"
             data-h2-width="l-tablet(100%)"
-            data-h2-z-index="base(9997)"
+            data-h2-z-index="base(7)"
             data-h2-overflow-y="base(auto) l-tablet(initial)"
             data-h2-max-height="base(85vh) l-tablet(none)"
             {...animConfig}
@@ -146,7 +146,7 @@ const NavMenuWrapper = ({
             data-h2-position="base(fixed)"
             data-h2-location="base(0, 0, 0, 0)"
             data-h2-background-color="base:all(black.light)"
-            data-h2-z-index="base(9996)"
+            data-h2-z-index="base(6)"
             data-h2-overflow="base(auto)"
             initial={{ opacity: 0.85 }}
             animate={{ opacity: 0.85 }}


### PR DESCRIPTION
🤖 Resolves #12020 

## 👋 Introduction

Fixes the action dropdown in the notification dialog to be a higher `z-index` than the dialog content.

## 🧪 Testing

1. Build app `pnpm run dev:fresh`
2. Login as any user
3. Force a notification
4. Open the notification dialog
5. Open the actions menu for the notification (vertical ellipses)
6. Confirm the menu is visible

## 📸 Screenshot

![2024-11-21_11-31](https://github.com/user-attachments/assets/3ae1c719-c723-41d1-b0bd-6013338896fc)
