### PR TITLE
[Copy] Updates dashboard based on community or admin

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1863,10 +1863,6 @@
     "defaultMessage": "Comment les données d’autodéclaration sont-elles utilisées?",
     "description": "Title for how self-declaration data is used section"
   },
-  "7nxtBm": {
-    "defaultMessage": "Il s’agit du carrefour de l’administrateur de la plateforme des talents numériques du GC à partir d’où il est possible de gérer, trier et recruter le talent pour le GC.",
-    "description": "Subtitle for the admin dashboard page"
-  },
   "7oq1Qa": {
     "defaultMessage": "Décision finale",
     "description": "Title displayed on the Pool Candidates table final decision column"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -515,6 +515,10 @@
     "defaultMessage": "Candidats du bassin",
     "description": "Title for pool candidates"
   },
+  "0Wx0kW": {
+    "defaultMessage": "Il s’agit du carrefour de l’administrateur de Talents numériques du GC. À partir d’ici, il est possible de recruter et gérer des talents, trouver des ressources et ajuster les paramètres de la plateforme.",
+    "description": "Subtitle for the admin dashboard page"
+  },
   "0YZeO0": {
     "defaultMessage": "Embauché(e) (occasionnel)",
     "description": "Status for an application that has been hired with a casual contract"
@@ -5498,6 +5502,10 @@
   "QNmxIN": {
     "defaultMessage": "Identifiant de processus copié",
     "description": "Button text to indicate that a specific qualified recruitment's ID has been copied"
+  },
+  "QOf3kT": {
+    "defaultMessage": "Voici votre tableau de bord de la collectivité. Vous pouvez y recruter et gérer des talents, et trouver des ressources.",
+    "description": "Subtitle for the community dashboard page"
   },
   "QQXvOh": {
     "defaultMessage": "Notre engagement à l’égard de l’accessibilité",

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboard.test.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboard.test.tsx
@@ -34,9 +34,15 @@ describe("Render dashboard page", () => {
     renderComponent("platform_admin");
 
     // card sections
-    expect(screen.getByText(/recruitment/i)).toBeInTheDocument();
-    expect(screen.getByText(/resources/i)).toBeInTheDocument();
-    expect(screen.getByText(/administration/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /recruitment/i, level: 2 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /resources/i, level: 2 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /administration/i, level: 2 }),
+    ).toBeInTheDocument();
 
     // recruitment links
     expect(
@@ -114,9 +120,15 @@ describe("Render dashboard page", () => {
     renderComponent("community_admin");
 
     // card sections
-    expect(screen.getByText(/recruitment/i)).toBeInTheDocument();
-    expect(screen.getByText(/resources/i)).toBeInTheDocument();
-    expect(screen.getByText(/administration/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /recruitment/i, level: 2 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /resources/i, level: 2 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /administration/i, level: 2 }),
+    ).toBeInTheDocument();
 
     // recruitment links
     expect(
@@ -194,9 +206,15 @@ describe("Render dashboard page", () => {
     renderComponent("process_operator");
 
     // card sections
-    expect(screen.getByText(/recruitment/i)).toBeInTheDocument();
-    expect(screen.getByText(/resources/i)).toBeInTheDocument();
-    expect(screen.getByText(/administration/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /recruitment/i, level: 2 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /resources/i, level: 2 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /administration/i, level: 2 }),
+    ).toBeInTheDocument();
 
     // recruitment links
     expect(
@@ -274,9 +292,15 @@ describe("Render dashboard page", () => {
     renderComponent("community_recruiter");
 
     // card sections
-    expect(screen.getByText(/recruitment/i)).toBeInTheDocument();
-    expect(screen.getByText(/resources/i)).toBeInTheDocument();
-    expect(screen.getByText(/administration/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /recruitment/i, level: 2 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /resources/i, level: 2 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /administration/i, level: 2 }),
+    ).toBeInTheDocument();
 
     // recruitment links
     expect(

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -48,8 +48,8 @@ import { orderRoles } from "../Communities/CommunityMembersPage/helpers";
 
 const subTitle = defineMessage({
   defaultMessage:
-    "This is the administrator hub of the GC Digital Talent platform, manage, sort and recruit talent to the GoC.",
-  id: "7nxtBm",
+    "This is the administrator hub of GC Digital Talent. Here you can recruit and manage talent, find resources, and adjust platform settings.",
+  id: "0Wx0kW",
   description: "Subtitle for the admin dashboard page",
 });
 

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -368,7 +368,7 @@ const AdminDashboard_Query = graphql(/* GraphQL */ `
   }
 `);
 
-export const DashboardPageApi = () => {
+export const AdminDashboardPageApi = () => {
   const [{ data, fetching, error }] = useQuery({
     query: AdminDashboard_Query,
   });
@@ -382,10 +382,8 @@ export const DashboardPageApi = () => {
 
 export const Component = () => (
   <RequireAuth roles={[ROLE_NAME.PlatformAdmin]}>
-    <DashboardPageApi />
+    <AdminDashboardPageApi />
   </RequireAuth>
 );
 
 Component.displayName = "AdminDashboardPage";
-
-export default DashboardPageApi;

--- a/apps/web/src/pages/CommunityDashboardPage/CommunityDashboardPage.tsx
+++ b/apps/web/src/pages/CommunityDashboardPage/CommunityDashboardPage.tsx
@@ -1,8 +1,384 @@
-import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { defineMessage, IntlShape, useIntl } from "react-intl";
+import { useQuery } from "urql";
+import RocketLaunchIcon from "@heroicons/react/24/outline/RocketLaunchIcon";
+import BookOpenIcon from "@heroicons/react/24/outline/BookOpenIcon";
+import ComputerDesktopIcon from "@heroicons/react/24/outline/ComputerDesktopIcon";
+import CogIcon from "@heroicons/react/24/outline/CogIcon";
+import uniqBy from "lodash/uniqBy";
 
+import {
+  CardBasic,
+  Chip,
+  Chips,
+  Heading,
+  Link,
+  Pending,
+} from "@gc-digital-talent/ui";
+import {
+  useAuthorization,
+  hasRole,
+  ROLE_NAME,
+  RoleName,
+} from "@gc-digital-talent/auth";
+import {
+  Maybe,
+  Role,
+  RoleAssignment,
+  User,
+  graphql,
+} from "@gc-digital-talent/graphql";
+import {
+  commonMessages,
+  getLocalizedName,
+  navigationMessages,
+} from "@gc-digital-talent/i18n";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
+
+import pageTitles from "~/messages/pageTitles";
+import SEO from "~/components/SEO/SEO";
+import { getFullNameHtml } from "~/utils/nameUtils";
+import useRoutes from "~/hooks/useRoutes";
+import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
+import AdminHero from "~/components/HeroDeprecated/AdminHero";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import adminMessages from "~/messages/adminMessages";
+import permissionConstants from "~/constants/permissionConstants";
 
-import { DashboardPageApi } from "../AdminDashboardPage/AdminDashboardPage";
+import { orderRoles } from "../Communities/CommunityMembersPage/helpers";
+
+const subTitle = defineMessage({
+  defaultMessage:
+    "This is your community dashboard where you can recruit and manage talent, and find resources.",
+  id: "QOf3kT",
+  description: "Subtitle for the community dashboard page",
+});
+
+interface RoleChipsProps {
+  roles: Role[];
+  intl: IntlShape;
+}
+
+// short-circuit hasRole if no roles were required so an empty array
+const hasRolesHandleNoRolesRequired = (
+  checkRole: RoleName | RoleName[],
+  userRoles: Maybe<(Maybe<RoleAssignment> | undefined)[]> | undefined,
+): boolean => {
+  if (Array.isArray(checkRole) && checkRole.length === 0) {
+    return true;
+  }
+  return hasRole(checkRole, userRoles);
+};
+
+const RoleChips = ({ roles, intl }: RoleChipsProps) => {
+  const uniqueRoles = uniqBy(roles, "name");
+  const roleChips = uniqueRoles
+    ? orderRoles(uniqueRoles, intl).map((role) => (
+        <Chip color="warning" key={role.id} data-h2-margin-right="base(x.25)">
+          {getLocalizedName(role.displayName, intl)}
+        </Chip>
+      ))
+    : null;
+
+  return roleChips ? <Chips>{roleChips}</Chips> : null;
+};
+
+export interface DashboardPageProps {
+  currentUser?: User | null;
+}
+
+export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
+  const intl = useIntl();
+  const adminRoutes = useRoutes();
+  const { roleAssignments } = useAuthorization();
+
+  interface CardLinkInfo {
+    label: string;
+    href: string;
+    roles: RoleName[];
+  }
+
+  // recruitment section
+  const recruitmentCollection: CardLinkInfo[] = [
+    {
+      label: intl.formatMessage(navigationMessages.candidates),
+      href: adminRoutes.poolCandidates(),
+      roles: permissionConstants.viewCandidates,
+    },
+    {
+      label: intl.formatMessage(navigationMessages.processes),
+      href: adminRoutes.poolTable(),
+      roles: permissionConstants.viewProcesses,
+    },
+    {
+      label: intl.formatMessage(pageTitles.talentRequests),
+      href: adminRoutes.searchRequestTable(),
+      roles: permissionConstants.viewRequests,
+    },
+  ];
+  const recruitmentCollectionFiltered = recruitmentCollection.filter((item) =>
+    hasRolesHandleNoRolesRequired(item.roles, roleAssignments),
+  );
+  const recruitmentCollectionSorted = recruitmentCollectionFiltered.sort(
+    (a, b) => {
+      const aName = a.label;
+      const bName = b.label;
+      return aName.localeCompare(bName);
+    },
+  );
+
+  // resources section
+  const resourcesCollection: CardLinkInfo[] = [
+    {
+      label: intl.formatMessage(navigationMessages.skillsLibrary),
+      href: adminRoutes.skills(),
+      roles: [],
+    },
+    {
+      label: intl.formatMessage({
+        defaultMessage: "Job templates library",
+        id: "MySfL/",
+        description: "Label for link to job templates library",
+      }),
+      href: adminRoutes.jobPosterTemplates(),
+      roles: [],
+    },
+  ];
+  const resourcesCollectionFiltered = resourcesCollection.filter((item) =>
+    hasRolesHandleNoRolesRequired(item.roles, roleAssignments),
+  );
+  const resourcesCollectionSorted = resourcesCollectionFiltered.sort((a, b) => {
+    const aName = a.label;
+    const bName = b.label;
+    return aName.localeCompare(bName);
+  });
+
+  // administration section
+  const administrationCollection: CardLinkInfo[] = [
+    {
+      label: intl.formatMessage(pageTitles.announcements),
+      href: adminRoutes.announcements(),
+      roles: [ROLE_NAME.PlatformAdmin],
+    },
+    {
+      label: intl.formatMessage(adminMessages.classifications),
+      href: adminRoutes.classificationTable(),
+      roles: [ROLE_NAME.PlatformAdmin],
+    },
+    {
+      label: intl.formatMessage(adminMessages.departments),
+      href: adminRoutes.departmentTable(),
+      roles: [ROLE_NAME.PlatformAdmin],
+    },
+    {
+      label: intl.formatMessage(navigationMessages.skills),
+      href: adminRoutes.skillTable(),
+      roles: [ROLE_NAME.PlatformAdmin],
+    },
+    {
+      label: intl.formatMessage(adminMessages.skillFamilies),
+      href: adminRoutes.skillFamilyTable(),
+      roles: [ROLE_NAME.PlatformAdmin],
+    },
+    {
+      label: intl.formatMessage(pageTitles.teams),
+      href: adminRoutes.teamTable(),
+      roles: [
+        ROLE_NAME.PoolOperator,
+        ROLE_NAME.CommunityManager,
+        ROLE_NAME.PlatformAdmin,
+      ],
+    },
+    {
+      label: intl.formatMessage(pageTitles.trainingOpportunities),
+      href: adminRoutes.trainingOpportunitiesIndex(),
+      roles: [ROLE_NAME.PlatformAdmin],
+    },
+    {
+      label: intl.formatMessage(navigationMessages.users),
+      href: adminRoutes.userTable(),
+      roles: permissionConstants.viewUsers,
+    },
+    {
+      label: intl.formatMessage(pageTitles.communities),
+      href: adminRoutes.communityTable(),
+      roles: [
+        ROLE_NAME.CommunityAdmin,
+        ROLE_NAME.CommunityRecruiter,
+        ROLE_NAME.PlatformAdmin,
+      ],
+    },
+  ];
+  const administrationCollectionFiltered = administrationCollection.filter(
+    (item) => hasRolesHandleNoRolesRequired(item.roles, roleAssignments),
+  );
+  const administrationCollectionSorted = administrationCollectionFiltered.sort(
+    (a, b) => {
+      const aName = a.label;
+      const bName = b.label;
+      return aName.localeCompare(bName);
+    },
+  );
+
+  // own roles, filtered
+  const ownRoles = unpackMaybes(roleAssignments)
+    .map((roleAssign) => roleAssign.role)
+    .filter((role) => !!role)
+    .filter((role) => !["guest", "base_user", "applicant"].includes(role.name));
+
+  return (
+    <>
+      <SEO
+        title={intl.formatMessage(pageTitles.dashboard)}
+        description={intl.formatMessage(subTitle)}
+      />
+      <AdminHero
+        title={intl.formatMessage(
+          {
+            defaultMessage: "Welcome back, {name}",
+            id: "lIwJp4",
+            description:
+              "Title for dashboard on the talent cloud admin portal.",
+          },
+          {
+            name: currentUser
+              ? getFullNameHtml(
+                  currentUser.firstName,
+                  currentUser.lastName,
+                  intl,
+                )
+              : intl.formatMessage(commonMessages.notAvailable),
+          },
+        )}
+        subtitle={intl.formatMessage(subTitle)}
+      />
+      <AdminContentWrapper>
+        <div
+          data-h2-display="base(flex)"
+          data-h2-flex-wrap="base(wrap)"
+          data-h2-gap="base(x2 x1.1)"
+        >
+          {recruitmentCollectionSorted.length > 0 && (
+            <div>
+              <Heading
+                size="h4"
+                data-h2-margin="base(0, 0, x1, 0)"
+                Icon={RocketLaunchIcon}
+                color="primary"
+              >
+                {intl.formatMessage({
+                  defaultMessage: "Recruitment",
+                  id: "UNEVD9",
+                  description: "Header for section called recruitment",
+                })}
+              </Heading>
+              <CardBasic data-h2-min-width="base(x14.5)">
+                <ul>
+                  {recruitmentCollectionSorted.map((item) => (
+                    <li key={item.label} data-h2-margin-bottom="base(x.5)">
+                      <Link color="primary" mode="inline" href={item.href}>
+                        {item.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </CardBasic>
+            </div>
+          )}
+          <div>
+            <Heading
+              size="h4"
+              data-h2-margin="base(0, 0, x1, 0)"
+              Icon={BookOpenIcon}
+              color="secondary"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Resources",
+                id: "nGSUzp",
+                description: "Card title for a 'resources' card",
+              })}
+            </Heading>
+            <CardBasic data-h2-min-width="base(x14.5)">
+              <ul>
+                {resourcesCollectionSorted.map((item) => (
+                  <li key={item.label} data-h2-margin-bottom="base(x.5)">
+                    <Link color="secondary" mode="inline" href={item.href}>
+                      {item.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </CardBasic>
+          </div>
+          {administrationCollectionSorted.length > 0 && (
+            <div>
+              <Heading
+                size="h4"
+                data-h2-margin="base(0, 0, x1, 0)"
+                Icon={ComputerDesktopIcon}
+                color="error"
+              >
+                {intl.formatMessage({
+                  defaultMessage: "Administration",
+                  id: "CdJQ7z",
+                  description: "Header for section called administration",
+                })}
+              </Heading>
+              <CardBasic data-h2-min-width="base(x14.5)">
+                <ul>
+                  {administrationCollectionSorted.map((item) => (
+                    <li key={item.label} data-h2-margin-bottom="base(x.5)">
+                      <Link color="error" mode="inline" href={item.href}>
+                        {item.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </CardBasic>
+            </div>
+          )}
+        </div>
+        <div data-h2-margin-top="base(x3)" data-h2-margin-bottom="base(x2)">
+          <Heading
+            size="h4"
+            data-h2-margin="base(0, 0, x1, 0)"
+            Icon={CogIcon}
+            color="warning"
+          >
+            {intl.formatMessage({
+              defaultMessage: "Your roles",
+              id: "IJlJF1",
+              description:
+                "Header for section displaying logged in user's roles",
+            })}
+          </Heading>
+          <RoleChips roles={ownRoles} intl={intl}></RoleChips>
+        </div>
+      </AdminContentWrapper>
+    </>
+  );
+};
+
+const CommunityDashboard_Query = graphql(/* GraphQL */ `
+  query CommunityDashboard_Query {
+    me {
+      id
+      firstName
+      lastName
+    }
+  }
+`);
+
+export const CommunityDashboardPageApi = () => {
+  const [{ data, fetching, error }] = useQuery({
+    query: CommunityDashboard_Query,
+  });
+
+  return (
+    <Pending fetching={fetching} error={error}>
+      <DashboardPage currentUser={data?.me} />
+    </Pending>
+  );
+};
 
 export const Component = () => (
   <RequireAuth
@@ -15,10 +391,8 @@ export const Component = () => (
       ROLE_NAME.ProcessOperator,
     ]}
   >
-    <DashboardPageApi />
+    <CommunityDashboardPageApi />
   </RequireAuth>
 );
 
 Component.displayName = "CommunityDashboardPage";
-
-export default DashboardPageApi;


### PR DESCRIPTION
🤖 Resolves #12209.

## 👋 Introduction

This PR updates dashboard subtitle copy based on the community or admin dashboard. It also splits the `AdminDashboardPage` component into `AdminDashboardPage` and `CommunityDashboardPage`.

## 🧪 Testing

1. Navigate to http://localhost:8000/en/admin
2. Use role switcher (is that the name of it?) to Admin 
3. Verify hero subtitle text matches issue copy
4. Use role switcher (is that the name of it?) to Community
5. Verify hero subtitle text matches issue copy

## 📸 Screenshots

<img width="1424" alt="Screen Shot 2024-12-05 at 12 46 49" src="https://github.com/user-attachments/assets/b1b916df-a68f-45b0-8598-ac2211160c69">

<img width="1420" alt="Screen Shot 2024-12-05 at 12 47 00" src="https://github.com/user-attachments/assets/fd74bed0-53c9-464e-bf81-25149d2566cd">

<img width="1412" alt="Screen Shot 2024-12-05 at 12 47 26" src="https://github.com/user-attachments/assets/e5d7a035-7632-46f2-869c-66bdf9eef571">

<img width="1403" alt="Screen Shot 2024-12-05 at 12 47 15" src="https://github.com/user-attachments/assets/a2c75c30-9c56-4ab3-a0ad-64ba4963a33e">

