### PR TITLE
[Fix] Prevent entering negative values in salary fields

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1409,8 +1409,12 @@ input CreateClassificationInput {
   name: LocalizedStringInput
   group: String!
   level: Int!
-  minSalary: Int @rename(attribute: "min_salary") @rules(apply: ["gt:0"])
-  maxSalary: Int @rename(attribute: "max_salary") @rules(apply: ["gt:0"])
+  minSalary: Int
+    @rename(attribute: "min_salary")
+    @rules(apply: ["numeric", "min:0"])
+  maxSalary: Int
+    @rename(attribute: "max_salary")
+    @rules(apply: ["numeric", "min:0", "gt:minSalary"])
 }
 
 input ClassificationBelongsToMany {
@@ -1430,8 +1434,12 @@ input CreatePoolCandidateAsAdminInput {
 input UpdateClassificationInput {
   name: LocalizedStringInput
   group: String
-  minSalary: Int @rename(attribute: "min_salary") @rules(apply: ["gt:0"])
-  maxSalary: Int @rename(attribute: "max_salary") @rules(apply: ["gt:0"])
+  minSalary: Int
+    @rename(attribute: "min_salary")
+    @rules(apply: ["numeric", "min:0"])
+  maxSalary: Int
+    @rename(attribute: "max_salary")
+    @rules(apply: ["numeric", "min:0", "gt:minSalary"])
 }
 
 input UpdatePoolCandidateStatusInput {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1409,8 +1409,8 @@ input CreateClassificationInput {
   name: LocalizedStringInput
   group: String!
   level: Int!
-  minSalary: Int @rename(attribute: "min_salary")
-  maxSalary: Int @rename(attribute: "max_salary")
+  minSalary: Int @rename(attribute: "min_salary") @rules(apply: ["gt:0"])
+  maxSalary: Int @rename(attribute: "max_salary") @rules(apply: ["gt:0"])
 }
 
 input ClassificationBelongsToMany {
@@ -1430,8 +1430,8 @@ input CreatePoolCandidateAsAdminInput {
 input UpdateClassificationInput {
   name: LocalizedStringInput
   group: String
-  minSalary: Int @rename(attribute: "min_salary")
-  maxSalary: Int @rename(attribute: "max_salary")
+  minSalary: Int @rename(attribute: "min_salary") @rules(apply: ["gt:0"])
+  maxSalary: Int @rename(attribute: "max_salary") @rules(apply: ["gt:0"])
 }
 
 input UpdatePoolCandidateStatusInput {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1414,7 +1414,7 @@ input CreateClassificationInput {
     @rules(apply: ["numeric", "min:0"])
   maxSalary: Int
     @rename(attribute: "max_salary")
-    @rules(apply: ["numeric", "min:0", "gt:minSalary"])
+    @rules(apply: ["numeric", "min:0", "gte:minSalary"])
 }
 
 input ClassificationBelongsToMany {
@@ -1439,7 +1439,7 @@ input UpdateClassificationInput {
     @rules(apply: ["numeric", "min:0"])
   maxSalary: Int
     @rename(attribute: "max_salary")
-    @rules(apply: ["numeric", "min:0", "gt:minSalary"])
+    @rules(apply: ["numeric", "min:0", "gte:minSalary"])
 }
 
 input UpdatePoolCandidateStatusInput {

--- a/apps/web/src/pages/Classifications/CreateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/CreateClassificationPage.tsx
@@ -190,6 +190,7 @@ export const CreateClassification = () => {
                         "Label displayed for the classification form min salary field.",
                     })}
                     type="number"
+                    min="0"
                     rules={{
                       required: intl.formatMessage(errorMessages.required),
                       min: {
@@ -213,6 +214,7 @@ export const CreateClassification = () => {
                         "Label displayed for the classification form max salary field.",
                     })}
                     type="number"
+                    min="0"
                     rules={{
                       required: intl.formatMessage(errorMessages.required),
                       min: {

--- a/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
@@ -254,6 +254,7 @@ export const UpdateClassificationForm = ({
                       "Label displayed for the classification form min salary field.",
                   })}
                   type="number"
+                  min="0"
                   rules={{
                     required: intl.formatMessage(errorMessages.required),
                     min: {
@@ -274,6 +275,7 @@ export const UpdateClassificationForm = ({
                       "Label displayed for the classification form max salary field.",
                   })}
                   type="number"
+                  min="0"
                   rules={{
                     required: intl.formatMessage(errorMessages.required),
                     min: {


### PR DESCRIPTION
🤖 Resolves #12170 

## 👋 Introduction

Updates the salary inputs on the classification forms to prevent entering negative values.

## 🕵️ Details

You can still type in negative values but the browser prevents it and using the spin buttons will prevent going lower than 0.

We did have validation at the database level but this also adds it at the graphql level so we can avoid even getting to the database.

## 🧪 Testing

1. Build the app `pnpm run dev:fresh`
2. Login is admin `admin@test.com`
3. Go to the create classification form `/admin/settings/classifications/create`
4. Attempt to submit a negative value in the salary fields
5. Confirm you get browser validation error
6. Try using spin buttons to go lower than 0
7. Confirm it prevents you from that action
8. Repeat steps 4-7 on the update classificatioon page `/admin/settings/classifications/{classicationId}`
9. Go to graphiql `/admin/graphiql` 
10. Attempt to run the mutations with negative values (as well as max salary being lower than min salary)
11. Confirm you get a graphql validation error rather than internal server error from DB

<details>
<summary>GraphQL request</summary>

```graphql
mutation CreateClassification($classification: CreateClassificationInput!) {
  createClassification(classification: $classification) {
    id
    __typename
  }
}
```

```json
{
  "classification": {
    "group": "Testing",
    "level": 8,
    "maxSalary": -1,
    "minSalary": 10,
    "name": {
      "en": "name EN",
      "fr": "name FR"
    }
  }
}
```

</details>

## 📸 Screenshot

![2024-12-03_12-28](https://github.com/user-attachments/assets/9fc04b95-f97d-4c41-81f6-db48aa134462)
