### PR TITLE
[Fix] Switch env constants to import.meta

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -23,7 +23,3 @@ FEATURE_DIRECTIVE_FORMS=true
 # Logging - enable by setting the logging level. Eight severity levels from rfc5424.
 LOG_CONSOLE_LEVEL="debug"
 LOG_APPLICATIONINSIGHTS_LEVEL="warning"
-
-# Support
-VITE_TALENTSEARCH_SUPPORT_EMAIL="support-soutien@talent.canada.ca"
-VITE_API_SUPPORT_ENDPOINT="/api/support/tickets"

--- a/apps/web/src/constants/talentSearchConstants.ts
+++ b/apps/web/src/constants/talentSearchConstants.ts
@@ -1,6 +1,4 @@
-export const TALENTSEARCH_SUPPORT_EMAIL =
-  process.env.TALENTSEARCH_SUPPORT_EMAIL! ?? "support-soutien@talent.canada.ca";
-export const API_SUPPORT_ENDPOINT =
-  process.env.API_SUPPORT_ENDPOINT! ?? "/api/support/tickets";
+export const TALENTSEARCH_SUPPORT_EMAIL = "support-soutien@talent.canada.ca";
+export const API_SUPPORT_ENDPOINT = "/api/support/tickets";
 // We allow word counts to be higher in French
 export const FRENCH_WORDS_PER_ENGLISH_WORD = 7 / 5;

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -6,5 +6,3 @@ declare const API_PROTECTED_URI: string;
 declare const BUILD_DATE: string;
 declare const VERSION: string;
 declare const COMMIT_HASH: string;
-declare const TALENTSEARCH_SUPPORT_EMAIL: string;
-declare const API_SUPPORT_ENDPOINT: string;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -24,7 +24,7 @@ const meta = {
   image: `${appUrl}/images/digital-talent/banner.jpg`,
 };
 
-const getEnvVar = (key: string, fallback: string = `""`): string => {
+const getEnvVar = (key: string, fallback = `""`): string => {
   return process.env[key] ? JSON.stringify(process.env[key]) : fallback;
 };
 
@@ -118,8 +118,6 @@ export default defineConfig(({ command }) => ({
     API_URI: getEnvVar("VITE_API_URI"),
     API_PROTECTED_URI: getEnvVar("VITE_API_PROTECTED_URI"),
     BUILD_DATE: JSON.stringify(new Date()),
-    API_SUPPORT_ENDPOINT: getEnvVar("VITE_API_SUPPORT_ENDPOINT"),
-    TALENTSEARCH_SUPPORT_EMAIL: getEnvVar("VITE_TALENTSEARCH_SUPPORT_EMAIL"),
 
     // run-time variables
     OAUTH_POST_LOGOUT_REDIRECT_EN: getEnvVar("OAUTH_POST_LOGOUT_REDIRECT_EN"),

--- a/infrastructure/azure-pipelines.yml
+++ b/infrastructure/azure-pipelines.yml
@@ -50,8 +50,6 @@ jobs:
           # Vite requires build-time variable to have the VITE_ prefix
           VITE_API_URI: /graphql
           VITE_API_PROTECTED_URI: /admin/graphql
-          VITE_API_SUPPORT_ENDPOINT: /api/support/tickets
-          VITE_TALENTSEARCH_SUPPORT_EMAIL: support-soutien@talent.canada.ca
 
       - task: CopyFiles@2
         displayName: "Copy files to staging directory"


### PR DESCRIPTION
🤖 Resolves #11578 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Switches the talentsearch constants to plain constants to let watch mode work properly on those pages.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->
Vite imports environment variables [a little differently](https://vite.dev/guide/env-and-mode) than Webpack.  However, switching to the import.meta imports that Vite uses [breaks Jest](url).  Working around this would require the import of yet another dependency and mocking the variables for testing.  After [some discussion on Slack](https://talent-cloud.slack.com/archives/CB424V61J/p1732656221379149) I decided to switch these to plain constants.



## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Build in watch mode `pnpm run watch`
2. Log in as `admin@test.com`
3. Visit `http://localhost:3000/en/admin/communities/{communityId}/edit` and confirm it doesn't crash.

Make sure the two constants still work:
1. Visit `http://localhost:3000/en/accessibility-statement` to see the support email
2. Submit a ticket at `http://localhost:3000/en/support` to confirm it requests the correct endpoint (but probably won't properly submit without more setup).

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the linked issue if deployment steps are needed

 -->
