### PR TITLE
[Bug] Wrap long emails on User information tab

### DIFF
--- a/apps/web/src/pages/Users/UserInformationPage/components/AboutSection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/AboutSection.tsx
@@ -28,7 +28,7 @@ const AboutSection = ({ user }: BasicUserInformationProps) => {
             {intl.formatMessage(commonMessages.email)}
             {intl.formatMessage(commonMessages.dividingColon)}
           </p>
-          <p>{user.email}</p>
+          <p data-h2-overflow-wrap="base(anywhere)">{user.email}</p>
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2) desktop(1of3)">
           <p data-h2-font-weight="base(700)">


### PR DESCRIPTION
🤖 Resolves #12169 

## 👋 Introduction

Using overflow-wrap, handle really long email addresses 


## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->


1. Navigate to `/admin/users/:id`
2. For a user with long email or edit an email to be long
3. Observe wrapped text


## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/91e6efdc-0f27-4740-a9d2-7567450e1e80)


