### PR TITLE
[Debt] Bump environment to PHP 8.3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.2"
+          php-version: "8.3"
           extensions: bcmath
 
       - name: Install composer dependencies

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.2"
+          php-version: "8.3"
           extensions: bcmath
           coverage: pcov
 

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.2"
+          php-version: "8.3"
           extensions: bcmath
 
       - name: Install composer dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ hydrogen-logs
 .jekyll-cache
 .turbo
 .env
+hostingstart.html

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2.9-apache-bullseye as base
+FROM php:8.3.9-apache-bullseye as base
 
 # Install pdo_pgsql extension.
 RUN apt-get update \

--- a/api/composer.json
+++ b/api/composer.json
@@ -9,7 +9,7 @@
   ],
   "license": "AGPL-3.0",
   "require": {
-    "php": "^8.2",
+    "php": "^8.3",
     "doctrine/dbal": "^3.1",
     "gctc-ntgc/laravel-scout-postgres-tsvector": "^1.0",
     "guzzlehttp/guzzle": "^7.4",
@@ -62,7 +62,7 @@
     "sort-packages": true,
     "optimize-autoloader": true,
     "platform": {
-      "php": "8.2.9"
+      "php": "8.3.9"
     },
     "allow-plugins": {
       "composer/package-versions-deprecated": true

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e5780e843af50fb14b19207b662e66f4",
+    "content-hash": "4a9d3132053a7edd33a435393ecdbd94",
     "packages": [
         {
             "name": "amphp/amp",
@@ -2971,13 +2971,13 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "10.x-dev"
-                },
                 "laravel": {
                     "providers": [
                         "Laravel\\Scout\\ScoutServiceProvider"
                     ]
+                },
+                "branch-alias": {
+                    "dev-master": "10.x-dev"
                 }
             },
             "autoload": {
@@ -4732,16 +4732,16 @@
         },
         {
             "name": "nuwave/lighthouse",
-            "version": "v6.45.1",
+            "version": "v6.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nuwave/lighthouse.git",
-                "reference": "6ed0ed1984f4e4be2be431fc355ead84310e2b43"
+                "reference": "104d2a271ef244a36b7de8afae519daa16f628a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nuwave/lighthouse/zipball/6ed0ed1984f4e4be2be431fc355ead84310e2b43",
-                "reference": "6ed0ed1984f4e4be2be431fc355ead84310e2b43",
+                "url": "https://api.github.com/repos/nuwave/lighthouse/zipball/104d2a271ef244a36b7de8afae519daa16f628a9",
+                "reference": "104d2a271ef244a36b7de8afae519daa16f628a9",
                 "shasum": ""
             },
             "require": {
@@ -4858,7 +4858,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2024-11-27T08:12:23+00:00"
+            "time": "2024-12-04T11:28:10+00:00"
         },
         {
             "name": "phpoffice/math",
@@ -9415,16 +9415,16 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v15.18.1",
+            "version": "v15.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "a167afab66d8aa74b7f552759c0bbd906afb4134"
+                "reference": "5203bf29c8be0280e8d0925538a310202bc10f29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/a167afab66d8aa74b7f552759c0bbd906afb4134",
-                "reference": "a167afab66d8aa74b7f552759c0bbd906afb4134",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/5203bf29c8be0280e8d0925538a310202bc10f29",
+                "reference": "5203bf29c8be0280e8d0925538a310202bc10f29",
                 "shasum": ""
             },
             "require": {
@@ -9437,12 +9437,12 @@
                 "amphp/http-server": "^2.1",
                 "dms/phpunit-arraysubset-asserts": "dev-master",
                 "ergebnis/composer-normalize": "^2.28",
-                "friendsofphp/php-cs-fixer": "3.64.0",
+                "friendsofphp/php-cs-fixer": "3.65.0",
                 "mll-lab/php-cs-fixer-config": "^5.9.2",
                 "nyholm/psr7": "^1.5",
                 "phpbench/phpbench": "^1.2",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "1.12.10",
+                "phpstan/phpstan": "1.12.12",
                 "phpstan/phpstan-phpunit": "1.4.1",
                 "phpstan/phpstan-strict-rules": "1.6.1",
                 "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",
@@ -9477,7 +9477,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v15.18.1"
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.19.0"
             },
             "funding": [
                 {
@@ -9485,7 +9485,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-11-13T16:21:54+00:00"
+            "time": "2024-12-04T19:14:22+00:00"
         }
     ],
     "packages-dev": [
@@ -10238,16 +10238,16 @@
         },
         {
             "name": "phpmyadmin/sql-parser",
-            "version": "5.10.1",
+            "version": "5.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmyadmin/sql-parser.git",
-                "reference": "b14fd66496a22d8dd7f7e2791edd9e8674422f17"
+                "reference": "72afbce7e4b421593b60d2eb7281e37a50734df8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmyadmin/sql-parser/zipball/b14fd66496a22d8dd7f7e2791edd9e8674422f17",
-                "reference": "b14fd66496a22d8dd7f7e2791edd9e8674422f17",
+                "url": "https://api.github.com/repos/phpmyadmin/sql-parser/zipball/72afbce7e4b421593b60d2eb7281e37a50734df8",
+                "reference": "72afbce7e4b421593b60d2eb7281e37a50734df8",
                 "shasum": ""
             },
             "require": {
@@ -10321,7 +10321,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2024-11-10T04:10:31+00:00"
+            "time": "2024-12-05T15:04:09+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -11772,15 +11772,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.3"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
-        "php": "8.2.9"
+        "php": "8.3.9"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/api/schema-directives.graphql
+++ b/api/schema-directives.graphql
@@ -685,7 +685,7 @@ directive @hide(
   Specify which environments must not use this field, e.g. ["production"].
   """
   env: [String!]!
-) repeatable on FIELD_DEFINITION
+) repeatable on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION | OBJECT
 
 # Directive class: Nuwave\Lighthouse\Schema\Directives\InDirective
 """
@@ -1083,7 +1083,7 @@ directive @show(
   Specify which environments may use this field, e.g. ["testing"].
   """
   env: [String!]!
-) repeatable on FIELD_DEFINITION
+) repeatable on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION | OBJECT
 
 # Directive class: Nuwave\Lighthouse\Schema\Directives\SpreadDirective
 """

--- a/documentation/linux-setup.md
+++ b/documentation/linux-setup.md
@@ -110,11 +110,11 @@ The version should be greater or equal to the version of `services.postgres.imag
 
 ## PHP
 
-We use [PHP](https://www.php.net/) version 8.2 to run the backend app. Ubuntu 22.04 does not come with PHP 8.2 in its repositories so add the [Ondrej PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php/) and install it with some extensions.
+We use [PHP](https://www.php.net/) version 8.3 to run the backend app. Ubuntu 22.04 does not come with PHP 8.3 in its repositories so add the [Ondrej PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php/) and install it with some extensions.
 
 ```
 LC_ALL=C.UTF-8 sudo add-apt-repository ppa:ondrej/php
-sudo apt-get install php8.2 php8.2-mbstring php8.2-xml php8.2-pgsql php8.2-zip php8.2-curl php8.2-bcmath php8.2-gd php8.2-dom php8.2-intl
+sudo apt-get install php8.3 php8.3-mbstring php8.3-xml php8.3-pgsql php8.3-zip php8.3-curl php8.3-bcmath php8.3-gd php8.3-dom php8.3-intl
 ```
 
 Double check:

--- a/infrastructure/azure-pipelines-dev.yml
+++ b/infrastructure/azure-pipelines-dev.yml
@@ -7,7 +7,7 @@ resources:
       type: git
       ref: refs/heads/main
 variables:
-  phpVersion: "8.2"
+  phpVersion: "8.3"
   serviceConnectionName: "Talent Cloud Service Connection"
   npm_config_user_config: "$(System.DefaultWorkingDirectory)/.npmrc"
   dirResults: "$(System.DefaultWorkingDirectory)/apps/playwright/test-results"

--- a/infrastructure/azure-pipelines.yml
+++ b/infrastructure/azure-pipelines.yml
@@ -22,7 +22,7 @@ resources:
       type: git
       ref: refs/heads/main
 variables:
-  phpVersion: "8.2"
+  phpVersion: "8.3"
 
 jobs:
   - job: build_artifact

--- a/infrastructure/maintenance-container/Dockerfile
+++ b/infrastructure/maintenance-container/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
   && apt-get install -y perl unzip wget curl \
-  && apt-get install -y php8.2 php8.2-mbstring php8.2-xml php8.2-pgsql php8.2-zip php8.2-curl php8.2-bcmath php8.2-gd \
+  && apt-get install -y php8.3 php8.3-mbstring php8.3-xml php8.3-pgsql php8.3-zip php8.3-curl php8.3-bcmath php8.3-gd \
   && apt-get install --yes --no-install-recommends git postgresql-client \
   && apt-get clean
 

--- a/infrastructure/webserver.Dockerfile
+++ b/infrastructure/webserver.Dockerfile
@@ -1,11 +1,10 @@
 # This setup should only install things that are set up in infrastructure/bin/post_deployment.sh as well
 
 # All images: https://mcr.microsoft.com/v2/appsvc/php/tags/list
-FROM mcr.microsoft.com/appsvc/php:8.2-fpm-xdebug_20230908.3.tuxprod
+FROM mcr.microsoft.com/appsvc/php:8.3-fpm-xdebug_20241021.7.tuxprod
 
 RUN echo 'memory_limit=256M' >> /usr/local/etc/php/conf.d/php.ini
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends supervisor cron postgresql-client \
-    && apt-get --yes autoremove \
     && apt-get clean


### PR DESCRIPTION
🤖 Resolves #11819 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Bumps the environment to PHP 8.3.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

### Locally

1. Bring your docker compose network down and rebuild the images
  - `docker compose build webserver`
  - `docker compose build maintenance`
2. Rebuild the `api` project

- [ ] The app still runs exactly as before

### Azure
- deploy app service with php 8.3
- deploy this branch into the app service

- [ ] The app still runs exactly as before

## 🚚 Deployment

- Set phpVersion in IaC to 8.3
  - [X] dev app servce
  - [ ] uat app service
  - [ ] prod app service
  - [ ] set default value in VERTICAL file