### PR TITLE
[Feature] Adds IAP card on search page when `IT-01` selected

### DIFF
--- a/apps/web/src/pages/Home/IAPManagerHomePage/IAPManagerHomePage.tsx
+++ b/apps/web/src/pages/Home/IAPManagerHomePage/IAPManagerHomePage.tsx
@@ -6,6 +6,7 @@ import { ReactNode } from "react";
 
 import { getLocale } from "@gc-digital-talent/i18n";
 import { Heading, Link, Well, headingStyles } from "@gc-digital-talent/ui";
+import { buildMailToUri } from "@gc-digital-talent/helpers";
 
 import logoImg from "~/assets/img/iap-logo.svg";
 import heroImg from "~/assets/img/IAPManager-Hero.webp";
@@ -25,20 +26,6 @@ const makeLink = (chunks: ReactNode, url: string) => (
     {chunks}
   </Link>
 );
-
-function buildMailToUri(
-  emailAddress: string,
-  subject: string,
-  body?: string | null,
-) {
-  const encodedSubject = encodeURIComponent(subject);
-  let linkBuilder = `mailto:${emailAddress}?subject=${encodedSubject}`;
-  if (body) {
-    const encodedBody = encodeURIComponent(body);
-    linkBuilder += `&body=${encodedBody}`;
-  }
-  return linkBuilder;
-}
 
 // eslint-disable-next-line import/prefer-default-export
 export const Component = () => {

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -6,8 +6,8 @@ import { ReactNode, useState, useEffect } from "react";
 
 import {
   Button,
-  CardFlat,
   Heading,
+  Link,
   Loading,
   Pending,
   Separator,
@@ -146,6 +146,13 @@ export const SearchForm = ({ classifications, skills }: SearchFormProps) => {
     ].join("\n"),
   );
 
+  const selectedClassificationIsIT1 = applicantFilter.qualifiedClassifications
+    ?.filter(notEmpty)
+    .some(
+      (classification) =>
+        classification.group === "IT" && classification.level === 1,
+    );
+
   return (
     <div
       data-h2-wrapper="base(center, large, x1) p-tablet(center, large, x2)"
@@ -264,30 +271,76 @@ export const SearchForm = ({ classifications, skills }: SearchFormProps) => {
                     data-h2-display="base(flex)"
                     data-h2-flex-direction="base(column)"
                   >
-                    <CardFlat
-                      title={intl.formatMessage({
-                        defaultMessage:
-                          "Have you considered hiring an Indigenous IT Apprentice?",
-                        id: "TZu/iQ",
-                        description:
-                          "Title for IT Apprenticeship Program for Indigenous Peoples search card",
-                      })}
-                      color="tertiary"
-                      links={[
-                        { href: "#", label: "With link", mode: "inline" },
-                        { href: "#", label: "Second link", mode: "inline" },
-                      ]}
-                    >
-                      <p>
-                        {intl.formatMessage({
-                          defaultMessage:
-                            "The IT Apprenticeship Program for Indigenous Peoples aims to help address and remove barriers that Indigenous peoples face when it comes to finding employment in the Government of Canada’s digital workforce. Contact the team today to become a hiring partner and discover how you can strengthen your team with Indigenous IT talent. Together we are empowered to capitalize on the diversity of experiences and ideas that Indigenous Peoples bring and build a more inclusive and dynamic Public Service. Your participation in the IT Apprenticeship Program for Indigenous Peoples contributes to the broader goal of inclusion, equity, and reconciliation in Canada.",
-                          id: "8fnrPY",
-                          description:
-                            "Paragraph for IT Apprenticeship Program for Indigenous Peoples search card",
-                        })}
-                      </p>
-                    </CardFlat>
+                    {selectedClassificationIsIT1 && (
+                      <div
+                        data-h2-background-color="base(foreground)"
+                        data-h2-shadow="base(larger)"
+                        data-h2-border-left="base(x.5 solid tertiary)"
+                        data-h2-margin="base(x1, 0, 0, 0)"
+                        data-h2-radius="base(0, s, s, 0)"
+                        data-h2-padding="base(x1)"
+                      >
+                        <p
+                          data-h2-font-size="base(h6)"
+                          data-h2-font-weight="base(700)"
+                        >
+                          {intl.formatMessage({
+                            defaultMessage:
+                              "Have you considered hiring an Indigenous IT Apprentice?",
+                            id: "TZu/iQ",
+                            description:
+                              "Title for IT Apprenticeship Program for Indigenous Peoples search card",
+                          })}
+                        </p>
+                        <p
+                          data-h2-margin="base(x.5, 0, x1, 0)"
+                          data-h2-display="base(flex)"
+                          data-h2-gap="base(0, x.5)"
+                        >
+                          {intl.formatMessage({
+                            defaultMessage:
+                              "The IT Apprenticeship Program for Indigenous Peoples aims to help address and remove barriers that Indigenous peoples face when it comes to finding employment in the Government of Canada’s digital workforce. Contact the team today to become a hiring partner and discover how you can strengthen your team with Indigenous IT talent. Together we are empowered to capitalize on the diversity of experiences and ideas that Indigenous Peoples bring and build a more inclusive and dynamic Public Service. Your participation in the IT Apprenticeship Program for Indigenous Peoples contributes to the broader goal of inclusion, equity, and reconciliation in Canada.",
+                            id: "8fnrPY",
+                            description:
+                              "Paragraph for IT Apprenticeship Program for Indigenous Peoples search card",
+                          })}
+                        </p>
+                        <Separator space="sm" />
+                        <div
+                          data-h2-display="base(flex)"
+                          data-h2-flex-direction="base(row)"
+                          data-h2-flex-wrap="base(wrap)"
+                          data-h2-align-items="base(center)"
+                          data-h2-gap="base(x1)"
+                          data-h2-margin="base(x1, 0, 0, 0)"
+                        >
+                          <Link
+                            mode="solid"
+                            color="tertiary"
+                            href={hireAnApprenticeEmailUri}
+                          >
+                            {intl.formatMessage({
+                              defaultMessage: "Contact the team",
+                              id: "gJ7CQw",
+                              description: "Link to send an email to the team",
+                            })}
+                          </Link>
+                          <Link
+                            mode="inline"
+                            color="tertiary"
+                            href={paths.iapManager()}
+                          >
+                            {intl.formatMessage({
+                              defaultMessage:
+                                "Visit the IT Apprenticeship Program for Indigenous Peoples manager page",
+                              id: "zVGzWa",
+                              description:
+                                "Link to visit IT Apprenticeship Program for Indigenous Peoples manager page",
+                            })}
+                          </Link>
+                        </div>
+                      </div>
+                    )}
                     {results.map(({ pool, candidateCount: resultsCount }) => (
                       <SearchResultCard
                         key={pool.id}

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -6,12 +6,17 @@ import { ReactNode, useState, useEffect } from "react";
 
 import {
   Button,
+  CardFlat,
   Heading,
   Loading,
   Pending,
   Separator,
 } from "@gc-digital-talent/ui";
-import { unpackMaybes, notEmpty } from "@gc-digital-talent/helpers";
+import {
+  unpackMaybes,
+  notEmpty,
+  buildMailToUri,
+} from "@gc-digital-talent/helpers";
 import {
   graphql,
   Classification,
@@ -100,6 +105,46 @@ export const SearchForm = ({ classifications, skills }: SearchFormProps) => {
     setValue("pool", "");
     setValue("count", candidateCount);
   };
+
+  const hireAnApprenticeEmailUri = buildMailToUri(
+    "edsc.patipa.jumelage.emplois-itapip.job.matching.esdc@hrsdc-rhdcc.gc.ca",
+    intl.formatMessage({
+      defaultMessage: "I'm interested in offering an apprenticeship",
+      id: "HqtjhD",
+      description: "Subject line of a manager's email for apprenticeship",
+    }),
+    [
+      intl.formatMessage({
+        defaultMessage:
+          "To best support you in your journey to hire an IT Apprentice, please let us know if you",
+        id: "ZKss5S",
+        description: "Paragraph 1 of a manager's email for apprenticeship",
+      }),
+      intl.formatMessage({
+        defaultMessage:
+          "1. are interested in hiring an Apprentice and would like to learn more about the IT Apprenticeship Program for Indigenous Peoples",
+        id: "ipKAvI",
+        description: "Paragraph 2 of a manager's email for apprenticeship",
+      }),
+      intl.formatMessage({
+        defaultMessage:
+          "2. have reviewed the checklist in the manager’s package and have positions available to hire an IT Apprentice",
+        id: "18pJdz",
+        description: "Paragraph 3 of a manager's email for apprenticeship",
+      }),
+      intl.formatMessage({
+        defaultMessage: "3. Other…",
+        id: "Fz49kD",
+        description: "Paragraph 4 of a manager's email for apprenticeship",
+      }),
+      intl.formatMessage({
+        defaultMessage:
+          "A team member from the Office of Indigenous Initiatives will be in touch shortly.",
+        id: "x45gSl",
+        description: "Paragraph 5 of a manager's email for apprenticeship",
+      }),
+    ].join("\n"),
+  );
 
   return (
     <div
@@ -219,6 +264,30 @@ export const SearchForm = ({ classifications, skills }: SearchFormProps) => {
                     data-h2-display="base(flex)"
                     data-h2-flex-direction="base(column)"
                   >
+                    <CardFlat
+                      title={intl.formatMessage({
+                        defaultMessage:
+                          "Have you considered hiring an Indigenous IT Apprentice?",
+                        id: "TZu/iQ",
+                        description:
+                          "Title for IT Apprenticeship Program for Indigenous Peoples search card",
+                      })}
+                      color="tertiary"
+                      links={[
+                        { href: "#", label: "With link", mode: "inline" },
+                        { href: "#", label: "Second link", mode: "inline" },
+                      ]}
+                    >
+                      <p>
+                        {intl.formatMessage({
+                          defaultMessage:
+                            "The IT Apprenticeship Program for Indigenous Peoples aims to help address and remove barriers that Indigenous peoples face when it comes to finding employment in the Government of Canada’s digital workforce. Contact the team today to become a hiring partner and discover how you can strengthen your team with Indigenous IT talent. Together we are empowered to capitalize on the diversity of experiences and ideas that Indigenous Peoples bring and build a more inclusive and dynamic Public Service. Your participation in the IT Apprenticeship Program for Indigenous Peoples contributes to the broader goal of inclusion, equity, and reconciliation in Canada.",
+                          id: "8fnrPY",
+                          description:
+                            "Paragraph for IT Apprenticeship Program for Indigenous Peoples search card",
+                        })}
+                      </p>
+                    </CardFlat>
                     {results.map(({ pool, candidateCount: resultsCount }) => (
                       <SearchResultCard
                         key={pool.id}

--- a/apps/web/src/utils/skillUtils.ts
+++ b/apps/web/src/utils/skillUtils.ts
@@ -141,7 +141,7 @@ export const getExperienceSkills = (
  * Get sorted skill levels
  *
  * Note: Codegen is sorting the enum alphabetically
- * We use this to sort them back into the proper oder
+ * We use this to sort them back into the proper order
  *
  * @returns SkillLevel[]
  */

--- a/packages/helpers/src/index.tsx
+++ b/packages/helpers/src/index.tsx
@@ -3,6 +3,7 @@ import {
   phoneNumberRegex,
   workEmailDomainRegex,
 } from "./constants/regularExpressions";
+import buildMailToUri from "./utils/buildMailToUri";
 import normalizeString from "./utils/normalizeString";
 import sanitizeUrl from "./utils/sanitizeUrl";
 import isUuidError from "./utils/uuid";
@@ -46,6 +47,7 @@ export {
   emptyToNull,
   emptyToUndefined,
   uniqueItems,
+  buildMailToUri,
   normalizeString,
   sanitizeUrl,
   isUuidError,

--- a/packages/helpers/src/utils/buildMailToUri.ts
+++ b/packages/helpers/src/utils/buildMailToUri.ts
@@ -1,0 +1,28 @@
+/**
+ * Build mailto URI
+ *
+ * Builds mailto URI string with email, subject, and optional body
+ *
+ * @param {emailAddress} str - The email address to be normalized
+ * @param {subject} str - The subject to be normalized
+ * @param {body} str - The body to be normalized
+ * @return {string}
+ *
+ * @example `const = buildMailToUri("user@domain.tld", "Test subject", "Test body content.");`
+ *
+ */
+const buildMailToUri = (
+  emailAddress: string,
+  subject: string,
+  body?: string | null,
+) => {
+  const encodedSubject = encodeURIComponent(subject);
+  let linkBuilder = `mailto:${emailAddress}?subject=${encodedSubject}`;
+  if (body) {
+    const encodedBody = encodeURIComponent(body);
+    linkBuilder += `&body=${encodedBody}`;
+  }
+  return linkBuilder;
+};
+
+export default buildMailToUri;


### PR DESCRIPTION
🤖 Resolves #12085.

## 👋 Introduction

This PR renders an IAP card on the search page at the beginning of the results section when the classification `IT-01` is selected. Also, it moves the function `buildMailToUri` into its own file so it can be reused for the IAP card on the search page. Finally, it fixes a minor typo in a comment.

> [!NOTE]  
> The "card" is not a reusable component as none of the existing components are able to accommodate the provided design.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/en/search
3. Verify element with text **Have you considered hiring an Indigenous IT Apprentice** does not render after **Or request candidates by pool** text
4. From the Classification filter `select` element, select **IT-02: Analyst**
Verify element with text **Have you considered hiring an Indigenous IT Apprentice** does not render after **Or request candidates by pool** text
5. From the Classification filter `select` element, select **IT-01: Technician**
6. Verify element with text **Have you considered hiring an Indigenous IT Apprentice** renders after **Or request candidates by pool** text

## 📸 Screenshot

<img width="1440" alt="Screen Shot 2024-11-29 at 14 51 07" src="https://github.com/user-attachments/assets/e21f1c43-b62b-4f6c-8941-80cf8d7dd07e">

## 🎥 Screen recording

https://github.com/user-attachments/assets/af85ce7c-68f6-4e16-bf8b-0e85ea7d8e90