### PR TITLE
[Debt] Removes the `experience.user` relationship

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -653,7 +653,6 @@ type SkillKeywords {
 
 interface Experience {
   id: ID!
-  user: User! @belongsTo(relation: "user") @canResolved(ability: "view")
   details: String
   skills: [Skill!] @hasMany
   # ExperienceSkillRecord is the pivot data and may only be queried when Experience is nested in a Skill (eg. skill->experiences->experienceSkillRecord). Querying for it otherwise will just return null.
@@ -1027,13 +1026,13 @@ type Query {
       )
       @with(
         relations: [
-          "user:id,first_name,last_name,email,preferred_lang",
-          "pool:id,process_number",
+          "user:id,first_name,last_name,email,preferred_lang"
+          "pool:id,process_number"
           "skills:id,name"
         ]
       )
-       # Limit fields for eager loading
-  ): [PoolCandidateWithSkillCount]!
+  ): # Limit fields for eager loading
+  [PoolCandidateWithSkillCount]!
     @guard
     @paginate(
       defaultCount: 10

--- a/api/programmatic-types.graphql
+++ b/api/programmatic-types.graphql
@@ -64,6 +64,16 @@ type LocalizedCitizenshipStatus {
   label: LocalizedString!
 }
 
+type LocalizedCourseFormat {
+  value: CourseFormat!
+  label: LocalizedString!
+}
+
+type LocalizedCourseLanguage {
+  value: CourseLanguage!
+  label: LocalizedString!
+}
+
 type LocalizedEducationRequirementOption {
   value: EducationRequirementOption!
   label: LocalizedString!
@@ -321,6 +331,15 @@ type NotificationPaginator {
 
   "A list of Notification items."
   data: [Notification!]!
+}
+
+"A paginated list of TrainingOpportunity items."
+type TrainingOpportunityPaginator {
+  "Pagination information about the list of items."
+  paginatorInfo: PaginatorInfo!
+
+  "A list of TrainingOpportunity items."
+  data: [TrainingOpportunity!]!
 }
 
 "Allowed column names for Query.poolsPaginated.orderBy."
@@ -672,6 +691,17 @@ enum ClaimVerificationResult {
   UNVERIFIED
 }
 
+enum CourseFormat {
+  ON_SITE
+  VIRTUAL
+}
+
+enum CourseLanguage {
+  ENGLISH
+  FRENCH
+  BILINGUAL
+}
+
 enum AdvertisementType {
   INTERNAL
   EXTERNAL
@@ -909,7 +939,7 @@ enum GenericJobTitleKey {
   TECHNICAL_ADVISOR_IT03
   SENIOR_ADVISOR_IT04
   MANAGER_IT04
-  EXECUTIVE_EX03
+  DIGITAL_LEADER_EX_03
 }
 
 enum GovEmployeeType {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -967,7 +967,6 @@ type SkillKeywords {
 
 interface Experience {
   id: ID!
-  user: User!
   details: String
   skills: [Skill!]
   experienceSkillRecord: ExperienceSkillRecord

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
@@ -43,10 +43,6 @@ export const CareerTimelineExperience_Fragment = graphql(/* GraphQL */ `
   fragment CareerTimelineExperience on Experience {
     id
     details
-    user {
-      id
-      email
-    }
     skills {
       id
       key

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -133,9 +133,6 @@ const ExperienceFormExperience_Fragment = graphql(/* GraphQL */ `
   fragment ExperienceFormExperience on Experience {
     id
     details
-    user {
-      id
-    }
     skills {
       id
       key

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -143,9 +143,6 @@ export const UpdateUserSkillExperience_Fragment = graphql(/* GraphQL */ `
     id
     __typename
     details
-    user {
-      id
-    }
     ... on AwardExperience {
       title
       issuedBy


### PR DESCRIPTION
🤖 Resolves #11230

## 👋 Introduction

Removes the `experience.user` relationship in our graphql API and updates some queries that were using it.

## 🕵️ Details

The queries using it seemed to be legacy documents that qeuried it only to satisfy the codegen types so removing them should now impact functionality.

## 🧪 Testing

1. Build the app `pnpm run dev:fresh`
2. Confirm no errors during codegen step
3. Navigate to the pages affected
4. Confirm no errors