### PR TITLE
[Feature]  Adds `userAgent` string to Freshdesk ticket

### DIFF
--- a/api/app/Http/Controllers/SupportController.php
+++ b/api/app/Http/Controllers/SupportController.php
@@ -49,6 +49,9 @@ class SupportController extends Controller
             }
             $parameters['custom_fields']['cf_page_url'] = $path;
         }
+        if ($request->input('user_agent')) {
+            $parameters['custom_fields']['cf_user_agent'] = (string) $request->input('user_agent');
+        }
         if ($request->input('user_id')) {
             $parameters['unique_external_id'] = (string) $request->input('user_id');
         }

--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
@@ -30,6 +30,7 @@ interface FormValues {
   description: string;
   subject: string;
   previous_url: string;
+  user_agent: string;
 }
 
 interface SupportFormProps {
@@ -118,6 +119,7 @@ const SupportForm = ({
   const intl = useIntl();
   const location = useLocation() as Location<LocationState>;
   const previousUrl = location?.state?.referrer ?? document?.referrer ?? "";
+  const userAgent = window?.navigator.userAgent ?? "";
   const methods = useForm<FormValues>({
     defaultValues: {
       user_id: currentUser?.id ?? "",
@@ -126,6 +128,7 @@ const SupportForm = ({
         : "",
       email: currentUser?.email ?? "",
       previous_url: previousUrl || "",
+      user_agent: userAgent || "",
     },
   });
   const { handleSubmit } = methods;

--- a/documentation/freshdesk.md
+++ b/documentation/freshdesk.md
@@ -8,6 +8,7 @@ Freshdesk is the customer service software used by GC Digital Talent for creatin
 2. Sign up for an account
 3. Make note of the _domain_ upon account creation
 4. Create custom string field for the ticket object named `page_url` (https://_domain_.freshdesk.com/a/admin/ticket_fields)
+5. Create custom string field for the ticket object named `user_agent` (https://_domain_.freshdesk.com/a/admin/ticket_fields)
 
 ## Local setup
 


### PR DESCRIPTION
🤖 Resolves #12072.

## 👋 Introduction

This PR adds the [userAgent](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent) string to a new support ticket via to the `SupportForm` component.

## 📸 Screenshot

<img width="1066" alt="Screen Shot 2024-12-03 at 16 21 59" src="https://github.com/user-attachments/assets/d133eb06-2dbe-44e2-a472-134f70825afa">

## 🧪 Testing

> [!NOTE]  
> To test creating a support ticket, you will need to access to and [credentials for Freshdesk](https://github.com/GCTC-NTGC/gc-digital-talent/blob/main/documentation/freshdesk.md).

1. `make refresh-api; pnpm build`
2. Navigate to http://localhost:8000/en/support
3. Fill out the support form and submit
5. Verify User Agent field in newly created Freshdesk ticket has the appropriate `userAgent` string value
