### PR TITLE
[Feature] Adds CR-04, PM-05, PM-06 to `scopeAvailableInSearch`

### DIFF
--- a/api/app/Models/Classification.php
+++ b/api/app/Models/Classification.php
@@ -57,7 +57,7 @@ class Classification extends Model
 
     /**
      * Used to limit the results for the search page input
-     * to IT up to level 5 and PM up to level 4
+     * to IT up to level 5 and PM up to level 6 and CR level 4
      *
      * TODO: Update in #9483 to derive from new column
      */
@@ -70,7 +70,9 @@ class Classification extends Model
         $query->where(function ($query) {
             $query->where('group', 'IT')->where('level', '<=', 5);
         })->orWhere(function ($query) {
-            $query->where('group', 'PM')->where('level', '<=', 4);
+            $query->where('group', 'PM')->where('level', '<=', 6);
+        })->orWhere(function ($query) {
+            $query->where('group', 'CR')->where('level', '=', 4);
         });
     }
 }

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2363,6 +2363,10 @@
     "defaultMessage": "Valider dès maintenant",
     "description": "Button to start the email address verification process"
   },
+  "AH2U9S": {
+    "defaultMessage": "Gestionnaire P M 6",
+    "description": "PM-06 classification aria label including titles"
+  },
   "AJs1VQ": {
     "defaultMessage": "Question (FR)",
     "description": "Label for an French general question"
@@ -5910,6 +5914,10 @@
   "SLedtO": {
     "defaultMessage": "Profil de l’utilisateur",
     "description": "Title for the user profile page"
+  },
+  "SM7PIR": {
+    "defaultMessage": "Analyste principal P M 5",
+    "description": "PM-05 classification aria label including titles"
   },
   "SNwPLZ": {
     "defaultMessage": "<strong>Ma situation concorde avec l’option d’expérience de travail appliquée</strong>",
@@ -11078,6 +11086,10 @@
     "defaultMessage": "Question de sélection {index}",
     "description": "Legend for screening question fieldset"
   },
+  "s+m6Sr": {
+    "defaultMessage": "PM-06 : Gestionnaire",
+    "description": "PM-06 classification label including titles"
+  },
   "s/BI/4": {
     "defaultMessage": "Au fil des ans, des centaines de candidats de différents groupes et niveaux ont été nominés aux tables rondes en gestion des talents; EXposition ciblant les cadres supérieurs et Prolonger EXposition se concentrant sur les candidats de groupes et niveaux EX équivalents et EX moins un.  Les nominations sont compilées dans la base de données en gestion des talents numériques. Cette base de données constitue la source principale de données lorsque les organisations veulent d'obtenir des références tout au long de l'année.",
     "description": "Description of identifying digital talents"
@@ -11161,6 +11173,10 @@
   "sa8LdD": {
     "defaultMessage": "Situation des RH – solutions de dotation disponible non viables",
     "description": "HR situation contracting rationale"
+  },
+  "sapiL3": {
+    "defaultMessage": "PM-05 : Analyste principal",
+    "description": "PM-05 classification label including titles"
   },
   "sapxcU": {
     "defaultMessage": "Avertissement",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6263,6 +6263,10 @@
     "defaultMessage": "À l’exception de quelques compétences comportementales très particulières, seuls des renseignements techniques sont recueillis auprès des candidats dans la candidature initiale. Cela signifie que lors de votre examen, vous ne verrez que les données d’expérience relatives aux compétences techniques et à quelques compétences comportementales précises. Deux raisons expliquent ce choix.",
     "description": "First paragraph of first answer of the Frequently Asked Questions for logging in"
   },
+  "UA37iG": {
+    "defaultMessage": "Commis C R 4",
+    "description": "CR-04 classification aria label including titles"
+  },
   "UCv0X2": {
     "defaultMessage": "L’engagement de l’équipe de Talents numériques du GC",
     "description": "Title for our commitment to inclusivity and equity"
@@ -9173,6 +9177,10 @@
   "i4OGTD": {
     "defaultMessage": "Créer une famille de compétences",
     "description": "Page title for the skill family creation page"
+  },
+  "i7nfvV": {
+    "defaultMessage": "CR-04 : Commis",
+    "description": "CR-04 classification label including titles"
   },
   "i8DgUB": {
     "defaultMessage": "Opérations d’infrastructure de la TI",

--- a/apps/web/src/pages/SearchRequests/SearchPage/labels.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/labels.ts
@@ -47,6 +47,16 @@ export const classificationLabels: Record<string, MessageDescriptor> =
       id: "46pgKa",
       description: "PM-04 classification label including titles",
     },
+    "PM-05": {
+      defaultMessage: "PM-05: Senior Analyst",
+      id: "sapiL3",
+      description: "PM-05 classification label including titles",
+    },
+    "PM-06": {
+      defaultMessage: "PM-06: Manager",
+      id: "s+m6Sr",
+      description: "PM-06 classification label including titles",
+    },
     "CR-04": {
       defaultMessage: "CR-04: Clerk",
       id: "i7nfvV",
@@ -100,6 +110,16 @@ export const classificationAriaLabels: Record<string, MessageDescriptor> =
       defaultMessage: "Analyst P M 4",
       id: "g54x1Z",
       description: "PM-04 classification aria label including titles",
+    },
+    "PM-05": {
+      defaultMessage: "Senior Analyst P M 5",
+      id: "SM7PIR",
+      description: "PM-05 classification aria label including titles",
+    },
+    "PM-06": {
+      defaultMessage: "Manager P M 6",
+      id: "AH2U9S",
+      description: "PM-06 classification aria label including titles",
     },
     "CR-04": {
       defaultMessage: "Clerk C R 4",

--- a/apps/web/src/pages/SearchRequests/SearchPage/labels.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/labels.ts
@@ -47,6 +47,11 @@ export const classificationLabels: Record<string, MessageDescriptor> =
       id: "46pgKa",
       description: "PM-04 classification label including titles",
     },
+    "CR-04": {
+      defaultMessage: "CR-04: Clerk",
+      id: "i7nfvV",
+      description: "CR-04 classification label including titles",
+    },
   });
 
 export const classificationAriaLabels: Record<string, MessageDescriptor> =
@@ -95,5 +100,10 @@ export const classificationAriaLabels: Record<string, MessageDescriptor> =
       defaultMessage: "Analyst P M 4",
       id: "g54x1Z",
       description: "PM-04 classification aria label including titles",
+    },
+    "CR-04": {
+      defaultMessage: "Clerk C R 4",
+      id: "UA37iG",
+      description: "CR-04 classification aria label including titles",
     },
   });

--- a/apps/web/src/utils/nameUtils.tsx
+++ b/apps/web/src/utils/nameUtils.tsx
@@ -209,6 +209,12 @@ export const wrapAbbr = (text: ReactNode, intl: IntlShape, title?: string) => {
           <span aria-label={splitAndJoin(stringifyText)}>{text}</span>
         </abbr>
       );
+    case /CR/.exec(stringifyText)?.input:
+      return (
+        <abbr title={intl.formatMessage(getAbbreviations("CR"))}>
+          <span aria-label={splitAndJoin(stringifyText)}>{text}</span>
+        </abbr>
+      );
     default:
       return (
         <abbr title={title ?? fallbackTitle}>

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -499,6 +499,12 @@ export const getClassificationSalaryRangeUrl = (
         fr: "https://www.tbs-sct.canada.ca/agreements-conventions/view-visualiser-fra.aspx?id=4",
       };
       break;
+    case "CR":
+      localizedUrl = {
+        en: "https://www.tbs-sct.canada.ca/agreements-conventions/view-visualiser-eng.aspx?id=15",
+        fr: "https://www.tbs-sct.canada.ca/agreements-conventions/view-visualiser-fra.aspx?id=15",
+      };
+      break;
     default:
       break;
   }

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -35,6 +35,10 @@
     "defaultMessage": "Sélectionnez {label}",
     "description": "Text to check checkbox button"
   },
+  "/pptJd": {
+    "defaultMessage": "Commis aux écritures et aux règlements",
+    "description": "Full name of abbreviation for CR"
+  },
   "/pzsYm": {
     "defaultMessage": "Profil du (de la) candidat(e)",
     "description": "Name of Applicant profile page"

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -617,6 +617,11 @@ const abbreviations = defineMessages({
     id: "W5Dkd1",
     description: "Full name of abbreviation for EC",
   },
+  CR: {
+    defaultMessage: "Clerical and Regulatory",
+    id: "/pptJd",
+    description: "Full name of abbreviation for CR",
+  },
 });
 
 export const getAbbreviations = (


### PR DESCRIPTION
🤖 Resolves #12084.

## 👋 Introduction

This PR adds CR-04, PM-05, and PM-06 to `scopeAvailableInSearch` so that they are available as options in the classification filter of the search for talent form.

## 🕵️ Details

The CR abbreviation was also added as it was not in the codebase before.

## 🧪 Testing

1. Navigate to http://localhost:8000/en/search
2. Verify CR-04, PM-05, and PM-06 are options with English job titles in classification filter select
3. Switch to French
4. Verify CR-04, PM-05, and PM-06 are options with French job titles in classification filter select

## 📸 Screenshots

<img width="851" alt="Screen Shot 2024-11-28 at 10 27 48" src="https://github.com/user-attachments/assets/36096102-4f3c-4069-a47e-5680373bdbd8">

<img width="856" alt="Screen Shot 2024-11-28 at 10 28 09" src="https://github.com/user-attachments/assets/cca78b57-df8c-4bd2-b00e-8ee83a254a23">