### PR TITLE
[Feature] Training event admin CRUD pages

### DIFF
--- a/api/app/Enums/DeadlineStatus.php
+++ b/api/app/Enums/DeadlineStatus.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+use App\Traits\HasLocalization;
+
+enum DeadlineStatus
+{
+    use HasLocalization;
+
+    case PUBLISHED;
+    case EXPIRED;
+
+    public static function getLangFilename(): string
+    {
+        return 'deadline_status';
+    }
+}

--- a/api/app/Models/TrainingOpportunity.php
+++ b/api/app/Models/TrainingOpportunity.php
@@ -3,7 +3,9 @@
 namespace App\Models;
 
 use App\Enums\CourseLanguage;
+use App\Enums\DeadlineStatus;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -52,6 +54,7 @@ class TrainingOpportunity extends Model
     {
         // if true only display where registration deadline is in the future
         if (isset($filterBool) && $filterBool) {
+            // this should match the logic in registrationDeadlineStatus
             $query->where(function ($query) {
                 $query->whereDate('registration_deadline', '>=', date('Y-m-d'))
                     ->orWhereNull('registration_deadline');
@@ -69,5 +72,20 @@ class TrainingOpportunity extends Model
         }
 
         return $query;
+    }
+
+    /**
+     * Get the registration deadline status with respect to the current date
+     */
+    protected function registrationDeadlineStatus(): Attribute
+    {
+        /** @disregard P1003 Not using value parameter */
+        return Attribute::make(
+            // this should match the logic in scopeHidePassedRegistrationDeadline
+            get: fn (mixed $value, array $attributes) => $attributes['registration_deadline'] >= date('Y-m-d') || is_null($attributes['registration_deadline'])
+                ? DeadlineStatus::PUBLISHED->name
+                : DeadlineStatus::EXPIRED->name
+
+        );
     }
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -917,6 +917,7 @@ type TrainingOpportunity {
   title: LocalizedString
   courseLanguage: LocalizedCourseLanguage @rename(attribute: "course_language")
   registrationDeadline: Date @rename(attribute: "registration_deadline")
+  registrationDeadlineStatus: LocalizedDeadlineStatus
   trainingStart: Date @rename(attribute: "training_start")
   trainingEnd: Date @rename(attribute: "training_end")
   description: LocalizedString
@@ -1030,9 +1031,8 @@ type Query {
           "pool:id,process_number"
           "skills:id,name"
         ]
-      )
-  ): # Limit fields for eager loading
-  [PoolCandidateWithSkillCount]!
+      ) # Limit fields for eager loading
+  ): [PoolCandidateWithSkillCount]!
     @guard
     @paginate(
       defaultCount: 10
@@ -1093,6 +1093,7 @@ type Query {
   trainingOpportunity(id: UUID! @eq): TrainingOpportunity @find
   trainingOpportunitiesPaginated(
     where: TrainingOpportunitiesFilterInput
+    orderBy: [OrderByClause!] @orderBy
   ): [TrainingOpportunity]
     @paginate(
       defaultCount: 10

--- a/api/lang/en/deadline_status.php
+++ b/api/lang/en/deadline_status.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'published' => 'Published',
+    'expired' => 'Expired',
+];

--- a/api/lang/fr/deadline_status.php
+++ b/api/lang/fr/deadline_status.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'published' => 'Publié',
+    'expired' => 'Expiré',
+];

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -63,6 +63,11 @@ type LocalizedCourseLanguage {
   label: LocalizedString!
 }
 
+type LocalizedDeadlineStatus {
+  value: DeadlineStatus!
+  label: LocalizedString!
+}
+
 type LocalizedEducationRequirementOption {
   value: EducationRequirementOption!
   label: LocalizedString!
@@ -332,6 +337,7 @@ type Query {
   ): NotificationPaginator!
   trainingOpportunitiesPaginated(
     where: TrainingOpportunitiesFilterInput
+    orderBy: [OrderByClause!]
 
     "Limits number of fetched items. Maximum allowed value: 1000."
     first: Int! = 10
@@ -1210,6 +1216,7 @@ type TrainingOpportunity {
   title: LocalizedString
   courseLanguage: LocalizedCourseLanguage
   registrationDeadline: Date
+  registrationDeadlineStatus: LocalizedDeadlineStatus
   trainingStart: Date
   trainingEnd: Date
   description: LocalizedString
@@ -2690,6 +2697,11 @@ enum CourseLanguage {
   ENGLISH
   FRENCH
   BILINGUAL
+}
+
+enum DeadlineStatus {
+  PUBLISHED
+  EXPIRED
 }
 
 enum AdvertisementType {

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -782,6 +782,40 @@ const createRoute = (locale: Locales) =>
                 ],
               },
               {
+                path: "training-events",
+                children: [
+                  {
+                    index: true,
+                    lazy: () =>
+                      import("../pages/TrainingEvents/IndexTrainingEventsPage"),
+                  },
+                  {
+                    path: "create",
+                    lazy: () =>
+                      import("../pages/TrainingEvents/CreateTrainingEventPage"),
+                  },
+                  // {
+                  //   path: ":skillFamilyId",
+                  //   children: [
+                  //     {
+                  //       index: true,
+                  //       lazy: () =>
+                  //         import(
+                  //           "../pages/SkillFamilies/ViewSkillFamilyPage"
+                  //         ),
+                  //     },
+                  //     {
+                  //       path: "edit",
+                  //       lazy: () =>
+                  //         import(
+                  //           "../pages/SkillFamilies/UpdateSkillFamilyPage"
+                  //         ),
+                  //     },
+                  //   ],
+                  // },
+                ],
+              },
+              {
                 path: "settings",
                 children: [
                   {

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -794,25 +794,25 @@ const createRoute = (locale: Locales) =>
                     lazy: () =>
                       import("../pages/TrainingEvents/CreateTrainingEventPage"),
                   },
-                  // {
-                  //   path: ":skillFamilyId",
-                  //   children: [
-                  //     {
-                  //       index: true,
-                  //       lazy: () =>
-                  //         import(
-                  //           "../pages/SkillFamilies/ViewSkillFamilyPage"
-                  //         ),
-                  //     },
-                  //     {
-                  //       path: "edit",
-                  //       lazy: () =>
-                  //         import(
-                  //           "../pages/SkillFamilies/UpdateSkillFamilyPage"
-                  //         ),
-                  //     },
-                  //   ],
-                  // },
+                  {
+                    path: ":trainingEventId",
+                    children: [
+                      {
+                        index: true,
+                        lazy: () =>
+                          import(
+                            "../pages/TrainingEvents/ViewTrainingEventPage"
+                          ),
+                      },
+                      {
+                        path: "edit",
+                        lazy: () =>
+                          import(
+                            "../pages/TrainingEvents/UpdateTrainingEventPage"
+                          ),
+                      },
+                    ],
+                  },
                 ],
               },
               {

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -327,6 +327,9 @@ const getRoutes = (lang: Locales) => {
       [adminUrl, "training-events", "create"].join("/"),
     trainingEventView: (trainingEventId: string) =>
       [adminUrl, "training-events", trainingEventId].join("/"),
+    trainingEventUpdate: (trainingEventId: string) =>
+      [adminUrl, "training-events", trainingEventId, "edit"].join("/"),
+
     /**
      * Deprecated
      *

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -321,6 +321,12 @@ const getRoutes = (lang: Locales) => {
     // IT Training Fund
     itTrainingFund: () => [baseUrl, "it-training-fund"].join("/"),
 
+    // Training Events (Admin)
+    trainingEventsIndex: () => [adminUrl, "training-events"].join("/"),
+    trainingEventCreate: () =>
+      [adminUrl, "training-events", "create"].join("/"),
+    trainingEventView: (trainingEventId: string) =>
+      [adminUrl, "training-events", trainingEventId].join("/"),
     /**
      * Deprecated
      *

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -11038,9 +11038,9 @@
     "defaultMessage": "La durée de l’étude est équivalente à l’exigence du diplôme",
     "description": "Text for education accepted information context in screening decision dialog"
   },
-  "sk9CeW": {
+  "k3i6lU": {
     "defaultMessage": "Langue",
-    "description": "Legend for the Working Language Ability radio buttons"
+    "description": "Legend for a language input or title"
   },
   "skfKnv": {
     "defaultMessage": "Veuillez sélectionner les Premières Nations qui détiennent le statut ou les Premières Nations qui ne détiennent pas le statut.",

--- a/apps/web/src/messages/pageTitles.ts
+++ b/apps/web/src/messages/pageTitles.ts
@@ -66,4 +66,9 @@ export default defineMessages({
     id: "bVQ/rm",
     description: "Title for the index user page",
   },
+  trainingEvents: {
+    defaultMessage: "Training events",
+    id: "rrE3Zr",
+    description: "Title for the index training events page",
+  },
 });

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -203,6 +203,11 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
       ],
     },
     {
+      label: intl.formatMessage(pageTitles.trainingEvents),
+      href: adminRoutes.trainingEventsIndex(),
+      roles: [ROLE_NAME.PlatformAdmin],
+    },
+    {
       label: intl.formatMessage(navigationMessages.users),
       href: adminRoutes.userTable(),
       roles: [

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
@@ -179,12 +179,7 @@ const FormFields = ({ classifications, skills }: FormFieldsProps) => {
       >
         <RadioGroup
           idPrefix="languageAbility"
-          legend={intl.formatMessage({
-            defaultMessage: "Language",
-            id: "sk9CeW",
-            description:
-              "Legend for the Working Language Ability radio buttons",
-          })}
+          legend={intl.formatMessage(commonMessages.language)}
           name="languageAbility"
           items={[
             {

--- a/apps/web/src/pages/TrainingEvents/CreateTrainingEventPage.tsx
+++ b/apps/web/src/pages/TrainingEvents/CreateTrainingEventPage.tsx
@@ -7,8 +7,8 @@ import { useMutation, useQuery } from "urql";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 import {
   CreateTrainingOpportunityInput,
+  FragmentType,
   graphql,
-  LocalizedEnumString,
   Scalars,
 } from "@gc-digital-talent/graphql";
 import { toast } from "@gc-digital-talent/toast";
@@ -31,20 +31,20 @@ import pageTitles from "~/messages/pageTitles";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import { convertFormValuesToCreateInput, FormValues } from "./apiUtils";
-import TrainingEventForm from "./components/TrainingEventForm";
+import TrainingEventForm, {
+  TrainingEventFormOptions_Fragment,
+} from "./components/TrainingEventForm";
 
 interface CreateTrainingEventFormProps {
   handleCreateTrainingEvent: (
     input: CreateTrainingOpportunityInput,
   ) => Promise<Scalars["UUID"]["output"]>;
-  courseLanguages: LocalizedEnumString[];
-  courseFormats: LocalizedEnumString[];
+  formOptionsQuery: FragmentType<typeof TrainingEventFormOptions_Fragment>;
 }
 
 const CreateTrainingEventForm = ({
   handleCreateTrainingEvent,
-  courseLanguages,
-  courseFormats,
+  formOptionsQuery,
 }: CreateTrainingEventFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
@@ -101,10 +101,7 @@ const CreateTrainingEventForm = ({
               })}
             </Heading>
           </div>
-          <TrainingEventForm
-            courseLanguages={courseLanguages}
-            courseFormats={courseFormats}
-          />
+          <TrainingEventForm query={formOptionsQuery} />
           <CardSeparator />
           <div
             data-h2-display="base(flex)"
@@ -139,20 +136,7 @@ const CreateTrainingEventForm = ({
 
 const CreateTrainingEventPage_Query = graphql(/* GraphQL */ `
   query CreateTrainingEventPage {
-    courseLanguages: localizedEnumStrings(enumName: "CourseLanguage") {
-      value
-      label {
-        en
-        fr
-      }
-    }
-    courseFormats: localizedEnumStrings(enumName: "CourseFormat") {
-      value
-      label {
-        en
-        fr
-      }
-    }
+    ...TrainingEventFormOptions
   }
 `);
 
@@ -209,11 +193,10 @@ const CreateTrainingEventPage = () => {
       <Hero title={pageTitle} crumbs={navigationCrumbs} overlap centered>
         <div data-h2-margin-bottom="base(x3)">
           <Pending fetching={fetching} error={error}>
-            {data?.courseLanguages && data?.courseFormats ? (
+            {data ? (
               <CreateTrainingEventForm
+                formOptionsQuery={data}
                 handleCreateTrainingEvent={handleCreateTrainingEvent}
-                courseLanguages={data.courseLanguages}
-                courseFormats={data.courseFormats}
               />
             ) : (
               <NotFound

--- a/apps/web/src/pages/TrainingEvents/CreateTrainingEventPage.tsx
+++ b/apps/web/src/pages/TrainingEvents/CreateTrainingEventPage.tsx
@@ -6,13 +6,7 @@ import IdentificationIcon from "@heroicons/react/24/outline/IdentificationIcon";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 import { CreateDepartmentInput, Scalars } from "@gc-digital-talent/graphql";
 import { toast } from "@gc-digital-talent/toast";
-import {
-  CardBasic,
-  CardSectioned,
-  CardSeparator,
-  Heading,
-  Link,
-} from "@gc-digital-talent/ui";
+import { CardBasic, CardSeparator, Heading, Link } from "@gc-digital-talent/ui";
 import { Input, Submit } from "@gc-digital-talent/forms";
 import { errorMessages } from "@gc-digital-talent/i18n";
 
@@ -27,11 +21,13 @@ import adminMessages from "~/messages/adminMessages";
 type FormValues = CreateDepartmentInput;
 
 interface CreateTrainingEventFormProps {
-  handleTrainingEvent: (data: FormValues) => Promise<Scalars["UUID"]["output"]>;
+  handleCreateTrainingEvent: (
+    data: FormValues,
+  ) => Promise<Scalars["UUID"]["output"]>;
 }
 
 const CreateTrainingEventForm = ({
-  handleTrainingEvent,
+  handleCreateTrainingEvent,
 }: CreateTrainingEventFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
@@ -40,7 +36,7 @@ const CreateTrainingEventForm = ({
   const { handleSubmit } = methods;
 
   const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
-    return handleTrainingEvent({
+    return handleCreateTrainingEvent({
       departmentNumber: Number(data.departmentNumber),
       name: data.name,
     })
@@ -84,8 +80,8 @@ const CreateTrainingEventForm = ({
             >
               {intl.formatMessage({
                 defaultMessage: "Event information",
-                id: "2rnlFj",
-                description: "Heading for the 'create an event' form",
+                id: "8ZTHFe",
+                description: "Heading for the event form information section",
               })}
             </Heading>
           </div>
@@ -165,7 +161,7 @@ const CreateTrainingEventPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
   // const [, executeMutation] = useMutation(CreateDepartment_Mutation);
-  const handleCreateDepartment = (data: CreateDepartmentInput) =>
+  const handleCreateTrainingEvent = (data: CreateDepartmentInput) =>
     Promise.reject(new Error("TODO"));
   // executeMutation({ department: data }).then((result) => {
   //   if (result.data?.createDepartment?.id) {
@@ -204,7 +200,7 @@ const CreateTrainingEventPage = () => {
       <Hero title={pageTitle} crumbs={navigationCrumbs} overlap centered>
         <div data-h2-margin-bottom="base(x3)">
           <CreateTrainingEventForm
-            handleCreateDepartment={handleCreateDepartment}
+            handleCreateTrainingEvent={handleCreateTrainingEvent}
           />
         </div>
       </Hero>

--- a/apps/web/src/pages/TrainingEvents/CreateTrainingEventPage.tsx
+++ b/apps/web/src/pages/TrainingEvents/CreateTrainingEventPage.tsx
@@ -1,0 +1,223 @@
+import { useIntl } from "react-intl";
+import { useNavigate } from "react-router-dom";
+import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+import IdentificationIcon from "@heroicons/react/24/outline/IdentificationIcon";
+
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { CreateDepartmentInput, Scalars } from "@gc-digital-talent/graphql";
+import { toast } from "@gc-digital-talent/toast";
+import {
+  CardBasic,
+  CardSectioned,
+  CardSeparator,
+  Heading,
+  Link,
+} from "@gc-digital-talent/ui";
+import { Input, Submit } from "@gc-digital-talent/forms";
+import { errorMessages } from "@gc-digital-talent/i18n";
+
+import Hero from "~/components/Hero";
+import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import SEO from "~/components/SEO/SEO";
+import useRoutes from "~/hooks/useRoutes";
+import pageTitles from "~/messages/pageTitles";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
+import adminMessages from "~/messages/adminMessages";
+
+type FormValues = CreateDepartmentInput;
+
+interface CreateTrainingEventFormProps {
+  handleTrainingEvent: (data: FormValues) => Promise<Scalars["UUID"]["output"]>;
+}
+
+const CreateTrainingEventForm = ({
+  handleTrainingEvent,
+}: CreateTrainingEventFormProps) => {
+  const intl = useIntl();
+  const navigate = useNavigate();
+  const paths = useRoutes();
+  const methods = useForm<FormValues>();
+  const { handleSubmit } = methods;
+
+  const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
+    return handleTrainingEvent({
+      departmentNumber: Number(data.departmentNumber),
+      name: data.name,
+    })
+      .then((id) => {
+        navigate(paths.trainingEventView(id));
+        toast.success(
+          intl.formatMessage({
+            defaultMessage: "Training event created successfully!",
+            id: "g2DtHI",
+            description:
+              "Message displayed to user after a training event is created successfully.",
+          }),
+        );
+      })
+      .catch(() => {
+        toast.error(
+          intl.formatMessage({
+            defaultMessage: "Error: creating training event failed",
+            id: "K2cRGq",
+            description:
+              "Message displayed to user after a training event fails to get created.",
+          }),
+        );
+      });
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <CardBasic>
+          <div
+            data-h2-display="base(flex)"
+            data-h2-justify-content="base(center) p-tablet(flex-start)"
+          >
+            <Heading
+              level="h2"
+              color="primary"
+              Icon={IdentificationIcon}
+              data-h2-margin="base(0, 0, x1.5, 0)"
+              data-h2-font-weight="base(400)"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Event information",
+                id: "2rnlFj",
+                description: "Heading for the 'create an event' form",
+              })}
+            </Heading>
+          </div>
+          <div
+            data-h2-display="base(grid)"
+            data-h2-grid-template-columns="p-tablet(repeat(2, 1fr))"
+            data-h2-gap="base(x1)"
+          >
+            <Input
+              id="name_en"
+              name="name.en"
+              label={intl.formatMessage(adminMessages.nameEn)}
+              type="text"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <Input
+              id="name_fr"
+              name="name.fr"
+              label={intl.formatMessage(adminMessages.nameFr)}
+              type="text"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <div data-h2-grid-column="p-tablet(span 2)">
+              <Input
+                id="departmentNumber"
+                name="departmentNumber"
+                label={intl.formatMessage({
+                  defaultMessage: "Department number",
+                  id: "66kU6k",
+                  description: "Label for department number",
+                })}
+                type="number"
+                rules={{
+                  required: intl.formatMessage(errorMessages.required),
+                }}
+                min="0"
+              />
+            </div>
+          </div>
+          <CardSeparator />
+          <div
+            data-h2-display="base(flex)"
+            data-h2-flex-direction="base(column) p-tablet(row)"
+            data-h2-gap="base(x1)"
+            data-h2-align-items="base(center)"
+          >
+            <Submit
+              text={intl.formatMessage({
+                defaultMessage: "Create event",
+                id: "vRmMjQ",
+                description: "Button label to create a new event",
+              })}
+            />
+            <Link
+              color="warning"
+              mode="inline"
+              href={paths.trainingEventsIndex()}
+            >
+              {intl.formatMessage({
+                defaultMessage: "Cancel and go back to events",
+                id: "qTJFY0",
+                description: "Button label to return to the events table",
+              })}
+            </Link>
+          </div>
+        </CardBasic>
+      </form>
+    </FormProvider>
+  );
+};
+
+const CreateTrainingEventPage = () => {
+  const intl = useIntl();
+  const routes = useRoutes();
+  // const [, executeMutation] = useMutation(CreateDepartment_Mutation);
+  const handleCreateDepartment = (data: CreateDepartmentInput) =>
+    Promise.reject(new Error("TODO"));
+  // executeMutation({ department: data }).then((result) => {
+  //   if (result.data?.createDepartment?.id) {
+  //     return result.data.createDepartment.id;
+  //   }
+  // return Promise.reject(new Error(result.error?.toString()));
+  // });
+
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(pageTitles.trainingEvents),
+        url: routes.departmentTable(),
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Create<hidden> an event</hidden>",
+          id: "R6j8QR",
+          description:
+            "Breadcrumb title for the create training event page link.",
+        }),
+        url: routes.trainingEventCreate(),
+      },
+    ],
+  });
+
+  const pageTitle = intl.formatMessage({
+    defaultMessage: "Create an event",
+    id: "y6UFyA",
+    description: "Page title for the training event creation page",
+  });
+
+  return (
+    <>
+      <SEO title={pageTitle} />
+      <Hero title={pageTitle} crumbs={navigationCrumbs} overlap centered>
+        <div data-h2-margin-bottom="base(x3)">
+          <CreateTrainingEventForm
+            handleCreateDepartment={handleCreateDepartment}
+          />
+        </div>
+      </Hero>
+    </>
+  );
+};
+
+export const Component = () => (
+  <RequireAuth roles={[ROLE_NAME.PlatformAdmin]}>
+    <CreateTrainingEventPage />
+  </RequireAuth>
+);
+
+Component.displayName = "AdminCreateTrainingEventPage";
+
+export default CreateTrainingEventPage;

--- a/apps/web/src/pages/TrainingEvents/CreateTrainingEventPage.tsx
+++ b/apps/web/src/pages/TrainingEvents/CreateTrainingEventPage.tsx
@@ -7,7 +7,13 @@ import { ROLE_NAME } from "@gc-digital-talent/auth";
 import { CreateDepartmentInput, Scalars } from "@gc-digital-talent/graphql";
 import { toast } from "@gc-digital-talent/toast";
 import { CardBasic, CardSeparator, Heading, Link } from "@gc-digital-talent/ui";
-import { Input, Submit } from "@gc-digital-talent/forms";
+import {
+  DATE_SEGMENT,
+  DateInput,
+  Input,
+  RichTextInput,
+  Submit,
+} from "@gc-digital-talent/forms";
 import { errorMessages } from "@gc-digital-talent/i18n";
 
 import Hero from "~/components/Hero";
@@ -16,7 +22,8 @@ import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import pageTitles from "~/messages/pageTitles";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
-import adminMessages from "~/messages/adminMessages";
+
+import formLabels from "./formLabels";
 
 type FormValues = CreateDepartmentInput;
 
@@ -93,7 +100,7 @@ const CreateTrainingEventForm = ({
             <Input
               id="name_en"
               name="name.en"
-              label={intl.formatMessage(adminMessages.nameEn)}
+              label={intl.formatMessage(formLabels.titleEn)}
               type="text"
               rules={{
                 required: intl.formatMessage(errorMessages.required),
@@ -102,28 +109,107 @@ const CreateTrainingEventForm = ({
             <Input
               id="name_fr"
               name="name.fr"
-              label={intl.formatMessage(adminMessages.nameFr)}
+              label={intl.formatMessage(formLabels.titleFr)}
               type="text"
               rules={{
                 required: intl.formatMessage(errorMessages.required),
               }}
             />
-            <div data-h2-grid-column="p-tablet(span 2)">
-              <Input
-                id="departmentNumber"
-                name="departmentNumber"
-                label={intl.formatMessage({
-                  defaultMessage: "Department number",
-                  id: "66kU6k",
-                  description: "Label for department number",
-                })}
-                type="number"
-                rules={{
-                  required: intl.formatMessage(errorMessages.required),
-                }}
-                min="0"
-              />
+            <Input
+              id="name_en"
+              name="name.en"
+              label={intl.formatMessage(formLabels.courseLanguage)}
+              type="text"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <Input
+              id="name_fr"
+              name="name.fr"
+              label={intl.formatMessage(formLabels.format)}
+              type="text"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <DateInput
+              id="awardedDate"
+              legend={intl.formatMessage(formLabels.registrationDeadline)}
+              name="awardedDate"
+              show={[DATE_SEGMENT.Day, DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+                // max: {
+                //   value: strToFormDate(todayDate.toISOString()),
+                //   message: intl.formatMessage(errorMessages.mustNotBeFuture),
+                // },
+              }}
+            />
+            <div data-h2-display="base(none) p-tablet(inherit)">
+              {/* intentionally left blank */}
             </div>
+            <DateInput
+              id="awardedDate"
+              legend={intl.formatMessage(formLabels.trainingStartDate)}
+              name="awardedDate"
+              show={[DATE_SEGMENT.Day, DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+                // max: {
+                //   value: strToFormDate(todayDate.toISOString()),
+                //   message: intl.formatMessage(errorMessages.mustNotBeFuture),
+                // },
+              }}
+            />
+            <DateInput
+              id="awardedDate"
+              legend={intl.formatMessage(formLabels.trainingEndDate)}
+              name="awardedDate"
+              show={[DATE_SEGMENT.Day, DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+              rules={
+                {
+                  // max: {
+                  //   value: strToFormDate(todayDate.toISOString()),
+                  //   message: intl.formatMessage(errorMessages.mustNotBeFuture),
+                  // },
+                }
+              }
+            />
+            <RichTextInput
+              id="descriptionEn"
+              label={intl.formatMessage(formLabels.descriptionEn)}
+              name="descriptionEn"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <RichTextInput
+              id="descriptionFr"
+              label={intl.formatMessage(formLabels.descriptionFr)}
+              name="descriptionFr"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <Input
+              id="name_en"
+              name="name.en"
+              label={intl.formatMessage(formLabels.applicationUrlEn)}
+              type="text"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <Input
+              id="name_fr"
+              name="name.fr"
+              label={intl.formatMessage(formLabels.applicationUrlFr)}
+              type="text"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
           </div>
           <CardSeparator />
           <div

--- a/apps/web/src/pages/TrainingEvents/IndexTrainingEventsPage.tsx
+++ b/apps/web/src/pages/TrainingEvents/IndexTrainingEventsPage.tsx
@@ -1,0 +1,51 @@
+import { useIntl } from "react-intl";
+
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+
+import Hero from "~/components/Hero";
+import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import SEO from "~/components/SEO/SEO";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
+import useRoutes from "~/hooks/useRoutes";
+import pageTitles from "~/messages/pageTitles";
+
+import TrainingEventsTableApi from "./components/TrainingEventsTable";
+
+export const IndexTrainingEventsPage = () => {
+  const intl = useIntl();
+  const routes = useRoutes();
+
+  const formattedPageTitle = intl.formatMessage(pageTitles.trainingEvents);
+
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: formattedPageTitle,
+        url: routes.trainingEventsIndex(),
+      },
+    ],
+  });
+
+  return (
+    <>
+      <SEO title={formattedPageTitle} />
+      <Hero title={formattedPageTitle} crumbs={navigationCrumbs} />
+      <div
+        data-h2-margin="base(x3 0)"
+        data-h2-wrapper="base(center, large, x1) p-tablet(center, large, x2)"
+      >
+        <TrainingEventsTableApi title={formattedPageTitle} />
+      </div>
+    </>
+  );
+};
+
+export const Component = () => (
+  <RequireAuth roles={[ROLE_NAME.PlatformAdmin]}>
+    <IndexTrainingEventsPage />
+  </RequireAuth>
+);
+
+Component.displayName = "AdminIndexTrainingEventsPage";
+
+export default IndexTrainingEventsPage;

--- a/apps/web/src/pages/TrainingEvents/IndexTrainingEventsPage.tsx
+++ b/apps/web/src/pages/TrainingEvents/IndexTrainingEventsPage.tsx
@@ -9,7 +9,7 @@ import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import useRoutes from "~/hooks/useRoutes";
 import pageTitles from "~/messages/pageTitles";
 
-import TrainingEventsTableApi from "./components/TrainingEventsTable";
+import TrainingEventsTable from "./components/TrainingEventsTable";
 
 export const IndexTrainingEventsPage = () => {
   const intl = useIntl();
@@ -34,7 +34,7 @@ export const IndexTrainingEventsPage = () => {
         data-h2-margin="base(x3 0)"
         data-h2-wrapper="base(center, large, x1) p-tablet(center, large, x2)"
       >
-        <TrainingEventsTableApi title={formattedPageTitle} />
+        <TrainingEventsTable title={formattedPageTitle} />
       </div>
     </>
   );

--- a/apps/web/src/pages/TrainingEvents/UpdateTrainingEventPage.tsx
+++ b/apps/web/src/pages/TrainingEvents/UpdateTrainingEventPage.tsx
@@ -5,17 +5,8 @@ import IdentificationIcon from "@heroicons/react/24/outline/IdentificationIcon";
 import { useMutation, useQuery } from "urql";
 
 import { toast } from "@gc-digital-talent/toast";
+import { Submit } from "@gc-digital-talent/forms";
 import {
-  DATE_SEGMENT,
-  DateInput,
-  Input,
-  localizedEnumToOptions,
-  RichTextInput,
-  Select,
-  Submit,
-} from "@gc-digital-talent/forms";
-import {
-  errorMessages,
   commonMessages,
   formMessages,
   getLocalizedName,
@@ -29,8 +20,6 @@ import {
   Pending,
 } from "@gc-digital-talent/ui";
 import {
-  CourseFormat,
-  CourseLanguage,
   FragmentType,
   LocalizedEnumString,
   Scalars,
@@ -48,38 +37,13 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import pageTitles from "~/messages/pageTitles";
 import Hero from "~/components/Hero";
 
-import formLabels from "./formLabels";
 import {
   FormValues,
   TrainingEventForm_Fragment,
   convertApiFragmentToFormValues,
+  convertFormValuesToUpdateInput,
 } from "./apiUtils";
-
-function convertFormValuesToApiInput(
-  id: string,
-  formValues: FormValues,
-): UpdateTrainingOpportunityInput {
-  return {
-    id: id,
-    title: {
-      en: formValues.titleEn,
-      fr: formValues.titleFr,
-    },
-    courseLanguage: formValues.courseLanguage as CourseLanguage,
-    courseFormat: formValues.courseFormat as CourseFormat,
-    registrationDeadline: formValues.registrationDeadline,
-    trainingStart: formValues.trainingStart,
-    trainingEnd: formValues.trainingEnd,
-    description: {
-      en: formValues.descriptionEn,
-      fr: formValues.descriptionFr,
-    },
-    applicationUrl: {
-      en: formValues.applicationUrlEn,
-      fr: formValues.applicationUrlFr,
-    },
-  };
-}
+import TrainingEventForm from "./components/TrainingEventForm";
 
 interface UpdateTrainingEventFormProps {
   query: FragmentType<typeof TrainingEventForm_Fragment>;
@@ -90,7 +54,7 @@ interface UpdateTrainingEventFormProps {
   courseFormats: LocalizedEnumString[];
 }
 
-export const UpdateTrainingEventForm = ({
+const UpdateTrainingEventForm = ({
   query,
   handleUpdateTrainingEvent,
   courseLanguages,
@@ -113,7 +77,7 @@ export const UpdateTrainingEventForm = ({
     formValues: FormValues,
   ) => {
     return handleUpdateTrainingEvent(
-      convertFormValuesToApiInput(trainingEventId, formValues),
+      convertFormValuesToUpdateInput(trainingEventId, formValues),
     )
       .then(() => {
         navigate(paths.trainingEventView(trainingEventId));
@@ -160,121 +124,10 @@ export const UpdateTrainingEventForm = ({
               })}
             </Heading>
           </div>
-          <div
-            data-h2-display="base(grid)"
-            data-h2-grid-template-columns="p-tablet(repeat(2, 1fr))"
-            data-h2-gap="base(x1)"
-          >
-            <Input
-              id="titleEn"
-              name="titleEn"
-              label={intl.formatMessage(formLabels.titleEn)}
-              type="text"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-            />
-            <Input
-              id="titleFr"
-              name="titleFr"
-              label={intl.formatMessage(formLabels.titleFr)}
-              type="text"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-            />
-            <Select
-              id="courseLanguage"
-              name="courseLanguage"
-              label={intl.formatMessage(formLabels.courseLanguage)}
-              nullSelection={intl.formatMessage({
-                defaultMessage: "Select a language",
-                id: "uup5F2",
-                description:
-                  "Placeholder displayed on the user form preferred communication language field.",
-              })}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-              options={localizedEnumToOptions(courseLanguages, intl)}
-            />
-            <Select
-              id="courseFormat"
-              name="courseFormat"
-              label={intl.formatMessage(formLabels.format)}
-              nullSelection={intl.formatMessage({
-                defaultMessage: "Select a format",
-                id: "m3c4o8",
-                description:
-                  "Placeholder displayed on the select input for a format",
-              })}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-              options={localizedEnumToOptions(courseFormats, intl)}
-            />
-            <DateInput
-              id="registrationDeadline"
-              legend={intl.formatMessage(formLabels.registrationDeadline)}
-              name="registrationDeadline"
-              show={[DATE_SEGMENT.Day, DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-            />
-            <div data-h2-display="base(none) p-tablet(inherit)">
-              {/* intentionally left blank */}
-            </div>
-            <DateInput
-              id="trainingStart"
-              legend={intl.formatMessage(formLabels.trainingStartDate)}
-              name="trainingStart"
-              show={[DATE_SEGMENT.Day, DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-            />
-            <DateInput
-              id="trainingEnd"
-              legend={intl.formatMessage(formLabels.trainingEndDate)}
-              name="trainingEnd"
-              show={[DATE_SEGMENT.Day, DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
-            />
-            <RichTextInput
-              id="descriptionEn"
-              label={intl.formatMessage(formLabels.descriptionEn)}
-              name="descriptionEn"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-            />
-            <RichTextInput
-              id="descriptionFr"
-              label={intl.formatMessage(formLabels.descriptionFr)}
-              name="descriptionFr"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-            />
-            <Input
-              id="applicationUrlEn"
-              name="applicationUrlEn"
-              label={intl.formatMessage(formLabels.applicationUrlEn)}
-              type="text"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-            />
-            <Input
-              id="applicationUrlFr"
-              name="applicationUrlFr"
-              label={intl.formatMessage(formLabels.applicationUrlFr)}
-              type="text"
-              rules={{
-                required: intl.formatMessage(errorMessages.required),
-              }}
-            />
-          </div>
+          <TrainingEventForm
+            courseLanguages={courseLanguages}
+            courseFormats={courseFormats}
+          />
           <CardSeparator />
           <div
             data-h2-display="base(flex)"

--- a/apps/web/src/pages/TrainingEvents/UpdateTrainingEventPage.tsx
+++ b/apps/web/src/pages/TrainingEvents/UpdateTrainingEventPage.tsx
@@ -1,24 +1,22 @@
 import { useNavigate } from "react-router-dom";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
-import pick from "lodash/pick";
-import { useMutation, useQuery } from "urql";
 import IdentificationIcon from "@heroicons/react/24/outline/IdentificationIcon";
 
 import { toast } from "@gc-digital-talent/toast";
-import { Input, Submit } from "@gc-digital-talent/forms";
+import {
+  DATE_SEGMENT,
+  DateInput,
+  Input,
+  RichTextInput,
+  Submit,
+} from "@gc-digital-talent/forms";
 import {
   errorMessages,
   commonMessages,
   formMessages,
 } from "@gc-digital-talent/i18n";
-import {
-  NotFound,
-  Heading,
-  Link,
-  CardSeparator,
-  CardBasic,
-} from "@gc-digital-talent/ui";
+import { Heading, Link, CardSeparator, CardBasic } from "@gc-digital-talent/ui";
 import {
   FragmentType,
   Scalars,
@@ -30,11 +28,12 @@ import { ROLE_NAME } from "@gc-digital-talent/auth";
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import useRequiredParams from "~/hooks/useRequiredParams";
-import adminMessages from "~/messages/adminMessages";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import pageTitles from "~/messages/pageTitles";
 import Hero from "~/components/Hero";
+
+import formLabels from "./formLabels";
 
 export const DepartmentForm_Fragment = graphql(/* GraphQL */ `
   fragment DepartmentForm on Department {
@@ -132,7 +131,7 @@ export const UpdateTrainingEventForm = ({
             <Input
               id="name_en"
               name="name.en"
-              label={intl.formatMessage(adminMessages.nameEn)}
+              label={intl.formatMessage(formLabels.titleEn)}
               type="text"
               rules={{
                 required: intl.formatMessage(errorMessages.required),
@@ -141,28 +140,107 @@ export const UpdateTrainingEventForm = ({
             <Input
               id="name_fr"
               name="name.fr"
-              label={intl.formatMessage(adminMessages.nameFr)}
+              label={intl.formatMessage(formLabels.titleFr)}
               type="text"
               rules={{
                 required: intl.formatMessage(errorMessages.required),
               }}
             />
-            <div data-h2-grid-column="p-tablet(span 2)">
-              <Input
-                id="departmentNumber"
-                name="departmentNumber"
-                label={intl.formatMessage({
-                  defaultMessage: "Department number",
-                  id: "66kU6k",
-                  description: "Label for department number",
-                })}
-                type="number"
-                rules={{
-                  required: intl.formatMessage(errorMessages.required),
-                }}
-                min="0"
-              />
+            <Input
+              id="name_fr"
+              name="name.fr"
+              label={intl.formatMessage(formLabels.courseLanguage)}
+              type="text"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <Input
+              id="name_fr"
+              name="name.fr"
+              label={intl.formatMessage(formLabels.format)}
+              type="text"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <DateInput
+              id="awardedDate"
+              legend={intl.formatMessage(formLabels.registrationDeadline)}
+              name="awardedDate"
+              show={[DATE_SEGMENT.Day, DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+                // max: {
+                //   value: strToFormDate(todayDate.toISOString()),
+                //   message: intl.formatMessage(errorMessages.mustNotBeFuture),
+                // },
+              }}
+            />
+            <div data-h2-display="base(none) p-tablet(inherit)">
+              {/* intentionally left blank */}
             </div>
+            <DateInput
+              id="awardedDate"
+              legend={intl.formatMessage(formLabels.trainingStartDate)}
+              name="awardedDate"
+              show={[DATE_SEGMENT.Day, DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+                // max: {
+                //   value: strToFormDate(todayDate.toISOString()),
+                //   message: intl.formatMessage(errorMessages.mustNotBeFuture),
+                // },
+              }}
+            />
+            <DateInput
+              id="awardedDate"
+              legend={intl.formatMessage(formLabels.trainingEndDate)}
+              name="awardedDate"
+              show={[DATE_SEGMENT.Day, DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+              rules={
+                {
+                  // max: {
+                  //   value: strToFormDate(todayDate.toISOString()),
+                  //   message: intl.formatMessage(errorMessages.mustNotBeFuture),
+                  // },
+                }
+              }
+            />
+            <RichTextInput
+              id="descriptionEn"
+              label={intl.formatMessage(formLabels.descriptionEn)}
+              name="descriptionEn"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <RichTextInput
+              id="descriptionFr"
+              label={intl.formatMessage(formLabels.descriptionFr)}
+              name="descriptionFr"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <Input
+              id="name_fr"
+              name="name.fr"
+              label={intl.formatMessage(formLabels.applicationUrlEn)}
+              type="text"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <Input
+              id="name_fr"
+              name="name.fr"
+              label={intl.formatMessage(formLabels.applicationUrlFr)}
+              type="text"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
           </div>
           <CardSeparator />
           <div

--- a/apps/web/src/pages/TrainingEvents/UpdateTrainingEventPage.tsx
+++ b/apps/web/src/pages/TrainingEvents/UpdateTrainingEventPage.tsx
@@ -21,7 +21,6 @@ import {
 } from "@gc-digital-talent/ui";
 import {
   FragmentType,
-  LocalizedEnumString,
   Scalars,
   UpdateTrainingOpportunityInput,
   getFragment,
@@ -43,22 +42,22 @@ import {
   convertApiFragmentToFormValues,
   convertFormValuesToUpdateInput,
 } from "./apiUtils";
-import TrainingEventForm from "./components/TrainingEventForm";
+import TrainingEventForm, {
+  TrainingEventFormOptions_Fragment,
+} from "./components/TrainingEventForm";
 
 interface UpdateTrainingEventFormProps {
-  query: FragmentType<typeof TrainingEventForm_Fragment>;
+  trainingOpportunityQuery: FragmentType<typeof TrainingEventForm_Fragment>;
   handleUpdateTrainingEvent: (
     input: UpdateTrainingOpportunityInput,
   ) => Promise<FragmentType<typeof TrainingEventForm_Fragment>>;
-  courseLanguages: LocalizedEnumString[];
-  courseFormats: LocalizedEnumString[];
+  formOptionsQuery: FragmentType<typeof TrainingEventFormOptions_Fragment>;
 }
 
 const UpdateTrainingEventForm = ({
-  query,
+  trainingOpportunityQuery,
   handleUpdateTrainingEvent,
-  courseLanguages,
-  courseFormats,
+  formOptionsQuery,
 }: UpdateTrainingEventFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
@@ -66,7 +65,7 @@ const UpdateTrainingEventForm = ({
   const { trainingEventId } = useRequiredParams<RouteParams>("trainingEventId");
   const initialTrainingOpportunity = getFragment(
     TrainingEventForm_Fragment,
-    query,
+    trainingOpportunityQuery,
   );
   const methods = useForm<FormValues>({
     defaultValues: convertApiFragmentToFormValues(initialTrainingOpportunity),
@@ -124,10 +123,7 @@ const UpdateTrainingEventForm = ({
               })}
             </Heading>
           </div>
-          <TrainingEventForm
-            courseLanguages={courseLanguages}
-            courseFormats={courseFormats}
-          />
+          <TrainingEventForm query={formOptionsQuery} />
           <CardSeparator />
           <div
             data-h2-display="base(flex)"
@@ -163,20 +159,7 @@ const UpdateTrainingEventPage_Query = graphql(/* GraphQL */ `
       }
       ...TrainingEventView
     }
-    courseLanguages: localizedEnumStrings(enumName: "CourseLanguage") {
-      value
-      label {
-        en
-        fr
-      }
-    }
-    courseFormats: localizedEnumStrings(enumName: "CourseFormat") {
-      value
-      label {
-        en
-        fr
-      }
-    }
+    ...TrainingEventFormOptions
   }
 `);
 
@@ -246,14 +229,11 @@ const UpdateTrainingEventPage = () => {
       <Hero title={pageTitle} crumbs={navigationCrumbs} overlap centered>
         <div data-h2-margin-bottom="base(x3)">
           <Pending fetching={fetching} error={error}>
-            {data?.trainingOpportunity &&
-            data?.courseLanguages &&
-            data?.courseFormats ? (
+            {data?.trainingOpportunity ? (
               <UpdateTrainingEventForm
-                query={data.trainingOpportunity}
+                trainingOpportunityQuery={data.trainingOpportunity}
                 handleUpdateTrainingEvent={handleUpdateTrainingEvent}
-                courseLanguages={data.courseLanguages}
-                courseFormats={data.courseFormats}
+                formOptionsQuery={data}
               />
             ) : (
               <NotFound

--- a/apps/web/src/pages/TrainingEvents/UpdateTrainingEventPage.tsx
+++ b/apps/web/src/pages/TrainingEvents/UpdateTrainingEventPage.tsx
@@ -1,0 +1,315 @@
+import { useNavigate } from "react-router-dom";
+import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+import { useIntl } from "react-intl";
+import pick from "lodash/pick";
+import { useMutation, useQuery } from "urql";
+import IdentificationIcon from "@heroicons/react/24/outline/IdentificationIcon";
+
+import { toast } from "@gc-digital-talent/toast";
+import { Input, Submit } from "@gc-digital-talent/forms";
+import {
+  errorMessages,
+  commonMessages,
+  formMessages,
+} from "@gc-digital-talent/i18n";
+import {
+  NotFound,
+  Heading,
+  Link,
+  CardSeparator,
+  CardBasic,
+} from "@gc-digital-talent/ui";
+import {
+  FragmentType,
+  Scalars,
+  UpdateDepartmentInput,
+  graphql,
+} from "@gc-digital-talent/graphql";
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+
+import SEO from "~/components/SEO/SEO";
+import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
+import adminMessages from "~/messages/adminMessages";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
+import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import pageTitles from "~/messages/pageTitles";
+import Hero from "~/components/Hero";
+
+export const DepartmentForm_Fragment = graphql(/* GraphQL */ `
+  fragment DepartmentForm on Department {
+    id
+    departmentNumber
+    name {
+      en
+      fr
+    }
+  }
+`);
+
+type FormValues = UpdateDepartmentInput;
+
+interface UpdateTrainingEventFormProps {
+  // query: FragmentType<typeof DepartmentForm_Fragment>;
+  handleUpdateTrainingEvent: (
+    id: string,
+    data: FormValues,
+  ) => Promise<FragmentType<typeof DepartmentForm_Fragment>>;
+}
+
+export const UpdateTrainingEventForm = ({
+  // query,
+  handleUpdateTrainingEvent,
+}: UpdateTrainingEventFormProps) => {
+  const intl = useIntl();
+  const navigate = useNavigate();
+  const paths = useRoutes();
+  const { trainingEventId } = useRequiredParams<RouteParams>("trainingEventId");
+  // const initialDepartment = getFragment(DepartmentForm_Fragment, query);
+  const methods = useForm<FormValues>({
+    // defaultValues: {
+    //   departmentNumber: initialDepartment.departmentNumber,
+    //   name: initialDepartment.name,
+    // },
+  });
+  const { handleSubmit } = methods;
+
+  const onSubmit: SubmitHandler<FormValues> = async (data: FormValues) => {
+    return handleUpdateTrainingEvent(trainingEventId, {
+      departmentNumber: Number(data.departmentNumber),
+      name: data.name,
+    })
+      .then(() => {
+        navigate(paths.departmentView(trainingEventId));
+        toast.success(
+          intl.formatMessage({
+            defaultMessage: "Department updated successfully!",
+            id: "GTR9Pt",
+            description:
+              "Message displayed to user after department is updated successfully.",
+          }),
+        );
+      })
+      .catch(() => {
+        toast.error(
+          intl.formatMessage({
+            defaultMessage: "Error: updating department failed",
+            id: "nXRLAX",
+            description:
+              "Message displayed to user after department fails to get updated.",
+          }),
+        );
+      });
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <CardBasic>
+          <div
+            data-h2-display="base(flex)"
+            data-h2-justify-content="base(center) p-tablet(flex-start)"
+          >
+            <Heading
+              level="h2"
+              color="primary"
+              Icon={IdentificationIcon}
+              data-h2-margin="base(0, 0, x1.5, 0)"
+              data-h2-font-weight="base(400)"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Event information",
+                id: "8ZTHFe",
+                description: "Heading for the event form information section",
+              })}
+            </Heading>
+          </div>
+          <div
+            data-h2-display="base(grid)"
+            data-h2-grid-template-columns="p-tablet(repeat(2, 1fr))"
+            data-h2-gap="base(x1)"
+          >
+            <Input
+              id="name_en"
+              name="name.en"
+              label={intl.formatMessage(adminMessages.nameEn)}
+              type="text"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <Input
+              id="name_fr"
+              name="name.fr"
+              label={intl.formatMessage(adminMessages.nameFr)}
+              type="text"
+              rules={{
+                required: intl.formatMessage(errorMessages.required),
+              }}
+            />
+            <div data-h2-grid-column="p-tablet(span 2)">
+              <Input
+                id="departmentNumber"
+                name="departmentNumber"
+                label={intl.formatMessage({
+                  defaultMessage: "Department number",
+                  id: "66kU6k",
+                  description: "Label for department number",
+                })}
+                type="number"
+                rules={{
+                  required: intl.formatMessage(errorMessages.required),
+                }}
+                min="0"
+              />
+            </div>
+          </div>
+          <CardSeparator />
+          <div
+            data-h2-display="base(flex)"
+            data-h2-flex-direction="base(column) p-tablet(row)"
+            data-h2-gap="base(x1)"
+            data-h2-align-items="base(center)"
+          >
+            <Submit text={intl.formatMessage(formMessages.saveChanges)} />
+            <Link
+              color="warning"
+              mode="inline"
+              href={paths.departmentView(trainingEventId)}
+            >
+              {intl.formatMessage(commonMessages.cancel)}
+            </Link>
+          </div>
+        </CardBasic>
+      </form>
+    </FormProvider>
+  );
+};
+
+interface RouteParams extends Record<string, string> {
+  trainingEventId: Scalars["ID"]["output"];
+}
+
+// const Department_Query = graphql(/* GraphQL */ `
+//   query Department($id: UUID!) {
+//     department(id: $id) {
+//       name {
+//         en
+//         fr
+//       }
+//       ...DepartmentForm
+//     }
+//   }
+// `);
+
+// const UpdateDepartment_Mutation = graphql(/* GraphQL */ `
+//   mutation UpdateDepartment($id: ID!, $department: UpdateDepartmentInput!) {
+//     updateDepartment(id: $id, department: $department) {
+//       ...DepartmentForm
+//     }
+//   }
+// `);
+
+const UpdateTrainingEventPage = () => {
+  const intl = useIntl();
+  const routes = useRoutes();
+  const { trainingEventId } = useRequiredParams<RouteParams>("trainingEventId");
+  // const [{ data: departmentData, fetching, error }] = useQuery({
+  //   query: Department_Query,
+  //   variables: { id: trainingEventId },
+  // });
+  // const [, executeMutation] = useMutation(UpdateDepartment_Mutation);
+  const handleUpdateTrainingEvent = (id: string, data: UpdateDepartmentInput) =>
+    Promise.reject(new Error("TODO"));
+  // executeMutation({
+  //   id,
+  //   department: pick(data, [
+  //     "departmentName",
+  //     "name.en",
+  //     "name.fr",
+  //     "departmentNumber",
+  //   ]),
+  // }).then((result) => {
+  //   if (result.data?.updateDepartment) {
+  //     return result.data?.updateDepartment;
+  //   }
+  //   return Promise.reject(new Error(result.error?.toString()));
+  // });
+
+  const trainingEventName = "TODO";
+  // const trainingEventName = getLocalizedName(
+  //   departmentData?.department?.name,
+  //   intl,
+  // );
+
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(pageTitles.trainingEvents),
+        url: routes.trainingEventsIndex(),
+      },
+      {
+        label: trainingEventName,
+        url: routes.trainingEventView(trainingEventId),
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "Edit<hidden> event</hidden>",
+          id: "NNWkJH",
+          description:
+            "Breadcrumb title for the edit training event page link.",
+        }),
+        url: routes.trainingEventUpdate(trainingEventId),
+      },
+    ],
+  });
+
+  const pageTitle = intl.formatMessage({
+    defaultMessage: "Edit an event",
+    id: "bUat3o",
+    description: "Page title for the training event edit page",
+  });
+
+  return (
+    <>
+      <SEO title={pageTitle} />
+      <Hero title={pageTitle} crumbs={navigationCrumbs} overlap centered>
+        <div data-h2-margin-bottom="base(x3)">
+          {/* <Pending fetching={fetching} error={error}> */}
+          {/* {departmentData?.department ? ( */}
+          <UpdateTrainingEventForm
+            // query={departmentData.department}
+            handleUpdateTrainingEvent={handleUpdateTrainingEvent}
+          />
+          {/* ) : (
+            <NotFound
+              headingMessage={intl.formatMessage(commonMessages.notFound)}
+            >
+              <p>
+                {intl.formatMessage(
+                  {
+                    defaultMessage: "Department {departmentId} not found.",
+                    id: "8Otaw9",
+                    description: "Message displayed for department not found.",
+                  },
+                  { departmentId: trainingEventId },
+                )}
+              </p>
+            </NotFound>
+          )} */}
+          {/* </Pending> */}
+        </div>
+      </Hero>
+    </>
+  );
+};
+
+export const Component = () => (
+  <RequireAuth roles={[ROLE_NAME.PlatformAdmin]}>
+    <UpdateTrainingEventPage />
+  </RequireAuth>
+);
+
+Component.displayName = "AdminUpdateTrainingEventPage";
+
+export default UpdateTrainingEventPage;

--- a/apps/web/src/pages/TrainingEvents/ViewTrainingEventPage.tsx
+++ b/apps/web/src/pages/TrainingEvents/ViewTrainingEventPage.tsx
@@ -20,7 +20,8 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import pageTitles from "~/messages/pageTitles";
 import Hero from "~/components/Hero";
 import FieldDisplay from "~/components/ToggleForm/FieldDisplay";
-import adminMessages from "~/messages/adminMessages";
+
+import formLabels from "./formLabels";
 
 // export const DepartmentView_Fragment = graphql(/* GraphQL */ `
 //   fragment DepartmentForm on Department {
@@ -71,23 +72,52 @@ export const ViewTrainingEventForm =
             data-h2-grid-template-columns="p-tablet(repeat(2, 1fr)) "
             data-h2-gap="base(x1)"
           >
-            <FieldDisplay label={intl.formatMessage(adminMessages.nameEn)}>
+            <FieldDisplay label={intl.formatMessage(formLabels.titleEn)}>
               {/* {department.name.en} */}
             </FieldDisplay>
-            <FieldDisplay label={intl.formatMessage(adminMessages.nameFr)}>
+            <FieldDisplay label={intl.formatMessage(formLabels.titleFr)}>
               {/* {department.name.fr} */}
             </FieldDisplay>
-            <div data-h2-grid-column="p-tablet(span 2)">
-              <FieldDisplay
-                label={intl.formatMessage({
-                  defaultMessage: "Department number",
-                  id: "66kU6k",
-                  description: "Label for department number",
-                })}
-              >
-                {/* {department.departmentNumber} */}
-              </FieldDisplay>
+            <FieldDisplay label={intl.formatMessage(formLabels.courseLanguage)}>
+              {/* {department.name.en} */}
+            </FieldDisplay>
+            <FieldDisplay label={intl.formatMessage(formLabels.format)}>
+              {/* {department.name.fr} */}
+            </FieldDisplay>
+            <FieldDisplay
+              label={intl.formatMessage(formLabels.registrationDeadline)}
+            >
+              {/* {department.name.fr} */}
+            </FieldDisplay>
+            <div data-h2-display="base(none) p-tablet(inherit)">
+              {/* intentionally left blank */}
             </div>
+            <FieldDisplay
+              label={intl.formatMessage(formLabels.trainingStartDate)}
+            >
+              {/* {department.name.fr} */}
+            </FieldDisplay>
+            <FieldDisplay
+              label={intl.formatMessage(formLabels.trainingEndDate)}
+            >
+              {/* {department.name.fr} */}
+            </FieldDisplay>
+            <FieldDisplay label={intl.formatMessage(formLabels.descriptionEn)}>
+              {/* {department.name.fr} */}
+            </FieldDisplay>
+            <FieldDisplay label={intl.formatMessage(formLabels.descriptionFr)}>
+              {/* {department.name.fr} */}
+            </FieldDisplay>
+            <FieldDisplay
+              label={intl.formatMessage(formLabels.applicationUrlEn)}
+            >
+              {/* {department.name.fr} */}
+            </FieldDisplay>
+            <FieldDisplay
+              label={intl.formatMessage(formLabels.applicationUrlFr)}
+            >
+              {/* {department.name.fr} */}
+            </FieldDisplay>
           </div>
           <CardSeparator />
           <div

--- a/apps/web/src/pages/TrainingEvents/ViewTrainingEventPage.tsx
+++ b/apps/web/src/pages/TrainingEvents/ViewTrainingEventPage.tsx
@@ -32,41 +32,10 @@ import FieldDisplay from "~/components/ToggleForm/FieldDisplay";
 import adminMessages from "~/messages/adminMessages";
 
 import formLabels from "./formLabels";
-
-export const TrainingEventView_Fragment = graphql(/* GraphQL */ `
-  fragment TrainingEventView on TrainingOpportunity {
-    title {
-      en
-      fr
-    }
-    courseLanguage {
-      label {
-        en
-        fr
-      }
-    }
-    courseFormat {
-      label {
-        en
-        fr
-      }
-    }
-    registrationDeadline
-    trainingStart
-    trainingEnd
-    description {
-      en
-      fr
-    }
-    applicationUrl {
-      en
-      fr
-    }
-  }
-`);
+import { TrainingEventForm_Fragment } from "./apiUtils";
 
 interface ViewTrainingEventFormProps {
-  query: FragmentType<typeof TrainingEventView_Fragment>;
+  query: FragmentType<typeof TrainingEventForm_Fragment>;
 }
 
 export const ViewTrainingEventForm = ({
@@ -75,7 +44,7 @@ export const ViewTrainingEventForm = ({
   const intl = useIntl();
   const paths = useRoutes();
   const { trainingEventId } = useRequiredParams<RouteParams>("trainingEventId");
-  const trainingOpportunity = getFragment(TrainingEventView_Fragment, query);
+  const trainingOpportunity = getFragment(TrainingEventForm_Fragment, query);
 
   return (
     <>
@@ -187,7 +156,7 @@ interface RouteParams extends Record<string, string> {
   trainingEventId: Scalars["ID"]["output"];
 }
 
-const TrainingEventPage_Query = graphql(/* GraphQL */ `
+const ViewTrainingEventPage_Query = graphql(/* GraphQL */ `
   query ViewTrainingEventPage($id: UUID!) {
     trainingOpportunity(id: $id) {
       title {
@@ -204,7 +173,7 @@ const ViewTrainingEventPage = () => {
   const routes = useRoutes();
   const { trainingEventId } = useRequiredParams<RouteParams>("trainingEventId");
   const [{ data, fetching, error }] = useQuery({
-    query: TrainingEventPage_Query,
+    query: ViewTrainingEventPage_Query,
     variables: { id: trainingEventId },
   });
 

--- a/apps/web/src/pages/TrainingEvents/ViewTrainingEventPage.tsx
+++ b/apps/web/src/pages/TrainingEvents/ViewTrainingEventPage.tsx
@@ -1,0 +1,217 @@
+import { useIntl } from "react-intl";
+import IdentificationIcon from "@heroicons/react/24/outline/IdentificationIcon";
+
+import { commonMessages } from "@gc-digital-talent/i18n";
+import {
+  NotFound,
+  Heading,
+  Link,
+  CardBasic,
+  CardSeparator,
+} from "@gc-digital-talent/ui";
+import { Scalars } from "@gc-digital-talent/graphql";
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+
+import SEO from "~/components/SEO/SEO";
+import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
+import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import pageTitles from "~/messages/pageTitles";
+import Hero from "~/components/Hero";
+import FieldDisplay from "~/components/ToggleForm/FieldDisplay";
+import adminMessages from "~/messages/adminMessages";
+
+// export const DepartmentView_Fragment = graphql(/* GraphQL */ `
+//   fragment DepartmentForm on Department {
+//     id
+//     departmentNumber
+//     name {
+//       en
+//       fr
+//     }
+//   }
+// `);
+
+interface ViewTrainingEventFormProps {
+  // query: FragmentType<typeof DepartmentView_Fragment>;
+}
+
+export const ViewTrainingEventForm =
+  (/*{ query }: ViewTrainingEventFormProps*/) => {
+    const intl = useIntl();
+    const paths = useRoutes();
+    const { trainingEventId } =
+      useRequiredParams<RouteParams>("trainingEventId");
+    // const department = getFragment(DepartmentView_Fragment, query);
+
+    return (
+      <>
+        <div
+          data-h2-display="base(flex)"
+          data-h2-justify-content="base(center) p-tablet(flex-start)"
+        >
+          <Heading
+            level="h2"
+            color="primary"
+            Icon={IdentificationIcon}
+            data-h2-margin="base(0, 0, x1.5, 0)"
+            data-h2-font-weight="base(400)"
+          >
+            {intl.formatMessage({
+              defaultMessage: "Event information",
+              id: "8ZTHFe",
+              description: "Heading for the event form information section",
+            })}
+          </Heading>
+        </div>
+        <CardBasic>
+          <div
+            data-h2-display="base(grid)"
+            data-h2-grid-template-columns="p-tablet(repeat(2, 1fr)) "
+            data-h2-gap="base(x1)"
+          >
+            <FieldDisplay label={intl.formatMessage(adminMessages.nameEn)}>
+              {/* {department.name.en} */}
+            </FieldDisplay>
+            <FieldDisplay label={intl.formatMessage(adminMessages.nameFr)}>
+              {/* {department.name.fr} */}
+            </FieldDisplay>
+            <div data-h2-grid-column="p-tablet(span 2)">
+              <FieldDisplay
+                label={intl.formatMessage({
+                  defaultMessage: "Department number",
+                  id: "66kU6k",
+                  description: "Label for department number",
+                })}
+              >
+                {/* {department.departmentNumber} */}
+              </FieldDisplay>
+            </div>
+          </div>
+          <CardSeparator />
+          <div
+            data-h2-display="base(flex)"
+            data-h2-justify-content="base(center) p-tablet(flex-start)"
+          >
+            <Link
+              href={paths.trainingEventUpdate(trainingEventId)}
+              data-h2-font-weight="base(bold)"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Edit event information",
+                id: "i83KtN",
+                description: "Link to edit the currently viewed training event",
+              })}
+            </Link>
+          </div>
+        </CardBasic>
+      </>
+    );
+  };
+
+interface RouteParams extends Record<string, string> {
+  trainingEventId: Scalars["ID"]["output"];
+}
+
+// const Department_Query = graphql(/* GraphQL */ `
+//   query ViewDepartmentPage($id: UUID!) {
+//     department(id: $id) {
+//       name {
+//         en
+//         fr
+//       }
+//       ...DepartmentForm
+//     }
+//   }
+// `);
+
+const ViewTrainingEventPage = () => {
+  const intl = useIntl();
+  const routes = useRoutes();
+  const { trainingEventId } = useRequiredParams<RouteParams>("trainingEventId");
+  // const [{ data: departmentData, fetching, error }] = useQuery({
+  //   query: Department_Query,
+  //   variables: { id: departmentId },
+  // });
+
+  const trainingEventName = "TODO";
+  // const trainingEventName = getLocalizedName(
+  //   departmentData?.department?.name,
+  //   intl,
+  // );
+
+  const navigationCrumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(pageTitles.trainingEvents),
+        url: routes.trainingEventsIndex(),
+      },
+      {
+        label: trainingEventName,
+        url: routes.trainingEventView(trainingEventId),
+      },
+    ],
+  });
+
+  const navTabs = [
+    {
+      url: routes.trainingEventView(trainingEventId),
+      label: intl.formatMessage({
+        defaultMessage: "Event information",
+        id: "8ZTHFe",
+        description: "Heading for the event form information section",
+      }),
+    },
+  ];
+
+  return (
+    <>
+      <SEO title={trainingEventName} />
+      <Hero
+        title={
+          /* fetching ? intl.formatMessage(commonMessages.loading) :*/ trainingEventName
+        }
+        crumbs={navigationCrumbs}
+        navTabs={navTabs}
+      />
+      <div data-h2-wrapper="base(center, large, x1) p-tablet(center, large, x2)">
+        <div data-h2-padding="base(x3, 0)">
+          {/* <Pending fetching={fetching} error={error}> */}
+          {true /*departmentData?.department*/ ? (
+            <ViewTrainingEventForm
+            // query={departmentData?.department}
+            />
+          ) : (
+            <NotFound
+              headingMessage={intl.formatMessage(commonMessages.notFound)}
+            >
+              <p>
+                {intl.formatMessage(
+                  {
+                    defaultMessage: "Event {trainingEventId} not found.",
+                    id: "z1otyE",
+                    description:
+                      "Message displayed for training event not found.",
+                  },
+                  { trainingEventId },
+                )}
+              </p>
+            </NotFound>
+          )}
+          {/* </Pending> */}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export const Component = () => (
+  <RequireAuth roles={[ROLE_NAME.PlatformAdmin]}>
+    <ViewTrainingEventPage />
+  </RequireAuth>
+);
+
+Component.displayName = "AdminViewTrainingEventPage";
+
+export default ViewTrainingEventPage;

--- a/apps/web/src/pages/TrainingEvents/ViewTrainingEventPage.tsx
+++ b/apps/web/src/pages/TrainingEvents/ViewTrainingEventPage.tsx
@@ -1,16 +1,25 @@
 import { useIntl } from "react-intl";
 import IdentificationIcon from "@heroicons/react/24/outline/IdentificationIcon";
+import { useQuery } from "urql";
 
-import { commonMessages } from "@gc-digital-talent/i18n";
+import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import {
   NotFound,
   Heading,
   Link,
   CardBasic,
   CardSeparator,
+  Pending,
+  Chip,
 } from "@gc-digital-talent/ui";
-import { Scalars } from "@gc-digital-talent/graphql";
+import {
+  FragmentType,
+  getFragment,
+  graphql,
+  Scalars,
+} from "@gc-digital-talent/graphql";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { htmlToRichTextJSON, RichTextRenderer } from "@gc-digital-talent/forms";
 
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
@@ -20,156 +29,189 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import pageTitles from "~/messages/pageTitles";
 import Hero from "~/components/Hero";
 import FieldDisplay from "~/components/ToggleForm/FieldDisplay";
+import adminMessages from "~/messages/adminMessages";
 
 import formLabels from "./formLabels";
 
-// export const DepartmentView_Fragment = graphql(/* GraphQL */ `
-//   fragment DepartmentForm on Department {
-//     id
-//     departmentNumber
-//     name {
-//       en
-//       fr
-//     }
-//   }
-// `);
+export const TrainingEventView_Fragment = graphql(/* GraphQL */ `
+  fragment TrainingEventView on TrainingOpportunity {
+    title {
+      en
+      fr
+    }
+    courseLanguage {
+      label {
+        en
+        fr
+      }
+    }
+    courseFormat {
+      label {
+        en
+        fr
+      }
+    }
+    registrationDeadline
+    trainingStart
+    trainingEnd
+    description {
+      en
+      fr
+    }
+    applicationUrl {
+      en
+      fr
+    }
+  }
+`);
 
 interface ViewTrainingEventFormProps {
-  // query: FragmentType<typeof DepartmentView_Fragment>;
+  query: FragmentType<typeof TrainingEventView_Fragment>;
 }
 
-export const ViewTrainingEventForm =
-  (/*{ query }: ViewTrainingEventFormProps*/) => {
-    const intl = useIntl();
-    const paths = useRoutes();
-    const { trainingEventId } =
-      useRequiredParams<RouteParams>("trainingEventId");
-    // const department = getFragment(DepartmentView_Fragment, query);
+export const ViewTrainingEventForm = ({
+  query,
+}: ViewTrainingEventFormProps) => {
+  const intl = useIntl();
+  const paths = useRoutes();
+  const { trainingEventId } = useRequiredParams<RouteParams>("trainingEventId");
+  const trainingOpportunity = getFragment(TrainingEventView_Fragment, query);
 
-    return (
-      <>
+  return (
+    <>
+      <div
+        data-h2-display="base(flex)"
+        data-h2-justify-content="base(center) p-tablet(flex-start)"
+      >
+        <Heading
+          level="h2"
+          color="primary"
+          Icon={IdentificationIcon}
+          data-h2-margin="base(0, 0, x1.5, 0)"
+          data-h2-font-weight="base(400)"
+        >
+          {intl.formatMessage({
+            defaultMessage: "Event information",
+            id: "8ZTHFe",
+            description: "Heading for the event form information section",
+          })}
+        </Heading>
+      </div>
+      <CardBasic>
+        <div
+          data-h2-display="base(grid)"
+          data-h2-grid-template-columns="p-tablet(repeat(2, 1fr)) "
+          data-h2-gap="base(x1)"
+        >
+          <FieldDisplay label={intl.formatMessage(formLabels.titleEn)}>
+            {trainingOpportunity.title?.en}
+          </FieldDisplay>
+          <FieldDisplay label={intl.formatMessage(formLabels.titleFr)}>
+            {trainingOpportunity.title?.fr}
+          </FieldDisplay>
+          <FieldDisplay label={intl.formatMessage(formLabels.courseLanguage)}>
+            <Chip color="primary">
+              {getLocalizedName(
+                trainingOpportunity.courseLanguage?.label,
+                intl,
+              )}
+            </Chip>
+          </FieldDisplay>
+          <FieldDisplay label={intl.formatMessage(formLabels.format)}>
+            {getLocalizedName(trainingOpportunity.courseFormat?.label, intl)}
+          </FieldDisplay>
+          <FieldDisplay
+            label={intl.formatMessage(formLabels.registrationDeadline)}
+          >
+            {trainingOpportunity.registrationDeadline}
+          </FieldDisplay>
+          <div data-h2-display="base(none) p-tablet(inherit)">
+            {/* intentionally left blank */}
+          </div>
+          <FieldDisplay
+            label={intl.formatMessage(formLabels.trainingStartDate)}
+          >
+            {trainingOpportunity.trainingStart}
+          </FieldDisplay>
+          <FieldDisplay label={intl.formatMessage(formLabels.trainingEndDate)}>
+            {trainingOpportunity.trainingEnd ??
+              intl.formatMessage(adminMessages.noneProvided)}
+          </FieldDisplay>
+          <FieldDisplay label={intl.formatMessage(formLabels.descriptionEn)}>
+            {trainingOpportunity.description?.en ? (
+              <RichTextRenderer
+                node={htmlToRichTextJSON(trainingOpportunity.description.en)}
+              />
+            ) : (
+              intl.formatMessage(adminMessages.noneProvided)
+            )}
+          </FieldDisplay>
+          <FieldDisplay label={intl.formatMessage(formLabels.descriptionFr)}>
+            {trainingOpportunity.description?.fr ? (
+              <RichTextRenderer
+                node={htmlToRichTextJSON(trainingOpportunity.description.fr)}
+              />
+            ) : (
+              intl.formatMessage(adminMessages.noneProvided)
+            )}
+          </FieldDisplay>
+          <FieldDisplay label={intl.formatMessage(formLabels.applicationUrlEn)}>
+            {trainingOpportunity.applicationUrl?.en}
+          </FieldDisplay>
+          <FieldDisplay label={intl.formatMessage(formLabels.applicationUrlFr)}>
+            {trainingOpportunity.applicationUrl?.fr}
+          </FieldDisplay>
+        </div>
+        <CardSeparator />
         <div
           data-h2-display="base(flex)"
           data-h2-justify-content="base(center) p-tablet(flex-start)"
         >
-          <Heading
-            level="h2"
-            color="primary"
-            Icon={IdentificationIcon}
-            data-h2-margin="base(0, 0, x1.5, 0)"
-            data-h2-font-weight="base(400)"
+          <Link
+            href={paths.trainingEventUpdate(trainingEventId)}
+            data-h2-font-weight="base(bold)"
           >
             {intl.formatMessage({
-              defaultMessage: "Event information",
-              id: "8ZTHFe",
-              description: "Heading for the event form information section",
+              defaultMessage: "Edit event information",
+              id: "i83KtN",
+              description: "Link to edit the currently viewed training event",
             })}
-          </Heading>
+          </Link>
         </div>
-        <CardBasic>
-          <div
-            data-h2-display="base(grid)"
-            data-h2-grid-template-columns="p-tablet(repeat(2, 1fr)) "
-            data-h2-gap="base(x1)"
-          >
-            <FieldDisplay label={intl.formatMessage(formLabels.titleEn)}>
-              {/* {department.name.en} */}
-            </FieldDisplay>
-            <FieldDisplay label={intl.formatMessage(formLabels.titleFr)}>
-              {/* {department.name.fr} */}
-            </FieldDisplay>
-            <FieldDisplay label={intl.formatMessage(formLabels.courseLanguage)}>
-              {/* {department.name.en} */}
-            </FieldDisplay>
-            <FieldDisplay label={intl.formatMessage(formLabels.format)}>
-              {/* {department.name.fr} */}
-            </FieldDisplay>
-            <FieldDisplay
-              label={intl.formatMessage(formLabels.registrationDeadline)}
-            >
-              {/* {department.name.fr} */}
-            </FieldDisplay>
-            <div data-h2-display="base(none) p-tablet(inherit)">
-              {/* intentionally left blank */}
-            </div>
-            <FieldDisplay
-              label={intl.formatMessage(formLabels.trainingStartDate)}
-            >
-              {/* {department.name.fr} */}
-            </FieldDisplay>
-            <FieldDisplay
-              label={intl.formatMessage(formLabels.trainingEndDate)}
-            >
-              {/* {department.name.fr} */}
-            </FieldDisplay>
-            <FieldDisplay label={intl.formatMessage(formLabels.descriptionEn)}>
-              {/* {department.name.fr} */}
-            </FieldDisplay>
-            <FieldDisplay label={intl.formatMessage(formLabels.descriptionFr)}>
-              {/* {department.name.fr} */}
-            </FieldDisplay>
-            <FieldDisplay
-              label={intl.formatMessage(formLabels.applicationUrlEn)}
-            >
-              {/* {department.name.fr} */}
-            </FieldDisplay>
-            <FieldDisplay
-              label={intl.formatMessage(formLabels.applicationUrlFr)}
-            >
-              {/* {department.name.fr} */}
-            </FieldDisplay>
-          </div>
-          <CardSeparator />
-          <div
-            data-h2-display="base(flex)"
-            data-h2-justify-content="base(center) p-tablet(flex-start)"
-          >
-            <Link
-              href={paths.trainingEventUpdate(trainingEventId)}
-              data-h2-font-weight="base(bold)"
-            >
-              {intl.formatMessage({
-                defaultMessage: "Edit event information",
-                id: "i83KtN",
-                description: "Link to edit the currently viewed training event",
-              })}
-            </Link>
-          </div>
-        </CardBasic>
-      </>
-    );
-  };
+      </CardBasic>
+    </>
+  );
+};
 
 interface RouteParams extends Record<string, string> {
   trainingEventId: Scalars["ID"]["output"];
 }
 
-// const Department_Query = graphql(/* GraphQL */ `
-//   query ViewDepartmentPage($id: UUID!) {
-//     department(id: $id) {
-//       name {
-//         en
-//         fr
-//       }
-//       ...DepartmentForm
-//     }
-//   }
-// `);
+const TrainingEventPage_Query = graphql(/* GraphQL */ `
+  query ViewTrainingEventPage($id: UUID!) {
+    trainingOpportunity(id: $id) {
+      title {
+        en
+        fr
+      }
+      ...TrainingEventView
+    }
+  }
+`);
 
 const ViewTrainingEventPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
   const { trainingEventId } = useRequiredParams<RouteParams>("trainingEventId");
-  // const [{ data: departmentData, fetching, error }] = useQuery({
-  //   query: Department_Query,
-  //   variables: { id: departmentId },
-  // });
+  const [{ data, fetching, error }] = useQuery({
+    query: TrainingEventPage_Query,
+    variables: { id: trainingEventId },
+  });
 
-  const trainingEventName = "TODO";
-  // const trainingEventName = getLocalizedName(
-  //   departmentData?.department?.name,
-  //   intl,
-  // );
+  const trainingEventName = getLocalizedName(
+    data?.trainingOpportunity?.title,
+    intl,
+  );
 
   const navigationCrumbs = useBreadcrumbs({
     crumbs: [
@@ -200,36 +242,36 @@ const ViewTrainingEventPage = () => {
       <SEO title={trainingEventName} />
       <Hero
         title={
-          /* fetching ? intl.formatMessage(commonMessages.loading) :*/ trainingEventName
+          fetching
+            ? intl.formatMessage(commonMessages.loading)
+            : trainingEventName
         }
         crumbs={navigationCrumbs}
         navTabs={navTabs}
       />
       <div data-h2-wrapper="base(center, large, x1) p-tablet(center, large, x2)">
         <div data-h2-padding="base(x3, 0)">
-          {/* <Pending fetching={fetching} error={error}> */}
-          {true /*departmentData?.department*/ ? (
-            <ViewTrainingEventForm
-            // query={departmentData?.department}
-            />
-          ) : (
-            <NotFound
-              headingMessage={intl.formatMessage(commonMessages.notFound)}
-            >
-              <p>
-                {intl.formatMessage(
-                  {
-                    defaultMessage: "Event {trainingEventId} not found.",
-                    id: "z1otyE",
-                    description:
-                      "Message displayed for training event not found.",
-                  },
-                  { trainingEventId },
-                )}
-              </p>
-            </NotFound>
-          )}
-          {/* </Pending> */}
+          <Pending fetching={fetching} error={error}>
+            {data?.trainingOpportunity ? (
+              <ViewTrainingEventForm query={data.trainingOpportunity} />
+            ) : (
+              <NotFound
+                headingMessage={intl.formatMessage(commonMessages.notFound)}
+              >
+                <p>
+                  {intl.formatMessage(
+                    {
+                      defaultMessage: "Event {trainingEventId} not found.",
+                      id: "z1otyE",
+                      description:
+                        "Message displayed for training event not found.",
+                    },
+                    { trainingEventId },
+                  )}
+                </p>
+              </NotFound>
+            )}
+          </Pending>
         </div>
       </div>
     </>

--- a/apps/web/src/pages/TrainingEvents/apiUtils.ts
+++ b/apps/web/src/pages/TrainingEvents/apiUtils.ts
@@ -1,0 +1,67 @@
+import { graphql, TrainingEventViewFragment } from "@gc-digital-talent/graphql";
+
+export const TrainingEventForm_Fragment = graphql(/* GraphQL */ `
+  fragment TrainingEventView on TrainingOpportunity {
+    title {
+      en
+      fr
+    }
+    courseLanguage {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    courseFormat {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    registrationDeadline
+    trainingStart
+    trainingEnd
+    description {
+      en
+      fr
+    }
+    applicationUrl {
+      en
+      fr
+    }
+  }
+`);
+
+export interface FormValues {
+  titleEn: string;
+  titleFr: string;
+  courseLanguage: string;
+  courseFormat: string;
+  registrationDeadline: string;
+  trainingStart: string;
+  trainingEnd: string;
+  descriptionEn: string;
+  descriptionFr: string;
+  applicationUrlEn: string;
+  applicationUrlFr: string;
+}
+
+export function convertApiFragmentToFormValues(
+  apiData: TrainingEventViewFragment,
+): FormValues {
+  return {
+    titleEn: apiData.title?.en ?? "",
+    titleFr: apiData.title?.fr ?? "",
+    courseLanguage: apiData.courseLanguage?.value ?? "",
+    courseFormat: apiData.courseFormat?.value ?? "",
+    registrationDeadline: apiData.registrationDeadline ?? "",
+    trainingStart: apiData.trainingStart ?? "",
+    trainingEnd: apiData.trainingEnd ?? "",
+    descriptionEn: apiData.description?.en ?? "",
+    descriptionFr: apiData.description?.fr ?? "",
+    applicationUrlEn: apiData.applicationUrl?.en ?? "",
+    applicationUrlFr: apiData.applicationUrl?.fr ?? "",
+  };
+}

--- a/apps/web/src/pages/TrainingEvents/apiUtils.ts
+++ b/apps/web/src/pages/TrainingEvents/apiUtils.ts
@@ -1,4 +1,11 @@
-import { graphql, TrainingEventViewFragment } from "@gc-digital-talent/graphql";
+import {
+  CourseFormat,
+  CourseLanguage,
+  CreateTrainingOpportunityInput,
+  graphql,
+  TrainingEventViewFragment,
+  UpdateTrainingOpportunityInput,
+} from "@gc-digital-talent/graphql";
 
 export const TrainingEventForm_Fragment = graphql(/* GraphQL */ `
   fragment TrainingEventView on TrainingOpportunity {
@@ -63,5 +70,41 @@ export function convertApiFragmentToFormValues(
     descriptionFr: apiData.description?.fr ?? "",
     applicationUrlEn: apiData.applicationUrl?.en ?? "",
     applicationUrlFr: apiData.applicationUrl?.fr ?? "",
+  };
+}
+
+export function convertFormValuesToCreateInput(
+  formValues: FormValues,
+): CreateTrainingOpportunityInput {
+  return {
+    title: {
+      en: formValues.titleEn,
+      fr: formValues.titleFr,
+    },
+    courseLanguage: formValues.courseLanguage as CourseLanguage,
+    courseFormat: formValues.courseFormat as CourseFormat,
+    registrationDeadline: formValues.registrationDeadline,
+    trainingStart: formValues.trainingStart,
+    trainingEnd: formValues.trainingEnd,
+    description: {
+      en: formValues.descriptionEn,
+      fr: formValues.descriptionFr,
+    },
+    applicationUrl: {
+      en: formValues.applicationUrlEn,
+      fr: formValues.applicationUrlFr,
+    },
+  };
+}
+
+export function convertFormValuesToUpdateInput(
+  id: string,
+  formValues: FormValues,
+): UpdateTrainingOpportunityInput {
+  const createInput = convertFormValuesToCreateInput(formValues);
+  return {
+    id: id,
+    // input is the same as the one for "create" but also includes ID
+    ...createInput,
   };
 }

--- a/apps/web/src/pages/TrainingEvents/components/TrainingEventForm.tsx
+++ b/apps/web/src/pages/TrainingEvents/components/TrainingEventForm.tsx
@@ -9,20 +9,39 @@ import {
   Select,
 } from "@gc-digital-talent/forms";
 import { errorMessages } from "@gc-digital-talent/i18n";
-import { LocalizedEnumString } from "@gc-digital-talent/graphql";
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import formLabels from "../formLabels";
 
+export const TrainingEventFormOptions_Fragment = graphql(/* GraphQL */ `
+  fragment TrainingEventFormOptions on Query {
+    courseLanguages: localizedEnumStrings(enumName: "CourseLanguage") {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    courseFormats: localizedEnumStrings(enumName: "CourseFormat") {
+      value
+      label {
+        en
+        fr
+      }
+    }
+  }
+`);
+
 interface TrainingEventFormProps {
-  courseLanguages: LocalizedEnumString[];
-  courseFormats: LocalizedEnumString[];
+  query: FragmentType<typeof TrainingEventFormOptions_Fragment>;
 }
 
-const TrainingEventForm = ({
-  courseLanguages,
-  courseFormats,
-}: TrainingEventFormProps) => {
+const TrainingEventForm = ({ query }: TrainingEventFormProps) => {
   const intl = useIntl();
+  const { courseLanguages, courseFormats } = getFragment(
+    TrainingEventFormOptions_Fragment,
+    query,
+  );
   return (
     <div
       data-h2-display="base(grid)"

--- a/apps/web/src/pages/TrainingEvents/components/TrainingEventForm.tsx
+++ b/apps/web/src/pages/TrainingEvents/components/TrainingEventForm.tsx
@@ -1,0 +1,144 @@
+import { useIntl } from "react-intl";
+
+import {
+  DATE_SEGMENT,
+  DateInput,
+  Input,
+  localizedEnumToOptions,
+  RichTextInput,
+  Select,
+} from "@gc-digital-talent/forms";
+import { errorMessages } from "@gc-digital-talent/i18n";
+import { LocalizedEnumString } from "@gc-digital-talent/graphql";
+
+import formLabels from "../formLabels";
+
+interface TrainingEventFormProps {
+  courseLanguages: LocalizedEnumString[];
+  courseFormats: LocalizedEnumString[];
+}
+
+const TrainingEventForm = ({
+  courseLanguages,
+  courseFormats,
+}: TrainingEventFormProps) => {
+  const intl = useIntl();
+  return (
+    <div
+      data-h2-display="base(grid)"
+      data-h2-grid-template-columns="p-tablet(repeat(2, 1fr))"
+      data-h2-gap="base(x1)"
+    >
+      <Input
+        id="titleEn"
+        name="titleEn"
+        label={intl.formatMessage(formLabels.titleEn)}
+        type="text"
+        rules={{
+          required: intl.formatMessage(errorMessages.required),
+        }}
+      />
+      <Input
+        id="titleFr"
+        name="titleFr"
+        label={intl.formatMessage(formLabels.titleFr)}
+        type="text"
+        rules={{
+          required: intl.formatMessage(errorMessages.required),
+        }}
+      />
+      <Select
+        id="courseLanguage"
+        name="courseLanguage"
+        label={intl.formatMessage(formLabels.courseLanguage)}
+        nullSelection={intl.formatMessage({
+          defaultMessage: "Select a language",
+          id: "uup5F2",
+          description:
+            "Placeholder displayed on the user form preferred communication language field.",
+        })}
+        rules={{
+          required: intl.formatMessage(errorMessages.required),
+        }}
+        options={localizedEnumToOptions(courseLanguages, intl)}
+      />
+      <Select
+        id="courseFormat"
+        name="courseFormat"
+        label={intl.formatMessage(formLabels.format)}
+        nullSelection={intl.formatMessage({
+          defaultMessage: "Select a format",
+          id: "m3c4o8",
+          description: "Placeholder displayed on the select input for a format",
+        })}
+        rules={{
+          required: intl.formatMessage(errorMessages.required),
+        }}
+        options={localizedEnumToOptions(courseFormats, intl)}
+      />
+      <DateInput
+        id="registrationDeadline"
+        legend={intl.formatMessage(formLabels.registrationDeadline)}
+        name="registrationDeadline"
+        show={[DATE_SEGMENT.Day, DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+        rules={{
+          required: intl.formatMessage(errorMessages.required),
+        }}
+      />
+      <div data-h2-display="base(none) p-tablet(inherit)">
+        {/* intentionally left blank */}
+      </div>
+      <DateInput
+        id="trainingStart"
+        legend={intl.formatMessage(formLabels.trainingStartDate)}
+        name="trainingStart"
+        show={[DATE_SEGMENT.Day, DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+        rules={{
+          required: intl.formatMessage(errorMessages.required),
+        }}
+      />
+      <DateInput
+        id="trainingEnd"
+        legend={intl.formatMessage(formLabels.trainingEndDate)}
+        name="trainingEnd"
+        show={[DATE_SEGMENT.Day, DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+      />
+      <RichTextInput
+        id="descriptionEn"
+        label={intl.formatMessage(formLabels.descriptionEn)}
+        name="descriptionEn"
+        rules={{
+          required: intl.formatMessage(errorMessages.required),
+        }}
+      />
+      <RichTextInput
+        id="descriptionFr"
+        label={intl.formatMessage(formLabels.descriptionFr)}
+        name="descriptionFr"
+        rules={{
+          required: intl.formatMessage(errorMessages.required),
+        }}
+      />
+      <Input
+        id="applicationUrlEn"
+        name="applicationUrlEn"
+        label={intl.formatMessage(formLabels.applicationUrlEn)}
+        type="text"
+        rules={{
+          required: intl.formatMessage(errorMessages.required),
+        }}
+      />
+      <Input
+        id="applicationUrlFr"
+        name="applicationUrlFr"
+        label={intl.formatMessage(formLabels.applicationUrlFr)}
+        type="text"
+        rules={{
+          required: intl.formatMessage(errorMessages.required),
+        }}
+      />
+    </div>
+  );
+};
+
+export default TrainingEventForm;

--- a/apps/web/src/pages/TrainingEvents/components/TrainingEventsTable.tsx
+++ b/apps/web/src/pages/TrainingEvents/components/TrainingEventsTable.tsx
@@ -7,6 +7,7 @@ import {
   SortingState,
 } from "@tanstack/react-table";
 import { useIntl } from "react-intl";
+import { useLocation } from "react-router-dom";
 
 import {
   DeadlineStatus,
@@ -79,38 +80,13 @@ function transformSortStateToOrderByClause(
   return orderBy?.length ? orderBy : undefined;
 }
 
-// export function transformUserInput(
-//   filterState: TrainingOpportunitiesFilterInput | undefined,
-//   searchBarTerm: string | undefined,
-//   searchType: string | undefined,
-// ): InputMaybe<TrainingOpportunitiesFilterInput> | undefined {
-//   if (
-//     filterState === undefined &&
-//     searchBarTerm === undefined &&
-//     searchType === undefined
-//   ) {
-//     return undefined;
-//   }
-
-//   return {
-//     // search bar
-//     generalSearch: searchBarTerm && !searchType ? searchBarTerm : undefined,
-//     // email: searchType === "email" ? searchBarTerm : undefined,
-//     // workEmail: searchType === "workEmail" ? searchBarTerm : undefined,
-//     // name: searchType === "name" ? searchBarTerm : undefined,
-//     // telephone: searchType === "phone" ? searchBarTerm : undefined,
-//   };
-// }
-
 const TrainingEventsPaginated_Query = graphql(/* GraphQL */ `
   query TrainingEventsPaginated(
-    $where: TrainingOpportunitiesFilterInput
     $first: Int
     $page: Int
     $orderBy: [OrderByClause!]
   ) {
     trainingOpportunitiesPaginated(
-      where: $where
       first: $first
       page: $page
       orderBy: $orderBy
@@ -157,14 +133,14 @@ interface TrainingEventsTableProps {
   title: ReactNode;
 }
 
-export const TrainingEventsTable = ({
-  // classificationsQuery,
-  title,
-}: TrainingEventsTableProps) => {
+export const TrainingEventsTable = ({ title }: TrainingEventsTableProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
   const paths = useRoutes();
   const initialState = getTableStateFromSearchParams(defaultState);
+
+  const { pathname, search, hash } = useLocation();
+  const currentUrl = `${pathname}${search}${hash}`;
 
   const [paginationState, setPaginationState] = useState<PaginationState>(
     initialState.paginationState
@@ -174,9 +150,6 @@ export const TrainingEventsTable = ({
         }
       : INITIAL_STATE.paginationState,
   );
-  // const [searchState, setSearchState] = useState<SearchState>(
-  //   initialState.searchState ?? INITIAL_STATE.searchState,
-  // );
   const [sortState, setSortState] = useState<SortingState | undefined>(
     initialState.sortState ?? [{ id: "title", desc: false }],
   );
@@ -193,17 +166,6 @@ export const TrainingEventsTable = ({
       pageSize: pageSize ?? INITIAL_STATE.paginationState.pageSize,
     }));
   };
-
-  // const handleSearchStateChange = ({ term, type }: SearchState) => {
-  //   setPaginationState((previous) => ({
-  //     ...previous,
-  //     pageIndex: 0,
-  //   }));
-  //   setSearchState({
-  //     term: term ?? INITIAL_STATE.searchState.term,
-  //     type: type ?? INITIAL_STATE.searchState.type,
-  //   });
-  // };
 
   const statusChipStyles: Record<DeadlineStatus, ChipProps["color"]> = {
     PUBLISHED: "primary",
@@ -270,12 +232,6 @@ export const TrainingEventsTable = ({
   const [{ data, fetching }] = useQuery({
     query: TrainingEventsPaginated_Query,
     variables: {
-      where: undefined,
-      // where: transformUserInput(
-      //   filterState,
-      //   searchState?.term,
-      //   searchState?.type,
-      // ),
       page: paginationState.pageIndex,
       first: paginationState.pageSize,
       orderBy: sortState
@@ -305,17 +261,21 @@ export const TrainingEventsTable = ({
           handlePaginationStateChange({ pageIndex, pageSize });
         },
       }}
-      // search={{
-      //   internal: false,
-      //   label: intl.formatMessage(adminMessages.searchByKeyword),
-      //   onChange: ({ term, type }: SearchState) => {
-      //     handleSearchStateChange({ term, type });
-      //   },
-      // }}
       sort={{
         internal: false,
         onSortChange: setSortState,
         initialState: defaultState.sortState,
+      }}
+      add={{
+        linkProps: {
+          href: paths.trainingEventCreate(),
+          label: intl.formatMessage({
+            defaultMessage: "Create an event",
+            id: "bWUOmk",
+            description: "Title for link to page to create a training event",
+          }),
+          from: currentUrl,
+        },
       }}
     />
   );

--- a/apps/web/src/pages/TrainingEvents/components/TrainingEventsTable.tsx
+++ b/apps/web/src/pages/TrainingEvents/components/TrainingEventsTable.tsx
@@ -1,29 +1,324 @@
-interface ClassificationTableProps {
-  // classificationsQuery: FragmentType<typeof ClassificationTableRow_Fragment>[];
-  title: string;
+import { useQuery } from "urql";
+import { ReactNode, useMemo, useState } from "react";
+import {
+  ColumnDef,
+  createColumnHelper,
+  PaginationState,
+  SortingState,
+} from "@tanstack/react-table";
+import { useIntl } from "react-intl";
+
+import {
+  DeadlineStatus,
+  graphql,
+  OrderByClause,
+  SortOrder,
+  TrainingOpportunitiesFilterInput,
+  TrainingOpportunity,
+} from "@gc-digital-talent/graphql";
+import { notEmpty } from "@gc-digital-talent/helpers";
+import {
+  commonMessages,
+  getLocale,
+  getLocalizedName,
+  Locales,
+} from "@gc-digital-talent/i18n";
+import { Chip, ChipProps, Link } from "@gc-digital-talent/ui";
+
+import Table, {
+  getTableStateFromSearchParams,
+} from "~/components/Table/ResponsiveTable/ResponsiveTable";
+import { InitialState } from "~/components/Table/ResponsiveTable/types";
+import adminMessages from "~/messages/adminMessages";
+import useRoutes from "~/hooks/useRoutes";
+
+import formLabels from "../formLabels";
+
+const columnHelper = createColumnHelper<TrainingOpportunity>();
+
+const INITIAL_STATE: InitialState = {
+  hiddenColumnIds: [],
+  paginationState: {
+    pageIndex: 0,
+    pageSize: 10,
+  },
+  sortState: [],
+  searchState: {},
+};
+
+const defaultState = {
+  ...INITIAL_STATE,
+  sortState: [{ id: "title", desc: false }],
+  filters: {},
+};
+
+function transformSortStateToOrderByClause(
+  locale: Locales,
+  sortingRule?: SortingState,
+): OrderByClause | OrderByClause[] | undefined {
+  const columnMap = new Map<string, string>([
+    ["name", `title->${locale}`],
+    ["language", "course_language"],
+    ["status", "registration_deadline"], // deadline status is not a real column, but storting by deadline achieves the same thing
+    ["registrationDeadline", "registration_deadline"],
+    ["trainingStartDate", "training_start"],
+    ["trainingEndDate", "training_end"],
+  ]);
+
+  const orderBy = sortingRule
+    ?.map((rule) => {
+      const columnName = columnMap.get(rule.id);
+      if (!columnName) return undefined;
+      return {
+        column: columnName,
+        order: rule.desc ? SortOrder.Desc : SortOrder.Asc,
+      };
+    })
+    .filter(notEmpty);
+
+  return orderBy?.length ? orderBy : undefined;
+}
+
+// export function transformUserInput(
+//   filterState: TrainingOpportunitiesFilterInput | undefined,
+//   searchBarTerm: string | undefined,
+//   searchType: string | undefined,
+// ): InputMaybe<TrainingOpportunitiesFilterInput> | undefined {
+//   if (
+//     filterState === undefined &&
+//     searchBarTerm === undefined &&
+//     searchType === undefined
+//   ) {
+//     return undefined;
+//   }
+
+//   return {
+//     // search bar
+//     generalSearch: searchBarTerm && !searchType ? searchBarTerm : undefined,
+//     // email: searchType === "email" ? searchBarTerm : undefined,
+//     // workEmail: searchType === "workEmail" ? searchBarTerm : undefined,
+//     // name: searchType === "name" ? searchBarTerm : undefined,
+//     // telephone: searchType === "phone" ? searchBarTerm : undefined,
+//   };
+// }
+
+const TrainingEventsPaginated_Query = graphql(/* GraphQL */ `
+  query TrainingEventsPaginated(
+    $where: TrainingOpportunitiesFilterInput
+    $first: Int
+    $page: Int
+    $orderBy: [OrderByClause!]
+  ) {
+    trainingOpportunitiesPaginated(
+      where: $where
+      first: $first
+      page: $page
+      orderBy: $orderBy
+    ) {
+      data {
+        id
+        title {
+          en
+          fr
+        }
+        courseLanguage {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        registrationDeadline
+        registrationDeadlineStatus {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        trainingStart
+        trainingEnd
+      }
+      paginatorInfo {
+        count
+        currentPage
+        firstItem
+        hasMorePages
+        lastItem
+        lastPage
+        perPage
+        total
+      }
+    }
+  }
+`);
+
+interface TrainingEventsTableProps {
+  title: ReactNode;
 }
 
 export const TrainingEventsTable = ({
   // classificationsQuery,
   title,
-}: ClassificationTableProps) => {
-  return <>{title}</>;
-};
+}: TrainingEventsTableProps) => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
+  const paths = useRoutes();
+  const initialState = getTableStateFromSearchParams(defaultState);
 
-const TrainingEventsTableApi = ({ title }: { title: string }) => {
-  // const [{ data, fetching, error }] = useQuery({
-  //   query: ClassificationTable_Query,
-  //   context,
-  // });
+  const [paginationState, setPaginationState] = useState<PaginationState>(
+    initialState.paginationState
+      ? {
+          ...initialState.paginationState,
+          pageIndex: initialState.paginationState.pageIndex + 1,
+        }
+      : INITIAL_STATE.paginationState,
+  );
+  // const [searchState, setSearchState] = useState<SearchState>(
+  //   initialState.searchState ?? INITIAL_STATE.searchState,
+  // );
+  const [sortState, setSortState] = useState<SortingState | undefined>(
+    initialState.sortState ?? [{ id: "title", desc: false }],
+  );
+
+  const handlePaginationStateChange = ({
+    pageIndex,
+    pageSize,
+  }: PaginationState) => {
+    setPaginationState((previous) => ({
+      pageIndex:
+        previous.pageSize === pageSize
+          ? (pageIndex ?? INITIAL_STATE.paginationState.pageIndex)
+          : 0,
+      pageSize: pageSize ?? INITIAL_STATE.paginationState.pageSize,
+    }));
+  };
+
+  // const handleSearchStateChange = ({ term, type }: SearchState) => {
+  //   setPaginationState((previous) => ({
+  //     ...previous,
+  //     pageIndex: 0,
+  //   }));
+  //   setSearchState({
+  //     term: term ?? INITIAL_STATE.searchState.term,
+  //     type: type ?? INITIAL_STATE.searchState.type,
+  //   });
+  // };
+
+  const statusChipStyles: Record<DeadlineStatus, ChipProps["color"]> = {
+    PUBLISHED: "primary",
+    EXPIRED: "black",
+  } as const;
+
+  const columns = [
+    columnHelper.accessor((event) => getLocalizedName(event.title, intl), {
+      id: "name",
+      header: intl.formatMessage(commonMessages.name),
+      cell: ({ row: { original: event } }) =>
+        event.id ? (
+          <Link
+            href={paths.trainingEventView(event.id)}
+            data-h2-font-weight="base(700)"
+          >
+            {getLocalizedName(event.title, intl)}
+          </Link>
+        ) : (
+          getLocalizedName(event.title, intl)
+        ),
+      meta: {
+        isRowTitle: true,
+      },
+    }),
+    columnHelper.accessor((event) => (event.courseLanguage?.label, intl), {
+      id: "language",
+      header: intl.formatMessage(commonMessages.language),
+      cell: ({ row: { original: event } }) =>
+        getLocalizedName(event.courseLanguage?.label, intl),
+    }),
+    columnHelper.accessor((event) => event.registrationDeadlineStatus, {
+      id: "status",
+      header: intl.formatMessage(commonMessages.status),
+      cell: ({ row: { original: event } }) =>
+        event.registrationDeadlineStatus?.value ? (
+          <Chip
+            color={statusChipStyles[event.registrationDeadlineStatus.value]}
+          >
+            {getLocalizedName(event.registrationDeadlineStatus?.label, intl)}
+          </Chip>
+        ) : (
+          intl.formatMessage(adminMessages.noneProvided)
+        ),
+    }),
+    columnHelper.accessor((event) => (event.registrationDeadline, intl), {
+      id: "registrationDeadline",
+      header: intl.formatMessage(formLabels.registrationDeadline),
+      cell: ({ row: { original: event } }) => event.registrationDeadline,
+    }),
+    columnHelper.accessor((event) => (event.trainingStart, intl), {
+      id: "trainingStartDate",
+      header: intl.formatMessage(formLabels.trainingStartDate),
+      cell: ({ row: { original: event } }) => event.trainingStart,
+    }),
+    columnHelper.accessor((event) => (event.trainingEnd, intl), {
+      id: "trainingEndDate",
+      header: intl.formatMessage(formLabels.trainingEndDate),
+      cell: ({ row: { original: event } }) =>
+        event.trainingEnd ?? intl.formatMessage(adminMessages.noneProvided),
+    }),
+  ] as ColumnDef<TrainingOpportunity>[];
+
+  const [{ data, fetching }] = useQuery({
+    query: TrainingEventsPaginated_Query,
+    variables: {
+      where: undefined,
+      // where: transformUserInput(
+      //   filterState,
+      //   searchState?.term,
+      //   searchState?.type,
+      // ),
+      page: paginationState.pageIndex,
+      first: paginationState.pageSize,
+      orderBy: sortState
+        ? transformSortStateToOrderByClause(locale, sortState)
+        : undefined,
+    },
+  });
+
+  const filteredData: TrainingOpportunity[] = useMemo(() => {
+    const opportunities = data?.trainingOpportunitiesPaginated?.data ?? [];
+    return opportunities.filter(notEmpty);
+  }, [data?.trainingOpportunitiesPaginated?.data]);
 
   return (
-    // <Pending fetching={fetching} error={error}>
-    <TrainingEventsTable
-      // classificationsQuery={unpackMaybes(data?.classifications)}
-      title={title}
+    <Table<TrainingOpportunity, TrainingOpportunitiesFilterInput>
+      data={filteredData}
+      caption={title}
+      columns={columns}
+      isLoading={fetching}
+      pagination={{
+        internal: false,
+        initialState: INITIAL_STATE.paginationState,
+        state: paginationState,
+        total: data?.trainingOpportunitiesPaginated?.paginatorInfo.total,
+        pageSizes: [10, 20, 50],
+        onPaginationChange: ({ pageIndex, pageSize }: PaginationState) => {
+          handlePaginationStateChange({ pageIndex, pageSize });
+        },
+      }}
+      // search={{
+      //   internal: false,
+      //   label: intl.formatMessage(adminMessages.searchByKeyword),
+      //   onChange: ({ term, type }: SearchState) => {
+      //     handleSearchStateChange({ term, type });
+      //   },
+      // }}
+      sort={{
+        internal: false,
+        onSortChange: setSortState,
+        initialState: defaultState.sortState,
+      }}
     />
-    // </Pending>
   );
 };
 
-export default TrainingEventsTableApi;
+export default TrainingEventsTable;

--- a/apps/web/src/pages/TrainingEvents/components/TrainingEventsTable.tsx
+++ b/apps/web/src/pages/TrainingEvents/components/TrainingEventsTable.tsx
@@ -1,0 +1,29 @@
+interface ClassificationTableProps {
+  // classificationsQuery: FragmentType<typeof ClassificationTableRow_Fragment>[];
+  title: string;
+}
+
+export const TrainingEventsTable = ({
+  // classificationsQuery,
+  title,
+}: ClassificationTableProps) => {
+  return <>{title}</>;
+};
+
+const TrainingEventsTableApi = ({ title }: { title: string }) => {
+  // const [{ data, fetching, error }] = useQuery({
+  //   query: ClassificationTable_Query,
+  //   context,
+  // });
+
+  return (
+    // <Pending fetching={fetching} error={error}>
+    <TrainingEventsTable
+      // classificationsQuery={unpackMaybes(data?.classifications)}
+      title={title}
+    />
+    // </Pending>
+  );
+};
+
+export default TrainingEventsTableApi;

--- a/apps/web/src/pages/TrainingEvents/formLabels.ts
+++ b/apps/web/src/pages/TrainingEvents/formLabels.ts
@@ -1,0 +1,55 @@
+import { defineMessages } from "react-intl";
+
+import adminMessages from "~/messages/adminMessages";
+
+const formLabels = defineMessages({
+  titleEn: {
+    defaultMessage: "Title (English)",
+    id: "MHZ1CD",
+    description: "The title, in English",
+  },
+  titleFr: {
+    defaultMessage: "Title (French)",
+    id: "55Me4a",
+    description: "The title, in French",
+  },
+  courseLanguage: {
+    defaultMessage: "Course language",
+    id: "358F+g",
+    description: "The language of the training event",
+  },
+  format: {
+    defaultMessage: "Format",
+    id: "/fVA+0",
+    description: "The format of the training event",
+  },
+  registrationDeadline: {
+    defaultMessage: "Registration deadline",
+    id: "fbRvL4",
+    description: "The registration deadline of the training event",
+  },
+  trainingStartDate: {
+    defaultMessage: "Training start date",
+    id: "ej13jn",
+    description: "The training start date of the training event",
+  },
+  trainingEndDate: {
+    defaultMessage: "Training end date",
+    id: "guY0Ld",
+    description: "The training end date of the training event",
+  },
+  descriptionEn: adminMessages.descriptionEn,
+  descriptionFr: adminMessages.descriptionFr,
+  applicationUrlEn: {
+    defaultMessage: "Application URL (English)",
+    id: "scK7Nc",
+    description: "The English application URL of the training event",
+  },
+  applicationUrlFr: {
+    defaultMessage: "Application URL (French)",
+    id: "p+X+Yq",
+    description: "The French application URL of the training event",
+  },
+});
+
+export default formLabels;

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -289,6 +289,11 @@ const commonMessages = defineMessages({
     id: "pOL68A",
     description: "Title for work email address",
   },
+  language: {
+    defaultMessage: "Language",
+    id: "k3i6lU",
+    description: "Legend for a language input or title",
+  },
 });
 
 export default commonMessages;


### PR DESCRIPTION
🤖 Resolves #11932 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Adds admin CRUD pages for the training events/opportunities

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->
There are a few small changes to the API to enable page functionality.

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Rebuild and log into the admin site with the `admin@test.com` user
2. Navigate to `/en/admin/training-events`
3. Try sorting, creating, viewing, and updating events

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/ae061761-6b53-48f2-8b72-5dfe57052448)