### PR TITLE
[Fix] Check for `BroadcastChannel` before using it

### DIFF
--- a/packages/auth/src/hooks/useLogoutChannel.ts
+++ b/packages/auth/src/hooks/useLogoutChannel.ts
@@ -11,8 +11,8 @@ let singleChannel: BroadcastChannel | undefined;
  *
  * @returns
  */
-const getChannel = () => {
-  if (!singleChannel) {
+const getChannel = (): BroadcastChannel | undefined => {
+  if (!singleChannel && "BroadcastChannel" in window) {
     singleChannel = new BroadcastChannel("logoutChannel");
   }
 
@@ -26,7 +26,7 @@ const useLogoutChannel = (onLogout: () => void) => {
   const isSubscribed = useRef(false);
 
   useEffect(() => {
-    if (!isSubscribed.current) {
+    if (!isSubscribed.current && channel) {
       channel.onmessage = (event) => {
         if (event.data === LOGOUT_MESSAGE) {
           onLogout();
@@ -35,7 +35,7 @@ const useLogoutChannel = (onLogout: () => void) => {
     }
 
     return () => {
-      if (isSubscribed.current) {
+      if (isSubscribed.current && channel) {
         channel.close();
         isSubscribed.current = false;
       }


### PR DESCRIPTION
🤖 Resolves #11669 

## 👋 Introduction

Updates our use of `BroadcastChannel` to check to make sure it exists in the window (supported by browser) before we use it. 

## 🕵️ Details

This was used to broadcast a logout event to all tabs so a user is not logged in on another tab accidentally.

> [!NOTE]
> I don't have access to any of the browsers that do not support this feature but this should work. Hopefully someone has access to one of the browsers that does not support `BroadcastChannel` to confirm the exception is not thrown. Of course Safari has only supported it for 2 years :woman_facepalming: 

## 🧪 Testing

1. Build app `pnpm run dev:fresh`
2. Login as any user account
3. Open another tab that is logged in
4. Logout of one of the tabs
5. Confirm the other tab still logs out as well
6. Repeat steps 2-4 in one of the unsupported browsers (if possible)
7. Confirm no exception is thrown but the other tab stays logged in
