### PR TITLE
[Feat] Add URL type to input component

### DIFF
--- a/apps/web/src/pages/TrainingOpportunities/components/TrainingOpportunityForm.tsx
+++ b/apps/web/src/pages/TrainingOpportunities/components/TrainingOpportunityForm.tsx
@@ -166,7 +166,7 @@ const TrainingOpportunityForm = ({ query }: TrainingOpportunityFormProps) => {
         id="applicationUrlEn"
         name="applicationUrlEn"
         label={intl.formatMessage(formLabels.applicationUrlEn)}
-        type="text"
+        type="url"
         rules={{
           required: intl.formatMessage(errorMessages.required),
         }}
@@ -175,7 +175,7 @@ const TrainingOpportunityForm = ({ query }: TrainingOpportunityFormProps) => {
         id="applicationUrlFr"
         name="applicationUrlFr"
         label={intl.formatMessage(formLabels.applicationUrlFr)}
-        type="text"
+        type="url"
         rules={{
           required: intl.formatMessage(errorMessages.required),
         }}

--- a/packages/forms/src/components/Input/Input.tsx
+++ b/packages/forms/src/components/Input/Input.tsx
@@ -15,7 +15,7 @@ import { sanitizeString } from "../../utils";
 export type InputProps = HTMLInputProps &
   CommonInputProps & {
     /** Set the type of the input. */
-    type: "text" | "number" | "email" | "tel" | "password" | "search";
+    type: "text" | "number" | "email" | "tel" | "password" | "search" | "url";
     // Whether to trim leading/ending whitespace upon blurring of an input, default on
     whitespaceTrim?: boolean;
     maxLength?: number;


### PR DESCRIPTION
🤖 Resolves #12080 

## 👋 Introduction

Adds the URL type to our input component and updates the training opportunity form to use that type for the application URL field.

## 🧪 Testing

1. Buld the app `pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Navigate to the training opportunity form `/admin/training-opportunities/create`
4. Attempt to submit form with a non-URL in the "Application URL" fields
5. Confirm it fails
6. Re-attempt to submit updating the "Application URL" fields to be real URLs
7. Confirm submission is successful

## 📸 Screenshot

![2024-12-02_08-17](https://github.com/user-attachments/assets/57ee4bb7-5939-48a6-8cb1-3c377810c4cf)
