### PR TITLE
[FIX] Add missing case for missing FinalDecision weighting

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -1176,6 +1176,9 @@ class PoolCandidate extends Model
                 PoolCandidateStatus::REMOVED->name => FinalDecision::REMOVED->name,
                 PoolCandidateStatus::EXPIRED->name => FinalDecision::QUALIFIED_EXPIRED->name,
 
+                PoolCandidateStatus::DRAFT->name,
+                PoolCandidateStatus::DRAFT_EXPIRED->name => 'DRAFT',
+
                 default => null
             };
         }
@@ -1189,13 +1192,18 @@ class PoolCandidate extends Model
             // Giving a decent buffer to increase max steps
             FinalDecision::DISQUALIFIED_PENDING->name => 200,
             FinalDecision::DISQUALIFIED->name => 210,
-            FinalDecision::DISQUALIFIED_REMOVED->name => 215,
+            FinalDecision::DISQUALIFIED_REMOVED->name => 215, // I don't think this can be reached right now.
             FinalDecision::QUALIFIED_REMOVED->name => 220,
             FinalDecision::TO_ASSESS_REMOVED->name => 230,
             FinalDecision::REMOVED->name => 240,
             FinalDecision::QUALIFIED_EXPIRED->name => 250,
+            'DRAFT' => null,
             default => $this->unMatchedDecision($decision)
         };
+
+        if ($decision === 'DRAFT') {
+            $decision = null;
+        }
 
         $assessmentStatus = $this->computed_assessment_status;
         $currentStep = null;

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -1189,6 +1189,7 @@ class PoolCandidate extends Model
             // Giving a decent buffer to increase max steps
             FinalDecision::DISQUALIFIED_PENDING->name => 200,
             FinalDecision::DISQUALIFIED->name => 210,
+            FinalDecision::DISQUALIFIED_REMOVED->name => 215,
             FinalDecision::QUALIFIED_REMOVED->name => 220,
             FinalDecision::TO_ASSESS_REMOVED->name => 230,
             FinalDecision::REMOVED->name => 240,

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -1141,6 +1141,11 @@ class PoolCandidate extends Model
         $status = $this->pool_candidate_status;
         $decision = null;
 
+        // Short circuit for a case which shouldn't really come up. A PoolCandidate should never go from non-draft back to draft, but just in case...
+        if($status === PoolCandidateStatus::DRAFT->name || $status === PoolCandidateStatus::DRAFT_EXPIRED->name) {
+            return [ 'decision' => null, 'weight' => null ];
+        }
+
         if (in_array($status, PoolCandidateStatus::toAssessGroup())) {
             $assessmentStatus = $this->computed_assessment_status;
             $overallStatus = null;
@@ -1176,9 +1181,6 @@ class PoolCandidate extends Model
                 PoolCandidateStatus::REMOVED->name => FinalDecision::REMOVED->name,
                 PoolCandidateStatus::EXPIRED->name => FinalDecision::QUALIFIED_EXPIRED->name,
 
-                PoolCandidateStatus::DRAFT->name,
-                PoolCandidateStatus::DRAFT_EXPIRED->name => 'DRAFT',
-
                 default => null
             };
         }
@@ -1197,13 +1199,8 @@ class PoolCandidate extends Model
             FinalDecision::DISQUALIFIED_REMOVED->name => 235, // I don't think this can be reached right now.
             FinalDecision::REMOVED->name => 240,
             FinalDecision::QUALIFIED_EXPIRED->name => 250,
-            'DRAFT' => null,
             default => $this->unMatchedDecision($decision)
         };
-
-        if ($decision === 'DRAFT') {
-            $decision = null;
-        }
 
         $assessmentStatus = $this->computed_assessment_status;
         $currentStep = null;

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -1142,8 +1142,8 @@ class PoolCandidate extends Model
         $decision = null;
 
         // Short circuit for a case which shouldn't really come up. A PoolCandidate should never go from non-draft back to draft, but just in case...
-        if($status === PoolCandidateStatus::DRAFT->name || $status === PoolCandidateStatus::DRAFT_EXPIRED->name) {
-            return [ 'decision' => null, 'weight' => null ];
+        if ($status === PoolCandidateStatus::DRAFT->name || $status === PoolCandidateStatus::DRAFT_EXPIRED->name) {
+            return ['decision' => null, 'weight' => null];
         }
 
         if (in_array($status, PoolCandidateStatus::toAssessGroup())) {

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -1192,9 +1192,9 @@ class PoolCandidate extends Model
             // Giving a decent buffer to increase max steps
             FinalDecision::DISQUALIFIED_PENDING->name => 200,
             FinalDecision::DISQUALIFIED->name => 210,
-            FinalDecision::DISQUALIFIED_REMOVED->name => 215, // I don't think this can be reached right now.
             FinalDecision::QUALIFIED_REMOVED->name => 220,
             FinalDecision::TO_ASSESS_REMOVED->name => 230,
+            FinalDecision::DISQUALIFIED_REMOVED->name => 235, // I don't think this can be reached right now.
             FinalDecision::REMOVED->name => 240,
             FinalDecision::QUALIFIED_EXPIRED->name => 250,
             'DRAFT' => null,


### PR DESCRIPTION
🤖 Resolves #12173

## 👋 Introduction

From what I can see, the only way to trigger thiswas to change the status of a PoolCandidate _to_ DRAFT or DRAFT_EXPIRED. Or to make an assessment on a DRAFT application. Neither of which should have happened... So further investigation into the prod logs might be worth it. Check the history table. Were any PoolCandidates updated when these logs happened? Why?

## 🕵️ Details

I like that it logs an error for unmatched decisions. This is a good red flag for us if we add a new status or FinalDecision value and forget to put it here. So for now, I allow the DRAFT statuses to skip the call to log an error, without changing the final values.

## 🧪 Testing

1. Log in as an admin
2. Change a submitted PoolCandidate status direction to DRAFT.
3. Check api/storage/logs/laravel.log. You should no longer see "local.ERROR: No match for decision"