### PR TITLE
[Feature] Add missing firm/agency name field

### DIFF
--- a/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
@@ -309,6 +309,7 @@ query getProfile($userId: UUID!) {
             fr
           }
         }
+        contractorFirmAgencyName
         cafEmploymentType {
           value
           label {

--- a/api/app/GraphQL/Validators/CreateUpdateWorkExperienceValidator.php
+++ b/api/app/GraphQL/Validators/CreateUpdateWorkExperienceValidator.php
@@ -3,6 +3,7 @@
 namespace App\GraphQL\Validators;
 
 use App\Enums\EmploymentCategory;
+use App\Enums\GovContractorType;
 use App\Enums\WorkExperienceGovEmployeeType;
 use Illuminate\Validation\Rule;
 use Nuwave\Lighthouse\Validation\Validator;
@@ -89,6 +90,18 @@ final class CreateUpdateWorkExperienceValidator extends Validator
                 Rule::prohibitedIf(
                     (
                         $this->arg('workExperience.employmentCategory') !== EmploymentCategory::GOVERNMENT_OF_CANADA->name
+                    )
+                ),
+            ],
+            'workExperience.contractorFirmAgencyName' => [
+                Rule::requiredIf(
+                    (
+                        $this->arg('workExperience.govContractorType') === GovContractorType::FIRM_OR_AGENCY->name
+                    )
+                ),
+                Rule::prohibitedIf(
+                    (
+                        $this->arg('workExperience.govContractorType') !== GovContractorType::FIRM_OR_AGENCY->name
                     )
                 ),
             ],

--- a/api/app/Http/Resources/WorkExperienceResource.php
+++ b/api/app/Http/Resources/WorkExperienceResource.php
@@ -34,6 +34,7 @@ class WorkExperienceResource extends JsonResource
             'govPositionType' => $this->gov_position_type,
             'govContractorRoleSeniority' => $this->gov_contractor_role_seniority,
             'govContractorType' => $this->gov_contractor_type,
+            'contractorFirmAgencyName' => $this->contractor_firm_agency_name,
             'cafEmploymentType' => $this->caf_employment_type,
             'cafForce' => $this->caf_force,
             'cafRank' => $this->caf_rank,

--- a/api/app/Models/WorkExperience.php
+++ b/api/app/Models/WorkExperience.php
@@ -34,6 +34,7 @@ use Staudenmeir\EloquentJsonRelations\HasJsonRelationships;
  * @property string $caf_rank
  * @property string $classification_id
  * @property string $department_id
+ * @property string $contractor_firm_agency_name
  */
 class WorkExperience extends Experience
 {
@@ -79,6 +80,7 @@ class WorkExperience extends Experience
         'caf_rank' => 'cafRank',
         'classification_id' => 'classificationId',
         'department_id' => 'departmentId',
+        'contractor_firm_agency_name' => 'contractorFirmAgencyName',
     ];
 
     public function getTitle(?string $lang = 'en'): string
@@ -188,6 +190,14 @@ class WorkExperience extends Experience
     protected function govContractorType(): Attribute
     {
         return $this->makeJsonPropertyStringAttribute('gov_contractor_type');
+    }
+
+    /**
+     * Interact with the contractor firm or agency name
+     */
+    protected function contractorFirmAgencyName(): Attribute
+    {
+        return $this->makeJsonPropertyStringAttribute('contractor_firm_agency_name');
     }
 
     /**

--- a/api/database/factories/WorkExperienceFactory.php
+++ b/api/database/factories/WorkExperienceFactory.php
@@ -78,6 +78,10 @@ class WorkExperienceFactory extends Factory
                 return $attributes['gov_employment_type'] === WorkExperienceGovEmployeeType::CONTRACTOR->name ?
                     $this->faker->randomElement(GovContractorType::cases())->name : null;
             },
+            'contractor_firm_agency_name' => function (array $attributes) {
+                return $attributes['gov_contractor_type'] === GovContractorType::FIRM_OR_AGENCY->name ?
+                    $this->faker->company : null;
+            },
             'caf_employment_type' => function (array $attributes) {
                 return $attributes['employment_category'] === EmploymentCategory::CANADIAN_ARMED_FORCES->name ?
                     $this->faker->randomElement(CafEmploymentType::cases())->name : null;

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -690,6 +690,8 @@ type WorkExperience implements Experience {
     @rename(attribute: "gov_contractor_role_seniority")
   govContractorType: LocalizedGovContractorType
     @rename(attribute: "gov_contractor_type")
+  contractorFirmAgencyName: String
+    @rename(attribute: "contractor_firm_agency_name")
   cafEmploymentType: LocalizedCafEmploymentType
     @rename(attribute: "caf_employment_type")
   cafForce: LocalizedCafForce @rename(attribute: "caf_force")
@@ -1641,6 +1643,8 @@ input WorkExperienceInput {
     @rename(attribute: "gov_contractor_role_seniority")
   govContractorType: GovContractorType @rename(attribute: "gov_contractor_type")
   cafEmploymentType: CafEmploymentType @rename(attribute: "caf_employment_type")
+  contractorFirmAgencyName: String
+    @rename(attribute: "contractor_firm_agency_name")
   cafForce: CafForce @rename(attribute: "caf_force")
   cafRank: CafRank @rename(attribute: "caf_rank")
   classification: ClassificationBelongsTo

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1049,6 +1049,7 @@ type WorkExperience implements Experience {
   govPositionType: LocalizedGovPositionType
   govContractorRoleSeniority: LocalizedGovContractorRoleSeniority
   govContractorType: LocalizedGovContractorType
+  contractorFirmAgencyName: String
   cafEmploymentType: LocalizedCafEmploymentType
   cafForce: LocalizedCafForce
   cafRank: LocalizedCafRank
@@ -1690,6 +1691,7 @@ input WorkExperienceInput {
   govContractorRoleSeniority: GovContractorRoleSeniority
   govContractorType: GovContractorType
   cafEmploymentType: CafEmploymentType
+  contractorFirmAgencyName: String
   cafForce: CafForce
   cafRank: CafRank
   classification: ClassificationBelongsTo

--- a/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
@@ -380,6 +380,96 @@ export const UserProfile_FragmentText = /* GraphQL */ `
         division
         startDate
         endDate
+        employmentCategory {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        extSizeOfOrganization {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        extRoleSeniority {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        govEmploymentType {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        govPositionType {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        govContractorRoleSeniority {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        govContractorType {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        contractorFirmAgencyName
+        cafEmploymentType {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        cafForce {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        cafRank {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        classification {
+          id
+          name {
+            en
+            fr
+          }
+          group
+          level
+          maxSalary
+          minSalary
+        }
+        department {
+          id
+          name {
+            en
+            fr
+          }
+          departmentNumber
+        }
       }
     }
     isProfileComplete


### PR DESCRIPTION
🤖 Resolves #12111

## 👋 Introduction

<!-- Describe what this PR is solving. -->
A field was missing from the batch added to work experiences. This adds it in alongside touches elsewhere


## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Field added, nothing missing, query/mutation functional
2. Name required for a firm or agency contractor, forbidden otherwise

Sample

```
mutation abc {
  createWorkExperience(
    userId: "be5e1e96-390d-4fb0-bc2a-3ba5c83727fd"
    workExperience: {
      employmentCategory: GOVERNMENT_OF_CANADA, 
      govEmploymentType: CONTRACTOR, 
      department: {connect: "063162f7-a036-4047-91fb-51b5a749f716"}
      govContractorRoleSeniority: EXECUTIVE
      govContractorType: FIRM_OR_AGENCY
      contractorFirmAgencyName: "name"
    }
  ) {
		id
  }
}
```




