### PR TITLE
[Debt] Differentiate error boundaries

### DIFF
--- a/apps/web/src/components/Layout/IAPLayout.tsx
+++ b/apps/web/src/components/Layout/IAPLayout.tsx
@@ -25,8 +25,8 @@ import micMessages from "~/lang/micCompiled.json";
 
 import SkipLink from "./SkipLink";
 import SitewideBanner from "./SitewideBanner";
-
-export { ErrorBoundary } from "./ErrorBoundary/ErrorBoundary";
+import ErrorBoundary from "./RouteErrorBoundary/RouteErrorBoundary";
+export { ErrorBoundary };
 
 const messages = new Map<string, Messages>([
   ["crg", crgMessages],

--- a/apps/web/src/components/Layout/MainLayout.tsx
+++ b/apps/web/src/components/Layout/MainLayout.tsx
@@ -7,8 +7,6 @@ import useLayoutTheme from "~/hooks/useLayoutTheme";
 
 import Layout from "./Layout";
 
-export { ErrorBoundary } from "./ErrorBoundary/ErrorBoundary";
-
 export const Component = () => {
   const intl = useIntl();
   useLayoutTheme("default");

--- a/apps/web/src/components/Layout/RouteErrorBoundary/RouteErrorBoundary.stories.tsx
+++ b/apps/web/src/components/Layout/RouteErrorBoundary/RouteErrorBoundary.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryFn } from "@storybook/react";
 
 import { CHROMATIC_VIEWPORTS } from "@gc-digital-talent/storybook-helpers";
 
-import { ErrorBoundary } from "./ErrorBoundary";
+import ErrorBoundary from "./RouteErrorBoundary";
 
 export default {
   component: ErrorBoundary,

--- a/apps/web/src/components/Layout/RouteErrorBoundary/RouteErrorBoundary.tsx
+++ b/apps/web/src/components/Layout/RouteErrorBoundary/RouteErrorBoundary.tsx
@@ -12,7 +12,7 @@ import useErrorMessages from "~/hooks/useErrorMessages";
 import darkPug from "~/assets/img/404_pug_dark.webp";
 import lightPug from "~/assets/img/404_pug_light.webp";
 
-export const ErrorBoundary = () => {
+export const RouteErrorBoundary = () => {
   const intl = useIntl();
   const paths = useRoutes();
   const { mode } = useTheme();
@@ -119,4 +119,4 @@ export const ErrorBoundary = () => {
   );
 };
 
-export default ErrorBoundary;
+export default RouteErrorBoundary;

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -17,8 +17,8 @@ const createRoute = (locale: Locales) =>
           {
             path: locale,
             async lazy() {
-              const { ErrorBoundary } = await import(
-                "./Layout/ErrorBoundary/ErrorBoundary"
+              const { RouteErrorBoundary: ErrorBoundary } = await import(
+                "./Layout/RouteErrorBoundary/RouteErrorBoundary"
               );
               return { ErrorBoundary };
             },


### PR DESCRIPTION
🤖 Resolves #11998 

## 👋 Introduction

Renames the router based error boundary to differentiate it from a component based error boundary

## 🧪 Testing

1. Build app `pnpm run dev:fresh`
2. Force a router error (404 is an easy one)
3. Confirm you still see the expected error boundary

## 📸 Screenshot

![2024-11-22_13-20](https://github.com/user-attachments/assets/c346dd0f-b2cc-44f2-880d-a8855bdaf11e)

