### PR TITLE
[Fix] Removes `directive-on-digital-talent` paths from `privilegedPaths` in `protectedEndpointExchange`

### DIFF
--- a/packages/client/src/exchanges/protectedEndpointExchange.ts
+++ b/packages/client/src/exchanges/protectedEndpointExchange.ts
@@ -3,14 +3,7 @@ import type { Exchange } from "@urql/core";
 
 import { apiHost, protectedUrl } from "../constants";
 
-const privilegedPaths = [
-  "/admin",
-  "/en/admin",
-  "/fr/admin",
-  "/directive-on-digital-talent",
-  "/en/directive-on-digital-talent",
-  "/fr/directive-on-digital-talent",
-];
+const privilegedPaths = ["/admin", "/en/admin", "/fr/admin"];
 
 // A custom exchange that changes to the protected endpoint depending on the current location
 


### PR DESCRIPTION
🤖 Resolves #12070.

## 👋 Introduction

This PR removes `directive-on-digital-talent` paths from `privilegedPaths` in `protectedEndpointExchange`.

## 🧪 Testing

If I understand correctly, this would need to be tested on one of the Azure verticals. 