### PR TITLE
[Copy] Updates English success message claim verification

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -10590,6 +10590,10 @@
     "defaultMessage": "Sélection de la rangée",
     "description": "Label for the row-selection column in the tables column-selection modal."
   },
+  "pFkIhb": {
+    "defaultMessage": "Mise à jour réussie de la vérification de la revendication",
+    "description": "Success message when updating a candidates claim verification"
+  },
   "pFowOu": {
     "defaultMessage": "Toutes les notifications",
     "description": "Link text to show all notifications"
@@ -11465,10 +11469,6 @@
   "uIWFvk": {
     "defaultMessage": "Vous êtes à l’affût des possibilités découlant de ce recrutement.",
     "description": "Message displayed when a user is appearing in a recruitment"
-  },
-  "uIzewF": {
-    "defaultMessage": "Mise à jour réussie de la vérification de la revendication",
-    "description": "Success message when updating a candidates claim verification"
   },
   "uJ1rk3": {
     "defaultMessage": "Il existe trois groupes distincts de peuples autochtones qui sont reconnus par la Constitution canadienne. On vous demandera de confirmer au(x)quel(s) de vous appartenez par l’entremise de la Formulaire d’autodéclaration à l’intention des peuples autochtones.",

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ClaimVerification/ClaimVerificationDialog.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ClaimVerification/ClaimVerificationDialog.tsx
@@ -103,8 +103,8 @@ const ClaimVerificationDialog = ({
         if (res.data?.updatePoolCandidateClaimVerification?.id) {
           toast.success(
             intl.formatMessage({
-              defaultMessage: "Successfully update claim verification",
-              id: "uIzewF",
+              defaultMessage: "Successfully updated claim verification",
+              id: "pFkIhb",
               description:
                 "Success message when updating a candidates claim verification",
             }),


### PR DESCRIPTION
🤖 Resolves #12171.

## 👋 Introduction

This PR updates the message for updating a candidate's claim verification to **Successfully updated claim verification**  so that it uses the correct verb tense.


## 🧪 Testing

1. `pnpm build`
2. Update a candidate's veteran status claim
3. Observe toast message is **Successfully updated claim verification**

## 📸 Screenshot

<img width="579" alt="Screen Shot 2024-12-03 at 12 55 10" src="https://github.com/user-attachments/assets/34ba8100-0ace-4c40-b5df-50c2d7e439f5">