### PR TITLE
[Copy] Fixes various typos

### DIFF
--- a/api/app/GraphQL/Directives/ResolveWithDirective.php
+++ b/api/app/GraphQL/Directives/ResolveWithDirective.php
@@ -34,7 +34,7 @@ GRAPHQL;
     /**
      * $value can be a scalar, an array of scalars, an ArgumentSet, or an array of argument sets.
      * ArgumentSets represent nested input types.
-     * This function will leave scalars and arrays of scalars alone, and convert ArgumetnSets into named php arrays.
+     * This function will leave scalars and arrays of scalars alone, and convert ArgumentSets into named php arrays.
      *
      * @param  mixed|\Nuwave\Lighthouse\Execution\Arguments\ArgumentSet|array<\Nuwave\Lighthouse\Execution\Arguments\ArgumentSet>  $value  The slice of arguments that belongs to this nested resolver.
      * @return mixed

--- a/api/app/Traits/Generator/GeneratesDoc.php
+++ b/api/app/Traits/Generator/GeneratesDoc.php
@@ -9,7 +9,7 @@ trait GeneratesDoc
     use GeneratesFile;
 
     /**
-     * Adds text accomponied by a strong label
+     * Adds text accompanied by a strong label
      *
      * @param  Section  $section  The section to add it to
      * @param  string  $label  Label for the text

--- a/api/tests/Feature/CandidateFinalDecisionTest.php
+++ b/api/tests/Feature/CandidateFinalDecisionTest.php
@@ -96,7 +96,7 @@ class CandidateFinalDecisionTest extends TestCase
     public static function statusProvider()
     {
 
-        $qualfied = [
+        $qualified = [
             'decision' => FinalDecision::QUALIFIED->name,
             'weight' => 10,
         ];
@@ -138,14 +138,14 @@ class CandidateFinalDecisionTest extends TestCase
 
         return [
             // Qualified
-            'Qualfied available' => [PoolCandidateStatus::QUALIFIED_AVAILABLE->name, $qualfied],
+            'Qualified available' => [PoolCandidateStatus::QUALIFIED_AVAILABLE->name, $qualified],
             // To assess
             'New application' => [PoolCandidateStatus::NEW_APPLICATION->name, $toAssess],
             'Application review' => [PoolCandidateStatus::APPLICATION_REVIEW->name, $toAssess],
             'Under assessment' => [PoolCandidateStatus::UNDER_ASSESSMENT->name, $toAssess],
             'Screened in' => [PoolCandidateStatus::SCREENED_IN->name, $toAssess],
 
-            // Qualfied - Placed
+            // Qualified - Placed
             'Placed casual' => [PoolCandidateStatus::PLACED_CASUAL->name, $qualifiedPlaced],
             'Placed indeterminate' => [PoolCandidateStatus::PLACED_INDETERMINATE->name, $qualifiedPlaced],
             'Placed term' => [PoolCandidateStatus::PLACED_TERM->name, $qualifiedPlaced],
@@ -156,8 +156,8 @@ class CandidateFinalDecisionTest extends TestCase
             'Screened out application' => [PoolCandidateStatus::SCREENED_OUT_APPLICATION->name, $disqualified],
 
             // Qualified - Removed
-            'Qualfied unavailable' => [PoolCandidateStatus::QUALIFIED_UNAVAILABLE->name, $qualifiedRemoved],
-            'Qualfied withdrew' => [PoolCandidateStatus::QUALIFIED_WITHDREW->name, $qualifiedRemoved],
+            'Qualified unavailable' => [PoolCandidateStatus::QUALIFIED_UNAVAILABLE->name, $qualifiedRemoved],
+            'Qualified withdrew' => [PoolCandidateStatus::QUALIFIED_WITHDREW->name, $qualifiedRemoved],
 
             // To assess - Removed
             'Screened out not interested' => [PoolCandidateStatus::SCREENED_OUT_NOT_INTERESTED->name, $toAssesRemoved],

--- a/api/tests/Feature/PoolCandidateUpdateTest.php
+++ b/api/tests/Feature/PoolCandidateUpdateTest.php
@@ -1015,8 +1015,8 @@ class PoolCandidateUpdateTest extends TestCase
 
         // Ensure other time stamps remain the same
         $unchanged = array_diff(['final_decision_at', 'removed_at', 'placed_at'], [$timestamp]);
-        foreach ($unchanged as $unchagedTimestamp) {
-            $this->assertEquals($this->poolCandidate->$unchagedTimestamp, $data[Str::camel($unchagedTimestamp)]);
+        foreach ($unchanged as $unchangedTimestamp) {
+            $this->assertEquals($this->poolCandidate->$unchangedTimestamp, $data[Str::camel($unchangedTimestamp)]);
         }
 
         // Attempt to make change again and assert it does not affect timestamp

--- a/api/tests/Feature/PoolCandidateUpdateTest.php
+++ b/api/tests/Feature/PoolCandidateUpdateTest.php
@@ -986,7 +986,7 @@ class PoolCandidateUpdateTest extends TestCase
      */
     public function testManualStatusUpdatesTimestamps($status, $timestamp)
     {
-        // Ensure time stamps are set to compare against
+        // Ensure timestamps are set to compare against
         // and we are starting from no status
         $past = config('constants.past_datetime');
         $this->poolCandidate->pool_candidate_status = PoolCandidateStatus::NEW_APPLICATION->name;
@@ -1004,7 +1004,7 @@ class PoolCandidateUpdateTest extends TestCase
                 'candidate' => ['status' => $status],
             ]);
 
-        // Assert the expected time stamp was changed
+        // Assert the expected timestamp was changed
         $data = $response['data']['updatePoolCandidateStatus'];
         $new = new Carbon($data[$camelTimestamp]);
         $this->assertGreaterThan($original->timestamp, $new->timestamp, sprintf(
@@ -1013,7 +1013,7 @@ class PoolCandidateUpdateTest extends TestCase
             $original->toDayDateTimeString()
         ));
 
-        // Ensure other time stamps remain the same
+        // Ensure other timestamps remain the same
         $unchanged = array_diff(['final_decision_at', 'removed_at', 'placed_at'], [$timestamp]);
         foreach ($unchanged as $unchangedTimestamp) {
             $this->assertEquals($this->poolCandidate->$unchangedTimestamp, $data[Str::camel($unchangedTimestamp)]);

--- a/api/tests/Feature/PoolCandidateUpdateTest.php
+++ b/api/tests/Feature/PoolCandidateUpdateTest.php
@@ -1080,7 +1080,7 @@ class PoolCandidateUpdateTest extends TestCase
                 PoolCandidateStatus::PLACED_CASUAL->name,
                 'placed_at',
             ],
-            'placed indetermined sets placed at' => [
+            'placed indeterminate sets placed at' => [
                 PoolCandidateStatus::PLACED_INDETERMINATE->name,
                 'placed_at',
             ],

--- a/api/tests/Feature/PoolCandidateUpdateTest.php
+++ b/api/tests/Feature/PoolCandidateUpdateTest.php
@@ -1068,7 +1068,7 @@ class PoolCandidateUpdateTest extends TestCase
             ],
 
             // Placed
-            'placed tenative sets removed at' => [
+            'placed tentative sets removed at' => [
                 PoolCandidateStatus::PLACED_TENTATIVE->name,
                 'placed_at',
             ],

--- a/api/tests/Unit/FilterableTraitTest.php
+++ b/api/tests/Unit/FilterableTraitTest.php
@@ -126,7 +126,7 @@ class FilterableTraitTest extends TestCase
     public static function applyProvider()
     {
         return [
-            'does not apply non-existant scopes' => [
+            'does not apply non-existent scopes' => [
                 ['not_real' => 'value'],
                 [],
                 ['not_real' => false],

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4892,7 +4892,7 @@
     "description": "Label for skills input in skill family form"
   },
   "NJUJl0": {
-    "defaultMessage": "Il n’y a aucun statut de selectionné.",
+    "defaultMessage": "Il n’y a aucun statut sélectionné.",
     "description": "Message displayed when no statuses are shown"
   },
   "NP/fsS": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       #   (for which subject/sub will be something like `admin@test.com`).
       JSON_CONFIG_PATH: /app/conf/mock-oauth2-server.json
       # Uncomment for direct access without proxy.
-      # We override default port 8080 sincer already used by adminer container.
+      # We override default port 8080 since it is already used by adminer container.
       #SERVER_PORT: 8081
     # Uncomment for direct access without proxy.
     #ports:


### PR DESCRIPTION
🤖 Resolves #12191.

## 👋 Introduction

This PR fixes a variety of typos in the codebase, only one of which (29c0a3815ff81860319acbd8eba9e7e7975b0f7f) is user-facing (thanks to @NienkeBr for catching the unnecessary _de_ 🏅).

## 🧪 Testing

Verify all of the typos that were listed have been corrected appropriately.