### PR TITLE
[Feature] Support headings in rich text editor

### DIFF
--- a/apps/web/src/pages/TrainingOpportunities/components/TrainingOpportunityForm.tsx
+++ b/apps/web/src/pages/TrainingOpportunities/components/TrainingOpportunityForm.tsx
@@ -148,6 +148,7 @@ const TrainingOpportunityForm = ({ query }: TrainingOpportunityFormProps) => {
         id="descriptionEn"
         label={intl.formatMessage(formLabels.descriptionEn)}
         name="descriptionEn"
+        allowHeadings
         rules={{
           required: intl.formatMessage(errorMessages.required),
         }}
@@ -156,6 +157,7 @@ const TrainingOpportunityForm = ({ query }: TrainingOpportunityFormProps) => {
         id="descriptionFr"
         label={intl.formatMessage(formLabels.descriptionFr)}
         name="descriptionFr"
+        allowHeadings
         rules={{
           required: intl.formatMessage(errorMessages.required),
         }}

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -27,6 +27,7 @@
     "@heroicons/react": "^2.2.0",
     "@hookform/error-message": "^2.0.1",
     "@tiptap/extension-character-count": "^2.10.0",
+    "@tiptap/extension-heading": "^2.10.0",
     "@tiptap/extension-link": "^2.10.0",
     "@tiptap/react": "^2.10.0",
     "@tiptap/starter-kit": "^2.10.0",

--- a/packages/forms/src/components/RichTextInput/ControlledInput.tsx
+++ b/packages/forms/src/components/RichTextInput/ControlledInput.tsx
@@ -11,7 +11,7 @@ import MenuBar from "./MenuBar";
 import Footer from "./Footer";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
 import { FieldState } from "../../types";
-import { buildExtentions, contentStyles } from "./utils";
+import { buildExtensions, contentStyles } from "./utils";
 
 interface ControlledInputProps {
   field: ControllerRenderProps<FieldValues, string>;
@@ -63,7 +63,7 @@ const ControlledInput = ({
   );
 
   const editor = useEditor({
-    extensions: buildExtentions(allowHeadings),
+    extensions: buildExtensions(allowHeadings),
     content,
     editorProps,
     editable,

--- a/packages/forms/src/components/RichTextInput/ControlledInput.tsx
+++ b/packages/forms/src/components/RichTextInput/ControlledInput.tsx
@@ -11,7 +11,7 @@ import MenuBar from "./MenuBar";
 import Footer from "./Footer";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
 import { FieldState } from "../../types";
-import { contentStyles, extensions } from "./utils";
+import { buildExtentions, contentStyles } from "./utils";
 
 interface ControlledInputProps {
   field: ControllerRenderProps<FieldValues, string>;
@@ -24,11 +24,13 @@ interface ControlledInputProps {
   /** Current field state (to update styles) */
   fieldState: FieldState;
   inputProps?: Record<string, string>;
+  allowHeadings?: boolean;
 }
 
 const ControlledInput = ({
   field: { onChange, name },
   formState: { defaultValues },
+  allowHeadings,
   fieldState,
   inputProps,
   editable,
@@ -61,7 +63,7 @@ const ControlledInput = ({
   );
 
   const editor = useEditor({
-    extensions,
+    extensions: buildExtentions(allowHeadings),
     content,
     editorProps,
     editable,
@@ -82,7 +84,7 @@ const ControlledInput = ({
 
   return (
     <div>
-      <MenuBar {...{ editor }} />
+      <MenuBar allowHeadings={allowHeadings} {...{ editor }} />
       <div data-h2-color="base(black)">
         <EditorContent {...{ content, editor }} />
       </div>

--- a/packages/forms/src/components/RichTextInput/MenuBar.tsx
+++ b/packages/forms/src/components/RichTextInput/MenuBar.tsx
@@ -3,6 +3,7 @@ import { Editor } from "@tiptap/react";
 import ListBulletIcon from "@heroicons/react/20/solid/ListBulletIcon";
 import ArrowUturnLeftIcon from "@heroicons/react/20/solid/ArrowUturnLeftIcon";
 import ArrowUturnRightIcon from "@heroicons/react/20/solid/ArrowUturnRightIcon";
+import H3Icon from "@heroicons/react/20/solid/H3Icon";
 
 import { richTextMessages } from "@gc-digital-talent/i18n";
 
@@ -11,9 +12,10 @@ import LinkDialog from "./LinkDialog";
 
 interface MenuBarProps {
   editor: Editor | null;
+  allowHeadings?: boolean;
 }
 
-const MenuBar = ({ editor }: MenuBarProps) => {
+const MenuBar = ({ editor, allowHeadings = false }: MenuBarProps) => {
   const intl = useIntl();
   const readOnly = !editor?.isEditable;
 
@@ -38,6 +40,18 @@ const MenuBar = ({ editor }: MenuBarProps) => {
           {intl.formatMessage(richTextMessages.bulletList)}
         </MenuButton>
         <LinkDialog editor={editor} />
+        {allowHeadings && (
+          <MenuButton
+            active={editor?.isActive("heading") ?? false}
+            onClick={() =>
+              editor?.chain().focus().toggleHeading({ level: 3 }).run()
+            }
+            disabled={readOnly || !editor?.can().toggleHeading({ level: 3 })}
+            icon={H3Icon}
+          >
+            {intl.formatMessage(richTextMessages.heading)}
+          </MenuButton>
+        )}
       </div>
       <div data-h2-display="base(flex)" data-h2-gap="base(x.5)">
         <MenuButton

--- a/packages/forms/src/components/RichTextInput/RichTextInput.stories.tsx
+++ b/packages/forms/src/components/RichTextInput/RichTextInput.stories.tsx
@@ -73,6 +73,7 @@ const Template: StoryFn<DefaultValueRichTextInputArgs> = (args) => {
         data-h2-padding="base(x1)"
         data-h2-shadow="base(larger)"
         data-h2-background-color="base(foreground)"
+        data-h2-margin-top="base:children[>*:first-child](0)"
       >
         <RichTextRenderer node={htmlToRichTextJSON(output)} />
       </div>
@@ -129,4 +130,10 @@ LongContent.args = {
   <p>Aenean id suscipit sapien. Praesent at mollis risus. Phasellus imperdiet, ante ac egestas viverra, turpis dolor porta augue, at pellentesque enim odio eget libero. Integer volutpat accumsan interdum. Curabitur fermentum dapibus dolor. Ut malesuada ante sit amet odio sagittis, eget convallis odio posuere. Sed vitae turpis nec diam maximus varius.</p>
   <p>Etiam sagittis urna lobortis, volutpat augue eu, molestie lacus. Praesent finibus lorem ut quam imperdiet fringilla. Duis accumsan facilisis erat, id blandit mi rhoncus eu. Sed tempor, justo eu pharetra molestie, sem justo laoreet urna, nec sagittis libero ipsum blandit lacus. Proin at libero et turpis dictum convallis. Aliquam ut pharetra dolor, pellentesque consequat sem. Phasellus dictum quam purus, fermentum ornare augue iaculis vel. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum pellentesque leo ac diam rutrum congue. Pellentesque at rutrum nibh.</p>
   `,
+};
+
+export const WithHeading = Template.bind({});
+WithHeading.args = {
+  defaultValue: `<h3>A heading 3</h3>${defaultContent}`,
+  allowHeadings: true,
 };

--- a/packages/forms/src/components/RichTextInput/RichTextInput.tsx
+++ b/packages/forms/src/components/RichTextInput/RichTextInput.tsx
@@ -20,6 +20,8 @@ type RichTextInputProps = Omit<
     wordLimit?: number;
     /** Set this component to be read only */
     readOnly?: boolean;
+    /** Determine if the option to add headings is enabled */
+    allowHeadings?: boolean;
   };
 
 const RichTextInput = ({
@@ -30,6 +32,7 @@ const RichTextInput = ({
   wordLimit,
   rules = {},
   readOnly,
+  allowHeadings,
   trackUnsaved = true,
   "aria-describedby": describedBy,
   "aria-labelledby": labelledBy,
@@ -90,6 +93,7 @@ const RichTextInput = ({
             wordLimit={wordLimit}
             trackUnsaved={trackUnsaved}
             fieldState={fieldState}
+            allowHeadings={allowHeadings}
             inputProps={{
               id,
               ...wordLimitStyles,

--- a/packages/forms/src/components/RichTextInput/RichTextRenderer.tsx
+++ b/packages/forms/src/components/RichTextInput/RichTextRenderer.tsx
@@ -1,6 +1,6 @@
 import { AnchorHTMLAttributes, JSX } from "react";
 
-import { Link, LinkProps } from "@gc-digital-talent/ui";
+import { Heading, Link, LinkProps } from "@gc-digital-talent/ui";
 
 import { RenderMap, Node, NodeRenderer } from "./types";
 
@@ -12,6 +12,7 @@ const DocNode: NodeRenderer = ({ children }) => (
   <div
     data-h2-color="base(black)"
     data-h2-margin="base:children[>p:not(:first-child)](x.5, 0, 0, 0)"
+    data-h2-margin-top="base:children[>*:first-child](0)"
   >
     {children}
   </div>
@@ -55,12 +56,17 @@ const ListItemNode: NodeRenderer = ({ children }) => {
   return <li>{children}</li>;
 };
 
+const HeadingNode: NodeRenderer = ({ children }) => {
+  return <Heading level="h3">{children}</Heading>;
+};
+
 const nodeRenderMap: RenderMap = {
   doc: DocNode,
   text: TextNode,
   paragraph: ParagraphNode,
   bulletList: BulletListNode,
   listItem: ListItemNode,
+  heading: HeadingNode,
 };
 
 interface RichTextRendererProps {

--- a/packages/forms/src/components/RichTextInput/RichTextRenderer.tsx
+++ b/packages/forms/src/components/RichTextInput/RichTextRenderer.tsx
@@ -57,7 +57,11 @@ const ListItemNode: NodeRenderer = ({ children }) => {
 };
 
 const HeadingNode: NodeRenderer = ({ children }) => {
-  return <Heading level="h3">{children}</Heading>;
+  return (
+    <Heading level="h3" size="h4">
+      {children}
+    </Heading>
+  );
 };
 
 const nodeRenderMap: RenderMap = {

--- a/packages/forms/src/components/RichTextInput/utils.tsx
+++ b/packages/forms/src/components/RichTextInput/utils.tsx
@@ -28,7 +28,7 @@ const extensions = [
   }),
 ];
 
-export const buildExtentions = (allowHeadings?: boolean) => [
+export const buildExtensions = (allowHeadings?: boolean) => [
   ...extensions,
   ...(allowHeadings ? [Heading.configure({ levels: [3] })] : []),
 ];

--- a/packages/forms/src/components/RichTextInput/utils.tsx
+++ b/packages/forms/src/components/RichTextInput/utils.tsx
@@ -1,8 +1,9 @@
 import { CharacterCount } from "@tiptap/extension-character-count";
+import { Heading } from "@tiptap/extension-heading";
 import { Link } from "@tiptap/extension-link";
 import { StarterKit } from "@tiptap/starter-kit";
 
-export const extensions = [
+const extensions = [
   // REF: https://tiptap.dev/api/extensions/starter-kit
   StarterKit.configure({
     // Disabled Nodes
@@ -25,6 +26,11 @@ export const extensions = [
   Link.configure({
     openOnClick: false,
   }),
+];
+
+export const buildExtentions = (allowHeadings?: boolean) => [
+  ...extensions,
+  ...(allowHeadings ? [Heading.configure({ levels: [3] })] : []),
 ];
 
 export const contentStyles = {

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1,4 +1,8 @@
 {
+  "5xaEhL": {
+    "defaultMessage": "Titre",
+    "description": "Label for toggling a heading in the rich text editor"
+  },
   "+6/qCF": {
     "defaultMessage": "Supprimer",
     "description": "Button text for a dismissible chip"

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1,8 +1,4 @@
 {
-  "5xaEhL": {
-    "defaultMessage": "Titre",
-    "description": "Label for toggling a heading in the rich text editor"
-  },
   "+6/qCF": {
     "defaultMessage": "Supprimer",
     "description": "Button text for a dismissible chip"
@@ -202,6 +198,10 @@
   "5hXz/z": {
     "defaultMessage": "Sélectionnez un mois",
     "description": "Placeholder for a month select field"
+  },
+  "5xaEhL": {
+    "defaultMessage": "Titre",
+    "description": "Label for toggling a heading in the rich text editor"
   },
   "6/U6rm": {
     "defaultMessage": "Décision finale relative à l’évaluation",

--- a/packages/i18n/src/messages/richTextMessages.ts
+++ b/packages/i18n/src/messages/richTextMessages.ts
@@ -6,6 +6,11 @@ const richTextMessages = defineMessages({
     id: "tEUGpL",
     description: "Label for toggling a bullet list in the rich text editor",
   },
+  heading: {
+    defaultMessage: "Heading",
+    id: "5xaEhL",
+    description: "Label for toggling a heading in the rich text editor",
+  },
   undo: {
     defaultMessage: "Undo",
     id: "cP2cZ0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -600,6 +600,9 @@ importers:
       '@tiptap/extension-character-count':
         specifier: ^2.10.0
         version: 2.10.0(@tiptap/core@2.10.0(@tiptap/pm@2.10.0))(@tiptap/pm@2.10.0)
+      '@tiptap/extension-heading':
+        specifier: ^2.10.0
+        version: 2.10.0(@tiptap/core@2.10.0(@tiptap/pm@2.10.0))
       '@tiptap/extension-link':
         specifier: ^2.10.0
         version: 2.10.0(@tiptap/core@2.10.0(@tiptap/pm@2.10.0))(@tiptap/pm@2.10.0)


### PR DESCRIPTION
🤖 Resolves #12086 

## 👋 Introduction

Adds the ability for heading 3 nodes in the rich text editor for the new training opportunities pages.

## 🕵️ Details

Adds a prop `allowHeadings?: boolean = false` to the `RichTextInput` component to allow adding only a heading 3 to the content. This feature has only been enabled for the training opportunities description right now.

## 🧪 Testing

1. Install new dependecy `pnpm i`
2. Build app `pnpm run dev:fresh`
3. Login as admin `admin@test.com`
4. Navigate to training opportunites (`/admin/training-opportunities`) and create a new one
5. Confirm you can add a heading
6. Submit the new opportunity
7. Navigate to the public side (`/en/it-training-fund/instructor-led-training`)
8. Find the new opportunity created in step 6
9. Click "Learn more and apply"
10. Confirm the heading is render at rank 3

## 📸 Screenshot

![2024-11-26_15-38](https://github.com/user-attachments/assets/4cc555d3-d708-407f-b5e1-e4d11daf1f62)
