### PR TITLE
[WIP] Migrate streams to `WorkStream` model

### DIFF
--- a/api/app/Builders/PoolBuilder.php
+++ b/api/app/Builders/PoolBuilder.php
@@ -137,14 +137,16 @@ class PoolBuilder extends Builder
         return $this->whereIn('publishing_group', $publishingGroups);
     }
 
-    public function streams(?array $streams): self
+    public function workStreams(?array $workStreams): self
     {
 
-        if (empty($streams)) {
+        if (empty($workStreams)) {
             return $this;
         }
 
-        return $this->whereIn('stream', $streams);
+        return $this->whereHas('workStream', function ($query) use ($workStreams) {
+            $query->whereIn('id', $workStreams);
+        });
     }
 
     public function whereClassifications(?array $classifications): self

--- a/api/app/Builders/PoolBuilder.php
+++ b/api/app/Builders/PoolBuilder.php
@@ -137,7 +137,7 @@ class PoolBuilder extends Builder
         return $this->whereIn('publishing_group', $publishingGroups);
     }
 
-    public function workStreams(?array $workStreams): self
+    public function whereWorkStreamIn(?array $workStreams): self
     {
 
         if (empty($workStreams)) {

--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -29,7 +29,7 @@ final class CountPoolCandidatesByPool
             }
 
             if (array_key_exists('qualifiedStreams', $filters)) {
-                $query->streams($filters['qualifiedStreams']);
+                $query->whereWorkStreamIn($filters['qualifiedStreams']);
             }
         });
 

--- a/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
+++ b/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
@@ -30,7 +30,7 @@ final class PoolIsCompleteValidator extends Validator
             'name.fr' => ['string'],
             'classification_id' => ['required', 'uuid', 'exists:classifications,id'],
             'department_id' => ['required', 'uuid', 'exists:departments,id'],
-            'stream' => ['required', 'string'],
+            'work_stream_id' => ['required', 'uuid', 'exists:work_streams,id'],
             'opportunity_length' => ['required', 'string'],
 
             // Closing date

--- a/api/app/Models/ApplicantFilter.php
+++ b/api/app/Models/ApplicantFilter.php
@@ -65,6 +65,11 @@ class ApplicantFilter extends Model
         return $this->belongsTo(Community::class);
     }
 
+    public function workStreams(): BelongsToMany
+    {
+        return $this->belongsToMany(WorkStream::class);
+    }
+
     /* these fields are factored out into a sub-object by this accessor to mirror the way they are queried */
     public function getEquityAttribute()
     {

--- a/api/app/Models/ApplicantFilter.php
+++ b/api/app/Models/ApplicantFilter.php
@@ -70,6 +70,7 @@ class ApplicantFilter extends Model
         return $this->belongsTo(Community::class);
     }
 
+    /** @return BelongsToMany<WorkStream, $this> */
     public function workStreams(): BelongsToMany
     {
         return $this->belongsToMany(WorkStream::class);

--- a/api/app/Models/Community.php
+++ b/api/app/Models/Community.php
@@ -87,6 +87,11 @@ class Community extends Model
         return $this->hasManyThrough(RoleAssignment::class, Team::class, 'teamable_id');
     }
 
+    public function workStreams(): HasMany
+    {
+        return $this->hasMany(WorkStream::class);
+    }
+
     /**
      * Attach the users to the related team creating one if there isn't already
      *

--- a/api/app/Models/Community.php
+++ b/api/app/Models/Community.php
@@ -86,6 +86,7 @@ class Community extends Model
         return $this->hasManyThrough(RoleAssignment::class, Team::class, 'teamable_id');
     }
 
+    /** @return HasMany<WorkStream, $this> */
     public function workStreams(): HasMany
     {
         return $this->hasMany(WorkStream::class);

--- a/api/app/Models/JobPosterTemplate.php
+++ b/api/app/Models/JobPosterTemplate.php
@@ -75,9 +75,7 @@ class JobPosterTemplate extends Model
             ->withPivot('type', 'required_skill_level');
     }
 
-    /**
-     * Associated work stream
-     */
+    /** @return BelongsTo<WorkStream, $this> */
     public function workStream(): BelongsTo
     {
         return $this->belongsTo(WorkStream::class);

--- a/api/app/Models/JobPosterTemplate.php
+++ b/api/app/Models/JobPosterTemplate.php
@@ -15,7 +15,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  * @property string $reference_id
  * @property array $description
  * @property string $supervisory_status
- * @property string $stream
+ * @property WorkStream $stream
  * @property array $work_description
  * @property array $tasks
  * @property array $keywords
@@ -53,7 +53,6 @@ class JobPosterTemplate extends Model
         'name',
         'description',
         'key',
-        'stream',
         'supervisory_status',
         'work_description',
         'tasks',
@@ -78,5 +77,13 @@ class JobPosterTemplate extends Model
     {
         return $this->belongsToMany(Skill::class)
             ->withPivot('type', 'required_skill_level');
+    }
+
+    /**
+     * Associated work stream
+     */
+    public function workStream(): BelongsTo
+    {
+        return $this->belongsTo(WorkStream::class);
     }
 }

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -39,7 +39,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property array $special_note
  * @property ?string $security_clearance
  * @property ?string $advertisement_language
- * @property ?string $stream
+ * @property ?WorkStream $workStream
  * @property ?string $process_number
  * @property ?string $publishing_group
  * @property ?string $opportunity_length
@@ -95,7 +95,6 @@ class Pool extends Model
         'published_at',
         'name',
         'key_tasks',
-        'stream',
         'security_clearance',
         'advertisement_language',
         'your_impact',
@@ -114,7 +113,7 @@ class Pool extends Model
         'id',
         'name',
         'user_id',
-        'stream',
+        'work_stream_id',
         'publishing_group',
         'published_at',
         'archived_at',
@@ -223,6 +222,11 @@ class Pool extends Model
     public function publishedPoolCandidates(): HasMany
     {
         return $this->hasMany(PoolCandidate::class)->notDraft();
+    }
+
+    public function workStream(): BelongsTo
+    {
+        return $this->belongsTo(WorkStream::class);
     }
 
     public function essentialSkills(): BelongsToMany

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -301,9 +301,7 @@ class PoolCandidate extends Model
             })
             // Now scope for valid pools, according to streams
             ->whereHas('pool', function ($query) use ($streams) {
-                $query->whereHas('workStream', function ($query) use ($streams) {
-                    $query->whereIn('id', $streams);
-                });
+                $query->whereWorkStreamIn($streams);
             });
 
         return $query;

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -301,7 +301,9 @@ class PoolCandidate extends Model
             })
             // Now scope for valid pools, according to streams
             ->whereHas('pool', function ($query) use ($streams) {
-                $query->whereIn('stream', $streams);
+                $query->whereHas('workStream', function ($query) use ($streams) {
+                    $query->whereIn('id', $streams);
+                });
             });
 
         return $query;

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -764,7 +764,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
                 }
 
                 if (array_key_exists('qualifiedStreams', $filters)) {
-                    $query->streams($filters['qualifiedStreams']);
+                    $query->whereWorkStreamIn($filters['qualifiedStreams']);
                 }
             });
 

--- a/api/app/Models/WorkStream.php
+++ b/api/app/Models/WorkStream.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Class WorkStream
+ *
+ * @property string $id
+ * @property array $name
+ * @property array $plain_language_name
+ * @property Community $community
+ * @property \Illuminate\Support\Carbon $created_at
+ * @property ?\Illuminate\Support\Carbon $updated_at
+ */
+class WorkStream extends Model
+{
+    protected $keyType = 'string';
+
+    protected $casts = [
+        'name' => 'array',
+        'plain_language_name' => 'array',
+    ];
+
+    protected $fillable = [
+        'key',
+        'name',
+        'plain_language_name',
+        'community_id',
+    ];
+
+    public function community(): BelongsTo
+    {
+        return $this->belongsTo(Community::class);
+    }
+}

--- a/api/app/Models/WorkStream.php
+++ b/api/app/Models/WorkStream.php
@@ -31,6 +31,7 @@ class WorkStream extends Model
         'community_id',
     ];
 
+    /** @return BelongsTo<Community, $this> */
     public function community(): BelongsTo
     {
         return $this->belongsTo(Community::class);

--- a/api/app/Policies/WorkStreamPolicy.php
+++ b/api/app/Policies/WorkStreamPolicy.php
@@ -4,14 +4,13 @@ namespace App\Policies;
 
 use App\Models\User;
 use App\Models\WorkStream;
-use Illuminate\Auth\Access\Response;
 
 class WorkStreamPolicy
 {
     /**
      * Determine whether the user can view any models.
      */
-    public function viewAny(User $user): bool
+    public function viewAny(?User $user): bool
     {
         return false;
     }
@@ -19,7 +18,7 @@ class WorkStreamPolicy
     /**
      * Determine whether the user can view the model.
      */
-    public function view(User $user, WorkStream $workStream): bool
+    public function view(?User $user, WorkStream $workStream): bool
     {
         return false;
     }
@@ -29,7 +28,7 @@ class WorkStreamPolicy
      */
     public function create(User $user): bool
     {
-        return false;
+        return $user->isAbleTo('create-any-workStream');
     }
 
     /**
@@ -37,7 +36,7 @@ class WorkStreamPolicy
      */
     public function update(User $user, WorkStream $workStream): bool
     {
-        return false;
+        return $user->isAbleTo('update-any-workStream');
     }
 
     /**

--- a/api/app/Policies/WorkStreamPolicy.php
+++ b/api/app/Policies/WorkStreamPolicy.php
@@ -12,7 +12,7 @@ class WorkStreamPolicy
      */
     public function viewAny(?User $user): bool
     {
-        return false;
+        return true;
     }
 
     /**

--- a/api/app/Policies/WorkStreamPolicy.php
+++ b/api/app/Policies/WorkStreamPolicy.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\WorkStream;
+use Illuminate\Auth\Access\Response;
+
+class WorkStreamPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, WorkStream $workStream): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, WorkStream $workStream): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, WorkStream $workStream): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, WorkStream $workStream): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, WorkStream $workStream): bool
+    {
+        return false;
+    }
+}

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -84,6 +84,7 @@ return [
         'poolTeamMembers' => 'poolTeamMembers',
         'communityTeamMembers' => 'communityTeamMembers',
         'trainingOpportunity' => 'trainingOpportunity',
+        'workStream' => 'workStream',
 
         'platformAdminMembership' => 'platformAdminMembership',
         'communityAdminMembership' => 'communityAdminMembership',
@@ -1230,6 +1231,9 @@ return [
             ],
             'trainingOpportunity' => [
                 'any' => ['create'],
+            ],
+            'workStream' => [
+                'any' => ['create', 'update'],
             ],
         ],
         'manager' => [

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -511,6 +511,15 @@ return [
             'fr' => 'Supprimer toute équipe',
         ],
 
+        'create-any-workStream' => [
+            'en' => 'Create Any Work Stream',
+            'fr' => 'Créer toute équipe',
+        ],
+        'update-any-workStream' => [
+            'en' => 'Update Any Work Stream',
+            'fr' => 'Mettre à jour toute équipe',
+        ],
+
         'view-any-role' => [
             'en' => 'View Any Role',
             'fr' => 'Visionner tout rôle',

--- a/api/database/factories/JobPosterTemplateFactory.php
+++ b/api/database/factories/JobPosterTemplateFactory.php
@@ -10,6 +10,7 @@ use App\Enums\SupervisoryStatus;
 use App\Models\Classification;
 use App\Models\JobPosterTemplate;
 use App\Models\Skill;
+use App\Models\WorkStream;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -50,6 +51,7 @@ class JobPosterTemplateFactory extends Factory
         return [
             'supervisory_status' => $this->faker->randomElement(SupervisoryStatus::cases())->name,
             'stream' => $this->faker->randomElement(PoolStream::cases())->name,
+            'work_stream_id' => WorkStream::inRandomOrder()->first()->id,
             'reference_id' => implode('_', $this->faker->words()),
             'classification_id' => $classification->id,
             'name' => [

--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -23,6 +23,7 @@ use App\Models\ScreeningQuestion;
 use App\Models\Skill;
 use App\Models\Team;
 use App\Models\User;
+use App\Models\WorkStream;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -202,6 +203,7 @@ class PoolFactory extends Factory
                 'special_note' => ! $hasSpecialNote ? ['en' => $this->faker->paragraph().' EN', 'fr' => $this->faker->paragraph().' FR'] : null,
                 'is_remote' => $this->faker->boolean,
                 'stream' => $this->faker->randomElement(PoolStream::cases())->name,
+                'work_stream_id' => WorkStream::inRandomOrder()->first()->id,
                 'process_number' => $this->faker->word(),
                 'publishing_group' => $this->faker->randomElement(array_column(PublishingGroup::cases(), 'name')),
                 'opportunity_length' => $this->faker->randomElement(array_column(PoolOpportunityLength::cases(), 'name')),
@@ -242,6 +244,7 @@ class PoolFactory extends Factory
                 'special_note' => ! $hasSpecialNote ? ['en' => $this->faker->paragraph().' EN', 'fr' => $this->faker->paragraph().' FR'] : null,
                 'is_remote' => $isRemote,
                 'stream' => $this->faker->randomElement(PoolStream::cases())->name,
+                'work_stream_id' => WorkStream::inRandomOrder()->first()->id,
                 'process_number' => $this->faker->word(),
                 'publishing_group' => $this->faker->randomElement(array_column(PublishingGroup::cases(), 'name')),
                 'opportunity_length' => $this->faker->randomElement(array_column(PoolOpportunityLength::cases(), 'name')),

--- a/api/database/migrations/2024_11_28_170013_create_work_streams_table.php
+++ b/api/database/migrations/2024_11_28_170013_create_work_streams_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('work_streams', function (Blueprint $table) {
+            $table->uuid('id')->primary()->default(new Expression('public.gen_random_uuid()'));
+            $table->string('key')->nullable();
+            $table->jsonb('name')->default(json_encode(['en' => '', 'fr' => '']));
+            $table->jsonb('plain_language_name')->default(json_encode(['en' => '', 'fr' => '']));
+            $table->foreignUuid('community_id')
+                ->constrained();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('work_streams');
+    }
+};

--- a/api/database/migrations/2024_11_28_174246_work_stream_relationships.php
+++ b/api/database/migrations/2024_11_28_174246_work_stream_relationships.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pools', function (Blueprint $table) {
+            $table->foreignUuid('work_stream_id')
+                ->nullable()
+                ->constrained();
+        });
+
+        Schema::table('job_poster_templates', function (Blueprint $table) {
+            $table->foreignUuid('work_stream_id')
+                ->nullable()
+                ->constrained();
+        });
+
+        Schema::create('applicant_filter_work_stream', function (Blueprint $table) {
+            $table->uuid('id')->primary()->default(new Expression('public.gen_random_uuid()'));
+            $table->foreignUuid('applicant_filter_id')
+                ->constrained()
+                ->onDelete('cascade');
+            $table->foreignUuid('work_stream_id')
+                ->constrained()
+                ->onDelete('cascade');
+
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pools', function (Blueprint $table) {
+            $table->dropForeign('work_stream_id');
+        });
+
+        Schema::table('job_poster_templates', function (Blueprint $table) {
+            $table->dropForeign('work_stream_id');
+        });
+
+        Schema::dropIfExists('applicant_filter_work_stream');
+    }
+};

--- a/api/database/seeders/CiSeeder.php
+++ b/api/database/seeders/CiSeeder.php
@@ -21,6 +21,7 @@ class CiSeeder extends Seeder
             SkillSeeder::class,
             CommunitySeeder::class,
             TeamSeeder::class,
+            WorkStreamSeeder::class,
             JobPosterTemplateSeeder::class,
 
             // convenient test data

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -23,6 +23,7 @@ class DatabaseSeeder extends Seeder
             SkillSeeder::class,
             CommunitySeeder::class,
             TeamSeeder::class,
+            WorkStreamSeeder::class,
             JobPosterTemplateSeeder::class,
 
             // convenient test data

--- a/api/database/seeders/JobPosterTemplateSeeder.php
+++ b/api/database/seeders/JobPosterTemplateSeeder.php
@@ -119,10 +119,15 @@ class JobPosterTemplateSeeder extends Seeder
                 ->where('level', $templateModel->classification->level)
                 ->sole();
 
+            $streamObject = DB::table('work_streams')
+                ->where('key', $templateModel->stream->value)
+                ->sole();
+
             JobPosterTemplate::updateOrCreate(
                 ['reference_id' => $templateModel->referenceId],
                 [
                     'stream' => $templateModel->stream->value,
+                    'work_stream_id' => $streamObject?->id,
                     'classification_id' => $classificationObject->id,
                     'supervisory_status' => $templateModel->supervisoryStatus,
                     'name' => [

--- a/api/database/seeders/PoolTestSeeder.php
+++ b/api/database/seeders/PoolTestSeeder.php
@@ -11,6 +11,7 @@ use App\Models\Community;
 use App\Models\Pool;
 use App\Models\Team;
 use App\Models\User;
+use App\Models\WorkStream;
 use Illuminate\Database\Seeder;
 
 class PoolTestSeeder extends Seeder
@@ -29,6 +30,7 @@ class PoolTestSeeder extends Seeder
         $dcmTeamId = Team::select('id')->where('name', 'digital-community-management')->sole()->id;
         $digitalCommunityId = Community::select('id')->where('key', 'digital')->sole()->id;
         $atipCommunityId = Community::select('id')->where('key', 'atip')->sole()->id;
+        $businessAdvisoryStreamId = WorkStream::select('id')->where('key', PoolStream::BUSINESS_ADVISORY_SERVICES->name)->sole()->id;
 
         // CMO Digital
         $createdPool = Pool::factory()
@@ -48,10 +50,12 @@ class PoolTestSeeder extends Seeder
                 'closing_date' => config('constants.far_future_date'),
                 'publishing_group' => PublishingGroup::IT_JOBS->name,
                 'stream' => PoolStream::BUSINESS_ADVISORY_SERVICES->name,
+                'work_stream_id' => $businessAdvisoryStreamId,
             ]);
         $classificationIT01Id = Classification::select('id')->where('group', 'ilike', 'IT')->where('level', 1)->sole()->id;
         $createdPool->classification_id = $classificationIT01Id;
         $createdPool->stream = PoolStream::BUSINESS_ADVISORY_SERVICES->name;
+        $createdPool->work_stream_id = $businessAdvisoryStreamId;
         $createdPool->advertisement_language = PoolLanguage::VARIOUS->name;
         if (! is_null($processOperatorUser)) {
             $createdPool->addProcessOperators([$processOperatorUser->id]);
@@ -76,6 +80,7 @@ class PoolTestSeeder extends Seeder
                     'closing_date' => config('constants.far_future_date'),
                     'publishing_group' => PublishingGroup::IAP->name,
                     'stream' => PoolStream::BUSINESS_ADVISORY_SERVICES->name,
+                    'work_stream_id' => $businessAdvisoryStreamId,
                 ],
             );
 
@@ -98,7 +103,7 @@ class PoolTestSeeder extends Seeder
                 'closing_date' => config('constants.far_future_date'),
                 'publishing_group' => PublishingGroup::IT_JOBS->name,
                 'stream' => PoolStream::BUSINESS_ADVISORY_SERVICES->name,
-
+                'work_stream_id' => $businessAdvisoryStreamId,
             ]);
 
         // IT -02
@@ -121,7 +126,7 @@ class PoolTestSeeder extends Seeder
                     'closing_date' => config('constants.far_future_date'),
                     'publishing_group' => PublishingGroup::IT_JOBS->name,
                     'stream' => PoolStream::BUSINESS_ADVISORY_SERVICES->name,
-
+                    'work_stream_id' => $businessAdvisoryStreamId,
                 ],
             );
 
@@ -146,7 +151,7 @@ class PoolTestSeeder extends Seeder
                 'closing_date' => config('constants.far_future_date'),
                 'publishing_group' => PublishingGroup::IT_JOBS_ONGOING->name,
                 'stream' => PoolStream::BUSINESS_ADVISORY_SERVICES->name,
-
+                'work_stream_id' => $businessAdvisoryStreamId,
             ]);
 
         //IT -04
@@ -170,7 +175,7 @@ class PoolTestSeeder extends Seeder
                 'closing_date' => now()->addMonths(6),
                 'publishing_group' => PublishingGroup::IT_JOBS->name,
                 'stream' => PoolStream::BUSINESS_ADVISORY_SERVICES->name,
-
+                'work_stream_id' => $businessAdvisoryStreamId,
             ]);
 
         // IT - 05 Closed - Simple
@@ -195,6 +200,7 @@ class PoolTestSeeder extends Seeder
                     'closing_date' => config('constants.past_date'),
                     'publishing_group' => PublishingGroup::IT_JOBS->name,
                     'stream' => PoolStream::BUSINESS_ADVISORY_SERVICES->name,
+                    'work_stream_id' => $businessAdvisoryStreamId,
                 ],
             );
 
@@ -214,6 +220,7 @@ class PoolTestSeeder extends Seeder
                     ],
                     'classification_id' => Classification::select('id')->where('group', 'ilike', 'EX')->where('level', 3)->sole()->id,
                     'stream' => PoolStream::EXECUTIVE_GROUP->name,
+                    'work_stream_id' => $businessAdvisoryStreamId,
                     'user_id' => $adminUserId,
                     'team_id' => $dcmTeamId,
                     'community_id' => $digitalCommunityId,
@@ -236,6 +243,7 @@ class PoolTestSeeder extends Seeder
                 ],
                 'classification_id' => Classification::select('id')->where('group', 'ilike', 'PM')->where('level', 1)->sole()->id,
                 'stream' => PoolStream::ACCESS_INFORMATION_PRIVACY->name,
+                'work_stream_id' => WorkStream::where('key', PoolStream::ACCESS_INFORMATION_PRIVACY->name)->first()->id,
                 'user_id' => $adminUserId,
                 'team_id' => $dcmTeamId,
                 'community_id' => $atipCommunityId,

--- a/api/database/seeders/WorkStreamSeeder.php
+++ b/api/database/seeders/WorkStreamSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\PoolStream;
+use App\Models\Community;
+use App\Models\WorkStream;
+use Illuminate\Database\Seeder;
+
+class WorkStreamSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $digital = Community::where('key', 'digital')->first('id');
+        $atip = Community::where('key', 'atip')->first('id');
+
+        foreach (array_column(PoolStream::cases(), 'name') as $key) {
+
+            WorkStream::create([
+                'key' => $key,
+                'name' => PoolStream::localizedString($key),
+                'community_id' => $key === PoolStream::ACCESS_INFORMATION_PRIVACY->name ? $atip->id : $digital->id,
+            ]);
+        }
+    }
+}

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -277,7 +277,7 @@ type Pool implements HasRoleAssignments {
     @rename(attribute: "security_clearance")
   language: LocalizedPoolLanguage @rename(attribute: "advertisement_language")
   status: LocalizedPoolStatus @rename(attribute: "status")
-  workStream: WorkStream
+  workStream: WorkStream @belongsTo
   processNumber: String @rename(attribute: "process_number")
   publishingGroup: LocalizedPublishingGroup
     @rename(attribute: "publishing_group")
@@ -589,9 +589,7 @@ type ApplicantFilter {
   skills: [Skill] @belongsToMany
   # request creation connects to qualifiedClassifications
   qualifiedClassifications: [Classification] @belongsToMany # Filters applicants based on the classifications pools they've qualified in.
-  qualifiedStreams: [LocalizedPoolStream]
-    @rename(attribute: "qualified_streams") # Filters applicants based on the streams of the pools they've qualified in.
-  workStreams: [WorkStream] @belongsToMany
+  qualifiedStreams: [WorkStream] @belongsToMany
   pools: [Pool] @belongsToMany @canResolved(ability: "view")
   community: Community @belongsTo # Currently does not affect search, scope needs to be added
 }
@@ -887,8 +885,7 @@ input ApplicantFilterInput {
   skillsIntersectional: [IdInput] @scope @pluck(key: "id") # AND filtering skills as opposed to OR
   qualifiedClassifications: [ClassificationFilterInput]
     @scope(name: "qualifiedClassifications") # Filters applicants based on the classification of pools they are currently qualified and available in.
-  qualifiedStreams: [PoolStream] @scope(name: "qualifiedStreams") # Filters applicants based on the stream of pools they are currently qualified and available in.
-  workStreams: [IdInput] @scope(name: "workStreams") @pluck(key: "id")
+  qualifiedStreams: [IdInput] @scope(name: "qualifiedStreams") # Filters applicants based on the stream of pools they are currently qualified and available in.
   community: IdInput @scope(name: "candidatesInCommunity") @pluck(key: "id")
 }
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -277,7 +277,7 @@ type Pool implements HasRoleAssignments {
     @rename(attribute: "security_clearance")
   language: LocalizedPoolLanguage @rename(attribute: "advertisement_language")
   status: LocalizedPoolStatus @rename(attribute: "status")
-  stream: LocalizedPoolStream
+  workStream: WorkStream
   processNumber: String @rename(attribute: "process_number")
   publishingGroup: LocalizedPublishingGroup
     @rename(attribute: "publishing_group")
@@ -514,6 +514,14 @@ type Team implements HasRoleAssignments {
   teamIdForRoleAssignment: ID @rename(attribute: "id")
 }
 
+type WorkStream {
+  id: UUID!
+  key: String
+  name: LocalizedString
+  plainLanguageName: LocalizedString @rename(attribute: "plain_language_name")
+  community: Community
+}
+
 type Role {
   id: ID!
   name: String! # represents a unique key for a role
@@ -583,6 +591,7 @@ type ApplicantFilter {
   qualifiedClassifications: [Classification] @belongsToMany # Filters applicants based on the classifications pools they've qualified in.
   qualifiedStreams: [LocalizedPoolStream]
     @rename(attribute: "qualified_streams") # Filters applicants based on the streams of the pools they've qualified in.
+  workStreams: [WorkStream] @belongsToMany
   pools: [Pool] @belongsToMany @canResolved(ability: "view")
   community: Community @belongsTo # Currently does not affect search, scope needs to be added
 }
@@ -772,7 +781,7 @@ type JobPosterTemplate {
   description: LocalizedString
   supervisoryStatus: LocalizedSupervisoryStatus
     @rename(attribute: "supervisory_status")
-  stream: LocalizedPoolStream
+  workStream: WorkStream
   workDescription: LocalizedString @rename(attribute: "work_description")
   tasks: LocalizedString
   keywords: LocalizedKeywords
@@ -845,7 +854,7 @@ input PoolFilterInput {
   generalSearch: String @scope
   name: String @scope
   team: String @scope
-  streams: [PoolStream!] @scope
+  workStreams: [UUID!] @scope
   statuses: [PoolStatus!] = [] @scope
   processNumber: String @scope
   publishingGroups: [PublishingGroup!] @scope
@@ -879,6 +888,7 @@ input ApplicantFilterInput {
   qualifiedClassifications: [ClassificationFilterInput]
     @scope(name: "qualifiedClassifications") # Filters applicants based on the classification of pools they are currently qualified and available in.
   qualifiedStreams: [PoolStream] @scope(name: "qualifiedStreams") # Filters applicants based on the stream of pools they are currently qualified and available in.
+  workStreams: [IdInput] @scope(name: "workStreams") @pluck(key: "id")
   community: IdInput @scope(name: "candidatesInCommunity") @pluck(key: "id")
 }
 
@@ -1104,6 +1114,7 @@ type Query {
   team(id: UUID! @eq): Team @find @canQuery(ability: "view")
   teams: [Team]! @all @canModel(ability: "viewAny")
   roles: [Role]! @all @canModel(ability: "viewAny")
+  workStreams: [WorkStream]! @all @canModel(ability: "viewAny")
 
   notifications(
     where: NotificationFilterInput
@@ -1470,6 +1481,22 @@ input UpdateDepartmentInput {
   name: LocalizedStringInput
 }
 
+input CreateWorkStreamInput {
+  key: String
+  name: LocalizedStringInput!
+  plainLanguageName: LocalizedStringInput
+    @rename(attribute: "plain_language_name")
+  community: CommunityBelongsTo!
+}
+
+input UpdateWorkStreamInput {
+  key: String
+  name: LocalizedStringInput
+  plainLanguageName: LocalizedStringInput
+    @rename(attribute: "plain_language_name")
+  community: CommunityBelongsTo
+}
+
 input PoolBelongsToMany {
   sync: [ID!]
 }
@@ -1485,6 +1512,15 @@ input DepartmentBelongsToMany {
 
 input CommunityBelongsTo {
   connect: UUID!
+}
+
+input WorkStreamBelongsTo {
+  connect: ID
+  disconnect: Boolean
+}
+
+input WorkStreamBelongsToMany {
+  sync: [ID!]
 }
 
 input CreateTeamInput {
@@ -1537,6 +1573,7 @@ input CreateApplicantFilterInput {
   armedForcesStatus: ArmedForcesStatus @rename(attribute: "armed_forces_status")
   qualifiedClassifications: ClassificationBelongsToMany
   qualifiedStreams: [PoolStream] @rename(attribute: "qualified_streams")
+  workStreams: WorkStreamBelongsToMany
   community: CommunityBelongsTo
 }
 
@@ -1784,7 +1821,7 @@ input UpdatePoolInput {
   name: LocalizedStringInput
   classification: ClassificationBelongsTo
   department: DepartmentBelongsTo
-  stream: PoolStream
+  workStream: WorkStreamBelongsTo
   processNumber: String @rename(attribute: "process_number")
   # Closing date
   closingDate: DateTime
@@ -2036,7 +2073,7 @@ input CreateJobPosterTemplateInput @validator {
   name: LocalizedStringInput!
   description: LocalizedStringInput!
   supervisoryStatus: SupervisoryStatus! @rename(attribute: "supervisory_status")
-  stream: PoolStream!
+  workStream: WorkStreamBelongsTo!
   workDescription: LocalizedStringInput @rename(attribute: "work_description")
   tasks: LocalizedStringInput!
   keywords: LocalizedKeywordsInput
@@ -2056,7 +2093,7 @@ input UpdateJobPosterTemplateInput @validator {
   name: LocalizedStringInput
   description: LocalizedStringInput
   supervisoryStatus: SupervisoryStatus @rename(attribute: "supervisory_status")
-  stream: PoolStream
+  workStream: WorkStreamBelongsTo
   workDescription: LocalizedStringInput @rename(attribute: "work_description")
   tasks: LocalizedStringInput
   keywords: LocalizedStringInput
@@ -2414,6 +2451,16 @@ type Mutation {
     @delete
     @guard
     @canFind(ability: "delete", find: "id")
+
+  # Work stream mutations
+  createWorkStream(workStream: CreateWorkStreamInput! @spread): WorkStream
+    @create
+    @guard
+    @canModel(ability: "create")
+  updateWorkStream(
+    id: ID!
+    workStream: UpdateWorkStreamInput! @spread
+  ): WorkStream @update @guard @canFind(ability: "update", find: "id")
 
   # Teams mutations
   createTeam(team: CreateTeamInput! @spread): Team

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -852,7 +852,7 @@ input PoolFilterInput {
   generalSearch: String @scope
   name: String @scope
   team: String @scope
-  workStreams: [UUID!] @scope
+  workStreams: [UUID!] @scope(name: "whereWorkStreamIn")
   statuses: [PoolStatus!] = [] @scope
   processNumber: String @scope
   publishingGroups: [PublishingGroup!] @scope

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -311,6 +311,7 @@ type Query {
   team(id: UUID!): Team
   teams: [Team]!
   roles: [Role]!
+  workStreams: [WorkStream]!
   sitewideAnnouncement: SitewideAnnouncement
   trainingOpportunity(id: UUID!): TrainingOpportunity
   localizedEnumStrings(enumName: String!): [LocalizedEnumString!]
@@ -471,6 +472,8 @@ type Mutation {
   createJobPosterTemplate(jobPosterTemplate: CreateJobPosterTemplateInput!): JobPosterTemplate
   updateJobPosterTemplate(jobPosterTemplate: UpdateJobPosterTemplateInput!): JobPosterTemplate
   deleteJobPosterTemplate(id: UUID!): JobPosterTemplate
+  createWorkStream(workStream: CreateWorkStreamInput!): WorkStream
+  updateWorkStream(id: ID!, workStream: UpdateWorkStreamInput!): WorkStream
   createTeam(team: CreateTeamInput!): Team
   updateTeam(id: UUID!, team: UpdateTeamInput!): Team
   deleteTeam(id: UUID!): Team
@@ -733,7 +736,7 @@ type Pool implements HasRoleAssignments {
   securityClearance: LocalizedSecurityStatus
   language: LocalizedPoolLanguage
   status: LocalizedPoolStatus
-  stream: LocalizedPoolStream
+  workStream: WorkStream
   processNumber: String
   publishingGroup: LocalizedPublishingGroup
   opportunityLength: LocalizedPoolOpportunityLength
@@ -908,6 +911,14 @@ type Team implements HasRoleAssignments {
   teamIdForRoleAssignment: ID
 }
 
+type WorkStream {
+  id: UUID!
+  key: String
+  name: LocalizedString
+  plainLanguageName: LocalizedString
+  community: Community
+}
+
 type Role {
   id: ID!
   name: String!
@@ -961,6 +972,7 @@ type ApplicantFilter {
   skills: [Skill]
   qualifiedClassifications: [Classification]
   qualifiedStreams: [LocalizedPoolStream]
+  workStreams: [WorkStream]
   pools: [Pool]
   community: Community
 }
@@ -1124,7 +1136,7 @@ type JobPosterTemplate {
   name: LocalizedString
   description: LocalizedString
   supervisoryStatus: LocalizedSupervisoryStatus
-  stream: LocalizedPoolStream
+  workStream: WorkStream
   workDescription: LocalizedString
   tasks: LocalizedString
   keywords: LocalizedKeywords
@@ -1193,7 +1205,7 @@ input PoolFilterInput {
   generalSearch: String
   name: String
   team: String
-  streams: [PoolStream!]
+  workStreams: [UUID!]
   statuses: [PoolStatus!] = []
   processNumber: String
   publishingGroups: [PublishingGroup!]
@@ -1223,6 +1235,7 @@ input ApplicantFilterInput {
   skillsIntersectional: [IdInput]
   qualifiedClassifications: [ClassificationFilterInput]
   qualifiedStreams: [PoolStream]
+  workStreams: [IdInput]
   community: IdInput
 }
 
@@ -1540,6 +1553,20 @@ input UpdateDepartmentInput {
   name: LocalizedStringInput
 }
 
+input CreateWorkStreamInput {
+  key: String
+  name: LocalizedStringInput!
+  plainLanguageName: LocalizedStringInput
+  community: CommunityBelongsTo!
+}
+
+input UpdateWorkStreamInput {
+  key: String
+  name: LocalizedStringInput
+  plainLanguageName: LocalizedStringInput
+  community: CommunityBelongsTo
+}
+
 input PoolBelongsToMany {
   sync: [ID!]
 }
@@ -1555,6 +1582,15 @@ input DepartmentBelongsToMany {
 
 input CommunityBelongsTo {
   connect: UUID!
+}
+
+input WorkStreamBelongsTo {
+  connect: ID
+  disconnect: Boolean
+}
+
+input WorkStreamBelongsToMany {
+  sync: [ID!]
 }
 
 input CreateTeamInput {
@@ -1600,6 +1636,7 @@ input CreateApplicantFilterInput {
   armedForcesStatus: ArmedForcesStatus
   qualifiedClassifications: ClassificationBelongsToMany
   qualifiedStreams: [PoolStream]
+  workStreams: WorkStreamBelongsToMany
   community: CommunityBelongsTo
 }
 
@@ -1828,7 +1865,7 @@ input UpdatePoolInput {
   name: LocalizedStringInput
   classification: ClassificationBelongsTo
   department: DepartmentBelongsTo
-  stream: PoolStream
+  workStream: WorkStreamBelongsTo
   processNumber: String
   closingDate: DateTime
   closingReason: String
@@ -2038,7 +2075,7 @@ input CreateJobPosterTemplateInput {
   name: LocalizedStringInput!
   description: LocalizedStringInput!
   supervisoryStatus: SupervisoryStatus!
-  stream: PoolStream!
+  workStream: WorkStreamBelongsTo!
   workDescription: LocalizedStringInput
   tasks: LocalizedStringInput!
   keywords: LocalizedKeywordsInput
@@ -2055,7 +2092,7 @@ input UpdateJobPosterTemplateInput {
   name: LocalizedStringInput
   description: LocalizedStringInput
   supervisoryStatus: SupervisoryStatus
-  stream: PoolStream
+  workStream: WorkStreamBelongsTo
   workDescription: LocalizedStringInput
   tasks: LocalizedStringInput
   keywords: LocalizedStringInput

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -971,8 +971,7 @@ type ApplicantFilter {
   positionDuration: [PositionDuration]
   skills: [Skill]
   qualifiedClassifications: [Classification]
-  qualifiedStreams: [LocalizedPoolStream]
-  workStreams: [WorkStream]
+  qualifiedStreams: [WorkStream]
   pools: [Pool]
   community: Community
 }
@@ -1234,8 +1233,7 @@ input ApplicantFilterInput {
   skills: [IdInput]
   skillsIntersectional: [IdInput]
   qualifiedClassifications: [ClassificationFilterInput]
-  qualifiedStreams: [PoolStream]
-  workStreams: [IdInput]
+  qualifiedStreams: [IdInput]
   community: IdInput
 }
 

--- a/api/tests/Feature/JobPosterTemplateTest.php
+++ b/api/tests/Feature/JobPosterTemplateTest.php
@@ -93,7 +93,7 @@ class JobPosterTemplateTest extends TestCase
             ->create();
     }
 
-    public function testAnonymousUsersCanViewAny()
+    public function test_anonymous_users_can_view_any()
     {
         $this->graphQL($this->queryOne, [
             'id' => $this->template->id,
@@ -116,21 +116,21 @@ class JobPosterTemplateTest extends TestCase
             ]);
     }
 
-    public function testAnonymousUserCannotCreate()
+    public function test_anonymous_user_cannot_create()
     {
         $this->graphQL($this->create, [
             'template' => $this->getCreateInput(),
         ])->assertGraphQLErrorMessage('Unauthenticated.');
     }
 
-    public function testNonAdminUserCannotCreate()
+    public function test_non_admin_user_cannot_create()
     {
         $this->actingAs($this->baseUser, 'api')->graphQL($this->create, [
             'template' => $this->getCreateInput(),
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function testAdminCanCreate()
+    public function test_admin_can_create()
     {
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
             'template' => $this->getCreateInput(),
@@ -139,7 +139,7 @@ class JobPosterTemplateTest extends TestCase
         $this->assertNotNull($res['data']['createJobPosterTemplate']);
     }
 
-    public function testAnonymousUserCannotUpdate()
+    public function test_anonymous_user_cannot_update()
     {
         $this->graphQL($this->update, [
             'template' => [
@@ -149,7 +149,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Unauthenticated.');
     }
 
-    public function testNonAdminUserCannotUpdate()
+    public function test_non_admin_user_cannot_update()
     {
         $this->actingAs($this->baseUser, 'api')->graphQL($this->update, [
             'template' => [
@@ -159,7 +159,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function testAdminCanUpdate()
+    public function test_admin_can_update()
     {
         $this->actingAs($this->adminUser, 'api')->graphQL($this->update, [
             'template' => [
@@ -176,7 +176,7 @@ class JobPosterTemplateTest extends TestCase
         ]);
     }
 
-    public function testNonAdminUserCannotDelete()
+    public function test_non_admin_user_cannot_delete()
     {
         $template = JobPosterTemplate::factory()->create();
 
@@ -185,7 +185,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function testAdminCanDelete()
+    public function test_admin_can_delete()
     {
         $template = JobPosterTemplate::factory()->create();
 
@@ -200,7 +200,7 @@ class JobPosterTemplateTest extends TestCase
         ]);
     }
 
-    public function testReferenceIdIsUnique()
+    public function test_reference_id_is_unique()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -211,7 +211,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function testCannotAddEssentialSkillWithNoLevel()
+    public function test_cannot_add_essential_skill_with_no_level()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -230,7 +230,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function testCanAddEssentialSkillWithLevel()
+    public function test_can_add_essential_skill_with_level()
     {
         $input = $this->getCreateInput();
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -251,7 +251,7 @@ class JobPosterTemplateTest extends TestCase
         $this->assertNotNull($res['data']['createJobPosterTemplate']);
     }
 
-    public function testCannotAddAssetSkillWithLevel()
+    public function test_cannot_add_asset_skill_with_level()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -270,7 +270,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function testCanAddAssetSkillWithNoLevel()
+    public function test_can_add_asset_skill_with_no_level()
     {
         $input = $this->getCreateInput();
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -301,6 +301,7 @@ class JobPosterTemplateTest extends TestCase
             'description' => $template->description,
             'supervisoryStatus' => $template->supervisory_status,
             'stream' => $template->stream,
+            'work_stream_id' => $template->work_stream_id,
             'tasks' => $template->tasks,
             'workDescription' => $template->work_description,
             'keywords' => $template->keywords,

--- a/api/tests/Feature/JobPosterTemplateTest.php
+++ b/api/tests/Feature/JobPosterTemplateTest.php
@@ -93,7 +93,7 @@ class JobPosterTemplateTest extends TestCase
             ->create();
     }
 
-    public function test_anonymous_users_can_view_any()
+    public function testAnonymousUsersCanViewAny()
     {
         $this->graphQL($this->queryOne, [
             'id' => $this->template->id,
@@ -116,21 +116,21 @@ class JobPosterTemplateTest extends TestCase
             ]);
     }
 
-    public function test_anonymous_user_cannot_create()
+    public function testAnonymousUserCannotCreate()
     {
         $this->graphQL($this->create, [
             'template' => $this->getCreateInput(),
         ])->assertGraphQLErrorMessage('Unauthenticated.');
     }
 
-    public function test_non_admin_user_cannot_create()
+    public function testNonAdminUserCannotCreate()
     {
         $this->actingAs($this->baseUser, 'api')->graphQL($this->create, [
             'template' => $this->getCreateInput(),
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function test_admin_can_create()
+    public function testAdminCanCreate()
     {
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
             'template' => $this->getCreateInput(),
@@ -139,7 +139,7 @@ class JobPosterTemplateTest extends TestCase
         $this->assertNotNull($res['data']['createJobPosterTemplate']);
     }
 
-    public function test_anonymous_user_cannot_update()
+    public function testAnonymousUserCannotUpdate()
     {
         $this->graphQL($this->update, [
             'template' => [
@@ -149,7 +149,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Unauthenticated.');
     }
 
-    public function test_non_admin_user_cannot_update()
+    public function testNonAdminUserCannotUpdate()
     {
         $this->actingAs($this->baseUser, 'api')->graphQL($this->update, [
             'template' => [
@@ -159,7 +159,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function test_admin_can_update()
+    public function testAdminCanUpdate()
     {
         $this->actingAs($this->adminUser, 'api')->graphQL($this->update, [
             'template' => [
@@ -176,7 +176,7 @@ class JobPosterTemplateTest extends TestCase
         ]);
     }
 
-    public function test_non_admin_user_cannot_delete()
+    public function testNonAdminUserCannotDelete()
     {
         $template = JobPosterTemplate::factory()->create();
 
@@ -185,7 +185,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function test_admin_can_delete()
+    public function testAdminCanDelete()
     {
         $template = JobPosterTemplate::factory()->create();
 
@@ -200,7 +200,7 @@ class JobPosterTemplateTest extends TestCase
         ]);
     }
 
-    public function test_reference_id_is_unique()
+    public function testReferenceIdIsUnique()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -211,7 +211,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function test_cannot_add_essential_skill_with_no_level()
+    public function testCannotAddEssentialSkillWithNoLevel()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -230,7 +230,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function test_can_add_essential_skill_with_level()
+    public function testCanAddEssentialSkillWithLevel()
     {
         $input = $this->getCreateInput();
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -251,7 +251,7 @@ class JobPosterTemplateTest extends TestCase
         $this->assertNotNull($res['data']['createJobPosterTemplate']);
     }
 
-    public function test_cannot_add_asset_skill_with_level()
+    public function testCannotAddAssetSkillWithLevel()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -270,7 +270,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function test_can_add_asset_skill_with_no_level()
+    public function testCanAddAssetSkillWithNoLevel()
     {
         $input = $this->getCreateInput();
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [

--- a/apps/playwright/tests/search-workflows.spec.ts
+++ b/apps/playwright/tests/search-workflows.spec.ts
@@ -21,6 +21,7 @@ import { createUserWithRoles, me } from "~/utils/user";
 import graphql from "~/utils/graphql";
 import { createAndPublishPool } from "~/utils/pools";
 import { getClassifications } from "~/utils/classification";
+import { getWorkStreams } from "~/utils/workStreams";
 
 test.describe("Talent search", () => {
   const uniqueTestId = Date.now().valueOf();
@@ -80,11 +81,16 @@ test.describe("Talent search", () => {
     classification = classifications[0];
 
     const adminUser = await me(adminCtx, {});
+    const workStreams = await getWorkStreams(adminCtx, {});
+    const businessLineAdvisory = workStreams.find(
+      (workStream) => workStream.key === "BUSINESS_ADVISORY_SERVICES",
+    );
     // Accepted pool
     const createdPool = await createAndPublishPool(adminCtx, {
       userId: adminUser.id,
       skillIds: technicalSkill ? [technicalSkill?.id] : undefined,
       classificationId: classification.id,
+      workStreamId: businessLineAdvisory?.id,
       name: {
         en: poolName,
         fr: `${poolName} (FR)`,

--- a/apps/playwright/utils/pools.ts
+++ b/apps/playwright/utils/pools.ts
@@ -7,7 +7,6 @@ import {
   PoolOpportunityLength,
   PoolSkill,
   PoolSkillType,
-  PoolStream,
   PublishingGroup,
   SecurityStatus,
   SkillCategory,
@@ -22,9 +21,9 @@ import { getCommunities } from "./communities";
 import { getClassifications } from "./classification";
 import { getDepartments } from "./departments";
 import { getSkills } from "./skills";
+import { getWorkStreams } from "./workStreams";
 
 const defaultPool: Partial<UpdatePoolInput> = {
-  stream: PoolStream.BusinessAdvisoryServices,
   closingDate: `${FAR_FUTURE_DATE} 00:00:00`,
   yourImpact: {
     en: "test impact EN",
@@ -49,12 +48,14 @@ const Test_CreatePoolMutationDocument = /* GraphQL */ `
     $userId: ID!
     $teamId: ID!
     $communityId: ID!
+    $workStreamId: ID!
     $pool: CreatePoolInput!
   ) {
     createPool(
       userId: $userId
       teamId: $teamId
       communityId: $communityId
+      workStreamId: $workStreamId
       pool: $pool
     ) {
       id
@@ -72,6 +73,7 @@ interface CreatePoolArgs {
   communityId?: string;
   classificationId?: string;
   departmentId?: string;
+  workStreamId?: string;
 }
 
 export const createPool: GraphQLRequestFunc<Pool, CreatePoolArgs> = async (
@@ -102,6 +104,12 @@ export const createPool: GraphQLRequestFunc<Pool, CreatePoolArgs> = async (
     departmentId = departments[0].id;
   }
 
+  let workStreamId = opts.workStreamId;
+  if (!workStreamId) {
+    const workStreams = await getWorkStreams(ctx, {});
+    workStreamId = workStreams[0].id;
+  }
+
   return ctx
     .post(Test_CreatePoolMutationDocument, {
       isPrivileged: true,
@@ -112,6 +120,7 @@ export const createPool: GraphQLRequestFunc<Pool, CreatePoolArgs> = async (
         pool: {
           classification: { connect: classificationId },
           department: { connect: departmentId },
+          workStream: { connect: workStreamId },
         },
       },
     })

--- a/apps/playwright/utils/workStreams.ts
+++ b/apps/playwright/utils/workStreams.ts
@@ -1,0 +1,28 @@
+import { WorkStream } from "@gc-digital-talent/graphql";
+
+import { GraphQLRequestFunc, GraphQLResponse } from "./graphql";
+
+const Test_WorkStreamQueryDocument = /* GraphQL */ `
+  query WorkStreams {
+    workStreams {
+      id
+      name {
+        en
+        fr
+      }
+    }
+  }
+`;
+
+/**
+ * Get work streams
+ *
+ * Get all the work streams directly from the API.
+ */
+export const getWorkStreams: GraphQLRequestFunc<WorkStream[]> = async (ctx) => {
+  return ctx
+    .post(Test_WorkStreamQueryDocument)
+    .then(
+      (res: GraphQLResponse<"workStreams", WorkStream[]>) => res.workStreams,
+    );
+};

--- a/apps/playwright/utils/workStreams.ts
+++ b/apps/playwright/utils/workStreams.ts
@@ -6,6 +6,7 @@ const Test_WorkStreamQueryDocument = /* GraphQL */ `
   query WorkStreams {
     workStreams {
       id
+      key
       name {
         en
         fr

--- a/apps/web/src/components/ApplicationCard/ApplicationCard.tsx
+++ b/apps/web/src/components/ApplicationCard/ApplicationCard.tsx
@@ -46,9 +46,9 @@ export const ApplicationCard_Fragment = graphql(/* GraphQL */ `
     pool {
       id
       closingDate
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }
@@ -114,13 +114,13 @@ const ApplicationCard = ({
     application.submittedAt,
   );
   const applicationTitle = getShortPoolTitleHtml(intl, {
-    stream: application.pool.stream,
+    workStream: application.pool.workStream,
     name: application.pool.name,
     publishingGroup: application.pool.publishingGroup,
     classification: application.pool.classification,
   });
   const applicationTitleString = getShortPoolTitleLabel(intl, {
-    stream: application.pool.stream,
+    workStream: application.pool.workStream,
     name: application.pool.name,
     publishingGroup: application.pool.publishingGroup,
     classification: application.pool.classification,

--- a/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
+++ b/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
@@ -118,13 +118,6 @@ export const AssessmentResultsTable_Fragment = graphql(/* GraphQL */ `
           fr
         }
       }
-      stream {
-        value
-        label {
-          en
-          fr
-        }
-      }
       name {
         en
         fr
@@ -134,9 +127,9 @@ export const AssessmentResultsTable_Fragment = graphql(/* GraphQL */ `
         group
         level
       }
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }

--- a/apps/web/src/components/CandidateDialog/ChangeDateDialog.tsx
+++ b/apps/web/src/components/CandidateDialog/ChangeDateDialog.tsx
@@ -37,9 +37,9 @@ export const ChangeDateDialog_PoolCandidateFragment = graphql(/* GraphQL */ `
     expiryDate
     pool {
       id
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }
@@ -177,7 +177,7 @@ const ChangeDateDialog = ({
           <p data-h2-font-weight="base(800)">
             -{" "}
             {getShortPoolTitleHtml(intl, {
-              stream: selectedCandidate.pool.stream,
+              workStream: selectedCandidate.pool.workStream,
               name: selectedCandidate.pool.name,
               publishingGroup: selectedCandidate.pool.publishingGroup,
               classification: selectedCandidate.pool.classification,

--- a/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
+++ b/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
@@ -78,9 +78,9 @@ const ChangeStatusDialog_UserFragment = graphql(/* GraphQL */ `
           group
           level
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }
@@ -123,9 +123,9 @@ export const ChangeStatusDialog_PoolCandidateFragment = graphql(/* GraphQL */ `
     }
     pool {
       id
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }
@@ -264,7 +264,7 @@ const ChangeStatusDialogForm = ({
                     {getShortPoolTitleHtml(
                       intl,
                       {
-                        stream: r.poolCandidate.pool.stream,
+                        workStream: r.poolCandidate.pool.workStream,
                         name: r.poolCandidate.pool.name,
                         publishingGroup: r.poolCandidate.pool.publishingGroup,
                         classification: r.poolCandidate.pool.classification,
@@ -412,7 +412,7 @@ const ChangeStatusDialog = ({
               {
                 status: getLocalizedName(selectedCandidate.status?.label, intl),
                 poolName: getShortPoolTitleLabel(intl, {
-                  stream: selectedCandidate.pool.stream,
+                  workStream: selectedCandidate.pool.workStream,
                   name: selectedCandidate.pool.name,
                   publishingGroup: selectedCandidate.pool.publishingGroup,
                   classification: selectedCandidate.pool.classification,
@@ -453,7 +453,7 @@ const ChangeStatusDialog = ({
           <p data-h2-font-weight="base(700)">
             -{" "}
             {getShortPoolTitleHtml(intl, {
-              stream: selectedCandidate.pool.stream,
+              workStream: selectedCandidate.pool.workStream,
               name: selectedCandidate.pool.name,
               publishingGroup: selectedCandidate.pool.publishingGroup,
               classification: selectedCandidate.pool.classification,

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -195,9 +195,9 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
               group
               level
             }
-            stream {
-              value
-              label {
+            workStream {
+              id
+              name {
                 en
                 fr
               }
@@ -718,7 +718,7 @@ const PoolCandidatesTable = ({
           columnHelper.accessor(
             ({ poolCandidate: { pool } }) =>
               getFullPoolTitleLabel(intl, {
-                stream: pool.stream,
+                workStream: pool.workStream,
                 name: pool.name,
                 publishingGroup: pool.publishingGroup,
                 classification: pool.classification,
@@ -737,7 +737,7 @@ const PoolCandidatesTable = ({
                 processCell(
                   {
                     id: pool.id,
-                    stream: pool.stream,
+                    workStream: pool.workStream,
                     name: pool.name,
                     publishingGroup: pool.publishingGroup,
                     classification: pool.classification,

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -13,7 +13,6 @@ import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 import { Link, Chip, Spoiler } from "@gc-digital-talent/ui";
 import {
   CandidateExpiryFilter,
-  PoolStream,
   PublishingGroup,
   Maybe,
   Pool,
@@ -34,7 +33,7 @@ import {
   LocalizedString,
   ClaimVerificationSort,
 } from "@gc-digital-talent/graphql";
-import { notEmpty } from "@gc-digital-talent/helpers";
+import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 
 import useRoutes from "~/hooks/useRoutes";
 import { getFullNameLabel } from "~/utils/nameUtils";
@@ -380,7 +379,9 @@ export function transformPoolCandidateSearchInputToFormValues(
       input?.appliedClassifications
         ?.filter(notEmpty)
         .map((c) => `${c.group}-${c.level}`) ?? [],
-    stream: input?.applicantFilter?.qualifiedStreams?.filter(notEmpty) ?? [],
+    stream: unpackMaybes(input?.applicantFilter?.qualifiedStreams).map(
+      ({ id }) => id,
+    ),
     languageAbility: input?.applicantFilter?.languageAbility ?? "",
     workRegion:
       input?.applicantFilter?.locationPreferences?.filter(notEmpty) ?? [],
@@ -427,7 +428,7 @@ export function transformFormValuesToFilterState(
       languageAbility: data.languageAbility
         ? stringToEnumLanguage(data.languageAbility)
         : undefined,
-      qualifiedStreams: data.stream as PoolStream[],
+      qualifiedStreams: data.stream.map((id) => ({ id })),
       operationalRequirements: data.operationalRequirement
         .map((requirement) => {
           return stringToEnumOperational(requirement);

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -100,14 +100,14 @@ export const candidateNameCell = (
 };
 
 export const processCell = (
-  pool: Pick<Pool, "id" | "stream" | "name" | "publishingGroup"> & {
+  pool: Pick<Pool, "id" | "workStream" | "name" | "publishingGroup"> & {
     classification?: Maybe<Pick<Classification, "group" | "level">>;
   },
   paths: ReturnType<typeof useRoutes>,
   intl: IntlShape,
 ) => {
   const poolName = getFullPoolTitleLabel(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,

--- a/apps/web/src/components/PoolCard/PoolCard.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.tsx
@@ -41,9 +41,9 @@ import IconLabel from "./IconLabel";
 export const PoolCard_Fragment = graphql(/* GraphQL */ `
   fragment PoolCard on Pool {
     id
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -258,7 +258,7 @@ const PoolCard = ({ poolQuery, headingLevel = "h3" }: PoolCardProps) => {
             data-h2-min-height="base(x4.5) p-tablet(auto)"
           >
             {getShortPoolTitleHtml(intl, {
-              stream: pool.stream,
+              workStream: pool.workStream,
               name: pool.name,
               publishingGroup: pool.publishingGroup,
               classification: pool.classification,

--- a/apps/web/src/components/PoolFilterInput/usePoolFilterOptions.ts
+++ b/apps/web/src/components/PoolFilterInput/usePoolFilterOptions.ts
@@ -32,9 +32,9 @@ const PoolFilter_Query = graphql(/* GraphQL */ `
             fr
           }
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }
@@ -85,7 +85,7 @@ const usePoolFilterOptions = (
       pools.map((pool) => ({
         value: pool.id,
         label: getShortPoolTitleLabel(intl, {
-          stream: pool.stream,
+          workStream: pool.workStream,
           name: pool.name,
           publishingGroup: pool.publishingGroup,
           classification: pool.classification,

--- a/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
+++ b/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
@@ -65,9 +65,9 @@ const PoolStatusTable_Fragment = graphql(/* GraphQL */ `
           group
           level
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }
@@ -105,7 +105,7 @@ const PoolStatusTable = ({ userQuery }: PoolStatusTableProps) => {
     columnHelper.accessor(
       (row) =>
         getShortPoolTitleLabel(intl, {
-          stream: row.pool.stream,
+          workStream: row.pool.workStream,
           name: row.pool.name,
           publishingGroup: row.pool.publishingGroup,
           classification: row.pool.classification,
@@ -195,7 +195,7 @@ const PoolStatusTable = ({ userQuery }: PoolStatusTableProps) => {
       },
     ),
     columnHelper.accessor(
-      ({ pool: { stream } }) => getLocalizedName(stream?.label, intl),
+      ({ pool: { workStream } }) => getLocalizedName(workStream?.name, intl),
       {
         id: "application",
         enableHiding: false,

--- a/apps/web/src/components/PoolStatusTable/types.ts
+++ b/apps/web/src/components/PoolStatusTable/types.ts
@@ -24,9 +24,9 @@ const PoolStatusTable_PoolCandidateFragment = graphql(/* GraphQL */ `
           fr
         }
       }
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }

--- a/apps/web/src/components/RecruitmentAvailabilityDialog/RecruitmentAvailabilityDialog.tsx
+++ b/apps/web/src/components/RecruitmentAvailabilityDialog/RecruitmentAvailabilityDialog.tsx
@@ -32,9 +32,9 @@ const RecruitmentAvailabilityDialog_Fragment = graphql(/* GraphQL */ `
     suspendedAt
     pool {
       id
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }
@@ -77,7 +77,7 @@ const RecruitmentAvailabilityDialog = ({
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const isSuspended = !!candidate.suspendedAt;
   const title = poolTitle(intl, {
-    stream: candidate.pool.stream,
+    workStream: candidate.pool.workStream,
     name: candidate.pool.name,
     publishingGroup: candidate.pool.publishingGroup,
     classification: candidate.pool.classification,

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -142,7 +142,7 @@ const ApplicantFilters = ({
               applicantFilter
                 ? applicantFilter?.pools?.filter(notEmpty)?.map((pool) =>
                     getShortPoolTitleHtml(intl, {
-                      stream: pool.stream,
+                      workStream: pool.workStream,
                       name: pool.name,
                       publishingGroup: pool.publishingGroup,
                       classification: pool.classification,
@@ -278,7 +278,7 @@ const SearchRequestFilters = ({
     : [];
 
   const streams = pools?.map((pool) =>
-    pool.stream?.label ? getLocalizedName(pool.stream.label, intl) : "",
+    getLocalizedName(pool.workStream?.name, intl, true),
   );
 
   // eslint-disable-next-line deprecation/deprecation
@@ -373,7 +373,7 @@ const SearchRequestFilters = ({
                 pools
                   ? pools.map((pool) =>
                       getShortPoolTitleHtml(intl, {
-                        stream: pool.stream,
+                        workStream: pool.workStream,
                         name: pool.name,
                         publishingGroup: pool.publishingGroup,
                         classification: pool.classification,

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -110,9 +110,9 @@ const ApplicantFilters = ({
     ),
   ).map((label) => getLocalizedName(label, intl));
 
-  const streams = unpackMaybes(
-    applicantFilter?.qualifiedStreams?.flatMap((stream) => stream?.label),
-  ).map((label) => getLocalizedName(label, intl));
+  const streams = unpackMaybes(applicantFilter?.qualifiedStreams).map(
+    (workStream) => getLocalizedName(workStream.name, intl),
+  );
 
   const communityName: string =
     applicantFilter && applicantFilter.community

--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -126,8 +126,8 @@ const SearchRequestTable_Query = graphql(/* GraphQL */ `
             level
           }
           qualifiedStreams {
-            value
-            label {
+            id
+            name {
               en
               fr
             }
@@ -271,7 +271,7 @@ const SearchRequestTable = ({ title }: SearchRequestTableProps) => {
       ({ applicantFilter }) =>
         unpackMaybes(
           applicantFilter?.qualifiedStreams?.map((stream) =>
-            getLocalizedName(stream?.label, intl),
+            getLocalizedName(stream?.name, intl),
           ),
         ).join(","),
       {
@@ -288,7 +288,7 @@ const SearchRequestTable = ({ title }: SearchRequestTableProps) => {
             list:
               unpackMaybes(
                 applicantFilter?.qualifiedStreams?.map((stream) =>
-                  getLocalizedName(stream?.label, intl, true),
+                  getLocalizedName(stream?.name, intl, true),
                 ),
               ) ?? [],
           }),

--- a/apps/web/src/pages/Applications/ApplicationWelcomePage/ApplicationWelcomePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationWelcomePage/ApplicationWelcomePage.tsx
@@ -71,7 +71,7 @@ const ApplicationWelcome = ({ application }: ApplicationPageProps) => {
     stepOrdinal: currentStepOrdinal,
   });
   const poolName = getShortPoolTitleHtml(intl, {
-    stream: application.pool.stream,
+    workStream: application.pool.workStream,
     name: application.pool.name,
     publishingGroup: application.pool.publishingGroup,
     classification: application.pool.classification,

--- a/apps/web/src/pages/Applications/fragment.ts
+++ b/apps/web/src/pages/Applications/fragment.ts
@@ -258,9 +258,9 @@ const Application_PoolCandidateFragment = graphql(/* GraphQL */ `
         en
         fr
       }
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/components/BasicDetails.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/components/BasicDetails.tsx
@@ -29,8 +29,9 @@ const JobPosterTemplateBasicDetails_Fragment = graphql(/* GraphQL */ `
       group
       level
     }
-    stream {
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -126,7 +127,7 @@ const BasicDetails = ({ jobPosterTemplateQuery }: BasicDetailsProps) => {
                 "Label displayed on the pool form stream/job title field.",
             })}
           >
-            {getLocalizedName(jobPosterTemplate.stream?.label, intl)}
+            {getLocalizedName(jobPosterTemplate.workStream?.name, intl)}
           </FieldDisplay>
           <FieldDisplay
             label={intl.formatMessage({

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -21,10 +21,9 @@ import {
 import {
   Classification,
   graphql,
-  LocalizedPoolStream,
   Maybe,
-  PoolStream,
   SupervisoryStatus,
+  WorkStream,
 } from "@gc-digital-talent/graphql";
 import {
   alphaSortOptions,
@@ -53,14 +52,14 @@ interface FormValues {
   keyword: string;
   classifications: string[];
   supervisoryStatuses: SupervisoryStatus[];
-  streams: PoolStream[];
+  workStreams: string[];
 }
 
 const defaultValues = {
   keyword: "",
   classifications: [],
   supervisoryStatuses: [],
-  streams: [],
+  workStreams: [],
 } satisfies FormValues;
 
 const JobPosterTemplates_Query = graphql(/* GraphQL */ `
@@ -77,18 +76,18 @@ const JobPosterTemplates_Query = graphql(/* GraphQL */ `
         fr
       }
     }
-    poolStreams: localizedEnumStrings(enumName: "PoolStream") {
-      value
-      label {
+    workStreams {
+      id
+      name {
         en
         fr
       }
     }
     jobPosterTemplates {
       id
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }
@@ -126,7 +125,7 @@ function assertIncludes(haystack: string[], needle?: Maybe<string>): boolean {
 function previewMetaData(
   intl: IntlShape,
   classification?: Maybe<Classification>,
-  stream?: Maybe<LocalizedPoolStream>,
+  workStream?: Maybe<WorkStream>,
 ): PreviewMetaData[] {
   const metaData = [];
   if (classification) {
@@ -137,11 +136,11 @@ function previewMetaData(
     } satisfies PreviewMetaData);
   }
 
-  if (stream) {
+  if (workStream) {
     metaData.push({
-      key: stream.value,
+      key: workStream.id,
       type: "text",
-      children: getLocalizedName(stream.label, intl),
+      children: getLocalizedName(workStream.name, intl),
     } satisfies PreviewMetaData);
   }
 
@@ -225,7 +224,7 @@ const JobPosterTemplatesPage = () => {
         );
       show =
         show &&
-        assertIncludes(formData.streams, jobPosterTemplate?.stream?.value);
+        assertIncludes(formData.workStreams, jobPosterTemplate?.workStream?.id);
 
       return show;
     });
@@ -256,7 +255,7 @@ const JobPosterTemplatesPage = () => {
     formData.keyword,
     formData.classifications,
     formData.supervisoryStatuses,
-    formData.streams,
+    formData.workStreams,
     locale,
     sortBy,
     intl,
@@ -374,11 +373,14 @@ const JobPosterTemplatesPage = () => {
                       })}
                     />
                     <Checklist
-                      idPrefix="streams"
-                      name="streams"
+                      idPrefix="workStreams"
+                      name="workStreams"
                       items={alphaSortOptions(
-                        localizedEnumToOptions(
-                          unpackMaybes(data?.poolStreams),
+                        unpackMaybes(data?.workStreams).map(
+                          (workStream) => ({
+                            value: workStream.id,
+                            label: getLocalizedName(workStream.name, intl),
+                          }),
                           intl,
                         ),
                       )}
@@ -497,7 +499,7 @@ const JobPosterTemplatesPage = () => {
                             metaData={previewMetaData(
                               intl,
                               jobPosterTemplate.classification,
-                              jobPosterTemplate.stream,
+                              jobPosterTemplate.workStream,
                             )}
                           >
                             {jobPosterTemplate.description && (

--- a/apps/web/src/pages/Manager/components/ReviewTalentRequestDialog.tsx
+++ b/apps/web/src/pages/Manager/components/ReviewTalentRequestDialog.tsx
@@ -56,7 +56,8 @@ const ReviewTalentRequestDialog_Query = graphql(/* GraphQL */ `
           level
         }
         qualifiedStreams {
-          label {
+          id
+          name {
             fr
             en
           }
@@ -189,7 +190,7 @@ const ReviewTalentRequestDialogContent = ({
             {workStreams.length > 0
               ? deriveSingleString(
                   workStreams,
-                  (stream) => getLocalizedName(stream.label, intl),
+                  (stream) => getLocalizedName(stream?.name, intl),
                   locale,
                 )
               : nullMessage}

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -105,9 +105,9 @@ const PoolCandidate_SnapshotQuery = graphql(/* GraphQL */ `
           group
           level
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }
@@ -168,7 +168,7 @@ export const ViewPoolCandidate = ({
       },
       {
         label: getFullPoolTitleLabel(intl, {
-          stream: poolCandidate.pool.stream,
+          workStream: poolCandidate.pool.workStream,
           name: poolCandidate.pool.name,
           publishingGroup: poolCandidate.pool.publishingGroup,
           classification: poolCandidate.pool.classification,

--- a/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
+++ b/apps/web/src/pages/Pools/BrowsePoolsPage/components/OngoingRecruitmentSection/OngoingRecruitmentSection.tsx
@@ -66,7 +66,7 @@ const selectPoolForSection = (
       .find(
         (p) =>
           // must match section stream
-          p.stream?.value === stream &&
+          p.workStream?.key === stream &&
           // must include section classification group and level
           !!(
             p.classification?.group === group &&
@@ -101,12 +101,9 @@ const OngoingRecruitmentSection_QueryFragment = graphql(/* GraphQL */ `
         }
       }
     }
-    streams: localizedEnumStrings(enumName: "PoolStream") {
-      value
-      label {
-        en
-        fr
-      }
+    workStreams {
+      id
+      key
     }
   }
 `);
@@ -1060,7 +1057,7 @@ const OngoingRecruitmentSection = ({
                   })
                 : getLocalizedEnumStringByValue(
                     quickFilterStream,
-                    data?.streams,
+                    data?.workStreams,
                     intl,
                   )}
             </Button>

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -51,6 +51,7 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import PoolNameSection, {
   PoolClassification_Fragment,
   PoolDepartment_Fragment,
+  PoolWorkStream_Fragment,
   type PoolNameSubmitData,
 } from "./components/PoolNameSection/PoolNameSection";
 import ClosingDateSection, {
@@ -102,9 +103,9 @@ export const EditPool_Fragment = graphql(/* GraphQL */ `
     ...EditPoolYourImpact
 
     id
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -241,6 +242,7 @@ export interface EditPoolFormProps {
   poolQuery: FragmentType<typeof EditPool_Fragment>;
   classifications: FragmentType<typeof PoolClassification_Fragment>[];
   departments: FragmentType<typeof PoolDepartment_Fragment>[];
+  workStreams: FragmentType<typeof PoolWorkStream_Fragment>[];
   skills: Skill[];
   onSave: (submitData: PoolSubmitData) => Promise<void>;
   onUpdatePublished: (submitData: UpdatePublishedPoolInput) => Promise<void>;
@@ -251,6 +253,7 @@ export const EditPoolForm = ({
   poolQuery,
   classifications,
   departments,
+  workStreams,
   skills,
   onSave,
   onUpdatePublished,
@@ -277,7 +280,7 @@ export const EditPoolForm = ({
       areaOfSelection: pool.areaOfSelection,
       classification: pool.classification,
       department: pool.department,
-      stream: pool.stream,
+      workStream: pool.workStream,
       name: pool.name,
       processNumber: pool.processNumber,
       publishingGroup: pool.publishingGroup,
@@ -315,7 +318,7 @@ export const EditPoolForm = ({
         areaOfSelection: pool.areaOfSelection,
         classification: pool.classification,
         department: pool.department,
-        stream: pool.stream,
+        workStream: pool.workStream,
         name: pool.name,
         processNumber: pool.processNumber,
         publishingGroup: pool.publishingGroup,
@@ -370,7 +373,7 @@ export const EditPoolForm = ({
     educationRequirements: {
       id: "education-requirements",
       hasError: educationRequirementIsNull({
-        stream: pool.stream,
+        workStream: pool.workStream,
         name: pool.name,
         processNumber: pool.processNumber,
         publishingGroup: pool.publishingGroup,
@@ -574,6 +577,7 @@ export const EditPoolForm = ({
                       poolQuery={pool}
                       classificationsQuery={classifications}
                       departmentsQuery={departments}
+                      workStreamsQuery={workStreams}
                       sectionMetadata={sectionMetadata.poolName}
                       onSave={onSave}
                     />
@@ -776,6 +780,11 @@ const EditPoolPage_Query = graphql(/* GraphQL */ `
       ...PoolDepartment
     }
 
+    # all work streams to populate form dropdown
+    workStreams {
+      ...PoolWorkStream
+    }
+
     # all skills to populate skill pickers
     skills {
       id
@@ -868,6 +877,7 @@ export const EditPoolPage = () => {
             classifications={unpackMaybes(data.classifications)}
             departments={unpackMaybes(data.departments)}
             skills={data.skills.filter(notEmpty)}
+            workStreams={unpackMaybes(data.workStreams)}
             onSave={(saveData) => mutations.update(poolId, saveData)}
             onUpdatePublished={(updateData) =>
               mutations.updatePublished(poolId, updateData)

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -29,7 +29,7 @@ const Display = ({
     selectionLimitations: poolSelectionLimitations,
     classification,
     department,
-    stream,
+    workStream,
     name,
     processNumber,
     publishingGroup,
@@ -105,10 +105,10 @@ const Display = ({
             : notProvided}
         </ToggleForm.FieldDisplay>
         <ToggleForm.FieldDisplay
-          hasError={!stream}
+          hasError={!workStream}
           label={intl.formatMessage(processMessages.stream)}
         >
-          {getLocalizedName(stream?.label, intl)}
+          {getLocalizedName(workStream?.name, intl)}
         </ToggleForm.FieldDisplay>
         <ToggleForm.FieldDisplay
           hasError={!name?.en}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
@@ -388,14 +388,14 @@ const PoolNameSection = ({
                   disabled={formDisabled}
                 />
                 <Select
-                  id="stream"
+                  id="workStream"
+                  name="workStream"
                   label={intl.formatMessage({
                     defaultMessage: "Work stream",
                     id: "UKw7sB",
                     description:
                       "Label displayed on the pool form stream/job title field.",
                   })}
-                  name="stream"
                   nullSelection={intl.formatMessage(
                     uiMessages.nullSelectionOption,
                   )}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
@@ -77,9 +77,9 @@ const EditPoolName_Fragment = graphql(/* GraphQL */ `
         fr
       }
     }
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -140,16 +140,19 @@ export const PoolDepartment_Fragment = graphql(/* GraphQL */ `
   }
 `);
 
+export const PoolWorkStream_Fragment = graphql(/* GraphQL */ `
+  fragment PoolWorkStream on WorkStream {
+    id
+    name {
+      en
+      fr
+    }
+  }
+`);
+
 const PoolNameOptions_Query = graphql(/* GraphQL */ `
   query PoolNameOptions {
     publishingGroups: localizedEnumStrings(enumName: "PublishingGroup") {
-      value
-      label {
-        en
-        fr
-      }
-    }
-    streams: localizedEnumStrings(enumName: "PoolStream") {
       value
       label {
         en
@@ -192,12 +195,14 @@ type PoolNameSectionProps = SectionProps<
 > & {
   classificationsQuery: FragmentType<typeof PoolClassification_Fragment>[];
   departmentsQuery: FragmentType<typeof PoolDepartment_Fragment>[];
+  workStreamsQuery: FragmentType<typeof PoolWorkStream_Fragment>[];
 };
 
 const PoolNameSection = ({
   poolQuery,
   classificationsQuery,
   departmentsQuery,
+  workStreamsQuery,
   sectionMetadata,
   onSave,
 }: PoolNameSectionProps): JSX.Element => {
@@ -217,6 +222,7 @@ const PoolNameSection = ({
     classificationsQuery,
   );
   const departments = getFragment(PoolDepartment_Fragment, departmentsQuery);
+  const workStreams = getFragment(PoolWorkStream_Fragment, workStreamsQuery);
 
   const methods = useForm<FormValues>({
     defaultValues: dataToFormValues(pool),
@@ -393,7 +399,10 @@ const PoolNameSection = ({
                   nullSelection={intl.formatMessage(
                     uiMessages.nullSelectionOption,
                   )}
-                  options={localizedEnumToOptions(data?.streams, intl)}
+                  options={workStreams.map((stream) => ({
+                    value: stream.id,
+                    label: getLocalizedName(stream.name, intl),
+                  }))}
                   disabled={formDisabled}
                 />
                 <Input

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
@@ -9,12 +9,12 @@ import {
   LocalizedString,
   Maybe,
   Pool,
-  PoolStream,
   PublishingGroup,
   UpdatePoolInput,
   Department,
   PoolAreaOfSelection,
   PoolSelectionLimitation,
+  WorkStream,
 } from "@gc-digital-talent/graphql";
 
 export interface FormValues {
@@ -22,7 +22,7 @@ export interface FormValues {
   selectionLimitations?: Maybe<PoolSelectionLimitation[]>;
   classification?: Classification["id"];
   department?: Department["id"];
-  stream?: PoolStream;
+  workStream?: WorkStream["id"];
   specificTitleEn?: LocalizedString["en"];
   specificTitleFr?: LocalizedString["fr"];
   processNumber?: string;
@@ -35,7 +35,7 @@ export const dataToFormValues = (initialData: Pool): FormValues => ({
   selectionLimitations: initialData.selectionLimitations?.map((l) => l.value),
   classification: initialData.classification?.id ?? "",
   department: initialData.department?.id ?? "",
-  stream: initialData.stream?.value ?? undefined,
+  workStream: initialData.workStream?.id ?? undefined,
   specificTitleEn: initialData.name?.en ?? "",
   specificTitleFr: initialData.name?.fr ?? "",
   processNumber: initialData.processNumber ?? "",
@@ -50,7 +50,7 @@ export type PoolNameSubmitData = Pick<
   | "classification"
   | "department"
   | "name"
-  | "stream"
+  | "workStream"
   | "processNumber"
   | "publishingGroup"
   | "opportunityLength"
@@ -71,7 +71,9 @@ export const formValuesToSubmitData = (
         connect: formValues.department,
       }
     : undefined,
-  stream: formValues.stream ? formValues.stream : undefined,
+  workStream: formValues.workStream
+    ? { connect: formValues.workStream }
+    : undefined,
   name: {
     en: formValues.specificTitleEn,
     fr: formValues.specificTitleFr,

--- a/apps/web/src/pages/Pools/EditPoolPage/components/UpdatePublishedProcessDialog/UpdatePublishedProcessDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/UpdatePublishedProcessDialog/UpdatePublishedProcessDialog.tsx
@@ -23,9 +23,9 @@ import { PublishedEditableSectionProps } from "../../types";
 const UpdatePublishedProcessDialog_Fragment = graphql(/* GraphQL */ `
   fragment UpdatePublishedProcessDialog on Pool {
     id
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -64,7 +64,7 @@ const UpdatePublishedProcessDialog = ({
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const pool = getFragment(UpdatePublishedProcessDialog_Fragment, poolQuery);
   const title = getShortPoolTitleHtml(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolFilterDialog.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolFilterDialog.tsx
@@ -4,14 +4,13 @@ import { Combobox, localizedEnumToOptions } from "@gc-digital-talent/forms";
 import {
   FragmentType,
   PoolStatus,
-  PoolStream,
   PublishingGroup,
   Scalars,
   getFragment,
   graphql,
 } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
-import { commonMessages } from "@gc-digital-talent/i18n";
+import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 
 import FilterDialog, {
   CommonFilterDialogProps,
@@ -22,7 +21,7 @@ export interface FormValues {
   publishingGroups: PublishingGroup[];
   statuses: PoolStatus[];
   classifications: Scalars["UUID"]["output"][];
-  streams: PoolStream[];
+  workStreams: Scalars["UUID"]["output"][];
 }
 
 const PoolFilterDialogOptions_Fragment = graphql(/* GraphQL */ `
@@ -30,6 +29,13 @@ const PoolFilterDialogOptions_Fragment = graphql(/* GraphQL */ `
     classifications {
       group
       level
+    }
+    workStreams {
+      id
+      name {
+        en
+        fr
+      }
     }
     publishingGroups: localizedEnumStrings(enumName: "PublishingGroup") {
       value
@@ -39,13 +45,6 @@ const PoolFilterDialogOptions_Fragment = graphql(/* GraphQL */ `
       }
     }
     statuses: localizedEnumStrings(enumName: "PoolStatus") {
-      value
-      label {
-        en
-        fr
-      }
-    }
-    streams: localizedEnumStrings(enumName: "PoolStream") {
       value
       label {
         en
@@ -92,11 +91,14 @@ const PoolFilterDialog = ({
           options={localizedEnumToOptions(data?.statuses, intl)}
         />
         <Combobox
-          id="streams"
-          name="streams"
+          id="workStreams"
+          name="workStreams"
           isMulti
           label={intl.formatMessage(adminMessages.streams)}
-          options={localizedEnumToOptions(data?.streams, intl)}
+          options={unpackMaybes(data?.workStreams).map((workStream) => ({
+            value: workStream.id,
+            label: getLocalizedName(workStream.name, intl),
+          }))}
         />
         <Combobox
           id="classifications"

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -72,9 +72,9 @@ const defaultState = {
 const PoolTable_PoolFragment = graphql(/* GraphQL */ `
   fragment PoolTable_Pool on Pool {
     id
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -295,7 +295,8 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
       },
     }),
     columnHelper.accessor(
-      (row) => poolNameAccessor({ name: row.name, stream: row.stream }, intl),
+      (row) =>
+        poolNameAccessor({ name: row.name, workStream: row.workStream }, intl),
       {
         id: "name",
         header: intl.formatMessage(commonMessages.name),
@@ -319,7 +320,7 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
         classificationCell(pool.classification),
     }),
     columnHelper.accessor(
-      ({ stream }) => getLocalizedName(stream?.label, intl),
+      ({ workStream }) => getLocalizedName(workStream?.name, intl),
       {
         id: "stream",
         enableColumnFilter: false,

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
@@ -30,11 +30,11 @@ import { FormValues } from "./PoolFilterDialog";
 import PoolBookmark, { PoolBookmark_Fragment } from "./PoolBookmark";
 
 export function poolNameAccessor(
-  pool: Pick<Pool, "name" | "stream">,
+  pool: Pick<Pool, "name" | "workStream">,
   intl: IntlShape,
 ) {
   const name = getLocalizedName(pool.name, intl);
-  return `${name.toLowerCase()} ${getLocalizedName(pool.stream?.label, intl, true)}`;
+  return `${name.toLowerCase()} ${getLocalizedName(pool.workStream?.name, intl, true)}`;
 }
 
 export function viewCell(
@@ -276,7 +276,7 @@ export function transformFormValuesToFilterInput(
   return {
     publishingGroups: data.publishingGroups,
     statuses: data.statuses,
-    streams: data.streams,
+    workStreams: data.workStreams,
     classifications: data.classifications.map((classification) => {
       const [group, level] = classification.split("-");
       return { group, level: Number(level) };
@@ -290,7 +290,7 @@ export function transformPoolFilterInputToFormValues(
   return {
     publishingGroups: unpackMaybes(input?.publishingGroups),
     statuses: unpackMaybes(input?.statuses),
-    streams: unpackMaybes(input?.streams),
+    workStreams: unpackMaybes(input?.workStreams),
     classifications: unpackMaybes(input?.classifications).map(
       (c) => `${c.group}-${c.level}`,
     ),

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -136,9 +136,9 @@ export const PoolAdvertisement_Fragment = graphql(/* GraphQL */ `
       en
       fr
     }
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -253,13 +253,6 @@ export const PoolAdvertisement_Fragment = graphql(/* GraphQL */ `
       en
       fr
     }
-    stream {
-      value
-      label {
-        en
-        fr
-      }
-    }
     processNumber
     publishingGroup {
       value
@@ -328,13 +321,13 @@ export const PoolPoster = ({
     });
   }
   const poolTitle = getShortPoolTitleLabel(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,
   });
   const fullPoolTitle = getFullPoolTitleHtml(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,
@@ -664,7 +657,7 @@ export const PoolPoster = ({
                       description: "Label for pool advertisement stream",
                     }) + intl.formatMessage(commonMessages.dividingColon)
                   }
-                  value={getLocalizedName(pool.stream?.label, intl)}
+                  value={getLocalizedName(pool.workStream?.name, intl)}
                   suffix={
                     classification?.group === "IT" ? (
                       <Link

--- a/apps/web/src/pages/Pools/PoolLayout.tsx
+++ b/apps/web/src/pages/Pools/PoolLayout.tsx
@@ -38,9 +38,9 @@ export const PoolLayout_Fragment = graphql(/* GraphQL */ `
   fragment PoolLayout on Pool {
     ...AssessmentPlanStatus
     id
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -92,7 +92,7 @@ const heroTitle = ({ currentPage, intl, pool }: HeroTitleProps) => {
     return currentPage?.title;
   }
   return getShortPoolTitleLabel(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,
@@ -127,7 +127,7 @@ const PoolHeader = ({ poolQuery }: PoolHeaderProps) => {
     id: pool.id,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
-    stream: pool.stream,
+    workStream: pool.workStream,
     classification: pool.classification,
   });
   const currentPage = useCurrentPage<PageNavKeys>(pages);

--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -71,9 +71,9 @@ export const ViewPool_Fragment = graphql(/* GraphQL */ `
     }
     closingDate
     processNumber
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -123,7 +123,7 @@ export const ViewPool = ({
   const { roleAssignments } = useAuthorization();
   const pool = getFragment(ViewPool_Fragment, poolQuery);
   const poolName = getShortPoolTitleHtml(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
@@ -144,9 +144,6 @@ const CareerTimelineApplication_Fragment = graphql(/* GraphQL */ `
       publishingGroup {
         value
       }
-      stream {
-        value
-      }
     }
   }
 `);

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -131,9 +131,9 @@ const PoolsInFilter_Query = graphql(/* GraphQL */ `
           group
           level
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }
@@ -177,9 +177,9 @@ const RequestOptions_Query = graphql(/* GraphQL */ `
         fr
       }
     }
-    streams: localizedEnumStrings(enumName: "PoolStream") {
-      value
-      label {
+    workStreams {
+      id
+      name {
         en
         fr
       }
@@ -386,10 +386,12 @@ export const RequestForm = ({
         ),
       ),
     ),
-    qualifiedStreams: unpackMaybes(
-      applicantFilter?.qualifiedStreams?.map((stream) =>
-        enumInputToLocalizedEnum(stream, optionsData?.streams),
-      ),
+    workStreams: unpackMaybes(
+      applicantFilter?.workStreams?.map((stream) => {
+        return unpackMaybes(optionsData?.workStreams).find((workStream) => {
+          return workStream.id === stream?.id;
+        });
+      }),
     ),
     qualifiedClassifications:
       applicantFilter?.qualifiedClassifications

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
@@ -12,6 +12,7 @@ import {
   commonMessages,
   errorMessages,
   getEmploymentEquityGroup,
+  getLocalizedName,
   sortWorkRegion,
 } from "@gc-digital-talent/i18n";
 import { Classification, Skill, graphql } from "@gc-digital-talent/graphql";
@@ -29,9 +30,9 @@ import { classificationAriaLabels, classificationLabels } from "../labels";
 
 const SearchRequestOptions_Query = graphql(/* GraphQL */ `
   query SearchRequestOptions {
-    poolStreams: localizedEnumStrings(enumName: "PoolStream") {
-      value
-      label {
+    workStreams {
+      id
+      name {
         en
         fr
       }
@@ -78,7 +79,10 @@ const FormFields = ({ classifications, skills }: FormFieldsProps) => {
     data?.languageAbilities,
     intl,
   );
-  const streamOptions = localizedEnumToOptions(data?.poolStreams, intl);
+  const streamOptions = unpackMaybes(data?.workStreams).map((workStream) => ({
+    value: workStream.id,
+    label: getLocalizedName(workStream?.name, intl),
+  }));
   const sortedWorkRegions = sortWorkRegion(unpackMaybes(data?.workRegions));
   const workRegionOptions = localizedEnumToOptions(sortedWorkRegions, intl);
 
@@ -125,9 +129,9 @@ const FormFields = ({ classifications, skills }: FormFieldsProps) => {
             trackUnsaved={false}
           />
           <Select
-            id="stream"
+            id="workStream"
             label={intl.formatMessage(processMessages.stream)}
-            name="stream"
+            name="workStream"
             nullSelection={intl.formatMessage({
               defaultMessage: "Select a job stream",
               id: "QJ5uDV",

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -17,6 +17,7 @@ import {
   Classification,
   ApplicantFilterInput,
   Skill,
+  WorkStream,
 } from "@gc-digital-talent/graphql";
 import { commonMessages } from "@gc-digital-talent/i18n";
 

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -44,6 +44,7 @@ const styledCount = (chunks: ReactNode) => (
 interface SearchFormProps {
   classifications: Pick<Classification, "group" | "level" | "id">[];
   skills: Skill[];
+  workStreams: WorkStream[];
 }
 
 export const SearchForm = ({ classifications, skills }: SearchFormProps) => {
@@ -246,6 +247,13 @@ const SearchForm_Query = graphql(/* GraphQL */ `
       group
       level
     }
+    workStreams {
+      id
+      name {
+        en
+        fr
+      }
+    }
     skills {
       id
       key
@@ -285,10 +293,15 @@ const SearchFormAPI = () => {
 
   const skills = unpackMaybes<Skill>(data?.skills);
   const classifications = unpackMaybes(data?.classifications);
+  const workStreams = unpackMaybes(data?.workStreams);
 
   return (
     <Pending fetching={fetching} error={error}>
-      <SearchForm skills={skills} classifications={classifications} />
+      <SearchForm
+        skills={skills}
+        classifications={classifications}
+        workStreams={workStreams}
+      />
     </Pending>
   );
 };

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
@@ -22,9 +22,9 @@ const testId = (text: ReactNode) => (
 const SearchResultCard_PoolFragment = graphql(/* GraphQL */ `
   fragment SearchResultCard_Pool on Pool {
     id
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -121,7 +121,7 @@ const SearchResultCard = ({ candidateCount, pool }: SearchResultCardProps) => {
         id={`search_pool_${pool.id}`}
       >
         {getShortPoolTitleHtml(intl, {
-          stream: pool.stream,
+          workStream: pool.workStream,
           name: pool.name,
           publishingGroup: pool.publishingGroup,
           classification: pool.classification,

--- a/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
@@ -104,7 +104,7 @@ export const dataToFormValues = (
   data: ApplicantFilterInput,
   selectedClassifications?: Maybe<Pick<Classification, "group" | "level">[]>,
 ): FormValues => {
-  const stream = data?.qualifiedStreams?.find(notEmpty);
+  const workStream = data?.workStreams?.find(notEmpty);
 
   return {
     classification: getCurrentClassification(selectedClassifications),
@@ -117,7 +117,7 @@ export const dataToFormValues = (
     ],
     educationRequirement: data.hasDiploma ? "has_diploma" : "no_diploma",
     skills: data.skills?.filter(notEmpty).map((s) => s.id) ?? [],
-    stream: stream ?? "",
+    workStream: workStream?.id,
     locationPreferences: data.locationPreferences?.filter(notEmpty) ?? [],
     operationalRequirements:
       data.operationalRequirements?.filter(notEmpty) ?? [],
@@ -172,6 +172,8 @@ export const formValuesToData = (
       ? durationSelectionToEnum(values.employmentDuration)
       : undefined,
     locationPreferences: values.locationPreferences ?? [],
-    qualifiedStreams: values.stream ? [values.stream] : undefined,
+    qualifiedStreams: values.workStream
+      ? [{ id: values.workStream }]
+      : undefined,
   };
 };

--- a/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
@@ -104,7 +104,7 @@ export const dataToFormValues = (
   data: ApplicantFilterInput,
   selectedClassifications?: Maybe<Pick<Classification, "group" | "level">[]>,
 ): FormValues => {
-  const workStream = data?.workStreams?.find(notEmpty);
+  const workStream = data?.qualifiedStreams?.find(notEmpty);
 
   return {
     classification: getCurrentClassification(selectedClassifications),

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -69,7 +69,7 @@ const transformApplicantFilterToPoolCandidateSearchInput = (
     pools: (pools) => pools?.filter(notEmpty).map(pickId),
     skills: (skills) => skills?.filter(notEmpty).map(pickId),
     positionDuration: identity,
-    qualifiedStreams: localizedEnumArrayToInput,
+    qualifiedStreams: (workStream) => (workStream ? workStream : undefined),
     community: (community) => (community ? pickId(community) : undefined),
   };
 

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
@@ -296,9 +296,9 @@ const ViewSearchRequest_SearchRequestFragment = graphql(/* GraphQL */ `
           group
           level
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }
@@ -367,9 +367,9 @@ const ViewSearchRequest_SearchRequestFragment = graphql(/* GraphQL */ `
           en
           fr
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }
@@ -389,9 +389,9 @@ const ViewSearchRequest_SearchRequestFragment = graphql(/* GraphQL */ `
         group
         level
       }
-      qualifiedStreams {
-        value
-        label {
+      workStreams {
+        id
+        name {
           en
           fr
         }

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
@@ -389,7 +389,7 @@ const ViewSearchRequest_SearchRequestFragment = graphql(/* GraphQL */ `
         group
         level
       }
-      workStreams {
+      qualifiedStreams {
         id
         name {
           en

--- a/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
+++ b/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
@@ -168,9 +168,9 @@ const AdminUserProfileUser_Fragment = graphql(/* GraphQL */ `
           group
           level
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }

--- a/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
@@ -172,9 +172,9 @@ export const UserInfo_Fragment = graphql(/* GraphQL */ `
             fr
           }
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }

--- a/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
@@ -63,16 +63,16 @@ const AvailablePoolsToAddTo_Query = graphql(/* GraphQL */ `
             fr
           }
         }
-        stream {
-          value
-          label {
-            en
-            fr
-          }
-        }
         name {
           en
           fr
+        }
+        workStream {
+          id
+          name {
+            en
+            fr
+          }
         }
         classification {
           id
@@ -187,7 +187,7 @@ const AddToPoolDialog = ({ user, poolCandidates }: AddToPoolDialogProps) => {
                 {rejectedRequests.map((rejected) => (
                   <li key={rejected.pool.id}>
                     {getShortPoolTitleHtml(intl, {
-                      stream: rejected.pool.stream,
+                      workStream: rejected.pool.workStream,
                       name: rejected.pool.name,
                       publishingGroup: rejected.pool.publishingGroup,
                       classification: rejected.pool.classification,

--- a/apps/web/src/pages/Users/UserInformationPage/components/NotesSection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/NotesSection.tsx
@@ -51,7 +51,7 @@ const NotesSection = ({ user }: BasicUserInformationProps) => {
                 },
                 {
                   poolName: getShortPoolTitleHtml(intl, {
-                    stream: candidate.pool.stream,
+                    workStream: candidate.pool.workStream,
                     name: candidate.pool.name,
                     publishingGroup: candidate.pool.publishingGroup,
                     classification: candidate.pool.classification,
@@ -72,7 +72,7 @@ const NotesSection = ({ user }: BasicUserInformationProps) => {
                 },
                 {
                   poolName: getShortPoolTitleHtml(intl, {
-                    stream: candidate.pool.stream,
+                    workStream: candidate.pool.workStream,
                     name: candidate.pool.name,
                     publishingGroup: candidate.pool.publishingGroup,
                     classification: candidate.pool.classification,
@@ -122,7 +122,7 @@ const NotesSection = ({ user }: BasicUserInformationProps) => {
                       },
                       {
                         poolName: getShortPoolTitleHtml(intl, {
-                          stream: candidate.pool.stream,
+                          workStream: candidate.pool.workStream,
                           name: candidate.pool.name,
                           publishingGroup: candidate.pool.publishingGroup,
                           classification: candidate.pool.classification,

--- a/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/UserCandidatesTable.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/UserCandidatesTable.tsx
@@ -84,9 +84,9 @@ const UserCandidatesTableRow_Fragment = graphql(/* GraphQL */ `
           en
           fr
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }
@@ -188,7 +188,7 @@ const UserCandidatesTable = ({
     columnHelper.accessor(
       ({ pool }) =>
         getFullPoolTitleLabel(intl, {
-          stream: pool.stream,
+          workStream: pool.workStream,
           name: pool.name,
           publishingGroup: pool.publishingGroup,
           classification: pool.classification,
@@ -205,7 +205,7 @@ const UserCandidatesTable = ({
           processCell(
             {
               id: pool.id,
-              stream: pool.stream,
+              workStream: pool.workStream,
               name: pool.name,
               publishingGroup: pool.publishingGroup,
               classification: pool.classification,

--- a/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/helpers.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/helpers.tsx
@@ -106,14 +106,14 @@ export const priorityCell = (
 };
 
 export const processCell = (
-  pool: Pick<Pool, "id" | "stream" | "name" | "publishingGroup"> & {
+  pool: Pick<Pool, "id" | "workStream" | "name" | "publishingGroup"> & {
     classification?: Maybe<Pick<Classification, "group" | "level">>;
   },
   paths: ReturnType<typeof useRoutes>,
   intl: IntlShape,
 ) => {
   const poolName = getFullPoolTitleLabel(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,

--- a/apps/web/src/types/searchRequest.ts
+++ b/apps/web/src/types/searchRequest.ts
@@ -2,7 +2,6 @@ import {
   Scalars,
   ApplicantFilterInput,
   LanguageAbility,
-  PoolStream,
   UserPoolFilterInput,
   Classification,
 } from "@gc-digital-talent/graphql";
@@ -16,7 +15,7 @@ export type FormValues = Pick<
   languageAbility: LanguageAbility | typeof NullSelection;
   employmentDuration: string;
   classification: string | undefined;
-  stream: PoolStream | "";
+  workStream: Scalars["UUID"]["output"] | undefined;
   skills: string[] | undefined;
   employmentEquity: string[] | undefined;
   educationRequirement: "has_diploma" | "no_diploma";

--- a/apps/web/src/utils/poolUtils.test.ts
+++ b/apps/web/src/utils/poolUtils.test.ts
@@ -70,13 +70,13 @@ describe("poolUtils tests", () => {
       expect(
         formattedPoolPosterTitle({
           ...baseInputs,
-          stream: null,
+          workStream: null,
         }).label,
       ).toBe("Web Developer (IT-01)");
       expect(
         formattedPoolPosterTitle({
           ...baseInputs,
-          stream: undefined,
+          workStream: undefined,
         }).label,
       ).toBe("Web Developer (IT-01)");
     });
@@ -85,14 +85,14 @@ describe("poolUtils tests", () => {
         formattedPoolPosterTitle({
           ...baseInputs,
           classification: undefined,
-          stream: null,
+          workStream: null,
         }).label,
       ).toBe("Web Developer");
       expect(
         formattedPoolPosterTitle({
           ...baseInputs,
           classification: null,
-          stream: undefined,
+          workStream: undefined,
         }).label,
       ).toBe("Web Developer");
     });
@@ -101,7 +101,7 @@ describe("poolUtils tests", () => {
         formattedPoolPosterTitle({
           title: "",
           classification: null,
-          stream: null,
+          workStream: null,
           intl,
         }).label,
       ).toBe("");

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -23,8 +23,8 @@ import {
   Maybe,
   Classification,
   Pool,
-  LocalizedPoolStream,
   LocalizedPoolStatus,
+  WorkStream,
 } from "@gc-digital-talent/graphql";
 
 import { PageNavInfo } from "~/types/pages";
@@ -91,7 +91,7 @@ export const formatClassificationString = ({
 interface formattedPoolPosterTitleProps {
   title: Maybe<string> | undefined;
   classification: Maybe<Pick<Classification, "group" | "level">> | undefined;
-  stream?: Maybe<LocalizedPoolStream>;
+  workStream?: Maybe<WorkStream>;
   short?: boolean;
   intl: IntlShape;
 }
@@ -99,14 +99,16 @@ interface formattedPoolPosterTitleProps {
 export const formattedPoolPosterTitle = ({
   title,
   classification,
-  stream,
+  workStream,
   short,
   intl,
 }: formattedPoolPosterTitleProps): {
   html: ReactNode;
   label: string;
 } => {
-  const streamString = stream ? getLocalizedName(stream.label, intl) : "";
+  const streamString = workStream
+    ? getLocalizedName(workStream?.name, intl)
+    : "";
   const groupAndLevel = classification
     ? formatClassificationString(classification)
     : "";
@@ -147,7 +149,7 @@ interface PoolTitleOptions {
 }
 
 type PoolTitle = Maybe<
-  Pick<Pool, "name" | "publishingGroup" | "stream"> & {
+  Pick<Pool, "name" | "publishingGroup" | "workStream"> & {
     classification?: Maybe<Pick<Classification, "group" | "level">>;
   }
 >;
@@ -184,7 +186,7 @@ export const poolTitle = (
   const formattedTitle = formattedPoolPosterTitle({
     title: specificTitle,
     classification: pool?.classification,
-    stream: pool?.stream,
+    workStream: pool?.workStream,
     short: options?.short,
     intl,
   });
@@ -233,7 +235,7 @@ export const useAdminPoolPages = (
 ) => {
   const paths = useRoutes();
   const poolName = getFullPoolTitleLabel(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,

--- a/apps/web/src/utils/testData.ts
+++ b/apps/web/src/utils/testData.ts
@@ -9,6 +9,7 @@ import {
   fakeSkillFamilies,
   fakeSkills,
   toLocalizedEnum,
+  fakeWorkStreams,
 } from "@gc-digital-talent/fake-data";
 import {
   AssessmentDecision,
@@ -31,6 +32,7 @@ const fakePool = fakePools(
   fakeSkills(20, fakeSkillFamilies(6)),
   fakeClassifications(),
   fakeDepartments(),
+  fakeWorkStreams(),
   3,
 )[0];
 // make three assessment steps which assess all the pool skills

--- a/apps/web/src/validators/process/classification.ts
+++ b/apps/web/src/validators/process/classification.ts
@@ -5,16 +5,16 @@ import { Pool } from "@gc-digital-talent/graphql";
   Note: The pool.classification should not be null, therefore it doesn't need to checked
 */
 export function isInNullState({
-  stream,
+  workStream,
   name,
   processNumber,
   publishingGroup,
 }: Pick<
   Pool,
-  "stream" | "name" | "processNumber" | "publishingGroup"
+  "workStream" | "name" | "processNumber" | "publishingGroup"
 >): boolean {
   return !!(
-    !stream &&
+    !workStream &&
     !name?.en &&
     !name?.fr &&
     !processNumber &&
@@ -27,7 +27,7 @@ export function hasEmptyRequiredFields({
   areaOfSelection,
   classification,
   department,
-  stream,
+  workStream,
   name,
   processNumber,
   publishingGroup,
@@ -37,7 +37,7 @@ export function hasEmptyRequiredFields({
   | "areaOfSelection"
   | "classification"
   | "department"
-  | "stream"
+  | "workStream"
   | "name"
   | "processNumber"
   | "publishingGroup"
@@ -47,7 +47,7 @@ export function hasEmptyRequiredFields({
     !areaOfSelection?.value ||
     !classification ||
     !department ||
-    !stream ||
+    !workStream ||
     !name?.en ||
     !name?.fr ||
     !processNumber ||

--- a/packages/fake-data/src/fakeApplicantFilters.ts
+++ b/packages/fake-data/src/fakeApplicantFilters.ts
@@ -8,18 +8,20 @@ import {
   LanguageAbility,
   PositionDuration,
   Skill,
-  PoolStream,
+  WorkStream,
 } from "@gc-digital-talent/graphql";
 
 import fakeSkills from "./fakeSkills";
 import fakePools from "./fakePools";
 import toLocalizedEnum from "./fakeLocalizedEnum";
+import fakeWorkStreams from "./fakeWorkStreams";
 
 const generateApplicantFilters = (
   operationalRequirements: OperationalRequirement[],
   pools: Pool[],
   skills: Skill[],
 ): ApplicantFilter => {
+  const workStreams = fakeWorkStreams();
   return {
     __typename: "ApplicantFilter",
     id: faker.string.uuid(),
@@ -47,9 +49,7 @@ const generateApplicantFilters = (
       Object.values(PositionDuration),
     ),
     skills,
-    qualifiedStreams: faker.helpers
-      .arrayElements<PoolStream>(Object.values(PoolStream), 1)
-      .map((stream) => toLocalizedEnum(stream)),
+    qualifiedStreams: faker.helpers.arrayElements<WorkStream>(workStreams),
   };
 };
 

--- a/packages/fake-data/src/fakePools.ts
+++ b/packages/fake-data/src/fakePools.ts
@@ -13,7 +13,6 @@ import {
   PoolLanguage,
   User,
   UserPublicProfile,
-  PoolStream,
   PublishingGroup,
   SecurityStatus,
   Skill,
@@ -27,6 +26,7 @@ import {
   PoolOpportunityLength,
   PoolAreaOfSelection,
   PoolSelectionLimitation,
+  WorkStream,
 } from "@gc-digital-talent/graphql";
 
 import fakeScreeningQuestions from "./fakeScreeningQuestions";
@@ -38,6 +38,7 @@ import fakeSkills from "./fakeSkills";
 import toLocalizedString from "./fakeLocalizedString";
 import fakeAssessmentSteps from "./fakeAssessmentSteps";
 import fakeDepartments from "./fakeDepartments";
+import fakeWorkStreams from "./fakeWorkStreams";
 import toLocalizedEnum from "./fakeLocalizedEnum";
 
 const generatePool = (
@@ -45,6 +46,7 @@ const generatePool = (
   skills: Skill[],
   classifications: Classification[],
   departments: Department[],
+  workStreams: WorkStream[],
   englishName = "",
   frenchName = "",
   essentialSkillCount = -1,
@@ -107,9 +109,7 @@ const generatePool = (
     classification: faker.helpers.arrayElement<Classification>(classifications),
     department: faker.helpers.arrayElement<Department>(departments),
     keyTasks: toLocalizedString(faker.lorem.paragraphs()),
-    stream: toLocalizedEnum(
-      faker.helpers.arrayElement<PoolStream>(Object.values(PoolStream)),
-    ),
+    workStream: faker.helpers.arrayElement<WorkStream>(workStreams),
     processNumber: faker.helpers.maybe(() => faker.lorem.word()),
     publishingGroup: faker.helpers.maybe(() =>
       toLocalizedEnum(
@@ -168,6 +168,7 @@ export default (
   skills = fakeSkills(100, fakeSkillFamilies(6)),
   classifications = fakeClassifications(),
   departments = fakeDepartments(),
+  workStreams = fakeWorkStreams(),
   essentialSkillCount = -1,
 ): Pool[] => {
   const users = fakeUsers();
@@ -180,6 +181,7 @@ export default (
           skills,
           classifications,
           departments,
+          workStreams,
           "CMO",
           "CMO",
           essentialSkillCount,
@@ -191,6 +193,7 @@ export default (
           skills,
           classifications,
           departments,
+          workStreams,
           "IT Apprenticeship Program for Indigenous Peoples",
           "Programme d’apprentissage en TI pour les personnes autochtones",
           essentialSkillCount,
@@ -202,6 +205,7 @@ export default (
           skills,
           classifications,
           departments,
+          workStreams,
           "",
           "",
           essentialSkillCount,

--- a/packages/fake-data/src/fakeWorkStreams.ts
+++ b/packages/fake-data/src/fakeWorkStreams.ts
@@ -1,0 +1,20 @@
+import { faker } from "@faker-js/faker/locale/en";
+
+import { WorkStream } from "@gc-digital-talent/graphql";
+
+import toLocalizedString from "./fakeLocalizedString";
+
+const generateWorkStream = (): WorkStream => {
+  return {
+    id: faker.string.uuid(),
+    key: faker.helpers.slugify(faker.string.sample()),
+    name: toLocalizedString(faker.company.name()),
+    plainLanguageName: toLocalizedString(faker.company.name()),
+  };
+};
+
+export default (numToGenerate = 10): WorkStream[] => {
+  faker.seed(0); // repeatable results
+
+  return Array.from({ length: numToGenerate }, () => generateWorkStream());
+};

--- a/packages/fake-data/src/fakeWorkStreams.ts
+++ b/packages/fake-data/src/fakeWorkStreams.ts
@@ -8,8 +8,8 @@ const generateWorkStream = (): WorkStream => {
   return {
     id: faker.string.uuid(),
     key: faker.helpers.slugify(faker.string.sample()),
-    name: toLocalizedString(faker.company.name()),
-    plainLanguageName: toLocalizedString(faker.company.name()),
+    name: toLocalizedString(faker.company.catchPhrase()),
+    plainLanguageName: toLocalizedString(faker.company.catchPhrase()),
   };
 };
 

--- a/packages/fake-data/src/index.ts
+++ b/packages/fake-data/src/index.ts
@@ -16,6 +16,7 @@ import fakeSkills, { getStaticSkills } from "./fakeSkills";
 import fakeTeams from "./fakeTeams";
 import fakeUsers, { fakeApplicants, fakeUser } from "./fakeUsers";
 import fakeUserSkills from "./fakeUserSkills";
+import fakeWorkStreams from "./fakeWorkStreams";
 
 // Faker Generated Data
 export {
@@ -38,6 +39,7 @@ export {
   fakeUsers,
   fakeUser,
   fakeUserSkills,
+  fakeWorkStreams,
   fakeLocalizedEnum,
   toLocalizedEnum,
 };


### PR DESCRIPTION
🤖 Resolves #7574 

## 👋 Introduction

Migrates out `PoolStream` enum to a new model `WorkStream`.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

<!--
1. ...
2. ...
 -->

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the linked issue if deployment steps are needed

 -->
