### PR TITLE
[Fix] Localized enums being available for form init

### DIFF
--- a/apps/playwright/tests/admin/admin-workflows.spec.ts
+++ b/apps/playwright/tests/admin/admin-workflows.spec.ts
@@ -5,7 +5,9 @@ import { loginBySub } from "~/utils/auth";
 const USERS_PAGINATED_QUERY = "UsersPaginated";
 
 const searchForUser = async (appPage: AppPage, name: string) => {
-  await appPage.page.getByRole("textbox", { name: /search/i }).fill(name);
+  await appPage.page
+    .getByRole("textbox", { name: /search/i })
+    .fill(name, { timeout: 30000 });
 
   await appPage.waitForGraphqlResponse(USERS_PAGINATED_QUERY);
 };
@@ -45,7 +47,6 @@ test.describe("Admin workflows", () => {
 
     await appPage.page.getByRole("link", { name: /edit gul fields/i }).click();
     await appPage.waitForGraphqlResponse("UpdateUserData");
-    await appPage.waitForGraphqlResponse("UpdateUserOptions");
 
     await appPage.page
       .getByRole("textbox", { name: /telephone/i })

--- a/apps/playwright/tests/applicant/profile-workflows.spec.ts
+++ b/apps/playwright/tests/applicant/profile-workflows.spec.ts
@@ -10,9 +10,6 @@ test.describe("User Profile", () => {
       .getByRole("button", { name: /edit personal/i })
       .click();
 
-    await applicantPage.waitForGraphqlResponse(
-      "PersonalInformationFormOptions",
-    );
     await applicantPage.page
       .getByRole("textbox", { name: /telephone/i })
       .fill("123-456-7890");
@@ -29,7 +26,6 @@ test.describe("User Profile", () => {
     await applicantPage.page
       .getByRole("button", { name: /edit work preferences/i })
       .click();
-    await applicantPage.waitForGraphqlResponse("WorkPreferencesOptions");
     await applicantPage.page
       .getByRole("textbox", { name: /please indicate if there is a city/i })
       .fill("Test locations");

--- a/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
+++ b/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
@@ -4,7 +4,7 @@ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import zipWith from "lodash/zipWith";
 import { useMutation, useQuery } from "urql";
 
-import { Dialog, Button } from "@gc-digital-talent/ui";
+import { Dialog, Button, Loading } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
 import { Select, localizedEnumToOptions } from "@gc-digital-talent/forms";
 import {
@@ -23,6 +23,7 @@ import {
   ChangeStatusDialog_UserFragment as ChangeStatusDialogUserFragmentType,
   FragmentType,
   getFragment,
+  ChangeStatusDialog_PoolCandidateFragment as CandidateFragment,
 } from "@gc-digital-talent/graphql";
 
 import PoolFilterInput from "~/components/PoolFilterInput/PoolFilterInput";
@@ -34,8 +35,8 @@ import {
 
 import UpdatePoolCandidateStatus_Mutation from "./mutation";
 
-const PoolCandidateStatuses_Query = graphql(/* GraphQL */ `
-  query PoolCandidateStatuses {
+const ChangeStatusFormOptions_Fragment = graphql(/* GraphQL */ `
+  fragment ChangeStatusFormOptions on Query {
     poolCandidateStatuses: localizedEnumStrings(
       enumName: "PoolCandidateStatus"
     ) {
@@ -47,34 +48,6 @@ const PoolCandidateStatuses_Query = graphql(/* GraphQL */ `
     }
   }
 `);
-
-const StatusInput = () => {
-  const intl = useIntl();
-  const [{ data }] = useQuery({ query: PoolCandidateStatuses_Query });
-
-  return (
-    <Select
-      id="changeStatusDialog-status"
-      name="status"
-      label={intl.formatMessage({
-        defaultMessage: "Pool status",
-        id: "n9YPWe",
-        description:
-          "Label displayed on the status field of the change candidate status dialog",
-      })}
-      nullSelection={intl.formatMessage({
-        defaultMessage: "Select a pool status",
-        id: "Bkxf6p",
-        description:
-          "Placeholder displayed on the status field of the change candidate status dialog.",
-      })}
-      rules={{
-        required: intl.formatMessage(errorMessages.required),
-      }}
-      options={localizedEnumToOptions(data?.poolCandidateStatuses, intl)}
-    />
-  );
-};
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ChangeStatusDialog_UserFragment = graphql(/* GraphQL */ `
@@ -177,25 +150,25 @@ export const ChangeStatusDialog_PoolCandidateFragment = graphql(/* GraphQL */ `
   }
 `);
 
-interface ChangeStatusDialogProps {
-  selectedCandidateQuery: FragmentType<
-    typeof ChangeStatusDialog_PoolCandidateFragment
-  >;
+interface ChangeStatusFormProps {
+  selectedCandidate: CandidateFragment;
+  optionsQuery?: FragmentType<typeof ChangeStatusFormOptions_Fragment>;
   user: ChangeStatusDialogUserFragmentType;
+  onSubmit: () => void;
 }
 
-const ChangeStatusDialog = ({
-  selectedCandidateQuery,
+const ChangeStatusDialogForm = ({
+  selectedCandidate,
+  optionsQuery,
+  onSubmit,
   user,
-}: ChangeStatusDialogProps) => {
+}: ChangeStatusFormProps) => {
   const intl = useIntl();
-  const [open, setOpen] = useState(false);
-  const selectedCandidate = getFragment(
-    ChangeStatusDialog_PoolCandidateFragment,
-    selectedCandidateQuery,
-  );
+  const options = getFragment(ChangeStatusFormOptions_Fragment, optionsQuery);
 
-  const methods = useForm<FormValues>();
+  const methods = useForm<FormValues>({
+    defaultValues: { status: selectedCandidate.status?.value },
+  });
 
   const [{ fetching }, executeMutation] = useMutation(
     UpdatePoolCandidateStatus_Mutation,
@@ -276,6 +249,7 @@ const ChangeStatusDialog = ({
                 "Toast for successful status update on view-user page",
             }),
           );
+          onSubmit();
         } else {
           toast.error(
             <>
@@ -305,7 +279,6 @@ const ChangeStatusDialog = ({
             </>,
           );
         }
-        setOpen(false);
       })
       .catch(() => {
         toast.error(
@@ -319,6 +292,110 @@ const ChangeStatusDialog = ({
   };
   const { handleSubmit } = methods;
 
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={handleSubmit(submitForm)}>
+        <p data-h2-margin="base(x1, 0, 0, 0)">
+          {intl.formatMessage({
+            defaultMessage: "Choose status:",
+            id: "Zbk4zf",
+            description:
+              "Third section of text on the change candidate status dialog",
+          })}
+        </p>
+        <div data-h2-margin="base(x.5, 0, x.125, 0)">
+          <Select
+            id="changeStatusDialog-status"
+            name="status"
+            label={intl.formatMessage({
+              defaultMessage: "Pool status",
+              id: "n9YPWe",
+              description:
+                "Label displayed on the status field of the change candidate status dialog",
+            })}
+            nullSelection={intl.formatMessage({
+              defaultMessage: "Select a pool status",
+              id: "Bkxf6p",
+              description:
+                "Placeholder displayed on the status field of the change candidate status dialog.",
+            })}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+            }}
+            options={localizedEnumToOptions(
+              options?.poolCandidateStatuses,
+              intl,
+            )}
+          />
+        </div>
+        <p data-h2-margin="base(x1, 0, 0, 0)">
+          {intl.formatMessage({
+            defaultMessage:
+              "If you want this status to change across multiple pools, select them here:",
+            id: "wiUfZL",
+            description:
+              "Header for section to add additional pools to the change status operation",
+          })}
+        </p>
+        <div data-h2-margin="base(x.5, 0, x.125, 0)">
+          <PoolFilterInput
+            includeIds={userPoolIds}
+            filterInput={{
+              statuses: [PoolStatus.Closed, PoolStatus.Published],
+            }}
+            label={intl.formatMessage({
+              defaultMessage: "Additional pools",
+              id: "8V8WwR",
+              description:
+                "Label displayed on the additional pools field of the change candidate status dialog",
+            })}
+          />
+        </div>
+        <Dialog.Footer>
+          <Button disabled={fetching} type="submit" color="secondary">
+            {fetching
+              ? intl.formatMessage(commonMessages.saving)
+              : intl.formatMessage({
+                  defaultMessage: "Change status",
+                  id: "iuve97",
+                  description: "Confirmation button for change status dialog",
+                })}
+          </Button>
+          <Dialog.Close>
+            <Button type="button" color="warning" mode="inline">
+              {intl.formatMessage(formMessages.cancelGoBack)}
+            </Button>
+          </Dialog.Close>
+        </Dialog.Footer>
+      </form>
+    </FormProvider>
+  );
+};
+
+const ChangeStatusDialog_Query = graphql(/* GraphQL */ `
+  query ChangeStatusDialog {
+    ...ChangeStatusFormOptions
+  }
+`);
+
+interface ChangeStatusDialogProps {
+  selectedCandidateQuery: FragmentType<
+    typeof ChangeStatusDialog_PoolCandidateFragment
+  >;
+  user: ChangeStatusDialogUserFragmentType;
+}
+
+const ChangeStatusDialog = ({
+  selectedCandidateQuery,
+  user,
+}: ChangeStatusDialogProps) => {
+  const intl = useIntl();
+  const [open, setOpen] = useState(false);
+  const [{ data, fetching }] = useQuery({ query: ChangeStatusDialog_Query });
+  const selectedCandidate = getFragment(
+    ChangeStatusDialog_PoolCandidateFragment,
+    selectedCandidateQuery,
+  );
   return (
     <Dialog.Root open={open} onOpenChange={setOpen}>
       <Dialog.Trigger>
@@ -382,61 +459,16 @@ const ChangeStatusDialog = ({
               classification: selectedCandidate.pool.classification,
             })}
           </p>
-          <FormProvider {...methods}>
-            <form onSubmit={handleSubmit(submitForm)}>
-              <p data-h2-margin="base(x1, 0, 0, 0)">
-                {intl.formatMessage({
-                  defaultMessage: "Choose status:",
-                  id: "Zbk4zf",
-                  description:
-                    "Third section of text on the change candidate status dialog",
-                })}
-              </p>
-              <div data-h2-margin="base(x.5, 0, x.125, 0)">
-                <StatusInput />
-              </div>
-              <p data-h2-margin="base(x1, 0, 0, 0)">
-                {intl.formatMessage({
-                  defaultMessage:
-                    "If you want this status to change across multiple pools, select them here:",
-                  id: "wiUfZL",
-                  description:
-                    "Header for section to add additional pools to the change status operation",
-                })}
-              </p>
-              <div data-h2-margin="base(x.5, 0, x.125, 0)">
-                <PoolFilterInput
-                  includeIds={userPoolIds}
-                  filterInput={{
-                    statuses: [PoolStatus.Closed, PoolStatus.Published],
-                  }}
-                  label={intl.formatMessage({
-                    defaultMessage: "Additional pools",
-                    id: "8V8WwR",
-                    description:
-                      "Label displayed on the additional pools field of the change candidate status dialog",
-                  })}
-                />
-              </div>
-              <Dialog.Footer>
-                <Button disabled={fetching} type="submit" color="secondary">
-                  {fetching
-                    ? intl.formatMessage(commonMessages.saving)
-                    : intl.formatMessage({
-                        defaultMessage: "Change status",
-                        id: "iuve97",
-                        description:
-                          "Confirmation button for change status dialog",
-                      })}
-                </Button>
-                <Dialog.Close>
-                  <Button type="button" color="warning" mode="inline">
-                    {intl.formatMessage(formMessages.cancelGoBack)}
-                  </Button>
-                </Dialog.Close>
-              </Dialog.Footer>
-            </form>
-          </FormProvider>
+          {fetching ? (
+            <Loading inline />
+          ) : (
+            <ChangeStatusDialogForm
+              selectedCandidate={selectedCandidate}
+              user={user}
+              optionsQuery={data}
+              onSubmit={() => setOpen(false)}
+            />
+          )}
         </Dialog.Body>
       </Dialog.Content>
     </Dialog.Root>

--- a/apps/web/src/components/FilterDialog/FilterDialog.tsx
+++ b/apps/web/src/components/FilterDialog/FilterDialog.tsx
@@ -14,12 +14,17 @@ import { Dialog, Button } from "@gc-digital-talent/ui";
 import { notEmpty } from "@gc-digital-talent/helpers";
 
 // Used by specific dialogs
-export interface CommonFilterDialogProps<TFieldValues extends FieldValues> {
+export interface CommonFilterDialogProps<
+  TFieldValues extends FieldValues,
+  TOptions = object,
+> {
   onSubmit: SubmitHandler<TFieldValues>;
   /** When the user resets filters they will return to these values. If initialValues is empty, resetValues is used to initialize the filters. */
   resetValues: TFieldValues;
   /** If initialValues is set, it will override resetValues when the filter form is first initialized. */
   initialValues?: Partial<TFieldValues>;
+  /** Any options that come from the API (e.g. localized enums) */
+  optionsQuery?: TOptions;
 }
 
 interface FilterDialogProps<TFieldValues extends FieldValues> {

--- a/apps/web/src/components/Profile/components/LanguageProfile/ConsideredLanguages.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/ConsideredLanguages.tsx
@@ -1,7 +1,6 @@
 import { useFormContext } from "react-hook-form";
 import { useIntl } from "react-intl";
 import { ReactNode, useEffect } from "react";
-import { useQuery } from "urql";
 
 import {
   RadioGroup,
@@ -16,7 +15,7 @@ import {
   sortEvaluatedLanguageAbility,
 } from "@gc-digital-talent/i18n";
 import { Link } from "@gc-digital-talent/ui";
-import { graphql } from "@gc-digital-talent/graphql";
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import { getEstimatedAbilityOptions, getExamValidityOptions } from "./utils";
 import { FormValues } from "./types";
@@ -53,8 +52,8 @@ const selfAssessmentLink = (msg: ReactNode, locale: Locales) => {
   );
 };
 
-const LanguageProfileOptions_Query = graphql(/* GraphQL */ `
-  query LanguageProfileOptions {
+export const LanguageProfileOptions_Fragment = graphql(/* GraphQL */ `
+  fragment LanguageProfileOptions on Query {
     evaluatedLanguageAbilities: localizedEnumStrings(
       enumName: "EvaluatedLanguageAbility"
     ) {
@@ -76,12 +75,16 @@ const LanguageProfileOptions_Query = graphql(/* GraphQL */ `
 
 interface ConsideredLanguagesProps {
   labels: FieldLabels;
+  optionsQuery?: FragmentType<typeof LanguageProfileOptions_Fragment>;
 }
 
-const ConsideredLanguages = ({ labels }: ConsideredLanguagesProps) => {
+const ConsideredLanguages = ({
+  labels,
+  optionsQuery,
+}: ConsideredLanguagesProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
-  const [{ data }] = useQuery({ query: LanguageProfileOptions_Query });
+  const data = getFragment(LanguageProfileOptions_Fragment, optionsQuery);
   const { watch, resetField } = useFormContext<FormValues>();
 
   // hooks to watch, needed for conditional rendering

--- a/apps/web/src/components/Profile/components/LanguageProfile/FormFields.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/FormFields.tsx
@@ -2,16 +2,20 @@ import { useIntl } from "react-intl";
 
 import { Checklist, FieldLabels } from "@gc-digital-talent/forms";
 import { errorMessages } from "@gc-digital-talent/i18n";
+import { FragmentType } from "@gc-digital-talent/graphql";
 
 import useDirtyFields from "../../hooks/useDirtyFields";
-import ConsideredLanguages from "./ConsideredLanguages";
+import ConsideredLanguages, {
+  LanguageProfileOptions_Fragment,
+} from "./ConsideredLanguages";
 import { getConsideredLangItems } from "./utils";
 
 interface FormFieldProps {
   labels: FieldLabels;
+  optionsQuery?: FragmentType<typeof LanguageProfileOptions_Fragment>;
 }
 
-const FormFields = ({ labels }: FormFieldProps) => {
+const FormFields = ({ labels, optionsQuery }: FormFieldProps) => {
   const intl = useIntl();
   const consideredLangOptions = getConsideredLangItems(intl);
   useDirtyFields("language");
@@ -32,7 +36,7 @@ const FormFields = ({ labels }: FormFieldProps) => {
         }}
         items={consideredLangOptions}
       />
-      <ConsideredLanguages labels={labels} />
+      <ConsideredLanguages labels={labels} optionsQuery={optionsQuery} />
     </div>
   );
 };

--- a/apps/web/src/components/Profile/components/LanguageProfile/LanguageProfile.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/LanguageProfile.tsx
@@ -1,12 +1,13 @@
 import { useIntl } from "react-intl";
 import { SubmitHandler } from "react-hook-form";
 import LanguageIcon from "@heroicons/react/24/outline/LanguageIcon";
+import { useQuery } from "urql";
 
-import { ToggleSection, Well } from "@gc-digital-talent/ui";
+import { Loading, ToggleSection, Well } from "@gc-digital-talent/ui";
 import { BasicForm } from "@gc-digital-talent/forms";
 import { toast } from "@gc-digital-talent/toast";
 import { commonMessages } from "@gc-digital-talent/i18n";
-import { Pool } from "@gc-digital-talent/graphql";
+import { graphql, Pool } from "@gc-digital-talent/graphql";
 
 import MissingLanguageRequirements from "~/components/MissingLanguageRequirements";
 import profileMessages from "~/messages/profileMessages";
@@ -26,6 +27,12 @@ import NullDisplay from "./NullDisplay";
 import Display from "./Display";
 import FormFields from "./FormFields";
 
+const LanguageProfile_Query = graphql(/* GraphQL */ `
+  query LanguageProfile {
+    ...LanguageProfileOptions
+  }
+`);
+
 const LanguageProfile = ({
   user,
   application,
@@ -42,6 +49,7 @@ const LanguageProfile = ({
     emptyRequired,
     fallbackIcon: LanguageIcon,
   });
+  const [{ data, fetching }] = useQuery({ query: LanguageProfile_Query });
 
   const missingLanguageRequirements = getMissingLanguageRequirements(user, {
     language: application?.pool?.language,
@@ -118,16 +126,20 @@ const LanguageProfile = ({
           {isNull ? <NullDisplay /> : <Display user={user} />}
         </ToggleSection.InitialContent>
         <ToggleSection.OpenContent>
-          <BasicForm
-            labels={labels}
-            onSubmit={handleSubmit}
-            options={{
-              defaultValues: dataToFormValues(user),
-            }}
-          >
-            <FormFields labels={labels} />
-            <FormActions isUpdating={isUpdating} />
-          </BasicForm>
+          {fetching ? (
+            <Loading inline />
+          ) : (
+            <BasicForm
+              labels={labels}
+              onSubmit={handleSubmit}
+              options={{
+                defaultValues: dataToFormValues(user),
+              }}
+            >
+              <FormFields labels={labels} optionsQuery={data} />
+              <FormActions isUpdating={isUpdating} />
+            </BasicForm>
+          )}
         </ToggleSection.OpenContent>
       </ToggleSection.Content>
     </ToggleSection.Root>

--- a/apps/web/src/components/Profile/components/PersonalInformation/FormFields.tsx
+++ b/apps/web/src/components/Profile/components/PersonalInformation/FormFields.tsx
@@ -1,5 +1,4 @@
 import { useIntl } from "react-intl";
-import { useQuery } from "urql";
 
 import {
   Input,
@@ -12,14 +11,14 @@ import {
   getArmedForcesStatusesProfile,
   getCitizenshipStatusesProfile,
 } from "@gc-digital-talent/i18n";
-import { graphql } from "@gc-digital-talent/graphql";
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import { FormFieldProps } from "../../types";
 import useDirtyFields from "../../hooks/useDirtyFields";
 import { armedForcesStatusOrdered, citizenshipStatusesOrdered } from "./utils";
 
-const PersonalInformationFormOptions_Query = graphql(/* GraphQL */ `
-  query PersonalInformationFormOptions {
+const PersonalInformationFormOptions_Fragment = graphql(/* GraphQL */ `
+  fragment PersonalInformationFormOptions on Query {
     languages: localizedEnumStrings(enumName: "Language") {
       value
       label {
@@ -30,9 +29,17 @@ const PersonalInformationFormOptions_Query = graphql(/* GraphQL */ `
   }
 `);
 
-const FormFields = ({ labels }: FormFieldProps) => {
+const FormFields = ({
+  labels,
+  optionsQuery,
+}: FormFieldProps<
+  FragmentType<typeof PersonalInformationFormOptions_Fragment>
+>) => {
   const intl = useIntl();
-  const [{ data }] = useQuery({ query: PersonalInformationFormOptions_Query });
+  const data = getFragment(
+    PersonalInformationFormOptions_Fragment,
+    optionsQuery,
+  );
   useDirtyFields("personal");
 
   const languageOptions = localizedEnumToOptions(data?.languages, intl);

--- a/apps/web/src/components/Profile/components/PersonalInformation/PersonalInformation.tsx
+++ b/apps/web/src/components/Profile/components/PersonalInformation/PersonalInformation.tsx
@@ -1,12 +1,13 @@
 import { useIntl } from "react-intl";
 import { SubmitHandler } from "react-hook-form";
 import UserIcon from "@heroicons/react/24/outline/UserIcon";
+import { useQuery } from "urql";
 
-import { ToggleSection, Well } from "@gc-digital-talent/ui";
+import { Loading, ToggleSection, Well } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
 import { BasicForm } from "@gc-digital-talent/forms";
 import { commonMessages } from "@gc-digital-talent/i18n";
-import { Pool } from "@gc-digital-talent/graphql";
+import { graphql, Pool } from "@gc-digital-talent/graphql";
 
 import profileMessages from "~/messages/profileMessages";
 import {
@@ -27,6 +28,12 @@ import NullDisplay from "./NullDisplay";
 import Display from "./Display";
 import FormFields from "./FormFields";
 
+const PersonalInformationForm_Query = graphql(/* GraphQL */ `
+  query PersonalInformationForm {
+    ...PersonalInformationFormOptions
+  }
+`);
+
 const PersonalInformation = ({
   user,
   onUpdate,
@@ -44,6 +51,9 @@ const PersonalInformation = ({
   });
   const applicationContext = useApplicationContext();
   const isInApplication = !!applicationContext.currentStepOrdinal;
+  const [{ data, fetching }] = useQuery({
+    query: PersonalInformationForm_Query,
+  });
 
   const handleSubmit: SubmitHandler<FormValues> = async (formValues) => {
     return onUpdate(user.id, formValuesToSubmitData(formValues, user))
@@ -116,16 +126,20 @@ const PersonalInformation = ({
           )}
         </ToggleSection.InitialContent>
         <ToggleSection.OpenContent>
-          <BasicForm
-            labels={labels}
-            onSubmit={handleSubmit}
-            options={{
-              defaultValues: dataToFormValues(user),
-            }}
-          >
-            <FormFields labels={labels} />
-            <FormActions isUpdating={isUpdating} />
-          </BasicForm>
+          {fetching ? (
+            <Loading inline />
+          ) : (
+            <BasicForm
+              labels={labels}
+              onSubmit={handleSubmit}
+              options={{
+                defaultValues: dataToFormValues(user),
+              }}
+            >
+              <FormFields labels={labels} optionsQuery={data} />
+              <FormActions isUpdating={isUpdating} />
+            </BasicForm>
+          )}
         </ToggleSection.OpenContent>
       </ToggleSection.Content>
     </ToggleSection.Root>

--- a/apps/web/src/components/Profile/components/WorkPreferences/FormFields.tsx
+++ b/apps/web/src/components/Profile/components/WorkPreferences/FormFields.tsx
@@ -1,5 +1,4 @@
 import { useIntl } from "react-intl";
-import { useQuery } from "urql";
 
 import {
   Checklist,
@@ -16,13 +15,13 @@ import {
   getOperationalRequirement,
   sortWorkRegion,
 } from "@gc-digital-talent/i18n";
-import { graphql } from "@gc-digital-talent/graphql";
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import { FormFieldProps } from "../../types";
 import useDirtyFields from "../../hooks/useDirtyFields";
 
-const WorkPreferencesOptions_Query = graphql(/* GraphQL */ `
-  query WorkPreferencesOptions {
+const WorkPreferencesFormOptions_Fragment = graphql(/* GraphQL */ `
+  fragment WorkPreferencesFormOptions on Query {
     workRegions: localizedEnumStrings(enumName: "WorkRegion") {
       value
       label {
@@ -42,9 +41,14 @@ const WorkPreferencesOptions_Query = graphql(/* GraphQL */ `
   }
 `);
 
-const FormFields = ({ labels }: FormFieldProps) => {
+const FormFields = ({
+  labels,
+  optionsQuery,
+}: FormFieldProps<
+  FragmentType<typeof WorkPreferencesFormOptions_Fragment>
+>) => {
   const intl = useIntl();
-  const [{ data }] = useQuery({ query: WorkPreferencesOptions_Query });
+  const data = getFragment(WorkPreferencesFormOptions_Fragment, optionsQuery);
   useDirtyFields("work");
 
   return (

--- a/apps/web/src/components/Profile/components/WorkPreferences/WorkPreferences.tsx
+++ b/apps/web/src/components/Profile/components/WorkPreferences/WorkPreferences.tsx
@@ -1,12 +1,13 @@
 import HandThumbUpIcon from "@heroicons/react/24/outline/HandThumbUpIcon";
 import { useIntl } from "react-intl";
 import { SubmitHandler } from "react-hook-form";
+import { useQuery } from "urql";
 
-import { ToggleSection, Well } from "@gc-digital-talent/ui";
+import { Loading, ToggleSection, Well } from "@gc-digital-talent/ui";
 import { BasicForm } from "@gc-digital-talent/forms";
 import { toast } from "@gc-digital-talent/toast";
 import { commonMessages } from "@gc-digital-talent/i18n";
-import { Pool } from "@gc-digital-talent/graphql";
+import { graphql, Pool } from "@gc-digital-talent/graphql";
 
 import profileMessages from "~/messages/profileMessages";
 import {
@@ -24,6 +25,12 @@ import FormFields from "./FormFields";
 import NullDisplay from "./NullDisplay";
 import Display from "./Display";
 
+const WorkPreferencesForm_Query = graphql(/* GraphQL */ `
+  query WorkPreferencesForm_Query {
+    ...WorkPreferencesFormOptions
+  }
+`);
+
 const WorkPreferences = ({
   user,
   onUpdate,
@@ -39,6 +46,7 @@ const WorkPreferences = ({
     emptyRequired,
     fallbackIcon: HandThumbUpIcon,
   });
+  const [{ data, fetching }] = useQuery({ query: WorkPreferencesForm_Query });
 
   const handleSubmit: SubmitHandler<FormValues> = async (formValues) => {
     return onUpdate(user.id, formValuesToSubmitData(formValues))
@@ -105,16 +113,20 @@ const WorkPreferences = ({
           {isNull ? <NullDisplay /> : <Display user={user} labels={labels} />}
         </ToggleSection.InitialContent>
         <ToggleSection.OpenContent>
-          <BasicForm
-            labels={labels}
-            onSubmit={handleSubmit}
-            options={{
-              defaultValues: dataToFormValues(user),
-            }}
-          >
-            <FormFields labels={labels} />
-            <FormActions isUpdating={isUpdating} />
-          </BasicForm>
+          {fetching ? (
+            <Loading inline />
+          ) : (
+            <BasicForm
+              labels={labels}
+              onSubmit={handleSubmit}
+              options={{
+                defaultValues: dataToFormValues(user),
+              }}
+            >
+              <FormFields labels={labels} optionsQuery={data} />
+              <FormActions isUpdating={isUpdating} />
+            </BasicForm>
+          )}
         </ToggleSection.OpenContent>
       </ToggleSection.Content>
     </ToggleSection.Root>

--- a/apps/web/src/components/Profile/types.ts
+++ b/apps/web/src/components/Profile/types.ts
@@ -27,6 +27,7 @@ export interface SectionProps<P = void> {
   ) => Promise<UpdateUserAsUserMutation["updateUserAsUser"]>;
 }
 
-export interface FormFieldProps {
+export interface FormFieldProps<TOptions = object> {
   labels: FieldLabels;
+  optionsQuery?: TOptions;
 }

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialogForm.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialogForm.tsx
@@ -9,7 +9,7 @@ import {
 } from "@gc-digital-talent/graphql";
 import { CardOptionGroup, Checklist, TextArea } from "@gc-digital-talent/forms";
 import { errorMessages } from "@gc-digital-talent/i18n";
-import { Well } from "@gc-digital-talent/ui";
+import { Loading, Well } from "@gc-digital-talent/ui";
 
 import { NO_DECISION } from "~/utils/assessmentResults";
 
@@ -66,8 +66,12 @@ const ScreeningDecisionDialogForm = ({
   const watchAssessmentDecision = watch("assessmentDecision");
   const watchJustifications = watch("justifications");
 
-  const { assessmentDecisionItems, successfulOptions, unsuccessfulOptions } =
-    options;
+  const {
+    assessmentDecisionItems,
+    successfulOptions,
+    unsuccessfulOptions,
+    fetching,
+  } = options;
 
   const isAssessmentDecisionSuccessful =
     watchAssessmentDecision === AssessmentDecision.Successful;
@@ -141,7 +145,9 @@ const ScreeningDecisionDialogForm = ({
     intl,
   );
 
-  return (
+  return fetching ? (
+    <Loading inline />
+  ) : (
     <>
       <div data-h2-margin-bottom="base(x1)">
         <CardOptionGroup

--- a/apps/web/src/components/ScreeningDecisions/useOptions.ts
+++ b/apps/web/src/components/ScreeningDecisions/useOptions.ts
@@ -75,9 +75,10 @@ const useOptions = (
   assessmentDecisionItems: CardOption[];
   successfulOptions: CardOption[];
   unsuccessfulOptions: CheckboxOption[];
+  fetching: boolean;
 } => {
   const intl = useIntl();
-  const [{ data }] = useQuery({ query: ScreeningOptions_Query });
+  const [{ data, fetching }] = useQuery({ query: ScreeningOptions_Query });
 
   const assessmentDecisionItems: CardOption[] = [
     {
@@ -222,6 +223,7 @@ const useOptions = (
     assessmentDecisionItems,
     successfulOptions,
     unsuccessfulOptions,
+    fetching,
   };
 };
 

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
@@ -1,5 +1,6 @@
 import { useIntl } from "react-intl";
 import UserCircleIcon from "@heroicons/react/20/solid/UserCircleIcon";
+import { useQuery } from "urql";
 
 import {
   FragmentType,
@@ -8,7 +9,7 @@ import {
   getFragment,
   graphql,
 } from "@gc-digital-talent/graphql";
-import { CardBasic, Link, Separator } from "@gc-digital-talent/ui";
+import { CardBasic, Link, Loading, Separator } from "@gc-digital-talent/ui";
 import { commonMessages } from "@gc-digital-talent/i18n";
 
 import { getFullNameLabel } from "~/utils/nameUtils";
@@ -59,6 +60,12 @@ export const MoreActions_Fragment = graphql(/* GraphQL */ `
   }
 `);
 
+const MoreActions_Query = graphql(/* GraphQL */ `
+  query MoreActions {
+    ...RemoveCandidateOptions
+  }
+`);
+
 interface MoreActionsProps {
   poolCandidate: FragmentType<typeof MoreActions_Fragment>;
   jobPlacementOptions: JobPlacementOptionsFragmentType;
@@ -79,6 +86,7 @@ const MoreActions = ({
   const parsedSnapshot = JSON.parse(
     String(poolCandidate.profileSnapshot),
   ) as Maybe<User>;
+  const [{ data, fetching }] = useQuery({ query: MoreActions_Query });
 
   return (
     <div
@@ -99,54 +107,64 @@ const MoreActions = ({
           candidateName={candidateName}
         />
         <Separator orientation="horizontal" data-h2-margin="base(x.5, 0)" />
-        {poolCandidate.status && isRemovedStatus(poolCandidate.status.value) ? (
-          <span>
-            {intl.formatMessage(commonMessages.status)}
-            {intl.formatMessage(commonMessages.dividingColon)}
-            <ReinstateCandidateDialog reinstateQuery={poolCandidate} />
-          </span>
+        {fetching ? (
+          <Loading inline />
         ) : (
           <>
             {poolCandidate.status &&
-              RECORD_DECISION_STATUSES.includes(poolCandidate.status.value) && (
-                <FinalDecisionDialog poolCandidate={poolCandidate} />
-              )}
-            {poolCandidate.status &&
-              [
-                ...REVERT_DECISION_STATUSES,
-                ...PLACEMENT_TYPE_STATUSES,
-              ].includes(poolCandidate.status.value) && (
+            isRemovedStatus(poolCandidate.status.value) ? (
+              <span>
+                {intl.formatMessage(commonMessages.status)}
+                {intl.formatMessage(commonMessages.dividingColon)}
+                <ReinstateCandidateDialog reinstateQuery={poolCandidate} />
+              </span>
+            ) : (
+              <>
+                {poolCandidate.status &&
+                  RECORD_DECISION_STATUSES.includes(
+                    poolCandidate.status.value,
+                  ) && <FinalDecisionDialog poolCandidate={poolCandidate} />}
+                {poolCandidate.status &&
+                  [
+                    ...REVERT_DECISION_STATUSES,
+                    ...PLACEMENT_TYPE_STATUSES,
+                  ].includes(poolCandidate.status.value) && (
+                    <span>
+                      {intl.formatMessage(commonMessages.status)}
+                      {intl.formatMessage(commonMessages.dividingColon)}
+                      <RevertFinalDecisionDialog
+                        revertFinalDecisionQuery={poolCandidate}
+                      />
+                    </span>
+                  )}
+                {poolCandidate.status &&
+                  isQualifiedStatus(poolCandidate.status.value) && (
+                    <span>
+                      {intl.formatMessage(commonMessages.expiryDate)}
+                      {intl.formatMessage(commonMessages.dividingColon)}
+                      <ChangeExpiryDateDialog expiryDateQuery={poolCandidate} />
+                    </span>
+                  )}
+                {poolCandidate.status &&
+                  isQualifiedStatus(poolCandidate.status.value) && (
+                    <span>
+                      {intl.formatMessage(commonMessages.jobPlacement)}
+                      {intl.formatMessage(commonMessages.dividingColon)}
+                      <JobPlacementDialog
+                        jobPlacementDialogQuery={poolCandidate}
+                        optionsQuery={jobPlacementOptions}
+                        context="view"
+                      />
+                    </span>
+                  )}
                 <span>
-                  {intl.formatMessage(commonMessages.status)}
-                  {intl.formatMessage(commonMessages.dividingColon)}
-                  <RevertFinalDecisionDialog
-                    revertFinalDecisionQuery={poolCandidate}
+                  <RemoveCandidateDialog
+                    removalQuery={poolCandidate}
+                    optionsQuery={data}
                   />
                 </span>
-              )}
-            {poolCandidate.status &&
-              isQualifiedStatus(poolCandidate.status.value) && (
-                <span>
-                  {intl.formatMessage(commonMessages.expiryDate)}
-                  {intl.formatMessage(commonMessages.dividingColon)}
-                  <ChangeExpiryDateDialog expiryDateQuery={poolCandidate} />
-                </span>
-              )}
-            {poolCandidate.status &&
-              isQualifiedStatus(poolCandidate.status.value) && (
-                <span>
-                  {intl.formatMessage(commonMessages.jobPlacement)}
-                  {intl.formatMessage(commonMessages.dividingColon)}
-                  <JobPlacementDialog
-                    jobPlacementDialogQuery={poolCandidate}
-                    optionsQuery={jobPlacementOptions}
-                    context="view"
-                  />
-                </span>
-              )}
-            <span>
-              <RemoveCandidateDialog removalQuery={poolCandidate} />
-            </span>
+              </>
+            )}
           </>
         )}
       </CardBasic>

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/RemoveCandidateDialog/RemoveCandidateDialog.stories.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/RemoveCandidateDialog/RemoveCandidateDialog.stories.tsx
@@ -15,6 +15,7 @@ import {
 
 import RemoveCandidateDialog, {
   RemoveCandidateDialog_Fragment,
+  RemoveCandidateOptions_Fragment,
 } from "./RemoveCandidateDialog";
 
 const mockCandidates = fakePoolCandidates(1);
@@ -23,22 +24,19 @@ const mockCandidateFragment = makeFragmentData(
   RemoveCandidateDialog_Fragment,
 );
 
+const optionsFragment = makeFragmentData(
+  { removalReasons: fakeLocalizedEnum(CandidateRemovalReason) },
+  RemoveCandidateOptions_Fragment,
+);
+
 const meta = {
   title: "Components/Remove Candidate Dialog",
   component: RemoveCandidateDialog,
   decorators: [OverlayOrDialogDecorator, MockGraphqlDecorator],
   args: {
     removalQuery: mockCandidateFragment,
+    optionsQuery: optionsFragment,
     defaultOpen: true,
-  },
-  parameters: {
-    apiResponses: {
-      RemoveCandidateOptions: {
-        data: {
-          removalReasons: fakeLocalizedEnum(CandidateRemovalReason),
-        },
-      },
-    },
   },
 } satisfies Meta<typeof RemoveCandidateDialog>;
 export default meta;

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/RemoveCandidateDialog/RemoveCandidateDialog.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/RemoveCandidateDialog/RemoveCandidateDialog.tsx
@@ -23,6 +23,7 @@ import {
   getLocalizedEnumStringByValue,
   sortCandidateRemovalReason,
 } from "@gc-digital-talent/i18n";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 import FormChangeNotifyWell from "~/components/FormChangeNotifyWell/FormChangeNotifyWell";
 
@@ -57,7 +58,7 @@ export const RemoveCandidateDialog_Fragment = graphql(/* GraphQL */ `
   }
 `);
 
-const RemoveCandidateOptions_Fragment = graphql(/* GraphQL */ `
+export const RemoveCandidateOptions_Fragment = graphql(/* GraphQL */ `
   fragment RemoveCandidateOptions on Query {
     removalReasons: localizedEnumStrings(enumName: "CandidateRemovalReason") {
       value
@@ -84,6 +85,8 @@ const RemoveCandidateDialog = ({
   const [isOpen, setIsOpen] = useState<boolean>(defaultOpen);
   const candidate = getFragment(RemoveCandidateDialog_Fragment, removalQuery);
   const options = getFragment(RemoveCandidateOptions_Fragment, optionsQuery);
+
+  const removalReasons = unpackMaybes(options?.removalReasons);
 
   const [{ fetching }, removeCandidate] = useMutation(RemoveCandidate_Mutation);
 
@@ -176,7 +179,7 @@ const RemoveCandidateDialog = ({
                     required: intl.formatMessage(errorMessages.required),
                   }}
                   items={localizedEnumToOptions(
-                    sortCandidateRemovalReason(options?.removalReasons),
+                    sortCandidateRemovalReason(removalReasons),
 
                     intl,
                   )}
@@ -190,7 +193,7 @@ const RemoveCandidateDialog = ({
                     }}
                     label={getLocalizedEnumStringByValue(
                       CandidateRemovalReason.Other,
-                      options?.removalReasons,
+                      removalReasons,
 
                       intl,
                     )}

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolFilterDialog.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolFilterDialog.tsx
@@ -1,12 +1,13 @@
 import { useIntl } from "react-intl";
-import { useQuery } from "urql";
 
 import { Combobox, localizedEnumToOptions } from "@gc-digital-talent/forms";
 import {
+  FragmentType,
   PoolStatus,
   PoolStream,
   PublishingGroup,
   Scalars,
+  getFragment,
   graphql,
 } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
@@ -24,8 +25,8 @@ export interface FormValues {
   streams: PoolStream[];
 }
 
-const PoolFilterDialog_Query = graphql(/* GraphQL */ `
-  query PoolFilterDialog {
+const PoolFilterDialogOptions_Fragment = graphql(/* GraphQL */ `
+  fragment PoolFilterDialogOptions on Query {
     classifications {
       group
       level
@@ -58,11 +59,13 @@ const PoolFilterDialog = ({
   onSubmit,
   resetValues,
   initialValues,
-}: CommonFilterDialogProps<FormValues>) => {
+  optionsQuery,
+}: CommonFilterDialogProps<
+  FormValues,
+  FragmentType<typeof PoolFilterDialogOptions_Fragment>
+>) => {
   const intl = useIntl();
-  const [{ data, fetching }] = useQuery({
-    query: PoolFilterDialog_Query,
-  });
+  const data = getFragment(PoolFilterDialogOptions_Fragment, optionsQuery);
 
   return (
     <FilterDialog<FormValues>
@@ -78,7 +81,6 @@ const PoolFilterDialog = ({
           id="publishingGroups"
           name="publishingGroups"
           isMulti
-          fetching={fetching}
           label={intl.formatMessage(adminMessages.publishingGroups)}
           options={localizedEnumToOptions(data?.publishingGroups, intl)}
         />
@@ -99,7 +101,6 @@ const PoolFilterDialog = ({
         <Combobox
           id="classifications"
           name="classifications"
-          {...{ fetching }}
           isMulti
           label={intl.formatMessage(adminMessages.classifications)}
           options={unpackMaybes(data?.classifications).map(

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -134,6 +134,9 @@ const PoolTable_Query = graphql(/* GraphQL */ `
       id
       ...PoolBookmark
     }
+
+    ...PoolFilterDialogOptions
+
     poolsPaginated(
       where: $where
       orderByPoolBookmarks: $orderByPoolBookmarks
@@ -468,6 +471,7 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
         state: filterRef.current,
         component: (
           <PoolFilterDialog
+            optionsQuery={data}
             onSubmit={handleFilterSubmit}
             resetValues={transformPoolFilterInputToFormValues(
               initialFilterInput,

--- a/apps/web/src/pages/Skills/operations.ts
+++ b/apps/web/src/pages/Skills/operations.ts
@@ -1,7 +1,7 @@
 import { graphql } from "@gc-digital-talent/graphql";
 
-export const SkillFormOptions_Query = graphql(/* GraphQL */ `
-  query SkillFormOptions {
+export const SkillFormOptions_Fragment = graphql(/* GraphQL */ `
+  fragment SkillFormOptions on Query {
     categories: localizedEnumStrings(enumName: "SkillCategory") {
       value
       label {

--- a/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.stories.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.stories.tsx
@@ -6,10 +6,9 @@ import {
   fakeRoles,
   fakeLocalizedEnum,
 } from "@gc-digital-talent/fake-data";
-import { Language } from "@gc-digital-talent/graphql";
-import { OperationalRequirements } from "@gc-digital-talent/i18n";
+import { Language, makeFragmentData } from "@gc-digital-talent/graphql";
 
-import UpdateUserPage from "./UpdateUserPage";
+import UpdateUserPage, { UpdateUserOptions_Fragment } from "./UpdateUserPage";
 
 const availableRoles = fakeRoles();
 const teamsData = fakeTeams(10);
@@ -42,12 +41,6 @@ export default {
           teams: teamsData,
         },
       },
-      UpdateUserOptions: {
-        data: {
-          languages: fakeLocalizedEnum(Language),
-          operationalRequirements: fakeLocalizedEnum(OperationalRequirements),
-        },
-      },
     },
   },
 } as Meta<typeof UpdateUserPage>;
@@ -61,6 +54,12 @@ Default.parameters = {
       data: {
         user: userData,
         roles: availableRoles,
+        ...makeFragmentData(
+          {
+            languages: fakeLocalizedEnum(Language),
+          },
+          UpdateUserOptions_Fragment,
+        ),
       },
     },
   },

--- a/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
@@ -28,6 +28,8 @@ import {
   User,
   graphql,
   UpdateUserDataQuery as UpdateUserDataQueryType,
+  FragmentType,
+  getFragment,
 } from "@gc-digital-talent/graphql";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 
@@ -53,8 +55,8 @@ import {
 import CommunityRoleTable from "./components/CommunityRoleTable";
 import ProcessRoleTable from "./components/ProcessRoleTable";
 
-const UpdateUserOptions_Query = graphql(/* GraphQL */ `
-  query UpdateUserOptions {
+const UpdateUserOptions_Fragment = graphql(/* GraphQL */ `
+  fragment UpdateUserOptions on Query {
     languages: localizedEnumStrings(enumName: "Language") {
       value
       label {
@@ -95,6 +97,7 @@ type FormValues = Pick<
 > & { isGovEmployee: string };
 interface UpdateUserFormProps {
   initialUser: PartialUser;
+  formOptionsQuery: FragmentType<typeof UpdateUserOptions_Fragment>;
   handleUpdateUser: (
     id: string,
     data: UpdateUserAsAdminInput,
@@ -103,12 +106,13 @@ interface UpdateUserFormProps {
 
 export const UpdateUserForm = ({
   initialUser,
+  formOptionsQuery,
   handleUpdateUser,
 }: UpdateUserFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();
-  const [{ data }] = useQuery({ query: UpdateUserOptions_Query });
+  const formOptions = getFragment(UpdateUserOptions_Fragment, formOptionsQuery);
 
   const formValuesToSubmitData = (
     values: FormValues,
@@ -178,7 +182,10 @@ export const UpdateUserForm = ({
       });
   };
 
-  const languageOptions = localizedEnumToOptions(data?.languages, intl);
+  const languageOptions = localizedEnumToOptions(
+    unpackMaybes(formOptions?.languages),
+    intl,
+  );
 
   return (
     <section data-h2-wrapper="base(left, s)">
@@ -422,6 +429,7 @@ const UpdateUserPage = () => {
         {data?.user ? (
           <>
             <UpdateUserForm
+              formOptionsQuery={data}
               initialUser={data.user}
               handleUpdateUser={handleUpdateUser}
             />

--- a/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
@@ -55,7 +55,7 @@ import {
 import CommunityRoleTable from "./components/CommunityRoleTable";
 import ProcessRoleTable from "./components/ProcessRoleTable";
 
-const UpdateUserOptions_Fragment = graphql(/* GraphQL */ `
+export const UpdateUserOptions_Fragment = graphql(/* GraphQL */ `
   fragment UpdateUserOptions on Query {
     languages: localizedEnumStrings(enumName: "Language") {
       value

--- a/apps/web/src/pages/Users/UpdateUserPage/operations.ts
+++ b/apps/web/src/pages/Users/UpdateUserPage/operations.ts
@@ -12,6 +12,8 @@ export const UpdateUserData_Query = graphql(/* GraphQL */ `
       }
     }
 
+    ...UpdateUserOptions
+
     user(id: $id, trashed: WITH) {
       id
       email


### PR DESCRIPTION
🤖 Resolves #12068 

## 👋 Introduction

Fixes the issue where localized enums used as options in forms were causing issues with form default values.

## 🕵️ Details

Some of the localized enums that come from the API were not available until after the form initialized, causing problems with rendering the default values. This moves the queries for the options up 1-2 levels so we can delay form initialization until the options have been returned from the API.

## 🧪 Testing

1. Build app `pnpm run dev:fresh`
2. Find all forms that use the `localizedEnumToOptions` helper
3. Confirm that their default values are initialized properly
