### PR TITLE
[Bug] Sort skills first then render chips for Skill family view

### DIFF
--- a/apps/web/src/pages/SkillFamilies/ViewSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/ViewSkillFamilyPage.tsx
@@ -68,6 +68,18 @@ export const ViewSkillFamily = ({ query }: ViewSkillFamilyProps) => {
   const pageTitle = getLocalizedName(skillFamily.name, intl);
   const subTitle = intl.formatMessage(messages.skillFamilyInfo);
 
+  const skillObjectsLocalized: { id: string; name: string }[] | undefined =
+    skillFamily.skills?.map((skill) => {
+      return { id: skill.id, name: getLocalizedName(skill.name, intl) };
+    });
+  const skillObjectsLocalizedSorted = skillObjectsLocalized
+    ? skillObjectsLocalized.sort((a, b) => {
+        const aName = a.name;
+        const bName = b.name;
+        return aName.localeCompare(bName);
+      })
+    : undefined;
+
   const navigationCrumbs = useBreadcrumbs({
     crumbs: [
       {
@@ -146,12 +158,11 @@ export const ViewSkillFamily = ({ query }: ViewSkillFamilyProps) => {
                     "Label for display of skills within a specific family",
                 })}
               >
-                {skillFamily?.skills?.length ? (
+                {skillObjectsLocalizedSorted &&
+                skillObjectsLocalizedSorted.length > 0 ? (
                   <Chips>
-                    {skillFamily.skills?.map((skill) => (
-                      <Chip key={skill.id}>
-                        {getLocalizedName(skill.name, intl)}
-                      </Chip>
+                    {skillObjectsLocalizedSorted.map((skillObject) => (
+                      <Chip key={skillObject.id}>{skillObject.name}</Chip>
                     ))}
                   </Chips>
                 ) : (

--- a/apps/web/src/pages/Skills/ViewSkillPage.tsx
+++ b/apps/web/src/pages/Skills/ViewSkillPage.tsx
@@ -73,6 +73,21 @@ export const ViewSkillForm = ({ query }: ViewSkillProps) => {
   const skill = getFragment(SkillView_Fragment, query);
 
   const skillFamilies = skill.families ?? [];
+  const skillFamilyObjectsLocalized: { id: string; name: string }[] =
+    skillFamilies.map((skillFamily) => {
+      return {
+        id: skillFamily.id,
+        name: getLocalizedName(skillFamily.name, intl),
+      };
+    });
+  const skillFamilyObjectsLocalizedSorted = skillFamilyObjectsLocalized.sort(
+    (a, b) => {
+      const aName = a.name;
+      const bName = b.name;
+      return aName.localeCompare(bName);
+    },
+  );
+
   return (
     <>
       <div
@@ -146,9 +161,9 @@ export const ViewSkillForm = ({ query }: ViewSkillProps) => {
             >
               {skillFamilies.length > 0 ? (
                 <Chips>
-                  {skillFamilies.map((family) => (
-                    <Chip key={family.id} color="primary">
-                      {getLocalizedName(family.name, intl)}
+                  {skillFamilyObjectsLocalizedSorted.map((skillFamily) => (
+                    <Chip key={skillFamily.id} color="primary">
+                      {skillFamily.name}
                     </Chip>
                   ))}
                 </Chips>


### PR DESCRIPTION
🤖 Resolves #12093

## 👋 Introduction

Sort the skills, then pass into the `<Chips />` for rendering, sorts in English and French 
<!-- Describe what this PR is solving. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Navigate to `en/admin/settings/skill-families`
2. View various skill family pages and observe skill sorting
3. In English and French


## 📸 Screenshot

![image](https://github.com/user-attachments/assets/79537e0c-b691-43ac-b4d9-dd18681218ad)

![image](https://github.com/user-attachments/assets/0a263f60-92bb-466a-9eda-c5eaa72ac6f4)



