### PR TITLE
[Feature] Adds notification in app work experience updates; ability to select channel to send via

### DIFF
--- a/api/app/Console/Commands/SendNotificationsSystem.php
+++ b/api/app/Console/Commands/SendNotificationsSystem.php
@@ -19,7 +19,10 @@ class SendNotificationsSystem extends Command
      */
     protected $signature = 'send-notifications:system
                             {viewGroup : The group of views to render the notification with}
-                            {emailAddress? : The email address of the user to send to}';
+                            {emailAddress? : The email address of the user to send to}
+                            {--channelEmail : The email channel to send notifications via}
+                            {--channelApp : The app channel to send notifications via}
+                            ';
 
     /**
      * The console command description.
@@ -33,6 +36,10 @@ class SendNotificationsSystem extends Command
      *
      * @var mixed
      */
+    private $channelEmail = false;
+
+    private $channelApp = false;
+
     private $emailSubject = ['en' => '', 'fr' => ''];
 
     private $emailContent = ['en' => '', 'fr' => ''];
@@ -53,34 +60,49 @@ class SendNotificationsSystem extends Command
 
         $viewGroup = $this->argument('viewGroup');
 
-        // find the views in api/resources/views/
-        $this->emailSubject = [
-            'en' => $viewGroup.'.email_subject_en',
-            'fr' => $viewGroup.'.email_subject_fr',
-        ];
-        $this->emailContent = [
-            'en' => $viewGroup.'.email_content_en',
-            'fr' => $viewGroup.'.email_subject_fr',
-        ];
-        $this->inAppMessage = [
-            'en' => $viewGroup.'.in_app_message_en',
-            'fr' => $viewGroup.'.in_app_message_fr',
-        ];
-        $this->inAppHref = [
-            'en' => $viewGroup.'.in_app_href_en',
-            'fr' => $viewGroup.'.in_app_href_fr',
-        ];
+        $this->channelEmail = $this->option('channelEmail');
 
-        collect([
-            $this->emailSubject['en'],
-            $this->emailSubject['fr'],
-            $this->emailContent['en'],
-            $this->emailContent['fr'],
-            $this->inAppMessage['en'],
-            $this->inAppMessage['fr'],
-            $this->inAppHref['en'],
-            $this->inAppHref['fr'],
-        ])->each(function ($viewName) {
+        $this->channelApp = $this->option('channelApp');
+
+        if(!$this->channelEmail && !$this->channelApp){
+            $this->error('No channels selected.');
+            return 1;
+        }
+
+        $collectionArr = [];
+
+        // find the views in api/resources/views/
+        if($this->channelEmail){
+            $this->emailSubject = [
+                'en' => $viewGroup.'.email_subject_en',
+                'fr' => $viewGroup.'.email_subject_fr',
+            ];
+            $this->emailContent = [
+                'en' => $viewGroup.'.email_content_en',
+                'fr' => $viewGroup.'.email_subject_fr',
+            ];
+            $collectionArr[] = $this->emailSubject['en'];
+            $collectionArr[] = $this->emailSubject['fr'];
+            $collectionArr[] = $this->emailContent['en'];
+            $collectionArr[] = $this->emailContent['fr'];
+        }
+
+        if($this->channelApp){
+            $this->inAppMessage = [
+                'en' => $viewGroup.'.in_app_message_en',
+                'fr' => $viewGroup.'.in_app_message_fr',
+            ];
+            $this->inAppHref = [
+                'en' => $viewGroup.'.in_app_href_en',
+                'fr' => $viewGroup.'.in_app_href_fr',
+            ];
+            $collectionArr[] = $this->inAppMessage['en'];
+            $collectionArr[] = $this->inAppMessage['fr'];
+            $collectionArr[] = $this->inAppHref['en'];
+            $collectionArr[] = $this->inAppHref['fr'];
+        }
+
+        collect($collectionArr)->each(function ($viewName) {
             if (! View::exists($viewName)) {
                 throw new Error('View not found: '.$viewName);
             }
@@ -93,7 +115,14 @@ class SendNotificationsSystem extends Command
             $this->sendNotification($user, $successCount, $failureCount);
         } else {
             // no email address provided - will send to everyone
-            $confirmedEveryone = $this->confirm('This will send the notification to every user.  Do you wish to continue?');
+            $confirmedEveryone = $this->confirm(
+                sprintf(
+                    'This will send the notification to every user via %s%s%s. Do you wish to continue?',
+                    $this->channelEmail ? 'email' : '',
+                    $this->channelEmail && $this->channelApp ? ', ' : '',
+                    $this->channelApp ? 'in-app' : ''
+                )
+            );
             if (! $confirmedEveryone) {
                 $this->warn('Abort');
 
@@ -119,6 +148,8 @@ class SendNotificationsSystem extends Command
     {
         try {
             $notification = new SystemNotification(
+                $this->channelEmail,
+                $this->channelApp,
                 $this->emailSubject['en'],
                 $this->emailSubject['fr'],
                 $this->emailContent['en'],

--- a/api/app/Notifications/System.php
+++ b/api/app/Notifications/System.php
@@ -17,6 +17,8 @@ class System extends Notification implements CanBeSentViaGcNotifyEmail
      * Create a new notification instance.
      */
     public function __construct(
+        public bool $channelEmail,
+        public bool $channelApp,
         public string $emailSubjectEn,
         public string $emailSubjectFr,
         public string $emailContentEn,
@@ -36,12 +38,23 @@ class System extends Notification implements CanBeSentViaGcNotifyEmail
     {
         // $notificationFamily = NotificationFamily::SYSTEM_MESSAGE->name;
         // Can't ignore system messages
-        return ['database', GcNotifyEmailChannel::class];
+
+        $arr = [];
+
+        if($this->channelApp){
+            $arr[] = 'database';
+        }
+
+        if($this->channelEmail){
+            $arr[] = GcNotifyEmailChannel::class;
+        }
+
+        return $arr;
     }
 
     /**
      * Get the array representation of the notification.
-     * https://laravel.com/docs/10.x/notifications#formatting-database-notifications
+     * https://laravel.com/docs/11.x/notifications#formatting-database-notifications
      *
      * @return array<string, mixed>
      */

--- a/api/resources/views/notification_work_experience_updates/in_app_href_en.blade.php
+++ b/api/resources/views/notification_work_experience_updates/in_app_href_en.blade.php
@@ -1,0 +1,1 @@
+/en/applicant/career-timeline

--- a/api/resources/views/notification_work_experience_updates/in_app_href_fr.blade.php
+++ b/api/resources/views/notification_work_experience_updates/in_app_href_fr.blade.php
@@ -1,0 +1,1 @@
+/fr/applicant/career-timeline

--- a/api/resources/views/notification_work_experience_updates/in_app_message_en.blade.php
+++ b/api/resources/views/notification_work_experience_updates/in_app_message_en.blade.php
@@ -1,0 +1,1 @@
+We've updated the work experience options on your profile. Please review your career timeline and ensure it’s up to date.

--- a/api/resources/views/notification_work_experience_updates/in_app_message_fr.blade.php
+++ b/api/resources/views/notification_work_experience_updates/in_app_message_fr.blade.php
@@ -1,0 +1,1 @@
+Nous avons mis à jour les options d'expérience professionnelle sur votre profil. Veuillez vérifier votre parcours professionnel et vous assurer qu'il est à jour.


### PR DESCRIPTION
🤖 Resolves #11875.

## 👋 Introduction

This PR adds the ability to send system notifications by either in-app, email, or both channels. Previously, the only option was to send to both channels. With that feature added, the PR adds a notification for work experience updates to be sent via the in-app channel.

1. `make queue-work`
2. In a separate terminal instance from `make queue-work`, `make artisan CMD="send-notifications:system notification_work_experience_updates --channelApp"`
3. Verify database table `notifications` has rows with the notification previously sent (`data` column)