### PR TITLE
[Debt] Bump FPM max worker count

### DIFF
--- a/infrastructure/conf/php-fpm-www.conf
+++ b/infrastructure/conf/php-fpm-www.conf
@@ -124,7 +124,7 @@ pm = dynamic
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 17
+pm.max_children = 25
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'


### PR DESCRIPTION
🤖 Resolves #11945 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Bumps the max FPM worker count to avoid queuing under load.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Restart the webserver docker container
2. Confirm that the API is still working by using the app
3. (Optional) Shell into the webserver container and run `curl http://127.0.0.1:8080/fpm-status` to see how max `active processes` rises under load.
4. (Optional) Deploy to Azure and repeat testing

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/e64fbb50-cce8-4f7b-8641-4cc0b7a8c4e2)
