### PR TITLE
[Copy] Updates navigation menu item name for skill library

### DIFF
--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -47,10 +47,6 @@
     "defaultMessage": "Minorité visible",
     "description": "Group for when someone indicates they are a visible minority"
   },
-  "/zFaLD": {
-    "defaultMessage": "Parcourir la bibliothèque de compétences",
-    "description": "Name of skill library page"
-  },
   "09LIbL": {
     "defaultMessage": "Date",
     "description": "Label to identify a date element"
@@ -146,6 +142,10 @@
   "3Nd6dv": {
     "defaultMessage": "Sur cette page",
     "description": "Title for  pages table of contents."
+  },
+  "3SDRDg": {
+    "defaultMessage": "Parcourir la bibliothèque de compétences",
+    "description": "Name of skill library page"
   },
   "3agw4G": {
     "defaultMessage": "<strong> Région de l'Ontario</strong>(excluant Ottawa)",

--- a/packages/i18n/src/messages/navigationMessages.ts
+++ b/packages/i18n/src/messages/navigationMessages.ts
@@ -132,8 +132,8 @@ const navigationMessages = defineMessages({
     description: "Name of contact us page",
   },
   skillLibrary: {
-    defaultMessage: "Browse the skill library",
-    id: "/zFaLD",
+    defaultMessage: "Browse the skills library",
+    id: "3SDRDg",
     description: "Name of skill library page",
   },
   jobTemplates: {


### PR DESCRIPTION
🤖 Resolves #12078.

## 👋 Introduction

This PR updates the navigation menu item to **Browse the skills library** in English.

## 🧪 Testing

1. Navigate to http://localhost:8000/en/applicant
2. Sign in as applicant@test.com
3. Verify navigation menu item is **Browse the skills library** in English

## 📸 Screenshot

<img width="1184" alt="Screen Shot 2024-11-25 at 20 16 25" src="https://github.com/user-attachments/assets/01dac393-2bb6-4ce5-b072-565325aec615">