### PR TITLE
[Feature] Override work email validation for admins

### DIFF
--- a/api/app/GraphQL/Validators/UpdateUserAsAdminInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateUserAsAdminInputValidator.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\GraphQL\Validators;
+
+use App\Rules\IsStatusOrNonStatus;
+use Illuminate\Validation\Rule;
+use Nuwave\Lighthouse\Validation\Validator;
+
+// Almost identical to UpdateUserAsUserInputValidator but with some rules removed for admin use only
+final class UpdateUserAsAdminInputValidator extends Validator
+{
+    /**
+     * Return the validation rules.
+     *
+     * @return array<string, array<mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => [
+                'sometimes',
+                'nullable',
+                /**
+                 * Note: Ignore the email for the user passed
+                 * in when executing the mutation so it is not
+                 * included in the unique check. This is required
+                 * for allowing a user to be updated while the email
+                 * remains the same.
+                 *
+                 * REF: https://laravel.com/docs/9.x/validation#rule-unique
+                 */
+                Rule::unique('users', 'email')->ignore($this->arg('id'), 'id'),
+                Rule::unique('users', 'work_email')->ignore($this->arg('id'), 'id'),
+            ],
+            'workEmail' => [
+                'sometimes',
+                'nullable',
+                /**
+                 * Note: Ignore the email for the user passed
+                 * in when executing the mutation so it is not
+                 * included in the unique check. This is required
+                 * for allowing a user to be updated while the email
+                 * remains the same.
+                 *
+                 * REF: https://laravel.com/docs/9.x/validation#rule-unique
+                 */
+                Rule::unique('users', 'email')->ignore($this->arg('id'), 'id'),
+                Rule::unique('users', 'work_email')->ignore($this->arg('id'), 'id'),
+            ],
+            'sub' => [
+                'sometimes',
+                'nullable',
+                Rule::unique('users', 'sub')->ignore($this->arg('id'), 'id'),
+            ],
+            'indigenousCommunities' => [new IsStatusOrNonStatus],
+        ];
+    }
+
+    /**
+     * Return the validation messages
+     */
+    public function messages(): array
+    {
+        return [
+            'email.unique' => 'EmailAddressInUse',
+            'workEmail.unique' => 'EmailAddressInUse',
+            'sub.unique' => 'SubInUse',
+        ];
+    }
+}

--- a/api/app/GraphQL/Validators/UpdateUserAsUserInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateUserAsUserInputValidator.php
@@ -6,7 +6,7 @@ use App\Rules\IsStatusOrNonStatus;
 use Illuminate\Validation\Rule;
 use Nuwave\Lighthouse\Validation\Validator;
 
-final class UpdateUserInputValidator extends Validator
+final class UpdateUserAsUserInputValidator extends Validator
 {
     /**
      * Return the validation rules.

--- a/api/app/GraphQL/Validators/UpdateUserInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateUserInputValidator.php
@@ -46,7 +46,7 @@ final class UpdateUserInputValidator extends Validator
                 Rule::unique('users', 'email')->ignore($this->arg('id'), 'id'),
                 Rule::unique('users', 'work_email')->ignore($this->arg('id'), 'id'),
                 // Note: Domains should be kept in sync with the workEmailDomainRegex
-                'ends_with:gc.ca,canada.ca,elections.ca',
+                'ends_with:gc.ca,canada.ca,elections.ca,ccc.ca,canadapost-postescanada.ca,gg.ca',
             ],
             'sub' => [
                 'sometimes',

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1237,8 +1237,7 @@ input CreateUserInput {
 """
 When updating a User, all fields are optional
 """
-input UpdateUserAsAdminInput
-  @validator(class: "App\\GraphQL\\Validators\\UpdateUserInputValidator") {
+input UpdateUserAsAdminInput @validator {
   id: ID
 
   # Personal info
@@ -1318,8 +1317,7 @@ input UpdateUserRolesInput {
   roleAssignmentsInput: RoleAssignmentHasMany!
 }
 
-input UpdateUserAsUserInput
-  @validator(class: "App\\GraphQL\\Validators\\UpdateUserInputValidator") {
+input UpdateUserAsUserInput @validator {
   id: ID
   # Personal info
   email: Email @lowerCase

--- a/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
+++ b/apps/web/src/pages/Users/UpdateUserPage/UpdateUserPage.tsx
@@ -13,11 +13,7 @@ import {
   Checkbox,
 } from "@gc-digital-talent/forms";
 import { errorMessages, commonMessages } from "@gc-digital-talent/i18n";
-import {
-  emptyToNull,
-  unpackMaybes,
-  workEmailDomainRegex,
-} from "@gc-digital-talent/helpers";
+import { emptyToNull, unpackMaybes } from "@gc-digital-talent/helpers";
 import { NotFound, Pending, Heading } from "@gc-digital-talent/ui";
 import {
   UpdateUserRolesInput,
@@ -304,18 +300,6 @@ export const UpdateUserForm = ({
             label={intl.formatMessage(commonMessages.workEmail)}
             type="email"
             name="workEmail"
-            rules={{
-              pattern: {
-                value: workEmailDomainRegex,
-                message: intl.formatMessage({
-                  defaultMessage:
-                    "This does not appear to be a Government of Canada email. If you are entering a Government of Canada email and still getting this error, please contact our support team.",
-                  id: "BLOt/e",
-                  description:
-                    "Description for rule pattern on work email field",
-                }),
-              },
-            }}
           />
           <div data-h2-align-self="base(flex-start)">
             <Submit />

--- a/packages/helpers/src/constants/regularExpressions.ts
+++ b/packages/helpers/src/constants/regularExpressions.ts
@@ -8,6 +8,7 @@
 export const keyStringRegex = /^[a-z]+[_a-z0-9]*$/;
 // See: https://regex101.com/r/EAZ8ha/6
 export const phoneNumberRegex = /^\+[1-9]\d{1,14}$/;
-// See: https://regex101.com/r/T8IYJU/1
+// See: https://regex101.com/r/T8IYJU/3
 // Note: This should be kept in sync with the check in the UpdateUserInputValidator
-export const workEmailDomainRegex = /(gc\.ca|canada\.ca|elections.ca)$/i;
+export const workEmailDomainRegex =
+  /(gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca)$/i;


### PR DESCRIPTION
🤖 Resolves #12027 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Relaxes the domain validation for work email when mutated by admins.  Also adds some new domains.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->
Confirmed that the domain for Canada Post is hyphenated, not period delimited.
https://www.canadapost-postescanada.ca

Added ccc.ca and canadapost-postescanada.ca and gg.ca as valid work domains.  Found a related bug: 
https://github.com/GCTC-NTGC/gc-digital-talent/issues/12144

I added a separate validator for UpdateUserAsAdmin.  Unfortunately, it's just a copy/paste job which makes it vulnerable to missing future additions to the main validator but I couldn't find a good way to share rules between validators.  If anyone has a bright idea, I'm all ears.

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

> [!WARNING]
Due to the previously mentioned bug, some domains that end with a valid string may pass validation unexpectedly.  For example, amazoncanada.ca will pass since it ends with canada.ca

### Frontend

1. Log in as admin@test.com
2. Navigate to the editor for any user: `/en/admin/users/{userId}/edit`
3. Change the work email to use an invalid domain (gmail, yahoo, etc) and confirm it is successful.
4. Log in as application@test.com
5. Navigate to /en/applicant/personal-information
6. Change the work email to use an invalid domain (gmail, yahoo, etc) and confirm that frontend validation blocks submission
7. Change the work email to use the three new domains and confirm that submission is successful

### Backend

1. Open http://localhost:8000/admin/graphiql and add a valid authorization header for admin@test.com
2. Update any user's work email with an invalid domain using the admin mutation and confirm it is successful.

```graphql
mutation UpdateUserAsAdmin($id: ID!, $user: UpdateUserAsAdminInput!) {
  updateUserAsAdmin(id: $id, user: $user) {
    workEmail    
  }
}
---------------------
{
  "id": "aa2969af-6a95-4544-aa5a-c2dbf749a08e",
  "user": {
    "workEmail": "big_boss@gmail.com"
  }
}
```
3. Update any user's work email with an invalid domain using the user mutation and confirm it fails with the "The user.work email field must end with one of the following..." error.
```graphql
mutation UpdateUserAsUser($id: ID!, $user: UpdateUserAsUserInput!) {
  updateUserAsUser(id: $id, user: $user) {
    workEmail
  }
}
----------------------------------
{
  "id": "5400b7ac-b68d-48e0-aa7b-607b67fbee14",
  "user": {    
    "workEmail": "big_boss2@gmail.com"
  }
}
```
4. Using the same mutation, test that the three new domains complete successfully.

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/32dd2933-3221-480c-9617-1ad059405d14)
