### PR TITLE
[Debt] Ignore unused modules warning for static assets

### DIFF
--- a/apps/web/src/index.d.ts
+++ b/apps/web/src/index.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unused-modules */
 // Static asset extension declarations
 declare module "*.jpg" {
   const url: string;


### PR DESCRIPTION
🤖 Resolves #12063 

## 👋 Introduction

This ignores the warnings for unused modules in the static asset import type declaration file. Since these aren't actually imports, we can safely ignore this warning.

## 🧪 Testing

1. Confirm warning is not showing in the lint workflow