### PR TITLE
[Bug] `SkillFamily` table now default sorted by name

### DIFF
--- a/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
+++ b/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
@@ -90,6 +90,7 @@ export const SkillFamilyTable = ({
       }}
       sort={{
         internal: true,
+        initialState: [{ id: "name", desc: false }],
       }}
       search={{
         internal: true,


### PR DESCRIPTION
🤖 Resolves #12094

## 👋 Introduction

Have the table default sort by the name column in ascending order

## 🧪 Testing

1. Navigate to `/en/admin/settings/skill-families`
2. Observe sorting

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

![image](https://github.com/user-attachments/assets/5f7af471-d0b2-4bf6-a250-7366770c7951)
