### PR TITLE
[Fix] Update font weights on IT training fund page

### DIFF
--- a/apps/web/src/pages/ItTrainingFundPage/ItTrainingFundPage.tsx
+++ b/apps/web/src/pages/ItTrainingFundPage/ItTrainingFundPage.tsx
@@ -88,6 +88,7 @@ export const Component = () => {
                 size="h2"
                 color="primary"
                 data-h2-margin="base(0, 0, x1.5, 0)"
+                data-h2-font-weight="base(400)"
               >
                 {intl.formatMessage({
                   defaultMessage: "Investing in the future of IT talent",
@@ -117,6 +118,7 @@ export const Component = () => {
                 size="h2"
                 color="tertiary"
                 data-h2-margin="base(0)"
+                data-h2-font-weight="base(400)"
               >
                 {intl.formatMessage({
                   defaultMessage:
@@ -249,6 +251,7 @@ export const Component = () => {
                 size="h2"
                 color="quaternary"
                 data-h2-margin="base(0)"
+                data-h2-font-weight="base(400)"
               >
                 {intl.formatMessage({
                   defaultMessage: "Three types of learning opportunities",


### PR DESCRIPTION
🤖 Resolves #11859

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Fixes the font weights on the IT training fund page.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->
We decided not to do any updates to the default values of our heading component.  This branch just fixes one spot I'm aware of.

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->


1. Open design at https://www.figma.com/design/Ml1qNqW5t8V0HDcB5ISQZu/IT-Community-Training-and-Development-Fund?node-id=848-3089&t=DsvHax6qfHYHKWdf-4
2. Rebuild site and go to /en/it-training-fund/instructor-led-training
3. Confirm that the h2 headings have a font weight of 400 as in the Figma design.


## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/09b1a92f-e0a4-4cec-8f99-8364a328e496)

