### PR TITLE
[Fix] Updates `workEmailDomainRegex`

### DIFF
--- a/api/app/GraphQL/Validators/UpdateUserAsUserInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateUserAsUserInputValidator.php
@@ -46,7 +46,7 @@ final class UpdateUserAsUserInputValidator extends Validator
                 Rule::unique('users', 'email')->ignore($this->arg('id'), 'id'),
                 Rule::unique('users', 'work_email')->ignore($this->arg('id'), 'id'),
                 // Note: Should be kept in sync with the workEmailDomainRegex
-                'regex:/@([A-Za-z0-9-.]+\.)*(gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca)$/i',
+                'regex:/@([A-Za-z0-9-]+\.)*(gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca)$/i',
             ],
             'sub' => [
                 'sometimes',

--- a/api/app/GraphQL/Validators/UpdateUserAsUserInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateUserAsUserInputValidator.php
@@ -46,7 +46,7 @@ final class UpdateUserAsUserInputValidator extends Validator
                 Rule::unique('users', 'email')->ignore($this->arg('id'), 'id'),
                 Rule::unique('users', 'work_email')->ignore($this->arg('id'), 'id'),
                 // Note: Should be kept in sync with the workEmailDomainRegex
-                'regex:/((?<=@)[A-Za-z0-9-.]+(?<=\.gc\.ca)|@gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca)$/i',
+                'regex:/@([A-Za-z0-9-.]+\.)*(gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca)$/i',
             ],
             'sub' => [
                 'sometimes',

--- a/api/app/GraphQL/Validators/UpdateUserAsUserInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateUserAsUserInputValidator.php
@@ -45,8 +45,8 @@ final class UpdateUserAsUserInputValidator extends Validator
                  */
                 Rule::unique('users', 'email')->ignore($this->arg('id'), 'id'),
                 Rule::unique('users', 'work_email')->ignore($this->arg('id'), 'id'),
-                // Note: Domains should be kept in sync with the workEmailDomainRegex
-                'ends_with:gc.ca,canada.ca,elections.ca,ccc.ca,canadapost-postescanada.ca,gg.ca',
+                // Note: Should be kept in sync with the workEmailDomainRegex
+                'regex:/((?<=@)[A-Za-z0-9-.]+(?<=\.gc\.ca)|@gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca)$/i',
             ],
             'sub' => [
                 'sometimes',

--- a/packages/helpers/src/constants/regularExpressions.ts
+++ b/packages/helpers/src/constants/regularExpressions.ts
@@ -8,7 +8,7 @@
 export const keyStringRegex = /^[a-z]+[_a-z0-9]*$/;
 // See: https://regex101.com/r/EAZ8ha/6
 export const phoneNumberRegex = /^\+[1-9]\d{1,14}$/;
-// See: https://regex101.com/r/T8IYJU/4
+// See: https://regex101.com/r/T8IYJU/5
 // Note: This should be kept in sync with the check in the UpdateUserInputValidator
 export const workEmailDomainRegex =
-  /((?<=@)[A-Za-z0-9-.]+(?<=\.gc\.ca)|@gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca)$/i;
+  /@([A-Za-z0-9-.]+\.)*(gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca)$/i;

--- a/packages/helpers/src/constants/regularExpressions.ts
+++ b/packages/helpers/src/constants/regularExpressions.ts
@@ -8,7 +8,7 @@
 export const keyStringRegex = /^[a-z]+[_a-z0-9]*$/;
 // See: https://regex101.com/r/EAZ8ha/6
 export const phoneNumberRegex = /^\+[1-9]\d{1,14}$/;
-// See: https://regex101.com/r/T8IYJU/5
+// See: https://regex101.com/r/T8IYJU/6
 // Note: This should be kept in sync with the check in the UpdateUserInputValidator
 export const workEmailDomainRegex =
-  /@([A-Za-z0-9-.]+\.)*(gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca)$/i;
+  /@([A-Za-z0-9-]+\.)*(gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca)$/i;

--- a/packages/helpers/src/constants/regularExpressions.ts
+++ b/packages/helpers/src/constants/regularExpressions.ts
@@ -8,7 +8,7 @@
 export const keyStringRegex = /^[a-z]+[_a-z0-9]*$/;
 // See: https://regex101.com/r/EAZ8ha/6
 export const phoneNumberRegex = /^\+[1-9]\d{1,14}$/;
-// See: https://regex101.com/r/T8IYJU/3
+// See: https://regex101.com/r/T8IYJU/4
 // Note: This should be kept in sync with the check in the UpdateUserInputValidator
 export const workEmailDomainRegex =
-  /(gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca)$/i;
+  /((?<=@)[A-Za-z0-9-.]+(?<=\.gc\.ca)|@gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca)$/i;


### PR DESCRIPTION
🤖 Resolves #12144.

## 👋 Introduction

This PR updates the `workEmailDomainRegex` to be more restrictive. It also updates the backend validator `UpdateUserAsUserInputValidator` to use the same regular expression as `workEmailDomainRegex`.

> [!NOTE]
> The regular expression is not perfect but it is better than what came before. 

## 🧪 Testing

> [!TIP]
> For testing regex against strings, https://regex101.com/r/T8IYJU/4.

1. `pnpm build`
2. Navigate to http://localhost:8000/en/applicant/personal-information#government-section
3. Edit Government employee information
4. Enter example@gc.ca in Work email address input
5. Save changes
6. Verify success toast Government information updated successfully!
7. Edit Government employee information
8. Enter example@tbs-sct.gc.ca in Work email address input
9. Save changes
10. Verify success toast Government information updated successfully!
11. Edit Government employee information
12. Enter example@dogc.ca in Work email address input
13. Verify frontend rule states not a valid government email